### PR TITLE
Make Task Failed event readable in cli 

### DIFF
--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -367,6 +367,9 @@ func getEventAttributes(e *historypb.HistoryEvent) interface{} {
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
 		data = e.GetWorkflowExecutionFailedEventAttributes()
 
+	case enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED:
+		data = e.GetWorkflowTaskFailedEventAttributes()
+
 	case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
 		data = e.GetWorkflowExecutionTimedOutEventAttributes()
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
WorkflowTaskFailed event now renders failure in human readable form (top level failure + stack trace + some of deeper lvl failures) 

<!-- Tell your future self why have you made these changes -->
**Why?**
Adds visibility into WorkflowTaskFailed data

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tests + ran command
![image](https://user-images.githubusercontent.com/11838981/95115594-9701cb80-06fa-11eb-856c-cc509523b582.png)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risks
