### PR TITLE
Allow for es scheme (https, http) to be configurable via container's env var

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -5,6 +5,7 @@ set -x
 DB="${DB:-cassandra}"
 ENABLE_ES="${ENABLE_ES:-false}"
 ES_PORT="${ES_PORT:-9200}"
+ES_SCHEME="${ES_SCHEME:-http}"
 RF=${RF:-1}
 DEFAULT_NAMESPACE="${DEFAULT_NAMESPACE:-default}"
 DEFAULT_NAMESPACE_RETENTION=${DEFAULT_NAMESPACE_RETENTION:-1}
@@ -63,9 +64,9 @@ setup_postgres_schema() {
 setup_es_template() {
     SCHEMA_FILE=$TEMPORAL_HOME/schema/elasticsearch/visibility/index_template.json
     server=`echo $ES_SEEDS | awk -F ',' '{print $1}'`
-    URL="http://$server:$ES_PORT/_template/temporal-visibility-template"
+    URL="${ES_SCHEME}://$server:$ES_PORT/_template/temporal-visibility-template"
     curl -X PUT $URL -H 'Content-Type: application/json' --data-binary "@$SCHEMA_FILE"
-    URL="http://$server:$ES_PORT/temporal-visibility-dev"
+    URL="${ES_SCHEME}://$server:$ES_PORT/temporal-visibility-dev"
     curl -X PUT $URL
 }
 
@@ -116,7 +117,7 @@ wait_for_postgres() {
 
 wait_for_es() {
     server=`echo $ES_SEEDS | awk -F ',' '{print $1}'`
-    URL="http://$server:$ES_PORT"
+    URL="${ES_SCHEME}://$server:$ES_PORT"
     curl -s $URL 2>&1 > /dev/null
     until [ $? -eq 0 ]; do
         echo 'waiting for elasticsearch to start up'


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This is a change for https://github.com/temporalio/temporal/issues/562. With this change, temporal container can be configuring to use a scheme other than http (such as https;) to connect to elastic search.

This change goes along with https://github.com/temporalio/helm-charts/pull/49

<!-- Tell your future self why have you made these changes -->
**Why?**
A customer reported that this is the behavior they would expect, but that was not the actual behavior.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I built the docker image and deployed it to a k8s cluster, using temporal helm chart (https://github.com/temporalio/helm-charts/pull/49), passing in "ES_SCHEME: https" env var. I made sure the env var took effect (I didn't have an ES listening on HTTPS port so the connection failed to esablish, as expected). 
```
◉ 22:44:48 [markmark ~/src/temporal-helm-charts] (master|m1u) $ helm install temporaltest --set elasticsearch.scheme=https --set server.kafka.host=kafkat-headless:9092 --set grafana.enabled=false --set kafka.enabled=false --set prometheus.enabled=false -f values/values.cassandra.yaml -f values/values.elasticsearch.yaml --set server.image.tag=markmark-local2 --set server.image.repository=markmark206/server --set admintools.image.tag=bfa0fce6ca193a6cd987402341e126f391764ec9 --set admintools.image.repository=markmark206/admin-tools . --timeout 15m --wait
...
operation timed out
```


I also tested with "ES_SCHEME: https" and made sure things continue to work.

```
◉ 22:42:52 [markmark ~/src/temporal-helm-charts] (master|m1u) $ helm install temporaltest --set server.kafka.host=kafkat-headless:9092 --set grafana.enabled=false --set kafka.enabled=false --set prometheus.enabled=false -f values/values.cassandra.yaml -f values/values.elasticsearch.yaml --set server.image.tag=markmark-local2 --set server.image.repository=markmark206/server --set admintools.image.tag=bfa0fce6ca193a6cd987402341e126f391764ec9 --set admintools.image.repository=markmark206/admin-tools . --timeout 15m --wait
NAME: temporaltest
LAST DEPLOYED: Fri Jul 17 22:44:01 2020
NAMESPACE: default
STATUS: deployed
REVISION: 1
NOTES:
To verify that Temporal has started, run:

  kubectl --namespace=default get pods -l "app.kubernetes.io/instance=temporaltest"
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Elastic search connectivity might become broken.