### PR TITLE
Update docker web tag 0.21.1

### DIFF
--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -55,7 +55,7 @@ services:
       - kafka
       - elasticsearch
   temporal-web:
-    image: temporalio/web:0.20.0
+    image: temporalio/web:0.21.1
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -35,7 +35,7 @@ services:
       - mysql
       - statsd
   temporal-web:
-    image: temporalio/web:0.20.0
+    image: temporalio/web:0.21.1
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -36,7 +36,7 @@ services:
     depends_on:
       - postgres
   temporal-web:
-    image: temporalio/web:0.20.0
+    image: temporalio/web:0.21.1
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - cassandra
   temporal-web:
-    image: temporalio/web:0.20.0
+    image: temporalio/web:0.21.1
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:


### PR DESCRIPTION
What changed?
Docker compose now uses the latest release web tags from docker hub

Why?
Getting started experience pulls docker-compose file from the repo to
function correctly.

How did you test it?
Locally run docker-compose up

Potential risks
No risk.