### PR TITLE
Fixes bug where terminating a parent with a lot of child workflows that continue-as-new doesn't propagate terminate to children

### DIFF
--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -117,8 +117,9 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 					WorkflowExecution: &commonpb.WorkflowExecution{
 						WorkflowId: execution.WorkflowID,
 					},
-					Reason:   "by parent close policy",
-					Identity: processorWFTypeName,
+					Reason:              "by parent close policy",
+					Identity:            processorWFTypeName,
+					FirstExecutionRunId: execution.RunID,
 				},
 			})
 		case enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL:
@@ -129,7 +130,8 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 					WorkflowExecution: &commonpb.WorkflowExecution{
 						WorkflowId: execution.WorkflowID,
 					},
-					Identity: processorWFTypeName,
+					Identity:            processorWFTypeName,
+					FirstExecutionRunId: execution.RunID,
 				},
 			})
 		}

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -116,7 +116,6 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 					Namespace: request.Namespace,
 					WorkflowExecution: &commonpb.WorkflowExecution{
 						WorkflowId: execution.WorkflowID,
-						RunId:      execution.RunID,
 					},
 					Reason:   "by parent close policy",
 					Identity: processorWFTypeName,
@@ -129,7 +128,6 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 					Namespace: request.Namespace,
 					WorkflowExecution: &commonpb.WorkflowExecution{
 						WorkflowId: execution.WorkflowID,
-						RunId:      execution.RunID,
 					},
 					Identity: processorWFTypeName,
 				},

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -117,7 +117,7 @@ func anyToString(d interface{}, printFully bool, maxFieldLength int) string {
 			if buf.Len() > 1 {
 				buf.WriteString(", ")
 			}
-			if !isAttributeName(fieldName) {
+			if !isAttributeName(fieldName) && !strings.HasSuffix(fieldName, "Failure") {
 				if !printFully {
 					fieldValue = trimTextAndBreakWords(fieldValue, maxFieldLength)
 				} else if maxFieldLength != 0 { // for command run workflow and observe history
@@ -126,9 +126,10 @@ func anyToString(d interface{}, printFully bool, maxFieldLength int) string {
 			}
 			if fieldName == "Reason" ||
 				fieldName == "Cause" ||
-				strings.HasSuffix(fieldName, "Details") ||
-				strings.HasSuffix(fieldName, "Failure") {
-				buf.WriteString(fmt.Sprintf("%s:%s", color.RedString(fieldName), color.MagentaString(fieldValue)))
+				strings.HasSuffix(fieldName, "Details") {
+				buf.WriteString(fmt.Sprintf("%s:%s", color.MagentaString(fieldName), fieldValue))
+			} else if strings.HasSuffix(fieldName, "Failure") {
+				buf.WriteString(fmt.Sprintf("%s:%s", color.RedString(fieldName), fieldValue))
 			} else {
 				buf.WriteString(fmt.Sprintf("%s:%s", fieldName, fieldValue))
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
The ParentClosePolicy Workflow was passing in the first run ID of a child workflow getting executed. This is problematic because if the child workflow is continued as new, the termination attempt will fail as that particular instance of the child execution is already completed.

<!-- Tell your future self why have you made these changes -->
This change was made because a Workflow with a lot of Child Workflows (more than the ParentClosePolicyThreshold setting) will not successfully terminate (or cancel) any Workflows that are continued as new.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Tested locally via the bench test.
STILL TODO: Investigating if we can add an integration test to exercise the ParentClosePolicy Workflow.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Low-risk as the intent of terminating a workflow *is* to cascade to its children for ParentClosePolicy = Terminate

