### PR TITLE
Add a server option for setting authorizer

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/urfave/cli"
 
+	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/headers"
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"      // needed to load mysql plugin
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql" // needed to load postgresql plugin
@@ -100,6 +101,7 @@ func buildCLI() *cli.App {
 					temporal.ForServices(services),
 					temporal.WithConfigLoader(configDir, env, zone),
 					temporal.InterruptOn(temporal.InterruptCh()),
+					temporal.WithAuthorizer(authorization.NewNopAuthorizer()),
 				)
 
 				err := s.Start()

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -316,7 +316,12 @@ func (s *Server) getServiceParams(
 
 	params.ArchiverProvider = provider.NewArchiverProvider(s.so.config.Archival.History.Provider, s.so.config.Archival.Visibility.Provider)
 	params.PersistenceConfig.TransactionSizeLimit = dc.GetIntProperty(dynamicconfig.TransactionSizeLimit, common.DefaultTransactionSizeLimit)
-	params.Authorizer = authorization.NewNopAuthorizer()
+
+	if s.so.params.Authorizer != nil {
+		params.Authorizer = s.so.params.Authorizer
+	} else {
+		params.Authorizer = authorization.NewNopAuthorizer()
+	}
 
 	return &params, nil
 }

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -317,8 +317,8 @@ func (s *Server) getServiceParams(
 	params.ArchiverProvider = provider.NewArchiverProvider(s.so.config.Archival.History.Provider, s.so.config.Archival.Visibility.Provider)
 	params.PersistenceConfig.TransactionSizeLimit = dc.GetIntProperty(dynamicconfig.TransactionSizeLimit, common.DefaultTransactionSizeLimit)
 
-	if s.so.params.Authorizer != nil {
-		params.Authorizer = s.so.params.Authorizer
+	if s.so.authorizer != nil {
+		params.Authorizer = s.so.authorizer
 	} else {
 		params.Authorizer = authorization.NewNopAuthorizer()
 	}

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -64,6 +64,6 @@ func InterruptOn(interruptCh <-chan interface{}) ServerOption {
 // Sets low level authorizer to allow/deny all API calls
 func WithAuthorizer(authorizer authorization.Authorizer) ServerOption {
 	return newApplyFuncContainer(func(s *serverOptions) {
-		s.params.Authorizer = authorizer
+		s.authorizer = authorizer
 	})
 }

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -25,6 +25,7 @@
 package temporal
 
 import (
+	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/service/config"
 )
 
@@ -57,5 +58,12 @@ func InterruptOn(interruptCh <-chan interface{}) ServerOption {
 	return newApplyFuncContainer(func(s *serverOptions) {
 		s.blockingStart = true
 		s.interruptCh = interruptCh
+	})
+}
+
+// Sets low level authorizer to allow/deny all API calls
+func WithAuthorizer(authorizer authorization.Authorizer) ServerOption {
+	return newApplyFuncContainer(func(s *serverOptions) {
+		s.params.Authorizer = authorizer
 	})
 }

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -27,17 +27,17 @@ package temporal
 import (
 	"fmt"
 
-	"go.temporal.io/server/common/resource"
+	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/service/config"
 )
 
 type (
 	serverOptions struct {
-		config    *config.Config
-		params    *resource.BootstrapParams
-		configDir string
-		env       string
-		zone      string
+		config     *config.Config
+		authorizer authorization.Authorizer
+		configDir  string
+		env        string
+		zone       string
 
 		serviceNames []string
 
@@ -49,7 +49,6 @@ type (
 func newServerOptions(opts []ServerOption) *serverOptions {
 	so := &serverOptions{
 		// Set defaults here.
-		params: &resource.BootstrapParams{},
 	}
 	for _, opt := range opts {
 		opt.apply(so)

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -27,12 +27,14 @@ package temporal
 import (
 	"fmt"
 
+	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/service/config"
 )
 
 type (
 	serverOptions struct {
 		config    *config.Config
+		params    *resource.BootstrapParams
 		configDir string
 		env       string
 		zone      string
@@ -47,6 +49,7 @@ type (
 func newServerOptions(opts []ServerOption) *serverOptions {
 	so := &serverOptions{
 		// Set defaults here.
+		params: &resource.BootstrapParams{},
 	}
 	for _, opt := range opts {
 		opt.apply(so)


### PR DESCRIPTION
**What changed?**
Added a server option for setting a low level API call authorizer.

**Why?**
In the absence of a more comprehensive AuthZ story, customers need to be able to authorize API calls at the low level as a stop gap solution.

**How did you test it?**
Manually verified that a custom authorizer gets set via the option.

**Potential risks**
I see no risk as this is an optional feature, and the `nopAuthority` is set today by default.
