### PR TITLE
Fix default out-of-box experience for tctl batch commands

### DIFF
--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -51,6 +51,8 @@ const (
 	CustomBoolField       = "CustomBoolField"
 	CustomDatetimeField   = "CustomDatetimeField"
 	TemporalChangeVersion = "TemporalChangeVersion"
+	CustomNamespace       = "CustomNamespace"
+	Operator              = "Operator"
 )
 
 // valid non-indexed fields on ES
@@ -74,6 +76,8 @@ func createDefaultIndexedKeys() map[string]interface{} {
 		CustomDatetimeField:   enumspb.INDEXED_VALUE_TYPE_DATETIME,
 		TemporalChangeVersion: enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		BinaryChecksums:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		CustomNamespace:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		Operator:              enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}
 	for k, v := range systemIndexedKeys {
 		defaultIndexedKeys[k] = v
@@ -98,6 +102,8 @@ var systemIndexedKeys = map[string]interface{}{
 	ExecutionStatus: enumspb.INDEXED_VALUE_TYPE_INT,
 	HistoryLength:   enumspb.INDEXED_VALUE_TYPE_INT,
 	TaskQueue:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	KafkaKey:        enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+	Encoding:        enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 }
 
 // IsSystemIndexedKey return true is key is system added

--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -39,8 +39,8 @@ const (
 	CloseTime       = "CloseTime"
 	ExecutionStatus = "ExecutionStatus"
 	HistoryLength   = "HistoryLength"
-	Encoding        = "Encoding"
 	KafkaKey        = "KafkaKey"
+	Encoding        = "Encoding"
 	BinaryChecksums = "BinaryChecksums"
 	TaskQueue       = "TaskQueue"
 

--- a/common/elasticsearch/defs.go
+++ b/common/elasticsearch/defs.go
@@ -42,6 +42,7 @@ const (
 	Memo            = "Memo"
 	Encoding        = "Encoding"
 	TaskQueue       = "TaskQueue"
+	CustomNamespace = "CustomNamespace"
 
 	KafkaKey = "KafkaKey"
 )

--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -16,6 +16,8 @@ frontend.validSearchAttributes:
       ExecutionStatus: "Int"
       HistoryLength: "Int"
       TaskQueue: "Keyword"
+      KafkaKey: "Keyword"
+      Encoding: "Keyword"
       CustomStringField: "String"
       CustomKeywordField: "Keyword"
       CustomIntField: "Int"

--- a/host/testdata/es_index_template.json
+++ b/host/testdata/es_index_template.json
@@ -43,6 +43,9 @@
         "KafkaKey": {
           "type": "keyword"
         },
+        "Encoding": {
+          "type": "keyword"
+        },
         "Attr": {
           "properties": {
             "TemporalChangeVersion":  { "type": "keyword" },

--- a/schema/elasticsearch/visibility/index_template.json
+++ b/schema/elasticsearch/visibility/index_template.json
@@ -43,6 +43,9 @@
         "KafkaKey": {
           "type": "keyword"
         },
+        "Encoding": {
+          "type": "keyword"
+        },
         "TaskQueue": {
           "type": "keyword"
         },

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -109,7 +109,7 @@ type (
 		Query string
 		// Reason for the operation
 		Reason string
-		// Supporting: reset,terminate
+		// Supporting: signal,cancel,terminate
 		BatchType string
 
 		// Below are all optional
@@ -195,9 +195,7 @@ func validateParams(params BatchParams) error {
 			return fmt.Errorf("must provide signal name")
 		}
 		return nil
-	case BatchTypeCancel:
-		fallthrough
-	case BatchTypeTerminate:
+	case BatchTypeCancel, BatchTypeTerminate:
 		return nil
 	default:
 		return fmt.Errorf("not supported batch type: %v", params.BatchType)

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -142,7 +142,7 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 			AdminOperationToken: dc.GetStringProperty(dynamicconfig.AdminOperationToken, common.DefaultAdminOperationToken),
 			ClusterMetadata:     params.ClusterMetadata,
 		},
-		EnableBatcher:                 dc.GetBoolProperty(dynamicconfig.EnableBatcher, false),
+		EnableBatcher:                 dc.GetBoolProperty(dynamicconfig.EnableBatcher, true),
 		EnableParentClosePolicyWorker: dc.GetBoolProperty(dynamicconfig.EnableParentClosePolicyWorker, true),
 		ThrottledLogRPS:               dc.GetIntProperty(dynamicconfig.WorkerThrottledLogRPS, 20),
 		PersistenceGlobalMaxQPS:       dc.GetIntProperty(dynamicconfig.WorkerPersistenceGlobalMaxQPS, 0),

--- a/tools/cli/workflowBatchCommands.go
+++ b/tools/cli/workflowBatchCommands.go
@@ -36,6 +36,7 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -194,8 +195,8 @@ func StartBatchJob(c *cli.Context) {
 			"Reason": reason,
 		},
 		SearchAttributes: map[string]interface{}{
-			"CustomNamespace": namespace,
-			"Operator":        operator,
+			definition.CustomNamespace: namespace,
+			definition.Operator:        operator,
 		},
 	}
 


### PR DESCRIPTION
- The EnableBatcher default value was set to false, which meant that batch commands would be accepted by the server, but never actually processed.
- For Temporal clusters with Elastic Search enabled, but without explicit dynamic configuration, key fields such as CustomNamespace, Operator, KafkaKey and Encoding were not registered as "indexed." This would cause any attempt to start the batch command to fail as the server would think we were performing an elastic search query on an unindexed field
- Adds missing ES index setup for "Encoding" key
- Cleans up a tiny bit of Batcher code/comments based on adhoc code-review

Change was verified through standard unit/integration test pipeline + manual validation of batch commands for starting (cancel, terminate, signal), terminating, describing, and listing

No risks unless the batching feature when enabled can cause issues for existing clusters. Verified that worker role is not affected if batching workflows are registered even for a cluster w/o ElasticSearch

