### PR TITLE
Fix developer docker-compose on Mac

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,11 +47,12 @@ Please check the top of our [Makefile](Makefile) for other useful build targets.
 
 ## Testing
 
-Tests require runtime dependencies. You can run them with `docker-compose`. Open new terminal window and run:
+Tests require runtime dependencies. They can be run with `start-dependencies` target (uses `docker-compose` internally). Open new terminal window and run:
 ```bash
-$ cd docker/dependencies
-$ docker-compose up
+$ make start-dependencies
 ```
+`make stop-dependencies` will bring `docker-compose` down.
+
 Before testing on MacOS, make sure you increase the file handle limit:
 ```bash
 $ ulimit -n 8192

--- a/Makefile
+++ b/Makefile
@@ -382,7 +382,21 @@ install-schema-cdc: temporal-cassandra-tool
 	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility_other setup-schema -v 0.0
 	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility_other update-schema -d ./schema/cassandra/visibility/versioned
 
-##### Start #####
+##### Run server #####
+start-dependencies:
+ifeq ($(GOOS),darwin)
+	docker-compose -f docker/dependencies/docker-compose.yml -f docker/dependencies/docker-compose.mac.yml up
+else
+	docker-compose -f docker/dependencies/docker-compose.yml up
+endif
+
+stop-dependencies:
+ifeq ($(GOOS),darwin)
+	docker-compose -f docker/dependencies/docker-compose.yml -f docker/dependencies/docker-compose.mac.yml down
+else
+	docker-compose -f docker/dependencies/docker-compose.yml down
+endif
+
 start: temporal-server
 	./temporal-server start
 

--- a/docker/dependencies/docker-compose.mac.sh
+++ b/docker/dependencies/docker-compose.mac.sh
@@ -1,1 +1,0 @@
-docker-compose -f docker-compose.yml -f docker-compose.mac.yml $1

--- a/docker/dependencies/docker-compose.mac.sh
+++ b/docker/dependencies/docker-compose.mac.sh
@@ -1,0 +1,1 @@
+docker-compose -f docker-compose.yml -f docker-compose.mac.yml up

--- a/docker/dependencies/docker-compose.mac.sh
+++ b/docker/dependencies/docker-compose.mac.sh
@@ -1,1 +1,1 @@
-docker-compose -f docker-compose.yml -f docker-compose.mac.yml up
+docker-compose -f docker-compose.yml -f docker-compose.mac.yml $1

--- a/docker/dependencies/docker-compose.mac.yml
+++ b/docker/dependencies/docker-compose.mac.yml
@@ -1,0 +1,10 @@
+# Overrides for Mac users.
+version: "3.5"
+
+services:
+  temporal-web:
+    environment:
+      - "TEMPORAL_GRPC_ENDPOINT=host.docker.internal:7233"
+    ports:
+      - "8088:8088"
+    network_mode: bridge

--- a/docker/dependencies/docker-compose.yml
+++ b/docker/dependencies/docker-compose.yml
@@ -70,7 +70,7 @@ services:
     networks:
       - temporal-dependencies-network
   temporal-web:
-    image: temporalio/web:latest
+    image: temporalio/web:1.0.0
     container_name: temporal-web
     environment:
       - "TEMPORAL_GRPC_ENDPOINT=localhost:7233"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added `docker-compose.yml` overrides for Mac developers. These 2 `make` commands work on Linux and Mac.
```
$ make start-dependencies
$ make stop-dependencies
```

<!-- Tell your future self why have you made these changes -->
**Why?**
Due to docker implementation on Mac (Linux VM) `web` can't reach server with original Linux configuration. This overrides should fix it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Wasn't able to test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
