### PR TITLE
Updated stale link

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -1,4 +1,4 @@
-Documentation for the Temporal command line interface is located at our [main site](https://docs.temporal.io/docs/learn-cli/).
+Documentation for the Temporal command line interface is located at our [main site](https://docs.temporal.io/docs/tctl/).
 
 ## Quick Start
 Run `make` from the project root. You should see an executable file called `tctl`. Try a few example commands to 


### PR DESCRIPTION
**What changed?**
Old stale link was updated to the new location of the documentation

**Why?**
Documentation clarity

**How did you test it?**
Checked archived version of the old link URL to verify the content was the same just hosted at a new location.

**Potential risks**
n/a
