### PR TITLE
Enable support for ScyllaDB

### DIFF
--- a/common/persistence/cassandra/cassandraQueue.go
+++ b/common/persistence/cassandra/cassandraQueue.go
@@ -329,7 +329,7 @@ func (q *cassandraQueue) insertInitialQueueMetadataRecord(
 	version := 0
 	clusterAckLevels := map[string]int64{}
 	query := q.session.Query(templateInsertQueueMetadataQuery, queueType, clusterAckLevels, version)
-	_, err := query.ScanCAS()
+	_, err := query.ScanCAS(nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("failed to insert initial queue metadata record: %v, Type: %v", err, queueType)
 	}


### PR DESCRIPTION
Passes in 3 "nil" references to the ScanCAS() call when inserting cluster membership data.
This change is needed for the gocql client to work against an instance of ScyllaDB.
Change was verified against a ScyllaDB cluster.
This is a low risk change as if it causes issues, it would be caught immediately.

