### PR TITLE
Adds support for differing gRPC ports for the same temporal service on a deployed cluster

### DIFF
--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -126,8 +126,12 @@ func (rpo *ringpopMonitor) Start() {
 		rpo.logger.Fatal("unable to get ring pop labels", tag.Error(err))
 	}
 
+	if err = labels.Set(RolePort, strconv.Itoa(rpo.services[rpo.serviceName])); err != nil {
+		rpo.logger.Fatal("unable to set ring pop ServicePort label", tag.Error(err))
+	}
+
 	if err = labels.Set(RoleKey, rpo.serviceName); err != nil {
-		rpo.logger.Fatal("unable to set ring pop labels", tag.Error(err))
+		rpo.logger.Fatal("unable to set ring pop ServiceRole label", tag.Error(err))
 	}
 
 	for _, ring := range rpo.rings {

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -27,6 +27,7 @@ package membership
 import (
 	"errors"
 	"net"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -47,7 +48,13 @@ import (
 const (
 	// RoleKey label is set by every single service as soon as it bootstraps its
 	// ringpop instance. The data for this key is the service name
-	RoleKey                = "serviceName"
+	RoleKey = "serviceName"
+
+	// RolePort label is set by every single service as soon as it bootstraps its
+	// ringpop instance. The data for this key represents the TCP port through which
+	// the service can be accessed.
+	RolePort = "servicePort"
+
 	minRefreshInternal     = time.Second * 4
 	defaultRefreshInterval = time.Second * 10
 	replicaPoints          = 100
@@ -156,11 +163,7 @@ func (r *ringpopServiceResolver) Lookup(
 		return nil, ErrInsufficientHosts
 	}
 
-	serviceAddress, err := replaceServicePort(addr, r.port)
-	if err != nil {
-		return nil, err
-	}
-	return NewHostInfo(serviceAddress, r.getLabelsMap()), nil
+	return NewHostInfo(addr, r.getLabelsMap()), nil
 }
 
 func (r *ringpopServiceResolver) AddListener(
@@ -241,7 +244,7 @@ func (r *ringpopServiceResolver) refreshWithBackoff() error {
 }
 
 func (r *ringpopServiceResolver) refreshNoLock() error {
-	addrs, err := r.rp.GetReachableMembers(swim.MemberWithLabelAndValue(RoleKey, r.service))
+	addrs, err := r.getReachableMembers()
 	if err != nil {
 		return err
 	}
@@ -262,6 +265,40 @@ func (r *ringpopServiceResolver) refreshNoLock() error {
 	r.ringValue.Store(ring)
 	r.logger.Info("Current reachable members", tag.Addresses(addrs))
 	return nil
+}
+
+func (r *ringpopServiceResolver) getReachableMembers() ([]string, error) {
+	members, err := r.rp.GetReachableMemberObjects(swim.MemberWithLabelAndValue(RoleKey, r.service))
+	if err != nil {
+		return nil, err
+	}
+
+	var hostPorts []string
+	for _, member := range members {
+		servicePort := r.port
+
+		// Each temporal service in the ring should advertise which port it has its gRPC listener
+		// on via a RingPop label. If we cannot find the label, we will assume that that the
+		// temporal service is listening on the same port that this node is listening on.
+		servicePortLabel, ok := member.Label(RolePort)
+		if ok {
+			servicePort, err = strconv.Atoi(servicePortLabel)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			r.logger.Warn("unable to find roleport label for ringpop member. using local container's port", tag.Service(r.service))
+		}
+
+		hostPort, err := replaceServicePort(member.Address, servicePort)
+		if err != nil {
+			return nil, err
+		}
+
+		hostPorts = append(hostPorts, hostPort)
+	}
+
+	return hostPorts, nil
 }
 
 func (r *ringpopServiceResolver) emitEvent(

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -287,7 +287,7 @@ func (r *ringpopServiceResolver) getReachableMembers() ([]string, error) {
 				return nil, err
 			}
 		} else {
-			r.logger.Warn("unable to find roleport label for ringpop member. using local container's port", tag.Service(r.service))
+			r.logger.Warn("unable to find roleport label for ringpop member. using local service's port", tag.Service(r.service))
 		}
 
 		hostPort, err := replaceServicePort(member.Address, servicePort)

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -287,7 +287,7 @@ func (r *ringpopServiceResolver) getReachableMembers() ([]string, error) {
 				return nil, err
 			}
 		} else {
-			r.logger.Warn("unable to find roleport label for ringpop member. using local service's port", tag.Service(r.service))
+			r.logger.Debug("unable to find roleport label for ringpop member. using local service's port", tag.Service(r.service))
 		}
 
 		hostPort, err := replaceServicePort(member.Address, servicePort)


### PR DESCRIPTION
**Why?**
Currently, we assume that if the Temporal service's gRPC port is defined in config, then all other services of the same type on the Temporal cluster are also communicating via the same port. This requires that the gRPC port for a given service type be identical across the entire cluster. Unfortunately, this breaks if a user wants to dynamically allocate gRPC ports or host two instances of a Temporal service type on the same IP address.

Rather than deriving other services' gRPC ports based on config, we will have each service write the gRPC port from its config as a ringpop label. Other services can then use this label to determine which port it needs to connect to to communicate with tthat particular service. This enables different instances of the same service type (e.g. history, frontend, matching) to have different gRPC ports on different nodes, but still be able to successfully communicate with each other.

**How did you test it?**
In addition to standard CI tests, I was also able to run two instances of the history service on the same box on different ports and have them communicate with each other, which was not possible before this change.

**Potential risks**
This is a low-risk change, since any functioning/deployed Temporal Cluster is already using static ports right now, all we've done is shift the source of truth from the config file to the RingPop label. Already existing deployments will write the same values that are in their config into the RingPop label, and those clusters already had to agree on the same port value to be working in the first place, so there is virtually no risk.
