### PR TITLE
Fix retry for wrapped failures

### DIFF
--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -78,6 +78,7 @@ var (
 	errInvalidEventQueryRange                             = serviceerror.NewInvalidArgument("Invalid event query range.")
 	errUnknownValueType                                   = serviceerror.NewInvalidArgument("Unknown value type, %v.")
 	errDLQTypeIsNotSupported                              = serviceerror.NewInvalidArgument("The DLQ type is not supported.")
+	errFailureMustHaveApplicationFailureInfo              = serviceerror.NewInvalidArgument("Failure must have ApplicationFailureInfo.")
 	errShuttingDown                                       = serviceerror.NewInternal("Shutting down")
 
 	errFailedUpdateDynamicConfig = serviceerror.NewInternal("Failed to update dynamic config, err: %v.")

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1568,6 +1568,10 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(ctx context.Context, reques
 		return nil, wh.error(err, scope)
 	}
 
+	if request.GetFailure() != nil && request.GetFailure().GetApplicationFailureInfo() == nil {
+		return nil, wh.error(errFailureMustHaveApplicationFailureInfo, scope)
+	}
+
 	scope, sw := wh.startRequestProfileWithNamespace(
 		metrics.FrontendRespondActivityTaskFailedScope,
 		namespaceEntry.GetInfo().Name,

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -97,9 +97,8 @@ func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 		if failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_START_TO_CLOSE &&
 			failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_HEARTBEAT {
 			return false
-		} else {
-			return true
 		}
+		return true
 	}
 
 	if failure.GetServerFailureInfo() != nil {
@@ -118,7 +117,6 @@ func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 			}
 		}
 	}
-
 	return true
 }
 
@@ -126,6 +124,5 @@ func getCauseFailure(failure *failurepb.Failure) *failurepb.Failure {
 	// Extract cause for ChildWorkflowExecutionFailure and ActivityFailure.
 	for ; failure.GetCause() != nil && (failure.GetChildWorkflowExecutionFailureInfo() != nil || failure.GetActivityFailureInfo() != nil); failure = failure.GetCause() {
 	}
-
 	return failure
 }

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -94,11 +94,8 @@ func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 	}
 
 	if failure.GetTimeoutFailureInfo() != nil {
-		if failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_START_TO_CLOSE &&
-			failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_HEARTBEAT {
-			return false
-		}
-		return true
+		return failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_START_TO_CLOSE &&
+			failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_HEARTBEAT
 	}
 
 	if failure.GetServerFailureInfo() != nil {

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -88,14 +88,13 @@ func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 		return true
 	}
 
-	failure = getCauseFailure(failure)
 	if failure.GetTerminatedFailureInfo() != nil || failure.GetCanceledFailureInfo() != nil {
 		return false
 	}
 
 	if failure.GetTimeoutFailureInfo() != nil {
-		return failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_START_TO_CLOSE &&
-			failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_HEARTBEAT
+		return failure.GetTimeoutFailureInfo().GetTimeoutType() == enumspb.TIMEOUT_TYPE_START_TO_CLOSE ||
+			failure.GetTimeoutFailureInfo().GetTimeoutType() == enumspb.TIMEOUT_TYPE_HEARTBEAT
 	}
 
 	if failure.GetServerFailureInfo() != nil {
@@ -115,11 +114,4 @@ func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 		}
 	}
 	return true
-}
-
-func getCauseFailure(failure *failurepb.Failure) *failurepb.Failure {
-	// Extract cause for ChildWorkflowExecutionFailure and ActivityFailure.
-	for ; failure.GetCause() != nil && (failure.GetChildWorkflowExecutionFailureInfo() != nil || failure.GetActivityFailureInfo() != nil); failure = failure.GetCause() {
-	}
-	return failure
 }

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -93,15 +93,15 @@ func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 		return false
 	}
 
-	if failure.GetApplicationFailureInfo().GetNonRetryable() || failure.GetServerFailureInfo().GetNonRetryable() {
-		return false
-	}
-
 	if failure.GetTimeoutFailureInfo() != nil {
 		if failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_START_TO_CLOSE &&
 			failure.GetTimeoutFailureInfo().GetTimeoutType() != enumspb.TIMEOUT_TYPE_HEARTBEAT {
 			return false
 		}
+	}
+
+	if failure.GetApplicationFailureInfo().GetNonRetryable() || failure.GetServerFailureInfo().GetNonRetryable() {
+		return false
 	}
 
 	if failure.GetApplicationFailureInfo() != nil {
@@ -117,8 +117,8 @@ func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 }
 
 func getCauseFailure(failure *failurepb.Failure) *failurepb.Failure {
-	for ; failure.GetCause() != nil; failure = failure.GetCause() {
+	// Unwrap failures till the first ApplicationFailure because only first ApplicationFailure controls retryable.
+	for ; failure.GetCause() != nil && failure.GetApplicationFailureInfo() == nil; failure = failure.GetCause() {
 	}
-
 	return failure
 }

--- a/service/history/retry_test.go
+++ b/service/history/retry_test.go
@@ -118,6 +118,7 @@ func Test_IsRetryable(t *testing.T) {
 	a.False(isRetryable(f, []string{"otherType", "type"}))
 	a.False(isRetryable(f, []string{"type"}))
 
+	// When any failure is inside ChildWorkflowExecutionFailure, it is always retryable because ChildWorkflow is always retryable.
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_ChildWorkflowExecutionFailureInfo{ChildWorkflowExecutionFailureInfo: &failurepb.ChildWorkflowExecutionFailureInfo{}},
 		Cause: &failurepb.Failure{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`getCauseFailure` stops at first `ApplicationFailureInfo`.

Closes https://github.com/temporalio/temporal-go-sdk/issues/175.

<!-- Tell your future self why have you made these changes -->
**Why?**
Non-retryable behaviour doesn't work correctly if non-retryable error has retryable error as a cause.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added bunch of unit tests to cover all possible cases.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
