### PR TITLE
Update docker tag for latest server release 0.21.1

### DIFF
--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -32,7 +32,7 @@ services:
     environment:
       - discovery.type=single-node
   temporal:
-    image: temporalio/auto-setup:0.20.0
+    image: temporalio/auto-setup:0.21.0
     ports:
      - "7233:7233"
      - "7234:7234"

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -32,7 +32,7 @@ services:
     environment:
       - discovery.type=single-node
   temporal:
-    image: temporalio/auto-setup:0.21.0
+    image: temporalio/auto-setup:0.21.1
     ports:
      - "7233:7233"
      - "7234:7234"

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -14,7 +14,7 @@ services:
       - "8125:8125"
       - "8126:8126"
   temporal:
-    image: temporalio/auto-setup:0.20.0
+    image: temporalio/auto-setup:0.21.0
     ports:
      - "7233:7233"
      - "7234:7234"

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -14,7 +14,7 @@ services:
       - "8125:8125"
       - "8126:8126"
   temporal:
-    image: temporalio/auto-setup:0.21.0
+    image: temporalio/auto-setup:0.21.1
     ports:
      - "7233:7233"
      - "7234:7234"

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -15,7 +15,7 @@ services:
       - "8125:8125"
       - "8126:8126"
   temporal:
-    image: temporalio/auto-setup:0.21.0
+    image: temporalio/auto-setup:0.21.1
     ports:
      - "7233:7233"
      - "7234:7234"

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -15,7 +15,7 @@ services:
       - "8125:8125"
       - "8126:8126"
   temporal:
-    image: temporalio/auto-setup:0.20.0
+    image: temporalio/auto-setup:0.21.0
     ports:
      - "7233:7233"
      - "7234:7234"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,24 +5,15 @@ services:
     image: cassandra:3.11
     ports:
       - "9042:9042"
-  statsd:
-    image: graphiteapp/graphite-statsd
-    ports:
-      - "8080:80"
-      - "2003:2003"
-      - "8125:8125"
-      - "8126:8126"
   temporal:
-    image: temporalio/auto-setup:0.20.0
+    image: temporalio/auto-setup:0.21.1
     ports:
      - "7233:7233"
     environment:
       - "CASSANDRA_SEEDS=cassandra"
-      - "STATSD_ENDPOINT=statsd:8125"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - cassandra
-      - statsd
   temporal-web:
     image: temporalio/web:0.20.0
     environment:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Docker compose now uses the latest release server tags from docker hub

<!-- Tell your future self why have you made these changes -->
**Why?**
Getting started experience pulls docker-compose file from the repo to 
function correctly. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Locally run docker-compose up

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk.

