### PR TITLE
Fix elastic search index name for ExecutionStatus

### DIFF
--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -13,7 +13,7 @@ frontend.validSearchAttributes:
       StartTime: "Int"
       ExecutionTime: "Int"
       CloseTime: "Int"
-      Status: "Int"
+      ExecutionStatus: "Int"
       HistoryLength: "Int"
       TaskQueue: "Keyword"
       CustomStringField: "String"
@@ -22,6 +22,8 @@ frontend.validSearchAttributes:
       CustomDoubleField: "Double"
       CustomBoolField: "Bool"
       CustomDatetimeField: "Datetime"
+      TemporalChangeVersion: "Keyword"
+      BinaryChecksums: "Keyword"
       project: "Keyword"
       service: "Keyword"
       environment: "Keyword"
@@ -31,7 +33,6 @@ frontend.validSearchAttributes:
       CustomNamespace: "Keyword"
       Operator: "Keyword"
       RolloutId: "Keyword"
-      TemporalChangeVersion: "Keyword"
-      BinaryChecksums: "Keyword"
+      
 system.minRetentionDays:
     - value: 0

--- a/docker/dependencies/docker-compose.yml
+++ b/docker/dependencies/docker-compose.yml
@@ -53,9 +53,6 @@ services:
       - temporal-dependencies-network
   elasticsearch:
     image: elasticsearch:6.8.8
-    # This is the full image which includes everything but needs a license after some grace period.
-    # image: docker.elastic.co/elasticsearch/elasticsearch:6.4.0
-
     # Make ES available both on _local_ and _site_,
     # and use use _local_ for the publish_host.
     #

--- a/docker/dependencies/docker-compose.yml
+++ b/docker/dependencies/docker-compose.yml
@@ -53,6 +53,15 @@ services:
       - temporal-dependencies-network
   elasticsearch:
     image: elasticsearch:6.8.8
+    # This is the full image which includes everything but needs a license after some grace period.
+    # image: docker.elastic.co/elasticsearch/elasticsearch:6.4.0
+
+    # Make ES available both on _local_ and _site_,
+    # and use use _local_ for the publish_host.
+    #
+    # See here for details on network configuration:
+    # https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-network.html
+    command: elasticsearch -Enetwork.host=_local_,_site_ -Enetwork.publish_host=_local_
     container_name: temporal-elasticsearch
     ports:
       - "9200:9200"

--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/olivere/elastic v6.2.32+incompatible
+	github.com/olivere/elastic v6.2.34+incompatible
 	github.com/onsi/ginkgo v1.10.3 // indirect
 	github.com/onsi/gomega v1.7.1 // indirect
 	github.com/pborman/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -268,8 +268,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
-github.com/olivere/elastic v6.2.32+incompatible h1:xieFzqQcQzxMmP5fb8LP+Ayk6Ap02fs72EO5/wEjCuE=
-github.com/olivere/elastic v6.2.32+incompatible/go.mod h1:J+q1zQJTgAz9woqsbVRqGeB5G1iqDKVBWLNSYW8yfJ8=
+github.com/olivere/elastic v6.2.34+incompatible h1:GdvWBAqyIyEEUd+J2sSj6EnIaBywz7zZtN+Ps4JCv0g=
+github.com/olivere/elastic v6.2.34+incompatible/go.mod h1:J+q1zQJTgAz9woqsbVRqGeB5G1iqDKVBWLNSYW8yfJ8=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.10.3 h1:OoxbjfXVZyod1fmWYhI7SEyaD8B00ynP3T+D5GiyHOY=
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/schema/elasticsearch/visibility/index_template.json
+++ b/schema/elasticsearch/visibility/index_template.json
@@ -35,10 +35,10 @@
           "type": "long"
         },
         "ExecutionStatus": {
-          "type": "integer"
+          "type": "long"
         },
         "HistoryLength": {
-          "type": "integer"
+          "type": "long"
         },
         "KafkaKey": {
           "type": "keyword"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update index key definition for Elastic Search in development_es.yaml to reflect the recent renaming from 
`Status` to `ExecutionStatus`.

<!-- Tell your future self why have you made these changes -->
**Why?**
Recently we did massive renaming of ElasticSearch indexes.  As part of this renaming `Status` index
created by the system to represent status of closed workflow execution was renamed to
`ExecutionStatus`.  Default in the code is updated to represent this change but dynamic config
override used by local development with ES support was not updated.  This resulted in indexes to
go out of sync in all places which relies on development_es.yaml dynamic config file.  This broke
local development setup and anyone using docker-compose_es.yaml.  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Locally run Temporal server using dynamic config overrides in development_es.yaml.  Made sure
visibility is working after execution closes.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This should only impact local development setups with Elastic Search.
