### PR TITLE
Add a drop keyspace command to cassandra tool

### DIFF
--- a/tools/cassandra/README.md
+++ b/tools/cassandra/README.md
@@ -47,3 +47,10 @@ You can only upgrade to a new version after the initial setup done above.
 ./temporal-cassandra-tool -ep 127.0.0.1 -k temporal_visibility update-schema -d ./schema/cassandra/visibility/versioned -v x.x    -- actually executes the upgrade to version x.x
 ```
 
+### To uninstall temporal from cassandra cluster
+It is possible to uninstall temporal from a cassandra cluster by dropping the keyspaces installed. This is a destructive operation and cannot be reversed. BACKUP FIRST OR DATA WILL BE LOST.
+
+```
+./temporal-cassandra-tool --endpoint $CASSANDRA_ENDPOINT drop -k $KEYSPACE_TO_REMOVE
+./temporal-cassandra-tool --endpoint $CASSANDRA_ENDPOINT drop -k $VISIBILITY_KEYSPACE_TO_REMOVE
+```

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -204,6 +204,20 @@ func buildCLIOptions() *cli.App {
 				cliHandler(c, createKeyspace)
 			},
 		},
+		{
+			Name:    "drop-Keyspace",
+			Aliases: []string{"drop"},
+			Usage:   "drops a Keyspace",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  schema.CLIFlagKeyspace,
+					Usage: "name of the Keyspace",
+				},
+			},
+			Action: func(c *cli.Context) {
+				cliHandler(c, dropKeyspace)
+			},
+		},
 	}
 
 	return app


### PR DESCRIPTION
Add a `drop-Keyspace` sub command to temporal-cassandra-tool to make this all we need to manage cass for temporal.

In operating cassandra clusters for temporal (especially for testing) it's nice to have one tool to create and drop keyspaces.

This was tested locally - but it might be nice to have unit tests.

The change itself is safe as it needs to be used explicitly but can drop keyspaces which could result in accidental data loss in the worst case.