### PR TITLE
Clean up unused feature flags

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -61,7 +61,6 @@ var keys = map[Key]string{
 	// system settings
 	EnableGlobalNamespace:                  "system.enableGlobalNamespace",
 	EnableNDC:                              "system.enableNDC",
-	EnableNewKafkaClient:                   "system.enableNewKafkaClient",
 	EnableVisibilitySampling:               "system.enableVisibilitySampling",
 	AdvancedVisibilityWritingMode:          "system.advancedVisibilityWritingMode",
 	EnableReadVisibilityFromES:             "system.enableReadVisibilityFromES",
@@ -314,8 +313,6 @@ const (
 	EnableGlobalNamespace
 	// EnableNDC is key for enable N data center events replication
 	EnableNDC
-	// EnableNewKafkaClient is key for using New Kafka client
-	EnableNewKafkaClient
 	// EnableVisibilitySampling is key for enable visibility sampling
 	EnableVisibilitySampling
 	// AdvancedVisibilityWritingMode is key for how to write to advanced visibility

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -153,7 +153,7 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 	)
 	if advancedVisWritingMode() != common.AdvancedVisibilityWritingModeOff {
 		config.IndexerCfg = &indexer.Config{
-			IndexerConcurrency:       dc.GetIntProperty(dynamicconfig.WorkerIndexerConcurrency, 1000),
+			IndexerConcurrency:       dc.GetIntProperty(dynamicconfig.WorkerIndexerConcurrency, 100),
 			ESProcessorNumOfWorkers:  dc.GetIntProperty(dynamicconfig.WorkerESProcessorNumOfWorkers, 1),
 			ESProcessorBulkActions:   dc.GetIntProperty(dynamicconfig.WorkerESProcessorBulkActions, 1000),
 			ESProcessorBulkSize:      dc.GetIntProperty(dynamicconfig.WorkerESProcessorBulkSize, 2<<24), // 16MB


### PR DESCRIPTION
`EnableNewKafkaClient` knob was not used at all and updated `IndexerConcurrency`value to 100 instead of 1000.

