### PR TITLE
MySQL Execution - Replace Insert Ignore Usage

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -33,9 +33,12 @@ import (
 )
 
 const (
-	templateCreateWorkflowExecutionStarted = `INSERT IGNORE INTO executions_visibility (` +
+	templateCreateWorkflowExecutionStarted = `INSERT INTO executions_visibility (` +
 		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, status, memo, encoding) ` +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) ` +
+		`ON DUPLICATE KEY UPDATE ` +
+		`run_id=VALUES(run_id)`
+
 
 	templateCreateWorkflowExecutionClosed = `INSERT INTO executions_visibility (` +
 		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding) ` +


### PR DESCRIPTION
`INSERT IGNORE` has many sharp edges and does more than just ignore Duplicate Key Conflicts. It also swallows errors such as partitioning allocation and divide by zero errors and we should aim to not use this anywhere. See more here: https://dev.mysql.com/doc/refman/5.7/en/sql-mode.html#ignore-strict-comparison 

Unfortunately MySQL does not have `ON DUPLICATE KEY DO NOTHING`, so instead we should use the `ON DUPLICATE KEY UPDATE` syntax and update something that is ideally part of the duplicate key conflict (in essence a no-op). However, that update should not be on the sharding key that we would want to use with Vitess, as this will cause issues with Vitess query validation. 

After this change there is only one more location to change - ImmutableClusterMetadata, but cannot be changed in its current state as this table has no column that satisfies the constraints above. However as we read the row back in that case to validate, it is not as critical to solve in the short term. 