### PR TITLE
Reduce Maximum Page Size when retrieving Workflow Execution History

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -68,7 +68,7 @@ const MaxTaskTimeoutSeconds = 31622400
 
 const (
 	// GetHistoryMaxPageSize is the max page size for get history
-	GetHistoryMaxPageSize = 1000
+	GetHistoryMaxPageSize = 100
 	// ReadDLQMessagesPageSize is the max page size for read DLQ messages
 	ReadDLQMessagesPageSize = 1000
 )


### PR DESCRIPTION
In this PR, we are reducing the Maximum Page Size when retrieving Workflow History Records from the Persistence Layer from 1000 to 100.

We are doing this, because by adding gRPC support, there is a maximum message size of 4 MB when talking to Temporal Clients. With a page size of 1000, we are seeing paginations which are 7-8MB. Once a pagination gets this big, the workflow is not processable unless the Client gRPC limit is increased or the page size limit is decreased. 

Verifying via unit / integration tests. Will do extra validation with our nightly stress test runs (which initially caught this issue). We also have a separate issue open to do more intelligent paging so that we can still have a page size of 1000, but cut off the pagination if it exceeds the RPC size limit.

The downside / risk here is that for Workflows with longer replay histories, it will take longer to rehydrate them as more round-trips to the server are needed. Our nightly stress runs will measure if there is any discernible impact here.



