### PR TITLE
Fixes nil reference exception when trying to cascade terminates to children

### DIFF
--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -110,7 +110,7 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 			//no-op
 			continue
 		case enumspb.PARENT_CLOSE_POLICY_TERMINATE:
-			_, err = client.TerminateWorkflowExecution(nil, &historyservice.TerminateWorkflowExecutionRequest{
+			_, err = client.TerminateWorkflowExecution(ctx, &historyservice.TerminateWorkflowExecutionRequest{
 				NamespaceId: request.NamespaceID,
 				TerminateRequest: &workflowservice.TerminateWorkflowExecutionRequest{
 					Namespace: request.Namespace,
@@ -123,7 +123,7 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 				},
 			})
 		case enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL:
-			_, err = client.RequestCancelWorkflowExecution(nil, &historyservice.RequestCancelWorkflowExecutionRequest{
+			_, err = client.RequestCancelWorkflowExecution(ctx, &historyservice.RequestCancelWorkflowExecutionRequest{
 				NamespaceId: request.NamespaceID,
 				CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
 					Namespace: request.Namespace,


### PR DESCRIPTION
The system workflow, when trying to terminate a child workflow, passes in a nil context, which causes a nil reference exception deeper into the service. We have the activity context available, so we will pass that instead.

Verified that child workflows were all terminated once this was fixed. Need to understand WHY nil was passed in. Also need to see if I can add a unit test.

Looks like this PR caused the issue: https://github.com/temporalio/temporal/pull/176/files. It refactored the init-if-nil logic out of the history client, but the parentclosepolicy workflow as not updated. The lack of test coverage caused this to get missed