### PR TITLE
TransferTask Proto Persistence

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -975,7 +975,7 @@ func createTransferTasks(
 		var taskList string
 		var scheduleID int64
 		targetWorkflowID := p.TransferTaskTransferTargetWorkflowID
-		targetRunID := p.TransferTaskTransferTargetRunID
+		targetRunID := ""
 		targetChildWorkflowOnly := false
 		recordVisibility := false
 
@@ -995,9 +995,7 @@ func createTransferTasks(
 			targetDomainID = task.(*p.CancelExecutionTask).TargetDomainID
 			targetWorkflowID = task.(*p.CancelExecutionTask).TargetWorkflowID
 			targetRunID = task.(*p.CancelExecutionTask).TargetRunID
-			if targetRunID == "" {
-				targetRunID = p.TransferTaskTransferTargetRunID
-			}
+
 			targetChildWorkflowOnly = task.(*p.CancelExecutionTask).TargetChildWorkflowOnly
 			scheduleID = task.(*p.CancelExecutionTask).InitiatedID
 
@@ -1005,9 +1003,7 @@ func createTransferTasks(
 			targetDomainID = task.(*p.SignalExecutionTask).TargetDomainID
 			targetWorkflowID = task.(*p.SignalExecutionTask).TargetWorkflowID
 			targetRunID = task.(*p.SignalExecutionTask).TargetRunID
-			if targetRunID == "" {
-				targetRunID = p.TransferTaskTransferTargetRunID
-			}
+
 			targetChildWorkflowOnly = task.(*p.SignalExecutionTask).TargetChildWorkflowOnly
 			scheduleID = task.(*p.SignalExecutionTask).InitiatedID
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -184,9 +184,6 @@ const (
 	// TransferTaskTransferTargetWorkflowID is the the dummy workflow ID for transfer tasks of types
 	// that do not have a target workflow
 	TransferTaskTransferTargetWorkflowID = "20000000-0000-f000-f000-000000000001"
-	// TransferTaskTransferTargetRunID is the the dummy run ID for transfer tasks of types
-	// that do not have a target workflow
-	TransferTaskTransferTargetRunID = "30000000-0000-f000-f000-000000000002"
 
 	// indicate invalid workflow state transition
 	invalidStateTransitionMsg = "unable to change workflow state from %v to %v, close status %v"

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -926,7 +926,7 @@ type (
 
 	// GetTransferTasksResponse is the response to GetTransferTasksRequest
 	GetTransferTasksResponse struct {
-		Tasks         []*TransferTaskInfo
+		Tasks         []*pblobs.TransferTaskInfo
 		NextPageToken []byte
 	}
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -338,24 +338,6 @@ type (
 		LastReplicationInfo map[string]*ReplicationInfo
 	}
 
-	// TransferTaskInfo describes a transfer task
-	TransferTaskInfo struct {
-		DomainID                string
-		WorkflowID              string
-		RunID                   string
-		VisibilityTimestamp     time.Time
-		TaskID                  int64
-		TargetDomainID          string
-		TargetWorkflowID        string
-		TargetRunID             string
-		TargetChildWorkflowOnly bool
-		TaskList                string
-		TaskType                int
-		ScheduleID              int64
-		Version                 int64
-		RecordVisibility        bool
-	}
-
 	// ReplicationTaskInfoWrapper describes a replication task.
 	ReplicationTaskInfoWrapper struct {
 		*pblobs.ReplicationTaskInfo
@@ -2277,51 +2259,6 @@ func (a *SyncActivityTask) GetVisibilityTimestamp() time.Time {
 // SetVisibilityTimestamp set the visibility timestamp
 func (a *SyncActivityTask) SetVisibilityTimestamp(timestamp time.Time) {
 	a.VisibilityTimestamp = timestamp
-}
-
-// GetTaskID returns the task ID for transfer task
-func (t *TransferTaskInfo) GetTaskID() int64 {
-	return t.TaskID
-}
-
-// GetVersion returns the task version for transfer task
-func (t *TransferTaskInfo) GetVersion() int64 {
-	return t.Version
-}
-
-// GetTaskType returns the task type for transfer task
-func (t *TransferTaskInfo) GetTaskType() int32 {
-	return int32(t.TaskType)
-}
-
-// GetVisibilityTimestamp returns the task type for transfer task
-func (t *TransferTaskInfo) GetVisibilityTimestamp() *types.Timestamp {
-	// Todo: This is temp unsafe time->type.timestamp validation until TransferTaskInfo is converted to proto
-	ret, _ := types.TimestampProto(t.VisibilityTimestamp)
-	return ret
-}
-
-// GetWorkflowID returns the workflow ID for transfer task
-func (t *TransferTaskInfo) GetWorkflowID() string {
-	return t.WorkflowID
-}
-
-// GetRunID returns the run ID for transfer task
-func (t *TransferTaskInfo) GetRunID() []byte {
-	return primitives.MustParseUUID(t.RunID)
-}
-
-// GetDomainID returns the domain ID for transfer task
-func (t *TransferTaskInfo) GetDomainID() []byte {
-	return primitives.MustParseUUID(t.DomainID)
-}
-
-// String returns string
-func (t *TransferTaskInfo) String() string {
-	return fmt.Sprintf(
-		"{DomainID: %v, WorkflowID: %v, RunID: %v, TaskID: %v, TargetDomainID: %v, TargetWorkflowID %v, TargetRunID: %v, TargetChildWorkflowOnly: %v, TaskList: %v, TaskType: %v, ScheduleID: %v, Version: %v.}",
-		t.DomainID, t.WorkflowID, t.RunID, t.TaskID, t.TargetDomainID, t.TargetWorkflowID, t.TargetRunID, t.TargetChildWorkflowOnly, t.TaskList, t.TaskType, t.ScheduleID, t.Version,
-	)
 }
 
 // GetTaskID returns the task ID for timer task

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1913,13 +1913,10 @@ func (s *ExecutionManagerSuite) TestTransferTasksThroughUpdate() {
 	s.NotNil(tasks1, "expected valid list of tasks.")
 	s.Equal(1, len(tasks1), "Expected 1 decision task.")
 	task1 := tasks1[0]
-	s.Equal(domainID, task1.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task1.RunID)
+	s.validateTransferTaskHighLevel(task1, p.TransferTaskTypeDecisionTask, domainID, workflowExecution)
 	s.Equal("queue1", task1.TaskList)
-	s.Equal(p.TransferTaskTypeDecisionTask, task1.TaskType)
 	s.Equal(int64(2), task1.ScheduleID)
-	s.Equal("", task1.TargetRunID)
+	s.EqualValues(primitives.MustParseUUID(""), task1.TargetRunID)
 
 	err3 := s.CompleteTransferTask(task1.TaskID)
 	s.NoError(err3)
@@ -1939,13 +1936,10 @@ func (s *ExecutionManagerSuite) TestTransferTasksThroughUpdate() {
 	s.NotNil(tasks2, "expected valid list of tasks.")
 	s.Equal(1, len(tasks2), "Expected 1 decision task.")
 	task2 := tasks2[0]
-	s.Equal(domainID, task2.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task2.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task2.RunID)
+	s.validateTransferTaskHighLevel(task2, p.TransferTaskTypeActivityTask, domainID, workflowExecution)
 	s.Equal("queue1", task2.TaskList)
-	s.Equal(p.TransferTaskTypeActivityTask, task2.TaskType)
 	s.Equal(int64(4), task2.ScheduleID)
-	s.Equal("", task2.TargetRunID)
+	s.EqualValues(primitives.MustParseUUID(""), task2.TargetRunID)
 
 	err4 := s.CompleteTransferTask(task2.TaskID)
 	s.NoError(err4)
@@ -1972,11 +1966,8 @@ func (s *ExecutionManagerSuite) TestTransferTasksThroughUpdate() {
 	s.NotNil(tasks3, "expected valid list of tasks.")
 	s.Equal(1, len(tasks3), "Expected 1 decision task.")
 	task3 := tasks3[0]
-	s.Equal(domainID, task3.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task3.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task3.RunID)
-	s.Equal(p.TransferTaskTypeCloseExecution, task3.TaskType)
-	s.Equal("", task3.TargetRunID)
+	s.validateTransferTaskHighLevel(task3, p.TransferTaskTypeCloseExecution, domainID, workflowExecution)
+	s.EqualValues(primitives.MustParseUUID(""), task3.TargetRunID)
 
 	err8 := s.CompleteTransferTask(task3.TaskID)
 	s.NoError(err8)
@@ -2005,6 +1996,9 @@ func (s *ExecutionManagerSuite) TestCancelTransferTaskTasks() {
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 
+	deleteCheck, err := s.GetTransferTasks(1, false)
+	s.Equal(0, len(deleteCheck), "Expected no decision task.")
+
 	state1, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
 	info1 := state1.ExecutionInfo
@@ -2032,13 +2026,8 @@ func (s *ExecutionManagerSuite) TestCancelTransferTaskTasks() {
 	s.NotNil(tasks1, "expected valid list of tasks.")
 	s.Equal(1, len(tasks1), "Expected 1 cancel task.")
 	task1 := tasks1[0]
-	s.Equal(p.TransferTaskTypeCancelExecution, task1.TaskType)
-	s.Equal(domainID, task1.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task1.RunID)
-	s.Equal(targetDomainID, task1.TargetDomainID)
-	s.Equal(targetWorkflowID, task1.TargetWorkflowID)
-	s.Equal(targetRunID, task1.TargetRunID)
+	s.validateTransferTaskHighLevel(task1, p.TransferTaskTypeCancelExecution, domainID, workflowExecution)
+	s.validateTransferTaskTargetInfo(task1, targetDomainID, targetWorkflowID, targetRunID)
 	s.Equal(targetChildWorkflowOnly, task1.TargetChildWorkflowOnly)
 
 	err = s.CompleteTransferTask(task1.TaskID)
@@ -2072,17 +2061,25 @@ func (s *ExecutionManagerSuite) TestCancelTransferTaskTasks() {
 	s.NotNil(tasks2, "expected valid list of tasks.")
 	s.Equal(1, len(tasks2), "Expected 1 cancel task.")
 	task2 := tasks2[0]
-	s.Equal(p.TransferTaskTypeCancelExecution, task2.TaskType)
-	s.Equal(domainID, task2.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task2.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task2.RunID)
-	s.Equal(targetDomainID, task2.TargetDomainID)
-	s.Equal(targetWorkflowID, task2.TargetWorkflowID)
-	s.Equal(targetRunID, task2.TargetRunID)
+	s.validateTransferTaskHighLevel(task2, p.TransferTaskTypeCancelExecution, domainID, workflowExecution)
+	s.validateTransferTaskTargetInfo(task2, targetDomainID, targetWorkflowID, targetRunID)
 	s.Equal(targetChildWorkflowOnly, task2.TargetChildWorkflowOnly)
 
 	err = s.CompleteTransferTask(task2.TaskID)
 	s.NoError(err)
+}
+
+func (s *ExecutionManagerSuite) validateTransferTaskHighLevel(task1 *pblobs.TransferTaskInfo, taskType int32, domainID string, workflowExecution gen.WorkflowExecution) {
+	s.EqualValues(taskType, task1.TaskType)
+	s.Equal(domainID, primitives.UUID(task1.DomainID).String())
+	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
+	s.Equal(workflowExecution.GetRunId(), primitives.UUID(task1.RunID).String())
+}
+
+func (s *ExecutionManagerSuite) validateTransferTaskTargetInfo(task2 *pblobs.TransferTaskInfo, targetDomainID string, targetWorkflowID string, targetRunID string) {
+	s.Equal(targetDomainID, primitives.UUID(task2.TargetDomainID).String())
+	s.Equal(targetWorkflowID, task2.TargetWorkflowID)
+	s.Equal(targetRunID, primitives.UUID(task2.TargetRunID).String())
 }
 
 // TestSignalTransferTaskTasks test
@@ -2129,13 +2126,8 @@ func (s *ExecutionManagerSuite) TestSignalTransferTaskTasks() {
 	s.NotNil(tasks1, "expected valid list of tasks.")
 	s.Equal(1, len(tasks1), "Expected 1 cancel task.")
 	task1 := tasks1[0]
-	s.Equal(p.TransferTaskTypeSignalExecution, task1.TaskType)
-	s.Equal(domainID, task1.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task1.RunID)
-	s.Equal(targetDomainID, task1.TargetDomainID)
-	s.Equal(targetWorkflowID, task1.TargetWorkflowID)
-	s.Equal(targetRunID, task1.TargetRunID)
+	s.validateTransferTaskHighLevel(task1, p.TransferTaskTypeSignalExecution, domainID, workflowExecution)
+	s.validateTransferTaskTargetInfo(task1, targetDomainID, targetWorkflowID, targetRunID)
 	s.Equal(targetChildWorkflowOnly, task1.TargetChildWorkflowOnly)
 
 	err = s.CompleteTransferTask(task1.TaskID)
@@ -2169,13 +2161,8 @@ func (s *ExecutionManagerSuite) TestSignalTransferTaskTasks() {
 	s.NotNil(tasks2, "expected valid list of tasks.")
 	s.Equal(1, len(tasks2), "Expected 1 cancel task.")
 	task2 := tasks2[0]
-	s.Equal(p.TransferTaskTypeSignalExecution, task2.TaskType)
-	s.Equal(domainID, task2.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task2.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task2.RunID)
-	s.Equal(targetDomainID, task2.TargetDomainID)
-	s.Equal(targetWorkflowID, task2.TargetWorkflowID)
-	s.Equal(targetRunID, task2.TargetRunID)
+	s.validateTransferTaskHighLevel(task2, p.TransferTaskTypeSignalExecution, domainID, workflowExecution)
+	s.validateTransferTaskTargetInfo(task2, targetDomainID, targetWorkflowID, targetRunID)
 	s.Equal(targetChildWorkflowOnly, task2.TargetChildWorkflowOnly)
 
 	err = s.CompleteTransferTask(task2.TaskID)
@@ -2289,14 +2276,14 @@ func (s *ExecutionManagerSuite) TestTransferTasksComplete() {
 	s.NotNil(tasks1, "expected valid list of tasks.")
 	s.Equal(1, len(tasks1), "Expected 1 decision task.")
 	task1 := tasks1[0]
-	s.Equal(domainID, task1.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task1.RunID)
+	taskType := p.TransferTaskTypeDecisionTask
+	scheduleId := int64(2)
+	targetWorkflowId := p.TransferTaskTransferTargetWorkflowID
+	targetRunId := ""
+	s.validateTransferTaskHighLevel(task1, int32(taskType), domainID, workflowExecution)
+	s.validateTransferTaskTargetInfo(task1, primitives.UUID(task1.TargetDomainID).String(), targetWorkflowId, targetRunId)
 	s.Equal(tasklist, task1.TaskList)
-	s.Equal(p.TransferTaskTypeDecisionTask, task1.TaskType)
-	s.Equal(int64(2), task1.ScheduleID)
-	s.Equal(p.TransferTaskTransferTargetWorkflowID, task1.TargetWorkflowID)
-	s.Equal("", task1.TargetRunID)
+	s.Equal(scheduleId, task1.ScheduleID)
 	err3 := s.CompleteTransferTask(task1.TaskID)
 	s.NoError(err3)
 
@@ -2331,14 +2318,16 @@ func (s *ExecutionManagerSuite) TestTransferTasksComplete() {
 	s.NotNil(txTasks, "expected valid list of tasks.")
 	s.Equal(len(tasks), len(txTasks))
 	for index := range tasks {
-		s.True(timeComparatorGo(tasks[index].GetVisibilityTimestamp(), txTasks[index].VisibilityTimestamp, TimePrecision))
+		t, err := types.TimestampFromProto(txTasks[index].VisibilityTimestamp)
+		s.NoError(err)
+		s.True(timeComparatorGo(tasks[index].GetVisibilityTimestamp(), t, TimePrecision))
 	}
-	s.Equal(p.TransferTaskTypeActivityTask, txTasks[0].TaskType)
-	s.Equal(p.TransferTaskTypeDecisionTask, txTasks[1].TaskType)
-	s.Equal(p.TransferTaskTypeCloseExecution, txTasks[2].TaskType)
-	s.Equal(p.TransferTaskTypeCancelExecution, txTasks[3].TaskType)
-	s.Equal(p.TransferTaskTypeSignalExecution, txTasks[4].TaskType)
-	s.Equal(p.TransferTaskTypeStartChildExecution, txTasks[5].TaskType)
+	s.EqualValues(p.TransferTaskTypeActivityTask, txTasks[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, txTasks[1].TaskType)
+	s.EqualValues(p.TransferTaskTypeCloseExecution, txTasks[2].TaskType)
+	s.EqualValues(p.TransferTaskTypeCancelExecution, txTasks[3].TaskType)
+	s.EqualValues(p.TransferTaskTypeSignalExecution, txTasks[4].TaskType)
+	s.EqualValues(p.TransferTaskTypeStartChildExecution, txTasks[5].TaskType)
 	s.Equal(int64(111), txTasks[0].Version)
 	s.Equal(int64(222), txTasks[1].Version)
 	s.Equal(int64(333), txTasks[2].Version)
@@ -2371,7 +2360,7 @@ func (s *ExecutionManagerSuite) TestTransferTasksComplete() {
 
 // TestTransferTasksRangeComplete test
 func (s *ExecutionManagerSuite) TestTransferTasksRangeComplete() {
-	domainID := "8bfb47be-5b57-4d55-9109-5fb35e20b1d7"
+	domainID := "8bfb47be-5b57-4d55-9109-5fb35e20b1d8"
 	workflowExecution := gen.WorkflowExecution{
 		WorkflowId: common.StringPtr("get-transfer-tasks-test-range-complete"),
 		RunId:      common.StringPtr("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
@@ -2387,14 +2376,11 @@ func (s *ExecutionManagerSuite) TestTransferTasksRangeComplete() {
 	s.NotNil(tasks1, "expected valid list of tasks.")
 	s.Equal(1, len(tasks1), "Expected 1 decision task.")
 	task1 := tasks1[0]
-	s.Equal(domainID, task1.DomainID)
-	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
-	s.Equal(workflowExecution.GetRunId(), task1.RunID)
+	s.validateTransferTaskHighLevel(task1, p.TransferTaskTypeDecisionTask, domainID, workflowExecution)
+	s.validateTransferTaskTargetInfo(task1, primitives.UUID(task1.DomainID).String(), p.TransferTaskTransferTargetWorkflowID, "")
 	s.Equal(tasklist, task1.TaskList)
-	s.Equal(p.TransferTaskTypeDecisionTask, task1.TaskType)
 	s.Equal(int64(2), task1.ScheduleID)
-	s.Equal(p.TransferTaskTransferTargetWorkflowID, task1.TargetWorkflowID)
-	s.Equal("", task1.TargetRunID)
+
 	err3 := s.CompleteTransferTask(task1.TaskID)
 	s.NoError(err3)
 
@@ -2429,14 +2415,16 @@ func (s *ExecutionManagerSuite) TestTransferTasksRangeComplete() {
 	s.NotNil(txTasks, "expected valid list of tasks.")
 	s.Equal(len(tasks), len(txTasks))
 	for index := range tasks {
-		s.True(timeComparatorGo(tasks[index].GetVisibilityTimestamp(), txTasks[index].VisibilityTimestamp, TimePrecision))
+		t, err := types.TimestampFromProto(txTasks[index].VisibilityTimestamp)
+		s.NoError(err)
+		s.True(timeComparatorGo(tasks[index].GetVisibilityTimestamp(), t, TimePrecision))
 	}
-	s.Equal(p.TransferTaskTypeActivityTask, txTasks[0].TaskType)
-	s.Equal(p.TransferTaskTypeDecisionTask, txTasks[1].TaskType)
-	s.Equal(p.TransferTaskTypeCloseExecution, txTasks[2].TaskType)
-	s.Equal(p.TransferTaskTypeCancelExecution, txTasks[3].TaskType)
-	s.Equal(p.TransferTaskTypeSignalExecution, txTasks[4].TaskType)
-	s.Equal(p.TransferTaskTypeStartChildExecution, txTasks[5].TaskType)
+	s.EqualValues(p.TransferTaskTypeActivityTask, txTasks[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, txTasks[1].TaskType)
+	s.EqualValues(p.TransferTaskTypeCloseExecution, txTasks[2].TaskType)
+	s.EqualValues(p.TransferTaskTypeCancelExecution, txTasks[3].TaskType)
+	s.EqualValues(p.TransferTaskTypeSignalExecution, txTasks[4].TaskType)
+	s.EqualValues(p.TransferTaskTypeStartChildExecution, txTasks[5].TaskType)
 	s.Equal(int64(111), txTasks[0].Version)
 	s.Equal(int64(222), txTasks[1].Version)
 	s.Equal(int64(333), txTasks[2].Version)
@@ -3292,7 +3280,7 @@ func (s *ExecutionManagerSuite) TestWorkflowReplicationState() {
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 

--- a/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
+++ b/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
@@ -437,7 +437,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 
@@ -717,7 +717,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetWithCurrWithReplicat
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 	taskD, err = s.GetTransferTasks(2, false)
@@ -1149,7 +1149,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrWithReplicate(
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 	taskD, err = s.GetTransferTasks(2, false)
@@ -1524,7 +1524,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrNoReplicate() 
 
 	taskD, err := s.GetTransferTasks(2, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)
 	taskD, err = s.GetTransferTasks(2, false)
@@ -1619,7 +1619,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowResetNoCurrNoReplicate() 
 	taskD, err = s.GetTransferTasks(3, false)
 	s.Equal(1, len(taskD), "Expected 1 decision task.")
 
-	s.Equal(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
+	s.EqualValues(p.TransferTaskTypeDecisionTask, taskD[0].TaskType)
 	s.Equal(int64(200), taskD[0].Version)
 	err = s.CompleteTransferTask(taskD[0].TaskID)
 	s.NoError(err)

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1031,8 +1031,8 @@ func (s *TestBase) DeleteCurrentWorkflowExecution(info *p.WorkflowExecutionInfo)
 }
 
 // GetTransferTasks is a utility method to get tasks from transfer task queue
-func (s *TestBase) GetTransferTasks(batchSize int, getAll bool) ([]*p.TransferTaskInfo, error) {
-	result := []*p.TransferTaskInfo{}
+func (s *TestBase) GetTransferTasks(batchSize int, getAll bool) ([]*pblobs.TransferTaskInfo, error) {
+	result := []*pblobs.TransferTaskInfo{}
 	var token []byte
 
 Loop:

--- a/common/persistence/sql/blob.go
+++ b/common/persistence/sql/blob.go
@@ -231,13 +231,13 @@ func taskListInfoFromBlob(b []byte, proto string) (*sqlblobs.TaskListInfo, error
 	return result, thriftRWDecode(b, proto, result)
 }
 
-func transferTaskInfoToBlob(info *sqlblobs.TransferTaskInfo) (p.DataBlob, error) {
-	return thriftRWEncode(info)
+func TransferTaskInfoToBlob(info *persistenceblobs.TransferTaskInfo) (p.DataBlob, error) {
+	return protoRWEncode(info)
 }
 
-func transferTaskInfoFromBlob(b []byte, proto string) (*sqlblobs.TransferTaskInfo, error) {
-	result := &sqlblobs.TransferTaskInfo{}
-	return result, thriftRWDecode(b, proto, result)
+func TransferTaskInfoFromBlob(b []byte, proto string) (*persistenceblobs.TransferTaskInfo, error) {
+	result := &persistenceblobs.TransferTaskInfo{}
+	return result, protoRWDecode(b, proto, result)
 }
 
 func TimerTaskInfoToBlob(info *persistenceblobs.TimerTaskInfo) (p.DataBlob, error) {

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -854,28 +854,15 @@ func (m *sqlExecutionManager) GetTransferTasks(
 			}
 		}
 	}
-	resp := &p.GetTransferTasksResponse{Tasks: make([]*p.TransferTaskInfo, len(rows))}
+	resp := &p.GetTransferTasksResponse{Tasks: make([]*persistenceblobs.TransferTaskInfo, len(rows))}
 	for i, row := range rows {
-		info, err := transferTaskInfoFromBlob(row.Data, row.DataEncoding)
+		info, err := TransferTaskInfoFromBlob(row.Data, row.DataEncoding)
 		if err != nil {
 			return nil, err
 		}
-		resp.Tasks[i] = &p.TransferTaskInfo{
-			TaskID:                  row.TaskID,
-			DomainID:                primitives.UUID(info.DomainID).String(),
-			WorkflowID:              info.GetWorkflowID(),
-			RunID:                   primitives.UUID(info.RunID).String(),
-			VisibilityTimestamp:     time.Unix(0, info.GetVisibilityTimestampNanos()),
-			TargetDomainID:          primitives.UUID(info.TargetDomainID).String(),
-			TargetWorkflowID:        info.GetTargetWorkflowID(),
-			TargetRunID:             primitives.UUID(info.TargetRunID).String(),
-			TargetChildWorkflowOnly: info.GetTargetChildWorkflowOnly(),
-			TaskList:                info.GetTaskList(),
-			TaskType:                int(info.GetTaskType()),
-			ScheduleID:              info.GetScheduleID(),
-			Version:                 info.GetVersion(),
-		}
+		resp.Tasks[i] = info
 	}
+
 	return resp, nil
 }
 

--- a/proto/persistenceblobs/persistenceblobs.proto
+++ b/proto/persistenceblobs/persistenceblobs.proto
@@ -77,3 +77,21 @@ message TimerTaskInfo {
     int64 taskID = 9;
     google.protobuf.Timestamp VisibilityTimestamp = 10;
 }
+
+
+message TransferTaskInfo {
+    bytes domainID = 1;
+    string workflowID = 2;
+    bytes runID = 3;
+    int32 taskType = 4;
+    bytes targetDomainID = 5;
+    string targetWorkflowID = 6;
+    bytes targetRunID = 7;
+    string taskList = 8;
+    bool targetChildWorkflowOnly = 9;
+    int64 scheduleID = 10;
+    int64 version = 11;
+    int64 taskID = 12;
+    google.protobuf.Timestamp visibilityTimestamp = 13;
+    bool recordVisibility = 14;
+}

--- a/proto/sqlblobs/sqlblobs.proto
+++ b/proto/sqlblobs/sqlblobs.proto
@@ -230,18 +230,3 @@ message TaskListInfo {
     int64 expiryTimeNanos = 3;
     int64 lastUpdatedNanos = 4;
 }
-
-message TransferTaskInfo {
-    bytes domainID = 1;
-    string workflowID = 2;
-    bytes runID = 3;
-    int32 taskType = 4;
-    bytes targetDomainID = 5;
-    string targetWorkflowID = 6;
-    bytes targetRunID = 7;
-    string taskList = 8;
-    bool targetChildWorkflowOnly = 9;
-    int64 scheduleID = 10;
-    int64 version = 11;
-    int64 visibilityTimestampNanos = 12;
-}

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -75,24 +75,6 @@ CREATE TYPE replication_state (
   last_replication_info            map<text, frozen<replication_info>>, -- information about replication events from other clusters
 );
 
--- TODO: Remove fields that are left over from activity and workflow tasks.
-CREATE TYPE transfer_task (
-  domain_id                  uuid,   -- The domain ID that this transfer task belongs to
-  workflow_id                text,   -- The workflow ID that this transfer task belongs to
-  run_id                     uuid,   -- The run ID that this transfer task belongs to
-  task_id                    bigint,
-  visibility_ts              timestamp, -- The timestamp when the transfer task is generated
-  target_domain_id           uuid,   -- The external domain ID that this transfer task is doing work for.
-  target_workflow_id         text,   -- The external workflow ID that this transfer task is doing work for.
-  target_run_id              uuid,   -- The external run ID that this transfer task is doing work for.
-  target_child_workflow_only boolean, -- The whether target child workflow only.
-  task_list                  text,
-  type                       int,    -- enum TaskType {ActivityTask, DecisionTask, DeleteExecution, CancelExecution, StartChildExecution, ReplicationTask}
-  schedule_id                bigint,
-  version                    bigint, -- the failover version when this task is created, used to compare against the mutable state, in case the events got overwritten
-  record_visibility          boolean, -- indicates whether or not to create a visibility record
-);
-
 -- Workflow activity in progress mutable state
 CREATE TYPE activity_info (
   version                   bigint,
@@ -268,7 +250,8 @@ CREATE TABLE executions (
   shard                          blob,
   shard_encoding                 text,
   execution                      frozen<workflow_execution>,
-  transfer                       frozen<transfer_task>,
+  transfer                       blob,
+  transfer_encoding              text,
   replication                    blob,
   replication_encoding           text,
   timer                          blob,

--- a/schema/cassandra/cadence/versioned/v1.0/schema.cql
+++ b/schema/cassandra/cadence/versioned/v1.0/schema.cql
@@ -75,24 +75,6 @@ CREATE TYPE replication_state (
   last_replication_info            map<text, frozen<replication_info>>, -- information about replication events from other clusters
 );
 
--- TODO: Remove fields that are left over from activity and workflow tasks.
-CREATE TYPE transfer_task (
-  domain_id                  uuid,   -- The domain ID that this transfer task belongs to
-  workflow_id                text,   -- The workflow ID that this transfer task belongs to
-  run_id                     uuid,   -- The run ID that this transfer task belongs to
-  task_id                    bigint,
-  visibility_ts              timestamp, -- The timestamp when the transfer task is generated
-  target_domain_id           uuid,   -- The external domain ID that this transfer task is doing work for.
-  target_workflow_id         text,   -- The external workflow ID that this transfer task is doing work for.
-  target_run_id              uuid,   -- The external run ID that this transfer task is doing work for.
-  target_child_workflow_only boolean, -- The whether target child workflow only.
-  task_list                  text,
-  type                       int,    -- enum TaskType {ActivityTask, DecisionTask, DeleteExecution, CancelExecution, StartChildExecution, ReplicationTask}
-  schedule_id                bigint,
-  version                    bigint, -- the failover version when this task is created, used to compare against the mutable state, in case the events got overwritten
-  record_visibility          boolean, -- indicates whether or not to create a visibility record
-);
-
 CREATE TYPE replication_task (
   domain_id                  uuid,   -- The domain ID that this replication task belongs to
   workflow_id                text,   -- The workflow ID that this replication task belongs to
@@ -280,7 +262,8 @@ CREATE TABLE executions (
   shard                          blob,
   shard_encoding                 text,
   execution                      frozen<workflow_execution>,
-  transfer                       frozen<transfer_task>,
+  transfer                       blob,
+  transfer_encoding              text,
   replication                    blob,
   replication_encoding           text,
   timer                          blob,

--- a/service/history/nDCStandbyTaskUtil.go
+++ b/service/history/nDCStandbyTaskUtil.go
@@ -31,7 +31,6 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/persistence"
 )
 
 type (
@@ -65,15 +64,15 @@ func standbyTransferTaskPostActionTaskDiscarded(
 		return nil
 	}
 
-	transferTask := task.task.(*persistence.TransferTaskInfo)
+	transferTask := task.task.(*persistenceblobs.TransferTaskInfo)
 	logger.Error("Discarding standby transfer task due to task being pending for too long.",
 		tag.WorkflowID(transferTask.WorkflowID),
-		tag.WorkflowRunID(transferTask.RunID),
-		tag.WorkflowDomainID(transferTask.DomainID),
+		tag.WorkflowRunIDBytes(transferTask.RunID),
+		tag.WorkflowDomainIDBytes(transferTask.DomainID),
 		tag.TaskID(transferTask.TaskID),
-		tag.TaskType(transferTask.TaskType),
+		tag.TaskType32(transferTask.TaskType),
 		tag.FailoverVersion(transferTask.GetVersion()),
-		tag.Timestamp(transferTask.VisibilityTimestamp),
+		tag.TimestampProto(transferTask.VisibilityTimestamp),
 		tag.WorkflowEventID(transferTask.ScheduleID))
 	return ErrTaskDiscarded
 }

--- a/service/history/nDCTaskUtil.go
+++ b/service/history/nDCTaskUtil.go
@@ -67,7 +67,7 @@ func verifyTaskVersion(
 // if still mutable state's next event ID <= task ID, will return nil, nil
 func loadMutableStateForTransferTask(
 	context workflowExecutionContext,
-	transferTask *persistence.TransferTaskInfo,
+	transferTask *persistenceblobs.TransferTaskInfo,
 	metricsClient metrics.Client,
 	logger log.Logger,
 ) (mutableState, error) {
@@ -174,7 +174,7 @@ func initializeLoggerForTask(
 		taskLogger = taskLogger.WithTags(
 			tag.WorkflowTimeoutType(int64(task.TimeoutType)),
 		)
-	case *persistence.TransferTaskInfo:
+	case *persistenceblobs.TransferTaskInfo:
 		// noop
 	case *persistence.ReplicationTaskInfoWrapper:
 		// noop

--- a/service/history/queueAckMgr_test.go
+++ b/service/history/queueAckMgr_test.go
@@ -130,10 +130,10 @@ func (s *queueAckMgrSuite) TestReadTimerTasks() {
 	moreInput := false
 	taskID1 := int64(59)
 	tasksInput := []queueTaskInfo{
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID1,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
@@ -152,10 +152,10 @@ func (s *queueAckMgrSuite) TestReadTimerTasks() {
 	moreInput = true
 	taskID2 := int64(60)
 	tasksInput = []queueTaskInfo{
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID2,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
@@ -180,10 +180,10 @@ func (s *queueAckMgrSuite) TestReadCompleteTimerTasks() {
 	moreInput := false
 	taskID := int64(59)
 	tasksInput := []queueTaskInfo{
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
@@ -213,28 +213,28 @@ func (s *queueAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 	taskID2 := int64(60)
 	taskID3 := int64(61)
 	tasksInput := []queueTaskInfo{
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID1,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
 			ScheduleID: 28,
 		},
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID2,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
 			ScheduleID: 28,
 		},
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID3,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
@@ -319,10 +319,10 @@ func (s *queueFailoverAckMgrSuite) TestReadQueueTasks() {
 	moreInput := true
 	taskID1 := int64(59)
 	tasksInput := []queueTaskInfo{
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID1,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
@@ -342,10 +342,10 @@ func (s *queueFailoverAckMgrSuite) TestReadQueueTasks() {
 	moreInput = false
 	taskID2 := int64(60)
 	tasksInput = []queueTaskInfo{
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID2,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
@@ -372,19 +372,19 @@ func (s *queueFailoverAckMgrSuite) TestReadCompleteQueueTasks() {
 	taskID1 := int64(59)
 	taskID2 := int64(60)
 	tasksInput := []queueTaskInfo{
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID1,
 			TaskList:   "some random tasklist",
 			TaskType:   1,
 			ScheduleID: 28,
 		},
-		&p.TransferTaskInfo{
-			DomainID:   "some random domain ID",
+		&persistenceblobs.TransferTaskInfo{
+			DomainID:   TestDomainId,
 			WorkflowID: "some random workflow ID",
-			RunID:      uuid.New(),
+			RunID:      uuid.NewRandom(),
 			TaskID:     taskID2,
 			TaskList:   "some random tasklist",
 			TaskType:   2,

--- a/service/history/transferQueueActiveProcessor_test.go
+++ b/service/history/transferQueueActiveProcessor_test.go
@@ -21,6 +21,7 @@
 package history
 
 import (
+	"github.com/temporalio/temporal/common/primitives"
 	"testing"
 	"time"
 
@@ -256,12 +257,12 @@ func (s *transferQueueActiveProcessorSuite) TestProcessActivityTask_Success() {
 	activityType := "some random activity type"
 	event, ai := addActivityTaskScheduledEvent(mutableState, event.GetEventId(), activityID, activityType, taskListName, []byte{}, 1, 1, 1)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:        s.version,
-		DomainID:       s.domainID,
-		TargetDomainID: testTargetDomainID,
+		DomainID:       s.GetDomainIDBytes(),
+		TargetDomainID: primitives.MustParseUUID(testTargetDomainID),
 		WorkflowID:     execution.GetWorkflowId(),
-		RunID:          execution.GetRunId(),
+		RunID:          primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:         taskID,
 		TaskList:       taskListName,
 		TaskType:       persistence.TransferTaskTypeActivityTask,
@@ -274,6 +275,10 @@ func (s *transferQueueActiveProcessorSuite) TestProcessActivityTask_Success() {
 
 	_, err = s.transferQueueActiveProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
+}
+
+func (s *transferQueueActiveProcessorSuite) GetDomainIDBytes() primitives.UUID {
+	return primitives.MustParseUUID(s.domainID)
 }
 
 func (s *transferQueueActiveProcessorSuite) TestProcessActivityTask_Duplication() {
@@ -310,12 +315,12 @@ func (s *transferQueueActiveProcessorSuite) TestProcessActivityTask_Duplication(
 	activityType := "some random activity type"
 	event, ai := addActivityTaskScheduledEvent(mutableState, event.GetEventId(), activityID, activityType, taskListName, []byte{}, 1, 1, 1)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:        s.version,
-		DomainID:       s.domainID,
-		TargetDomainID: s.targetDomainID,
+		DomainID:       s.GetDomainIDBytes(),
+		TargetDomainID: primitives.MustParseUUID(s.targetDomainID),
 		WorkflowID:     execution.GetWorkflowId(),
-		RunID:          execution.GetRunId(),
+		RunID:          primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:         taskID,
 		TaskList:       taskListName,
 		TaskType:       persistence.TransferTaskTypeActivityTask,
@@ -360,11 +365,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_FirstDecisio
 	taskID := int64(59)
 	di := addDecisionTaskScheduledEvent(mutableState)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeDecisionTask,
@@ -413,11 +418,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_NonFirstDeci
 	taskID := int64(59)
 	di = addDecisionTaskScheduledEvent(mutableState)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeDecisionTask,
@@ -472,11 +477,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_Sticky_NonFi
 	taskID := int64(59)
 	di = addDecisionTaskScheduledEvent(mutableState)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   stickyTaskListName,
 		TaskType:   persistence.TransferTaskTypeDecisionTask,
@@ -531,11 +536,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_DecisionNotS
 	taskID := int64(59)
 	di = addDecisionTaskScheduledEvent(mutableState)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeDecisionTask,
@@ -580,11 +585,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_Duplication(
 	di.StartedID = event.GetEventId()
 	event = addDecisionTaskCompletedEvent(mutableState, di.ScheduleID, di.StartedID, nil, "some random identity")
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeDecisionTask,
@@ -643,11 +648,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_HasParent(
 	taskID := int64(59)
 	event = addCompleteWorkflowEvent(mutableState, event.GetEventId(), nil)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeCloseExecution,
@@ -702,11 +707,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_NoParent()
 	taskID := int64(59)
 	event = addCompleteWorkflowEvent(mutableState, event.GetEventId(), nil)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeCloseExecution,
@@ -835,11 +840,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_NoParent_H
 	taskID := int64(59)
 	event = addCompleteWorkflowEvent(mutableState, event.GetEventId(), nil)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeCloseExecution,
@@ -927,11 +932,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_NoParent_H
 	taskID := int64(59)
 	event = addCompleteWorkflowEvent(mutableState, event.GetEventId(), nil)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeCloseExecution,
@@ -1018,11 +1023,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_NoParent_H
 	taskID := int64(59)
 	event = addCompleteWorkflowEvent(mutableState, event.GetEventId(), nil)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeCloseExecution,
@@ -1075,14 +1080,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Success()
 	taskID := int64(59)
 	event, rci := addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   s.targetDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(s.targetDomainID),
 		TargetWorkflowID: targetExecution.GetWorkflowId(),
-		TargetRunID:      targetExecution.GetRunId(),
+		TargetRunID:      primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeCancelExecution,
@@ -1137,14 +1142,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Failure()
 	taskID := int64(59)
 	event, rci := addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   s.targetDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(s.targetDomainID),
 		TargetWorkflowID: targetExecution.GetWorkflowId(),
-		TargetRunID:      targetExecution.GetRunId(),
+		TargetRunID:      primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeCancelExecution,
@@ -1199,14 +1204,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Duplicati
 	taskID := int64(59)
 	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   s.targetDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(s.targetDomainID),
 		TargetWorkflowID: targetExecution.GetWorkflowId(),
-		TargetRunID:      targetExecution.GetRunId(),
+		TargetRunID:      primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeCancelExecution,
@@ -1263,14 +1268,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Success()
 	event, si := addRequestSignalInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
 		testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), signalName, signalInput, signalControl)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   s.targetDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(s.targetDomainID),
 		TargetWorkflowID: targetExecution.GetWorkflowId(),
-		TargetRunID:      targetExecution.GetRunId(),
+		TargetRunID:      primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeSignalExecution,
@@ -1285,10 +1290,10 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Success()
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(s.version).Return(cluster.TestCurrentClusterName).AnyTimes()
 
 	s.mockHistoryClient.EXPECT().RemoveSignalMutableState(gomock.Any(), &historyservice.RemoveSignalMutableStateRequest{
-		DomainUUID: transferTask.TargetDomainID,
+		DomainUUID: primitives.UUID(transferTask.TargetDomainID).String(),
 		WorkflowExecution: &commonproto.WorkflowExecution{
 			WorkflowId: transferTask.TargetWorkflowID,
-			RunId:      transferTask.TargetRunID,
+			RunId:      primitives.UUID(transferTask.TargetRunID).String(),
 		},
 		RequestId: si.SignalRequestID,
 	}).Return(nil, nil).Times(1)
@@ -1338,14 +1343,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Failure()
 	event, si := addRequestSignalInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
 		testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), signalName, signalInput, signalControl)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   s.targetDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(s.targetDomainID),
 		TargetWorkflowID: targetExecution.GetWorkflowId(),
-		TargetRunID:      targetExecution.GetRunId(),
+		TargetRunID:      primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeSignalExecution,
@@ -1404,14 +1409,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Duplicati
 	event, _ = addRequestSignalInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
 		testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), signalName, signalInput, signalControl)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   s.targetDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(s.targetDomainID),
 		TargetWorkflowID: targetExecution.GetWorkflowId(),
-		TargetRunID:      targetExecution.GetRunId(),
+		TargetRunID:      primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeSignalExecution,
@@ -1466,14 +1471,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 	event, ci := addStartChildWorkflowExecutionInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
 		s.childDomainName, childWorkflowID, childWorkflowType, childTaskListName, nil, 1, 1)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   testChildDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(testChildDomainID),
 		TargetWorkflowID: childWorkflowID,
-		TargetRunID:      "",
+		TargetRunID:      nil,
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeStartChildExecution,
@@ -1553,14 +1558,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Failu
 		1,
 	)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   testChildDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(testChildDomainID),
 		TargetWorkflowID: childWorkflowID,
-		TargetRunID:      "",
+		TargetRunID:      nil,
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeStartChildExecution,
@@ -1633,14 +1638,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 		1,
 	)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   testChildDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(testChildDomainID),
 		TargetWorkflowID: childWorkflowID,
-		TargetRunID:      "",
+		TargetRunID:      nil,
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeStartChildExecution,
@@ -1716,14 +1721,14 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Dupli
 		1,
 	)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:          s.version,
-		DomainID:         s.domainID,
+		DomainID:         s.GetDomainIDBytes(),
 		WorkflowID:       execution.GetWorkflowId(),
-		RunID:            execution.GetRunId(),
-		TargetDomainID:   testChildDomainID,
+		RunID:            primitives.MustParseUUID(execution.GetRunId()),
+		TargetDomainID:   primitives.MustParseUUID(testChildDomainID),
 		TargetWorkflowID: childExecution.GetWorkflowId(),
-		TargetRunID:      "",
+		TargetRunID:      nil,
 		TaskID:           taskID,
 		TaskList:         taskListName,
 		TaskType:         persistence.TransferTaskTypeStartChildExecution,
@@ -1776,11 +1781,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessRecordWorkflowStartedTask
 	taskID := int64(59)
 	di := addDecisionTaskScheduledEvent(mutableState)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeRecordWorkflowStarted,
@@ -1823,11 +1828,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessUpsertWorkflowSearchAttri
 	taskID := int64(59)
 	di := addDecisionTaskScheduledEvent(mutableState)
 
-	transferTask := &persistence.TransferTaskInfo{
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:    s.version,
-		DomainID:   s.domainID,
+		DomainID:   s.GetDomainIDBytes(),
 		WorkflowID: execution.GetWorkflowId(),
-		RunID:      execution.GetRunId(),
+		RunID:      primitives.MustParseUUID(execution.GetRunId()),
 		TaskID:     taskID,
 		TaskList:   taskListName,
 		TaskType:   persistence.TransferTaskTypeUpsertWorkflowSearchAttributes,
@@ -1858,15 +1863,15 @@ func (s *transferQueueActiveProcessorSuite) TestCopySearchAttributes() {
 }
 
 func (s *transferQueueActiveProcessorSuite) createAddActivityTaskRequest(
-	task *persistence.TransferTaskInfo,
+	task *persistenceblobs.TransferTaskInfo,
 	ai *persistence.ActivityInfo,
 ) *matchingservice.AddActivityTaskRequest {
 	return &matchingservice.AddActivityTaskRequest{
-		DomainUUID:       task.TargetDomainID,
-		SourceDomainUUID: task.DomainID,
+		DomainUUID:       primitives.UUID(task.TargetDomainID).String(),
+		SourceDomainUUID: primitives.UUID(task.DomainID).String(),
 		Execution: &commonproto.WorkflowExecution{
 			WorkflowId: task.WorkflowID,
-			RunId:      task.RunID,
+			RunId:      primitives.UUID(task.RunID).String(),
 		},
 		TaskList:                      &commonproto.TaskList{Name: task.TaskList},
 		ScheduleId:                    task.ScheduleID,
@@ -1875,13 +1880,13 @@ func (s *transferQueueActiveProcessorSuite) createAddActivityTaskRequest(
 }
 
 func (s *transferQueueActiveProcessorSuite) createAddDecisionTaskRequest(
-	task *persistence.TransferTaskInfo,
+	task *persistenceblobs.TransferTaskInfo,
 	mutableState mutableState,
 ) *matchingservice.AddDecisionTaskRequest {
 
 	execution := commonproto.WorkflowExecution{
 		WorkflowId: task.WorkflowID,
-		RunId:      task.RunID,
+		RunId:      primitives.UUID(task.RunID).String(),
 	}
 	taskList := &commonproto.TaskList{Name: task.TaskList}
 	executionInfo := mutableState.GetExecutionInfo()
@@ -1892,7 +1897,7 @@ func (s *transferQueueActiveProcessorSuite) createAddDecisionTaskRequest(
 	}
 
 	return &matchingservice.AddDecisionTaskRequest{
-		DomainUUID:                    task.DomainID,
+		DomainUUID:                    primitives.UUID(task.DomainID).String(),
 		Execution:                     &execution,
 		TaskList:                      taskList,
 		ScheduleId:                    task.ScheduleID,
@@ -1903,20 +1908,20 @@ func (s *transferQueueActiveProcessorSuite) createAddDecisionTaskRequest(
 func (s *transferQueueActiveProcessorSuite) createRecordWorkflowExecutionStartedRequest(
 	domainName string,
 	startEvent *shared.HistoryEvent,
-	task *persistence.TransferTaskInfo,
+	task *persistenceblobs.TransferTaskInfo,
 	mutableState mutableState,
 	backoffSeconds int32,
 ) *persistence.RecordWorkflowExecutionStartedRequest {
 	execution := shared.WorkflowExecution{
 		WorkflowId: common.StringPtr(task.WorkflowID),
-		RunId:      common.StringPtr(task.RunID),
+		RunId:      common.StringPtr(primitives.UUID(task.RunID).String()),
 	}
 	executionInfo := mutableState.GetExecutionInfo()
 	executionTimestamp := time.Unix(0, startEvent.GetTimestamp()).Add(time.Duration(backoffSeconds) * time.Second)
 
 	return &persistence.RecordWorkflowExecutionStartedRequest{
 		Domain:             domainName,
-		DomainUUID:         task.DomainID,
+		DomainUUID:         primitives.UUID(task.DomainID).String(),
 		Execution:          execution,
 		WorkflowTypeName:   executionInfo.WorkflowTypeName,
 		StartTimestamp:     startEvent.GetTimestamp(),
@@ -1928,21 +1933,21 @@ func (s *transferQueueActiveProcessorSuite) createRecordWorkflowExecutionStarted
 
 func (s *transferQueueActiveProcessorSuite) createRequestCancelWorkflowExecutionRequest(
 	targetDomainName string,
-	task *persistence.TransferTaskInfo,
+	task *persistenceblobs.TransferTaskInfo,
 	rci *persistence.RequestCancelInfo,
 ) *historyservice.RequestCancelWorkflowExecutionRequest {
 
 	sourceExecution := commonproto.WorkflowExecution{
 		WorkflowId: task.WorkflowID,
-		RunId:      task.RunID,
+		RunId:      primitives.UUID(task.RunID).String(),
 	}
 	targetExecution := commonproto.WorkflowExecution{
 		WorkflowId: task.TargetWorkflowID,
-		RunId:      task.TargetRunID,
+		RunId:      primitives.UUID(task.TargetRunID).String(),
 	}
 
 	return &historyservice.RequestCancelWorkflowExecutionRequest{
-		DomainUUID: task.TargetDomainID,
+		DomainUUID: primitives.UUID(task.TargetDomainID).String(),
 		CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
 			Domain:            targetDomainName,
 			WorkflowExecution: &targetExecution,
@@ -1958,21 +1963,21 @@ func (s *transferQueueActiveProcessorSuite) createRequestCancelWorkflowExecution
 
 func (s *transferQueueActiveProcessorSuite) createSignalWorkflowExecutionRequest(
 	targetDomainName string,
-	task *persistence.TransferTaskInfo,
+	task *persistenceblobs.TransferTaskInfo,
 	si *persistence.SignalInfo,
 ) *historyservice.SignalWorkflowExecutionRequest {
 
 	sourceExecution := commonproto.WorkflowExecution{
 		WorkflowId: task.WorkflowID,
-		RunId:      task.RunID,
+		RunId:      primitives.UUID(task.RunID).String(),
 	}
 	targetExecution := commonproto.WorkflowExecution{
 		WorkflowId: task.TargetWorkflowID,
-		RunId:      task.TargetRunID,
+		RunId:      primitives.UUID(task.TargetRunID).String(),
 	}
 
 	return &historyservice.SignalWorkflowExecutionRequest{
-		DomainUUID: task.TargetDomainID,
+		DomainUUID: primitives.UUID(task.TargetDomainID).String(),
 		SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
 			Domain:            targetDomainName,
 			WorkflowExecution: &targetExecution,
@@ -1990,7 +1995,7 @@ func (s *transferQueueActiveProcessorSuite) createSignalWorkflowExecutionRequest
 func (s *transferQueueActiveProcessorSuite) createChildWorkflowExecutionRequest(
 	domainName string,
 	childDomainName string,
-	task *persistence.TransferTaskInfo,
+	task *persistenceblobs.TransferTaskInfo,
 	mutableState mutableState,
 	ci *persistence.ChildExecutionInfo,
 ) *historyservice.StartWorkflowExecutionRequest {
@@ -2001,11 +2006,11 @@ func (s *transferQueueActiveProcessorSuite) createChildWorkflowExecutionRequest(
 	attributes := event.GetStartChildWorkflowExecutionInitiatedEventAttributes()
 	execution := commonproto.WorkflowExecution{
 		WorkflowId: task.WorkflowID,
-		RunId:      task.RunID,
+		RunId:      primitives.UUID(task.RunID).String(),
 	}
 	now := time.Now()
 	return &historyservice.StartWorkflowExecutionRequest{
-		DomainUUID: task.TargetDomainID,
+		DomainUUID: primitives.UUID(task.TargetDomainID).String(),
 		StartRequest: &workflowservice.StartWorkflowExecutionRequest{
 			Domain:                              childDomainName,
 			WorkflowId:                          attributes.WorkflowId,
@@ -2019,7 +2024,7 @@ func (s *transferQueueActiveProcessorSuite) createChildWorkflowExecutionRequest(
 			WorkflowIdReusePolicy: attributes.WorkflowIdReusePolicy,
 		},
 		ParentExecutionInfo: &commonproto.ParentExecutionInfo{
-			DomainUUID:  task.DomainID,
+			DomainUUID:  primitives.UUID(task.DomainID).String(),
 			Domain:      testDomainName,
 			Execution:   &execution,
 			InitiatedId: task.ScheduleID,
@@ -2031,19 +2036,19 @@ func (s *transferQueueActiveProcessorSuite) createChildWorkflowExecutionRequest(
 func (s *transferQueueActiveProcessorSuite) createUpsertWorkflowSearchAttributesRequest(
 	domainName string,
 	startEvent *shared.HistoryEvent,
-	task *persistence.TransferTaskInfo,
+	task *persistenceblobs.TransferTaskInfo,
 	mutableState mutableState,
 ) *persistence.UpsertWorkflowExecutionRequest {
 
 	execution := shared.WorkflowExecution{
 		WorkflowId: common.StringPtr(task.WorkflowID),
-		RunId:      common.StringPtr(task.RunID),
+		RunId:      common.StringPtr(primitives.UUID(task.RunID).String()),
 	}
 	executionInfo := mutableState.GetExecutionInfo()
 
 	return &persistence.UpsertWorkflowExecutionRequest{
 		Domain:           domainName,
-		DomainUUID:       task.DomainID,
+		DomainUUID:       primitives.UUID(task.DomainID).String(),
 		Execution:        execution,
 		WorkflowTypeName: executionInfo.WorkflowTypeName,
 		StartTimestamp:   startEvent.GetTimestamp(),

--- a/service/history/transferQueueStandbyProcessor_test.go
+++ b/service/history/transferQueueStandbyProcessor_test.go
@@ -21,6 +21,8 @@
 package history
 
 import (
+	"github.com/gogo/protobuf/types"
+	"github.com/temporalio/temporal/common/primitives"
 	"testing"
 	"time"
 
@@ -224,12 +226,12 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Pending() {
 	activityType := "some random activity type"
 	event, _ = addActivityTaskScheduledEvent(mutableState, event.GetEventId(), activityID, activityType, taskListName, []byte{}, 1, 1, 1)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -240,7 +242,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Pending() {
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskRetry, err)
 }
@@ -279,13 +281,13 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Pending_Pus
 	activityType := "some random activity type"
 	event, _ = addActivityTaskScheduledEvent(mutableState, event.GetEventId(), activityID, activityType, taskListName, []byte{}, 1, 1, 1)
 
-	now := time.Now()
-	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC().Add(s.fetchHistoryDuration))
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -297,7 +299,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Pending_Pus
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), gomock.Any()).Return(&matchingservice.AddActivityTaskResponse{}, nil).Times(1)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -336,12 +338,12 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Success() {
 	activityType := "some random activity type"
 	event, _ = addActivityTaskScheduledEvent(mutableState, event.GetEventId(), activityID, activityType, taskListName, []byte{}, 1, 1, 1)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -354,7 +356,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Success() {
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -386,12 +388,12 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Pending() {
 	taskID := int64(59)
 	di := addDecisionTaskScheduledEvent(mutableState)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -402,7 +404,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Pending() {
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, di.ScheduleID, di.Version)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskRetry, err)
 }
@@ -434,13 +436,13 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Pending_Pus
 	taskID := int64(59)
 	di := addDecisionTaskScheduledEvent(mutableState)
 
-	now := time.Now()
-	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC().Add(s.fetchHistoryDuration))
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -452,7 +454,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Pending_Pus
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), gomock.Any()).Return(&matchingservice.AddDecisionTaskResponse{}, nil).Times(1)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(nil, err)
 }
@@ -484,12 +486,12 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Success_Fir
 	taskID := int64(59)
 	di := addDecisionTaskScheduledEvent(mutableState)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -503,7 +505,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Success_Fir
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -540,12 +542,12 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Success_Non
 	taskID := int64(59)
 	di = addDecisionTaskScheduledEvent(mutableState)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -559,7 +561,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Success_Non
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -596,12 +598,12 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCloseExecution() {
 	taskID := int64(59)
 	event = addCompleteWorkflowEvent(mutableState, event.GetEventId(), nil)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -614,7 +616,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCloseExecution() {
 	s.mockVisibilityMgr.On("RecordWorkflowExecutionClosed", mock.Anything).Return(nil).Once()
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -657,16 +659,16 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCancelExecution_Pending(
 	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
 	nextEventID := event.GetEventId() + 1
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
-		TargetDomainID:      testTargetDomainID,
+		TargetDomainID:      primitives.MustParseUUID(testTargetDomainID),
 		TargetWorkflowID:    targetExecution.GetWorkflowId(),
-		TargetRunID:         targetExecution.GetRunId(),
+		TargetRunID:         primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:              taskID,
 		TaskList:            taskListName,
 		TaskType:            persistence.TransferTaskTypeCancelExecution,
@@ -676,20 +678,20 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCancelExecution_Pending(
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskRetry, err)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC().Add(s.fetchHistoryDuration))
 	s.mockHistoryRereplicator.On("SendMultiWorkflowHistory",
-		transferTask.DomainID, transferTask.WorkflowID,
-		transferTask.RunID, nextEventID,
-		transferTask.RunID, common.EndEventID,
+		primitives.UUIDString(transferTask.DomainID), transferTask.WorkflowID,
+		primitives.UUIDString(transferTask.RunID), nextEventID,
+		primitives.UUIDString(transferTask.RunID), common.EndEventID,
 	).Return(nil).Once()
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskRetry, err)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC().Add(s.discardDuration))
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskDiscarded, err)
 }
@@ -731,16 +733,16 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCancelExecution_Success(
 	taskID := int64(59)
 	event, _ = addRequestCancelInitiatedEvent(mutableState, event.GetEventId(), uuid.New(), testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId())
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
-		TargetDomainID:      testTargetDomainID,
+		TargetDomainID:      primitives.MustParseUUID(testTargetDomainID),
 		TargetWorkflowID:    targetExecution.GetWorkflowId(),
-		TargetRunID:         targetExecution.GetRunId(),
+		TargetRunID:         primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:              taskID,
 		TaskList:            taskListName,
 		TaskType:            persistence.TransferTaskTypeCancelExecution,
@@ -752,7 +754,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCancelExecution_Success(
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -797,16 +799,16 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessSignalExecution_Pending(
 		testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), signalName, nil, nil)
 	nextEventID := event.GetEventId() + 1
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
-		TargetDomainID:      testTargetDomainID,
+		TargetDomainID:      primitives.MustParseUUID(testTargetDomainID),
 		TargetWorkflowID:    targetExecution.GetWorkflowId(),
-		TargetRunID:         targetExecution.GetRunId(),
+		TargetRunID:         primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:              taskID,
 		TaskList:            taskListName,
 		TaskType:            persistence.TransferTaskTypeSignalExecution,
@@ -816,20 +818,20 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessSignalExecution_Pending(
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskRetry, err)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC().Add(s.fetchHistoryDuration))
 	s.mockHistoryRereplicator.On("SendMultiWorkflowHistory",
-		transferTask.DomainID, transferTask.WorkflowID,
-		transferTask.RunID, nextEventID,
-		transferTask.RunID, common.EndEventID,
+		primitives.UUIDString(transferTask.DomainID), transferTask.WorkflowID,
+		primitives.UUIDString(transferTask.RunID), nextEventID,
+		primitives.UUIDString(transferTask.RunID), common.EndEventID,
 	).Return(nil).Once()
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskRetry, err)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC().Add(s.discardDuration))
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskDiscarded, err)
 }
@@ -873,16 +875,16 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessSignalExecution_Success(
 	event, _ = addRequestSignalInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
 		testTargetDomainName, targetExecution.GetWorkflowId(), targetExecution.GetRunId(), signalName, nil, nil)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
-		TargetDomainID:      testTargetDomainID,
+		TargetDomainID:      primitives.MustParseUUID(testTargetDomainID),
 		TargetWorkflowID:    targetExecution.GetWorkflowId(),
-		TargetRunID:         targetExecution.GetRunId(),
+		TargetRunID:         primitives.MustParseUUID(targetExecution.GetRunId()),
 		TaskID:              taskID,
 		TaskList:            taskListName,
 		TaskType:            persistence.TransferTaskTypeSignalExecution,
@@ -894,7 +896,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessSignalExecution_Success(
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -937,16 +939,16 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessStartChildExecution_Pend
 		testChildDomainName, childWorkflowID, childWorkflowType, childTaskListName, nil, 1, 1)
 	nextEventID := event.GetEventId() + 1
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
-		TargetDomainID:      testChildDomainID,
+		TargetDomainID:      primitives.MustParseUUID(testChildDomainID),
 		TargetWorkflowID:    childWorkflowID,
-		TargetRunID:         "",
+		TargetRunID:         nil,
 		TaskID:              taskID,
 		TaskList:            taskListName,
 		TaskType:            persistence.TransferTaskTypeStartChildExecution,
@@ -956,20 +958,20 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessStartChildExecution_Pend
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskRetry, err)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC().Add(s.fetchHistoryDuration))
 	s.mockHistoryRereplicator.On("SendMultiWorkflowHistory",
-		transferTask.DomainID, transferTask.WorkflowID,
-		transferTask.RunID, nextEventID,
-		transferTask.RunID, common.EndEventID,
+		primitives.UUIDString(transferTask.DomainID), transferTask.WorkflowID,
+		primitives.UUIDString(transferTask.RunID), nextEventID,
+		primitives.UUIDString(transferTask.RunID), common.EndEventID,
 	).Return(nil).Once()
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskRetry, err)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC().Add(s.discardDuration))
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Equal(ErrTaskDiscarded, err)
 }
@@ -1011,16 +1013,16 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessStartChildExecution_Succ
 	event, childInfo := addStartChildWorkflowExecutionInitiatedEvent(mutableState, event.GetEventId(), uuid.New(),
 		testChildDomainName, childWorkflowID, childWorkflowType, childTaskListName, nil, 1, 1)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
-		TargetDomainID:      testChildDomainID,
+		TargetDomainID:      primitives.MustParseUUID(testChildDomainID),
 		TargetWorkflowID:    childWorkflowID,
-		TargetRunID:         "",
+		TargetRunID:         nil,
 		TaskID:              taskID,
 		TaskList:            taskListName,
 		TaskType:            persistence.TransferTaskTypeStartChildExecution,
@@ -1033,7 +1035,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessStartChildExecution_Succ
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -1066,12 +1068,12 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessRecordWorkflowStartedTas
 
 	di := addDecisionTaskScheduledEvent(mutableState)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -1095,7 +1097,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessRecordWorkflowStartedTas
 		TaskID:           taskID,
 	}).Return(nil).Once()
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }
@@ -1128,12 +1130,12 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessUpsertWorkflowSearchAttr
 
 	di := addDecisionTaskScheduledEvent(mutableState)
 
-	now := time.Now()
-	transferTask := &persistence.TransferTaskInfo{
+	now := types.TimestampNow()
+	transferTask := &persistenceblobs.TransferTaskInfo{
 		Version:             s.version,
-		DomainID:            s.domainID,
+		DomainID:            primitives.MustParseUUID(s.domainID),
 		WorkflowID:          execution.GetWorkflowId(),
-		RunID:               execution.GetRunId(),
+		RunID:               primitives.MustParseUUID(execution.GetRunId()),
 		VisibilityTimestamp: now,
 		TaskID:              taskID,
 		TaskList:            taskListName,
@@ -1157,7 +1159,7 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessUpsertWorkflowSearchAttr
 		TaskID:           taskID,
 	}).Return(nil).Once()
 
-	s.mockShard.SetCurrentTime(s.clusterName, now)
+	s.mockShard.SetCurrentTime(s.clusterName, time.Unix(now.Seconds, int64(now.Nanos)).UTC())
 	_, err = s.transferQueueStandbyProcessor.process(newTaskInfo(nil, transferTask, s.logger))
 	s.Nil(err)
 }


### PR DESCRIPTION
- Converting TransferTask pogo usage into proto
- SQL - Move TransferTask thrift serialization to Proto
- Cassandra - Move from Frozen<transfer_task> to proto
- Serialization occurs at store level until ExecutionStore interface is created with datablobs