### PR TITLE
Archiver interface method comments

### DIFF
--- a/common/archiver/interface.go
+++ b/common/archiver/interface.go
@@ -78,19 +78,19 @@ type (
 
 	// HistoryArchiver is used to archive history and read archived history
 	HistoryArchiver interface {
-        // Archive is used to archive a Workflow's history. When the context expires the method should stop trying to archive.
-        // Implementors are free to archive however they want, including implementing retries of sub-operations. The URI defines
-        // the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
-        // The Archive method may or may not be automatically retried by the caller. ArchiveOptions are used
-        // to interact with these retries including giving the implementor the ability to cancel retries and record progress
-        // between retry attempts.
-        // This method will be invoked after a workflow passes its retention period.
-        Archive(context.Context, URI, *ArchiveHistoryRequest, ...ArchiveOption) error
-        // Get is used to access an archived history. When context expires this method should stop trying to fetch history.
-        // The URI identifies the resource from which history should be accessed and it is up to the implementor to interpret this URI.
-        // This method should emit api service errors - see the filestore as an example.
+    // Archive is used to archive a Workflow's history. When the context expires the method should stop trying to archive.
+    // Implementors are free to archive however they want, including implementing retries of sub-operations. The URI defines
+    // the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
+    // The Archive method may or may not be automatically retried by the caller. ArchiveOptions are used
+    // to interact with these retries including giving the implementor the ability to cancel retries and record progress
+    // between retry attempts.
+    // This method will be invoked after a workflow passes its retention period.
+    Archive(context.Context, URI, *ArchiveHistoryRequest, ...ArchiveOption) error
+    // Get is used to access an archived history. When context expires this method should stop trying to fetch history.
+    // The URI identifies the resource from which history should be accessed and it is up to the implementor to interpret this URI.
+    // This method should emit api service errors - see the filestore as an example.
 		Get(context.Context, URI, *GetHistoryRequest) (*GetHistoryResponse, error)
-        // ValidateURI is used to define what a valid URI for an implementation is.
+    // ValidateURI is used to define what a valid URI for an implementation is.
 		ValidateURI(URI) error
 	}
 
@@ -118,22 +118,22 @@ type (
 
 	// VisibilityArchiver is used to archive visibility and read archived visibility
 	VisibilityArchiver interface {
-        // Archive is used to archive one Workflow visibility record.
-        // Check the Archive method of the HistoryArchiver interface for parameters' meaning and requirements.
-        // The only difference is that the ArchiveOption parameter won't include an option for recording process.
-        // Please make sure your implementation is lossless. If any in-memory batching mechanism is used
-        // then those batched records will be lost during server restarts. This method will be invoked when the Workflow closes.
-        // Note that because of conflict resolution, it is possible for a Workflow to through the closing process multiple times,
-        // which means that this method can be invoked more than once after a Workflow closes.
+    // Archive is used to archive one Workflow visibility record.
+    // Check the Archive method of the HistoryArchiver interface for parameters' meaning and requirements.
+    // The only difference is that the ArchiveOption parameter won't include an option for recording process.
+    // Please make sure your implementation is lossless. If any in-memory batching mechanism is used
+    // then those batched records will be lost during server restarts. This method will be invoked when the Workflow closes.
+    // Note that because of conflict resolution, it is possible for a Workflow to through the closing process multiple times,
+    // which means that this method can be invoked more than once after a Workflow closes.
 		Archive(context.Context, URI, *archiverspb.ArchiveVisibilityRequest, ...ArchiveOption) error
-        // Query is used to retrieve archived visibility records.
-        // Check the Get() method of the HistoryArchiver interface in Step 2 for parameters' meaning and requirements.
-        // The request includes a string field called query, which describes what kind of visibility records should be returned.
-        // For example, it can be  some SQL-like syntax query string.
-        // Your implementation is responsible for parsing and validating the query, and also returning all visibility records that match the query.
-        // Currently the maximum context timeout passed into the method is 3 minutes, so it's accetable if this method takes some time to run.
+    // Query is used to retrieve archived visibility records.
+    // Check the Get() method of the HistoryArchiver interface in Step 2 for parameters' meaning and requirements.
+    // The request includes a string field called query, which describes what kind of visibility records should be returned.
+    // For example, it can be  some SQL-like syntax query string.
+    // Your implementation is responsible for parsing and validating the query, and also returning all visibility records that match the query.
+    // Currently the maximum context timeout passed into the method is 3 minutes, so it's accetable if this method takes some time to run.
 		Query(context.Context, URI, *QueryVisibilityRequest) (*QueryVisibilityResponse, error)
-        // ValidateURI is used to define what a valid URI for an implementation is.
+    // ValidateURI is used to define what a valid URI for an implementation is.
 		ValidateURI(URI) error
 	}
 )

--- a/common/archiver/interface.go
+++ b/common/archiver/interface.go
@@ -78,19 +78,19 @@ type (
 
 	// HistoryArchiver is used to archive history and read archived history
 	HistoryArchiver interface {
-    // Archive is used to archive a Workflow's history. When the context expires the method should stop trying to archive.
-    // Implementors are free to archive however they want, including implementing retries of sub-operations. The URI defines
-    // the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
-    // The Archive method may or may not be automatically retried by the caller. ArchiveOptions are used
-    // to interact with these retries including giving the implementor the ability to cancel retries and record progress
-    // between retry attempts.
-    // This method will be invoked after a workflow passes its retention period.
-    Archive(context.Context, URI, *ArchiveHistoryRequest, ...ArchiveOption) error
-    // Get is used to access an archived history. When context expires this method should stop trying to fetch history.
-    // The URI identifies the resource from which history should be accessed and it is up to the implementor to interpret this URI.
-    // This method should emit api service errors - see the filestore as an example.
+		// Archive is used to archive a Workflow's history. When the context expires the method should stop trying to archive.
+		// Implementors are free to archive however they want, including implementing retries of sub-operations. The URI defines
+		// the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
+		// The Archive method may or may not be automatically retried by the caller. ArchiveOptions are used
+		// to interact with these retries including giving the implementor the ability to cancel retries and record progress
+		// between retry attempts.
+		// This method will be invoked after a workflow passes its retention period.
+		Archive(context.Context, URI, *ArchiveHistoryRequest, ...ArchiveOption) error
+		// Get is used to access an archived history. When context expires this method should stop trying to fetch history.
+		// The URI identifies the resource from which history should be accessed and it is up to the implementor to interpret this URI.
+		// This method should emit api service errors - see the filestore as an example.
 		Get(context.Context, URI, *GetHistoryRequest) (*GetHistoryResponse, error)
-    // ValidateURI is used to define what a valid URI for an implementation is.
+		// ValidateURI is used to define what a valid URI for an implementation is.
 		ValidateURI(URI) error
 	}
 
@@ -118,22 +118,22 @@ type (
 
 	// VisibilityArchiver is used to archive visibility and read archived visibility
 	VisibilityArchiver interface {
-    // Archive is used to archive one Workflow visibility record.
-    // Check the Archive method of the HistoryArchiver interface for parameters' meaning and requirements.
-    // The only difference is that the ArchiveOption parameter won't include an option for recording process.
-    // Please make sure your implementation is lossless. If any in-memory batching mechanism is used
-    // then those batched records will be lost during server restarts. This method will be invoked when the Workflow closes.
-    // Note that because of conflict resolution, it is possible for a Workflow to through the closing process multiple times,
-    // which means that this method can be invoked more than once after a Workflow closes.
+		// Archive is used to archive one Workflow visibility record.
+		// Check the Archive method of the HistoryArchiver interface for parameters' meaning and requirements.
+		// The only difference is that the ArchiveOption parameter won't include an option for recording process.
+		// Please make sure your implementation is lossless. If any in-memory batching mechanism is used
+		// then those batched records will be lost during server restarts. This method will be invoked when the Workflow closes.
+		// Note that because of conflict resolution, it is possible for a Workflow to through the closing process multiple times,
+		// which means that this method can be invoked more than once after a Workflow closes.
 		Archive(context.Context, URI, *archiverspb.ArchiveVisibilityRequest, ...ArchiveOption) error
-    // Query is used to retrieve archived visibility records.
-    // Check the Get() method of the HistoryArchiver interface in Step 2 for parameters' meaning and requirements.
-    // The request includes a string field called query, which describes what kind of visibility records should be returned.
-    // For example, it can be  some SQL-like syntax query string.
-    // Your implementation is responsible for parsing and validating the query, and also returning all visibility records that match the query.
-    // Currently the maximum context timeout passed into the method is 3 minutes, so it's accetable if this method takes some time to run.
+		// Query is used to retrieve archived visibility records.
+		// Check the Get() method of the HistoryArchiver interface in Step 2 for parameters' meaning and requirements.
+		// The request includes a string field called query, which describes what kind of visibility records should be returned.
+		// For example, it can be  some SQL-like syntax query string.
+		// Your implementation is responsible for parsing and validating the query, and also returning all visibility records that match the query.
+		// Currently the maximum context timeout passed into the method is 3 minutes, so it's accetable if this method takes some time to run.
 		Query(context.Context, URI, *QueryVisibilityRequest) (*QueryVisibilityResponse, error)
-    // ValidateURI is used to define what a valid URI for an implementation is.
+		// ValidateURI is used to define what a valid URI for an implementation is.
 		ValidateURI(URI) error
 	}
 )


### PR DESCRIPTION
The archiver interface methods are referenced in documentation about how to create a custom archiver. Currently, the interface code is copied into the documentation where comments are added to describe the methods usage. This PR moves those comments to be inline with the code. Now we can reference the interfaces as the source of truth.

<!-- Describe what has changed in this PR -->
**What changed?**

Comments are added to archiver interface methods.

<!-- Tell your future self why have you made these changes -->
**Why?**

To create a source of truth for the information regarding the interface methods.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

No testing needed, comments only.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None

