### PR TITLE
Create CLI persistence helper

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -832,6 +832,11 @@ func getDBFlags() []cli.Flag {
 			Name:  FlagKeyspace,
 			Usage: "cassandra keyspace",
 		},
+		cli.StringFlag{
+			Name:  FlagVisibilityKeyspace,
+			Value: "temporal_visibility",
+			Usage: "cassandra visibility keyspace",
+		},
 		cli.BoolFlag{
 			Name:  FlagEnableTLS,
 			Usage: "enable TLS over cassandra connection",

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -832,11 +832,6 @@ func getDBFlags() []cli.Flag {
 			Name:  FlagKeyspace,
 			Usage: "cassandra keyspace",
 		},
-		cli.StringFlag{
-			Name:  FlagVisibilityKeyspace,
-			Value: "temporal_visibility",
-			Usage: "cassandra visibility keyspace",
-		},
 		cli.BoolFlag{
 			Name:  FlagEnableTLS,
 			Usage: "enable TLS over cassandra connection",

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -70,6 +70,9 @@ const (
 	showErrorStackEnv    = `TEMPORAL_CLI_SHOW_STACKS`
 
 	searchAttrInputSeparator = "|"
+
+	cassandraKey = "cassandra"
+	mySQLKey     = "mysql"
 )
 
 var envKeysForUserName = []string{

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -71,8 +71,8 @@ const (
 
 	searchAttrInputSeparator = "|"
 
-	cassandraKey = "cassandra"
-	mySQLKey     = "mysql"
+	cassandraDBType = "cassandra"
+	mySQLDBType     = "mysql"
 )
 
 var envKeysForUserName = []string{

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -31,6 +31,7 @@ const (
 	FlagUsername                          = "username"
 	FlagPassword                          = "password"
 	FlagKeyspace                          = "keyspace"
+	FlagVisibilityKeyspace                = "visibility-keyspace"
 	FlagAddress                           = "address"
 	FlagAddressWithAlias                  = FlagAddress + ", ad"
 	FlagHistoryAddress                    = "history_address"

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -34,6 +34,7 @@ const (
 	FlagAddress                           = "address"
 	FlagAddressWithAlias                  = FlagAddress + ", ad"
 	FlagHistoryAddress                    = "history_address"
+	FlagDBEngine                          = "db_engine"
 	FlagDBAddress                         = "db_address"
 	FlagDBPort                            = "db_port"
 	FlagHistoryAddressWithAlias           = FlagHistoryAddress + ", had"

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -31,7 +31,6 @@ const (
 	FlagUsername                          = "username"
 	FlagPassword                          = "password"
 	FlagKeyspace                          = "keyspace"
-	FlagVisibilityKeyspace                = "visibility-keyspace"
 	FlagAddress                           = "address"
 	FlagAddressWithAlias                  = FlagAddress + ", ad"
 	FlagHistoryAddress                    = "history_address"

--- a/tools/cli/persistenceUtil.go
+++ b/tools/cli/persistenceUtil.go
@@ -1,0 +1,75 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli
+
+import (
+	"log"
+
+	"github.com/urfave/cli"
+
+	"github.com/temporalio/temporal/common/log/loggerimpl"
+	"github.com/temporalio/temporal/common/log/tag"
+	persistenceClient "github.com/temporalio/temporal/common/persistence/client"
+	"github.com/temporalio/temporal/common/resource"
+	"github.com/temporalio/temporal/common/service/dynamicconfig"
+)
+
+// InitializePersistenceFactory returns an initialized persistence managers factory.
+// The factory allows to easily initialize concrete persistence managers to execute commands against persistence layer
+func InitializePersistenceFactory(c *cli.Context) persistenceClient.Factory {
+	config := loadConfig(c)
+
+	if err := config.Validate(); err != nil {
+		log.Fatalf("config validation failed: %v", err)
+	}
+
+	params := resource.BootstrapParams{}
+	params.Name = "cli"
+	params.Logger = loggerimpl.NewLogger(config.Log.NewZapLogger())
+	params.PersistenceConfig = config.Persistence
+
+	doneC := make(chan struct{})
+	dConfig, err := dynamicconfig.NewFileBasedClient(&config.DynamicConfigClient, params.Logger.WithTags(tag.Service(params.Name)), doneC)
+	if err != nil {
+		log.Printf("error creating file based dynamic config client, use no-op config client instead. error: %v", err)
+		params.DynamicConfig = dynamicconfig.NewNopClient()
+	}
+	params.DynamicConfig = dConfig
+	dc := dynamicconfig.NewCollection(params.DynamicConfig, params.Logger)
+
+	clusterMetadata := config.ClusterMetadata
+
+	logger := params.Logger.WithTags(tag.ComponentMetadataInitializer)
+	factory := persistenceClient.NewFactory(
+		&params.PersistenceConfig,
+		dc.GetIntProperty(dynamicconfig.HistoryPersistenceMaxQPS, 3000),
+		params.AbstractDatastoreFactory,
+		clusterMetadata.CurrentClusterName,
+		nil, // MetricsClient
+		logger,
+	)
+
+	return factory
+}

--- a/tools/cli/persistenceUtil.go
+++ b/tools/cli/persistenceUtil.go
@@ -74,7 +74,7 @@ func CreatePersistenceFactory(c *cli.Context) persistenceClient.Factory {
 func CreateDefaultDBConfig(c *cli.Context) (config.DataStore, error) {
 	engine := getRequiredOption(c, FlagDBEngine)
 
-	if engine == cassandraKey {
+	if engine == cassandraDBType {
 		defaultConfig := &config.Cassandra{
 			Hosts:    getRequiredOption(c, FlagDBAddress),
 			Port:     c.Int(FlagDBPort),

--- a/tools/cli/persistenceUtil.go
+++ b/tools/cli/persistenceUtil.go
@@ -36,21 +36,16 @@ import (
 	"github.com/temporalio/temporal/common/service/dynamicconfig"
 )
 
-// InitializePersistenceFactory returns an initialized persistence managers factory.
+// CreatePersistenceFactory returns an initialized persistence managers factory.
 // The factory allows to easily initialize concrete persistence managers to execute commands against persistence layer
-func InitializePersistenceFactory(c *cli.Context) persistenceClient.Factory {
+func CreatePersistenceFactory(c *cli.Context) persistenceClient.Factory {
 
-	defaultStore, err := InitializeDefaultDBConfig(c)
-
+	defaultStore, err := CreateDefaultDBConfig(c)
 	if err != nil {
-		ErrorAndExit("InitializePersistenceFactory err", err)
+		ErrorAndExit("CreatePersistenceFactory err", err)
 	}
 
-	visibilityStore, err := InitializeVisibilityDBConfig(c)
-
-	if err != nil {
-		ErrorAndExit("InitializePersistenceFactory err", err)
-	}
+	visibilityStore, _ := CreateDefaultDBConfig(c)
 
 	persistence := config.Persistence{
 		DefaultStore:    "db-default",
@@ -76,9 +71,8 @@ func InitializePersistenceFactory(c *cli.Context) persistenceClient.Factory {
 	return factory
 }
 
-// InitializeDefaultDBConfig return default DB configuration based on provided options
-func InitializeDefaultDBConfig(c *cli.Context) (config.DataStore, error) {
-
+// CreateDefaultDBConfig return default DB configuration based on provided options
+func CreateDefaultDBConfig(c *cli.Context) (config.DataStore, error) {
 	engine := getRequiredOption(c, FlagDBEngine)
 
 	if engine == "cassandra" {
@@ -88,40 +82,6 @@ func InitializeDefaultDBConfig(c *cli.Context) (config.DataStore, error) {
 			User:     c.String(FlagUsername),
 			Password: c.String(FlagPassword),
 			Keyspace: getRequiredOption(c, FlagKeyspace),
-		}
-
-		if c.Bool(FlagEnableTLS) {
-			defaultConfig.TLS = &auth.TLS{
-				Enabled:                true,
-				CertFile:               c.String(FlagTLSCertPath),
-				KeyFile:                c.String(FlagTLSKeyPath),
-				CaFile:                 c.String(FlagTLSCaPath),
-				EnableHostVerification: c.Bool(FlagTLSEnableHostVerification),
-			}
-		}
-
-		defaultStore := config.DataStore{
-			Cassandra: defaultConfig,
-		}
-
-		return defaultStore, nil
-	}
-
-	return config.DataStore{}, fmt.Errorf("DB type is not supported by CLI")
-}
-
-// InitializeVisibilityDBConfig return visibility DB configuration based on provided options
-func InitializeVisibilityDBConfig(c *cli.Context) (config.DataStore, error) {
-
-	engine := getRequiredOption(c, FlagDBEngine)
-
-	if engine == "cassandra" {
-		defaultConfig := &config.Cassandra{
-			Hosts:    getRequiredOption(c, FlagDBAddress),
-			Port:     c.Int(FlagDBPort),
-			User:     c.String(FlagUsername),
-			Password: c.String(FlagPassword),
-			Keyspace: getRequiredOption(c, FlagVisibilityKeyspace),
 		}
 
 		if c.Bool(FlagEnableTLS) {

--- a/tools/cli/persistenceUtil.go
+++ b/tools/cli/persistenceUtil.go
@@ -30,6 +30,7 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/temporalio/temporal/common/auth"
+	"github.com/temporalio/temporal/common/log/loggerimpl"
 	persistenceClient "github.com/temporalio/temporal/common/persistence/client"
 	"github.com/temporalio/temporal/common/resource"
 	"github.com/temporalio/temporal/common/service/config"
@@ -63,7 +64,7 @@ func CreatePersistenceFactory(c *cli.Context) persistenceClient.Factory {
 		params.AbstractDatastoreFactory,
 		c.String(FlagTargetCluster),
 		nil, // MetricsClient
-		nil,
+		loggerimpl.NewNopLogger(),
 	)
 
 	return factory

--- a/tools/cli/persistenceUtil.go
+++ b/tools/cli/persistenceUtil.go
@@ -121,7 +121,7 @@ func InitializeVisibilityDBConfig(c *cli.Context) (config.DataStore, error) {
 			Port:     c.Int(FlagDBPort),
 			User:     c.String(FlagUsername),
 			Password: c.String(FlagPassword),
-			Keyspace: "temporal_visibility", //getRequiredOption(c, FlagKeyspace), TODO
+			Keyspace: getRequiredOption(c, FlagVisibilityKeyspace),
 		}
 
 		if c.Bool(FlagEnableTLS) {

--- a/tools/cli/persistenceUtil.go
+++ b/tools/cli/persistenceUtil.go
@@ -46,7 +46,6 @@ func CreatePersistenceFactory(c *cli.Context) persistenceClient.Factory {
 	}
 
 	visibilityStore, _ := CreateDefaultDBConfig(c)
-
 	persistence := config.Persistence{
 		DefaultStore:    "db-default",
 		VisibilityStore: "db-visibility",
@@ -55,7 +54,6 @@ func CreatePersistenceFactory(c *cli.Context) persistenceClient.Factory {
 			"db-visibility": visibilityStore,
 		},
 	}
-
 	params := resource.BootstrapParams{}
 	params.Name = "cli"
 
@@ -75,7 +73,7 @@ func CreatePersistenceFactory(c *cli.Context) persistenceClient.Factory {
 func CreateDefaultDBConfig(c *cli.Context) (config.DataStore, error) {
 	engine := getRequiredOption(c, FlagDBEngine)
 
-	if engine == "cassandra" {
+	if engine == cassandraKey {
 		defaultConfig := &config.Cassandra{
 			Hosts:    getRequiredOption(c, FlagDBAddress),
 			Port:     c.Int(FlagDBPort),

--- a/tools/cli/persistenceUtil.go
+++ b/tools/cli/persistenceUtil.go
@@ -100,7 +100,7 @@ func CreateDefaultDBConfig(c *cli.Context) (config.DataStore, error) {
 		return defaultStore, nil
 	}
 
-	return config.DataStore{}, fmt.Errorf("DB type is not supported by CLI")
+	return config.DataStore{}, fmt.Errorf("DB type %q is not supported by CLI", engine)
 }
 
 // GetQPS returns default queries per second


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Created an util that allows to easily initialize persistence managers 

<!-- Tell your future self why have you made these changes -->
**Why?**
Speeds up the development of CLI admin commands by providing a single method to get access to persistence

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran commands using the new method and ran unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks
