### PR TITLE
Switch parentClosePolicy from int32 to an enum

### DIFF
--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -1012,7 +1012,7 @@ func (v *InternalChildExecutionInfo) ToProto() *persistenceblobs.ChildExecutionI
 		CreateRequestId:        v.CreateRequestID,
 		Namespace:              v.Namespace,
 		WorkflowTypeName:       v.WorkflowTypeName,
-		ParentClosePolicy:      int32(v.ParentClosePolicy),
+		ParentClosePolicy:      v.ParentClosePolicy,
 	}
 	return info
 }

--- a/proto/persistenceblobs/server_message.proto
+++ b/proto/persistenceblobs/server_message.proto
@@ -26,6 +26,7 @@ option go_package = "github.com/temporalio/temporal/.gen/proto/persistenceblobs"
 import "google/protobuf/timestamp.proto";
 import "google/protobuf/wrappers.proto";
 
+import "common/enum.proto";
 import "common/message.proto";
 import "common/server_enum.proto";
 
@@ -307,7 +308,7 @@ message ChildExecutionInfo {
     string createRequestId = 10;
     string namespace = 11;
     string workflowTypeName = 12;
-    int32 parentClosePolicy = 13;
+    common.ParentClosePolicy parentClosePolicy = 13;
     int64 initiatedId = 14;
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Switching the type of `ChildExecutionInfo.parentClosePolicy` to an (already existing) `enum`, and removing the no-longer-needed cast.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is part of our general effort to simplify and clean up the code.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Build, run unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is just code cleanup; this change should have no effect on the behavior. If something breaks, will fix or revert.
