### PR TITLE
Fix DynamicConfig Path, add more local dynamicConfig values

### DIFF
--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -58,7 +58,7 @@ func (c *Collection) logError(key Key, err error) {
 	errCount := atomic.AddInt64(&c.errCount, 1)
 	if errCount%errCountLogThreshold == 0 {
 		// log only every 'x' errors to reduce mem allocs and to avoid log noise
-		c.logger.Warn("Failed to fetch key from dynamic config", tag.Key(key.String()), tag.Error(err))
+		c.logger.Debug("Failed to fetch key from dynamic config", tag.Key(key.String()), tag.Error(err))
 	}
 }
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -122,6 +122,6 @@ publicClient:
   hostPort: "localhost:7233"
 
 dynamicConfigClient:
-  filepath: "config/dynamicconfig/development.yaml"
+  filepath: "./config/dynamicconfig/development.yaml"
   pollInterval: "10s"
 

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -7,3 +7,24 @@ system.minRetentionDays:
 history.EnableConsistentQueryByDomain:
 - value: true
   constraints: {}
+history.persistenceMaxQPS:
+- value: 3000
+  constraints: {}
+frontend.persistenceMaxQPS:
+- value: 3000
+  constraints: {}
+frontend.historyMgrNumConns:
+- value: 10
+  constraints: {}
+frontend.throttledLogRPS:
+- value: 20
+  constraints: {}
+history.historyMgrNumConns:
+- value: 50
+  constraints: {}
+system.advancedVisibilityWritingMode:
+- value: "off"
+  constraints: {}
+matching.numTasklistReadPartitions:
+- value: 1
+  constraints: {}


### PR DESCRIPTION
Development dynamicConfig path is wrong, updating to reference path correctly. Additionally adding additional dynamicConfig values (set to their existing defaults) to give example definitions.