### PR TITLE
Refactor cli workflow list commands, enhance paginate util

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -352,7 +352,7 @@ func newAdminNamespaceCommands() []cli.Command {
 		{
 			Name:  "list",
 			Usage: "List namespaces",
-			Flags: append(getDBFlags(), getFlagsForList()...),
+			Flags: append(getDBFlags(), flagsForPagination...),
 			Action: func(c *cli.Context) {
 				AdminListNamespaces(c)
 			},
@@ -538,7 +538,7 @@ clusters:
 			Usage: "List replication tasks from dlq",
 			Flags: append(append(
 				getDBFlags(),
-				getFlagsForList()...),
+				flagsForPagination...),
 				cli.IntFlag{
 					Name:  FlagShardIDWithAlias,
 					Usage: "ShardId",

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -208,7 +208,7 @@ func AdminListNamespaces(c *cli.Context) {
 		}
 		return items, token, nil
 	}
-	paginate(c, paginationFunc)
+	paginate(c, paginationFunc, []string{})
 }
 
 // AdminDeleteWorkflow delete a workflow execution for admin
@@ -479,7 +479,7 @@ func AdminListTasks(c *cli.Context) {
 			}
 			return items, token, nil
 		}
-		paginate(c, paginationFunc)
+		paginate(c, paginationFunc, []string{})
 	} else if category == enumsspb.TASK_CATEGORY_TIMER {
 		minVis := parseTime(c.String(FlagMinVisibilityTimestamp), time.Time{}, time.Now().UTC())
 		maxVis := parseTime(c.String(FlagMaxVisibilityTimestamp), time.Time{}, time.Now().UTC())
@@ -499,7 +499,7 @@ func AdminListTasks(c *cli.Context) {
 			}
 			return items, token, nil
 		}
-		paginate(c, paginationFunc)
+		paginate(c, paginationFunc, []string{})
 	} else if category == enumsspb.TASK_CATEGORY_REPLICATION {
 		req := &persistence.GetReplicationTasksRequest{}
 		paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
@@ -516,7 +516,7 @@ func AdminListTasks(c *cli.Context) {
 			}
 			return items, token, nil
 		}
-		paginate(c, paginationFunc)
+		paginate(c, paginationFunc, []string{})
 	} else {
 		ErrorAndExit("Failed to describe task", fmt.Errorf("Unrecognized task type, task_type=%v", category))
 	}

--- a/tools/cli/adminKafkaCommands.go
+++ b/tools/cli/adminKafkaCommands.go
@@ -889,7 +889,7 @@ func AdminListDLQ(c *cli.Context) {
 		}
 		return items, token, nil
 	}
-	paginate(c, paginationFunc)
+	paginate(c, paginationFunc, []string{})
 }
 
 func createConsumerAndWaitForReady(brokers []string, tlsConfig *tls.Config, group, fromTopic string) *cluster.Consumer {

--- a/tools/cli/adminTaskQueueCommands.go
+++ b/tools/cli/adminTaskQueueCommands.go
@@ -171,5 +171,5 @@ func AdminListTaskQueueTasks(c *cli.Context) {
 		return items, nil, nil
 	}
 
-	paginate(c, paginationFunc)
+	paginate(c, paginationFunc, []string{})
 }

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -249,7 +249,7 @@ var flagsForPagination = []cli.Flag{
 	},
 	cli.BoolFlag{
 		Name:  FlagMoreWithAlias,
-		Usage: "Keep interactively listing pages by pressing Enter. Default: prints first page and exits",
+		Usage: "Interactively list pages by pressing Enter. Default: prints first page and exits",
 	},
 	cli.IntFlag{
 		Name:  FlagPageSizeWithAlias,

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -244,13 +244,17 @@ var flagsForExecution = []cli.Flag{
 
 var flagsForPagination = []cli.Flag{
 	cli.BoolFlag{
+		Name:  FlagAllWithAlias,
+		Usage: "List all pages",
+	},
+	cli.BoolFlag{
 		Name:  FlagMoreWithAlias,
-		Usage: "List more pages, default is to list one page of default page size 10",
+		Usage: "Keep interactively listing pages by pressing Enter. Default: prints first page and exits",
 	},
 	cli.IntFlag{
 		Name:  FlagPageSizeWithAlias,
 		Value: 10,
-		Usage: "Result page size",
+		Usage: "Items per size. Default: 10",
 	},
 }
 
@@ -388,78 +392,67 @@ func getFlagsForRun() []cli.Flag {
 	return flagsForRun
 }
 
-func getCommonFlagsForVisibility() []cli.Flag {
-	return []cli.Flag{
-		cli.BoolFlag{
-			Name:  FlagPrintRawTimeWithAlias,
-			Usage: "Print raw timestamp",
-		},
-		cli.BoolFlag{
-			Name:  FlagPrintDateTimeWithAlias,
-			Usage: "Print full date time in '2006-01-02T15:04:05Z07:00' format",
-		},
-		cli.BoolFlag{
-			Name:  FlagPrintMemoWithAlias,
-			Usage: "Print memo",
-		},
-		cli.BoolFlag{
-			Name:  FlagPrintSearchAttrWithAlias,
-			Usage: "Print search attributes",
-		},
-		cli.BoolFlag{
-			Name:  FlagPrintFullyDetailWithAlias,
-			Usage: "Print full message without table format",
-		},
-		cli.BoolFlag{
-			Name:  FlagPrintJSONWithAlias,
-			Usage: "Print in raw json format",
-		},
-	}
+var flagsForVisibility = []cli.Flag{
+	cli.BoolFlag{
+		Name:  FlagPrintRawTimeWithAlias,
+		Usage: "Print raw timestamp",
+	},
+	cli.BoolFlag{
+		Name:  FlagPrintDateTimeWithAlias,
+		Usage: "Print full date time in '2006-01-02T15:04:05Z07:00' format",
+	},
+	cli.BoolFlag{
+		Name:  FlagPrintMemoWithAlias,
+		Usage: "Print memo",
+	},
+	cli.BoolFlag{
+		Name:  FlagPrintSearchAttrWithAlias,
+		Usage: "Print search attributes",
+	},
+	cli.BoolFlag{
+		Name:  FlagPrintFullyDetailWithAlias,
+		Usage: "Print full message without table format",
+	},
+	cli.BoolFlag{
+		Name:  FlagPrintJSONWithAlias,
+		Usage: "Print in raw json format",
+	},
 }
 
-func getFlagsForList() []cli.Flag {
-	flagsForList := append(getFlagsForListAll(), flagsForPagination...)
-	return flagsForList
-}
-
-func getFlagsForListAll() []cli.Flag {
-	flagsForListAll := []cli.Flag{
-		cli.BoolFlag{
-			Name:  FlagOpenWithAlias,
-			Usage: "List for open workflow executions, default is to list for closed ones",
-		},
-		cli.StringFlag{
-			Name: FlagEarliestTimeWithAlias,
-			Usage: "EarliestTime of start time, supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
-				"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
-				"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes.",
-		},
-		cli.StringFlag{
-			Name: FlagLatestTimeWithAlias,
-			Usage: "LatestTime of start time, supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
-				"time range (N<duration>), where 0 < N < 1000000 and duration (in full-notation/short-notation) can be second/s, " +
-				"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes",
-		},
-		cli.StringFlag{
-			Name:  FlagWorkflowIDWithAlias,
-			Usage: "WorkflowId",
-		},
-		cli.StringFlag{
-			Name:  FlagWorkflowTypeWithAlias,
-			Usage: "WorkflowTypeName",
-		},
-		cli.StringFlag{
-			Name:  FlagWorkflowStatusWithAlias,
-			Usage: "Workflow status [completed, failed, canceled, terminated, continuedasnew, timedout]",
-		},
-		cli.StringFlag{
-			Name: FlagListQueryWithAlias,
-			Usage: "Optional SQL like query for use of search attributes. NOTE: using query will ignore all other filter flags including: " +
-				"[open, earliest_time, latest_time, workflow_id, workflow_type]",
-		},
-	}
-	flagsForListAll = append(getCommonFlagsForVisibility(), flagsForListAll...)
-	return flagsForListAll
+var flagsForWorkflowFiltering = []cli.Flag{
+	cli.BoolFlag{
+		Name:  FlagOpenWithAlias,
+		Usage: "List for open workflow executions, default is to list for closed ones",
+	},
+	cli.StringFlag{
+		Name: FlagEarliestTimeWithAlias,
+		Usage: "EarliestTime of start time, supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
+			"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
+			"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes.",
+	},
+	cli.StringFlag{
+		Name: FlagLatestTimeWithAlias,
+		Usage: "LatestTime of start time, supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
+			"time range (N<duration>), where 0 < N < 1000000 and duration (in full-notation/short-notation) can be second/s, " +
+			"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes",
+	},
+	cli.StringFlag{
+		Name:  FlagWorkflowIDWithAlias,
+		Usage: "WorkflowId",
+	},
+	cli.StringFlag{
+		Name:  FlagWorkflowTypeWithAlias,
+		Usage: "WorkflowTypeName",
+	},
+	cli.StringFlag{
+		Name:  FlagWorkflowStatusWithAlias,
+		Usage: "Workflow status [completed, failed, canceled, terminated, continuedasnew, timedout]",
+	},
+	cli.StringFlag{
+		Name: FlagListQueryWithAlias,
+		Usage: "Optional SQL like query for use of search attributes. NOTE: using query will ignore all other filter flags including: " +
+			"[open, earliest_time, latest_time, workflow_id, workflow_type]",
+	},
 }
 
 func getFlagsForScan() []cli.Flag {
@@ -474,7 +467,7 @@ func getFlagsForScan() []cli.Flag {
 			Usage: "Optional SQL like query",
 		},
 	}
-	flagsForScan = append(getCommonFlagsForVisibility(), flagsForScan...)
+	flagsForScan = append(flagsForVisibility, flagsForScan...)
 	return flagsForScan
 }
 
@@ -494,7 +487,7 @@ func getFlagsForListArchived() []cli.Flag {
 			Usage: "List all pages",
 		},
 	}
-	flagsForListArchived = append(getCommonFlagsForVisibility(), flagsForListArchived...)
+	flagsForListArchived = append(flagsForVisibility, flagsForListArchived...)
 	return flagsForListArchived
 }
 

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -254,7 +254,7 @@ var flagsForPagination = []cli.Flag{
 	cli.IntFlag{
 		Name:  FlagPageSizeWithAlias,
 		Value: 10,
-		Usage: "Items per size. Default: 10",
+		Usage: "Items per page. Default: 10",
 	},
 }
 

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -137,6 +137,16 @@ func newWorkflowCommands() []cli.Command {
 			},
 		},
 		{
+			Name:        "list2",
+			Aliases:     []string{"ls"},
+			Usage:       "list open or closed workflow executions",
+			Description: "list one page (default size 10 items) by default, use flag --pagesize to change page size",
+			Flags:       getFlagsForList(),
+			Action: func(c *cli.Context) {
+				ListWorkflow2(c)
+			},
+		},
+		{
 			Name:    "listall",
 			Aliases: []string{"la"},
 			Usage:   "list all open or closed workflow executions",

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -128,37 +128,23 @@ func newWorkflowCommands() []cli.Command {
 		},
 		{
 			Name:        "list",
-			Aliases:     []string{"l"},
+			Aliases:     []string{"ls"},
 			Usage:       "list open or closed workflow executions",
 			Description: "list one page (default size 10 items) by default, use flag --pagesize to change page size",
-			Flags:       getFlagsForList(),
+			Flags:       append(append(flagsForPagination, flagsForWorkflowFiltering...), flagsForVisibility...),
 			Action: func(c *cli.Context) {
 				ListWorkflow(c)
 			},
 		},
 		{
-			Name:        "list2",
-			Aliases:     []string{"ls"},
-			Usage:       "list open or closed workflow executions",
-			Description: "list one page (default size 10 items) by default, use flag --pagesize to change page size",
-			Flags:       getFlagsForList(),
-			Action: func(c *cli.Context) {
-				ListWorkflow2(c)
-			},
-		},
-		{
-			Name:    "listall",
-			Aliases: []string{"la"},
-			Usage:   "list all open or closed workflow executions",
-			Flags:   getFlagsForListAll(),
-			Action: func(c *cli.Context) {
-				ListAllWorkflow(c)
-			},
-		},
-		{
 			Name:  "listarchived",
 			Usage: "list archived workflow executions",
-			Flags: getFlagsForListArchived(),
+			Flags: append(append(flagsForPagination, flagsForVisibility...),
+				cli.StringFlag{
+					Name:  FlagListQueryWithAlias,
+					Usage: "SQL like query. Please check the documentation of the visibility archiver used by your namespace for detailed instructions",
+				},
+			),
 			Action: func(c *cli.Context) {
 				ListArchivedWorkflow(c)
 			},

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -697,8 +697,7 @@ func ListWorkflow2(c *cli.Context) {
 		return items, token, nil
 	}
 
-	// fields := []string{"Type.Name", "Execution.WorkflowId", "Execution.RunId", "TaskQueue", "StartTime", "ExecutionTime", "CloseTime"}
-	fields := []string{"Type", "Execution", "TaskQueue", "StartTime", "ExecutionTime", "CloseTime"}
+	fields := []string{"Type.Name", "Execution.WorkflowId", "Execution.RunId", "TaskQueue", "StartTime", "ExecutionTime", "CloseTime"}
 	paginate(c, paginationFunc, fields)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* `paginate` cli util: added `fields` param that allows to specify what fields to be printed.
For example, the following will print corresponding fields of WorkflowExecution:
``` golang
fields := []string{"Type.Name", "Execution.WorkflowId", "Execution.RunId", "TaskQueue", "StartTime", "ExecutionTime", "CloseTime"}
paginate(c, paginationFunc, fields)
```

* `tctl workflow list` now uses `paginate` util instead of hardcoding the whole pagination and printing table behaviors.

* `tctl workflow listarchived` now uses `paginate` util instead of hardcoding the whole pagination and printing table behaviors.

* `tctl workflow listall` is removed, because the `paginate` util allows to specify `--all` cli argument and it takes care of printing all of the results at once


<!-- Tell your future self why have you made these changes -->
**Why?**
- Allows to easily modify the Columns in the printed table by simply passing field names to paginate util, instead of hardcoding createTable functions for each of the list commands
Creating table function that previously was taking more than a page of code just for one command is now achieved by one line such as
```
fields := []string{"Type.Name", "Execution.WorkflowId", "Execution.RunId", "TaskQueue", "StartTime", "ExecutionTime", "CloseTime"}
```
This can also allow to easily expose the control over the printed fields to the users as a CLI param (if needed)

- Reduces the complexity, total amount of code.
The total amount of code can be reduced even further. `scan` command uses some of the code from `list` and `listarchived`. When scan command is refactored the same way, the total amount of code will be reduced by few more hundreds of lines

 - Streamlines `list` commands, they now have the same simple body template based on `paginate` util
As an example feel free to look into this PR to see the minimal command example that uses `paginate`. https://github.com/temporalio/temporal/pull/463/files

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit Tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No major risks, some chance of minor cli output differentiation
