### PR TITLE
Add Ringpop 'BroadcastIp' configuration option

### DIFF
--- a/common/membership/rpMonitor_test.go
+++ b/common/membership/rpMonitor_test.go
@@ -44,7 +44,7 @@ func (s *RpoSuite) SetupTest() {
 }
 
 func (s *RpoSuite) TestRingpopMonitor() {
-	testService := NewTestRingpopCluster("rpm-test", 3, "127.0.0.1", "", "rpm-test")
+	testService := NewTestRingpopCluster("rpm-test", 3, "0.0.0.0", "", "rpm-test", "127.0.0.1")
 	s.NotNil(testService, "Failed to create test service")
 
 	logger := loggerimpl.NewNopLogger()

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -301,7 +301,7 @@ func (r *ringpopServiceResolver) getLabelsMap() map[string]string {
 	return labels
 }
 
-func ExternalAddressResolver(listenerPeerInfo tchannel.LocalPeerInfo, broadcastIP *string) (string, error) {
+func BuildBroadcastHostPort(listenerPeerInfo tchannel.LocalPeerInfo, broadcastAddress string) (string, error) {
 	// Ephemeral port check copied from ringpop-go/ringpop.go/channelAddressResolver
 	// Check that TChannel is listening on a real hostport. By default,
 	// TChannel listens on an ephemeral host/port. The real port is then
@@ -313,17 +313,17 @@ func ExternalAddressResolver(listenerPeerInfo tchannel.LocalPeerInfo, broadcastI
 	}
 
 	// Broadcast IP override
-	if broadcastIP != nil && *broadcastIP != "" {
+	if broadcastAddress != "" {
 		// Parse listener hostport
 		_, port, err := net.SplitHostPort(listenerPeerInfo.HostPort)
 		if err != nil {
 			return "", err
 		}
 
-		// Parse supplied BroadcastIP override
-		ip := net.ParseIP(*broadcastIP)
+		// Parse supplied broadcastAddress override
+		ip := net.ParseIP(broadcastAddress)
 		if ip == nil || ip.To4() == nil {
-			return "", errors.New("broadcastIP set but unknown failure encountered while parsing")
+			return "", errors.New("broadcastAddress set but unknown failure encountered while parsing")
 		}
 
 		// If no errors, use the parsed IP with the port from our listener

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -21,9 +21,14 @@
 package membership
 
 import (
+	"errors"
+	"net"
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/uber/ringpop-go"
+	"github.com/uber/tchannel-go"
 
 	"github.com/dgryski/go-farm"
 	"github.com/uber/ringpop-go/events"
@@ -294,4 +299,36 @@ func (r *ringpopServiceResolver) getLabelsMap() map[string]string {
 	labels := make(map[string]string)
 	labels[RoleKey] = r.service
 	return labels
+}
+
+func ExternalAddressResolver(listenerPeerInfo tchannel.LocalPeerInfo, broadcastIP *string) (string, error) {
+	// Ephemeral port check copied from ringpop-go/ringpop.go/channelAddressResolver
+	// Check that TChannel is listening on a real hostport. By default,
+	// TChannel listens on an ephemeral host/port. The real port is then
+	// assigned by the OS when ListenAndServe is called. If the hostport is
+	// ephemeral, it means TChannel is not yet listening and the hostport
+	// cannot be resolved.
+	if listenerPeerInfo.IsEphemeralHostPort() {
+		return "", ringpop.ErrEphemeralAddress
+	}
+
+	// Broadcast IP override
+	if broadcastIP != nil && *broadcastIP != "" {
+		// Parse listener hostport
+		_, port, err := net.SplitHostPort(listenerPeerInfo.HostPort)
+		if err != nil {
+			return "", err
+		}
+
+		// Parse supplied BroadcastIP override
+		ip := net.ParseIP(*broadcastIP)
+		if ip == nil || ip.To4() == nil {
+			return "", errors.New("broadcastIP set but unknown failure encountered while parsing")
+		}
+
+		// If no errors, use the parsed IP with the port from our listener
+		return ip.To4().String() + ":" + port, nil
+	}
+
+	return listenerPeerInfo.HostPort, nil
 }

--- a/common/membership/rp_cluster_test.go
+++ b/common/membership/rp_cluster_test.go
@@ -48,7 +48,7 @@ type TestRingpopCluster struct {
 // NewTestRingpopCluster creates a new test cluster with the given name and cluster size
 // All the nodes in the test cluster will register themselves in Ringpop
 // with the specified name. This is only intended for unit tests.
-func NewTestRingpopCluster(ringPopApp string, size int, listenIpAddr string, seed string, serviceName string, broadcastIP string) *TestRingpopCluster {
+func NewTestRingpopCluster(ringPopApp string, size int, listenIpAddr string, seed string, serviceName string, broadcastAddress string) *TestRingpopCluster {
 	logger, err := loggerimpl.NewDevelopment()
 	if err != nil {
 		logger.Error("Failed to create test logger", tag.Error(err))
@@ -78,9 +78,9 @@ func NewTestRingpopCluster(ringPopApp string, size int, listenIpAddr string, see
 			return nil
 		}
 		cluster.hostUUIDs[i] = uuid.New()
-		cluster.hostAddrs[i], err = ExternalAddressResolver(cluster.channels[i].PeerInfo(), &broadcastIP)
+		cluster.hostAddrs[i], err = BuildBroadcastHostPort(cluster.channels[i].PeerInfo(), broadcastAddress)
 		if err != nil {
-			logger.Error("tchannel hostport parse", tag.Error(err))
+			logger.Error("Failed to build broadcast hostport", tag.Error(err))
 			return nil
 		}
 		cluster.hostInfoList[i] = HostInfo{addr: cluster.hostAddrs[i]}
@@ -98,7 +98,7 @@ func NewTestRingpopCluster(ringPopApp string, size int, listenIpAddr string, see
 
 	for i := 0; i < size; i++ {
 		resolver := func() (string, error) {
-			return ExternalAddressResolver(cluster.channels[i].PeerInfo(), &broadcastIP)
+			return BuildBroadcastHostPort(cluster.channels[i].PeerInfo(), broadcastAddress)
 		}
 
 		ringPop, err := ringpop.New(ringPopApp, ringpop.Channel(cluster.channels[i]), ringpop.AddressResolverFunc(resolver))

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -375,7 +375,8 @@ func (h *Impl) Start() {
 	h.hostInfo = hostInfo
 
 	// The service is now started up
-	h.logger.Info("service started")
+	h.logger.Info("service started", tag.Address(hostInfo.GetAddress()))
+
 	// seed the random generator once for this service
 	rand.Seed(time.Now().UTC().UnixNano())
 }

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -119,10 +119,10 @@ type (
 		MaxJoinDuration time.Duration `yaml:"maxJoinDuration"`
 		// Custom discovery provider, cannot be specified through yaml
 		DiscoveryProvider discovery.DiscoverProvider `yaml:"-"`
-		// BroadcastIP is used as the address that is communicated to remote nodes to connect on.
+		// broadcastAddress is used as the address that is communicated to remote nodes to connect on.
 		// This is generally used when BindOnIP would be the same across several nodes (ie: 0.0.0.0)
 		// and for nat traversal scenarios. Check net.ParseIP for supported syntax, only IPv4 is supported.
-		BroadcastIP string `yaml:"broadcastIP"`
+		broadcastAddress string `yaml:"broadcastAddress"`
 	}
 
 	// Persistence contains the configuration for data store / persistence layer

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -119,6 +119,10 @@ type (
 		MaxJoinDuration time.Duration `yaml:"maxJoinDuration"`
 		// Custom discovery provider, cannot be specified through yaml
 		DiscoveryProvider discovery.DiscoverProvider `yaml:"-"`
+		// BroadcastIP is used as the address that is communicated to remote nodes to connect on.
+		// This is generally used when BindOnIP would be the same across several nodes (ie: 0.0.0.0)
+		// and for nat traversal scenarios. Check net.ParseIP for supported syntax, only IPv4 is supported.
+		BroadcastIP string `yaml:"broadcastIP"`
 	}
 
 	// Persistence contains the configuration for data store / persistence layer

--- a/common/service/config/ringpop.go
+++ b/common/service/config/ringpop.go
@@ -218,7 +218,7 @@ func (factory *RingpopFactory) getRingpop() (*membership.RingPop, error) {
 	return ringPop, nil
 }
 
-func (factory *RingpopFactory) externalAddressResolver() (string, error) {
+func (factory *RingpopFactory) broadcastAddressResolver() (string, error) {
 	// This initial piece is copied from ringpop-go/ringpop.go/channelAddressResolver
 	var ch *tcg.Channel
 	var err error
@@ -226,7 +226,7 @@ func (factory *RingpopFactory) externalAddressResolver() (string, error) {
 		return "", err
 	}
 
-	return membership.ExternalAddressResolver(ch.PeerInfo(), &factory.config.BroadcastIP)
+	return membership.BuildBroadcastHostPort(ch.PeerInfo(), factory.config.broadcastAddress)
 }
 
 func (factory *RingpopFactory) createRingpop() (*membership.RingPop, error) {
@@ -237,7 +237,7 @@ func (factory *RingpopFactory) createRingpop() (*membership.RingPop, error) {
 		return nil, err
 	}
 
-	rp, err := ringpop.New(factory.config.Name, ringpop.Channel(ch), ringpop.AddressResolverFunc(factory.externalAddressResolver))
+	rp, err := ringpop.New(factory.config.Name, ringpop.Channel(ch), ringpop.AddressResolverFunc(factory.broadcastAddressResolver))
 	if err != nil {
 		return nil, err
 	}

--- a/common/service/config/ringpop.go
+++ b/common/service/config/ringpop.go
@@ -218,6 +218,17 @@ func (factory *RingpopFactory) getRingpop() (*membership.RingPop, error) {
 	return ringPop, nil
 }
 
+func (factory *RingpopFactory) externalAddressResolver() (string, error) {
+	// This initial piece is copied from ringpop-go/ringpop.go/channelAddressResolver
+	var ch *tcg.Channel
+	var err error
+	if ch, err = factory.getChannel(factory.dispatcher); err != nil {
+		return "", err
+	}
+
+	return membership.ExternalAddressResolver(ch.PeerInfo(), &factory.config.BroadcastIP)
+}
+
 func (factory *RingpopFactory) createRingpop() (*membership.RingPop, error) {
 
 	var ch *tcg.Channel
@@ -226,7 +237,7 @@ func (factory *RingpopFactory) createRingpop() (*membership.RingPop, error) {
 		return nil, err
 	}
 
-	rp, err := ringpop.New(factory.config.Name, ringpop.Channel(ch))
+	rp, err := ringpop.New(factory.config.Name, ringpop.Channel(ch), ringpop.AddressResolverFunc(factory.externalAddressResolver))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This allows Temporal services to broadcast a different IP address to be connected on by other members of the cluster. This enables multi-host setups to listen on 0.0.0.0, but still requires a static address at runtime (Dynamic methods or DNS is not supported).

`BroadcastAddress` is configured under the `ringpop` configuration section and accepts any valid IPv4 address.

This is implements a Custom Host Identity from -  https://github.com/temporalio/temporal/issues/83