### PR TITLE
Add table-view support for CLI list commands

### DIFF
--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -957,13 +957,12 @@ func printTable(items []interface{}) error {
 	table.SetHeaderLine(false)
 	for i := 0; i < len(items); i++ {
 		item := reflect.ValueOf(items[i]).Elem()
-		var values []string
+		var columns []string
 		for j := 0; j < len(fields); j++ {
-			f := item.Field(j)
-			v := fmt.Sprintf("%v", f.Interface())
-			values = append(values, v)
+			col := item.Field(j)
+			columns = append(columns, fmt.Sprintf("%v", col.Interface()))
 		}
-		table.Append(values)
+		table.Append(columns)
 	}
 	table.Render()
 	table.ClearRows()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added Table view to CLI list util in addition to JSON view.  Use --print_json to switch between them. Default is Table view.

<!-- Tell your future self why have you made these changes -->
**Why?**
Allows to switch between table and json view for CLI list commands.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran tests and a list command that utilizes the new util. Example:
`./tctl admin shard list_tasks --shard_id 3 --task_type 3 --pagesize 4 --more --print_json --username <db_flags>`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Smaller risk of not properly handling a field of a row since the table view constructs the table dynamically using reflection
