### PR TITLE
Runtime bug fixes for ClusterMetadata initialization

### DIFF
--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -799,18 +799,18 @@ func (c *clusterMetadataRateLimitedPersistenceClient) Close() {
 	c.persistence.Close()
 }
 
-func (c clusterMetadataRateLimitedPersistenceClient) GetName() string {
+func (c *clusterMetadataRateLimitedPersistenceClient) GetName() string {
 	return c.persistence.GetName()
 }
 
-func (c clusterMetadataRateLimitedPersistenceClient) InitializeImmutableClusterMetadata(request *InitializeImmutableClusterMetadataRequest) (*InitializeImmutableClusterMetadataResponse, error) {
+func (c *clusterMetadataRateLimitedPersistenceClient) InitializeImmutableClusterMetadata(request *InitializeImmutableClusterMetadataRequest) (*InitializeImmutableClusterMetadataResponse, error) {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return c.InitializeImmutableClusterMetadata(request)
+	return c.persistence.InitializeImmutableClusterMetadata(request)
 }
 
-func (c clusterMetadataRateLimitedPersistenceClient) GetImmutableClusterMetadata() (*GetImmutableClusterMetadataResponse, error) {
+func (c *clusterMetadataRateLimitedPersistenceClient) GetImmutableClusterMetadata() (*GetImmutableClusterMetadataResponse, error) {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}


### PR DESCRIPTION
These were not caught as I (incorrectly) assumed the integration tests ran through these server initialization paths. 