### PR TITLE
Handle nil TLS options

### DIFF
--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -52,6 +52,10 @@ func (s *localStoreCertProvider) GetSettings() *config.GroupTLS {
 }
 
 func (s *localStoreCertProvider) FetchServerCertificate() (*tls.Certificate, error) {
+	if s.tlsSettings.Server.CertFile == "" {
+		return nil, nil
+	}
+
 	// Check under a read lock first
 	s.RLock()
 	if s.serverCert != nil {
@@ -74,6 +78,10 @@ func (s *localStoreCertProvider) FetchServerCertificate() (*tls.Certificate, err
 }
 
 func (s *localStoreCertProvider) FetchClientCAs() (*x509.CertPool, error) {
+	if s.tlsSettings.Server.ClientCAFiles == nil {
+		return nil, nil
+	}
+
 	// Check under a read lock first
 	s.RLock()
 	if s.clientCAs != nil {
@@ -99,6 +107,9 @@ func (s *localStoreCertProvider) FetchClientCAs() (*x509.CertPool, error) {
 }
 
 func (s *localStoreCertProvider) FetchServerRootCAsForClient() (*x509.CertPool, error) {
+	if s.tlsSettings.Client.RootCAFiles == nil {
+		return nil, nil
+	}
 	// Check under a read lock first
 	s.RLock()
 	if s.serverCAs != nil {

--- a/common/rpc/encryption/localStoreTlsFactory.go
+++ b/common/rpc/encryption/localStoreTlsFactory.go
@@ -33,7 +33,7 @@ import (
 	"github.com/temporalio/temporal/common/service/config"
 )
 
-type localStoreTlsFactory struct {
+type localStoreTlsProvider struct {
 	sync.RWMutex
 
 	settings *config.RootTLS
@@ -47,8 +47,8 @@ type localStoreTlsFactory struct {
 	frontendClientConfig  *tls.Config
 }
 
-func NewLocalStoreTlsFactory(tlsConfig *config.RootTLS) (TLSConfigProvider, error) {
-	return &localStoreTlsFactory{
+func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS) (TLSConfigProvider, error) {
+	return &localStoreTlsProvider{
 		internodeCertProvider: &localStoreCertProvider{tlsSettings: &tlsConfig.Internode},
 		frontendCertProvider:  &localStoreCertProvider{tlsSettings: &tlsConfig.Frontend},
 		RWMutex:               sync.RWMutex{},
@@ -56,23 +56,23 @@ func NewLocalStoreTlsFactory(tlsConfig *config.RootTLS) (TLSConfigProvider, erro
 	}, nil
 }
 
-func (s *localStoreTlsFactory) GetInternodeClientConfig() (*tls.Config, error) {
+func (s *localStoreTlsProvider) GetInternodeClientConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(&s.internodeClientConfig, newClientTLSConfig, s.internodeCertProvider, s.internodeCertProvider)
 }
 
-func (s *localStoreTlsFactory) GetFrontendClientConfig() (*tls.Config, error) {
+func (s *localStoreTlsProvider) GetFrontendClientConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(&s.frontendClientConfig, newClientTLSConfig, s.internodeCertProvider, s.frontendCertProvider)
 }
 
-func (s *localStoreTlsFactory) GetFrontendServerConfig() (*tls.Config, error) {
+func (s *localStoreTlsProvider) GetFrontendServerConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(&s.frontendServerConfig, newServerTLSConfig, s.frontendCertProvider, s.frontendCertProvider)
 }
 
-func (s *localStoreTlsFactory) GetInternodeServerConfig() (*tls.Config, error) {
+func (s *localStoreTlsProvider) GetInternodeServerConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(&s.internodeServerConfig, newServerTLSConfig, s.internodeCertProvider, s.internodeCertProvider)
 }
 
-func (s *localStoreTlsFactory) getOrCreateConfig(
+func (s *localStoreTlsProvider) getOrCreateConfig(
 	cachedConfig **tls.Config,
 	configConstructor tlsConfigConstructor,
 	localCertProvider CertProvider,

--- a/common/rpc/encryption/localStoreTlsFactory.go
+++ b/common/rpc/encryption/localStoreTlsFactory.go
@@ -111,6 +111,11 @@ func newServerTLSConfig(certProvider CertProvider, settingsProvider CertProvider
 		return nil, fmt.Errorf("loading server tls certificate failed: %v", err)
 	}
 
+	// tls disabled, responsibility of cert provider above to error otherwise
+	if serverCert == nil {
+		return nil, nil
+	}
+
 	// Default to NoClientAuth
 	clientAuthType := tls.NoClientCert
 	var clientCaPool *x509.CertPool
@@ -149,7 +154,16 @@ func newClientTLSConfig(localProvider CertProvider, remoteProvider CertProvider)
 		if err != nil {
 			return nil, err
 		}
+
+		if cert == nil {
+			return nil, fmt.Errorf("client auth required, but no certificate provided")
+		}
 		clientCerts = []tls.Certificate{*cert}
+	}
+
+	// No client settings
+	if clientCerts == nil && serverCa == nil {
+		return nil, nil
 	}
 
 	return &tls.Config{

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -59,16 +59,17 @@ const (
 )
 
 // NewTLSConfigProviderFromConfig creates a new TLS Configuration provider from RootTLS config
-func NewTLSConfigProviderFromConfig(encryptionSettings *config.RootTLS, hostname string) (TLSConfigProvider, error) {
-	if encryptionSettings == nil /*|| encryptionSettings.Provider == "" */ {
+func NewTLSConfigProviderFromConfig(encryptionSettings config.RootTLS, hostname string) (TLSConfigProvider, error) {
+	/* if || encryptionSettings.Provider == ""  {
 		return nil, nil
 	}
+	*/
 
 	/*switch providerType(encryptionSettings.Provider) {
 	case providerTypeSelfSigned:
 		return NewSelfSignedTlsFactory(encryptionSettings, hostname)
 	case providerTypeLocalStore:*/
-	return NewLocalStoreTlsFactory(encryptionSettings)
+	return NewLocalStoreTlsFactory(&encryptionSettings)
 	//}
 
 	//return nil, fmt.Errorf("unknown provider: %v", encryptionSettings.Provider)

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -69,7 +69,7 @@ func NewTLSConfigProviderFromConfig(encryptionSettings config.RootTLS, hostname 
 	case providerTypeSelfSigned:
 		return NewSelfSignedTlsFactory(encryptionSettings, hostname)
 	case providerTypeLocalStore:*/
-	return NewLocalStoreTlsFactory(&encryptionSettings)
+	return NewLocalStoreTlsProvider(&encryptionSettings)
 	//}
 
 	//return nil, fmt.Errorf("unknown provider: %v", encryptionSettings.Provider)

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -56,7 +56,7 @@ type RPCFactory struct {
 // conforming to the underlying configuration
 func NewFactory(cfg *config.RPC, sName string, logger log.Logger, serverCfg *config.Global) (*RPCFactory, error) {
 	tlsFactory, err := encryption.NewTLSConfigProviderFromConfig(
-		&serverCfg.TLS,
+		serverCfg.TLS,
 		getBroadcastAddressFromConfig(serverCfg, cfg, logger))
 
 	if err != nil {
@@ -65,8 +65,8 @@ func NewFactory(cfg *config.RPC, sName string, logger log.Logger, serverCfg *con
 	return newFactory(cfg, sName, logger, tlsFactory)
 }
 
-func newFactory(cfg *config.RPC, sName string, logger log.Logger, frontendTls encryption.TLSConfigProvider) (*RPCFactory, error) {
-	factory := &RPCFactory{config: cfg, serviceName: sName, logger: logger, tlsFactory: frontendTls}
+func newFactory(cfg *config.RPC, sName string, logger log.Logger, tlsProvider encryption.TLSConfigProvider) (*RPCFactory, error) {
+	factory := &RPCFactory{config: cfg, serviceName: sName, logger: logger, tlsFactory: tlsProvider}
 	return factory, nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The RootTLS config object is always created by our config loader as its not a pointer, I was passing this object as a pointer down to the tls/certProviders which check the pointer to determine if TLS has been enabled; since this is never nil, these providers would then try to load nil paths. 

Rather than doing this, I need to check the individual paths inside each call to the tls/certProvider and return nil when an individual setting is not specified. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Because I can't start the server!

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran server locally with no tls config, passed unit tests. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No additional risks that TLS PR did not already introduce.
