### PR TITLE
Fix proto dependencies and wildcards in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,8 @@ GOCOVERPKG_ARG := -coverpkg="$(PROJECT_ROOT)/common/...,$(PROJECT_ROOT)/service/
 PROTO_ROOT := .gen/proto
 PROTO_REPO := github.com/temporalio/temporal-proto
 # List only subdirectories with *.proto files (sort to remove duplicates).
-PROTO_DIRS = $(sort $(dir $(wildcard $(PROTO_ROOT)/*/*.proto)))
+# Note: using "shell find" instead of "wildcard" because "wildcard" caches directory structure.
+PROTO_DIRS = $(sort $(dir $(shell find $(PROTO_ROOT) -name "*.proto")))
 
 # Everything that deals with go modules (go.mod) needs to take dependency on this target.
 $(PROTO_ROOT)/go.mod:
@@ -116,7 +117,7 @@ $(PROTO_ROOT)/go.mod:
 
 clean-proto:
 	$(foreach PROTO_DIR,$(PROTO_DIRS),rm -f $(PROTO_DIR)*.go;)
-	$(foreach PROTO_MOCK_DIR,$(wildcard $(PROTO_ROOT)/*mock),rm -rf $(PROTO_MOCK_DIR);)
+	rm -rf $(PROTO_ROOT)/*mock
 
 update-proto-submodule:
 	git submodule update --remote $(PROTO_ROOT)
@@ -130,7 +131,7 @@ protoc:
 	$(foreach PROTO_DIR,$(PROTO_DIRS),protoc --proto_path=$(PROTO_ROOT) --yarpc-go_out=$(PROTO_ROOT) $(PROTO_DIR)*.proto;)
 
 # All YARPC generated service files pathes relative to PROTO_ROOT
-PROTO_YARPC_SERVICES = $(patsubst $(PROTO_ROOT)/%,%,$(wildcard $(PROTO_ROOT)/*/service.pb.yarpc.go))
+PROTO_YARPC_SERVICES = $(patsubst $(PROTO_ROOT)/%,%,$(shell find $(PROTO_ROOT) -name "service.pb.yarpc.go"))
 dir_no_slash = $(patsubst %/,%,$(dir $(1)))
 dirname = $(notdir $(call dir_no_slash,$(1)))
 

--- a/go.sum
+++ b/go.sum
@@ -315,6 +315,7 @@ go.uber.org/tools v0.0.0-20190430173459-422a61c266e1/go.mod h1:vJERXedbb3MVM5f9E
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee h1:0mgffUl7nfd+FpvXMVz4IDEaUSmT1ysygQC7qYo7sG4=
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/yarpc v1.38.0/go.mod h1:5wt+WtAfoQh3yGyup7479I35hUobLqCfb0oewxC58jE=
+go.uber.org/yarpc v1.42.0/go.mod h1:5wt+WtAfoQh3yGyup7479I35hUobLqCfb0oewxC58jE=
 go.uber.org/yarpc v1.42.1 h1:DowzHhyllp/n4oKANH8/+Z8xAeAwLVF7SO57h6ndXM0=
 go.uber.org/yarpc v1.42.1/go.mod h1:5wt+WtAfoQh3yGyup7479I35hUobLqCfb0oewxC58jE=
 go.uber.org/zap v1.8.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=


### PR DESCRIPTION
Found few bugs when build doesn't work on the fresh clone. Now it should be fine. If you ever have any issues with generated proto dependencies (client, server, mock,...) just run `make proto` and it will clean up and regenerate everything.