### PR TITLE
Set Backoff.MaxDelay to 10 seconds.

### DIFF
--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -64,7 +64,6 @@ func Dial(hostName string, tlsConfig *tls.Config) (*grpc.ClientConn, error) {
 	// If connection goes down, gRPC will try to reconnect using exponential backoff strategy:
 	// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 	// Default MaxDelay is 120 seconds which is too high.
-	// Setting it to retryPollOperationMaxInterval here will correlate with poll reconnect interval.
 	var cp = grpc.ConnectParams{
 		Backoff: backoff.DefaultConfig,
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
gRPC MaxDelay was decreased to 10 seconds from default 120 seconds.

<!-- Tell your future self why have you made these changes -->
**Why?**
When failed connection is restored client (another service) needs to know about it faster than 2 minutes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run samples and will test under failures.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
