### PR TITLE
Use Payload for SearchAttributes, Memo, and Headers

### DIFF
--- a/common/archiver/filestore/visibilityArchiver_test.go
+++ b/common/archiver/filestore/visibilityArchiver_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/temporalio/temporal/common/codec"
 	"github.com/temporalio/temporal/common/convert"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/service/config"
 )
 
@@ -179,8 +179,8 @@ func (s *visibilityArchiverSuite) TestArchive_Success() {
 		Status:             executionpb.WorkflowExecutionStatus_Failed,
 		HistoryLength:      int64(101),
 		Memo: &commonpb.Memo{
-			Fields: map[string]*commonpb.Payloads{
-				"testFields": payloads.EncodeBytes([]byte{1, 2, 3}),
+			Fields: map[string]*commonpb.Payload{
+				"testFields": payload.EncodeBytes([]byte{1, 2, 3}),
 			},
 		},
 		SearchAttributes: map[string]string{

--- a/common/archiver/filestore/visibilityArchiver_test.go
+++ b/common/archiver/filestore/visibilityArchiver_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/temporalio/temporal/common/codec"
 	"github.com/temporalio/temporal/common/convert"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/service/config"
 )
 
@@ -180,7 +180,7 @@ func (s *visibilityArchiverSuite) TestArchive_Success() {
 		HistoryLength:      int64(101),
 		Memo: &commonpb.Memo{
 			Fields: map[string]*commonpb.Payloads{
-				"testFields": payload.EncodeBytes([]byte{1, 2, 3}),
+				"testFields": payloads.EncodeBytes([]byte{1, 2, 3}),
 			},
 		},
 		SearchAttributes: map[string]string{

--- a/common/archiver/s3store/visibilityArchiver_test.go
+++ b/common/archiver/s3store/visibilityArchiver_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 
 	"github.com/uber-go/tally"
 	commonpb "go.temporal.io/temporal-proto/common"
@@ -208,8 +208,8 @@ func (s *visibilityArchiverSuite) TestArchive_Success() {
 		Status:             executionpb.WorkflowExecutionStatus_Failed,
 		HistoryLength:      int64(101),
 		Memo: &commonpb.Memo{
-			Fields: map[string]*commonpb.Payloads{
-				"testFields": payloads.EncodeBytes([]byte{1, 2, 3}),
+			Fields: map[string]*commonpb.Payload{
+				"testFields": payload.EncodeBytes([]byte{1, 2, 3}),
 			},
 		},
 		SearchAttributes: map[string]string{

--- a/common/archiver/s3store/visibilityArchiver_test.go
+++ b/common/archiver/s3store/visibilityArchiver_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 
 	"github.com/uber-go/tally"
 	commonpb "go.temporal.io/temporal-proto/common"
@@ -209,7 +209,7 @@ func (s *visibilityArchiverSuite) TestArchive_Success() {
 		HistoryLength:      int64(101),
 		Memo: &commonpb.Memo{
 			Fields: map[string]*commonpb.Payloads{
-				"testFields": payload.EncodeBytes([]byte{1, 2, 3}),
+				"testFields": payloads.EncodeBytes([]byte{1, 2, 3}),
 			},
 		},
 		SearchAttributes: map[string]string{

--- a/common/archiver/util.go
+++ b/common/archiver/util.go
@@ -32,7 +32,7 @@ import (
 	archivergenpb "github.com/temporalio/temporal/.gen/proto/archiver"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 )
 
 var (
@@ -151,10 +151,10 @@ func ValidateQueryRequest(request *QueryVisibilityRequest) error {
 }
 
 // ConvertSearchAttrToPayload converts search attribute value from string back to byte array
-func ConvertSearchAttrToPayload(searchAttrStr map[string]string) map[string]*commonpb.Payloads {
-	searchAttr := make(map[string]*commonpb.Payloads)
+func ConvertSearchAttrToPayload(searchAttrStr map[string]string) map[string]*commonpb.Payload {
+	searchAttr := make(map[string]*commonpb.Payload)
 	for k, v := range searchAttrStr {
-		searchAttr[k] = payloads.EncodeBytes([]byte(v))
+		searchAttr[k] = payload.EncodeBytes([]byte(v))
 	}
 	return searchAttr
 }

--- a/common/archiver/util.go
+++ b/common/archiver/util.go
@@ -32,7 +32,7 @@ import (
 	archivergenpb "github.com/temporalio/temporal/.gen/proto/archiver"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 var (
@@ -154,7 +154,7 @@ func ValidateQueryRequest(request *QueryVisibilityRequest) error {
 func ConvertSearchAttrToPayload(searchAttrStr map[string]string) map[string]*commonpb.Payloads {
 	searchAttr := make(map[string]*commonpb.Payloads)
 	for k, v := range searchAttrStr {
-		searchAttr[k] = payload.EncodeBytes([]byte(v))
+		searchAttr[k] = payloads.EncodeBytes([]byte(v))
 	}
 	return searchAttr
 }

--- a/common/elasticsearch/validator/searchAttrValidator.go
+++ b/common/elasticsearch/validator/searchAttrValidator.go
@@ -34,7 +34,7 @@ import (
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 )
 
@@ -92,7 +92,7 @@ func (sv *SearchAttributesValidator) ValidateSearchAttributes(input *commonpb.Se
 		// verify: value has the correct type
 		if !sv.isValidSearchAttributesValue(validAttr, key, val) {
 			var invalidValue interface{}
-			if err := payload.Decode(val, &invalidValue); err != nil {
+			if err := payloads.Decode(val, &invalidValue); err != nil {
 				invalidValue = fmt.Sprintf("value from %q", val.String())
 			}
 
@@ -142,7 +142,7 @@ func (sv *SearchAttributesValidator) isValidSearchAttributesKey(
 func (sv *SearchAttributesValidator) isValidSearchAttributesValue(
 	validAttr map[string]interface{},
 	key string,
-	value *commonpb.Payloads,
+	value *commonpb.Payload,
 ) bool {
 	valueType := common.ConvertIndexedValueTypeToProtoType(validAttr[key], sv.logger)
 	_, err := common.DeserializeSearchAttributeValue(value, valueType)

--- a/common/elasticsearch/validator/searchAttrValidator.go
+++ b/common/elasticsearch/validator/searchAttrValidator.go
@@ -34,7 +34,7 @@ import (
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 )
 
@@ -92,7 +92,7 @@ func (sv *SearchAttributesValidator) ValidateSearchAttributes(input *commonpb.Se
 		// verify: value has the correct type
 		if !sv.isValidSearchAttributesValue(validAttr, key, val) {
 			var invalidValue interface{}
-			if err := payloads.Decode(val, &invalidValue); err != nil {
+			if err := payload.Decode(val, &invalidValue); err != nil {
 				invalidValue = fmt.Sprintf("value from %q", val.String())
 			}
 
@@ -107,10 +107,7 @@ func (sv *SearchAttributesValidator) ValidateSearchAttributes(input *commonpb.Se
 			return serviceerror.NewInvalidArgument(fmt.Sprintf("%s is read-only Temporal reservered attribute", key))
 		}
 		// verify: size of single value <= limit
-		dataSize := 0
-		for _, payloadItem := range val.GetPayloads() {
-			dataSize += len(payloadItem.GetData())
-		}
+		dataSize := len(val.GetData())
 		if dataSize > sv.searchAttributesSizeOfValueLimit(namespace) {
 			sv.logger.WithTags(tag.ESKey(key), tag.Number(int64(dataSize)), tag.WorkflowNamespace(namespace)).
 				Error("value size of search attribute exceed limit")

--- a/common/elasticsearch/validator/searchAttrValidator_test.go
+++ b/common/elasticsearch/validator/searchAttrValidator_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 )
 
@@ -62,9 +62,9 @@ func (s *searchAttributesValidatorSuite) TestValidateSearchAttributes() {
 	err := validator.ValidateSearchAttributes(attr, namespace)
 	s.Nil(err)
 
-	intPayload, err := payloads.Encode(1)
+	intPayload, err := payload.Encode(1)
 	s.NoError(err)
-	fields := map[string]*commonpb.Payloads{
+	fields := map[string]*commonpb.Payload{
 		"CustomIntField": intPayload,
 	}
 	attr = &commonpb.SearchAttributes{
@@ -73,56 +73,56 @@ func (s *searchAttributesValidatorSuite) TestValidateSearchAttributes() {
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Nil(err)
 
-	fields = map[string]*commonpb.Payloads{
+	fields = map[string]*commonpb.Payload{
 		"CustomIntField":     intPayload,
-		"CustomKeywordField": payloads.EncodeString("keyword"),
-		"CustomBoolField":    payloads.EncodeString("true"),
+		"CustomKeywordField": payload.EncodeString("keyword"),
+		"CustomBoolField":    payload.EncodeString("true"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("number of keys 3 exceed limit", err.Error())
 
-	fields = map[string]*commonpb.Payloads{
-		"InvalidKey": payloads.EncodeString("1"),
+	fields = map[string]*commonpb.Payload{
+		"InvalidKey": payload.EncodeString("1"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("InvalidKey is not valid search attribute key", err.Error())
 
-	fields = map[string]*commonpb.Payloads{
-		"CustomStringField": payloads.EncodeString("1"),
-		"CustomBoolField":   payloads.EncodeString("123"),
+	fields = map[string]*commonpb.Payload{
+		"CustomStringField": payload.EncodeString("1"),
+		"CustomBoolField":   payload.EncodeString("123"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("123 is not a valid search attribute value for key CustomBoolField", err.Error())
 
-	intArrayPayload, err := payloads.Encode([]int{1, 2})
+	intArrayPayload, err := payload.Encode([]int{1, 2})
 	s.NoError(err)
-	fields = map[string]*commonpb.Payloads{
+	fields = map[string]*commonpb.Payload{
 		"CustomIntField": intArrayPayload,
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.NoError(err)
 
-	fields = map[string]*commonpb.Payloads{
+	fields = map[string]*commonpb.Payload{
 		"StartTime": intPayload,
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("StartTime is read-only Temporal reservered attribute", err.Error())
 
-	fields = map[string]*commonpb.Payloads{
-		"CustomKeywordField": payloads.EncodeString("123456"),
+	fields = map[string]*commonpb.Payload{
+		"CustomKeywordField": payload.EncodeString("123456"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("size limit exceed for key CustomKeywordField", err.Error())
 
-	fields = map[string]*commonpb.Payloads{
-		"CustomKeywordField": payloads.EncodeString("123"),
-		"CustomStringField":  payloads.EncodeString("12"),
+	fields = map[string]*commonpb.Payload{
+		"CustomKeywordField": payload.EncodeString("123"),
+		"CustomStringField":  payload.EncodeString("12"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)

--- a/common/elasticsearch/validator/searchAttrValidator_test.go
+++ b/common/elasticsearch/validator/searchAttrValidator_test.go
@@ -32,7 +32,7 @@ import (
 
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 )
 
@@ -62,7 +62,7 @@ func (s *searchAttributesValidatorSuite) TestValidateSearchAttributes() {
 	err := validator.ValidateSearchAttributes(attr, namespace)
 	s.Nil(err)
 
-	intPayload, err := payload.Encode(1)
+	intPayload, err := payloads.Encode(1)
 	s.NoError(err)
 	fields := map[string]*commonpb.Payloads{
 		"CustomIntField": intPayload,
@@ -75,29 +75,29 @@ func (s *searchAttributesValidatorSuite) TestValidateSearchAttributes() {
 
 	fields = map[string]*commonpb.Payloads{
 		"CustomIntField":     intPayload,
-		"CustomKeywordField": payload.EncodeString("keyword"),
-		"CustomBoolField":    payload.EncodeString("true"),
+		"CustomKeywordField": payloads.EncodeString("keyword"),
+		"CustomBoolField":    payloads.EncodeString("true"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("number of keys 3 exceed limit", err.Error())
 
 	fields = map[string]*commonpb.Payloads{
-		"InvalidKey": payload.EncodeString("1"),
+		"InvalidKey": payloads.EncodeString("1"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("InvalidKey is not valid search attribute key", err.Error())
 
 	fields = map[string]*commonpb.Payloads{
-		"CustomStringField": payload.EncodeString("1"),
-		"CustomBoolField":   payload.EncodeString("123"),
+		"CustomStringField": payloads.EncodeString("1"),
+		"CustomBoolField":   payloads.EncodeString("123"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("123 is not a valid search attribute value for key CustomBoolField", err.Error())
 
-	intArrayPayload, err := payload.Encode([]int{1, 2})
+	intArrayPayload, err := payloads.Encode([]int{1, 2})
 	s.NoError(err)
 	fields = map[string]*commonpb.Payloads{
 		"CustomIntField": intArrayPayload,
@@ -114,15 +114,15 @@ func (s *searchAttributesValidatorSuite) TestValidateSearchAttributes() {
 	s.Equal("StartTime is read-only Temporal reservered attribute", err.Error())
 
 	fields = map[string]*commonpb.Payloads{
-		"CustomKeywordField": payload.EncodeString("123456"),
+		"CustomKeywordField": payloads.EncodeString("123456"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)
 	s.Equal("size limit exceed for key CustomKeywordField", err.Error())
 
 	fields = map[string]*commonpb.Payloads{
-		"CustomKeywordField": payload.EncodeString("123"),
-		"CustomStringField":  payload.EncodeString("12"),
+		"CustomKeywordField": payloads.EncodeString("123"),
+		"CustomStringField":  payloads.EncodeString("12"),
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, namespace)

--- a/common/payload/payload.go
+++ b/common/payload/payload.go
@@ -1,0 +1,54 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package payload
+
+import (
+	commonpb "go.temporal.io/temporal-proto/common"
+	"go.temporal.io/temporal/encoded"
+)
+
+var (
+	payloadConverter = encoded.GetDefaultPayloadConverter()
+)
+
+func EncodeString(str string) *commonpb.Payload {
+	// Error can be safely ignored here becase string always can be converted to JSON
+	payload, _ := payloadConverter.ToData(str)
+	return payload
+}
+
+func EncodeBytes(bytes []byte) *commonpb.Payload {
+	// Error can be safely ignored here becase []byte always can be raw encoded
+	payload, _ := payloadConverter.ToData(bytes)
+	return payload
+}
+
+func Encode(valuePtr interface{}) (*commonpb.Payload, error) {
+	return payloadConverter.ToData(valuePtr)
+}
+
+func Decode(payload *commonpb.Payload, valuePtr interface{}) error {
+	return payloadConverter.FromData(payload, valuePtr)
+}

--- a/common/payloads/payloads.go
+++ b/common/payloads/payloads.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package payload
+package payloads
 
 import (
 	commonpb "go.temporal.io/temporal-proto/common"

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -304,8 +304,8 @@ type (
 		ClientFeatureVersion               string
 		ClientImpl                         string
 		AutoResetPoints                    *executionpb.ResetPoints
-		Memo                               map[string]*commonpb.Payloads
-		SearchAttributes                   map[string]*commonpb.Payloads
+		Memo                               map[string]*commonpb.Payload
+		SearchAttributes                   map[string]*commonpb.Payload
 		// for retry
 		Attempt                int32
 		HasRetryPolicy         bool

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -895,7 +895,7 @@ func (v *esVisibilityStore) convertSearchResultToVisibilityRecord(hit *elastic.S
 
 func getVisibilityMessage(namespaceID string, wid, rid string, workflowTypeName string, taskList string,
 	startTimeUnixNano, executionTimeUnixNano int64, taskID int64, memo []byte, encoding common.EncodingType,
-	searchAttributes map[string]*commonpb.Payloads) *indexergenpb.Message {
+	searchAttributes map[string]*commonpb.Payload) *indexergenpb.Message {
 
 	msgType := indexergenpb.MessageType_Index
 	fields := map[string]*indexergenpb.Field{
@@ -909,12 +909,10 @@ func getVisibilityMessage(namespaceID string, wid, rid string, workflowTypeName 
 		fields[es.Encoding] = &indexergenpb.Field{Type: es.FieldTypeString, StringData: string(encoding)}
 	}
 	for k, v := range searchAttributes {
-		// TODO: current implementation assumes that there is always one single PayloadItem in payload and it's content is JSON.
-		// This neds to be saved in generic way (as commonpb.Payloads) and then deserialized on consumer side.
-		if len(v.GetPayloads()) > 0 { // There must be always one single item
-			data := v.GetPayloads()[0].GetData() // content must always be JSON
-			fields[k] = &indexergenpb.Field{Type: es.FieldTypeBinary, BinaryData: data}
-		}
+		// TODO: current implementation assumes that payload is JSON.
+		// This needs to be saved in generic way (as commonpb.Payload) and then deserialized on consumer side.
+		data := v.GetData() // content must always be JSON
+		fields[k] = &indexergenpb.Field{Type: es.FieldTypeBinary, BinaryData: data}
 	}
 
 	msg := &indexergenpb.Message{
@@ -931,7 +929,7 @@ func getVisibilityMessage(namespaceID string, wid, rid string, workflowTypeName 
 func getVisibilityMessageForCloseExecution(namespaceID string, wid, rid string, workflowTypeName string,
 	startTimeUnixNano int64, executionTimeUnixNano int64, endTimeUnixNano int64, status executionpb.WorkflowExecutionStatus,
 	historyLength int64, taskID int64, memo []byte, taskList string, encoding common.EncodingType,
-	searchAttributes map[string]*commonpb.Payloads) *indexergenpb.Message {
+	searchAttributes map[string]*commonpb.Payload) *indexergenpb.Message {
 
 	msgType := indexergenpb.MessageType_Index
 	fields := map[string]*indexergenpb.Field{
@@ -948,12 +946,10 @@ func getVisibilityMessageForCloseExecution(namespaceID string, wid, rid string, 
 		fields[es.Encoding] = &indexergenpb.Field{Type: es.FieldTypeString, StringData: string(encoding)}
 	}
 	for k, v := range searchAttributes {
-		// TODO: current implementation assumes that there is always one single PayloadItem in payload and it's content is JSON.
-		// This neds to be saved in generic way (as commonpb.Payloads) and then deserialized on consumer side.
-		if len(v.GetPayloads()) > 0 { // There must be always one single item
-			data := v.GetPayloads()[0].GetData() // content must always be JSON
-			fields[k] = &indexergenpb.Field{Type: es.FieldTypeBinary, BinaryData: data}
-		}
+		// TODO: current implementation assumes that payload is JSON.
+		// This needs to be saved in generic way (as commonpb.Payload) and then deserialized on consumer side.
+		data := v.GetData() // content must always be JSON
+		fields[k] = &indexergenpb.Field{Type: es.FieldTypeBinary, BinaryData: data}
 	}
 
 	msg := &indexergenpb.Message{

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -50,7 +50,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/checksum"
 	"github.com/temporalio/temporal/common/cluster"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	p "github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -1210,13 +1210,13 @@ func (s *ExecutionManagerSuite) TestGetWorkflow() {
 		},
 	}
 	testSearchAttrKey := "env"
-	testSearchAttrVal := payload.EncodeString("test")
+	testSearchAttrVal := payloads.EncodeString("test")
 	testSearchAttr := map[string]*commonpb.Payloads{
 		testSearchAttrKey: testSearchAttrVal,
 	}
 
 	testMemoKey := "memoKey"
-	testMemoVal := payload.EncodeString("memoVal")
+	testMemoVal := payloads.EncodeString("memoVal")
 	testMemo := map[string]*commonpb.Payloads{
 		testMemoKey: testMemoVal,
 	}
@@ -1417,11 +1417,11 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	updatedInfo.WorkflowExpirationTime = time.Now()
 	updatedInfo.NonRetriableErrors = []string{"accessDenied", "badRequest"}
 	searchAttrKey := "env"
-	searchAttrVal := payload.EncodeBytes([]byte("test"))
+	searchAttrVal := payloads.EncodeBytes([]byte("test"))
 	updatedInfo.SearchAttributes = map[string]*commonpb.Payloads{searchAttrKey: searchAttrVal}
 
 	memoKey := "memoKey"
-	memoVal := payload.EncodeBytes([]byte("memoVal"))
+	memoVal := payloads.EncodeBytes([]byte("memoVal"))
 	updatedInfo.Memo = map[string]*commonpb.Payloads{memoKey: memoVal}
 	updatedStats.HistorySize = math.MaxInt64
 
@@ -2593,7 +2593,7 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateActivities() {
 		ScheduledTime:            currentTime,
 		ActivityID:               uuid.New(),
 		RequestID:                uuid.New(),
-		Details:                  payload.EncodeString(uuid.New()),
+		Details:                  payloads.EncodeString(uuid.New()),
 		StartedID:                2,
 		StartedEvent:             &eventpb.HistoryEvent{EventId: 2},
 		StartedTime:              currentTime,
@@ -2618,7 +2618,7 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateActivities() {
 		NonRetriableErrors:       []string{"accessDenied", "badRequest"},
 		LastFailureReason:        "some random error",
 		LastWorkerIdentity:       uuid.New(),
-		LastFailureDetails:       payload.EncodeString(uuid.New()),
+		LastFailureDetails:       payloads.EncodeString(uuid.New()),
 	}}
 	err2 := s.UpdateWorkflowExecution(updatedInfo, updatedStats, nil, []int64{int64(4)}, nil, int64(3), nil, activityInfos, nil, nil, nil)
 	s.NoError(err2)
@@ -2871,7 +2871,7 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateSignalInfo() {
 		InitiatedEventBatchId: 1,
 		RequestId:             uuid.New(),
 		Name:                  "my signal",
-		Input:                 payload.EncodeString("test signal input"),
+		Input:                 payloads.EncodeString("test signal input"),
 		Control:               uuid.New(),
 	}
 	err2 := s.UpsertSignalInfoState(updatedInfo, updatedStats, nil, int64(3), []*persistenceblobs.SignalInfo{signalInfo})
@@ -3706,7 +3706,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 				InitiatedEventBatchId: 38,
 				RequestId:             "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 				Name:                  "signalA",
-				Input:                 payload.EncodeString("signal_input_A"),
+				Input:                 payloads.EncodeString("signal_input_A"),
 				Control:               "signal_control_A",
 			},
 		},
@@ -3915,7 +3915,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 			InitiatedId: 39,
 			RequestId:   "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			Name:        "signalB",
-			Input:       payload.EncodeString("signal_input_b"),
+			Input:       payloads.EncodeString("signal_input_b"),
 			Control:     "signal_control_b",
 		},
 		{
@@ -3923,7 +3923,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 			InitiatedId: 42,
 			RequestId:   "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
 			Name:        "signalC",
-			Input:       payload.EncodeString("signal_input_c"),
+			Input:       payloads.EncodeString("signal_input_c"),
 			Control:     "signal_control_c",
 		}}
 
@@ -4011,7 +4011,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 	s.Equal(int64(39), si.GetInitiatedId())
 	s.Equal("signalB", si.Name)
 	var signal string
-	err := payload.Decode(si.GetInput(), &signal)
+	err := payloads.Decode(si.GetInput(), &signal)
 	s.NoError(err)
 	s.Equal("signal_input_b", signal)
 	s.Equal("signal_control_b", si.Control)
@@ -4022,7 +4022,7 @@ func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSel
 	s.Equal(int64(3336), si.Version)
 	s.Equal(int64(42), si.GetInitiatedId())
 	s.Equal("signalC", si.Name)
-	err = payload.Decode(si.GetInput(), &signal)
+	err = payloads.Decode(si.GetInput(), &signal)
 	s.NoError(err)
 	s.Equal("signal_input_c", signal)
 	s.Equal("signal_control_c", si.Control)

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -50,6 +50,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/checksum"
 	"github.com/temporalio/temporal/common/cluster"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	p "github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
@@ -1210,14 +1211,14 @@ func (s *ExecutionManagerSuite) TestGetWorkflow() {
 		},
 	}
 	testSearchAttrKey := "env"
-	testSearchAttrVal := payloads.EncodeString("test")
-	testSearchAttr := map[string]*commonpb.Payloads{
+	testSearchAttrVal := payload.EncodeString("test")
+	testSearchAttr := map[string]*commonpb.Payload{
 		testSearchAttrKey: testSearchAttrVal,
 	}
 
 	testMemoKey := "memoKey"
-	testMemoVal := payloads.EncodeString("memoVal")
-	testMemo := map[string]*commonpb.Payloads{
+	testMemoVal := payload.EncodeString("memoVal")
+	testMemo := map[string]*commonpb.Payload{
 		testMemoKey: testMemoVal,
 	}
 
@@ -1417,12 +1418,12 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	updatedInfo.WorkflowExpirationTime = time.Now()
 	updatedInfo.NonRetriableErrors = []string{"accessDenied", "badRequest"}
 	searchAttrKey := "env"
-	searchAttrVal := payloads.EncodeBytes([]byte("test"))
-	updatedInfo.SearchAttributes = map[string]*commonpb.Payloads{searchAttrKey: searchAttrVal}
+	searchAttrVal := payload.EncodeBytes([]byte("test"))
+	updatedInfo.SearchAttributes = map[string]*commonpb.Payload{searchAttrKey: searchAttrVal}
 
 	memoKey := "memoKey"
-	memoVal := payloads.EncodeBytes([]byte("memoVal"))
-	updatedInfo.Memo = map[string]*commonpb.Payloads{memoKey: memoVal}
+	memoVal := payload.EncodeBytes([]byte("memoVal"))
+	updatedInfo.Memo = map[string]*commonpb.Payload{memoKey: memoVal}
 	updatedStats.HistorySize = math.MaxInt64
 
 	err2 := s.UpdateWorkflowExecution(updatedInfo, updatedStats, nil, []int64{int64(4)}, nil, int64(3), nil, nil, nil, nil, nil)

--- a/common/persistence/persistence-tests/visibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/visibilityPersistenceTest.go
@@ -37,7 +37,7 @@ import (
 	"go.temporal.io/temporal-proto/serviceerror"
 
 	"github.com/temporalio/temporal/common/definition"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 	p "github.com/temporalio/temporal/common/persistence"
 )
 
@@ -693,8 +693,8 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 				WorkflowTimeout:    0,
 				TaskID:             0,
 				Memo:               nil,
-				SearchAttributes: map[string]*commonpb.Payloads{
-					definition.TemporalChangeVersion: payloads.EncodeBytes([]byte("dummy")),
+				SearchAttributes: map[string]*commonpb.Payload{
+					definition.TemporalChangeVersion: payload.EncodeBytes([]byte("dummy")),
 				},
 			},
 			expected: nil,

--- a/common/persistence/persistence-tests/visibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/visibilityPersistenceTest.go
@@ -37,7 +37,7 @@ import (
 	"go.temporal.io/temporal-proto/serviceerror"
 
 	"github.com/temporalio/temporal/common/definition"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	p "github.com/temporalio/temporal/common/persistence"
 )
 
@@ -694,7 +694,7 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 				TaskID:             0,
 				Memo:               nil,
 				SearchAttributes: map[string]*commonpb.Payloads{
-					definition.TemporalChangeVersion: payload.EncodeBytes([]byte("dummy")),
+					definition.TemporalChangeVersion: payloads.EncodeBytes([]byte("dummy")),
 				},
 			},
 			expected: nil,

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -258,8 +258,8 @@ type (
 		NonRetriableErrors []string
 		BranchToken        []byte
 		CronSchedule       string
-		Memo               map[string]*commonpb.Payloads
-		SearchAttributes   map[string]*commonpb.Payloads
+		Memo               map[string]*commonpb.Payload
+		SearchAttributes   map[string]*commonpb.Payload
 
 		// attributes which are not related to mutable state at all
 		HistorySize int64
@@ -597,7 +597,7 @@ type (
 		TaskID             int64
 		Memo               *serialization.DataBlob
 		TaskList           string
-		SearchAttributes   map[string]*commonpb.Payloads
+		SearchAttributes   map[string]*commonpb.Payload
 	}
 
 	// InternalRecordWorkflowExecutionClosedRequest is request to RecordWorkflowExecutionClosed
@@ -611,7 +611,7 @@ type (
 		TaskID             int64
 		Memo               *serialization.DataBlob
 		TaskList           string
-		SearchAttributes   map[string]*commonpb.Payloads
+		SearchAttributes   map[string]*commonpb.Payload
 		CloseTimestamp     int64
 		Status             executionpb.WorkflowExecutionStatus
 		HistoryLength      int64
@@ -630,7 +630,7 @@ type (
 		TaskID             int64
 		Memo               *serialization.DataBlob
 		TaskList           string
-		SearchAttributes   map[string]*commonpb.Payloads
+		SearchAttributes   map[string]*commonpb.Payload
 	}
 
 	// InternalCreateNamespaceRequest is used to create the namespace

--- a/common/persistence/serializer_test.go
+++ b/common/persistence/serializer_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 )
 
@@ -95,8 +96,8 @@ func (s *temporalSerializerSuite) TestSerializer() {
 
 	history0 := &eventpb.History{Events: []*eventpb.HistoryEvent{event0, event0}}
 
-	memoFields := map[string]*commonpb.Payloads{
-		"TestField": payloads.EncodeString("Test binary"),
+	memoFields := map[string]*commonpb.Payload{
+		"TestField": payload.EncodeString("Test binary"),
 	}
 	memo0 := &commonpb.Memo{Fields: memoFields}
 

--- a/common/persistence/serializer_test.go
+++ b/common/persistence/serializer_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 type (
@@ -85,7 +85,7 @@ func (s *temporalSerializerSuite) TestSerializer() {
 		EventType: eventType,
 		Attributes: &eventpb.HistoryEvent_ActivityTaskCompletedEventAttributes{
 			ActivityTaskCompletedEventAttributes: &eventpb.ActivityTaskCompletedEventAttributes{
-				Result:           payload.EncodeString("result-1-event-1"),
+				Result:           payloads.EncodeString("result-1-event-1"),
 				ScheduledEventId: 4,
 				StartedEventId:   5,
 				Identity:         "event-1",
@@ -96,7 +96,7 @@ func (s *temporalSerializerSuite) TestSerializer() {
 	history0 := &eventpb.History{Events: []*eventpb.HistoryEvent{event0, event0}}
 
 	memoFields := map[string]*commonpb.Payloads{
-		"TestField": payload.EncodeString("Test binary"),
+		"TestField": payloads.EncodeString("Test binary"),
 	}
 	memo0 := &commonpb.Memo{Fields: memoFields}
 

--- a/common/persistence/sql/sqlplugin/postgres/postgres_server_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/postgres_server_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	testUser      = "temporal"
+	testUser      = "postgres"
 	testPassword  = "temporal"
 	testSchemaDir = "schema/postgres"
 )

--- a/common/persistence/sql/sqlplugin/postgres/postgres_server_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/postgres_server_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	testUser      = "postgres"
+	testUser      = "temporal"
 	testPassword  = "temporal"
 	testSchemaDir = "schema/postgres"
 )

--- a/common/persistence/visibilityInterfaces.go
+++ b/common/persistence/visibilityInterfaces.go
@@ -52,7 +52,7 @@ type (
 		TaskID             int64 // not persisted, used as condition update version for ES
 		Memo               *commonpb.Memo
 		TaskList           string
-		SearchAttributes   map[string]*commonpb.Payloads
+		SearchAttributes   map[string]*commonpb.Payload
 	}
 
 	// RecordWorkflowExecutionClosedRequest is used to add a record of a newly
@@ -71,7 +71,7 @@ type (
 		TaskID             int64 // not persisted, used as condition update version for ES
 		Memo               *commonpb.Memo
 		TaskList           string
-		SearchAttributes   map[string]*commonpb.Payloads
+		SearchAttributes   map[string]*commonpb.Payload
 	}
 
 	// UpsertWorkflowExecutionRequest is used to upsert workflow execution
@@ -86,7 +86,7 @@ type (
 		TaskID             int64 // not persisted, used as condition update version for ES
 		Memo               *commonpb.Memo
 		TaskList           string
-		SearchAttributes   map[string]*commonpb.Payloads
+		SearchAttributes   map[string]*commonpb.Payload
 	}
 
 	// ListWorkflowExecutionsRequest is used to list executions in a namespace

--- a/common/persistence/visibilityStore.go
+++ b/common/persistence/visibilityStore.go
@@ -29,12 +29,11 @@ import (
 	commonpb "go.temporal.io/temporal-proto/common"
 	executionpb "go.temporal.io/temporal-proto/execution"
 
-	"github.com/temporalio/temporal/common/payloads"
-	"github.com/temporalio/temporal/common/persistence/serialization"
-
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
+	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/persistence/serialization"
 )
 
 type (
@@ -234,11 +233,11 @@ func (v *visibilityManagerImpl) convertInternalListResponse(internalResp *Intern
 }
 
 func (v *visibilityManagerImpl) getSearchAttributes(attr map[string]interface{}) (*commonpb.SearchAttributes, error) {
-	indexedFields := make(map[string]*commonpb.Payloads)
+	indexedFields := make(map[string]*commonpb.Payload)
 	var err error
-	var valBytes *commonpb.Payloads
+	var valBytes *commonpb.Payload
 	for k, val := range attr {
-		valBytes, err = payloads.Encode(val)
+		valBytes, err = payload.Encode(val)
 		if err != nil {
 			v.logger.Error("error when encode search attributes", tag.Value(val))
 			continue

--- a/common/persistence/visibilityStore.go
+++ b/common/persistence/visibilityStore.go
@@ -29,7 +29,7 @@ import (
 	commonpb "go.temporal.io/temporal-proto/common"
 	executionpb "go.temporal.io/temporal-proto/execution"
 
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence/serialization"
 
 	"github.com/temporalio/temporal/common"
@@ -238,7 +238,7 @@ func (v *visibilityManagerImpl) getSearchAttributes(attr map[string]interface{})
 	var err error
 	var valBytes *commonpb.Payloads
 	for k, val := range attr {
-		valBytes, err = payload.Encode(val)
+		valBytes, err = payloads.Encode(val)
 		if err != nil {
 			v.logger.Error("error when encode search attributes", tag.Value(val))
 			continue

--- a/common/util.go
+++ b/common/util.go
@@ -47,7 +47,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 )
 
 const (
@@ -517,41 +517,41 @@ func DeserializeSearchAttributeValue(value *commonpb.Payload, valueType commonpb
 	switch valueType {
 	case commonpb.IndexedValueType_String, commonpb.IndexedValueType_Keyword:
 		var val string
-		if err := payloads.Decode(value, &val); err != nil {
+		if err := payload.Decode(value, &val); err != nil {
 			var listVal []string
-			err = payloads.Decode(value, &listVal)
+			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil
 	case commonpb.IndexedValueType_Int:
 		var val int64
-		if err := payloads.Decode(value, &val); err != nil {
+		if err := payload.Decode(value, &val); err != nil {
 			var listVal []int64
-			err = payloads.Decode(value, &listVal)
+			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil
 	case commonpb.IndexedValueType_Double:
 		var val float64
-		if err := payloads.Decode(value, &val); err != nil {
+		if err := payload.Decode(value, &val); err != nil {
 			var listVal []float64
-			err = payloads.Decode(value, &listVal)
+			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil
 	case commonpb.IndexedValueType_Bool:
 		var val bool
-		if err := payloads.Decode(value, &val); err != nil {
+		if err := payload.Decode(value, &val); err != nil {
 			var listVal []bool
-			err = payloads.Decode(value, &listVal)
+			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil
 	case commonpb.IndexedValueType_Datetime:
 		var val time.Time
-		if err := payloads.Decode(value, &val); err != nil {
+		if err := payload.Decode(value, &val); err != nil {
 			var listVal []time.Time
-			err = payloads.Decode(value, &listVal)
+			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil

--- a/common/util.go
+++ b/common/util.go
@@ -47,7 +47,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 const (
@@ -513,45 +513,45 @@ func ConvertIndexedValueTypeToProtoType(fieldType interface{}, logger log.Logger
 
 // DeserializeSearchAttributeValue takes json encoded search attribute value and it's type as input, then
 // unmarshal the value into a concrete type and return the value
-func DeserializeSearchAttributeValue(value *commonpb.Payloads, valueType commonpb.IndexedValueType) (interface{}, error) {
+func DeserializeSearchAttributeValue(value *commonpb.Payload, valueType commonpb.IndexedValueType) (interface{}, error) {
 	switch valueType {
 	case commonpb.IndexedValueType_String, commonpb.IndexedValueType_Keyword:
 		var val string
-		if err := payload.Decode(value, &val); err != nil {
+		if err := payloads.Decode(value, &val); err != nil {
 			var listVal []string
-			err = payload.Decode(value, &listVal)
+			err = payloads.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil
 	case commonpb.IndexedValueType_Int:
 		var val int64
-		if err := payload.Decode(value, &val); err != nil {
+		if err := payloads.Decode(value, &val); err != nil {
 			var listVal []int64
-			err = payload.Decode(value, &listVal)
+			err = payloads.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil
 	case commonpb.IndexedValueType_Double:
 		var val float64
-		if err := payload.Decode(value, &val); err != nil {
+		if err := payloads.Decode(value, &val); err != nil {
 			var listVal []float64
-			err = payload.Decode(value, &listVal)
+			err = payloads.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil
 	case commonpb.IndexedValueType_Bool:
 		var val bool
-		if err := payload.Decode(value, &val); err != nil {
+		if err := payloads.Decode(value, &val); err != nil {
 			var listVal []bool
-			err = payload.Decode(value, &listVal)
+			err = payloads.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil
 	case commonpb.IndexedValueType_Datetime:
 		var val time.Time
-		if err := payload.Decode(value, &val); err != nil {
+		if err := payloads.Decode(value, &val); err != nil {
 			var listVal []time.Time
-			err = payload.Decode(value, &listVal)
+			err = payloads.Decode(value, &listVal)
 			return listVal, err
 		}
 		return val, nil

--- a/go.mod
+++ b/go.mod
@@ -63,8 +63,8 @@ require (
 	github.com/urfave/cli v1.20.0
 	github.com/valyala/fastjson v1.4.1
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
-	go.temporal.io/temporal v0.22.6
-	go.temporal.io/temporal-proto v0.20.30
+	go.temporal.io/temporal v0.22.7
+	go.temporal.io/temporal-proto v0.20.31
 	go.uber.org/atomic v1.6.0
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0
@@ -83,7 +83,3 @@ require (
 
 // TODO https://github.com/uber/cadence/issues/2863
 replace github.com/jmoiron/sqlx v1.2.0 => github.com/longquanzheng/sqlx v0.0.0-20191125235044-053e6130695c
-
-replace go.temporal.io/temporal-proto v0.20.30 => ../temporal-proto-go
-
-replace go.temporal.io/temporal v0.22.6 => ../temporal-go-sdk

--- a/go.mod
+++ b/go.mod
@@ -83,3 +83,7 @@ require (
 
 // TODO https://github.com/uber/cadence/issues/2863
 replace github.com/jmoiron/sqlx v1.2.0 => github.com/longquanzheng/sqlx v0.0.0-20191125235044-053e6130695c
+
+replace go.temporal.io/temporal-proto v0.20.30 => ../temporal-proto-go
+
+replace go.temporal.io/temporal v0.22.6 => ../temporal-go-sdk

--- a/go.sum
+++ b/go.sum
@@ -244,10 +244,10 @@ github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2/go.mod h1:hzfGeI
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
-go.temporal.io/temporal v0.22.6 h1:wckPYZ/v+x3cuPN77ETfh85hvWLiDOIxHjfXhOnE1Co=
-go.temporal.io/temporal v0.22.6/go.mod h1:zCLxgZ4CtF4QuWA8+mUqUl6f6JUlw4EZb1yV5sy5G6M=
-go.temporal.io/temporal-proto v0.20.30 h1:QxvCfTZ1U686bmlMPTTg0F/dvMvt02m7i3jF3zWEX/E=
-go.temporal.io/temporal-proto v0.20.30/go.mod h1:Lv8L8YBpbp0Z7V5nbvw5UD0j7x0isebhCOIDLkBqn6s=
+go.temporal.io/temporal v0.22.7 h1:il0yKuZh8cioDF0Si+x1fmRrncWy9mB4mN4NbN7HzuQ=
+go.temporal.io/temporal v0.22.7/go.mod h1:+3O0OE/Y5pAKG5vJQ8ROVpLyWLLnyPi+T12OIIxYVi0=
+go.temporal.io/temporal-proto v0.20.31 h1:AlY49UhslnoUSV9HvnEewgy0ursxMPrOJAaQZHmDwzM=
+go.temporal.io/temporal-proto v0.20.31/go.mod h1:Lv8L8YBpbp0Z7V5nbvw5UD0j7x0isebhCOIDLkBqn6s=
 go.uber.org/atomic v1.5.0 h1:OI5t8sDa1Or+q8AeE+yKeB/SDYioSHAgcVljj9JIETY=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0 h1:Ezj3JGmsOnG1MoRWQkPBsKLe9DwWD9QeXzTRzzldNVk=

--- a/host/activity_test.go
+++ b/host/activity_test.go
@@ -43,7 +43,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/service/matching"
 )
 
@@ -59,7 +59,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 	taskList := &tasklistpb.TaskList{Name: tl}
 
 	header := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payload.EncodeString("sample data")},
+		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("sample data")},
 	}
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
@@ -97,7 +97,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					Header:                        header,
 					ScheduleToCloseTimeoutSeconds: 15,
 					ScheduleToStartTimeoutSeconds: 1,
@@ -113,7 +113,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -126,12 +126,12 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 		for i := 0; i < 10; i++ {
 			s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(activityID), tag.Counter(i))
 			_, err := s.engine.RecordActivityTaskHeartbeat(NewContext(), &workflowservice.RecordActivityTaskHeartbeatRequest{
-				TaskToken: taskToken, Details: payload.EncodeString("details")})
+				TaskToken: taskToken, Details: payloads.EncodeString("details")})
 			s.NoError(err)
 			time.Sleep(10 * time.Millisecond)
 		}
 		activityExecutedCount++
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -234,13 +234,13 @@ func (s *integrationSuite) TestActivityHeartbeatDetailsDuringRetry() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
 
 	activityExecutedCount := 0
-	heartbeatDetails := payload.EncodeString("details")
+	heartbeatDetails := payloads.EncodeString("details")
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 		s.Equal(id, execution.GetWorkflowId())
@@ -318,7 +318,7 @@ func (s *integrationSuite) TestActivityHeartbeatDetailsDuringRetry() {
 				expectedErrString := "retryable-error"
 				s.Equal(expectedErrString, pendingActivity.GetLastFailureReason())
 				var d string
-				err = payload.Decode(pendingActivity.GetLastFailureDetails(), &d)
+				err = payloads.Decode(pendingActivity.GetLastFailureDetails(), &d)
 				s.NoError(err)
 				s.Equal(expectedErrString, d)
 			}
@@ -391,7 +391,7 @@ func (s *integrationSuite) TestActivityRetry() {
 						ActivityId:                    "A",
 						ActivityType:                  &commonpb.ActivityType{Name: activityName},
 						TaskList:                      &tasklistpb.TaskList{Name: tl},
-						Input:                         payload.EncodeString("1"),
+						Input:                         payloads.EncodeString("1"),
 						ScheduleToCloseTimeoutSeconds: 4,
 						ScheduleToStartTimeoutSeconds: 4,
 						StartToCloseTimeoutSeconds:    4,
@@ -410,7 +410,7 @@ func (s *integrationSuite) TestActivityRetry() {
 						ActivityId:                    "B",
 						ActivityType:                  &commonpb.ActivityType{Name: timeoutActivityName},
 						TaskList:                      &tasklistpb.TaskList{Name: "no_worker_tasklist"},
-						Input:                         payload.EncodeString("2"),
+						Input:                         payloads.EncodeString("2"),
 						ScheduleToCloseTimeoutSeconds: 5,
 						ScheduleToStartTimeoutSeconds: 5,
 						StartToCloseTimeoutSeconds:    5,
@@ -447,7 +447,7 @@ func (s *integrationSuite) TestActivityRetry() {
 			return []*decisionpb.Decision{{
 				DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 				Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-					Result: payload.EncodeString("Done"),
+					Result: payloads.EncodeString("Done"),
 				}},
 			}}, nil
 		}
@@ -515,7 +515,7 @@ func (s *integrationSuite) TestActivityRetry() {
 			expectedErrString := "bad-luck-please-retry"
 			s.Equal(expectedErrString, pendingActivity.GetLastFailureReason())
 			var d string
-			err = payload.Decode(pendingActivity.GetLastFailureDetails(), &d)
+			err = payloads.Decode(pendingActivity.GetLastFailureDetails(), &d)
 			s.NoError(err)
 			s.Equal(expectedErrString, d)
 			s.Equal(identity, pendingActivity.GetLastWorkerIdentity())
@@ -533,7 +533,7 @@ func (s *integrationSuite) TestActivityRetry() {
 			s.Equal(expectedErrString, pendingActivity.GetLastFailureReason())
 
 			var d string
-			err = payload.Decode(pendingActivity.GetLastFailureDetails(), &d)
+			err = payloads.Decode(pendingActivity.GetLastFailureDetails(), &d)
 			s.NoError(err)
 			s.Equal(expectedErrString, d)
 			s.Equal(identity2, pendingActivity.GetLastWorkerIdentity())
@@ -611,7 +611,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 15,
 					ScheduleToStartTimeoutSeconds: 1,
 					StartToCloseTimeoutSeconds:    15,
@@ -624,7 +624,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -637,7 +637,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 		// Timing out more than HB time.
 		time.Sleep(2 * time.Second)
 		activityExecutedCount++
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -708,7 +708,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 					ActivityId:                    "A",
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: "NoWorker"},
-					Input:                         payload.EncodeString("ScheduleToStart"),
+					Input:                         payloads.EncodeString("ScheduleToStart"),
 					ScheduleToCloseTimeoutSeconds: 35,
 					ScheduleToStartTimeoutSeconds: 3, // ActivityID A is expected to timeout using ScheduleToStart
 					StartToCloseTimeoutSeconds:    30,
@@ -720,7 +720,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 					ActivityId:                    "B",
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeString("ScheduleClose"),
+					Input:                         payloads.EncodeString("ScheduleClose"),
 					ScheduleToCloseTimeoutSeconds: 7, // ActivityID B is expected to timeout using ScheduleClose
 					ScheduleToStartTimeoutSeconds: 5,
 					StartToCloseTimeoutSeconds:    10,
@@ -732,7 +732,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 					ActivityId:                    "C",
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeString("StartToClose"),
+					Input:                         payloads.EncodeString("StartToClose"),
 					ScheduleToCloseTimeoutSeconds: 15,
 					ScheduleToStartTimeoutSeconds: 1,
 					StartToCloseTimeoutSeconds:    5, // ActivityID C is expected to timeout using StartToClose
@@ -744,7 +744,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 					ActivityId:                    "D",
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeString("Heartbeat"),
+					Input:                         payloads.EncodeString("Heartbeat"),
 					ScheduleToCloseTimeoutSeconds: 35,
 					ScheduleToStartTimeoutSeconds: 20,
 					StartToCloseTimeoutSeconds:    15,
@@ -820,7 +820,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 			return []*decisionpb.Decision{{
 				DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 				Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-					Result: payload.EncodeString("Done"),
+					Result: payloads.EncodeString("Done"),
 				}},
 			}}, nil
 		}
@@ -833,7 +833,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 		s.Equal(id, execution.GetWorkflowId())
 		s.Equal(activityName, activityType.GetName())
 		var timeoutType string
-		err := payload.Decode(input, &timeoutType)
+		err := payloads.Decode(input, &timeoutType)
 		s.NoError(err)
 		switch timeoutType {
 		case "ScheduleToStart":
@@ -850,7 +850,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 				for i := 0; i < 6; i++ {
 					s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(activityID), tag.Counter(i))
 					_, err := s.engine.RecordActivityTaskHeartbeat(NewContext(), &workflowservice.RecordActivityTaskHeartbeatRequest{
-						TaskToken: taskToken, Details: payload.EncodeString(string(i))})
+						TaskToken: taskToken, Details: payloads.EncodeString(string(i))})
 					s.NoError(err)
 					time.Sleep(1 * time.Second)
 				}
@@ -860,7 +860,7 @@ func (s *integrationSuite) TestActivityTimeouts() {
 			time.Sleep(10 * time.Second)
 		}
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -946,7 +946,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 						ActivityId:                    aID,
 						ActivityType:                  &commonpb.ActivityType{Name: activityName},
 						TaskList:                      &tasklistpb.TaskList{Name: tl},
-						Input:                         payload.EncodeString("Heartbeat"),
+						Input:                         payloads.EncodeString("Heartbeat"),
 						ScheduleToCloseTimeoutSeconds: 60,
 						ScheduleToStartTimeoutSeconds: 5,
 						StartToCloseTimeoutSeconds:    60,
@@ -985,7 +985,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 						activitiesTimedout++
 						scheduleID := timeoutEvent.GetScheduledEventId()
 						var details string
-						err := payload.Decode(timeoutEvent.GetDetails(), &details)
+						err := payloads.Decode(timeoutEvent.GetDetails(), &details)
 						s.NoError(err)
 						lastHeartbeat, _ := strconv.Atoi(details)
 						lastHeartbeatMap[scheduleID] = lastHeartbeat
@@ -1015,7 +1015,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 			return []*decisionpb.Decision{{
 				DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 				Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-					Result: payload.EncodeString("Done"),
+					Result: payloads.EncodeString("Done"),
 				}},
 			}}, nil
 		}
@@ -1030,7 +1030,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 			if !workflowComplete {
 				s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(activityID), tag.Counter(i))
 				_, err := s.engine.RecordActivityTaskHeartbeat(NewContext(), &workflowservice.RecordActivityTaskHeartbeatRequest{
-					TaskToken: taskToken, Details: payload.EncodeString(strconv.Itoa(i))})
+					TaskToken: taskToken, Details: payloads.EncodeString(strconv.Itoa(i))})
 				if err != nil {
 					s.Logger.Error("Activity heartbeat failed", tag.WorkflowActivityID(activityID), tag.Counter(i), tag.Error(err))
 				}
@@ -1045,7 +1045,7 @@ func (s *integrationSuite) TestActivityHeartbeatTimeouts() {
 		s.Logger.Info("Sleeping activity before completion", tag.WorkflowActivityID(activityID))
 		time.Sleep(7 * time.Second)
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1135,7 +1135,7 @@ func (s *integrationSuite) TestActivityCancellation() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 15,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    15,
@@ -1158,7 +1158,7 @@ func (s *integrationSuite) TestActivityCancellation() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1172,15 +1172,15 @@ func (s *integrationSuite) TestActivityCancellation() {
 			s.Logger.Info("Heartbeating for activity", tag.WorkflowActivityID(activityID), tag.Counter(i))
 			response, err := s.engine.RecordActivityTaskHeartbeat(NewContext(),
 				&workflowservice.RecordActivityTaskHeartbeatRequest{
-					TaskToken: taskToken, Details: payload.EncodeString("details")})
+					TaskToken: taskToken, Details: payloads.EncodeString("details")})
 			if response != nil && response.CancelRequested {
-				return payload.EncodeString("Activity Cancelled"), true, nil
+				return payloads.EncodeString("Activity Cancelled"), true, nil
 			}
 			s.NoError(err)
 			time.Sleep(10 * time.Millisecond)
 		}
 		activityExecutedCount++
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1260,7 +1260,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 15,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    15,
@@ -1283,7 +1283,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1311,7 +1311,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 
 	// Send signal so that worker can send an activity cancel
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{

--- a/host/activity_test.go
+++ b/host/activity_test.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"github.com/temporalio/temporal/common/log/tag"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/service/matching"
 )
@@ -59,7 +60,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 	taskList := &tasklistpb.TaskList{Name: tl}
 
 	header := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("sample data")},
+		Fields: map[string]*commonpb.Payload{"tracing": payload.EncodeString("sample data")},
 	}
 
 	request := &workflowservice.StartWorkflowExecutionRequest{

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/convert"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -268,7 +268,7 @@ func (s *integrationSuite) startAndFinishWorkflow(id, wt, tl, namespace, namespa
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -297,7 +297,7 @@ func (s *integrationSuite) startAndFinishWorkflow(id, wt, tl, namespace, namespa
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -314,14 +314,14 @@ func (s *integrationSuite) startAndFinishWorkflow(id, wt, tl, namespace, namespa
 		id, _ := strconv.Atoi(activityID)
 		s.Equal(int(expectedActivityID), id)
 		var b []byte
-		err := payload.Decode(input, &b)
+		err := payloads.Decode(input, &b)
 		s.NoError(err)
 		buf := bytes.NewReader(b)
 		var in int32
 		binary.Read(buf, binary.LittleEndian, &in)
 		s.Equal(expectedActivityID, in)
 		expectedActivityID++
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{

--- a/host/cancelworkflow_test.go
+++ b/host/cancelworkflow_test.go
@@ -40,7 +40,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
@@ -86,7 +86,7 @@ func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -98,14 +98,14 @@ func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CancelWorkflowExecution,
 			Attributes: &decisionpb.Decision_CancelWorkflowExecutionDecisionAttributes{CancelWorkflowExecutionDecisionAttributes: &decisionpb.CancelWorkflowExecutionDecisionAttributes{
-				Details: payload.EncodeString("Cancelled"),
+				Details: payloads.EncodeString("Cancelled"),
 			}},
 		}}, nil
 	}
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -172,7 +172,7 @@ GetHistoryLoop:
 
 		cancelledEventAttributes := lastEvent.GetWorkflowExecutionCanceledEventAttributes()
 		var details string
-		err = payload.Decode(cancelledEventAttributes.GetDetails(), &details)
+		err = payloads.Decode(cancelledEventAttributes.GetDetails(), &details)
 		s.NoError(err)
 		s.Equal("Cancelled", details)
 		executionCancelled = true
@@ -237,7 +237,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -258,7 +258,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -287,7 +287,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 					ActivityId:                    strconv.Itoa(int(foreignActivityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -299,7 +299,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CancelWorkflowExecution,
 			Attributes: &decisionpb.Decision_CancelWorkflowExecutionDecisionAttributes{CancelWorkflowExecutionDecisionAttributes: &decisionpb.CancelWorkflowExecutionDecisionAttributes{
-				Details: payload.EncodeString("Cancelled"),
+				Details: payloads.EncodeString("Cancelled"),
 			}},
 		}}, nil
 	}
@@ -392,7 +392,7 @@ GetHistoryLoop:
 
 		cancelledEventAttributes := lastEvent.GetWorkflowExecutionCanceledEventAttributes()
 		var details string
-		err = payload.Decode(cancelledEventAttributes.GetDetails(), &details)
+		err = payloads.Decode(cancelledEventAttributes.GetDetails(), &details)
 		s.NoError(err)
 		s.Equal("Cancelled", details)
 		executionCancelled = true
@@ -457,7 +457,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution_UnKnownTar
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -478,7 +478,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution_UnKnownTar
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -48,7 +48,7 @@ import (
 	"go.uber.org/zap"
 
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/rpc"
 )
 
@@ -294,7 +294,7 @@ func (s *clientIntegrationSuite) TestClientDataConverter_Failed() {
 		if event.GetEventType() == eventpb.EventType_ActivityTaskFailed {
 			failedAct++
 			var message string
-			err = payload.Decode(event.GetActivityTaskFailedEventAttributes().GetDetails(), &message)
+			err = payloads.Decode(event.GetActivityTaskFailedEventAttributes().GetDetails(), &message)
 			s.NoError(err)
 			s.True(strings.HasPrefix(message, "unable to decode the activity function input payload with error"))
 		}

--- a/host/continueasnew_test.go
+++ b/host/continueasnew_test.go
@@ -43,7 +43,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 func (s *integrationSuite) TestContinueAsNewWorkflow() {
@@ -57,13 +57,13 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 	taskList := &tasklistpb.TaskList{Name: tl}
 
 	header := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payload.EncodeString("sample payload")},
+		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("sample payload")},
 	}
 	memo := &commonpb.Memo{
-		Fields: map[string]*commonpb.Payloads{"memoKey": payload.EncodeString("memoVal")},
+		Fields: map[string]*commonpb.Payloads{"memoKey": payloads.EncodeString("memoVal")},
 	}
 	searchAttr := &commonpb.SearchAttributes{
-		IndexedFields: map[string]*commonpb.Payloads{"CustomKeywordField": payload.EncodeString("1")},
+		IndexedFields: map[string]*commonpb.Payloads{"CustomKeywordField": payloads.EncodeString("1")},
 	}
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
@@ -104,7 +104,7 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 				Attributes: &decisionpb.Decision_ContinueAsNewWorkflowExecutionDecisionAttributes{ContinueAsNewWorkflowExecutionDecisionAttributes: &decisionpb.ContinueAsNewWorkflowExecutionDecisionAttributes{
 					WorkflowType:               workflowType,
 					TaskList:                   &tasklistpb.TaskList{Name: tl},
-					Input:                      payload.EncodeBytes(buf.Bytes()),
+					Input:                      payloads.EncodeBytes(buf.Bytes()),
 					Header:                     header,
 					Memo:                       memo,
 					SearchAttributes:           searchAttr,
@@ -119,7 +119,7 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -192,7 +192,7 @@ func (s *integrationSuite) TestContinueAsNewRun_Timeout() {
 				Attributes: &decisionpb.Decision_ContinueAsNewWorkflowExecutionDecisionAttributes{ContinueAsNewWorkflowExecutionDecisionAttributes: &decisionpb.ContinueAsNewWorkflowExecutionDecisionAttributes{
 					WorkflowType:               workflowType,
 					TaskList:                   &tasklistpb.TaskList{Name: tl},
-					Input:                      payload.EncodeBytes(buf.Bytes()),
+					Input:                      payloads.EncodeBytes(buf.Bytes()),
 					WorkflowRunTimeoutSeconds:  1, // set timeout to 1
 					WorkflowTaskTimeoutSeconds: 1,
 				}},
@@ -203,7 +203,7 @@ func (s *integrationSuite) TestContinueAsNewRun_Timeout() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -405,7 +405,7 @@ func (s *integrationSuite) TestWorkflowContinueAsNew_TaskID() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("succeed"),
+				Result: payloads.EncodeString("succeed"),
 			}},
 		}}, nil
 
@@ -495,7 +495,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 				return []*decisionpb.Decision{{
 					DecisionType: decisionpb.DecisionType_ContinueAsNewWorkflowExecution,
 					Attributes: &decisionpb.Decision_ContinueAsNewWorkflowExecutionDecisionAttributes{ContinueAsNewWorkflowExecutionDecisionAttributes: &decisionpb.ContinueAsNewWorkflowExecutionDecisionAttributes{
-						Input: payload.EncodeBytes(buf.Bytes()),
+						Input: payloads.EncodeBytes(buf.Bytes()),
 					}},
 				}}, nil
 			}
@@ -504,7 +504,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 			return []*decisionpb.Decision{{
 				DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 				Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-					Result: payload.EncodeString("Child Done"),
+					Result: payloads.EncodeString("Child Done"),
 				}},
 			}}, nil
 		}
@@ -523,7 +523,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 						Namespace:    s.namespace,
 						WorkflowId:   childID,
 						WorkflowType: childWorkflowType,
-						Input:        payload.EncodeBytes(buf.Bytes()),
+						Input:        payloads.EncodeBytes(buf.Bytes()),
 					}},
 				}}, nil
 			} else if previousStartedEventID > 0 {
@@ -538,7 +538,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 						return []*decisionpb.Decision{{
 							DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 							Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-								Result: payload.EncodeString("Done"),
+								Result: payloads.EncodeString("Done"),
 							}},
 						}}, nil
 					}
@@ -594,7 +594,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 		completedAttributes.WorkflowExecution.RunId)
 	s.Equal(wtChild, completedAttributes.WorkflowType.Name)
 	var result string
-	err = payload.Decode(completedAttributes.GetResult(), &result)
+	err = payloads.Decode(completedAttributes.GetResult(), &result)
 	s.NoError(err)
 	s.Equal("Child Done", result)
 

--- a/host/continueasnew_test.go
+++ b/host/continueasnew_test.go
@@ -31,6 +31,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/service/matching"
 
 	"github.com/pborman/uuid"
@@ -57,13 +58,13 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 	taskList := &tasklistpb.TaskList{Name: tl}
 
 	header := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("sample payload")},
+		Fields: map[string]*commonpb.Payload{"tracing": payload.EncodeString("sample payload")},
 	}
 	memo := &commonpb.Memo{
-		Fields: map[string]*commonpb.Payloads{"memoKey": payloads.EncodeString("memoVal")},
+		Fields: map[string]*commonpb.Payload{"memoKey": payload.EncodeString("memoVal")},
 	}
 	searchAttr := &commonpb.SearchAttributes{
-		IndexedFields: map[string]*commonpb.Payloads{"CustomKeywordField": payloads.EncodeString("1")},
+		IndexedFields: map[string]*commonpb.Payload{"CustomKeywordField": payload.EncodeString("1")},
 	}
 
 	request := &workflowservice.StartWorkflowExecutionRequest{

--- a/host/decision_test.go
+++ b/host/decision_test.go
@@ -39,7 +39,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"github.com/temporalio/temporal/common/codec"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 func (s *integrationSuite) TestDecisionHeartbeatingWithEmptyResult() {
@@ -131,7 +131,7 @@ func (s *integrationSuite) TestDecisionHeartbeatingWithEmptyResult() {
 			{
 				DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 				Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-					Result: payload.EncodeString("efg"),
+					Result: payloads.EncodeString("efg"),
 				},
 				},
 			}},
@@ -217,7 +217,7 @@ func (s *integrationSuite) TestDecisionHeartbeatingWithLocalActivitiesResult() {
 				DecisionType: decisionpb.DecisionType_RecordMarker,
 				Attributes: &decisionpb.Decision_RecordMarkerDecisionAttributes{RecordMarkerDecisionAttributes: &decisionpb.RecordMarkerDecisionAttributes{
 					MarkerName: "localActivity1",
-					Details:    payload.EncodeString("abc"),
+					Details:    payloads.EncodeString("abc"),
 				},
 				},
 			}},
@@ -237,7 +237,7 @@ func (s *integrationSuite) TestDecisionHeartbeatingWithLocalActivitiesResult() {
 				DecisionType: decisionpb.DecisionType_RecordMarker,
 				Attributes: &decisionpb.Decision_RecordMarkerDecisionAttributes{RecordMarkerDecisionAttributes: &decisionpb.RecordMarkerDecisionAttributes{
 					MarkerName: "localActivity2",
-					Details:    payload.EncodeString("abc"),
+					Details:    payloads.EncodeString("abc"),
 				},
 				},
 			}},
@@ -256,7 +256,7 @@ func (s *integrationSuite) TestDecisionHeartbeatingWithLocalActivitiesResult() {
 			{
 				DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 				Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-					Result: payload.EncodeString("efg"),
+					Result: payloads.EncodeString("efg"),
 				},
 				},
 			}},
@@ -327,7 +327,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalBeforeRegularDecisionSta
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
-		Input:             payload.EncodeString(""),
+		Input:             payloads.EncodeString(""),
 		Identity:          "integ test",
 		RequestId:         uuid.New(),
 	})
@@ -411,7 +411,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterRegularDecisionStar
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
-		Input:             payload.EncodeString(""),
+		Input:             payloads.EncodeString(""),
 		Identity:          "integ test",
 		RequestId:         uuid.New(),
 	})
@@ -486,7 +486,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterRegularDecisionStar
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
-		Input:             payload.EncodeString(""),
+		Input:             payloads.EncodeString(""),
 		Identity:          "integ test",
 		RequestId:         uuid.New(),
 	})
@@ -585,7 +585,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalBeforeTransientDecisionS
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
-		Input:             payload.EncodeString(""),
+		Input:             payloads.EncodeString(""),
 		Identity:          "integ test",
 		RequestId:         uuid.New(),
 	})
@@ -699,7 +699,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterTransientDecisionSt
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
-		Input:             payload.EncodeString(""),
+		Input:             payloads.EncodeString(""),
 		Identity:          "integ test",
 		RequestId:         uuid.New(),
 	})
@@ -799,7 +799,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterTransientDecisionSt
 		Namespace:         s.namespace,
 		WorkflowExecution: we,
 		SignalName:        "sig-for-integ-test",
-		Input:             payload.EncodeString(""),
+		Input:             payloads.EncodeString(""),
 		Identity:          "integ test",
 		RequestId:         uuid.New(),
 	})

--- a/host/elasticsearch_test.go
+++ b/host/elasticsearch_test.go
@@ -54,7 +54,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 const (
@@ -107,7 +107,7 @@ func (s *elasticsearchIntegrationSuite) TestListOpenWorkflow() {
 	tl := "es-integration-start-workflow-test-tasklist"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payloads.Encode(s.testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			s.testSearchAttributeKey: attrValBytes,
@@ -186,7 +186,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_SearchAttribute() {
 	tl := "es-integration-list-workflow-by-search-attr-test-tasklist"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payloads.Encode(s.testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			s.testSearchAttributeKey: attrValBytes,
@@ -290,7 +290,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrQuery() {
 
 	// start 3 workflows
 	key := definition.CustomIntField
-	attrValBytes, _ := payload.Encode(1)
+	attrValBytes, _ := payloads.Encode(1)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			key: attrValBytes,
@@ -302,14 +302,14 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrQuery() {
 
 	request.RequestId = uuid.New()
 	request.WorkflowId = id + "-2"
-	attrValBytes, _ = payload.Encode(2)
+	attrValBytes, _ = payloads.Encode(2)
 	searchAttr.IndexedFields[key] = attrValBytes
 	we2, err := s.engine.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
 
 	request.RequestId = uuid.New()
 	request.WorkflowId = id + "-3"
-	attrValBytes, _ = payload.Encode(3)
+	attrValBytes, _ = payloads.Encode(3)
 	searchAttr.IndexedFields[key] = attrValBytes
 	we3, err := s.engine.StartWorkflowExecution(NewContext(), request)
 	s.NoError(err)
@@ -338,7 +338,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrQuery() {
 	s.True(openExecution.GetExecutionTime() >= openExecution.GetStartTime().GetValue())
 	searchValBytes := openExecution.SearchAttributes.GetIndexedFields()[key]
 	var searchVal int
-	payload.Decode(searchValBytes, &searchVal)
+	payloads.Decode(searchValBytes, &searchVal)
 	s.Equal(1, searchVal)
 
 	// query with or clause
@@ -364,7 +364,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrQuery() {
 	s.Equal(we1.GetRunId(), e1.GetExecution().GetRunId())
 	s.Equal(we2.GetRunId(), e2.GetExecution().GetRunId())
 	searchValBytes = e2.SearchAttributes.GetIndexedFields()[key]
-	payload.Decode(searchValBytes, &searchVal)
+	payloads.Decode(searchValBytes, &searchVal)
 	s.Equal(2, searchVal)
 
 	// query for open
@@ -385,7 +385,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrQuery() {
 	s.Equal(we3.GetRunId(), e1.GetExecution().GetRunId())
 	s.Equal(we2.GetRunId(), e2.GetExecution().GetRunId())
 	searchValBytes = e1.SearchAttributes.GetIndexedFields()[key]
-	payload.Decode(searchValBytes, &searchVal)
+	payloads.Decode(searchValBytes, &searchVal)
 	s.Equal(3, searchVal)
 }
 
@@ -446,10 +446,10 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrderBy() {
 		startRequest.WorkflowId = id + strconv.Itoa(i)
 
 		if i < defaultTestValueOfESIndexMaxResultWindow-1 { // 4 workflow has search attr
-			intVal, _ := payload.Encode(i)
-			doubleVal, _ := payload.Encode(float64(i))
-			strVal, _ := payload.Encode(strconv.Itoa(i))
-			timeVal, _ := payload.Encode(time.Now())
+			intVal, _ := payloads.Encode(i)
+			doubleVal, _ := payloads.Encode(float64(i))
+			strVal, _ := payloads.Encode(strconv.Itoa(i))
+			timeVal, _ := payloads.Encode(time.Now())
 			searchAttr := &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payloads{
 					definition.CustomIntField:      intVal,
@@ -696,7 +696,7 @@ func (s *elasticsearchIntegrationSuite) testHelperForReadOnce(runID, query strin
 	if openExecution.SearchAttributes != nil && len(openExecution.SearchAttributes.GetIndexedFields()) > 0 {
 		searchValBytes := openExecution.SearchAttributes.GetIndexedFields()[s.testSearchAttributeKey]
 		var searchVal string
-		payload.Decode(searchValBytes, &searchVal)
+		payloads.Decode(searchValBytes, &searchVal)
 		s.Equal(s.testSearchAttributeVal, searchVal)
 	}
 }
@@ -735,7 +735,7 @@ func (s *elasticsearchIntegrationSuite) TestScanWorkflow_SearchAttribute() {
 	tl := "es-integration-scan-workflow-search-attr-test-tasklist"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payloads.Encode(s.testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			s.testSearchAttributeKey: attrValBytes,
@@ -781,7 +781,7 @@ func (s *elasticsearchIntegrationSuite) TestCountWorkflow() {
 	tl := "es-integration-count-workflow-test-tasklist"
 	request := s.createStartWorkflowExecutionRequest(id, wt, tl)
 
-	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payloads.Encode(s.testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			s.testSearchAttributeKey: attrValBytes,
@@ -872,7 +872,7 @@ func (s *elasticsearchIntegrationSuite) TestUpsertWorkflowExecution() {
 		if decisionCount == 0 {
 			decisionCount++
 
-			attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+			attrValBytes, _ := payloads.Encode(s.testSearchAttributeVal)
 			upsertSearchAttr := &commonpb.SearchAttributes{
 				IndexedFields: map[string]*commonpb.Payloads{
 					s.testSearchAttributeKey: attrValBytes,
@@ -891,7 +891,7 @@ func (s *elasticsearchIntegrationSuite) TestUpsertWorkflowExecution() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -946,7 +946,7 @@ func (s *elasticsearchIntegrationSuite) TestUpsertWorkflowExecution() {
 			if retrievedSearchAttr != nil && len(retrievedSearchAttr.GetIndexedFields()) > 0 {
 				searchValBytes := retrievedSearchAttr.GetIndexedFields()[s.testSearchAttributeKey]
 				var searchVal string
-				err = payload.Decode(searchValBytes, &searchVal)
+				err = payloads.Decode(searchValBytes, &searchVal)
 				s.NoError(err)
 				s.Equal(s.testSearchAttributeVal, searchVal)
 				verified = true
@@ -994,19 +994,19 @@ func (s *elasticsearchIntegrationSuite) testListResultForUpsertSearchAttributes(
 				fields := retrievedSearchAttr.GetIndexedFields()
 				searchValBytes := fields[s.testSearchAttributeKey]
 				var searchVal string
-				err := payload.Decode(searchValBytes, &searchVal)
+				err := payloads.Decode(searchValBytes, &searchVal)
 				s.NoError(err)
 				s.Equal("another string", searchVal)
 
 				searchValBytes2 := fields[definition.CustomIntField]
 				var searchVal2 int
-				err = payload.Decode(searchValBytes2, &searchVal2)
+				err = payloads.Decode(searchValBytes2, &searchVal2)
 				s.NoError(err)
 				s.Equal(123, searchVal2)
 
 				binaryChecksumsBytes := fields[definition.BinaryChecksums]
 				var binaryChecksums []string
-				err = payload.Decode(binaryChecksumsBytes, &binaryChecksums)
+				err = payloads.Decode(binaryChecksumsBytes, &binaryChecksums)
 				s.NoError(err)
 				s.Equal([]string{"binary-v1", "binary-v2"}, binaryChecksums)
 
@@ -1020,9 +1020,9 @@ func (s *elasticsearchIntegrationSuite) testListResultForUpsertSearchAttributes(
 }
 
 func getUpsertSearchAttributes() *commonpb.SearchAttributes {
-	attrValBytes1, _ := payload.Encode("another string")
-	attrValBytes2, _ := payload.Encode(123)
-	binaryChecksums, _ := payload.Encode([]string{"binary-v1", "binary-v2"})
+	attrValBytes1, _ := payloads.Encode("another string")
+	attrValBytes2, _ := payloads.Encode(123)
+	binaryChecksums, _ := payloads.Encode([]string{"binary-v1", "binary-v2"})
 	upsertSearchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			definition.CustomStringField: attrValBytes1,
@@ -1068,7 +1068,7 @@ func (s *elasticsearchIntegrationSuite) TestUpsertWorkflowExecution_InvalidKey()
 			Attributes: &decisionpb.Decision_UpsertWorkflowSearchAttributesDecisionAttributes{UpsertWorkflowSearchAttributesDecisionAttributes: &decisionpb.UpsertWorkflowSearchAttributesDecisionAttributes{
 				SearchAttributes: &commonpb.SearchAttributes{
 					IndexedFields: map[string]*commonpb.Payloads{
-						"INVALIDKEY": payload.EncodeBytes([]byte("1")),
+						"INVALIDKEY": payloads.EncodeBytes([]byte("1")),
 					},
 				},
 			}}}

--- a/host/gethistory_test.go
+++ b/host/gethistory_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/temporalio/temporal/.gen/proto/adminservice"
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/persistence/serialization"
 )
@@ -94,7 +94,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 					ActivityId:                    strconv.Itoa(int(1)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      taskList,
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 25,
 					StartToCloseTimeoutSeconds:    50,
@@ -106,7 +106,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -115,7 +115,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -260,7 +260,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 					ActivityId:                    strconv.Itoa(int(1)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      taskList,
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 25,
 					StartToCloseTimeoutSeconds:    50,
@@ -272,7 +272,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -281,7 +281,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -420,7 +420,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 						ActivityId:                    "1",
 						ActivityType:                  &commonpb.ActivityType{Name: activityName},
 						TaskList:                      taskList,
-						Input:                         payload.EncodeBytes(buf.Bytes()),
+						Input:                         payloads.EncodeBytes(buf.Bytes()),
 						ScheduleToCloseTimeoutSeconds: 100,
 						ScheduleToStartTimeoutSeconds: 25,
 						StartToCloseTimeoutSeconds:    50,
@@ -434,7 +434,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{
 				CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-					Result: payload.EncodeString("Done"),
+					Result: payloads.EncodeString("Done"),
 				}},
 		}}, nil
 	}
@@ -443,7 +443,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result."), false, nil
+		return payloads.EncodeString("Activity Result."), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -625,7 +625,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_All() {
 					ActivityId:                    strconv.Itoa(int(1)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      taskList,
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 25,
 					StartToCloseTimeoutSeconds:    50,
@@ -637,7 +637,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_All() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -646,7 +646,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_All() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -842,7 +842,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_InTheMiddle()
 					ActivityId:                    strconv.Itoa(int(1)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      taskList,
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 25,
 					StartToCloseTimeoutSeconds:    50,
@@ -854,7 +854,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_InTheMiddle()
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -863,7 +863,7 @@ func (s *integrationSuite) TestAdminGetWorkflowExecutionRawHistory_InTheMiddle()
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -51,7 +51,7 @@ import (
 
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/service/matching"
 )
 
@@ -176,7 +176,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -188,7 +188,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -196,7 +196,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -215,7 +215,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 	s.NoError(err)
 
 	terminateReason := "terminate reason"
-	terminateDetails := payload.EncodeString("terminate details")
+	terminateDetails := payloads.EncodeString("terminate details")
 	_, err = s.engine.TerminateWorkflowExecution(NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -329,7 +329,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -342,7 +342,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -355,7 +355,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 		id, _ := strconv.Atoi(activityID)
 		s.Equal(int(expectedActivity), id)
 		var b []byte
-		err := payload.Decode(input, &b)
+		err := payloads.Decode(input, &b)
 		s.NoError(err)
 		buf := bytes.NewReader(b)
 		var in int32
@@ -363,7 +363,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 		s.Equal(expectedActivity, in)
 		expectedActivity++
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -436,7 +436,7 @@ func (s *integrationSuite) TestCompleteDecisionTaskAndCreateNewOne() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -515,7 +515,7 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 1,
 					ScheduleToStartTimeoutSeconds: 1,
 					StartToCloseTimeoutSeconds:    1,
@@ -530,7 +530,7 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -540,7 +540,7 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 		s.EqualValues(id, execution.WorkflowId)
 		s.Equal(activityName, activityType.Name)
 		s.Logger.Info("Activity ID", tag.WorkflowActivityID(activityID))
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -637,7 +637,7 @@ func (s *integrationSuite) TestWorkflowRetry() {
 				{
 					DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 					Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-						Result: payload.EncodeString("succeed-after-retry"),
+						Result: payloads.EncodeString("succeed-after-retry"),
 					}},
 				}}, nil
 		}
@@ -712,7 +712,7 @@ func (s *integrationSuite) TestWorkflowRetryFailures() {
 					{
 						DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 						Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-							Result: payload.EncodeString("succeed-after-retry"),
+							Result: payloads.EncodeString("succeed-after-retry"),
 						}},
 					}}, nil
 			}
@@ -840,11 +840,11 @@ func (s *integrationSuite) TestCronWorkflow() {
 	backoffDurationTolerance := time.Millisecond * 500
 
 	memo := &commonpb.Memo{
-		Fields: map[string]*commonpb.Payloads{"memoKey": payload.EncodeString("memoVal")},
+		Fields: map[string]*commonpb.Payloads{"memoKey": payloads.EncodeString("memoVal")},
 	}
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
-			"CustomKeywordField": payload.EncodeString("1"),
+			"CustomKeywordField": payloads.EncodeString("1"),
 		},
 	}
 
@@ -882,7 +882,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 				{
 					DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 					Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-						Result: payload.EncodeString("cron-test-result"),
+						Result: payloads.EncodeString("cron-test-result"),
 					}},
 				}}, nil
 		}
@@ -968,7 +968,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	s.Equal("", attributes.GetFailureReason())
 
 	var r string
-	err = payload.Decode(attributes.GetLastCompletionResult(), &r)
+	err = payloads.Decode(attributes.GetLastCompletionResult(), &r)
 	s.NoError(err)
 	s.Equal("cron-test-result", r)
 	s.Equal(memo, attributes.Memo)
@@ -981,7 +981,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	s.Equal(commonpb.ContinueAsNewInitiator_CronSchedule, attributes.GetInitiator())
 	s.Equal("cron-test-error", attributes.GetFailureReason())
 
-	err = payload.Decode(attributes.GetLastCompletionResult(), &r)
+	err = payloads.Decode(attributes.GetLastCompletionResult(), &r)
 	s.NoError(err)
 	s.Equal("cron-test-result", r)
 	s.Equal(memo, attributes.Memo)
@@ -1045,12 +1045,12 @@ func (s *integrationSuite) TestCronWorkflowTimeout() {
 
 	memo := &commonpb.Memo{
 		Fields: map[string]*commonpb.Payloads{
-			"memoKey": payload.EncodeString("memoVal"),
+			"memoKey": payloads.EncodeString("memoVal"),
 		},
 	}
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
-			"CustomKeywordField": payload.EncodeString("1"),
+			"CustomKeywordField": payloads.EncodeString("1"),
 		},
 	}
 
@@ -1181,7 +1181,7 @@ func (s *integrationSuite) TestSequential_UserTimers() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1257,12 +1257,12 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 			for i := 0; i < 100; i++ {
 				buf := new(bytes.Buffer)
 				binary.Write(buf, binary.LittleEndian, i)
-				s.Nil(s.sendSignal(s.namespace, workflowExecution, "SignalName", payload.EncodeBytes(buf.Bytes()), identity))
+				s.Nil(s.sendSignal(s.namespace, workflowExecution, "SignalName", payloads.EncodeBytes(buf.Bytes()), identity))
 			}
 
 			buf := new(bytes.Buffer)
 			binary.Write(buf, binary.LittleEndian, 101)
-			signalErr := s.sendSignal(s.namespace, workflowExecution, "SignalName", payload.EncodeBytes(buf.Bytes()), identity)
+			signalErr := s.sendSignal(s.namespace, workflowExecution, "SignalName", payloads.EncodeBytes(buf.Bytes()), identity)
 			s.Nil(signalErr)
 
 			// this decision will be ignored as he decision task is already failed
@@ -1273,7 +1273,7 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1347,7 +1347,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 						WorkflowId: id,
 					},
 					SignalName: "buffered-signal",
-					Input:      payload.EncodeString("buffered-signal-input"),
+					Input:      payloads.EncodeString("buffered-signal-input"),
 					Identity:   identity,
 				})
 			s.NoError(err)
@@ -1357,7 +1357,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 					ActivityId:                    "1",
 					ActivityType:                  &commonpb.ActivityType{Name: "test-activity-type"},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeString("test-input"),
+					Input:                         payloads.EncodeString("test-input"),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -1376,7 +1376,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1476,7 +1476,7 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 					ActivityId:                    "1",
 					ActivityType:                  &commonpb.ActivityType{Name: "test-activity-type"},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeString("test-input"),
+					Input:                         payloads.EncodeString("test-input"),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -1489,14 +1489,14 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1574,7 +1574,7 @@ func (s *integrationSuite) TestVisibility() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1694,7 +1694,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	taskListChild.Name = tlChild
 
 	header := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payload.EncodeString("sample payload")},
+		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("sample payload")},
 	}
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
@@ -1722,10 +1722,10 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 
 	memo := &commonpb.Memo{
 		Fields: map[string]*commonpb.Payloads{
-			"Info": payload.EncodeString("memo"),
+			"Info": payloads.EncodeString("memo"),
 		},
 	}
-	attrValPayload := payload.EncodeString("attrVal")
+	attrValPayload := payloads.EncodeString("attrVal")
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			"CustomKeywordField": attrValPayload,
@@ -1748,7 +1748,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 						WorkflowId:                 childID,
 						WorkflowType:               childWorkflowType,
 						TaskList:                   taskListChild,
-						Input:                      payload.EncodeString("child-workflow-input"),
+						Input:                      payloads.EncodeString("child-workflow-input"),
 						Header:                     header,
 						WorkflowRunTimeoutSeconds:  200,
 						WorkflowTaskTimeoutSeconds: 2,
@@ -1769,7 +1769,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 						return []*decisionpb.Decision{{
 							DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 							Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-								Result: payload.EncodeString("Done"),
+								Result: payloads.EncodeString("Done"),
 							}},
 						}}, nil
 					}
@@ -1793,7 +1793,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Child Done"),
+				Result: payloads.EncodeString("Child Done"),
 			}},
 		}}, nil
 	}
@@ -1856,7 +1856,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	s.Equal(childID, completedAttributes.WorkflowExecution.WorkflowId)
 	s.Equal(wtChild, completedAttributes.WorkflowType.Name)
 	var r string
-	err = payload.Decode(completedAttributes.GetResult(), &r)
+	err = payloads.Decode(completedAttributes.GetResult(), &r)
 	s.NoError(err)
 	s.Equal("Child Done", r)
 }
@@ -1930,7 +1930,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 				return []*decisionpb.Decision{{
 					DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 					Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-						Result: payload.EncodeString("Done"),
+						Result: payloads.EncodeString("Done"),
 					}},
 				}}, nil
 			}
@@ -2212,7 +2212,7 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 					ActivityId:                    strconv.Itoa(int(1)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -2235,7 +2235,7 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -2244,7 +2244,7 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -2383,7 +2383,7 @@ func (s *integrationSuite) TestDescribeTaskList() {
 					ActivityId:                    strconv.Itoa(int(1)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 25,
 					StartToCloseTimeoutSeconds:    50,
@@ -2395,14 +2395,14 @@ func (s *integrationSuite) TestDescribeTaskList() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -2511,7 +2511,7 @@ func (s *integrationSuite) TestTransientDecisionTimeout() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -2590,7 +2590,7 @@ func (s *integrationSuite) TestNoTransientDecisionAfterFlushBufferedEvents() {
 						WorkflowId: id,
 					},
 					SignalName: "buffered-signal-1",
-					Input:      payload.EncodeString("buffered-signal-input"),
+					Input:      payloads.EncodeString("buffered-signal-input"),
 					Identity:   identity,
 				})
 			s.NoError(err)
@@ -2611,7 +2611,7 @@ func (s *integrationSuite) TestNoTransientDecisionAfterFlushBufferedEvents() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -2794,7 +2794,7 @@ func (s *integrationSuite) TestTaskProcessingProtectionForRateLimitError() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -2818,7 +2818,7 @@ func (s *integrationSuite) TestTaskProcessingProtectionForRateLimitError() {
 	// Send one signal to create a new decision
 	buf := new(bytes.Buffer)
 	binary.Write(buf, binary.LittleEndian, 0)
-	s.Nil(s.sendSignal(s.namespace, workflowExecution, "SignalName", payload.EncodeBytes(buf.Bytes()), identity))
+	s.Nil(s.sendSignal(s.namespace, workflowExecution, "SignalName", payloads.EncodeBytes(buf.Bytes()), identity))
 
 	// Drop decision to cause all events to be buffered from now on
 	_, err = poller.PollAndProcessDecisionTask(false, true)
@@ -2829,13 +2829,13 @@ func (s *integrationSuite) TestTaskProcessingProtectionForRateLimitError() {
 	for i := 1; i < 101; i++ {
 		buf := new(bytes.Buffer)
 		binary.Write(buf, binary.LittleEndian, i)
-		s.Nil(s.sendSignal(s.namespace, workflowExecution, "SignalName", payload.EncodeBytes(buf.Bytes()), identity))
+		s.Nil(s.sendSignal(s.namespace, workflowExecution, "SignalName", payloads.EncodeBytes(buf.Bytes()), identity))
 	}
 
 	// 101 signal, which will fail the decision
 	buf = new(bytes.Buffer)
 	binary.Write(buf, binary.LittleEndian, 101)
-	signalErr := s.sendSignal(s.namespace, workflowExecution, "SignalName", payload.EncodeBytes(buf.Bytes()), identity)
+	signalErr := s.sendSignal(s.namespace, workflowExecution, "SignalName", payloads.EncodeBytes(buf.Bytes()), identity)
 	s.Nil(signalErr)
 
 	// Process signal in decider
@@ -2893,7 +2893,7 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientDecision() {
 				DecisionType: decisionpb.DecisionType_RecordMarker,
 				Attributes: &decisionpb.Decision_RecordMarkerDecisionAttributes{RecordMarkerDecisionAttributes: &decisionpb.RecordMarkerDecisionAttributes{
 					MarkerName: "local activity marker",
-					Details:    payload.EncodeString("local activity data"),
+					Details:    payloads.EncodeString("local activity data"),
 				}},
 			}}, nil
 		}
@@ -2918,7 +2918,7 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientDecision() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -2943,7 +2943,7 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientDecision() {
 		Namespace:         s.namespace,
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalA",
-		Input:             payload.EncodeString("signal input"),
+		Input:             payloads.EncodeString("signal input"),
 		Identity:          identity,
 		RequestId:         uuid.New(),
 	})
@@ -2974,7 +2974,7 @@ WaitForStickyTimeoutLoop:
 		Namespace:         s.namespace,
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalB",
-		Input:             payload.EncodeString("signal input"),
+		Input:             payloads.EncodeString("signal input"),
 		Identity:          identity,
 		RequestId:         uuid.New(),
 	})
@@ -3061,7 +3061,7 @@ func (s *integrationSuite) TestStickyTasklistResetThenTimeout() {
 				DecisionType: decisionpb.DecisionType_RecordMarker,
 				Attributes: &decisionpb.Decision_RecordMarkerDecisionAttributes{RecordMarkerDecisionAttributes: &decisionpb.RecordMarkerDecisionAttributes{
 					MarkerName: "local activity marker",
-					Details:    payload.EncodeString("local activity data"),
+					Details:    payloads.EncodeString("local activity data"),
 				}},
 			}}, nil
 		}
@@ -3074,7 +3074,7 @@ func (s *integrationSuite) TestStickyTasklistResetThenTimeout() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -3099,7 +3099,7 @@ func (s *integrationSuite) TestStickyTasklistResetThenTimeout() {
 		Namespace:         s.namespace,
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalA",
-		Input:             payload.EncodeString("signal input"),
+		Input:             payloads.EncodeString("signal input"),
 		Identity:          identity,
 		RequestId:         uuid.New(),
 	})
@@ -3136,7 +3136,7 @@ WaitForStickyTimeoutLoop:
 		Namespace:         s.namespace,
 		WorkflowExecution: workflowExecution,
 		SignalName:        "signalB",
-		Input:             payload.EncodeString("signal input"),
+		Input:             payloads.EncodeString("signal input"),
 		Identity:          identity,
 		RequestId:         uuid.New(),
 	})
@@ -3220,7 +3220,7 @@ func (s *integrationSuite) TestBufferedEventsOutOfOrder() {
 				DecisionType: decisionpb.DecisionType_RecordMarker,
 				Attributes: &decisionpb.Decision_RecordMarkerDecisionAttributes{RecordMarkerDecisionAttributes: &decisionpb.RecordMarkerDecisionAttributes{
 					MarkerName: "some random marker name",
-					Details:    payload.EncodeString("some random marker details"),
+					Details:    payloads.EncodeString("some random marker details"),
 				}},
 			}, {
 				DecisionType: decisionpb.DecisionType_ScheduleActivityTask,
@@ -3229,7 +3229,7 @@ func (s *integrationSuite) TestBufferedEventsOutOfOrder() {
 					ActivityType:                  &commonpb.ActivityType{Name: "ActivityType"},
 					Namespace:                     s.namespace,
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeString("some random activity input"),
+					Input:                         payloads.EncodeString("some random activity input"),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 100,
 					StartToCloseTimeoutSeconds:    100,
@@ -3244,7 +3244,7 @@ func (s *integrationSuite) TestBufferedEventsOutOfOrder() {
 				DecisionType: decisionpb.DecisionType_RecordMarker,
 				Attributes: &decisionpb.Decision_RecordMarkerDecisionAttributes{RecordMarkerDecisionAttributes: &decisionpb.RecordMarkerDecisionAttributes{
 					MarkerName: "some random marker name",
-					Details:    payload.EncodeString("some random marker details"),
+					Details:    payloads.EncodeString("some random marker details"),
 				}},
 			}}, nil
 		}
@@ -3253,14 +3253,14 @@ func (s *integrationSuite) TestBufferedEventsOutOfOrder() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
 	// activity handler
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -3344,7 +3344,7 @@ func (s *integrationSuite) TestStartWithMemo() {
 
 	memo := &commonpb.Memo{
 		Fields: map[string]*commonpb.Payloads{
-			"Info": payload.EncodeString(id),
+			"Info": payloads.EncodeString(id),
 		},
 	}
 
@@ -3375,12 +3375,12 @@ func (s *integrationSuite) TestSignalWithStartWithMemo() {
 
 	memo := &commonpb.Memo{
 		Fields: map[string]*commonpb.Payloads{
-			"Info": payload.EncodeString(id),
+			"Info": payloads.EncodeString(id),
 		},
 	}
 
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	request := &workflowservice.SignalWithStartWorkflowExecutionRequest{
 		RequestId:                  uuid.New(),
 		Namespace:                  s.namespace,
@@ -3479,7 +3479,7 @@ func (s *integrationSuite) TestCancelTimer() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -3500,14 +3500,14 @@ func (s *integrationSuite) TestCancelTimer() {
 	s.Logger.Info("PollAndProcessDecisionTask: completed")
 	s.NoError(err)
 
-	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payload.EncodeString("random signal payload"), identity))
+	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 
 	// receive the signal & cancel the timer
 	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask: completed")
 	s.NoError(err)
 
-	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payload.EncodeString("random signal payload"), identity))
+	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 	// complete the workflow
 	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask: completed")
@@ -3611,7 +3611,7 @@ func (s *integrationSuite) TestCancelTimer_CancelFiredAndBuffered() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -3632,14 +3632,14 @@ func (s *integrationSuite) TestCancelTimer_CancelFiredAndBuffered() {
 	s.Logger.Info("PollAndProcessDecisionTask: completed")
 	s.NoError(err)
 
-	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payload.EncodeString("random signal payload"), identity))
+	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 
 	// receive the signal & cancel the timer
 	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask: completed")
 	s.NoError(err)
 
-	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payload.EncodeString("random signal payload"), identity))
+	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 	// complete the workflow
 	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask: completed")
@@ -3679,7 +3679,7 @@ func (s *integrationSuite) startWithMemoHelper(startFn startFunc, id string, tas
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -51,6 +51,7 @@ import (
 
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log/tag"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/service/matching"
 )
@@ -840,11 +841,11 @@ func (s *integrationSuite) TestCronWorkflow() {
 	backoffDurationTolerance := time.Millisecond * 500
 
 	memo := &commonpb.Memo{
-		Fields: map[string]*commonpb.Payloads{"memoKey": payloads.EncodeString("memoVal")},
+		Fields: map[string]*commonpb.Payload{"memoKey": payload.EncodeString("memoVal")},
 	}
 	searchAttr := &commonpb.SearchAttributes{
-		IndexedFields: map[string]*commonpb.Payloads{
-			"CustomKeywordField": payloads.EncodeString("1"),
+		IndexedFields: map[string]*commonpb.Payload{
+			"CustomKeywordField": payload.EncodeString("1"),
 		},
 	}
 
@@ -1044,13 +1045,13 @@ func (s *integrationSuite) TestCronWorkflowTimeout() {
 	cronSchedule := "@every 3s"
 
 	memo := &commonpb.Memo{
-		Fields: map[string]*commonpb.Payloads{
-			"memoKey": payloads.EncodeString("memoVal"),
+		Fields: map[string]*commonpb.Payload{
+			"memoKey": payload.EncodeString("memoVal"),
 		},
 	}
 	searchAttr := &commonpb.SearchAttributes{
-		IndexedFields: map[string]*commonpb.Payloads{
-			"CustomKeywordField": payloads.EncodeString("1"),
+		IndexedFields: map[string]*commonpb.Payload{
+			"CustomKeywordField": payload.EncodeString("1"),
 		},
 	}
 
@@ -1694,7 +1695,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	taskListChild.Name = tlChild
 
 	header := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("sample payload")},
+		Fields: map[string]*commonpb.Payload{"tracing": payload.EncodeString("sample payload")},
 	}
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
@@ -1721,13 +1722,13 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	var completedEvent *eventpb.HistoryEvent
 
 	memo := &commonpb.Memo{
-		Fields: map[string]*commonpb.Payloads{
-			"Info": payloads.EncodeString("memo"),
+		Fields: map[string]*commonpb.Payload{
+			"Info": payload.EncodeString("memo"),
 		},
 	}
-	attrValPayload := payloads.EncodeString("attrVal")
+	attrValPayload := payload.EncodeString("attrVal")
 	searchAttr := &commonpb.SearchAttributes{
-		IndexedFields: map[string]*commonpb.Payloads{
+		IndexedFields: map[string]*commonpb.Payload{
 			"CustomKeywordField": attrValPayload,
 		},
 	}
@@ -3343,8 +3344,8 @@ func (s *integrationSuite) TestStartWithMemo() {
 	identity := "worker1"
 
 	memo := &commonpb.Memo{
-		Fields: map[string]*commonpb.Payloads{
-			"Info": payloads.EncodeString(id),
+		Fields: map[string]*commonpb.Payload{
+			"Info": payload.EncodeString(id),
 		},
 	}
 
@@ -3374,8 +3375,8 @@ func (s *integrationSuite) TestSignalWithStartWithMemo() {
 	identity := "worker1"
 
 	memo := &commonpb.Memo{
-		Fields: map[string]*commonpb.Payloads{
-			"Info": payloads.EncodeString(id),
+		Fields: map[string]*commonpb.Payload{
+			"Info": payload.EncodeString(id),
 		},
 	}
 

--- a/host/ndc/nDC_integration_test.go
+++ b/host/ndc/nDC_integration_test.go
@@ -38,7 +38,7 @@ import (
 
 	eventgenpb "github.com/temporalio/temporal/.gen/proto/event"
 	replicationgenpb "github.com/temporalio/temporal/.gen/proto/replication"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence/serialization"
 
 	"github.com/golang/mock/gomock"
@@ -444,7 +444,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranches() {
 				EventType: eventpb.EventType_MarkerRecorded,
 				Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 					MarkerName:                   "some marker name",
-					Details:                      payload.EncodeString("some marker details"),
+					Details:                      payloads.EncodeString("some marker details"),
 					DecisionTaskCompletedEventId: 4,
 				}},
 			},
@@ -485,7 +485,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranches() {
 				EventType: eventpb.EventType_WorkflowExecutionSignaled,
 				Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 					SignalName: "some signal name 1",
-					Input:      payload.EncodeString("some signal details 1"),
+					Input:      payloads.EncodeString("some signal details 1"),
 					Identity:   identity,
 				}},
 			},
@@ -529,7 +529,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranches() {
 				EventType: eventpb.EventType_WorkflowExecutionSignaled,
 				Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 					SignalName: "some signal name 2",
-					Input:      payload.EncodeString("some signal details 2"),
+					Input:      payloads.EncodeString("some signal details 2"),
 					Identity:   identity,
 				}},
 			},
@@ -749,7 +749,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieConti
 				EventType: eventpb.EventType_MarkerRecorded,
 				Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 					MarkerName:                   "some marker name",
-					Details:                      payload.EncodeString("some marker details"),
+					Details:                      payloads.EncodeString("some marker details"),
 					DecisionTaskCompletedEventId: 4,
 				}},
 			},
@@ -790,7 +790,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieConti
 				EventType: eventpb.EventType_WorkflowExecutionSignaled,
 				Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 					SignalName: "some signal name 1",
-					Input:      payload.EncodeString("some signal details 1"),
+					Input:      payloads.EncodeString("some signal details 1"),
 					Identity:   identity,
 				}},
 			},
@@ -834,7 +834,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieConti
 				EventType: eventpb.EventType_WorkflowExecutionSignaled,
 				Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 					SignalName: "some signal name 2",
-					Input:      payload.EncodeString("some signal details 2"),
+					Input:      payloads.EncodeString("some signal details 2"),
 					Identity:   identity,
 				}},
 			},
@@ -1104,7 +1104,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_UpdateNonCurrentBranch() {
 					TaskId:    taskID,
 					Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 						SignalName: "signal",
-						Input:      payload.EncodeBytes([]byte{}),
+						Input:      payloads.EncodeBytes([]byte{}),
 						Identity:   "ndc_integration_test",
 					}},
 				},
@@ -1216,7 +1216,7 @@ func (s *nDCIntegrationTestSuite) TestAdminGetWorkflowExecutionRawHistoryV2() {
 				EventType: eventpb.EventType_MarkerRecorded,
 				Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 					MarkerName:                   "some marker name",
-					Details:                      payload.EncodeString("some marker details"),
+					Details:                      payloads.EncodeString("some marker details"),
 					DecisionTaskCompletedEventId: 4,
 				}},
 			},
@@ -1257,7 +1257,7 @@ func (s *nDCIntegrationTestSuite) TestAdminGetWorkflowExecutionRawHistoryV2() {
 				EventType: eventpb.EventType_WorkflowExecutionSignaled,
 				Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 					SignalName: "some signal name 1",
-					Input:      payload.EncodeString("some signal details 1"),
+					Input:      payloads.EncodeString("some signal details 1"),
 					Identity:   identity,
 				}},
 			},
@@ -1301,7 +1301,7 @@ func (s *nDCIntegrationTestSuite) TestAdminGetWorkflowExecutionRawHistoryV2() {
 				EventType: eventpb.EventType_WorkflowExecutionSignaled,
 				Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 					SignalName: "some signal name 2",
-					Input:      payload.EncodeString("some signal details 2"),
+					Input:      payloads.EncodeString("some signal details 2"),
 					Identity:   identity,
 				}},
 			},

--- a/host/queryworkflow_test.go
+++ b/host/queryworkflow_test.go
@@ -43,7 +43,7 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/rpc"
 	"github.com/temporalio/temporal/service/history"
 )
@@ -98,7 +98,7 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 					ActivityId:                    "1",
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -110,7 +110,7 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -119,14 +119,14 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) (*commonpb.Payloads, error) {
 		s.NotNil(task.Query)
 		s.NotNil(task.Query.QueryType)
 		if task.Query.QueryType == queryType {
-			return payload.EncodeString("query-result"), nil
+			return payloads.EncodeString("query-result"), nil
 		}
 
 		return nil, errors.New("unknown-query-type")
@@ -188,7 +188,7 @@ func (s *integrationSuite) TestQueryWorkflow_Sticky() {
 	s.NotNil(queryResult.Resp)
 	s.NotNil(queryResult.Resp.QueryResult)
 	var queryResultString string
-	err = payload.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
+	err = payloads.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 
@@ -258,7 +258,7 @@ func (s *integrationSuite) TestQueryWorkflow_StickyTimeout() {
 					ActivityId:                    "1",
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -270,7 +270,7 @@ func (s *integrationSuite) TestQueryWorkflow_StickyTimeout() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -279,14 +279,14 @@ func (s *integrationSuite) TestQueryWorkflow_StickyTimeout() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) (*commonpb.Payloads, error) {
 		s.NotNil(task.Query)
 		s.NotNil(task.Query.QueryType)
 		if task.Query.QueryType == queryType {
-			return payload.EncodeString("query-result"), nil
+			return payloads.EncodeString("query-result"), nil
 		}
 
 		return nil, errors.New("unknown-query-type")
@@ -350,7 +350,7 @@ func (s *integrationSuite) TestQueryWorkflow_StickyTimeout() {
 	s.NotNil(queryResult.Resp)
 	s.NotNil(queryResult.Resp.QueryResult)
 	var queryResultString string
-	err = payload.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
+	err = payloads.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 }
@@ -402,7 +402,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -414,7 +414,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -422,14 +422,14 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	// activity handler
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) (*commonpb.Payloads, error) {
 		s.NotNil(task.Query)
 		s.NotNil(task.Query.QueryType)
 		if task.Query.QueryType == queryType {
-			return payload.EncodeString("query-result"), nil
+			return payloads.EncodeString("query-result"), nil
 		}
 
 		return nil, errors.New("unknown-query-type")
@@ -490,7 +490,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	s.NotNil(queryResult.Resp.QueryResult)
 	s.Nil(queryResult.Resp.QueryRejected)
 	var queryResultString string
-	err = payload.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
+	err = payloads.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 
@@ -529,7 +529,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	s.NotNil(queryResult.Resp)
 	s.NotNil(queryResult.Resp.QueryResult)
 	s.Nil(queryResult.Resp.QueryRejected)
-	err = payload.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
+	err = payloads.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 
@@ -558,7 +558,7 @@ func (s *integrationSuite) TestQueryWorkflow_NonSticky() {
 	s.NotNil(queryResult.Resp)
 	s.NotNil(queryResult.Resp.QueryResult)
 	s.Nil(queryResult.Resp.QueryRejected)
-	err = payload.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
+	err = payloads.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 }
@@ -611,7 +611,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -630,7 +630,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -638,14 +638,14 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	// activity handler
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) (*commonpb.Payloads, error) {
 		s.NotNil(task.Query)
 		s.NotNil(task.Query.QueryType)
 		if task.Query.QueryType == queryType {
-			return payload.EncodeString("query-result"), nil
+			return payloads.EncodeString("query-result"), nil
 		}
 
 		return nil, errors.New("unknown-query-type")
@@ -698,7 +698,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	// send signal to ensure there is an outstanding decision task to dispatch query on
 	// otherwise query will just go through matching
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -730,7 +730,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 		false,
 		&querypb.WorkflowQueryResult{
 			ResultType: querypb.QueryResultType_Answered,
-			Answer:     payload.EncodeString("consistent query result"),
+			Answer:     payloads.EncodeString("consistent query result"),
 		})
 
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
@@ -743,7 +743,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	s.NotNil(queryResult.Resp.QueryResult)
 	s.Nil(queryResult.Resp.QueryRejected)
 	var queryResultString string
-	err = payload.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
+	err = payloads.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
 	s.NoError(err)
 	s.Equal("consistent query result", queryResultString)
 }
@@ -795,7 +795,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10, // ensure longer than time it takes to handle signal
 					StartToCloseTimeoutSeconds:    50, // ensure longer than time takes to handle signal
@@ -814,7 +814,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -822,14 +822,14 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 	// activity handler
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) (*commonpb.Payloads, error) {
 		s.NotNil(task.Query)
 		s.NotNil(task.Query.QueryType)
 		if task.Query.QueryType == queryType {
-			return payload.EncodeString("query-result"), nil
+			return payloads.EncodeString("query-result"), nil
 		}
 
 		return nil, errors.New("unknown-query-type")
@@ -876,7 +876,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 	}
 
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -955,7 +955,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10, // ensure longer than time it takes to handle signal
 					StartToCloseTimeoutSeconds:    50, // ensure longer than time takes to handle signal
@@ -976,7 +976,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -984,14 +984,14 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 	// activity handler
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) (*commonpb.Payloads, error) {
 		s.NotNil(task.Query)
 		s.NotNil(task.Query.QueryType)
 		if task.Query.QueryType == queryType {
-			return payload.EncodeString("query-result"), nil
+			return payloads.EncodeString("query-result"), nil
 		}
 
 		return nil, errors.New("unknown-query-type")
@@ -1040,7 +1040,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 	// send a signal that will take 5 seconds to handle
 	// this causes the signal to still be outstanding at the time query arrives
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -1086,7 +1086,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonStic
 	s.NotNil(queryResult.Resp.QueryResult)
 	s.Nil(queryResult.Resp.QueryRejected)
 	var queryResultString string
-	err = payload.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
+	err = payloads.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 }
@@ -1143,7 +1143,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10, // ensure longer than time it takes to handle signal
 					StartToCloseTimeoutSeconds:    50, // ensure longer than time takes to handle signal
@@ -1164,7 +1164,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1172,14 +1172,14 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 	// activity handler
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	queryHandler := func(task *workflowservice.PollForDecisionTaskResponse) (*commonpb.Payloads, error) {
 		s.NotNil(task.Query)
 		s.NotNil(task.Query.QueryType)
 		if task.Query.QueryType == queryType {
-			return payload.EncodeString("query-result"), nil
+			return payloads.EncodeString("query-result"), nil
 		}
 
 		return nil, errors.New("unknown-query-type")
@@ -1230,7 +1230,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 	// send a signal that will take 5 seconds to handle
 	// this causes the signal to still be outstanding at the time query arrives
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -1252,7 +1252,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 
 		// at this point there is a decision task started on the worker so this second signal will become buffered
 		signalName := "my signal"
-		signalInput := payload.EncodeString("my signal input")
+		signalInput := payloads.EncodeString("my signal input")
 		_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			WorkflowExecution: &executionpb.WorkflowExecution{
@@ -1291,7 +1291,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 		false,
 		&querypb.WorkflowQueryResult{
 			ResultType: querypb.QueryResultType_Answered,
-			Answer:     payload.EncodeString("consistent query result"),
+			Answer:     payloads.EncodeString("consistent query result"),
 		})
 
 	// the task should not be a query task because at the time outstanding decision task completed
@@ -1305,7 +1305,7 @@ func (s *integrationSuite) TestQueryWorkflow_Consistent_NewDecisionTask_Sticky()
 	s.NotNil(queryResult.Resp.QueryResult)
 	s.Nil(queryResult.Resp.QueryRejected)
 	var queryResultString string
-	err = payload.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
+	err = payloads.Decode(queryResult.Resp.GetQueryResult(), &queryResultString)
 	s.NoError(err)
 	s.Equal("consistent query result", queryResultString)
 }

--- a/host/signalworkflow_test.go
+++ b/host/signalworkflow_test.go
@@ -42,7 +42,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/rpc"
 )
 
@@ -108,7 +108,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -128,7 +128,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -137,7 +137,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -158,7 +158,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 
 	// Send first signal using RunID
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -184,7 +184,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 
 	// Send another signal without RunID
 	signalName = "another signal"
-	signalInput = payload.EncodeString("another signal input")
+	signalInput = payloads.EncodeString("another signal input")
 	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -282,7 +282,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -304,7 +304,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -313,7 +313,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -334,7 +334,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 
 	// Send first signal
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	requestID := uuid.New()
 	signalReqest := &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
@@ -421,7 +421,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 	activityCount := int32(1)
 	activityCounter := int32(0)
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	dtHandler := func(execution *executionpb.WorkflowExecution, wt *commonpb.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *eventpb.History) ([]*decisionpb.Decision, error) {
 		if activityCounter < activityCount {
@@ -435,7 +435,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -460,7 +460,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -491,7 +491,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 					ActivityId:                    strconv.Itoa(int(foreignActivityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -511,7 +511,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -625,7 +625,7 @@ func (s *integrationSuite) TestSignalWorkflow_Cron_NoDecisionTaskCreated() {
 
 	// Send first signal using RunID
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -647,7 +647,7 @@ func (s *integrationSuite) TestSignalWorkflow_Cron_NoDecisionTaskCreated() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -714,7 +714,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 	activityCount := int32(1)
 	activityCounter := int32(0)
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	dtHandler := func(execution *executionpb.WorkflowExecution, wt *commonpb.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *eventpb.History) ([]*decisionpb.Decision, error) {
 		if activityCounter < activityCount {
@@ -728,7 +728,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -753,7 +753,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -784,7 +784,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 					ActivityId:                    strconv.Itoa(int(foreignActivityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -804,7 +804,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -913,7 +913,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_UnKnownTarget() {
 	activityCount := int32(1)
 	activityCounter := int32(0)
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	dtHandler := func(execution *executionpb.WorkflowExecution, wt *commonpb.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *eventpb.History) ([]*decisionpb.Decision, error) {
 		if activityCounter < activityCount {
@@ -927,7 +927,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_UnKnownTarget() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -952,7 +952,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_UnKnownTarget() {
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1038,7 +1038,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_SignalSelf() {
 	activityCount := int32(1)
 	activityCounter := int32(0)
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	dtHandler := func(execution *executionpb.WorkflowExecution, wt *commonpb.WorkflowType,
 		previousStartedEventID, startedEventID int64, history *eventpb.History) ([]*decisionpb.Decision, error) {
 		if activityCounter < activityCount {
@@ -1052,7 +1052,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_SignalSelf() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -1077,7 +1077,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_SignalSelf() {
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1147,7 +1147,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	taskList := &tasklistpb.TaskList{Name: tl}
 
 	header := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payload.EncodeString("sample data")},
+		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("sample data")},
 	}
 
 	// Start a workflow
@@ -1188,7 +1188,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 2,
 					StartToCloseTimeoutSeconds:    50,
@@ -1223,7 +1223,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1232,7 +1232,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1253,7 +1253,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	// Send a signal
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	wfIDReusePolicy := commonpb.WorkflowIdReusePolicy_AllowDuplicate
 	sRequest := &workflowservice.SignalWithStartWorkflowExecutionRequest{
 		RequestId:                  uuid.New(),
@@ -1299,7 +1299,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	// Send signal to terminated workflow
 	signalName = "signal to terminate"
-	signalInput = payload.EncodeString("signal to terminate input")
+	signalInput = payloads.EncodeString("signal to terminate input")
 	sRequest.SignalName = signalName
 	sRequest.SignalInput = signalInput
 	sRequest.WorkflowId = id
@@ -1326,7 +1326,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	// Send signal to not existed workflow
 	id = "integration-signal-with-start-workflow-test-non-exist"
 	signalName = "signal to non exist"
-	signalInput = payload.EncodeString("signal to non exist input")
+	signalInput = payloads.EncodeString("signal to non exist input")
 	sRequest.SignalName = signalName
 	sRequest.SignalInput = signalInput
 	sRequest.WorkflowId = id
@@ -1445,7 +1445,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -1458,14 +1458,14 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
 
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{
@@ -1490,7 +1490,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 
 	// test policy WorkflowIdReusePolicyRejectDuplicate
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	sRequest := &workflowservice.SignalWithStartWorkflowExecutionRequest{
 		RequestId:                  uuid.New(),
 		Namespace:                  s.namespace,

--- a/host/signalworkflow_test.go
+++ b/host/signalworkflow_test.go
@@ -42,6 +42,7 @@ import (
 	"go.temporal.io/temporal-proto/workflowservice"
 
 	"github.com/temporalio/temporal/common/log/tag"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/rpc"
 )
@@ -1147,7 +1148,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	taskList := &tasklistpb.TaskList{Name: tl}
 
 	header := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("sample data")},
+		Fields: map[string]*commonpb.Payload{"tracing": payload.EncodeString("sample data")},
 	}
 
 	// Start a workflow

--- a/host/sizelimit_test.go
+++ b/host/sizelimit_test.go
@@ -46,7 +46,7 @@ import (
 
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 type sizeLimitIntegrationSuite struct {
@@ -118,7 +118,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -130,7 +130,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -138,7 +138,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &TaskPoller{

--- a/host/taskpoller.go
+++ b/host/taskpoller.go
@@ -39,7 +39,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/service/history"
 	"github.com/temporalio/temporal/service/matching"
 )
@@ -246,7 +246,7 @@ Loop:
 			_, err = p.Engine.RespondDecisionTaskFailed(NewContext(), &workflowservice.RespondDecisionTaskFailedRequest{
 				TaskToken: response.TaskToken,
 				Cause:     eventpb.DecisionTaskFailedCause_WorkflowWorkerUnhandledFailure,
-				Details:   payload.EncodeString(err.Error()),
+				Details:   payloads.EncodeString(err.Error()),
 				Identity:  p.Identity,
 			})
 			return isQueryTask, nil, err
@@ -314,7 +314,7 @@ func (p *TaskPoller) HandlePartialDecision(response *workflowservice.PollForDeci
 		_, err = p.Engine.RespondDecisionTaskFailed(NewContext(), &workflowservice.RespondDecisionTaskFailedRequest{
 			TaskToken: response.TaskToken,
 			Cause:     eventpb.DecisionTaskFailedCause_WorkflowWorkerUnhandledFailure,
-			Details:   payload.EncodeString(err.Error()),
+			Details:   payloads.EncodeString(err.Error()),
 			Identity:  p.Identity,
 		})
 		return nil, err
@@ -377,7 +377,7 @@ retry:
 			p.Logger.Info("Executing RespondActivityTaskCanceled")
 			_, err := p.Engine.RespondActivityTaskCanceled(NewContext(), &workflowservice.RespondActivityTaskCanceledRequest{
 				TaskToken: response.TaskToken,
-				Details:   payload.EncodeString("details"),
+				Details:   payloads.EncodeString("details"),
 				Identity:  p.Identity,
 			})
 			return err
@@ -387,7 +387,7 @@ retry:
 			_, err := p.Engine.RespondActivityTaskFailed(NewContext(), &workflowservice.RespondActivityTaskFailedRequest{
 				TaskToken: response.TaskToken,
 				Reason:    err2.Error(),
-				Details:   payload.EncodeString(err2.Error()),
+				Details:   payloads.EncodeString(err2.Error()),
 				Identity:  p.Identity,
 			})
 			return err
@@ -448,7 +448,7 @@ retry:
 				WorkflowId: response.WorkflowExecution.GetWorkflowId(),
 				RunId:      response.WorkflowExecution.GetRunId(),
 				ActivityId: response.GetActivityId(),
-				Details:    payload.EncodeString("details"),
+				Details:    payloads.EncodeString("details"),
 				Identity:   p.Identity,
 			})
 			return err
@@ -461,7 +461,7 @@ retry:
 				RunId:      response.WorkflowExecution.GetRunId(),
 				ActivityId: response.GetActivityId(),
 				Reason:     err2.Error(),
-				Details:    payload.EncodeString(err2.Error()),
+				Details:    payloads.EncodeString(err2.Error()),
 				Identity:   p.Identity,
 			})
 			return err

--- a/host/xdc/elasticsearch_test.go
+++ b/host/xdc/elasticsearch_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/log/tag"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/environment"
 	"github.com/temporalio/temporal/host"
@@ -185,9 +186,9 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 	identity := "worker1"
 	workflowType := &commonpb.WorkflowType{Name: wt}
 	taskList := &tasklistpb.TaskList{Name: tl}
-	attrValBytes, _ := payloads.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
-		IndexedFields: map[string]*commonpb.Payloads{
+		IndexedFields: map[string]*commonpb.Payload{
 			s.testSearchAttributeKey: attrValBytes,
 		},
 	}
@@ -236,7 +237,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 		s.Equal(we.GetRunId(), openExecution.GetExecution().GetRunId())
 		searchValBytes := openExecution.SearchAttributes.GetIndexedFields()[s.testSearchAttributeKey]
 		var searchVal string
-		payloads.Decode(searchValBytes, &searchVal)
+		payload.Decode(searchValBytes, &searchVal)
 		s.Equal(s.testSearchAttributeVal, searchVal)
 	}
 
@@ -295,12 +296,12 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 					fields := retrievedSearchAttr.GetIndexedFields()
 					searchValBytes := fields[s.testSearchAttributeKey]
 					var searchVal string
-					payloads.Decode(searchValBytes, &searchVal)
+					payload.Decode(searchValBytes, &searchVal)
 					s.Equal("another string", searchVal)
 
 					searchValBytes2 := fields[definition.CustomIntField]
 					var searchVal2 int
-					payloads.Decode(searchValBytes2, &searchVal2)
+					payload.Decode(searchValBytes2, &searchVal2)
 					s.Equal(123, searchVal2)
 
 					verified = true
@@ -387,10 +388,10 @@ GetHistoryLoop2:
 }
 
 func getUpsertSearchAttributes() *commonpb.SearchAttributes {
-	attrValBytes1, _ := payloads.Encode("another string")
-	attrValBytes2, _ := payloads.Encode(123)
+	attrValBytes1, _ := payload.Encode("another string")
+	attrValBytes2, _ := payload.Encode(123)
 	upsertSearchAttr := &commonpb.SearchAttributes{
-		IndexedFields: map[string]*commonpb.Payloads{
+		IndexedFields: map[string]*commonpb.Payload{
 			definition.CustomStringField: attrValBytes1,
 			definition.CustomIntField:    attrValBytes2,
 		},

--- a/host/xdc/elasticsearch_test.go
+++ b/host/xdc/elasticsearch_test.go
@@ -58,7 +58,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/environment"
 	"github.com/temporalio/temporal/host"
 )
@@ -185,7 +185,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 	identity := "worker1"
 	workflowType := &commonpb.WorkflowType{Name: wt}
 	taskList := &tasklistpb.TaskList{Name: tl}
-	attrValBytes, _ := payload.Encode(s.testSearchAttributeVal)
+	attrValBytes, _ := payloads.Encode(s.testSearchAttributeVal)
 	searchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			s.testSearchAttributeKey: attrValBytes,
@@ -236,7 +236,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 		s.Equal(we.GetRunId(), openExecution.GetExecution().GetRunId())
 		searchValBytes := openExecution.SearchAttributes.GetIndexedFields()[s.testSearchAttributeKey]
 		var searchVal string
-		payload.Decode(searchValBytes, &searchVal)
+		payloads.Decode(searchValBytes, &searchVal)
 		s.Equal(s.testSearchAttributeVal, searchVal)
 	}
 
@@ -295,12 +295,12 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 					fields := retrievedSearchAttr.GetIndexedFields()
 					searchValBytes := fields[s.testSearchAttributeKey]
 					var searchVal string
-					payload.Decode(searchValBytes, &searchVal)
+					payloads.Decode(searchValBytes, &searchVal)
 					s.Equal("another string", searchVal)
 
 					searchValBytes2 := fields[definition.CustomIntField]
 					var searchVal2 int
-					payload.Decode(searchValBytes2, &searchVal2)
+					payloads.Decode(searchValBytes2, &searchVal2)
 					s.Equal(123, searchVal2)
 
 					verified = true
@@ -317,7 +317,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 
 	// terminate workflow
 	terminateReason := "force terminate to make sure standby process tasks"
-	terminateDetails := payload.EncodeString("terminate details")
+	terminateDetails := payloads.EncodeString("terminate details")
 	_, err = client1.TerminateWorkflowExecution(host.NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -387,8 +387,8 @@ GetHistoryLoop2:
 }
 
 func getUpsertSearchAttributes() *commonpb.SearchAttributes {
-	attrValBytes1, _ := payload.Encode("another string")
-	attrValBytes2, _ := payload.Encode(123)
+	attrValBytes1, _ := payloads.Encode("another string")
+	attrValBytes2, _ := payloads.Encode(123)
 	upsertSearchAttr := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payloads{
 			definition.CustomStringField: attrValBytes1,

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -58,7 +58,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/environment"
 	"github.com/temporalio/temporal/host"
 )
@@ -290,7 +290,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 30,
 					StartToCloseTimeoutSeconds:    50,
@@ -303,7 +303,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -311,7 +311,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	queryType := "test-query"
@@ -319,7 +319,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 		s.NotNil(task.Query)
 		s.NotNil(task.Query.QueryType)
 		if task.Query.QueryType == queryType {
-			return payload.EncodeString("query-result"), nil
+			return payloads.EncodeString("query-result"), nil
 		}
 
 		return nil, errors.New("unknown-query-type")
@@ -391,7 +391,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	s.NotNil(queryResult.Resp)
 	s.NotNil(queryResult.Resp.QueryResult)
 	var queryResultString string
-	err = payload.Decode(queryResult.Resp.QueryResult, &queryResultString)
+	err = payloads.Decode(queryResult.Resp.QueryResult, &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 
@@ -415,7 +415,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	s.NoError(queryResult.Err)
 	s.NotNil(queryResult.Resp)
 	s.NotNil(queryResult.Resp.QueryResult)
-	err = payload.Decode(queryResult.Resp.QueryResult, &queryResultString)
+	err = payloads.Decode(queryResult.Resp.QueryResult, &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 
@@ -474,7 +474,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	s.NoError(queryResult.Err)
 	s.NotNil(queryResult.Resp)
 	s.NotNil(queryResult.Resp.QueryResult)
-	err = payload.Decode(queryResult.Resp.QueryResult, &queryResultString)
+	err = payloads.Decode(queryResult.Resp.QueryResult, &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 
@@ -495,7 +495,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	s.NoError(queryResult.Err)
 	s.NotNil(queryResult.Resp)
 	s.NotNil(queryResult.Resp.QueryResult)
-	err = payload.Decode(queryResult.Resp.QueryResult, &queryResultString)
+	err = payloads.Decode(queryResult.Resp.QueryResult, &queryResultString)
 	s.NoError(err)
 	s.Equal("query-result", queryResultString)
 
@@ -598,7 +598,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -634,7 +634,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 
 	// Send a signal in cluster
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err = client1.SignalWorkflowExecution(host.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -759,7 +759,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -898,7 +898,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 					ActivityId:                    strconv.Itoa(int(activityCounter)),
 					ActivityType:                  &commonpb.ActivityType{Name: activityName},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeBytes(buf.Bytes()),
+					Input:                         payloads.EncodeBytes(buf.Bytes()),
 					ScheduleToCloseTimeoutSeconds: 100,
 					ScheduleToStartTimeoutSeconds: 10,
 					StartToCloseTimeoutSeconds:    50,
@@ -910,7 +910,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -918,7 +918,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 	atHandler := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller := &host.TaskPoller{
@@ -955,7 +955,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 
 	// terminate workflow at cluster 2
 	terminateReason := "terminate reason"
-	terminateDetails := payload.EncodeString("terminate details")
+	terminateDetails := payloads.EncodeString("terminate details")
 	_, err = client2.TerminateWorkflowExecution(host.NewContext(), &workflowservice.TerminateWorkflowExecutionRequest{
 		Namespace: namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -1085,7 +1085,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 				Attributes: &decisionpb.Decision_ContinueAsNewWorkflowExecutionDecisionAttributes{ContinueAsNewWorkflowExecutionDecisionAttributes: &decisionpb.ContinueAsNewWorkflowExecutionDecisionAttributes{
 					WorkflowType:               workflowType,
 					TaskList:                   &tasklistpb.TaskList{Name: tl},
-					Input:                      payload.EncodeBytes(buf.Bytes()),
+					Input:                      payloads.EncodeBytes(buf.Bytes()),
 					WorkflowRunTimeoutSeconds:  100,
 					WorkflowTaskTimeoutSeconds: 10,
 				}},
@@ -1097,7 +1097,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1222,7 +1222,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1249,7 +1249,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Send a signal in cluster 1
 	signalName := "my signal"
-	signalInput := payload.EncodeString("my signal input")
+	signalInput := payloads.EncodeString("my signal input")
 	_, err = client1.SignalWorkflowExecution(host.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -1307,7 +1307,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Send another signal in cluster 2
 	signalName2 := "my signal 2"
-	signalInput2 := payload.EncodeString("my signal input 2")
+	signalInput2 := payloads.EncodeString("my signal input 2")
 	_, err = client2.SignalWorkflowExecution(host.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace: namespace,
 		WorkflowExecution: &executionpb.WorkflowExecution{
@@ -1406,7 +1406,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 
 			// Send a signal in cluster
 			signalName := "my signal"
-			signalInput := payload.EncodeString("my signal input")
+			signalInput := payloads.EncodeString("my signal input")
 			_, err = client1.SignalWorkflowExecution(host.NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 				Namespace: namespace,
 				WorkflowExecution: &executionpb.WorkflowExecution{
@@ -1450,7 +1450,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1579,7 +1579,7 @@ func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 					ActivityId:                    strconv.Itoa(1),
 					ActivityType:                  &commonpb.ActivityType{Name: "some random activity type"},
 					TaskList:                      &tasklistpb.TaskList{Name: tl},
-					Input:                         payload.EncodeString("some random input"),
+					Input:                         payloads.EncodeString("some random input"),
 					ScheduleToCloseTimeoutSeconds: 1000,
 					ScheduleToStartTimeoutSeconds: 1000,
 					StartToCloseTimeoutSeconds:    1000,
@@ -1598,14 +1598,14 @@ func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
 
 	// activity handler
 	activity1Called := false
-	heartbeatDetails := payload.EncodeString("details")
+	heartbeatDetails := payloads.EncodeString("details")
 	atHandler1 := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 		activity1Called = true
@@ -1613,7 +1613,7 @@ func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 			TaskToken: taskToken, Details: heartbeatDetails})
 		s.NoError(err)
 		time.Sleep(5 * time.Second)
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	// activity handler
@@ -1621,7 +1621,7 @@ func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 	atHandler2 := func(execution *executionpb.WorkflowExecution, activityType *commonpb.ActivityType,
 		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
 		activity2Called = true
-		return payload.EncodeString("Activity Result"), false, nil
+		return payloads.EncodeString("Activity Result"), false, nil
 	}
 
 	poller1 := &host.TaskPoller{
@@ -1789,7 +1789,7 @@ func (s *integrationClustersTestSuite) TestTransientDecisionFailover() {
 		return []*decisionpb.Decision{{
 			DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 			Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-				Result: payload.EncodeString("Done"),
+				Result: payloads.EncodeString("Done"),
 			}},
 		}}, nil
 	}
@@ -1895,7 +1895,7 @@ func (s *integrationClustersTestSuite) TestCronWorkflowFailover() {
 			{
 				DecisionType: decisionpb.DecisionType_CompleteWorkflowExecution,
 				Attributes: &decisionpb.Decision_CompleteWorkflowExecutionDecisionAttributes{CompleteWorkflowExecutionDecisionAttributes: &decisionpb.CompleteWorkflowExecutionDecisionAttributes{
-					Result: payload.EncodeString("cron-test-result"),
+					Result: payloads.EncodeString("cron-test-result"),
 				}},
 			}}, nil
 	}

--- a/proto/persistenceblobs/server_message.proto
+++ b/proto/persistenceblobs/server_message.proto
@@ -278,8 +278,8 @@ message WorkflowExecutionInfo {
     string clientImpl = 53;
     bytes autoResetPoints = 54;
     string autoResetPointsEncoding = 55;
-    map<string, common.Payloads> searchAttributes = 56;
-    map<string, common.Payloads> memo = 57;
+    map<string, common.Payload> searchAttributes = 56;
+    map<string, common.Payload> memo = 57;
     bytes versionHistories = 58;
     string versionHistoriesEncoding = 59;
 }

--- a/service/history/conflictResolver_test.go
+++ b/service/history/conflictResolver_test.go
@@ -48,7 +48,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
@@ -166,7 +166,7 @@ func (s *conflictResolverSuite) TestReset() {
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: &eventpb.WorkflowExecutionStartedEventAttributes{
 			WorkflowType:                    &commonpb.WorkflowType{Name: "some random workflow type"},
 			TaskList:                        &tasklistpb.TaskList{Name: "some random workflow type"},
-			Input:                           payload.EncodeString("some random input"),
+			Input:                           payloads.EncodeString("some random input"),
 			WorkflowExecutionTimeoutSeconds: 123,
 			WorkflowRunTimeoutSeconds:       231,
 			WorkflowTaskTimeoutSeconds:      233,

--- a/service/history/decisionChecker.go
+++ b/service/history/decisionChecker.go
@@ -43,7 +43,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 )
 
@@ -146,7 +146,7 @@ func (c *workflowSizeChecker) failWorkflowIfPayloadSizeExceedsLimit(
 
 	attributes := &decisionpb.FailWorkflowExecutionDecisionAttributes{
 		Reason:  common.FailureReasonDecisionBlobSizeExceedsLimit,
-		Details: payload.EncodeString(message),
+		Details: payloads.EncodeString(message),
 	}
 
 	if _, err := c.mutableState.AddFailWorkflowEvent(c.completedID, attributes); err != nil {
@@ -171,7 +171,7 @@ func (c *workflowSizeChecker) failWorkflowSizeExceedsLimit() (bool, error) {
 
 		attributes := &decisionpb.FailWorkflowExecutionDecisionAttributes{
 			Reason:  common.FailureReasonSizeExceedsLimit,
-			Details: payload.EncodeString("Workflow history size / count exceeds limit."),
+			Details: payloads.EncodeString("Workflow history size / count exceeds limit."),
 		}
 
 		if _, err := c.mutableState.AddFailWorkflowEvent(c.completedID, attributes); err != nil {

--- a/service/history/decisionChecker_test.go
+++ b/service/history/decisionChecker_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/temporalio/temporal/common/cluster"
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 )
 
@@ -136,7 +136,7 @@ func (s *decisionAttrValidatorSuite) TestValidateSignalExternalWorkflowExecution
 	err = s.validator.validateSignalExternalWorkflowExecutionAttributes(s.testNamespaceID, s.testTargetNamespaceID, attributes)
 	s.NoError(err)
 
-	attributes.Input = payload.EncodeString("test input")
+	attributes.Input = payloads.EncodeString("test input")
 	err = s.validator.validateSignalExternalWorkflowExecutionAttributes(s.testNamespaceID, s.testTargetNamespaceID, attributes)
 	s.NoError(err)
 }
@@ -156,7 +156,7 @@ func (s *decisionAttrValidatorSuite) TestValidateUpsertWorkflowSearchAttributes(
 	err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.EqualError(err, "IndexedFields is empty on decision.")
 
-	attributes.SearchAttributes.IndexedFields = map[string]*commonpb.Payloads{"CustomKeywordField": payload.EncodeString("bytes")}
+	attributes.SearchAttributes.IndexedFields = map[string]*commonpb.Payloads{"CustomKeywordField": payloads.EncodeString("bytes")}
 	err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.Nil(err)
 }

--- a/service/history/decisionChecker_test.go
+++ b/service/history/decisionChecker_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/temporalio/temporal/common/cluster"
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 )
@@ -156,7 +157,7 @@ func (s *decisionAttrValidatorSuite) TestValidateUpsertWorkflowSearchAttributes(
 	err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.EqualError(err, "IndexedFields is empty on decision.")
 
-	attributes.SearchAttributes.IndexedFields = map[string]*commonpb.Payloads{"CustomKeywordField": payloads.EncodeString("bytes")}
+	attributes.SearchAttributes.IndexedFields = map[string]*commonpb.Payload{"CustomKeywordField": payload.EncodeString("bytes")}
 	err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.Nil(err)
 }

--- a/service/history/decisionHandler.go
+++ b/service/history/decisionHandler.go
@@ -45,7 +45,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -453,7 +453,7 @@ Update_History_Loop:
 				tag.WorkflowID(token.GetWorkflowId()),
 				tag.WorkflowRunIDBytes(token.GetRunId()),
 				tag.WorkflowNamespaceIDBytes(namespaceID))
-			msBuilder, err = handler.historyEngine.failDecision(weContext, scheduleID, startedID, failDecision.cause, payload.EncodeString(failDecision.message), request)
+			msBuilder, err = handler.historyEngine.failDecision(weContext, scheduleID, startedID, failDecision.cause, payloads.EncodeString(failDecision.message), request)
 			if err != nil {
 				return nil, err
 			}
@@ -539,7 +539,7 @@ Update_History_Loop:
 					msBuilder,
 					eventBatchFirstEventID,
 					common.FailureReasonTransactionSizeExceedsLimit,
-					payload.EncodeString(updateErr.Error()),
+					payloads.EncodeString(updateErr.Error()),
 					identityHistoryService,
 				); err != nil {
 					return nil, err

--- a/service/history/decisionHandler_test.go
+++ b/service/history/decisionHandler_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/temporalio/temporal/common/headers"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 )
 
@@ -119,7 +119,7 @@ func (s *DecisionHandlerSuite) constructQueryResults(ids []string, resultSize in
 	for _, id := range ids {
 		results[id] = &querypb.WorkflowQueryResult{
 			ResultType: querypb.QueryResultType_Answered,
-			Answer:     payload.EncodeBytes(make([]byte, resultSize, resultSize)),
+			Answer:     payloads.EncodeBytes(make([]byte, resultSize, resultSize)),
 		}
 	}
 	return results

--- a/service/history/decisionTaskHandler.go
+++ b/service/history/decisionTaskHandler.go
@@ -873,14 +873,12 @@ func (handler *decisionTaskHandlerImpl) handleDecisionUpsertWorkflowSearchAttrib
 	return err
 }
 
-func searchAttributesSize(fields map[string]*commonpb.Payloads) int {
+func searchAttributesSize(fields map[string]*commonpb.Payload) int {
 	result := 0
 
 	for k, v := range fields {
 		result += len(k)
-		for _, payloadItem := range v.GetPayloads() {
-			result += len(payloadItem.GetData())
-		}
+		result += len(v.GetData())
 	}
 	return result
 }

--- a/service/history/decisionTaskHandler.go
+++ b/service/history/decisionTaskHandler.go
@@ -39,7 +39,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/primitives"
 )
 
@@ -269,7 +269,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionRequestCancelActivity(
 				ai.ScheduleID,
 				ai.StartedID,
 				actCancelReqEvent.GetEventId(),
-				payload.EncodeString(activityCancellationMsgActivityNotStarted),
+				payloads.EncodeString(activityCancellationMsgActivityNotStarted),
 				handler.identity,
 			)
 			if err != nil {

--- a/service/history/historyBuilder_test.go
+++ b/service/history/historyBuilder_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/cache"
 	"github.com/temporalio/temporal/common/log"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -114,7 +114,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	wt := "dynamic-historybuilder-success-type"
 	tl := "dynamic-historybuilder-success-tasklist"
 	identity := "dynamic-historybuilder-success-worker"
-	input := payload.EncodeString("dynamic-historybuilder-success-input")
+	input := payloads.EncodeString("dynamic-historybuilder-success-input")
 	execTimeout := int32(70)
 	runTimeout := int32(60)
 	taskTimeout := int32(10)
@@ -159,8 +159,8 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 
 	activity1ID := "activity1"
 	activity1Type := "dynamic-historybuilder-success-activity1-type"
-	activity1Input := payload.EncodeString("dynamic-historybuilder-success-activity1-input")
-	activity1Result := payload.EncodeString("dynamic-historybuilder-success-activity1-result")
+	activity1Input := payloads.EncodeString("dynamic-historybuilder-success-activity1-input")
+	activity1Result := payloads.EncodeString("dynamic-historybuilder-success-activity1-result")
 	activity1ScheduledEvent, _ := s.addActivityTaskScheduledEvent(4, activity1ID, activity1Type,
 		activityTaskList, activity1Input, activityTimeout, queueTimeout, hearbeatTimeout, nil)
 	s.validateActivityTaskScheduledEvent(activity1ScheduledEvent, 5, 4, activity1ID, activity1Type,
@@ -173,9 +173,9 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 
 	activity2ID := "activity2"
 	activity2Type := "dynamic-historybuilder-success-activity2-type"
-	activity2Input := payload.EncodeString("dynamic-historybuilder-success-activity2-input")
+	activity2Input := payloads.EncodeString("dynamic-historybuilder-success-activity2-input")
 	activity2Reason := "dynamic-historybuilder-success-activity2-failed"
-	activity2Details := payload.EncodeString("dynamic-historybuilder-success-activity2-callstack")
+	activity2Details := payloads.EncodeString("dynamic-historybuilder-success-activity2-callstack")
 	activity2ScheduledEvent, _ := s.addActivityTaskScheduledEvent(4, activity2ID, activity2Type,
 		activityTaskList, activity2Input, activityTimeout, queueTimeout, hearbeatTimeout, nil)
 	s.validateActivityTaskScheduledEvent(activity2ScheduledEvent, 6, 4, activity2ID, activity2Type,
@@ -188,7 +188,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 
 	activity3ID := "activity3"
 	activity3Type := "dynamic-historybuilder-success-activity3-type"
-	activity3Input := payload.EncodeString("dynamic-historybuilder-success-activity3-input")
+	activity3Input := payloads.EncodeString("dynamic-historybuilder-success-activity3-input")
 	activity3RetryPolicy := &commonpb.RetryPolicy{
 		InitialIntervalInSeconds: 1,
 		MaximumAttempts:          3,
@@ -270,7 +270,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
 	activity3Reason := "dynamic-historybuilder-success-activity3-failed"
-	activity3Details := payload.EncodeString("dynamic-historybuilder-success-activity3-callstack")
+	activity3Details := payloads.EncodeString("dynamic-historybuilder-success-activity3-callstack")
 	s.msBuilder.RetryActivity(ai5, activity3Reason, activity3Details)
 	ai6, activity3Running2 := s.msBuilder.GetActivityInfo(7)
 	s.Equal(activity3Reason, ai6.LastFailureReason)
@@ -285,7 +285,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.Equal(common.TransientEventID, ai7.StartedID)
 	s.Equal(int64(3), s.getPreviousDecisionStartedEventID())
 
-	activity3Result := payload.EncodeString("dynamic-historybuilder-success-activity1-result")
+	activity3Result := payloads.EncodeString("dynamic-historybuilder-success-activity1-result")
 	activity3CompletedEvent := s.addActivityTaskCompletedEvent(7, common.TransientEventID, activity3Result, identity)
 	s.validateActivityTaskCompletedEvent(activity3CompletedEvent, common.BufferedEventID, 7, common.TransientEventID,
 		activity3Result, identity)
@@ -302,9 +302,9 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.Len(historyEvents, 14)
 	s.validateActivityTaskStartedEvent(historyEvents[12], 13, 7, identity, 1, activity3Reason, activity3Details)
 
-	markerDetails := payload.EncodeString("dynamic-historybuilder-success-marker-details")
-	markerHeaderField1 := payload.EncodeString("dynamic-historybuilder-success-marker-header1")
-	markerHeaderField2 := payload.EncodeString("dynamic-historybuilder-success-marker-header2")
+	markerDetails := payloads.EncodeString("dynamic-historybuilder-success-marker-details")
+	markerHeaderField1 := payloads.EncodeString("dynamic-historybuilder-success-marker-header1")
+	markerHeaderField2 := payloads.EncodeString("dynamic-historybuilder-success-marker-header2")
 	markerHeader := map[string]*commonpb.Payloads{
 		"name1": markerHeaderField1,
 		"name2": markerHeaderField2,
@@ -323,7 +323,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowStartFailures() {
 	wt := "historybuilder-workflowstart-failures-type"
 	tl := "historybuilder-workflowstart-failures-tasklist"
 	identity := "historybuilder-workflowstart-failures-worker"
-	input := payload.EncodeString("historybuilder-workflowstart-failures-input")
+	input := payloads.EncodeString("historybuilder-workflowstart-failures-input")
 	execTimeout := int32(70)
 	runTimeout := int32(60)
 	taskTimeout := int32(10)
@@ -374,7 +374,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDecisionScheduledFailures() {
 	wt := "historybuilder-decisionscheduled-failures-type"
 	tl := "historybuilder-decisionscheduled-failures-tasklist"
 	identity := "historybuilder-decisionscheduled-failures-worker"
-	input := payload.EncodeString("historybuilder-decisionscheduled-failures-input")
+	input := payloads.EncodeString("historybuilder-decisionscheduled-failures-input")
 	execTimeout := int32(70)
 	runTimeout := int32(60)
 	taskTimeout := int32(10)
@@ -410,7 +410,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderDecisionStartedFailures() {
 	wt := "historybuilder-decisionstarted-failures-type"
 	tl := "historybuilder-decisionstarted-failures-tasklist"
 	identity := "historybuilder-decisionstarted-failures-worker"
-	input := payload.EncodeString("historybuilder-decisionstarted-failures-input")
+	input := payloads.EncodeString("historybuilder-decisionstarted-failures-input")
 	execTimeout := int32(70)
 	runTimeout := int32(60)
 	taskTimeout := int32(10)
@@ -467,7 +467,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 	wt := "flush-buffered-events-type"
 	tl := "flush-buffered-events-tasklist"
 	identity := "flush-buffered-events-worker"
-	input := payload.EncodeString("flush-buffered-events-input")
+	input := payloads.EncodeString("flush-buffered-events-input")
 	execTimeout := int32(70)
 	runTimeout := int32(60)
 	taskTimeout := int32(10)
@@ -517,8 +517,8 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 	// 5 activity1 scheduled
 	activity1ID := "activity1"
 	activity1Type := "flush-buffered-events-activity1-type"
-	activity1Input := payload.EncodeString("flush-buffered-events-activity1-input")
-	activity1Result := payload.EncodeString("flush-buffered-events-activity1-result")
+	activity1Input := payloads.EncodeString("flush-buffered-events-activity1-input")
+	activity1Result := payloads.EncodeString("flush-buffered-events-activity1-result")
 	activity1ScheduledEvent, _ := s.addActivityTaskScheduledEvent(4, activity1ID, activity1Type,
 		activityTaskList, activity1Input, activityTimeout, queueTimeout, hearbeatTimeout, nil)
 	s.validateActivityTaskScheduledEvent(activity1ScheduledEvent, 5, 4, activity1ID, activity1Type,
@@ -532,7 +532,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 	// 6 activity 2 scheduled
 	activity2ID := "activity2"
 	activity2Type := "flush-buffered-events-activity2-type"
-	activity2Input := payload.EncodeString("flush-buffered-events-activity2-input")
+	activity2Input := payloads.EncodeString("flush-buffered-events-activity2-input")
 	activity2ScheduledEvent, _ := s.addActivityTaskScheduledEvent(4, activity2ID, activity2Type,
 		activityTaskList, activity2Input, activityTimeout, queueTimeout, hearbeatTimeout, nil)
 	s.validateActivityTaskScheduledEvent(activity2ScheduledEvent, 6, 4, activity2ID, activity2Type,
@@ -598,7 +598,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 
 	// 12 (buffered) activity2 failed
 	activity2Reason := "flush-buffered-events-activity2-failed"
-	activity2Details := payload.EncodeString("flush-buffered-events-activity2-callstack")
+	activity2Details := payloads.EncodeString("flush-buffered-events-activity2-callstack")
 	activity2FailedEvent := s.addActivityTaskFailedEvent(6, common.BufferedEventID, activity2Reason, activity2Details, identity)
 	s.validateActivityTaskFailedEvent(activity2FailedEvent, common.BufferedEventID, 6, common.BufferedEventID, activity2Reason,
 		activity2Details, identity)
@@ -633,7 +633,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationRequested() 
 	workflowType := "some random workflow type"
 	tasklist := "some random tasklist"
 	identity := "some random identity"
-	input := payload.EncodeString("some random workflow input")
+	input := payloads.EncodeString("some random workflow input")
 	execTimeout := int32(70)
 	runTimeout := int32(60)
 	taskTimeout := int32(10)
@@ -705,7 +705,7 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationFailed() {
 	workflowType := "some random workflow type"
 	tasklist := "some random tasklist"
 	identity := "some random identity"
-	input := payload.EncodeString("some random workflow input")
+	input := payloads.EncodeString("some random workflow input")
 	execTimeout := int32(70)
 	runTimeout := int32(60)
 	taskTimeout := int32(10)

--- a/service/history/historyBuilder_test.go
+++ b/service/history/historyBuilder_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/cache"
 	"github.com/temporalio/temporal/common/log"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
@@ -303,9 +304,9 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 	s.validateActivityTaskStartedEvent(historyEvents[12], 13, 7, identity, 1, activity3Reason, activity3Details)
 
 	markerDetails := payloads.EncodeString("dynamic-historybuilder-success-marker-details")
-	markerHeaderField1 := payloads.EncodeString("dynamic-historybuilder-success-marker-header1")
-	markerHeaderField2 := payloads.EncodeString("dynamic-historybuilder-success-marker-header2")
-	markerHeader := map[string]*commonpb.Payloads{
+	markerHeaderField1 := payload.EncodeString("dynamic-historybuilder-success-marker-header1")
+	markerHeaderField2 := payload.EncodeString("dynamic-historybuilder-success-marker-header2")
+	markerHeader := map[string]*commonpb.Payload{
 		"name1": markerHeaderField1,
 		"name2": markerHeaderField2,
 	}
@@ -886,8 +887,8 @@ func (s *historyBuilderSuite) addActivityTaskFailedEvent(scheduleID, startedID i
 	return event
 }
 
-func (s *historyBuilderSuite) addMarkerRecordedEvent(decisionCompletedEventID int64, markerName string, details *commonpb.Payloads, header *map[string]*commonpb.Payloads) *eventpb.HistoryEvent {
-	fields := make(map[string]*commonpb.Payloads)
+func (s *historyBuilderSuite) addMarkerRecordedEvent(decisionCompletedEventID int64, markerName string, details *commonpb.Payloads, header *map[string]*commonpb.Payload) *eventpb.HistoryEvent {
+	fields := make(map[string]*commonpb.Payload)
 	if header != nil {
 		for name, value := range *header {
 			fields[name] = value
@@ -1057,7 +1058,7 @@ func (s *historyBuilderSuite) validateActivityTaskFailedEvent(event *eventpb.His
 
 func (s *historyBuilderSuite) validateMarkerRecordedEvent(
 	event *eventpb.HistoryEvent, eventID, decisionTaskCompletedEventID int64,
-	markerName string, details *commonpb.Payloads, header *map[string]*commonpb.Payloads) {
+	markerName string, details *commonpb.Payloads, header *map[string]*commonpb.Payload) {
 	s.NotNil(event)
 	s.Equal(eventpb.EventType_MarkerRecorded, event.EventType)
 	s.Equal(eventID, event.EventId)

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -56,7 +56,7 @@ import (
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	p "github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -180,7 +180,7 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyExpired() {
 	executionInfo := msBuilder.GetExecutionInfo()
 	executionInfo.StickyTaskList = stickyTl
 
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 
 	ms := createMutableState(msBuilder)
@@ -249,7 +249,7 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 	executionInfo.LastUpdatedTimestamp = time.Now()
 	executionInfo.StickyTaskList = stickyTl
 
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 
 	ms := createMutableState(msBuilder)
@@ -718,7 +718,7 @@ func (s *engine2Suite) TestRecordActivityTaskStartedSuccess() {
 
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, true)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, int64(2), int64(3), identity)
@@ -827,7 +827,7 @@ func (s *engine2Suite) createExecutionStartedState(we executionpb.WorkflowExecut
 	startDecision bool) mutableState {
 	msBuilder := newMutableStateBuilderWithEventV2(s.historyEngine.shard, s.mockEventsCache,
 		s.logger, we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	if startDecision {
 		addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
@@ -855,12 +855,12 @@ func (s *engine2Suite) TestRespondDecisionTaskCompletedRecordMarkerDecision() {
 	}
 	serializedTaskToken, _ := taskToken.Marshal()
 	identity := "testIdentity"
-	markerDetails := payload.EncodeString("marker details")
+	markerDetails := payloads.EncodeString("marker details")
 	markerName := "marker name"
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.historyEngine.shard, s.mockEventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -1164,7 +1164,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 	runID := testRunID
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	sRequest = &historyservice.SignalWithStartWorkflowExecutionRequest{
 		NamespaceId: namespaceID,
 		SignalWithStartRequest: &workflowservice.SignalWithStartWorkflowExecutionRequest{
@@ -1205,7 +1205,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 	taskList := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	requestID := uuid.New()
 
 	sRequest = &historyservice.SignalWithStartWorkflowExecutionRequest{
@@ -1246,7 +1246,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_CreateTimeout() {
 	taskList := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	requestID := uuid.New()
 
 	sRequest = &historyservice.SignalWithStartWorkflowExecutionRequest{
@@ -1288,7 +1288,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning()
 	taskList := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	requestID := uuid.New()
 	sRequest = &historyservice.SignalWithStartWorkflowExecutionRequest{
 		NamespaceId: namespaceID,
@@ -1340,7 +1340,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_DuplicateReque
 	taskList := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	requestID := "testRequestID"
 	sRequest := &historyservice.SignalWithStartWorkflowExecutionRequest{
 		NamespaceId: namespaceID,
@@ -1400,7 +1400,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_WorkflowAlread
 	taskList := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	requestID := "testRequestID"
 	sRequest := &historyservice.SignalWithStartWorkflowExecutionRequest{
 		NamespaceId: namespaceID,

--- a/service/history/historyEngine3_eventsv2_test.go
+++ b/service/history/historyEngine3_eventsv2_test.go
@@ -52,7 +52,7 @@ import (
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	p "github.com/temporalio/temporal/common/persistence"
 )
 
@@ -177,7 +177,7 @@ func (s *engine3Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 	executionInfo.LastUpdatedTimestamp = time.Now()
 	executionInfo.StickyTaskList = stickyTl
 
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 
 	ms := createMutableState(msBuilder)
@@ -280,7 +280,7 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 	runID := testRunID
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	sRequest = &historyservice.SignalWithStartWorkflowExecutionRequest{
 		NamespaceId: namespaceID,
 		SignalWithStartRequest: &workflowservice.SignalWithStartWorkflowExecutionRequest{
@@ -327,7 +327,7 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 	taskList := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	requestID := uuid.New()
 	sRequest = &historyservice.SignalWithStartWorkflowExecutionRequest{
 		NamespaceId: namespaceID,

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -65,7 +65,7 @@ import (
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 	cconfig "github.com/temporalio/temporal/common/service/config"
@@ -290,7 +290,7 @@ func (s *engineSuite) TestGetMutableStateSync() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	ms := createMutableState(msBuilder)
@@ -350,7 +350,7 @@ func (s *engineSuite) TestGetMutableStateLongPoll() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	ms := createMutableState(msBuilder)
@@ -424,7 +424,7 @@ func (s *engineSuite) TestGetMutableStateLongPoll_CurrentBranchChanged() {
 		s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite),
 		execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	ms := createMutableState(msBuilder)
@@ -485,7 +485,7 @@ func (s *engineSuite) TestGetMutableStateLongPollTimeout() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	ms := createMutableState(msBuilder)
@@ -531,7 +531,7 @@ func (s *engineSuite) TestQueryWorkflow_RejectBasedOnCompleted() {
 	identity := "testIdentity"
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache, loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	event := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	di.StartedID = event.GetEventId()
@@ -565,12 +565,12 @@ func (s *engineSuite) TestQueryWorkflow_RejectBasedOnFailed() {
 	identity := "testIdentity"
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache, loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	event := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	di.StartedID = event.GetEventId()
 	event = addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, di.StartedID, "some random identity")
-	addFailWorkflowEvent(msBuilder, event.GetEventId(), "failure reason", payload.EncodeBytes([]byte{1, 2, 3}))
+	addFailWorkflowEvent(msBuilder, event.GetEventId(), "failure reason", payloads.EncodeBytes([]byte{1, 2, 3}))
 	ms := createMutableState(msBuilder)
 	gweResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gweResponse, nil).Once()
@@ -613,7 +613,7 @@ func (s *engineSuite) TestQueryWorkflow_FirstDecisionNotCompleted() {
 	identity := "testIdentity"
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache, loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	ms := createMutableState(msBuilder)
@@ -641,7 +641,7 @@ func (s *engineSuite) TestQueryWorkflow_DirectlyThroughMatching() {
 	identity := "testIdentity"
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache, loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	startedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, startedEvent.EventId, identity)
@@ -651,7 +651,7 @@ func (s *engineSuite) TestQueryWorkflow_DirectlyThroughMatching() {
 	ms := createMutableState(msBuilder)
 	gweResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gweResponse, nil).Once()
-	s.mockMatchingClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(&matchingservice.QueryWorkflowResponse{QueryResult: payload.EncodeBytes([]byte{1, 2, 3})}, nil)
+	s.mockMatchingClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(&matchingservice.QueryWorkflowResponse{QueryResult: payloads.EncodeBytes([]byte{1, 2, 3})}, nil)
 	s.mockHistoryEngine.matchingClient = s.mockMatchingClient
 	request := &historyservice.QueryWorkflowRequest{
 		NamespaceId: testNamespaceID,
@@ -669,7 +669,7 @@ func (s *engineSuite) TestQueryWorkflow_DirectlyThroughMatching() {
 	s.Nil(resp.GetResponse().QueryRejected)
 
 	var queryResult []byte
-	err = payload.Decode(resp.GetResponse().GetQueryResult(), &queryResult)
+	err = payloads.Decode(resp.GetResponse().GetQueryResult(), &queryResult)
 	s.NoError(err)
 	s.Equal([]byte{1, 2, 3}, queryResult)
 }
@@ -682,7 +682,7 @@ func (s *engineSuite) TestQueryWorkflow_DecisionTaskDispatch_Timeout() {
 	tasklist := "testTaskList"
 	identity := "testIdentity"
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache, loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	startedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, startedEvent.EventId, identity)
@@ -737,7 +737,7 @@ func (s *engineSuite) TestQueryWorkflow_ConsistentQueryBufferFull() {
 	tasklist := "testTaskList"
 	identity := "testIdentity"
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache, loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	startedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, startedEvent.EventId, identity)
@@ -779,7 +779,7 @@ func (s *engineSuite) TestQueryWorkflow_DecisionTaskDispatch_Complete() {
 	tasklist := "testTaskList"
 	identity := "testIdentity"
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache, loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	startedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, startedEvent.EventId, identity)
@@ -805,7 +805,7 @@ func (s *engineSuite) TestQueryWorkflow_DecisionTaskDispatch_Complete() {
 				queryTerminationType: queryTerminationTypeCompleted,
 				queryResult: &querypb.WorkflowQueryResult{
 					ResultType: resultType,
-					Answer:     payload.EncodeBytes(answer),
+					Answer:     payloads.EncodeBytes(answer),
 				},
 			}
 			err := qr.setTerminationState(id, completedTerminationState)
@@ -831,7 +831,7 @@ func (s *engineSuite) TestQueryWorkflow_DecisionTaskDispatch_Complete() {
 	s.NoError(err)
 
 	var queryResult []byte
-	err = payload.Decode(resp.GetResponse().GetQueryResult(), &queryResult)
+	err = payloads.Decode(resp.GetResponse().GetQueryResult(), &queryResult)
 	s.NoError(err)
 	s.Equal([]byte{1, 2, 3}, queryResult)
 
@@ -851,7 +851,7 @@ func (s *engineSuite) TestQueryWorkflow_DecisionTaskDispatch_Unblocked() {
 	tasklist := "testTaskList"
 	identity := "testIdentity"
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache, loggerimpl.NewDevelopmentForTest(s.Suite), execution.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	startedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tasklist, identity)
 	addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, startedEvent.EventId, identity)
@@ -861,7 +861,7 @@ func (s *engineSuite) TestQueryWorkflow_DecisionTaskDispatch_Unblocked() {
 	ms := createMutableState(msBuilder)
 	gweResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gweResponse, nil).Once()
-	s.mockMatchingClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(&matchingservice.QueryWorkflowResponse{QueryResult: payload.EncodeBytes([]byte{1, 2, 3})}, nil)
+	s.mockMatchingClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(&matchingservice.QueryWorkflowResponse{QueryResult: payloads.EncodeBytes([]byte{1, 2, 3})}, nil)
 	s.mockHistoryEngine.matchingClient = s.mockMatchingClient
 	waitGroup := &sync.WaitGroup{}
 	waitGroup.Add(1)
@@ -895,7 +895,7 @@ func (s *engineSuite) TestQueryWorkflow_DecisionTaskDispatch_Unblocked() {
 	s.NoError(err)
 
 	var queryResult []byte
-	err = payload.Decode(resp.GetResponse().GetQueryResult(), &queryResult)
+	err = payloads.Decode(resp.GetResponse().GetQueryResult(), &queryResult)
 	s.NoError(err)
 	s.Equal([]byte{1, 2, 3}, queryResult)
 
@@ -989,7 +989,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedUpdateExecutionFailed() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -1029,7 +1029,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedIfTaskCompleted() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	startedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, startedEvent.EventId, identity)
@@ -1067,7 +1067,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedIfTaskNotStarted() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 
 	ms := createMutableState(msBuilder)
@@ -1095,19 +1095,19 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedConflictOnUpdate() {
 	identity := "testIdentity"
 	activity1ID := "activity1"
 	activity1Type := "activity_type1"
-	activity1Input := payload.EncodeString("input1")
-	activity1Result := payload.EncodeString("activity1_result")
+	activity1Input := payloads.EncodeString("input1")
+	activity1Result := payloads.EncodeString("activity1_result")
 	activity2ID := "activity2"
 	activity2Type := "activity_type2"
-	activity2Input := payload.EncodeString("input2")
-	activity2Result := payload.EncodeString("activity2_result")
+	activity2Input := payloads.EncodeString("input2")
+	activity2Result := payloads.EncodeString("activity2_result")
 	activity3ID := "activity3"
 	activity3Type := "activity_type3"
-	activity3Input := payload.EncodeString("input3")
+	activity3Input := payloads.EncodeString("input3")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di1 := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di1.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di1.ScheduleID, decisionStartedEvent1.EventId, identity)
@@ -1192,7 +1192,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedConflictOnUpdate() {
 
 func (s *engineSuite) TestValidateSignalRequest() {
 	workflowType := "testType"
-	input := payload.EncodeString("input")
+	input := payloads.EncodeString("input")
 	startRequest := &workflowservice.StartWorkflowExecutionRequest{
 		WorkflowId:                      "ID",
 		WorkflowType:                    &commonpb.WorkflowType{Name: workflowType},
@@ -1221,11 +1221,11 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedMaxAttemptsExceeded() {
 	}
 	taskToken, _ := tt.Marshal()
 	identity := "testIdentity"
-	input := payload.EncodeString("input")
+	input := payloads.EncodeString("input")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -1275,17 +1275,17 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedCompleteWorkflowFailed() {
 	identity := "testIdentity"
 	activity1ID := "activity1"
 	activity1Type := "activity_type1"
-	activity1Input := payload.EncodeString("input1")
-	activity1Result := payload.EncodeString("activity1_result")
+	activity1Input := payloads.EncodeString("input1")
+	activity1Result := payloads.EncodeString("activity1_result")
 	activity2ID := "activity2"
 	activity2Type := "activity_type2"
-	activity2Input := payload.EncodeString("input2")
-	activity2Result := payload.EncodeString("activity2_result")
-	workflowResult := payload.EncodeString("workflow result")
+	activity2Input := payloads.EncodeString("input2")
+	activity2Result := payloads.EncodeString("activity2_result")
+	workflowResult := payloads.EncodeString("workflow result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 25, 20, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 25, 20, 200, identity)
 	di1 := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di1.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di1.ScheduleID, decisionStartedEvent1.EventId, identity)
@@ -1355,18 +1355,18 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedFailWorkflowFailed() {
 	identity := "testIdentity"
 	activity1ID := "activity1"
 	activity1Type := "activity_type1"
-	activity1Input := payload.EncodeString("input1")
-	activity1Result := payload.EncodeString("activity1_result")
+	activity1Input := payloads.EncodeString("input1")
+	activity1Result := payloads.EncodeString("activity1_result")
 	activity2ID := "activity2"
 	activity2Type := "activity_type2"
-	activity2Input := payload.EncodeString("input2")
-	activity2Result := payload.EncodeString("activity2_result")
+	activity2Input := payloads.EncodeString("input2")
+	activity2Result := payloads.EncodeString("activity2_result")
 	reason := "workflow fail reason"
-	details := payload.EncodeString("workflow fail details")
+	details := payloads.EncodeString("workflow fail details")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 25, 20, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 25, 20, 200, identity)
 	di1 := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di1.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di1.ScheduleID, decisionStartedEvent1.EventId, identity)
@@ -1437,12 +1437,12 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedBadDecisionAttributes() {
 	identity := "testIdentity"
 	activity1ID := "activity1"
 	activity1Type := "activity_type1"
-	activity1Input := payload.EncodeString("input1")
-	activity1Result := payload.EncodeString("activity1_result")
+	activity1Input := payloads.EncodeString("input1")
+	activity1Result := payloads.EncodeString("activity1_result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 25, 20, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 25, 20, 200, identity)
 	di1 := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di1.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di1.ScheduleID, decisionStartedEvent1.EventId, identity)
@@ -1559,11 +1559,11 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledAtt
 		}
 		taskToken, _ := tt.Marshal()
 		identity := "testIdentity"
-		input := payload.EncodeString("input")
+		input := payloads.EncodeString("input")
 
 		msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 			loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-		addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), runTimeout*10, runTimeout, 200, identity)
+		addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), runTimeout*10, runTimeout, 200, identity)
 		di := addDecisionTaskScheduledEvent(msBuilder)
 		addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -1654,7 +1654,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedBadBinary() {
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
 	msBuilder.namespaceEntry = namespaceEntry
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -1700,11 +1700,11 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledDec
 	}
 	taskToken, _ := tt.Marshal()
 	identity := "testIdentity"
-	input := payload.EncodeString("input")
+	input := payloads.EncodeString("input")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 90, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 90, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -1773,7 +1773,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompleted_DecisionHeartbeatTimeout(
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	msBuilder.executionInfo.DecisionOriginalScheduledTimestamp = time.Now().Add(-time.Hour).UnixNano()
@@ -1816,7 +1816,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompleted_DecisionHeartbeatNotTimeo
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	msBuilder.executionInfo.DecisionOriginalScheduledTimestamp = time.Now().Add(-time.Minute).UnixNano()
@@ -1859,7 +1859,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompleted_DecisionHeartbeatNotTimeo
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	msBuilder.executionInfo.DecisionOriginalScheduledTimestamp = 0
@@ -1899,11 +1899,11 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedCompleteWorkflowSuccess() 
 	}
 	taskToken, _ := tt.Marshal()
 	identity := "testIdentity"
-	workflowResult := payload.EncodeString("success")
+	workflowResult := payloads.EncodeString("success")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -1951,12 +1951,12 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedFailWorkflowSuccess() {
 	}
 	taskToken, _ := tt.Marshal()
 	identity := "testIdentity"
-	details := payload.EncodeString("fail workflow details")
+	details := payloads.EncodeString("fail workflow details")
 	reason := "fail workflow reason"
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -2008,7 +2008,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSignalExternalWorkflowSucc
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -2021,7 +2021,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSignalExternalWorkflowSucc
 				RunId:      we.RunId,
 			},
 			SignalName: "signal",
-			Input:      payload.EncodeString("test input"),
+			Input:      payloads.EncodeString("test input"),
 		}},
 	}}
 
@@ -2063,7 +2063,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedStartChildWorkflowWithAban
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -2126,7 +2126,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedStartChildWorkflowWithTerm
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -2239,7 +2239,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSignalExternalWorkflowFail
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -2252,7 +2252,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSignalExternalWorkflowFail
 				RunId:      we.RunId,
 			},
 			SignalName: "signal",
-			Input:      payload.EncodeString("test input"),
+			Input:      payloads.EncodeString("test input"),
 		}},
 	}}
 
@@ -2377,7 +2377,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedIfNoAIdProvided() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), testRunID)
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 	ms := createMutableState(msBuilder)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
@@ -2413,7 +2413,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedIfNotFound() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), testRunID)
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 	ms := createMutableState(msBuilder)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
@@ -2448,12 +2448,12 @@ func (s *engineSuite) TestRespondActivityTaskCompletedUpdateExecutionFailed() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
-	activityResult := payload.EncodeString("activity result")
+	activityInput := payloads.EncodeString("input1")
+	activityResult := payloads.EncodeString("activity result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -2496,12 +2496,12 @@ func (s *engineSuite) TestRespondActivityTaskCompletedIfTaskCompleted() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
-	activityResult := payload.EncodeString("activity result")
+	activityInput := payloads.EncodeString("input1")
+	activityResult := payloads.EncodeString("activity result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -2545,12 +2545,12 @@ func (s *engineSuite) TestRespondActivityTaskCompletedIfTaskNotStarted() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
-	activityResult := payload.EncodeString("activity result")
+	activityInput := payloads.EncodeString("input1")
+	activityResult := payloads.EncodeString("activity result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 50, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -2590,15 +2590,15 @@ func (s *engineSuite) TestRespondActivityTaskCompletedConflictOnUpdate() {
 	identity := "testIdentity"
 	activity1ID := "activity1"
 	activity1Type := "activity_type1"
-	activity1Input := payload.EncodeString("input1")
-	activity1Result := payload.EncodeString("activity1_result")
+	activity1Input := payloads.EncodeString("input1")
+	activity1Result := payloads.EncodeString("activity1_result")
 	activity2ID := "activity2"
 	activity2Type := "activity_type2"
-	activity2Input := payload.EncodeString("input2")
+	activity2Input := payloads.EncodeString("input2")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent1.EventId, identity)
@@ -2661,12 +2661,12 @@ func (s *engineSuite) TestRespondActivityTaskCompletedMaxAttemptsExceeded() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
-	activityResult := payload.EncodeString("activity result")
+	activityInput := payloads.EncodeString("input1")
+	activityResult := payloads.EncodeString("activity result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -2710,12 +2710,12 @@ func (s *engineSuite) TestRespondActivityTaskCompletedSuccess() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
-	activityResult := payload.EncodeString("activity result")
+	activityInput := payloads.EncodeString("input1")
+	activityResult := payloads.EncodeString("activity result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -2763,8 +2763,8 @@ func (s *engineSuite) TestRespondActivityTaskCompletedByIdSuccess() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
-	activityResult := payload.EncodeString("activity result")
+	activityInput := payloads.EncodeString("input1")
+	activityResult := payloads.EncodeString("activity result")
 	tt := &tokengenpb.Task{
 		WorkflowId: we.WorkflowId,
 		ScheduleId: common.EmptyEventID,
@@ -2774,7 +2774,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedByIdSuccess() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	decisionScheduledEvent := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, decisionScheduledEvent.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, decisionScheduledEvent.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -2916,7 +2916,7 @@ func (s *engineSuite) TestRespondActivityTaskFailededIfNoAIdProvided() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), testRunID)
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 	ms := createMutableState(msBuilder)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
@@ -2952,7 +2952,7 @@ func (s *engineSuite) TestRespondActivityTaskFailededIfNotFound() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), testRunID)
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 	ms := createMutableState(msBuilder)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
@@ -2987,11 +2987,11 @@ func (s *engineSuite) TestRespondActivityTaskFailedUpdateExecutionFailed() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3033,13 +3033,13 @@ func (s *engineSuite) TestRespondActivityTaskFailedIfTaskCompleted() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 	failReason := "fail reason"
-	details := payload.EncodeString("fail details")
+	details := payloads.EncodeString("fail details")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3084,11 +3084,11 @@ func (s *engineSuite) TestRespondActivityTaskFailedIfTaskNotStarted() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3127,17 +3127,17 @@ func (s *engineSuite) TestRespondActivityTaskFailedConflictOnUpdate() {
 	identity := "testIdentity"
 	activity1ID := "activity1"
 	activity1Type := "activity_type1"
-	activity1Input := payload.EncodeString("input1")
+	activity1Input := payloads.EncodeString("input1")
 	failReason := "fail reason"
-	details := payload.EncodeString("fail details.")
+	details := payloads.EncodeString("fail details.")
 	activity2ID := "activity2"
 	activity2Type := "activity_type2"
-	activity2Input := payload.EncodeString("input2")
-	activity2Result := payload.EncodeString("activity2_result")
+	activity2Input := payloads.EncodeString("input2")
+	activity2Result := payloads.EncodeString("activity2_result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 25, 25, 25, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 25, 25, 25, identity)
 	di1 := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di1.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di1.ScheduleID, decisionStartedEvent1.EventId, identity)
@@ -3205,11 +3205,11 @@ func (s *engineSuite) TestRespondActivityTaskFailedMaxAttemptsExceeded() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3252,13 +3252,13 @@ func (s *engineSuite) TestRespondActivityTaskFailedSuccess() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 	failReason := "failed"
-	failDetails := payload.EncodeString("fail details.")
+	failDetails := payloads.EncodeString("fail details.")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3307,9 +3307,9 @@ func (s *engineSuite) TestRespondActivityTaskFailedByIdSuccess() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 	failReason := "failed"
-	failDetails := payload.EncodeString("fail details.")
+	failDetails := payloads.EncodeString("fail details.")
 	tt := &tokengenpb.Task{
 		WorkflowId: we.WorkflowId,
 		ScheduleId: common.EmptyEventID,
@@ -3319,7 +3319,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedByIdSuccess() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	decisionScheduledEvent := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, decisionScheduledEvent.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, decisionScheduledEvent.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3375,11 +3375,11 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_NoTimer() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3393,7 +3393,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_NoTimer() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gwmsResponse, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	detais := payload.EncodeString("details")
+	detais := payloads.EncodeString("details")
 
 	_, err := s.mockHistoryEngine.RecordActivityTaskHeartbeat(context.Background(), &historyservice.RecordActivityTaskHeartbeatRequest{
 		NamespaceId: testNamespaceID,
@@ -3422,11 +3422,11 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_TimerRunning() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3441,7 +3441,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_TimerRunning() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gwmsResponse, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	detais := payload.EncodeString("details")
+	detais := payloads.EncodeString("details")
 
 	_, err := s.mockHistoryEngine.RecordActivityTaskHeartbeat(context.Background(), &historyservice.RecordActivityTaskHeartbeatRequest{
 		NamespaceId: testNamespaceID,
@@ -3469,7 +3469,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatByIDSuccess() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 	tt := &tokengenpb.Task{
 		WorkflowId: we.WorkflowId,
 		RunId:      primitives.MustParseUUID(we.RunId),
@@ -3480,7 +3480,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatByIDSuccess() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3494,7 +3494,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatByIDSuccess() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gwmsResponse, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	detais := payload.EncodeString("details")
+	detais := payloads.EncodeString("details")
 
 	_, err := s.mockHistoryEngine.RecordActivityTaskHeartbeat(context.Background(), &historyservice.RecordActivityTaskHeartbeatRequest{
 		NamespaceId: testNamespaceID,
@@ -3523,11 +3523,11 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Scheduled() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3544,7 +3544,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Scheduled() {
 		CancelRequest: &workflowservice.RespondActivityTaskCanceledRequest{
 			TaskToken: taskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.NotNil(err)
@@ -3567,11 +3567,11 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Started() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3593,7 +3593,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Started() {
 		CancelRequest: &workflowservice.RespondActivityTaskCanceledRequest{
 			TaskToken: taskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.Nil(err)
@@ -3620,7 +3620,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceledById_Started() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 	tt := &tokengenpb.Task{
 		WorkflowId: we.WorkflowId,
 		ScheduleId: common.EmptyEventID,
@@ -3630,7 +3630,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceledById_Started() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	decisionScheduledEvent := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, decisionScheduledEvent.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, decisionScheduledEvent.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3654,7 +3654,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceledById_Started() {
 		CancelRequest: &workflowservice.RespondActivityTaskCanceledRequest{
 			TaskToken: taskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.Nil(err)
@@ -3768,7 +3768,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_NotSchedule
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -3818,11 +3818,11 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_Scheduled()
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3882,11 +3882,11 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_Started() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -3943,12 +3943,12 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_Completed()
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
-	workflowResult := payload.EncodeString("workflow result")
+	activityInput := payloads.EncodeString("input1")
+	workflowResult := payloads.EncodeString("workflow result")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -4011,11 +4011,11 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_NoHeartBeat
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -4070,7 +4070,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_NoHeartBeat
 		HeartbeatRequest: &workflowservice.RecordActivityTaskHeartbeatRequest{
 			TaskToken: activityTaskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.Nil(err)
@@ -4086,7 +4086,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_NoHeartBeat
 		CancelRequest: &workflowservice.RespondActivityTaskCanceledRequest{
 			TaskToken: activityTaskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.Nil(err)
@@ -4114,11 +4114,11 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_Success() {
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -4173,7 +4173,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_Success() {
 		HeartbeatRequest: &workflowservice.RecordActivityTaskHeartbeatRequest{
 			TaskToken: activityTaskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.Nil(err)
@@ -4189,7 +4189,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_Success() {
 		CancelRequest: &workflowservice.RespondActivityTaskCanceledRequest{
 			TaskToken: activityTaskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.Nil(err)
@@ -4216,11 +4216,11 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_SuccessWith
 	identity := "testIdentity"
 	activityID := "activity1_id"
 	activityType := "activity_type1"
-	activityInput := payload.EncodeString("input1")
+	activityInput := payloads.EncodeString("input1")
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -4258,7 +4258,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_SuccessWith
 	release(nil)
 	result1 := &querypb.WorkflowQueryResult{
 		ResultType: querypb.QueryResultType_Answered,
-		Answer:     payload.EncodeBytes([]byte{1, 2, 3}),
+		Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 	}
 	result2 := &querypb.WorkflowQueryResult{
 		ResultType:   querypb.QueryResultType_Failed,
@@ -4316,7 +4316,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_SuccessWith
 		HeartbeatRequest: &workflowservice.RecordActivityTaskHeartbeatRequest{
 			TaskToken: activityTaskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.Nil(err)
@@ -4332,7 +4332,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_SuccessWith
 		CancelRequest: &workflowservice.RespondActivityTaskCanceledRequest{
 			TaskToken: activityTaskToken,
 			Identity:  identity,
-			Details:   payload.EncodeString("details"),
+			Details:   payloads.EncodeString("details"),
 		},
 	})
 	s.Nil(err)
@@ -4367,7 +4367,7 @@ func (s *engineSuite) TestStarTimer_DuplicateTimerID() {
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
 
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -4463,7 +4463,7 @@ func (s *engineSuite) TestUserTimer_RespondDecisionTaskCompleted() {
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
 	// Verify cancel timer with a start event.
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -4521,7 +4521,7 @@ func (s *engineSuite) TestCancelTimer_RespondDecisionTaskCompleted_NoStartTimer(
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
 	// Verify cancel timer with a start event.
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -4575,7 +4575,7 @@ func (s *engineSuite) TestCancelTimer_RespondDecisionTaskCompleted_TimerFired() 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
 	// Verify cancel timer with a start event.
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payload.EncodeString("input"), 100, 100, 100, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100, 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID, decisionStartedEvent.EventId, identity)
@@ -4635,7 +4635,7 @@ func (s *engineSuite) TestSignalWorkflowExecution() {
 	tasklist := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	signalRequest = &historyservice.SignalWorkflowExecutionRequest{
 		NamespaceId: testNamespaceID,
 		SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
@@ -4649,7 +4649,7 @@ func (s *engineSuite) TestSignalWorkflowExecution() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 	ms := createMutableState(msBuilder)
 	ms.ExecutionInfo.NamespaceID = testNamespaceID
@@ -4676,7 +4676,7 @@ func (s *engineSuite) TestSignalWorkflowExecution_DuplicateRequest() {
 	tasklist := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name 2"
-	input := payload.EncodeString("test input 2")
+	input := payloads.EncodeString("test input 2")
 	requestID := uuid.New()
 	signalRequest = &historyservice.SignalWorkflowExecutionRequest{
 		NamespaceId: testNamespaceID,
@@ -4692,7 +4692,7 @@ func (s *engineSuite) TestSignalWorkflowExecution_DuplicateRequest() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 	ms := createMutableState(msBuilder)
 	// assume duplicate request id
@@ -4720,7 +4720,7 @@ func (s *engineSuite) TestSignalWorkflowExecution_Failed() {
 	tasklist := "testTaskList"
 	identity := "testIdentity"
 	signalName := "my signal name"
-	input := payload.EncodeString("test input")
+	input := payloads.EncodeString("test input")
 	signalRequest = &historyservice.SignalWorkflowExecutionRequest{
 		NamespaceId: testNamespaceID,
 		SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
@@ -4734,7 +4734,7 @@ func (s *engineSuite) TestSignalWorkflowExecution_Failed() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), we.GetRunId())
-	addWorkflowExecutionStartedEvent(msBuilder, *we, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, *we, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 	ms := createMutableState(msBuilder)
 	ms.ExecutionInfo.State = persistence.WorkflowStateCompleted
@@ -4766,7 +4766,7 @@ func (s *engineSuite) TestRemoveSignalMutableState() {
 
 	msBuilder := newMutableStateBuilderWithEventV2(s.mockHistoryEngine.shard, s.eventsCache,
 		loggerimpl.NewDevelopmentForTest(s.Suite), testRunID)
-	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payload.EncodeString("input"), 100, 50, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, execution, "wType", tasklist, payloads.EncodeString("input"), 100, 50, 200, identity)
 	addDecisionTaskScheduledEvent(msBuilder)
 	ms := createMutableState(msBuilder)
 	ms.ExecutionInfo.NamespaceID = testNamespaceID

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -45,7 +45,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/persistence/serialization"
 )
@@ -988,7 +988,7 @@ func (r *historyReplicator) terminateWorkflow(
 			if _, err := msBuilder.AddWorkflowExecutionTerminatedEvent(
 				eventBatchFirstEventID,
 				workflowTerminationReason,
-				payload.EncodeString(fmt.Sprintf("terminated by version: %v", incomingVersion)),
+				payloads.EncodeString(fmt.Sprintf("terminated by version: %v", incomingVersion)),
 				workflowTerminationIdentity,
 			); err != nil {
 				return serviceerror.NewInternal("Unable to terminate workflow execution.")

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -52,7 +52,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -260,7 +260,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsMissingMutableState_Incomin
 	currentNextEventID := int64(2333)
 
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalIdentity := "some random signal identity"
 
 	req := &historyservice.ReplicateEventsRequest{
@@ -340,7 +340,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsMissingMutableState_Incomin
 	now := time.Now().UnixNano()
 
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalIdentity := "some random signal identity"
 
 	currentRunID := uuid.New()
@@ -973,7 +973,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingLes
 	currentLastWriteVersion := lastWriteVersion
 
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalIdentity := "some random signal identity"
 
 	weContext := NewMockworkflowExecutionContext(s.controller)
@@ -1057,7 +1057,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingLes
 	currentLastWriteVersion := lastWriteVersion
 
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalIdentity := "some random signal identity"
 
 	decisionStickyTasklist := "some random decision sticky tasklist"
@@ -1174,7 +1174,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingLes
 	currentLastWriteVersion := int64(123)
 
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalIdentity := "some random signal identity"
 
 	weContext := NewMockworkflowExecutionContext(s.controller)
@@ -1223,7 +1223,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingLes
 	currentLastWriteVersion := int64(123)
 
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalIdentity := "some random signal identity"
 
 	decisionStickyTasklist := "some random decision sticky tasklist"
@@ -2800,7 +2800,7 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 	parentRunID := uuid.New()
 
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalIdentity := "some random signal identity"
 
 	weContext := newWorkflowExecutionContext(namespaceID, executionpb.WorkflowExecution{
@@ -2977,7 +2977,7 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 	parentRunID := uuid.New()
 
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalIdentity := "some random signal identity"
 
 	weContext := newWorkflowExecutionContext(namespaceID, executionpb.WorkflowExecution{

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -53,7 +53,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -1983,12 +1983,12 @@ func (e *mutableStateBuilder) addBinaryCheckSumIfNotExists(
 	exeInfo.AutoResetPoints = &executionpb.ResetPoints{
 		Points: currResetPoints,
 	}
-	bytes, err := payloads.Encode(recentBinaryChecksums)
+	bytes, err := payload.Encode(recentBinaryChecksums)
 	if err != nil {
 		return err
 	}
 	if exeInfo.SearchAttributes == nil {
-		exeInfo.SearchAttributes = make(map[string]*commonpb.Payloads)
+		exeInfo.SearchAttributes = make(map[string]*commonpb.Payload)
 	}
 	exeInfo.SearchAttributes[definition.BinaryChecksums] = bytes
 	if e.shard.GetConfig().AdvancedVisibilityWritingMode() != common.AdvancedVisibilityWritingModeOff {
@@ -2925,12 +2925,12 @@ func (e *mutableStateBuilder) ReplicateUpsertWorkflowSearchAttributesEvent(
 }
 
 func mergeMapOfPayload(
-	current map[string]*commonpb.Payloads,
-	upsert map[string]*commonpb.Payloads,
-) map[string]*commonpb.Payloads {
+	current map[string]*commonpb.Payload,
+	upsert map[string]*commonpb.Payload,
+) map[string]*commonpb.Payload {
 
 	if current == nil {
-		current = make(map[string]*commonpb.Payloads)
+		current = make(map[string]*commonpb.Payload)
 	}
 	for k, v := range upsert {
 		current[k] = v

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -53,7 +53,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -1983,7 +1983,7 @@ func (e *mutableStateBuilder) addBinaryCheckSumIfNotExists(
 	exeInfo.AutoResetPoints = &executionpb.ResetPoints{
 		Points: currResetPoints,
 	}
-	bytes, err := payload.Encode(recentBinaryChecksums)
+	bytes, err := payloads.Encode(recentBinaryChecksums)
 	if err != nil {
 		return err
 	}

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -47,6 +47,7 @@ import (
 	"github.com/temporalio/temporal/common/checksum"
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
@@ -527,16 +528,16 @@ func (s *mutableStateSuite) TestTrimEvents() {
 }
 
 func (s *mutableStateSuite) TestMergeMapOfPayload() {
-	var currentMap map[string]*commonpb.Payloads
-	var newMap map[string]*commonpb.Payloads
+	var currentMap map[string]*commonpb.Payload
+	var newMap map[string]*commonpb.Payload
 	resultMap := mergeMapOfPayload(currentMap, newMap)
-	s.Equal(make(map[string]*commonpb.Payloads), resultMap)
+	s.Equal(make(map[string]*commonpb.Payload), resultMap)
 
-	newMap = map[string]*commonpb.Payloads{"key": payloads.EncodeString("val")}
+	newMap = map[string]*commonpb.Payload{"key": payload.EncodeString("val")}
 	resultMap = mergeMapOfPayload(currentMap, newMap)
 	s.Equal(newMap, resultMap)
 
-	currentMap = map[string]*commonpb.Payloads{"number": payloads.EncodeString("1")}
+	currentMap = map[string]*commonpb.Payload{"number": payload.EncodeString("1")}
 	resultMap = mergeMapOfPayload(currentMap, newMap)
 	s.Equal(2, len(resultMap))
 }

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -47,7 +47,7 @@ import (
 	"github.com/temporalio/temporal/common/checksum"
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 )
@@ -179,7 +179,7 @@ func (s *mutableStateSuite) TestTransientDecisionCompletionFirstBatchReplicated_
 		newDecisionScheduleEvent.GetEventId(),
 		newDecisionStartedEvent.GetEventId(),
 		eventpb.DecisionTaskFailedCause_WorkflowWorkerUnhandledFailure,
-		payload.EncodeString("some random decision failure details"),
+		payloads.EncodeString("some random decision failure details"),
 		"some random decision failure identity",
 		"", "", "", "", 0,
 	))
@@ -271,7 +271,7 @@ func (s *mutableStateSuite) TestReorderEvents() {
 	}
 	tl := "testTaskList"
 	activityID := "activity_id"
-	activityResult := payload.EncodeString("activity_result")
+	activityResult := payloads.EncodeString("activity_result")
 
 	info := &persistence.WorkflowExecutionInfo{
 		NamespaceID:          namespaceID,
@@ -532,11 +532,11 @@ func (s *mutableStateSuite) TestMergeMapOfPayload() {
 	resultMap := mergeMapOfPayload(currentMap, newMap)
 	s.Equal(make(map[string]*commonpb.Payloads), resultMap)
 
-	newMap = map[string]*commonpb.Payloads{"key": payload.EncodeString("val")}
+	newMap = map[string]*commonpb.Payloads{"key": payloads.EncodeString("val")}
 	resultMap = mergeMapOfPayload(currentMap, newMap)
 	s.Equal(newMap, resultMap)
 
-	currentMap = map[string]*commonpb.Payloads{"number": payload.EncodeString("1")}
+	currentMap = map[string]*commonpb.Payloads{"number": payloads.EncodeString("1")}
 	resultMap = mergeMapOfPayload(currentMap, newMap)
 	s.Equal(2, len(resultMap))
 }
@@ -796,7 +796,7 @@ func (s *mutableStateSuite) buildWorkflowMutableState() *persistence.WorkflowMut
 			InitiatedEventBatchId: 17,
 			RequestId:             uuid.New(),
 			Name:                  "test-signal-75",
-			Input:                 payload.EncodeString("signal-input-75"),
+			Input:                 payloads.EncodeString("signal-input-75"),
 		},
 	}
 
@@ -811,7 +811,7 @@ func (s *mutableStateSuite) buildWorkflowMutableState() *persistence.WorkflowMut
 			Version:   failoverVersion,
 			Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 				SignalName: "test-signal-buffered",
-				Input:      payload.EncodeString("test-signal-buffered-input"),
+				Input:      payloads.EncodeString("test-signal-buffered-input"),
 			}},
 		},
 	}

--- a/service/history/nDCActivityReplicator_test.go
+++ b/service/history/nDCActivityReplicator_test.go
@@ -48,7 +48,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -861,7 +861,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_Update_SameVe
 	startedTime := scheduledTime.Add(time.Minute)
 	heartBeatUpdatedTime := startedTime.Add(time.Minute)
 	attempt := int32(0)
-	details := payload.EncodeString("some random activity heartbeat progress")
+	details := payloads.EncodeString("some random activity heartbeat progress")
 	nextEventID := scheduleID + 10
 
 	key := definition.NewWorkflowIdentifier(namespaceID, workflowID, runID)
@@ -933,7 +933,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_Update_SameVe
 	startedTime := scheduledTime.Add(time.Minute)
 	heartBeatUpdatedTime := startedTime.Add(time.Minute)
 	attempt := int32(100)
-	details := payload.EncodeString("some random activity heartbeat progress")
+	details := payloads.EncodeString("some random activity heartbeat progress")
 	nextEventID := scheduleID + 10
 
 	key := definition.NewWorkflowIdentifier(namespaceID, workflowID, runID)
@@ -1005,7 +1005,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_Update_Larger
 	startedTime := scheduledTime.Add(time.Minute)
 	heartBeatUpdatedTime := startedTime.Add(time.Minute)
 	attempt := int32(100)
-	details := payload.EncodeString("some random activity heartbeat progress")
+	details := payloads.EncodeString("some random activity heartbeat progress")
 	nextEventID := scheduleID + 10
 
 	key := definition.NewWorkflowIdentifier(namespaceID, workflowID, runID)
@@ -1077,7 +1077,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning() {
 	startedTime := scheduledTime.Add(time.Minute)
 	heartBeatUpdatedTime := startedTime.Add(time.Minute)
 	attempt := int32(100)
-	details := payload.EncodeString("some random activity heartbeat progress")
+	details := payloads.EncodeString("some random activity heartbeat progress")
 	nextEventID := scheduleID + 10
 
 	key := definition.NewWorkflowIdentifier(namespaceID, workflowID, runID)
@@ -1161,7 +1161,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_ZombieWorkflo
 	startedTime := scheduledTime.Add(time.Minute)
 	heartBeatUpdatedTime := startedTime.Add(time.Minute)
 	attempt := int32(100)
-	details := payload.EncodeString("some random activity heartbeat progress")
+	details := payloads.EncodeString("some random activity heartbeat progress")
 	nextEventID := scheduleID + 10
 
 	key := definition.NewWorkflowIdentifier(namespaceID, workflowID, runID)

--- a/service/history/nDCEventsReapplier_test.go
+++ b/service/history/nDCEventsReapplier_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 )
 
@@ -87,7 +87,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_AppliedEvent() {
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			Identity:   "test",
 			SignalName: "signal",
-			Input:      payload.EncodeBytes([]byte{}),
+			Input:      payloads.EncodeBytes([]byte{}),
 		}},
 	}
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()
@@ -121,7 +121,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Noop() {
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			Identity:   "test",
 			SignalName: "signal",
-			Input:      payload.EncodeBytes([]byte{}),
+			Input:      payloads.EncodeBytes([]byte{}),
 		}},
 	}
 
@@ -148,7 +148,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			Identity:   "test",
 			SignalName: "signal",
-			Input:      payload.EncodeBytes([]byte{}),
+			Input:      payloads.EncodeBytes([]byte{}),
 		}},
 	}
 	event2 := &eventpb.HistoryEvent{
@@ -157,7 +157,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			Identity:   "test",
 			SignalName: "signal",
-			Input:      payload.EncodeBytes([]byte{}),
+			Input:      payloads.EncodeBytes([]byte{}),
 		}},
 	}
 	attr1 := event1.GetWorkflowExecutionSignaledEventAttributes()
@@ -197,7 +197,7 @@ func (s *nDCEventReapplicationSuite) TestReapplyEvents_Error() {
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			Identity:   "test",
 			SignalName: "signal",
-			Input:      payload.EncodeBytes([]byte{}),
+			Input:      payloads.EncodeBytes([]byte{}),
 		}},
 	}
 	attr := event.GetWorkflowExecutionSignaledEventAttributes()

--- a/service/history/nDCStateRebuilder_test.go
+++ b/service/history/nDCStateRebuilder_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/temporalio/temporal/common/definition"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -257,7 +257,7 @@ func (s *nDCStateRebuilderSuite) TestRebuild() {
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: &eventpb.WorkflowExecutionStartedEventAttributes{
 			WorkflowType:                    &commonpb.WorkflowType{Name: "some random workflow type"},
 			TaskList:                        &tasklistpb.TaskList{Name: "some random workflow type"},
-			Input:                           payload.EncodeString("some random input"),
+			Input:                           payloads.EncodeString("some random input"),
 			WorkflowExecutionTimeoutSeconds: 123,
 			WorkflowRunTimeoutSeconds:       233,
 			WorkflowTaskTimeoutSeconds:      45,
@@ -270,7 +270,7 @@ func (s *nDCStateRebuilderSuite) TestRebuild() {
 		EventType: eventpb.EventType_WorkflowExecutionSignaled,
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			SignalName: "some random signal name",
-			Input:      payload.EncodeString("some random signal input"),
+			Input:      payloads.EncodeString("some random signal input"),
 			Identity:   "some random identity",
 		}},
 	}}

--- a/service/history/nDCWorkflow.go
+++ b/service/history/nDCWorkflow.go
@@ -36,7 +36,7 @@ import (
 
 	"github.com/temporalio/temporal/common/cache"
 	"github.com/temporalio/temporal/common/cluster"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 )
 
@@ -265,7 +265,7 @@ func (r *nDCWorkflowImpl) terminateWorkflow(
 	_, err := r.mutableState.AddWorkflowExecutionTerminatedEvent(
 		eventBatchFirstEventID,
 		workflowTerminationReason,
-		payload.EncodeString(fmt.Sprintf("terminated by version: %v", incomingLastWriteVersion)),
+		payloads.EncodeString(fmt.Sprintf("terminated by version: %v", incomingLastWriteVersion)),
 		workflowTerminationIdentity,
 	)
 

--- a/service/history/queryRegistry_test.go
+++ b/service/history/queryRegistry_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	querypb "go.temporal.io/temporal-proto/query"
 
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 type QueryRegistrySuite struct {
@@ -65,7 +65,7 @@ func (s *QueryRegistrySuite) TestQueryRegistry() {
 			queryTerminationType: queryTerminationTypeCompleted,
 			queryResult: &querypb.WorkflowQueryResult{
 				ResultType: querypb.QueryResultType_Answered,
-				Answer:     payload.EncodeBytes([]byte{1, 2, 3}),
+				Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 			},
 		})
 		s.NoError(err)

--- a/service/history/query_test.go
+++ b/service/history/query_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	querypb "go.temporal.io/temporal-proto/query"
 
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 type QuerySuite struct {
@@ -85,7 +85,7 @@ func (s *QuerySuite) TestValidateTerminationState() {
 				queryTerminationType: queryTerminationTypeCompleted,
 				queryResult: &querypb.WorkflowQueryResult{
 					ResultType:   querypb.QueryResultType_Answered,
-					Answer:       payload.EncodeBytes([]byte{1, 2, 3}),
+					Answer:       payloads.EncodeBytes([]byte{1, 2, 3}),
 					ErrorMessage: "err",
 				},
 			},
@@ -96,7 +96,7 @@ func (s *QuerySuite) TestValidateTerminationState() {
 				queryTerminationType: queryTerminationTypeCompleted,
 				queryResult: &querypb.WorkflowQueryResult{
 					ResultType: querypb.QueryResultType_Failed,
-					Answer:     payload.EncodeBytes([]byte{1, 2, 3}),
+					Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 				},
 			},
 			expectErr: true,
@@ -116,7 +116,7 @@ func (s *QuerySuite) TestValidateTerminationState() {
 				queryTerminationType: queryTerminationTypeCompleted,
 				queryResult: &querypb.WorkflowQueryResult{
 					ResultType: querypb.QueryResultType_Answered,
-					Answer:     payload.EncodeBytes([]byte{1, 2, 3}),
+					Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 				},
 			},
 			expectErr: false,
@@ -186,7 +186,7 @@ func (s *QuerySuite) TestTerminationState_Completed() {
 		queryTerminationType: queryTerminationTypeCompleted,
 		queryResult: &querypb.WorkflowQueryResult{
 			ResultType: querypb.QueryResultType_Answered,
-			Answer:     payload.EncodeBytes([]byte{1, 2, 3}),
+			Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 		},
 	}
 	s.testSetTerminationState(answeredTerminationState)

--- a/service/history/replicatorQueueProcessor_test.go
+++ b/service/history/replicatorQueueProcessor_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/temporalio/temporal/common/cluster"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -297,10 +297,10 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRetry() {
 	activityStartedTime := time.Time{}
 	activityHeartbeatTime := time.Time{}
 	activityAttempt := int32(16384)
-	activityDetails := payload.EncodeString("some random activity progress")
+	activityDetails := payloads.EncodeString("some random activity progress")
 	activityLastFailureReason := "some random reason"
 	activityLastWorkerIdentity := "some random worker identity"
-	activityLastFailureDetails := payload.EncodeString("some random failure details")
+	activityLastFailureDetails := payloads.EncodeString("some random failure details")
 	s.mockMutableState.EXPECT().StartTransaction(gomock.Any()).Return(false, nil).Times(1)
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().GetActivityInfo(scheduleID).Return(&persistence.ActivityInfo{
@@ -410,10 +410,10 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRunning() {
 	activityStartedTime := activityScheduledTime.Add(time.Minute)
 	activityHeartbeatTime := activityStartedTime.Add(time.Minute)
 	activityAttempt := int32(16384)
-	activityDetails := payload.EncodeString("some random activity progress")
+	activityDetails := payloads.EncodeString("some random activity progress")
 	activityLastFailureReason := "some random reason"
 	activityLastWorkerIdentity := "some random worker identity"
-	activityLastFailureDetails := payload.EncodeString("some random failure details")
+	activityLastFailureDetails := payloads.EncodeString("some random failure details")
 	s.mockMutableState.EXPECT().StartTransaction(gomock.Any()).Return(false, nil).Times(1)
 	s.mockMutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().GetActivityInfo(scheduleID).Return(&persistence.ActivityInfo{

--- a/service/history/stateBuilder_test.go
+++ b/service/history/stateBuilder_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/temporalio/temporal/common/cache"
 	"github.com/temporalio/temporal/common/cluster"
 	"github.com/temporalio/temporal/common/log"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 )
@@ -456,7 +456,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 		EventType: eventpb.EventType_WorkflowExecutionSignaled,
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			SignalName: "some random signal name",
-			Input:      payload.EncodeString("some random signal input"),
+			Input:      payloads.EncodeString("some random signal input"),
 			Identity:   "some random identity",
 		}},
 	}
@@ -1675,7 +1675,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeSignalExternalWorkflowExecu
 	now := time.Now()
 	signalRequestID := uuid.New()
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	control := "some random control"
 	evenType := eventpb.EventType_SignalExternalWorkflowExecutionInitiated
 	event := &eventpb.HistoryEvent{

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -58,7 +58,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	p "github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
@@ -772,7 +772,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 						Name: "child workflow type",
 					},
 					TaskList:          &tasklistpb.TaskList{Name: taskListName},
-					Input:             payload.EncodeString("random input"),
+					Input:             payloads.EncodeString("random input"),
 					ParentClosePolicy: parentClosePolicy1,
 				}},
 			},
@@ -784,7 +784,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 						Name: "child workflow type",
 					},
 					TaskList:          &tasklistpb.TaskList{Name: taskListName},
-					Input:             payload.EncodeString("random input"),
+					Input:             payloads.EncodeString("random input"),
 					ParentClosePolicy: parentClosePolicy2,
 				}},
 			},
@@ -796,7 +796,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 						Name: "child workflow type",
 					},
 					TaskList:          &tasklistpb.TaskList{Name: taskListName},
-					Input:             payload.EncodeString("random input"),
+					Input:             payloads.EncodeString("random input"),
 					ParentClosePolicy: parentClosePolicy3,
 				}},
 			},
@@ -809,7 +809,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			Name: "child workflow type",
 		},
 		TaskList:          &tasklistpb.TaskList{Name: taskListName},
-		Input:             payload.EncodeString("random input"),
+		Input:             payloads.EncodeString("random input"),
 		ParentClosePolicy: parentClosePolicy1,
 	})
 	s.Nil(err)
@@ -819,7 +819,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			Name: "child workflow type",
 		},
 		TaskList:          &tasklistpb.TaskList{Name: taskListName},
-		Input:             payload.EncodeString("random input"),
+		Input:             payloads.EncodeString("random input"),
 		ParentClosePolicy: parentClosePolicy2,
 	})
 	s.Nil(err)
@@ -829,7 +829,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 			Name: "child workflow type",
 		},
 		TaskList:          &tasklistpb.TaskList{Name: taskListName},
-		Input:             payload.EncodeString("random input"),
+		Input:             payloads.EncodeString("random input"),
 		ParentClosePolicy: parentClosePolicy3,
 	})
 	s.Nil(err)
@@ -901,7 +901,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 					Name: "child workflow type",
 				},
 				TaskList:          &tasklistpb.TaskList{Name: taskListName},
-				Input:             payload.EncodeString("random input"),
+				Input:             payloads.EncodeString("random input"),
 				ParentClosePolicy: parentClosePolicy,
 			}},
 		})
@@ -919,7 +919,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 				Name: "child workflow type",
 			},
 			TaskList:          &tasklistpb.TaskList{Name: taskListName},
-			Input:             payload.EncodeString("random input"),
+			Input:             payloads.EncodeString("random input"),
 			ParentClosePolicy: parentClosePolicy,
 		})
 		s.Nil(err)
@@ -991,7 +991,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 					Name: "child workflow type",
 				},
 				TaskList:          &tasklistpb.TaskList{Name: taskListName},
-				Input:             payload.EncodeString("random input"),
+				Input:             payloads.EncodeString("random input"),
 				ParentClosePolicy: parentClosePolicy,
 			}},
 		})
@@ -1009,7 +1009,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 				Name: "child workflow type",
 			},
 			TaskList:          &tasklistpb.TaskList{Name: taskListName},
-			Input:             payload.EncodeString("random input"),
+			Input:             payloads.EncodeString("random input"),
 			ParentClosePolicy: parentClosePolicy,
 		})
 		s.Nil(err)
@@ -1238,7 +1238,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Succes
 		RunId:      uuid.New(),
 	}
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalControl := "some random signal control"
 
 	mutableState := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
@@ -1313,7 +1313,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Failur
 		RunId:      uuid.New(),
 	}
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalControl := "some random signal control"
 
 	mutableState := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
@@ -1379,7 +1379,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessSignalExecution_Duplic
 		RunId:      uuid.New(),
 	}
 	signalName := "some random signal name"
-	signalInput := payload.EncodeString("some random signal input")
+	signalInput := payloads.EncodeString("some random signal input")
 	signalControl := "some random signal control"
 
 	mutableState := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
@@ -1738,7 +1738,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessStartChildExecution_Du
 	event = addChildWorkflowExecutionStartedEvent(mutableState, event.GetEventId(), testChildNamespaceID, childExecution.GetWorkflowId(), childExecution.GetRunId(), childWorkflowType)
 	ci.StartedID = event.GetEventId()
 	event = addChildWorkflowExecutionCompletedEvent(mutableState, ci.InitiatedID, &childExecution, &eventpb.WorkflowExecutionCompletedEventAttributes{
-		Result:                       payload.EncodeString("some random child workflow execution result"),
+		Result:                       payloads.EncodeString("some random child workflow execution result"),
 		DecisionTaskCompletedEventId: transferTask.GetScheduleId(),
 	})
 
@@ -1852,7 +1852,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestCopySearchAttributes() {
 	s.Nil(copySearchAttributes(input))
 
 	key := "key"
-	val := payload.EncodeBytes([]byte{'1', '2', '3'})
+	val := payloads.EncodeBytes([]byte{'1', '2', '3'})
 	input = map[string]*commonpb.Payloads{
 		key: val,
 	}

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -58,6 +58,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	p "github.com/temporalio/temporal/common/persistence"
@@ -1848,18 +1849,18 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAt
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) TestCopySearchAttributes() {
-	var input map[string]*commonpb.Payloads
+	var input map[string]*commonpb.Payload
 	s.Nil(copySearchAttributes(input))
 
 	key := "key"
-	val := payloads.EncodeBytes([]byte{'1', '2', '3'})
-	input = map[string]*commonpb.Payloads{
+	val := payload.EncodeBytes([]byte{'1', '2', '3'})
+	input = map[string]*commonpb.Payload{
 		key: val,
 	}
 	result := copySearchAttributes(input)
 	s.Equal(input, result)
-	result[key].GetPayloads()[0].GetData()[0] = '0'
-	s.Equal(byte('1'), val.GetPayloads()[0].GetData()[0])
+	result[key].GetData()[0] = '0'
+	s.Equal(byte('1'), val.GetData()[0])
 }
 
 func (s *transferQueueActiveTaskExecutorSuite) createAddActivityTaskRequest(

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -159,7 +159,7 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowStarted(
 	taskID int64,
 	taskList string,
 	visibilityMemo *commonpb.Memo,
-	searchAttributes map[string]*commonpb.Payloads,
+	searchAttributes map[string]*commonpb.Payload,
 ) error {
 
 	namespace := defaultNamespace
@@ -208,7 +208,7 @@ func (t *transferQueueTaskExecutorBase) upsertWorkflowExecution(
 	taskID int64,
 	taskList string,
 	visibilityMemo *commonpb.Memo,
-	searchAttributes map[string]*commonpb.Payloads,
+	searchAttributes map[string]*commonpb.Payload,
 ) error {
 
 	namespace := defaultNamespace
@@ -254,7 +254,7 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowClosed(
 	taskID int64,
 	visibilityMemo *commonpb.Memo,
 	taskList string,
-	searchAttributes map[string]*commonpb.Payloads,
+	searchAttributes map[string]*commonpb.Payload,
 ) error {
 
 	// Record closing in visibility store
@@ -357,7 +357,7 @@ func getWorkflowExecutionTimestamp(
 }
 
 func getWorkflowMemo(
-	memo map[string]*commonpb.Payloads,
+	memo map[string]*commonpb.Payload,
 ) *commonpb.Memo {
 
 	if memo == nil {
@@ -367,16 +367,16 @@ func getWorkflowMemo(
 }
 
 func copySearchAttributes(
-	input map[string]*commonpb.Payloads,
-) map[string]*commonpb.Payloads {
+	input map[string]*commonpb.Payload,
+) map[string]*commonpb.Payload {
 
 	if input == nil {
 		return nil
 	}
 
-	result := make(map[string]*commonpb.Payloads)
+	result := make(map[string]*commonpb.Payload)
 	for k, v := range input {
-		result[k] = proto.Clone(v).(*commonpb.Payloads)
+		result[k] = proto.Clone(v).(*commonpb.Payload)
 	}
 	return result
 }

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -45,7 +45,7 @@ import (
 	"github.com/temporalio/temporal/common/cluster"
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 	commonpb "go.temporal.io/temporal-proto/common"
@@ -283,7 +283,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 								Name: wfType,
 							},
 							TaskList:                        taskList,
-							Input:                           payload.EncodeString("testInput"),
+							Input:                           payloads.EncodeString("testInput"),
 							WorkflowExecutionTimeoutSeconds: 100,
 							WorkflowRunTimeoutSeconds:       50,
 							WorkflowTaskTimeoutSeconds:      200,
@@ -329,7 +329,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 						EventType: eventpb.EventType_MarkerRecorded,
 						Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 							MarkerName:                   "Version",
-							Details:                      payload.EncodeString("details"),
+							Details:                      payloads.EncodeString("details"),
 							DecisionTaskCompletedEventId: 4,
 						}},
 					},
@@ -962,7 +962,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication_WithRequestCance
 								Name: wfType,
 							},
 							TaskList:                        taskList,
-							Input:                           payload.EncodeString("testInput"),
+							Input:                           payloads.EncodeString("testInput"),
 							WorkflowExecutionTimeoutSeconds: 100,
 							WorkflowTaskTimeoutSeconds:      200,
 						}},
@@ -1007,7 +1007,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication_WithRequestCance
 						EventType: eventpb.EventType_MarkerRecorded,
 						Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 							MarkerName:                   "Version",
-							Details:                      payload.EncodeString("details"),
+							Details:                      payloads.EncodeString("details"),
 							DecisionTaskCompletedEventId: 4,
 						}},
 					},
@@ -1555,7 +1555,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 								Name: wfType,
 							},
 							TaskList:                        taskList,
-							Input:                           payload.EncodeString("testInput"),
+							Input:                           payloads.EncodeString("testInput"),
 							WorkflowExecutionTimeoutSeconds: 100,
 							WorkflowTaskTimeoutSeconds:      200,
 						}},
@@ -1600,7 +1600,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 						EventType: eventpb.EventType_MarkerRecorded,
 						Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 							MarkerName:                   "Version",
-							Details:                      payload.EncodeString("details"),
+							Details:                      payloads.EncodeString("details"),
 							DecisionTaskCompletedEventId: 4,
 						}},
 					},
@@ -2255,7 +2255,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 								Name: wfType,
 							},
 							TaskList:                   taskList,
-							Input:                      payload.EncodeString("testInput"),
+							Input:                      payloads.EncodeString("testInput"),
 							WorkflowRunTimeoutSeconds:  100,
 							WorkflowTaskTimeoutSeconds: 200,
 						}},
@@ -2300,7 +2300,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 						EventType: eventpb.EventType_MarkerRecorded,
 						Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 							MarkerName:                   "Version",
-							Details:                      payload.EncodeString("details"),
+							Details:                      payloads.EncodeString("details"),
 							DecisionTaskCompletedEventId: 4,
 						}},
 					},
@@ -2852,7 +2852,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 								Name: wfType,
 							},
 							TaskList:                   taskList,
-							Input:                      payload.EncodeString("testInput"),
+							Input:                      payloads.EncodeString("testInput"),
 							WorkflowRunTimeoutSeconds:  100,
 							WorkflowTaskTimeoutSeconds: 200,
 						}},
@@ -2897,7 +2897,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 						EventType: eventpb.EventType_MarkerRecorded,
 						Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 							MarkerName:                   "Version",
-							Details:                      payload.EncodeString("details"),
+							Details:                      payloads.EncodeString("details"),
 							DecisionTaskCompletedEventId: 4,
 						}},
 					},
@@ -3526,7 +3526,7 @@ func (s *resetorSuite) TestApplyReset() {
 								Name: wfType,
 							},
 							TaskList:                   taskList,
-							Input:                      payload.EncodeString("testInput"),
+							Input:                      payloads.EncodeString("testInput"),
 							WorkflowRunTimeoutSeconds:  100,
 							WorkflowTaskTimeoutSeconds: 200,
 						}},
@@ -3571,7 +3571,7 @@ func (s *resetorSuite) TestApplyReset() {
 						EventType: eventpb.EventType_MarkerRecorded,
 						Attributes: &eventpb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: &eventpb.MarkerRecordedEventAttributes{
 							MarkerName:                   "Version",
-							Details:                      payload.EncodeString("details"),
+							Details:                      payloads.EncodeString("details"),
 							DecisionTaskCompletedEventId: 4,
 						}},
 					},

--- a/service/history/workflowResetter_test.go
+++ b/service/history/workflowResetter_test.go
@@ -42,7 +42,7 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 )
 
@@ -274,7 +274,7 @@ func (s *workflowResetterSuite) TestFailInflightActivity() {
 		Version:         12,
 		ScheduleID:      123,
 		StartedID:       124,
-		Details:         payload.EncodeString("some random activity 1 details"),
+		Details:         payloads.EncodeString("some random activity 1 details"),
 		StartedIdentity: "some random activity 1 started identity",
 	}
 	activity2 := &persistence.ActivityInfo{
@@ -537,7 +537,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 		EventType: eventpb.EventType_WorkflowExecutionSignaled,
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			SignalName: "some random signal name",
-			Input:      payload.EncodeString("some random signal input"),
+			Input:      payloads.EncodeString("some random signal input"),
 			Identity:   "some random signal identity",
 		}},
 	}
@@ -551,7 +551,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 		EventType: eventpb.EventType_WorkflowExecutionSignaled,
 		Attributes: &eventpb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &eventpb.WorkflowExecutionSignaledEventAttributes{
 			SignalName: "another random signal name",
-			Input:      payload.EncodeString("another random signal input"),
+			Input:      payloads.EncodeString("another random signal input"),
 			Identity:   "another random signal identity",
 		}},
 	}

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -43,7 +43,7 @@ import (
 	"github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 	"github.com/temporalio/temporal/common/cache"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives/timestamp"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
@@ -279,7 +279,7 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatch() {
 			time.Sleep(10 * time.Millisecond)
 			t.rootMatcher.OfferQuery(ctx, task)
 		},
-	).Return(&matchingservice.QueryWorkflowResponse{QueryResult: payload.EncodeString("answer")}, nil)
+	).Return(&matchingservice.QueryWorkflowResponse{QueryResult: payloads.EncodeString("answer")}, nil)
 
 	result, err := t.matcher.OfferQuery(ctx, task)
 	cancel()
@@ -289,7 +289,7 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatch() {
 	t.True(querySet.Load())
 
 	var answer string
-	err = payload.Decode(result.GetQueryResult(), &answer)
+	err = payloads.Decode(result.GetQueryResult(), &answer)
 	t.NoError(err)
 	t.Equal("answer", answer)
 	t.Equal(t.taskList.name, req.GetForwardedFrom())

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -62,7 +62,7 @@ import (
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
 	"github.com/temporalio/temporal/common/quotas"
@@ -539,7 +539,7 @@ func (s *matchingEngineSuite) TestAddThenConsumeActivities() {
 	activityTypeName := "activity1"
 	activityID := "activityId1"
 	activityType := &commonpb.ActivityType{Name: activityTypeName}
-	activityInput := payload.EncodeString("Activity1 Input")
+	activityInput := payloads.EncodeString("Activity1 Input")
 
 	identity := "nobody"
 
@@ -651,7 +651,7 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	activityTypeName := "activity1"
 	activityID := "activityId1"
 	activityType := &commonpb.ActivityType{Name: activityTypeName}
-	activityInput := payload.EncodeString("Activity1 Input")
+	activityInput := payloads.EncodeString("Activity1 Input")
 
 	identity := "nobody"
 
@@ -870,9 +870,9 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	activityTypeName := "activity1"
 	activityID := "activityId1"
 	activityType := &commonpb.ActivityType{Name: activityTypeName}
-	activityInput := payload.EncodeString("Activity1 Input")
+	activityInput := payloads.EncodeString("Activity1 Input")
 	activityHeader := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payload.EncodeString("tracing data")},
+		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("tracing data")},
 	}
 
 	identity := "nobody"
@@ -1167,7 +1167,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesActivitiesRangeStealing() {
 	activityTypeName := "activity1"
 	activityID := "activityId1"
 	activityType := &commonpb.ActivityType{Name: activityTypeName}
-	activityInput := payload.EncodeString("Activity1 Input")
+	activityInput := payloads.EncodeString("Activity1 Input")
 
 	identity := "nobody"
 
@@ -1649,7 +1649,7 @@ func (s *matchingEngineSuite) setupRecordActivityTaskStartedMock(tlName string) 
 	activityTypeName := "activity1"
 	activityID := "activityId1"
 	activityType := &commonpb.ActivityType{Name: activityTypeName}
-	activityInput := payload.EncodeString("Activity1 Input")
+	activityInput := payloads.EncodeString("Activity1 Input")
 
 	// History service is using mock
 	s.mockHistoryClient.EXPECT().RecordActivityTaskStarted(gomock.Any(), gomock.Any()).DoAndReturn(

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -62,6 +62,7 @@ import (
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/mocks"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/persistence"
 	"github.com/temporalio/temporal/common/primitives"
@@ -872,7 +873,7 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	activityType := &commonpb.ActivityType{Name: activityTypeName}
 	activityInput := payloads.EncodeString("Activity1 Input")
 	activityHeader := &commonpb.Header{
-		Fields: map[string]*commonpb.Payloads{"tracing": payloads.EncodeString("tracing data")},
+		Fields: map[string]*commonpb.Payload{"tracing": payload.EncodeString("tracing data")},
 	}
 
 	identity := "nobody"

--- a/service/worker/archiver/client.go
+++ b/service/worker/archiver/client.go
@@ -80,7 +80,7 @@ type (
 		Status             executionpb.WorkflowExecutionStatus
 		HistoryLength      int64
 		Memo               *commonpb.Memo
-		SearchAttributes   map[string]*commonpb.Payloads
+		SearchAttributes   map[string]*commonpb.Payload
 		VisibilityURI      string
 
 		// archival targets: history and/or visibility

--- a/service/worker/archiver/util.go
+++ b/service/worker/archiver/util.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 )
 
 // MaxArchivalIterationTimeout returns the max allowed timeout for a single iteration of archival workflow
@@ -100,11 +100,11 @@ func tagLoggerWithActivityInfo(logger log.Logger, activityInfo activity.Info) lo
 		tag.Attempt(activityInfo.Attempt))
 }
 
-func convertSearchAttributesToString(searchAttr map[string]*commonpb.Payloads) map[string]string {
+func convertSearchAttributesToString(searchAttr map[string]*commonpb.Payload) map[string]string {
 	searchAttrStr := make(map[string]string)
 	for k, v := range searchAttr {
 		var s string
-		_ = payloads.Decode(v, &s)
+		_ = payload.Decode(v, &s)
 		searchAttrStr[k] = s
 	}
 	return searchAttrStr

--- a/service/worker/archiver/util.go
+++ b/service/worker/archiver/util.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 // MaxArchivalIterationTimeout returns the max allowed timeout for a single iteration of archival workflow
@@ -104,7 +104,7 @@ func convertSearchAttributesToString(searchAttr map[string]*commonpb.Payloads) m
 	searchAttrStr := make(map[string]string)
 	for k, v := range searchAttr {
 		var s string
-		_ = payload.Decode(v, &s)
+		_ = payloads.Decode(v, &s)
 		searchAttrStr[k] = s
 	}
 	return searchAttrStr

--- a/service/worker/archiver/util_test.go
+++ b/service/worker/archiver/util_test.go
@@ -33,7 +33,7 @@ import (
 	commonpb "go.temporal.io/temporal-proto/common"
 	executionpb "go.temporal.io/temporal-proto/execution"
 
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 type UtilSuite struct {
@@ -75,13 +75,13 @@ func (s *UtilSuite) TestHashDeterminism() {
 				Status:      executionpb.WorkflowExecutionStatus_ContinuedAsNew,
 				Memo: &commonpb.Memo{
 					Fields: map[string]*commonpb.Payloads{
-						"memoKey1": payload.EncodeBytes([]byte{1, 2, 3}),
-						"memoKey2": payload.EncodeBytes([]byte{4, 5, 6}),
+						"memoKey1": payloads.EncodeBytes([]byte{1, 2, 3}),
+						"memoKey2": payloads.EncodeBytes([]byte{4, 5, 6}),
 					},
 				},
 				SearchAttributes: map[string]*commonpb.Payloads{
-					"customKey1": payload.EncodeBytes([]byte{1, 2, 3}),
-					"customKey2": payload.EncodeBytes([]byte{4, 5, 6}),
+					"customKey1": payloads.EncodeBytes([]byte{1, 2, 3}),
+					"customKey2": payloads.EncodeBytes([]byte{4, 5, 6}),
 				},
 				Targets: []ArchivalTarget{ArchiveTargetHistory, ArchiveTargetVisibility},
 			},

--- a/service/worker/archiver/util_test.go
+++ b/service/worker/archiver/util_test.go
@@ -29,11 +29,10 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
 	commonpb "go.temporal.io/temporal-proto/common"
 	executionpb "go.temporal.io/temporal-proto/execution"
 
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 )
 
 type UtilSuite struct {
@@ -74,14 +73,14 @@ func (s *UtilSuite) TestHashDeterminism() {
 				NextEventID: int64(123),
 				Status:      executionpb.WorkflowExecutionStatus_ContinuedAsNew,
 				Memo: &commonpb.Memo{
-					Fields: map[string]*commonpb.Payloads{
-						"memoKey1": payloads.EncodeBytes([]byte{1, 2, 3}),
-						"memoKey2": payloads.EncodeBytes([]byte{4, 5, 6}),
+					Fields: map[string]*commonpb.Payload{
+						"memoKey1": payload.EncodeBytes([]byte{1, 2, 3}),
+						"memoKey2": payload.EncodeBytes([]byte{4, 5, 6}),
 					},
 				},
-				SearchAttributes: map[string]*commonpb.Payloads{
-					"customKey1": payloads.EncodeBytes([]byte{1, 2, 3}),
-					"customKey2": payloads.EncodeBytes([]byte{4, 5, 6}),
+				SearchAttributes: map[string]*commonpb.Payload{
+					"customKey1": payload.EncodeBytes([]byte{1, 2, 3}),
+					"customKey2": payload.EncodeBytes([]byte{4, 5, 6}),
 				},
 				Targets: []ArchivalTarget{ArchiveTargetHistory, ArchiveTargetVisibility},
 			},

--- a/service/worker/replicator/processor_test.go
+++ b/service/worker/replicator/processor_test.go
@@ -46,7 +46,7 @@ import (
 	messageMocks "github.com/temporalio/temporal/common/messaging/mocks"
 	"github.com/temporalio/temporal/common/metrics"
 	"github.com/temporalio/temporal/common/namespace"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 	"github.com/temporalio/temporal/common/task"
 	"github.com/temporalio/temporal/common/xdc"
@@ -281,7 +281,7 @@ func (s *replicationTaskProcessorSuite) TestDecodeMsgAndSubmit_SyncActivity_Succ
 		StartedId:         1236,
 		StartedTime:       time.Now().UnixNano(),
 		LastHeartbeatTime: time.Now().UnixNano(),
-		Details:           payload.EncodeString("some random details"),
+		Details:           payloads.EncodeString("some random details"),
 		Attempt:           1048576,
 	}
 	replicationTask := &replicationgenpb.ReplicationTask{
@@ -307,7 +307,7 @@ func (s *replicationTaskProcessorSuite) TestDecodeMsgAndSubmit_SyncActivity_Fail
 		StartedId:         1236,
 		StartedTime:       time.Now().UnixNano(),
 		LastHeartbeatTime: time.Now().UnixNano(),
-		Details:           payload.EncodeString("some random details"),
+		Details:           payloads.EncodeString("some random details"),
 		Attempt:           1048576,
 	}
 	replicationTask := &replicationgenpb.ReplicationTask{

--- a/service/worker/replicator/replicationTask_test.go
+++ b/service/worker/replicator/replicationTask_test.go
@@ -47,7 +47,7 @@ import (
 	"github.com/temporalio/temporal/common/log/loggerimpl"
 	messageMocks "github.com/temporalio/temporal/common/messaging/mocks"
 	"github.com/temporalio/temporal/common/metrics"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 	"github.com/temporalio/temporal/common/task"
 	"github.com/temporalio/temporal/common/xdc"
@@ -792,11 +792,11 @@ func (s *activityReplicationTaskSuite) getActivityReplicationTask() *replication
 		StartedId:          1015,
 		StartedTime:        time.Now().UnixNano(),
 		LastHeartbeatTime:  time.Now().UnixNano(),
-		Details:            payload.EncodeString("some random detail"),
+		Details:            payloads.EncodeString("some random detail"),
 		Attempt:            59,
 		LastFailureReason:  "some random failure reason",
 		LastWorkerIdentity: "some random worker identity",
-		LastFailureDetails: payload.EncodeString("some random failure details"),
+		LastFailureDetails: payloads.EncodeString("some random failure details"),
 	}
 	replicationTask := &replicationgenpb.ReplicationTask{
 		TaskType:   replicationgenpb.ReplicationTaskType_SyncActivityTask,

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -50,7 +50,7 @@ import (
 
 	"github.com/temporalio/temporal/.gen/proto/adminservice"
 	"github.com/temporalio/temporal/.gen/proto/adminservicemock"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 )
 
 type cliAppSuite struct {
@@ -372,7 +372,7 @@ func (s *cliAppSuite) TestSignalWorkflow_Failed() {
 
 func (s *cliAppSuite) TestQueryWorkflow() {
 	resp := &workflowservice.QueryWorkflowResponse{
-		QueryResult: payload.EncodeString("query-result"),
+		QueryResult: payloads.EncodeString("query-result"),
 	}
 	s.frontendClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(resp, nil)
 	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "query", "-w", "wid", "-qt", "query-type-test"})
@@ -381,7 +381,7 @@ func (s *cliAppSuite) TestQueryWorkflow() {
 
 func (s *cliAppSuite) TestQueryWorkflowUsingStackTrace() {
 	resp := &workflowservice.QueryWorkflowResponse{
-		QueryResult: payload.EncodeString("query-result"),
+		QueryResult: payloads.EncodeString("query-result"),
 	}
 	s.frontendClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(resp, nil)
 	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "stack", "-w", "wid"})
@@ -390,7 +390,7 @@ func (s *cliAppSuite) TestQueryWorkflowUsingStackTrace() {
 
 func (s *cliAppSuite) TestQueryWorkflow_Failed() {
 	resp := &workflowservice.QueryWorkflowResponse{
-		QueryResult: payload.EncodeString("query-result"),
+		QueryResult: payloads.EncodeString("query-result"),
 	}
 	s.frontendClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(resp, serviceerror.NewInvalidArgument("faked error"))
 	errorCode := s.RunErrorExitCode([]string{"", "--ns", cliTestNamespace, "workflow", "query", "-w", "wid", "-qt", "query-type-test"})
@@ -708,7 +708,7 @@ func (s *cliAppSuite) TestAnyToString() {
 			WorkflowRunTimeoutSeconds:  60,
 			WorkflowTaskTimeoutSeconds: 10,
 			Identity:                   "tester",
-			Input:                      payload.EncodeString(arg),
+			Input:                      payloads.EncodeString(arg),
 		}},
 	}
 	res := anyToString(event, false, defaultMaxFieldLength)
@@ -719,7 +719,7 @@ func (s *cliAppSuite) TestAnyToString() {
 
 func (s *cliAppSuite) TestAnyToString_DecodeMapValues() {
 	fields := map[string]*commonpb.Payloads{
-		"TestKey": payload.EncodeString("testValue"),
+		"TestKey": payloads.EncodeString("testValue"),
 	}
 	execution := &executionpb.WorkflowExecutionInfo{
 		Status: executionpb.WorkflowExecutionStatus_Running,
@@ -727,7 +727,7 @@ func (s *cliAppSuite) TestAnyToString_DecodeMapValues() {
 	}
 	s.Equal("{Status:Running, HistoryLength:0, ExecutionTime:0, Memo:{Fields:map{TestKey:testValue}}}", anyToString(execution, true, 0))
 
-	fields["TestKey2"] = payload.EncodeString(`anotherTestValue`)
+	fields["TestKey2"] = payloads.EncodeString(`anotherTestValue`)
 	execution.Memo = &commonpb.Memo{Fields: fields}
 	got := anyToString(execution, true, 0)
 	expected := got == "{Status:Running, HistoryLength:0, ExecutionTime:0, Memo:{Fields:map{TestKey2:anotherTestValue, TestKey:testValue}}}" ||

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -50,6 +50,7 @@ import (
 
 	"github.com/temporalio/temporal/.gen/proto/adminservice"
 	"github.com/temporalio/temporal/.gen/proto/adminservicemock"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 )
 
@@ -713,13 +714,13 @@ func (s *cliAppSuite) TestAnyToString() {
 	}
 	res := anyToString(event, false, defaultMaxFieldLength)
 	ss, l := tablewriter.WrapString(res, 10)
-	s.Equal(7, len(ss))
+	s.Equal(8, len(ss))
 	s.Equal(120, l)
 }
 
 func (s *cliAppSuite) TestAnyToString_DecodeMapValues() {
-	fields := map[string]*commonpb.Payloads{
-		"TestKey": payloads.EncodeString("testValue"),
+	fields := map[string]*commonpb.Payload{
+		"TestKey": payload.EncodeString("testValue"),
 	}
 	execution := &executionpb.WorkflowExecutionInfo{
 		Status: executionpb.WorkflowExecutionStatus_Running,
@@ -727,7 +728,7 @@ func (s *cliAppSuite) TestAnyToString_DecodeMapValues() {
 	}
 	s.Equal("{Status:Running, HistoryLength:0, ExecutionTime:0, Memo:{Fields:map{TestKey:testValue}}}", anyToString(execution, true, 0))
 
-	fields["TestKey2"] = payloads.EncodeString(`anotherTestValue`)
+	fields["TestKey2"] = payload.EncodeString(`anotherTestValue`)
 	execution.Memo = &commonpb.Memo{Fields: fields}
 	got := anyToString(execution, true, 0)
 	expected := got == "{Status:Running, HistoryLength:0, ExecutionTime:0, Memo:{Fields:map{TestKey2:anotherTestValue, TestKey:testValue}}}" ||

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -52,7 +52,7 @@ import (
 	sdkclient "go.temporal.io/temporal/client"
 
 	"github.com/temporalio/temporal/common/codec"
-	"github.com/temporalio/temporal/common/payloads"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/rpc"
 )
 
@@ -147,9 +147,9 @@ func valueToString(v reflect.Value, printFully bool, maxFieldLength int) string 
 			switch typedV := val.Interface().(type) {
 			case []byte:
 				str += string(typedV)
-			case *commonpb.Payloads:
+			case *commonpb.Payload:
 				var data string
-				err := payloads.Decode(typedV, &data)
+				err := payload.Decode(typedV, &data)
 				if err == nil {
 					str += data
 				} else {

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -52,7 +52,7 @@ import (
 	sdkclient "go.temporal.io/temporal/client"
 
 	"github.com/temporalio/temporal/common/codec"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/common/rpc"
 )
 
@@ -149,7 +149,7 @@ func valueToString(v reflect.Value, printFully bool, maxFieldLength int) string 
 				str += string(typedV)
 			case *commonpb.Payloads:
 				var data string
-				err := payload.Decode(typedV, &data)
+				err := payloads.Decode(typedV, &data)
 				if err == nil {
 					str += data
 				} else {

--- a/tools/cli/workflowBatchCommands.go
+++ b/tools/cli/workflowBatchCommands.go
@@ -36,7 +36,7 @@ import (
 	sdkclient "go.temporal.io/temporal/client"
 
 	"github.com/temporalio/temporal/common"
-	"github.com/temporalio/temporal/common/payload"
+	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/service/worker/batcher"
 )
 
@@ -81,7 +81,7 @@ func DescribeBatchJob(c *cli.Context) {
 		if len(wf.PendingActivities) > 0 {
 			hbdPayload := wf.PendingActivities[0].HeartbeatDetails
 			var hbd batcher.HeartBeatDetails
-			err := payload.Decode(hbdPayload, &hbd)
+			err := payloads.Decode(hbdPayload, &hbd)
 			if err != nil {
 				ErrorAndExit("Failed to describe batch job", err)
 			}
@@ -110,12 +110,12 @@ func ListBatchJobs(c *cli.Context) {
 	output := make([]interface{}, 0, len(resp.Executions))
 	for _, wf := range resp.Executions {
 		var reason, operator string
-		err = payload.Decode(wf.Memo.Fields["Reason"], &reason)
+		err = payloads.Decode(wf.Memo.Fields["Reason"], &reason)
 		if err != nil {
 			ErrorAndExit("Failed to deserialize reason memo field", err)
 		}
 
-		err = payload.Decode(wf.SearchAttributes.IndexedFields["Operator"], &operator)
+		err = payloads.Decode(wf.SearchAttributes.IndexedFields["Operator"], &operator)
 		if err != nil {
 			ErrorAndExit("Failed to deserialize operator search attribute", err)
 		}
@@ -197,7 +197,7 @@ func StartBatchJob(c *cli.Context) {
 		},
 	}
 
-	sigInput, err := payload.Encode(sigVal)
+	sigInput, err := payloads.Encode(sigVal)
 	if err != nil {
 		ErrorAndExit("Failed to serialize signal value", err)
 	}

--- a/tools/cli/workflowBatchCommands.go
+++ b/tools/cli/workflowBatchCommands.go
@@ -36,6 +36,7 @@ import (
 	sdkclient "go.temporal.io/temporal/client"
 
 	"github.com/temporalio/temporal/common"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/service/worker/batcher"
 )
@@ -110,12 +111,12 @@ func ListBatchJobs(c *cli.Context) {
 	output := make([]interface{}, 0, len(resp.Executions))
 	for _, wf := range resp.Executions {
 		var reason, operator string
-		err = payloads.Decode(wf.Memo.Fields["Reason"], &reason)
+		err = payload.Decode(wf.Memo.Fields["Reason"], &reason)
 		if err != nil {
 			ErrorAndExit("Failed to deserialize reason memo field", err)
 		}
 
-		err = payloads.Decode(wf.SearchAttributes.IndexedFields["Operator"], &operator)
+		err = payload.Decode(wf.SearchAttributes.IndexedFields["Operator"], &operator)
 		if err != nil {
 			ErrorAndExit("Failed to deserialize operator search attribute", err)
 		}

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -58,6 +58,7 @@ import (
 	"github.com/temporalio/temporal/common"
 	"github.com/temporalio/temporal/common/clock"
 	"github.com/temporalio/temporal/common/codec"
+	"github.com/temporalio/temporal/common/payload"
 	"github.com/temporalio/temporal/common/payloads"
 	"github.com/temporalio/temporal/service/history"
 )
@@ -273,7 +274,7 @@ func startWorkflowHelper(c *cli.Context, shouldPrintProgress bool) {
 	}
 }
 
-func processSearchAttr(c *cli.Context) map[string]*commonpb.Payloads {
+func processSearchAttr(c *cli.Context) map[string]*commonpb.Payload {
 	rawSearchAttrKey := c.String(FlagSearchAttributesKey)
 	var searchAttrKeys []string
 	if strings.TrimSpace(rawSearchAttrKey) != "" {
@@ -294,9 +295,9 @@ func processSearchAttr(c *cli.Context) map[string]*commonpb.Payloads {
 		ErrorAndExit("Number of search attributes keys and values are not equal.", nil)
 	}
 
-	fields := map[string]*commonpb.Payloads{}
+	fields := map[string]*commonpb.Payload{}
 	for i, key := range searchAttrKeys {
-		val, err := payloads.Encode(searchAttrVals[i])
+		val, err := payload.Encode(searchAttrVals[i])
 		if err != nil {
 			ErrorAndExit(fmt.Sprintf("Encode value %v error", val), err)
 		}
@@ -306,7 +307,7 @@ func processSearchAttr(c *cli.Context) map[string]*commonpb.Payloads {
 	return fields
 }
 
-func processMemo(c *cli.Context) map[string]*commonpb.Payloads {
+func processMemo(c *cli.Context) map[string]*commonpb.Payload {
 	rawMemoKey := c.String(FlagMemoKey)
 	var memoKeys []string
 	if strings.TrimSpace(rawMemoKey) != "" {
@@ -328,9 +329,9 @@ func processMemo(c *cli.Context) map[string]*commonpb.Payloads {
 		ErrorAndExit("Number of memo keys and values are not equal.", nil)
 	}
 
-	fields := map[string]*commonpb.Payloads{}
+	fields := map[string]*commonpb.Payload{}
 	for i, key := range memoKeys {
-		fields[key] = payloads.EncodeString(memoValues[i])
+		fields[key] = payload.EncodeString(memoValues[i])
 	}
 	return fields
 }
@@ -339,7 +340,7 @@ func getPrintableMemo(memo *commonpb.Memo) string {
 	buf := new(bytes.Buffer)
 	for k, v := range memo.Fields {
 		var memo string
-		err := payloads.Decode(v, &memo)
+		err := payload.Decode(v, &memo)
 		if err != nil {
 			ErrorAndExit("Memo has incoorect formtat.", err)
 		}
@@ -353,7 +354,7 @@ func getPrintableSearchAttr(searchAttr *commonpb.SearchAttributes) string {
 	buf := new(bytes.Buffer)
 	for k, v := range searchAttr.IndexedFields {
 		var decodedVal interface{}
-		_ = payloads.Decode(v, &decodedVal)
+		_ = payload.Decode(v, &decodedVal)
 		_, _ = fmt.Fprintf(buf, "%s=%v\n", k, decodedVal)
 	}
 	return buf.String()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`SearchAttributes`, `Memo`, and `Headers` are using `Payload` not `Payloads` now.

<!-- Tell your future self why have you made these changes -->
**Why?**
These fields always have single encoded value. There is no reason to use `Payloads` there.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
All tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
