### PR TITLE
Set MinConnectTimeout to 20 seconds

### DIFF
--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -46,6 +46,9 @@ const (
 
 	// MaxBackoffDelay is a maximum interval between reconnect attempts.
 	MaxBackoffDelay = 10 * time.Second
+
+	// minConnectTimeout is the minimum amount of time we are willing to give a connection to complete.
+	minConnectTimeout = 20 * time.Second
 )
 
 // Dial creates a client connection to the given target with default options.
@@ -65,7 +68,8 @@ func Dial(hostName string, tlsConfig *tls.Config) (*grpc.ClientConn, error) {
 	// https://github.com/grpc/grpc/blob/master/doc/connection-backoff.md.
 	// Default MaxDelay is 120 seconds which is too high.
 	var cp = grpc.ConnectParams{
-		Backoff: backoff.DefaultConfig,
+		Backoff:           backoff.DefaultConfig,
+		MinConnectTimeout: minConnectTimeout,
 	}
 	cp.Backoff.MaxDelay = MaxBackoffDelay
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`MinConnectTimeout` is set to its former default value of 20 seconds.

<!-- Tell your future self why have you made these changes -->
**Why?**
Change similar to SDK PR: https://github.com/temporalio/sdk-go/pull/250
Issue is here: https://github.com/temporalio/sdk-go/pull/249

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
All tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks, bug fixing.
