### PR TITLE
Exit with error code when tests are failing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,6 @@ check: copyright goimports-check lint vet staticcheck errcheck
 clean-test-results:
 	@rm -f test.log
 
-UNIT_TEST_DIRS := "go.temporal.io/server/cmd/server/temporal"
 unit-test: clean-test-results
 	@printf $(COLOR) "Run unit tests..."
 	$(foreach UNIT_TEST_DIR,$(UNIT_TEST_DIRS), @go test -timeout $(TEST_TIMEOUT) -race $(UNIT_TEST_DIR) $(TEST_TAG) | tee -a test.log$(NEWLINE))

--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,9 @@ clean-test-results:
 
 unit-test: clean-test-results
 	@printf $(COLOR) "Run unit tests..."
-	$(foreach UNIT_TEST_DIR,$(UNIT_TEST_DIRS), @go test -timeout $(TEST_TIMEOUT) -race $(UNIT_TEST_DIR) $(TEST_TAG) | tee -a test.log$(NEWLINE))
+	EXIT_CODE=0
+	$(foreach UNIT_TEST_DIR,$(UNIT_TEST_DIRS), @go test -timeout $(TEST_TIMEOUT) -race $(UNIT_TEST_DIR) $(TEST_TAG) | tee -a test.log ; EXIT_CODE=$(shell expr $(EXIT_CODE) + $(PIPESTATUS[0]) )$(NEWLINE))
+	exit $(EXIT_CODE)
 
 integration-test: clean-test-results
 	@printf $(COLOR) "Run integration tests..."
@@ -390,3 +392,6 @@ go-generate:
 gomodtidy:
 	@printf $(COLOR) "go mod tidy..."
 	@go mod tidy
+
+echo:
+	true | tee 1.log ; test ${PIPESTATUS[0]} -eq 0


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
If unit tests or integration tests are failing with `make unit-test` or `make integration-test` commands, `make` returns non-zero exit code now.

<!-- Tell your future self why have you made these changes -->
**Why?**
There was a bug due to `| tee` redirection.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests with failing and non failing scenarious.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
