### PR TITLE
Support configurable PublicClient in docker config_template.yaml

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -213,8 +213,10 @@ kafka:
             topic: temporal-visibility-dev
             dlq-topic: temporal-visibility-dev-dlq
 
+{{ $publicIp := default .Env.BIND_ON_IP "127.0.0.1" -}}
+{{- $defaultPublicHostPost := (print $publicIp ":7233") -}}
 publicClient:
-    hostPort: {{ default .Env.BIND_ON_IP "127.0.0.1" }}:7233
+    hostPort: {{ default .Env.PUBLIC_FRONTEND_ADDRESS $defaultPublicHostPost }}
 
 dynamicConfigClient:
     filepath: {{ default .Env.DYNAMIC_CONFIG_FILE_PATH "/etc/temporal/config/dynamicconfig" }}


### PR DESCRIPTION
Support configurable public client dnsName:port in the docker `config_template.yaml` using envVar `PUBLIC_FRONTEND_ADDRESS`

Without this, config_template.yaml consumers are forced to run an instance of worker on every node. 