### PR TITLE
Fixes MySQL persistence for workflow reset

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,6 @@
 {
 	"version": "0.2.0",
 	"configurations": [
-	
 		{
 			"name": "Debug Server",
 			"type": "go",
@@ -23,6 +22,19 @@
 			"args": [
 				"--env",
 				"development_active",
+				"start",
+			]
+		},
+		{
+			"name": "Debug Server with MySql",
+			"type": "go",
+			"request": "launch",
+			"mode": "debug",
+			"program": "${workspaceFolder}/cmd/server",
+			"cwd": "${workspaceFolder}",
+			"args": [
+				"--env",
+				"development_mysql",
 				"start",
 			]
 		},

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -123,6 +123,7 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(
 			if rowsAffected != 1 {
 				return fmt.Errorf("expected 1 row to be affected for node table, got %v", rowsAffected)
 			}
+
 			result, err = tx.InsertIntoHistoryTree(treeRow)
 			if err != nil {
 				return err
@@ -131,7 +132,7 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(
 			if err != nil {
 				return err
 			}
-			if rowsAffected != 1 {
+			if !(rowsAffected == 1 || rowsAffected == 2) {
 				return fmt.Errorf("expected 1 row to be affected for tree table, got %v", rowsAffected)
 			}
 			return nil
@@ -355,6 +356,7 @@ func (m *sqlHistoryV2Manager) ForkHistoryBranch(
 		Data:         blob.Data,
 		DataEncoding: blob.Encoding.String(),
 	}
+
 	result, err := m.db.InsertIntoHistoryTree(row)
 	if err != nil {
 		return nil, err

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -133,7 +133,7 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(
 				return err
 			}
 			if !(rowsAffected == 1 || rowsAffected == 2) {
-				return fmt.Errorf("expected 1 row to be affected for tree table, got %v", rowsAffected)
+				return fmt.Errorf("expected 1 or 2 rows to be affected for tree table as we allow upserts, got %v", rowsAffected)
 			}
 			return nil
 		})

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -42,7 +42,7 @@ const (
 	deleteHistoryNodesQuery = `DELETE FROM history_node WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ? `
 
 	// below are templates for history_tree table
-	addHistoryTreeQuery = `INSERT INTO history_tree (` +
+	upsertHistoryTreeQuery = `INSERT INTO history_tree (` +
 		`shard_id, tree_id, branch_id, data, data_encoding) ` +
 		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) ` +
 		`ON DUPLICATE KEY UPDATE ` +
@@ -83,7 +83,7 @@ func (mdb *db) DeleteFromHistoryNode(filter *sqlplugin.HistoryNodeFilter) (sql.R
 
 // InsertIntoHistoryTree inserts a row into history_tree table
 func (mdb *db) InsertIntoHistoryTree(row *sqlplugin.HistoryTreeRow) (sql.Result, error) {
-	return mdb.conn.NamedExec(addHistoryTreeQuery, row)
+	return mdb.conn.NamedExec(upsertHistoryTreeQuery, row)
 }
 
 // SelectFromHistoryTree reads one or more rows from history_tree table

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -44,7 +44,9 @@ const (
 	// below are templates for history_tree table
 	addHistoryTreeQuery = `INSERT INTO history_tree (` +
 		`shard_id, tree_id, branch_id, data, data_encoding) ` +
-		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) `
+		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) ` +
+		`ON DUPLICATE KEY UPDATE ` +
+		`data=VALUES(data), data_encoding=VALUES(data_encoding)`
 
 	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = ? AND tree_id = ? `
 

--- a/host/resetworkflow_test.go
+++ b/host/resetworkflow_test.go
@@ -1,0 +1,202 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package host
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strconv"
+	"time"
+
+	"github.com/pborman/uuid"
+	commandpb "go.temporal.io/api/command/v1"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/primitives/timestamp"
+)
+
+func (s *integrationSuite) TestResetWorkflow() {
+	id := "integration-reset-workflow-test"
+	wt := "integration-reset-workflow-test-type"
+	tl := "integration-reset-workflow-test-taskqueue"
+	identity := "worker1"
+
+	workflowType := &commonpb.WorkflowType{Name: wt}
+
+	taskQueue := &taskqueuepb.TaskQueue{Name: tl}
+
+	// Start workflow execution
+	request := &workflowservice.StartWorkflowExecutionRequest{
+		RequestId:           uuid.New(),
+		Namespace:           s.namespace,
+		WorkflowId:          id,
+		WorkflowType:        workflowType,
+		TaskQueue:           taskQueue,
+		Input:               nil,
+		WorkflowRunTimeout:  timestamp.DurationPtr(100 * time.Second),
+		WorkflowTaskTimeout: timestamp.DurationPtr(1 * time.Second),
+		Identity:            identity,
+	}
+
+	we, err0 := s.engine.StartWorkflowExecution(NewContext(), request)
+	s.NoError(err0)
+
+	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.RunId))
+
+	// workflow logic
+	workflowComplete := false
+	activityData := int32(1)
+	activityCount := 3
+	isFirstTaskProcessed := false
+	isSecondTaskProcessed := false
+	var firstActivityCompletionEvent *historypb.HistoryEvent
+	wtHandler := func(execution *commonpb.WorkflowExecution, wt *commonpb.WorkflowType,
+		previousStartedEventID, startedEventID int64, history *historypb.History) ([]*commandpb.Command, error) {
+
+		if !isFirstTaskProcessed {
+			// Schedule 3 activities on first workflow task
+			isFirstTaskProcessed = true
+			buf := new(bytes.Buffer)
+			s.Nil(binary.Write(buf, binary.LittleEndian, activityData))
+
+			var scheduleActivityCommands []*commandpb.Command
+			for i := 1; i <= activityCount; i++ {
+				scheduleActivityCommands = append(scheduleActivityCommands, &commandpb.Command{
+					CommandType: enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK,
+					Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
+						ActivityId:             strconv.Itoa(i),
+						ActivityType:           &commonpb.ActivityType{Name: "ResetActivity"},
+						TaskQueue:              &taskqueuepb.TaskQueue{Name: tl},
+						Input:                  payloads.EncodeBytes(buf.Bytes()),
+						ScheduleToCloseTimeout: timestamp.DurationPtr(100 * time.Second),
+						ScheduleToStartTimeout: timestamp.DurationPtr(2 * time.Second),
+						StartToCloseTimeout:    timestamp.DurationPtr(50 * time.Second),
+						HeartbeatTimeout:       timestamp.DurationPtr(5 * time.Second),
+					}},
+				})
+			}
+
+			return scheduleActivityCommands, nil
+		} else if !isSecondTaskProcessed {
+			// Confirm one activity completion on second workflow task
+			isSecondTaskProcessed = true
+			for _, event := range history.Events[previousStartedEventID:] {
+				if event.GetEventType() == enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED {
+					firstActivityCompletionEvent = event
+					return []*commandpb.Command{}, nil
+				}
+			}
+		}
+
+		// Complete workflow after reset
+		workflowComplete = true
+		return []*commandpb.Command{{
+			CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
+			Attributes: &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{
+				Result: payloads.EncodeString("Done"),
+			}},
+		}}, nil
+
+	}
+
+	// activity handler
+	atHandler := func(execution *commonpb.WorkflowExecution, activityType *commonpb.ActivityType,
+		activityID string, input *commonpb.Payloads, taskToken []byte) (*commonpb.Payloads, bool, error) {
+
+		return payloads.EncodeString("Activity Result"), false, nil
+	}
+
+	poller := &TaskPoller{
+		Engine:              s.engine,
+		Namespace:           s.namespace,
+		TaskQueue:           taskQueue,
+		Identity:            identity,
+		WorkflowTaskHandler: wtHandler,
+		ActivityTaskHandler: atHandler,
+		Logger:              s.Logger,
+		T:                   s.T(),
+	}
+
+	// Process first workflow task to schedule activities
+	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+	s.NoError(err)
+
+	// Process one activity task which also creates second workflow task
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("Poll and process first activity", tag.Error(err))
+	s.NoError(err)
+
+	// Process second workflow task which checks
+	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	s.Logger.Info("Poll and process second workflow task", tag.Error(err))
+	s.NoError(err)
+
+	// Find reset point (last completed workflow task)
+	events := s.getHistory(s.namespace, &commonpb.WorkflowExecution{
+		WorkflowId: id,
+		RunId:      we.GetRunId(),
+	})
+	var lastWorkflowTask *historypb.HistoryEvent
+	for _, event := range events {
+		if event.GetEventType() == enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED {
+			lastWorkflowTask = event
+		}
+	}
+
+	// Reset workflow execution
+	_, err = s.engine.ResetWorkflowExecution(NewContext(), &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace: s.namespace,
+		WorkflowExecution: &commonpb.WorkflowExecution{
+			WorkflowId: id,
+			RunId:      we.RunId,
+		},
+		Reason:                    "reset execution from test",
+		WorkflowTaskFinishEventId: lastWorkflowTask.GetEventId(),
+		RequestId:                 uuid.New(),
+	})
+	s.NoError(err)
+
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("Poll and process first activity", tag.Error(err))
+	s.NoError(err)
+
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("Poll and process first activity", tag.Error(err))
+	s.NoError(err)
+
+	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	s.Logger.Info("Poll and process final workflow task", tag.Error(err))
+	s.NoError(err)
+
+	s.NotNil(firstActivityCompletionEvent)
+	s.True(workflowComplete)
+}

--- a/host/resetworkflow_test.go
+++ b/host/resetworkflow_test.go
@@ -46,12 +46,12 @@ import (
 func (s *integrationSuite) TestResetWorkflow() {
 	id := "integration-reset-workflow-test"
 	wt := "integration-reset-workflow-test-type"
-	tl := "integration-reset-workflow-test-taskqueue"
+	tq := "integration-reset-workflow-test-taskqueue"
 	identity := "worker1"
 
 	workflowType := &commonpb.WorkflowType{Name: wt}
 
-	taskQueue := &taskqueuepb.TaskQueue{Name: tl}
+	taskQueue := &taskqueuepb.TaskQueue{Name: tq}
 
 	// Start workflow execution
 	request := &workflowservice.StartWorkflowExecutionRequest{
@@ -94,7 +94,7 @@ func (s *integrationSuite) TestResetWorkflow() {
 					Attributes: &commandpb.Command_ScheduleActivityTaskCommandAttributes{ScheduleActivityTaskCommandAttributes: &commandpb.ScheduleActivityTaskCommandAttributes{
 						ActivityId:             strconv.Itoa(i),
 						ActivityType:           &commonpb.ActivityType{Name: "ResetActivity"},
-						TaskQueue:              &taskqueuepb.TaskQueue{Name: tl},
+						TaskQueue:              &taskqueuepb.TaskQueue{Name: tq},
 						Input:                  payloads.EncodeBytes(buf.Bytes()),
 						ScheduleToCloseTimeout: timestamp.DurationPtr(100 * time.Second),
 						ScheduleToStartTimeout: timestamp.DurationPtr(2 * time.Second),
@@ -155,7 +155,7 @@ func (s *integrationSuite) TestResetWorkflow() {
 	s.Logger.Info("Poll and process first activity", tag.Error(err))
 	s.NoError(err)
 
-	// Process second workflow task which checks
+	// Process second workflow task which checks activity completion
 	_, err = poller.PollAndProcessWorkflowTask(false, false)
 	s.Logger.Info("Poll and process second workflow task", tag.Error(err))
 	s.NoError(err)
@@ -186,11 +186,11 @@ func (s *integrationSuite) TestResetWorkflow() {
 	s.NoError(err)
 
 	err = poller.PollAndProcessActivityTask(false)
-	s.Logger.Info("Poll and process first activity", tag.Error(err))
+	s.Logger.Info("Poll and process second activity", tag.Error(err))
 	s.NoError(err)
 
 	err = poller.PollAndProcessActivityTask(false)
-	s.Logger.Info("Poll and process first activity", tag.Error(err))
+	s.Logger.Info("Poll and process third activity", tag.Error(err))
 	s.NoError(err)
 
 	_, err = poller.PollAndProcessWorkflowTask(false, false)


### PR DESCRIPTION
After 2dc removal we trigger a slightly different codepath on mysql
persistence when resetting workflows.
AppendHistoryNodes when called with IsNewBranch add both
history_tree metadata and history_node.  This caused the problem
because history_node is already added when fork was called so
adding it again failed with duplicate error.  Updated
AppendHistoryNodes api to upsert instead.

Another issue was with create workflow execution never expected
to be called with `CreateWorkflowModeContinueAsNew` mode.  With
NDC now workflow reset is implemented in similar fashion as
doing continue as new.  So removed the check to disallow
`CreateWorkflowModeContinueAsNew` on create execution and added
appropriate validation.
