### PR TITLE
Makes TaskType constraint in dynamic configuration optional when specifying Task Queue Partitions

### DIFF
--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -188,14 +188,29 @@ func (c *Collection) GetIntPropertyFilteredByNamespace(key Key, defaultValue int
 // GetIntPropertyFilteredByTaskQueueInfo gets property with taskQueueInfo as filters and asserts that it's an integer
 func (c *Collection) GetIntPropertyFilteredByTaskQueueInfo(key Key, defaultValue int) IntPropertyFnWithTaskQueueInfoFilters {
 	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) int {
-		val, err := c.client.GetIntValue(
-			key,
+		val := defaultValue
+		var err error
+
+		filterMaps := []map[Filter]interface{}{
 			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
-			defaultValue,
-		)
-		if err != nil {
-			c.logError(key, err)
+			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
 		}
+
+		for _, filterMap := range filterMaps {
+			val, err = c.client.GetIntValue(
+				key,
+				filterMap,
+				defaultValue,
+			)
+			if err != nil {
+				c.logError(key, err)
+			}
+
+			if val != defaultValue {
+				break
+			}
+		}
+
 		c.logValue(key, val, defaultValue, intCompareEquals)
 		return val
 	}
@@ -284,14 +299,29 @@ func (c *Collection) GetDurationPropertyFilteredByNamespaceID(key Key, defaultVa
 // GetDurationPropertyFilteredByTaskQueueInfo gets property with taskQueueInfo as filters and asserts that it's a duration
 func (c *Collection) GetDurationPropertyFilteredByTaskQueueInfo(key Key, defaultValue time.Duration) DurationPropertyFnWithTaskQueueInfoFilters {
 	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) time.Duration {
-		val, err := c.client.GetDurationValue(
-			key,
+		val := defaultValue
+		var err error
+
+		filterMaps := []map[Filter]interface{}{
 			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
-			defaultValue,
-		)
-		if err != nil {
-			c.logError(key, err)
+			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
 		}
+
+		for _, filterMap := range filterMaps {
+			val, err = c.client.GetDurationValue(
+				key,
+				filterMap,
+				defaultValue,
+			)
+			if err != nil {
+				c.logError(key, err)
+			}
+
+			if val != defaultValue {
+				break
+			}
+		}
+
 		c.logValue(key, val, defaultValue, durationCompareEquals)
 		return val
 	}
@@ -400,14 +430,29 @@ func (c *Collection) GetBoolPropertyFnWithNamespaceIDFilter(key Key, defaultValu
 // GetBoolPropertyFilteredByTaskQueueInfo gets property with taskQueueInfo as filters and asserts that it's an bool
 func (c *Collection) GetBoolPropertyFilteredByTaskQueueInfo(key Key, defaultValue bool) BoolPropertyFnWithTaskQueueInfoFilters {
 	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) bool {
-		val, err := c.client.GetBoolValue(
-			key,
+		val := defaultValue
+		var err error
+
+		filterMaps := []map[Filter]interface{}{
 			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
-			defaultValue,
-		)
-		if err != nil {
-			c.logError(key, err)
+			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
 		}
+
+		for _, filterMap := range filterMaps {
+			val, err = c.client.GetBoolValue(
+				key,
+				filterMap,
+				defaultValue,
+			)
+			if err != nil {
+				c.logError(key, err)
+			}
+
+			if val != defaultValue {
+				break
+			}
+		}
+
 		c.logValue(key, val, defaultValue, boolCompareEquals)
 		return val
 	}

--- a/common/service/dynamicconfig/config/testConfig.yaml
+++ b/common/service/dynamicconfig/config/testConfig.yaml
@@ -37,12 +37,16 @@ testGetIntPropertyKey:
   constraints:
     namespace: global-samples-namespace
     taskQueueName: test-tq
-    taskType: "Workflow"
+    taskType: Workflow
 - value: 1002
   constraints:
     namespace: global-samples-namespace
     taskQueueName: test-tq
-    taskType: "Activity"
+    taskType: Activity
+- value: 1003
+  constraints:
+    namespace: global-samples-namespace
+    taskQueueName: test-tq
 testGetMapPropertyKey:
 - value:
     key1: "1"

--- a/common/service/dynamicconfig/fileBasedClient_test.go
+++ b/common/service/dynamicconfig/fileBasedClient_test.go
@@ -148,6 +148,17 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilteredByWorkflowTaskQueueInfo()
 	s.Equal(expectedValue, v)
 }
 
+func (s *fileBasedClientSuite) TestGetIntValue_FilteredByNoTaskTypeQueueInfo() {
+	expectedValue := 1003
+	filters := map[Filter]interface{}{
+		Namespace:     "global-samples-namespace",
+		TaskQueueName: "test-tq",
+	}
+	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
+	s.NoError(err)
+	s.Equal(expectedValue, v)
+}
+
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByActivityTaskQueueInfo() {
 	expectedValue := 1002
 	filters := map[Filter]interface{}{


### PR DESCRIPTION
We've noticed that a lot of users, when attempting to override TaskQueue partition count, don't realize that they need to explicitly set the taskType and have an entry for both "Workflow" and "Activity." In most cases, users are fine just scaling both simultaneously and don't need to care about the taskType.

We've changed the dynamic configuration so that it will match a constraint if the user chooses to omit taskType as well. It first searches for a constraint with the specific taskType set, and if it cannot find it, will search for a constraint w/o taskType.

Test using both unit tests and the local one box environment.

Users might be incorrectly thinking they have task queue partitioning enabled. After upgrading to this change, they will actually have task queue partitioning enabled. They won't notice a functional difference, but may notice a performance difference.
