### PR TITLE
Add makefile target for legacy mysql schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -266,6 +266,14 @@ install-schema: bins
 	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility setup-schema -v 0.0
 	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility update-schema -d ./schema/cassandra/visibility/versioned
 
+install-schema-mysql-pre5720: bins
+	./temporal-sql-tool --ep 127.0.0.1 --ca tx_isolation='READ-COMMITTED' create --db temporal
+	./temporal-sql-tool --ep 127.0.0.1 --ca tx_isolation='READ-COMMITTED' --db temporal setup-schema -v 0.0
+	./temporal-sql-tool --ep 127.0.0.1 --ca tx_isolation='READ-COMMITTED' --db temporal update-schema -d ./schema/mysql/v57/temporal/versioned
+	./temporal-sql-tool --ep 127.0.0.1 --ca tx_isolation='READ-COMMITTED' create --db temporal_visibility
+	./temporal-sql-tool --ep 127.0.0.1 --ca tx_isolation='READ-COMMITTED' --db temporal_visibility setup-schema -v 0.0
+	./temporal-sql-tool --ep 127.0.0.1 --ca tx_isolation='READ-COMMITTED' --db temporal_visibility update-schema -d ./schema/mysql/v57/visibility/versioned
+
 install-schema-mysql: bins
 	./temporal-sql-tool --ep 127.0.0.1 create --db temporal
 	./temporal-sql-tool --ep 127.0.0.1 --db temporal setup-schema -v 0.0

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -96,7 +96,7 @@ persistence:
 ```
 
 ## MySQL
-The default isolation level for MySQL is READ-COMMITTED. For MySQL 5.6 and below only, the isolation level needs to be 
+The default isolation level for MySQL is READ-COMMITTED. For MySQL 5.7.20 and below only, the isolation level needs to be
 specified explicitly in the config via connectAttributes.
  
 ```
@@ -116,7 +116,7 @@ persistence:
         maxConnLifetime: "1h"          -- max connection lifetime before it is discarded (optional)
         maxQPS: 1000                   -- max qps to sql server from one host (optional)
         connectAttributes:             -- custom dsn attributes, map of key-value pairs
-          tx_isolation: "READ-COMMITTED"   -- required only for mysql 5.6 and below, optional otherwise
+          tx_isolation: "READ-COMMITTED"   -- required only for mysql 5.7.20 and below, optional otherwise
 ```
 
 # Adding support for new database


### PR DESCRIPTION
Adding convenience target to allow schema installation for pre 5.7.20 mysql installs. 