### PR TITLE
Fix integration test log messages

### DIFF
--- a/host/activity_test.go
+++ b/host/activity_test.go
@@ -862,7 +862,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 	for i := 0; i < 3; i++ {
 		go func() {
 			err = poller.PollAndProcessActivityTask(false)
-			s.Logger.Error("Activity Processing Completed.  Error", tag.Error(err))
+			s.Logger.Error("Activity Processing Completed", tag.Error(err))
 		}()
 	}
 
@@ -870,7 +870,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 	for i := 0; i < 10; i++ {
 		s.Logger.Info("Processing decision task", tag.Counter(i))
 		_, err := poller.PollAndProcessDecisionTask(false, false)
-		s.NoError(err, "Poll for decision task failed.")
+		s.NoError(err, "Poll for decision task failed")
 
 		if workflowComplete {
 			break
@@ -1044,7 +1044,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 	for i := 0; i < activityCount; i++ {
 		go func() {
 			err := poller.PollAndProcessActivityTask(false)
-			s.Logger.Error("Activity Processing Completed.", tag.Error(err))
+			s.Logger.Error("Activity Processing Completed", tag.Error(err))
 		}()
 	}
 
@@ -1052,7 +1052,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 	for i := 0; i < 10; i++ {
 		s.Logger.Info("Processing decision task", tag.Counter(i))
 		_, err := poller.PollAndProcessDecisionTask(false, false)
-		s.NoError(err, "Poll for decision task failed.")
+		s.NoError(err, "Poll for decision task failed")
 
 		if workflowComplete {
 			break

--- a/host/activity_test.go
+++ b/host/activity_test.go
@@ -99,13 +99,13 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 			}}, nil
 		}
 
-		s.Logger.Info("Completing Workflow.")
+		s.Logger.Info("Completing Workflow")
 
 		workflowComplete = true
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -123,7 +123,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 			time.Sleep(10 * time.Millisecond)
 		}
 		activityExecutedCount++
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -223,11 +223,11 @@ func (s *integrationSuite) TestActivityHeartbeatDetailsDuringRetry() {
 		}
 
 		workflowComplete = true
-		s.Logger.Info("Completing Workflow.")
+		s.Logger.Info("Completing Workflow")
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -433,12 +433,12 @@ func (s *integrationSuite) TestActivityRetry() {
 		}
 
 		if activityAFailed != nil && activityBTimeout != nil {
-			s.Logger.Info("Completing Workflow.")
+			s.Logger.Info("Completing Workflow")
 			workflowComplete = true
 			return nil, []*commonproto.Decision{{
 				DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 				Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-					Result: []byte("Done."),
+					Result: []byte("Done"),
 				}},
 			}}, nil
 		}
@@ -536,7 +536,7 @@ func (s *integrationSuite) TestActivityRetry() {
 				RunId:      we.GetRunId(),
 			})
 		}
-		s.NoError(err, "Poll for decision task failed.")
+		s.NoError(err, "Poll for decision task failed")
 
 		if workflowComplete {
 			break
@@ -608,7 +608,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -621,7 +621,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 		// Timing out more than HB time.
 		time.Sleep(2 * time.Second)
 		activityExecutedCount++
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -748,7 +748,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 						return nil, []*commonproto.Decision{{
 							DecisionType: enums.DecisionTypeFailWorkflowExecution,
 							Attributes: &commonproto.Decision_FailWorkflowExecutionDecisionAttributes{FailWorkflowExecutionDecisionAttributes: &commonproto.FailWorkflowExecutionDecisionAttributes{
-								Reason: "ScheduledEvent not found.",
+								Reason: "ScheduledEvent not found",
 							}},
 						}}, nil
 					}
@@ -788,7 +788,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 		}
 
 		if failWorkflow {
-			s.Logger.Error("Failing workflow.")
+			s.Logger.Error("Failing workflow")
 			workflowComplete = true
 			return nil, []*commonproto.Decision{{
 				DecisionType: enums.DecisionTypeFailWorkflowExecution,
@@ -799,12 +799,12 @@ func (s *integrationSuite) TestActivityTimeouts() {
 		}
 
 		if activityATimedout && activityBTimedout && activityCTimedout && activityDTimedout {
-			s.Logger.Info("Completing Workflow.")
+			s.Logger.Info("Completing Workflow")
 			workflowComplete = true
 			return nil, []*commonproto.Decision{{
 				DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 				Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-					Result: []byte("Done."),
+					Result: []byte("Done"),
 				}},
 			}}, nil
 		}
@@ -819,15 +819,15 @@ func (s *integrationSuite) TestActivityTimeouts() {
 		timeoutType := string(input)
 		switch timeoutType {
 		case "ScheduleToStart":
-			s.Fail("Activity A not expected to be started.")
+			s.Fail("Activity A not expected to be started")
 		case "ScheduleClose":
-			s.Logger.Info("Sleeping activityB for 6 seconds.")
+			s.Logger.Info("Sleeping activityB for 6 seconds")
 			time.Sleep(7 * time.Second)
 		case "StartToClose":
-			s.Logger.Info("Sleeping activityC for 6 seconds.")
+			s.Logger.Info("Sleeping activityC for 6 seconds")
 			time.Sleep(8 * time.Second)
 		case "Heartbeat":
-			s.Logger.Info("Starting hearbeat activity.")
+			s.Logger.Info("Starting hearbeat activity")
 			go func() {
 				for i := 0; i < 6; i++ {
 					s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(activityID), tag.Counter(i))
@@ -836,13 +836,13 @@ func (s *integrationSuite) TestActivityTimeouts() {
 					s.NoError(err)
 					time.Sleep(1 * time.Second)
 				}
-				s.Logger.Info("End Heartbeating.")
+				s.Logger.Info("End Heartbeating")
 			}()
-			s.Logger.Info("Sleeping hearbeat activity.")
+			s.Logger.Info("Sleeping hearbeat activity")
 			time.Sleep(10 * time.Second)
 		}
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -958,7 +958,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 					_, ok := lastHeartbeatMap[timeoutEvent.GetScheduledEventId()]
 					if !ok {
 						failWorkflow = true
-						failReason = "ScheduledEvent not found."
+						failReason = "ScheduledEvent not found"
 						break ProcessLoop
 					}
 
@@ -994,7 +994,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 			return nil, []*commonproto.Decision{{
 				DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 				Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-					Result: []byte("Done."),
+					Result: []byte("Done"),
 				}},
 			}}, nil
 		}
@@ -1019,12 +1019,12 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 				time.Sleep(time.Duration(secondsToSleep) * time.Second)
 			}
 		}
-		s.Logger.Info("End Heartbeating.", tag.WorkflowActivityID(activityID))
+		s.Logger.Info("End Heartbeating", tag.WorkflowActivityID(activityID))
 
 		s.Logger.Info("Sleeping activity before completion", tag.WorkflowActivityID(activityID))
 		time.Sleep(7 * time.Second)
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1132,12 +1132,12 @@ func (s *integrationSuite) TestActivityCancellation() {
 			}}, nil
 		}
 
-		s.Logger.Info("Completing Workflow.")
+		s.Logger.Info("Completing Workflow")
 
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1153,13 +1153,13 @@ func (s *integrationSuite) TestActivityCancellation() {
 				&workflowservice.RecordActivityTaskHeartbeatRequest{
 					TaskToken: taskToken, Details: []byte("details")})
 			if response != nil && response.CancelRequested {
-				return []byte("Activity Cancelled."), true, nil
+				return []byte("Activity Cancelled"), true, nil
 			}
 			s.NoError(err)
 			time.Sleep(10 * time.Millisecond)
 		}
 		activityExecutedCount++
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1179,7 +1179,7 @@ func (s *integrationSuite) TestActivityCancellation() {
 	cancelCh := make(chan struct{})
 
 	go func() {
-		s.Logger.Info("Trying to cancel the task in a different thread.")
+		s.Logger.Info("Trying to cancel the task in a different thread")
 		scheduleActivity = false
 		requestCancellation = true
 		_, err := poller.PollAndProcessDecisionTask(false, false)
@@ -1232,7 +1232,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 			activityCounter++
 			buf := new(bytes.Buffer)
 			s.Nil(binary.Write(buf, binary.LittleEndian, activityCounter))
-			s.Logger.Info("Scheduling activity.")
+			s.Logger.Info("Scheduling activity")
 			return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 				DecisionType: enums.DecisionTypeScheduleActivityTask,
 				Attributes: &commonproto.Decision_ScheduleActivityTaskDecisionAttributes{ScheduleActivityTaskDecisionAttributes: &commonproto.ScheduleActivityTaskDecisionAttributes{
@@ -1249,7 +1249,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 		}
 
 		if requestCancellation {
-			s.Logger.Info("Requesting cancellation.")
+			s.Logger.Info("Requesting cancellation")
 			return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 				DecisionType: enums.DecisionTypeRequestCancelActivityTask,
 				Attributes: &commonproto.Decision_RequestCancelActivityTaskDecisionAttributes{RequestCancelActivityTaskDecisionAttributes: &commonproto.RequestCancelActivityTaskDecisionAttributes{
@@ -1258,11 +1258,11 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 			}}, nil
 		}
 
-		s.Logger.Info("Completing Workflow.")
+		s.Logger.Info("Completing Workflow")
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1290,7 +1290,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 
 	// Send signal so that worker can send an activity cancel
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -288,7 +288,7 @@ func (s *integrationSuite) startAndFinishWorkflow(id, wt, tl, domain, domainID s
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -309,7 +309,7 @@ func (s *integrationSuite) startAndFinishWorkflow(id, wt, tl, domain, domainID s
 		binary.Read(buf, binary.LittleEndian, &in)
 		s.Equal(expectedActivityID, in)
 		expectedActivityID++
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -325,14 +325,14 @@ func (s *integrationSuite) startAndFinishWorkflow(id, wt, tl, domain, domainID s
 	for run := 0; run < numRuns; run++ {
 		for i := 0; i < numActivities; i++ {
 			_, err := poller.PollAndProcessDecisionTask(false, false)
-			s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+			s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 			s.NoError(err)
 			if i%2 == 0 {
 				err = poller.PollAndProcessActivityTask(false)
 			} else { // just for testing respondActivityTaskCompleteByID
 				err = poller.PollAndProcessActivityTaskWithID(false)
 			}
-			s.Logger.Error("PollAndProcessActivityTask", tag.Error(err))
+			s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 			s.NoError(err)
 		}
 

--- a/host/cancelworkflow_test.go
+++ b/host/cancelworkflow_test.go
@@ -113,11 +113,11 @@ func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
 	}
 
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	err = poller.PollAndProcessActivityTask(false)
-	s.Logger.Error("PollAndProcessActivityTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 	s.NoError(err)
 
 	_, err = s.engine.RequestCancelWorkflowExecution(NewContext(), &workflowservice.RequestCancelWorkflowExecutionRequest{
@@ -140,7 +140,7 @@ func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
 	s.Equal(codes.AlreadyExists, status.Code(err))
 
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	executionCancelled := false
@@ -307,20 +307,20 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 
 	// Start both current and foreign workflows to make some progress.
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	_, err = foreignPoller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("foreign PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("foreign PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	err = foreignPoller.PollAndProcessActivityTask(false)
-	s.Logger.Error("foreign PollAndProcessActivityTask", tag.Error(err))
+	s.Logger.Info("foreign PollAndProcessActivityTask", tag.Error(err))
 	s.NoError(err)
 
 	// Cancel the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	cancellationSent := false
@@ -357,7 +357,7 @@ CheckHistoryLoopForCancelSent:
 
 	// Accept cancellation.
 	_, err = foreignPoller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("foreign PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("foreign PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	executionCancelled := false
@@ -481,12 +481,12 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution_UnKnownTar
 
 	// Start workflows to make some progress.
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// Cancel the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	cancellationSentFailed := false

--- a/host/cancelworkflow_test.go
+++ b/host/cancelworkflow_test.go
@@ -98,7 +98,7 @@ func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -158,7 +158,7 @@ GetHistoryLoop:
 
 		lastEvent := history.Events[len(history.Events)-1]
 		if lastEvent.EventType != enums.EventTypeWorkflowExecutionCanceled {
-			s.Logger.Warn("Execution not cancelled yet.")
+			s.Logger.Warn("Execution not cancelled yet")
 			time.Sleep(100 * time.Millisecond)
 			continue GetHistoryLoop
 		}
@@ -248,7 +248,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -339,7 +339,7 @@ CheckHistoryLoopForCancelSent:
 
 		lastEvent := history.Events[len(history.Events)-2]
 		if lastEvent.EventType != enums.EventTypeExternalWorkflowExecutionCancelRequested {
-			s.Logger.Info("Cancellation still not sent.")
+			s.Logger.Info("Cancellation still not sent")
 			time.Sleep(100 * time.Millisecond)
 			continue CheckHistoryLoopForCancelSent
 		}
@@ -375,7 +375,7 @@ GetHistoryLoop:
 
 		lastEvent := history.Events[len(history.Events)-1]
 		if lastEvent.EventType != enums.EventTypeWorkflowExecutionCanceled {
-			s.Logger.Warn("Execution not cancelled yet.")
+			s.Logger.Warn("Execution not cancelled yet")
 			time.Sleep(100 * time.Millisecond)
 			continue GetHistoryLoop
 		}
@@ -465,7 +465,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution_UnKnownTar
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -505,7 +505,7 @@ CheckHistoryLoopForCancelSent:
 
 		lastEvent := history.Events[len(history.Events)-2]
 		if lastEvent.EventType != enums.EventTypeRequestCancelExternalWorkflowExecutionFailed {
-			s.Logger.Info("Cancellaton not cancelled yet.")
+			s.Logger.Info("Cancellaton not cancelled yet")
 			time.Sleep(100 * time.Millisecond)
 			continue CheckHistoryLoopForCancelSent
 		}

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -305,13 +305,13 @@ func testParentWorkflow(ctx workflow.Context) (string, error) {
 	}
 
 	res := fmt.Sprintf("Complete child1 %s times, complete child2 %s times", result, result1)
-	logger.Info("Parent execution completed.", zap.String("Result", res))
+	logger.Info("Parent execution completed", zap.String("Result", res))
 	return res, nil
 }
 
 func testChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string, error) {
 	logger := workflow.GetLogger(ctx)
-	logger.Info("Child workflow execution started.")
+	logger.Info("Child workflow execution started")
 	if runCount <= 0 {
 		logger.Error("Invalid valid for run count", zap.Int("RunCount", runCount))
 		return "", errors.New("invalid run count")
@@ -325,7 +325,7 @@ func testChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string, 
 		return strconv.Itoa(totalCount), nil
 	}
 
-	logger.Info("Child workflow starting new run.", zap.Int("RunCount", runCount), zap.Int("TotalCount",
+	logger.Info("Child workflow starting new run", zap.Int("RunCount", runCount), zap.Int("TotalCount",
 		totalCount))
 	return "", workflow.NewContinueAsNewError(ctx, testChildWorkflow, totalCount, runCount)
 }

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -285,7 +285,7 @@ func testParentWorkflow(ctx workflow.Context) (string, error) {
 	var result string
 	err := workflow.ExecuteChildWorkflow(ctx, testChildWorkflow, 0, 3).Get(ctx, &result)
 	if err != nil {
-		logger.Error("Parent execution received child execution failure.", zap.Error(err))
+		logger.Error("Parent execution received child execution failure", zap.Error(err))
 		return "", err
 	}
 
@@ -300,7 +300,7 @@ func testParentWorkflow(ctx workflow.Context) (string, error) {
 	var result1 string
 	err1 := workflow.ExecuteChildWorkflow(ctx1, testChildWorkflow, 0, 2).Get(ctx1, &result1)
 	if err1 != nil {
-		logger.Error("Parent execution received child execution 1 failure.", zap.Error(err1))
+		logger.Error("Parent execution received child execution 1 failure", zap.Error(err1))
 		return "", err1
 	}
 
@@ -313,7 +313,7 @@ func testChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string, 
 	logger := workflow.GetLogger(ctx)
 	logger.Info("Child workflow execution started.")
 	if runCount <= 0 {
-		logger.Error("Invalid valid for run count.", zap.Int("RunCount", runCount))
+		logger.Error("Invalid valid for run count", zap.Int("RunCount", runCount))
 		return "", errors.New("invalid run count")
 	}
 
@@ -321,7 +321,7 @@ func testChildWorkflow(ctx workflow.Context, totalCount, runCount int) (string, 
 	runCount--
 	if runCount == 0 {
 		result := fmt.Sprintf("Child workflow execution completed after %v runs", totalCount)
-		logger.Info("Child workflow completed.", zap.String("Result", result))
+		logger.Info("Child workflow completed", zap.String("Result", result))
 		return strconv.Itoa(totalCount), nil
 	}
 

--- a/host/continueasnew_test.go
+++ b/host/continueasnew_test.go
@@ -108,7 +108,7 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 		return []byte(strconv.Itoa(int(continueAsNewCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -192,7 +192,7 @@ func (s *integrationSuite) TestContinueAsNewWorkflow_Timeout() {
 		return []byte(strconv.Itoa(int(continueAsNewCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -229,7 +229,7 @@ GetHistoryLoop:
 
 		lastEvent := history.Events[len(history.Events)-1]
 		if lastEvent.GetEventType() != enums.EventTypeWorkflowExecutionTimedOut {
-			s.Logger.Warn("Execution not timedout yet.")
+			s.Logger.Warn("Execution not timedout yet")
 			time.Sleep(200 * time.Millisecond)
 			continue GetHistoryLoop
 		}
@@ -393,7 +393,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 			return nil, []*commonproto.Decision{{
 				DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 				Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-					Result: []byte("Child Done."),
+					Result: []byte("Child Done"),
 				}},
 			}}, nil
 		}
@@ -401,7 +401,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 		// Parent Decider Logic
 		if execution.GetWorkflowId() == parentID {
 			if !childExecutionStarted {
-				s.Logger.Info("Starting child execution.")
+				s.Logger.Info("Starting child execution")
 				childExecutionStarted = true
 				buf := new(bytes.Buffer)
 				s.Nil(binary.Write(buf, binary.LittleEndian, childData))
@@ -427,7 +427,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 						return nil, []*commonproto.Decision{{
 							DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 							Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-								Result: []byte("Done."),
+								Result: []byte("Done"),
 							}},
 						}}, nil
 					}
@@ -482,7 +482,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	s.NotEqual(startedEvent.GetChildWorkflowExecutionStartedEventAttributes().WorkflowExecution.RunId,
 		completedAttributes.WorkflowExecution.RunId)
 	s.Equal(wtChild, completedAttributes.WorkflowType.Name)
-	s.Equal([]byte("Child Done."), completedAttributes.Result)
+	s.Equal([]byte("Child Done"), completedAttributes.Result)
 
 	s.Logger.Info("Parent Workflow Execution History: ")
 }

--- a/host/continueasnew_test.go
+++ b/host/continueasnew_test.go
@@ -125,7 +125,7 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 
 	for i := 0; i < 10; i++ {
 		_, err := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
@@ -209,7 +209,7 @@ func (s *integrationSuite) TestContinueAsNewWorkflow_Timeout() {
 
 	// process the decision and continue as new
 	_, err := poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -450,7 +450,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 
 	// Make first decision to start child execution
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
@@ -458,7 +458,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	for i := 0; i < 11; i++ {
 		s.Logger.Warn("decision", tag.Counter(i))
 		_, err = poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err)
 	}
 
@@ -467,13 +467,13 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 
 	// Process Child Execution final decision to complete it
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childComplete)
 
 	// Process ChildExecution completed event and complete parent execution
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(completedEvent)
 	completedAttributes := completedEvent.GetChildWorkflowExecutionCompletedEventAttributes()

--- a/host/elasticsearch_test.go
+++ b/host/elasticsearch_test.go
@@ -877,7 +877,7 @@ func (s *elasticsearchIntegrationSuite) TestUpsertWorkflowExecution() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1107,5 +1107,5 @@ func (s *elasticsearchIntegrationSuite) verifyMaxResultWindowSize(indexName stri
 		}
 		time.Sleep(waitTimeInMs * time.Millisecond)
 	}
-	s.FailNow(fmt.Sprintf("ES max result window size hasn't reach target size within %v.", (numOfRetry*waitTimeInMs)*time.Millisecond))
+	s.FailNow(fmt.Sprintf("ES max result window size hasn't reach target size within %v", (numOfRetry*waitTimeInMs)*time.Millisecond))
 }

--- a/host/gethistory_test.go
+++ b/host/gethistory_test.go
@@ -97,7 +97,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -106,7 +106,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -263,7 +263,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -272,7 +272,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -425,7 +425,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_All() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -434,7 +434,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_All() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -642,7 +642,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_InTheMiddle()
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -651,7 +651,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_InTheMiddle()
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -789,7 +789,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionRawHistory_All() {
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{
 				CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-					Result: []byte("Done."),
+					Result: []byte("Done"),
 				}},
 		}}, nil
 	}
@@ -798,7 +798,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionRawHistory_All() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{

--- a/host/gethistory_test.go
+++ b/host/gethistory_test.go
@@ -154,7 +154,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 	// make first decision to schedule activity, this should affect the long poll above
 	time.AfterFunc(time.Second*8, func() {
 		_, errDecision1 := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(errDecision1))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(errDecision1))
 	})
 	start = time.Now()
 	events, token = getHistory(s.domainName, workflowID, token, true)
@@ -166,11 +166,11 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 	// finish the activity and poll all events
 	time.AfterFunc(time.Second*5, func() {
 		errActivity := poller.PollAndProcessActivityTask(false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(errActivity))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(errActivity))
 	})
 	time.AfterFunc(time.Second*8, func() {
 		_, errDecision2 := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(errDecision2))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(errDecision2))
 	})
 	for token != nil {
 		events, token = getHistory(s.domainName, workflowID, token, true)
@@ -321,7 +321,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 	// make first decision to schedule activity, this should affect the long poll above
 	time.AfterFunc(time.Second*8, func() {
 		_, errDecision1 := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(errDecision1))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(errDecision1))
 	})
 	start = time.Now()
 	events, token = getHistory(s.domainName, workflowID, token, true)
@@ -333,11 +333,11 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 	// finish the activity and poll all events
 	time.AfterFunc(time.Second*5, func() {
 		errActivity := poller.PollAndProcessActivityTask(false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(errActivity))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(errActivity))
 	})
 	time.AfterFunc(time.Second*8, func() {
 		_, errDecision2 := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(errDecision2))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(errDecision2))
 	})
 	for token != nil {
 		events, token = getHistory(s.domainName, workflowID, token, true)

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -171,7 +171,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -179,7 +179,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -197,8 +197,8 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
-	terminateReason := "terminate reason."
-	terminateDetails := []byte("terminate details.")
+	terminateReason := "terminate reason"
+	terminateDetails := []byte("terminate details")
 	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -226,7 +226,7 @@ GetHistoryLoop:
 
 		lastEvent := history.Events[len(history.Events)-1]
 		if lastEvent.EventType != enums.EventTypeWorkflowExecutionTerminated {
-			s.Logger.Warn("Execution not terminated yet.")
+			s.Logger.Warn("Execution not terminated yet")
 			time.Sleep(100 * time.Millisecond)
 			continue GetHistoryLoop
 		}
@@ -325,7 +325,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -343,7 +343,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 		s.Equal(expectedActivity, in)
 		expectedActivity++
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -416,7 +416,7 @@ func (s *integrationSuite) TestCompleteDecisionTaskAndCreateNewOne() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -504,13 +504,13 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 			}}, nil
 		}
 
-		s.Logger.Info("Completing enums.")
+		s.Logger.Info("Completing enums")
 
 		workflowComplete = true
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -520,7 +520,7 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 		s.Equal(id, execution.WorkflowId)
 		s.Equal(activityName, activityType.Name)
 		s.Logger.Info("Activity ID", tag.WorkflowActivityID(activityID))
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1157,7 +1157,7 @@ func (s *integrationSuite) TestSequential_UserTimers() {
 		return []byte(strconv.Itoa(int(timerCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1249,7 +1249,7 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1271,7 +1271,7 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 	s.NotNil(err)
 	st := status.Convert(err)
 	s.Equal(codes.NotFound, st.Code())
-	s.Equal("Decision task not found.", st.Message())
+	s.Equal("Decision task not found", st.Message())
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
@@ -1353,7 +1353,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1466,14 +1466,14 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1551,7 +1551,7 @@ func (s *integrationSuite) TestVisibility() {
 		return []byte{}, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1717,7 +1717,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 
 		if execution.WorkflowId == parentID {
 			if !childExecutionStarted {
-				s.Logger.Info("Starting child execution.")
+				s.Logger.Info("Starting child execution")
 				childExecutionStarted = true
 
 				return nil, []*commonproto.Decision{{
@@ -1747,7 +1747,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 						return nil, []*commonproto.Decision{{
 							DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 							Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-								Result: []byte("Done."),
+								Result: []byte("Done"),
 							}},
 						}}, nil
 					}
@@ -1771,7 +1771,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Child Done."),
+				Result: []byte("Child Done"),
 			}},
 		}}, nil
 	}
@@ -1833,7 +1833,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	s.Empty(completedAttributes.Domain)
 	s.Equal(childID, completedAttributes.WorkflowExecution.WorkflowId)
 	s.Equal(wtChild, completedAttributes.WorkflowType.Name)
-	s.Equal([]byte("Child Done."), completedAttributes.Result)
+	s.Equal([]byte("Child Done"), completedAttributes.Result)
 }
 
 func (s *integrationSuite) TestCronChildWorkflowExecution() {
@@ -1882,7 +1882,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 		s.Logger.Info("Processing decision task for ", tag.WorkflowID(execution.WorkflowId))
 
 		if !childExecutionStarted {
-			s.Logger.Info("Starting child execution.")
+			s.Logger.Info("Starting child execution")
 			childExecutionStarted = true
 			startChildWorkflowTS = time.Now()
 			return nil, []*commonproto.Decision{{
@@ -1905,7 +1905,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 				return nil, []*commonproto.Decision{{
 					DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 					Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-						Result: []byte("Done."),
+						Result: []byte("Done"),
 					}},
 				}}, nil
 			}
@@ -2078,7 +2078,7 @@ GetHistoryLoop:
 
 		lastEvent := history.Events[len(history.Events)-1]
 		if lastEvent.GetEventType() != enums.EventTypeWorkflowExecutionTimedOut {
-			s.Logger.Warn("Execution not timedout yet.")
+			s.Logger.Warn("Execution not timedout yet")
 			time.Sleep(200 * time.Millisecond)
 			continue GetHistoryLoop
 		}
@@ -2208,7 +2208,7 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -2217,7 +2217,7 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -2367,14 +2367,14 @@ func (s *integrationSuite) TestDescribeTaskList() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -2483,7 +2483,7 @@ func (s *integrationSuite) TestTransientDecisionTimeout() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -2583,7 +2583,7 @@ func (s *integrationSuite) TestNoTransientDecisionAfterFlushBufferedEvents() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -2766,7 +2766,7 @@ func (s *integrationSuite) TestTaskProcessingProtectionForRateLimitError() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -2890,7 +2890,7 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientDecision() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -2934,7 +2934,7 @@ WaitForStickyTimeoutLoop:
 		}
 		time.Sleep(time.Second)
 	}
-	s.True(stickyTimeout, "Decision not timed out.")
+	s.True(stickyTimeout, "Decision not timed out")
 
 	for i := 0; i < 3; i++ {
 		_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, true, int64(i))
@@ -3046,7 +3046,7 @@ func (s *integrationSuite) TestStickyTasklistResetThenTimeout() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -3096,7 +3096,7 @@ WaitForStickyTimeoutLoop:
 		}
 		time.Sleep(time.Second)
 	}
-	s.True(stickyTimeout, "Decision not timed out.")
+	s.True(stickyTimeout, "Decision not timed out")
 
 	for i := 0; i < 3; i++ {
 		_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, true, int64(i))
@@ -3225,14 +3225,14 @@ func (s *integrationSuite) TestBufferedEventsOutOfOrder() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
 	// activity handler
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -3354,7 +3354,7 @@ func (s *integrationSuite) TestSignalWithStartWithMemo() {
 	}
 
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	request := &workflowservice.SignalWithStartWorkflowExecutionRequest{
 		RequestId:                           uuid.New(),
 		Domain:                              s.domainName,
@@ -3453,7 +3453,7 @@ func (s *integrationSuite) TestCancelTimer() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -3585,7 +3585,7 @@ func (s *integrationSuite) TestCancelTimer_CancelFiredAndBuffered() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -3653,7 +3653,7 @@ func (s *integrationSuite) startWithMemoHelper(startFn startFunc, id string, tas
 		return []byte(strconv.Itoa(1)), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -1271,7 +1271,7 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 	s.NotNil(err)
 	st := status.Convert(err)
 	s.Equal(codes.NotFound, st.Code())
-	s.Equal("Decision task not found", st.Message())
+	s.Equal("Decision task not found.", st.Message())
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -194,7 +194,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 	}
 
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	terminateReason := "terminate reason."
@@ -359,14 +359,14 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 
 	for i := 0; i < 10; i++ {
 		_, err := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err)
 		if i%2 == 0 {
 			err = poller.PollAndProcessActivityTask(false)
 		} else { // just for testing respondActivityTaskCompleteByID
 			err = poller.PollAndProcessActivityTaskWithID(false)
 		}
-		s.Logger.Error("PollAndProcessActivityTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 		s.NoError(err)
 	}
 
@@ -1267,7 +1267,7 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 
 	// first decision to send 101 signals, the last signal will force fail decision and flush buffered events.
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NotNil(err)
 	st := status.Convert(err)
 	s.Equal(codes.NotFound, st.Code())
@@ -1275,7 +1275,7 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(workflowComplete)
@@ -1371,7 +1371,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 
 	// first decision, which sends signal and the signal event should be buffered to append after first decision closed
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// check history, the signal event should be after the complete decision task
@@ -1391,7 +1391,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(signalEvent)
 	s.Equal(signalName, signalEvent.GetWorkflowExecutionSignaledEventAttributes().SignalName)
@@ -1489,7 +1489,7 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 
 	// first decision to schedule new activity
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	dweResponse, err = describeWorkflowExecution()
@@ -1798,17 +1798,17 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 
 	// Make first decision to start child execution
 	_, err := pollerParent.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event and Process Child Execution and complete it
 	_, err = pollerParent.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	_, err = pollerChild.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(startedEvent)
 	s.True(childComplete)
@@ -1826,7 +1826,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 
 	// Process ChildExecution completed event and complete parent execution
 	_, err = pollerParent.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(completedEvent)
 	completedAttributes := completedEvent.GetChildWorkflowExecutionCompletedEventAttributes()
@@ -1945,13 +1945,13 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 
 	// Make first decision to start child execution
 	_, err := pollerParent.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event
 	_, err = pollerParent.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	startFilter := &commonproto.StartTimeFilter{}
@@ -1973,7 +1973,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 		s.Equal(1, len(resp.GetExecutions()))
 
 		_, err = pollerChild.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err)
 
 		backoffDuration := time.Now().Sub(startChildWorkflowTS)
@@ -1992,7 +1992,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 
 	// Process ChildExecution terminated event and complete parent execution
 	_, err = pollerParent.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(terminatedEvent)
 	terminatedAttributes := terminatedEvent.GetChildWorkflowExecutionTerminatedEventAttributes()
@@ -2233,12 +2233,12 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// process activity
 	err = poller.PollAndProcessActivityTask(false)
-	s.Logger.Error("PollAndProcessActivityTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 	s.NoError(err)
 
 	// fail decision 5 times
@@ -2252,7 +2252,7 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 
 	// process signal
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.Equal(1, signalCount)
 
@@ -2282,7 +2282,7 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 
 	// Make complete workflow decision
 	_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, false, int64(2))
-	s.Logger.Error("pollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
 	s.Equal(16, signalCount)
@@ -2501,7 +2501,7 @@ func (s *integrationSuite) TestTransientDecisionTimeout() {
 
 	// First decision immediately fails and schedules a transient decision
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// Now send a signal when transient decision is scheduled
@@ -2510,12 +2510,12 @@ func (s *integrationSuite) TestTransientDecisionTimeout() {
 
 	// Drop decision task to cause a Decision Timeout
 	_, err = poller.PollAndProcessDecisionTask(true, true)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// Now process signal and complete workflow execution
 	_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, false, int64(1))
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.Equal(1, signalCount)
@@ -2601,13 +2601,13 @@ func (s *integrationSuite) TestNoTransientDecisionAfterFlushBufferedEvents() {
 	// fist decision, this try to do a continue as new but there is a buffered event,
 	// so it will fail and create a new decision
 	_, err := poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("pollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// second decision, which will complete the workflow
 	// this expect the decision to have attempt == 0
 	_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, false, 0)
-	s.Logger.Error("pollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(workflowComplete)
@@ -3064,7 +3064,7 @@ func (s *integrationSuite) TestStickyTasklistResetThenTimeout() {
 	}
 
 	_, err := poller.PollAndProcessDecisionTaskWithAttempt(false, false, false, true, int64(0))
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
@@ -3100,7 +3100,7 @@ WaitForStickyTimeoutLoop:
 
 	for i := 0; i < 3; i++ {
 		_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, true, int64(i))
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err)
 	}
 
@@ -3116,7 +3116,7 @@ WaitForStickyTimeoutLoop:
 
 	for i := 0; i < 2; i++ {
 		_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, true, int64(i))
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err)
 	}
 
@@ -3695,7 +3695,7 @@ func (s *integrationSuite) startWithMemoHelper(startFn startFunc, id string, tas
 
 	// make progress of workflow
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// verify history

--- a/host/ndc/replication_integration_test.go
+++ b/host/ndc/replication_integration_test.go
@@ -147,5 +147,5 @@ Loop:
 		}
 	}
 
-	s.Fail("Failed to get messages from DLQ.")
+	s.Fail("Failed to get messages from DLQ")
 }

--- a/host/queryworkflow_test.go
+++ b/host/queryworkflow_test.go
@@ -138,7 +138,7 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTaskWithAttempt(false, false, false, true, int64(0))
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {
@@ -166,7 +166,7 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTaskWithSticky(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -184,7 +184,7 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTaskWithSticky(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -297,7 +297,7 @@ func (s *integrationSuite) TestQueryWorkflow_StickyTimeout() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTaskWithAttempt(false, false, false, true, int64(0))
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {
@@ -327,7 +327,7 @@ func (s *integrationSuite) TestQueryWorkflow_StickyTimeout() {
 		// here we poll on normal tasklist, to simulate a worker crash and restart
 		// on the server side, server will first try the sticky tasklist and then the normal tasklist
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -436,7 +436,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {
@@ -465,7 +465,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -483,7 +483,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -504,7 +504,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -532,7 +532,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -649,7 +649,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {
@@ -717,7 +717,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 			Answer:     []byte("consistent query result"),
 		})
 
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(errInner)
 	s.False(isQueryTask)
 
@@ -831,7 +831,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {
@@ -993,7 +993,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {
@@ -1181,7 +1181,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTaskWithAttempt(false, false, false, true, int64(0))
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {

--- a/host/queryworkflow_test.go
+++ b/host/queryworkflow_test.go
@@ -100,7 +100,7 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -109,7 +109,7 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) ([]byte, error) {
@@ -259,7 +259,7 @@ func (s *integrationSuite) TestQueryWorkflow_StickyTimeout() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -268,7 +268,7 @@ func (s *integrationSuite) TestQueryWorkflow_StickyTimeout() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) ([]byte, error) {
@@ -401,7 +401,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -409,7 +409,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	// activity handler
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) ([]byte, error) {
@@ -614,7 +614,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -622,7 +622,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	// activity handler
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) ([]byte, error) {
@@ -682,7 +682,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	// send signal to ensure there is an outstanding decision task to dispatch query on
 	// otherwise query will just go through matching
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -796,7 +796,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -804,7 +804,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 	// activity handler
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) ([]byte, error) {
@@ -858,7 +858,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 	}
 
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -958,7 +958,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -966,7 +966,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 	// activity handler
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) ([]byte, error) {
@@ -1022,7 +1022,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 	// send a signal that will take 5 seconds to handle
 	// this causes the signal to still be outstanding at the time query arrives
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -1144,7 +1144,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1152,7 +1152,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 	// activity handler
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) ([]byte, error) {
@@ -1210,7 +1210,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 	// send a signal that will take 5 seconds to handle
 	// this causes the signal to still be outstanding at the time query arrives
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -1232,7 +1232,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 
 		// at this point there is a decision task started on the worker so this second signal will become buffered
 		signalName := "my signal"
-		signalInput := []byte("my signal input.")
+		signalInput := []byte("my signal input")
 		_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 			Domain: s.domainName,
 			WorkflowExecution: &commonproto.WorkflowExecution{

--- a/host/signalworkflow_test.go
+++ b/host/signalworkflow_test.go
@@ -56,7 +56,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 			WorkflowId: id,
 			RunId:      uuid.New(),
 		},
-		SignalName: "failed signal.",
+		SignalName: "failed signal",
 		Input:      nil,
 		Identity:   identity,
 	})
@@ -120,7 +120,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -129,7 +129,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -150,7 +150,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 
 	// Send first signal using RunID
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -176,7 +176,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 
 	// Send another signal without RunID
 	signalName = "another signal"
-	signalInput = []byte("another signal input.")
+	signalInput = []byte("another signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -218,7 +218,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 			WorkflowId: id,
 			RunId:      we.RunId,
 		},
-		SignalName: "failed signal 1.",
+		SignalName: "failed signal 1",
 		Input:      nil,
 		Identity:   identity,
 	})
@@ -296,7 +296,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -305,7 +305,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -326,7 +326,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 
 	// Send first signal
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	requestID := uuid.New()
 	signalReqest := &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
@@ -413,7 +413,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 	activityCount := int32(1)
 	activityCounter := int32(0)
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	dtHandler := func(execution *commonproto.WorkflowExecution, wt *commonproto.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *commonproto.History) ([]byte, []*commonproto.Decision, error) {
 		if activityCounter < activityCount {
@@ -452,7 +452,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -503,7 +503,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -555,7 +555,7 @@ CheckHistoryLoopForSignalSent:
 
 		signalRequestedEvent := history.Events[len(history.Events)-2]
 		if signalRequestedEvent.GetEventType() != enums.EventTypeExternalWorkflowExecutionSignaled {
-			s.Logger.Info("Signal still not sent.")
+			s.Logger.Info("Signal still not sent")
 			time.Sleep(100 * time.Millisecond)
 			continue CheckHistoryLoopForSignalSent
 		}
@@ -617,7 +617,7 @@ func (s *integrationSuite) TestSignalWorkflow_Cron_NoDecisionTaskCreated() {
 
 	// Send first signal using RunID
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: s.domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -639,7 +639,7 @@ func (s *integrationSuite) TestSignalWorkflow_Cron_NoDecisionTaskCreated() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -706,7 +706,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 	activityCount := int32(1)
 	activityCounter := int32(0)
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	dtHandler := func(execution *commonproto.WorkflowExecution, wt *commonproto.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *commonproto.History) ([]byte, []*commonproto.Decision, error) {
 		if activityCounter < activityCount {
@@ -745,7 +745,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -796,7 +796,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -847,7 +847,7 @@ CheckHistoryLoopForSignalSent:
 
 		signalRequestedEvent := history.Events[len(history.Events)-2]
 		if signalRequestedEvent.GetEventType() != enums.EventTypeExternalWorkflowExecutionSignaled {
-			s.Logger.Info("Signal still not sent.")
+			s.Logger.Info("Signal still not sent")
 			time.Sleep(100 * time.Millisecond)
 			continue CheckHistoryLoopForSignalSent
 		}
@@ -905,7 +905,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_UnKnownTarget() {
 	activityCount := int32(1)
 	activityCounter := int32(0)
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	dtHandler := func(execution *commonproto.WorkflowExecution, wt *commonproto.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *commonproto.History) ([]byte, []*commonproto.Decision, error) {
 		if activityCounter < activityCount {
@@ -944,7 +944,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_UnKnownTarget() {
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -984,7 +984,7 @@ CheckHistoryLoopForCancelSent:
 
 		signalFailedEvent := history.Events[len(history.Events)-2]
 		if signalFailedEvent.GetEventType() != enums.EventTypeSignalExternalWorkflowExecutionFailed {
-			s.Logger.Info("Cancellaton not cancelled yet.")
+			s.Logger.Info("Cancellaton not cancelled yet")
 			time.Sleep(100 * time.Millisecond)
 			continue CheckHistoryLoopForCancelSent
 		}
@@ -1030,7 +1030,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_SignalSelf() {
 	activityCount := int32(1)
 	activityCounter := int32(0)
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	dtHandler := func(execution *commonproto.WorkflowExecution, wt *commonproto.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *commonproto.History) ([]byte, []*commonproto.Decision, error) {
 		if activityCounter < activityCount {
@@ -1069,7 +1069,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_SignalSelf() {
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1109,7 +1109,7 @@ CheckHistoryLoopForCancelSent:
 
 		signalFailedEvent := history.Events[len(history.Events)-2]
 		if signalFailedEvent.GetEventType() != enums.EventTypeSignalExternalWorkflowExecutionFailed {
-			s.Logger.Info("Cancellaton not cancelled yet.")
+			s.Logger.Info("Cancellaton not cancelled yet")
 			time.Sleep(100 * time.Millisecond)
 			continue CheckHistoryLoopForCancelSent
 		}
@@ -1215,7 +1215,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1224,7 +1224,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1245,7 +1245,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	// Send a signal
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	wfIDReusePolicy := enums.WorkflowIdReusePolicyAllowDuplicate
 	sRequest := &workflowservice.SignalWithStartWorkflowExecutionRequest{
 		RequestId:                           uuid.New(),
@@ -1291,7 +1291,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	// Send signal to terminated workflow
 	signalName = "signal to terminate"
-	signalInput = []byte("signal to terminate input.")
+	signalInput = []byte("signal to terminate input")
 	sRequest.SignalName = signalName
 	sRequest.SignalInput = signalInput
 	sRequest.WorkflowId = id
@@ -1318,7 +1318,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	// Send signal to not existed workflow
 	id = "integration-signal-with-start-workflow-test-non-exist"
 	signalName = "signal to non exist"
-	signalInput = []byte("signal to non exist input.")
+	signalInput = []byte("signal to non exist input")
 	sRequest.SignalName = signalName
 	sRequest.SignalInput = signalInput
 	sRequest.WorkflowId = id
@@ -1450,14 +1450,14 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
 
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1482,7 +1482,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 
 	// test policy WorkflowIdReusePolicyRejectDuplicate
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	sRequest := &workflowservice.SignalWithStartWorkflowExecutionRequest{
 		RequestId:                           uuid.New(),
 		Domain:                              s.domainName,

--- a/host/signalworkflow_test.go
+++ b/host/signalworkflow_test.go
@@ -145,7 +145,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// Send first signal using RunID
@@ -165,7 +165,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -190,7 +190,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -321,7 +321,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// Send first signal
@@ -344,7 +344,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -360,7 +360,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -521,20 +521,20 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 
 	// Start both current and foreign workflows to make some progress.
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	_, err = foreignPoller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("foreign PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("foreign PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	err = foreignPoller.PollAndProcessActivityTask(false)
-	s.Logger.Error("foreign PollAndProcessActivityTask", tag.Error(err))
+	s.Logger.Info("foreign PollAndProcessActivityTask", tag.Error(err))
 	s.NoError(err)
 
 	// Signal the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// in source workflow
@@ -574,7 +574,7 @@ CheckHistoryLoopForSignalSent:
 
 	// process signal in decider for foreign workflow
 	_, err = foreignPoller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -656,7 +656,7 @@ func (s *integrationSuite) TestSignalWorkflow_Cron_NoDecisionTaskCreated() {
 
 	// Make first decision to schedule activity
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(decisionTaskDelay > time.Second*2)
 }
@@ -814,20 +814,20 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 
 	// Start both current and foreign workflows to make some progress.
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	_, err = foreignPoller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("foreign PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("foreign PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	err = foreignPoller.PollAndProcessActivityTask(false)
-	s.Logger.Error("foreign PollAndProcessActivityTask", tag.Error(err))
+	s.Logger.Info("foreign PollAndProcessActivityTask", tag.Error(err))
 	s.NoError(err)
 
 	// Signal the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// in source workflow
@@ -866,7 +866,7 @@ CheckHistoryLoopForSignalSent:
 
 	// process signal in decider for foreign workflow
 	_, err = foreignPoller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -960,12 +960,12 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_UnKnownTarget() {
 
 	// Start workflows to make some progress.
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// Signal the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	signalSentFailed := false
@@ -1085,12 +1085,12 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_SignalSelf() {
 
 	// Start workflows to make some progress.
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// Signal the foreign workflow with this decision request.
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	signalSentFailed := false
@@ -1240,7 +1240,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	// Make first decision to schedule activity
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// Send a signal
@@ -1268,7 +1268,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -1304,7 +1304,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -1329,7 +1329,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	// Process signal in decider
 	_, err = poller.PollAndProcessDecisionTask(true, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
@@ -1473,10 +1473,10 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 
 	// Start workflows, make some progress and complete workflow
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
 

--- a/host/sizelimit_test.go
+++ b/host/sizelimit_test.go
@@ -121,7 +121,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -129,7 +129,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{

--- a/host/sizelimit_test.go
+++ b/host/sizelimit_test.go
@@ -145,17 +145,17 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
 
 	for i := int32(0); i < activityCount-1; i++ {
 		_, err := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err)
 
 		err = poller.PollAndProcessActivityTask(false)
-		s.Logger.Error("PollAndProcessActivityTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessActivityTask", tag.Error(err))
 		s.NoError(err)
 	}
 
 	// process this decision will trigger history exceed limit error
 	_, err := poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// verify last event is terminated event

--- a/host/taskpoller.go
+++ b/host/taskpoller.go
@@ -139,7 +139,7 @@ Loop:
 		})
 
 		if err1 == history.ErrDuplicate {
-			p.Logger.Info("Duplicate Decision task: Polling again.")
+			p.Logger.Info("Duplicate Decision task: Polling again")
 			continue Loop
 		}
 
@@ -148,7 +148,7 @@ Loop:
 		}
 
 		if response == nil || len(response.TaskToken) == 0 {
-			p.Logger.Info("Empty Decision task: Polling again.")
+			p.Logger.Info("Empty Decision task: Polling again")
 			continue Loop
 		}
 
@@ -285,7 +285,7 @@ Loop:
 func (p *TaskPoller) HandlePartialDecision(response *workflowservice.PollForDecisionTaskResponse) (
 	*workflowservice.RespondDecisionTaskCompletedResponse, error) {
 	if response == nil || len(response.TaskToken) == 0 {
-		p.Logger.Info("Empty Decision task: Polling again.")
+		p.Logger.Info("Empty Decision task: Polling again")
 		return nil, nil
 	}
 
@@ -346,7 +346,7 @@ retry:
 		})
 
 		if err == history.ErrDuplicate {
-			p.Logger.Info("Duplicate Activity task: Polling again.")
+			p.Logger.Info("Duplicate Activity task: Polling again")
 			continue retry
 		}
 
@@ -355,7 +355,7 @@ retry:
 		}
 
 		if response == nil || len(response.TaskToken) == 0 {
-			p.Logger.Info("Empty Activity task: Polling again.")
+			p.Logger.Info("Empty Activity task: Polling again")
 			return nil
 		}
 
@@ -409,7 +409,7 @@ retry:
 		})
 
 		if err1 == history.ErrDuplicate {
-			p.Logger.Info("Duplicate Activity task: Polling again.")
+			p.Logger.Info("Duplicate Activity task: Polling again")
 			continue retry
 		}
 
@@ -418,7 +418,7 @@ retry:
 		}
 
 		if response == nil || len(response.TaskToken) == 0 {
-			p.Logger.Info("Empty Activity task: Polling again.")
+			p.Logger.Info("Empty Activity task: Polling again")
 			return nil
 		}
 

--- a/host/xdc/elasticsearch_test.go
+++ b/host/xdc/elasticsearch_test.go
@@ -263,7 +263,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 	}
 
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	time.Sleep(waitForESToSettle)

--- a/host/xdc/elasticsearch_test.go
+++ b/host/xdc/elasticsearch_test.go
@@ -308,7 +308,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 
 	// terminate workflow
 	terminateReason := "force terminate to make sure standby process tasks"
-	terminateDetails := []byte("terminate details.")
+	terminateDetails := []byte("terminate details")
 	_, err = client1.TerminateWorkflowExecution(host.NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Domain: domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -336,7 +336,7 @@ GetHistoryLoop:
 
 		lastEvent := history.Events[len(history.Events)-1]
 		if lastEvent.EventType != enums.EventTypeWorkflowExecutionTerminated {
-			s.logger.Warn("Execution not terminated yet.")
+			s.logger.Warn("Execution not terminated yet")
 			time.Sleep(100 * time.Millisecond)
 			continue GetHistoryLoop
 		}

--- a/host/xdc/elasticsearch_test.go
+++ b/host/xdc/elasticsearch_test.go
@@ -263,7 +263,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 	}
 
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	time.Sleep(waitForESToSettle)

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -343,7 +343,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 
 	// make some progress in cluster 1
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {
@@ -371,7 +371,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Info("PollAndProcessQueryTask", tag.Error(err))
+		s.logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -394,7 +394,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller2.PollAndProcessDecisionTask(false, false)
-		s.Logger.Info("PollAndProcessQueryTask", tag.Error(err))
+		s.logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -452,7 +452,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+		s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -472,7 +472,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller2.PollAndProcessDecisionTask(false, false)
-		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+		s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -488,12 +488,12 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 
 	// make process in cluster 2
 	err = poller2.PollAndProcessActivityTask(false)
-	s.Logger.Info("PollAndProcessActivityTask 2", tag.Error(err))
+	s.logger.Info("PollAndProcessActivityTask 2", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
 	_, err = poller2.PollAndProcessDecisionTask(false, false)
-	s.Logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
 
@@ -615,7 +615,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 	}
 
 	_, err = poller1.PollAndProcessDecisionTaskWithAttemptAndRetry(false, false, false, true, 0, 5)
-	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(firstDecisionMade)
 
@@ -651,7 +651,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 	time.Sleep(cacheRefreshInterval)
 
 	_, err = poller2.PollAndProcessDecisionTaskWithAttemptAndRetry(false, false, false, true, 0, 5)
-	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(secondDecisionMade)
 
@@ -681,7 +681,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 	s.Equal(int64(10), updateResp.GetFailoverVersion())
 
 	_, err = poller1.PollAndProcessDecisionTask(true, false)
-	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowCompleted)
 }
@@ -775,7 +775,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 
 	// Complete the workflow in cluster 1
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.Equal(1, workflowCompleteTimes)
 
@@ -820,7 +820,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 	s.logger.Info("StartWorkflowExecution in cluster 2: ", tag.WorkflowRunID(we.GetRunId()))
 
 	_, err = poller2.PollAndProcessDecisionTask(false, false)
-	s.Logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
 	s.NoError(err)
 	s.Equal(2, workflowCompleteTimes)
 }
@@ -923,7 +923,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 
 	// make some progress in cluster 1
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// update domain to fail over
@@ -1114,7 +1114,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 	// make some progress in cluster 1 and did some continueAsNew
 	for i := 0; i < 3; i++ {
 		_, err := poller.PollAndProcessDecisionTask(false, false)
-		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+		s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
@@ -1137,7 +1137,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 	// finish the rest in cluster 2
 	for i := 0; i < 2; i++ {
 		_, err := poller2.PollAndProcessDecisionTask(false, false)
-		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+		s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
@@ -1254,7 +1254,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 	// Process signal in cluster 1
 	s.False(eventSignaled)
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(eventSignaled)
 
@@ -1311,7 +1311,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 	// Process signal in cluster 2
 	eventSignaled = false
 	_, err = poller2.PollAndProcessDecisionTask(false, false)
-	s.Logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
+	s.logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
 	s.NoError(err)
 	s.True(eventSignaled)
 

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -295,7 +295,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -303,7 +303,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	queryType := "test-query"
@@ -585,7 +585,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -621,7 +621,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 
 	// Send a signal in cluster
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err = client1.SignalWorkflowExecution(host.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -746,7 +746,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -899,7 +899,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 		return []byte(strconv.Itoa(int(activityCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -907,7 +907,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 	atHandler := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller := &host.TaskPoller{
@@ -943,8 +943,8 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 	time.Sleep(cacheRefreshInterval)
 
 	// terminate workflow at cluster 2
-	terminateReason := "terminate reason."
-	terminateDetails := []byte("terminate details.")
+	terminateReason := "terminate reason"
+	terminateDetails := []byte("terminate details")
 	_, err = client2.TerminateWorkflowExecution(host.NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Domain: domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -972,7 +972,7 @@ GetHistoryLoop:
 
 		lastEvent := history.Events[len(history.Events)-1]
 		if lastEvent.EventType != enums.EventTypeWorkflowExecutionTerminated {
-			s.logger.Warn("Execution not terminated yet.")
+			s.logger.Warn("Execution not terminated yet")
 			time.Sleep(100 * time.Millisecond)
 			continue GetHistoryLoop
 		}
@@ -1086,7 +1086,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 		return []byte(strconv.Itoa(int(continueAsNewCounter))), []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1211,7 +1211,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1238,7 +1238,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Send a signal in cluster 1
 	signalName := "my signal"
-	signalInput := []byte("my signal input.")
+	signalInput := []byte("my signal input")
 	_, err = client1.SignalWorkflowExecution(host.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -1296,7 +1296,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Send another signal in cluster 2
 	signalName2 := "my signal 2"
-	signalInput2 := []byte("my signal input 2.")
+	signalInput2 := []byte("my signal input 2")
 	_, err = client2.SignalWorkflowExecution(host.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Domain: domainName,
 		WorkflowExecution: &commonproto.WorkflowExecution{
@@ -1395,7 +1395,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 
 			// Send a signal in cluster
 			signalName := "my signal"
-			signalInput := []byte("my signal input.")
+			signalInput := []byte("my signal input")
 			_, err = client1.SignalWorkflowExecution(host.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 				Domain: domainName,
 				WorkflowExecution: &commonproto.WorkflowExecution{
@@ -1439,7 +1439,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1588,7 +1588,7 @@ func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}
@@ -1603,7 +1603,7 @@ func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 			TaskToken: taskToken, Details: heartbeatDetails})
 		s.NoError(err)
 		time.Sleep(5 * time.Second)
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	// activity handler
@@ -1611,7 +1611,7 @@ func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 	atHandler2 := func(execution *commonproto.WorkflowExecution, activityType *commonproto.ActivityType,
 		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
 		activity2Called = true
-		return []byte("Activity Result."), false, nil
+		return []byte("Activity Result"), false, nil
 	}
 
 	poller1 := &host.TaskPoller{
@@ -1779,7 +1779,7 @@ func (s *integrationClustersTestSuite) TestTransientDecisionFailover() {
 		return nil, []*commonproto.Decision{{
 			DecisionType: enums.DecisionTypeCompleteWorkflowExecution,
 			Attributes: &commonproto.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &commonproto.CompleteWorkflowExecutionDecisionAttributes{
-				Result: []byte("Done."),
+				Result: []byte("Done"),
 			}},
 		}}, nil
 	}

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -343,7 +343,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 
 	// make some progress in cluster 1
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	type QueryResult struct {
@@ -371,7 +371,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.logger.Error("PollAndProcessQueryTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -394,7 +394,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller2.PollAndProcessDecisionTask(false, false)
-		s.logger.Error("PollAndProcessQueryTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -452,7 +452,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller.PollAndProcessDecisionTask(false, false)
-		s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -472,7 +472,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	for {
 		// loop until process the query task
 		isQueryTask, errInner := poller2.PollAndProcessDecisionTask(false, false)
-		s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
 			break
@@ -488,12 +488,12 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 
 	// make process in cluster 2
 	err = poller2.PollAndProcessActivityTask(false)
-	s.logger.Error("PollAndProcessActivityTask 2", tag.Error(err))
+	s.Logger.Info("PollAndProcessActivityTask 2", tag.Error(err))
 	s.NoError(err)
 
 	s.False(workflowComplete)
 	_, err = poller2.PollAndProcessDecisionTask(false, false)
-	s.logger.Error("PollAndProcessDecisionTask 2", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
 
@@ -615,7 +615,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 	}
 
 	_, err = poller1.PollAndProcessDecisionTaskWithAttemptAndRetry(false, false, false, true, 0, 5)
-	s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(firstDecisionMade)
 
@@ -651,7 +651,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 	time.Sleep(cacheRefreshInterval)
 
 	_, err = poller2.PollAndProcessDecisionTaskWithAttemptAndRetry(false, false, false, true, 0, 5)
-	s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(secondDecisionMade)
 
@@ -681,7 +681,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 	s.Equal(int64(10), updateResp.GetFailoverVersion())
 
 	_, err = poller1.PollAndProcessDecisionTask(true, false)
-	s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowCompleted)
 }
@@ -775,7 +775,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 
 	// Complete the workflow in cluster 1
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.Equal(1, workflowCompleteTimes)
 
@@ -820,7 +820,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 	s.logger.Info("StartWorkflowExecution in cluster 2: ", tag.WorkflowRunID(we.GetRunId()))
 
 	_, err = poller2.PollAndProcessDecisionTask(false, false)
-	s.logger.Error("PollAndProcessDecisionTask 2", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
 	s.NoError(err)
 	s.Equal(2, workflowCompleteTimes)
 }
@@ -923,7 +923,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 
 	// make some progress in cluster 1
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 
 	// update domain to fail over
@@ -1114,7 +1114,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 	// make some progress in cluster 1 and did some continueAsNew
 	for i := 0; i < 3; i++ {
 		_, err := poller.PollAndProcessDecisionTask(false, false)
-		s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
@@ -1137,7 +1137,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 	// finish the rest in cluster 2
 	for i := 0; i < 2; i++ {
 		_, err := poller2.PollAndProcessDecisionTask(false, false)
-		s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+		s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
@@ -1254,7 +1254,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 	// Process signal in cluster 1
 	s.False(eventSignaled)
 	_, err = poller.PollAndProcessDecisionTask(false, false)
-	s.logger.Error("PollAndProcessDecisionTask", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.NoError(err)
 	s.True(eventSignaled)
 
@@ -1311,7 +1311,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 	// Process signal in cluster 2
 	eventSignaled = false
 	_, err = poller2.PollAndProcessDecisionTask(false, false)
-	s.logger.Error("PollAndProcessDecisionTask 2", tag.Error(err))
+	s.Logger.Info("PollAndProcessDecisionTask 2", tag.Error(err))
 	s.NoError(err)
 	s.True(eventSignaled)
 


### PR DESCRIPTION
I did too aggressive renames last time (#113) and did not realized that most of errors in the logs are actually `.Info`, not `.Error`.