### PR TITLE
Remove cancel failed events for activity and timer

### DIFF
--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -287,21 +287,6 @@ func (b *historyBuilder) AddTimerCanceledEvent(startedEventID int64,
 	return b.addEventToHistory(event)
 }
 
-func (b *historyBuilder) AddCancelTimerFailedEvent(timerID string, workflowTaskCompletedEventID int64,
-	cause string, identity string) *historypb.HistoryEvent {
-
-	attributes := &historypb.CancelTimerFailedEventAttributes{}
-	attributes.TimerId = timerID
-	attributes.WorkflowTaskCompletedEventId = workflowTaskCompletedEventID
-	attributes.Cause = cause
-	attributes.Identity = identity
-
-	event := b.msBuilder.CreateNewHistoryEvent(enumspb.EVENT_TYPE_CANCEL_TIMER_FAILED)
-	event.Attributes = &historypb.HistoryEvent_CancelTimerFailedEventAttributes{CancelTimerFailedEventAttributes: attributes}
-
-	return b.addEventToHistory(event)
-}
-
 func (b *historyBuilder) AddWorkflowExecutionCancelRequestedEvent(cause string,
 	request *historyservice.RequestCancelWorkflowExecutionRequest) *historypb.HistoryEvent {
 	event := b.newWorkflowExecutionCancelRequestedEvent(cause, request)

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4501,7 +4501,7 @@ func (s *engineSuite) TestCancelTimer_RespondWorkflowTaskCompleted_NoStartTimer(
 	s.Equal(int64(5), executionBuilder.GetExecutionInfo().NextEventID)
 	s.Equal(int64(common.EmptyEventID), executionBuilder.GetExecutionInfo().LastProcessedEvent)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, executionBuilder.GetExecutionInfo().State)
-	s.False(executionBuilder.HasPendingWorkflowTask())
+	s.True(executionBuilder.HasPendingWorkflowTask())
 }
 
 func (s *engineSuite) TestCancelTimer_RespondWorkflowTaskCompleted_TimerFired() {

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4472,6 +4472,9 @@ func (s *engineSuite) TestCancelTimer_RespondWorkflowTaskCompleted_NoStartTimer(
 	ms := createMutableState(msBuilder)
 	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
 
+	ms2 := createMutableState(msBuilder)
+	gwmsResponse2 := &persistence.GetWorkflowExecutionResponse{State: ms2}
+
 	commands := []*commandpb.Command{{
 		CommandType: enumspb.COMMAND_TYPE_CANCEL_TIMER,
 		Attributes: &commandpb.Command_CancelTimerCommandAttributes{CancelTimerCommandAttributes: &commandpb.CancelTimerCommandAttributes{
@@ -4480,6 +4483,7 @@ func (s *engineSuite) TestCancelTimer_RespondWorkflowTaskCompleted_NoStartTimer(
 	}}
 
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gwmsResponse, nil).Once()
+	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gwmsResponse2, nil).Once()
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything).Return(&persistence.AppendHistoryNodesResponse{Size: 0}, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
@@ -4494,8 +4498,8 @@ func (s *engineSuite) TestCancelTimer_RespondWorkflowTaskCompleted_NoStartTimer(
 	s.Nil(err)
 
 	executionBuilder := s.getBuilder(testNamespaceID, we)
-	s.Equal(int64(6), executionBuilder.GetExecutionInfo().NextEventID)
-	s.Equal(int64(3), executionBuilder.GetExecutionInfo().LastProcessedEvent)
+	s.Equal(int64(5), executionBuilder.GetExecutionInfo().NextEventID)
+	s.Equal(int64(common.EmptyEventID), executionBuilder.GetExecutionInfo().LastProcessedEvent)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, executionBuilder.GetExecutionInfo().State)
 	s.False(executionBuilder.HasPendingWorkflowTask())
 }

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -74,7 +74,6 @@ type (
 		AddActivityTaskScheduledEvent(int64, *commandpb.ScheduleActivityTaskCommandAttributes) (*historypb.HistoryEvent, *persistence.ActivityInfo, error)
 		AddActivityTaskStartedEvent(*persistence.ActivityInfo, int64, string, string) (*historypb.HistoryEvent, error)
 		AddActivityTaskTimedOutEvent(int64, int64, *failurepb.Failure, enumspb.RetryState) (*historypb.HistoryEvent, error)
-		AddCancelTimerFailedEvent(int64, *commandpb.CancelTimerCommandAttributes, string) (*historypb.HistoryEvent, error)
 		AddChildWorkflowExecutionCanceledEvent(int64, *commonpb.WorkflowExecution, *historypb.WorkflowExecutionCanceledEventAttributes) (*historypb.HistoryEvent, error)
 		AddChildWorkflowExecutionCompletedEvent(int64, *commonpb.WorkflowExecution, *historypb.WorkflowExecutionCompletedEventAttributes) (*historypb.HistoryEvent, error)
 		AddChildWorkflowExecutionFailedEvent(int64, *commonpb.WorkflowExecution, *historypb.WorkflowExecutionFailedEventAttributes) (*historypb.HistoryEvent, error)

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -961,10 +961,9 @@ func (e *mutableStateBuilder) shouldBufferEvent(
 		enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED,
 		enumspb.EVENT_TYPE_TIMER_STARTED,
 		// CommandTypeCancelTimer is an exception. This command will be mapped
-		// to either workflow.EventTypeTimerCanceled, or workflow.EventTypeCancelTimerFailed.
-		// So both should not be buffered. Ref: historyEngine, search for "workflow.CommandTypeCancelTimer"
+		// to workflow.EventTypeTimerCanceled.
+		// This event should not be buffered. Ref: historyEngine, search for "workflow.CommandTypeCancelTimer"
 		enumspb.EVENT_TYPE_TIMER_CANCELED,
-		enumspb.EVENT_TYPE_CANCEL_TIMER_FAILED,
 		enumspb.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED,
 		enumspb.EVENT_TYPE_MARKER_RECORDED,
 		enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED,
@@ -3191,23 +3190,6 @@ func (e *mutableStateBuilder) ReplicateTimerCanceledEvent(
 	timerID := attributes.GetTimerId()
 
 	return e.DeleteUserTimer(timerID)
-}
-
-func (e *mutableStateBuilder) AddCancelTimerFailedEvent(
-	workflowTaskCompletedEventID int64,
-	attributes *commandpb.CancelTimerCommandAttributes,
-	identity string,
-) (*historypb.HistoryEvent, error) {
-
-	opTag := tag.WorkflowActionTimerCancelFailed
-	if err := e.checkMutability(opTag); err != nil {
-		return nil, err
-	}
-
-	// No Operation: We couldn't cancel it probably TIMER_ID_UNKNOWN
-	timerID := attributes.GetTimerId()
-	return e.hBuilder.AddCancelTimerFailedEvent(timerID, workflowTaskCompletedEventID,
-		timerCancellationMsgTimerIDUnknown, identity), nil
 }
 
 func (e *mutableStateBuilder) AddRecordMarkerEvent(

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -260,8 +260,7 @@ OtherEventsLoop:
 
 	commandTypes := enumspb.CommandType_name
 	delete(commandTypes, 0) // Remove Unspecified.
-	// +1 is because CommandTypeCancelTimer will be mapped to workflow.EventTypeTimerCanceled.
-	s.Equal(len(commandTypes)+1, len(commandEvents),
+	s.Equal(len(commandTypes), len(commandEvents),
 		"This assertion will be broken a new command is added and no corresponding logic added to shouldBufferEvent()")
 }
 

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -220,7 +220,6 @@ func (s *mutableStateSuite) TestShouldBufferEvent() {
 		enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED:                       true,
 		enumspb.EVENT_TYPE_TIMER_STARTED:                                        true,
 		enumspb.EVENT_TYPE_TIMER_CANCELED:                                       true,
-		enumspb.EVENT_TYPE_CANCEL_TIMER_FAILED:                                  true,
 		enumspb.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED: true,
 		enumspb.EVENT_TYPE_MARKER_RECORDED:                                      true,
 		enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED:             true,
@@ -261,8 +260,7 @@ OtherEventsLoop:
 
 	commandTypes := enumspb.CommandType_name
 	delete(commandTypes, 0) // Remove Unspecified.
-	// +1 is because CommandTypeCancelTimer will be mapped
-	// to either workflow.EventTypeTimerCanceled, or workflow.EventTypeCancelTimerFailed.
+	// +1 is because CommandTypeCancelTimer will be mapped to workflow.EventTypeTimerCanceled.
 	s.Equal(len(commandTypes)+1, len(commandEvents),
 		"This assertion will be broken a new command is added and no corresponding logic added to shouldBufferEvent()")
 }

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -177,21 +177,6 @@ func (mr *MockmutableStateMockRecorder) AddActivityTaskTimedOutEvent(arg0, arg1,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddActivityTaskTimedOutEvent", reflect.TypeOf((*MockmutableState)(nil).AddActivityTaskTimedOutEvent), arg0, arg1, arg2, arg3)
 }
 
-// AddCancelTimerFailedEvent mocks base method.
-func (m *MockmutableState) AddCancelTimerFailedEvent(arg0 int64, arg1 *command.CancelTimerCommandAttributes, arg2 string) (*history.HistoryEvent, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddCancelTimerFailedEvent", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*history.HistoryEvent)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// AddCancelTimerFailedEvent indicates an expected call of AddCancelTimerFailedEvent.
-func (mr *MockmutableStateMockRecorder) AddCancelTimerFailedEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCancelTimerFailedEvent", reflect.TypeOf((*MockmutableState)(nil).AddCancelTimerFailedEvent), arg0, arg1, arg2)
-}
-
 // AddChildWorkflowExecutionCanceledEvent mocks base method.
 func (m *MockmutableState) AddChildWorkflowExecutionCanceledEvent(arg0 int64, arg1 *common.WorkflowExecution, arg2 *history.WorkflowExecutionCanceledEventAttributes) (*history.HistoryEvent, error) {
 	m.ctrl.T.Helper()

--- a/service/history/stateBuilder.go
+++ b/service/history/stateBuilder.go
@@ -352,9 +352,6 @@ func (b *stateBuilderImpl) applyEvents(
 				return nil, err
 			}
 
-		case enumspb.EVENT_TYPE_REQUEST_CANCEL_ACTIVITY_TASK_FAILED:
-			// No mutable state action is needed
-
 		case enumspb.EVENT_TYPE_TIMER_STARTED:
 			if _, err := b.mutableState.ReplicateTimerStartedEvent(
 				event,
@@ -375,9 +372,6 @@ func (b *stateBuilderImpl) applyEvents(
 			); err != nil {
 				return nil, err
 			}
-
-		case enumspb.EVENT_TYPE_CANCEL_TIMER_FAILED:
-			// no mutable state action is needed
 
 		case enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED:
 			if _, err := b.mutableState.ReplicateStartChildWorkflowExecutionInitiatedEvent(

--- a/service/history/stateBuilder_test.go
+++ b/service/history/stateBuilder_test.go
@@ -972,33 +972,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerFired() {
 	s.Nil(err)
 }
 
-func (s *stateBuilderSuite) TestApplyEvents_EventTypeCancelTimerFailed() {
-	version := int64(1)
-	requestID := uuid.New()
-
-	execution := commonpb.WorkflowExecution{
-		WorkflowId: "some random workflow ID",
-		RunId:      testRunID,
-	}
-
-	now := time.Now()
-	evenType := enumspb.EVENT_TYPE_CANCEL_TIMER_FAILED
-	event := &historypb.HistoryEvent{
-		Version:    version,
-		EventId:    130,
-		Timestamp:  now.UnixNano(),
-		EventType:  evenType,
-		Attributes: &historypb.HistoryEvent_CancelTimerFailedEventAttributes{CancelTimerFailedEventAttributes: &historypb.CancelTimerFailedEventAttributes{}},
-	}
-	s.mockUpdateVersion(event)
-	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
-	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
-	// need to be refreshed each time
-	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
-	_, err := s.stateBuilder.applyEvents(testNamespaceID, requestID, execution, s.toHistory(event), nil, false)
-	s.Nil(err)
-}
-
 func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerCanceled() {
 	version := int64(1)
 	requestID := uuid.New()

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -510,12 +510,8 @@ func (handler *workflowTaskHandlerImpl) handleCommandCancelTimer(
 		handler.hasBufferedEvents = handler.mutableState.HasBufferedEvents()
 		return nil
 	case *serviceerror.InvalidArgument:
-		_, err = handler.mutableState.AddCancelTimerFailedEvent(
-			handler.workflowTaskCompletedID,
-			attr,
-			handler.identity,
-		)
-		return err
+		return handler.handlerFailDecision(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_CANCEL_TIMER_ATTRIBUTES,
+			err.Error())
 	default:
 		return err
 	}

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -510,7 +510,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCancelTimer(
 		handler.hasBufferedEvents = handler.mutableState.HasBufferedEvents()
 		return nil
 	case *serviceerror.InvalidArgument:
-		return handler.handlerFailDecision(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_CANCEL_TIMER_ATTRIBUTES,
+		return handler.handlerFailCommand(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_CANCEL_TIMER_ATTRIBUTES,
 			err.Error())
 	default:
 		return err

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -260,9 +260,6 @@ func ColorEvent(e *historypb.HistoryEvent) string {
 	case enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED:
 		data = e.EventType.String()
 
-	case enumspb.EVENT_TYPE_REQUEST_CANCEL_ACTIVITY_TASK_FAILED:
-		data = color.RedString(e.EventType.String())
-
 	case enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCELED:
 		data = e.EventType.String()
 
@@ -271,9 +268,6 @@ func ColorEvent(e *historypb.HistoryEvent) string {
 
 	case enumspb.EVENT_TYPE_TIMER_FIRED:
 		data = e.EventType.String()
-
-	case enumspb.EVENT_TYPE_CANCEL_TIMER_FAILED:
-		data = color.RedString(e.EventType.String())
 
 	case enumspb.EVENT_TYPE_TIMER_CANCELED:
 		data = color.MagentaString(e.EventType.String())
@@ -400,9 +394,6 @@ func getEventAttributes(e *historypb.HistoryEvent) interface{} {
 
 	case enumspb.EVENT_TYPE_TIMER_FIRED:
 		data = e.GetTimerFiredEventAttributes()
-
-	case enumspb.EVENT_TYPE_CANCEL_TIMER_FAILED:
-		data = e.GetCancelTimerFailedEventAttributes()
 
 	case enumspb.EVENT_TYPE_TIMER_CANCELED:
 		data = e.GetTimerCanceledEventAttributes()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
RequestCancelActivityTaskFailed was already removed in PR #355, so
this PR removes the unused EVENT_TYPE_REQUEST_CANCEL_ACTIVITY_TASK_FAILED
enum.
Removing all logic which results in CancelTimerFailed event in the
history when TimerCancel decision is made and instead fail the
entire decision.


<!-- Tell your future self why have you made these changes -->
**Why?**
Whenever workflow worker makes a cancel decision, requestCancelActivity
in the case of an activity and cancelTimer in the case of timer we
no longer fail the individual decision if we cannot find the activity
or timer to cancel.  This means sdk code has a bug which resulted in
client code to be able to make cancellation decision in the first
place.  We should be failing the entire decision like we do in all
other places.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit and Integration Tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk
