### PR TITLE
Register default domain on container start up

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,13 +16,6 @@ services:
     image: temporalio/temporal:master-auto-setup
     ports:
      - "7233:7233"
-     - "7234:7234"
-     - "7235:7235"
-     - "7239:7239"
-     - "6933:6933"
-     - "6934:6934"
-     - "6935:6935"
-     - "6939:6939"
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "STATSD_ENDPOINT=statsd:8125"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Docker container can be configured to automatically register a
default domain when container starts up.  Use the flag
'SKIP_DEFAULT_DOMAIN_CREATION' to skip creation of default domain.

Removed tcheck layer from Dockerfile as all tchannel rpc is now
removed.  Also cleaned up unnecessary ports from docker-compose
definition.


<!-- Tell your future self why have you made these changes -->
**Why?**

This simplifies Temporal experience, as first time users won't have 
to think about domain concept.  Once they download and run docker
container for the service it will automatically create a default domain 
when container comes up.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Buildkite automatically builds all relevant images and pushes to
dockerhub.

Tested docker-compose changes locally by bringing up the server
with 'SKIP_DEFAULT_DOMAIN_CREATION' set to 'true' and 'false'
values.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Very minimal risk.  Use 'SKIP_DEFAULT_DOMAIN_CREATION' flag to 
completely bypass default domain registration on startup.
