### PR TITLE
Update contribution guide with a note about increasing file handle limit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,10 @@ Tests require runtime dependencies. You can run them with `docker-compose`. Open
 $ cd docker/dependencies
 $ docker-compose up
 ```
+Before testing on MacOS, make sure you increase the file handle limit:
+```
+$ ulimit -n 8192
+```
 
 Run unit tests:
 ```bash


### PR DESCRIPTION
**What changed?**
Contribution guide.

**Why?**
Unit tests are failing on MacOS without the increased file handle limit.

**How did you test it?**
Unit tests on MacOS succeed after running `ulimit -n 8192`.

**Potential risks**
None
