### PR TITLE
Fix development_*.yml PublicClient/ClusterRpcAddress Ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ WORKDIR /etc/temporal
 
 ENV SERVICES="history,matching,frontend,worker"
 
-EXPOSE 7933 7934 7935 7939 6933 6934 6935 6939 7233 7234 7235 7239
+EXPOSE 6933 6934 6935 6939 7233 7234 7235 7239
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD /start.sh
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -72,7 +72,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -71,7 +71,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
     standby:
       enabled: true
       initialFailoverVersion: 2
@@ -147,4 +147,4 @@ namespaceDefaults:
       URI: "file:///tmp/temporal_vis_archival/development"
 
 publicClient:
-  hostPort: "localhost:7933"
+  hostPort: "localhost:7233"

--- a/config/development_archival.yaml
+++ b/config/development_archival.yaml
@@ -72,7 +72,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development_es.yaml
+++ b/config/development_es.yaml
@@ -77,7 +77,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"
@@ -126,7 +126,7 @@ kafka:
       dlq-topic: temporal-visibility-dev-dlq
 
 publicClient:
-  hostPort: "localhost:7933"
+  hostPort: "localhost:7233"
 
 dynamicConfigClient:
   filepath: "config/dynamicconfig/development_es.yaml"

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -84,7 +84,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -127,4 +127,4 @@ kafka:
       cluster: test
 
 publicClient:
-  hostPort: "localhost:7933"
+  hostPort: "127.0.0.1:7233"

--- a/config/development_other.yaml
+++ b/config/development_other.yaml
@@ -72,7 +72,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
     standby:
       enabled: true
       initialFailoverVersion: 2

--- a/config/development_postgres.yaml
+++ b/config/development_postgres.yaml
@@ -84,7 +84,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"
@@ -127,4 +127,4 @@ kafka:
       cluster: test
 
 publicClient:
-  hostPort: "localhost:7933"
+  hostPort: "localhost:7233"

--- a/config/development_prometheus.yaml
+++ b/config/development_prometheus.yaml
@@ -70,7 +70,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"
@@ -113,5 +113,5 @@ kafka:
       cluster: test
 
 publicClient:
-  hostPort: "localhost:7933"
+  hostPort: "localhost:7233"
 

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -72,7 +72,7 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7233"
     standby:
       enabled: true
       initialFailoverVersion: 2


### PR DESCRIPTION
Make sample yaml point at frontend on correct port. Current configuration will make worker fail.