### PR TITLE
Add server option for overriding default TLS config provider

### DIFF
--- a/common/resource/bootstrapParams.go
+++ b/common/resource/bootstrapParams.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/messaging"
 	"go.temporal.io/server/common/metrics"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
+	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/service/config"
 	"go.temporal.io/server/common/service/dynamicconfig"
 )
@@ -69,6 +70,7 @@ type (
 		ArchivalMetadata             archiver.ArchivalMetadata
 		ArchiverProvider             provider.ArchiverProvider
 		Authorizer                   authorization.Authorizer
+		TLSConfigProvider            encryption.TLSConfigProvider
 	}
 
 	// MembershipMonitorFactory provides a bootstrapped membership monitor

--- a/common/resource/bootstrapParams.go
+++ b/common/resource/bootstrapParams.go
@@ -39,7 +39,6 @@ import (
 	"go.temporal.io/server/common/messaging"
 	"go.temporal.io/server/common/metrics"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
-	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/service/config"
 	"go.temporal.io/server/common/service/dynamicconfig"
 )
@@ -70,7 +69,6 @@ type (
 		ArchivalMetadata             archiver.ArchivalMetadata
 		ArchiverProvider             provider.ArchiverProvider
 		Authorizer                   authorization.Authorizer
-		TLSConfigProvider            encryption.TLSConfigProvider
 	}
 
 	// MembershipMonitorFactory provides a bootstrapped membership monitor

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -113,8 +113,8 @@ func (s *Server) Start() error {
 	}
 
 	var tlsFactory encryption.TLSConfigProvider
-	if s.so.params.TLSConfigProvider != nil {
-		tlsFactory = s.so.params.TLSConfigProvider
+	if s.so.tlsConfigProvider != nil {
+		tlsFactory = s.so.tlsConfigProvider
 	} else {
 		tlsFactory, err = encryption.NewTLSConfigProviderFromConfig(s.so.config.Global.TLS)
 		if err != nil {

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -118,7 +118,7 @@ func (s *Server) Start() error {
 	} else {
 		tlsFactory, err = encryption.NewTLSConfigProviderFromConfig(s.so.config.Global.TLS)
 		if err != nil {
-			return fmt.Errorf("TLS provider initialization error : %w", err)
+			return fmt.Errorf("TLS provider initialization error: %w", err)
 		}
 	}
 

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -112,9 +112,14 @@ func (s *Server) Start() error {
 		return err
 	}
 
-	tlsFactory, err := encryption.NewTLSConfigProviderFromConfig(s.so.config.Global.TLS)
-	if err != nil {
-		return fmt.Errorf("TLS provider initialization error : %w", err)
+	var tlsFactory encryption.TLSConfigProvider
+	if s.so.params.TLSConfigProvider != nil {
+		tlsFactory = s.so.params.TLSConfigProvider
+	} else {
+		tlsFactory, err = encryption.NewTLSConfigProviderFromConfig(s.so.config.Global.TLS)
+		if err != nil {
+			return fmt.Errorf("TLS provider initialization error : %w", err)
+		}
 	}
 
 	dynamicConfig, err := dynamicconfig.NewFileBasedClient(&s.so.config.DynamicConfigClient, s.logger, s.stoppedCh)

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -26,6 +26,7 @@ package temporal
 
 import (
 	"go.temporal.io/server/common/authorization"
+	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/service/config"
 )
 
@@ -65,5 +66,12 @@ func InterruptOn(interruptCh <-chan interface{}) ServerOption {
 func WithAuthorizer(authorizer authorization.Authorizer) ServerOption {
 	return newApplyFuncContainer(func(s *serverOptions) {
 		s.authorizer = authorizer
+	})
+}
+
+// Overrides default provider of TLS configuration
+func WithTLSConfigFactory(tlsConfigProvider encryption.TLSConfigProvider) ServerOption {
+	return newApplyFuncContainer(func(s *serverOptions) {
+		s.params.TLSConfigProvider = tlsConfigProvider
 	})
 }

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -72,6 +72,6 @@ func WithAuthorizer(authorizer authorization.Authorizer) ServerOption {
 // Overrides default provider of TLS configuration
 func WithTLSConfigFactory(tlsConfigProvider encryption.TLSConfigProvider) ServerOption {
 	return newApplyFuncContainer(func(s *serverOptions) {
-		s.params.TLSConfigProvider = tlsConfigProvider
+		s.tlsConfigProvider = tlsConfigProvider
 	})
 }

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -28,16 +28,18 @@ import (
 	"fmt"
 
 	"go.temporal.io/server/common/authorization"
+	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/service/config"
 )
 
 type (
 	serverOptions struct {
-		config     *config.Config
-		authorizer authorization.Authorizer
-		configDir  string
-		env        string
-		zone       string
+		config            *config.Config
+		authorizer        authorization.Authorizer
+		tlsConfigProvider encryption.TLSConfigProvider
+		configDir         string
+		env               string
+		zone              string
 
 		serviceNames []string
 


### PR DESCRIPTION
**What changed?**
Added a server option for overriding default TLS config provider. Depends on #829.

**Why?**
In the absence of a more flexible configuration story, this allows customers to completely override TLS configuration at the low level if needed.

**How did you test it?**
Manually tested that the server option when set is used by the server code. 

**Potential risks**
I see no risk as this setting is optional and is not set by default.
