### PR TITLE
Add jq to admin-tools image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,8 @@ ENTRYPOINT ["tctl"]
 # All temporal tool binaries
 FROM alpine AS temporal-admin-tools
 
+RUN apk add --update --no-cache jq
+
 ENV TEMPORAL_HOME /etc/temporal
 RUN mkdir -p /etc/temporal
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adding jq to admin tools docker image.

<!-- Tell your future self why have you made these changes -->
**Why?**

"tctl produces a lot of json. having jq there might be helpful for everybody"
- Alex.
;)

(also useful in our test pipelines)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Build the docker image and verified that it now has jq, the tool for processing json data.

```
$ make docker-images
...

$ docker run -it temporalio/admin-tools:markmark-local
...
 
$ docker exec -it youthful_bhabha ash
/usr/local/bin # jq
jq - commandline JSON processor [version master-v20191114-85-g260888d269]

Usage:	jq [options] <jq filter> [file...]
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Not sure what could go wrong here, but we can always revert.
