### PR TITLE
Make pprof once per process, introduce Server config section

### DIFF
--- a/cmd/server/temporal/server.go
+++ b/cmd/server/temporal/server.go
@@ -131,7 +131,7 @@ func (s *server) startService() common.Daemon {
 	params.MembershipFactoryInitializer =
 		func(persistenceBean persistenceClient.Bean, logger l.Logger) (resource.MembershipMonitorFactory, error) {
 			return ringpop.NewRingpopFactory(
-				&s.cfg.Ringpop,
+				&s.cfg.Server.Ringpop,
 				params.RPCFactory.GetRingpopChannel(),
 				params.Name,
 				servicePortMap,
@@ -139,8 +139,6 @@ func (s *server) startService() common.Daemon {
 				persistenceBean.GetClusterMetadataManager(),
 			)
 		}
-
-	params.PProfInitializer = svcCfg.PProf.NewInitializer(params.Logger)
 
 	params.DCRedirectionPolicy = s.cfg.DCRedirectionPolicy
 

--- a/cmd/server/temporal/temporal.go
+++ b/cmd/server/temporal/temporal.go
@@ -27,6 +27,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/primitives"
 
 	"github.com/urfave/cli"
@@ -62,11 +63,15 @@ func startHandler(c *cli.Context) {
 	}
 	// cassandra schema version validation
 	if err := cassandra.VerifyCompatibleVersion(cfg.Persistence); err != nil {
-		log.Fatal("cassandra schema version compatibility check failed: ", err)
+		log.Fatalf("cassandra schema version compatibility check failed: %v", err)
 	}
 	// sql schema version validation
 	if err := sql.VerifyCompatibleVersion(cfg.Persistence); err != nil {
-		log.Fatal("sql schema version compatibility check failed: ", err)
+		log.Fatalf("sql schema version compatibility check failed: %v", err)
+	}
+
+	if err := cfg.Server.PProf.NewInitializer(loggerimpl.NewLogger(cfg.Log.NewZapLogger())).Start(); err != nil {
+		log.Fatalf("fail to start PProf: %v", err)
 	}
 
 	var daemons []common.Daemon

--- a/common/resource/bootstrapParams.go
+++ b/common/resource/bootstrapParams.go
@@ -52,7 +52,6 @@ type (
 		MembershipFactoryInitializer MembershipFactoryInitializerFunc
 		RPCFactory                   common.RPCFactory
 		AbstractDatastoreFactory     persistenceClient.AbstractDataStoreFactory
-		PProfInitializer             common.PProfInitializer
 		PersistenceConfig            config.Persistence
 		ClusterMetadata              cluster.Metadata
 		ReplicatorConfig             config.Replicator

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -121,8 +121,6 @@ type (
 		ringpopChannel *tchannel.Channel
 
 		// internal vars
-
-		pprofInitializer       common.PProfInitializer
 		runtimeMetricsReporter *metrics.RuntimeMetricsReporter
 		rpcFactory             common.RPCFactory
 	}
@@ -327,7 +325,6 @@ func New(
 		ringpopChannel: ringpopChannel,
 
 		// internal vars
-		pprofInitializer: params.PProfInitializer,
 		runtimeMetricsReporter: metrics.NewRuntimeMetricsReporter(
 			params.MetricScope,
 			time.Minute,
@@ -353,9 +350,6 @@ func (h *Impl) Start() {
 	h.metricsScope.Counter(metrics.RestartCount).Inc(1)
 	h.runtimeMetricsReporter.Start()
 
-	if err := h.pprofInitializer.Start(); err != nil {
-		h.logger.WithTags(tag.Error(err)).Fatal("fail to start PProf")
-	}
 	h.membershipMonitor.Start()
 	h.domainCache.Start()
 

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -43,9 +43,9 @@ const (
 type (
 	// Config contains the configuration for a set of cadence services
 	Config struct {
-		// Ringpop is the ringpop related configuration
-		Ringpop Ringpop `yaml:"ringpop"`
-		// Persistence contains the configuration for cadence datastores
+		// Server is process-wide service-related configuration
+		Server Server `yaml:"server"`
+		// Persistence contains the configuration for temporal datastores
 		Persistence Persistence `yaml:"persistence"`
 		// Log is the logging config
 		Log Logger `yaml:"log"`
@@ -59,7 +59,7 @@ type (
 		Kafka messaging.KafkaConfig `yaml:"kafka"`
 		// Archival is the config for archival
 		Archival Archival `yaml:"archival"`
-		// PublicClient is config for connecting to cadence frontend
+		// PublicClient is config for connecting to temporal frontend
 		PublicClient PublicClient `yaml:"publicClient"`
 		// DynamicConfigClient is the config for setting up the file based dynamic config client
 		// Filepath should be relative to the root directory
@@ -74,8 +74,6 @@ type (
 		RPC RPC `yaml:"rpc"`
 		// Metrics is the metrics subsystem configuration
 		Metrics Metrics `yaml:"metrics"`
-		// PProf is the PProf configuration
-		PProf PProf `yaml:"pprof"`
 	}
 
 	// PProf contains the rpc config items
@@ -100,6 +98,14 @@ type (
 		DisableLogging bool `yaml:"disableLogging"`
 		// LogLevel is the desired log level
 		LogLevel string `yaml:"logLevel"`
+	}
+
+	// Server contains config items that apply process-wide to all services
+	Server struct {
+		// Ringpop is the ringpop related configuration
+		Ringpop Ringpop `yaml:"ringpop"`
+		// PProf is the PProf configuration
+		PProf PProf `yaml:"pprof"`
 	}
 
 	// Ringpop contains the ringpop config items

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -13,11 +13,13 @@ persistence:
       cassandra:
         hosts: "127.0.0.1"
         keyspace: "temporal_visibility"
-
-ringpop:
-  name: cadence
-  maxJoinDuration: 30s
-  broadcastAddress: "127.0.0.1"
+server:
+  ringpop:
+    name: cadence
+    maxJoinDuration: 30s
+    broadcastAddress: "127.0.0.1"
+  pprof:
+    port: 7936
 
 services:
   frontend:
@@ -29,8 +31,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7936
 
   matching:
     rpc:
@@ -41,8 +41,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7938
 
   history:
     rpc:
@@ -53,8 +51,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7937
 
   worker:
     rpc:
@@ -65,8 +61,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7940
 
 clusterMetadata:
   enableGlobalDomain: false

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -11,11 +11,13 @@ persistence:
       cassandra:
         hosts: "127.0.0.1"
         keyspace: "temporal_visibility_active"
-
-ringpop:
-  name: temporal_active
-  maxJoinDuration: 30s
-  broadcastAddress: "127.0.0.1"
+server:
+  ringpop:
+    name: temporal_active
+    maxJoinDuration: 30s
+    broadcastAddress: "127.0.0.1"
+  pprof:
+    port: 7936
 
 services:
   frontend:
@@ -27,8 +29,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_active"
-    pprof:
-      port: 7936
 
   matching:
     rpc:
@@ -39,8 +39,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_active"
-    pprof:
-      port: 7938
 
   history:
     rpc:
@@ -51,8 +49,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_active"
-    pprof:
-      port: 7937
 
   worker:
     rpc:
@@ -62,8 +58,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_active"
-    pprof:
-      port: 7941
 
 clusterMetadata:
   enableGlobalDomain: true

--- a/config/development_es.yaml
+++ b/config/development_es.yaml
@@ -19,10 +19,12 @@ persistence:
           host: "127.0.0.1:9200"
         indices:
           visibility: temporal-visibility-dev
-
-ringpop:
-  name: temporal
-  maxJoinDuration: 30s
+server:
+  ringpop:
+    name: temporal
+    maxJoinDuration: 30s
+  pprof:
+      port: 7936
 
 services:
   frontend:
@@ -34,8 +36,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7936
 
   matching:
     rpc:
@@ -46,8 +46,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7938
 
   history:
     rpc:
@@ -58,8 +56,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7937
 
   worker:
     rpc:
@@ -70,8 +66,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7940
 
 clusterMetadata:
   enableGlobalDomain: false

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -26,9 +26,12 @@ persistence:
         maxIdleConns: 2
         maxConnLifetime: "1h"
 
-ringpop:
-  name: temporal
-  maxJoinDuration: 30s
+server:
+  ringpop:
+    name: temporal
+    maxJoinDuration: 30s
+  pprof:
+    port: 7936
 
 services:
   frontend:
@@ -40,8 +43,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7936
 
   matching:
     rpc:
@@ -52,8 +53,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7938
 
   history:
     rpc:
@@ -64,8 +63,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7937
 
   worker:
     rpc:
@@ -76,8 +73,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7940
 
 clusterMetadata:
   enableGlobalDomain: false

--- a/config/development_other.yaml
+++ b/config/development_other.yaml
@@ -12,9 +12,12 @@ persistence:
         hosts: "127.0.0.1"
         keyspace: "temporal_visibility_other"
 
-ringpop:
-  name: temporal_other
-  maxJoinDuration: 30s
+server:
+  ringpop:
+    name: temporal_other
+    maxJoinDuration: 30s
+  pprof:
+    port: 9936
 
 services:
   frontend:
@@ -26,8 +29,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_other"
-    pprof:
-      port: 9936
 
   matching:
     rpc:
@@ -38,8 +39,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_other"
-    pprof:
-      port: 9938
 
   history:
     rpc:
@@ -50,8 +49,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_other"
-    pprof:
-      port: 9937
 
   worker:
     rpc:
@@ -62,8 +59,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_other"
-    pprof:
-      port: 9941
 
 clusterMetadata:
   enableGlobalDomain: true

--- a/config/development_postgres.yaml
+++ b/config/development_postgres.yaml
@@ -26,9 +26,12 @@ persistence:
         maxIdleConns: 2
         maxConnLifetime: "1h"
 
-ringpop:
-  name: cadence
-  maxJoinDuration: 30s
+server:
+  ringpop:
+    name: cadence
+    maxJoinDuration: 30s
+  pprof:
+    port: 7936
 
 services:
   frontend:
@@ -40,8 +43,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7936
 
   matching:
     rpc:
@@ -52,8 +53,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7938
 
   history:
     rpc:
@@ -64,8 +63,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7937
 
   worker:
     rpc:
@@ -76,8 +73,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal"
-    pprof:
-      port: 7940
 
 clusterMetadata:
   enableGlobalDomain: false

--- a/config/development_prometheus.yaml
+++ b/config/development_prometheus.yaml
@@ -12,9 +12,12 @@ persistence:
         hosts: "127.0.0.1"
         keyspace: "temporal_visibility"
 
-ringpop:
-  name: cadence
-  maxJoinDuration: 30s
+server:
+  ringpop:
+    name: cadence
+    maxJoinDuration: 30s
+  pprof:
+    port: 7936
 
 services:
   frontend:
@@ -26,8 +29,6 @@ services:
       prometheus:
         timerType: "histogram"
         listenAddress: "127.0.0.1:8000"
-    pprof:
-      port: 7936
 
   matching:
     rpc:
@@ -38,8 +39,6 @@ services:
       prometheus:
         timerType: "histogram"
         listenAddress: "127.0.0.1:8001"
-    pprof:
-      port: 7938
 
   history:
     rpc:
@@ -50,8 +49,6 @@ services:
       prometheus:
         timerType: "histogram"
         listenAddress: "127.0.0.1:8002"
-    pprof:
-      port: 7937
 
   worker:
     rpc:
@@ -62,8 +59,6 @@ services:
       prometheus:
         timerType: "histogram"
         listenAddress: "127.0.0.1:8003"
-    pprof:
-      port: 7940
 
 clusterMetadata:
   enableGlobalDomain: false

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -12,9 +12,12 @@ persistence:
         hosts: "127.0.0.1"
         keyspace: "temporal_visibility_standby"
 
-ringpop:
-  name: temporal_standby
-  maxJoinDuration: 30s
+server:
+  ringpop:
+    name: temporal_standby
+    maxJoinDuration: 30s
+  pprof:
+    port: 8936
 
 services:
   frontend:
@@ -26,8 +29,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_standby"
-    pprof:
-      port: 8936
 
   matching:
     rpc:
@@ -38,8 +39,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_standby"
-    pprof:
-      port: 8938
 
   history:
     rpc:
@@ -50,8 +49,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_standby"
-    pprof:
-      port: 8937
 
   worker:
     rpc:
@@ -62,8 +59,6 @@ services:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "temporal_standby"
-    pprof:
-      port: 8941
 
 clusterMetadata:
   enableGlobalDomain: true

--- a/go.sum
+++ b/go.sum
@@ -229,13 +229,8 @@ github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2 h1:zzrxE1FKn5ryB
 github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeIUDq/j97IG+FhNqkowIyEcD88LrW6fyU3K3WqY=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
-go.temporal.io/temporal v0.0.0-20200314013520-c42e945ca2a2 h1:O8W7ff/iPcndLtufXN0eV8uwMHVsRqqWMZ00dklMDrM=
-go.temporal.io/temporal v0.0.0-20200314013520-c42e945ca2a2/go.mod h1:4iG21ZgnHW0zgOFbxIuSlp/M5HwLhEe4EHKimMqXABM=
-go.temporal.io/temporal v0.10.11 h1:6sNA/S9gujfL27mHzZakMBAqbswL6b3ClW9ePMZ8z5M=
-go.temporal.io/temporal v0.10.11/go.mod h1:40Idznv+1A+C0q/pHZSEwzTzpe+phMWgzRqIDwv/b+U=
 go.temporal.io/temporal v0.10.12 h1:6nLCyY26EjyFUYXPW4t81Pr6JBwi+o501al3H2w7YbA=
 go.temporal.io/temporal v0.10.12/go.mod h1:4iG21ZgnHW0zgOFbxIuSlp/M5HwLhEe4EHKimMqXABM=
-go.temporal.io/temporal-proto v0.0.0-20200303231739-1a10aa50117a/go.mod h1:SszgPhzKZvtDenZxaN68OKKj1RD1uVmDOHUn1RnTctk=
 go.temporal.io/temporal-proto v0.0.0-20200313230351-15ab29fd00f3 h1:TcP3gsEAA64kGVc/1dH/dJrhuLES1SsWLku9I1+ecyg=
 go.temporal.io/temporal-proto v0.0.0-20200313230351-15ab29fd00f3/go.mod h1:SszgPhzKZvtDenZxaN68OKKj1RD1uVmDOHUn1RnTctk=
 go.temporal.io/temporal-proto v0.0.0-20200316214407-583dbd3e3b32 h1:4otOD3el3H50v1/WEDnKZMsYSOcRvxDWDvmFIPGT13Q=


### PR DESCRIPTION
**What changed?**

<!-- Describe what has changed in this PR -->
- Server config section introduced 
  - Pprof and ringpop moved under Server section
- Pprof is now initialized once per process

<!-- Tell your future self why have you made these changes -->
**Why?**
- To make sense of pprof and other settings which should run only once per process

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integ Tests, Manual Server Start

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Pprof stops working
- Ringpop is misconfigured and causes Server to stop.
