### PR TITLE
Remove statsd from / add admin-tools to docker-compose files

### DIFF
--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -14,10 +14,11 @@ services:
     command: ["start", "--insecure"]
 
   temporal:
-    image: temporalio/auto-setup:0.26.0
+    image: temporalio/server:0.26.0
     ports:
      - "7233:7233"
     environment:
+      - "AUTO_SETUP=true"
       - "DB=postgres"
       - "DB_PORT=26257"
       - "POSTGRES_USER=root"

--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -12,7 +12,6 @@ services:
     cap_drop:
     - ALL
     command: ["start", "--insecure"]
-
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.26.0}
     ports:

--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -14,7 +14,7 @@ services:
     command: ["start", "--insecure"]
 
   temporal:
-    image: temporalio/server:0.26.0
+    image: temporalio/server:${SERVER_TAG:-0.26.0}
     ports:
      - "7233:7233"
     environment:
@@ -30,7 +30,7 @@ services:
     links:
     - cockroach:postgres
   temporal-admin-tools:
-    image: temporalio/admin-tools:0.26.0
+    image: temporalio/admin-tools:${SERVER_TAG:-0.26.0}
     stdin_open: true
     tty: true
     environment:

--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -38,7 +38,7 @@ services:
     depends_on:
       - temporal
   temporal-web:
-    image: temporalio/web:0.26.0
+    image: temporalio/web:${WEB_TAG:-0.26.0}
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:

--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -28,7 +28,14 @@ services:
       - cockroach
     links:
     - cockroach:postgres
-    
+  temporal-admin-tools:
+    image: temporalio/admin-tools:0.26.0
+    stdin_open: true
+    tty: true
+    environment:
+      - "TEMPORAL_CLI_ADDRESS=temporal:7233"
+    depends_on:
+      - temporal
   temporal-web:
     image: temporalio/web:0.26.0
     environment:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -49,7 +49,7 @@ services:
     depends_on:
       - temporal
   temporal-web:
-    image: temporalio/web:0.26.0
+    image: temporalio/web:${WEB_TAG:-0.26.0}
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -41,7 +41,7 @@ services:
       - kafka
       - elasticsearch
   temporal-admin-tools:
-    image: temporalio/admin-tools:${ADMIN_TOOLS_TAG:-0.26.0}
+    image: temporalio/admin-tools:${SERVER_TAG:-0.26.0}
     stdin_open: true
     tty: true
     environment:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -14,10 +14,11 @@ services:
       - "8125:8125"
       - "8126:8126"
   temporal:
-    image: temporalio/auto-setup:0.26.0
+    image: temporalio/server:0.26.0
     ports:
      - "7233:7233"
     environment:
+      - "AUTO_SETUP=true"
       - "DB=mysql"
       - "MYSQL_USER=root"
       - "MYSQL_PWD=root"

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -37,7 +37,7 @@ services:
     depends_on:
       - temporal
   temporal-web:
-    image: temporalio/web:0.26.0
+    image: temporalio/web:${WEB_TAG:-0.26.0}
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -14,7 +14,7 @@ services:
       - "8125:8125"
       - "8126:8126"
   temporal:
-    image: temporalio/server:0.26.0
+    image: temporalio/server:${SERVER_TAG:-0.26.0}
     ports:
      - "7233:7233"
     environment:
@@ -29,7 +29,7 @@ services:
       - mysql
       - statsd
   temporal-admin-tools:
-    image: temporalio/admin-tools:0.26.0
+    image: temporalio/admin-tools:${SERVER_TAG:-0.26.0}
     stdin_open: true
     tty: true
     environment:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -27,6 +27,14 @@ services:
     depends_on:
       - mysql
       - statsd
+  temporal-admin-tools:
+    image: temporalio/admin-tools:0.26.0
+    stdin_open: true
+    tty: true
+    environment:
+      - "TEMPORAL_CLI_ADDRESS=temporal:7233"
+    depends_on:
+      - temporal
   temporal-web:
     image: temporalio/web:0.26.0
     environment:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -6,13 +6,6 @@ services:
       - "3306:3306"
     environment:
       - "MYSQL_ROOT_PASSWORD=root"
-  statsd:
-    image: graphiteapp/graphite-statsd
-    ports:
-      - "8080:80"
-      - "2003:2003"
-      - "8125:8125"
-      - "8126:8126"
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.26.0}
     ports:
@@ -23,11 +16,9 @@ services:
       - "MYSQL_USER=root"
       - "MYSQL_PWD=root"
       - "MYSQL_SEEDS=mysql"
-      - "STATSD_ENDPOINT=statsd:8125"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - mysql
-      - statsd
   temporal-admin-tools:
     image: temporalio/admin-tools:${SERVER_TAG:-0.26.0}
     stdin_open: true

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -7,13 +7,6 @@ services:
       POSTGRES_PASSWORD: temporal
     ports:
       - "5432:5432"
-  statsd:
-    image: graphiteapp/graphite-statsd
-    ports:
-      - "8080:80"
-      - "2003:2003"
-      - "8125:8125"
-      - "8126:8126"
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.26.0}
     ports:
@@ -25,7 +18,6 @@ services:
       - "POSTGRES_USER=temporal"
       - "POSTGRES_PWD=temporal"
       - "POSTGRES_SEEDS=postgres"
-      - "STATSD_ENDPOINT=statsd:8125"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - postgres

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -38,7 +38,7 @@ services:
     depends_on:
       - temporal
   temporal-web:
-    image: temporalio/web:0.26.0
+    image: temporalio/web:${WEB_TAG:-0.26.0}
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -28,6 +28,14 @@ services:
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - postgres
+  temporal-admin-tools:
+    image: temporalio/admin-tools:0.26.0
+    stdin_open: true
+    tty: true
+    environment:
+      - "TEMPORAL_CLI_ADDRESS=temporal:7233"
+    depends_on:
+      - temporal
   temporal-web:
     image: temporalio/web:0.26.0
     environment:

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -15,10 +15,11 @@ services:
       - "8125:8125"
       - "8126:8126"
   temporal:
-    image: temporalio/auto-setup:0.26.0
+    image: temporalio/server:0.26.0
     ports:
      - "7233:7233"
     environment:
+      - "AUTO_SETUP=true"
       - "DB=postgres"
       - "DB_PORT=5432"
       - "POSTGRES_USER=temporal"

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -15,7 +15,7 @@ services:
       - "8125:8125"
       - "8126:8126"
   temporal:
-    image: temporalio/server:0.26.0
+    image: temporalio/server:${SERVER_TAG:-0.26.0}
     ports:
      - "7233:7233"
     environment:
@@ -30,7 +30,7 @@ services:
     depends_on:
       - postgres
   temporal-admin-tools:
-    image: temporalio/admin-tools:0.26.0
+    image: temporalio/admin-tools:${SERVER_TAG:-0.26.0}
     stdin_open: true
     tty: true
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -15,19 +15,19 @@ services:
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - cassandra
-  temporal-web:
-    image: temporalio/web:${WEB_TAG:-0.26.0}
-    environment:
-      - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
-    ports:
-      - "8088:8088"
-    depends_on:
-      - temporal
   temporal-admin-tools:
     image: temporalio/admin-tools:${SERVER_TAG:-0.26.0}
     stdin_open: true
     tty: true
     environment:
       - "TEMPORAL_CLI_ADDRESS=temporal:7233"
+    depends_on:
+      - temporal
+  temporal-web:
+    image: temporalio/web:${WEB_TAG:-0.26.0}
+    environment:
+      - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
+    ports:
+      - "8088:8088"
     depends_on:
       - temporal

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -22,3 +22,11 @@ services:
       - "8088:8088"
     depends_on:
       - temporal
+  temporal-admin-tools:
+    image: temporalio/admin-tools:0.26.0
+    stdin_open: true
+    tty: true
+    environment:
+      - "TEMPORAL_CLI_ADDRESS=temporal:7233"
+    depends_on:
+      - temporal

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     depends_on:
       - cassandra
   temporal-web:
-    image: temporalio/web:0.26.0
+    image: temporalio/web:${WEB_TAG:-0.26.0}
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=temporal:7233"
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,10 +6,11 @@ services:
     ports:
       - "9042:9042"
   temporal:
-    image: temporalio/auto-setup:0.26.0
+    image: temporalio/server:0.26.0
     ports:
      - "7233:7233"
     environment:
+      - "AUTO_SETUP=true"
       - "CASSANDRA_SEEDS=cassandra"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "9042:9042"
   temporal:
-    image: temporalio/server:0.26.0
+    image: temporalio/server:${SERVER_TAG:-0.26.0}
     ports:
      - "7233:7233"
     environment:
@@ -24,7 +24,7 @@ services:
     depends_on:
       - temporal
   temporal-admin-tools:
-    image: temporalio/admin-tools:0.26.0
+    image: temporalio/admin-tools:${SERVER_TAG:-0.26.0}
     stdin_open: true
     tty: true
     environment:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
docker-compose updates:
* remove statsd,
* add admin-tools,
* make it easy to specify the docker image tag for server and web images,
* switch from `temporalio/auto-setup` to `temporalio/server` + `AUTO_SETUP=True`,
* minor cleanup.

<!-- Tell your future self why have you made these changes -->
**Why?**

This is the fix for https://github.com/temporalio/temporal/issues/319 + making things a little cleaner / easier to use.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I ran each of the docker-compose files (`docker-compose -f docker-compose.yml up`), together with benchtest, ran a test workflow and made sure the workflow completed. Then I used web to check the UI. 

The behavior was unchanged before and after these changes.

(However, I noticed that cockroachdb docker-compose didn't work -- the service would fail to start. In all of the other docker-compose files web ui would not be able to list namespaces. These problems existed before and after these changes.)


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

If this is broken, systems started with docker-compose will fail to run as expected.