### PR TITLE
Enables Cassandra auto-setup to specify username, password, port and TLS

### DIFF
--- a/docker/start.sh
+++ b/docker/start.sh
@@ -28,8 +28,8 @@ setup_cassandra_schema() {
     export CASSANDRA_USER=$CASSANDRA_USER
     export CASSANDRA_PORT=$CASSANDRA_PORT
     export CASSANDRA_ENABLE_TLS=$CASSANDRA_TLS_ENABLED
-    export CASSANDRA_TLS_CERT=$CASSANDRA_CERT;
-    export CASSANDRA_TLS_KEY=$CASSANDRA_CERT_KEY;
+    export CASSANDRA_TLS_CERT=$CASSANDRA_CERT
+    export CASSANDRA_TLS_KEY=$CASSANDRA_CERT_KEY
     export CASSANDRA_TLS_CA=$CASSANDRA_CA
 
     { export CASSANDRA_PASSWORD=$CASSANDRA_PASSWORD; } 2> /dev/null
@@ -42,7 +42,7 @@ setup_cassandra_schema() {
     VISIBILITY_SCHEMA_DIR=$TEMPORAL_HOME/schema/cassandra/visibility/versioned
     temporal-cassandra-tool --ep $CASSANDRA_SEEDS create -k $VISIBILITY_KEYSPACE --rf $RF
     temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $VISIBILITY_KEYSPACE setup-schema -v 0.0
-    temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $VISIBILITY_KEYSPACE update-schema -d $VISIBILITY_SCHEMA_DIR   
+    temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $VISIBILITY_KEYSPACE update-schema -d $VISIBILITY_SCHEMA_DIR
 }
 
 setup_mysql_schema() {

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -11,7 +11,7 @@ RF=${RF:-1}
 DEFAULT_NAMESPACE="${DEFAULT_NAMESPACE:-default}"
 DEFAULT_NAMESPACE_RETENTION=${DEFAULT_NAMESPACE_RETENTION:-1}
 CASSANDRA_PORT="${CASSANDRA_PORT:-9042}"
-CASSANDRA_TLS_ENABLED="${CASSANDRA_TLS_ENABLED:-false}"
+
 # tctl env
 export TEMPORAL_CLI_ADDRESS="${BIND_ON_IP}:7233"
 
@@ -27,33 +27,22 @@ export DB_PORT=${DB_PORT:-3306}
 setup_cassandra_schema() {
     export CASSANDRA_USER=$CASSANDRA_USER
     export CASSANDRA_PORT=$CASSANDRA_PORT
+    export CASSANDRA_ENABLE_TLS=$CASSANDRA_TLS_ENABLED
+    export CASSANDRA_TLS_CERT=$CASSANDRA_CERT;
+    export CASSANDRA_TLS_KEY=$CASSANDRA_CERT_KEY;
+    export CASSANDRA_TLS_CA=$CASSANDRA_CA
+
     { export CASSANDRA_PASSWORD=$CASSANDRA_PASSWORD; } 2> /dev/null
 
-    if [ "$CASSANDRA_TLS_ENABLED" == "true" ]; then
-        export CASSANDRA_TLS_CERT=$CASSANDRA_CERT;
-        export CASSANDRA_TLS_KEY=$CASSANDRA_CERT_KEY;
-        export CASSANDRA_TLS_CA=$CASSANDRA_CA
+    SCHEMA_DIR=$TEMPORAL_HOME/schema/cassandra/temporal/versioned
+    temporal-cassandra-tool --ep $CASSANDRA_SEEDS create -k $KEYSPACE --rf $RF
+    temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $KEYSPACE setup-schema -v 0.0
+    temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $KEYSPACE update-schema -d $SCHEMA_DIR
 
-        SCHEMA_DIR=$TEMPORAL_HOME/schema/cassandra/temporal/versioned
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS --tls create -k $KEYSPACE --rf $RF
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS --tls -k $KEYSPACE setup-schema -v 0.0
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS --tls -k $KEYSPACE update-schema -d $SCHEMA_DIR
-
-        VISIBILITY_SCHEMA_DIR=$TEMPORAL_HOME/schema/cassandra/visibility/versioned
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS --tls create -k $VISIBILITY_KEYSPACE --rf $RF
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS --tls -k $VISIBILITY_KEYSPACE setup-schema -v 0.0
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS --tls -k $VISIBILITY_KEYSPACE update-schema -d $VISIBILITY_SCHEMA_DIR
-    else
-        SCHEMA_DIR=$TEMPORAL_HOME/schema/cassandra/temporal/versioned
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS create -k $KEYSPACE --rf $RF
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $KEYSPACE setup-schema -v 0.0
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $KEYSPACE update-schema -d $SCHEMA_DIR
-
-        VISIBILITY_SCHEMA_DIR=$TEMPORAL_HOME/schema/cassandra/visibility/versioned
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS create -k $VISIBILITY_KEYSPACE --rf $RF
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $VISIBILITY_KEYSPACE setup-schema -v 0.0
-        temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $VISIBILITY_KEYSPACE update-schema -d $VISIBILITY_SCHEMA_DIR
-    fi
+    VISIBILITY_SCHEMA_DIR=$TEMPORAL_HOME/schema/cassandra/visibility/versioned
+    temporal-cassandra-tool --ep $CASSANDRA_SEEDS create -k $VISIBILITY_KEYSPACE --rf $RF
+    temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $VISIBILITY_KEYSPACE setup-schema -v 0.0
+    temporal-cassandra-tool --ep $CASSANDRA_SEEDS -k $VISIBILITY_KEYSPACE update-schema -d $VISIBILITY_SCHEMA_DIR   
 }
 
 setup_mysql_schema() {


### PR DESCRIPTION
For auto-setup, the temporal-cassandra-tool is capable of reading certain values (such as username / password) via Environment Variables. We export those variables before invoking the tool in startup.sh so that a user can set values in Docker-Compose as needed.