### PR TITLE
Use timestamp instead of convert for time.Time pointer conversion

### DIFF
--- a/common/convert/convert.go
+++ b/common/convert/convert.go
@@ -27,7 +27,6 @@ package convert
 import (
 	"math"
 	"strconv"
-	"time"
 )
 
 // IntPtr makes a copy and returns the pointer to an int.
@@ -57,16 +56,6 @@ func BoolPtr(v bool) *bool {
 
 // StringPtr makes a copy and returns the pointer to a string.
 func StringPtr(v string) *string {
-	return &v
-}
-
-// TimePtr makes a copy and returns the pointer to a time.Time.
-func TimePtr(v time.Time) *time.Time {
-	return &v
-}
-
-// DurationPtr makes a copy and returns the pointer to a time.Duration.
-func DurationPtr(v time.Duration) *time.Duration {
 	return &v
 }
 

--- a/common/persistence/sql/sqlplugin/tests/visibility_test.go
+++ b/common/persistence/sql/sqlplugin/tests/visibility_test.go
@@ -35,6 +35,7 @@ import (
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/shuffle"
 )
 
@@ -212,7 +213,7 @@ func (s *visibilitySuite) TestReplaceSelect_NonExists() {
 		startTime,
 		executionTime,
 		status,
-		convert.TimePtr(closeTime),
+		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
 	)
 	result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -252,7 +253,7 @@ func (s *visibilitySuite) TestReplaceSelect_Exists() {
 		startTime,
 		executionTime,
 		status,
-		convert.TimePtr(closeTime),
+		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
 	)
 	result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -269,7 +270,7 @@ func (s *visibilitySuite) TestReplaceSelect_Exists() {
 		startTime,
 		executionTime,
 		status,
-		convert.TimePtr(closeTime),
+		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
 	)
 	_, err = s.store.ReplaceIntoVisibility(&visibility)
@@ -377,7 +378,7 @@ func (s *visibilitySuite) TestReplaceDeleteSelect() {
 		startTime,
 		executionTime,
 		status,
-		convert.TimePtr(closeTime),
+		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
 	)
 	result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -441,8 +442,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 		WorkflowID:       convert.StringPtr(workflowID),
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -502,8 +503,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 		WorkflowID:       convert.StringPtr(workflowID),
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -515,7 +516,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 
 		if len(rowsPerPage) > 0 {
 			lastVisibility := rowsPerPage[len(rowsPerPage)-1]
-			selectFilter.MaxTime = convert.TimePtr(lastVisibility.StartTime)
+			selectFilter.MaxTime = timestamp.TimePtr(lastVisibility.StartTime)
 			selectFilter.RunID = convert.StringPtr(lastVisibility.RunID)
 		} else {
 			break
@@ -549,7 +550,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 		startTime,
 		executionTime,
 		status,
-		convert.TimePtr(closeTime),
+		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
 	)
 	result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -565,8 +566,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 		WorkflowID:       convert.StringPtr(workflowID),
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -606,7 +607,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 				startTime,
 				executionTime,
 				status,
-				convert.TimePtr(closeTime),
+				timestamp.TimePtr(closeTime),
 				convert.Int64Ptr(historyLength),
 			)
 			result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -625,8 +626,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 		WorkflowID:       convert.StringPtr(workflowID),
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -689,8 +690,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: convert.StringPtr(workflowTypeName),
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -750,8 +751,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: convert.StringPtr(workflowTypeName),
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -763,7 +764,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 
 		if len(rowsPerPage) > 0 {
 			lastVisibility := rowsPerPage[len(rowsPerPage)-1]
-			selectFilter.MaxTime = convert.TimePtr(lastVisibility.StartTime)
+			selectFilter.MaxTime = timestamp.TimePtr(lastVisibility.StartTime)
 			selectFilter.RunID = convert.StringPtr(lastVisibility.RunID)
 		} else {
 			break
@@ -797,7 +798,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 		startTime,
 		executionTime,
 		status,
-		convert.TimePtr(closeTime),
+		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
 	)
 	result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -813,8 +814,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: convert.StringPtr(workflowTypeName),
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -854,7 +855,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 				startTime,
 				executionTime,
 				status,
-				convert.TimePtr(closeTime),
+				timestamp.TimePtr(closeTime),
 				convert.Int64Ptr(historyLength),
 			)
 			result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -873,8 +874,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: convert.StringPtr(workflowTypeName),
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -937,8 +938,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusOpen_Single
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -998,8 +999,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusOpen_Multip
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -1011,7 +1012,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusOpen_Multip
 
 		if len(rowsPerPage) > 0 {
 			lastVisibility := rowsPerPage[len(rowsPerPage)-1]
-			selectFilter.MaxTime = convert.TimePtr(lastVisibility.StartTime)
+			selectFilter.MaxTime = timestamp.TimePtr(lastVisibility.StartTime)
 			selectFilter.RunID = convert.StringPtr(lastVisibility.RunID)
 		} else {
 			break
@@ -1052,7 +1053,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseSingle(
 		startTime,
 		executionTime,
 		int32(status),
-		convert.TimePtr(closeTime),
+		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
 	)
 	result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -1068,8 +1069,8 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseSingle(
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -1110,7 +1111,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusClose_Multi
 				startTime,
 				executionTime,
 				status,
-				convert.TimePtr(closeTime),
+				timestamp.TimePtr(closeTime),
 				convert.Int64Ptr(historyLength),
 			)
 			result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -1129,8 +1130,8 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusClose_Multi
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -1184,7 +1185,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeSin
 		startTime,
 		executionTime,
 		int32(status),
-		convert.TimePtr(closeTime),
+		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
 	)
 	result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -1200,8 +1201,8 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeSin
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: convert.StringPtr(workflowTypeName),
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(status),
 		PageSize:         convert.IntPtr(pageSize),
 	}
@@ -1248,7 +1249,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeMul
 				startTime,
 				executionTime,
 				int32(status),
-				convert.TimePtr(closeTime),
+				timestamp.TimePtr(closeTime),
 				convert.Int64Ptr(historyLength),
 			)
 			result, err := s.store.ReplaceIntoVisibility(&visibility)
@@ -1267,8 +1268,8 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeMul
 		WorkflowID:       nil,
 		RunID:            convert.StringPtr(""),
 		WorkflowTypeName: nil,
-		MinTime:          convert.TimePtr(minStartTime),
-		MaxTime:          convert.TimePtr(maxStartTime),
+		MinTime:          timestamp.TimePtr(minStartTime),
+		MaxTime:          timestamp.TimePtr(maxStartTime),
 		Status:           int32(status),
 		PageSize:         convert.IntPtr(pageSize),
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Use timestamp instead of convert package for time.Time pointer conversion

<!-- Tell your future self why have you made these changes -->
**Why?**
Remove duplicated functionality

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Make bins

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
