### PR TITLE
Fix the bug with 1.1 startup on Mysql after the upgrade

### DIFF
--- a/common/persistence/cassandra/cassandraClusterMetadata.go
+++ b/common/persistence/cassandra/cassandraClusterMetadata.go
@@ -159,7 +159,7 @@ func (m *cassandraClusterMetadata) GetClusterMetadata() (*p.InternalGetClusterMe
 		return nil, convertCommonErrors("GetClusterMetadata", err)
 	}
 	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
-	if clusterMetadata == nil {
+	if len(clusterMetadata) == 0 {
 		clusterMetadata = immutableMetadata
 		encoding = immutableMetadataEncoding
 		// Version can only be 0 for legacy records that have NULL version in the DB.

--- a/common/persistence/sql/sqlClusterMetadataManager.go
+++ b/common/persistence/sql/sqlClusterMetadataManager.go
@@ -51,7 +51,7 @@ func (s *sqlClusterMetadataManager) GetClusterMetadata() (*p.InternalGetClusterM
 	}
 
 	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
-	if row.Data == nil || len(row.Data) == 0 {
+	if len(row.Data) == 0 {
 		row.Data = row.ImmutableData
 		row.DataEncoding = row.ImmutableDataEncoding
 	}

--- a/common/persistence/sql/sqlClusterMetadataManager.go
+++ b/common/persistence/sql/sqlClusterMetadataManager.go
@@ -51,7 +51,7 @@ func (s *sqlClusterMetadataManager) GetClusterMetadata() (*p.InternalGetClusterM
 	}
 
 	// TODO(vitarb): immutable metadata is needed for backward compatibility only, remove after 1.1 release.
-	if row.Data == nil {
+	if row.Data == nil || len(row.Data) == 0 {
 		row.Data = row.ImmutableData
 		row.DataEncoding = row.ImmutableDataEncoding
 	}


### PR DESCRIPTION
Mysql upgrade from 1.0 - 1.1 was causing server startup issues due to the fact that cluster metadata hasn't been backfilled.

Also although not required (as cql client returns nil slice) I made a similar change on the cassandra side just for the symmetry.