### PR TITLE
feat(docker): add cockroach example

### DIFF
--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -1,0 +1,52 @@
+
+version: '3'
+services:
+  cockroach:
+    hostname: cockroach
+    image: cockroachdb/cockroach
+    container_name: cockroach
+    tty: false
+    restart: "on-failure:5"
+    security_opt:
+     - "no-new-privileges"
+    cap_drop:
+    - ALL
+    command: ["start", "--insecure"]
+  statsd:
+    image: graphiteapp/graphite-statsd
+    ports:
+      - "8080:80"
+      - "2003:2003"
+      - "8125:8125"
+      - "8126:8126"
+  temporal:
+    image: temporalio/auto-setup:0.21.1
+    ports:
+     - "7233:7233"
+     - "7234:7234"
+     - "7235:7235"
+     - "7239:7239"
+     - "6933:6933"
+     - "6934:6934"
+     - "6935:6935"
+     - "6939:6939"
+    environment:
+      - "DB=postgres"
+      - "DB_PORT=26257"
+      - "POSTGRES_USER=root"
+      - "POSTGRES_PWD="
+      - "POSTGRES_SEEDS=postgres"
+      - "STATSD_ENDPOINT=statsd:8125"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
+    depends_on:
+      - cockroach
+    links:
+    - cockroach:postgres
+  temporal-web:
+    image: temporalio/web:0.21.1
+    environment:
+      - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
+    ports:
+      - "8088:8088"
+    depends_on:
+      - temporal

--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -12,36 +12,23 @@ services:
     cap_drop:
     - ALL
     command: ["start", "--insecure"]
-  statsd:
-    image: graphiteapp/graphite-statsd
-    ports:
-      - "8080:80"
-      - "2003:2003"
-      - "8125:8125"
-      - "8126:8126"
+
   temporal:
     image: temporalio/auto-setup:0.21.1
     ports:
      - "7233:7233"
-     - "7234:7234"
-     - "7235:7235"
-     - "7239:7239"
-     - "6933:6933"
-     - "6934:6934"
-     - "6935:6935"
-     - "6939:6939"
     environment:
       - "DB=postgres"
       - "DB_PORT=26257"
       - "POSTGRES_USER=root"
       - "POSTGRES_PWD="
       - "POSTGRES_SEEDS=postgres"
-      - "STATSD_ENDPOINT=statsd:8125"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - cockroach
     links:
     - cockroach:postgres
+    
   temporal-web:
     image: temporalio/web:0.21.1
     environment:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added example using CockroachDB.

<!-- Tell your future self why have you made these changes -->
**Why?**
CockroachDB is PostgreSQL compliant but uses Raft under the hood, which makes for -very- easy clustering. Besides it's written in Go, so static binary.
This allows cadence to boot *much* faster compared to cassandra.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```go
version: '3.7'

networks:
  backend:
    name: backend
    internal: true
  frontend:
    name: frontend
    internal: false

services:
  db:
    hostname: db
    image: cockroachdb:20.1
    container_name: db
    tty: false
    restart: "on-failure:5"
    security_opt:
    - "no-new-privileges"
    read_only: true
    cap_drop:
    - ALL
    networks:
    - backend
    command: ["start", "--insecure"]

  cadencedb:
    hostname: cadencedb
    image: cockroachdb:20.1
    container_name: cadencedb
    tty: false
    restart: "on-failure:5"
    security_opt:
      - "no-new-privileges"
    read_only: true
    cap_drop:
      - ALL
    networks:
      - backend
    command: ["start", "--insecure"]

  api:
    read_only: true
    build:
      context: ../
      dockerfile: docker/api.Dockerfile
    image: api
    command: ["-config=/dev.yaml"]
    networks:
      - backend
      - frontend
    depends_on:
      - db
    links:
      - db
    ports:
      - 127.0.0.1:8585:8080

  worker:
    read_only: true
    build:
      context: ../
      dockerfile: docker/worker.Dockerfile
    image: worker
    command: ["-config=/dev.yaml"]
    cap_add:
    - cap_net_raw
    - cap_net_admin
    - cap_net_bind_service
    tmpfs:
    - /tmp:uid=1000,gid=1000,mode=700,noexec
    networks:
    - backend
    - frontend
    depends_on:
    - db
    - cadence
    links:
    - db
    - cadence

  statsd:
    image: graphiteapp/graphite-statsd
    networks:
    - backend

  cadence:
    image: ubercadence/server:master-auto-setup
    networks:
      - backend
    environment:
      - "DB=postgres"
      - "DB_PORT=26257"
      - "POSTGRES_USER=root"
      - "POSTGRES_PWD="
      - "POSTGRES_SEEDS=postgres"
      - "STATSD_ENDPOINT=statsd:8125"
      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
    links:
      - statsd
      - cadencedb:postgres
    ports:
      - 7933
    depends_on:
      - cadencedb
      - statsd
```

