### PR TITLE
Require BroadcastAddress when BindOnIP 0.0.0.0

### DIFF
--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -314,14 +314,14 @@ func BuildBroadcastHostPort(listenerPeerInfo tchannel.LocalPeerInfo, broadcastAd
 		return "", ringpop.ErrEphemeralAddress
 	}
 
+	// Parse listener hostport
+	listenerIpString, port, err := net.SplitHostPort(listenerPeerInfo.HostPort)
+	if err != nil {
+		return "", err
+	}
+
 	// Broadcast IP override
 	if broadcastAddress != "" {
-		// Parse listener hostport
-		_, port, err := net.SplitHostPort(listenerPeerInfo.HostPort)
-		if err != nil {
-			return "", err
-		}
-
 		// Parse supplied broadcastAddress override
 		ip := net.ParseIP(broadcastAddress)
 		if ip == nil || ip.To4() == nil {
@@ -330,6 +330,15 @@ func BuildBroadcastHostPort(listenerPeerInfo tchannel.LocalPeerInfo, broadcastAd
 
 		// If no errors, use the parsed IP with the port from our listener
 		return ip.To4().String() + ":" + port, nil
+	}
+
+	listenerIp := net.ParseIP(listenerIpString)
+	if listenerIp  == nil {
+		return "", errors.New("unable to parse listenerIp")
+	}
+
+	if listenerIp.IsUnspecified() {
+		return "", errors.New("broadcastAddress required when listening on all interfaces (0.0.0.0/[::])")
 	}
 
 	return listenerPeerInfo.HostPort, nil

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -84,7 +84,7 @@ server:
     ringpop:
         name: temporal
         maxJoinDuration: 30s
-        broadcastAddress: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
+        broadcastAddress: {{ default .Env.TEMPORAL_BROADCAST_ADDRESS "" }}
 
 services:
     frontend:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Users can specify 0.0.0.0 in BindOnIp which will never work for both membership sharding in a multi-node cluster and reachability as 0.0.0.0 is not a valid connect address. This requires users to specify BroadcastAddress in this case. 

1: Bind 0.0.0.0, Broadcast Unspecified - Failure
2: Bind Anything else, Broadcast Unspecified - Use Bind address
3: Bind Anything else, Broadcast Specified - Use Broadcast
4: Bind 0.0.0.0, Broadcast Specified - Use Broadcast

Also exposing this option in a new Docker environment variable `TEMPORAL_BROADCAST_ADDRESS`

<!-- Tell your future self why have you made these changes -->
**Why?**
To provide an easier way to determine this issue/invalid configuration for customers. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested this by manually starting the server with the matrix of possible cases.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None
