### PR TITLE
Fix install-schema target (and docker image) idempotency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	go.uber.org/atomic v1.6.0
 	go.uber.org/multierr v1.5.0
 	go.uber.org/zap v1.15.0
+	golang.org/x/mod v0.3.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	golang.org/x/tools v0.0.0-20200609164405-eb789aa7ce50 // indirect


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`make install-schema` can be run any number of times w/o harm to the database.

<!-- Tell your future self why have you made these changes -->
**Why?**
#697 broke idempotency of `make install-schema` and docker image.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run `make install-schema` many times and ensured that server still can run.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks, bug fix.
