### PR TITLE
Reset for workflows without completed tasks

### DIFF
--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -752,7 +752,7 @@ func validateLastBatchOfReset(lastBatch []*historypb.HistoryEvent, workflowTaskF
 
 	if lastEvent.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED &&
 		lastEvent.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("unable to use provided event id %v as a reset point as previous batch [%v-%v] should end with s or WorkflowTaskScheduled event.",
+		return serviceerror.NewInvalidArgument(fmt.Sprintf("unable to use provided event id %v as a reset point as previous batch [%v-%v] should end with WorkflowTaskStarted or WorkflowTaskScheduled event",
 			workflowTaskFinishEventID, firstEvent.GetEventId(), lastEvent.GetEventId()))
 	}
 

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -187,7 +187,7 @@ func (w *workflowResetorImpl) validateResetWorkflowAfterReplay(newMutableState m
 	if retError := newMutableState.CheckResettable(); retError != nil {
 		return retError
 	}
-	if !newMutableState.HasInFlightWorkflowTask() && !newMutableState.HasPendingWorkflowTask() {
+	if !newMutableState.HasPendingWorkflowTask() {
 		return serviceerror.NewInternal(fmt.Sprintf("can't find the last started workflow task"))
 	}
 	if newMutableState.HasBufferedEvents() {
@@ -290,10 +290,7 @@ func (w *workflowResetorImpl) buildNewMutableStateForReset(
 
 	// failed the in-flight workflow task(started).
 	// Note that we need to ensure WorkflowTaskFailed event is appended right after WorkflowTaskStarted event
-	workflowTask, _ := newMutableState.GetInFlightWorkflowTask()
-	if workflowTask == nil {
-		workflowTask, _ = newMutableState.GetPendingWorkflowTask()
-	}
+	workflowTask, _ := newMutableState.GetPendingWorkflowTask()
 	_, err := newMutableState.AddWorkflowTaskFailedEvent(workflowTask.ScheduleID, workflowTask.StartedID, enumspb.WORKFLOW_TASK_FAILED_CAUSE_RESET_WORKFLOW, nil,
 		identityHistoryService, resetReason, baseRunID, newRunID, forkEventVersion)
 	if err != nil {

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -187,7 +187,7 @@ func (w *workflowResetorImpl) validateResetWorkflowAfterReplay(newMutableState m
 	if retError := newMutableState.CheckResettable(); retError != nil {
 		return retError
 	}
-	if !newMutableState.HasInFlightWorkflowTask() {
+	if !newMutableState.HasInFlightWorkflowTask() && !newMutableState.HasPendingWorkflowTask() {
 		return serviceerror.NewInternal(fmt.Sprintf("can't find the last started workflow task"))
 	}
 	if newMutableState.HasBufferedEvents() {
@@ -291,7 +291,9 @@ func (w *workflowResetorImpl) buildNewMutableStateForReset(
 	// failed the in-flight workflow task(started).
 	// Note that we need to ensure WorkflowTaskFailed event is appended right after WorkflowTaskStarted event
 	workflowTask, _ := newMutableState.GetInFlightWorkflowTask()
-
+	if workflowTask == nil {
+		workflowTask, _ = newMutableState.GetPendingWorkflowTask()
+	}
 	_, err := newMutableState.AddWorkflowTaskFailedEvent(workflowTask.ScheduleID, workflowTask.StartedID, enumspb.WORKFLOW_TASK_FAILED_CAUSE_RESET_WORKFLOW, nil,
 		identityHistoryService, resetReason, baseRunID, newRunID, forkEventVersion)
 	if err != nil {
@@ -751,8 +753,10 @@ func validateLastBatchOfReset(lastBatch []*historypb.HistoryEvent, workflowTaskF
 		return serviceerror.NewInvalidArgument(fmt.Sprintf("wrong WorkflowTaskFinishEventId, it must be WorkflowTaskStarted + 1: %v", lastEvent.GetEventId()))
 	}
 
-	if lastEvent.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED {
-		return serviceerror.NewInvalidArgument(fmt.Sprintf("wrong WorkflowTaskFinishEventId, previous batch doesn't include WorkflowTaskStarted, lastFirstEventId: %v", firstEvent.GetEventId()))
+	if lastEvent.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED &&
+		lastEvent.GetEventType() != enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED {
+		return serviceerror.NewInvalidArgument(fmt.Sprintf("unable to use provided event id %v as a reset point as previous batch [%v-%v] should end with s or WorkflowTaskScheduled event.",
+			workflowTaskFinishEventID, firstEvent.GetEventId(), lastEvent.GetEventId()))
 	}
 
 	return nil

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -709,7 +709,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 		for _, e := range be.Events {
 			eid++
 			if e.GetEventId() != eid {
-				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+				s.Fail(fmt.Sprintf("non-continuous eventID: %v, %v", eid, e.GetEventId()))
 			}
 			e.EventTime = &eventTime
 		}
@@ -1403,7 +1403,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication_WithRequestCance
 		for _, e := range be.Events {
 			eid++
 			if e.GetEventId() != eid {
-				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+				s.Fail(fmt.Sprintf("non-continuous eventID: %v, %v", eid, e.GetEventId()))
 			}
 			e.EventTime = &eventTime
 		}
@@ -1998,7 +1998,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 		for _, e := range be.Events {
 			eid++
 			if e.GetEventId() != eid {
-				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+				s.Fail(fmt.Sprintf("non-continuous eventID: %v, %v", eid, e.GetEventId()))
 			}
 			e.EventTime = &eventTime
 		}
@@ -2703,7 +2703,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 		for _, e := range be.Events {
 			eid++
 			if e.GetEventId() != eid {
-				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+				s.Fail(fmt.Sprintf("non-continuous eventID: %v, %v", eid, e.GetEventId()))
 			}
 			e.EventTime = &eventTime
 		}
@@ -3304,7 +3304,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 		for _, e := range be.Events {
 			eid++
 			if e.GetEventId() != eid {
-				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+				s.Fail(fmt.Sprintf("non-continuous eventID: %v, %v", eid, e.GetEventId()))
 			}
 			e.EventTime = &eventTime
 		}
@@ -3923,7 +3923,7 @@ func (s *resetorSuite) TestApplyReset() {
 		for _, e := range be.Events {
 			eid++
 			if e.GetEventId() != eid {
-				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+				s.Fail(fmt.Sprintf("non-continuous eventID: %v, %v", eid, e.GetEventId()))
 			}
 			e.EventTime = &eventTime
 		}
@@ -4319,7 +4319,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_WithoutRunID() {
 		for _, e := range be.Events {
 			eid++
 			if e.GetEventId() != eid {
-				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+				s.Fail(fmt.Sprintf("non-continuous eventID: %v, %v", eid, e.GetEventId()))
 			}
 			e.EventTime = &eventTime
 		}
@@ -4459,7 +4459,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoCompletedTasks() {
 		for _, e := range be.Events {
 			eid++
 			if e.GetEventId() != eid {
-				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+				s.Fail(fmt.Sprintf("non-continuous eventID: %v, %v", eid, e.GetEventId()))
 			}
 			e.EventTime = &eventTime
 		}

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -4371,3 +4371,165 @@ func (s *resetorSuite) TestResetWorkflowExecution_WithoutRunID() {
 	s.Nil(err)
 	s.NotNil(response.RunId)
 }
+
+func (s *resetorSuite) TestResetWorkflowExecution_NoCompletedTasks() {
+	testNamespaceEntry := cache.NewLocalNamespaceCacheEntryForTest(
+		&persistenceblobs.NamespaceInfo{Id: testNamespaceID}, &persistenceblobs.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "", nil,
+	)
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
+
+	namespaceID := testNamespaceID
+
+	request := &historyservice.ResetWorkflowExecutionRequest{NamespaceId: namespaceID, ResetRequest: &workflowservice.ResetWorkflowExecutionRequest{}}
+
+	wid := "wId"
+	wfType := "wfType"
+	taskQueueName := "taskQueue"
+	forkRunID := uuid.New().String()
+	currRunID := uuid.New().String()
+
+	we := commonpb.WorkflowExecution{
+		WorkflowId: wid,
+		RunId:      forkRunID,
+	}
+
+	request.ResetRequest = &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 "testNamespace",
+		WorkflowExecution:         &we,
+		Reason:                    "test reset",
+		WorkflowTaskFinishEventId: 3,
+		RequestId:                 uuid.New().String(),
+	}
+
+	forkBranchToken := []byte("forkBranchToken")
+	taskQueue := &taskqueuepb.TaskQueue{
+		Name: taskQueueName,
+	}
+	// Prepare history event sequence.
+	readHistoryResponse := &persistence.ReadHistoryBranchByBatchResponse{
+		NextPageToken:    nil,
+		Size:             1000,
+		LastFirstEventID: int64(3),
+		History: []*historypb.History{
+			{
+				Events: []*historypb.HistoryEvent{
+					{
+						EventId:   1,
+						Version:   common.EmptyVersion,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_STARTED,
+						Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{
+							WorkflowType: &commonpb.WorkflowType{
+								Name: wfType,
+							},
+							TaskQueue:                taskQueue,
+							Input:                    payloads.EncodeString("testInput"),
+							WorkflowExecutionTimeout: timestamp.DurationPtr(100 * time.Second),
+							WorkflowRunTimeout:       timestamp.DurationPtr(50 * time.Second),
+							WorkflowTaskTimeout:      timestamp.DurationPtr(200 * time.Second),
+						}},
+					},
+					{
+						EventId:   2,
+						Version:   common.EmptyVersion,
+						EventType: enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED,
+						Attributes: &historypb.HistoryEvent_WorkflowTaskScheduledEventAttributes{WorkflowTaskScheduledEventAttributes: &historypb.WorkflowTaskScheduledEventAttributes{
+							TaskQueue:           taskQueue,
+							StartToCloseTimeout: timestamp.DurationPtr(100 * time.Second),
+						}},
+					},
+				},
+			},
+			{
+				Events: []*historypb.HistoryEvent{
+					{
+						EventId:    3,
+						Version:    common.EmptyVersion,
+						EventType:  enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT,
+						Attributes: &historypb.HistoryEvent_WorkflowTaskTimedOutEventAttributes{WorkflowTaskTimedOutEventAttributes: &historypb.WorkflowTaskTimedOutEventAttributes{}},
+					},
+				},
+			},
+		},
+	}
+
+	eid := int64(0)
+	eventTime := time.Unix(0, 1000).UTC()
+	for _, be := range readHistoryResponse.History {
+		for _, e := range be.Events {
+			eid++
+			if e.GetEventId() != eid {
+				s.Fail(fmt.Sprintf("inconintous eventID: %v, %v", eid, e.GetEventId()))
+			}
+			e.EventTime = &eventTime
+		}
+	}
+
+	// Mock calls.
+	s.mockExecutionMgr.On("GetWorkflowExecution", &persistence.GetWorkflowExecutionRequest{
+		NamespaceID: namespaceID,
+		Execution: commonpb.WorkflowExecution{
+			WorkflowId: wid,
+			RunId:      forkRunID,
+		},
+	}).Return(&persistence.GetWorkflowExecutionResponse{State: &persistence.WorkflowMutableState{
+		ExecutionInfo: &persistence.WorkflowExecutionInfo{
+			NamespaceID:            namespaceID,
+			WorkflowID:             wid,
+			WorkflowTypeName:       wfType,
+			TaskQueue:              taskQueueName,
+			RunID:                  forkRunID,
+			BranchToken:            forkBranchToken,
+			NextEventID:            4,
+			WorkflowTaskVersion:    common.EmptyVersion,
+			WorkflowTaskScheduleID: common.EmptyEventID,
+			WorkflowTaskStartedID:  common.EmptyEventID,
+			State:                  enumsspb.WORKFLOW_EXECUTION_STATE_CREATED,
+		},
+		ExecutionStats: &persistenceblobs.ExecutionStats{},
+	}}, nil).Once()
+	s.mockExecutionMgr.On("GetCurrentExecution", mock.Anything).Return(&persistence.GetCurrentExecutionResponse{
+		RunID: currRunID,
+	}, nil).Once()
+	s.mockExecutionMgr.On("GetWorkflowExecution", &persistence.GetWorkflowExecutionRequest{
+		NamespaceID: namespaceID,
+		Execution: commonpb.WorkflowExecution{
+			WorkflowId: wid,
+			RunId:      currRunID,
+		},
+	}).Return(&persistence.GetWorkflowExecutionResponse{State: &persistence.WorkflowMutableState{
+		ExecutionInfo: &persistence.WorkflowExecutionInfo{
+			NamespaceID:            namespaceID,
+			WorkflowID:             wid,
+			WorkflowTypeName:       wfType,
+			TaskQueue:              taskQueueName,
+			RunID:                  currRunID,
+			NextEventID:            common.FirstEventID,
+			WorkflowTaskVersion:    common.EmptyVersion,
+			WorkflowTaskScheduleID: common.EmptyEventID,
+			WorkflowTaskStartedID:  common.EmptyEventID,
+			State:                  enumsspb.WORKFLOW_EXECUTION_STATE_CREATED,
+		},
+		ExecutionStats: &persistenceblobs.ExecutionStats{},
+	}}, nil).Once()
+	s.mockHistoryV2Mgr.On("ReadHistoryBranchByBatch", &persistence.ReadHistoryBranchRequest{
+		BranchToken:   forkBranchToken,
+		MinEventID:    common.FirstEventID,
+		MaxEventID:    int64(4),
+		PageSize:      defaultHistoryPageSize,
+		NextPageToken: nil,
+		ShardID:       &s.shardID,
+	}).Return(readHistoryResponse, nil).Once()
+	s.mockHistoryV2Mgr.On("ForkHistoryBranch", mock.Anything).Return(&persistence.ForkHistoryBranchResponse{
+		NewBranchToken: []byte("newBranch"),
+	}, nil).Once()
+	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything).Return(&persistence.AppendHistoryNodesResponse{
+		Size: 200,
+	}, nil).Times(2)
+	s.mockExecutionMgr.On("ResetWorkflowExecution", mock.Anything).Return(nil).Once()
+
+	// Perform a reset and make sure there is no error.
+	response, err := s.historyEngine.ResetWorkflowExecution(context.Background(), request)
+	s.Nil(err)
+	s.NotNil(response.RunId)
+}

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -81,8 +81,8 @@ var envKeysForUserName = []string{
 }
 
 var resetTypesMap = map[string]string{
-	"FirstWorkflowTaskCompleted": "",
-	"LastWorkflowTaskCompleted":  "",
+	"FirstWorkflowTask": "",
+	"LastWorkflowTask":  "",
 	"LastContinuedAsNew":         "",
 	"BadBinary":                  FlagResetBadBinaryChecksum,
 }

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -1725,8 +1725,8 @@ func isLastEventWorkflowTaskFailedWithNonDeterminism(ctx context.Context, namesp
 func getResetEventIDByType(ctx context.Context, c *cli.Context, resetType, namespace, wid, rid string, frontendClient workflowservice.WorkflowServiceClient) (resetBaseRunID string, workflowTaskFinishID int64, err error) {
 	fmt.Println("resetType:", resetType)
 	switch resetType {
-	case "LastWorkflowTaskCompleted":
-		resetBaseRunID, workflowTaskFinishID, err = getLastWorkflowTaskCompletedID(ctx, namespace, wid, rid, frontendClient)
+	case "LastWorkflowTask":
+		resetBaseRunID, workflowTaskFinishID, err = getLastWorkflowTaskID(ctx, namespace, wid, rid, frontendClient)
 		if err != nil {
 			return
 		}
@@ -1735,8 +1735,8 @@ func getResetEventIDByType(ctx context.Context, c *cli.Context, resetType, names
 		if err != nil {
 			return
 		}
-	case "FirstWorkflowTaskCompleted":
-		resetBaseRunID, workflowTaskFinishID, err = getFirstWorkflowTaskCompletedID(ctx, namespace, wid, rid, frontendClient)
+	case "FirstWorkflowTask":
+		resetBaseRunID, workflowTaskFinishID, err = getFirstWorkflowTaskID(ctx, namespace, wid, rid, frontendClient)
 		if err != nil {
 			return
 		}
@@ -1752,7 +1752,7 @@ func getResetEventIDByType(ctx context.Context, c *cli.Context, resetType, names
 	return
 }
 
-func getLastWorkflowTaskCompletedID(ctx context.Context, namespace, wid, rid string, frontendClient workflowservice.WorkflowServiceClient) (resetBaseRunID string, workflowTaskCompletedID int64, err error) {
+func getLastWorkflowTaskID(ctx context.Context, namespace, wid, rid string, frontendClient workflowservice.WorkflowServiceClient) (resetBaseRunID string, workflowTaskID int64, err error) {
 	resetBaseRunID = rid
 	req := &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace: namespace,
@@ -1770,8 +1770,8 @@ func getLastWorkflowTaskCompletedID(ctx context.Context, namespace, wid, rid str
 			return "", 0, printErrorAndReturn("GetWorkflowExecutionHistory failed", err)
 		}
 		for _, e := range resp.GetHistory().GetEvents() {
-			if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
-				workflowTaskCompletedID = e.GetEventId()
+			if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED {
+				workflowTaskID = e.GetEventId() + 1
 			}
 		}
 		if len(resp.NextPageToken) != 0 {
@@ -1780,8 +1780,8 @@ func getLastWorkflowTaskCompletedID(ctx context.Context, namespace, wid, rid str
 			break
 		}
 	}
-	if workflowTaskCompletedID == 0 {
-		return "", 0, printErrorAndReturn("Get LastWorkflowTaskCompletedID failed", fmt.Errorf("no WorkflowTaskCompletedID"))
+	if workflowTaskID == 0 {
+		return "", 0, printErrorAndReturn("Get LastWorkflowTaskID failed", fmt.Errorf("unable to find any scheduled or completed task"))
 	}
 	return
 }
@@ -1814,7 +1814,7 @@ func getBadWorkflowTaskCompletedID(ctx context.Context, namespace, wid, rid, bin
 	return
 }
 
-func getFirstWorkflowTaskCompletedID(ctx context.Context, namespace, wid, rid string, frontendClient workflowservice.WorkflowServiceClient) (resetBaseRunID string, workflowTaskCompletedID int64, err error) {
+func getFirstWorkflowTaskID(ctx context.Context, namespace, wid, rid string, frontendClient workflowservice.WorkflowServiceClient) (resetBaseRunID string, workflowTaskID int64, err error) {
 	resetBaseRunID = rid
 	req := &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace: namespace,
@@ -1825,16 +1825,15 @@ func getFirstWorkflowTaskCompletedID(ctx context.Context, namespace, wid, rid st
 		MaximumPageSize: 1000,
 		NextPageToken:   nil,
 	}
-
 	for {
 		resp, err := frontendClient.GetWorkflowExecutionHistory(ctx, req)
 		if err != nil {
 			return "", 0, printErrorAndReturn("GetWorkflowExecutionHistory failed", err)
 		}
 		for _, e := range resp.GetHistory().GetEvents() {
-			if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
-				workflowTaskCompletedID = e.GetEventId()
-				return resetBaseRunID, workflowTaskCompletedID, nil
+			if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED {
+				workflowTaskID = e.GetEventId() + 1
+				return resetBaseRunID, workflowTaskID, nil
 			}
 		}
 		if len(resp.NextPageToken) != 0 {
@@ -1843,8 +1842,8 @@ func getFirstWorkflowTaskCompletedID(ctx context.Context, namespace, wid, rid st
 			break
 		}
 	}
-	if workflowTaskCompletedID == 0 {
-		return "", 0, printErrorAndReturn("Get FirstWorkflowTaskCompletedID failed", fmt.Errorf("no WorkflowTaskCompletedID"))
+	if workflowTaskID == 0 {
+		return "", 0, printErrorAndReturn("Get FirstWorkflowTaskID failed", fmt.Errorf("unable to find any scheduled or completed task"))
 	}
 	return
 }

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -1836,10 +1836,13 @@ func getFirstWorkflowTaskEventID(ctx context.Context, namespace, wid, rid string
 		}
 		for _, e := range resp.GetHistory().GetEvents() {
 			if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+				workflowTaskEventID = e.GetEventId()
 				return resetBaseRunID, workflowTaskEventID, nil
 			}
 			if e.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED {
-				workflowTaskEventID = e.GetEventId() + 1
+				if workflowTaskEventID == 0 {
+					workflowTaskEventID = e.GetEventId() + 1
+				}
 			}
 		}
 		if len(resp.NextPageToken) != 0 {


### PR DESCRIPTION
This PR addressed an issue described in #494 allowing users to reset workflows without completed tasks.
In case if there is no completed task reset would use next event after workflow task scheduled event as a reset point.
It allows us to perform a reset on workflows that were unable to make any progress due to worker related issues.

Note that due to change in semantics two CLI parameters responsible for reset types were renamed:
- LastWorkflowTaskCompleted was renamed to LastWorkflowTask
- FirstWorkflowTaskCompleted was renamed to FirstWorkflowTask