### PR TITLE
Disable version checking on buildkite

### DIFF
--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -95,6 +95,7 @@ services:
       - "CASSANDRA_SEEDS=cassandra"
       - "MYSQL_SEEDS=mysql"
       - "POSTGRES_SEEDS=postgresql"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
     depends_on:
       - cassandra
       - mysql
@@ -132,6 +133,7 @@ services:
       - "PERSISTENCE_TYPE=nosql"
       - "PERSISTENCE_DRIVER=cassandra"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
     depends_on:
       - cassandra
       - elasticsearch
@@ -169,6 +171,7 @@ services:
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_DRIVER=mysql"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
     depends_on:
       - mysql
       - elasticsearch
@@ -206,6 +209,7 @@ services:
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_DRIVER=postgres"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
     depends_on:
       - postgresql
       - elasticsearch
@@ -243,6 +247,7 @@ services:
       - "PERSISTENCE_TYPE=nosql"
       - "PERSISTENCE_DRIVER=cassandra"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
     depends_on:
       - cassandra
       - elasticsearch
@@ -280,6 +285,7 @@ services:
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_DRIVER=mysql"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
     depends_on:
       - mysql
       - elasticsearch
@@ -317,6 +323,7 @@ services:
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_DRIVER=postgres"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
     depends_on:
       - postgresql
       - elasticsearch

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -84,6 +84,7 @@ services:
       - "CASSANDRA_SEEDS=cassandra"
       - "MYSQL_SEEDS=mysql"
       - "POSTGRES_SEEDS=postgresql"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID
@@ -111,6 +112,7 @@ services:
       - "PERSISTENCE_TYPE=nosql"
       - "PERSISTENCE_DRIVER=cassandra"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID
@@ -138,6 +140,7 @@ services:
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_DRIVER=mysql"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID
@@ -165,6 +168,7 @@ services:
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_DRIVER=postgres"
       - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID
@@ -193,6 +197,7 @@ services:
       - "PERSISTENCE_DRIVER=cassandra"
       - "TEST_TAG=esintegration"
       - "TEST_RUN_COUNT=10"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID
@@ -221,6 +226,7 @@ services:
       - "PERSISTENCE_DRIVER=mysql"
       - "TEST_TAG=esintegration"
       - "TEST_RUN_COUNT=10"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID
@@ -249,6 +255,7 @@ services:
       - "PERSISTENCE_DRIVER=postgres"
       - "TEST_TAG=esintegration"
       - "TEST_RUN_COUNT=10"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID


### PR DESCRIPTION
This PR disables version checking on our buildkite jobs reducing unnecessary requests from these build environments.