### PR TITLE
Fixes issue #673

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -129,7 +129,7 @@ services:
         metrics:
             prometheus:
                 timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
-                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
+                listenAddress: {{ .Env.PROMETHEUS_FRONTEND_ENDPOINT }}
         {{- end }}
 
     matching:
@@ -146,7 +146,7 @@ services:
         metrics:
             prometheus:
                 timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
-                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
+                listenAddress: {{ .Env.PROMETHEUS_MATCHING_ENDPOINT }}
         {{- end }}
 
     history:
@@ -163,7 +163,7 @@ services:
         metrics:
             prometheus:
                 timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
-                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
+                listenAddress: {{ .Env.PROMETHEUS_HISTORY_ENDPOINT }}
         {{- end }}
 
     worker:
@@ -180,7 +180,7 @@ services:
         metrics:
             prometheus:
                 timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
-                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
+                listenAddress: {{ .Env.PROMETHEUS_WORKER_ENDPOINT }}
         {{- end }}
 
 clusterMetadata:


### PR DESCRIPTION
**What changed?**

* The environment variable specification for prometheus address. 

**Why?**

* This fixes issue #673. Before, you could configure only one address and that same address was used to start HTTP servers using this listen address for the frontend, history, matching, and worker services. By having a distinct environment variable for each, we avoid bind problems on startup. 

**How did you test it?**

* Locally in the docker-compose file for Postgres. 

```
docker logs docker_temporal_1 2>&1 | grep bind
```

  As you can see there are no more logs regarding bind issues. 

**Potential risks**

* If the docker container is updated then folks that were using the original configuration will not see prometheus running for any services. Since it was the case that only one or the four services would successfully run, I don't see this as much of a risk. However, if we have documentation somewhere regarding prometheus endpoint configuration we should probably update it. 
