### PR TITLE
Fix error message for the reset

### DIFF
--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -1370,7 +1370,7 @@ func ResetWorkflow(c *cli.Context) {
 	resetType := c.String(FlagResetType)
 	extraForResetType, ok := resetTypesMap[resetType]
 	if !ok && eventID <= 0 {
-		ErrorAndExit("Must specify valid eventId or valid resetType", nil)
+		ErrorAndExit(fmt.Sprintf("must specify either valid event_id or reset_type (one of %s)", strings.Join(mapKeysToArray(resetTypesMap), ", ")), nil)
 	}
 	if ok && len(extraForResetType) > 0 {
 		getRequiredOption(c, extraForResetType)


### PR DESCRIPTION
Fix error message for the reset, which was providing wrong argument names as well as didn't print valid options for the reset_type parameter.