### PR TITLE
Expose MySQL connectAttributes for schema setup

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -34,13 +34,18 @@ setup_cassandra_schema() {
 
 setup_mysql_schema() {
     SCHEMA_DIR=$TEMPORAL_HOME/schema/mysql/v57/temporal/versioned
-    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD create --db $DBNAME
-    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD --db $DBNAME setup-schema -v 0.0
-    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD --db $DBNAME update-schema -d $SCHEMA_DIR
+
+    if [ "$MYSQL_TX_ISOLATION_COMPAT" == "true" ]; then
+        MYSQL_CONNECT_ATTR='--connect-attributes tx_isolation=READ-COMMITTED'
+    fi
+
+    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD $MYSQL_CONNECT_ATTR create --db $DBNAME
+    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD $MYSQL_CONNECT_ATTR --db $DBNAME setup-schema -v 0.0
+    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD $MYSQL_CONNECT_ATTR --db $DBNAME update-schema -d $SCHEMA_DIR
     VISIBILITY_SCHEMA_DIR=$TEMPORAL_HOME/schema/mysql/v57/visibility/versioned
-    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD create --db $VISIBILITY_DBNAME
-    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD --db $VISIBILITY_DBNAME setup-schema -v 0.0
-    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD --db $VISIBILITY_DBNAME update-schema -d $VISIBILITY_SCHEMA_DIR
+    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD $MYSQL_CONNECT_ATTR create --db $VISIBILITY_DBNAME
+    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD $MYSQL_CONNECT_ATTR --db $VISIBILITY_DBNAME setup-schema -v 0.0
+    temporal-sql-tool --ep $MYSQL_SEEDS -u $MYSQL_USER --pw $MYSQL_PWD $MYSQL_CONNECT_ATTR --db $VISIBILITY_DBNAME update-schema -d $VISIBILITY_SCHEMA_DIR
 }
 
 setup_postgres_schema() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This exposes an environment variable knob to expose a way to use the correct connectAttributes for legacy MySQL (<5.7.20).

<!-- Tell your future self why have you made these changes -->
**Why?**
Customers need to be able to setup their schema in legacy MySQL installations.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I have not verified this change manually 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Conditonal option that does not introduce any default behavior. 
