### PR TITLE
Changed activity ScheduleToStart to optional

### DIFF
--- a/service/history/decisionChecker.go
+++ b/service/history/decisionChecker.go
@@ -242,20 +242,6 @@ func (v *decisionAttrValidator) validateActivityScheduleAttributes(
 		return serviceerror.NewInvalidArgument("A valid timeout may not be negative.")
 	}
 
-	// ensure activity timeout never larger than workflow timeout
-	if attributes.GetScheduleToCloseTimeoutSeconds() > wfTimeout {
-		attributes.ScheduleToCloseTimeoutSeconds = wfTimeout
-	}
-	if attributes.GetScheduleToStartTimeoutSeconds() > wfTimeout {
-		attributes.ScheduleToStartTimeoutSeconds = wfTimeout
-	}
-	if attributes.GetStartToCloseTimeoutSeconds() > wfTimeout {
-		attributes.StartToCloseTimeoutSeconds = wfTimeout
-	}
-	if attributes.GetHeartbeatTimeoutSeconds() > wfTimeout {
-		attributes.HeartbeatTimeoutSeconds = wfTimeout
-	}
-
 	validScheduleToClose := attributes.GetScheduleToCloseTimeoutSeconds() > 0
 	validScheduleToStart := attributes.GetScheduleToStartTimeoutSeconds() > 0
 	validStartToClose := attributes.GetStartToCloseTimeoutSeconds() > 0
@@ -267,15 +253,37 @@ func (v *decisionAttrValidator) validateActivityScheduleAttributes(
 		if !validStartToClose {
 			attributes.StartToCloseTimeoutSeconds = attributes.GetScheduleToCloseTimeoutSeconds()
 		}
-	} else if validScheduleToStart && validStartToClose {
-		attributes.ScheduleToCloseTimeoutSeconds = attributes.GetScheduleToStartTimeoutSeconds() + attributes.GetStartToCloseTimeoutSeconds()
-		if attributes.GetScheduleToCloseTimeoutSeconds() > wfTimeout {
+	} else if validStartToClose {
+		// We are in !validScheduleToClose due to the first if above
+		if validScheduleToStart {
+			attributes.ScheduleToCloseTimeoutSeconds = attributes.GetScheduleToStartTimeoutSeconds() + attributes.GetStartToCloseTimeoutSeconds()
+		} else {
+			attributes.ScheduleToStartTimeoutSeconds = wfTimeout
 			attributes.ScheduleToCloseTimeoutSeconds = wfTimeout
 		}
 	} else {
 		// Deduction failed as there's not enough information to fill in missing timeouts.
-		return serviceerror.NewInvalidArgument("A valid ScheduleToCloseTimeout is not set on decision.")
+		return serviceerror.NewInvalidArgument("A valid StartToClose or ScheduleToCloseTimeout is not set on decision.")
 	}
+	// ensure activity timeout never larger than workflow timeout
+	if wfTimeout > 0 {
+		if attributes.GetScheduleToCloseTimeoutSeconds() > wfTimeout {
+			attributes.ScheduleToCloseTimeoutSeconds = wfTimeout
+		}
+		if attributes.GetScheduleToStartTimeoutSeconds() > wfTimeout {
+			attributes.ScheduleToStartTimeoutSeconds = wfTimeout
+		}
+		if attributes.GetStartToCloseTimeoutSeconds() > wfTimeout {
+			attributes.StartToCloseTimeoutSeconds = wfTimeout
+		}
+		if attributes.GetHeartbeatTimeoutSeconds() > wfTimeout {
+			attributes.HeartbeatTimeoutSeconds = wfTimeout
+		}
+	}
+	if attributes.GetHeartbeatTimeoutSeconds() > attributes.GetScheduleToCloseTimeoutSeconds() {
+		attributes.HeartbeatTimeoutSeconds = attributes.GetScheduleToCloseTimeoutSeconds()
+	}
+
 	// ensure activity's SCHEDULE_TO_START and SCHEDULE_TO_CLOSE is as long as expiration on retry policy
 	p := attributes.RetryPolicy
 	if p != nil {

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -1512,6 +1512,9 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledAtt
 		// will use ScheduleToClose for ScheduleToStart and StartToClose
 		{7, 0, 0, 0,
 			7, 7, 7, false},
+		// Only StartToClose timeout
+		{0, 0, 7, 0,
+			workflowTimeout, workflowTimeout, 7, false},
 		// No ScheduleToClose timeout, ScheduleToStart or StartToClose, expect error return
 		{0, 0, 0, 0,
 			0, 0, 0, true},
@@ -1536,7 +1539,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledAtt
 		{0, workflowTimeout + 1, 0, 0,
 			0, 0, 0, true},
 		{0, 0, workflowTimeout + 1, 0,
-			0, 0, 0, true},
+			workflowTimeout, workflowTimeout, workflowTimeout, false},
 		{0, 0, 0, workflowTimeout + 1,
 			0, 0, 0, true},
 		// No ScheduleToClose timeout, will use ScheduleToStart + StartToClose, but exceed limit


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Logic of defaulting activity timeouts. After this change only one of ScheduleToClose or StartToClose is required. If only ScheduleToClose is specified then both ScheduleToStart and StartToClose are defaulted to ScheduleToClose. If only StartToClose is specified then both ScheduleToStart and ScheduleToClose default to the workflow execution timeout.

<!-- Tell your future self why have you made these changes -->
**Why?**
In the majority of the practical situations ScheduleToStart for an activity should be as large as the maximum time of all possible activity worker outages. But most of the developer new to the workflows choose this value much lower than necessary. Making it optional and defaulting to the workflow timeout will eliminate the large class of production issues.
One less timeout to specify also improves the onboarding experience.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**Test**
Unit tested. 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Activities will have an invalid schedule to start timeout.
