### PR TITLE
Add failure type info to tctl wf describe

### DIFF
--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -971,13 +971,20 @@ func convertFailure(failure *failurepb.Failure) *clispb.Failure {
 		return nil
 	}
 
-	return &clispb.Failure{
+	fType := reflect.TypeOf(failure.GetFailureInfo()).Elem().Name()
+	if failure.GetTimeoutFailureInfo() != nil {
+		fType = fmt.Sprintf("%s: %s", fType, failure.GetTimeoutFailureInfo().GetTimeoutType().String())
+	}
+
+	f := &clispb.Failure{
 		Message:     failure.GetMessage(),
 		Source:      failure.GetSource(),
 		StackTrace:  failure.GetStackTrace(),
 		Cause:       convertFailure(failure.GetCause()),
-		FailureType: reflect.TypeOf(failure.GetFailureInfo()).Elem().Name(),
+		FailureType: fType,
 	}
+
+	return f
 }
 
 func createTableForListWorkflow(c *cli.Context, listAll bool, queryOpen bool) *tablewriter.Table {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`tctl workflow describe` now properly outputs failure type for timeout

<!-- Tell your future self why have you made these changes -->
**Why?**
failure type was missing for timeout failures

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
ran command and tests
![image](https://user-images.githubusercontent.com/11838981/94323466-c0786580-ff4a-11ea-8e2e-fdd367e1d964.png)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risks
