### PR TITLE
Skip BufferedEvents persistence when empty

### DIFF
--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -406,7 +406,7 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 	}
 
 	var serializedNewBufferedEvents *serialization.DataBlob
-	if input.NewBufferedEvents != nil && len(input.NewBufferedEvents) > 0 {
+	if len(input.NewBufferedEvents) > 0 {
 		serializedNewBufferedEvents, err = m.serializer.SerializeBatchEvents(input.NewBufferedEvents, encoding)
 		if err != nil {
 			return nil, err

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -406,7 +406,7 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 	}
 
 	var serializedNewBufferedEvents *serialization.DataBlob
-	if input.NewBufferedEvents != nil {
+	if input.NewBufferedEvents != nil && len(input.NewBufferedEvents) > 0 {
 		serializedNewBufferedEvents, err = m.serializer.SerializeBatchEvents(input.NewBufferedEvents, encoding)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
BufferedEvents should not be written to when there is no data to persist. 

There is an additional vulnerability on the read-path side where an empty row can cause a nil pointer exception in statsComputer.go -- Read path will discard these and log in a follow-up PR. 