### PR TITLE
ReplicationTask Proto Persistence

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -26,6 +26,10 @@ import (
 	"strings"
 	"time"
 
+	"github.com/temporalio/temporal/common/primitives"
+
+	commonproto "go.temporal.io/temporal-proto/common"
+
 	pblobs "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 
 	"github.com/temporalio/temporal/.gen/go/persistenceblobs"
@@ -353,23 +357,9 @@ type (
 		RecordVisibility        bool
 	}
 
-	// ReplicationTaskInfo describes the replication task created for replication of history events
-	ReplicationTaskInfo struct {
-		DomainID          string
-		WorkflowID        string
-		RunID             string
-		TaskID            int64
-		TaskType          int
-		FirstEventID      int64
-		NextEventID       int64
-		Version           int64
-		ScheduledID       int64
-		BranchToken       []byte
-		NewRunBranchToken []byte
-		ResetWorkflow     bool
-
-		// TODO deprecate when NDC is fully released && migrated
-		LastReplicationInfo map[string]*ReplicationInfo
+	// ReplicationTaskInfoWrapper describes a replication task.
+	ReplicationTaskInfoWrapper struct {
+		*pblobs.ReplicationTaskInfo
 	}
 
 	// TimerTaskInfo describes a timer task.
@@ -948,7 +938,7 @@ type (
 
 	// GetReplicationTasksResponse is the response to GetReplicationTask
 	GetReplicationTasksResponse struct {
-		Tasks         []*ReplicationTaskInfo
+		Tasks         []*pblobs.ReplicationTaskInfo
 		NextPageToken []byte
 	}
 
@@ -976,7 +966,7 @@ type (
 	// PutReplicationTaskToDLQRequest is used to put a replication task to dlq
 	PutReplicationTaskToDLQRequest struct {
 		SourceClusterName string
-		TaskInfo          *ReplicationTaskInfo
+		TaskInfo          *pblobs.ReplicationTaskInfo
 	}
 
 	// GetReplicationTasksFromDLQRequest is used to get replication tasks from dlq
@@ -1716,6 +1706,11 @@ func (d *DecisionTask) SetTaskID(id int64) {
 }
 
 // GetVisibilityTimestamp get the visibility timestamp
+func (d ReplicationTaskInfoWrapper) GetVisibilityTimestamp() time.Time {
+	return time.Time{}
+}
+
+// GetVisibilityTimestamp get the visibility timestamp
 func (d *DecisionTask) GetVisibilityTimestamp() time.Time {
 	return d.VisibilityTimestamp
 }
@@ -2328,41 +2323,6 @@ func (t *TransferTaskInfo) String() string {
 	)
 }
 
-// GetTaskID returns the task ID for replication task
-func (t *ReplicationTaskInfo) GetTaskID() int64 {
-	return t.TaskID
-}
-
-// GetVersion returns the task version for replication task
-func (t *ReplicationTaskInfo) GetVersion() int64 {
-	return t.Version
-}
-
-// GetTaskType returns the task type for replication task
-func (t *ReplicationTaskInfo) GetTaskType() int {
-	return t.TaskType
-}
-
-// GetVisibilityTimestamp returns the task type for replication task
-func (t *ReplicationTaskInfo) GetVisibilityTimestamp() time.Time {
-	return time.Time{}
-}
-
-// GetWorkflowID returns the workflow ID for replication task
-func (t *ReplicationTaskInfo) GetWorkflowID() string {
-	return t.WorkflowID
-}
-
-// GetRunID returns the run ID for replication task
-func (t *ReplicationTaskInfo) GetRunID() string {
-	return t.RunID
-}
-
-// GetDomainID returns the domain ID for replication task
-func (t *ReplicationTaskInfo) GetDomainID() string {
-	return t.DomainID
-}
-
 // GetTaskID returns the task ID for timer task
 func (t *TimerTaskInfo) GetTaskID() int64 {
 	return t.TaskID
@@ -2442,6 +2402,10 @@ func (config *ClusterReplicationConfig) deserialize(input map[string]interface{}
 func (config *ClusterReplicationConfig) GetCopy() *ClusterReplicationConfig {
 	res := *config
 	return &res
+}
+
+func (r *ReplicationInfo) ToProto() *commonproto.ReplicationInfo {
+	return &commonproto.ReplicationInfo{Version: r.Version, LastEventId: r.LastEventID}
 }
 
 // DBTimestampToUnixNano converts CQL timestamp to UnixNano

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -2291,8 +2291,8 @@ func (t *TransferTaskInfo) GetVersion() int64 {
 }
 
 // GetTaskType returns the task type for transfer task
-func (t *TransferTaskInfo) GetTaskType() int {
-	return t.TaskType
+func (t *TransferTaskInfo) GetTaskType() int32 {
+	return int32(t.TaskType)
 }
 
 // GetVisibilityTimestamp returns the task type for transfer task
@@ -2306,13 +2306,13 @@ func (t *TransferTaskInfo) GetWorkflowID() string {
 }
 
 // GetRunID returns the run ID for transfer task
-func (t *TransferTaskInfo) GetRunID() string {
-	return t.RunID
+func (t *TransferTaskInfo) GetRunID() []byte {
+	return primitives.MustParseUUID(t.RunID)
 }
 
 // GetDomainID returns the domain ID for transfer task
-func (t *TransferTaskInfo) GetDomainID() string {
-	return t.DomainID
+func (t *TransferTaskInfo) GetDomainID() []byte {
+	return primitives.MustParseUUID(t.DomainID)
 }
 
 // String returns string
@@ -2334,8 +2334,8 @@ func (t *TimerTaskInfo) GetVersion() int64 {
 }
 
 // GetTaskType returns the task type for timer task
-func (t *TimerTaskInfo) GetTaskType() int {
-	return t.TaskType
+func (t *TimerTaskInfo) GetTaskType() int32 {
+	return int32(t.TaskType)
 }
 
 // GetVisibilityTimestamp returns the task type for timer task
@@ -2349,13 +2349,13 @@ func (t *TimerTaskInfo) GetWorkflowID() string {
 }
 
 // GetRunID returns the run ID for timer task
-func (t *TimerTaskInfo) GetRunID() string {
-	return t.RunID
+func (t *TimerTaskInfo) GetRunID() []byte {
+	return primitives.MustParseUUID(t.RunID)
 }
 
 // GetDomainID returns the domain ID for timer task
-func (t *TimerTaskInfo) GetDomainID() string {
-	return t.DomainID
+func (t *TimerTaskInfo) GetDomainID() []byte {
+	return primitives.MustParseUUID(t.DomainID)
 }
 
 // GetTaskType returns the task type for timer task

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -31,6 +31,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/temporalio/temporal/common/primitives"
+
 	"github.com/gogo/protobuf/types"
 
 	pblobs "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
@@ -2243,7 +2245,7 @@ func (s *ExecutionManagerSuite) TestReplicationTasks() {
 
 	for index := range replicationTasks {
 		s.Equal(replicationTasks[index].GetTaskID(), respTasks[index].GetTaskID())
-		s.Equal(replicationTasks[index].GetType(), respTasks[index].GetTaskType())
+		s.Equal(int32(replicationTasks[index].GetType()), respTasks[index].GetTaskType())
 		s.Equal(replicationTasks[index].GetVersion(), respTasks[index].GetVersion())
 		switch replicationTasks[index].GetType() {
 		case p.ReplicationTaskTypeHistory:
@@ -2258,7 +2260,7 @@ func (s *ExecutionManagerSuite) TestReplicationTasks() {
 				got, ok := respTasks[index].LastReplicationInfo[k]
 				s.True(ok, "replication info missing key")
 				s.Equal(v.Version, got.Version)
-				s.Equal(v.LastEventID, got.LastEventID)
+				s.Equal(v.LastEventID, got.LastEventId)
 			}
 		case p.ReplicationTaskTypeSyncActivity:
 			expected := replicationTasks[index].(*p.SyncActivityTask)
@@ -3104,23 +3106,23 @@ func (s *ExecutionManagerSuite) TestReplicationTransferTaskTasks() {
 	s.NotNil(tasks1, "expected valid list of tasks.")
 	s.Equal(1, len(tasks1), "Expected 1 replication task.")
 	task1 := tasks1[0]
-	s.Equal(p.ReplicationTaskTypeHistory, task1.TaskType)
-	s.Equal(domainID, task1.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(task1.TaskType))
+	s.Equal(domainID, primitives.UUID(task1.DomainID).String())
 	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task1.RunID)
+	s.Equal(workflowExecution.GetRunId(), primitives.UUID(task1.RunID).String())
 	s.Equal(int64(1), task1.FirstEventID)
 	s.Equal(int64(3), task1.NextEventID)
 	s.Equal(int64(9), task1.Version)
 	s.Equal(2, len(task1.LastReplicationInfo))
 	for k, v := range task1.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(3), v.Version)
-			s.Equal(int64(1), v.LastEventID)
+			s.Equal(int64(1), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(5), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}
@@ -3207,10 +3209,10 @@ func (s *ExecutionManagerSuite) TestReplicationTransferTaskRangeComplete() {
 	s.NotNil(tasks1, "expected valid list of tasks.")
 	s.Equal(1, len(tasks1), "Expected 1 replication task.")
 	task1 := tasks1[0]
-	s.Equal(p.ReplicationTaskTypeHistory, task1.TaskType)
-	s.Equal(domainID, task1.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(task1.TaskType))
+	s.Equal(domainID, primitives.UUID(task1.DomainID).String())
 	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task1.RunID)
+	s.Equal(workflowExecution.GetRunId(), primitives.UUID(task1.RunID).String())
 	s.Equal(int64(1), task1.FirstEventID)
 	s.Equal(int64(3), task1.NextEventID)
 	s.Equal(int64(9), task1.Version)
@@ -3222,10 +3224,10 @@ func (s *ExecutionManagerSuite) TestReplicationTransferTaskRangeComplete() {
 	s.NoError(err)
 	s.NotNil(tasks2, "expected valid list of tasks.")
 	task2 := tasks2[0]
-	s.Equal(p.ReplicationTaskTypeHistory, task2.TaskType)
-	s.Equal(domainID, task2.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(task2.TaskType))
+	s.Equal(domainID, primitives.UUID(task2.DomainID).String())
 	s.Equal(workflowExecution.GetWorkflowId(), task2.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task2.RunID)
+	s.Equal(workflowExecution.GetRunId(), primitives.UUID(task2.RunID).String())
 	s.Equal(int64(4), task2.FirstEventID)
 	s.Equal(int64(5), task2.NextEventID)
 	s.Equal(int64(9), task2.Version)
@@ -3292,23 +3294,23 @@ func (s *ExecutionManagerSuite) TestWorkflowReplicationState() {
 	taskR, err := s.GetReplicationTasks(1, false)
 	s.Equal(1, len(taskR), "Expected 1 replication task.")
 	tsk := taskR[0]
-	s.Equal(p.ReplicationTaskTypeHistory, tsk.TaskType)
-	s.Equal(domainID, tsk.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(tsk.TaskType))
+	s.Equal(domainID, primitives.UUID(tsk.DomainID).String())
 	s.Equal(workflowExecution.GetWorkflowId(), tsk.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), tsk.RunID)
+	s.Equal(workflowExecution.GetRunId(), primitives.UUID(tsk.RunID).String())
 	s.Equal(int64(1), tsk.FirstEventID)
 	s.Equal(int64(3), tsk.NextEventID)
 	s.Equal(int64(9), tsk.Version)
 	s.Equal(2, len(tsk.LastReplicationInfo))
 	for k, v := range tsk.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(3), v.Version)
-			s.Equal(int64(1), v.LastEventID)
+			s.Equal(int64(1), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(5), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}
@@ -3383,23 +3385,23 @@ func (s *ExecutionManagerSuite) TestWorkflowReplicationState() {
 	taskR1, err := s.GetReplicationTasks(1, false)
 	s.Equal(1, len(taskR1), "Expected 1 replication task.")
 	tsk1 := taskR1[0]
-	s.Equal(p.ReplicationTaskTypeHistory, tsk1.TaskType)
-	s.Equal(domainID, tsk1.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(tsk1.TaskType))
+	s.Equal(domainID, primitives.UUID(tsk1.DomainID).String())
 	s.Equal(workflowExecution.GetWorkflowId(), tsk1.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), tsk1.RunID)
+	s.Equal(workflowExecution.GetRunId(), primitives.UUID(tsk1.RunID).String())
 	s.Equal(int64(3), tsk1.FirstEventID)
 	s.Equal(int64(5), tsk1.NextEventID)
 	s.Equal(int64(10), tsk1.Version)
 	s.Equal(2, len(tsk1.LastReplicationInfo))
 	for k, v := range tsk1.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(4), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(5), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}

--- a/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
+++ b/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
@@ -26,6 +26,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/temporalio/temporal/common/primitives"
+
 	"github.com/temporalio/temporal/common/checksum"
 
 	"github.com/pborman/uuid"
@@ -442,10 +444,10 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 	taskR, err := s.GetReplicationTasks(1, false)
 	s.Equal(1, len(taskR), "Expected 1 replication task.")
 	tsk := taskR[0]
-	s.Equal(p.ReplicationTaskTypeHistory, tsk.TaskType)
-	s.Equal(domainID, tsk.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(tsk.TaskType))
+	s.Equal(domainID, primitives.UUID(tsk.DomainID).String())
 	s.Equal(*workflowExecution.WorkflowId, tsk.WorkflowID)
-	s.Equal(*workflowExecution.RunId, tsk.RunID)
+	s.Equal(*workflowExecution.RunId, primitives.UUID(tsk.RunID).String())
 	s.Equal(int64(1), tsk.FirstEventID)
 	s.Equal(int64(3), tsk.NextEventID)
 	s.Equal(int64(9), tsk.Version)
@@ -453,14 +455,14 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 	s.Equal([]byte("branchToken2"), tsk.NewRunBranchToken)
 	s.Equal(2, len(tsk.LastReplicationInfo))
 	for k, v := range tsk.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(3), v.Version)
-			s.Equal(int64(1), v.LastEventID)
+			s.Equal(int64(1), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(5), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}
@@ -540,10 +542,10 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 	taskR1, err := s.GetReplicationTasks(1, false)
 	s.Equal(1, len(taskR1), "Expected 1 replication task.")
 	tsk1 := taskR1[0]
-	s.Equal(p.ReplicationTaskTypeHistory, tsk1.TaskType)
-	s.Equal(domainID, tsk1.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(tsk1.TaskType))
+	s.Equal(domainID, primitives.UUID(tsk1.DomainID).String())
 	s.Equal(*workflowExecution.WorkflowId, tsk1.WorkflowID)
-	s.Equal(*workflowExecution.RunId, tsk1.RunID)
+	s.Equal(*workflowExecution.RunId, primitives.UUID(tsk1.RunID).String())
 	s.Equal(int64(3), tsk1.FirstEventID)
 	s.Equal(int64(5), tsk1.NextEventID)
 	s.Equal(int64(10), tsk1.Version)
@@ -552,14 +554,14 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 
 	s.Equal(2, len(tsk1.LastReplicationInfo))
 	for k, v := range tsk1.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(4), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(5), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}
@@ -733,10 +735,10 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetWithCurrWithReplicat
 	s.Nil(err)
 	s.Equal(1, len(taskR), "Expected 1 replication task.")
 	tsk := taskR[0]
-	s.Equal(p.ReplicationTaskTypeHistory, tsk.TaskType)
-	s.Equal(domainID, tsk.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(tsk.TaskType))
+	s.Equal(domainID, primitives.UUID(tsk.DomainID).String())
 	s.Equal(*workflowExecution.WorkflowId, tsk.WorkflowID)
-	s.Equal(*workflowExecution.RunId, tsk.RunID)
+	s.Equal(*workflowExecution.RunId, primitives.UUID(tsk.RunID).String())
 	s.Equal(int64(1), tsk.FirstEventID)
 	s.Equal(int64(3), tsk.NextEventID)
 	s.Equal(int64(9), tsk.Version)
@@ -744,14 +746,14 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetWithCurrWithReplicat
 	s.Equal([]byte("branchToken2"), tsk.NewRunBranchToken)
 	s.Equal(2, len(tsk.LastReplicationInfo))
 	for k, v := range tsk.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(3), v.Version)
-			s.Equal(int64(1), v.LastEventID)
+			s.Equal(int64(1), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(5), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}
@@ -963,10 +965,10 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetWithCurrWithReplicat
 	s.Nil(err)
 	s.Equal(1, len(taskR), "Expected 1 replication task.")
 	tsk = taskR[0]
-	s.Equal(p.ReplicationTaskTypeHistory, tsk.TaskType)
-	s.Equal(domainID, tsk.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(tsk.TaskType))
+	s.Equal(domainID, primitives.UUID(tsk.DomainID).String())
 	s.Equal(*workflowExecution.WorkflowId, tsk.WorkflowID)
-	s.Equal(insertInfo.RunID, tsk.RunID)
+	s.Equal(insertInfo.RunID, primitives.UUID(tsk.RunID).String())
 	s.Equal(int64(10), tsk.FirstEventID)
 	s.Equal(int64(30), tsk.NextEventID)
 	s.Equal(true, tsk.ResetWorkflow)
@@ -975,14 +977,14 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetWithCurrWithReplicat
 	s.Equal(0, len(tsk.NewRunBranchToken))
 	s.Equal(2, len(tsk.LastReplicationInfo))
 	for k, v := range tsk.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(30), v.Version)
-			s.Equal(int64(10), v.LastEventID)
+			s.Equal(int64(10), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(50), v.Version)
-			s.Equal(int64(20), v.LastEventID)
+			s.Equal(int64(20), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}
@@ -1165,10 +1167,10 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrWithReplicate(
 	s.Nil(err)
 	s.Equal(1, len(taskR), "Expected 1 replication task.")
 	tsk := taskR[0]
-	s.Equal(p.ReplicationTaskTypeHistory, tsk.TaskType)
-	s.Equal(domainID, tsk.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(tsk.TaskType))
+	s.Equal(domainID, primitives.UUID(tsk.DomainID).String())
 	s.Equal(*workflowExecution.WorkflowId, tsk.WorkflowID)
-	s.Equal(*workflowExecution.RunId, tsk.RunID)
+	s.Equal(*workflowExecution.RunId, primitives.UUID(tsk.RunID).String())
 	s.Equal(int64(1), tsk.FirstEventID)
 	s.Equal(int64(3), tsk.NextEventID)
 	s.Equal(int64(9), tsk.Version)
@@ -1176,14 +1178,14 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrWithReplicate(
 	s.Equal([]byte("branchToken2"), tsk.NewRunBranchToken)
 	s.Equal(2, len(tsk.LastReplicationInfo))
 	for k, v := range tsk.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(3), v.Version)
-			s.Equal(int64(1), v.LastEventID)
+			s.Equal(int64(1), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(5), v.Version)
-			s.Equal(int64(2), v.LastEventID)
+			s.Equal(int64(2), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}
@@ -1371,10 +1373,10 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrWithReplicate(
 	s.Nil(err)
 	s.Equal(1, len(taskR), "Expected 1 replication task.")
 	tsk = taskR[0]
-	s.Equal(p.ReplicationTaskTypeHistory, tsk.TaskType)
-	s.Equal(domainID, tsk.DomainID)
+	s.Equal(p.ReplicationTaskTypeHistory, int(tsk.TaskType))
+	s.Equal(domainID, primitives.UUID(tsk.DomainID).String())
 	s.Equal(*workflowExecution.WorkflowId, tsk.WorkflowID)
-	s.Equal(insertInfo.RunID, tsk.RunID)
+	s.Equal(insertInfo.RunID, primitives.UUID(tsk.RunID).String())
 	s.Equal(int64(10), tsk.FirstEventID)
 	s.Equal(int64(30), tsk.NextEventID)
 	s.Equal(int64(90), tsk.Version)
@@ -1382,14 +1384,14 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrWithReplicate(
 	s.Equal(0, len(tsk.NewRunBranchToken))
 	s.Equal(2, len(tsk.LastReplicationInfo))
 	for k, v := range tsk.LastReplicationInfo {
-		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventID)
+		log.Infof("ReplicationInfo for %v: {Version: %v, LastEventID: %v}", k, v.Version, v.LastEventId)
 		switch k {
 		case "dc1":
 			s.Equal(int64(30), v.Version)
-			s.Equal(int64(10), v.LastEventID)
+			s.Equal(int64(10), v.LastEventId)
 		case "dc2":
 			s.Equal(int64(50), v.Version)
-			s.Equal(int64(20), v.LastEventID)
+			s.Equal(int64(20), v.LastEventId)
 		default:
 			s.Fail("Unexpected key")
 		}

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1062,8 +1062,8 @@ Loop:
 }
 
 // GetReplicationTasks is a utility method to get tasks from replication task queue
-func (s *TestBase) GetReplicationTasks(batchSize int, getAll bool) ([]*p.ReplicationTaskInfo, error) {
-	result := []*p.ReplicationTaskInfo{}
+func (s *TestBase) GetReplicationTasks(batchSize int, getAll bool) ([]*pblobs.ReplicationTaskInfo, error) {
+	result := []*pblobs.ReplicationTaskInfo{}
 	var token []byte
 
 Loop:

--- a/common/persistence/sql/blob.go
+++ b/common/persistence/sql/blob.go
@@ -249,11 +249,11 @@ func timerTaskInfoFromBlob(b []byte, proto string) (*sqlblobs.TimerTaskInfo, err
 	return result, thriftRWDecode(b, proto, result)
 }
 
-func replicationTaskInfoToBlob(info *sqlblobs.ReplicationTaskInfo) (p.DataBlob, error) {
-	return thriftRWEncode(info)
+func ReplicationTaskInfoToBlob(info *persistenceblobs.ReplicationTaskInfo) (p.DataBlob, error) {
+	return protoRWEncode(info)
 }
 
-func replicationTaskInfoFromBlob(b []byte, proto string) (*sqlblobs.ReplicationTaskInfo, error) {
-	result := &sqlblobs.ReplicationTaskInfo{}
-	return result, thriftRWDecode(b, proto, result)
+func ReplicationTaskInfoFromBlob(b []byte, proto string) (*persistenceblobs.ReplicationTaskInfo, error) {
+	result := &persistenceblobs.ReplicationTaskInfo{}
+	return result, protoRWDecode(b, proto, result)
 }

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -25,9 +25,10 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
-	"github.com/temporalio/temporal/common/primitives"
 	"math"
 	"time"
+
+	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 

--- a/common/persistence/sql/sqlExecutionManagerUtil.go
+++ b/common/persistence/sql/sqlExecutionManagerUtil.go
@@ -24,8 +24,9 @@ import (
 	"bytes"
 	"database/sql"
 	"fmt"
-	"github.com/temporalio/temporal/common/primitives"
 	"time"
+
+	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 

--- a/common/persistence/sql/sqlExecutionManagerUtil.go
+++ b/common/persistence/sql/sqlExecutionManagerUtil.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"time"
 
+	commonproto "go.temporal.io/temporal-proto/common"
+
 	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
@@ -855,7 +857,7 @@ func createReplicationTasks(
 		nextEventID := common.EmptyEventID
 		version := common.EmptyVersion
 		activityScheduleID := common.EmptyEventID
-		var lastReplicationInfo map[string]*persistenceblobs.ReplicationInfo
+		var lastReplicationInfo map[string]*commonproto.ReplicationInfo
 
 		var branchToken, newRunBranchToken []byte
 		var resetWorkflow bool
@@ -874,15 +876,15 @@ func createReplicationTasks(
 			branchToken = historyReplicationTask.BranchToken
 			newRunBranchToken = historyReplicationTask.NewRunBranchToken
 			resetWorkflow = historyReplicationTask.ResetWorkflow
-			lastReplicationInfo = make(map[string]*persistenceblobs.ReplicationInfo, len(historyReplicationTask.LastReplicationInfo))
+			lastReplicationInfo = make(map[string]*commonproto.ReplicationInfo, len(historyReplicationTask.LastReplicationInfo))
 			for k, v := range historyReplicationTask.LastReplicationInfo {
-				lastReplicationInfo[k] = &persistenceblobs.ReplicationInfo{Version: v.Version, LastEventID: v.LastEventID}
+				lastReplicationInfo[k] = &commonproto.ReplicationInfo{Version: v.Version, LastEventId: v.LastEventID}
 			}
 
 		case p.ReplicationTaskTypeSyncActivity:
 			version = task.GetVersion()
 			activityScheduleID = task.(*p.SyncActivityTask).ScheduledID
-			lastReplicationInfo = map[string]*persistenceblobs.ReplicationInfo{}
+			lastReplicationInfo = map[string]*commonproto.ReplicationInfo{}
 
 		default:
 			return &workflow.InternalServiceError{
@@ -891,6 +893,7 @@ func createReplicationTasks(
 		}
 
 		blob, err := ReplicationTaskInfoToBlob(&persistenceblobs.ReplicationTaskInfo{
+			TaskID:                  task.GetTaskID(),
 			DomainID:                domainID,
 			WorkflowID:              workflowID,
 			RunID:                   runID,

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -23,6 +23,7 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/temporalio/temporal/.gen/go/shared"

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -23,6 +23,7 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/temporalio/temporal/.gen/go/shared"
 	"github.com/temporalio/temporal/.gen/go/sqlblobs"
@@ -65,8 +66,8 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(
 	}
 
 	nodeRow := &sqlplugin.HistoryNodeRow{
-		TreeID:       sqlplugin.MustParseUUID(branchInfo.GetTreeID()),
-		BranchID:     sqlplugin.MustParseUUID(branchInfo.GetBranchID()),
+		TreeID:       primitives.MustParseUUID(branchInfo.GetTreeID()),
+		BranchID:     primitives.MustParseUUID(branchInfo.GetBranchID()),
 		NodeID:       request.NodeID,
 		TxnID:        &request.TransactionID,
 		Data:         request.Events.Data,
@@ -93,8 +94,8 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(
 
 		treeRow := &sqlplugin.HistoryTreeRow{
 			ShardID:      request.ShardID,
-			TreeID:       sqlplugin.MustParseUUID(branchInfo.GetTreeID()),
-			BranchID:     sqlplugin.MustParseUUID(branchInfo.GetBranchID()),
+			TreeID:       primitives.MustParseUUID(branchInfo.GetTreeID()),
+			BranchID:     primitives.MustParseUUID(branchInfo.GetBranchID()),
 			Data:         blob.Data,
 			DataEncoding: string(blob.Encoding),
 		}
@@ -160,8 +161,8 @@ func (m *sqlHistoryV2Manager) ReadHistoryBranch(
 	}
 
 	filter := &sqlplugin.HistoryNodeFilter{
-		TreeID:    sqlplugin.MustParseUUID(request.TreeID),
-		BranchID:  sqlplugin.MustParseUUID(request.BranchID),
+		TreeID:    primitives.MustParseUUID(request.TreeID),
+		BranchID:  primitives.MustParseUUID(request.BranchID),
 		MinNodeID: &minNodeID,
 		MaxNodeID: &maxNodeID,
 		PageSize:  &request.PageSize,
@@ -332,8 +333,8 @@ func (m *sqlHistoryV2Manager) ForkHistoryBranch(
 
 	row := &sqlplugin.HistoryTreeRow{
 		ShardID:      request.ShardID,
-		TreeID:       sqlplugin.MustParseUUID(treeID),
-		BranchID:     sqlplugin.MustParseUUID(request.NewBranchID),
+		TreeID:       primitives.MustParseUUID(treeID),
+		BranchID:     primitives.MustParseUUID(request.NewBranchID),
 		Data:         blob.Data,
 		DataEncoding: string(blob.Encoding),
 	}
@@ -385,9 +386,9 @@ func (m *sqlHistoryV2Manager) DeleteHistoryBranch(
 	}
 
 	return m.txExecute("DeleteHistoryBranch", func(tx sqlplugin.Tx) error {
-		branchID := sqlplugin.MustParseUUID(*branch.BranchID)
+		branchID := primitives.MustParseUUID(*branch.BranchID)
 		treeFilter := &sqlplugin.HistoryTreeFilter{
-			TreeID:   sqlplugin.MustParseUUID(treeID),
+			TreeID:   primitives.MustParseUUID(treeID),
 			BranchID: &branchID,
 			ShardID:  request.ShardID,
 		}
@@ -402,8 +403,8 @@ func (m *sqlHistoryV2Manager) DeleteHistoryBranch(
 			br := brsToDelete[i]
 			maxReferredEndNodeID, ok := validBRsMaxEndNode[*br.BranchID]
 			nodeFilter := &sqlplugin.HistoryNodeFilter{
-				TreeID:   sqlplugin.MustParseUUID(treeID),
-				BranchID: sqlplugin.MustParseUUID(*br.BranchID),
+				TreeID:   primitives.MustParseUUID(treeID),
+				BranchID: primitives.MustParseUUID(*br.BranchID),
 				ShardID:  request.ShardID,
 			}
 
@@ -441,7 +442,7 @@ func (m *sqlHistoryV2Manager) GetHistoryTree(
 	request *p.GetHistoryTreeRequest,
 ) (*p.GetHistoryTreeResponse, error) {
 
-	treeID := sqlplugin.MustParseUUID(request.TreeID)
+	treeID := primitives.MustParseUUID(request.TreeID)
 	branches := make([]*shared.HistoryBranch, 0)
 
 	treeFilter := &sqlplugin.HistoryTreeFilter{

--- a/common/persistence/sql/sqlMetadataManagerV2.go
+++ b/common/persistence/sql/sqlMetadataManagerV2.go
@@ -23,6 +23,7 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/temporalio/temporal/common/primitives"
 
 	workflow "github.com/temporalio/temporal/.gen/go/shared"

--- a/common/persistence/sql/sqlMetadataManagerV2.go
+++ b/common/persistence/sql/sqlMetadataManagerV2.go
@@ -23,6 +23,7 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+	"github.com/temporalio/temporal/common/primitives"
 
 	workflow "github.com/temporalio/temporal/.gen/go/shared"
 	"github.com/temporalio/temporal/.gen/go/sqlblobs"
@@ -130,7 +131,7 @@ func (m *sqlMetadataManagerV2) CreateDomain(request *persistence.InternalCreateD
 	err = m.txExecute("CreateDomain", func(tx sqlplugin.Tx) error {
 		if _, err1 := tx.InsertIntoDomain(&sqlplugin.DomainRow{
 			Name:         request.Info.Name,
-			ID:           sqlplugin.MustParseUUID(request.Info.ID),
+			ID:           primitives.MustParseUUID(request.Info.ID),
 			Data:         blob.Data,
 			DataEncoding: string(blob.Encoding),
 			IsGlobal:     request.IsGlobalDomain,
@@ -164,7 +165,7 @@ func (m *sqlMetadataManagerV2) GetDomain(request *persistence.GetDomainRequest) 
 	case request.Name != "":
 		filter.Name = &request.Name
 	case request.ID != "":
-		filter.ID = sqlplugin.UUIDPtr(sqlplugin.MustParseUUID(request.ID))
+		filter.ID = primitives.UUIDPtr(primitives.MustParseUUID(request.ID))
 	default:
 		return nil, &workflow.BadRequestError{
 			Message: "GetDomain operation failed.  Both ID and Name are empty.",
@@ -290,7 +291,7 @@ func (m *sqlMetadataManagerV2) UpdateDomain(request *persistence.InternalUpdateD
 	return m.txExecute("UpdateDomain", func(tx sqlplugin.Tx) error {
 		result, err := tx.UpdateDomain(&sqlplugin.DomainRow{
 			Name:         request.Info.Name,
-			ID:           sqlplugin.MustParseUUID(request.Info.ID),
+			ID:           primitives.MustParseUUID(request.Info.ID),
 			Data:         blob.Data,
 			DataEncoding: string(blob.Encoding),
 		})
@@ -313,7 +314,7 @@ func (m *sqlMetadataManagerV2) UpdateDomain(request *persistence.InternalUpdateD
 
 func (m *sqlMetadataManagerV2) DeleteDomain(request *persistence.DeleteDomainRequest) error {
 	return m.txExecute("DeleteDomain", func(tx sqlplugin.Tx) error {
-		_, err := tx.DeleteFromDomain(&sqlplugin.DomainFilter{ID: sqlplugin.UUIDPtr(sqlplugin.MustParseUUID(request.ID))})
+		_, err := tx.DeleteFromDomain(&sqlplugin.DomainFilter{ID: primitives.UUIDPtr(primitives.MustParseUUID(request.ID))})
 		return err
 	})
 }
@@ -336,9 +337,9 @@ func (m *sqlMetadataManagerV2) GetMetadata() (*persistence.GetMetadataResponse, 
 }
 
 func (m *sqlMetadataManagerV2) ListDomains(request *persistence.ListDomainsRequest) (*persistence.InternalListDomainsResponse, error) {
-	var pageToken *sqlplugin.UUID
+	var pageToken *primitives.UUID
 	if request.NextPageToken != nil {
-		token := sqlplugin.UUID(request.NextPageToken)
+		token := primitives.UUID(request.NextPageToken)
 		pageToken = &token
 	}
 	rows, err := m.db.SelectFromDomain(&sqlplugin.DomainFilter{

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -23,9 +23,10 @@ package sql
 import (
 	"database/sql"
 	"fmt"
-	"github.com/temporalio/temporal/common/primitives"
 	"math"
 	"time"
+
+	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/dgryski/go-farm"
 

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -22,8 +22,9 @@ package sqlplugin
 
 import (
 	"database/sql"
-	"github.com/temporalio/temporal/common/primitives"
 	"time"
+
+	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/temporalio/temporal/common/persistence"
 

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -22,6 +22,7 @@ package sqlplugin
 
 import (
 	"database/sql"
+	"github.com/temporalio/temporal/common/primitives"
 	"time"
 
 	"github.com/temporalio/temporal/common/persistence"
@@ -75,7 +76,7 @@ type (
 
 	// DomainRow represents a row in domain table
 	DomainRow struct {
-		ID           UUID
+		ID           primitives.UUID
 		Name         string
 		Data         []byte
 		DataEncoding string
@@ -88,9 +89,9 @@ type (
 	// Name will be used for WHERE condition. When both ID and Name are nil,
 	// no WHERE clause will be used
 	DomainFilter struct {
-		ID            *UUID
+		ID            *primitives.UUID
 		Name          *string
-		GreaterThanID *UUID
+		GreaterThanID *primitives.UUID
 		PageSize      *int
 	}
 
@@ -133,9 +134,9 @@ type (
 	// ExecutionsRow represents a row in executions table
 	ExecutionsRow struct {
 		ShardID                  int
-		DomainID                 UUID
+		DomainID                 primitives.UUID
 		WorkflowID               string
-		RunID                    UUID
+		RunID                    primitives.UUID
 		NextEventID              int64
 		LastWriteVersion         int64
 		Data                     []byte
@@ -148,17 +149,17 @@ type (
 	// can be used to filter results through a WHERE clause
 	ExecutionsFilter struct {
 		ShardID    int
-		DomainID   UUID
+		DomainID   primitives.UUID
 		WorkflowID string
-		RunID      UUID
+		RunID      primitives.UUID
 	}
 
 	// CurrentExecutionsRow represents a row in current_executions table
 	CurrentExecutionsRow struct {
 		ShardID          int64
-		DomainID         UUID
+		DomainID         primitives.UUID
 		WorkflowID       string
-		RunID            UUID
+		RunID            primitives.UUID
 		CreateRequestID  string
 		State            int
 		CloseStatus      int
@@ -170,17 +171,17 @@ type (
 	// can be used to filter results through a WHERE clause
 	CurrentExecutionsFilter struct {
 		ShardID    int64
-		DomainID   UUID
+		DomainID   primitives.UUID
 		WorkflowID string
-		RunID      UUID
+		RunID      primitives.UUID
 	}
 
 	// BufferedEventsRow represents a row in buffered_events table
 	BufferedEventsRow struct {
 		ShardID      int
-		DomainID     UUID
+		DomainID     primitives.UUID
 		WorkflowID   string
-		RunID        UUID
+		RunID        primitives.UUID
 		Data         []byte
 		DataEncoding string
 	}
@@ -189,14 +190,14 @@ type (
 	// can be used to filter results through a WHERE clause
 	BufferedEventsFilter struct {
 		ShardID    int
-		DomainID   UUID
+		DomainID   primitives.UUID
 		WorkflowID string
-		RunID      UUID
+		RunID      primitives.UUID
 	}
 
 	// TasksRow represents a row in tasks table
 	TasksRow struct {
-		DomainID     UUID
+		DomainID     primitives.UUID
 		TaskType     int64
 		TaskID       int64
 		TaskListName string
@@ -207,7 +208,7 @@ type (
 	// TasksFilter contains the column names within tasks table that
 	// can be used to filter results through a WHERE clause
 	TasksFilter struct {
-		DomainID             UUID
+		DomainID             primitives.UUID
 		TaskListName         string
 		TaskType             int64
 		TaskID               *int64
@@ -221,7 +222,7 @@ type (
 	// TaskListsRow represents a row in task_lists table
 	TaskListsRow struct {
 		ShardID      int
-		DomainID     UUID
+		DomainID     primitives.UUID
 		Name         string
 		TaskType     int64
 		RangeID      int64
@@ -233,10 +234,10 @@ type (
 	// can be used to filter results through a WHERE clause
 	TaskListsFilter struct {
 		ShardID             int
-		DomainID            *UUID
+		DomainID            *primitives.UUID
 		Name                *string
 		TaskType            *int64
-		DomainIDGreaterThan *UUID
+		DomainIDGreaterThan *primitives.UUID
 		NameGreaterThan     *string
 		TaskTypeGreaterThan *int64
 		RangeID             *int64
@@ -300,9 +301,9 @@ type (
 
 	// EventsRow represents a row in events table
 	EventsRow struct {
-		DomainID     UUID
+		DomainID     primitives.UUID
 		WorkflowID   string
-		RunID        UUID
+		RunID        primitives.UUID
 		FirstEventID int64
 		BatchVersion int64
 		RangeID      int64
@@ -314,9 +315,9 @@ type (
 	// EventsFilter contains the column names within events table that
 	// can be used to filter results through a WHERE clause
 	EventsFilter struct {
-		DomainID     UUID
+		DomainID     primitives.UUID
 		WorkflowID   string
-		RunID        UUID
+		RunID        primitives.UUID
 		FirstEventID *int64
 		NextEventID  *int64
 		PageSize     *int
@@ -325,8 +326,8 @@ type (
 	// HistoryNodeRow represents a row in history_node table
 	HistoryNodeRow struct {
 		ShardID  int
-		TreeID   UUID
-		BranchID UUID
+		TreeID   primitives.UUID
+		BranchID primitives.UUID
 		NodeID   int64
 		// use pointer so that it's easier to multiple by -1
 		TxnID        *int64
@@ -338,8 +339,8 @@ type (
 	// can be used to filter results through a WHERE clause
 	HistoryNodeFilter struct {
 		ShardID  int
-		TreeID   UUID
-		BranchID UUID
+		TreeID   primitives.UUID
+		BranchID primitives.UUID
 		// Inclusive
 		MinNodeID *int64
 		// Exclusive
@@ -350,8 +351,8 @@ type (
 	// HistoryTreeRow represents a row in history_tree table
 	HistoryTreeRow struct {
 		ShardID      int
-		TreeID       UUID
-		BranchID     UUID
+		TreeID       primitives.UUID
+		BranchID     primitives.UUID
 		Data         []byte
 		DataEncoding string
 	}
@@ -360,16 +361,16 @@ type (
 	// can be used to filter results through a WHERE clause
 	HistoryTreeFilter struct {
 		ShardID  int
-		TreeID   UUID
-		BranchID *UUID
+		TreeID   primitives.UUID
+		BranchID *primitives.UUID
 	}
 
 	// ActivityInfoMapsRow represents a row in activity_info_maps table
 	ActivityInfoMapsRow struct {
 		ShardID                  int64
-		DomainID                 UUID
+		DomainID                 primitives.UUID
 		WorkflowID               string
-		RunID                    UUID
+		RunID                    primitives.UUID
 		ScheduleID               int64
 		Data                     []byte
 		DataEncoding             string
@@ -381,18 +382,18 @@ type (
 	// can be used to filter results through a WHERE clause
 	ActivityInfoMapsFilter struct {
 		ShardID    int64
-		DomainID   UUID
+		DomainID   primitives.UUID
 		WorkflowID string
-		RunID      UUID
+		RunID      primitives.UUID
 		ScheduleID *int64
 	}
 
 	// TimerInfoMapsRow represents a row in timer_info_maps table
 	TimerInfoMapsRow struct {
 		ShardID      int64
-		DomainID     UUID
+		DomainID     primitives.UUID
 		WorkflowID   string
-		RunID        UUID
+		RunID        primitives.UUID
 		TimerID      string
 		Data         []byte
 		DataEncoding string
@@ -402,18 +403,18 @@ type (
 	// can be used to filter results through a WHERE clause
 	TimerInfoMapsFilter struct {
 		ShardID    int64
-		DomainID   UUID
+		DomainID   primitives.UUID
 		WorkflowID string
-		RunID      UUID
+		RunID      primitives.UUID
 		TimerID    *string
 	}
 
 	// ChildExecutionInfoMapsRow represents a row in child_execution_info_maps table
 	ChildExecutionInfoMapsRow struct {
 		ShardID      int64
-		DomainID     UUID
+		DomainID     primitives.UUID
 		WorkflowID   string
-		RunID        UUID
+		RunID        primitives.UUID
 		InitiatedID  int64
 		Data         []byte
 		DataEncoding string
@@ -423,18 +424,18 @@ type (
 	// can be used to filter results through a WHERE clause
 	ChildExecutionInfoMapsFilter struct {
 		ShardID     int64
-		DomainID    UUID
+		DomainID    primitives.UUID
 		WorkflowID  string
-		RunID       UUID
+		RunID       primitives.UUID
 		InitiatedID *int64
 	}
 
 	// RequestCancelInfoMapsRow represents a row in request_cancel_info_maps table
 	RequestCancelInfoMapsRow struct {
 		ShardID      int64
-		DomainID     UUID
+		DomainID     primitives.UUID
 		WorkflowID   string
-		RunID        UUID
+		RunID        primitives.UUID
 		InitiatedID  int64
 		Data         []byte
 		DataEncoding string
@@ -444,18 +445,18 @@ type (
 	// can be used to filter results through a WHERE clause
 	RequestCancelInfoMapsFilter struct {
 		ShardID     int64
-		DomainID    UUID
+		DomainID    primitives.UUID
 		WorkflowID  string
-		RunID       UUID
+		RunID       primitives.UUID
 		InitiatedID *int64
 	}
 
 	// SignalInfoMapsRow represents a row in signal_info_maps table
 	SignalInfoMapsRow struct {
 		ShardID      int64
-		DomainID     UUID
+		DomainID     primitives.UUID
 		WorkflowID   string
-		RunID        UUID
+		RunID        primitives.UUID
 		InitiatedID  int64
 		Data         []byte
 		DataEncoding string
@@ -465,18 +466,18 @@ type (
 	// can be used to filter results through a WHERE clause
 	SignalInfoMapsFilter struct {
 		ShardID     int64
-		DomainID    UUID
+		DomainID    primitives.UUID
 		WorkflowID  string
-		RunID       UUID
+		RunID       primitives.UUID
 		InitiatedID *int64
 	}
 
 	// SignalsRequestedSetsRow represents a row in signals_requested_sets table
 	SignalsRequestedSetsRow struct {
 		ShardID    int64
-		DomainID   UUID
+		DomainID   primitives.UUID
 		WorkflowID string
-		RunID      UUID
+		RunID      primitives.UUID
 		SignalID   string
 	}
 
@@ -484,9 +485,9 @@ type (
 	// can be used to filter results through a WHERE clause
 	SignalsRequestedSetsFilter struct {
 		ShardID    int64
-		DomainID   UUID
+		DomainID   primitives.UUID
 		WorkflowID string
-		RunID      UUID
+		RunID      primitives.UUID
 		SignalID   *string
 	}
 

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -23,8 +23,9 @@ package sql
 import (
 	"database/sql"
 	"fmt"
-	"github.com/temporalio/temporal/common/primitives"
 	"time"
+
+	"github.com/temporalio/temporal/common/primitives"
 
 	workflow "github.com/temporalio/temporal/.gen/go/shared"
 	"github.com/temporalio/temporal/.gen/go/sqlblobs"

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -23,6 +23,7 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+	"github.com/temporalio/temporal/common/primitives"
 	"time"
 
 	workflow "github.com/temporalio/temporal/.gen/go/shared"
@@ -37,9 +38,9 @@ func updateActivityInfos(
 	activityInfos []*persistence.InternalActivityInfo,
 	deleteInfos []int64,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if len(activityInfos) > 0 {
@@ -139,9 +140,9 @@ func updateActivityInfos(
 func getActivityInfoMap(
 	db sqlplugin.DB,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) (map[int64]*persistence.InternalActivityInfo, error) {
 
 	rows, err := db.SelectFromActivityInfoMaps(&sqlplugin.ActivityInfoMapsFilter{
@@ -208,9 +209,9 @@ func getActivityInfoMap(
 func deleteActivityInfoMap(
 	tx sqlplugin.Tx,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if _, err := tx.DeleteFromActivityInfoMaps(&sqlplugin.ActivityInfoMapsFilter{
@@ -231,9 +232,9 @@ func updateTimerInfos(
 	timerInfos []*persistence.TimerInfo,
 	deleteInfos []string,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if len(timerInfos) > 0 {
@@ -300,9 +301,9 @@ func updateTimerInfos(
 func getTimerInfoMap(
 	db sqlplugin.DB,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) (map[string]*persistence.TimerInfo, error) {
 
 	rows, err := db.SelectFromTimerInfoMaps(&sqlplugin.TimerInfoMapsFilter{
@@ -340,9 +341,9 @@ func getTimerInfoMap(
 func deleteTimerInfoMap(
 	tx sqlplugin.Tx,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if _, err := tx.DeleteFromTimerInfoMaps(&sqlplugin.TimerInfoMapsFilter{
@@ -363,9 +364,9 @@ func updateChildExecutionInfos(
 	childExecutionInfos []*persistence.InternalChildExecutionInfo,
 	deleteInfos *int64,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if len(childExecutionInfos) > 0 {
@@ -383,7 +384,7 @@ func updateChildExecutionInfos(
 				StartedEventEncoding:   &startEncoding,
 				StartedID:              &v.StartedID,
 				StartedWorkflowID:      &v.StartedWorkflowID,
-				StartedRunID:           sqlplugin.MustParseUUID(v.StartedRunID),
+				StartedRunID:           primitives.MustParseUUID(v.StartedRunID),
 				CreateRequestID:        &v.CreateRequestID,
 				DomainName:             &v.DomainName,
 				WorkflowTypeName:       &v.WorkflowTypeName,
@@ -429,9 +430,9 @@ func updateChildExecutionInfos(
 func getChildExecutionInfoMap(
 	db sqlplugin.DB,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) (map[int64]*persistence.InternalChildExecutionInfo, error) {
 
 	rows, err := db.SelectFromChildExecutionInfoMaps(&sqlplugin.ChildExecutionInfoMapsFilter{
@@ -458,7 +459,7 @@ func getChildExecutionInfoMap(
 			Version:               rowInfo.GetVersion(),
 			StartedID:             rowInfo.GetStartedID(),
 			StartedWorkflowID:     rowInfo.GetStartedWorkflowID(),
-			StartedRunID:          sqlplugin.UUID(rowInfo.GetStartedRunID()).String(),
+			StartedRunID:          primitives.UUID(rowInfo.GetStartedRunID()).String(),
 			CreateRequestID:       rowInfo.GetCreateRequestID(),
 			DomainName:            rowInfo.GetDomainName(),
 			WorkflowTypeName:      rowInfo.GetWorkflowTypeName(),
@@ -479,9 +480,9 @@ func getChildExecutionInfoMap(
 func deleteChildExecutionInfoMap(
 	tx sqlplugin.Tx,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if _, err := tx.DeleteFromChildExecutionInfoMaps(&sqlplugin.ChildExecutionInfoMapsFilter{
@@ -502,9 +503,9 @@ func updateRequestCancelInfos(
 	requestCancelInfos []*persistence.RequestCancelInfo,
 	deleteInfo *int64,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if len(requestCancelInfos) > 0 {
@@ -567,9 +568,9 @@ func updateRequestCancelInfos(
 func getRequestCancelInfoMap(
 	db sqlplugin.DB,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) (map[int64]*persistence.RequestCancelInfo, error) {
 
 	rows, err := db.SelectFromRequestCancelInfoMaps(&sqlplugin.RequestCancelInfoMapsFilter{
@@ -604,9 +605,9 @@ func getRequestCancelInfoMap(
 func deleteRequestCancelInfoMap(
 	tx sqlplugin.Tx,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if _, err := tx.DeleteFromRequestCancelInfoMaps(&sqlplugin.RequestCancelInfoMapsFilter{
@@ -627,9 +628,9 @@ func updateSignalInfos(
 	signalInfos []*persistence.SignalInfo,
 	deleteInfo *int64,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if len(signalInfos) > 0 {
@@ -695,9 +696,9 @@ func updateSignalInfos(
 func getSignalInfoMap(
 	db sqlplugin.DB,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) (map[int64]*persistence.SignalInfo, error) {
 
 	rows, err := db.SelectFromSignalInfoMaps(&sqlplugin.SignalInfoMapsFilter{
@@ -735,9 +736,9 @@ func getSignalInfoMap(
 func deleteSignalInfoMap(
 	tx sqlplugin.Tx,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if _, err := tx.DeleteFromSignalInfoMaps(&sqlplugin.SignalInfoMapsFilter{

--- a/common/persistence/sql/workflowStateNonMaps.go
+++ b/common/persistence/sql/workflowStateNonMaps.go
@@ -23,6 +23,7 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/temporalio/temporal/common"
 
@@ -36,9 +37,9 @@ func updateSignalsRequested(
 	signalRequestedIDs []string,
 	deleteSignalRequestID string,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if len(signalRequestedIDs) > 0 {
@@ -79,9 +80,9 @@ func updateSignalsRequested(
 func getSignalsRequested(
 	db sqlplugin.DB,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) (map[string]struct{}, error) {
 
 	rows, err := db.SelectFromSignalsRequestedSets(&sqlplugin.SignalsRequestedSetsFilter{
@@ -105,9 +106,9 @@ func getSignalsRequested(
 func deleteSignalsRequestedSet(
 	tx sqlplugin.Tx,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if _, err := tx.DeleteFromSignalsRequestedSets(&sqlplugin.SignalsRequestedSetsFilter{
@@ -127,9 +128,9 @@ func updateBufferedEvents(
 	tx sqlplugin.Tx,
 	batch *p.DataBlob,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if batch == nil {
@@ -155,9 +156,9 @@ func updateBufferedEvents(
 func getBufferedEvents(
 	db sqlplugin.DB,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) ([]*p.DataBlob, error) {
 
 	rows, err := db.SelectFromBufferedEvents(&sqlplugin.BufferedEventsFilter{
@@ -181,9 +182,9 @@ func getBufferedEvents(
 func deleteBufferedEvents(
 	tx sqlplugin.Tx,
 	shardID int,
-	domainID sqlplugin.UUID,
+	domainID primitives.UUID,
 	workflowID string,
-	runID sqlplugin.UUID,
+	runID primitives.UUID,
 ) error {
 
 	if _, err := tx.DeleteFromBufferedEvents(&sqlplugin.BufferedEventsFilter{

--- a/common/persistence/sql/workflowStateNonMaps.go
+++ b/common/persistence/sql/workflowStateNonMaps.go
@@ -23,6 +23,7 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/temporalio/temporal/common"

--- a/common/primitives/uuid.go
+++ b/common/primitives/uuid.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package sqlplugin
+package primitives
 
 import (
 	"database/sql/driver"

--- a/proto/persistenceblobs/persistenceblobs.proto
+++ b/proto/persistenceblobs/persistenceblobs.proto
@@ -24,6 +24,7 @@ package persistenceblobs;
 option go_package = "github.com/temporalio/temporal/.gen/proto/persistenceblobs";
 
 import "google/protobuf/timestamp.proto";
+import "temporal-proto/common/replication.proto";
 
 // ImmutableClusterMetadata contains initialization configuration and metadata for the cluster
 message ImmutableClusterMetadata {
@@ -44,4 +45,22 @@ message ShardInfo {
     map<string, int64> clusterTransferAckLevel = 10;
     map<string, google.protobuf.Timestamp> clusterTimerAckLevel = 11;
     map<string, int64> clusterReplicationLevel = 12;
+}
+
+message ReplicationTaskInfo {
+    bytes domainID = 1;
+    string workflowID = 2;
+    bytes runID = 3;
+    int32 taskType = 4;
+    int64 version = 5;
+    int64 firstEventID = 6;
+    int64 nextEventID = 7;
+    int64 scheduledID = 8;
+    int32 eventStoreVersion = 9;
+    int32 newRunEventStoreVersion = 10;
+    bytes branch_token = 11;
+    map<string, common.ReplicationInfo> lastReplicationInfo = 12;
+    bytes newRunBranchToken = 13;
+    bool resetWorkflow = 14;
+    int64 taskID = 15;
 }

--- a/proto/sqlblobs/sqlblobs.proto
+++ b/proto/sqlblobs/sqlblobs.proto
@@ -256,20 +256,3 @@ message TimerTaskInfo {
     int64 scheduleAttempt = 7;
     int64 eventID = 8;
 }
-
-message ReplicationTaskInfo {
-    bytes domainID = 1;
-    string workflowID = 2;
-    bytes runID = 3;
-    int32 taskType = 4;
-    int64 version = 5;
-    int64 firstEventID = 6;
-    int64 nextEventID = 7;
-    int64 scheduledID = 8;
-    int32 eventStoreVersion = 9;
-    int32 newRunEventStoreVersion = 10;
-    bytes branch_token = 11;
-    map<string, ReplicationInfo> lastReplicationInfo = 12;
-    bytes newRunBranchToken = 13;
-    bool resetWorkflow = 14;
-}

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -93,24 +93,6 @@ CREATE TYPE transfer_task (
   record_visibility          boolean, -- indicates whether or not to create a visibility record
 );
 
-CREATE TYPE replication_task (
-  domain_id                  uuid,   -- The domain ID that this replication task belongs to
-  workflow_id                text,   -- The workflow ID that this replication task belongs to
-  run_id                     uuid,   -- The run ID that this replication task belongs to
-  task_id                    bigint,
-  type                       int,    -- enum TaskType {History, Heartbeat}
-  first_event_id             bigint,  -- Used by ReplicationTask to set the first event ID of the applied transaction
-  next_event_id              bigint,  -- Used by ReplicationTask to set the next event ID of the applied transaction
-  version                    bigint,  -- Used by ReplicationTask to set the failover version of the applied transaction
-  last_replication_info      map<text, frozen<replication_info>>, -- Used by replication task to snapshot replication information when the transaction was applied
-  scheduled_id               bigint, -- Used by ReplicationTask to sync activity info
-  event_store_version        int, -- indicates which version of event store to query
-  branch_token               blob, -- if eventV2, then query with this token
-  new_run_event_store_version        int, -- indicates which version of event store to query for new run(continueAsNew)
-  new_run_branch_token               blob, -- if eventV2, then query with this token for new run(continueAsNew)
-  reset_workflow             boolean, -- whether the task is for resetWorkflowExecution
-);
-
 CREATE TYPE timer_task (
   domain_id        uuid,
   workflow_id      text,
@@ -300,7 +282,8 @@ CREATE TABLE executions (
   shard_encoding                 text,
   execution                      frozen<workflow_execution>,
   transfer                       frozen<transfer_task>,
-  replication                    frozen<replication_task>,
+  replication                    blob,
+  replication_encoding           text,
   timer                          frozen<timer_task>,
   next_event_id                  bigint,  -- This is needed to make conditional updates on session history
   range_id                       bigint, -- Increasing sequence identifier for transfer queue, checkpointed into shard info

--- a/schema/cassandra/cadence/versioned/v1.0/schema.cql
+++ b/schema/cassandra/cadence/versioned/v1.0/schema.cql
@@ -294,7 +294,8 @@ CREATE TABLE executions (
   shard_encoding                 text,
   execution                      frozen<workflow_execution>,
   transfer                       frozen<transfer_task>,
-  replication                    frozen<replication_task>,
+  replication                    blob,
+  replication_encoding           text,
   timer                          frozen<timer_task>,
   next_event_id                  bigint,  -- This is needed to make conditional updates on session history
   range_id                       bigint, -- Increasing sequence identifier for transfer queue, checkpointed into shard info

--- a/service/history/historyEngineInterfaces.go
+++ b/service/history/historyEngineInterfaces.go
@@ -67,11 +67,11 @@ type (
 	queueTaskInfo interface {
 		GetVersion() int64
 		GetTaskID() int64
-		GetTaskType() int
+		GetTaskType() int32
 		GetVisibilityTimestamp() time.Time
 		GetWorkflowID() string
-		GetRunID() string
-		GetDomainID() string
+		GetRunID() []byte
+		GetDomainID() []byte
 	}
 
 	taskExecutor interface {

--- a/service/history/nDCTaskUtil.go
+++ b/service/history/nDCTaskUtil.go
@@ -23,6 +23,8 @@ package history
 import (
 	"fmt"
 
+	"github.com/temporalio/temporal/common/primitives"
+
 	workflow "github.com/temporalio/temporal/.gen/go/shared"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
@@ -161,10 +163,10 @@ func initializeLoggerForTask(
 		tag.ShardID(shardID),
 		tag.TaskID(task.GetTaskID()),
 		tag.FailoverVersion(task.GetVersion()),
-		tag.TaskType(task.GetTaskType()),
-		tag.WorkflowDomainID(task.GetDomainID()),
+		tag.TaskType(int(task.GetTaskType())),
+		tag.WorkflowDomainID(primitives.UUID(task.GetDomainID()).String()),
 		tag.WorkflowID(task.GetWorkflowID()),
-		tag.WorkflowRunID(task.GetRunID()),
+		tag.WorkflowRunID(primitives.UUID(task.GetRunID()).String()),
 	)
 
 	switch task := task.(type) {
@@ -174,7 +176,7 @@ func initializeLoggerForTask(
 		)
 	case *persistence.TransferTaskInfo:
 		// noop
-	case *persistence.ReplicationTaskInfo:
+	case *persistence.ReplicationTaskInfoWrapper:
 		// noop
 	default:
 		taskLogger.Error(fmt.Sprintf("Unknown queue task type: %v", task))

--- a/service/history/replicationTaskProcessor.go
+++ b/service/history/replicationTaskProcessor.go
@@ -29,6 +29,9 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
+	"github.com/temporalio/temporal/common/primitives"
+
 	commonproto "go.temporal.io/temporal-proto/common"
 	"go.temporal.io/temporal-proto/enums"
 	"go.uber.org/yarpc/yarpcerrors"
@@ -452,10 +455,10 @@ func (p *ReplicationTaskProcessorImpl) generateDLQRequest(
 		taskAttributes := replicationTask.GetSyncActivityTaskAttributes()
 		return &persistence.PutReplicationTaskToDLQRequest{
 			SourceClusterName: p.sourceCluster,
-			TaskInfo: &persistence.ReplicationTaskInfo{
-				DomainID:    taskAttributes.GetDomainId(),
+			TaskInfo: &persistenceblobs.ReplicationTaskInfo{
+				DomainID:    primitives.MustParseUUID(taskAttributes.GetDomainId()),
 				WorkflowID:  taskAttributes.GetWorkflowId(),
-				RunID:       taskAttributes.GetRunId(),
+				RunID:       primitives.MustParseUUID(taskAttributes.GetRunId()),
 				TaskID:      replicationTask.GetSourceTaskId(),
 				TaskType:    persistence.ReplicationTaskTypeSyncActivity,
 				ScheduledID: taskAttributes.GetScheduledId(),
@@ -466,16 +469,16 @@ func (p *ReplicationTaskProcessorImpl) generateDLQRequest(
 		taskAttributes := replicationTask.GetHistoryTaskAttributes()
 		return &persistence.PutReplicationTaskToDLQRequest{
 			SourceClusterName: p.sourceCluster,
-			TaskInfo: &persistence.ReplicationTaskInfo{
-				DomainID:            taskAttributes.GetDomainId(),
+			TaskInfo: &persistenceblobs.ReplicationTaskInfo{
+				DomainID:            primitives.MustParseUUID(taskAttributes.GetDomainId()),
 				WorkflowID:          taskAttributes.GetWorkflowId(),
-				RunID:               taskAttributes.GetRunId(),
+				RunID:               primitives.MustParseUUID(taskAttributes.GetRunId()),
 				TaskID:              replicationTask.GetSourceTaskId(),
 				TaskType:            persistence.ReplicationTaskTypeHistory,
 				FirstEventID:        taskAttributes.GetFirstEventId(),
 				NextEventID:         taskAttributes.GetNextEventId(),
 				Version:             taskAttributes.GetVersion(),
-				LastReplicationInfo: toPersistenceReplicationInfo(taskAttributes.GetReplicationInfo()),
+				LastReplicationInfo: taskAttributes.GetReplicationInfo(),
 				ResetWorkflow:       taskAttributes.GetResetWorkflow(),
 			},
 		}, nil
@@ -495,10 +498,10 @@ func (p *ReplicationTaskProcessorImpl) generateDLQRequest(
 
 		return &persistence.PutReplicationTaskToDLQRequest{
 			SourceClusterName: p.sourceCluster,
-			TaskInfo: &persistence.ReplicationTaskInfo{
-				DomainID:     taskAttributes.GetDomainId(),
+			TaskInfo: &persistenceblobs.ReplicationTaskInfo{
+				DomainID:     primitives.MustParseUUID(taskAttributes.GetDomainId()),
 				WorkflowID:   taskAttributes.GetWorkflowId(),
-				RunID:        taskAttributes.GetRunId(),
+				RunID:        primitives.MustParseUUID(taskAttributes.GetRunId()),
 				TaskID:       replicationTask.GetSourceTaskId(),
 				TaskType:     persistence.ReplicationTaskTypeHistory,
 				FirstEventID: events[0].GetEventId(),

--- a/service/history/replicationTaskProcessor_test.go
+++ b/service/history/replicationTaskProcessor_test.go
@@ -376,20 +376,20 @@ func (s *replicationTaskProcessorSuite) TestProcessTaskOnce_HistoryV2Replication
 }
 
 func (s *replicationTaskProcessorSuite) TestPutReplicationTaskToDLQ_SyncActivityReplicationTask() {
-	domainID := uuid.New()
+	domainID := uuid.NewRandom()
 	workflowID := uuid.New()
-	runID := uuid.New()
+	runID := uuid.NewRandom()
 	task := &commonproto.ReplicationTask{
 		TaskType: enums.ReplicationTaskTypeSyncActivity,
 		Attributes: &commonproto.ReplicationTask_SyncActivityTaskAttributes{SyncActivityTaskAttributes: &commonproto.SyncActivityTaskAttributes{
-			DomainId:   domainID,
+			DomainId:   domainID.String(),
 			WorkflowId: workflowID,
-			RunId:      runID,
+			RunId:      runID.String(),
 		}},
 	}
 	request := &persistence.PutReplicationTaskToDLQRequest{
 		SourceClusterName: "standby",
-		TaskInfo: &persistence.ReplicationTaskInfo{
+		TaskInfo: &persistenceblobs.ReplicationTaskInfo{
 			DomainID:   domainID,
 			WorkflowID: workflowID,
 			RunID:      runID,
@@ -402,25 +402,24 @@ func (s *replicationTaskProcessorSuite) TestPutReplicationTaskToDLQ_SyncActivity
 }
 
 func (s *replicationTaskProcessorSuite) TestPutReplicationTaskToDLQ_HistoryReplicationTask() {
-	domainID := uuid.New()
+	domainID := uuid.NewRandom()
 	workflowID := uuid.New()
-	runID := uuid.New()
+	runID := uuid.NewRandom()
 	task := &commonproto.ReplicationTask{
 		TaskType: enums.ReplicationTaskTypeHistory,
 		Attributes: &commonproto.ReplicationTask_HistoryTaskAttributes{HistoryTaskAttributes: &commonproto.HistoryTaskAttributes{
-			DomainId:   domainID,
+			DomainId:   domainID.String(),
 			WorkflowId: workflowID,
-			RunId:      runID,
+			RunId:      runID.String(),
 		}},
 	}
 	request := &persistence.PutReplicationTaskToDLQRequest{
 		SourceClusterName: "standby",
-		TaskInfo: &persistence.ReplicationTaskInfo{
-			DomainID:            domainID,
-			WorkflowID:          workflowID,
-			RunID:               runID,
-			TaskType:            persistence.ReplicationTaskTypeHistory,
-			LastReplicationInfo: make(map[string]*persistence.ReplicationInfo),
+		TaskInfo: &persistenceblobs.ReplicationTaskInfo{
+			DomainID:   domainID,
+			WorkflowID: workflowID,
+			RunID:      runID,
+			TaskType:   persistence.ReplicationTaskTypeHistory,
 		},
 	}
 	s.executionManager.On("PutReplicationTaskToDLQ", request).Return(nil)
@@ -429,9 +428,9 @@ func (s *replicationTaskProcessorSuite) TestPutReplicationTaskToDLQ_HistoryRepli
 }
 
 func (s *replicationTaskProcessorSuite) TestPutReplicationTaskToDLQ_HistoryV2ReplicationTask() {
-	domainID := uuid.New()
+	domainID := uuid.NewRandom()
 	workflowID := uuid.New()
-	runID := uuid.New()
+	runID := uuid.NewRandom()
 	events := []*shared.HistoryEvent{
 		{
 			EventId: common.Int64Ptr(1),
@@ -444,9 +443,9 @@ func (s *replicationTaskProcessorSuite) TestPutReplicationTaskToDLQ_HistoryV2Rep
 	task := &commonproto.ReplicationTask{
 		TaskType: enums.ReplicationTaskTypeHistoryV2,
 		Attributes: &commonproto.ReplicationTask_HistoryTaskV2Attributes{HistoryTaskV2Attributes: &commonproto.HistoryTaskV2Attributes{
-			DomainId:   domainID,
+			DomainId:   domainID.String(),
 			WorkflowId: workflowID,
-			RunId:      runID,
+			RunId:      runID.String(),
 			Events: &commonproto.DataBlob{
 				EncodingType: enums.EncodingTypeThriftRW,
 				Data:         data.Data,
@@ -455,7 +454,7 @@ func (s *replicationTaskProcessorSuite) TestPutReplicationTaskToDLQ_HistoryV2Rep
 	}
 	request := &persistence.PutReplicationTaskToDLQRequest{
 		SourceClusterName: "standby",
-		TaskInfo: &persistence.ReplicationTaskInfo{
+		TaskInfo: &persistenceblobs.ReplicationTaskInfo{
 			DomainID:     domainID,
 			WorkflowID:   workflowID,
 			RunID:        runID,

--- a/service/history/replicatorQueueProcessor_test.go
+++ b/service/history/replicatorQueueProcessor_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/temporalio/temporal/common/primitives"
+
 	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 
 	"github.com/golang/mock/gomock"
@@ -122,12 +124,12 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowMissing() {
 	runID := uuid.New()
 	scheduleID := int64(144)
 	taskID := int64(1444)
-	task := &persistence.ReplicationTaskInfo{
+	task := &persistenceblobs.ReplicationTaskInfo{
 		TaskType:    persistence.ReplicationTaskTypeSyncActivity,
 		TaskID:      taskID,
-		DomainID:    domainID,
+		DomainID:    primitives.MustParseUUID(domainID),
 		WorkflowID:  workflowID,
-		RunID:       runID,
+		RunID:       primitives.MustParseUUID(runID),
 		ScheduledID: scheduleID,
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
@@ -152,7 +154,8 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowMissing() {
 		nil,
 	), nil).AnyTimes()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	wrapper := &persistence.ReplicationTaskInfoWrapper{ReplicationTaskInfo: task}
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, wrapper, s.logger))
 	s.Nil(err)
 }
 
@@ -164,12 +167,12 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowCompleted() {
 	scheduleID := int64(144)
 	taskID := int64(1444)
 	version := int64(2333)
-	task := &persistence.ReplicationTaskInfo{
+	task := &persistenceblobs.ReplicationTaskInfo{
 		TaskType:    persistence.ReplicationTaskTypeSyncActivity,
 		TaskID:      taskID,
-		DomainID:    domainID,
+		DomainID:    primitives.MustParseUUID(domainID),
 		WorkflowID:  workflowID,
-		RunID:       runID,
+		RunID:       primitives.MustParseUUID(runID),
 		ScheduledID: scheduleID,
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
@@ -199,7 +202,8 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowCompleted() {
 		nil,
 	), nil).AnyTimes()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	wrapper := &persistence.ReplicationTaskInfoWrapper{ReplicationTaskInfo: task}
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, wrapper, s.logger))
 	s.Nil(err)
 }
 
@@ -211,12 +215,12 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityCompleted() {
 	scheduleID := int64(144)
 	taskID := int64(1444)
 	version := int64(2333)
-	task := &persistence.ReplicationTaskInfo{
+	task := &persistenceblobs.ReplicationTaskInfo{
 		TaskType:    persistence.ReplicationTaskTypeSyncActivity,
 		TaskID:      taskID,
-		DomainID:    domainID,
+		DomainID:    primitives.MustParseUUID(domainID),
 		WorkflowID:  workflowID,
-		RunID:       runID,
+		RunID:       primitives.MustParseUUID(runID),
 		ScheduledID: scheduleID,
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
@@ -248,7 +252,8 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityCompleted() {
 		nil,
 	), nil).AnyTimes()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	wrapper := &persistence.ReplicationTaskInfoWrapper{ReplicationTaskInfo: task}
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, wrapper, s.logger))
 	s.Nil(err)
 }
 
@@ -260,12 +265,12 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRetry() {
 	scheduleID := int64(144)
 	taskID := int64(1444)
 	version := int64(2333)
-	task := &persistence.ReplicationTaskInfo{
+	task := &persistenceblobs.ReplicationTaskInfo{
 		TaskType:    persistence.ReplicationTaskTypeSyncActivity,
 		TaskID:      taskID,
-		DomainID:    domainID,
+		DomainID:    primitives.MustParseUUID(domainID),
 		WorkflowID:  workflowID,
-		RunID:       runID,
+		RunID:       primitives.MustParseUUID(runID),
 		ScheduledID: scheduleID,
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
@@ -358,7 +363,8 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRetry() {
 		},
 	}).Return(nil).Once()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	wrapper := &persistence.ReplicationTaskInfoWrapper{ReplicationTaskInfo: task}
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, wrapper, s.logger))
 	s.Nil(err)
 }
 
@@ -370,12 +376,12 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRunning() {
 	scheduleID := int64(144)
 	taskID := int64(1444)
 	version := int64(2333)
-	task := &persistence.ReplicationTaskInfo{
+	task := &persistenceblobs.ReplicationTaskInfo{
 		TaskType:    persistence.ReplicationTaskTypeSyncActivity,
 		TaskID:      taskID,
-		DomainID:    domainID,
+		DomainID:    primitives.MustParseUUID(domainID),
 		WorkflowID:  workflowID,
-		RunID:       runID,
+		RunID:       primitives.MustParseUUID(runID),
 		ScheduledID: scheduleID,
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
@@ -467,7 +473,8 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRunning() {
 		},
 	}).Return(nil).Once()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	wrapper := &persistence.ReplicationTaskInfoWrapper{ReplicationTaskInfo: task}
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, wrapper, s.logger))
 	s.Nil(err)
 }
 

--- a/service/history/transferQueueProcessorBase.go
+++ b/service/history/transferQueueProcessorBase.go
@@ -144,7 +144,7 @@ func (t *transferQueueProcessorBase) pushActivity(
 	defer cancel()
 
 	if task.TaskType != persistence.TransferTaskTypeActivityTask {
-		t.logger.Fatal("Cannot process non activity task", tag.TaskType(task.GetTaskType()))
+		t.logger.Fatal("Cannot process non activity task", tag.TaskType(int(task.GetTaskType())))
 	}
 
 	_, err := t.matchingClient.AddActivityTask(ctx, &matchingservice.AddActivityTaskRequest{
@@ -172,7 +172,7 @@ func (t *transferQueueProcessorBase) pushDecision(
 	defer cancel()
 
 	if task.TaskType != persistence.TransferTaskTypeDecisionTask {
-		t.logger.Fatal("Cannot process non decision task", tag.TaskType(task.GetTaskType()))
+		t.logger.Fatal("Cannot process non decision task", tag.TaskType(int(task.GetTaskType())))
 	}
 
 	_, err := t.matchingClient.AddDecisionTask(ctx, &matchingservice.AddDecisionTaskRequest{

--- a/tools/cli/adminKafkaCommands.go
+++ b/tools/cli/adminKafkaCommands.go
@@ -28,6 +28,11 @@ import (
 	"errors"
 	"fmt"
 
+	commonproto "go.temporal.io/temporal-proto/common"
+
+	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
+	"github.com/temporalio/temporal/common/primitives"
+
 	"github.com/temporalio/temporal/common/auth"
 
 	"io"
@@ -501,18 +506,18 @@ func doRereplicate(shardID int, domainID, wid, rid string, minID, maxID int64, t
 		}
 
 		currVersion := resp.State.ReplicationState.CurrentVersion
-		repInfo := map[string]*persistence.ReplicationInfo{
+		repInfo := map[string]*commonproto.ReplicationInfo{
 			"": {
 				Version:     currVersion,
-				LastEventID: 0,
+				LastEventId: 0,
 			},
 		}
 
 		exeInfo := resp.State.ExecutionInfo
-		taskTemplate := &persistence.ReplicationTaskInfo{
-			DomainID:            domainID,
+		taskTemplate := &persistenceblobs.ReplicationTaskInfo{
+			DomainID:            primitives.MustParseUUID(domainID),
 			WorkflowID:          wid,
-			RunID:               rid,
+			RunID:               primitives.MustParseUUID(rid),
 			Version:             currVersion,
 			LastReplicationInfo: repInfo,
 			BranchToken:         exeInfo.BranchToken,


### PR DESCRIPTION
Roughly same changes as ShardInfo - https://github.com/temporalio/temporal/pull/136

- Convert sql thrift usage of sqlblobs.ReplicationTaskInfo to persistenceblobs.ReplicationTaskInfo proto
- Cassandra now uses data/encoding to persist the proto file
- Serialization still happens at store level and will need to be migrated to manager, so for now Cassandra imports the SQL serializer
- As ReplicationTask used to meet the queueTaskInfo interface, the interface was changed to meet the raw types of IDs (string uuid -> []byte uuid) and int types (int->int32).
  - The non-proto tasks needed (timer and transfer) to meet this new interface as well and runtime conversions were added, but they will eventually be converted to protos as well.