### PR TITLE
Replace CLI options to accept enum names instead of integers

### DIFF
--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -372,13 +372,13 @@ func AdminGetShardID(c *cli.Context) {
 func AdminDescribeTask(c *cli.Context) {
 	sid := getRequiredIntOption(c, FlagShardID)
 	tid := getRequiredIntOption(c, FlagTaskID)
-	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), enumspb.TaskCategory_value)
+	categoryInt, err := stringToEnum(c.String(FlagTaskType), enumsgenpb.TaskCategory_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse Task Type", err)
 	}
-	category := enumspb.TaskCategory(categoryInt)
-	if category == enumspb.TASK_CATEGORY_UNSPECIFIED {
-		ErrorAndExit("Task type Unspecified is currently not supported", nil)
+	category := enumsgenpb.TaskCategory(categoryInt)
+	if category == enumsgenpb.TASK_CATEGORY_UNSPECIFIED {
+		ErrorAndExit(fmt.Sprintf("Task type %s is currently not supported", category), nil)
 	}
 
 	pFactory := CreatePersistenceFactory(c)
@@ -387,7 +387,7 @@ func AdminDescribeTask(c *cli.Context) {
 		ErrorAndExit("Failed to initialize execution manager", err)
 	}
 
-	if category == enumspb.TASK_CATEGORY_TIMER {
+	if category == enumsgenpb.TASK_CATEGORY_TIMER {
 		vis := getRequiredInt64Option(c, FlagTaskVisibilityTimestamp)
 		req := &persistence.GetTimerTaskRequest{ShardID: int32(sid), TaskID: int64(tid), VisibilityTimestamp: time.Unix(0, vis)}
 		task, err := executionManager.GetTimerTask(req)
@@ -395,14 +395,14 @@ func AdminDescribeTask(c *cli.Context) {
 			ErrorAndExit("Failed to get Timer Task", err)
 		}
 		prettyPrintJSONObject(task)
-	} else if category == enumspb.TASK_CATEGORY_REPLICATION {
+	} else if category == enumsgenpb.TASK_CATEGORY_REPLICATION {
 		req := &persistence.GetReplicationTaskRequest{ShardID: int32(sid), TaskID: int64(tid)}
 		task, err := executionManager.GetReplicationTask(req)
 		if err != nil {
 			ErrorAndExit("Failed to get Replication Task", err)
 		}
 		prettyPrintJSONObject(task)
-	} else if category == enumspb.TASK_CATEGORY_TRANSFER {
+	} else if category == enumsgenpb.TASK_CATEGORY_TRANSFER {
 		req := &persistence.GetTransferTaskRequest{ShardID: int32(sid), TaskID: int64(tid)}
 		task, err := executionManager.GetTransferTask(req)
 		if err != nil {
@@ -417,13 +417,13 @@ func AdminDescribeTask(c *cli.Context) {
 // AdminListTasks outputs a list of a tasks for given Shard and Task Type
 func AdminListTasks(c *cli.Context) {
 	sid := getRequiredIntOption(c, FlagShardID)
-	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), enumspb.TaskCategory_value)
+	categoryInt, err := stringToEnum(c.String(FlagTaskType), enumsgenpb.TaskCategory_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse Task Type", err)
 	}
-	category := enumspb.TaskCategory(categoryInt)
-	if category == enumspb.TASK_CATEGORY_UNSPECIFIED {
-		ErrorAndExit("Task type Unspecified is currently not supported", nil)
+	category := enumsgenpb.TaskCategory(categoryInt)
+	if category == enumsgenpb.TASK_CATEGORY_UNSPECIFIED {
+		ErrorAndExit(fmt.Sprintf("Task type %s is currently not supported", category), nil)
 	}
 
 	pFactory := CreatePersistenceFactory(c)
@@ -432,7 +432,7 @@ func AdminListTasks(c *cli.Context) {
 		ErrorAndExit("Failed to initialize execution manager", err)
 	}
 
-	if category == enumspb.TASK_CATEGORY_TRANSFER {
+	if category == enumsgenpb.TASK_CATEGORY_TRANSFER {
 		req := &persistence.GetTransferTasksRequest{}
 
 		paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
@@ -472,7 +472,7 @@ func AdminListTasks(c *cli.Context) {
 			return items, token, nil
 		}
 		paginate(c, paginationFunc)
-	} else if category == enumspb.TASK_CATEGORY_REPLICATION {
+	} else if category == enumsgenpb.TASK_CATEGORY_REPLICATION {
 		req := &persistence.GetReplicationTasksRequest{}
 		paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
 			req.NextPageToken = paginationToken
@@ -499,16 +499,16 @@ func AdminRemoveTask(c *cli.Context) {
 	adminClient := cFactory.AdminClient(c)
 	shardID := getRequiredIntOption(c, FlagShardID)
 	taskID := getRequiredInt64Option(c, FlagTaskID)
-	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), enumspb.TaskCategory_value)
+	categoryInt, err := stringToEnum(c.String(FlagTaskType), enumsgenpb.TaskCategory_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse Task Type", err)
 	}
-	category := enumspb.TaskCategory(categoryInt)
-	if category == enumspb.TASK_CATEGORY_UNSPECIFIED {
-		ErrorAndExit("Task type Unspecified is currently not supported", nil)
+	category := enumsgenpb.TaskCategory(categoryInt)
+	if category == enumsgenpb.TASK_CATEGORY_UNSPECIFIED {
+		ErrorAndExit(fmt.Sprintf("Task type %s is currently not supported", category), nil)
 	}
 	var visibilityTimestamp int64
-	if category == enumspb.TASK_CATEGORY_TIMER {
+	if category == enumsgenpb.TASK_CATEGORY_TIMER {
 		visibilityTimestamp = getRequiredInt64Option(c, FlagTaskVisibilityTimestamp)
 	}
 

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -372,12 +372,12 @@ func AdminGetShardID(c *cli.Context) {
 func AdminDescribeTask(c *cli.Context) {
 	sid := getRequiredIntOption(c, FlagShardID)
 	tid := getRequiredIntOption(c, FlagTaskID)
-	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), commongenpb.TaskCategory_value)
+	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), enumspb.TaskCategory_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse Task Type", err)
 	}
-	category := commongenpb.TaskCategory(categoryInt)
-	if category == commongenpb.TASK_CATEGORY_UNSPECIFIED {
+	category := enumspb.TaskCategory(categoryInt)
+	if category == enumspb.TASK_CATEGORY_UNSPECIFIED {
 		ErrorAndExit("Task type Unspecified is currently not supported", nil)
 	}
 
@@ -387,7 +387,7 @@ func AdminDescribeTask(c *cli.Context) {
 		ErrorAndExit("Failed to initialize execution manager", err)
 	}
 
-	if category == enumsgenpb.TASK_CATEGORY_TIMER {
+	if category == enumspb.TASK_CATEGORY_TIMER {
 		vis := getRequiredInt64Option(c, FlagTaskVisibilityTimestamp)
 		req := &persistence.GetTimerTaskRequest{ShardID: int32(sid), TaskID: int64(tid), VisibilityTimestamp: time.Unix(0, vis)}
 		task, err := executionManager.GetTimerTask(req)
@@ -395,14 +395,14 @@ func AdminDescribeTask(c *cli.Context) {
 			ErrorAndExit("Failed to get Timer Task", err)
 		}
 		prettyPrintJSONObject(task)
-	} else if category == enumsgenpb.TASK_CATEGORY_REPLICATION {
+	} else if category == enumspb.TASK_CATEGORY_REPLICATION {
 		req := &persistence.GetReplicationTaskRequest{ShardID: int32(sid), TaskID: int64(tid)}
 		task, err := executionManager.GetReplicationTask(req)
 		if err != nil {
 			ErrorAndExit("Failed to get Replication Task", err)
 		}
 		prettyPrintJSONObject(task)
-	} else if category == enumsgenpb.TASK_CATEGORY_TRANSFER {
+	} else if category == enumspb.TASK_CATEGORY_TRANSFER {
 		req := &persistence.GetTransferTaskRequest{ShardID: int32(sid), TaskID: int64(tid)}
 		task, err := executionManager.GetTransferTask(req)
 		if err != nil {
@@ -417,12 +417,12 @@ func AdminDescribeTask(c *cli.Context) {
 // AdminListTasks outputs a list of a tasks for given Shard and Task Type
 func AdminListTasks(c *cli.Context) {
 	sid := getRequiredIntOption(c, FlagShardID)
-	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), commongenpb.TaskCategory_value)
+	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), enumspb.TaskCategory_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse Task Type", err)
 	}
-	category := commongenpb.TaskCategory(categoryInt)
-	if category == commongenpb.TASK_CATEGORY_UNSPECIFIED {
+	category := enumspb.TaskCategory(categoryInt)
+	if category == enumspb.TASK_CATEGORY_UNSPECIFIED {
 		ErrorAndExit("Task type Unspecified is currently not supported", nil)
 	}
 
@@ -432,7 +432,7 @@ func AdminListTasks(c *cli.Context) {
 		ErrorAndExit("Failed to initialize execution manager", err)
 	}
 
-	if category == enumsgenpb.TASK_CATEGORY_TRANSFER {
+	if category == enumspb.TASK_CATEGORY_TRANSFER {
 		req := &persistence.GetTransferTasksRequest{}
 
 		paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
@@ -472,7 +472,7 @@ func AdminListTasks(c *cli.Context) {
 			return items, token, nil
 		}
 		paginate(c, paginationFunc)
-	} else if category == enumsgenpb.TASK_CATEGORY_REPLICATION {
+	} else if category == enumspb.TASK_CATEGORY_REPLICATION {
 		req := &persistence.GetReplicationTasksRequest{}
 		paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
 			req.NextPageToken = paginationToken
@@ -499,16 +499,16 @@ func AdminRemoveTask(c *cli.Context) {
 	adminClient := cFactory.AdminClient(c)
 	shardID := getRequiredIntOption(c, FlagShardID)
 	taskID := getRequiredInt64Option(c, FlagTaskID)
-	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), commongenpb.TaskCategory_value)
+	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), enumspb.TaskCategory_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse Task Type", err)
 	}
-	category := commongenpb.TaskCategory(categoryInt)
-	if category == commongenpb.TASK_CATEGORY_UNSPECIFIED {
+	category := enumspb.TaskCategory(categoryInt)
+	if category == enumspb.TASK_CATEGORY_UNSPECIFIED {
 		ErrorAndExit("Task type Unspecified is currently not supported", nil)
 	}
 	var visibilityTimestamp int64
-	if category == enumsgenpb.TASK_CATEGORY_TIMER {
+	if category == enumspb.TASK_CATEGORY_TIMER {
 		visibilityTimestamp = getRequiredInt64Option(c, FlagTaskVisibilityTimestamp)
 	}
 

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -413,9 +413,14 @@ func AdminDescribeTask(c *cli.Context) {
 // AdminListTasks outputs a list of a tasks for given Shard and Task Type
 func AdminListTasks(c *cli.Context) {
 	sid := getRequiredIntOption(c, FlagShardID)
-	categoryFlag := strings.Title(c.String(FlagTaskType))
-	categoryInt := enumsgenpb.TaskCategory_value[categoryFlag]
-	category := enumsgenpb.TaskCategory(categoryInt)
+	categoryInt, err := mapToEnumValue(c.String(FlagTaskType), commongenpb.TaskCategory_value)
+	if err != nil {
+		ErrorAndExit("Failed to parse Task Type", err)
+	}
+	category := commongenpb.TaskCategory(categoryInt)
+	if category == commongenpb.TASK_CATEGORY_UNSPECIFIED {
+		ErrorAndExit("Task type Unspecified is currently not supported", nil)
+	}
 
 	pFactory := CreatePersistenceFactory(c)
 	executionManager, err := pFactory.NewExecutionManager(sid)

--- a/tools/cli/adminTaskListCommands.go
+++ b/tools/cli/adminTaskListCommands.go
@@ -43,7 +43,7 @@ func AdminDescribeTaskList(c *cli.Context) {
 	frontendClient := cFactory.FrontendClient(c)
 	namespace := getRequiredGlobalOption(c, FlagNamespace)
 	taskList := getRequiredOption(c, FlagTaskList)
-	tlTypeInt, err := mapToEnumValue(c.String(FlagTaskListType), enumspb.TaskListType_value)
+	tlTypeInt, err := stringToEnum(c.String(FlagTaskListType), enumspb.TaskListType_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse TaskList Type", err)
 	}
@@ -117,7 +117,7 @@ func printPollerInfo(pollers []*tasklistpb.PollerInfo, taskListType enumspb.Task
 func AdminListTaskListTasks(c *cli.Context) {
 	namespace := getRequiredOption(c, FlagNamespaceID)
 	tlName := getRequiredOption(c, FlagTaskList)
-	tlTypeInt, err := mapToEnumValue(c.String(FlagTaskListType), enumspb.TaskListType_value)
+	tlTypeInt, err := stringToEnum(c.String(FlagTaskListType), enumspb.TaskListType_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse TaskList Type", err)
 	}

--- a/tools/cli/adminTaskListCommands.go
+++ b/tools/cli/adminTaskListCommands.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
@@ -44,17 +43,20 @@ func AdminDescribeTaskList(c *cli.Context) {
 	frontendClient := cFactory.FrontendClient(c)
 	namespace := getRequiredGlobalOption(c, FlagNamespace)
 	taskList := getRequiredOption(c, FlagTaskList)
-	taskListType := enumspb.TASK_LIST_TYPE_DECISION
-	if strings.ToLower(c.String(FlagTaskListType)) == "activity" {
-		taskListType = enumspb.TASK_LIST_TYPE_ACTIVITY
+	tlTypeInt, err := mapToEnumValue(c.String(FlagTaskListType), tasklistpb.TaskListType_value)
+	if err != nil {
+		ErrorAndExit("Failed to parse TaskList Type", err)
 	}
-
+	tlType := tasklistpb.TaskListType(tlTypeInt)
+	if tlType == tasklistpb.TASK_LIST_TYPE_UNSPECIFIED {
+		ErrorAndExit("TaskList type Unspecified is currently not supported", nil)
+	}
 	ctx, cancel := newContext(c)
 	defer cancel()
 	request := &workflowservice.DescribeTaskListRequest{
 		Namespace:             namespace,
 		TaskList:              &tasklistpb.TaskList{Name: taskList},
-		TaskListType:          taskListType,
+		TaskListType:          tlType,
 		IncludeTaskListStatus: true,
 	}
 
@@ -74,7 +76,7 @@ func AdminDescribeTaskList(c *cli.Context) {
 	if len(pollers) == 0 {
 		ErrorAndExit(colorMagenta("No poller for tasklist: "+taskList), nil)
 	}
-	printPollerInfo(pollers, taskListType)
+	printPollerInfo(pollers, tlType)
 }
 
 func printTaskListStatus(taskListStatus *tasklistpb.TaskListStatus) {
@@ -115,9 +117,14 @@ func printPollerInfo(pollers []*tasklistpb.PollerInfo, taskListType enumspb.Task
 func AdminListTaskListTasks(c *cli.Context) {
 	namespace := getRequiredOption(c, FlagNamespaceID)
 	tlName := getRequiredOption(c, FlagTaskList)
-	tlTypeFlag := strings.Title(c.String(FlagTaskListType))
-	tlTypeInt := enumspb.TaskListType_value[tlTypeFlag]
-	tlType := enumspb.TaskListType(tlTypeInt)
+	tlTypeInt, err := mapToEnumValue(c.String(FlagTaskListType), tasklistpb.TaskListType_value)
+	if err != nil {
+		ErrorAndExit("Failed to parse TaskList Type", err)
+	}
+	tlType := tasklistpb.TaskListType(tlTypeInt)
+	if tlType == tasklistpb.TASK_LIST_TYPE_UNSPECIFIED {
+		ErrorAndExit("TaskList type Unspecified is currently not supported", nil)
+	}
 	minReadLvl := getRequiredInt64Option(c, FlagMinReadLevel)
 	maxReadLvl := getRequiredInt64Option(c, FlagMaxReadLevel)
 

--- a/tools/cli/adminTaskListCommands.go
+++ b/tools/cli/adminTaskListCommands.go
@@ -43,12 +43,12 @@ func AdminDescribeTaskList(c *cli.Context) {
 	frontendClient := cFactory.FrontendClient(c)
 	namespace := getRequiredGlobalOption(c, FlagNamespace)
 	taskList := getRequiredOption(c, FlagTaskList)
-	tlTypeInt, err := mapToEnumValue(c.String(FlagTaskListType), tasklistpb.TaskListType_value)
+	tlTypeInt, err := mapToEnumValue(c.String(FlagTaskListType), enumspb.TaskListType_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse TaskList Type", err)
 	}
-	tlType := tasklistpb.TaskListType(tlTypeInt)
-	if tlType == tasklistpb.TASK_LIST_TYPE_UNSPECIFIED {
+	tlType := enumspb.TaskListType(tlTypeInt)
+	if tlType == enumspb.TASK_LIST_TYPE_UNSPECIFIED {
 		ErrorAndExit("TaskList type Unspecified is currently not supported", nil)
 	}
 	ctx, cancel := newContext(c)
@@ -117,12 +117,12 @@ func printPollerInfo(pollers []*tasklistpb.PollerInfo, taskListType enumspb.Task
 func AdminListTaskListTasks(c *cli.Context) {
 	namespace := getRequiredOption(c, FlagNamespaceID)
 	tlName := getRequiredOption(c, FlagTaskList)
-	tlTypeInt, err := mapToEnumValue(c.String(FlagTaskListType), tasklistpb.TaskListType_value)
+	tlTypeInt, err := mapToEnumValue(c.String(FlagTaskListType), enumspb.TaskListType_value)
 	if err != nil {
 		ErrorAndExit("Failed to parse TaskList Type", err)
 	}
-	tlType := tasklistpb.TaskListType(tlTypeInt)
-	if tlType == tasklistpb.TASK_LIST_TYPE_UNSPECIFIED {
+	tlType := enumspb.TaskListType(tlTypeInt)
+	if tlType == enumspb.TASK_LIST_TYPE_UNSPECIFIED {
 		ErrorAndExit("TaskList type Unspecified is currently not supported", nil)
 	}
 	minReadLvl := getRequiredInt64Option(c, FlagMinReadLevel)

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -742,37 +742,6 @@ func (s *cliAppSuite) TestIsAttributeName() {
 	s.False(isAttributeName("workflowExecutionStartedEventAttributes"))
 }
 
-func (s *cliAppSuite) TestGetWorkflowIdReusePolicy() {
-	res := getWorkflowIDReusePolicy(1)
-	s.Equal(res, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE)
-	res = getWorkflowIDReusePolicy(2)
-	s.Equal(res, enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY)
-	res = getWorkflowIDReusePolicy(3)
-	s.Equal(res, enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE)
-}
-
-func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_ExceedRange() {
-	oldOsExit := osExit
-	defer func() { osExit = oldOsExit }()
-	var errorCode int
-	osExit = func(code int) {
-		errorCode = code
-	}
-	getWorkflowIDReusePolicy(2147483647)
-	s.Equal(1, errorCode)
-}
-
-func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_Negative() {
-	oldOsExit := osExit
-	defer func() { osExit = oldOsExit }()
-	var errorCode int
-	osExit = func(code int) {
-		errorCode = code
-	}
-	getWorkflowIDReusePolicy(-1)
-	s.Equal(1, errorCode)
-}
-
 func (s *cliAppSuite) TestGetSearchAttributes() {
 	s.sdkClient.On("GetSearchAttributes", mock.Anything).Return(&workflowservice.GetSearchAttributesResponse{}, nil).Once()
 	err := s.app.Run([]string{"", "cluster", "get-search-attr"})

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -977,6 +977,10 @@ func printTable(items []interface{}) error {
 }
 
 func stringToEnum(search string, candidates map[string]int32) (int32, error) {
+	if search == "" {
+		return 0, nil
+	}
+
 	var candidateNames []string
 	for key, value := range candidates {
 		if strings.EqualFold(key, search) {

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -976,11 +976,10 @@ func printTable(items []interface{}) error {
 	return nil
 }
 
-func mapToEnumValue(search string, candidates map[string]int32) (int32, error) {
-	search = strings.ToLower(search)
+func stringToEnum(search string, candidates map[string]int32) (int32, error) {
 	var candidateNames []string
 	for key, value := range candidates {
-		if search == strings.ToLower(key) {
+		if strings.EqualFold(key, search) {
 			return value, nil
 		}
 		candidateNames = append(candidateNames, key)

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -976,6 +976,19 @@ func printTable(items []interface{}) error {
 	return nil
 }
 
+func mapToEnumValue(search string, candidates map[string]int32) (int32, error) {
+	search = strings.ToLower(search)
+	var candidateNames []string
+	for key, value := range candidates {
+		if search == strings.ToLower(key) {
+			return value, nil
+		}
+		candidateNames = append(candidateNames, key)
+	}
+
+	return 0, fmt.Errorf("Could not find corresponding candidate for %v. Possible candidates: %q", search, candidateNames)
+}
+
 // prompt will show input msg, then waiting user input y/yes to continue
 func prompt(msg string, autoConfirm bool) {
 	reader := bufio.NewReader(os.Stdin)

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -985,7 +985,7 @@ func stringToEnum(search string, candidates map[string]int32) (int32, error) {
 		candidateNames = append(candidateNames, key)
 	}
 
-	return 0, fmt.Errorf("Could not find corresponding candidate for %v. Possible candidates: %q", search, candidateNames)
+	return 0, fmt.Errorf("Could not find corresponding candidate for %s. Possible candidates: %q", search, candidateNames)
 }
 
 // prompt will show input msg, then waiting user input y/yes to continue

--- a/tools/cli/util_test.go
+++ b/tools/cli/util_test.go
@@ -1,0 +1,91 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+func (s *utilSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+func TestUtilSuite(t *testing.T) {
+	suite.Run(t, new(utilSuite))
+}
+
+type utilSuite struct {
+	*require.Assertions
+	suite.Suite
+}
+
+func (s *utilSuite) TestStringToEnum_MapCaseInsensitive() {
+	enumValues := map[string]int32{
+		"Unspecified": 0,
+		"Transfer":    1,
+		"Timer":       2,
+		"Replication": 3,
+	}
+
+	result, err := stringToEnum("timeR", enumValues)
+	s.NoError(err)
+	s.Equal(result, int32(2)) // Timer
+}
+
+func (s *utilSuite) TestStringToEnum_MapNonExisting() {
+	enumValues := map[string]int32{
+		"Unspecified": 0,
+		"Transfer":    1,
+		"Timer":       2,
+		"Replication": 3,
+	}
+
+	result, err := stringToEnum("Timer2", enumValues)
+	s.Error(err)
+	s.Equal(result, int32(0))
+}
+
+func (s *utilSuite) TestStringToEnum_MapEmptyValue() {
+	enumValues := map[string]int32{
+		"Unspecified": 0,
+		"Transfer":    1,
+		"Timer":       2,
+		"Replication": 3,
+	}
+
+	result, err := stringToEnum("", enumValues)
+	s.Error(err)
+	s.Equal(result, int32(0))
+}
+
+func (s *utilSuite) TestStringToEnum_MapEmptyEnum() {
+	enumValues := map[string]int32{}
+
+	result, err := stringToEnum("Timer", enumValues)
+	s.Error(err)
+	s.Equal(result, int32(0))
+}

--- a/tools/cli/util_test.go
+++ b/tools/cli/util_test.go
@@ -78,7 +78,7 @@ func (s *utilSuite) TestStringToEnum_MapEmptyValue() {
 	}
 
 	result, err := stringToEnum("", enumValues)
-	s.Error(err)
+	s.NoError(err)
 	s.Equal(result, int32(0))
 }
 

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -195,7 +195,7 @@ func startWorkflowHelper(c *cli.Context, shouldPrintProgress bool) {
 	}
 	reusePolicy := defaultWorkflowIDReusePolicy
 	if c.IsSet(FlagWorkflowIDReusePolicy) {
-		reusePolicyInt, err := mapToEnumValue(c.String(FlagWorkflowIDReusePolicy), enumspb.WorkflowIdReusePolicy_value)
+		reusePolicyInt, err := stringToEnum(c.String(FlagWorkflowIDReusePolicy), enumspb.WorkflowIdReusePolicy_value)
 		if err != nil {
 			ErrorAndExit("Failed to parse Reuse Policy", err)
 		}

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -195,11 +195,11 @@ func startWorkflowHelper(c *cli.Context, shouldPrintProgress bool) {
 	}
 	reusePolicy := defaultWorkflowIDReusePolicy
 	if c.IsSet(FlagWorkflowIDReusePolicy) {
-		reusePolicyInt, err := mapToEnumValue(c.String(FlagWorkflowIDReusePolicy), commonpb.WorkflowIdReusePolicy_value)
+		reusePolicyInt, err := mapToEnumValue(c.String(FlagWorkflowIDReusePolicy), enumspb.WorkflowIdReusePolicy_value)
 		if err != nil {
 			ErrorAndExit("Failed to parse Reuse Policy", err)
 		}
-		reusePolicy = commonpb.WorkflowIdReusePolicy(reusePolicyInt)
+		reusePolicy = enumspb.WorkflowIdReusePolicy(reusePolicyInt)
 	}
 
 	input := processJSONInput(c)

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -195,7 +195,11 @@ func startWorkflowHelper(c *cli.Context, shouldPrintProgress bool) {
 	}
 	reusePolicy := defaultWorkflowIDReusePolicy
 	if c.IsSet(FlagWorkflowIDReusePolicy) {
-		reusePolicy = getWorkflowIDReusePolicy(c.Int(FlagWorkflowIDReusePolicy))
+		reusePolicyInt, err := mapToEnumValue(c.String(FlagWorkflowIDReusePolicy), commonpb.WorkflowIdReusePolicy_value)
+		if err != nil {
+			ErrorAndExit("Failed to parse Reuse Policy", err)
+		}
+		reusePolicy = commonpb.WorkflowIdReusePolicy(reusePolicyInt)
 	}
 
 	input := processJSONInput(c)
@@ -1318,15 +1322,6 @@ func getWorkflowStatus(statusStr string) enumspb.WorkflowExecutionStatus {
 	ErrorAndExit(optionErr, errors.New("option status is not one of allowed values "+
 		"[running, completed, failed, canceled, terminated, continueasnew, timedout]"))
 	return 0
-}
-
-func getWorkflowIDReusePolicy(value int) enumspb.WorkflowIdReusePolicy {
-	if value > 0 && value < len(enumspb.WorkflowIdReusePolicy_value) {
-		return enumspb.WorkflowIdReusePolicy(value)
-	}
-	// At this point, the policy should return if the value is valid
-	ErrorAndExit(fmt.Sprintf("Option %v value is not in supported range.", FlagWorkflowIDReusePolicy), nil)
-	return enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE_FAILED_ONLY //doesn't really matter
 }
 
 // default will print decoded raw


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added util to map user CLI input to concrete enums. Replaced integer options to actual enum names.

<!-- Tell your future self why have you made these changes -->
**Why?**
In CLI, users can now type human friendly options instead of obscure integers. Example:
before:
`-- workflowidreusepolicy 1`
after:
`--workflowidreusepolicy AllowDuplicateFailedOnly` (case-insensitive)
If typed incorrectly, CLI will print out possible candidates.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran tests and commands.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Low risk. Main inconvenience for some users will be having to re-learn the usage of affected CLI options.
