### PR TITLE
Change CLI task_type option to string value from int

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -151,10 +151,10 @@ func newAdminShardManagementCommands() []cli.Command {
 					Name:  FlagTaskID,
 					Usage: "The ID of the timer task to describe",
 				},
-				cli.IntFlag{
+				cli.StringFlag{
 					Name:  FlagTaskType,
-					Value: 2,
-					Usage: "Task type: 2 - transfer task, 3 - timer task, 4 - replication task",
+					Value: "transfer",
+					Usage: "Task type: transfer (default), timer, replication",
 				},
 				cli.Int64Flag{
 					Name:  FlagTaskVisibilityTimestamp,
@@ -185,10 +185,10 @@ func newAdminShardManagementCommands() []cli.Command {
 					Name:  FlagShardID,
 					Usage: "The ID of the shard",
 				},
-				cli.IntFlag{
+				cli.StringFlag{
 					Name:  FlagTaskType,
-					Value: 2,
-					Usage: "Task type: 2 - transfer task (default), 3 - timer task, 4 - replication task",
+					Value: "transfer",
+					Usage: "Task type: transfer (default), timer, replication",
 				},
 				cli.StringFlag{
 					Name:  FlagMinVisibilityTimestamp,
@@ -236,9 +236,10 @@ func newAdminShardManagementCommands() []cli.Command {
 					Name:  FlagTaskID,
 					Usage: "taskId",
 				},
-				cli.IntFlag{
+				cli.StringFlag{
 					Name:  FlagTaskType,
-					Usage: "task type : 2 (transfer task), 3 (timer task) or 4 (replication task)",
+					Value: "transfer",
+					Usage: "Task type: transfer (default), timer, replication",
 				},
 				cli.Int64Flag{
 					Name:  FlagTaskVisibilityTimestamp,

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/gocql/gocql"
@@ -373,7 +374,9 @@ func AdminGetShardID(c *cli.Context) {
 func AdminDescribeTask(c *cli.Context) {
 	sid := getRequiredIntOption(c, FlagShardID)
 	tid := getRequiredIntOption(c, FlagTaskID)
-	category := commongenpb.TaskCategory(c.Int(FlagTaskType))
+	categoryFlag := strings.Title(c.String(FlagTaskType))
+	categoryInt := commongenpb.TaskCategory_value[categoryFlag]
+	category := commongenpb.TaskCategory(categoryInt)
 
 	pFactory := CreatePersistenceFactory(c)
 	executionManager, err := pFactory.NewExecutionManager(sid)
@@ -411,7 +414,9 @@ func AdminDescribeTask(c *cli.Context) {
 // AdminListTasks outputs a list of a tasks for given Shard and Task Type
 func AdminListTasks(c *cli.Context) {
 	sid := getRequiredIntOption(c, FlagShardID)
-	category := commongenpb.TaskCategory(c.Int(FlagTaskType))
+	categoryFlag := strings.Title(c.String(FlagTaskType))
+	categoryInt := commongenpb.TaskCategory_value[categoryFlag]
+	category := commongenpb.TaskCategory(categoryInt)
 
 	pFactory := CreatePersistenceFactory(c)
 	executionManager, err := pFactory.NewExecutionManager(sid)
@@ -466,9 +471,11 @@ func AdminRemoveTask(c *cli.Context) {
 
 	shardID := getRequiredIntOption(c, FlagShardID)
 	taskID := getRequiredInt64Option(c, FlagTaskID)
-	taskCategory := commongenpb.TaskCategory(getRequiredIntOption(c, FlagTaskType))
+	categoryFlag := strings.Title(c.String(FlagTaskType))
+	categoryInt := commongenpb.TaskCategory_value[categoryFlag]
+	category := commongenpb.TaskCategory(categoryInt)
 	var visibilityTimestamp int64
-	if taskCategory == commongenpb.TASK_CATEGORY_TIMER {
+	if category == commongenpb.TASK_CATEGORY_TIMER {
 		visibilityTimestamp = getRequiredInt64Option(c, FlagTaskVisibilityTimestamp)
 	}
 
@@ -477,7 +484,7 @@ func AdminRemoveTask(c *cli.Context) {
 
 	req := &adminservice.RemoveTaskRequest{
 		ShardId:             int32(shardID),
-		Category:            taskCategory,
+		Category:            category,
 		TaskId:              taskID,
 		VisibilityTimestamp: visibilityTimestamp,
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed the type of task_type option from int to string

<!-- Tell your future self why have you made these changes -->
**Why?**
Makes CLI experience friendlier by allowing users to type task type name (replication, transfer, timer) instead of obscure integers (0,1,3)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran tests and commands

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Incompatible change, old task CLI commands will stop working and require to change to string values 
