### PR TITLE
Fix default workflowIdReusePolicy in help message

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -302,7 +302,7 @@ func getFlagsForStart() []cli.Flag {
 		cli.IntFlag{
 			Name: FlagWorkflowIDReusePolicyAlias,
 			Usage: "Optional input to configure if the same workflow ID is allow to use for new workflow execution. " +
-				"Available options: 0: AllowDuplicateFailedOnly, 1: AllowDuplicate, 2: RejectDuplicate",
+				"Available options: 0: AllowDuplicate, 1: AllowDuplicateFailedOnly, 2: RejectDuplicate",
 		},
 		cli.StringFlag{
 			Name:  FlagInputWithAlias,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix help message to swap workflowIdReusePolicy values


<!-- Tell your future self why have you made these changes -->
**Why did you make the changes?**
Help message should be heplful

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**Testing?**
I didnt

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Risks?**
Noone
