### PR TITLE
Don't fail if schema_version and schema_update_history tables already exist

### DIFF
--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -74,12 +74,12 @@ const (
 	writeSchemaVersionCQL       = `INSERT into schema_version(keyspace_name, creation_time, curr_version, min_compatible_version) VALUES (?,?,?,?)`
 	writeSchemaUpdateHistoryCQL = `INSERT into schema_update_history(year, month, update_time, old_version, new_version, manifest_md5, description) VALUES(?,?,?,?,?,?,?)`
 
-	createSchemaVersionTableCQL = `CREATE TABLE schema_version(keyspace_name text PRIMARY KEY, ` +
+	createSchemaVersionTableCQL = `CREATE TABLE IF NOT EXISTS schema_version(keyspace_name text PRIMARY KEY, ` +
 		`creation_time timestamp, ` +
 		`curr_version text, ` +
 		`min_compatible_version text);`
 
-	createSchemaUpdateHistoryTableCQL = `CREATE TABLE schema_update_history(` +
+	createSchemaUpdateHistoryTableCQL = `CREATE TABLE IF NOT EXISTS schema_update_history(` +
 		`year int, ` +
 		`month int, ` +
 		`update_time timestamp, ` +


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Don't fail if cassandra tables already exist. This allows us to retry and roll forward in case of mid-stream failures during installations.

<!-- Tell your future self why have you made these changes -->
**Why?**

Our test pipelines occasionally experienced failures, especially as we started testing with larger, replicated cassandra cluster 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I built a docker image with this change and used it to deploy to kubernetes cluster a few times.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

If this doesn't work for some reason, we can rollback or fix.