### PR TITLE
Adds support for --tls_enable_host_verification as global option for TCTL

### DIFF
--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -83,6 +83,11 @@ func NewCliApp() *cli.App {
 			Usage:  "path to server CA certificate",
 			EnvVar: "TEMPORAL_CLI_TLS_CA",
 		},
+		cli.BoolFlag{
+			Name:   FlagTLSEnableHostVerification,
+			Usage:  "validates hostname of temporal cluster against Certificate",
+			EnvVar: "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION",
+		},
 	}
 	app.Commands = []cli.Command{
 		{

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -85,7 +85,7 @@ func NewCliApp() *cli.App {
 		},
 		cli.BoolFlag{
 			Name:   FlagTLSEnableHostVerification,
-			Usage:  "validates hostname of temporal cluster against certificate",
+			Usage:  "validates hostname of temporal cluster against server certificate",
 			EnvVar: "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION",
 		},
 	}

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -85,7 +85,7 @@ func NewCliApp() *cli.App {
 		},
 		cli.BoolFlag{
 			Name:   FlagTLSEnableHostVerification,
-			Usage:  "validates hostname of temporal cluster against Certificate",
+			Usage:  "validates hostname of temporal cluster against certificate",
 			EnvVar: "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION",
 		},
 	}


### PR DESCRIPTION
By default, tctl does not perform host verification on the temporal cluster it is talking to (if using TLS). The underlying code checks a flag, but the flag is not exposed as a Global option. This PR exposes the flag as a global option.

Validated this fix by running against a private environment with a mismatched server-name for the TLS cert. With the flag enabled, tctl gives the appropriate error message when communicating with the private environment.