### PR TITLE
Add an option to tctl to override server name for TLS host verification

### DIFF
--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -88,6 +88,12 @@ func NewCliApp() *cli.App {
 			Usage:  "validates hostname of temporal cluster against server certificate",
 			EnvVar: "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION",
 		},
+		cli.StringFlag{
+			Name:   FlagTLSServerName,
+			Value:  "",
+			Usage:  "override for target server name",
+			EnvVar: "TEMPORAL_CLI_TLS_SERVER_NAME",
+		},
 	}
 	app.Commands = []cli.Command{
 		{

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -134,18 +134,14 @@ func (b *clientFactory) createGRPCConnection(c *cli.Context) (*grpc.ClientConn, 
 }
 
 func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
-	hostPort := c.GlobalString(FlagAddress)
-	if hostPort == "" {
-		hostPort = localHostPort
-	}
-	// Ignoring error as we'll fail to dial anyway, and that will produce a meaningful error
-	host, _, _ := net.SplitHostPort(hostPort)
 
 	certPath := c.GlobalString(FlagTLSCertPath)
 	keyPath := c.GlobalString(FlagTLSKeyPath)
 	caPath := c.GlobalString(FlagTLSCaPath)
 	hostNameVerification := c.GlobalBool(FlagTLSEnableHostVerification)
+	serverName := c.GlobalString(FlagTLSServerName)
 
+	var host string
 	var cert *tls.Certificate
 	var caPool *x509.CertPool
 
@@ -167,6 +163,16 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 	}
 	// If we are given arguments to verify either server or client, configure TLS
 	if caPool != nil || cert != nil {
+		if serverName != "" {
+			host = serverName
+		} else {
+			hostPort := c.GlobalString(FlagAddress)
+			if hostPort == "" {
+				hostPort = localHostPort
+			}
+			// Ignoring error as we'll fail to dial anyway, and that will produce a meaningful error
+			host, _, _ = net.SplitHostPort(hostPort)
+		}
 		tlsConfig := auth.NewTLSConfigForServer(host, hostNameVerification)
 		if caPool != nil {
 			tlsConfig.RootCAs = caPool

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -165,6 +165,9 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 	if caPool != nil || cert != nil {
 		if serverName != "" {
 			host = serverName
+			// If server name is provided, we enable host verification
+			// because that's the only reason for providing server name
+			hostNameVerification = true
 		} else {
 			hostPort := c.GlobalString(FlagAddress)
 			if hostPort == "" {

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -217,6 +217,7 @@ const (
 	FlagTLSKeyPath                       = "tls_key_path"
 	FlagTLSCaPath                        = "tls_ca_path"
 	FlagTLSEnableHostVerification        = "tls_enable_host_verification"
+	FlagTLSServerName                    = "tls_server_name"
 	FlagDLQType                          = "dlq_type"
 	FlagDLQTypeWithAlias                 = FlagDLQType + ", dt"
 	FlagMaxMessageCount                  = "max_message_count"


### PR DESCRIPTION
**What changed?**
Added an option for `tctl` to override server name for TLS host verification.

**Why?**
When `tctl` connects to frontend over mTLS, the target server address or host name may differ from the CN in the server certificate, and that fails server host verification. This option allows `tctl` to specify the expected CN of the server it is connecting to.

**How did you test it?**
Manually verified that `tctl` is able to successfully connect to server by specifying `--tls_server_name` option where before it was failing to connect.

**Potential risks**
No risk. This is an optional flag.
