### PR TITLE
Fix casing of TLS CA settings in config template

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -96,22 +96,22 @@ global:
                 certFile: {{ default .Env.TEMPORAL_TLS_SERVER_CERT "" }}
                 keyFile: {{ default .Env.TEMPORAL_TLS_SERVER_KEY "" }}
                 requireClientAuth: {{ default .Env.TEMPORAL_TLS_REQUIRE_CLIENT_AUTH "false" }}
-                clientCAFiles:
+                clientCaFiles:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}
             client:
-                rootCAFiles:
+                rootCaFiles:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}
         frontend:
             server:
                 certFile: {{ default .Env.TEMPORAL_TLS_FRONTEND_CERT "" }}
                 keyFile: {{ default .Env.TEMPORAL_TLS_FRONTEND_KEY "" }}
                 requireClientAuth: {{ default .Env.TEMPORAL_TLS_REQUIRE_CLIENT_AUTH "false" }}
-                clientCAFiles:
+                clientCaFiles:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}
                     - {{ default .Env.TEMPORAL_TLS_CLIENT1_CA_CERT "" }}
                     - {{ default .Env.TEMPORAL_TLS_CLIENT2_CA_CERT "" }}
             client:
-                rootCAFiles:
+                rootCaFiles:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}
 
 services:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -107,7 +107,6 @@ global:
                 keyFile: {{ default .Env.TEMPORAL_TLS_FRONTEND_KEY "" }}
                 requireClientAuth: {{ default .Env.TEMPORAL_TLS_REQUIRE_CLIENT_AUTH "false" }}
                 clientCaFiles:
-                    - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}
                     - {{ default .Env.TEMPORAL_TLS_CLIENT1_CA_CERT "" }}
                     - {{ default .Env.TEMPORAL_TLS_CLIENT2_CA_CERT "" }}
             client:


### PR DESCRIPTION
**What changed?**
Fixed casing of TLS CA settings from "CA" as in go code to "Ca" as in the YAML schema.
Also remove server CA from the list of frontend's client CAs because that's extraneous.

**Why?**
The config settings weren't being loaded from config file produced with the config template.

**How did you test it?**
Manually tested that settings get loaded with the right casing.

**Potential risks**
No risk as those settings weren't being loaded before this fix.
