### PR TITLE
Split overloaded transfer / timer task APIs

### DIFF
--- a/common/persistence/sql/sqlplugin/definition.go
+++ b/common/persistence/sql/sqlplugin/definition.go
@@ -111,23 +111,6 @@ type (
 		ShardID int64
 	}
 
-	// TransferTasksRow represents a row in transfer_tasks table
-	TransferTasksRow struct {
-		ShardID      int32
-		TaskID       int64
-		Data         []byte
-		DataEncoding string
-	}
-
-	// TransferTasksFilter contains the column names within transfer_tasks table that
-	// can be used to filter results through a WHERE clause
-	TransferTasksFilter struct {
-		ShardID   int32
-		TaskID    *int64
-		MinTaskID *int64
-		MaxTaskID *int64
-	}
-
 	// ExecutionsRow represents a row in executions table
 	ExecutionsRow struct {
 		ShardID                  int
@@ -270,26 +253,6 @@ type (
 	ReplicationTasksDLQFilter struct {
 		ReplicationTasksFilter
 		SourceClusterName string
-	}
-
-	// TimerTasksRow represents a row in timer_tasks table
-	TimerTasksRow struct {
-		ShardID             int32
-		VisibilityTimestamp time.Time
-		TaskID              int64
-		Data                []byte
-		DataEncoding        string
-	}
-
-	// TimerTasksFilter contains the column names within timer_tasks table that
-	// can be used to filter results through a WHERE clause
-	TimerTasksFilter struct {
-		ShardID                int32
-		TaskID                 *int64
-		VisibilityTimestamp    *time.Time
-		MinVisibilityTimestamp *time.Time
-		MaxVisibilityTimestamp *time.Time
-		PageSize               *int
 	}
 
 	// EventsRow represents a row in events table

--- a/common/persistence/sql/sqlplugin/history.go
+++ b/common/persistence/sql/sqlplugin/history.go
@@ -154,31 +154,6 @@ type (
 		DeleteFromSignalsRequestedSets(filter *SignalsRequestedSetsFilter) (sql.Result, error)
 	}
 
-	// HistoryTransferTask is the SQL persistence interface for history nodes and history transfer tasks
-	HistoryTransferTask interface {
-		InsertIntoTransferTasks(rows []TransferTasksRow) (sql.Result, error)
-		// SelectFromTransferTasks returns rows that match filter criteria from transfer_tasks table.
-		// Required filter params - {shardID, minTaskID, maxTaskID}
-		SelectFromTransferTasks(filter *TransferTasksFilter) ([]TransferTasksRow, error)
-		// DeleteFromTransferTasks deletes one or more rows from transfer_tasks table.
-		// Filter params - shardID is required. If TaskID is not nil, a single row is deleted.
-		// When MinTaskID and MaxTaskID are not-nil, a range of rows are deleted.
-		DeleteFromTransferTasks(filter *TransferTasksFilter) (sql.Result, error)
-	}
-
-	// HistoryTimerTask is the SQL persistence interface for history nodes and history timer tasks
-	HistoryTimerTask interface {
-		InsertIntoTimerTasks(rows []TimerTasksRow) (sql.Result, error)
-		// SelectFromTimerTasks returns one or more rows from timer_tasks table
-		// Required filter Params - {shardID, taskID, minVisibilityTimestamp, maxVisibilityTimestamp, pageSize}
-		SelectFromTimerTasks(filter *TimerTasksFilter) ([]TimerTasksRow, error)
-		// DeleteFromTimerTasks deletes one or more rows from timer_tasks table
-		// Required filter Params:
-		//  - to delete one row - {shardID, visibilityTimestamp, taskID}
-		//  - to delete multiple rows - {shardID, minVisibilityTimestamp, maxVisibilityTimestamp}
-		DeleteFromTimerTasks(filter *TimerTasksFilter) (sql.Result, error)
-	}
-
 	// HistoryReplicationTask is the SQL persistence interface for history nodes and history replication tasks
 	HistoryReplicationTask interface {
 		InsertIntoReplicationTasks(rows []ReplicationTasksRow) (sql.Result, error)
@@ -191,6 +166,7 @@ type (
 		// DeleteFromReplicationTasks deletes multi rows from replication_tasks table
 		// Required filter params - {shardID, inclusiveEndTaskID}
 		RangeDeleteFromReplicationTasks(filter *ReplicationTasksFilter) (sql.Result, error)
+
 		// InsertIntoReplicationTasksDLQ puts the replication task into DLQ
 		InsertIntoReplicationTasksDLQ(row *ReplicationTaskDLQRow) (sql.Result, error)
 		// SelectFromReplicationTasksDLQ returns one or more rows from replication_tasks_dlq table

--- a/common/persistence/sql/sqlplugin/history_timer_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_timer_tasks.go
@@ -1,0 +1,71 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sqlplugin
+
+import (
+	"database/sql"
+	"time"
+)
+
+type (
+	// TimerTasksRow represents a row in timer_tasks table
+	TimerTasksRow struct {
+		ShardID             int32
+		VisibilityTimestamp time.Time
+		TaskID              int64
+		Data                []byte
+		DataEncoding        string
+	}
+
+	// TimerTasksFilter contains the column names within timer_tasks table that
+	// can be used to filter results through a WHERE clause
+	TimerTasksFilter struct {
+		ShardID             int32
+		TaskID              int64
+		VisibilityTimestamp time.Time
+	}
+
+	// TimerTasksFilter contains the column names within timer_tasks table that
+	// can be used to filter results through a WHERE clause
+	TimerTasksRangeFilter struct {
+		ShardID                int32
+		TaskID                 int64
+		MinVisibilityTimestamp time.Time
+		MaxVisibilityTimestamp time.Time
+		PageSize               int
+	}
+
+	// HistoryTimerTask is the SQL persistence interface for history nodes and history timer tasks
+	HistoryTimerTask interface {
+		InsertIntoTimerTasks(rows []TimerTasksRow) (sql.Result, error)
+		// SelectFromTimerTasks returns one or more rows from timer_tasks table
+		SelectFromTimerTasks(filter TimerTasksFilter) ([]TimerTasksRow, error)
+		// RangeSelectFromTimerTasks returns one or more rows from timer_tasks table
+		RangeSelectFromTimerTasks(filter TimerTasksRangeFilter) ([]TimerTasksRow, error)
+		// DeleteFromTimerTasks deletes one or more rows from timer_tasks table
+		DeleteFromTimerTasks(filter TimerTasksFilter) (sql.Result, error)
+		// RangeDeleteFromTimerTasks deletes one or more rows from timer_tasks table
+		//  TimerTasksRangeFilter {TaskID, PageSize} will be ignored
+		RangeDeleteFromTimerTasks(filter TimerTasksRangeFilter) (sql.Result, error)
+	}
+)

--- a/common/persistence/sql/sqlplugin/history_transfer_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_transfer_tasks.go
@@ -1,0 +1,63 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sqlplugin
+
+import "database/sql"
+
+type (
+	// TransferTasksRow represents a row in transfer_tasks table
+	TransferTasksRow struct {
+		ShardID      int32
+		TaskID       int64
+		Data         []byte
+		DataEncoding string
+	}
+
+	// TransferTasksFilter contains the column names within transfer_tasks table that
+	// can be used to filter results through a WHERE clause
+	TransferTasksFilter struct {
+		ShardID int32
+		TaskID  int64
+	}
+
+	// TransferTasksRangeFilter contains the column names within transfer_tasks table that
+	// can be used to filter results through a WHERE clause
+	TransferTasksRangeFilter struct {
+		ShardID   int32
+		MinTaskID int64
+		MaxTaskID int64
+	}
+
+	// HistoryTransferTask is the SQL persistence interface for history nodes and history transfer tasks
+	HistoryTransferTask interface {
+		InsertIntoTransferTasks(rows []TransferTasksRow) (sql.Result, error)
+		// SelectFromTransferTasks returns rows that match filter criteria from transfer_tasks table.
+		SelectFromTransferTasks(filter TransferTasksFilter) ([]TransferTasksRow, error)
+		// RangeSelectFromTransferTasks returns rows that match filter criteria from transfer_tasks table.
+		RangeSelectFromTransferTasks(filter TransferTasksRangeFilter) ([]TransferTasksRow, error)
+		// DeleteFromTransferTasks deletes one rows from transfer_tasks table.
+		DeleteFromTransferTasks(filter TransferTasksFilter) (sql.Result, error)
+		// RangeDeleteFromTransferTasks deletes one or more rows from transfer_tasks table.
+		RangeDeleteFromTransferTasks(filter TransferTasksRangeFilter) (sql.Result, error)
+	}
+)

--- a/common/persistence/sql/sqlplugin/mysql/execution.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution.go
@@ -27,8 +27,6 @@ package mysql
 import (
 	"database/sql"
 
-	"go.temporal.io/api/serviceerror"
-
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
 
@@ -245,23 +243,19 @@ func (mdb *db) InsertIntoTransferTasks(rows []sqlplugin.TransferTasksRow) (sql.R
 }
 
 // SelectFromTransferTasks reads one or more rows from transfer_tasks table
-func (mdb *db) SelectFromTransferTasks(filter *sqlplugin.TransferTasksFilter) ([]sqlplugin.TransferTasksRow, error) {
+func (mdb *db) SelectFromTransferTasks(filter sqlplugin.TransferTasksFilter) ([]sqlplugin.TransferTasksRow, error) {
 	var rows []sqlplugin.TransferTasksRow
-	if filter.TaskID != nil {
-		if filter.MinTaskID != nil || filter.MaxTaskID != nil {
-			return nil, serviceerror.NewInternal("MySQL SelectFromTransferTasks operation failed, invalid input")
-		}
-		err := mdb.conn.Select(&rows, getTransferTaskQuery, filter.ShardID, *filter.TaskID)
-		if err != nil {
-			return nil, err
-		}
-		return rows, err
+	err := mdb.conn.Select(&rows, getTransferTaskQuery, filter.ShardID, filter.TaskID)
+	if err != nil {
+		return nil, err
 	}
+	return rows, err
+}
 
-	if filter.MinTaskID == nil || filter.MaxTaskID == nil {
-		return nil, serviceerror.NewInternal("MySQL SelectFromTransferTasks operation failed, invalid input")
-	}
-	err := mdb.conn.Select(&rows, getTransferTasksQuery, filter.ShardID, *filter.MinTaskID, *filter.MaxTaskID)
+// RangeSelectFromTransferTasks reads one or more rows from transfer_tasks table
+func (mdb *db) RangeSelectFromTransferTasks(filter sqlplugin.TransferTasksRangeFilter) ([]sqlplugin.TransferTasksRow, error) {
+	var rows []sqlplugin.TransferTasksRow
+	err := mdb.conn.Select(&rows, getTransferTasksQuery, filter.ShardID, filter.MinTaskID, filter.MaxTaskID)
 	if err != nil {
 		return nil, err
 	}
@@ -269,18 +263,13 @@ func (mdb *db) SelectFromTransferTasks(filter *sqlplugin.TransferTasksFilter) ([
 }
 
 // DeleteFromTransferTasks deletes one or more rows from transfer_tasks table
-func (mdb *db) DeleteFromTransferTasks(filter *sqlplugin.TransferTasksFilter) (sql.Result, error) {
-	if filter.TaskID != nil {
-		if filter.MinTaskID != nil || filter.MaxTaskID != nil {
-			return nil, serviceerror.NewInternal("MySQL DeleteFromTransferTasks operation failed, invalid input")
-		}
-		return mdb.conn.Exec(deleteTransferTaskQuery, filter.ShardID, *filter.TaskID)
-	}
+func (mdb *db) DeleteFromTransferTasks(filter sqlplugin.TransferTasksFilter) (sql.Result, error) {
+	return mdb.conn.Exec(deleteTransferTaskQuery, filter.ShardID, filter.TaskID)
+}
 
-	if filter.MinTaskID == nil || filter.MaxTaskID == nil {
-		return nil, serviceerror.NewInternal("MySQL DeleteFromTransferTasks operation failed, invalid input")
-	}
-	return mdb.conn.Exec(rangeDeleteTransferTaskQuery, filter.ShardID, *filter.MinTaskID, *filter.MaxTaskID)
+// RangeDeleteFromTransferTasks deletes one or more rows from transfer_tasks table
+func (mdb *db) RangeDeleteFromTransferTasks(filter sqlplugin.TransferTasksRangeFilter) (sql.Result, error) {
+	return mdb.conn.Exec(rangeDeleteTransferTaskQuery, filter.ShardID, filter.MinTaskID, filter.MaxTaskID)
 }
 
 // InsertIntoTimerTasks inserts one or more rows into timer_tasks table
@@ -292,34 +281,26 @@ func (mdb *db) InsertIntoTimerTasks(rows []sqlplugin.TimerTasksRow) (sql.Result,
 }
 
 // SelectFromTimerTasks reads one or more rows from timer_tasks table
-func (mdb *db) SelectFromTimerTasks(filter *sqlplugin.TimerTasksFilter) ([]sqlplugin.TimerTasksRow, error) {
+func (mdb *db) SelectFromTimerTasks(filter sqlplugin.TimerTasksFilter) ([]sqlplugin.TimerTasksRow, error) {
 	var rows []sqlplugin.TimerTasksRow
+	filter.VisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.VisibilityTimestamp)
+	err := mdb.conn.Select(&rows, getTimerTaskQuery, filter.ShardID, filter.VisibilityTimestamp, filter.TaskID)
+	if err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i].VisibilityTimestamp = mdb.converter.FromMySQLDateTime(rows[i].VisibilityTimestamp)
+	}
+	return rows, err
+}
 
-	if filter.VisibilityTimestamp != nil && filter.TaskID != nil {
-		if filter.PageSize != nil || filter.MinVisibilityTimestamp != nil || filter.MaxVisibilityTimestamp != nil {
-			return nil, serviceerror.NewInternal("MySQL SelectFromTimerTasks operation failed, invalid input")
-		}
-		err := mdb.conn.Select(&rows, getTimerTaskQuery, filter.ShardID, *filter.VisibilityTimestamp, *filter.TaskID)
-		if err != nil {
-			return nil, err
-		}
-		for i := range rows {
-			rows[i].VisibilityTimestamp = mdb.converter.FromMySQLDateTime(rows[i].VisibilityTimestamp)
-		}
-		return rows, err
-	}
-
-	if filter.PageSize == nil || filter.MinVisibilityTimestamp == nil || filter.MaxVisibilityTimestamp == nil {
-		return nil, serviceerror.NewInternal("MySQL SelectFromTimerTasks operation failed, invalid input")
-	}
-	taskID := int64(0)
-	if filter.TaskID != nil {
-		taskID = *filter.TaskID
-	}
-	*filter.MinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(*filter.MinVisibilityTimestamp)
-	*filter.MaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(*filter.MaxVisibilityTimestamp)
-	err := mdb.conn.Select(&rows, getTimerTasksQuery, filter.ShardID, *filter.MinVisibilityTimestamp,
-		taskID, *filter.MinVisibilityTimestamp, *filter.MaxVisibilityTimestamp, *filter.PageSize)
+// RangeSelectFromTimerTasks reads one or more rows from timer_tasks table
+func (mdb *db) RangeSelectFromTimerTasks(filter sqlplugin.TimerTasksRangeFilter) ([]sqlplugin.TimerTasksRow, error) {
+	var rows []sqlplugin.TimerTasksRow
+	filter.MinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.MinVisibilityTimestamp)
+	filter.MaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.MaxVisibilityTimestamp)
+	err := mdb.conn.Select(&rows, getTimerTasksQuery, filter.ShardID, filter.MinVisibilityTimestamp,
+		filter.TaskID, filter.MinVisibilityTimestamp, filter.MaxVisibilityTimestamp, filter.PageSize)
 	if err != nil {
 		return nil, err
 	}
@@ -330,21 +311,16 @@ func (mdb *db) SelectFromTimerTasks(filter *sqlplugin.TimerTasksFilter) ([]sqlpl
 }
 
 // DeleteFromTimerTasks deletes one or more rows from timer_tasks table
-func (mdb *db) DeleteFromTimerTasks(filter *sqlplugin.TimerTasksFilter) (sql.Result, error) {
-	if filter.VisibilityTimestamp != nil && filter.TaskID != nil {
-		if filter.PageSize != nil || filter.MinVisibilityTimestamp != nil || filter.MaxVisibilityTimestamp != nil {
-			return nil, serviceerror.NewInternal("MySQL DeleteFromTimerTasks operation failed, invalid input")
-		}
-		*filter.VisibilityTimestamp = mdb.converter.ToMySQLDateTime(*filter.VisibilityTimestamp)
-		return mdb.conn.Exec(deleteTimerTaskQuery, filter.ShardID, *filter.VisibilityTimestamp, *filter.TaskID)
-	}
+func (mdb *db) DeleteFromTimerTasks(filter sqlplugin.TimerTasksFilter) (sql.Result, error) {
+	filter.VisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.VisibilityTimestamp)
+	return mdb.conn.Exec(deleteTimerTaskQuery, filter.ShardID, filter.VisibilityTimestamp, filter.TaskID)
+}
 
-	if filter.PageSize != nil || filter.MinVisibilityTimestamp == nil || filter.MaxVisibilityTimestamp == nil {
-		return nil, serviceerror.NewInternal("MySQL DeleteFromTimerTasks operation failed, invalid input")
-	}
-	*filter.MinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(*filter.MinVisibilityTimestamp)
-	*filter.MaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(*filter.MaxVisibilityTimestamp)
-	return mdb.conn.Exec(rangeDeleteTimerTaskQuery, filter.ShardID, *filter.MinVisibilityTimestamp, *filter.MaxVisibilityTimestamp)
+// RangeDeleteFromTimerTasks deletes one or more rows from timer_tasks table
+func (mdb *db) RangeDeleteFromTimerTasks(filter sqlplugin.TimerTasksRangeFilter) (sql.Result, error) {
+	filter.MinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.MinVisibilityTimestamp)
+	filter.MaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.MaxVisibilityTimestamp)
+	return mdb.conn.Exec(rangeDeleteTimerTaskQuery, filter.ShardID, filter.MinVisibilityTimestamp, filter.MaxVisibilityTimestamp)
 }
 
 // InsertIntoBufferedEvents inserts one or more rows into buffered_events table

--- a/common/persistence/sql/sqlplugin/tests/history_timer_task_test.go
+++ b/common/persistence/sql/sqlplugin/tests/history_timer_task_test.go
@@ -30,7 +30,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/shuffle"
 )
@@ -159,13 +158,10 @@ func (s *historyHistoryTimerTaskSuite) TestInsertSelect_Single() {
 	s.NoError(err)
 	s.Equal(1, int(rowsAffected))
 
-	filter := &sqlplugin.TimerTasksFilter{
-		ShardID:                shardID,
-		VisibilityTimestamp:    &timestamp,
-		TaskID:                 convert.Int64Ptr(taskID),
-		MinVisibilityTimestamp: nil,
-		MaxVisibilityTimestamp: nil,
-		PageSize:               nil,
+	filter := sqlplugin.TimerTasksFilter{
+		ShardID:             shardID,
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
 	}
 	rows, err := s.store.SelectFromTimerTasks(filter)
 	s.NoError(err)
@@ -197,15 +193,13 @@ func (s *historyHistoryTimerTaskSuite) TestInsertSelect_Multiple() {
 	s.NoError(err)
 	s.Equal(numTasks, int(rowsAffected))
 
-	filter := &sqlplugin.TimerTasksFilter{
+	filter := sqlplugin.TimerTasksRangeFilter{
 		ShardID:                shardID,
-		VisibilityTimestamp:    nil,
-		TaskID:                 nil,
-		MinVisibilityTimestamp: &minTimestamp,
-		MaxVisibilityTimestamp: &maxTimestamp,
-		PageSize:               convert.IntPtr(numTasks),
+		MinVisibilityTimestamp: minTimestamp,
+		MaxVisibilityTimestamp: maxTimestamp,
+		PageSize:               numTasks,
 	}
-	rows, err := s.store.SelectFromTimerTasks(filter)
+	rows, err := s.store.RangeSelectFromTimerTasks(filter)
 	s.NoError(err)
 	for index := range rows {
 		rows[index].ShardID = shardID
@@ -218,13 +212,10 @@ func (s *historyHistoryTimerTaskSuite) TestDeleteSelect_Single() {
 	timestamp := s.now()
 	taskID := int64(1)
 
-	filter := &sqlplugin.TimerTasksFilter{
-		ShardID:                shardID,
-		VisibilityTimestamp:    &timestamp,
-		TaskID:                 convert.Int64Ptr(taskID),
-		MinVisibilityTimestamp: nil,
-		MaxVisibilityTimestamp: nil,
-		PageSize:               nil,
+	filter := sqlplugin.TimerTasksFilter{
+		ShardID:             shardID,
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
 	}
 	result, err := s.store.DeleteFromTimerTasks(filter)
 	s.NoError(err)
@@ -247,22 +238,20 @@ func (s *historyHistoryTimerTaskSuite) TestDeleteSelect_Multiple() {
 	minTimestamp := s.now()
 	maxTimestamp := minTimestamp.Add(time.Minute)
 
-	filter := &sqlplugin.TimerTasksFilter{
+	filter := sqlplugin.TimerTasksRangeFilter{
 		ShardID:                shardID,
-		VisibilityTimestamp:    nil,
-		TaskID:                 nil,
-		MinVisibilityTimestamp: &minTimestamp,
-		MaxVisibilityTimestamp: &maxTimestamp,
-		PageSize:               nil,
+		MinVisibilityTimestamp: minTimestamp,
+		MaxVisibilityTimestamp: maxTimestamp,
+		PageSize:               0,
 	}
-	result, err := s.store.DeleteFromTimerTasks(filter)
+	result, err := s.store.RangeDeleteFromTimerTasks(filter)
 	s.NoError(err)
 	rowsAffected, err := result.RowsAffected()
 	s.NoError(err)
 	s.Equal(0, int(rowsAffected))
 
-	filter.PageSize = convert.IntPtr(pageSize)
-	rows, err := s.store.SelectFromTimerTasks(filter)
+	filter.PageSize = pageSize
+	rows, err := s.store.RangeSelectFromTimerTasks(filter)
 	s.NoError(err)
 	for index := range rows {
 		rows[index].ShardID = shardID
@@ -282,13 +271,10 @@ func (s *historyHistoryTimerTaskSuite) TestInsertDeleteSelect_Single() {
 	s.NoError(err)
 	s.Equal(1, int(rowsAffected))
 
-	filter := &sqlplugin.TimerTasksFilter{
-		ShardID:                shardID,
-		VisibilityTimestamp:    &timestamp,
-		TaskID:                 convert.Int64Ptr(taskID),
-		MinVisibilityTimestamp: nil,
-		MaxVisibilityTimestamp: nil,
-		PageSize:               nil,
+	filter := sqlplugin.TimerTasksFilter{
+		ShardID:             shardID,
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
 	}
 	result, err = s.store.DeleteFromTimerTasks(filter)
 	s.NoError(err)
@@ -327,22 +313,20 @@ func (s *historyHistoryTimerTaskSuite) TestInsertDeleteSelect_Multiple() {
 	s.NoError(err)
 	s.Equal(numTasks, int(rowsAffected))
 
-	filter := &sqlplugin.TimerTasksFilter{
+	filter := sqlplugin.TimerTasksRangeFilter{
 		ShardID:                shardID,
-		VisibilityTimestamp:    nil,
-		TaskID:                 nil,
-		MinVisibilityTimestamp: &minTimestamp,
-		MaxVisibilityTimestamp: &maxTimestamp,
-		PageSize:               nil,
+		MinVisibilityTimestamp: minTimestamp,
+		MaxVisibilityTimestamp: maxTimestamp,
+		PageSize:               0,
 	}
-	result, err = s.store.DeleteFromTimerTasks(filter)
+	result, err = s.store.RangeDeleteFromTimerTasks(filter)
 	s.NoError(err)
 	rowsAffected, err = result.RowsAffected()
 	s.NoError(err)
 	s.Equal(numTasks, int(rowsAffected))
 
-	filter.PageSize = convert.IntPtr(pageSize)
-	rows, err := s.store.SelectFromTimerTasks(filter)
+	filter.PageSize = pageSize
+	rows, err := s.store.RangeSelectFromTimerTasks(filter)
 	s.NoError(err)
 	for index := range rows {
 		rows[index].ShardID = shardID

--- a/common/persistence/sql/sqlplugin/tests/history_transfer_task_test.go
+++ b/common/persistence/sql/sqlplugin/tests/history_transfer_task_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/shuffle"
 )
@@ -150,11 +149,9 @@ func (s *historyHistoryTransferTaskSuite) TestInsertSelect_Single() {
 	s.NoError(err)
 	s.Equal(1, int(rowsAffected))
 
-	filter := &sqlplugin.TransferTasksFilter{
-		ShardID:   shardID,
-		TaskID:    convert.Int64Ptr(taskID),
-		MinTaskID: nil,
-		MaxTaskID: nil,
+	filter := sqlplugin.TransferTasksFilter{
+		ShardID: shardID,
+		TaskID:  taskID,
 	}
 	rows, err := s.store.SelectFromTransferTasks(filter)
 	s.NoError(err)
@@ -184,13 +181,12 @@ func (s *historyHistoryTransferTaskSuite) TestInsertSelect_Multiple() {
 	s.NoError(err)
 	s.Equal(numTasks, int(rowsAffected))
 
-	filter := &sqlplugin.TransferTasksFilter{
+	filter := sqlplugin.TransferTasksRangeFilter{
 		ShardID:   shardID,
-		TaskID:    nil,
-		MinTaskID: convert.Int64Ptr(minTaskID),
-		MaxTaskID: convert.Int64Ptr(maxTaskID),
+		MinTaskID: minTaskID,
+		MaxTaskID: maxTaskID,
 	}
-	rows, err := s.store.SelectFromTransferTasks(filter)
+	rows, err := s.store.RangeSelectFromTransferTasks(filter)
 	s.NoError(err)
 	for index := range rows {
 		rows[index].ShardID = shardID
@@ -202,11 +198,9 @@ func (s *historyHistoryTransferTaskSuite) TestDeleteSelect_Single() {
 	shardID := rand.Int31()
 	taskID := int64(1)
 
-	filter := &sqlplugin.TransferTasksFilter{
-		ShardID:   shardID,
-		TaskID:    convert.Int64Ptr(taskID),
-		MinTaskID: nil,
-		MaxTaskID: nil,
+	filter := sqlplugin.TransferTasksFilter{
+		ShardID: shardID,
+		TaskID:  taskID,
 	}
 	result, err := s.store.DeleteFromTransferTasks(filter)
 	s.NoError(err)
@@ -227,19 +221,18 @@ func (s *historyHistoryTransferTaskSuite) TestDeleteSelect_Multiple() {
 	minTaskID := int64(1)
 	maxTaskID := int64(100)
 
-	filter := &sqlplugin.TransferTasksFilter{
+	filter := sqlplugin.TransferTasksRangeFilter{
 		ShardID:   shardID,
-		TaskID:    nil,
-		MinTaskID: convert.Int64Ptr(minTaskID),
-		MaxTaskID: convert.Int64Ptr(maxTaskID),
+		MinTaskID: minTaskID,
+		MaxTaskID: maxTaskID,
 	}
-	result, err := s.store.DeleteFromTransferTasks(filter)
+	result, err := s.store.RangeDeleteFromTransferTasks(filter)
 	s.NoError(err)
 	rowsAffected, err := result.RowsAffected()
 	s.NoError(err)
 	s.Equal(0, int(rowsAffected))
 
-	rows, err := s.store.SelectFromTransferTasks(filter)
+	rows, err := s.store.RangeSelectFromTransferTasks(filter)
 	s.NoError(err)
 	for index := range rows {
 		rows[index].ShardID = shardID
@@ -258,11 +251,9 @@ func (s *historyHistoryTransferTaskSuite) TestInsertDeleteSelect_Single() {
 	s.NoError(err)
 	s.Equal(1, int(rowsAffected))
 
-	filter := &sqlplugin.TransferTasksFilter{
-		ShardID:   shardID,
-		TaskID:    convert.Int64Ptr(taskID),
-		MinTaskID: nil,
-		MaxTaskID: nil,
+	filter := sqlplugin.TransferTasksFilter{
+		ShardID: shardID,
+		TaskID:  taskID,
 	}
 	result, err = s.store.DeleteFromTransferTasks(filter)
 	s.NoError(err)
@@ -298,19 +289,18 @@ func (s *historyHistoryTransferTaskSuite) TestInsertDeleteSelect_Multiple() {
 	s.NoError(err)
 	s.Equal(numTasks, int(rowsAffected))
 
-	filter := &sqlplugin.TransferTasksFilter{
+	filter := sqlplugin.TransferTasksRangeFilter{
 		ShardID:   shardID,
-		TaskID:    nil,
-		MinTaskID: convert.Int64Ptr(minTaskID),
-		MaxTaskID: convert.Int64Ptr(maxTaskID),
+		MinTaskID: minTaskID,
+		MaxTaskID: maxTaskID,
 	}
-	result, err = s.store.DeleteFromTransferTasks(filter)
+	result, err = s.store.RangeDeleteFromTransferTasks(filter)
 	s.NoError(err)
 	rowsAffected, err = result.RowsAffected()
 	s.NoError(err)
 	s.Equal(numTasks, int(rowsAffected))
 
-	rows, err := s.store.SelectFromTransferTasks(filter)
+	rows, err := s.store.RangeSelectFromTransferTasks(filter)
 	s.NoError(err)
 	for index := range rows {
 		rows[index].ShardID = shardID


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Split overloaded transfer / timer task APIs
* Split TransferTasksFilter into TransferTasksFilter and TransferTasksRangeFilter
* Split SelectFromTransferTasks into SelectFromTransferTasks and RangeSelectFromTransferTasks
* Split DeleteFromTransferTasks into DeleteFromTransferTasks and RangeDeleteFromTransferTasks
* Split TimerTasksFilter into TimerTasksFilter and TimerTasksRangeFilter
* Split SelectFromTimerTasks into SelectFromTimerTasks and RangeSelectFromTimerTasks
* Split DeleteFromTimerTasks into DeleteFromTimerTasks and RangeDeleteFromTimerTasks

<!-- Tell your future self why have you made these changes -->
**Why?**
This PR provides better test coverage and code management.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minor business logic code change.