### PR TITLE
Fix cli watching history times out after 2 minutes

### DIFF
--- a/common/rpc/context.go
+++ b/common/rpc/context.go
@@ -46,7 +46,12 @@ func NewContextFromParentWithTimeoutAndHeaders(parentCtx context.Context, timeou
 	return context.WithTimeout(headers.SetVersions(parentCtx), timeout)
 }
 
-// NewContextWithTimeoutAndHeaders creates context with timeout and version headers for CLI.
+// NewContextWithCLIHeaders creates context with version headers for CLI.
+func NewContextWithCLIHeaders() (context.Context, context.CancelFunc) {
+	return context.WithCancel(headers.SetCLIVersions(context.Background()))
+}
+
+// NewContextWithTimeoutAndCLIHeaders creates context with timeout and version headers for CLI.
 func NewContextWithTimeoutAndCLIHeaders(timeout time.Duration) (context.Context, context.CancelFunc) {
 	return context.WithTimeout(headers.SetCLIVersions(context.Background()), timeout)
 }

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -729,7 +729,7 @@ func newContextForLongPoll(c *cli.Context) (context.Context, context.CancelFunc)
 	return newContextWithTimeout(c, defaultContextTimeoutForLongPoll)
 }
 
-func newContextForBackground(c *cli.Context) (context.Context, context.CancelFunc) {
+func newIndefiniteContext(c *cli.Context) (context.Context, context.CancelFunc) {
 	if c.GlobalIsSet(FlagContextTimeout) {
 		timeout := time.Duration(c.GlobalInt(FlagContextTimeout)) * time.Second
 		return rpc.NewContextWithTimeoutAndCLIHeaders(timeout)

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -729,6 +729,15 @@ func newContextForLongPoll(c *cli.Context) (context.Context, context.CancelFunc)
 	return newContextWithTimeout(c, defaultContextTimeoutForLongPoll)
 }
 
+func newContextForBackground(c *cli.Context) (context.Context, context.CancelFunc) {
+	if c.GlobalIsSet(FlagContextTimeout) {
+		timeout := time.Duration(c.GlobalInt(FlagContextTimeout)) * time.Second
+		return rpc.NewContextWithTimeoutAndCLIHeaders(timeout)
+	}
+
+	return rpc.NewContextWithCLIHeaders()
+}
+
 func newContextWithTimeout(c *cli.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if c.GlobalIsSet(FlagContextTimeout) {
 		timeout = time.Duration(c.GlobalInt(FlagContextTimeout)) * time.Second

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -371,7 +371,7 @@ func printWorkflowProgress(c *cli.Context, wid, rid string) {
 	var lastEvent *eventpb.HistoryEvent // used for print result of this run
 	ticker := time.NewTicker(time.Second).C
 
-	tcCtx, cancel := newContextForBackground(c)
+	tcCtx, cancel := newIndefiniteContext(c)
 	defer cancel()
 
 	showDetails := c.Bool(FlagShowDetail)

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -371,7 +371,7 @@ func printWorkflowProgress(c *cli.Context, wid, rid string) {
 	var lastEvent *eventpb.HistoryEvent // used for print result of this run
 	ticker := time.NewTicker(time.Second).C
 
-	tcCtx, cancel := newContextForLongPoll(c)
+	tcCtx, cancel := newContextForBackground(c)
 	defer cancel()
 
 	showDetails := c.Bool(FlagShowDetail)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
CLI `workflow run` command will now run and listen to history events as long as the workflow is executing

<!-- Tell your future self why have you made these changes -->
**Why?**
So that I can keep watching the execution progress and not experience random watch termination

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran two options:
  - to verify that watching works after 2 minutes `workflow run --tasklist TestTaskList --workflow_type TestWorkflow_test --execution_timeout 10000 --input '{}'`
  - to verify that i can see the completion of workflow  `workflow run --tasklist TestTaskList --workflow_type TestWorkflow_test --execution_timeout 10 --input '{}'` and wait for 11 seconds to see output

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No/low risk as the changes are local to workflow run command only
