### PR TITLE
Support multiple input options in cli

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -336,8 +336,9 @@ func getFlagsForStart() []cli.Flag {
 				"Options: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate",
 		},
 		cli.StringSliceFlag{
-			Name:  FlagInputWithAlias,
-			Usage: "Optional input for the workflow, in JSON format. If there are multiple parameters, pass each as a separate input flag.",
+			Name: FlagInputWithAlias,
+			Usage: "Optional input for the workflow in JSON format. If there are multiple parameters, pass each as a separate input flag. " +
+				"Pass \"null\" for null values",
 		},
 		cli.StringFlag{
 			Name: FlagInputFileWithAlias,

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -335,9 +335,9 @@ func getFlagsForStart() []cli.Flag {
 			Usage: "Configure if the same workflow Id is allowed for use in new workflow execution. " +
 				"Options: AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:  FlagInputWithAlias,
-			Usage: "Optional input for the workflow, in JSON format. If there are multiple parameters, concatenate them and separate by space.",
+			Usage: "Optional input for the workflow, in JSON format. If there are multiple parameters, pass each as a separate input flag.",
 		},
 		cli.StringFlag{
 			Name: FlagInputFileWithAlias,

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -738,17 +738,22 @@ func newContextWithTimeout(c *cli.Context, timeout time.Duration) (context.Conte
 
 // process and validate input provided through cmd or file
 func processJSONInput(c *cli.Context) *commonpb.Payloads {
-	rawJson := processJSONInputHelper(c, jsonTypeInput)
-	if len(rawJson) == 0 {
-		return nil
+	jsonsRaw := readJSONInputs(c, jsonTypeInput)
+
+	var jsons []interface{}
+	for _, jsonRaw := range jsonsRaw {
+		if len(jsonRaw) == 0 {
+			continue
+		}
+
+		var j interface{}
+		if err := json.Unmarshal(jsonRaw, &j); err != nil {
+			ErrorAndExit("Input is not a valid JSON.", err)
+		}
+		jsons = append(jsons, j)
 	}
 
-	var v interface{}
-	if err := json.Unmarshal(rawJson, &v); err != nil {
-		ErrorAndExit("Input is not a valid JSON.", err)
-	}
-
-	p, err := payloads.Encode(v)
+	p, err := payloads.Encode(jsons...)
 	if err != nil {
 		ErrorAndExit("Unable to encode Input.", err)
 	}
@@ -756,33 +761,48 @@ func processJSONInput(c *cli.Context) *commonpb.Payloads {
 	return p
 }
 
-// process and validate json
-func processJSONInputHelper(c *cli.Context, jType jsonType) []byte {
-	var flagNameOfRawInput string
-	var flagNameOfInputFileName string
+// read multiple inputs presented in json format
+func readJSONInputs(c *cli.Context, jType jsonType) [][]byte {
+	var flagRawInput string
+	var flagInputFileName string
 
 	switch jType {
 	case jsonTypeInput:
-		flagNameOfRawInput = FlagInput
-		flagNameOfInputFileName = FlagInputFile
+		flagRawInput = FlagInput
+		flagInputFileName = FlagInputFile
 	case jsonTypeMemo:
-		flagNameOfRawInput = FlagMemo
-		flagNameOfInputFileName = FlagMemoFile
+		flagRawInput = FlagMemo
+		flagInputFileName = FlagMemoFile
 	default:
 		return nil
 	}
 
-	if c.IsSet(flagNameOfRawInput) {
-		return []byte(c.String(flagNameOfRawInput))
-	} else if c.IsSet(flagNameOfInputFileName) {
-		inputFile := c.String(flagNameOfInputFileName)
+	if c.IsSet(flagRawInput) {
+		inputsG := c.Generic(flagRawInput)
+
+		var inputs *cli.StringSlice
+		var ok bool
+		if inputs, ok = inputsG.(*cli.StringSlice); !ok {
+			// input could be provided as StringFlag instead of StringSliceFlag
+			ss := make(cli.StringSlice, 1)
+			ss[0] = fmt.Sprintf("%v", inputsG)
+			inputs = &ss
+		}
+
+		var inputsRaw [][]byte
+		for _, i := range *inputs {
+			inputsRaw = append(inputsRaw, []byte(i))
+		}
+		return inputsRaw
+	} else if c.IsSet(flagInputFileName) {
+		inputFile := c.String(flagInputFileName)
 		// This method is purely used to parse input from the CLI. The input comes from a trusted user
 		// #nosec
 		data, err := ioutil.ReadFile(inputFile)
 		if err != nil {
 			ErrorAndExit("Error reading input file", err)
 		}
-		return data
+		return [][]byte{data}
 	}
 	return nil
 }

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -742,17 +742,17 @@ func processJSONInput(c *cli.Context) *commonpb.Payloads {
 
 	var jsons []interface{}
 	for _, jsonRaw := range jsonsRaw {
-		if len(jsonRaw) == 0 {
-			continue
+		if jsonRaw == nil {
+			jsons = append(jsons, nil)
+		} else {
+			var j interface{}
+			if err := json.Unmarshal(jsonRaw, &j); err != nil {
+				ErrorAndExit("Input is not a valid JSON.", err)
+			}
+			jsons = append(jsons, j)
 		}
 
-		var j interface{}
-		if err := json.Unmarshal(jsonRaw, &j); err != nil {
-			ErrorAndExit("Input is not a valid JSON.", err)
-		}
-		jsons = append(jsons, j)
 	}
-
 	p, err := payloads.Encode(jsons...)
 	if err != nil {
 		ErrorAndExit("Unable to encode Input.", err)
@@ -791,8 +791,15 @@ func readJSONInputs(c *cli.Context, jType jsonType) [][]byte {
 
 		var inputsRaw [][]byte
 		for _, i := range *inputs {
-			inputsRaw = append(inputsRaw, []byte(i))
+			if i == "nil" {
+				ErrorAndExit("Empty input flag. Pass \"null\" for nil parameter value.", nil)
+			} else if i == "null" {
+				inputsRaw = append(inputsRaw, []byte(nil))
+			} else {
+				inputsRaw = append(inputsRaw, []byte(i))
+			}
 		}
+
 		return inputsRaw
 	} else if c.IsSet(flagInputFileName) {
 		inputFile := c.String(flagInputFileName)

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -791,9 +791,7 @@ func readJSONInputs(c *cli.Context, jType jsonType) [][]byte {
 
 		var inputsRaw [][]byte
 		for _, i := range *inputs {
-			if i == "nil" {
-				ErrorAndExit("Empty input flag. Pass \"null\" for nil parameter value.", nil)
-			} else if i == "null" {
+			if strings.EqualFold(i, "null") {
 				inputsRaw = append(inputsRaw, []byte(nil))
 			} else {
 				inputsRaw = append(inputsRaw, []byte(i))

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -322,10 +322,11 @@ func processMemo(c *cli.Context) map[string]*commonpb.Payload {
 		memoKeys = strings.Split(rawMemoKey, " ")
 	}
 
-	rawMemoValue := string(processJSONInputHelper(c, jsonTypeMemo))
-	if rawMemoValue == "" {
+	jsonsRaw := readJSONInputs(c, jsonTypeMemo)
+	if len(jsonsRaw) == 0 {
 		return nil
 	}
+	rawMemoValue := string(jsonsRaw[0]) // StringFlag may contain up to one json
 
 	if err := validateJSONs(rawMemoValue); err != nil {
 		ErrorAndExit("Input is not valid JSON, or JSONs concatenated with spaces/newlines.", err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixes #502 
Added support for multiple input payloads
`tctl workflow start --tq helloWorldGroup --wt main.WorkflowWithInputs --et 60 -i '{"Joker":"Heheheh", "Harley":"Pumpkin!"}' -i '"to infinity and beyond"' -i 'null'`

<!-- Tell your future self why have you made these changes -->
**Why?**
Before you could specify only one payload as `--input`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran the command. Ran tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Low risk. The code shares some logic with --memo flag
