### PR TITLE
Add LFS tracking for .png and .jpg files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.png filter=lfs diff=lfs merge=lfs -text
+*.jpg filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
**What changed?**
Added Large File Storage tracking for .png and .jpg files.

**Why?**
To prevent bloating of git history with accidental committing of graphic files.

**How did you test it?**
Submitted #861 with these settings in place.

**Potential risks**
No risk.
