### PR TITLE
Fixes bug where we were not persisting the failure details for a marker recorded event, which corrupts workflow on replay 

### DIFF
--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -700,6 +700,7 @@ func (b *historyBuilder) newMarkerRecordedEventAttributes(workflowTaskCompletedE
 	attributes.Details = request.Details
 	attributes.WorkflowTaskCompletedEventId = workflowTaskCompletedEventID
 	attributes.Header = request.Header
+	attributes.Failure = request.Failure
 	historyEvent.Attributes = &historypb.HistoryEvent_MarkerRecordedEventAttributes{MarkerRecordedEventAttributes: attributes}
 
 	return historyEvent


### PR DESCRIPTION
We are not persisting the failure details on an incoming RecordLocalMarkerCommand. As a result on replay, if we have recorded a local activity failure, the SDK will panic since the expected failure field is missing.

