### PR TITLE
Fix --services flag format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,7 @@ COPY docker/start.sh /start.sh
 
 WORKDIR /etc/temporal
 
-ENV SERVICES="history,matching,frontend,worker"
+ENV SERVICES="--services=history --services=matching --services=frontend --services=worker"
 
 EXPOSE 6933 6934 6935 6939 7233 7234 7235 7239
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/urfave/cli"
 
@@ -95,7 +96,7 @@ func buildCLI() *cli.App {
 				zone := c.GlobalString("zone")
 				configDir := path.Join(c.GlobalString("root"), c.GlobalString("config"))
 
-				services := c.StringSlice("services")
+				services := splitServices(c.StringSlice("services"))
 
 				s := temporal.NewServer(
 					temporal.ForServices(services),
@@ -113,4 +114,13 @@ func buildCLI() *cli.App {
 		},
 	}
 	return app
+}
+
+// For backward compatiblity to support old flag format (i.e. `--services=frontend,history,matching`).
+func splitServices(services []string) []string {
+	var result []string
+	for _, service := range services {
+		result = append(result, strings.Split(service, ",")...)
+	}
+	return result
 }

--- a/docker/start-temporal.sh
+++ b/docker/start-temporal.sh
@@ -4,4 +4,4 @@ set -ex
 
 dockerize -template /etc/temporal/config/config_template.yaml:/etc/temporal/config/docker.yaml
 
-exec temporal-server --root $TEMPORAL_HOME --env docker start --services=$SERVICES
+exec temporal-server --root $TEMPORAL_HOME --env docker start $SERVICES

--- a/docs/persistence.md
+++ b/docs/persistence.md
@@ -21,7 +21,7 @@ make install-schema
 ### Start temporal server
 ```
 cd $GOPATH/github.com/temporalio/temporal
-./temporal-server start --services=frontend,matching,history,worker
+./temporal-server start
 ```  
  
 ## MySQL
@@ -40,7 +40,7 @@ make install-schema-mysql
 ```
 cd $GOPATH/github.com/temporalio/temporal
 cp config/development_mysql.yaml config/development.yaml
-./temporal-server start --services=frontend,matching,history,worker
+./temporal-server start
 ```
 
 # Config


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`--services` flag format was fixed in `docker-compose.yml` file. Aslo code to support backwards compatibility was added.

<!-- Tell your future self why have you made these changes -->
**Why?**
Recently I changed format of the flag in `temporal-server` CLI but forget to fix it in `docker-compose.yml` file.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
