### PR TITLE
Migrate nDC integration tests to history gRPC client

### DIFF
--- a/common/persistence/sql/sqlClusterMetadataManager.go
+++ b/common/persistence/sql/sqlClusterMetadataManager.go
@@ -20,10 +20,6 @@
 package sql
 
 import (
-	"encoding/json"
-	"errors"
-	"fmt"
-	"math"
 	"net"
 	"time"
 
@@ -95,9 +91,9 @@ func (s *sqlClusterMetadataManager) GetImmutableClusterMetadata() (*p.InternalGe
 func (s *sqlClusterMetadataManager) GetClusterMembers(request *p.GetClusterMembersRequest) (*p.GetClusterMembersResponse, error) {
 	now := time.Now().UTC()
 	filter := &sqlplugin.ClusterMembershipFilter{
-		HostIDEquals:       request.HostIDEquals,
-		RoleEquals:         request.RoleEquals,
-		RecordExpiryAfter:  now,
+		HostIDEquals:      request.HostIDEquals,
+		RoleEquals:        request.RoleEquals,
+		RecordExpiryAfter: now,
 	}
 
 	if request.LastHeartbeatWithin > 0 {

--- a/common/persistence/versionHistory.go
+++ b/common/persistence/versionHistory.go
@@ -24,6 +24,8 @@ import (
 	"bytes"
 	"fmt"
 
+	commonproto "go.temporal.io/temporal-proto/common"
+
 	"github.com/temporalio/temporal/.gen/go/shared"
 	"github.com/temporalio/temporal/common"
 )
@@ -69,6 +71,15 @@ func (item *VersionHistoryItem) ToThrift() *shared.VersionHistoryItem {
 	return &shared.VersionHistoryItem{
 		EventID: common.Int64Ptr(item.EventID),
 		Version: common.Int64Ptr(item.Version),
+	}
+}
+
+// ToProto returns proto format of version history item
+func (item *VersionHistoryItem) ToProto() *commonproto.VersionHistoryItem {
+
+	return &commonproto.VersionHistoryItem{
+		EventID: item.EventID,
+		Version: item.Version,
 	}
 }
 
@@ -146,6 +157,23 @@ func (v *VersionHistory) ToThrift() *shared.VersionHistory {
 		Items:       items,
 	}
 	return tHistory
+}
+
+// ToProto returns proto format of version history
+func (v *VersionHistory) ToProto() *commonproto.VersionHistory {
+
+	token := make([]byte, len(v.BranchToken))
+	copy(token, v.BranchToken)
+	var items []*commonproto.VersionHistoryItem
+	for _, item := range v.Items {
+		items = append(items, item.ToProto())
+	}
+
+	pHistory := &commonproto.VersionHistory{
+		BranchToken: token,
+		Items:       items,
+	}
+	return pHistory
 }
 
 // DuplicateUntilLCAItem duplicate the version history up until LCA item

--- a/common/testing/history_event_test.go
+++ b/common/testing/history_event_test.go
@@ -26,8 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
-	"github.com/temporalio/temporal/.gen/go/shared"
+	commonproto "go.temporal.io/temporal-proto/common"
 )
 
 type (
@@ -64,7 +63,7 @@ func (s *historyEventTestSuit) Test_HistoryEvent_Generator() {
 
 		fmt.Println("########################")
 		for _, e := range events {
-			event := e.GetData().(*shared.HistoryEvent)
+			event := e.GetData().(*commonproto.HistoryEvent)
 			if maxEventID != event.GetEventId()-1 {
 				s.Fail("event id sequence is incorrect")
 			}
@@ -88,7 +87,7 @@ func (s *historyEventTestSuit) Test_HistoryEvent_Generator() {
 		events := branchGenerator1.GetNextVertices()
 		fmt.Println("########################")
 		for _, e := range events {
-			event := e.GetData().(*shared.HistoryEvent)
+			event := e.GetData().(*commonproto.HistoryEvent)
 			if maxEventID != event.GetEventId()-1 {
 				s.Fail("event id sequence is incorrect")
 			}
@@ -107,12 +106,12 @@ func (s *historyEventTestSuit) Test_HistoryEvent_Generator() {
 	}
 	fmt.Println("==========================")
 	history := s.generator.ListGeneratedVertices()
-	maxEventID = history[len(history)-1].GetData().(*shared.HistoryEvent).GetEventId()
+	maxEventID = history[len(history)-1].GetData().(*commonproto.HistoryEvent).GetEventId()
 	for i := 0; i < 10 && s.generator.HasNextVertex(); i++ {
 		events := s.generator.GetNextVertices()
 		fmt.Println("########################")
 		for _, e := range events {
-			event := e.GetData().(*shared.HistoryEvent)
+			event := e.GetData().(*commonproto.HistoryEvent)
 			if maxEventID != event.GetEventId()-1 {
 				s.Fail("event id sequence is incorrect")
 			}

--- a/host/client.go
+++ b/host/client.go
@@ -21,15 +21,12 @@
 package host
 
 import (
-	"go.uber.org/yarpc"
 	"google.golang.org/grpc"
 
 	"go.temporal.io/temporal-proto/workflowservice"
 
-	"github.com/temporalio/temporal/.gen/go/history/historyserviceclient"
 	"github.com/temporalio/temporal/.gen/proto/adminservice"
 	"github.com/temporalio/temporal/.gen/proto/historyservice"
-	"github.com/temporalio/temporal/common"
 )
 
 // AdminClient is the interface exposed by admin service client
@@ -44,11 +41,6 @@ type FrontendClient interface {
 
 // HistoryClient is the interface exposed by history service client
 type HistoryClient interface {
-	historyserviceclient.Interface
-}
-
-// HistoryClientGRPC is the interface exposed by history service client
-type HistoryClientGRPC interface {
 	historyservice.HistoryServiceClient
 }
 
@@ -63,11 +55,6 @@ func NewFrontendClient(connection *grpc.ClientConn) workflowservice.WorkflowServ
 }
 
 // NewHistoryClient creates a client to cadence history service client
-func NewHistoryClient(d *yarpc.Dispatcher) HistoryClient {
-	return historyserviceclient.New(d.ClientConfig(common.HistoryServiceName))
-}
-
-// NewHistoryClient creates a client to cadence history service client
-func NewHistoryClientGRPC(connection *grpc.ClientConn) HistoryClientGRPC {
+func NewHistoryClient(connection *grpc.ClientConn) HistoryClient {
 	return historyservice.NewHistoryServiceClient(connection)
 }

--- a/host/ndc/nDC_integration_test.go
+++ b/host/ndc/nDC_integration_test.go
@@ -197,7 +197,7 @@ func (s *nDCIntegrationTestSuite) TestSingleBranch() {
 	tasklist := "event-generator-taskList"
 
 	// active has initial version 0
-	historyClient := s.active.GetHistoryClientGRPC()
+	historyClient := s.active.GetHistoryClient()
 
 	versions := []int64{101, 1, 201, 301, 401, 601, 501, 801, 1001, 901, 701, 1101}
 	for _, version := range versions {
@@ -286,7 +286,7 @@ func (s *nDCIntegrationTestSuite) TestMultipleBranches() {
 	tasklist := "event-generator-taskList"
 
 	// active has initial version 0
-	historyClient := s.active.GetHistoryClientGRPC()
+	historyClient := s.active.GetHistoryClient()
 
 	versions := []int64{101, 1, 201}
 	for _, version := range versions {
@@ -374,7 +374,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranches() {
 	identity := "worker-identity"
 
 	// active has initial version 0
-	historyClient := s.active.GetHistoryClientGRPC()
+	historyClient := s.active.GetHistoryClient()
 
 	eventsBatch1 := []*commonproto.History{
 		{Events: []*commonproto.HistoryEvent{
@@ -679,7 +679,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieConti
 	identity := "worker-identity"
 
 	// active has initial version 0
-	historyClient := s.active.GetHistoryClientGRPC()
+	historyClient := s.active.GetHistoryClient()
 
 	eventsBatch1 := []*commonproto.History{
 		{Events: []*commonproto.HistoryEvent{
@@ -945,7 +945,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_ZombieWorkflow() {
 	tasklist := "event-generator-taskList"
 
 	// active has initial version 0
-	historyClient := s.active.GetHistoryClientGRPC()
+	historyClient := s.active.GetHistoryClient()
 
 	version := int64(101)
 	runID := uuid.New()
@@ -1009,7 +1009,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_UpdateNonCurrentBranch() {
 	version := int64(101)
 	isWorkflowFinished := false
 
-	historyClient := s.active.GetHistoryClientGRPC()
+	historyClient := s.active.GetHistoryClient()
 
 	s.generator = test.InitializeHistoryEventGenerator(s.domainName, version)
 	baseBranch := []*commonproto.History{}
@@ -1118,7 +1118,7 @@ func (s *nDCIntegrationTestSuite) TestAdminGetWorkflowExecutionRawHistoryV2() {
 	tasklist := "event-generator-taskList"
 	identity := "ndc-re-send-test"
 
-	historyClient := s.active.GetHistoryClientGRPC()
+	historyClient := s.active.GetHistoryClient()
 	adminClient := s.active.GetAdminClient()
 	getHistory := func(
 		domain string,
@@ -1709,7 +1709,7 @@ func (s *nDCIntegrationTestSuite) applyEvents(
 	tasklist string,
 	versionHistory *persistence.VersionHistory,
 	eventBatches []*commonproto.History,
-	historyClient host.HistoryClientGRPC,
+	historyClient host.HistoryClient,
 ) {
 	for _, batch := range eventBatches {
 		eventBlob, newRunEventBlob := s.generateEventBlobs(workflowID, runID, workflowType, tasklist, batch)

--- a/host/ndc/replication_integration_test.go
+++ b/host/ndc/replication_integration_test.go
@@ -25,12 +25,10 @@ import (
 	"reflect"
 	"time"
 
-	"github.com/temporalio/temporal/common/persistence"
-
 	"github.com/pborman/uuid"
+	commonproto "go.temporal.io/temporal-proto/common"
 
-	"github.com/temporalio/temporal/.gen/go/shared"
-	"github.com/temporalio/temporal/common"
+	"github.com/temporalio/temporal/common/persistence"
 	test "github.com/temporalio/temporal/common/testing"
 )
 
@@ -41,14 +39,14 @@ func (s *nDCIntegrationTestSuite) TestReplicationMessageApplication() {
 	workflowType := "event-generator-workflow-type"
 	tasklist := "event-generator-taskList"
 
-	var historyBatch []*shared.History
+	var historyBatch []*commonproto.History
 	s.generator = test.InitializeHistoryEventGenerator(s.domainName, 1)
 
 	for s.generator.HasNextVertex() {
 		events := s.generator.GetNextVertices()
-		historyEvents := &shared.History{}
+		historyEvents := &commonproto.History{}
 		for _, event := range events {
-			historyEvents.Events = append(historyEvents.Events, event.GetData().(*shared.HistoryEvent))
+			historyEvents.Events = append(historyEvents.Events, event.GetData().(*commonproto.HistoryEvent))
 		}
 		historyBatch = append(historyBatch, historyEvents)
 	}
@@ -84,20 +82,20 @@ func (s *nDCIntegrationTestSuite) TestReplicationMessageDLQ() {
 	workflowType := "event-generator-workflow-type"
 	tasklist := "event-generator-taskList"
 
-	var historyBatch []*shared.History
+	var historyBatch []*commonproto.History
 	s.generator = test.InitializeHistoryEventGenerator(s.domainName, 1)
 
 	events := s.generator.GetNextVertices()
-	historyEvents := &shared.History{}
+	historyEvents := &commonproto.History{}
 	for _, event := range events {
-		historyEvents.Events = append(historyEvents.Events, event.GetData().(*shared.HistoryEvent))
+		historyEvents.Events = append(historyEvents.Events, event.GetData().(*commonproto.HistoryEvent))
 	}
 	historyBatch = append(historyBatch, historyEvents)
 
 	versionHistory := s.eventBatchesToVersionHistory(nil, historyBatch)
 
 	s.NotNil(historyBatch)
-	historyBatch[0].Events[1].Version = common.Int64Ptr(2)
+	historyBatch[0].Events[1].Version = 2
 
 	s.applyEventsThroughFetcher(
 		workflowID,

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -38,7 +38,6 @@ import (
 	"go.uber.org/yarpc/transport/tchannel"
 	"google.golang.org/grpc"
 
-	"github.com/temporalio/temporal/.gen/go/history/historyserviceclient"
 	"github.com/temporalio/temporal/.gen/go/shared"
 	"github.com/temporalio/temporal/.gen/proto/adminservice"
 	"github.com/temporalio/temporal/client"
@@ -75,8 +74,7 @@ type Cadence interface {
 	GetAdminClient() adminservice.AdminServiceClient
 	GetFrontendClient() workflowservice.WorkflowServiceClient
 	FrontendAddress() string
-	GetHistoryClient() historyserviceclient.Interface
-	GetHistoryClientGRPC() historyservice.HistoryServiceClient
+	GetHistoryClient() historyservice.HistoryServiceClient
 	GetExecutionManagerFactory() persistence.ExecutionManagerFactory
 }
 
@@ -88,8 +86,7 @@ type (
 
 		adminClient            adminservice.AdminServiceClient
 		frontendClient         workflowservice.WorkflowServiceClient
-		historyClient          historyserviceclient.Interface
-		historyClientGRPC      historyservice.HistoryServiceClient
+		historyClient          historyservice.HistoryServiceClient
 		logger                 log.Logger
 		clusterMetadata        cluster.Metadata
 		persistenceConfig      config.Persistence
@@ -481,12 +478,8 @@ func (c *cadenceImpl) GetFrontendClient() workflowservice.WorkflowServiceClient 
 	return c.frontendClient
 }
 
-func (c *cadenceImpl) GetHistoryClient() historyserviceclient.Interface {
+func (c *cadenceImpl) GetHistoryClient() historyservice.HistoryServiceClient {
 	return c.historyClient
-}
-
-func (c *cadenceImpl) GetHistoryClientGRPC() historyservice.HistoryServiceClient {
-	return c.historyClientGRPC
 }
 
 func (c *cadenceImpl) startFrontend(hosts map[string][]string, startWG *sync.WaitGroup) {
@@ -616,13 +609,12 @@ func (c *cadenceImpl) startHistory(
 		// However current interface for getting history client doesn't specify which client it needs and the tests that use this API
 		// depends on the fact that there's only one history host.
 		// Need to change those tests and modify the interface for getting history client.
-		c.historyClient = NewHistoryClient(historyService.GetDispatcher())
 		historyConnection, err := grpc.Dial(c.HistoryServiceAddress(3)[0], grpc.WithInsecure())
 		if err != nil {
 			c.logger.Fatal("Failed to create connection for history", tag.Error(err))
 		}
 
-		c.historyClientGRPC = NewHistoryClientGRPC(historyConnection)
+		c.historyClient = NewHistoryClient(historyConnection)
 		c.historyServices = append(c.historyServices, historyService)
 
 		go historyService.Start()

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -617,6 +617,12 @@ func (c *cadenceImpl) startHistory(
 		// depends on the fact that there's only one history host.
 		// Need to change those tests and modify the interface for getting history client.
 		c.historyClient = NewHistoryClient(historyService.GetDispatcher())
+		historyConnection, err := grpc.Dial(c.HistoryServiceAddress(3)[0], grpc.WithInsecure())
+		if err != nil {
+			c.logger.Fatal("Failed to create connection for history", tag.Error(err))
+		}
+
+		c.historyClientGRPC = NewHistoryClientGRPC(historyConnection)
 		c.historyServices = append(c.historyServices, historyService)
 
 		go historyService.Start()

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -289,11 +289,6 @@ func (tc *TestCluster) GetHistoryClient() HistoryClient {
 	return tc.host.GetHistoryClient()
 }
 
-// GetHistoryClient returns a history client from the test cluster
-func (tc *TestCluster) GetHistoryClientGRPC() HistoryClientGRPC {
-	return tc.host.GetHistoryClientGRPC()
-}
-
 // GetExecutionManagerFactory returns an execution manager factory from the test cluster
 func (tc *TestCluster) GetExecutionManagerFactory() persistence.ExecutionManagerFactory {
 	return tc.host.GetExecutionManagerFactory()


### PR DESCRIPTION
Mostly mechanical changes from Thrift packages (`shared`, `history`) to proto packages (`commonproto`, `historyservice`, `enums`).