### PR TITLE
Fixes Internal Server Error returned on simultaneous SignalWithStart requests for the same WF ID

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1004,6 +1004,9 @@ func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context, request 
 		select {
 		case <-ctx.Done():
 			isContextDone = true
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				err2 = ctxErr
+			}
 		default:
 		}
 

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -982,12 +982,35 @@ func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context, request 
 		return nil, h.error(err1, scope, namespaceID, workflowID)
 	}
 
-	resp, err2 := engine.SignalWithStartWorkflowExecution(ctx, request)
-	if err2 != nil {
-		return nil, h.error(err2, scope, namespaceID, workflowID)
-	}
+	for {
+		resp, err2 := engine.SignalWithStartWorkflowExecution(ctx, request)
+		if err2 == nil {
+			return resp, nil
+		}
 
-	return resp, nil
+		// Two simultaneous SignalWithStart requests might try to start a workflow at the same time.
+		// This can result in one of the requests failing with one of two possible errors:
+		//    1) If it is a brand new WF ID, one of the requests can fail with WorkflowExecutionAlreadyStartedError
+		//       (createMode is persistence.CreateWorkflowModeBrandNew)
+		//    2) If it an already existing WF ID, one of the requests can fail with a CurrentWorkflowConditionFailedError
+		//       (createMode is persisetence.CreateWorkflowModeWorkflowIDReuse)
+		// If either error occurs, just go ahead and retry. It should succeed on the subsequent attempt.
+		// For simplicity, we keep trying unless the context finishes or we get an error that is not one of the
+		// two mentioned above.
+		_, isExecutionAlreadyStartedErr := err2.(*persistence.WorkflowExecutionAlreadyStartedError)
+		_, isWorkflowConditionFailedErr := err2.(*persistence.CurrentWorkflowConditionFailedError)
+
+		isContextDone := false
+		select {
+		case <-ctx.Done():
+			isContextDone = true
+		default:
+		}
+
+		if (!isExecutionAlreadyStartedErr && !isWorkflowConditionFailedErr) || isContextDone {
+			return nil, h.error(err2, scope, namespaceID, workflowID)
+		}
+	}
 }
 
 // RemoveSignalMutableState is used to remove a signal request ID that was previously recorded.  This is currently


### PR DESCRIPTION
This PR fixes a bug where simultaneous SignalWithStart requests for the same WorkflowID randomly results in one of them failing with a "Workflow Execution Already Started Error." This error does not make sense given that SignalWithStart is supposed to seamlessly handle both the case where the WF is already running and the case where it needs to be created.

Our throughput stress scenario easily reproduces this issue in the one box environment. The issue stopped reproducing once this change was integrated.

This is a relatively low-risk change. We only retry under certain error conditions that we expect to be transient, and in the worst case, we keep retrying until the request times out.

