### PR TITLE
Update local namespace workflows to use version history

### DIFF
--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -171,7 +171,7 @@ type (
 		IsWorkflowExecutionRunning() bool
 		IsResourceDuplicated(resourceDedupKey definition.DeduplicationID) bool
 		UpdateDuplicatedResource(resourceDedupKey definition.DeduplicationID)
-		Load(*persistencespb.WorkflowMutableState)
+		Load(*persistencespb.WorkflowMutableState) error
 		ReplicateActivityInfo(*historyservice.SyncActivityRequest, bool) error
 		ReplicateActivityTaskCancelRequestedEvent(*historypb.HistoryEvent) error
 		ReplicateActivityTaskCanceledEvent(*historypb.HistoryEvent) error

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -40,6 +40,7 @@ import (
 	history "go.temporal.io/api/history/v1"
 	taskqueue "go.temporal.io/api/taskqueue/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
+
 	enums0 "go.temporal.io/server/api/enums/v1"
 	historyservice "go.temporal.io/server/api/historyservice/v1"
 	persistence "go.temporal.io/server/api/persistence/v1"
@@ -1577,9 +1578,11 @@ func (mr *MockmutableStateMockRecorder) UpdateDuplicatedResource(resourceDedupKe
 }
 
 // Load mocks base method.
-func (m *MockmutableState) Load(arg0 *persistence.WorkflowMutableState) {
+func (m *MockmutableState) Load(arg0 *persistence.WorkflowMutableState) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Load", arg0)
+	ret := m.ctrl.Call(m, "Load", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Load indicates an expected call of Load.

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -249,7 +249,9 @@ func (c *workflowExecutionContextImpl) loadWorkflowExecutionForReplication(
 			namespaceEntry,
 		)
 
-		c.mutableState.Load(response.State)
+		if err := c.mutableState.Load(response.State); err != nil {
+			return nil, err
+		}
 
 		c.stats = response.State.ExecutionInfo.ExecutionStats
 		c.updateCondition = response.State.NextEventId
@@ -322,7 +324,9 @@ func (c *workflowExecutionContextImpl) loadWorkflowExecution() (mutableState, er
 			namespaceEntry,
 		)
 
-		c.mutableState.Load(response.State)
+		if err := c.mutableState.Load(response.State); err != nil {
+			return nil, err
+		}
 
 		c.stats = response.State.ExecutionInfo.ExecutionStats
 		c.updateCondition = response.State.NextEventId


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Make local namespace workflows also use version history

Solves #703 

<!-- Tell your future self why have you made these changes -->
**Why?**
Unify code path, less if / else

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run server & canary locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
