### PR TITLE
Create CLI command to list Cluster Memberships

### DIFF
--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -128,8 +128,10 @@ func (rpo *ringpopMonitor) Start() {
 	}
 }
 
-func serviceNameToServiceTypeEnum(name string) (persistence.ServiceType, error) {
+func ServiceNameToServiceTypeEnum(name string) (persistence.ServiceType, error) {
 	switch name {
+	case primitives.AllServices:
+		return persistence.All, nil
 	case primitives.FrontendService:
 		return persistence.Frontend, nil
 	case primitives.HistoryService:
@@ -185,7 +187,7 @@ func (rpo *ringpopMonitor) startHeartbeatAndFetchBootstrapHosts(broadcastHostpor
 	}
 
 	// Parse and validate existing service name
-	role, err := serviceNameToServiceTypeEnum(rpo.serviceName)
+	role, err := ServiceNameToServiceTypeEnum(rpo.serviceName)
 	if err != nil {
 		return nil, err
 	}

--- a/common/primitives/role.go
+++ b/common/primitives/role.go
@@ -26,6 +26,7 @@ package primitives
 
 // These const represent role strings
 const (
+	AllServices     = "all"
 	FrontendService = "frontend"
 	HistoryService  = "history"
 	MatchingService = "matching"

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -214,6 +214,38 @@ func newAdminShardManagementCommands() []cli.Command {
 	}
 }
 
+func newAdminMembershipCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:    "list",
+			Aliases: []string{"ls"},
+			Usage:   "List memberships",
+			Flags: append(
+				getDBFlags(),
+				cli.StringFlag{
+					Name:  FlagEarliestTime,
+					Value: "0",
+					Usage: "Last heartbeat lower bound filter. Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
+						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
+						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes.",
+				},
+				cli.IntFlag{
+					Name:  FlagClusterMembershipRole,
+					Value: 0,
+					Usage: "Membership role filter: 0 - All, 1 - Frontend, 2 - History, 3 - Matching, 4 - Worker",
+				},
+				cli.StringFlag{
+					Name:  FlagTargetCluster,
+					Value: "active",
+					Usage: "Temporal cluster to use",
+				},
+			),
+			Action: func(c *cli.Context) {
+				AdminListMembers(c)
+			}},
+	}
+}
+
 func newAdminHistoryHostCommands() []cli.Command {
 	return []cli.Command{
 		{

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -217,15 +217,15 @@ func newAdminShardManagementCommands() []cli.Command {
 func newAdminMembershipCommands() []cli.Command {
 	return []cli.Command{
 		{
-			Name:    "list",
-			Aliases: []string{"ls"},
-			Usage:   "List memberships",
+			Name:    "db_heartbeats",
+			Aliases: []string{"h"},
+			Usage:   "List cluster membership heartbeats",
 			Flags: append(
 				getDBFlags(),
 				cli.StringFlag{
-					Name:  FlagEarliestTime,
+					Name:  FlagHeartbeatedWithin,
 					Value: "0",
-					Usage: "Last heartbeat lower bound filter. Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
+					Usage: "Filter by last heartbeat date time. Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
 						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
 						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes.",
 				},
@@ -236,7 +236,7 @@ func newAdminMembershipCommands() []cli.Command {
 				},
 			),
 			Action: func(c *cli.Context) {
-				AdminListMembers(c)
+				AdminListClusterMembership(c)
 			}},
 	}
 }

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -224,15 +224,15 @@ func newAdminMembershipCommands() []cli.Command {
 				getDBFlags(),
 				cli.StringFlag{
 					Name:  FlagHeartbeatedWithin,
-					Value: "0",
+					Value: "15m",
 					Usage: "Filter by last heartbeat date time. Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
 						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
 						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes.",
 				},
-				cli.IntFlag{
+				cli.StringFlag{
 					Name:  FlagClusterMembershipRole,
-					Value: 0,
-					Usage: "Membership role filter: 0 - All, 1 - Frontend, 2 - History, 3 - Matching, 4 - Worker",
+					Value: "all",
+					Usage: "Membership role filter: all (default), frontend, history, matching, worker",
 				},
 			),
 			Action: func(c *cli.Context) {

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -217,9 +217,8 @@ func newAdminShardManagementCommands() []cli.Command {
 func newAdminMembershipCommands() []cli.Command {
 	return []cli.Command{
 		{
-			Name:    "db_heartbeats",
-			Aliases: []string{"h"},
-			Usage:   "List cluster membership heartbeats",
+			Name:  "list_db",
+			Usage: "List cluster membership heartbeats",
 			Flags: append(
 				getDBFlags(),
 				cli.StringFlag{

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -234,11 +234,6 @@ func newAdminMembershipCommands() []cli.Command {
 					Value: 0,
 					Usage: "Membership role filter: 0 - All, 1 - Frontend, 2 - History, 3 - Matching, 4 - Worker",
 				},
-				cli.StringFlag{
-					Name:  FlagTargetCluster,
-					Value: "active",
-					Usage: "Temporal cluster to use",
-				},
 			),
 			Action: func(c *cli.Context) {
 				AdminListMembers(c)

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -446,8 +446,8 @@ func AdminShardManagement(c *cli.Context) {
 	}
 }
 
-// AdminListMembers outputs a table of members
-func AdminListMembers(c *cli.Context) {
+// AdminListClusterMembership outputs a list of cluster membership items
+func AdminListClusterMembership(c *cli.Context) {
 	role := persistence.ServiceType(c.Int(FlagClusterMembershipRole))
 	heartbeatFlag := parseTime(c.String(FlagEarliestTime), 0, time.Now())
 	heartbeat := time.Duration(heartbeatFlag)

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -446,6 +446,28 @@ func AdminShardManagement(c *cli.Context) {
 	}
 }
 
+// AdminListMembers outputs a table of members
+func AdminListMembers(c *cli.Context) {
+	role := persistence.ServiceType(c.Int(FlagClusterMembershipRole))
+	heartbeatFlag := parseTime(c.String(FlagEarliestTime), 0, time.Now())
+	heartbeat := time.Duration(heartbeatFlag)
+
+	pFactory := CreatePersistenceFactory(c)
+	manager, err := pFactory.NewClusterMetadataManager()
+	if err != nil {
+		ErrorAndExit("Failed to initialize cluster metadata manager", err)
+	}
+
+	req := &persistence.GetClusterMembersRequest{
+		RoleEquals:          role,
+		LastHeartbeatWithin: heartbeat,
+	}
+
+	members, err := manager.GetClusterMembers(req)
+
+	prettyPrintJSONObject(members)
+}
+
 // AdminDescribeHistoryHost describes history host
 func AdminDescribeHistoryHost(c *cli.Context) {
 	adminClient := cFactory.AdminClient(c)

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -148,7 +148,7 @@ func NewCliApp() *cli.App {
 					Subcommands: newAdminTaskListCommands(),
 				},
 				{
-					Name:        "members",
+					Name:        "membership",
 					Usage:       "Run admin operation on membership",
 					Subcommands: newAdminMembershipCommands(),
 				},

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -148,6 +148,12 @@ func NewCliApp() *cli.App {
 					Subcommands: newAdminTaskListCommands(),
 				},
 				{
+					Name:        "members",
+					Aliases:     []string{"memb"},
+					Usage:       "Run admin operation on membership",
+					Subcommands: newAdminMembershipCommands(),
+				},
+				{
 					Name:        "cluster",
 					Aliases:     []string{"cl"},
 					Usage:       "Run admin operation on cluster",

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -149,7 +149,6 @@ func NewCliApp() *cli.App {
 				},
 				{
 					Name:        "members",
-					Aliases:     []string{"memb"},
 					Usage:       "Run admin operation on membership",
 					Subcommands: newAdminMembershipCommands(),
 				},

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -153,6 +153,7 @@ const (
 	FlagActiveClusterNameWithAlias        = FlagActiveClusterName + ", ac"
 	FlagClusters                          = "clusters"
 	FlagClustersWithAlias                 = FlagClusters + ", cl"
+	FlagClusterMembershipRole             = "role"
 	FlagIsGlobalNamespace                 = "global_namespace"
 	FlagIsGlobalNamespaceWithAlias        = FlagIsGlobalNamespace + ", gd"
 	FlagNamespaceData                     = "namespace_data"

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -132,6 +132,7 @@ const (
 	FlagHistoryArchivalStatusWithAlias    = FlagHistoryArchivalStatus + ", has"
 	FlagHistoryArchivalURI                = "history_uri"
 	FlagHistoryArchivalURIWithAlias       = FlagHistoryArchivalURI + ", huri"
+	FlagHeartbeatedWithin                 = "heartbeated_within"
 	FlagVisibilityArchivalStatus          = "visibility_archival_status"
 	FlagVisibilityArchivalStatusWithAlias = FlagVisibilityArchivalStatus + ", vas"
 	FlagVisibilityArchivalURI             = "visibility_uri"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Created an admin CLI command that allows to list Cluster Memberships. Optionally allows to filter based on role and last heartbeat

<!-- Tell your future self why have you made these changes -->
**Why?**
Allows to discover and get information on cluster memberships

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran with and without options "--role", "frontend", "--heartbeated_within", "15m"

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minimal risk. Adds new path to mapping between service names to service type enum: add "all" as a primitive to reference all services