### PR TITLE
Use gRPC healthservice from frontend handler 

### DIFF
--- a/service/frontend/accessControlledHandler.go
+++ b/service/frontend/accessControlledHandler.go
@@ -27,9 +27,7 @@ import (
 	"go.uber.org/yarpc/encoding/protobuf"
 	"go.uber.org/yarpc/yarpcerrors"
 
-	"github.com/temporalio/temporal/.gen/go/health"
-	"github.com/temporalio/temporal/.gen/go/health/metaserver"
-	"github.com/temporalio/temporal/common"
+	"github.com/temporalio/temporal/.gen/proto/healthservice"
 	"github.com/temporalio/temporal/common/authorization"
 	"github.com/temporalio/temporal/common/resource"
 )
@@ -71,12 +69,11 @@ func NewAccessControlledHandlerImpl(wfHandler *DCRedirectionHandlerImpl, authori
 // RegisterHandler register this handler, must be called before Start()
 func (a *AccessControlledWorkflowHandler) RegisterHandler() {
 	a.GetGRPCDispatcher().Register(workflowservice.BuildWorkflowServiceYARPCProcedures(a))
-	a.GetDispatcher().Register(metaserver.New(a))
+	a.GetGRPCDispatcher().Register(healthservice.BuildMetaYARPCProcedures(a))
 }
 
-// Health callback for for health check
-func (a *AccessControlledWorkflowHandler) Health(ctx context.Context) (*health.HealthStatus, error) {
-	hs := &health.HealthStatus{Ok: true, Msg: common.StringPtr("auth is good")}
+func (a *AccessControlledWorkflowHandler) Health(context.Context, *healthservice.HealthRequest) (*healthservice.HealthStatus, error) {
+	hs := &healthservice.HealthStatus{Ok: true, Msg: "Frontend health check endpoint (gRPC) reached."}
 	return hs, nil
 }
 

--- a/service/frontend/dcRedirectionHandler.go
+++ b/service/frontend/dcRedirectionHandler.go
@@ -26,8 +26,6 @@ import (
 
 	"go.temporal.io/temporal-proto/workflowservice"
 
-	"github.com/temporalio/temporal/.gen/go/health"
-	"github.com/temporalio/temporal/.gen/go/health/metaserver"
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/metrics"
@@ -80,7 +78,6 @@ func NewDCRedirectionHandler(
 // RegisterHandler register this handler, must be called before Start()
 func (handler *DCRedirectionHandlerImpl) RegisterHandler() {
 	handler.GetGRPCDispatcher().Register(workflowservice.BuildWorkflowServiceYARPCProcedures(handler))
-	handler.GetDispatcher().Register(metaserver.New(handler))
 }
 
 // Start starts the handler
@@ -91,12 +88,6 @@ func (handler *DCRedirectionHandlerImpl) Start() {
 // Stop stops the handler
 func (handler *DCRedirectionHandlerImpl) Stop() {
 	handler.stopFn()
-}
-
-// Health is for health check
-func (handler *DCRedirectionHandlerImpl) Health(ctx context.Context) (*health.HealthStatus, error) {
-	hs := &health.HealthStatus{Ok: true, Msg: common.StringPtr("dc redirection good")}
-	return hs, nil
 }
 
 // Domain APIs, domain APIs does not require redirection

--- a/service/frontend/workflowHandlerGRPC.go
+++ b/service/frontend/workflowHandlerGRPC.go
@@ -38,7 +38,7 @@ type (
 	}
 )
 
-// NewWorkflowHandlerGRPC creates a thrift handler for the cadence workflowservice
+// NewWorkflowHandlerGRPC creates a gRPC handler for the cadence workflowservice
 func NewWorkflowHandlerGRPC(
 	workflowHandlerThrift *WorkflowHandler,
 ) *WorkflowHandlerGRPC {
@@ -47,12 +47,6 @@ func NewWorkflowHandlerGRPC(
 	}
 
 	return handler
-}
-
-// RegisterHandler register this handler, must be called before Start()
-// if DCRedirectionHandler is also used, use RegisterHandler in DCRedirectionHandler instead
-func (wh *WorkflowHandlerGRPC) RegisterHandler() {
-	wh.workflowHandlerThrift.GetGRPCDispatcher().Register(workflowservice.BuildWorkflowServiceYARPCProcedures(wh))
 }
 
 // RegisterDomain creates a new domain which can be used as a container for all resources.  Domain is a top level


### PR DESCRIPTION
Old Thrift version of `health` service was used before. Now it used proto version.