### PR TITLE
Fixes Dynamic Configuration bug where TaskType Constraint match always failed

### DIFF
--- a/common/service/dynamicconfig/config/testConfig.yaml
+++ b/common/service/dynamicconfig/config/testConfig.yaml
@@ -33,6 +33,11 @@ testGetIntPropertyKey:
 - value: 1000.1
   constraints:
     namespace: global-samples-namespace
+- value: 1001
+  constraints:
+    namespace: global-samples-namespace
+    taskQueueName: test-tq
+    taskType: 1
 testGetMapPropertyKey:
 - value:
     key1: "1"

--- a/common/service/dynamicconfig/config/testConfig.yaml
+++ b/common/service/dynamicconfig/config/testConfig.yaml
@@ -37,7 +37,12 @@ testGetIntPropertyKey:
   constraints:
     namespace: global-samples-namespace
     taskQueueName: test-tq
-    taskType: 1
+    taskType: "Workflow"
+- value: 1002
+  constraints:
+    namespace: global-samples-namespace
+    taskQueueName: test-tq
+    taskType: "Activity"
 testGetMapPropertyKey:
 - value:
     key1: "1"

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -870,7 +870,7 @@ func NamespaceIDFilter(namespaceID string) FilterOption {
 // TaskTypeFilter filters by task type
 func TaskTypeFilter(taskType enumspb.TaskQueueType) FilterOption {
 	return func(filterMap map[Filter]interface{}) {
-		filterMap[TaskType] = int(taskType)
+		filterMap[TaskType] = enumspb.TaskQueueType_name[int32(taskType)]
 	}
 }
 

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -870,7 +870,7 @@ func NamespaceIDFilter(namespaceID string) FilterOption {
 // TaskTypeFilter filters by task type
 func TaskTypeFilter(taskType enumspb.TaskQueueType) FilterOption {
 	return func(filterMap map[Filter]interface{}) {
-		filterMap[TaskType] = taskType
+		filterMap[TaskType] = int(taskType)
 	}
 }
 

--- a/common/service/dynamicconfig/fileBasedClient_test.go
+++ b/common/service/dynamicconfig/fileBasedClient_test.go
@@ -136,6 +136,18 @@ func (s *fileBasedClientSuite) TestGetIntValue_WrongType() {
 	s.Equal(defaultValue, v)
 }
 
+func (s *fileBasedClientSuite) TestGetIntValue_FilteredByTaskQueueInfo() {
+	expectedValue := 1001
+	filters := map[Filter]interface{}{
+		Namespace:     "global-samples-namespace",
+		TaskQueueName: "test-tq",
+		TaskType:      1,
+	}
+	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
+	s.NoError(err)
+	s.Equal(expectedValue, v)
+}
+
 func (s *fileBasedClientSuite) TestGetFloatValue() {
 	v, err := s.client.GetFloatValue(testGetFloat64PropertyKey, nil, 1)
 	s.NoError(err)

--- a/common/service/dynamicconfig/fileBasedClient_test.go
+++ b/common/service/dynamicconfig/fileBasedClient_test.go
@@ -136,12 +136,24 @@ func (s *fileBasedClientSuite) TestGetIntValue_WrongType() {
 	s.Equal(defaultValue, v)
 }
 
-func (s *fileBasedClientSuite) TestGetIntValue_FilteredByTaskQueueInfo() {
+func (s *fileBasedClientSuite) TestGetIntValue_FilteredByWorkflowTaskQueueInfo() {
 	expectedValue := 1001
 	filters := map[Filter]interface{}{
 		Namespace:     "global-samples-namespace",
 		TaskQueueName: "test-tq",
-		TaskType:      1,
+		TaskType:      "Workflow",
+	}
+	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
+	s.NoError(err)
+	s.Equal(expectedValue, v)
+}
+
+func (s *fileBasedClientSuite) TestGetIntValue_FilteredByActivityTaskQueueInfo() {
+	expectedValue := 1002
+	filters := map[Filter]interface{}{
+		Namespace:     "global-samples-namespace",
+		TaskQueueName: "test-tq",
+		TaskType:      "Activity",
 	}
 	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
 	s.NoError(err)


### PR DESCRIPTION
Our Dynamic Configuration File-based logic was comparing a value that is typically supplied as an integer / string to an enum value, which would never match. As a result, any constraint that specified TaskQueueType would never match, which means that this constraint setting never worked.

This PR fixes this issue by converting the TaskType enum filter into its String equivalent, so the user can specify "Activity" or "Workflow" (case-sensitive)

Not in scope for this PR:
- Allowing multiple ways to specify TaskType (e.g. 1 or 2 instead of "Workflow" or "Activity") - this requires a heavier rewrite of Dynamic Config.
- Assumed defaults for Constrained Values - this also requires a very significant change for dynamic config

Verified this test on a local development environment and via unit-tests.

The breaking change risk here is minimal. The taskType constraint never worked properly in the first place. But, if someone has tested their system with the taskType constraint set (incorrectly assuming the override was applied), when they roll out this fix, they could see a change in the number of task queue partitions for this scenario, which, while not having a functional impact, could lead to a observed difference in performance.

