### PR TITLE
Add message to Timeout failures

### DIFF
--- a/common/failure/failure.go
+++ b/common/failure/failure.go
@@ -30,6 +30,10 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 )
 
+const (
+	failureSourceServer = "Server"
+)
+
 func NewServerFailure(message string, nonRetryable bool) *failurepb.Failure {
 	f := &failurepb.Failure{
 		Message: message,
@@ -52,8 +56,10 @@ func NewResetWorkflowFailure(message string, lastHeartbeatDetails *commonpb.Payl
 	return f
 }
 
-func NewTimeoutFailure(timeoutType enumspb.TimeoutType) *failurepb.Failure {
+func NewTimeoutFailure(message string, timeoutType enumspb.TimeoutType) *failurepb.Failure {
 	f := &failurepb.Failure{
+		Message: message,
+		Source:  failureSourceServer,
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
 			TimeoutType: timeoutType,
 		}},

--- a/host/activity_test.go
+++ b/host/activity_test.go
@@ -316,7 +316,7 @@ func (s *integrationSuite) TestActivityHeartbeatDetailsDuringRetry() {
 			s.Equal(int32(i+2), pendingActivity.GetAttempt())
 			s.Equal(enumspb.PENDING_ACTIVITY_STATE_SCHEDULED, pendingActivity.GetState())
 			if i == 0 {
-				s.Equal(failure.NewTimeoutFailure(enumspb.TIMEOUT_TYPE_HEARTBEAT), pendingActivity.GetLastFailure())
+				s.Equal(failure.NewTimeoutFailure("ActivityTask timeout", enumspb.TIMEOUT_TYPE_HEARTBEAT), pendingActivity.GetLastFailure())
 			} else { // i == 1
 				expectedErrString := "retryable-error"
 				s.NotNil(pendingActivity.GetLastFailure().GetApplicationFailureInfo())

--- a/service/history/timerQueueActiveTaskExecutor.go
+++ b/service/history/timerQueueActiveTaskExecutor.go
@@ -219,7 +219,7 @@ Loop:
 			break Loop
 		}
 
-		timeoutFailure := failure.NewTimeoutFailure(timerSequenceID.timerType)
+		timeoutFailure := failure.NewTimeoutFailure("ActivityTask timeout", timerSequenceID.timerType)
 		var retryState enumspb.RetryState
 		if retryState, err = mutableState.RetryActivity(
 			activityInfo,
@@ -486,7 +486,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowTimeoutTask(
 
 	eventBatchFirstEventID := mutableState.GetNextEventID()
 
-	timeoutFailure := failure.NewTimeoutFailure(enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
+	timeoutFailure := failure.NewTimeoutFailure("WorkflowTask timeout", enumspb.TIMEOUT_TYPE_START_TO_CLOSE)
 	backoffInterval := backoff.NoBackoff
 	retryState := enumspb.RETRY_STATE_TIMEOUT
 	continueAsNewInitiator := enumspb.CONTINUE_AS_NEW_INITIATOR_RETRY


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Activity and Workflow timeout failures now contain message and source information

<!-- Tell your future self why have you made these changes -->
**Why?**
Such failures by default were showing up empty in web/tctl/any other consumer unless have a special case of processing internal Timeout structure

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran tests and tried creating a timeout failure and verified through web/tctl
![image](https://user-images.githubusercontent.com/11838981/94071651-288f4600-fda9-11ea-9e6b-d629530ae39d.png)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks
