### PR TITLE
Fixes blockage of Transfer Queue if UpsertSearchAttributes is invoked on a Temporal Server w/o Elastic Search

### DIFF
--- a/common/persistence/cassandra/cassandraVisibilityPersistence.go
+++ b/common/persistence/cassandra/cassandraVisibilityPersistence.go
@@ -287,11 +287,8 @@ func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionClosed(
 }
 
 func (v *cassandraVisibilityPersistence) UpsertWorkflowExecution(
-	request *p.InternalUpsertWorkflowExecutionRequest) error {
-	if p.IsNopUpsertWorkflowRequest(request) {
-		return nil
-	}
-	return p.NewOperationNotSupportErrorForVis()
+	_ *p.InternalUpsertWorkflowExecutionRequest) error {
+	return nil
 }
 
 func (v *cassandraVisibilityPersistence) ListOpenWorkflowExecutions(

--- a/common/persistence/persistence-tests/visibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/visibilityPersistenceTest.go
@@ -714,7 +714,10 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 				Memo:               nil,
 				SearchAttributes:   nil,
 			},
-			expected: p.NewOperationNotSupportErrorForVis(),
+			// To avoid blocking the task queue processors on non-ElasticSearch visibility stores
+			// we simply treat any attempts to perform Upserts as "no-ops"
+			// Attempts to Scan, Count or List will still fail for non-ES stores.
+			expected: nil,
 		},
 	}
 

--- a/common/persistence/sql/sqlVisibilityStore.go
+++ b/common/persistence/sql/sqlVisibilityStore.go
@@ -108,11 +108,8 @@ func (s *sqlVisibilityStore) RecordWorkflowExecutionClosed(request *p.InternalRe
 	return nil
 }
 
-func (s *sqlVisibilityStore) UpsertWorkflowExecution(request *p.InternalUpsertWorkflowExecutionRequest) error {
-	if p.IsNopUpsertWorkflowRequest(request) {
-		return nil
-	}
-	return p.NewOperationNotSupportErrorForVis()
+func (s *sqlVisibilityStore) UpsertWorkflowExecution(_ *p.InternalUpsertWorkflowExecutionRequest) error {
+	return nil
 }
 
 func (s *sqlVisibilityStore) ListOpenWorkflowExecutions(request *p.ListWorkflowExecutionsRequest) (*p.InternalListWorkflowExecutionsResponse, error) {


### PR DESCRIPTION
The current implementations of UpsertWorkflowExecution on the Cassandra/SQL visibility persistence stores return a Service Error since Query Operations are not supported for those stores.

The problem is that we do allow customers to invoke UpsertWorkflowExecution successfully even if Elastic Search isn't enabled. This results in our Transfer Task Queues getting clogged because it keeps retrying a persistence operation that will always fail.

The fix is to just have all attempts to UpsertWorkflowExecution on Cassandra/SQL to function as a no-op so that it does not "fail" the transfer task perpetually. We will still fail with explicit errors on List/Scan/Count, so the user should be able to easily tell that their application logic is broken if it does depend on Elastic Search.

The change was verified as follows:
1) Existing Unit test was modified to ensure that no-op is always returned for UpsertWorkflowExecution
2) Running Bench Test on Temporal Server w/o ES cluster stopped spamming the "Critical error processing task" error log once this change was made.

This is a very low risk change.
