### PR TITLE
Add consistency to admin cli command names

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -74,7 +74,7 @@ func newAdminWorkflowCommands() []cli.Command {
 			},
 		},
 		{
-			Name:    "refresh-tasks",
+			Name:    "refresh_tasks",
 			Aliases: []string{"rt"},
 			Usage:   "Refreshes all the tasks of a workflow",
 			Flags: []cli.Flag{
@@ -138,7 +138,7 @@ func newAdminShardManagementCommands() []cli.Command {
 			},
 		},
 		{
-			Name:    "describe-task",
+			Name:    "describe_task",
 			Aliases: []string{"dt"},
 			Usage:   "Describe a task based on task Id, task type, shard Id and task visibility timestamp",
 			Flags: append(
@@ -172,7 +172,7 @@ func newAdminShardManagementCommands() []cli.Command {
 		},
 
 		{
-			Name:    "closeShard",
+			Name:    "close_shard",
 			Aliases: []string{"clsh"},
 			Usage:   "close a shard given a shard id",
 			Flags: []cli.Flag{
@@ -186,7 +186,7 @@ func newAdminShardManagementCommands() []cli.Command {
 			},
 		},
 		{
-			Name:    "removeTask",
+			Name:    "remove_task",
 			Aliases: []string{"rmtk"},
 			Usage:   "remove a task based on shardId, task type, taskId, and task visibility timestamp",
 			Flags: []cli.Flag{
@@ -269,7 +269,7 @@ func newAdminHistoryHostCommands() []cli.Command {
 			},
 		},
 		{
-			Name:    "getshard",
+			Name:    "get_shardid",
 			Aliases: []string{"gsh"},
 			Usage:   "Get shardId for a workflowId",
 			Flags: []cli.Flag{
@@ -319,7 +319,7 @@ func newAdminNamespaceCommands() []cli.Command {
 			},
 		},
 		{
-			Name:    "getnamespaceidorname",
+			Name:    "get_namespaceidorname",
 			Aliases: []string{"getdn"},
 			Usage:   "Get namespaceId or namespace",
 			Flags: append(getDBFlags(),
@@ -380,7 +380,7 @@ func newAdminKafkaCommands() []cli.Command {
 			},
 		},
 		{
-			Name:    "purgeTopic",
+			Name:    "purge_topic",
 			Aliases: []string{"purge"},
 			Usage:   "purge Kafka topic by consumer group",
 			Flags: []cli.Flag{
@@ -416,7 +416,7 @@ clusters:
 			},
 		},
 		{
-			Name:    "mergeDLQ",
+			Name:    "merge_dlq",
 			Aliases: []string{"mgdlq"},
 			Usage:   "Merge replication tasks to target topic(from input file or DLQ topic)",
 			Flags: []cli.Flag{
@@ -674,7 +674,7 @@ func newAdminTaskListCommands() []cli.Command {
 func newAdminClusterCommands() []cli.Command {
 	return []cli.Command{
 		{
-			Name:    "add-search-attr",
+			Name:    "add_search_attr",
 			Aliases: []string{"asa"},
 			Usage:   "whitelist search attribute",
 			Flags: []cli.Flag{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed the names of admin CLI commands to be consistent between each other

<!-- Tell your future self why have you made these changes -->
**Why?**
Was confusing having commands in completely different naming patterns

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
ran commands

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Changes the API of Admin CLI - requires checking the new names. No other risks
