### PR TITLE
Allow dynamic config editting outside of container when running docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,8 +102,7 @@ COPY --from=builder /temporal/temporal-server /usr/local/bin
 COPY --from=builder /temporal/schema /etc/temporal/schema
 
 COPY docker/entrypoint.sh /docker-entrypoint.sh
-COPY config/dynamicconfig /etc/temporal/config/dynamicconfig
-COPY docker/config_template.yaml /etc/temporal/config
+COPY docker/config_template.yaml /etc/temporal/config/config_template.yaml
 COPY docker/start-temporal.sh /start-temporal.sh
 
 WORKDIR /usr/local/bin

--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ${DYNAMIC_CONFIG_DIR:-../config/dynamicconfig}:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "DB=postgres"

--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config:/mnt/temporal/config
+      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "DB=postgres"
@@ -25,7 +25,7 @@ services:
       - "POSTGRES_USER=root"
       - "POSTGRES_PWD="
       - "POSTGRES_SEEDS=postgres"
-      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - cockroach
     links:

--- a/docker/docker-compose-cockroach.yml
+++ b/docker/docker-compose-cockroach.yml
@@ -15,7 +15,9 @@ services:
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.28.0}
     ports:
-     - "7233:7233"
+      - "7233:7233"
+    volumes:
+      - ../config:/mnt/temporal/config
     environment:
       - "AUTO_SETUP=true"
       - "DB=postgres"
@@ -23,7 +25,7 @@ services:
       - "POSTGRES_USER=root"
       - "POSTGRES_PWD="
       - "POSTGRES_SEEDS=postgres"
-      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development.yaml"
     depends_on:
       - cockroach
     links:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -30,11 +30,11 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config:/mnt/temporal/config
+      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "CASSANDRA_SEEDS=cassandra"
-      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development_es.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development_es.yaml"
       - "ENABLE_ES=true"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -30,7 +30,7 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ${DYNAMIC_CONFIG_DIR:-../config/dynamicconfig}:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "CASSANDRA_SEEDS=cassandra"

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -28,11 +28,13 @@ services:
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.28.0}
     ports:
-     - "7233:7233"
+      - "7233:7233"
+    volumes:
+      - ../config:/mnt/temporal/config
     environment:
       - "AUTO_SETUP=true"
       - "CASSANDRA_SEEDS=cassandra"
-      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development_es.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development_es.yaml"
       - "ENABLE_ES=true"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/docker-compose-mysql-es.yml
+++ b/docker/docker-compose-mysql-es.yml
@@ -25,7 +25,7 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ${DYNAMIC_CONFIG_DIR:-../config/dynamicconfig}:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "DB=mysql"

--- a/docker/docker-compose-mysql-es.yml
+++ b/docker/docker-compose-mysql-es.yml
@@ -23,14 +23,16 @@ services:
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.27.0}
     ports:
-     - "7233:7233"
+      - "7233:7233"
+    volumes:
+      - ../config:/mnt/temporal/config
     environment:
       - "AUTO_SETUP=true"
       - "DB=mysql"
       - "MYSQL_USER=root"
       - "MYSQL_PWD=root"
       - "MYSQL_SEEDS=mysql"
-      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development_es.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development_es.yaml"
       - "ENABLE_ES=true"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/docker-compose-mysql-es.yml
+++ b/docker/docker-compose-mysql-es.yml
@@ -25,14 +25,14 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config:/mnt/temporal/config
+      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "DB=mysql"
       - "MYSQL_USER=root"
       - "MYSQL_PWD=root"
       - "MYSQL_SEEDS=mysql"
-      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development_es.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development_es.yaml"
       - "ENABLE_ES=true"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -9,14 +9,16 @@ services:
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.28.0}
     ports:
-     - "7233:7233"
+      - "7233:7233"
+    volumes:
+      - ../config:/mnt/temporal/config
     environment:
       - "AUTO_SETUP=true"
       - "DB=mysql"
       - "MYSQL_USER=root"
       - "MYSQL_PWD=root"
       - "MYSQL_SEEDS=mysql"
-      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development.yaml"
     depends_on:
       - mysql
   temporal-admin-tools:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -11,14 +11,14 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config:/mnt/temporal/config
+      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "DB=mysql"
       - "MYSQL_USER=root"
       - "MYSQL_PWD=root"
       - "MYSQL_SEEDS=mysql"
-      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - mysql
   temporal-admin-tools:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -11,7 +11,7 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ${DYNAMIC_CONFIG_DIR:-../config/dynamicconfig}:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "DB=mysql"

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config:/mnt/temporal/config
+      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "DB=postgres"
@@ -20,7 +20,7 @@ services:
       - "POSTGRES_USER=temporal"
       - "POSTGRES_PWD=temporal"
       - "POSTGRES_SEEDS=postgres"
-      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - postgres
   temporal-admin-tools:

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -12,7 +12,7 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ${DYNAMIC_CONFIG_DIR:-../config/dynamicconfig}:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "DB=postgres"

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -10,7 +10,9 @@ services:
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.28.0}
     ports:
-     - "7233:7233"
+      - "7233:7233"
+    volumes:
+      - ../config:/mnt/temporal/config
     environment:
       - "AUTO_SETUP=true"
       - "DB=postgres"
@@ -18,7 +20,7 @@ services:
       - "POSTGRES_USER=temporal"
       - "POSTGRES_PWD=temporal"
       - "POSTGRES_SEEDS=postgres"
-      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development.yaml"
     depends_on:
       - postgres
   temporal-admin-tools:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,11 +10,11 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config:/mnt/temporal/config
+      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "CASSANDRA_SEEDS=cassandra"
-      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - cassandra
   temporal-admin-tools:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,11 +8,13 @@ services:
   temporal:
     image: temporalio/server:${SERVER_TAG:-0.28.0}
     ports:
-     - "7233:7233"
+      - "7233:7233"
+    volumes:
+      - ../config:/mnt/temporal/config
     environment:
       - "AUTO_SETUP=true"
       - "CASSANDRA_SEEDS=cassandra"
-      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
+      - "DYNAMIC_CONFIG_FILE_PATH=/mnt/temporal/config/dynamicconfig/development.yaml"
     depends_on:
       - cassandra
   temporal-admin-tools:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     ports:
       - "7233:7233"
     volumes:
-      - ../config/dynamicconfig:/etc/temporal/config/dynamicconfig
+      - ${DYNAMIC_CONFIG_DIR:-../config/dynamicconfig}:/etc/temporal/config/dynamicconfig
     environment:
       - "AUTO_SETUP=true"
       - "CASSANDRA_SEEDS=cassandra"


### PR DESCRIPTION
This PR introduces a mounted folder with the dynamic config, which is used in the docker-compose startup process.
`DYNAMIC_CONFIG_FILE_PATH` points to the new location of dynamic config on the filesystem.
In case if user changes dynamic config on their machine, changes will also be reflected in the docker container automatically after the next refresh interval.