### PR TITLE
Create Workflowing is unreliable when History Shards have recently moved around the cluster

### DIFF
--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -502,7 +502,6 @@ Create_Loop:
 					} else {
 						// Shard is stolen, trigger shutdown of history engine
 						s.closeShard()
-						break Create_Loop
 					}
 				}
 			default:


### PR DESCRIPTION
When we merged Cadence into Temporal, we pulled in this change (https://github.com/uber/cadence/pull/3136), but not the subsequent fix for the regression it introduced (https://github.com/uber/cadence/pull/3405).

Temporal Frontend servers rely on ShardOwnershipLost to know to "retry" in the event a Shard has moved. The first Cadence change was masks ShardOwnershipLost with MaxRetriesExceeded, which the Temporal Frontend would not retry and simply pass back to the client. The net result is that during cluster startup / upgrades, the perceived reliability of the Create Workflow operation would be substantially reduced because our standard shard-movement-retry-logic in the FrontEnd was being circumvented.

Note that this pattern was introduced for:
1) CreateWorkflowExecution
2) UpdateWorkflowExecution
3) ResetWorkflowExecution
4) ConflictResolveWorkflowExecution

It makes sense to have the FrontEnd retry for CreateWorkflowExecution on ShardOwnershipLost. For the other functions, masking ShardOwnershipLost with MaxAttemptsExceeded is probably the right approach since the client may need to re-obtain the workflow state (as what they initially had could be stale), and they may action upon the latest state differently. CreateWorkflowExecution on the other hand is idempotent, so it is safe to do a retry here.

In addition to unit / integration test validation, our nightly pipelines were flaky because of this issue (which is how this was identified). This same change was also landed in Cadence months back, which provides additional validation
