### PR TITLE
Create SchemaVersion Tables with Partition Column

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/admin.go
+++ b/common/persistence/sql/sqlplugin/mysql/admin.go
@@ -30,18 +30,24 @@ import (
 )
 
 const (
-	readSchemaVersionQuery = `SELECT curr_version from schema_version where db_name=?`
+	readSchemaVersionQuery = `SELECT curr_version from schema_version where version_partition=0 and db_name=?`
 
-	writeSchemaVersionQuery = `REPLACE into schema_version(db_name, creation_time, curr_version, min_compatible_version) VALUES (?,?,?,?)`
+	writeSchemaVersionQuery = `INSERT into schema_version(version_partition, db_name, creation_time, curr_version, min_compatible_version) ` +
+		`VALUES (0,?,?,?,?) ` +
+		`ON DUPLICATE KEY UPDATE ` +
+		`creation_time=VALUES(creation_time), curr_version=VALUES(curr_version), min_compatible_version=VALUES(min_compatible_version)`
 
-	writeSchemaUpdateHistoryQuery = `INSERT into schema_update_history(year, month, update_time, old_version, new_version, manifest_md5, description) VALUES(?,?,?,?,?,?,?)`
+	writeSchemaUpdateHistoryQuery = `INSERT into schema_update_history(version_partition, year, month, update_time, old_version, new_version, manifest_md5, description) VALUES(0,?,?,?,?,?,?,?)`
 
-	createSchemaVersionTableQuery = `CREATE TABLE schema_version(db_name VARCHAR(255) not null PRIMARY KEY, ` +
+	createSchemaVersionTableQuery = `CREATE TABLE schema_version(version_partition INT not null, ` +
+		`db_name VARCHAR(255) not null, ` +
 		`creation_time DATETIME(6), ` +
 		`curr_version VARCHAR(64), ` +
-		`min_compatible_version VARCHAR(64));`
+		`min_compatible_version VARCHAR(64), ` +
+		`PRIMARY KEY (version_partition, db_name));`
 
 	createSchemaUpdateHistoryTableQuery = `CREATE TABLE schema_update_history(` +
+		`version_partition INT not null, ` +
 		`year int not null, ` +
 		`month int not null, ` +
 		`update_time DATETIME(6) not null, ` +
@@ -49,7 +55,7 @@ const (
 		`manifest_md5 VARCHAR(64), ` +
 		`new_version VARCHAR(64), ` +
 		`old_version VARCHAR(64), ` +
-		`PRIMARY KEY (year, month, update_time));`
+		`PRIMARY KEY (version_partition, year, month, update_time));`
 
 	//NOTE we have to use %v because somehow mysql doesn't work with ? here
 	createDatabaseQuery = "CREATE database %v CHARACTER SET UTF8"

--- a/common/persistence/sql/sqlplugin/postgres/admin.go
+++ b/common/persistence/sql/sqlplugin/postgres/admin.go
@@ -30,22 +30,26 @@ import (
 )
 
 const (
-	readSchemaVersionQuery = `SELECT curr_version from schema_version where db_name=$1`
+	readSchemaVersionQuery = `SELECT curr_version from schema_version where version_partition=0 and db_name=$1`
 
-	writeSchemaVersionQuery = `INSERT into schema_version(db_name, creation_time, curr_version, min_compatible_version) VALUES ($1,$2,$3,$4)
-										ON CONFLICT (db_name) DO UPDATE 
+	writeSchemaVersionQuery = `INSERT into schema_version(version_partition, db_name, creation_time, curr_version, min_compatible_version) VALUES (0,$1,$2,$3,$4)
+										ON CONFLICT (version_partition, db_name) DO UPDATE 
 										  SET creation_time = excluded.creation_time,
 										   	  curr_version = excluded.curr_version,
 										      min_compatible_version = excluded.min_compatible_version;`
 
-	writeSchemaUpdateHistoryQuery = `INSERT into schema_update_history(year, month, update_time, old_version, new_version, manifest_md5, description) VALUES($1,$2,$3,$4,$5,$6,$7)`
+	writeSchemaUpdateHistoryQuery = `INSERT into schema_update_history(version_partition, year, month, update_time, old_version, new_version, manifest_md5, description) VALUES(0,$1,$2,$3,$4,$5,$6,$7)`
 
-	createSchemaVersionTableQuery = `CREATE TABLE schema_version(db_name VARCHAR(255) not null PRIMARY KEY, ` +
+	createSchemaVersionTableQuery = `CREATE TABLE schema_version(` +
+		`version_partition INT not null, ` +
+		`db_name VARCHAR(255) not null, ` +
 		`creation_time TIMESTAMP, ` +
 		`curr_version VARCHAR(64), ` +
-		`min_compatible_version VARCHAR(64));`
+		`min_compatible_version VARCHAR(64), `+
+		`PRIMARY KEY (version_partition, db_name));`
 
 	createSchemaUpdateHistoryTableQuery = `CREATE TABLE schema_update_history(` +
+		`version_partition INT not null, ` +
 		`year int not null, ` +
 		`month int not null, ` +
 		`update_time TIMESTAMP not null, ` +
@@ -53,7 +57,7 @@ const (
 		`manifest_md5 VARCHAR(64), ` +
 		`new_version VARCHAR(64), ` +
 		`old_version VARCHAR(64), ` +
-		`PRIMARY KEY (year, month, update_time));`
+		`PRIMARY KEY (version_partition, year, month, update_time));`
 
 	// NOTE we have to use %v because somehow postgres doesn't work with ? here
 	// It's a small bug in sqlx library


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add `version_partition` column to MySQL/Postgres `schema_version` and `schema_update_history` tables.
- Convert MySQL `REPLACE INTO` usage to `INSERT ON DUPLICATE KEY UPDATE` for the `writeSchemaVersionQuery`.

<!-- Tell your future self why have you made these changes -->
**Why?**
We will need to change schema creation behavior in the future to support Vitess as we cannot perform schema structure CRUD operations over the mysql interface. However this ensures we have the correct key structure for the future. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing CLI Schema Update Unit Tests
