### PR TITLE
Enforce minimum TLS version of 1.2

### DIFF
--- a/common/auth/tlsConfigHelper.go
+++ b/common/auth/tlsConfigHelper.go
@@ -2,8 +2,6 @@
 //
 // Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
 //
-// Copyright (c) 2020 Uber Technologies, Inc.
-//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights

--- a/common/auth/tlsConfigHelper.go
+++ b/common/auth/tlsConfigHelper.go
@@ -1,0 +1,59 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package auth
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+)
+
+// Helper methods for creating tls.Config structs to ensure MinVersion is 1.3
+
+func NewEmptyTLSConfig() *tls.Config {
+	return &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+}
+
+func NewTLSConfigForServer(serverName string) *tls.Config {
+	c := NewEmptyTLSConfig()
+	c.ServerName = serverName
+	return c
+}
+
+func NewTLSConfigWithCertsAndCAs(certificates []tls.Certificate, rootCAs *x509.CertPool, serverName string) *tls.Config {
+	c := NewTLSConfigForServer(serverName)
+	c.Certificates = certificates
+	c.RootCAs = rootCAs
+	return c
+}
+
+func NewTLSConfigWithClientAuthAndCAs(clientAuth tls.ClientAuthType, certificates []tls.Certificate, clientCAs *x509.CertPool) *tls.Config {
+	c := NewEmptyTLSConfig()
+	c.ClientAuth = clientAuth
+	c.Certificates = certificates
+	c.ClientCAs = clientCAs
+	return c
+}

--- a/common/cassandra/cassandraCluster.go
+++ b/common/cassandra/cassandraCluster.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/gocql/gocql"
 
+	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/service/config"
 )
 
@@ -65,9 +66,7 @@ func NewCassandraCluster(cfg config.Cassandra) (*gocql.ClusterConfig, error) {
 			CaPath:                 cfg.TLS.CaFile,
 			EnableHostVerification: cfg.TLS.EnableHostVerification,
 
-			Config: &tls.Config{
-				ServerName: cfg.TLS.ServerName,
-			},
+			Config: auth.NewTLSConfigForServer(cfg.TLS.ServerName),
 		}
 
 		if cfg.TLS.CertData != "" {

--- a/common/messaging/kafkaClient.go
+++ b/common/messaging/kafkaClient.go
@@ -195,8 +195,5 @@ func CreateTLSConfig(tlsConfig auth.TLS) (*tls.Config, error) {
 	}
 	caCertPool.AppendCertsFromPEM(pemData)
 
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      caCertPool,
-	}, nil
+	return auth.NewTLSConfigWithCertsAndCAs([]tls.Certificate{cert}, caCertPool, ""), nil
 }

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -38,6 +38,7 @@ import (
 	"github.com/iancoleman/strcase"
 	"github.com/jmoiron/sqlx"
 
+	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/persistence/sql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/service/config"
@@ -128,9 +129,7 @@ func registerTLSConfig(cfg *config.SQL) error {
 	}
 
 	// TODO: create a way to set MinVersion and CipherSuites via cfg.
-	tlsConfig := &tls.Config{
-		ServerName: host,
-	}
+	tlsConfig := auth.NewTLSConfigForServer(host)
 
 	if cfg.TLS.CaFile != "" {
 		rootCertPool := x509.NewCertPool()

--- a/common/rpc/encryption/localStoreTlsFactory.go
+++ b/common/rpc/encryption/localStoreTlsFactory.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"sync"
 
+	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/service/config"
 )
 
@@ -137,11 +138,7 @@ func newServerTLSConfig(certProvider CertProvider, settingsProvider CertProvider
 		clientCaPool = ca
 	}
 
-	return &tls.Config{
-		ClientAuth:   clientAuthType,
-		Certificates: []tls.Certificate{*serverCert},
-		ClientCAs:    clientCaPool,
-	}, nil
+	return auth.NewTLSConfigWithClientAuthAndCAs(clientAuthType, []tls.Certificate{*serverCert}, clientCaPool), nil
 }
 
 func newClientTLSConfig(localProvider CertProvider, remoteProvider CertProvider) (*tls.Config, error) {
@@ -165,9 +162,9 @@ func newClientTLSConfig(localProvider CertProvider, remoteProvider CertProvider)
 		clientCerts = []tls.Certificate{*cert}
 	}
 
-	return &tls.Config{
-		Certificates: clientCerts,
-		RootCAs:      serverCa,
-		ServerName:   remoteProvider.GetSettings().Client.ServerName,
-	}, nil
+	return auth.NewTLSConfigWithCertsAndCAs(
+		clientCerts,
+		serverCa,
+		remoteProvider.GetSettings().Client.ServerName,
+	), nil
 }

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -39,6 +39,7 @@ import (
 	"google.golang.org/grpc/credentials"
 
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/log"
 )
 
@@ -135,9 +136,7 @@ func (b *clientFactory) createGRPCConnection(c *cli.Context) (*grpc.ClientConn, 
 	}
 	// If we are given arguments to verify either server or client, configure TLS
 	if caPool != nil || cert != nil {
-		tlsConfig := &tls.Config{
-			ServerName: host,
-		}
+		tlsConfig := auth.NewTLSConfigForServer(host)
 		if caPool != nil {
 			tlsConfig.RootCAs = caPool
 		}


### PR DESCRIPTION
**What changed?**
Set minimum version of the TLS protocol to 1.2.
Consolidated instantiation of `tls.Config` structs to a set of helper function for easier maintenance going forward

**Why?**
 To prevent connections over obsolete and insecure versions of the TLS protocol.

**How did you test it?**
Ran Unit tests.
Will rely on BuildKite tests for broader test coverage.

**Potential risks**
If some of our dependencies don't support TLS 1.2, communication might break. 
