### PR TITLE
Convert REPLACE INTO ->  INSERT ON DUPLICATE KEY UPDATE (MySQL)

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
@@ -46,9 +46,11 @@ VALUES(?, ?, ?)`
 cluster_metadata WHERE metadata_partition = ?`
 
 	// ****** CLUSTER_MEMBERSHIP TABLE ******
-	templateUpsertActiveClusterMembership = `REPLACE INTO
+	templateUpsertActiveClusterMembership = `INSERT INTO
 cluster_membership (membership_partition, host_id, rpc_address, rpc_port, role, session_start, last_heartbeat, record_expiry)
-VALUES(?, ?, ?, ?, ?, ?, ?, ?)`
+VALUES(?, ?, ?, ?, ?, ?, ?, ?) 
+ON DUPLICATE KEY UPDATE 
+session_start=VALUES(session_start), last_heartbeat=VALUES(last_heartbeat), record_expiry=VALUES(record_expiry)`
 
 	templatePruneStaleClusterMembership = `DELETE FROM
 cluster_membership 

--- a/common/persistence/sql/sqlplugin/mysql/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution_maps.go
@@ -43,13 +43,16 @@ run_id = ?`
 	// %[2]v is the columns of the value struct (i.e. no primary key columns), comma separated
 	// %[3]v should be %[2]v with colons prepended.
 	// i.e. %[3]v = ",".join(":" + s for s in %[2]v)
+	// %[4]v should be %[2]v in the format of n=VALUES(n).
+	// i.e. %[4]v = ",".join(s + "=VALUES(" + s + ")" for s in %[2]v)
 	// So that this query can be used with BindNamed
-	// %[4]v should be the name of the key associated with the map
+	// %[5]v should be the name of the key associated with the map
 	// e.g. for ActivityInfo it is "schedule_id"
-	setKeyInMapQryTemplate = `REPLACE INTO %[1]v
-(shard_id, namespace_id, workflow_id, run_id, %[4]v, %[2]v)
+	setKeyInMapQryTemplate = `INSERT INTO %[1]v
+(shard_id, namespace_id, workflow_id, run_id, %[5]v, %[2]v)
 VALUES
-(:shard_id, :namespace_id, :workflow_id, :run_id, :%[4]v, %[3]v)`
+(:shard_id, :namespace_id, :workflow_id, :run_id, :%[5]v, %[3]v) 
+ON DUPLICATE KEY UPDATE %[5]v=VALUES(%[5]v), %[4]v;`
 
 	// %[2]v is the name of the key
 	deleteKeyInMapQryTemplate = `DELETE FROM %[1]v
@@ -90,6 +93,9 @@ func makeSetKeyInMapQry(tableName string, nonPrimaryKeyColumns []string, mapKeyN
 		strings.Join(stringMap(nonPrimaryKeyColumns, func(x string) string {
 			return ":" + x
 		}), ","),
+		strings.Join(stringMap(nonPrimaryKeyColumns, func(x string) string {
+			return x + "=VALUES(" + x + ")"
+		}), ","),
 		mapKeyName)
 }
 
@@ -123,7 +129,37 @@ var (
 
 // ReplaceIntoActivityInfoMaps replaces one or more rows in activity_info_maps table
 func (mdb *db) ReplaceIntoActivityInfoMaps(rows []sqlplugin.ActivityInfoMapsRow) (sql.Result, error) {
-	return mdb.conn.NamedExec(setKeyInActivityInfoMapQry, rows)
+	q, args, err := mdb.db.BindNamed(setKeyInActivityInfoMapQry, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	q = expandBatchInsertQuery(q, len(rows))
+
+	return mdb.conn.Exec(q, args...)
+}
+
+func expandBatchInsertQuery(q string, rowCount int) string {
+	b := strings.Builder{}
+	// Inclusive start index
+	valStartIdx := strings.Index(q, "(?,")
+
+	// Add 2 to get exclusive end index
+	valEndIdx := strings.Index(q, "?)") + 2
+
+	// Write initial half of query
+	b.WriteString(q[0:valEndIdx])
+
+	// Create rowCount-1 more (?, ?, ?) placeholders
+	for i := 0; i < rowCount-1; i++ {
+		b.WriteString(",")
+		b.WriteString(q[valStartIdx:valEndIdx])
+	}
+
+	// sqlx does not like VALUES() and is generating an artifact into the sql code.
+	// Removing that while writing the second half of the query.
+	b.WriteString(q[valEndIdx:strings.LastIndex(q, ",")])
+	return b.String()
 }
 
 // SelectFromActivityInfoMaps reads one or more rows from activity_info_maps table
@@ -131,7 +167,7 @@ func (mdb *db) SelectFromActivityInfoMaps(filter *sqlplugin.ActivityInfoMapsFilt
 	var rows []sqlplugin.ActivityInfoMapsRow
 	err := mdb.conn.Select(&rows, getActivityInfoMapQry, filter.ShardID, filter.NamespaceID, filter.WorkflowID, filter.RunID)
 	for i := 0; i < len(rows); i++ {
-		rows[i].ShardID = int64(filter.ShardID)
+		rows[i].ShardID = filter.ShardID
 		rows[i].NamespaceID = filter.NamespaceID
 		rows[i].WorkflowID = filter.WorkflowID
 		rows[i].RunID = filter.RunID
@@ -163,7 +199,15 @@ var (
 
 // ReplaceIntoTimerInfoMaps replaces one or more rows in timer_info_maps table
 func (mdb *db) ReplaceIntoTimerInfoMaps(rows []sqlplugin.TimerInfoMapsRow) (sql.Result, error) {
-	return mdb.conn.NamedExec(setKeyInTimerInfoMapSQLQuery, rows)
+	q, args, err := mdb.db.BindNamed(setKeyInTimerInfoMapSQLQuery, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	q = expandBatchInsertQuery(q, len(rows))
+
+	return mdb.conn.Exec(q, args...)
+
 }
 
 // SelectFromTimerInfoMaps reads one or more rows from timer_info_maps table
@@ -203,7 +247,15 @@ var (
 
 // ReplaceIntoChildExecutionInfoMaps replaces one or more rows in child_execution_info_maps table
 func (mdb *db) ReplaceIntoChildExecutionInfoMaps(rows []sqlplugin.ChildExecutionInfoMapsRow) (sql.Result, error) {
-	return mdb.conn.NamedExec(setKeyInChildExecutionInfoMapQry, rows)
+	q, args, err := mdb.db.BindNamed(setKeyInChildExecutionInfoMapQry, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	q = expandBatchInsertQuery(q, len(rows))
+
+	return mdb.conn.Exec(q, args...)
+
 }
 
 // SelectFromChildExecutionInfoMaps reads one or more rows from child_execution_info_maps table
@@ -243,7 +295,15 @@ var (
 
 // ReplaceIntoRequestCancelInfoMaps replaces one or more rows in request_cancel_info_maps table
 func (mdb *db) ReplaceIntoRequestCancelInfoMaps(rows []sqlplugin.RequestCancelInfoMapsRow) (sql.Result, error) {
-	return mdb.conn.NamedExec(setKeyInRequestCancelInfoMapQry, rows)
+	q, args, err := mdb.db.BindNamed(setKeyInRequestCancelInfoMapQry, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	q = expandBatchInsertQuery(q, len(rows))
+
+	return mdb.conn.Exec(q, args...)
+
 }
 
 // SelectFromRequestCancelInfoMaps reads one or more rows from request_cancel_info_maps table
@@ -283,7 +343,14 @@ var (
 
 // ReplaceIntoSignalInfoMaps replaces one or more rows in signal_info_maps table
 func (mdb *db) ReplaceIntoSignalInfoMaps(rows []sqlplugin.SignalInfoMapsRow) (sql.Result, error) {
-	return mdb.conn.NamedExec(setKeyInSignalInfoMapQry, rows)
+	q, args, err := mdb.db.BindNamed(setKeyInSignalInfoMapQry, rows)
+	if err != nil {
+		return nil, err
+	}
+
+	q = expandBatchInsertQuery(q, len(rows))
+
+	return mdb.conn.Exec(q, args...)
 }
 
 // SelectFromSignalInfoMaps reads one or more rows from signal_info_maps table

--- a/common/persistence/sql/sqlplugin/mysql/task.go
+++ b/common/persistence/sql/sqlplugin/mysql/task.go
@@ -40,7 +40,9 @@ const (
 	// (default range ID: initialRangeID == 1)
 	createTaskQueueQry = `INSERT ` + taskQueueCreatePart
 
-	replaceTaskQueueQry = `REPLACE ` + taskQueueCreatePart
+	replaceTaskQueueQry = `INSERT ` + taskQueueCreatePart + `
+ON DUPLICATE KEY UPDATE
+range_id=VALUES(range_id), data=VALUES(data), data_encoding=VALUES(data_encoding)`
 
 	updateTaskQueueQry = `UPDATE task_queues SET
 range_id = :range_id,

--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -37,9 +37,11 @@ const (
 		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, status, memo, encoding) ` +
 		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
-	templateCreateWorkflowExecutionClosed = `REPLACE INTO executions_visibility (` +
+	templateCreateWorkflowExecutionClosed = `INSERT INTO executions_visibility (` +
 		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding) ` +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ` +
+		`ON DUPLICATE KEY UPDATE start_time = VALUES(start_time), execution_time = VALUES(execution_time), workflow_type_name = VALUES(workflow_type_name), ` +
+		`close_time = VALUES(close_time), status = VALUES(status), history_length = VALUES(history_length), memo = VALUES(memo), encoding = VALUES(encoding)`
 
 	// RunID condition is needed for correct pagination
 	templateConditions = ` AND namespace_id = ?


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Converted all REPLACE INTO usages with INSERT ON DUPLICATE KEY UPDATE semantics.

Docs - https://dev.mysql.com/doc/refman/8.0/en/insert-on-duplicate.html

<!-- Tell your future self why have you made these changes -->
**Why?**
Vitess does not support REPLACE INTO with fully sharded setups as REPLACE INTO deletes and reinserts the new row, which could possibly be in another shard depending on the VIndex. INSERT ON DUPLICATE KEY UPDATE forces you to specify which columns are being updated (cannot be VIndex column) and modifies the existing row.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing Unit Tests, Buildkite, Manual BenchTest on EKS cluster.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Update behavior change of REPLACE vs INSERT could bring in subtle changes in behavior, but this should not be a major issue. 

**Todo**
This needs to be validated for Postgres, but as Postgres does not support REPLACE INTO, this may not be an issue. In any case this is a backwards compatible change. Will do in a separate PR.