### PR TITLE
Update cadence references to temporal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -111,7 +111,7 @@ FROM alpine AS temporal-tctl
 COPY --from=tcheck /go/bin/tcheck /usr/local/bin
 COPY --from=builder /temporal/tctl /usr/local/bin
 
-ENTRYPOINT ["temporal"]
+ENTRYPOINT ["tctl"]
 
 # All temporal tool binaries
 FROM alpine AS temporal-admin-tools

--- a/common/elasticsearch/esql/README.md
+++ b/common/elasticsearch/esql/README.md
@@ -91,7 +91,7 @@ page_token_colB := "bbc"
 dsl_page2_search_after, sortFields, err := e.ConvertPretty(sql_page2_search_after, page_colA, page_colB)
 ~~~~
 
-For Cadence usage, refer to [this link](cadenceDevReadme.md).
+For Temporal usage, refer to [this link](temporalDevReadme.md).
 
 
 ## ES V2.x vs ES V6.5

--- a/common/elasticsearch/esql/esql.go
+++ b/common/elasticsearch/esql/esql.go
@@ -44,7 +44,7 @@ type ESql struct {
 	filterValue  FilterFunc  // select the column we want to process value macro
 	processKey   ProcessFunc // if selected by filterKey, change the query name
 	processValue ProcessFunc // if selected by filterValue, change the query value
-	cadence      bool
+	temporal     bool
 	pageSize     int
 	bucketNumber int
 }
@@ -54,7 +54,7 @@ func NewESql() *ESql {
 	return &ESql{
 		pageSize:     DefaultPageSize,
 		bucketNumber: DefaultBucketNumber,
-		cadence:      false,
+		temporal:     false,
 		processKey:   nil,
 		processValue: nil,
 		filterKey:    nil,

--- a/common/elasticsearch/esql/globals.go
+++ b/common/elasticsearch/esql/globals.go
@@ -71,7 +71,7 @@ var opBinaryExpr = map[string]string{
 	"<<": "<<",
 }
 
-// default sizes and identifiers used in cadence visibility
+// default sizes and identifiers used in temporal visibility
 const (
 	DefaultPageSize      = 1000
 	DefaultBucketNumber  = 1000

--- a/common/elasticsearch/esql/select.go
+++ b/common/elasticsearch/esql/select.go
@@ -45,9 +45,9 @@ func (e *ESql) convertSelect(sel sqlparser.Select, domainID string, pagination .
 		}
 		dslMap["query"] = dslQuery
 	}
-	// cadence special handling: add domain ID query and time query bounds
-	if e.cadence {
-		e.addCadenceDomainTimeQuery(sel, domainID, dslMap)
+	// temporal special handling: add domain ID query and time query bounds
+	if e.temporal {
+		e.addTemporalDomainTimeQuery(sel, domainID, dslMap)
 	}
 
 	// handle FROM keyword, currently only support 1 target table
@@ -126,9 +126,9 @@ func (e *ESql) convertSelect(sel sqlparser.Select, domainID string, pagination .
 			orderBySlice = append(orderBySlice, orderByStr)
 			sortField = append(sortField, colNameStr)
 		}
-		// cadence special handling: add runID as sorting tie breaker
-		if e.cadence {
-			orderBySlice, sortField, err = e.addCadenceSort(orderBySlice, sortField)
+		// temporal special handling: add runID as sorting tie breaker
+		if e.temporal {
+			orderBySlice, sortField, err = e.addTemporalSort(orderBySlice, sortField)
 			if err != nil {
 				return "", nil, err
 			}

--- a/common/elasticsearch/esql/temporalDevReadme.md
+++ b/common/elasticsearch/esql/temporalDevReadme.md
@@ -1,9 +1,9 @@
-# ESQL Cadence Usage
+# ESQL Temporal Usage
 
 ## Motivation
-Currently [Cadence](https://github.com/temporalio/temporal) is using [elasticsql](https://github.com/cch123/elasticsql) to translate sql query. However it only support up to ES V2.x while Cadence is using ES V6.x. Beyond that, Cadence has some specific requirements that not supported by elasticsql yet.
+Currently [Temporal](https://github.com/temporalio/temporal) is using [elasticsql](https://github.com/cch123/elasticsql) to translate sql query. However it only support up to ES V2.x while Temporal is using ES V6.x. Beyond that, Temporal has some specific requirements that not supported by elasticsql yet.
 
-Current Cadence query request processing steps are listed below:
+Current Temporal query request processing steps are listed below:
 - generate SQL from query
 - use elasticsql to translate SQL to DSL
 - ES V6.x does not support "missing" field, convert "missing" to "bool","must_not","exist" for ExecutionTime query if any
@@ -14,14 +14,14 @@ Current Cadence query request processing steps are listed below:
 - modify sorting field (add workflow id as sorting tie breaker)
 - setup search after for pagination
 
-ESQL aims at dealing all these addtional processing steps and providing an api to generate DSL in one step for visibility usage in Cadence.
+ESQL aims at dealing all these addtional processing steps and providing an api to generate DSL in one step for visibility usage in Temporal.
 
 ## Usage
-ESQL has convert functions specific for cadence usage. Please refer to `cadencesql.go`. Below shows an example.
-Attention: to use cadence version api, `SetCadence()` must be called at initialzation.
+ESQL has convert functions specific for temporal usage. Please refer to `temporalsql.go`. Below shows an example.
+Attention: to use temporal version api, `SetTemporal()` must be called at initialzation.
 ~~~~go
 sql := "SELECT colA FROM myTable WHERE colB < 10 AND dateTime = '2015-01-01T02:59:59Z'"
-domainID := "CadenceSampleDomain"
+domainID := "TemporalSampleDomain"
 // custom policy that change colName like "col.." to "myCol.."
 func myKeyFilter(colName string) bool {
     return strings.HasPrefix(colName, "col")
@@ -42,10 +42,10 @@ func myValueProcess(timeStr string) (string, error) {
 // "SELECT myColA FROM myTable WHERE myColB < 10 AND dateTime = '1561678568048000000'
 // in which the time is in unix nano format
 e := NewESql()
-e.SetCadence()
+e.SetTemporal()
 e.ProcessQueryKey(myKeyFilter, myKeyProcess)         // set up filtering policy
 e.ProcessQueryValue(myValueFilter, myValueProcess)     // set up process policy
-dsl, _, err := e.ConvertPrettyCadence(sql, domainID)             // convert sql to dsl
+dsl, _, err := e.ConvertPrettyTemporal(sql, domainID)             // convert sql to dsl
 if err == nil {
     fmt.Println(dsl)
 }
@@ -53,8 +53,8 @@ if err == nil {
 
 ## Testing
 To setup local testing environment:
-- start cassandra service locally. Please refer to [Cadence](https://github.com/temporalio/temporal) readme.
+- start cassandra service locally. Please refer to [Temporal](https://github.com/temporalio/temporal) readme.
 - start zookeeper and kafka service locally. Here is a [referecne](https://kafka.apache.org/quickstart).
 - start elasticsearch and kibana service locally.
-- start a cadence worker by `./bin/helloworld -m worker` under cadence directory.
-- start cadence service locally. Please refer to [Cadence](https://github.com/temporalio/temporal) readme.
+- start a temporal worker by `./bin/helloworld -m worker` under temporal directory.
+- start temporal service locally. Please refer to [Temporal](https://github.com/temporalio/temporal) readme.

--- a/common/elasticsearch/esql/temporalSpecial.go
+++ b/common/elasticsearch/esql/temporalSpecial.go
@@ -27,30 +27,30 @@ import (
 	"github.com/xwb1989/sqlparser"
 )
 
-func (e *ESql) addCadenceSort(orderBySlice []string, sortFields []string) ([]string, []string, error) {
+func (e *ESql) addTemporalSort(orderBySlice []string, sortFields []string) ([]string, []string, error) {
 	switch len(orderBySlice) {
 	case 0: // if unsorted, use default sorting
-		cadenceOrderStartTime := fmt.Sprintf(`{"%v": "%v"}`, StartTime, StartTimeOrder)
-		orderBySlice = append(orderBySlice, cadenceOrderStartTime)
+		temporalOrderStartTime := fmt.Sprintf(`{"%v": "%v"}`, StartTime, StartTimeOrder)
+		orderBySlice = append(orderBySlice, temporalOrderStartTime)
 		sortFields = append(sortFields, StartTime)
 	case 1: // user should not use tieBreaker to sort
 		if sortFields[0] == TieBreaker {
-			err := fmt.Errorf("esql: Cadence does not allow user sort by RunID")
+			err := fmt.Errorf("esql: Temporal does not allow user sort by RunID")
 			return nil, nil, err
 		}
 	default:
-		err := fmt.Errorf("esql: Cadence only allow 1 custom sort field")
+		err := fmt.Errorf("esql: Temporal only allow 1 custom sort field")
 		return nil, nil, err
 	}
 
 	// add tie breaker
-	cadenceOrderTieBreaker := fmt.Sprintf(`{"%v": "%v"}`, TieBreaker, TieBreakerOrder)
-	orderBySlice = append(orderBySlice, cadenceOrderTieBreaker)
+	temporalOrderTieBreaker := fmt.Sprintf(`{"%v": "%v"}`, TieBreaker, TieBreakerOrder)
+	orderBySlice = append(orderBySlice, temporalOrderTieBreaker)
 	sortFields = append(sortFields, TieBreaker)
 	return orderBySlice, sortFields, nil
 }
 
-func (e *ESql) addCadenceDomainTimeQuery(sel sqlparser.Select, domainID string, dslMap map[string]interface{}) {
+func (e *ESql) addTemporalDomainTimeQuery(sel sqlparser.Select, domainID string, dslMap map[string]interface{}) {
 	var domainIDQuery string
 	if domainID != "" {
 		domainIDQuery = fmt.Sprintf(`{"term": {"%v": "%v"}}`, DomainID, domainID)

--- a/common/elasticsearch/esql/temporalsql.go
+++ b/common/elasticsearch/esql/temporalsql.go
@@ -28,17 +28,17 @@ import (
 	"github.com/xwb1989/sqlparser"
 )
 
-// SetCadence ... specify whether do special handling for cadence visibility
+// SetTemporal ... specify whether do special handling for temporal visibility
 // should not be called if there is potential race condition
-// should not be called by non-cadence user
-func (e *ESql) SetCadence(cadenceArg bool) {
-	e.cadence = cadenceArg
+// should not be called by non-temporal user
+func (e *ESql) SetTemporal(temporalArg bool) {
+	e.temporal = temporalArg
 }
 
-// ConvertPrettyCadence ...
-// convert sql to es dsl, for cadence usage
-func (e *ESql) ConvertPrettyCadence(sql string, domainID string, pagination ...interface{}) (dsl string, sortFields []string, err error) {
-	dsl, sortFields, err = e.ConvertCadence(sql, domainID, pagination...)
+// ConvertPrettyTemporal ...
+// convert sql to es dsl, for temporal usage
+func (e *ESql) ConvertPrettyTemporal(sql string, domainID string, pagination ...interface{}) (dsl string, sortFields []string, err error) {
+	dsl, sortFields, err = e.ConvertTemporal(sql, domainID, pagination...)
 	if err != nil {
 		return "", nil, err
 	}
@@ -51,11 +51,11 @@ func (e *ESql) ConvertPrettyCadence(sql string, domainID string, pagination ...i
 	return prettifiedDSLBytes.String(), sortFields, err
 }
 
-// ConvertCadence ...
-// convert sql to es dsl, for cadence usage
-func (e *ESql) ConvertCadence(sql string, domainID string, pagination ...interface{}) (dsl string, sortFields []string, err error) {
-	if !e.cadence {
-		err = fmt.Errorf(`esql: cadence option not turned on`)
+// ConvertTemporal ...
+// convert sql to es dsl, for temporal usage
+func (e *ESql) ConvertTemporal(sql string, domainID string, pagination ...interface{}) (dsl string, sortFields []string, err error) {
+	if !e.temporal {
+		err = fmt.Errorf(`esql: temporal option not turned on`)
 		return "", nil, err
 	}
 	stmt, err := sqlparser.Parse(sql)

--- a/common/elasticsearch/validator/searchAttrValidator.go
+++ b/common/elasticsearch/validator/searchAttrValidator.go
@@ -86,7 +86,7 @@ func (sv *SearchAttributesValidator) ValidateSearchAttributes(input *commonproto
 		if definition.IsSystemIndexedKey(key) {
 			sv.logger.WithTags(tag.ESKey(key), tag.WorkflowDomainName(domain)).
 				Error("illegal update of system reserved attribute")
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("%s is read-only Cadence reservered attribute", key))
+			return serviceerror.NewInvalidArgument(fmt.Sprintf("%s is read-only Temporal reservered attribute", key))
 		}
 		// verify: size of single value <= limit
 		if len(val) > sv.searchAttributesSizeOfValueLimit(domain) {

--- a/common/elasticsearch/validator/searchAttrValidator_test.go
+++ b/common/elasticsearch/validator/searchAttrValidator_test.go
@@ -87,7 +87,7 @@ func (s *searchAttributesValidatorSuite) TestValidateSearchAttributes() {
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, domain)
-	s.Equal("StartTime is read-only Cadence reservered attribute", err.Error())
+	s.Equal("StartTime is read-only Temporal reservered attribute", err.Error())
 
 	fields = map[string][]byte{
 		"CustomKeywordField": []byte("123456"),

--- a/common/headers/headers.go
+++ b/common/headers/headers.go
@@ -36,9 +36,9 @@ const (
 	// tchannel / http header that contains the client
 	// feature version
 	// the feature version sent from client represents the
-	// feature set of the cadence client library support.
+	// feature set of the temporal sdk support.
 	// This can be used for client capibility check, on
-	// Cadence server, for backward compatibility
+	// Temporal server, for backward compatibility
 	FeatureVersionHeaderName = "temporal-sdk-feature-version"
 
 	// ClientImplHeaderName refers to the name of the

--- a/common/headers/versionChecker.go
+++ b/common/headers/versionChecker.go
@@ -31,9 +31,9 @@ import (
 
 const (
 	// GoSDK is the header value for common.ClientImplHeaderName indicating a go sdk client
-	GoSDK = "uber-go"
+	GoSDK = "temporal-go"
 	// JavaSDK is the header value for common.ClientImplHeaderName indicating a java sdk client
-	JavaSDK = "uber-java"
+	JavaSDK = "temporal-java"
 	// CLI is the header value for common.ClientImplHeaderName indicating a cli client
 	CLI = "cli"
 

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -236,8 +236,8 @@ func sanitizeAttr(inkey string, invalue string) (string, string) {
 }
 
 const (
-	testUser      = "uber"
-	testPassword  = "uber"
+	testUser      = "temporal"
+	testPassword  = "temporal"
 	testSchemaDir = "schema/mysql/v57"
 )
 

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -9,8 +9,8 @@ persistence:
         databaseName: "temporal"
         connectAddr: "127.0.0.1:3306"
         connectProtocol: "tcp"
-        user: "uber"
-        password: "uber"
+        user: "temporal"
+        password: "temporal"
         maxConns: 20
         maxIdleConns: 20
         maxConnLifetime: "1h"
@@ -20,8 +20,8 @@ persistence:
         databaseName: "temporal_visibility"
         connectAddr: "127.0.0.1:3306"
         connectProtocol: "tcp"
-        user: "uber"
-        password: "uber"
+        user: "temporal"
+        password: "temporal"
         maxConns: 2
         maxIdleConns: 2
         maxConnLifetime: "1h"

--- a/docker/README.md
+++ b/docker/README.md
@@ -14,10 +14,10 @@ docker-compose up
 
 View metrics at localhost:8080/dashboard    
 View Cadence-Web at localhost:8088  
-Use Temporal-CLI with `docker run --network=host --rm temporalio/cli:master`
+Use Temporal-CLI with `docker run --network=host --rm temporalio/tctl:master`
 
 For example to register new domain 'test-domain' with 1 retention day
-`docker run --network=host --rm temporalio/cli:master --do test-domain domain register -rd 1`
+`docker run --network=host --rm temporalio/tctl:master --do test-domain domain register -rd 1`
 
 
 Using a pre-built image

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -14,7 +14,7 @@ services:
     image: mysql:5.7
     environment:
       MYSQL_DATABASE: db
-      MYSQL_ROOT_PASSWORD: uber
+      MYSQL_ROOT_PASSWORD: temporal
     volumes:
       - ./mysql-init:/docker-entrypoint-initdb.d
     ports:

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     image: mysql:5.7
     environment:
       MYSQL_DATABASE: db
-      MYSQL_ROOT_PASSWORD: uber
+      MYSQL_ROOT_PASSWORD: temporal
     volumes:
       - ./mysql-init:/docker-entrypoint-initdb.d
     networks:

--- a/docker/buildkite/mysql-init/init.sql
+++ b/docker/buildkite/mysql-init/init.sql
@@ -1,1 +1,1 @@
-GRANT ALL PRIVILEGES ON *.* TO 'uber'@'%' IDENTIFIED BY 'uber';
+GRANT ALL PRIVILEGES ON *.* TO 'temporal'@'%' IDENTIFIED BY 'temporal';

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -145,7 +145,7 @@ services:
         metrics:
             statsd:
                 hostPort: {{ .Env.STATSD_ENDPOINT }}
-                prefix: "cadence-worker"
+                prefix: "worker"
         {{- else if .Env.PROMETHEUS_ENDPOINT }}
         metrics:
             prometheus:

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -30,7 +30,6 @@ services:
       - "DB_PORT=5432"
       - "POSTGRES_USER=temporal"
       - "POSTGRES_PWD=temporal"
-      - "POSTGRES_PWD=temporal"
       - "POSTGRES_SEEDS=postgres"
       - "STATSD_ENDPOINT=statsd:8125"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -109,8 +109,8 @@ persistence:
         databaseName: "temporal"        -- name of the database to connect to
         connectAddr: "127.0.0.1:3306"  -- connection address, could be ip address or domain socket
         connectProtocol: "tcp"         -- connection protocol, tcp or anything that SQL Data Source Name accepts
-        user: "uber" 
-        password: "uber"
+        user: "temporal" 
+        password: "temporal"
         maxConns: 20                   -- max number of connections to sql server from one host (optional)
         maxIdleConns: 20               -- max number of idle conns to sql server from one host (optional)
         maxConnLifetime: "1h"          -- max connection lifetime before it is discarded (optional)

--- a/scripts/travis/setup-mysql.sh
+++ b/scripts/travis/setup-mysql.sh
@@ -4,4 +4,4 @@ set -e
 
 # Setup mysql before running test
 echo setting up mysql
-mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'uber'@'localhost' IDENTIFIED BY 'uber';"
+mysql -u root -e "GRANT ALL PRIVILEGES ON *.* TO 'temporal'@'localhost' IDENTIFIED BY 'temporal';"

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -40,7 +40,7 @@ type SetupSchemaConfig struct {
 	schema.SetupConfig
 }
 
-// VerifyCompatibleVersion ensures that the installed version of cadence and visibility keyspaces
+// VerifyCompatibleVersion ensures that the installed version of temporal and visibility keyspaces
 // is greater than or equal to the expected version.
 // In most cases, the versions should match. However if after a schema upgrade there is a code
 // rollback, the code version (expected version) would fall lower than the actual version in

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -59,7 +59,7 @@ func buildCLIOptions() *cli.App {
 
 	app := cli.NewApp()
 	app.Name = "temporal-cassandra-tool"
-	app.Usage = "Command line tool for cadence cassandra operations"
+	app.Usage = "Command line tool for temporal cassandra operations"
 	app.Version = "0.0.1"
 
 	app.Flags = []cli.Flag{

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -211,7 +211,7 @@ func newAdminShardManagementCommands() []cli.Command {
 			Flags: []cli.Flag{
 				cli.IntFlag{
 					Name:  FlagShardID,
-					Usage: "ShardID for the cadence cluster to manage",
+					Usage: "ShardID for the temporal cluster to manage",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -225,7 +225,7 @@ func newAdminShardManagementCommands() []cli.Command {
 			Flags: []cli.Flag{
 				cli.IntFlag{
 					Name:  FlagShardID,
-					Usage: "ShardID for the cadence cluster to manage",
+					Usage: "ShardID for the temporal cluster to manage",
 				},
 				cli.Int64Flag{
 					Name:  FlagRemoveTaskID,
@@ -282,7 +282,7 @@ func newAdminHistoryHostCommands() []cli.Command {
 				},
 				cli.IntFlag{
 					Name:  FlagNumberOfShards,
-					Usage: "NumberOfShards for the cadence cluster(see config for numHistoryShards)",
+					Usage: "NumberOfShards for the temporal cluster(see config for numHistoryShards)",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -691,7 +691,7 @@ func newAdminElasticSearchCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name: FlagInputFileWithAlias,
-					Usage: "Input file name. Redirect cadence wf list result (with tale format) to a file and use as delete input. " +
+					Usage: "Input file name. Redirect temporal wf list result (with tale format) to a file and use as delete input. " +
 						"First line should be table header like WORKFLOW TYPE | WORKFLOW ID | RUN ID | ...",
 				},
 				cli.IntFlag{

--- a/tools/cli/adminElasticSearchCommands.go
+++ b/tools/cli/adminElasticSearchCommands.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2017 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -339,9 +340,9 @@ func GenerateReport(c *cli.Context) {
 
 	// convert sql to dsl
 	e := esql.NewESql()
-	e.SetCadence(true)
+	e.SetTemporal(true)
 	e.ProcessQueryValue(timeKeyFilter, timeValProcess)
-	dsl, sortFields, err := e.ConvertPrettyCadence(sql, "")
+	dsl, sortFields, err := e.ConvertPrettyTemporal(sql, "")
 	if err != nil {
 		ErrorAndExit("Fail to convert sql to dsl", err)
 	}
@@ -371,7 +372,7 @@ func GenerateReport(c *cli.Context) {
 	bucket = buckets[0].(map[string]interface{})
 	// record the column position in the table of each returned item
 	ids := make(map[string]int)
-	// We want these 3 columns shows at leftmost of the table in cadence report usage. It can be changed in future.
+	// We want these 3 columns shows at leftmost of the table in temporal report usage. It can be changed in future.
 	primaryCols := []string{"group_DomainID", "group_WorkflowType", "group_CloseStatus"}
 	primaryColsMap := map[string]int{
 		"group_DomainID":     1,
@@ -434,7 +435,7 @@ func GenerateReport(c *cli.Context) {
 					datum = fmt.Sprintf("%v", vmap["value_as_string"])
 				} else {
 					datum = fmt.Sprintf("%v", vmap["value"])
-					// convert Cadence stored time (unix nano) to readable format
+					// convert Temporal stored time (unix nano) to readable format
 					if strings.Contains(k, "Time") && !strings.Contains(k, "Attr_") {
 						datum = toTimeStr(datum)
 					}

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -39,18 +39,18 @@ func SetFactory(factory ClientFactory) {
 func NewCliApp() *cli.App {
 	app := cli.NewApp()
 	app.Name = "temporal"
-	app.Usage = "A command-line tool for cadence users"
+	app.Usage = "A command-line tool for temporal users"
 	app.Version = Version
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:   FlagAddressWithAlias,
 			Value:  "",
-			Usage:  "host:port for cadence frontend service",
+			Usage:  "host:port for temporal frontend service",
 			EnvVar: "TEMPORAL_CLI_ADDRESS",
 		},
 		cli.StringFlag{
 			Name:   FlagDomainWithAlias,
-			Usage:  "cadence workflow domain",
+			Usage:  "temporal workflow domain",
 			EnvVar: "TEMPORAL_CLI_DOMAIN",
 		},
 		cli.IntFlag{
@@ -64,19 +64,19 @@ func NewCliApp() *cli.App {
 		{
 			Name:        "domain",
 			Aliases:     []string{"d"},
-			Usage:       "Operate cadence domain",
+			Usage:       "Operate temporal domain",
 			Subcommands: newDomainCommands(),
 		},
 		{
 			Name:        "workflow",
 			Aliases:     []string{"wf"},
-			Usage:       "Operate cadence workflow",
+			Usage:       "Operate temporal workflow",
 			Subcommands: newWorkflowCommands(),
 		},
 		{
 			Name:        "tasklist",
 			Aliases:     []string{"tl"},
-			Usage:       "Operate cadence tasklist",
+			Usage:       "Operate temporal tasklist",
 			Subcommands: newTaskListCommands(),
 		},
 		{
@@ -143,7 +143,7 @@ func NewCliApp() *cli.App {
 		{
 			Name:        "cluster",
 			Aliases:     []string{"cl"},
-			Usage:       "Operate cadence cluster",
+			Usage:       "Operate temporal cluster",
 			Subcommands: newClusterCommands(),
 		},
 	}

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -47,7 +47,7 @@ func newWorkflowCommands() []cli.Command {
 		{
 			Name:        "showid",
 			Usage:       "show workflow history with given workflow_id and optional run_id (a shortcut of `show -w <wid> -r <rid>`)",
-			Description: "cadence workflow showid <workflow_id> <run_id>. workflow_id is required; run_id is optional",
+			Description: "temporal workflow showid <workflow_id> <run_id>. workflow_id is required; run_id is optional",
 			Flags:       getFlagsForShowID(),
 			Action: func(c *cli.Context) {
 				ShowHistoryWithWID(c)
@@ -160,7 +160,7 @@ func newWorkflowCommands() []cli.Command {
 		{
 			Name:    "scan",
 			Aliases: []string{"sc", "scanall"},
-			Usage: "scan workflow executions (need to enable Cadence server on ElasticSearch). " +
+			Usage: "scan workflow executions (need to enable Temporal server on ElasticSearch). " +
 				"It will be faster than listall, but result are not sorted.",
 			Flags: getFlagsForScan(),
 			Action: func(c *cli.Context) {
@@ -170,7 +170,7 @@ func newWorkflowCommands() []cli.Command {
 		{
 			Name:    "count",
 			Aliases: []string{"cnt"},
-			Usage:   "count number of workflow executions (need to enable Cadence server on ElasticSearch)",
+			Usage:   "count number of workflow executions (need to enable Temporal server on ElasticSearch)",
 			Flags:   getFlagsForCount(),
 			Action: func(c *cli.Context) {
 				CountWorkflow(c)
@@ -205,7 +205,7 @@ func newWorkflowCommands() []cli.Command {
 			Name:        "describeid",
 			Aliases:     []string{"descid"},
 			Usage:       "show information of workflow execution with given workflow_id and optional run_id (a shortcut of `describe -w <wid> -r <rid>`)",
-			Description: "cadence workflow describeid <workflow_id> <run_id>. workflow_id is required; run_id is optional",
+			Description: "tctl workflow describeid <workflow_id> <run_id>. workflow_id is required; run_id is optional",
 			Flags:       getFlagsForDescribeID(),
 			Action: func(c *cli.Context) {
 				DescribeWorkflowWithID(c)

--- a/tools/sql/README.md
+++ b/tools/sql/README.md
@@ -1,6 +1,6 @@
 ## Using the SQL schema tool
  
-This package contains the tooling for cadence sql operations. The tooling itself is agnostic of the storage engine behind
+This package contains the tooling for temporal sql operations. The tooling itself is agnostic of the storage engine behind
 the sql interface. So, this same tool can be used against, say, OracleDB and MySQLDB
 
 ## For localhost development

--- a/tools/sql/clitest/connTest.go
+++ b/tools/sql/clitest/connTest.go
@@ -44,8 +44,8 @@ type (
 var _ test.DB = (*sql.Connection)(nil)
 
 const (
-	testUser     = "uber"
-	testPassword = "uber"
+	testUser     = "temporal"
+	testPassword = "temporal"
 )
 
 // NewSQLConnTestSuite returns the test suite

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -34,7 +34,7 @@ import (
 	"github.com/temporalio/temporal/tools/common/schema"
 )
 
-// VerifyCompatibleVersion ensures that the installed version of cadence and visibility
+// VerifyCompatibleVersion ensures that the installed version of temporal and visibility
 // is greater than or equal to the expected version.
 func VerifyCompatibleVersion(
 	cfg config.Persistence,

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -50,7 +50,7 @@ func BuildCLIOptions() *cli.App {
 
 	app := cli.NewApp()
 	app.Name = "temporal-sql-tool"
-	app.Usage = "Command line tool for cadence sql operations"
+	app.Usage = "Command line tool for temporal sql operations"
 	app.Version = "0.0.1"
 
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
Change all cadence references to temporal references throughout
source code and documentation.

Change docker entry point to tctl as we renamed it from temporal
to tctl.