### PR TITLE
Set logger in tctl GoSDK client

### DIFF
--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -32,6 +32,7 @@ import (
 	"google.golang.org/grpc"
 
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/rpc"
 )
 
@@ -82,6 +83,7 @@ func (b *clientFactory) SDKClient(c *cli.Context, namespace string) sdkclient.Cl
 	sdkClient, err := sdkclient.NewClient(sdkclient.Options{
 		HostPort:  hostPort,
 		Namespace: namespace,
+		Logger:    log.NewZapAdapter(b.logger),
 		ConnectionOptions: sdkclient.ConnectionOptions{
 			DisableHealthCheck: true,
 		},


### PR DESCRIPTION
Annoying message `2020/09/18 17:53:01 INFO  No logger configured for temporal client. Created default one.` was added to every `tctl` output. This PR to fix it.