### PR TITLE
Remove unused BufferedReplicationTasks in schema

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -319,7 +319,7 @@ workflow_state = ? ` +
 
 	templateGetWorkflowExecutionQuery = `SELECT execution, execution_encoding, execution_state, execution_state_encoding, next_event_id, replication_state, activity_map, activity_map_encoding, timer_map, timer_map_encoding, ` +
 		`child_executions_map, child_executions_map_encoding, request_cancel_map, request_cancel_map_encoding, signal_map, signal_map_encoding, signal_requested, buffered_events_list, ` +
-		`buffered_replication_tasks_map, version_histories, version_histories_encoding, checksum, checksum_encoding ` +
+		`version_histories, version_histories_encoding, checksum, checksum_encoding ` +
 		`FROM executions ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/temporalio/temporal/common/primitives"
 
-	pblobs "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
+	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 
 	"github.com/temporalio/temporal/common/checksum"
 
@@ -251,7 +251,7 @@ type (
 
 	// ShardInfoWithFailover describes a shard
 	ShardInfoWithFailover struct {
-		*pblobs.ShardInfo
+		*persistenceblobs.ShardInfo
 		TransferFailoverLevels map[string]TransferFailoverLevel // uuid -> TransferFailoverLevel
 		TimerFailoverLevels    map[string]TimerFailoverLevel    // uuid -> TimerFailoverLevel
 	}
@@ -351,7 +351,7 @@ type (
 
 	// ReplicationTaskInfoWrapper describes a replication task.
 	ReplicationTaskInfoWrapper struct {
-		*pblobs.ReplicationTaskInfo
+		*persistenceblobs.ReplicationTaskInfo
 	}
 
 	// Task is the generic interface for workflow tasks
@@ -561,10 +561,10 @@ type (
 	// WorkflowMutableState indicates workflow related state
 	WorkflowMutableState struct {
 		ActivityInfos       map[int64]*ActivityInfo
-		TimerInfos          map[string]*pblobs.TimerInfo
+		TimerInfos          map[string]*persistenceblobs.TimerInfo
 		ChildExecutionInfos map[int64]*ChildExecutionInfo
-		RequestCancelInfos  map[int64]*pblobs.RequestCancelInfo
-		SignalInfos         map[int64]*pblobs.SignalInfo
+		RequestCancelInfos  map[int64]*persistenceblobs.RequestCancelInfo
+		SignalInfos         map[int64]*persistenceblobs.SignalInfo
 		SignalRequestedIDs  map[string]struct{}
 		ExecutionInfo       *WorkflowExecutionInfo
 		ExecutionStats      *ExecutionStats
@@ -632,7 +632,7 @@ type (
 
 	// CreateShardRequest is used to create a shard in executions table
 	CreateShardRequest struct {
-		ShardInfo *pblobs.ShardInfo
+		ShardInfo *persistenceblobs.ShardInfo
 	}
 
 	// GetShardRequest is used to get shard information
@@ -642,12 +642,12 @@ type (
 
 	// GetShardResponse is the response to GetShard
 	GetShardResponse struct {
-		ShardInfo *pblobs.ShardInfo
+		ShardInfo *persistenceblobs.ShardInfo
 	}
 
 	// UpdateShardRequest  is used to update shard information
 	UpdateShardRequest struct {
-		ShardInfo       *pblobs.ShardInfo
+		ShardInfo       *persistenceblobs.ShardInfo
 		PreviousRangeID int64
 	}
 
@@ -776,13 +776,13 @@ type (
 
 		UpsertActivityInfos       []*ActivityInfo
 		DeleteActivityInfos       []int64
-		UpsertTimerInfos          []*pblobs.TimerInfo
+		UpsertTimerInfos          []*persistenceblobs.TimerInfo
 		DeleteTimerInfos          []string
 		UpsertChildExecutionInfos []*ChildExecutionInfo
 		DeleteChildExecutionInfo  *int64
-		UpsertRequestCancelInfos  []*pblobs.RequestCancelInfo
+		UpsertRequestCancelInfos  []*persistenceblobs.RequestCancelInfo
 		DeleteRequestCancelInfo   *int64
-		UpsertSignalInfos         []*pblobs.SignalInfo
+		UpsertSignalInfos         []*persistenceblobs.SignalInfo
 		DeleteSignalInfo          *int64
 		UpsertSignalRequestedIDs  []string
 		DeleteSignalRequestedID   string
@@ -805,10 +805,10 @@ type (
 		VersionHistories *VersionHistories
 
 		ActivityInfos       []*ActivityInfo
-		TimerInfos          []*pblobs.TimerInfo
+		TimerInfos          []*persistenceblobs.TimerInfo
 		ChildExecutionInfos []*ChildExecutionInfo
-		RequestCancelInfos  []*pblobs.RequestCancelInfo
-		SignalInfos         []*pblobs.SignalInfo
+		RequestCancelInfos  []*persistenceblobs.RequestCancelInfo
+		SignalInfos         []*persistenceblobs.SignalInfo
 		SignalRequestedIDs  []string
 
 		TransferTasks    []Task
@@ -851,7 +851,7 @@ type (
 
 	// GetTransferTasksResponse is the response to GetTransferTasksRequest
 	GetTransferTasksResponse struct {
-		Tasks         []*pblobs.TransferTaskInfo
+		Tasks         []*persistenceblobs.TransferTaskInfo
 		NextPageToken []byte
 	}
 
@@ -865,7 +865,7 @@ type (
 
 	// GetReplicationTasksResponse is the response to GetReplicationTask
 	GetReplicationTasksResponse struct {
-		Tasks         []*pblobs.ReplicationTaskInfo
+		Tasks         []*persistenceblobs.ReplicationTaskInfo
 		NextPageToken []byte
 	}
 
@@ -893,7 +893,7 @@ type (
 	// PutReplicationTaskToDLQRequest is used to put a replication task to dlq
 	PutReplicationTaskToDLQRequest struct {
 		SourceClusterName string
-		TaskInfo          *pblobs.ReplicationTaskInfo
+		TaskInfo          *persistenceblobs.ReplicationTaskInfo
 	}
 
 	// GetReplicationTasksFromDLQRequest is used to get replication tasks from dlq
@@ -947,7 +947,7 @@ type (
 	// UpdateTaskListRequest is used to update task list implementation information
 	UpdateTaskListRequest struct {
 		RangeID      int64
-		TaskListInfo *pblobs.TaskListInfo
+		TaskListInfo *persistenceblobs.TaskListInfo
 	}
 
 	// UpdateTaskListResponse is the response to UpdateTaskList
@@ -975,7 +975,7 @@ type (
 	// CreateTasksRequest is used to create a new task for a workflow execution
 	CreateTasksRequest struct {
 		TaskListInfo *PersistedTaskListInfo
-		Tasks        []*pblobs.AllocatedTaskInfo
+		Tasks        []*persistenceblobs.AllocatedTaskInfo
 	}
 
 	// CreateTasksResponse is the response to CreateTasksRequest
@@ -983,7 +983,7 @@ type (
 	}
 
 	PersistedTaskListInfo struct {
-		Data    *pblobs.TaskListInfo
+		Data    *persistenceblobs.TaskListInfo
 		RangeID int64
 	}
 
@@ -999,7 +999,7 @@ type (
 
 	// GetTasksResponse is the response to GetTasksRequests
 	GetTasksResponse struct {
-		Tasks []*pblobs.AllocatedTaskInfo
+		Tasks []*persistenceblobs.AllocatedTaskInfo
 	}
 
 	// CompleteTaskRequest is used to complete a task
@@ -1028,7 +1028,7 @@ type (
 
 	// GetTimerIndexTasksResponse is the response for GetTimerIndexTasks
 	GetTimerIndexTasksResponse struct {
-		Timers        []*pblobs.TimerTaskInfo
+		Timers        []*persistenceblobs.TimerTaskInfo
 		NextPageToken []byte
 	}
 
@@ -1331,7 +1331,7 @@ type (
 	// GetHistoryTreeResponse is a response to GetHistoryTreeRequest
 	GetHistoryTreeResponse struct {
 		// all branches of a tree
-		Branches []*pblobs.HistoryBranch
+		Branches []*persistenceblobs.HistoryBranch
 	}
 
 	// GetAllHistoryTreeBranchesRequest is a request of GetAllHistoryTreeBranches
@@ -1353,19 +1353,19 @@ type (
 	// InitializeImmutableClusterMetadataRequest is a request of InitializeImmutableClusterMetadata
 	// These values can only be set a single time upon cluster initialization.
 	InitializeImmutableClusterMetadataRequest struct {
-		pblobs.ImmutableClusterMetadata
+		persistenceblobs.ImmutableClusterMetadata
 	}
 
 	// InitializeImmutableClusterMetadataResponse is a request of InitializeImmutableClusterMetadata
 	InitializeImmutableClusterMetadataResponse struct {
-		PersistedImmutableData pblobs.ImmutableClusterMetadata
+		PersistedImmutableData persistenceblobs.ImmutableClusterMetadata
 		RequestApplied         bool
 	}
 
 	// GetImmutableClusterMetadataResponse is the response to GetImmutableClusterMetadata
 	// These values are set a single time upon cluster initialization.
 	GetImmutableClusterMetadataResponse struct {
-		pblobs.ImmutableClusterMetadata
+		persistenceblobs.ImmutableClusterMetadata
 	}
 
 	// GetClusterMembersRequest is the response to GetClusterMembers
@@ -2270,10 +2270,10 @@ func UnixNanoToDBTimestamp(timestamp int64) int64 {
 // NewHistoryBranchToken return a new branch token
 func NewHistoryBranchToken(treeID []byte) ([]byte, error) {
 	branchID := uuid.NewRandom()
-	bi := &pblobs.HistoryBranch{
+	bi := &persistenceblobs.HistoryBranch{
 		TreeID:    treeID,
 		BranchID:  branchID,
-		Ancestors: []*pblobs.HistoryBranchRange{},
+		Ancestors: []*persistenceblobs.HistoryBranchRange{},
 	}
 	datablob, err := serialization.HistoryBranchToBlob(bi)
 	if err != nil {
@@ -2285,10 +2285,10 @@ func NewHistoryBranchToken(treeID []byte) ([]byte, error) {
 
 // NewHistoryBranchTokenByBranchID return a new branch token with treeID/branchID
 func NewHistoryBranchTokenByBranchID(treeID, branchID []byte) ([]byte, error) {
-	bi := &pblobs.HistoryBranch{
+	bi := &persistenceblobs.HistoryBranch{
 		TreeID:    treeID,
 		BranchID:  branchID,
-		Ancestors: []*pblobs.HistoryBranchRange{},
+		Ancestors: []*persistenceblobs.HistoryBranchRange{},
 	}
 	datablob, err := serialization.HistoryBranchToBlob(bi)
 	if err != nil {

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -40,7 +40,7 @@ import (
 	"go.temporal.io/temporal-proto/enums"
 	"go.temporal.io/temporal-proto/serviceerror"
 
-	pblobs "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
+	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 	"github.com/temporalio/temporal/.gen/proto/replication"
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/checksum"
@@ -2067,14 +2067,14 @@ func (s *ExecutionManagerSuite) TestCancelTransferTaskTasks() {
 	s.NoError(err)
 }
 
-func (s *ExecutionManagerSuite) validateTransferTaskHighLevel(task1 *pblobs.TransferTaskInfo, taskType int32, namespaceID string, workflowExecution commonproto.WorkflowExecution) {
+func (s *ExecutionManagerSuite) validateTransferTaskHighLevel(task1 *persistenceblobs.TransferTaskInfo, taskType int32, namespaceID string, workflowExecution commonproto.WorkflowExecution) {
 	s.EqualValues(taskType, task1.TaskType)
 	s.Equal(namespaceID, primitives.UUID(task1.NamespaceID).String())
 	s.Equal(workflowExecution.GetWorkflowId(), task1.WorkflowID)
 	s.Equal(workflowExecution.GetRunId(), primitives.UUID(task1.RunID).String())
 }
 
-func (s *ExecutionManagerSuite) validateTransferTaskTargetInfo(task2 *pblobs.TransferTaskInfo, targetNamespaceID string, targetWorkflowID string, targetRunID string) {
+func (s *ExecutionManagerSuite) validateTransferTaskTargetInfo(task2 *persistenceblobs.TransferTaskInfo, targetNamespaceID string, targetWorkflowID string, targetRunID string) {
 	s.Equal(targetNamespaceID, primitives.UUID(task2.TargetNamespaceID).String())
 	s.Equal(targetWorkflowID, task2.TargetWorkflowID)
 	s.Equal(targetRunID, primitives.UUID(task2.TargetRunID).String())
@@ -2708,7 +2708,7 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateTimers() {
 	updatedInfo.LastProcessedEvent = int64(2)
 	currentTime := types.TimestampNow()
 	timerID := "id_1"
-	timerInfos := []*pblobs.TimerInfo{{
+	timerInfos := []*persistenceblobs.TimerInfo{{
 		Version:    3345,
 		TimerID:    timerID,
 		ExpiryTime: currentTime,
@@ -2827,13 +2827,13 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateRequestCancel() {
 	updatedStats := copyExecutionStats(state0.ExecutionStats)
 	updatedInfo.NextEventID = int64(5)
 	updatedInfo.LastProcessedEvent = int64(2)
-	requestCancelInfo := &pblobs.RequestCancelInfo{
+	requestCancelInfo := &persistenceblobs.RequestCancelInfo{
 		Version:               456,
 		InitiatedID:           2,
 		InitiatedEventBatchID: 1,
 		CancelRequestID:       uuid.New(),
 	}
-	err2 := s.UpsertRequestCancelState(updatedInfo, updatedStats, nil, int64(3), []*pblobs.RequestCancelInfo{requestCancelInfo})
+	err2 := s.UpsertRequestCancelState(updatedInfo, updatedStats, nil, int64(3), []*persistenceblobs.RequestCancelInfo{requestCancelInfo})
 	s.NoError(err2)
 
 	state, err1 := s.GetWorkflowExecutionInfo(namespaceID, workflowExecution)
@@ -2876,7 +2876,7 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateSignalInfo() {
 	updatedStats := copyExecutionStats(state0.ExecutionStats)
 	updatedInfo.NextEventID = int64(5)
 	updatedInfo.LastProcessedEvent = int64(2)
-	signalInfo := &pblobs.SignalInfo{
+	signalInfo := &persistenceblobs.SignalInfo{
 		Version:               123,
 		InitiatedID:           2,
 		InitiatedEventBatchID: 1,
@@ -2885,7 +2885,7 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateSignalInfo() {
 		Input:                 []byte("test signal input"),
 		Control:               []byte(uuid.New()),
 	}
-	err2 := s.UpsertSignalInfoState(updatedInfo, updatedStats, nil, int64(3), []*pblobs.SignalInfo{signalInfo})
+	err2 := s.UpsertSignalInfoState(updatedInfo, updatedStats, nil, int64(3), []*persistenceblobs.SignalInfo{signalInfo})
 	s.NoError(err2)
 
 	state, err1 := s.GetWorkflowExecutionInfo(namespaceID, workflowExecution)
@@ -3666,7 +3666,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 				TimerTaskStatus:          1,
 			}},
 
-		TimerInfos: map[string]*pblobs.TimerInfo{
+		TimerInfos: map[string]*persistenceblobs.TimerInfo{
 			"t1": {
 				Version:    2333,
 				TimerID:    "t1",
@@ -3701,7 +3701,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 			},
 		},
 
-		RequestCancelInfos: map[int64]*pblobs.RequestCancelInfo{
+		RequestCancelInfos: map[int64]*persistenceblobs.RequestCancelInfo{
 			19: {
 				Version:               2335,
 				InitiatedID:           19,
@@ -3710,7 +3710,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 			},
 		},
 
-		SignalInfos: map[int64]*pblobs.SignalInfo{
+		SignalInfos: map[int64]*persistenceblobs.SignalInfo{
 			39: {
 				Version:               2336,
 				InitiatedID:           39,
@@ -3887,7 +3887,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 			TimerTaskStatus:          1,
 		}}
 
-	resetTimerInfos := []*pblobs.TimerInfo{
+	resetTimerInfos := []*persistenceblobs.TimerInfo{
 		{
 			Version:    3333,
 			TimerID:    "t1_new",
@@ -3913,14 +3913,14 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 			CreateRequestID: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 		}}
 
-	resetRequestCancelInfos := []*pblobs.RequestCancelInfo{
+	resetRequestCancelInfos := []*persistenceblobs.RequestCancelInfo{
 		{
 			Version:         3335,
 			InitiatedID:     29,
 			CancelRequestID: "new_cancel_requested_id",
 		}}
 
-	resetSignalInfos := []*pblobs.SignalInfo{
+	resetSignalInfos := []*persistenceblobs.SignalInfo{
 		{
 			Version:     3336,
 			InitiatedID: 39,
@@ -4111,10 +4111,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithCASCurre
 	}
 	resetStats := &p.ExecutionStats{}
 	resetActivityInfos := []*p.ActivityInfo{}
-	resetTimerInfos := []*pblobs.TimerInfo{}
+	resetTimerInfos := []*persistenceblobs.TimerInfo{}
 	resetChildExecutionInfos := []*p.ChildExecutionInfo{}
-	resetRequestCancelInfos := []*pblobs.RequestCancelInfo{}
-	resetSignalInfos := []*pblobs.SignalInfo{}
+	resetRequestCancelInfos := []*persistenceblobs.RequestCancelInfo{}
+	resetSignalInfos := []*persistenceblobs.SignalInfo{}
 	rState := &p.ReplicationState{
 		CurrentVersion: int64(8789),
 		StartVersion:   int64(8780),
@@ -4243,10 +4243,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithCASMisma
 	}
 	resetStats := &p.ExecutionStats{}
 	resetActivityInfos := []*p.ActivityInfo{}
-	resetTimerInfos := []*pblobs.TimerInfo{}
+	resetTimerInfos := []*persistenceblobs.TimerInfo{}
 	resetChildExecutionInfos := []*p.ChildExecutionInfo{}
-	resetRequestCancelInfos := []*pblobs.RequestCancelInfo{}
-	resetSignalInfos := []*pblobs.SignalInfo{}
+	resetRequestCancelInfos := []*persistenceblobs.RequestCancelInfo{}
+	resetSignalInfos := []*persistenceblobs.SignalInfo{}
 	rState := &p.ReplicationState{
 		CurrentVersion: int64(8789),
 		StartVersion:   int64(8780),
@@ -4367,10 +4367,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition:        int64(5),
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		NewWorkflowSnapshot: nil,
@@ -4381,10 +4381,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition:        int64(3),
 
 			UpsertActivityInfos:       []*p.ActivityInfo{},
-			UpsertTimerInfos:          []*pblobs.TimerInfo{},
+			UpsertTimerInfos:          []*persistenceblobs.TimerInfo{},
 			UpsertChildExecutionInfos: []*p.ChildExecutionInfo{},
-			UpsertRequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			UpsertSignalInfos:         []*pblobs.SignalInfo{},
+			UpsertRequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			UpsertSignalInfos:         []*persistenceblobs.SignalInfo{},
 			UpsertSignalRequestedIDs:  []string{},
 		},
 		CurrentWorkflowCAS: nil,
@@ -4524,10 +4524,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition: int64(5),
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		NewWorkflowSnapshot: &p.WorkflowSnapshot{
@@ -4537,10 +4537,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition:        0,
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		CurrentWorkflowMutation: &p.WorkflowMutation{
@@ -4550,10 +4550,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition:        int64(3),
 
 			UpsertActivityInfos:       []*p.ActivityInfo{},
-			UpsertTimerInfos:          []*pblobs.TimerInfo{},
+			UpsertTimerInfos:          []*persistenceblobs.TimerInfo{},
 			UpsertChildExecutionInfos: []*p.ChildExecutionInfo{},
-			UpsertRequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			UpsertSignalInfos:         []*pblobs.SignalInfo{},
+			UpsertRequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			UpsertSignalInfos:         []*persistenceblobs.SignalInfo{},
 			UpsertSignalRequestedIDs:  []string{},
 		},
 		CurrentWorkflowCAS: nil,
@@ -4670,10 +4670,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition:        nextEventID,
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		NewWorkflowSnapshot:     nil,
@@ -4783,10 +4783,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition: nextEventID,
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		NewWorkflowSnapshot: &p.WorkflowSnapshot{
@@ -4796,10 +4796,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition:        0,
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		CurrentWorkflowMutation: nil,
@@ -4926,10 +4926,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition:        int64(5),
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		NewWorkflowSnapshot:     nil,
@@ -5052,10 +5052,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition: int64(5),
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		NewWorkflowSnapshot: &p.WorkflowSnapshot{
@@ -5065,10 +5065,10 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionWithTransact
 			Condition:        0,
 
 			ActivityInfos:       []*p.ActivityInfo{},
-			TimerInfos:          []*pblobs.TimerInfo{},
+			TimerInfos:          []*persistenceblobs.TimerInfo{},
 			ChildExecutionInfos: []*p.ChildExecutionInfo{},
-			RequestCancelInfos:  []*pblobs.RequestCancelInfo{},
-			SignalInfos:         []*pblobs.SignalInfo{},
+			RequestCancelInfos:  []*persistenceblobs.RequestCancelInfo{},
+			SignalInfos:         []*persistenceblobs.SignalInfo{},
 			SignalRequestedIDs:  []string{},
 		},
 		CurrentWorkflowMutation: nil,
@@ -5117,7 +5117,7 @@ func (s *ExecutionManagerSuite) TestCreateGetShardBackfill() {
 	currentReplicationAck := int64(27)
 	currentClusterTransferAck := int64(21)
 	currentClusterTimerAck := timestampConvertor(time.Now().Add(-10 * time.Second))
-	shardInfo := &pblobs.ShardInfo{
+	shardInfo := &persistenceblobs.ShardInfo{
 		ShardID:                 shardID,
 		Owner:                   "some random owner",
 		RangeID:                 rangeID,
@@ -5165,7 +5165,7 @@ func (s *ExecutionManagerSuite) TestCreateGetUpdateGetShard() {
 	currentClusterTimerAck := timestampConvertor(time.Now().Add(-10 * time.Second))
 	alternativeClusterTimerAck := timestampConvertor(time.Now().Add(-20 * time.Second))
 	namespaceNotificationVersion := int64(8192)
-	shardInfo := &pblobs.ShardInfo{
+	shardInfo := &persistenceblobs.ShardInfo{
 		ShardID:             shardID,
 		Owner:               "some random owner",
 		RangeID:             rangeID,
@@ -5209,7 +5209,7 @@ func (s *ExecutionManagerSuite) TestCreateGetUpdateGetShard() {
 	currentClusterTimerAck = timestampConvertor(time.Now().Add(-100 * time.Second))
 	alternativeClusterTimerAck = timestampConvertor(time.Now().Add(-200 * time.Second))
 	namespaceNotificationVersion = int64(16384)
-	shardInfo = &pblobs.ShardInfo{
+	shardInfo = &persistenceblobs.ShardInfo{
 		ShardID:             shardID,
 		Owner:               "some random owner",
 		RangeID:             int64(28),
@@ -5252,7 +5252,7 @@ func (s *ExecutionManagerSuite) TestCreateGetUpdateGetShard() {
 // TestReplicationDLQ test
 func (s *ExecutionManagerSuite) TestReplicationDLQ() {
 	sourceCluster := "test"
-	taskInfo := &pblobs.ReplicationTaskInfo{
+	taskInfo := &persistenceblobs.ReplicationTaskInfo{
 		NamespaceID: primitives.MustParseUUID(uuid.New()),
 		WorkflowID:  uuid.New(),
 		RunID:       primitives.MustParseUUID(uuid.New()),
@@ -5270,14 +5270,14 @@ func (s *ExecutionManagerSuite) TestReplicationDLQ() {
 	s.NoError(err)
 	s.Len(resp.Tasks, 0)
 
-	taskInfo1 := &pblobs.ReplicationTaskInfo{
+	taskInfo1 := &persistenceblobs.ReplicationTaskInfo{
 		NamespaceID: primitives.MustParseUUID(uuid.New()),
 		WorkflowID:  uuid.New(),
 		RunID:       primitives.MustParseUUID(uuid.New()),
 		TaskID:      1,
 		TaskType:    0,
 	}
-	taskInfo2 := &pblobs.ReplicationTaskInfo{
+	taskInfo2 := &persistenceblobs.ReplicationTaskInfo{
 		NamespaceID: primitives.MustParseUUID(uuid.New()),
 		WorkflowID:  uuid.New(),
 		RunID:       primitives.MustParseUUID(uuid.New()),

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -34,7 +34,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
 
-	pblobs "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
+	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 	"github.com/temporalio/temporal/.gen/proto/replication"
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/backoff"
@@ -84,7 +84,7 @@ type (
 		MetadataManager           p.MetadataManager
 		VisibilityMgr             p.VisibilityManager
 		NamespaceReplicationQueue p.NamespaceReplicationQueue
-		ShardInfo                 *pblobs.ShardInfo
+		ShardInfo                 *persistenceblobs.ShardInfo
 		TaskIDGenerator           TransferTaskIDGenerator
 		ClusterMetadata           cluster.Metadata
 		ReadLevel                 int64
@@ -220,7 +220,7 @@ func (s *TestBase) Setup() {
 
 	s.ReadLevel = 0
 	s.ReplicationReadLevel = 0
-	s.ShardInfo = &pblobs.ShardInfo{
+	s.ShardInfo = &persistenceblobs.ShardInfo{
 		ShardID:                 shardID,
 		RangeID:                 0,
 		TransferAckLevel:        0,
@@ -247,7 +247,7 @@ func (s *TestBase) fatalOnError(msg string, err error) {
 
 // CreateShard is a utility method to create the shard using persistence layer
 func (s *TestBase) CreateShard(shardID int32, owner string, rangeID int64) error {
-	info := &pblobs.ShardInfo{
+	info := &persistenceblobs.ShardInfo{
 		ShardID: shardID,
 		Owner:   owner,
 		RangeID: rangeID,
@@ -259,7 +259,7 @@ func (s *TestBase) CreateShard(shardID int32, owner string, rangeID int64) error
 }
 
 // GetShard is a utility method to get the shard using persistence layer
-func (s *TestBase) GetShard(shardID int32) (*pblobs.ShardInfo, error) {
+func (s *TestBase) GetShard(shardID int32) (*persistenceblobs.ShardInfo, error) {
 	response, err := s.ShardMgr.GetShard(&p.GetShardRequest{
 		ShardID: shardID,
 	})
@@ -272,7 +272,7 @@ func (s *TestBase) GetShard(shardID int32) (*pblobs.ShardInfo, error) {
 }
 
 // UpdateShard is a utility method to update the shard using persistence layer
-func (s *TestBase) UpdateShard(updatedInfo *pblobs.ShardInfo, previousRangeID int64) error {
+func (s *TestBase) UpdateShard(updatedInfo *persistenceblobs.ShardInfo, previousRangeID int64) error {
 	return s.ShardMgr.UpdateShard(&p.UpdateShardRequest{
 		ShardInfo:       updatedInfo,
 		PreviousRangeID: previousRangeID,
@@ -601,7 +601,7 @@ func (s *TestBase) ContinueAsNewExecutionWithReplication(updatedInfo *p.Workflow
 func (s *TestBase) UpdateWorkflowExecution(updatedInfo *p.WorkflowExecutionInfo, updatedStats *p.ExecutionStats, updatedVersionHistories *p.VersionHistories,
 	decisionScheduleIDs []int64, activityScheduleIDs []int64, condition int64, timerTasks []p.Task,
 	upsertActivityInfos []*p.ActivityInfo, deleteActivityInfos []int64,
-	upsertTimerInfos []*pblobs.TimerInfo, deleteTimerInfos []string) error {
+	upsertTimerInfos []*persistenceblobs.TimerInfo, deleteTimerInfos []string) error {
 	return s.UpdateWorkflowExecutionWithRangeID(updatedInfo, updatedStats, updatedVersionHistories, decisionScheduleIDs, activityScheduleIDs,
 		s.ShardInfo.RangeID, condition, timerTasks, upsertActivityInfos, deleteActivityInfos,
 		upsertTimerInfos, deleteTimerInfos, nil, nil, nil, nil,
@@ -641,7 +641,7 @@ func (s *TestBase) UpsertChildExecutionsState(updatedInfo *p.WorkflowExecutionIn
 
 // UpsertRequestCancelState is a utility method to update mutable state of workflow execution
 func (s *TestBase) UpsertRequestCancelState(updatedInfo *p.WorkflowExecutionInfo, updatedStats *p.ExecutionStats, updatedVersionHistories *p.VersionHistories,
-	condition int64, upsertCancelInfos []*pblobs.RequestCancelInfo) error {
+	condition int64, upsertCancelInfos []*persistenceblobs.RequestCancelInfo) error {
 	return s.UpdateWorkflowExecutionWithRangeID(updatedInfo, updatedStats, updatedVersionHistories, nil, nil,
 		s.ShardInfo.RangeID, condition, nil, nil, nil,
 		nil, nil, nil, nil, upsertCancelInfos, nil,
@@ -650,7 +650,7 @@ func (s *TestBase) UpsertRequestCancelState(updatedInfo *p.WorkflowExecutionInfo
 
 // UpsertSignalInfoState is a utility method to update mutable state of workflow execution
 func (s *TestBase) UpsertSignalInfoState(updatedInfo *p.WorkflowExecutionInfo, updatedStats *p.ExecutionStats, updatedVersionHistories *p.VersionHistories,
-	condition int64, upsertSignalInfos []*pblobs.SignalInfo) error {
+	condition int64, upsertSignalInfos []*persistenceblobs.SignalInfo) error {
 	return s.UpdateWorkflowExecutionWithRangeID(updatedInfo, updatedStats, updatedVersionHistories, nil, nil,
 		s.ShardInfo.RangeID, condition, nil, nil, nil,
 		nil, nil, nil, nil, nil, nil,
@@ -714,10 +714,10 @@ func (s *TestBase) UpdateWorklowStateAndReplication(updatedInfo *p.WorkflowExecu
 // UpdateWorkflowExecutionWithRangeID is a utility method to update workflow execution
 func (s *TestBase) UpdateWorkflowExecutionWithRangeID(updatedInfo *p.WorkflowExecutionInfo, updatedStats *p.ExecutionStats, updatedVersionHistories *p.VersionHistories,
 	decisionScheduleIDs []int64, activityScheduleIDs []int64, rangeID, condition int64, timerTasks []p.Task,
-	upsertActivityInfos []*p.ActivityInfo, deleteActivityInfos []int64, upsertTimerInfos []*pblobs.TimerInfo,
+	upsertActivityInfos []*p.ActivityInfo, deleteActivityInfos []int64, upsertTimerInfos []*persistenceblobs.TimerInfo,
 	deleteTimerInfos []string, upsertChildInfos []*p.ChildExecutionInfo, deleteChildInfo *int64,
-	upsertCancelInfos []*pblobs.RequestCancelInfo, deleteCancelInfo *int64,
-	upsertSignalInfos []*pblobs.SignalInfo, deleteSignalInfo *int64,
+	upsertCancelInfos []*persistenceblobs.RequestCancelInfo, deleteCancelInfo *int64,
+	upsertSignalInfos []*persistenceblobs.SignalInfo, deleteSignalInfo *int64,
 	upsertSignalRequestedIDs []string, deleteSignalRequestedID string) error {
 	return s.UpdateWorkflowExecutionWithReplication(updatedInfo, updatedStats, nil, updatedVersionHistories, decisionScheduleIDs, activityScheduleIDs, rangeID,
 		condition, timerTasks, []p.Task{}, upsertActivityInfos, deleteActivityInfos, upsertTimerInfos, deleteTimerInfos,
@@ -729,9 +729,9 @@ func (s *TestBase) UpdateWorkflowExecutionWithRangeID(updatedInfo *p.WorkflowExe
 func (s *TestBase) UpdateWorkflowExecutionWithReplication(updatedInfo *p.WorkflowExecutionInfo, updatedStats *p.ExecutionStats,
 	updatedReplicationState *p.ReplicationState, updatedVersionHistories *p.VersionHistories, decisionScheduleIDs []int64, activityScheduleIDs []int64, rangeID,
 	condition int64, timerTasks []p.Task, txTasks []p.Task, upsertActivityInfos []*p.ActivityInfo,
-	deleteActivityInfos []int64, upsertTimerInfos []*pblobs.TimerInfo, deleteTimerInfos []string,
-	upsertChildInfos []*p.ChildExecutionInfo, deleteChildInfo *int64, upsertCancelInfos []*pblobs.RequestCancelInfo,
-	deleteCancelInfo *int64, upsertSignalInfos []*pblobs.SignalInfo, deleteSignalInfo *int64, upsertSignalRequestedIDs []string,
+	deleteActivityInfos []int64, upsertTimerInfos []*persistenceblobs.TimerInfo, deleteTimerInfos []string,
+	upsertChildInfos []*p.ChildExecutionInfo, deleteChildInfo *int64, upsertCancelInfos []*persistenceblobs.RequestCancelInfo,
+	deleteCancelInfo *int64, upsertSignalInfos []*persistenceblobs.SignalInfo, deleteSignalInfo *int64, upsertSignalRequestedIDs []string,
 	deleteSignalRequestedID string) error {
 	var transferTasks []p.Task
 	var replicationTasks []p.Task
@@ -830,7 +830,7 @@ func (s *TestBase) UpdateWorkflowExecutionForChildExecutionsInitiated(
 // UpdateWorkflowExecutionForRequestCancel is a utility method to update workflow execution
 func (s *TestBase) UpdateWorkflowExecutionForRequestCancel(
 	updatedInfo *p.WorkflowExecutionInfo, updatedStats *p.ExecutionStats, condition int64, transferTasks []p.Task,
-	upsertRequestCancelInfo []*pblobs.RequestCancelInfo) error {
+	upsertRequestCancelInfo []*persistenceblobs.RequestCancelInfo) error {
 	_, err := s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:            updatedInfo,
@@ -848,7 +848,7 @@ func (s *TestBase) UpdateWorkflowExecutionForRequestCancel(
 // UpdateWorkflowExecutionForSignal is a utility method to update workflow execution
 func (s *TestBase) UpdateWorkflowExecutionForSignal(
 	updatedInfo *p.WorkflowExecutionInfo, updatedStats *p.ExecutionStats, condition int64, transferTasks []p.Task,
-	upsertSignalInfos []*pblobs.SignalInfo) error {
+	upsertSignalInfos []*persistenceblobs.SignalInfo) error {
 	_, err := s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:     updatedInfo,
@@ -889,7 +889,7 @@ func (s *TestBase) UpdateAllMutableState(updatedMutableState *p.WorkflowMutableS
 		aInfos = append(aInfos, ai)
 	}
 
-	var tInfos []*pblobs.TimerInfo
+	var tInfos []*persistenceblobs.TimerInfo
 	for _, ti := range updatedMutableState.TimerInfos {
 		tInfos = append(tInfos, ti)
 	}
@@ -899,12 +899,12 @@ func (s *TestBase) UpdateAllMutableState(updatedMutableState *p.WorkflowMutableS
 		cInfos = append(cInfos, ci)
 	}
 
-	var rcInfos []*pblobs.RequestCancelInfo
+	var rcInfos []*persistenceblobs.RequestCancelInfo
 	for _, rci := range updatedMutableState.RequestCancelInfos {
 		rcInfos = append(rcInfos, rci)
 	}
 
-	var sInfos []*pblobs.SignalInfo
+	var sInfos []*persistenceblobs.SignalInfo
 	for _, si := range updatedMutableState.SignalInfos {
 		sInfos = append(sInfos, si)
 	}
@@ -935,8 +935,8 @@ func (s *TestBase) UpdateAllMutableState(updatedMutableState *p.WorkflowMutableS
 // ConflictResolveWorkflowExecution is  utility method to reset mutable state
 func (s *TestBase) ConflictResolveWorkflowExecution(prevRunID string, prevLastWriteVersion int64, prevState int,
 	info *p.WorkflowExecutionInfo, stats *p.ExecutionStats, replicationState *p.ReplicationState, nextEventID int64,
-	activityInfos []*p.ActivityInfo, timerInfos []*pblobs.TimerInfo, childExecutionInfos []*p.ChildExecutionInfo,
-	requestCancelInfos []*pblobs.RequestCancelInfo, signalInfos []*pblobs.SignalInfo, ids []string) error {
+	activityInfos []*p.ActivityInfo, timerInfos []*persistenceblobs.TimerInfo, childExecutionInfos []*p.ChildExecutionInfo,
+	requestCancelInfos []*persistenceblobs.RequestCancelInfo, signalInfos []*persistenceblobs.SignalInfo, ids []string) error {
 	return s.ExecutionManager.ConflictResolveWorkflowExecution(&p.ConflictResolveWorkflowExecutionRequest{
 		RangeID: s.ShardInfo.RangeID,
 		CurrentWorkflowCAS: &p.CurrentWorkflowCAS{
@@ -964,8 +964,8 @@ func (s *TestBase) ConflictResolveWorkflowExecution(prevRunID string, prevLastWr
 // ResetWorkflowExecution is  utility method to reset WF
 func (s *TestBase) ResetWorkflowExecution(condition int64, info *p.WorkflowExecutionInfo,
 	executionStats *p.ExecutionStats, replicationState *p.ReplicationState,
-	activityInfos []*p.ActivityInfo, timerInfos []*pblobs.TimerInfo, childExecutionInfos []*p.ChildExecutionInfo,
-	requestCancelInfos []*pblobs.RequestCancelInfo, signalInfos []*pblobs.SignalInfo, ids []string, trasTasks, timerTasks, replTasks []p.Task,
+	activityInfos []*p.ActivityInfo, timerInfos []*persistenceblobs.TimerInfo, childExecutionInfos []*p.ChildExecutionInfo,
+	requestCancelInfos []*persistenceblobs.RequestCancelInfo, signalInfos []*persistenceblobs.SignalInfo, ids []string, trasTasks, timerTasks, replTasks []p.Task,
 	updateCurr bool, currInfo *p.WorkflowExecutionInfo, currExecutionStats *p.ExecutionStats, currReplicationState *p.ReplicationState,
 	currTrasTasks, currTimerTasks []p.Task, forkRunID string, forkRunNextEventID int64) error {
 
@@ -1034,8 +1034,8 @@ func (s *TestBase) DeleteCurrentWorkflowExecution(info *p.WorkflowExecutionInfo)
 }
 
 // GetTransferTasks is a utility method to get tasks from transfer task queue
-func (s *TestBase) GetTransferTasks(batchSize int, getAll bool) ([]*pblobs.TransferTaskInfo, error) {
-	result := []*pblobs.TransferTaskInfo{}
+func (s *TestBase) GetTransferTasks(batchSize int, getAll bool) ([]*persistenceblobs.TransferTaskInfo, error) {
+	result := []*persistenceblobs.TransferTaskInfo{}
 	var token []byte
 
 Loop:
@@ -1065,8 +1065,8 @@ Loop:
 }
 
 // GetReplicationTasks is a utility method to get tasks from replication task queue
-func (s *TestBase) GetReplicationTasks(batchSize int, getAll bool) ([]*pblobs.ReplicationTaskInfo, error) {
-	result := []*pblobs.ReplicationTaskInfo{}
+func (s *TestBase) GetReplicationTasks(batchSize int, getAll bool) ([]*persistenceblobs.ReplicationTaskInfo, error) {
+	result := []*persistenceblobs.ReplicationTaskInfo{}
 	var token []byte
 
 Loop:
@@ -1105,7 +1105,7 @@ func (s *TestBase) RangeCompleteReplicationTask(inclusiveEndTaskID int64) error 
 // PutReplicationTaskToDLQ is a utility method to insert a replication task info
 func (s *TestBase) PutReplicationTaskToDLQ(
 	sourceCluster string,
-	taskInfo *pblobs.ReplicationTaskInfo,
+	taskInfo *persistenceblobs.ReplicationTaskInfo,
 ) error {
 
 	return s.ExecutionManager.PutReplicationTaskToDLQ(&p.PutReplicationTaskToDLQRequest{
@@ -1185,8 +1185,8 @@ func (s *TestBase) CompleteReplicationTask(taskID int64) error {
 }
 
 // GetTimerIndexTasks is a utility method to get tasks from transfer task queue
-func (s *TestBase) GetTimerIndexTasks(batchSize int, getAll bool) ([]*pblobs.TimerTaskInfo, error) {
-	result := []*pblobs.TimerTaskInfo{}
+func (s *TestBase) GetTimerIndexTasks(batchSize int, getAll bool) ([]*persistenceblobs.TimerTaskInfo, error) {
+	result := []*persistenceblobs.TimerTaskInfo{}
 	var token []byte
 
 Loop:
@@ -1248,10 +1248,10 @@ func (s *TestBase) CreateDecisionTask(namespaceID primitives.UUID, workflowExecu
 	}
 
 	taskID := s.GetNextSequenceNumber()
-	tasks := []*pblobs.AllocatedTaskInfo{
+	tasks := []*persistenceblobs.AllocatedTaskInfo{
 		{
 			TaskID: taskID,
-			Data: &pblobs.TaskInfo{
+			Data: &persistenceblobs.TaskInfo{
 				NamespaceID: namespaceID,
 				WorkflowID:  workflowExecution.WorkflowId,
 				RunID:       primitives.MustParseUUID(workflowExecution.RunId),
@@ -1293,9 +1293,9 @@ func (s *TestBase) CreateActivityTasks(namespaceID primitives.UUID, workflowExec
 	var taskIDs []int64
 	for activityScheduleID, taskList := range activities {
 		taskID := s.GetNextSequenceNumber()
-		tasks := []*pblobs.AllocatedTaskInfo{
+		tasks := []*persistenceblobs.AllocatedTaskInfo{
 			{
-				Data: &pblobs.TaskInfo{
+				Data: &persistenceblobs.TaskInfo{
 					NamespaceID: namespaceID,
 					WorkflowID:  workflowExecution.WorkflowId,
 					RunID:       primitives.MustParseUUID(workflowExecution.RunId),

--- a/common/persistence/persistence-tests/shardPersistenceTest.go
+++ b/common/persistence/persistence-tests/shardPersistenceTest.go
@@ -30,7 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/temporal-proto/serviceerror"
 
-	pblobs "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
+	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 	p "github.com/temporalio/temporal/common/persistence"
 )
 
@@ -160,8 +160,8 @@ func (s *ShardPersistenceSuite) TestUpdateShard() {
 	s.EqualTimes(updatedTimerAckLevel, info1timerAckLevelTime)
 }
 
-func copyShardInfo(sourceInfo *pblobs.ShardInfo) *pblobs.ShardInfo {
-	return &pblobs.ShardInfo{
+func copyShardInfo(sourceInfo *persistenceblobs.ShardInfo) *persistenceblobs.ShardInfo {
+	return &persistenceblobs.ShardInfo{
 		ShardID:             sourceInfo.ShardID,
 		Owner:               sourceInfo.Owner,
 		RangeID:             sourceInfo.RangeID,

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -50,17 +50,6 @@ CREATE TYPE serialized_event_batch (
   data          blob,
 );
 
--- Storage for out of order replication tasks for an execution
-CREATE TYPE buffered_replication_task_info (
-  first_event_id  bigint,
-  next_event_id   bigint,
-  version         bigint,
-  history         frozen<serialized_event_batch>,
-  new_run_history frozen<serialized_event_batch>,
-  event_store_version                int, -- indicates which version of event store to query
-  new_run_event_store_version        int, -- indicates which version of event store to query for new run(continueAsNew)
-);
-
 CREATE TABLE executions (
   shard_id                       int,
   type                           int, -- enum RowType { Shard, Execution, TransferTask, TimerTask, ReplicationTask}
@@ -97,7 +86,6 @@ CREATE TABLE executions (
   signal_requested               set<uuid>,
   buffered_events_list           list<frozen<serialized_event_batch>>,
   replication_state              frozen<replication_state>, -- Replication information part of mutable state
-  buffered_replication_tasks_map map<bigint, frozen<buffered_replication_task_info>>,
   workflow_last_write_version    bigint,
   workflow_state                 int,
   version_histories              blob, -- the metadata of history branching

--- a/schema/cassandra/temporal/versioned/v1.0/schema.cql
+++ b/schema/cassandra/temporal/versioned/v1.0/schema.cql
@@ -50,17 +50,6 @@ CREATE TYPE serialized_event_batch (
   data          blob,
 );
 
--- Storage for out of order replication tasks for an execution
-CREATE TYPE buffered_replication_task_info (
-  first_event_id  bigint,
-  next_event_id   bigint,
-  version         bigint,
-  history         frozen<serialized_event_batch>,
-  new_run_history frozen<serialized_event_batch>,
-  event_store_version                int, -- indicates which version of event store to query
-  new_run_event_store_version        int, -- indicates which version of event store to query for new run(continueAsNew)
-);
-
 CREATE TABLE executions (
   shard_id                       int,
   type                           int, -- enum RowType { Shard, Execution, TransferTask, TimerTask, ReplicationTask}
@@ -97,7 +86,6 @@ CREATE TABLE executions (
   signal_requested               set<uuid>,
   buffered_events_list           list<frozen<serialized_event_batch>>,
   replication_state              frozen<replication_state>, -- Replication information part of mutable state
-  buffered_replication_tasks_map map<bigint, frozen<buffered_replication_task_info>>,
   workflow_last_write_version    bigint,
   workflow_state                 int,
   version_histories              blob, -- the metadata of history branching

--- a/schema/mysql/v57/temporal/schema.sql
+++ b/schema/mysql/v57/temporal/schema.sql
@@ -191,24 +191,6 @@ CREATE TABLE signal_info_maps (
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
 );
 
-CREATE TABLE buffered_replication_task_maps (
-  shard_id INT NOT NULL,
-  namespace_id BINARY(16) NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
-  run_id BINARY(16) NOT NULL,
-  first_event_id BIGINT NOT NULL,
---
-  version BIGINT NOT NULL,
-  next_event_id BIGINT NOT NULL,
-  history MEDIUMBLOB,
-  history_encoding VARCHAR(16) NOT NULL,
-  new_run_history BLOB,
-  new_run_history_encoding VARCHAR(16) NOT NULL DEFAULT 'json',
-  event_store_version          INT NOT NULL, -- indiciates which version of event store to query
-  new_run_event_store_version  INT NOT NULL, -- indiciates which version of event store to query for new run(continueAsNew)
-  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, first_event_id)
-);
-
 CREATE TABLE signals_requested_sets (
   shard_id INT NOT NULL,
   namespace_id BINARY(16) NOT NULL,

--- a/schema/mysql/v57/temporal/versioned/v0.1/base.sql
+++ b/schema/mysql/v57/temporal/versioned/v0.1/base.sql
@@ -196,24 +196,6 @@ CREATE TABLE signal_info_maps (
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
 );
 
-CREATE TABLE buffered_replication_task_maps (
-  shard_id INT NOT NULL,
-  namespace_id BINARY(16) NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
-  run_id BINARY(16) NOT NULL,
-  first_event_id BIGINT NOT NULL,
---
-  version BIGINT NOT NULL,
-  next_event_id BIGINT NOT NULL,
-  history MEDIUMBLOB,
-  history_encoding VARCHAR(16) NOT NULL,
-  new_run_history BLOB,
-  new_run_history_encoding VARCHAR(16) NOT NULL DEFAULT 'json',
-  event_store_version          INT NOT NULL, -- indiciates which version of event store to query
-  new_run_event_store_version  INT NOT NULL, -- indiciates which version of event store to query for new run(continueAsNew)
-  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, first_event_id)
-);
-
 CREATE TABLE signals_requested_sets (
   shard_id INT NOT NULL,
   namespace_id BINARY(16) NOT NULL,

--- a/schema/postgres/temporal/schema.sql
+++ b/schema/postgres/temporal/schema.sql
@@ -191,24 +191,6 @@ CREATE TABLE signal_info_maps (
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
 );
 
-CREATE TABLE buffered_replication_task_maps (
-  shard_id INTEGER NOT NULL,
-  namespace_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
-  run_id BYTEA NOT NULL,
-  first_event_id BIGINT NOT NULL,
---
-  version BIGINT NOT NULL,
-  next_event_id BIGINT NOT NULL,
-  history BYTEA,
-  history_encoding VARCHAR(16) NOT NULL,
-  new_run_history BYTEA,
-  new_run_history_encoding VARCHAR(16) NOT NULL DEFAULT 'json',
-  event_store_version          INTEGER NOT NULL, -- indiciates which version of event store to query
-  new_run_event_store_version  INTEGER NOT NULL, -- indiciates which version of event store to query for new run(continueAsNew)
-  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, first_event_id)
-);
-
 CREATE TABLE signals_requested_sets (
   shard_id INTEGER NOT NULL,
   namespace_id BYTEA NOT NULL,

--- a/schema/postgres/temporal/versioned/v0.1/base.sql
+++ b/schema/postgres/temporal/versioned/v0.1/base.sql
@@ -181,24 +181,6 @@ CREATE TABLE signal_info_maps (
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
 );
 
-CREATE TABLE buffered_replication_task_maps (
-  shard_id INTEGER NOT NULL,
-  namespace_id BYTEA NOT NULL,
-  workflow_id VARCHAR(255) NOT NULL,
-  run_id BYTEA NOT NULL,
-  first_event_id BIGINT NOT NULL,
---
-  version BIGINT NOT NULL,
-  next_event_id BIGINT NOT NULL,
-  history BYTEA,
-  history_encoding VARCHAR(16) NOT NULL,
-  new_run_history BYTEA,
-  new_run_history_encoding VARCHAR(16) NOT NULL DEFAULT 'json',
-  event_store_version          INTEGER NOT NULL, -- indiciates which version of event store to query
-  new_run_event_store_version  INTEGER NOT NULL, -- indiciates which version of event store to query for new run(continueAsNew)
-  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, first_event_id)
-);
-
 CREATE TABLE signals_requested_sets (
   shard_id INTEGER NOT NULL,
   namespace_id BYTEA NOT NULL,

--- a/service/history/historyEngine3_eventsv2_test.go
+++ b/service/history/historyEngine3_eventsv2_test.go
@@ -37,7 +37,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"github.com/temporalio/temporal/.gen/proto/historyservice"
-	pblobs "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
+	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/cache"
 	"github.com/temporalio/temporal/common/clock"
@@ -97,7 +97,7 @@ func (s *engine3Suite) SetupTest() {
 
 	s.mockShard = newTestShardContext(
 		s.controller,
-		&p.ShardInfoWithFailover{ShardInfo: &pblobs.ShardInfo{
+		&p.ShardInfoWithFailover{ShardInfo: &persistenceblobs.ShardInfo{
 			ShardID:          0,
 			RangeID:          1,
 			TransferAckLevel: 0,

--- a/service/history/replicationDLQHandler_test.go
+++ b/service/history/replicationDLQHandler_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/temporalio/temporal/.gen/proto/adminservice"
 	"github.com/temporalio/temporal/.gen/proto/adminservicemock"
 	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
-	pblobs "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
+	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 	"github.com/temporalio/temporal/.gen/proto/replication"
 	"github.com/temporalio/temporal/client"
 	"github.com/temporalio/temporal/common/cluster"
@@ -131,8 +131,8 @@ func (s *replicationDLQHandlerSuite) TestReadMessages_OK() {
 	pageToken := []byte{}
 
 	resp := &persistence.GetReplicationTasksFromDLQResponse{
-		Tasks: []*pblobs.ReplicationTaskInfo{
-			&pblobs.ReplicationTaskInfo{
+		Tasks: []*persistenceblobs.ReplicationTaskInfo{
+			&persistenceblobs.ReplicationTaskInfo{
 				NamespaceID: primitives.MustParseUUID(uuid.New()),
 				WorkflowID:  uuid.New(),
 				RunID:       primitives.MustParseUUID(uuid.New()),
@@ -185,8 +185,8 @@ func (s *replicationDLQHandlerSuite) TestMergeMessages_OK() {
 	pageToken := []byte{}
 
 	resp := &persistence.GetReplicationTasksFromDLQResponse{
-		Tasks: []*pblobs.ReplicationTaskInfo{
-			&pblobs.ReplicationTaskInfo{
+		Tasks: []*persistenceblobs.ReplicationTaskInfo{
+			&persistenceblobs.ReplicationTaskInfo{
 				NamespaceID: primitives.MustParseUUID(uuid.New()),
 				WorkflowID:  uuid.New(),
 				RunID:       primitives.MustParseUUID(uuid.New()),

--- a/service/history/replicationDLQHandler_test.go
+++ b/service/history/replicationDLQHandler_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/temporalio/temporal/.gen/proto/adminservice"
 	"github.com/temporalio/temporal/.gen/proto/adminservicemock"
 	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
-	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 	"github.com/temporalio/temporal/.gen/proto/replication"
 	"github.com/temporalio/temporal/client"
 	"github.com/temporalio/temporal/common/cluster"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Remove unused BufferedReplicationTasks in persistence schema
- Also removed pblobs alias usage in this PR

<!-- Tell your future self why have you made these changes -->
**Why?**
Cleaning up schema and these are unused tables/fields/types

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Buildkite/Local unit testing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None as they are not used
