### PR TITLE
upgrade gocql to latest release

### DIFF
--- a/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
+++ b/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
@@ -285,20 +285,25 @@ func (m *cassandraMetadataPersistenceV2) ListNamespaces(request *p.ListNamespace
 		return nil, serviceerror.NewInternal("ListNamespaces operation failed.  Not able to create query iterator.")
 	}
 
-	var name string
-	var detail []byte
-	var detailEncoding string
-	var notificationVersion int64
-	var isGlobal bool
 	response := &p.InternalListNamespacesResponse{}
-	for iter.Scan(
-		nil,
-		&name,
-		&detail,
-		&detailEncoding,
-		&notificationVersion,
-		&isGlobal,
-	) {
+	for {
+		var name string
+		var detail []byte
+		var detailEncoding string
+		var notificationVersion int64
+		var isGlobal bool
+		if !iter.Scan(
+			nil,
+			&name,
+			&detail,
+			&detailEncoding,
+			&notificationVersion,
+			&isGlobal,
+		) {
+			// done iterating over all namespaces in this page
+			break
+		}
+
 		// do not include the metadata record
 		if name != namespaceMetadataRecordName {
 			response.Namespaces = append(response.Namespaces, &p.InternalGetNamespaceResponse{

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/emirpasic/gods v0.0.0-20190624094223-e689965507ab
 	github.com/fatih/color v1.9.0
 	github.com/go-sql-driver/mysql v1.5.0
-	github.com/gocql/gocql v0.0.0-20171220143535-56a164ee9f31
+	github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e
 	github.com/gogo/protobuf v1.3.1
 	github.com/gogo/status v1.1.0
 	github.com/golang/mock v1.4.3

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,7 @@ github.com/benbjohnson/clock v1.0.2 h1:Z0CN0Yb4ig9sGPXkvAQcGJfnrrMQ5QYLCMPRi9iD7
 github.com/benbjohnson/clock v1.0.2/go.mod h1:bGMdMPoPVvcYyt1gHDf4J2KE153Yf9BuiUKYMaxlTDM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
 github.com/bitly/go-hostpool v0.1.0 h1:XKmsF6k5el6xHG3WPJ8U0Ku/ye7njX7W81Ng7O2ioR0=
 github.com/bitly/go-hostpool v0.1.0/go.mod h1:4gOCgp6+NZnVqlKyZ/iBZFTAJKembaVENUpMkpg42fw=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
@@ -114,6 +115,8 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/gocql/gocql v0.0.0-20171220143535-56a164ee9f31 h1:kPjRO/S+4pjIgvub1+xsaQ6xudIgvVPoJYGGkJ7Qx8E=
 github.com/gocql/gocql v0.0.0-20171220143535-56a164ee9f31/go.mod h1:GjP0ITc4WbMO5dEWwikPqq0ZWbloAO6CO6g0VAK7tTc=
+github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e h1:SroDcndcOU9BVAduPf/PXihXoR2ZYTQYLXbupbqxAyQ=
+github.com/gocql/gocql v0.0.0-20200624222514-34081eda590e/go.mod h1:DL0ekTmBSTdlNF25Orwt/JMzqIq3EJ4MVa/J/uK64OY=
 github.com/gogo/googleapis v0.0.0-20180223154316-0cd9801be74a/go.mod h1:gf4bu3Q80BeJ6H1S1vYPm8/ELATdvryBaNFGgqEef3s=
 github.com/gogo/googleapis v1.4.0 h1:zgVt4UpGxcqVOw97aRGxT4svlcmdK35fynLNctY32zI=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
@@ -148,6 +151,7 @@ github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvq
 github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QDs8UjoX8=
 github.com/golang/protobuf v1.4.2 h1:+Z5KGCizgyZCbGh1KZqA0fcLLkwbsjIzS4aV2v7wJX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
+github.com/golang/snappy v0.0.0-20170215233205-553a64147049/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1 h1:Qgr9rKW7uDUkrbSmQeiDsGa8SjGyCOGtuasMWwvp2P4=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Upgrade gocql to latest release

<!-- Tell your future self why have you made these changes -->
**Why?**
Fixes #140 
We had to pin gocql to very old bits due to failures in running persistence unit test on upgrade.
I chased these failures were caused by [this](https://github.com/gocql/gocql/commit/f596bd36e19ecaa7a9be478cf137fedc75036b02) change in gocql.  The behavior changed where byte arrays are no longer copied before returning back to the caller.  If a buffer is passed in to read byte buffer from database then gocql will write the value in the preallocated buffer instead of allocating a new buffer for each value.  This requires a change in the caller pattern when they are passing in slices as if multiple values are read in the same buffer then it would cause the previous value to be overwritten resulting in corruption of payload.
Updated all call locations to make sure new buffer is allocated when reading multiple values from database.

Similar situation was happening with page token getting corrupted before being returned back to the user.  Pagination logic in GetClusterMembers was completely broken resulting in caller to cycle on results if last page has less items then the page size.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
ran unit and integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Could impact interaction with Cassandra persistence.
