### PR TITLE
Use Stop instead of GracefulStop

### DIFF
--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -306,7 +306,8 @@ func (s *Service) Stop() {
 	s.GetLogger().Info("ShutdownHandler: Draining traffic")
 	time.Sleep(requestDrainTime)
 
-	s.server.GracefulStop()
+	// TODO: Change this to GracefulStop when integration tests are refactored.
+	s.server.Stop()
 	s.Resource.Stop()
 	s.params.Logger.Info("frontend stopped")
 }

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -549,7 +549,8 @@ func (s *Service) Stop() {
 	s.handler.PrepareToStop()
 	remainingTime = s.sleep(gracePeriod, remainingTime)
 
-	s.server.GracefulStop()
+	// TODO: Change this to GracefulStop when integration tests are refactored.
+	s.server.Stop()
 
 	s.handler.Stop()
 	s.Resource.Stop()

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -130,7 +130,8 @@ func (s *Service) Stop() {
 	s.GetLogger().Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
 	time.Sleep(s.config.ShutdownDrainDuration())
 
-	s.server.GracefulStop()
+	// TODO: Change this to GracefulStop when integration tests are refactored.
+	s.server.Stop()
 
 	s.handler.Stop()
 	s.Resource.Stop()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`server.GracefulStop()` was replaced with `server.Stop()`.

<!-- Tell your future self why have you made these changes -->
**Why?**
I did some investigations and found that there are 3 open connections (at least to frontend) at the moment we call `GracefulStop()`. It makes server to wait for these connections to be closed. I found one connection and was able to close it but it is very hard to track where the other two are coming from. Refactoring is required to shrink number of connection to 1 and properly close it before stopping the server. As long as we call `service.Stop()` only from integration tests (which also need to be refactored) it is safe to replace `GracefulStop()` with `Stop()` and decrease tests shutdown time. I don't want to invest time in proper fix because a lot of things need to be refactored and simplified first. Production code path doesn't stop at all, so it is not affected.

I also see gRPC error when we trying to close already closed connection. Same refactoring should solve this problem also.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
All tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
