### PR TITLE
Removing unused namespacestatus type conversions

### DIFF
--- a/common/namespace/transmissionTaskHandler.go
+++ b/common/namespace/transmissionTaskHandler.go
@@ -34,7 +34,6 @@ import (
 	"github.com/temporalio/temporal/common/log"
 	"github.com/temporalio/temporal/common/log/tag"
 	"github.com/temporalio/temporal/common/messaging"
-	"github.com/temporalio/temporal/common/persistence"
 )
 
 // NOTE: the counterpart of namespace replication receiving logic is in service/worker package
@@ -116,17 +115,4 @@ func (namespaceReplicator *namespaceReplicatorImpl) convertClusterReplicationCon
 		output = append(output, &replicationpb.ClusterReplicationConfiguration{ClusterName: clusterName})
 	}
 	return output
-}
-
-func (namespaceReplicator *namespaceReplicatorImpl) convertNamespaceStatusToProto(input int) (namespacepb.NamespaceStatus, error) {
-	switch input {
-	case persistence.NamespaceStatusRegistered:
-		output := namespacepb.NamespaceStatus_Registered
-		return output, nil
-	case persistence.NamespaceStatusDeprecated:
-		output := namespacepb.NamespaceStatus_Deprecated
-		return output, nil
-	default:
-		return namespacepb.NamespaceStatus_Registered, ErrInvalidNamespaceStatus
-	}
 }

--- a/common/namespace/transmissionTaskHandler_test.go
+++ b/common/namespace/transmissionTaskHandler_test.go
@@ -201,7 +201,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_I
 	taskType := replicationgenpb.ReplicationTaskType_NamespaceTask
 	id := primitives.NewUUID().String()
 	name := "some random namespace test name"
-	status, _ := s.namespaceReplicator.convertNamespaceStatusToProto(int(namespacepb.NamespaceStatus_Deprecated))
+	status := namespacepb.NamespaceStatus_Deprecated
 	description := "some random test description"
 	ownerEmail := "some random test owner"
 	data := map[string]string{"k": "v"}

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -48,13 +48,6 @@ import (
 	"github.com/temporalio/temporal/common/primitives"
 )
 
-// Namespace status
-const (
-	NamespaceStatusRegistered = iota
-	NamespaceStatusDeprecated
-	NamespaceStatusDeleted
-)
-
 const (
 	// EventStoreVersion is already deprecated, this is used for forward
 	// compatibility (so that rollback is possible).


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Minor code cleanup: removing unnecessary / virtually unused `convertNamespaceStatusToProto ` and the unnecessary definitions that go along with it.

<!-- Tell your future self why have you made these changes -->
**Why?**
The code is unused, just cleaning things up, as part of the general int/enum clean up effort.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Built and ran unit tests. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is purely a (minor) refactoring, no behavior changes are expected. If anything breaks, will fix or revert. 
