### PR TITLE
Remove unused breaking dependency (bzr) from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ARG GOPROXY
 # Build Temporal binaries
 FROM golang:1.14-alpine AS builder
 
-RUN apk add --update --no-cache ca-certificates make curl git mercurial bzr protobuf
+RUN apk add --update --no-cache ca-certificates make curl git mercurial protobuf
 
 # Making sure that dependency is not touched
 ENV GOFLAGS="-mod=readonly"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removing what appears to be an unused package dependency (`bzr`) from `Dockerfile`. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Our cicd builds started breaking, with the following error: 

```
...
Step 3/60 : FROM golang:1.14-alpine AS builder
...
Step 4/60 : RUN apk add --update --no-cache ca-certificates make curl git mercurial bzr protobuf
 ---> Running in 8b21fbae2528
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
ERROR: unsatisfiable constraints:
  bzr (missing):
    required by: world[bzr]
The command '/bin/sh -c apk add --update --no-cache ca-certificates make curl git mercurial bzr protobuf' returned a non-zero code: 1
```
It appears that `golang:1.14-alpine` switched to alpine 3.12 (https://github.com/docker-library/golang/commit/4598bb8c77b4e162d2a1d14598d9d83a8e3750c2#diff-4dfe5141125014b0c616fe3f9ab43f24), which doesn't have `bzr` available (https://github.com/alpinelinux/docker-alpine/issues/87).

This caused our docker builds to break, because our `Dockerfiles` appear to attempt to install `bzr`.

It also appears that this dependency is unused.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I was able to successfully build docker images locally (`make docker-images`), and to successfully start the service via `docker-compose` (after updating docker-compose to use my locally built docker images).

```
10:54:20 [markmark ~/src/temporal-mm/docker] (badbzr|m1u) $ docker-compose -f docker-compose-mysql.yml up
```


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

If something breaks and our docker images are not working as expected, our pipeline will hopefully catch it. In which case we will investigate and fix. 