### PR TITLE
Fix type assertion panic

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -723,8 +723,8 @@ func (e *historyEngineImpl) updateEntityNotExistsErrorOnPassiveCluster(err error
 		if namespaceCacheErr != nil {
 			return err // if could not access namespace cache simply return original error
 		}
-		namespaceNotActiveErr := namespaceCache.GetNamespaceNotActiveErr().(*serviceerror.NamespaceNotActive)
-		if namespaceNotActiveErr != nil {
+
+		if namespaceNotActiveErr, ok := namespaceCache.GetNamespaceNotActiveErr().(*serviceerror.NamespaceNotActive); ok && namespaceNotActiveErr != nil {
 			updatedErr := serviceerror.NewNotFound("Workflow execution not found in non-active cluster")
 			updatedErr.ActiveCluster = namespaceNotActiveErr.ActiveCluster
 			updatedErr.CurrentCluster = namespaceNotActiveErr.CurrentCluster


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`updateEntityNotExistsErrorOnPassiveCluster` generated panic on active cluster (=always). This func is called (at least) every time when `tctl` is called with some non-existing object (`workflow_id`, `run_id`, `namespace`, etc.) and instead of proper "Not found" error it shows "context cancelled" error.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix bug.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run `tctl` commands manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
