### PR TITLE
TransferTask Proto Persistence

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -975,7 +975,7 @@ func createTransferTasks(
 		var taskList string
 		var scheduleID int64
 		targetWorkflowID := p.TransferTaskTransferTargetWorkflowID
-		targetRunID := p.TransferTaskTransferTargetRunID
+		targetRunID := ""
 		targetChildWorkflowOnly := false
 		recordVisibility := false
 
@@ -995,9 +995,7 @@ func createTransferTasks(
 			targetDomainID = task.(*p.CancelExecutionTask).TargetDomainID
 			targetWorkflowID = task.(*p.CancelExecutionTask).TargetWorkflowID
 			targetRunID = task.(*p.CancelExecutionTask).TargetRunID
-			if targetRunID == "" {
-				targetRunID = p.TransferTaskTransferTargetRunID
-			}
+
 			targetChildWorkflowOnly = task.(*p.CancelExecutionTask).TargetChildWorkflowOnly
 			scheduleID = task.(*p.CancelExecutionTask).InitiatedID
 
@@ -1005,9 +1003,7 @@ func createTransferTasks(
 			targetDomainID = task.(*p.SignalExecutionTask).TargetDomainID
 			targetWorkflowID = task.(*p.SignalExecutionTask).TargetWorkflowID
 			targetRunID = task.(*p.SignalExecutionTask).TargetRunID
-			if targetRunID == "" {
-				targetRunID = p.TransferTaskTransferTargetRunID
-			}
+
 			targetChildWorkflowOnly = task.(*p.SignalExecutionTask).TargetChildWorkflowOnly
 			scheduleID = task.(*p.SignalExecutionTask).InitiatedID
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -184,9 +184,6 @@ const (
 	// TransferTaskTransferTargetWorkflowID is the the dummy workflow ID for transfer tasks of types
 	// that do not have a target workflow
 	TransferTaskTransferTargetWorkflowID = "20000000-0000-f000-f000-000000000001"
-	// TransferTaskTransferTargetRunID is the the dummy run ID for transfer tasks of types
-	// that do not have a target workflow
-	TransferTaskTransferTargetRunID = "30000000-0000-f000-f000-000000000002"
 
 	// indicate invalid workflow state transition
 	invalidStateTransitionMsg = "unable to change workflow state from %v to %v, close status %v"

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -926,7 +926,7 @@ type (
 
 	// GetTransferTasksResponse is the response to GetTransferTasksRequest
 	GetTransferTasksResponse struct {
-		Tasks         []*TransferTaskInfo
+		Tasks         []*pblobs.TransferTaskInfo
 		NextPageToken []byte
 	}
 

--- a/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
+++ b/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
@@ -437,7 +437,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 
@@ -717,7 +717,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetWithCurrWithReplicat
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 	taskD, err = s.GetTransferTasks(2, false)
@@ -1149,7 +1149,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrWithReplicate(
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 	taskD, err = s.GetTransferTasks(2, false)
@@ -1524,7 +1524,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrNoReplicate() 
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 	taskD, err = s.GetTransferTasks(2, false)
@@ -1619,7 +1619,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrNoReplicate() 
 	taskD, err = s.GetTransferTasks(3, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
 
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	s.Equal(int64(200), taskD[0].Version)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1031,8 +1031,8 @@ func (s *TestBase) DeleteCurrentWorkflowExecution(info *p.WorkflowExecutionInfo)
 }
 
 // GetTransferTasks is a utility method to get tasks from transfer task queue
-func (s *TestBase) GetTransferTasks(batchSize int, getAll bool) ([]*p.TransferTaskInfo, error) {
-	result := []*p.TransferTaskInfo{}
+func (s *TestBase) GetTransferTasks(batchSize int, getAll bool) ([]*pblobs.TransferTaskInfo, error) {
+	result := []*pblobs.TransferTaskInfo{}
 	var token []byte
 
 Loop:

--- a/common/persistence/sql/blob.go
+++ b/common/persistence/sql/blob.go
@@ -231,13 +231,13 @@ func taskListInfoFromBlob(b []byte, proto string) (*sqlblobs.TaskListInfo, error
 	return result, thriftRWDecode(b, proto, result)
 }
 
-func transferTaskInfoToBlob(info *sqlblobs.TransferTaskInfo) (p.DataBlob, error) {
-	return thriftRWEncode(info)
+func TransferTaskInfoToBlob(info *persistenceblobs.TransferTaskInfo) (p.DataBlob, error) {
+	return protoRWEncode(info)
 }
 
-func transferTaskInfoFromBlob(b []byte, proto string) (*sqlblobs.TransferTaskInfo, error) {
-	result := &sqlblobs.TransferTaskInfo{}
-	return result, thriftRWDecode(b, proto, result)
+func TransferTaskInfoFromBlob(b []byte, proto string) (*persistenceblobs.TransferTaskInfo, error) {
+	result := &persistenceblobs.TransferTaskInfo{}
+	return result, protoRWDecode(b, proto, result)
 }
 
 func TimerTaskInfoToBlob(info *persistenceblobs.TimerTaskInfo) (p.DataBlob, error) {

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -854,28 +854,15 @@ func (m *sqlExecutionManager) GetTransferTasks(
 			}
 		}
 	}
-	resp := &p.GetTransferTasksResponse{Tasks: make([]*p.TransferTaskInfo, len(rows))}
+	resp := &p.GetTransferTasksResponse{Tasks: make([]*persistenceblobs.TransferTaskInfo, len(rows))}
 	for i, row := range rows {
-		info, err := transferTaskInfoFromBlob(row.Data, row.DataEncoding)
+		info, err := TransferTaskInfoFromBlob(row.Data, row.DataEncoding)
 		if err != nil {
 			return nil, err
 		}
-		resp.Tasks[i] = &p.TransferTaskInfo{
-			TaskID:                  row.TaskID,
-			DomainID:                primitives.UUID(info.DomainID).String(),
-			WorkflowID:              info.GetWorkflowID(),
-			RunID:                   primitives.UUID(info.RunID).String(),
-			VisibilityTimestamp:     time.Unix(0, info.GetVisibilityTimestampNanos()),
-			TargetDomainID:          primitives.UUID(info.TargetDomainID).String(),
-			TargetWorkflowID:        info.GetTargetWorkflowID(),
-			TargetRunID:             primitives.UUID(info.TargetRunID).String(),
-			TargetChildWorkflowOnly: info.GetTargetChildWorkflowOnly(),
-			TaskList:                info.GetTaskList(),
-			TaskType:                int(info.GetTaskType()),
-			ScheduleID:              info.GetScheduleID(),
-			Version:                 info.GetVersion(),
-		}
+		resp.Tasks[i] = info
 	}
+
 	return resp, nil
 }
 

--- a/proto/persistenceblobs/persistenceblobs.proto
+++ b/proto/persistenceblobs/persistenceblobs.proto
@@ -77,3 +77,21 @@ message TimerTaskInfo {
     int64 taskID = 9;
     google.protobuf.Timestamp VisibilityTimestamp = 10;
 }
+
+
+message TransferTaskInfo {
+    bytes domainID = 1;
+    string workflowID = 2;
+    bytes runID = 3;
+    int32 taskType = 4;
+    bytes targetDomainID = 5;
+    string targetWorkflowID = 6;
+    bytes targetRunID = 7;
+    string taskList = 8;
+    bool targetChildWorkflowOnly = 9;
+    int64 scheduleID = 10;
+    int64 version = 11;
+    int64 taskID = 12;
+    google.protobuf.Timestamp visibilityTimestamp = 13;
+    bool recordVisibility = 14;
+}

--- a/proto/sqlblobs/sqlblobs.proto
+++ b/proto/sqlblobs/sqlblobs.proto
@@ -230,18 +230,3 @@ message TaskListInfo {
     int64 expiryTimeNanos = 3;
     int64 lastUpdatedNanos = 4;
 }
-
-message TransferTaskInfo {
-    bytes domainID = 1;
-    string workflowID = 2;
-    bytes runID = 3;
-    int32 taskType = 4;
-    bytes targetDomainID = 5;
-    string targetWorkflowID = 6;
-    bytes targetRunID = 7;
-    string taskList = 8;
-    bool targetChildWorkflowOnly = 9;
-    int64 scheduleID = 10;
-    int64 version = 11;
-    int64 visibilityTimestampNanos = 12;
-}

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -75,24 +75,6 @@ CREATE TYPE replication_state (
   last_replication_info            map<text, frozen<replication_info>>, -- information about replication events from other clusters
 );
 
--- TODO: Remove fields that are left over from activity and workflow tasks.
-CREATE TYPE transfer_task (
-  domain_id                  uuid,   -- The domain ID that this transfer task belongs to
-  workflow_id                text,   -- The workflow ID that this transfer task belongs to
-  run_id                     uuid,   -- The run ID that this transfer task belongs to
-  task_id                    bigint,
-  visibility_ts              timestamp, -- The timestamp when the transfer task is generated
-  target_domain_id           uuid,   -- The external domain ID that this transfer task is doing work for.
-  target_workflow_id         text,   -- The external workflow ID that this transfer task is doing work for.
-  target_run_id              uuid,   -- The external run ID that this transfer task is doing work for.
-  target_child_workflow_only boolean, -- The whether target child workflow only.
-  task_list                  text,
-  type                       int,    -- enum TaskType {ActivityTask, DecisionTask, DeleteExecution, CancelExecution, StartChildExecution, ReplicationTask}
-  schedule_id                bigint,
-  version                    bigint, -- the failover version when this task is created, used to compare against the mutable state, in case the events got overwritten
-  record_visibility          boolean, -- indicates whether or not to create a visibility record
-);
-
 -- Workflow activity in progress mutable state
 CREATE TYPE activity_info (
   version                   bigint,
@@ -268,7 +250,8 @@ CREATE TABLE executions (
   shard                          blob,
   shard_encoding                 text,
   execution                      frozen<workflow_execution>,
-  transfer                       frozen<transfer_task>,
+  transfer                       blob,
+  transfer_encoding              text,
   replication                    blob,
   replication_encoding           text,
   timer                          blob,

--- a/schema/cassandra/cadence/versioned/v1.0/schema.cql
+++ b/schema/cassandra/cadence/versioned/v1.0/schema.cql
@@ -75,24 +75,6 @@ CREATE TYPE replication_state (
   last_replication_info            map<text, frozen<replication_info>>, -- information about replication events from other clusters
 );
 
--- TODO: Remove fields that are left over from activity and workflow tasks.
-CREATE TYPE transfer_task (
-  domain_id                  uuid,   -- The domain ID that this transfer task belongs to
-  workflow_id                text,   -- The workflow ID that this transfer task belongs to
-  run_id                     uuid,   -- The run ID that this transfer task belongs to
-  task_id                    bigint,
-  visibility_ts              timestamp, -- The timestamp when the transfer task is generated
-  target_domain_id           uuid,   -- The external domain ID that this transfer task is doing work for.
-  target_workflow_id         text,   -- The external workflow ID that this transfer task is doing work for.
-  target_run_id              uuid,   -- The external run ID that this transfer task is doing work for.
-  target_child_workflow_only boolean, -- The whether target child workflow only.
-  task_list                  text,
-  type                       int,    -- enum TaskType {ActivityTask, DecisionTask, DeleteExecution, CancelExecution, StartChildExecution, ReplicationTask}
-  schedule_id                bigint,
-  version                    bigint, -- the failover version when this task is created, used to compare against the mutable state, in case the events got overwritten
-  record_visibility          boolean, -- indicates whether or not to create a visibility record
-);
-
 CREATE TYPE replication_task (
   domain_id                  uuid,   -- The domain ID that this replication task belongs to
   workflow_id                text,   -- The workflow ID that this replication task belongs to
@@ -280,7 +262,8 @@ CREATE TABLE executions (
   shard                          blob,
   shard_encoding                 text,
   execution                      frozen<workflow_execution>,
-  transfer                       frozen<transfer_task>,
+  transfer                       blob,
+  transfer_encoding              text,
   replication                    blob,
   replication_encoding           text,
   timer                          blob,


### PR DESCRIPTION
Creating Draft for BuldKite run. Don't worry about reviewing yet. 

- Converting TransferTask persistence usage into proto
- Serialization occurs at store level until ExecutionStore interface is created with datablobs
- Removal of Cassandra frozen transfer_task type
