### PR TITLE
Replace Slack with Discourse info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Temporal  
 [![Build status](https://badge.buildkite.com/fc0e676d7bee1a159916af52ebdb541708d4b9f88b8a980f6b.svg)](https://buildkite.com/temporal/temporal-server)
 [![Coverage Status](https://coveralls.io/repos/github/temporalio/temporal/badge.svg?branch=master)](https://coveralls.io/github/temporalio/temporal?branch=master)
-[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://join.slack.com/t/temporalio/shared_invite/zt-c1e99p8g-beF7~ZZW2HP6gGStXD8Nuw)
+[![Discourse](https://img.shields.io/static/v1?label=Discourse&message=Get%20Help&color=informational)](https://community.temporal.io)
 
 Visit [docs.temporal.io](https://docs.temporal.io) to learn about Temporal.
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Replacing the `Join Slack` badge with a badge linking to Discourse.

<!-- Tell your future self why have you made these changes -->
**Why?**

Due to the announcement that Discourse is now the official support forum.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Manual verification of hyperlink.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None.