### PR TITLE
Allow for empty postgres db password

### DIFF
--- a/common/persistence/sql/sqlplugin/postgres/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgres/plugin.go
@@ -77,7 +77,7 @@ func composeConnectionString(user, password, host, port, dbName string) string {
 	composeSegment := func(paramName string, paramValue string) string {
 		paramValue = strings.TrimSpace(paramValue)
 		if paramValue != "" {
-			return paramName + "=" + paramValue + " "
+			return fmt.Sprintf("%s=%s ", paramName, paramValue)
 		}
 		return ""
 	}

--- a/common/persistence/sql/sqlplugin/postgres/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgres/plugin.go
@@ -28,6 +28,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/iancoleman/strcase"
 	"github.com/jmoiron/sqlx"
@@ -39,8 +40,7 @@ import (
 
 const (
 	// PluginName is the name of the plugin
-	PluginName             = "postgres"
-	dataSourceNamePostgres = "user=%v password=%v host=%v port=%v dbname=%v sslmode=disable "
+	PluginName = "postgres"
 )
 
 var errTLSNotImplemented = errors.New("tls for postgres has not been implemented")
@@ -73,6 +73,23 @@ func (d *plugin) CreateAdminDB(cfg *config.SQL) (sqlplugin.AdminDB, error) {
 	return db, nil
 }
 
+func composeConnectionString(user, password, host, port, dbName string) string {
+	composeSegment := func(paramName string, paramValue string) string {
+		paramValue = strings.TrimSpace(paramValue)
+		if paramValue != "" {
+			return paramName + "=" + paramValue + " "
+		}
+		return ""
+	}
+
+	return composeSegment("user", user) +
+		composeSegment("password", password) +
+		composeSegment("host", host) +
+		composeSegment("port", port) +
+		composeSegment("dbname", dbName) +
+		composeSegment("sslmode", "disable")
+}
+
 // CreateDBConnection creates a returns a reference to a logical connection to the
 // underlying SQL database. The returned object is to tied to a single
 // SQL database and the object can be used to perform CRUD operations on
@@ -93,8 +110,8 @@ func (d *plugin) createDBConnection(cfg *config.SQL) (*sqlx.DB, error) {
 	if dbName == "" {
 		dbName = "postgres"
 	}
-	db, err := sqlx.Connect(PluginName, fmt.Sprintf(dataSourceNamePostgres, cfg.User, cfg.Password, host, port, dbName))
 
+	db, err := sqlx.Connect(PluginName, composeConnectionString(cfg.User, cfg.Password, host, port, dbName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Instead of using a hardcoded format string, compose postres connection string dynamically, based on which parameters were actually supplied.

<!-- Tell your future self why have you made these changes -->
**Why?**

This fixes issue https://github.com/temporalio/temporal/issues/460. Using a hardcoded format string resulted in connection strings that were incorrect (causing the behavior described in the issue).

This change makes it so the connection string is composed only using non-empty elements.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I used docker/docker-compose-postgres.yml to test this to bring up the server, `docker-compose -f docker-compose-postgres.yml  up`.

Before the fix, starting the server with an empty value for `POSTGRES_PWD` caused the server trying to connect to 127.0.0.1.

After the fix,  an empty value of `POSTGRES_PWD` does not cause this effect, the server tries to connect to the db server defined in `POSTGRES_SEEDS`. Things continue to work when the value of `POSTGRES_PWD` is not empty.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

if this is broken, postgres connectivity might become broken. in which case, we will fix or backout the change.
