### PR TITLE
Fix cli reuse policy flag type

### DIFF
--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -288,10 +288,10 @@ func (s *cliAppSuite) TestStartWorkflow() {
 	resp := &workflowservice.StartWorkflowExecutionResponse{RunId: uuid.New()}
 	s.frontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(resp, nil).Times(2)
 	// start with wid
-	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "-w", "wid", "wrp", "2"})
+	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "-w", "wid", "-wrp", "AllowDuplicateFailedOnly"})
 	s.Nil(err)
 	// start without wid
-	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "wrp", "2"})
+	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "-wrp", "AllowDuplicateFailedOnly"})
 	s.Nil(err)
 }
 

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -318,10 +318,10 @@ func getFlagsForStart() []cli.Flag {
 				"\t│ │ │ │ │ \n" +
 				"\t* * * * *",
 		},
-		cli.IntFlag{
+		cli.StringFlag{
 			Name: FlagWorkflowIDReusePolicyAlias,
-			Usage: "Optional input to configure if the same workflow Id is allow to use for new workflow execution. " +
-				"Available options: 0: AllowDuplicate, 1: AllowDuplicateFailedOnly, 2: RejectDuplicate",
+			Usage: "Configure if the same workflow Id is allowed for use in new workflow execution. " +
+				"Options: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate",
 		},
 		cli.StringFlag{
 			Name:  FlagInputWithAlias,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed the type of the FlagWorkflowIDReusePolicy op

<!-- Tell your future self why have you made these changes -->
**Why?**
The input from users would not be accepted if ReusePolicy is specified

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran tests and command

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Low risk: the flag affects two commands: workflow start and run. Other than these commands nothing else is affected. Both of these commands properly process ReusePolicy with the current fix
