### PR TITLE
Adding admin command for retrieving cluster metadata

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -755,6 +755,14 @@ func newAdminClusterCommands() []cli.Command {
 				AdminDescribeCluster(c)
 			},
 		},
+		{
+			Name:    "metadata",
+			Aliases: []string{"m"},
+			Usage:   "Show cluster metadata",
+			Action: func(c *cli.Context) {
+				AdminClusterMetadata(c)
+			},
+		},
 	}
 }
 

--- a/tools/cli/adminClusterCommands.go
+++ b/tools/cli/adminClusterCommands.go
@@ -30,6 +30,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/server/api/adminservice/v1"
 )
@@ -81,4 +82,17 @@ func AdminDescribeCluster(c *cli.Context) {
 	}
 
 	prettyPrintJSONObject(response)
+}
+
+// AdminDescribeCluster is used to dump information about the cluster
+func AdminClusterMetadata(c *cli.Context) {
+	frontendClient := cFactory.FrontendClient(c)
+	ctx, cancel := newContext(c)
+	defer cancel()
+
+	info, err := frontendClient.GetClusterInfo(ctx, &workflowservice.GetClusterInfoRequest{})
+	if err != nil {
+		ErrorAndExit("Operation AdminClusterMetadata failed.", err)
+	}
+	prettyPrintJSONObject(info)
 }


### PR DESCRIPTION
Sample output:
```
❯ ./tctl admin cluster metadata
{
  "supportedClients": {
    "temporal-cli": "\u003c2.0.0",
    "temporal-go": "\u003c2.0.0",
    "temporal-java": "\u003c2.0.0",
    "temporal-server": "\u003c2.0.0"
  },
  "serverVersion": "1.1.0",
  "clusterId": "48477d99-5847-45e1-bdcc-29c565230259",
  "versionInfo": {
    "current": {
      "version": "1.1.0",
      "releaseTime": "2020-10-13T01:30:00Z",
      "notes": "Temporal v1.1.0"
    },
    "recommended": {
      "version": "1.1.0",
      "releaseTime": "2020-10-13T01:30:00Z",
      "notes": "Temporal v1.1.0"
    },
    "lastUpdateTime": "2020-10-15T19:48:03.506578320Z"
  },
  "clusterName": "active",
  "historyShardCount": 4
}
```