### PR TITLE
Added configuration to publish binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: goreleaser
+on:
+  release:
+    types:
+      - released
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      - name: Get build date
+        id: date
+        run: echo "::set-output name=date::$(date '+%F-%T')"
+      - name: Get build unix timestamp
+        id: timestamp
+        run: echo "::set-output name=timestamp::$(date '+%s')"
+      - name: Get git branch
+        id: branch
+        run: echo "::set-output name=branch::$(git rev-parse --abbrev-ref HEAD)"
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BUILD_DATE: ${{ steps.date.outputs.date }}
+          BUILD_TS_UNIX: ${{ steps.timestamp.outputs.timestamp }}
+          GIT_BRANCH: ${{ steps.branch.outputs.branch }}

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,7 @@
 
 # Buf proto image
 /proto/image.bin
+
+#Goreleaser
+/dist
+/bin

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,64 @@
+env:
+  - GO111MODULE=on
+before:
+  hooks:
+    - go mod download
+builds:
+  - id: "temporal-server"
+    dir: cmd/server
+    binary: temporal-server
+    ldflags:
+      - -X go.temporal.io/server/common/metrics.GitRevision={{.ShortCommit}}
+      - -X go.temporal.io/server/common/metrics.GitBranch={{.Env.GIT_BRANCH}}
+      - -X go.temporal.io/server/common/metrics.GitVersion={{.Tag}}
+      - -X go.temporal.io/server/common/metrics.BuildDate={{.Env.BUILD_DATE}}
+      - -X go.temporal.io/server/common/metrics.BuildTimeUnix={{.Env.BUILD_TS_UNIX}}
+      - -X go.temporal.io/server/cmd/server/temporal.GitVersion={{.Tag}}
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+  - id: "tctl"
+    dir: cmd/tools/cli
+    binary: tctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+  - id: "temporal-cassandra-tool"
+    dir: cmd/tools/cassandra
+    binary: temporal-cassandra-tool
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+  - id: "temporal-sql-tool"
+    dir: cmd/tools/sql
+    binary: temporal-sql-tool
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+snapshot:
+  name_template: "{{ .Tag }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'

--- a/Makefile
+++ b/Makefile
@@ -404,3 +404,12 @@ go-generate:
 gomodtidy:
 	@printf $(COLOR) "go mod tidy..."
 	@go mod tidy
+
+goreleaser:
+	@curl -sfL https://install.goreleaser.com/github.com/goreleaser/goreleaser.sh | sh
+
+release-snapshot:
+	@BUILD_DATE=$(shell date '+%F-%T') BUILD_TS_UNIX=$(shell date '+%s') GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) ./bin/goreleaser --snapshot --rm-dist
+
+release:
+	@BUILD_DATE=$(shell date '+%F-%T') BUILD_TS_UNIX=$(shell date '+%s') GIT_BRANCH=$(shell git rev-parse --abbrev-ref HEAD) ./bin/goreleaser

--- a/cmd/server/temporal/temporal.go
+++ b/cmd/server/temporal/temporal.go
@@ -42,6 +42,8 @@ import (
 	"go.temporal.io/server/tools/sql"
 )
 
+var GitVersion = "0.0.1"
+
 // validServices is the list of all valid temporal services
 var validServices = []string{primitives.FrontendService, primitives.HistoryService, primitives.MatchingService, primitives.WorkerService}
 
@@ -166,7 +168,7 @@ func BuildCLI() *cli.App {
 	app := cli.NewApp()
 	app.Name = "temporal"
 	app.Usage = "Temporal server"
-	app.Version = "0.0.1"
+	app.Version = GitVersion
 
 	app.Flags = []cli.Flag{
 		cli.StringFlag{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added .goreleaser.yml configuration to build go binaries. Goreleaser is a tool for publishing go binaries. More at https://goreleaser.com/intro/

Added Github action to upload binary artifacts to a release. This action runs when a new release is done.

<!-- Tell your future self why have you made these changes -->
**Why?**

As an alternative to Docker images of the temporal client and server tools


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested the Github action integration https://github.com/h7kanna/temporal/runs/1171998437?check_suite_focus=true
Tested Goreleaser artifacts generation https://github.com/h7kanna/temporal/releases/tag/v0.31.1


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Does not impact production

