### PR TITLE
Update makefile to not install dependencies for binaries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,23 +126,23 @@ copyright: cmd/tools/copyright/licensegen.go
 
 temporal-cassandra-tool: $(TOOLS_SRC)
 	@echo "compiling temporal-cassandra-tool with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -i -o temporal-cassandra-tool cmd/tools/cassandra/main.go
+	go build -o temporal-cassandra-tool cmd/tools/cassandra/main.go
 
 temporal-sql-tool: $(TOOLS_SRC)
 	@echo "compiling temporal-sql-tool with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -i -o temporal-sql-tool cmd/tools/sql/main.go
+	go build -o temporal-sql-tool cmd/tools/sql/main.go
 
 tctl: $(TOOLS_SRC)
 	@echo "compiling tctl with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -i -o tctl cmd/tools/cli/main.go
+	go build -o tctl cmd/tools/cli/main.go
 
 temporal-server: $(ALL_SRC)
 	@echo "compiling temporal-server with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -ldflags '$(GO_BUILD_LDFLAGS)' -i -o temporal-server cmd/server/main.go
+	go build -ldflags '$(GO_BUILD_LDFLAGS)' -o temporal-server cmd/server/main.go
 
 temporal-canary: $(ALL_SRC)
 	@echo "compiling temporal-canary with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -i -o temporal-canary cmd/canary/main.go
+	go build -o temporal-canary cmd/canary/main.go
 
 go-generate:
 	go get github.com/golang/mock/mockgen@latest

--- a/go.mod
+++ b/go.mod
@@ -70,6 +70,7 @@ require (
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 	golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+	golang.org/x/tools v0.0.0-20200325194147-644a21fb1449 // indirect
 	google.golang.org/api v0.4.0
 	google.golang.org/grpc v1.28.0
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -339,6 +339,8 @@ golang.org/x/tools v0.0.0-20191130070609-6e064ea0cf2d/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200130002326-2f3ba24bd6e7/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/tools v0.0.0-20200317043434-63da46f3035e h1:8ogAbHWoJTPepnVbNRqXLOpzMkl0rtRsM7crbflc4XM=
 golang.org/x/tools v0.0.0-20200317043434-63da46f3035e/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
+golang.org/x/tools v0.0.0-20200325194147-644a21fb1449 h1:KOG4qpDXI4j4YMkZezw18+e2jkjrRw5f/n+3p9JiIjY=
+golang.org/x/tools v0.0.0-20200325194147-644a21fb1449/go.mod h1:Sl4aGygMT6LrqrWclx+PTx3U+LnKx/seiNR+3G19Ar8=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Dependencies are not installed as part of building executables


<!-- Tell your future self why have you made these changes -->
**Why?**
It feels unnecessary to install dependencies for all built binaries
and could cause permissions issues on some machines.

Also some go.mod changes if you are running with 1.14 runtime.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local build.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk
