### PR TITLE
Allow reset for workflow with corrupted history when possible

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -1108,6 +1108,8 @@ type (
 		Size int
 		// the first_event_id of last loaded batch
 		LastFirstEventID int64
+		// event id of the last event in the last loaded batch
+		LastEventID int64
 	}
 
 	// ReadRawHistoryBranchResponse is the response to ReadHistoryBranchRequest


### PR DESCRIPTION
This PR addresses #585 allowing resets on workflows with corrupted history given that reset point is located before the place where history corruption has occurred. If corruption occurs after the reset point then all valid batches will be carried out to the next workflow.

Reset behavior for workflows with normal history should remain unchanged.

