### PR TITLE
Use time datatype instead of unix nano representation for archival

### DIFF
--- a/common/archiver/gcloud/util.go
+++ b/common/archiver/gcloud/util.go
@@ -67,8 +67,7 @@ func constructVisibilityFilenamePrefix(namespaceID, tag string) string {
 	return fmt.Sprintf("%s/%s", namespaceID, tag)
 }
 
-func constructTimeBasedSearchKey(namespaceID, tag string, timestamp int64, precision string) string {
-	t := time.Unix(0, timestamp).UTC()
+func constructTimeBasedSearchKey(namespaceID, tag string, t time.Time, precision string) string {
 	var timeFormat = ""
 	switch precision {
 	case PrecisionSecond:

--- a/common/archiver/gcloud/util_test.go
+++ b/common/archiver/gcloud/util_test.go
@@ -136,7 +136,8 @@ func (s *utilSuite) TestConstructVisibilityFilenamePrefix() {
 }
 
 func (s *utilSuite) TestConstructTimeBasedSearchKey() {
-	s.Equal("namespaceID/startTimeout_1970-01-01T", constructTimeBasedSearchKey("namespaceID", indexKeyStartTimeout, 1580819141, "Day"))
+	t, _ := time.Parse(time.RFC3339, "2019-10-04T11:00:00+00:00")
+	s.Equal("namespaceID/startTimeout_2019-10-04T", constructTimeBasedSearchKey("namespaceID", indexKeyStartTimeout, t, "Day"))
 }
 
 func (s *utilSuite) TestConstructVisibilityFilename() {

--- a/common/archiver/gcloud/visibilityArchiver.go
+++ b/common/archiver/gcloud/visibilityArchiver.go
@@ -191,10 +191,10 @@ func (v *visibilityArchiver) query(ctx context.Context, URI archiver.URI, reques
 	}
 
 	var prefix = constructVisibilityFilenamePrefix(request.namespaceID, indexKeyCloseTimeout)
-	if request.parsedQuery.closeTime != 0 {
+	if !request.parsedQuery.closeTime.IsZero() {
 		prefix = constructTimeBasedSearchKey(request.namespaceID, indexKeyCloseTimeout, request.parsedQuery.closeTime, *request.parsedQuery.searchPrecision)
 	}
-	if request.parsedQuery.startTime != 0 {
+	if !request.parsedQuery.startTime.IsZero() {
 		prefix = constructTimeBasedSearchKey(request.namespaceID, indexKeyStartTimeout, request.parsedQuery.startTime, *request.parsedQuery.searchPrecision)
 	}
 

--- a/common/archiver/gcloud/visibilityArchiver_test.go
+++ b/common/archiver/gcloud/visibilityArchiver_test.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/mock"
@@ -232,9 +233,11 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidToken() {
 	defer mockCtrl.Finish()
 
 	mockParser := NewMockQueryParser(mockCtrl)
+	startTime, _ := time.Parse(time.RFC3339, "2019-10-04T11:00:00+00:00")
+	closeTime := startTime.Add(time.Hour)
 	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
-		closeTime: int64(101),
-		startTime: int64(1),
+		closeTime: closeTime,
+		startTime: startTime,
 	}, nil)
 	visibilityArchiver.queryParser = mockParser
 	request := &archiver.QueryVisibilityRequest{
@@ -264,8 +267,9 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 
 	mockParser := NewMockQueryParser(mockCtrl)
 	dayPrecision := string("Day")
+	closeTime, _ := time.Parse(time.RFC3339, "2019-10-04T11:00:00+00:00")
 	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
-		closeTime:       int64(101),
+		closeTime:       closeTime,
 		searchPrecision: &dayPrecision,
 		workflowType:    convert.StringPtr("MobileOnlyWorkflow::processMobileOnly"),
 		workflowID:      convert.StringPtr(testWorkflowID),
@@ -307,8 +311,9 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 
 	mockParser := NewMockQueryParser(mockCtrl)
 	dayPrecision := "Day"
+	closeTime, _ := time.Parse(time.RFC3339, "2019-10-04T11:00:00+00:00")
 	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
-		closeTime:       int64(101),
+		closeTime:       closeTime,
 		searchPrecision: &dayPrecision,
 		workflowType:    convert.StringPtr("MobileOnlyWorkflow::processMobileOnly"),
 		workflowID:      convert.StringPtr(testWorkflowID),

--- a/common/archiver/s3store/util.go
+++ b/common/archiver/s3store/util.go
@@ -169,9 +169,8 @@ func constructTimeBasedSearchKey(path, namespaceID, primaryIndexKey, primaryInde
 	return fmt.Sprintf("%s/%s", constructVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey), t.Format(timeFormat))
 }
 
-func constructTimestampIndex(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey string, timestamp int64, runID string) string {
-	t := time.Unix(0, timestamp).UTC()
-	return fmt.Sprintf("%s/%s/%s", constructVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey), t.Format(time.RFC3339), runID)
+func constructTimestampIndex(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey string, secondaryIndexValue time.Time, runID string) string {
+	return fmt.Sprintf("%s/%s/%s", constructVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey), secondaryIndexValue.Format(time.RFC3339), runID)
 }
 
 func constructVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexType string) string {

--- a/common/archiver/s3store/visibilityArchiver.go
+++ b/common/archiver/s3store/visibilityArchiver.go
@@ -26,6 +26,7 @@ package s3store
 
 import (
 	"context"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -59,7 +60,7 @@ type (
 		primaryIndex            string
 		primaryIndexValue       string
 		secondaryIndex          string
-		secondaryIndexTimestamp int64
+		secondaryIndexTimestamp time.Time
 	}
 )
 
@@ -154,10 +155,10 @@ func (v *visibilityArchiver) Archive(
 }
 func createIndexesToArchive(request *archiverspb.ArchiveVisibilityRequest) []indexToArchive {
 	return []indexToArchive{
-		{primaryIndexKeyWorkflowTypeName, request.WorkflowTypeName, secondaryIndexKeyCloseTimeout, timestamp.TimeValue(request.CloseTime).UnixNano()},
-		{primaryIndexKeyWorkflowTypeName, request.WorkflowTypeName, secondaryIndexKeyStartTimeout, timestamp.TimeValue(request.StartTime).UnixNano()},
-		{primaryIndexKeyWorkflowID, request.GetWorkflowId(), secondaryIndexKeyCloseTimeout, timestamp.TimeValue(request.CloseTime).UnixNano()},
-		{primaryIndexKeyWorkflowID, request.GetWorkflowId(), secondaryIndexKeyStartTimeout, timestamp.TimeValue(request.StartTime).UnixNano()},
+		{primaryIndexKeyWorkflowTypeName, request.WorkflowTypeName, secondaryIndexKeyCloseTimeout, timestamp.TimeValue(request.CloseTime)},
+		{primaryIndexKeyWorkflowTypeName, request.WorkflowTypeName, secondaryIndexKeyStartTimeout, timestamp.TimeValue(request.StartTime)},
+		{primaryIndexKeyWorkflowID, request.GetWorkflowId(), secondaryIndexKeyCloseTimeout, timestamp.TimeValue(request.CloseTime)},
+		{primaryIndexKeyWorkflowID, request.GetWorkflowId(), secondaryIndexKeyStartTimeout, timestamp.TimeValue(request.StartTime)},
 	}
 }
 

--- a/common/archiver/s3store/visibilityArchiver_test.go
+++ b/common/archiver/s3store/visibilityArchiver_test.go
@@ -223,7 +223,7 @@ func (s *visibilityArchiverSuite) TestArchive_Success() {
 	err = visibilityArchiver.Archive(context.Background(), URI, request)
 	s.NoError(err)
 
-	expectedKey := constructTimestampIndex(URI.Path(), testNamespaceID, primaryIndexKeyWorkflowID, testWorkflowID, secondaryIndexKeyCloseTimeout, closeTimestamp.UnixNano(), testRunID)
+	expectedKey := constructTimestampIndex(URI.Path(), testNamespaceID, primaryIndexKeyWorkflowID, testWorkflowID, secondaryIndexKeyCloseTimeout, timestamp.TimeValue(closeTimestamp), testRunID)
 	data, err := download(context.Background(), visibilityArchiver.s3cli, URI, expectedKey)
 	s.NoError(err, expectedKey)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Archival logic uses time as data type instead of unix nano

<!-- Tell your future self why have you made these changes -->
**Why?**
Temporal made a call to use time datatype everywhere in the code instead of timestamps

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit and integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
May cause issues with querying archival records using timestamps
