### PR TITLE
Adding dual read/write for immutable metadata

### DIFF
--- a/common/persistence/cassandra/cassandraClusterMetadata.go
+++ b/common/persistence/cassandra/cassandraClusterMetadata.go
@@ -55,7 +55,7 @@ WHERE metadata_partition = ?`
 
 	templateGetClusterMetadata = `SELECT data, data_encoding, version FROM cluster_metadata WHERE metadata_partition = ?`
 
-	templateCreateClusterMetadata = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, version) VALUES(?, ?, ?, ?) IF NOT EXISTS`
+	templateCreateClusterMetadata = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, immutable_data, immutable_data_encoding, version) VALUES(?, ?, ?, ?, ?, ?) IF NOT EXISTS`
 	templateUpdateClusterMetadata = `UPDATE cluster_metadata SET data = ?, data_encoding = ?, version = ? WHERE metadata_partition = ? IF version = ?`
 
 	// ****** CLUSTER_MEMBERSHIP TABLE ******
@@ -160,7 +160,7 @@ func (m *cassandraClusterMetadata) GetClusterMetadata() (*p.InternalGetClusterMe
 
 func (m *cassandraClusterMetadata) SaveClusterMetadata(request *p.InternalSaveClusterMetadataRequest) (bool, error) {
 	query := m.session.Query(templateCreateClusterMetadata,
-		constMembershipPartition, request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), 1)
+		constMembershipPartition, request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), 1)
 	if request.Version > 0 {
 		query = m.session.Query(templateUpdateClusterMetadata,
 			request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), request.Version+1, constMembershipPartition, request.Version)

--- a/common/persistence/cassandra/cassandraClusterMetadata.go
+++ b/common/persistence/cassandra/cassandraClusterMetadata.go
@@ -53,12 +53,14 @@ WHERE metadata_partition = ?`
 
 	immutableEncodingFieldName = immutablePayloadFieldName + `_encoding`
 
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	templateGetClusterMetadata = `SELECT data, data_encoding, immutable_data, immutable_data_encoding, version FROM cluster_metadata WHERE metadata_partition = ?`
 
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	templateCreateClusterMetadata = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, immutable_data, immutable_data_encoding, version) VALUES(?, ?, ?, ?, ?, ?) IF NOT EXISTS`
 	templateUpdateClusterMetadata = `UPDATE cluster_metadata SET data = ?, data_encoding = ?, version = ? WHERE metadata_partition = ? IF version = ?`
+	// TODO(vitarb): needed only to support legacy records in the immutable metadata, remove after 1.1 release.
+	templateInitializeVersionIfNull = `UPDATE cluster_metadata SET version = 1 WHERE metadata_partition = ? IF version = NULL`
 
 	// ****** CLUSTER_MEMBERSHIP TABLE ******
 	templateUpsertActiveClusterMembership = `INSERT INTO 
@@ -148,7 +150,7 @@ func (m *cassandraClusterMetadata) GetClusterMetadata() (*p.InternalGetClusterMe
 	query := m.session.Query(templateGetClusterMetadata, constMetadataPartition)
 	var clusterMetadata []byte
 	var encoding string
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	var immutableMetadata []byte
 	var immutableMetadataEncoding string
 	var version int64
@@ -156,10 +158,22 @@ func (m *cassandraClusterMetadata) GetClusterMetadata() (*p.InternalGetClusterMe
 	if err != nil {
 		return nil, convertCommonErrors("GetClusterMetadata", err)
 	}
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	if clusterMetadata == nil {
 		clusterMetadata = immutableMetadata
 		encoding = immutableMetadataEncoding
+	}
+	// Version can only be 0 for legacy records that have NULL version in the DB.
+	// In this case we want to initialize version with a value 1 so that conditional updates can proceed successfully.
+	if version == 0 {
+		applied, err := m.initializeClusterMetadataVersion()
+		if err != nil {
+			return nil, convertCommonErrors("GetClusterMetadata", err)
+		}
+		if !applied {
+			return nil, serviceerror.NewInternal("GetClusterMetadata was unable to initialize version for the legacy record.")
+		}
+		version = 1
 	}
 	return &p.InternalGetClusterMetadataResponse{
 		ClusterMetadata: p.NewDataBlob(clusterMetadata, encoding),
@@ -168,13 +182,26 @@ func (m *cassandraClusterMetadata) GetClusterMetadata() (*p.InternalGetClusterMe
 }
 
 func (m *cassandraClusterMetadata) SaveClusterMetadata(request *p.InternalSaveClusterMetadataRequest) (bool, error) {
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	query := m.session.Query(templateCreateClusterMetadata,
 		constMembershipPartition, request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), 1)
 	if request.Version > 0 {
 		query = m.session.Query(templateUpdateClusterMetadata,
 			request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), request.Version+1, constMembershipPartition, request.Version)
 	}
+	previous := make(map[string]interface{})
+	applied, err := query.MapScanCAS(previous)
+	if err != nil {
+		return false, convertCommonErrors("SaveClusterMetadata", err)
+	}
+	if !applied {
+		return false, serviceerror.NewInternal("SaveClusterMetadata operation encountered concurrent write.")
+	}
+	return true, nil
+}
+
+func (m *cassandraClusterMetadata) initializeClusterMetadataVersion() (bool, error) {
+	query := m.session.Query(templateInitializeVersionIfNull, constMetadataPartition)
 	previous := make(map[string]interface{})
 	applied, err := query.MapScanCAS(previous)
 	if err != nil {

--- a/common/persistence/cassandra/cassandraClusterMetadata.go
+++ b/common/persistence/cassandra/cassandraClusterMetadata.go
@@ -162,18 +162,18 @@ func (m *cassandraClusterMetadata) GetClusterMetadata() (*p.InternalGetClusterMe
 	if clusterMetadata == nil {
 		clusterMetadata = immutableMetadata
 		encoding = immutableMetadataEncoding
-	}
-	// Version can only be 0 for legacy records that have NULL version in the DB.
-	// In this case we want to initialize version with a value 1 so that conditional updates can proceed successfully.
-	if version == 0 {
-		applied, err := m.initializeClusterMetadataVersion()
-		if err != nil {
-			return nil, convertCommonErrors("GetClusterMetadata", err)
+		// Version can only be 0 for legacy records that have NULL version in the DB.
+		// In this case we want to initialize version with a value 1 so that conditional updates can proceed successfully.
+		if version == 0 {
+			applied, err := m.initializeClusterMetadataVersion()
+			if err != nil {
+				return nil, convertCommonErrors("GetClusterMetadata", err)
+			}
+			if !applied {
+				return nil, serviceerror.NewInternal("GetClusterMetadata was unable to initialize version for the legacy record.")
+			}
+			version = 1
 		}
-		if !applied {
-			return nil, serviceerror.NewInternal("GetClusterMetadata was unable to initialize version for the legacy record.")
-		}
-		version = 1
 	}
 	return &p.InternalGetClusterMetadataResponse{
 		ClusterMetadata: p.NewDataBlob(clusterMetadata, encoding),

--- a/common/persistence/cassandra/cassandraClusterMetadata.go
+++ b/common/persistence/cassandra/cassandraClusterMetadata.go
@@ -168,6 +168,7 @@ func (m *cassandraClusterMetadata) GetClusterMetadata() (*p.InternalGetClusterMe
 }
 
 func (m *cassandraClusterMetadata) SaveClusterMetadata(request *p.InternalSaveClusterMetadataRequest) (bool, error) {
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
 	query := m.session.Query(templateCreateClusterMetadata,
 		constMembershipPartition, request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), request.ClusterMetadata.Data, request.ClusterMetadata.Encoding.String(), 1)
 	if request.Version > 0 {

--- a/common/persistence/clusterMetadataStore.go
+++ b/common/persistence/clusterMetadataStore.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/api/persistenceblobs/v1"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -135,10 +136,10 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(request *SaveClusterMet
 	if request.Version != 0 && oldClusterMetadata.Version != request.Version {
 		return false, serviceerror.NewInternal(fmt.Sprintf("SaveClusterMetadata encountered version mismatch, expected %v but got %v.",
 			request.Version, oldClusterMetadata.Version))
-	} else {
-		// TODO(vitarb): Needed to handle legacy records during upgrade. Can be removed after v1.1 release.
-		request.Version = oldClusterMetadata.Version
 	}
+	// TODO(vitarb): Needed to handle legacy records during upgrade. Can be removed after v1.1 release.
+	request.Version = oldClusterMetadata.Version
+
 	return m.persistence.SaveClusterMetadata(&InternalSaveClusterMetadataRequest{ClusterMetadata: mcm, Version: request.Version})
 }
 

--- a/common/persistence/clusterMetadataStore.go
+++ b/common/persistence/clusterMetadataStore.go
@@ -133,6 +133,7 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(request *SaveClusterMet
 	if immutableFieldsChanged(oldClusterMetadata.ClusterMetadata, request.ClusterMetadata) {
 		return false, nil
 	}
+	// TODO(vitarb): Check for Version != 0 is needed to allow legacy record override with a new cluster ID. Can be removed after v1.1 release.
 	if request.Version != 0 && oldClusterMetadata.Version != request.Version {
 		return false, serviceerror.NewInternal(fmt.Sprintf("SaveClusterMetadata encountered version mismatch, expected %v but got %v.",
 			request.Version, oldClusterMetadata.Version))

--- a/common/persistence/clusterMetadataStore.go
+++ b/common/persistence/clusterMetadataStore.go
@@ -141,7 +141,7 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(request *SaveClusterMet
 
 // immutableFieldsChanged returns true if any of immutable fields changed.
 func immutableFieldsChanged(old persistenceblobs.ClusterMetadata, cur persistenceblobs.ClusterMetadata) bool {
-	return old.ClusterName != cur.ClusterName ||
-		old.ClusterId != cur.ClusterId ||
-		old.HistoryShardCount != cur.HistoryShardCount
+	return (old.ClusterName != "" && old.ClusterName != cur.ClusterName) ||
+		(old.ClusterId != "" && old.ClusterId != cur.ClusterId) ||
+		(old.HistoryShardCount != 0 && old.HistoryShardCount != cur.HistoryShardCount)
 }

--- a/common/persistence/clusterMetadataStore.go
+++ b/common/persistence/clusterMetadataStore.go
@@ -132,9 +132,12 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(request *SaveClusterMet
 	if immutableFieldsChanged(oldClusterMetadata.ClusterMetadata, request.ClusterMetadata) {
 		return false, nil
 	}
-	if oldClusterMetadata.Version != request.Version {
+	if request.Version != 0 && oldClusterMetadata.Version != request.Version {
 		return false, serviceerror.NewInternal(fmt.Sprintf("SaveClusterMetadata encountered version mismatch, expected %v but got %v.",
 			request.Version, oldClusterMetadata.Version))
+	} else {
+		// TODO(vitarb): Needed to handle legacy records during upgrade. Can be removed after v1.1 release.
+		request.Version = oldClusterMetadata.Version
 	}
 	return m.persistence.SaveClusterMetadata(&InternalSaveClusterMetadataRequest{ClusterMetadata: mcm, Version: request.Version})
 }

--- a/common/persistence/sql/sqlClusterMetadataManager.go
+++ b/common/persistence/sql/sqlClusterMetadataManager.go
@@ -50,6 +50,11 @@ func (s *sqlClusterMetadataManager) GetClusterMetadata() (*p.InternalGetClusterM
 		return nil, convertCommonErrors("GetClusterMetadata", err)
 	}
 
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	if row.Data == nil {
+		row.Data = row.ImmutableData
+		row.DataEncoding = row.ImmutableDataEncoding
+	}
 	return &p.InternalGetClusterMetadataResponse{
 		ClusterMetadata: p.NewDataBlob(row.Data, row.DataEncoding),
 		Version:         row.Version,

--- a/common/persistence/sql/sqlClusterMetadataManager.go
+++ b/common/persistence/sql/sqlClusterMetadataManager.go
@@ -50,7 +50,7 @@ func (s *sqlClusterMetadataManager) GetClusterMetadata() (*p.InternalGetClusterM
 		return nil, convertCommonErrors("GetClusterMetadata", err)
 	}
 
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	if row.Data == nil {
 		row.Data = row.ImmutableData
 		row.DataEncoding = row.ImmutableDataEncoding

--- a/common/persistence/sql/sqlplugin/definition.go
+++ b/common/persistence/sql/sqlplugin/definition.go
@@ -36,6 +36,9 @@ type (
 		Data         []byte
 		DataEncoding string
 		Version      int64
+		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+		ImmutableData         []byte
+		ImmutableDataEncoding string
 	}
 
 	// ClusterMembershipRow represents a row in the cluster_membership table

--- a/common/persistence/sql/sqlplugin/definition.go
+++ b/common/persistence/sql/sqlplugin/definition.go
@@ -36,7 +36,7 @@ type (
 		Data         []byte
 		DataEncoding string
 		Version      int64
-		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 		ImmutableData         []byte
 		ImmutableDataEncoding string
 	}

--- a/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
@@ -37,11 +37,13 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
 	insertClusterMetadataQry = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, immutable_data, immutable_data_encoding, version) VALUES(?, ?, ?, ?, ?, ?)`
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata SET data = ?, data_encoding = ?, version = ? WHERE metadata_partition = ?`
 
-	getClusterMetadataQry          = `SELECT data, data_encoding, version FROM cluster_metadata WHERE metadata_partition = ?`
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	getClusterMetadataQry          = `SELECT data, data_encoding, immutable_data, immutable_data_encoding, version FROM cluster_metadata WHERE metadata_partition = ?`
 	writeLockGetClusterMetadataQry = getClusterMetadataQry + ` FOR UPDATE`
 
 	// ****** CLUSTER_MEMBERSHIP TABLE ******

--- a/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
@@ -76,6 +76,7 @@ cluster_membership WHERE membership_partition = ?`
 
 func (mdb *db) SaveClusterMetadata(row *sqlplugin.ClusterMetadataRow) (sql.Result, error) {
 	if row.Version == 0 {
+		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
 		mdb.conn.Exec(insertClusterMetadataQry, constMetadataPartition, row.Data, row.DataEncoding, row.Data, row.DataEncoding, 1)
 	}
 	return mdb.conn.Exec(updateClusterMetadataQry, row.Data, row.DataEncoding, row.Version+1, constMetadataPartition)

--- a/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
@@ -37,7 +37,7 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
-	insertClusterMetadataQry = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, version) VALUES(?, ?, ?, ?)`
+	insertClusterMetadataQry = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, immutable_data, immutable_data_encoding, version) VALUES(?, ?, ?, ?, ?, ?)`
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata SET data = ?, data_encoding = ?, version = ? WHERE metadata_partition = ?`
 
@@ -74,7 +74,7 @@ cluster_membership WHERE membership_partition = ?`
 
 func (mdb *db) SaveClusterMetadata(row *sqlplugin.ClusterMetadataRow) (sql.Result, error) {
 	if row.Version == 0 {
-		mdb.conn.Exec(insertClusterMetadataQry, constMetadataPartition, row.Data, row.DataEncoding, 1)
+		mdb.conn.Exec(insertClusterMetadataQry, constMetadataPartition, row.Data, row.DataEncoding, row.Data, row.DataEncoding, 1)
 	}
 	return mdb.conn.Exec(updateClusterMetadataQry, row.Data, row.DataEncoding, row.Version+1, constMetadataPartition)
 }

--- a/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
@@ -37,12 +37,12 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	insertClusterMetadataQry = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, immutable_data, immutable_data_encoding, version) VALUES(?, ?, ?, ?, ?, ?)`
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata SET data = ?, data_encoding = ?, version = ? WHERE metadata_partition = ?`
 
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	getClusterMetadataQry          = `SELECT data, data_encoding, immutable_data, immutable_data_encoding, version FROM cluster_metadata WHERE metadata_partition = ?`
 	writeLockGetClusterMetadataQry = getClusterMetadataQry + ` FOR UPDATE`
 
@@ -76,7 +76,7 @@ cluster_membership WHERE membership_partition = ?`
 
 func (mdb *db) SaveClusterMetadata(row *sqlplugin.ClusterMetadataRow) (sql.Result, error) {
 	if row.Version == 0 {
-		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 		mdb.conn.Exec(insertClusterMetadataQry, constMetadataPartition, row.Data, row.DataEncoding, row.Data, row.DataEncoding, 1)
 	}
 	return mdb.conn.Exec(updateClusterMetadataQry, row.Data, row.DataEncoding, row.Version+1, constMetadataPartition)

--- a/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
@@ -42,7 +42,8 @@ const (
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata SET data = $1, data_encoding = $2, version = $3 WHERE metadata_partition = $4`
 
-	getClusterMetadataQry = `SELECT data, data_encoding, version FROM cluster_metadata WHERE metadata_partition = $1`
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	getClusterMetadataQry = `SELECT data, data_encoding, immutable_data, immutable_data_encoding, version FROM cluster_metadata WHERE metadata_partition = $1`
 
 	writeLockGetClusterMetadataQry = getClusterMetadataQry + ` FOR UPDATE`
 

--- a/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
@@ -38,6 +38,7 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
 	insertClusterMetadataQry = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, immutable_data, immutable_data_encoding, version) VALUES($1, $2, $3, $4, $5, $6)`
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata SET data = $1, data_encoding = $2, version = $3 WHERE metadata_partition = $4`
@@ -79,6 +80,7 @@ cluster_membership WHERE membership_partition = $`
 
 func (pdb *db) SaveClusterMetadata(row *sqlplugin.ClusterMetadataRow) (sql.Result, error) {
 	if row.Version == 0 {
+		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
 		pdb.conn.Exec(insertClusterMetadataQry, constMetadataPartition, row.Data, row.DataEncoding, row.Data, row.DataEncoding, 1)
 	}
 	return pdb.conn.Exec(updateClusterMetadataQry, row.Data, row.DataEncoding, row.Version+1, constMetadataPartition)

--- a/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
@@ -38,12 +38,12 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	insertClusterMetadataQry = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, immutable_data, immutable_data_encoding, version) VALUES($1, $2, $3, $4, $5, $6)`
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata SET data = $1, data_encoding = $2, version = $3 WHERE metadata_partition = $4`
 
-	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 	getClusterMetadataQry = `SELECT data, data_encoding, immutable_data, immutable_data_encoding, version FROM cluster_metadata WHERE metadata_partition = $1`
 
 	writeLockGetClusterMetadataQry = getClusterMetadataQry + ` FOR UPDATE`
@@ -80,7 +80,7 @@ cluster_membership WHERE membership_partition = $`
 
 func (pdb *db) SaveClusterMetadata(row *sqlplugin.ClusterMetadataRow) (sql.Result, error) {
 	if row.Version == 0 {
-		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove in the next release.
+		// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
 		pdb.conn.Exec(insertClusterMetadataQry, constMetadataPartition, row.Data, row.DataEncoding, row.Data, row.DataEncoding, 1)
 	}
 	return pdb.conn.Exec(updateClusterMetadataQry, row.Data, row.DataEncoding, row.Version+1, constMetadataPartition)

--- a/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
@@ -38,7 +38,7 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
-	insertClusterMetadataQry = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, version) VALUES($1, $2, $3, $4)`
+	insertClusterMetadataQry = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, immutable_data, immutable_data_encoding, version) VALUES($1, $2, $3, $4, $5, $6)`
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata SET data = $1, data_encoding = $2, version = $3 WHERE metadata_partition = $4`
 
@@ -78,7 +78,7 @@ cluster_membership WHERE membership_partition = $`
 
 func (pdb *db) SaveClusterMetadata(row *sqlplugin.ClusterMetadataRow) (sql.Result, error) {
 	if row.Version == 0 {
-		pdb.conn.Exec(insertClusterMetadataQry, constMetadataPartition, row.Data, row.DataEncoding, 1)
+		pdb.conn.Exec(insertClusterMetadataQry, constMetadataPartition, row.Data, row.DataEncoding, row.Data, row.DataEncoding, 1)
 	}
 	return pdb.conn.Exec(updateClusterMetadataQry, row.Data, row.DataEncoding, row.Version+1, constMetadataPartition)
 }

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -126,6 +126,8 @@ CREATE TABLE cluster_metadata (
   metadata_partition      int,
   data                    blob,
   data_encoding           text,
+  immutable_data          blob,
+  immutable_data_encoding text,
   version                 bigint,
   PRIMARY KEY  (metadata_partition)
 ) WITH COMPACTION = {

--- a/schema/cassandra/temporal/versioned/v1.1/cluster_metadata.cql
+++ b/schema/cassandra/temporal/versioned/v1.1/cluster_metadata.cql
@@ -1,2 +1,3 @@
 ALTER TABLE cluster_metadata ADD data blob;
 ALTER TABLE cluster_metadata ADD data_encoding text;
+ALTER TABLE cluster_metadata ADD version bigint;

--- a/schema/cassandra/temporal/versioned/v1.1/cluster_metadata.cql
+++ b/schema/cassandra/temporal/versioned/v1.1/cluster_metadata.cql
@@ -1,11 +1,2 @@
-DROP TABLE cluster_metadata;
-
-CREATE TABLE cluster_metadata (
-  metadata_partition      int,
-  data                    blob,
-  data_encoding           text,
-  immutable_data          blob,
-  immutable_data_encoding text,
-  version                 bigint,
-  PRIMARY KEY  (metadata_partition)
-) WITH COMPACTION = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'};
+ALTER TABLE cluster_metadata ADD data blob;
+ALTER TABLE cluster_metadata ADD data_encoding text;

--- a/schema/cassandra/temporal/versioned/v1.1/cluster_metadata.cql
+++ b/schema/cassandra/temporal/versioned/v1.1/cluster_metadata.cql
@@ -4,6 +4,8 @@ CREATE TABLE cluster_metadata (
   metadata_partition      int,
   data                    blob,
   data_encoding           text,
+  immutable_data          blob,
+  immutable_data_encoding text,
   version                 bigint,
   PRIMARY KEY  (metadata_partition)
 ) WITH COMPACTION = {'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'};

--- a/schema/mysql/v57/temporal/schema.sql
+++ b/schema/mysql/v57/temporal/schema.sql
@@ -238,6 +238,8 @@ CREATE TABLE cluster_metadata (
   metadata_partition        INT NOT NULL,
   data                      BLOB NOT NULL,
   data_encoding             VARCHAR(16) NOT NULL,
+  immutable_data            BLOB NOT NULL,
+  immutable_data_encoding   VARCHAR(16) NOT NULL,
   version                   BIGINT NOT NULL,
   PRIMARY KEY(metadata_partition)
 );

--- a/schema/mysql/v57/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.1/cluster_metadata.sql
@@ -1,11 +1,2 @@
-DROP TABLE cluster_metadata;
-
-CREATE TABLE cluster_metadata (
-  metadata_partition        INT NOT NULL,
-  data                      BLOB NOT NULL,
-  data_encoding             VARCHAR(16) NOT NULL,
-  immutable_data            BLOB NOT NULL,
-  immutable_data_encoding   VARCHAR(16) NOT NULL,
-  version                   BIGINT NOT NULL,
-  PRIMARY KEY(metadata_partition)
-);
+ALTER TABLE cluster_metadata ADD data BLOB NOT NULL;
+ALTER TABLE cluster_metadata ADD data_encoding VARCHAR(16) NOT NULL;

--- a/schema/mysql/v57/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.1/cluster_metadata.sql
@@ -4,6 +4,8 @@ CREATE TABLE cluster_metadata (
   metadata_partition        INT NOT NULL,
   data                      BLOB NOT NULL,
   data_encoding             VARCHAR(16) NOT NULL,
+  immutable_data            BLOB NOT NULL,
+  immutable_data_encoding   VARCHAR(16) NOT NULL,
   version                   BIGINT NOT NULL,
   PRIMARY KEY(metadata_partition)
 );

--- a/schema/mysql/v57/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.1/cluster_metadata.sql
@@ -1,2 +1,3 @@
 ALTER TABLE cluster_metadata ADD data BLOB NOT NULL;
 ALTER TABLE cluster_metadata ADD data_encoding VARCHAR(16) NOT NULL;
+ALTER TABLE cluster_metadata ADD version BIGINT NOT NULL;

--- a/schema/mysql/v57/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.1/cluster_metadata.sql
@@ -1,3 +1,3 @@
 ALTER TABLE cluster_metadata ADD data BLOB NOT NULL;
 ALTER TABLE cluster_metadata ADD data_encoding VARCHAR(16) NOT NULL;
-ALTER TABLE cluster_metadata ADD version BIGINT NOT NULL;
+ALTER TABLE cluster_metadata ADD version BIGINT DEFAULT 1 NOT NULL;

--- a/schema/postgresql/v96/temporal/schema.sql
+++ b/schema/postgresql/v96/temporal/schema.sql
@@ -238,6 +238,8 @@ CREATE TABLE cluster_metadata (
   metadata_partition        INTEGER NOT NULL,
   data                      BYTEA NOT NULL,
   data_encoding             VARCHAR(16) NOT NULL,
+  immutable_data            BYTEA NOT NULL,
+  immutable_data_encoding   VARCHAR(16) NOT NULL,
   version                   BIGINT NOT NULL,
   PRIMARY KEY(metadata_partition)
 );

--- a/schema/postgresql/v96/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/postgresql/v96/temporal/versioned/v1.1/cluster_metadata.sql
@@ -1,11 +1,2 @@
-DROP TABLE cluster_metadata;
-
-CREATE TABLE cluster_metadata (
-  metadata_partition        INTEGER NOT NULL,
-  data                      BYTEA NOT NULL,
-  data_encoding             VARCHAR(16) NOT NULL,
-  immutable_data            BYTEA NOT NULL,
-  immutable_data_encoding   VARCHAR(16) NOT NULL,
-  version                   BIGINT NOT NULL,
-  PRIMARY KEY(metadata_partition)
-);
+ALTER TABLE cluster_metadata ADD data BYTEA NOT NULL;
+ALTER TABLE cluster_metadata ADD data_encoding VARCHAR(16) NOT NULL;

--- a/schema/postgresql/v96/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/postgresql/v96/temporal/versioned/v1.1/cluster_metadata.sql
@@ -1,2 +1,3 @@
 ALTER TABLE cluster_metadata ADD data BYTEA NOT NULL;
 ALTER TABLE cluster_metadata ADD data_encoding VARCHAR(16) NOT NULL;
+ALTER TABLE cluster_metadata ADD version BIGINT NOT NULL;

--- a/schema/postgresql/v96/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/postgresql/v96/temporal/versioned/v1.1/cluster_metadata.sql
@@ -1,3 +1,3 @@
 ALTER TABLE cluster_metadata ADD data BYTEA NOT NULL;
 ALTER TABLE cluster_metadata ADD data_encoding VARCHAR(16) NOT NULL;
-ALTER TABLE cluster_metadata ADD version BIGINT NOT NULL;
+ALTER TABLE cluster_metadata ADD version BIGINT DEFAULT 1 NOT NULL;

--- a/schema/postgresql/v96/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/postgresql/v96/temporal/versioned/v1.1/cluster_metadata.sql
@@ -4,6 +4,8 @@ CREATE TABLE cluster_metadata (
   metadata_partition        INTEGER NOT NULL,
   data                      BYTEA NOT NULL,
   data_encoding             VARCHAR(16) NOT NULL,
+  immutable_data            BYTEA NOT NULL,
+  immutable_data_encoding   VARCHAR(16) NOT NULL,
   version                   BIGINT NOT NULL,
   PRIMARY KEY(metadata_partition)
 );

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -379,7 +379,7 @@ func (s *Server) immutableClusterMetadataInitialization(dc *dynamicconfig.Collec
 				ClusterId:         uuid.New(),
 			}})
 	if err != nil {
-		return fmt.Errorf("error while saving cluster metadata: %w", err)
+		logger.Info(fmt.Sprintf("Failed to save cluster metadata: %v", err))
 	}
 	if applied {
 		logger.Info("Successfully saved cluster metadata.")

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -379,7 +379,7 @@ func (s *Server) immutableClusterMetadataInitialization(dc *dynamicconfig.Collec
 				ClusterId:         uuid.New(),
 			}})
 	if err != nil {
-		logger.Info(fmt.Sprintf("Failed to save cluster metadata: %v", err))
+		logger.Warn(fmt.Sprintf("Failed to save cluster metadata: %v", err))
 	}
 	if applied {
 		logger.Info("Successfully saved cluster metadata.")


### PR DESCRIPTION
This change adds immutable_data field back to allow older versions of temporal to be able to start on a new version of schema.
When we write metadata we'll write into both `data` and `immutable_data` columns.
When we read, we'll backfill data from the `immutable_data` when `data` is empty.

Special logic is needed to handle conditional updates and versioning for legacy records:
- In cassandra, due to lack of default column values we set `version=1` when legacy record is read.
- In SQL `version` column will be initialized with value 1 by default.
- When server starts up it will try to write a record with version 0 containing new cluster id, which will get recorded once. All subsequent writes will be rejected due to a change in the `cluster_id` field.

Cluster metadata initialization has been made non-critical, only logging an error instead of returning it. This is done to avoid server startup failures due to race conditions during version check.

All changes marked with TODOs should be cleaned up after the next release and are there only for backward compatibility.

In addition to unit test this PR has been manually tested in following scenarios:
1. Able to start using legacy record.
2. Able to start on a fresh DB.
3. Able to start 1.0.0 on v1.1 DB.