### PR TITLE
Rework PublicClient Config section

### DIFF
--- a/cmd/server/temporal/server.go
+++ b/cmd/server/temporal/server.go
@@ -161,12 +161,12 @@ func (s *server) startService() common.Daemon {
 		clusterMetadata.ReplicationConsumer,
 	)
 
-	if s.cfg.PublicClient.HostPort == "" {
-		log.Fatalf("need to provide an endpoint config for PublicClient")
-	} else if h, _, err := net.SplitHostPort(s.cfg.PublicClient.HostPort); err != nil || len(h) == 0 {
-		log.Fatalf("Malformed PublicClient HostPort, must be host:port - '%v' - Error - %v", s.cfg.PublicClient.HostPort, err)
+	if s.cfg.Clients.Frontend.PublicHostPort == "" {
+		log.Fatalf("need to provide an endpoint config for Clients.Frontend.PublicHostPort")
+	} else if h, _, err := net.SplitHostPort(s.cfg.Clients.Frontend.PublicHostPort); err != nil || len(h) == 0 {
+		log.Fatalf("Malformed Clients.Frontend.PublicHostPort, must be host:port - '%v' - Error - %v", s.cfg.Clients.Frontend.PublicHostPort, err)
 	} else {
-		connection, err := rpc.Dial(s.cfg.PublicClient.HostPort)
+		connection, err := rpc.Dial(s.cfg.Clients.Frontend.PublicHostPort)
 		if err != nil {
 			log.Fatalf("failed to dial gRPC connection: %v", err)
 		}

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -59,13 +59,17 @@ type (
 		Kafka messaging.KafkaConfig `yaml:"kafka"`
 		// Archival is the config for archival
 		Archival Archival `yaml:"archival"`
-		// PublicClient is config for connecting to temporal frontend
-		PublicClient PublicClient `yaml:"publicClient"`
+		// Clients is connection configuration for temporal clients
+		Clients Clients `yaml:"clients" validate:"nonzero"`
 		// DynamicConfigClient is the config for setting up the file based dynamic config client
 		// Filepath should be relative to the root directory
 		DynamicConfigClient dynamicconfig.FileBasedClientConfig `yaml:"dynamicConfigClient"`
 		// DomainDefaults is the default config for every domain
 		DomainDefaults DomainDefaults `yaml:"domainDefaults"`
+	}
+
+	Clients struct {
+		Frontend FrontendClient `yaml:"frontend" validate:"nonzero"`
 	}
 
 	// Service contains the service specific config items
@@ -380,10 +384,10 @@ type (
 		S3ForcePathStyle bool    `yaml:"s3ForcePathStyle"`
 	}
 
-	// PublicClient is config for connecting to cadence frontend
-	PublicClient struct {
+	// FrontendClient is config for connecting to cadence frontend
+	FrontendClient struct {
 		// HostPort is the host port to connect on. Host can be DNS name
-		HostPort string `yaml:"hostPort" validate:"nonzero"`
+		PublicHostPort string `yaml:"publicHostPort" validate:"nonzero"`
 		// interval to refresh DNS. Default to 10s
 		RefreshInterval time.Duration `yaml:"RefreshInterval"`
 	}

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -118,8 +118,9 @@ kafka:
     temporal-visibility-dev-dlq:
       cluster: test
 
-publicClient:
-  hostPort: "localhost:7233"
+clients:
+  frontend:
+    publicHostPort: "localhost:7233"
 
 dynamicConfigClient:
   filepath: "config/dynamicconfig/development.yaml"

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -146,5 +146,6 @@ domainDefaults:
       status: "enabled"
       URI: "file:///tmp/cadence_vis_archival/development"
 
-publicClient:
-  hostPort: "localhost:7933"
+clients:
+  frontend:
+    publicHostPort: "localhost:7933"

--- a/config/development_es.yaml
+++ b/config/development_es.yaml
@@ -125,8 +125,9 @@ kafka:
       topic: temporal-visibility-dev
       dlq-topic: temporal-visibility-dev-dlq
 
-publicClient:
-  hostPort: "localhost:7933"
+clients:
+  frontend:
+    publicHostPort: "localhost:7933"
 
 dynamicConfigClient:
   filepath: "config/dynamicconfig/development_es.yaml"

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -126,5 +126,6 @@ kafka:
     temporal-visibility-dev-dlq:
       cluster: test
 
-publicClient:
-  hostPort: "localhost:7933"
+clients:
+  frontend:
+    publicHostPort: "localhost:7933"

--- a/config/development_other.yaml
+++ b/config/development_other.yaml
@@ -147,5 +147,6 @@ domainDefaults:
       status: "enabled"
       URI: "file:///tmp/cadence_vis_archival/development"
 
-publicClient:
-  hostPort: "localhost:9933"
+clients:
+  frontend:
+    publicHostPort: "localhost:9933"

--- a/config/development_postgres.yaml
+++ b/config/development_postgres.yaml
@@ -126,5 +126,6 @@ kafka:
     temporal-visibility-dev-dlq:
       cluster: test
 
-publicClient:
-  hostPort: "localhost:7933"
+clients:
+  frontend:
+    publicHostPort: "localhost:7933"

--- a/config/development_prometheus.yaml
+++ b/config/development_prometheus.yaml
@@ -112,6 +112,7 @@ kafka:
     temporal-visibility-dev-dlq:
       cluster: test
 
-publicClient:
-  hostPort: "localhost:7933"
+clients:
+  frontend:
+    publicHostPort: "localhost:7933"
 

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -147,5 +147,6 @@ domainDefaults:
       status: "enabled"
       URI: "file:///tmp/cadence_vis_archival/development"
 
-publicClient:
-  hostPort: "localhost:8933"
+clients:
+  frontend:
+    publicHostPort: "localhost:8933"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -206,8 +206,9 @@ kafka:
             topic: temporal-visibility-dev
             dlq-topic: temporal-visibility-dev-dlq
 
-publicClient:
-    hostPort: {{ default .Env.BIND_ON_IP "127.0.0.1" }}:7233
+clients:
+  frontend:
+    publicHostPort: {{ default .Env.BIND_ON_IP "127.0.0.1" }}:7233
 
 dynamicConfigClient:
     filepath: {{ default .Env.DYNAMIC_CONFIG_FILE_PATH "/etc/temporal/config/dynamicconfig" }}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
```
publicClient:
  hostPort: "localhost:7233"
```
becomes
```
clients:
  frontend:
    publicHostPort: "localhost:7233"
```

<!-- Tell your future self why have you made these changes -->
**Why?**
To have an extensible config section or client settings similar to services

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Draft PR integ tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None
