### PR TITLE
Return NamespaceAlreadyExistsError from CreateNamespace implementation

### DIFF
--- a/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
+++ b/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
@@ -63,7 +63,7 @@ const (
 	templateGetNamespaceByNameQueryV2 = templateListNamespaceQueryV2 + `and name = ?`
 
 	templateUpdateNamespaceByNameQueryWithinBatchV2 = `UPDATE namespaces_by_name_v2 ` +
-		`SET detail = ? ,`  +
+		`SET detail = ? ,` +
 		`detail_encoding = ? ,` +
 		`notification_version = ? ` +
 		`WHERE namespaces_partition = ? ` +
@@ -135,7 +135,7 @@ func (m *cassandraMetadataPersistenceV2) CreateNamespace(request *p.InternalCrea
 		return nil, serviceerror.NewInternal(fmt.Sprintf("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err))
 	}
 	if !applied {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("CreateNamespace operation failed because of uuid collision."))
+		return nil, serviceerror.NewNamespaceAlreadyExists("CreateNamespace operation failed because of uuid collision.")
 	}
 
 	return m.CreateNamespaceInV2Table(request)
@@ -300,8 +300,8 @@ func (m *cassandraMetadataPersistenceV2) ListNamespaces(request *p.ListNamespace
 		// do not include the metadata record
 		if name != namespaceMetadataRecordName {
 			response.Namespaces = append(response.Namespaces, &p.InternalGetNamespaceResponse{
-				Namespace:  p.NewDataBlob(detail, common.EncodingType(detailEncoding)),
-				IsGlobal:   isGlobal,
+				Namespace:           p.NewDataBlob(detail, common.EncodingType(detailEncoding)),
+				IsGlobal:            isGlobal,
 				NotificationVersion: notificationVersion,
 			})
 		}

--- a/common/persistence/metadataStore.go
+++ b/common/persistence/metadataStore.go
@@ -25,8 +25,8 @@
 package persistence
 
 import (
-	"go.temporal.io/temporal-proto/serviceerror"
 	namespacepb "go.temporal.io/temporal-proto/namespace"
+	"go.temporal.io/temporal-proto/serviceerror"
 
 	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 	"github.com/temporalio/temporal/common"
@@ -69,10 +69,10 @@ func (m *metadataManagerImpl) CreateNamespace(request *CreateNamespaceRequest) (
 	}
 
 	return m.persistence.CreateNamespace(&InternalCreateNamespaceRequest{
-		ID:				   request.Namespace.Info.Id,
-		Name:              request.Namespace.Info.Name,
-		IsGlobal: 		   request.IsGlobalNamespace,
-		Namespace: 		   &datablob,
+		ID:        request.Namespace.Info.Id,
+		Name:      request.Namespace.Info.Name,
+		IsGlobal:  request.IsGlobalNamespace,
+		Namespace: &datablob,
 	})
 }
 
@@ -91,7 +91,7 @@ func (m *metadataManagerImpl) UpdateNamespace(request *UpdateNamespaceRequest) e
 	}
 
 	return m.persistence.UpdateNamespace(&InternalUpdateNamespaceRequest{
-		Id:				     request.Namespace.Info.Id,
+		Id:                  request.Namespace.Info.Id,
 		Name:                request.Namespace.Info.Name,
 		Namespace:           &datablob,
 		NotificationVersion: request.NotificationVersion,
@@ -154,18 +154,21 @@ func (m *metadataManagerImpl) InitializeSystemNamespaces(currentClusterName stri
 			Info: &persistenceblobs.NamespaceInfo{
 				Id:          primitives.MustParseUUID(common.SystemNamespaceID),
 				Name:        common.SystemLocalNamespace,
+				Status:      namespacepb.NamespaceStatus_Registered,
 				Description: "Temporal internal system namespace",
-				Owner: "temporal-core@temporal.io",
+				Owner:       "temporal-core@temporal.io",
 			},
 			Config: &persistenceblobs.NamespaceConfig{
-				RetentionDays:  common.SystemNamespaceRetentionDays,
-				EmitMetric: true,
+				RetentionDays:            common.SystemNamespaceRetentionDays,
+				HistoryArchivalStatus:    namespacepb.ArchivalStatus_Disabled,
+				VisibilityArchivalStatus: namespacepb.ArchivalStatus_Disabled,
+				EmitMetric:               true,
 			},
 			ReplicationConfig: &persistenceblobs.NamespaceReplicationConfig{
 				ActiveClusterName: currentClusterName,
 				Clusters:          GetOrUseDefaultClusters(currentClusterName, nil),
 			},
-			FailoverVersion:   common.EmptyVersion,
+			FailoverVersion:             common.EmptyVersion,
 			FailoverNotificationVersion: -1,
 		},
 		IsGlobalNamespace: false,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Cassandra implementation of CreateNamespace to return 
NamespaceAleadyExistsError instead of InternalServiceError 
it was returning before.

Also updated onebox setup used for integration tests to also use
the newly added InitializeSystemNamespace API.

<!-- Tell your future self why have you made these changes -->
**Why?**
Cassandra implementation returns InternalServiceError on duplicate
calls to namespace registration instead of NamespaceAleadyExistsError
which is preventing Temporal server to start as now we try to register
SystemNamespace on server startup.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated integration tests to use the new InitializeSystemNamespace API.

Test Temporal Server so it starts on dev machine.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Fixes a critical bug which is preventing server to start.

