### PR TITLE
Remove validation for ShardID being 0 as it is valid

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1397,9 +1397,11 @@ func (h *Handler) SyncShardStatus(ctx context.Context, request *historyservice.S
 		return nil, h.error(errSourceClusterNotSet, scope, "", "")
 	}
 
-	if request.GetShardId() == 0 {
-		return nil, h.error(errShardIDNotSet, scope, "", "")
-	}
+	// TODO: Disabling this check as 0 is a valid ShardID.  Correct long term fix is to have ShardID start from 1
+	// so we can enable this check to validate ShardID is not set.
+	// if request.GetShardId() == 0 {
+	// 	return nil, h.error(errShardIDNotSet, scope, "", "")
+	// }
 
 	if request.GetTimestamp() == 0 {
 		return nil, h.error(errTimestampNotSet, scope, "", "")


### PR DESCRIPTION
fixes #379 

<!-- Describe what has changed in this PR -->
**What changed?**
Remove validation for ShardID being 0

<!-- Tell your future self why have you made these changes -->
**Why?**
Every Shard sends a SyncShard message and 0 is a valid shard id.  So this validation is now broken.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit and integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks
