### PR TITLE
Change the type of "Task List Kind" from int32 to a protobuff enum, TaskListKind

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -42,6 +42,8 @@ import (
 	"github.com/temporalio/temporal/common/primitives"
 	"github.com/temporalio/temporal/common/service/config"
 	"go.temporal.io/temporal-proto/serviceerror"
+
+	tasklistpb "go.temporal.io/temporal-proto/tasklist"
 )
 
 //	"go.temporal.io/temporal-proto/serviceerror"
@@ -2254,7 +2256,7 @@ func (d *cassandraPersistence) LeaseTaskList(request *p.LeaseTaskListRequest) (*
 func (d *cassandraPersistence) UpdateTaskList(request *p.UpdateTaskListRequest) (*p.UpdateTaskListResponse, error) {
 	tli := *request.TaskListInfo
 	tli.LastUpdated = types.TimestampNow()
-	if tli.Kind == p.TaskListKindSticky { // if task_list is sticky, then update with TTL
+	if tli.Kind == tasklistpb.TaskListKind_Sticky { // if task_list is sticky, then update with TTL
 		expiry := types.TimestampNow()
 		expiry.Seconds += int64(stickyTaskListTTL)
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -125,12 +125,6 @@ const (
 	WorkflowStateCorrupted
 )
 
-// Kinds of task lists
-const (
-	TaskListKindNormal int32 = iota
-	TaskListKindSticky
-)
-
 // Transfer task types
 const (
 	TransferTaskTypeDecisionTask = iota
@@ -920,7 +914,7 @@ type (
 		NamespaceID  primitives.UUID
 		TaskList     string
 		TaskType     tasklistpb.TaskListType
-		TaskListKind int32
+		TaskListKind tasklistpb.TaskListKind
 		RangeID      int64
 	}
 

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -346,7 +346,7 @@ func (s *MatchingPersistenceSuite) TestLeaseAndUpdateTaskList() {
 		Name:        taskList,
 		TaskType:    tasklistpb.TaskListType_Activity,
 		AckLevel:    0,
-		Kind:        p.TaskListKindNormal,
+		Kind:        tasklistpb.TaskListKind_Normal,
 	}
 
 	_, err = s.TaskMgr.UpdateTaskList(&p.UpdateTaskListRequest{
@@ -370,20 +370,20 @@ func (s *MatchingPersistenceSuite) TestLeaseAndUpdateTaskListSticky() {
 		NamespaceID:  namespaceID,
 		TaskList:     taskList,
 		TaskType:     tasklistpb.TaskListType_Decision,
-		TaskListKind: p.TaskListKindSticky,
+		TaskListKind: tasklistpb.TaskListKind_Sticky,
 	})
 	s.NoError(err)
 	tli := response.TaskListInfo
 	s.EqualValues(1, tli.RangeID)
 	s.EqualValues(0, tli.Data.AckLevel)
-	s.EqualValues(p.TaskListKindSticky, tli.Data.Kind)
+	s.EqualValues(tasklistpb.TaskListKind_Sticky, tli.Data.Kind)
 
 	taskListInfo := &persistenceblobs.TaskListInfo{
 		NamespaceId: namespaceID,
 		Name:        taskList,
 		TaskType:    tasklistpb.TaskListType_Decision,
 		AckLevel:    0,
-		Kind:        p.TaskListKindSticky,
+		Kind:        tasklistpb.TaskListKind_Sticky,
 	}
 	_, err = s.TaskMgr.UpdateTaskList(&p.UpdateTaskListRequest{
 		TaskListInfo: taskListInfo,
@@ -437,7 +437,7 @@ func (s *MatchingPersistenceSuite) TestListWithOneTaskList() {
 			NamespaceID:  namespaceID,
 			TaskList:     "list-task-list-test-tl0",
 			TaskType:     tasklistpb.TaskListType_Activity,
-			TaskListKind: p.TaskListKindSticky,
+			TaskListKind: tasklistpb.TaskListKind_Sticky,
 		})
 		s.NoError(err)
 
@@ -448,7 +448,7 @@ func (s *MatchingPersistenceSuite) TestListWithOneTaskList() {
 		s.EqualValues(namespaceID, resp.Items[0].Data.GetNamespaceId())
 		s.Equal("list-task-list-test-tl0", resp.Items[0].Data.Name)
 		s.Equal(tasklistpb.TaskListType_Activity, resp.Items[0].Data.TaskType)
-		s.EqualValues(p.TaskListKindSticky, resp.Items[0].Data.Kind)
+		s.EqualValues(tasklistpb.TaskListKind_Sticky, resp.Items[0].Data.Kind)
 		s.Equal(rangeID, resp.Items[0].RangeID)
 		s.Equal(ackLevel, resp.Items[0].Data.AckLevel)
 		lu0, err := types.TimestampFromProto(resp.Items[0].Data.LastUpdated)
@@ -490,7 +490,7 @@ func (s *MatchingPersistenceSuite) TestListWithMultipleTaskList() {
 			NamespaceID:  primitives.MustParseUUID(namespaceID),
 			TaskList:     name,
 			TaskType:     tasklistpb.TaskListType_Activity,
-			TaskListKind: p.TaskListKindNormal,
+			TaskListKind: tasklistpb.TaskListKind_Normal,
 		})
 		s.NoError(err)
 		tlNames[name] = struct{}{}
@@ -503,7 +503,7 @@ func (s *MatchingPersistenceSuite) TestListWithMultipleTaskList() {
 				it := i.Data
 				s.EqualValues(primitives.MustParseUUID(namespaceID), it.GetNamespaceId())
 				s.Equal(tasklistpb.TaskListType_Activity, it.TaskType)
-				s.Equal(p.TaskListKindNormal, it.Kind)
+				s.Equal(tasklistpb.TaskListKind_Normal, it.Kind)
 				_, ok := listedNames[it.Name]
 				s.False(ok, "list API returns duplicate entries - have: %+v got:%v", listedNames, it.Name)
 				listedNames[it.Name] = struct{}{}

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -173,7 +173,7 @@ func (m *sqlTaskManager) UpdateTaskList(request *persistence.UpdateTaskListReque
 
 	var blob serialization.DataBlob
 	var err error
-	if request.TaskListInfo.Kind == persistence.TaskListKindSticky {
+	if request.TaskListInfo.Kind == tasklistpb.TaskListKind_Sticky {
 		tl.Expiry, err = types.TimestampProto(stickyTaskListTTL())
 		if err != nil {
 			return nil, err

--- a/proto/persistenceblobs/server_message.proto
+++ b/proto/persistenceblobs/server_message.proto
@@ -194,8 +194,7 @@ message TaskListInfo {
     bytes namespaceId = 1;
     string name = 2;
     tasklist.TaskListType taskType = 3;
-    // {Normal, Sticky}
-    int32 kind = 5;
+    tasklist.TaskListKind kind = 5;
     int64 ackLevel = 6;
     google.protobuf.Timestamp expiry = 7;
     google.protobuf.Timestamp lastUpdated = 8;

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -41,7 +41,7 @@ type (
 		sync.Mutex
 		namespaceID  primitives.UUID
 		taskListName string
-		taskListKind int32
+		taskListKind tasklistpb.TaskListKind
 		taskType     tasklistpb.TaskListType
 		rangeID      int64
 		ackLevel     int64
@@ -64,7 +64,7 @@ type (
 // - To provide the guarantee that there is only writer who updates taskList in persistence at any given point in time
 //   This guarantee makes some of the other code simpler and there is no impact to perf because updates to tasklist are
 //   spread out and happen in background routines
-func newTaskListDB(store persistence.TaskManager, namespaceID primitives.UUID, name string, taskType tasklistpb.TaskListType, kind int32, logger log.Logger) *taskListDB {
+func newTaskListDB(store persistence.TaskManager, namespaceID primitives.UUID, name string, taskType tasklistpb.TaskListType, kind tasklistpb.TaskListKind, logger log.Logger) *taskListDB {
 	return &taskListDB{
 		namespaceID:  namespaceID,
 		taskListName: name,

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -145,7 +145,7 @@ func newTaskListManager(
 		return nil, err
 	}
 
-	db := newTaskListDB(e.taskManager, primitives.MustParseUUID(taskList.namespaceID), taskList.name, taskList.taskType, int32(taskListKind), e.logger)
+	db := newTaskListDB(e.taskManager, primitives.MustParseUUID(taskList.namespaceID), taskList.name, taskList.taskType, taskListKind, e.logger)
 
 	tlMgr := &taskListManagerImpl{
 		namespaceCache: e.namespaceCache,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Replacing the type of "Task List Kind" from `int32` to a protobuff enum, `TaskListKind`:
 https://github.com/temporalio/temporal-proto/blob/8a95bbac3a1febf23d2e7f43954fa525ca300864/tasklist/enum.proto#L29-L32

<!-- Tell your future self why have you made these changes -->
**Why?**

This is part of the effort to make the code cleaner and more maintainable, via removing redundant types, and by using stronger typing. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I build the code and ran unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

There should be no externally-visible functionality change as a result of this change, this change is purely a code refactoring. If any of the existing functionality breaks, we should be able to fix or back out.
