### PR TITLE
Fixes panic when ListTaskQueuePartitions is invoked

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -617,23 +617,24 @@ func (e *matchingEngineImpl) listTaskQueuePartitions(request *matchingservice.Li
 		*request.TaskQueue,
 		taskQueueType,
 	)
-	if err != nil {
-		return nil, err
-	}
-	partitionHostInfo := make([]*taskqueuepb.TaskQueuePartitionMetadata, len(partitions))
 
 	if err != nil {
 		return nil, err
 	}
-	for _, partition := range partitions {
-		if host, err := e.getHostInfo(partition); err != nil {
-			partitionHostInfo = append(partitionHostInfo,
-				&taskqueuepb.TaskQueuePartitionMetadata{
-					Key:           partition,
-					OwnerHostName: host,
-				})
+
+	partitionHostInfo := make([]*taskqueuepb.TaskQueuePartitionMetadata, len(partitions))
+	for i, partition := range partitions {
+		host, err := e.getHostInfo(partition)
+		if err != nil {
+			return nil, err
+		}
+
+		partitionHostInfo[i] = &taskqueuepb.TaskQueuePartitionMetadata{
+			Key:           partition,
+			OwnerHostName: host,
 		}
 	}
+
 	return partitionHostInfo, nil
 }
 


### PR DESCRIPTION
We were appending to a pre-allocated array instead of updating the elements in-line. This results in nil elements in the array which caused a nil reference exception in the protobuf layer that crashed the matching service.

We have no unit tests for this. Will open an item to add unit tests. In the interim, this fixes the panic and was verified on a developer environment