### PR TITLE
Remove statsd from docker-compose-mysql.yml

### DIFF
--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -6,13 +6,6 @@ services:
       - "3306:3306"
     environment:
       - "MYSQL_ROOT_PASSWORD=root"
-  statsd:
-    image: graphiteapp/graphite-statsd
-    ports:
-      - "8080:80"
-      - "2003:2003"
-      - "8125:8125"
-      - "8126:8126"
   temporal:
     image: temporalio/auto-setup:0.23.1
     ports:
@@ -22,11 +15,9 @@ services:
       - "MYSQL_USER=root"
       - "MYSQL_PWD=root"
       - "MYSQL_SEEDS=mysql"
-      - "STATSD_ENDPOINT=statsd:8125"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - mysql
-      - statsd
   temporal-web:
     image: temporalio/web:0.23.2
     environment:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Removing statsd from `docker-compose-mysql.yml`

<!-- Tell your future self why have you made these changes -->
**Why?**

We don't need statsd dependency in docker compose files, and this may help troubleshoot a problem. Once this is in, we may want to do the same thing for all our docker-compose files.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I started the service locally by running 
```
$ docker-compose -f docker-compose-mysql.yml up
```
and made sure the service came up as expected.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

if this is broken, docker-compose runs won't work. will investigate and fix / or back our. there is no production workflow that depends on this currently.
