### PR TITLE
Add proto breaking change detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,15 +12,11 @@
 /*.iml
 *.cov
 *.html
-test
-test.log
-test_xdc
-test_xdc.log
-test_eventsV2
-test_eventsV2.log
-test_eventsV2_xdc
-test_eventsV2_xdc.log
+/test.log
 
 # Executables produced by temporal repo
 /temporal*
-/tctl
+/tctl*
+
+# Buf proto image
+/proto/image.bin

--- a/Makefile
+++ b/Makefile
@@ -235,7 +235,11 @@ api-linter:
 
 buf:
 	@printf $(COLOR) "Running buf linter..."
-	@(cd $(PROTO_ROOT) && buf check lint)
+	@buf check lint
+
+buf-breaking:
+	@printf $(COLOR) "Running buf breaking changes check against master branch..."
+	@buf check breaking --against-input '.git#branch=master'
 
 check: copyright goimports-check lint vet staticcheck errcheck
 

--- a/Makefile
+++ b/Makefile
@@ -12,10 +12,10 @@ all: update-tools clean proto bins check test
 clean: clean-bins clean-test-results
 
 # Recompile proto files.
-proto: clean-proto install-proto-submodule buf api-linter protoc fix-proto-path proto-mock goimports-proto copyright-proto
+proto: clean-proto install-proto-submodule buf-lint api-linter protoc fix-proto-path proto-mock goimports-proto copyright-proto
 
 # Update proto submodule from remote and recompile proto files.
-update-proto: clean-proto update-proto-submodule buf api-linter protoc fix-proto-path update-go-api proto-mock goimports-proto copyright-proto gomodtidy
+update-proto: clean-proto update-proto-submodule buf-lint api-linter protoc fix-proto-path update-go-api proto-mock goimports-proto copyright-proto gomodtidy
 
 # Build all docker images.
 docker-images:
@@ -230,16 +230,20 @@ errcheck:
 	@errcheck ./... || true
 
 api-linter:
-	@printf $(COLOR) "Running api-linter..."
+	@printf $(COLOR) "Run api-linter..."
 	@api-linter --set-exit-status --output-format=summary $(PROTO_IMPORTS) --config=$(PROTO_ROOT)/api-linter.yaml $(PROTO_FILES)
 
-buf:
-	@printf $(COLOR) "Running buf linter..."
-	@buf check lint
+buf-lint:
+	@printf $(COLOR) "Run buf linter..."
+	@(cd $(PROTO_ROOT) && buf check lint)
+
+buf-build:
+	@printf $(COLOR) "Build image.bin with buf..."
+	@(cd $(PROTO_ROOT) && buf image build -o image.bin)
 
 buf-breaking:
-	@printf $(COLOR) "Running buf breaking changes check against master branch..."
-	@buf check breaking --against-input '.git#branch=master'
+	@printf $(COLOR) "Run buf breaking changes check against image.bin..."
+	@(cd $(PROTO_ROOT) && buf check breaking --against-input image.bin)
 
 check: copyright goimports-check lint vet staticcheck errcheck
 

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,7 +1,7 @@
 build:
   roots:
-    - internal
-    - api
+    - proto/internal
+    - proto/api
 lint:
   ignore:
     - temporal/api # from `api` root: do not lint public api
@@ -11,3 +11,6 @@ lint:
   except:
     - PACKAGE_SAME_JAVA_MULTIPLE_FILES
     - PACKAGE_SAME_JAVA_PACKAGE
+breaking:
+  use:
+    - WIRE

--- a/proto/buf.yaml
+++ b/proto/buf.yaml
@@ -1,7 +1,7 @@
 build:
   roots:
-    - proto/internal
-    - proto/api
+    - internal
+    - api
 lint:
   ignore:
     - temporal/api # from `api` root: do not lint public api


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Two `Makefile` targets were added. 
The process has two steps:
1. Run `make buf-build` on golden branch first (master) and it will create `proto/image.bin` file. 
2. Switch to the branches with changes, or make those changes to proto files and run `make buf-breaking`. Output should not contains any rows. All errors must be fixed.

<!-- Tell your future self why have you made these changes -->
**Why?**
These targets allow to detect and recent proto changes are braking or not.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run targets over various changes.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks, build process improvment.
