### PR TITLE
Use environment.GetCassandraPort() instead of defaultCassandraPort in tests

### DIFF
--- a/environment/env.go
+++ b/environment/env.go
@@ -39,35 +39,35 @@ const (
 	// CassandraPort env
 	CassandraPort = "CASSANDRA_PORT"
 	// CassandraDefaultPort Cassandra default port
-	CassandraDefaultPort = "9042"
+	CassandraDefaultPort = 9042
 
 	// MySQLSeeds env
 	MySQLSeeds = "MYSQL_SEEDS"
 	// MySQLPort env
 	MySQLPort = "MYSQL_PORT"
 	// MySQLDefaultPort MySQL default port
-	MySQLDefaultPort = "3306"
+	MySQLDefaultPort = 3306
 
 	// KafkaSeeds env
 	KafkaSeeds = "KAFKA_SEEDS"
 	// KafkaPort env
 	KafkaPort = "KAFKA_PORT"
 	// KafkaDefaultPort Kafka default port
-	KafkaDefaultPort = "9092"
+	KafkaDefaultPort = 9092
 
 	// ESSeeds env
 	ESSeeds = "ES_SEEDS"
 	// ESPort env
 	ESPort = "ES_PORT"
 	// ESDefaultPort ES default port
-	ESDefaultPort = "9200"
+	ESDefaultPort = 9200
 
 	// PostgresSeeds env
 	PostgresSeeds = "POSTGRES_SEEDS"
 	// PostgresPort env
 	PostgresPort = "POSTGRES_PORT"
 	// PostgresDefaultPort Postgres default port
-	PostgresDefaultPort = "5432"
+	PostgresDefaultPort = 5432
 )
 
 // SetupEnv setup the necessary env
@@ -80,7 +80,7 @@ func SetupEnv() {
 	}
 
 	if os.Getenv(CassandraPort) == "" {
-		err := os.Setenv(CassandraPort, CassandraDefaultPort)
+		err := os.Setenv(CassandraPort, strconv.Itoa(CassandraDefaultPort))
 		if err != nil {
 			panic(fmt.Sprintf("error setting env %v", CassandraPort))
 		}
@@ -94,7 +94,7 @@ func SetupEnv() {
 	}
 
 	if os.Getenv(MySQLPort) == "" {
-		err := os.Setenv(MySQLPort, MySQLDefaultPort)
+		err := os.Setenv(MySQLPort, strconv.Itoa(MySQLDefaultPort))
 		if err != nil {
 			panic(fmt.Sprintf("error setting env %v", MySQLPort))
 		}
@@ -108,7 +108,7 @@ func SetupEnv() {
 	}
 
 	if os.Getenv(PostgresPort) == "" {
-		err := os.Setenv(PostgresPort, PostgresDefaultPort)
+		err := os.Setenv(PostgresPort, strconv.Itoa(PostgresDefaultPort))
 		if err != nil {
 			panic(fmt.Sprintf("error setting env %v", PostgresPort))
 		}
@@ -122,7 +122,7 @@ func SetupEnv() {
 	}
 
 	if os.Getenv(KafkaPort) == "" {
-		err := os.Setenv(KafkaPort, KafkaDefaultPort)
+		err := os.Setenv(KafkaPort, strconv.Itoa(KafkaDefaultPort))
 		if err != nil {
 			panic(fmt.Sprintf("error setting env %v", KafkaPort))
 		}
@@ -136,7 +136,7 @@ func SetupEnv() {
 	}
 
 	if os.Getenv(ESPort) == "" {
-		err := os.Setenv(ESPort, ESDefaultPort)
+		err := os.Setenv(ESPort, strconv.Itoa(ESDefaultPort))
 		if err != nil {
 			panic(fmt.Sprintf("error setting env %v", ESPort))
 		}
@@ -156,7 +156,7 @@ func GetCassandraAddress() string {
 func GetCassandraPort() int {
 	port := os.Getenv(CassandraPort)
 	if port == "" {
-		port = CassandraDefaultPort
+		return CassandraDefaultPort
 	}
 	p, err := strconv.Atoi(port)
 	if err != nil {
@@ -178,7 +178,7 @@ func GetMySQLAddress() string {
 func GetMySQLPort() int {
 	port := os.Getenv(MySQLPort)
 	if port == "" {
-		port = MySQLDefaultPort
+		return MySQLDefaultPort
 	}
 	p, err := strconv.Atoi(port)
 	if err != nil {
@@ -200,7 +200,7 @@ func GetPostgresAddress() string {
 func GetPostgresPort() int {
 	port := os.Getenv(PostgresPort)
 	if port == "" {
-		port = PostgresDefaultPort
+		return PostgresDefaultPort
 	}
 	p, err := strconv.Atoi(port)
 	if err != nil {
@@ -222,7 +222,7 @@ func GetKafkaAddress() string {
 func GetKafkaPort() int {
 	port := os.Getenv(KafkaPort)
 	if port == "" {
-		port = KafkaDefaultPort
+		return KafkaDefaultPort
 	}
 	p, err := strconv.Atoi(port)
 	if err != nil {
@@ -244,7 +244,7 @@ func GetESAddress() string {
 func GetESPort() int {
 	port := os.Getenv(ESPort)
 	if port == "" {
-		port = ESDefaultPort
+		return ESDefaultPort
 	}
 	p, err := strconv.Atoi(port)
 	if err != nil {

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -61,11 +61,10 @@ var errNoHosts = errors.New("Cassandra Hosts list is empty or malformed")
 var errGetSchemaVersion = errors.New("Failed to get current schema version from cassandra")
 
 const (
-	defaultTimeout       = 30    // Timeout in seconds
-	cqlProtoVersion      = 4     // default CQL protocol version
-	defaultConsistency   = "ALL" // schema updates must always be ALL
-	defaultCassandraPort = 9042
-	systemKeyspace       = "system"
+	defaultTimeout     = 30    // Timeout in seconds
+	cqlProtoVersion    = 4     // default CQL protocol version
+	defaultConsistency = "ALL" // schema updates must always be ALL
+	systemKeyspace     = "system"
 )
 
 const (

--- a/tools/cassandra/cqlclient_test.go
+++ b/tools/cassandra/cqlclient_test.go
@@ -79,7 +79,7 @@ func (s *CQLClientTestSuite) TestCQLClient() {
 func newTestCQLClient(keyspace string) (*cqlClient, error) {
 	return newCQLClient(&CQLClientConfig{
 		Hosts:       environment.GetCassandraAddress(),
-		Port:        defaultCassandraPort,
+		Port:        environment.GetCassandraPort(),
 		Keyspace:    keyspace,
 		Timeout:     defaultTimeout,
 		numReplicas: 1,

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -32,6 +32,7 @@ import (
 
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/service/config"
+	"go.temporal.io/server/environment"
 	"go.temporal.io/server/schema/cassandra"
 	"go.temporal.io/server/tools/common/schema"
 )
@@ -216,7 +217,7 @@ func validateCQLClientConfig(config *CQLClientConfig, isDryRun bool) error {
 		config.Keyspace = schema.DryrunDBName
 	}
 	if config.Port == 0 {
-		config.Port = defaultCassandraPort
+		config.Port = environment.GetCassandraPort()
 	}
 	if config.numReplicas == 0 {
 		config.numReplicas = defaultNumReplicas

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/urfave/cli"
 
+	"go.temporal.io/server/environment"
 	"go.temporal.io/server/tools/common/schema"
 )
 
@@ -75,7 +76,7 @@ func buildCLIOptions() *cli.App {
 		},
 		cli.IntFlag{
 			Name:   schema.CLIFlagPort,
-			Value:  defaultCassandraPort,
+			Value:  environment.GetCassandraPort(),
 			Usage:  "Port of cassandra host to connect to",
 			EnvVar: "CASSANDRA_PORT",
 		},

--- a/tools/cassandra/version_test.go
+++ b/tools/cassandra/version_test.go
@@ -79,7 +79,7 @@ func (s *VersionTestSuite) TestVerifyCompatibleVersion() {
 
 	defaultCfg := config.Cassandra{
 		Hosts:    environment.GetCassandraAddress(),
-		Port:     defaultCassandraPort,
+		Port:     environment.GetCassandraPort(),
 		User:     "",
 		Password: "",
 		Keyspace: keyspace,
@@ -118,7 +118,7 @@ func (s *VersionTestSuite) TestCheckCompatibleVersion() {
 func (s *VersionTestSuite) createKeyspace(keyspace string) func() {
 	cfg := &CQLClientConfig{
 		Hosts:       environment.GetCassandraAddress(),
-		Port:        defaultCassandraPort,
+		Port:        environment.GetCassandraPort(),
 		Keyspace:    "system",
 		Timeout:     defaultTimeout,
 		numReplicas: 1,
@@ -128,7 +128,7 @@ func (s *VersionTestSuite) createKeyspace(keyspace string) func() {
 
 	err = client.createKeyspace(keyspace)
 	if err != nil {
-		log.Fatalf("error creating Keyspace, err=%v", err)
+		log.Fatalf("error creating keyspace, err=%v", err)
 	}
 	return func() {
 		s.NoError(client.dropKeyspace(keyspace))
@@ -166,7 +166,7 @@ func (s *VersionTestSuite) runCheckCompatibleVersion(
 
 	cfg := config.Cassandra{
 		Hosts:    environment.GetCassandraAddress(),
-		Port:     defaultCassandraPort,
+		Port:     environment.GetCassandraPort(),
 		User:     "",
 		Password: "",
 		Keyspace: keyspace,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`environment.GetCassandraPort()` is used instead of `defaultCassandraPort` in tests.

<!-- Tell your future self why have you made these changes -->
**Why?**
To be able to configure to run tests against cassandra on different port.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
