### PR TITLE
Fix replication task processor when converting to replication task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,6 +1,7 @@
 {
 	"version": "0.2.0",
 	"configurations": [
+	
 		{
 			"name": "Debug Server",
 			"type": "go",
@@ -9,6 +10,19 @@
 			"program": "${workspaceFolder}/cmd/server",
 			"cwd": "${workspaceFolder}",
 			"args": [
+				"start",
+			]
+		},
+		{
+			"name": "Debug Active Server",
+			"type": "go",
+			"request": "launch",
+			"mode": "debug",
+			"program": "${workspaceFolder}/cmd/server",
+			"cwd": "${workspaceFolder}",
+			"args": [
+				"--env",
+				"development_active",
 				"start",
 			]
 		},

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -1540,7 +1540,7 @@ func (d *DecisionTask) SetTaskID(id int64) {
 }
 
 // GetVisibilityTimestamp get the visibility timestamp
-func (d ReplicationTaskInfoWrapper) GetVisibilityTimestamp() *types.Timestamp {
+func (d *ReplicationTaskInfoWrapper) GetVisibilityTimestamp() *types.Timestamp {
 	return &types.Timestamp{}
 }
 

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -213,7 +213,7 @@ func (p *replicatorQueueProcessorImpl) processSyncActivityTask(
 func (p *replicatorQueueProcessorImpl) processHistoryReplicationTask(
 	task *persistenceblobs.ReplicationTaskInfo,
 ) error {
-	replicationTask, err := p.toReplicationTask(context.Background(), persistence.ReplicationTaskInfoWrapper{task})
+	replicationTask, err := p.toReplicationTask(context.Background(), &persistence.ReplicationTaskInfoWrapper{task})
 	if err != nil || replicationTask == nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When reading messages from replication task processor we would wrap it
into ReplicationTaskInfoWrapper object.  Instead of creating a object reference 
we would pass it by value resulting in type cast to `*persistence.ReplicationTaskInfoWrapper`
fail.  This causes replication queue processor to get stuck.

<!-- Tell your future self why have you made these changes -->
**Why?**
Replication queue processing for history events is broken.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually run active/standby setup and confirm history events are getting replicated.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This impacts CrossDC path for replication queue processing.
