### PR TITLE
Sets default activity maximum retry interval to be 100x minimum retry interval

### DIFF
--- a/common/defaultActivityRetrySettings.go
+++ b/common/defaultActivityRetrySettings.go
@@ -1,0 +1,10 @@
+package common
+
+// DefaultActivityRetrySettings indicates what the "default" activity retry settings
+// are of it is not specified on an Activity
+type DefaultActivityRetrySettings struct {
+	InitialRetryIntervalInSeconds   int32
+	MaximumRetryIntervalCoefficient float64
+	ExponentialBackoffCoefficient   float64
+	MaximumAttempts                 int32
+}

--- a/common/defaultActivityRetrySettings.go
+++ b/common/defaultActivityRetrySettings.go
@@ -3,8 +3,8 @@ package common
 // DefaultActivityRetrySettings indicates what the "default" activity retry settings
 // are of it is not specified on an Activity
 type DefaultActivityRetrySettings struct {
-	InitialRetryIntervalInSeconds   int32
-	MaximumRetryIntervalCoefficient float64
-	ExponentialBackoffCoefficient   float64
-	MaximumAttempts                 int32
+	InitialIntervalInSeconds   int32
+	MaximumIntervalCoefficient float64
+	BackoffCoefficient         float64
+	MaximumAttempts            int32
 }

--- a/common/util.go
+++ b/common/util.go
@@ -385,15 +385,15 @@ func EnsureRetryPolicyDefaults(originalPolicy *commonpb.RetryPolicy, defaultSett
 	}
 
 	if merged.GetInitialIntervalInSeconds() == 0 {
-		merged.InitialIntervalInSeconds = int32(defaultSettings.InitialRetryIntervalInSeconds)
+		merged.InitialIntervalInSeconds = int32(defaultSettings.InitialIntervalInSeconds)
 	}
 
 	if merged.GetMaximumIntervalInSeconds() == 0 {
-		merged.MaximumIntervalInSeconds = int32(defaultSettings.MaximumRetryIntervalCoefficient * float64(merged.GetInitialIntervalInSeconds()))
+		merged.MaximumIntervalInSeconds = int32(defaultSettings.MaximumIntervalCoefficient * float64(merged.GetInitialIntervalInSeconds()))
 	}
 
 	if merged.GetBackoffCoefficient() == 0 {
-		merged.BackoffCoefficient = defaultSettings.ExponentialBackoffCoefficient
+		merged.BackoffCoefficient = defaultSettings.BackoffCoefficient
 	}
 
 	return &merged

--- a/common/util.go
+++ b/common/util.go
@@ -368,35 +368,35 @@ func SortInt64Slice(slice []int64) {
 }
 
 // EnsureRetryPolicyDefaults ensures the policy subfields, if not explicitly set, are set to the specified defaults
-func EnsureRetryPolicyDefaults(originalPolicy *commonpb.RetryPolicy, defaultPolicy *commonpb.RetryPolicy) *commonpb.RetryPolicy {
-	if originalPolicy == nil {
-		return defaultPolicy
-	}
+func EnsureRetryPolicyDefaults(originalPolicy *commonpb.RetryPolicy, defaultSettings DefaultActivityRetrySettings) *commonpb.RetryPolicy {
+	var merged commonpb.RetryPolicy = commonpb.RetryPolicy{}
 
-	merged := &commonpb.RetryPolicy{
-		BackoffCoefficient:       originalPolicy.GetBackoffCoefficient(),
-		InitialIntervalInSeconds: originalPolicy.GetInitialIntervalInSeconds(),
-		MaximumIntervalInSeconds: originalPolicy.GetMaximumIntervalInSeconds(),
-		MaximumAttempts:          originalPolicy.GetMaximumAttempts(),
+	if originalPolicy != nil {
+		merged = commonpb.RetryPolicy{
+			BackoffCoefficient:       originalPolicy.GetBackoffCoefficient(),
+			InitialIntervalInSeconds: originalPolicy.GetInitialIntervalInSeconds(),
+			MaximumIntervalInSeconds: originalPolicy.GetMaximumIntervalInSeconds(),
+			MaximumAttempts:          originalPolicy.GetMaximumAttempts(),
+		}
 	}
 
 	if merged.GetMaximumAttempts() == 0 {
-		merged.MaximumAttempts = defaultPolicy.GetMaximumAttempts()
+		merged.MaximumAttempts = int32(defaultSettings.MaximumAttempts)
 	}
 
 	if merged.GetInitialIntervalInSeconds() == 0 {
-		merged.InitialIntervalInSeconds = defaultPolicy.GetInitialIntervalInSeconds()
+		merged.InitialIntervalInSeconds = int32(defaultSettings.InitialRetryIntervalInSeconds)
 	}
 
 	if merged.GetMaximumIntervalInSeconds() == 0 {
-		merged.MaximumIntervalInSeconds = 100 * merged.GetInitialIntervalInSeconds()
+		merged.MaximumIntervalInSeconds = int32(defaultSettings.MaximumRetryIntervalCoefficient * float64(merged.GetInitialIntervalInSeconds()))
 	}
 
 	if merged.GetBackoffCoefficient() == 0 {
-		merged.BackoffCoefficient = defaultPolicy.GetBackoffCoefficient()
+		merged.BackoffCoefficient = defaultSettings.ExponentialBackoffCoefficient
 	}
 
-	return merged
+	return &merged
 }
 
 // ValidateRetryPolicy validates a retry policy

--- a/common/util.go
+++ b/common/util.go
@@ -369,10 +369,10 @@ func SortInt64Slice(slice []int64) {
 
 // EnsureRetryPolicyDefaults ensures the policy subfields, if not explicitly set, are set to the specified defaults
 func EnsureRetryPolicyDefaults(originalPolicy *commonpb.RetryPolicy, defaultSettings DefaultActivityRetrySettings) *commonpb.RetryPolicy {
-	var merged commonpb.RetryPolicy = commonpb.RetryPolicy{}
+	var merged *commonpb.RetryPolicy = &commonpb.RetryPolicy{}
 
 	if originalPolicy != nil {
-		merged = commonpb.RetryPolicy{
+		merged = &commonpb.RetryPolicy{
 			BackoffCoefficient:       originalPolicy.GetBackoffCoefficient(),
 			InitialIntervalInSeconds: originalPolicy.GetInitialIntervalInSeconds(),
 			MaximumIntervalInSeconds: originalPolicy.GetMaximumIntervalInSeconds(),
@@ -396,7 +396,7 @@ func EnsureRetryPolicyDefaults(originalPolicy *commonpb.RetryPolicy, defaultSett
 		merged.BackoffCoefficient = defaultSettings.BackoffCoefficient
 	}
 
-	return &merged
+	return merged
 }
 
 // ValidateRetryPolicy validates a retry policy

--- a/common/util.go
+++ b/common/util.go
@@ -389,7 +389,7 @@ func EnsureRetryPolicyDefaults(originalPolicy *commonpb.RetryPolicy, defaultPoli
 	}
 
 	if merged.GetMaximumIntervalInSeconds() == 0 {
-		merged.MaximumIntervalInSeconds = defaultPolicy.GetMaximumIntervalInSeconds()
+		merged.MaximumIntervalInSeconds = 100 * merged.GetInitialIntervalInSeconds()
 	}
 
 	if merged.GetBackoffCoefficient() == 0 {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -89,10 +89,17 @@ func TestValidateRetryPolicy(t *testing.T) {
 }
 
 func TestEnsureRetryPolicyDefaults(t *testing.T) {
+	defaultActivityRetrySettings := DefaultActivityRetrySettings{
+		InitialRetryIntervalInSeconds:   1,
+		MaximumRetryIntervalCoefficient: 100,
+		ExponentialBackoffCoefficient:   2.0,
+		MaximumAttempts:                 120,
+	}
+
 	defaultRetryPolicy := &commonpb.RetryPolicy{
 		InitialIntervalInSeconds: 1,
 		MaximumIntervalInSeconds: 100,
-		BackoffCoefficient:       2,
+		BackoffCoefficient:       2.0,
 		MaximumAttempts:          120,
 	}
 
@@ -163,7 +170,7 @@ func TestEnsureRetryPolicyDefaults(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			got := EnsureRetryPolicyDefaults(tt.input, defaultRetryPolicy)
+			got := EnsureRetryPolicyDefaults(tt.input, defaultActivityRetrySettings)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -90,10 +90,10 @@ func TestValidateRetryPolicy(t *testing.T) {
 
 func TestEnsureRetryPolicyDefaults(t *testing.T) {
 	defaultActivityRetrySettings := DefaultActivityRetrySettings{
-		InitialRetryIntervalInSeconds:   1,
-		MaximumRetryIntervalCoefficient: 100,
-		ExponentialBackoffCoefficient:   2.0,
-		MaximumAttempts:                 120,
+		InitialIntervalInSeconds:   1,
+		MaximumIntervalCoefficient: 100,
+		BackoffCoefficient:         2.0,
+		MaximumAttempts:            120,
 	}
 
 	defaultRetryPolicy := &commonpb.RetryPolicy{

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -118,7 +118,7 @@ func TestEnsureRetryPolicyDefaults(t *testing.T) {
 			},
 			want: &commonpb.RetryPolicy{
 				InitialIntervalInSeconds: 2,
-				MaximumIntervalInSeconds: 100,
+				MaximumIntervalInSeconds: 200,
 				BackoffCoefficient:       2,
 				MaximumAttempts:          120,
 			},

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -24,7 +24,7 @@ system.advancedVisibilityWritingMode:
   constraints: {}
 history.defaultActivityRetryPolicy:
 - value:
-    InitialRetryIntervalInSeconds: 1
-    MaximumRetryIntervalCoefficient: 100.0
-    ExponentialBackoffCoefficient: 2.0
+    InitialIntervalInSeconds: 1
+    MaximumIntervalCoefficient: 100.0
+    BackoffCoefficient: 2.0
     MaximumAttempts: 0

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -25,6 +25,6 @@ system.advancedVisibilityWritingMode:
 history.defaultActivityRetryPolicy:
 - value:
     InitialRetryIntervalInSeconds: 1
-    MaximumRetryIntervalInSeconds: 120
+    MaximumRetryIntervalCoefficient: 100.0
     ExponentialBackoffCoefficient: 2.0
     MaximumAttempts: 0

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -51,11 +51,11 @@ import (
 
 type (
 	commandAttrValidator struct {
-		namespaceCache             cache.NamespaceCache
-		config                     *Config
-		maxIDLengthLimit           int
-		searchAttributesValidator  *validator.SearchAttributesValidator
-		defaultActivityRetryPolicy *commonpb.RetryPolicy
+		namespaceCache               cache.NamespaceCache
+		config                       *Config
+		maxIDLengthLimit             int
+		searchAttributesValidator    *validator.SearchAttributesValidator
+		defaultActivityRetrySettings common.DefaultActivityRetrySettings
 	}
 
 	workflowSizeChecker struct {
@@ -96,7 +96,7 @@ func newCommandAttrValidator(
 			config.SearchAttributesSizeOfValueLimit,
 			config.SearchAttributesTotalSizeLimit,
 		),
-		defaultActivityRetryPolicy: fromConfigToActivityRetryPolicy(config.DefaultActivityRetryPolicy()),
+		defaultActivityRetrySettings: fromConfigToDefaultActivityRetrySettings(config.DefaultActivityRetryPolicy()),
 	}
 }
 
@@ -652,12 +652,7 @@ func (v *commandAttrValidator) validateTaskQueue(
 }
 
 func (v *commandAttrValidator) validateActivityRetryPolicy(attributes *commandpb.ScheduleActivityTaskCommandAttributes) error {
-	if attributes.RetryPolicy == nil {
-		attributes.RetryPolicy = v.defaultActivityRetryPolicy
-		return nil
-	}
-
-	attributes.RetryPolicy = common.EnsureRetryPolicyDefaults(attributes.RetryPolicy, v.defaultActivityRetryPolicy)
+	attributes.RetryPolicy = common.EnsureRetryPolicyDefaults(attributes.RetryPolicy, v.defaultActivityRetrySettings)
 	return common.ValidateRetryPolicy(attributes.RetryPolicy)
 }
 

--- a/service/history/commandChecker_test.go
+++ b/service/history/commandChecker_test.go
@@ -587,7 +587,7 @@ func (s *commandAttrValidatorSuite) TestValidateActivityRetryPolicy() {
 			},
 		},
 		{
-			name: "partial override set policy",
+			name: "partial override of fields",
 			input: &commonpb.RetryPolicy{
 				InitialIntervalInSeconds: 0,
 				BackoffCoefficient:       1.2,
@@ -599,6 +599,19 @@ func (s *commandAttrValidatorSuite) TestValidateActivityRetryPolicy() {
 				BackoffCoefficient:       1.2,
 				MaximumIntervalInSeconds: 100,
 				MaximumAttempts:          7,
+			},
+		},
+		{
+			name: "set expected max interval if only init interval set",
+			input: &commonpb.RetryPolicy{
+				InitialIntervalInSeconds: 3,
+				MaximumIntervalInSeconds: 0,
+			},
+			want: &commonpb.RetryPolicy{
+				InitialIntervalInSeconds: 3,
+				BackoffCoefficient:       2,
+				MaximumIntervalInSeconds: 300,
+				MaximumAttempts:          0,
 			},
 		},
 		{

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -35,9 +35,9 @@ import (
 	"go.temporal.io/server/common/backoff"
 )
 
-const defaultInitialRetryIntervalInSeconds = 1
-const defaultMaximumRetryIntervalCoefficient = 100.0
-const defaultExponentialBackoffCoefficient = 2.0
+const defaultInitialIntervalInSeconds = 1
+const defaultMaximumIntervalCoefficient = 100.0
+const defaultBackoffCoefficient = 2.0
 const defaultMaximumAttempts = 0
 
 func getBackoffInterval(
@@ -136,41 +136,39 @@ func isRetryable(failure *failurepb.Failure, nonRetryableTypes []string) bool {
 
 func getDefaultActivityRetryPolicyConfigOptions() map[string]interface{} {
 	return map[string]interface{}{
-		"InitialRetryIntervalInSeconds": 1,
-		"MaximumRetryIntervalInSeconds": 100,
-		"ExponentialBackoffCoefficient": 2.0,
-		"MaximumAttempts":               0,
+		"InitialIntervalInSeconds": 1,
+		"MaximumIntervalInSeconds": 100,
+		"BackoffCoefficient":       2.0,
+		"MaximumAttempts":          0,
 	}
 }
 
 func fromConfigToDefaultActivityRetrySettings(options map[string]interface{}) common.DefaultActivityRetrySettings {
-	defaultSettings := common.DefaultActivityRetrySettings{}
-	initialRetryInterval, ok := options["InitialRetryIntervalInSeconds"]
-	if ok {
-		defaultSettings.InitialRetryIntervalInSeconds = int32(initialRetryInterval.(int))
-	} else {
-		defaultSettings.InitialRetryIntervalInSeconds = defaultInitialRetryIntervalInSeconds
+	defaultSettings := common.DefaultActivityRetrySettings{
+		InitialIntervalInSeconds:   defaultInitialIntervalInSeconds,
+		MaximumIntervalCoefficient: defaultMaximumIntervalCoefficient,
+		BackoffCoefficient:         defaultBackoffCoefficient,
+		MaximumAttempts:            defaultMaximumAttempts,
 	}
 
-	maxRetryIntervalCoefficient, ok := options["MaximumRetryIntervalCoefficient"]
+	initialRetryInterval, ok := options["InitialIntervalInSeconds"]
 	if ok {
-		defaultSettings.MaximumRetryIntervalCoefficient = maxRetryIntervalCoefficient.(float64)
-	} else {
-		defaultSettings.MaximumRetryIntervalCoefficient = defaultMaximumRetryIntervalCoefficient
+		defaultSettings.InitialIntervalInSeconds = int32(initialRetryInterval.(int))
 	}
 
-	exponentialBackoffCoefficient, ok := options["ExponentialBackoffCoefficient"]
+	maxRetryIntervalCoefficient, ok := options["MaximumIntervalCoefficient"]
 	if ok {
-		defaultSettings.ExponentialBackoffCoefficient = exponentialBackoffCoefficient.(float64)
-	} else {
-		defaultSettings.ExponentialBackoffCoefficient = defaultExponentialBackoffCoefficient
+		defaultSettings.MaximumIntervalCoefficient = maxRetryIntervalCoefficient.(float64)
+	}
+
+	exponentialBackoffCoefficient, ok := options["BackoffCoefficient"]
+	if ok {
+		defaultSettings.BackoffCoefficient = exponentialBackoffCoefficient.(float64)
 	}
 
 	maximumAttempts, ok := options["MaximumAttempts"]
 	if ok {
 		defaultSettings.MaximumAttempts = int32(maximumAttempts.(int))
-	} else {
-		defaultSettings.MaximumAttempts = defaultMaximumAttempts
 	}
 
 	return defaultSettings

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -25,6 +25,7 @@
 package history
 
 import (
+	"fmt"
 	"math"
 	"time"
 
@@ -169,6 +170,15 @@ func fromConfigToDefaultActivityRetrySettings(options map[string]interface{}) co
 	maximumAttempts, ok := options["MaximumAttempts"]
 	if ok {
 		defaultSettings.MaximumAttempts = int32(maximumAttempts.(int))
+	}
+
+	err := common.ValidateRetryPolicy(common.EnsureRetryPolicyDefaults(nil, defaultSettings))
+	if err != nil {
+		panic(
+			fmt.Sprintf(
+				"Bad Default Activity Retry Settings defined: %+v failed validation %v",
+				defaultSettings,
+				err))
 	}
 
 	return defaultSettings

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -35,6 +35,11 @@ import (
 	"go.temporal.io/server/common/backoff"
 )
 
+const defaultInitialRetryIntervalInSeconds = 1
+const defaultMaximumRetryIntervalCoefficient = 100.0
+const defaultExponentialBackoffCoefficient = 2.0
+const defaultMaximumAttempts = 0
+
 func getBackoffInterval(
 	now time.Time,
 	expirationTime time.Time,
@@ -144,28 +149,28 @@ func fromConfigToDefaultActivityRetrySettings(options map[string]interface{}) co
 	if ok {
 		defaultSettings.InitialRetryIntervalInSeconds = int32(initialRetryInterval.(int))
 	} else {
-		defaultSettings.InitialRetryIntervalInSeconds = 1
+		defaultSettings.InitialRetryIntervalInSeconds = defaultInitialRetryIntervalInSeconds
 	}
 
 	maxRetryIntervalCoefficient, ok := options["MaximumRetryIntervalCoefficient"]
 	if ok {
 		defaultSettings.MaximumRetryIntervalCoefficient = maxRetryIntervalCoefficient.(float64)
 	} else {
-		defaultSettings.MaximumRetryIntervalCoefficient = 100
+		defaultSettings.MaximumRetryIntervalCoefficient = defaultMaximumRetryIntervalCoefficient
 	}
 
 	exponentialBackoffCoefficient, ok := options["ExponentialBackoffCoefficient"]
 	if ok {
 		defaultSettings.ExponentialBackoffCoefficient = exponentialBackoffCoefficient.(float64)
 	} else {
-		defaultSettings.ExponentialBackoffCoefficient = 2.0
+		defaultSettings.ExponentialBackoffCoefficient = defaultExponentialBackoffCoefficient
 	}
 
 	maximumAttempts, ok := options["MaximumAttempts"]
 	if ok {
 		defaultSettings.MaximumAttempts = int32(maximumAttempts.(int))
 	} else {
-		defaultSettings.MaximumAttempts = 0
+		defaultSettings.MaximumAttempts = defaultMaximumAttempts
 	}
 
 	return defaultSettings

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -25,11 +25,9 @@
 package history
 
 import (
-	"fmt"
 	"math"
 	"time"
 
-	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 
@@ -140,36 +138,35 @@ func getDefaultActivityRetryPolicyConfigOptions() map[string]interface{} {
 	}
 }
 
-func fromConfigToActivityRetryPolicy(options map[string]interface{}) *commonpb.RetryPolicy {
-	retryPolicy := &commonpb.RetryPolicy{}
+func fromConfigToDefaultActivityRetrySettings(options map[string]interface{}) common.DefaultActivityRetrySettings {
+	defaultSettings := common.DefaultActivityRetrySettings{}
 	initialRetryInterval, ok := options["InitialRetryIntervalInSeconds"]
 	if ok {
-		retryPolicy.InitialIntervalInSeconds = int32(initialRetryInterval.(int))
+		defaultSettings.InitialRetryIntervalInSeconds = int32(initialRetryInterval.(int))
+	} else {
+		defaultSettings.InitialRetryIntervalInSeconds = 1
 	}
 
-	maxRetryInterval, ok := options["MaximumRetryIntervalInSeconds"]
+	maxRetryIntervalCoefficient, ok := options["MaximumRetryIntervalCoefficient"]
 	if ok {
-		retryPolicy.MaximumIntervalInSeconds = int32(maxRetryInterval.(int))
+		defaultSettings.MaximumRetryIntervalCoefficient = maxRetryIntervalCoefficient.(float64)
+	} else {
+		defaultSettings.MaximumRetryIntervalCoefficient = 100
 	}
 
 	exponentialBackoffCoefficient, ok := options["ExponentialBackoffCoefficient"]
 	if ok {
-		retryPolicy.BackoffCoefficient = exponentialBackoffCoefficient.(float64)
+		defaultSettings.ExponentialBackoffCoefficient = exponentialBackoffCoefficient.(float64)
+	} else {
+		defaultSettings.ExponentialBackoffCoefficient = 2.0
 	}
 
 	maximumAttempts, ok := options["MaximumAttempts"]
 	if ok {
-		retryPolicy.MaximumAttempts = int32(maximumAttempts.(int))
+		defaultSettings.MaximumAttempts = int32(maximumAttempts.(int))
+	} else {
+		defaultSettings.MaximumAttempts = 0
 	}
 
-	err := common.ValidateRetryPolicy(retryPolicy)
-	if err != nil {
-		panic(
-			fmt.Sprintf(
-				"Bad Default Activity Retry Policy defined: %+v failed validation %v",
-				retryPolicy,
-				err))
-	}
-
-	return retryPolicy
+	return defaultSettings
 }

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -151,19 +151,19 @@ func fromConfigToDefaultActivityRetrySettings(options map[string]interface{}) co
 		MaximumAttempts:            defaultMaximumAttempts,
 	}
 
-	initialRetryInterval, ok := options["InitialIntervalInSeconds"]
+	initialIntervalInSeconds, ok := options["InitialIntervalInSeconds"]
 	if ok {
-		defaultSettings.InitialIntervalInSeconds = int32(initialRetryInterval.(int))
+		defaultSettings.InitialIntervalInSeconds = int32(initialIntervalInSeconds.(int))
 	}
 
-	maxRetryIntervalCoefficient, ok := options["MaximumIntervalCoefficient"]
+	maximumIntervalCoefficient, ok := options["MaximumIntervalCoefficient"]
 	if ok {
-		defaultSettings.MaximumIntervalCoefficient = maxRetryIntervalCoefficient.(float64)
+		defaultSettings.MaximumIntervalCoefficient = maximumIntervalCoefficient.(float64)
 	}
 
-	exponentialBackoffCoefficient, ok := options["BackoffCoefficient"]
+	backoffCoefficient, ok := options["BackoffCoefficient"]
 	if ok {
-		defaultSettings.BackoffCoefficient = exponentialBackoffCoefficient.(float64)
+		defaultSettings.BackoffCoefficient = backoffCoefficient.(float64)
 	}
 
 	maximumAttempts, ok := options["MaximumAttempts"]

--- a/service/history/retry_test.go
+++ b/service/history/retry_test.go
@@ -398,15 +398,15 @@ func Test_NextRetry(t *testing.T) {
 
 func Test_FromConfigToActivityRetryPolicy(t *testing.T) {
 	options := map[string]interface{}{
-		"InitialRetryIntervalInSeconds": 2,
-		"MaximumRetryIntervalInSeconds": 200,
-		"ExponentialBackoffCoefficient": 4.0,
-		"MaximumAttempts":               5,
+		"InitialRetryIntervalInSeconds":   2,
+		"MaximumRetryIntervalCoefficient": 100.0,
+		"ExponentialBackoffCoefficient":   4.0,
+		"MaximumAttempts":                 5,
 	}
 
-	policy := fromConfigToActivityRetryPolicy(options)
-	assert.Equal(t, int32(2), policy.GetInitialIntervalInSeconds())
-	assert.Equal(t, int32(200), policy.GetMaximumIntervalInSeconds())
-	assert.Equal(t, 4.0, policy.GetBackoffCoefficient())
-	assert.Equal(t, int32(5), policy.GetMaximumAttempts())
+	defaultSettings := fromConfigToDefaultActivityRetrySettings(options)
+	assert.Equal(t, int32(2), defaultSettings.InitialRetryIntervalInSeconds)
+	assert.Equal(t, 100.0, defaultSettings.MaximumRetryIntervalCoefficient)
+	assert.Equal(t, 4.0, defaultSettings.ExponentialBackoffCoefficient)
+	assert.Equal(t, int32(5), defaultSettings.MaximumAttempts)
 }

--- a/service/history/retry_test.go
+++ b/service/history/retry_test.go
@@ -398,15 +398,15 @@ func Test_NextRetry(t *testing.T) {
 
 func Test_FromConfigToActivityRetryPolicy(t *testing.T) {
 	options := map[string]interface{}{
-		"InitialRetryIntervalInSeconds":   2,
-		"MaximumRetryIntervalCoefficient": 100.0,
-		"ExponentialBackoffCoefficient":   4.0,
-		"MaximumAttempts":                 5,
+		"InitialIntervalInSeconds":   2,
+		"MaximumIntervalCoefficient": 100.0,
+		"BackoffCoefficient":         4.0,
+		"MaximumAttempts":            5,
 	}
 
 	defaultSettings := fromConfigToDefaultActivityRetrySettings(options)
-	assert.Equal(t, int32(2), defaultSettings.InitialRetryIntervalInSeconds)
-	assert.Equal(t, 100.0, defaultSettings.MaximumRetryIntervalCoefficient)
-	assert.Equal(t, 4.0, defaultSettings.ExponentialBackoffCoefficient)
+	assert.Equal(t, int32(2), defaultSettings.InitialIntervalInSeconds)
+	assert.Equal(t, 100.0, defaultSettings.MaximumIntervalCoefficient)
+	assert.Equal(t, 4.0, defaultSettings.BackoffCoefficient)
 	assert.Equal(t, int32(5), defaultSettings.MaximumAttempts)
 }


### PR DESCRIPTION
Fixes situation where user sets an initial retry interval that is greater than 100 seconds, but doesn't explicitly set the maximum retry interval, which will lead to a validation failure when they try to start an activity.