### PR TITLE
Fix delete workflow execution admin command

### DIFF
--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -252,6 +252,8 @@ func AdminDeleteWorkflow(c *cli.Context) {
 	rid := c.String(FlagRunID)
 
 	resp := describeMutableState(c)
+	// TODO: this is temporary solution for JSON version of WorkflowMutableState.
+	// Proper refactoring is required here: resp.GetDatabaseMutableState() should return proto object.
 	msStr := resp.GetDatabaseMutableState()
 	ms := map[string]interface{}{}
 	err := json.Unmarshal([]byte(msStr), &ms)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`tctl admin wf delete` command is fixed.

<!-- Tell your future self why have you made these changes -->
**Why?**
Command was broken due to erros in JSON serialization.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run command manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
