### PR TITLE
Removed invalid check on frontend handler

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -338,7 +338,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(ctx context.Context, request *
 		return nil, err
 	}
 
-	if request.GetExecutionStartToCloseTimeoutSeconds() <= 0 {
+	if request.GetExecutionStartToCloseTimeoutSeconds() < 0 {
 		return nil, wh.error(errInvalidExecutionStartToCloseTimeoutSeconds, scope)
 	}
 
@@ -1913,7 +1913,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(errRequestIDTooLong, scope)
 	}
 
-	if request.GetExecutionStartToCloseTimeoutSeconds() <= 0 {
+	if request.GetExecutionStartToCloseTimeoutSeconds() < 0 {
 		return nil, wh.error(errInvalidExecutionStartToCloseTimeoutSeconds, scope)
 	}
 

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -248,7 +248,6 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_RequestIdNotSet
 		TaskList: &tasklistpb.TaskList{
 			Name: "task-list",
 		},
-		ExecutionStartToCloseTimeoutSeconds: 1,
 		TaskStartToCloseTimeoutSeconds:      1,
 		RetryPolicy: &commonpb.RetryPolicy{
 			InitialIntervalInSeconds:    1,
@@ -375,8 +374,6 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_TaskListNotSet(
 		TaskList: &tasklistpb.TaskList{
 			Name: "",
 		},
-		ExecutionStartToCloseTimeoutSeconds: 1,
-		TaskStartToCloseTimeoutSeconds:      1,
 		RetryPolicy: &commonpb.RetryPolicy{
 			InitialIntervalInSeconds:    1,
 			BackoffCoefficient:          2,
@@ -405,7 +402,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_InvalidExecutio
 		TaskList: &tasklistpb.TaskList{
 			Name: "task-list",
 		},
-		ExecutionStartToCloseTimeoutSeconds: 0,
+		ExecutionStartToCloseTimeoutSeconds: -1,
 		RetryPolicy: &commonpb.RetryPolicy{
 			InitialIntervalInSeconds:    1,
 			BackoffCoefficient:          2,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed outdated check for workflowExecutionTimeout

<!-- Tell your future self why have you made these changes -->
**Why?**
The workflowExecutionTimeout is already optional by history engine. So I removed excessive check in the frontend.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tested

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Invalid execution timeout is configured
