### PR TITLE
ShardID starts at 1

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -240,7 +240,7 @@ func IsWhitelistServiceTransientError(err error) bool {
 // WorkflowIDToHistoryShard is used to map workflowID to a shardID
 func WorkflowIDToHistoryShard(workflowID string, numberOfShards int) int {
 	hash := farm.Fingerprint32([]byte(workflowID))
-	return int(hash % uint32(numberOfShards))
+	return int(hash % uint32(numberOfShards)) + 1
 }
 
 // PrettyPrintHistory prints history in human readable format

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1396,11 +1396,9 @@ func (h *Handler) SyncShardStatus(ctx context.Context, request *historyservice.S
 		return nil, h.error(errSourceClusterNotSet, scope, "", "")
 	}
 
-	// TODO: Disabling this check as 0 is a valid ShardID.  Correct long term fix is to have ShardID start from 1
-	// so we can enable this check to validate ShardID is not set.
-	// if request.GetShardId() == 0 {
-	// 	return nil, h.error(errShardIDNotSet, scope, "", "")
-	// }
+	if request.GetShardId() == 0 {
+		return nil, h.error(errShardIDNotSet, scope, "", "")
+	}
 
 	if request.GetTimestamp() == 0 {
 		return nil, h.error(errTimestampNotSet, scope, "", "")

--- a/service/history/queueAckMgr_test.go
+++ b/service/history/queueAckMgr_test.go
@@ -101,7 +101,7 @@ func (s *queueAckMgrSuite) SetupTest() {
 		s.controller,
 		&p.ShardInfoWithFailover{
 			ShardInfo: &persistenceblobs.ShardInfo{
-				ShardId: 0,
+				ShardId: 1,
 				RangeId: 1,
 				ClusterTimerAckLevel: map[string]*types.Timestamp{
 					cluster.TestCurrentClusterName:     gogoProtoTimestampNowAddDuration(-8),
@@ -290,7 +290,7 @@ func (s *queueFailoverAckMgrSuite) SetupTest() {
 		s.controller,
 		&p.ShardInfoWithFailover{
 			ShardInfo: &persistenceblobs.ShardInfo{
-				ShardId: 0,
+				ShardId: 1,
 				RangeId: 1,
 				ClusterTimerAckLevel: map[string]*types.Timestamp{
 					cluster.TestCurrentClusterName:     types.TimestampNow(),

--- a/service/history/replicationTaskFetcher.go
+++ b/service/history/replicationTaskFetcher.go
@@ -27,6 +27,7 @@
 package history
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -253,7 +254,12 @@ func (f *ReplicationTaskFetcherImpl) fetchAndDistributeTasks(requestByShard map[
 	f.logger.Debug("Successfully fetched replication tasks.", tag.Counter(len(messagesByShard)))
 
 	for shardID, tasks := range messagesByShard {
-		request := requestByShard[shardID]
+		request, ok := requestByShard[shardID]
+
+		if !ok {
+			return fmt.Errorf("request by shard empty for shardId: %v", err)
+		}
+
 		request.respChan <- tasks
 		close(request.respChan)
 		delete(requestByShard, shardID)

--- a/service/history/replicationTaskFetcher_test.go
+++ b/service/history/replicationTaskFetcher_test.go
@@ -90,11 +90,11 @@ func (s *replicationTaskFetcherSuite) TearDownTest() {
 func (s *replicationTaskFetcherSuite) TestGetMessages() {
 	requestByShard := make(map[int32]*request)
 	token := &replicationgenpb.ReplicationToken{
-		ShardId:                0,
+		ShardId:                1,
 		LastProcessedMessageId: 1,
 		LastRetrievedMessageId: 2,
 	}
-	requestByShard[0] = &request{
+	requestByShard[1] = &request{
 		token: token,
 	}
 	replicationMessageRequest := &adminservice.GetReplicationMessagesRequest{
@@ -104,7 +104,7 @@ func (s *replicationTaskFetcherSuite) TestGetMessages() {
 		ClusterName: "active",
 	}
 	messageByShared := make(map[int32]*replicationgenpb.ReplicationMessages)
-	messageByShared[0] = &replicationgenpb.ReplicationMessages{}
+	messageByShared[1] = &replicationgenpb.ReplicationMessages{}
 	expectedResponse := &adminservice.GetReplicationMessagesResponse{
 		MessagesByShard: messageByShared,
 	}
@@ -117,12 +117,12 @@ func (s *replicationTaskFetcherSuite) TestGetMessages() {
 func (s *replicationTaskFetcherSuite) TestFetchAndDistributeTasks() {
 	requestByShard := make(map[int32]*request)
 	token := &replicationgenpb.ReplicationToken{
-		ShardId:                0,
+		ShardId:                1,
 		LastProcessedMessageId: 1,
 		LastRetrievedMessageId: 2,
 	}
 	respChan := make(chan *replicationgenpb.ReplicationMessages, 1)
-	requestByShard[0] = &request{
+	requestByShard[1] = &request{
 		token:    token,
 		respChan: respChan,
 	}
@@ -133,7 +133,7 @@ func (s *replicationTaskFetcherSuite) TestFetchAndDistributeTasks() {
 		ClusterName: "active",
 	}
 	messageByShared := make(map[int32]*replicationgenpb.ReplicationMessages)
-	messageByShared[0] = &replicationgenpb.ReplicationMessages{}
+	messageByShared[1] = &replicationgenpb.ReplicationMessages{}
 	expectedResponse := &adminservice.GetReplicationMessagesResponse{
 		MessagesByShard: messageByShared,
 	}
@@ -141,5 +141,5 @@ func (s *replicationTaskFetcherSuite) TestFetchAndDistributeTasks() {
 	err := s.replicationTaskFetcher.fetchAndDistributeTasks(requestByShard)
 	s.NoError(err)
 	respToken := <-respChan
-	s.Equal(messageByShared[0], respToken)
+	s.Equal(messageByShared[1], respToken)
 }

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -337,7 +337,7 @@ func (c *shardController) acquireShards() {
 		}()
 	}
 	// Submit tasks to the channel.
-	for shardID := 0; shardID < c.config.NumberOfShards; shardID++ {
+	for shardID := 1; shardID <= c.config.NumberOfShards; shardID++ {
 		shardActionCh <- shardID
 		if c.isShuttingDown() {
 			return

--- a/service/history/shardController_test.go
+++ b/service/history/shardController_test.go
@@ -262,12 +262,12 @@ func (s *shardControllerSuite) TestAcquireShardsConcurrently() {
 func (s *shardControllerSuite) TestAcquireShardLookupFailure() {
 	numShards := 2
 	s.config.NumberOfShards = numShards
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		s.mockServiceResolver.EXPECT().Lookup(string(shardID)).Return(nil, errors.New("ring failure")).Times(1)
 	}
 
 	s.shardController.acquireShards()
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		s.mockServiceResolver.EXPECT().Lookup(string(shardID)).Return(nil, errors.New("ring failure")).Times(1)
 		s.Nil(s.shardController.getEngineForShard(shardID))
 	}
@@ -335,12 +335,12 @@ func (s *shardControllerSuite) TestAcquireShardRenewSuccess() {
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestSingleDCClusterInfo).AnyTimes()
 	s.shardController.acquireShards()
 
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		s.mockServiceResolver.EXPECT().Lookup(string(shardID)).Return(s.hostInfo, nil).Times(1)
 	}
 	s.shardController.acquireShards()
 
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		s.NotNil(s.shardController.getEngineForShard(shardID))
 	}
 }
@@ -407,12 +407,12 @@ func (s *shardControllerSuite) TestAcquireShardRenewLookupFailed() {
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestSingleDCClusterInfo).AnyTimes()
 	s.shardController.acquireShards()
 
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		s.mockServiceResolver.EXPECT().Lookup(string(shardID)).Return(nil, errors.New("ring failure")).Times(1)
 	}
 	s.shardController.acquireShards()
 
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		s.NotNil(s.shardController.getEngineForShard(shardID))
 	}
 }
@@ -422,7 +422,7 @@ func (s *shardControllerSuite) TestHistoryEngineClosed() {
 	s.config.NumberOfShards = numShards
 	s.shardController = newShardController(s.mockResource, s.mockEngineFactory, s.config)
 	historyEngines := make(map[int]*MockEngine)
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		mockEngine := NewMockEngine(s.controller)
 		historyEngines[shardID] = mockEngine
 		s.setupMocksForAcquireShard(shardID, mockEngine, 5, 6)
@@ -439,7 +439,7 @@ func (s *shardControllerSuite) TestHistoryEngineClosed() {
 		workerWG.Add(1)
 		go func() {
 			for attempt := 0; attempt < 10; attempt++ {
-				for shardID := 0; shardID < numShards; shardID++ {
+				for shardID := 1; shardID <= numShards; shardID++ {
 					engine, err := s.shardController.getEngineForShard(shardID)
 					s.Nil(err)
 					s.NotNil(engine)
@@ -452,7 +452,7 @@ func (s *shardControllerSuite) TestHistoryEngineClosed() {
 	workerWG.Wait()
 
 	differentHostInfo := membership.NewHostInfo("another-host", nil)
-	for shardID := 0; shardID < 2; shardID++ {
+	for shardID := 1; shardID <= 2; shardID++ {
 		mockEngine := historyEngines[shardID]
 		mockEngine.EXPECT().Stop().Return().Times(1)
 		s.mockServiceResolver.EXPECT().Lookup(string(shardID)).Return(differentHostInfo, nil).AnyTimes()
@@ -479,7 +479,7 @@ func (s *shardControllerSuite) TestHistoryEngineClosed() {
 		go func() {
 			shardLost := false
 			for attempt := 0; !shardLost && attempt < 10; attempt++ {
-				for shardID := 0; shardID < 2; shardID++ {
+				for shardID := 1; shardID <= 2; shardID++ {
 					_, err := s.shardController.getEngineForShard(shardID)
 					if err != nil {
 						s.logger.Error("ShardLost", tag.Error(err))
@@ -510,7 +510,7 @@ func (s *shardControllerSuite) TestShardControllerClosed() {
 	s.config.NumberOfShards = numShards
 	s.shardController = newShardController(s.mockResource, s.mockEngineFactory, s.config)
 	historyEngines := make(map[int]*MockEngine)
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		mockEngine := NewMockEngine(s.controller)
 		historyEngines[shardID] = mockEngine
 		s.setupMocksForAcquireShard(shardID, mockEngine, 5, 6)
@@ -528,7 +528,7 @@ func (s *shardControllerSuite) TestShardControllerClosed() {
 		go func() {
 			shardLost := false
 			for attempt := 0; !shardLost && attempt < 10; attempt++ {
-				for shardID := 0; shardID < numShards; shardID++ {
+				for shardID := 1; shardID <= numShards; shardID++ {
 					_, err := s.shardController.getEngineForShard(shardID)
 					if err != nil {
 						s.logger.Error("ShardLost", tag.Error(err))
@@ -544,7 +544,7 @@ func (s *shardControllerSuite) TestShardControllerClosed() {
 	}
 
 	s.mockServiceResolver.EXPECT().RemoveListener(shardControllerMembershipUpdateListenerName).Return(nil).AnyTimes()
-	for shardID := 0; shardID < numShards; shardID++ {
+	for shardID := 1; shardID <= numShards; shardID++ {
 		mockEngine := historyEngines[shardID]
 		mockEngine.EXPECT().Stop().Times(1)
 		s.mockServiceResolver.EXPECT().Lookup(string(shardID)).Return(s.hostInfo, nil).AnyTimes()

--- a/service/history/timerQueueAckMgr_test.go
+++ b/service/history/timerQueueAckMgr_test.go
@@ -116,7 +116,7 @@ func (s *timerQueueAckMgrSuite) SetupTest() {
 		s.controller,
 		&persistence.ShardInfoWithFailover{
 			ShardInfo: &persistenceblobs.ShardInfo{
-				ShardId: 0,
+				ShardId: 1,
 				RangeId: 1,
 				ClusterTimerAckLevel: map[string]*types.Timestamp{
 					cluster.TestCurrentClusterName:     gogoProtoTimestampNowAddDuration(-8),
@@ -555,7 +555,7 @@ func (s *timerQueueFailoverAckMgrSuite) SetupTest() {
 		s.controller,
 		&persistence.ShardInfoWithFailover{
 			ShardInfo: &persistenceblobs.ShardInfo{
-				ShardId: 0,
+				ShardId: 1,
 				RangeId: 1,
 				ClusterTimerAckLevel: map[string]*types.Timestamp{
 					cluster.TestCurrentClusterName:     types.TimestampNow(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Make shardID start at 1, not 0.

<!-- Tell your future self why have you made these changes -->
**Why?**
Protos cannot differentiate between default and nil on primitive types. This allows us to differentiate for shardID.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local unit tests, submitting as draft PR first to run buildkite

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Well, if we have a testing hole here, this could be catastrophic in terms of stability
