### PR TITLE
Cleans up comments in config / config_template.yaml

### DIFF
--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -133,7 +133,7 @@ type (
 		// The path to the file containing the PEM-encoded private key of the certificate to use.
 		KeyFile string `yaml:"keyFile"`
 		// A list of paths to files containing the PEM-encoded public key of the Certificate Authorities you wish to trust for client authentication.
-		// This value is ignored if `requireClientAuth` is not enabled. Merged with the data from ClientCAData.
+		// This value is ignored if `requireClientAuth` is not enabled. Cannot specify both ClientCAFiles and ClientCAData
 		ClientCAFiles []string `yaml:"clientCaFiles"`
 
 		// Base64 equivalents of the above artifacts.

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -146,18 +146,18 @@ type (
 		RequireClientAuth bool `yaml:"requireClientAuth"`
 	}
 
-	// ClientTLS contains TLS configuration for clients.
+	// ClientTLS contains TLS configuration for clients. It is used to create
 	ClientTLS struct {
 		// DNS name to validate against for server to server connections.
 		// Required when TLS is enabled in a multi-host cluster.
 		// This name should be referenced by the certificate specified in the ServerTLS section.
 		ServerName string `yaml:"serverName"`
 
-		// Optional - A list of paths to files containing the PEM-encoded public key of the Certificate Authorities you wish to return to the client.
+		// Optional - A list of paths to files containing the PEM-encoded public key of the Certificate Authorities that are used to validate the server's TLS certificate
 		// You cannot specify both RootCAFiles and RootCAData
 		RootCAFiles []string `yaml:"rootCaFiles"`
 
-		// Optional - A list of base64 PEM-encoded public keys of the Certificate Authorities you wish to return to the client.
+		// Optional - A list of base64 PEM-encoded public keys of the Certificate Authorities that are used to validate the server's TLS certificate.
 		// You cannot specify both RootCAFiles and RootCAData
 		RootCAData []string `yaml:"rootCaData"`
 	}

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -146,7 +146,7 @@ type (
 		RequireClientAuth bool `yaml:"requireClientAuth"`
 	}
 
-	// ClientTLS contains TLS configuration for clients. It is used to create
+	// ClientTLS contains TLS configuration for clients within the Temporal Cluster to connect to Temporal nodes.
 	ClientTLS struct {
 		// DNS name to validate against for server to server connections.
 		// Required when TLS is enabled in a multi-host cluster.

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -141,8 +141,8 @@ global:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT_DATA "" }}
         frontend:
             # This server section configures the TLS certificate that the Frontend
-            # server presents to all clients (both within the Temporal Cluster and
-            # external SDKs connecting to the Cluster)
+            # server presents to all clients (specifically the Worker role within
+            # the Temporal Cluster and all External SDKs connecting to the Cluster)
             server:
                 requireClientAuth: {{ default .Env.TEMPORAL_TLS_REQUIRE_CLIENT_AUTH "false" }}
                 certFile: {{ default .Env.TEMPORAL_TLS_FRONTEND_CERT "" }}
@@ -158,7 +158,7 @@ global:
                     - {{ default .Env.TEMPORAL_TLS_CLIENT2_CA_CERT_DATA "" }}
             
             # This client section is used to configure the TLS clients within
-            # the Temporal Cluster that connect to the Frontend service
+            # the Temporal Cluster (specifically the Worker role) that connect to the Frontend service
             client:
                 rootCaFiles:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -117,6 +117,8 @@ global:
         broadcastAddress: {{ default .Env.TEMPORAL_BROADCAST_ADDRESS "" }}
     tls:
         internode:
+            # This server section configures the TLS certificate that internal temporal
+            # cluster nodes (history or matching) present to other clients within the Temporal Cluster. 
             server:
                 requireClientAuth: {{ default .Env.TEMPORAL_TLS_REQUIRE_CLIENT_AUTH "false" }}
 
@@ -129,12 +131,18 @@ global:
                 keyData: {{ default .Env.TEMPORAL_TLS_SERVER_KEY_DATA "" }}
                 clientCaData:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT_DATA "" }}
+            
+            # This client section is used to configure the TLS clients within
+            # the Temporal Cluster that connect to an Internode (history or matching)
             client:
                 rootCaFiles:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}
                 rootCaData:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT_DATA "" }}
         frontend:
+            # This server section configures the TLS certificate that the Frontend
+            # server presents to all clients (both within the Temporal Cluster and
+            # external SDKs connecting to the Cluster)
             server:
                 requireClientAuth: {{ default .Env.TEMPORAL_TLS_REQUIRE_CLIENT_AUTH "false" }}
                 certFile: {{ default .Env.TEMPORAL_TLS_FRONTEND_CERT "" }}
@@ -148,6 +156,9 @@ global:
                 clientCaData:
                     - {{ default .Env.TEMPORAL_TLS_CLIENT1_CA_CERT_DATA "" }}
                     - {{ default .Env.TEMPORAL_TLS_CLIENT2_CA_CERT_DATA "" }}
+            
+            # This client section is used to configure the TLS clients within
+            # the Temporal Cluster that connect to the Frontend service
             client:
                 rootCaFiles:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}


### PR DESCRIPTION
1) The current TLS configuration is a bit confusing because it is not obvious internode vs frontend and server vs. client. We add comments to config_template.yaml to clean that up.

2) Previous checkin introduced a bad comment. This fixes that