### PR TITLE
CLI Defaults - Domain 'default' and WRP 'AllowDuplicate'

### DIFF
--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -50,6 +50,7 @@ func NewCliApp() *cli.App {
 		},
 		cli.StringFlag{
 			Name:   FlagDomainWithAlias,
+			Value:  "default",
 			Usage:  "temporal workflow domain",
 			EnvVar: "TEMPORAL_CLI_DOMAIN",
 		},

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -59,7 +59,7 @@ const (
 	defaultDecisionTimeoutInSeconds = 10
 	defaultPageSizeForList          = 500
 	defaultPageSizeForScan          = 2000
-	defaultWorkflowIDReusePolicy    = enums.WorkflowIdReusePolicyAllowDuplicateFailedOnly
+	defaultWorkflowIDReusePolicy    = enums.WorkflowIdReusePolicyAllowDuplicate
 
 	workflowStatusNotSet = -1
 	showErrorStackEnv    = `TEMPORAL_CLI_SHOW_STACKS`


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated tctl to use following defaults:
- domain = "default"
- workflowIdReusePolicy = enums.WorkflowIdReusePolicyAllowDuplicate 

<!-- Tell your future self why have you made these changes -->
**Why?**
Better usability in default situations

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested against local samples and temporal server with before and after behavior.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Defaults have changed, users must update behavior