### PR TITLE
Adds nil parameter to ScanCAS call()

### DIFF
--- a/common/persistence/cassandra/cassandraQueue.go
+++ b/common/persistence/cassandra/cassandraQueue.go
@@ -408,7 +408,7 @@ func (q *cassandraQueue) updateQueueMetadata(
 		queueType,
 		metadata.version-1,
 	)
-	applied, err := query.ScanCAS()
+	applied, err := query.ScanCAS(nil)
 	if err != nil {
 		return serviceerror.NewInternal(fmt.Sprintf("UpdateAckLevel operation failed. Error %v", err))
 	}


### PR DESCRIPTION
When running against certain Cassandra-compatible implementations (such as ScyllaDB), the ScanCAS call needs to take in as many arguments as there are parameters that are expected to be returned. We had an incorrect number of parameters for another one of our cassandra queue methods. We fix this so that Temporal can work properly.

Tested against a real-life ScyllaDB cluster. Also unit-tests/integration-tests will fail if this breaks anything. This is a low-risk change.


