### PR TITLE
Add global.metrics section and deprecate service.metrics

### DIFF
--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -77,7 +77,7 @@ type (
 		// RPC is the rpc configuration
 		RPC RPC `yaml:"rpc"`
 		// Deprecated. Use Metrics in global section instead.
-		Metrics *Metrics `yaml:"metrics"`
+		Metrics Metrics `yaml:"metrics"`
 	}
 
 	// PProf contains the config items for the pprof utility

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -76,8 +76,8 @@ type (
 	Service struct {
 		// RPC is the rpc configuration
 		RPC RPC `yaml:"rpc"`
-		// Metrics is the metrics subsystem configuration
-		Metrics Metrics `yaml:"metrics"`
+		// Deprecated. Use Metrics in global section instead.
+		Metrics *Metrics `yaml:"metrics"`
 	}
 
 	// PProf contains the config items for the pprof utility
@@ -108,6 +108,8 @@ type (
 		PProf PProf `yaml:"pprof"`
 		// TLS controls the communication encryption configuration
 		TLS RootTLS `yaml:"tls"`
+		// Metrics is the metrics subsystem configuration
+		Metrics *Metrics `yaml:"metrics"`
 	}
 
 	// RootTLS contains all TLS settings for the Temporal server
@@ -373,8 +375,7 @@ type (
 		Statsd *Statsd `yaml:"statsd"`
 		// Prometheus is the configuration for prometheus reporter
 		Prometheus *prometheus.Configuration `yaml:"prometheus"`
-		// Tags is the set of key-value pairs to be reported
-		// as part of every metric
+		// Tags is the set of key-value pairs to be reported as part of every metric
 		Tags map[string]string `yaml:"tags"`
 		// Prefix sets the prefix to all outgoing metrics
 		Prefix string `yaml:"prefix"`

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -17,6 +17,10 @@ global:
     broadcastAddress: "127.0.0.1"
   pprof:
     port: 7936
+  metrics:
+    statsd:
+      hostPort: "127.0.0.1:8125"
+      prefix: "temporal"
 
 services:
   frontend:
@@ -24,40 +28,24 @@ services:
       grpcPort: 7233
       membershipPort: 6933
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   matching:
     rpc:
       grpcPort: 7235
       membershipPort: 6935
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   history:
     rpc:
       grpcPort: 7234
       membershipPort: 6934
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   worker:
     rpc:
       grpcPort: 7239
       membershipPort: 6939
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
 clusterMetadata:
   enableGlobalNamespace: false

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -17,6 +17,10 @@ global:
     broadcastAddress: "127.0.0.1"
   pprof:
     port: 7936
+  metrics:
+    statsd:
+      hostPort: "127.0.0.1:8125"
+      prefix: "temporal_active"
 
 services:
   frontend:
@@ -24,40 +28,24 @@ services:
       grpcPort: 7233
       membershipPort: 6933
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_active"
 
   matching:
     rpc:
       grpcPort: 7235
       membershipPort: 6935
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_active"
 
   history:
     rpc:
       grpcPort: 7234
       membershipPort: 6934
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_active"
 
   worker:
     rpc:
       grpcPort: 7940
       membershipPort: 6940
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_active"
 
 clusterMetadata:
   enableGlobalNamespace: true

--- a/config/development_archival.yaml
+++ b/config/development_archival.yaml
@@ -17,6 +17,10 @@ global:
     broadcastAddress: "127.0.0.1"
   pprof:
     port: 7936
+  metrics:
+    statsd:
+      hostPort: "127.0.0.1:8125"
+      prefix: "temporal"
 
 services:
   frontend:
@@ -24,40 +28,24 @@ services:
       grpcPort: 7233
       membershipPort: 6933
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   matching:
     rpc:
       grpcPort: 7235
       membershipPort: 6935
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   history:
     rpc:
       grpcPort: 7234
       membershipPort: 6934
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   worker:
     rpc:
       grpcPort: 7239
       membershipPort: 6939
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
 clusterMetadata:
   enableGlobalNamespace: false

--- a/config/development_es.yaml
+++ b/config/development_es.yaml
@@ -24,6 +24,10 @@ global:
     maxJoinDuration: 30s
   pprof:
       port: 7936
+  metrics:
+    statsd:
+      hostPort: "127.0.0.1:8125"
+      prefix: "temporal"
 
 services:
   frontend:
@@ -31,40 +35,24 @@ services:
       grpcPort: 7233
       membershipPort: 6933
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   matching:
     rpc:
       grpcPort: 7235
       membershipPort: 6935
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   history:
     rpc:
       grpcPort: 7234
       membershipPort: 6934
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   worker:
     rpc:
       grpcPort: 7239
       membershipPort: 6939
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
 clusterMetadata:
   enableGlobalNamespace: false

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -31,6 +31,10 @@ global:
     maxJoinDuration: 30s
   pprof:
     port: 7936
+  metrics:
+    statsd:
+      hostPort: "127.0.0.1:8125"
+      prefix: "temporal"
 
 services:
   frontend:
@@ -38,40 +42,24 @@ services:
       grpcPort: 7233
       membershipPort: 6933
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   matching:
     rpc:
       grpcPort: 7235
       membershipPort: 6935
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   history:
     rpc:
       grpcPort: 7234
       membershipPort: 6934
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   worker:
     rpc:
       grpcPort: 7239
       membershipPort: 6939
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
 clusterMetadata:
   enableGlobalNamespace: false

--- a/config/development_other.yaml
+++ b/config/development_other.yaml
@@ -17,6 +17,10 @@ global:
     maxJoinDuration: 30s
   pprof:
     port: 9936
+  metrics:
+    statsd:
+      hostPort: "127.0.0.1:8125"
+      prefix: "temporal_other"
 
 services:
   frontend:
@@ -24,40 +28,24 @@ services:
       grpcPort: 9233
       membershipPort: 9933
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_other"
 
   matching:
     rpc:
       grpcPort: 9235
       membershipPort: 9935
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_other"
 
   history:
     rpc:
       grpcPort: 9234
       membershipPort: 9934
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_other"
 
   worker:
     rpc:
       grpcPort: 9240
       membershipPort: 9940
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_other"
 
 clusterMetadata:
   enableGlobalNamespace: true

--- a/config/development_postgres.yaml
+++ b/config/development_postgres.yaml
@@ -31,6 +31,10 @@ global:
     maxJoinDuration: 30s
   pprof:
     port: 7936
+  metrics:
+    statsd:
+      hostPort: "127.0.0.1:8125"
+      prefix: "temporal"
 
 services:
   frontend:
@@ -38,40 +42,24 @@ services:
       grpcPort: 7233
       membershipPort: 6933
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   matching:
     rpc:
       grpcPort: 7235
       membershipPort: 6935
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   history:
     rpc:
       grpcPort: 7234
       membershipPort: 6934
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
   worker:
     rpc:
       grpcPort: 7239
       membershipPort: 6939
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal"
 
 clusterMetadata:
   enableGlobalNamespace: false

--- a/config/development_prometheus.yaml
+++ b/config/development_prometheus.yaml
@@ -17,6 +17,10 @@ global:
     maxJoinDuration: 30s
   pprof:
     port: 7936
+  metrics:
+    prometheus:
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
 
 services:
   frontend:
@@ -24,40 +28,24 @@ services:
       grpcPort: 7233
       membershipPort: 6933
       bindOnLocalHost: true
-    metrics:
-      prometheus:
-        timerType: "histogram"
-        listenAddress: "127.0.0.1:8000"
 
   matching:
     rpc:
       grpcPort: 7235
       membershipPort: 6935
       bindOnLocalHost: true
-    metrics:
-      prometheus:
-        timerType: "histogram"
-        listenAddress: "127.0.0.1:8001"
 
   history:
     rpc:
       grpcPort: 7234
       membershipPort: 6934
       bindOnLocalHost: true
-    metrics:
-      prometheus:
-        timerType: "histogram"
-        listenAddress: "127.0.0.1:8002"
 
   worker:
     rpc:
       grpcPort: 7239
       membershipPort: 6939
       bindOnLocalHost: true
-    metrics:
-      prometheus:
-        timerType: "histogram"
-        listenAddress: "127.0.0.1:8003"
 
 clusterMetadata:
   enableGlobalNamespace: false

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -17,6 +17,10 @@ global:
     maxJoinDuration: 30s
   pprof:
     port: 8936
+  metrics:
+    statsd:
+      hostPort: "127.0.0.1:8125"
+      prefix: "temporal_standby"
 
 services:
   frontend:
@@ -24,40 +28,24 @@ services:
       grpcPort: 8233
       membershipPort: 8933
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_standby"
 
   matching:
     rpc:
       grpcPort: 8235
       membershipPort: 8935
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_standby"
 
   history:
     rpc:
       grpcPort: 8234
       membershipPort: 8934
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_standby"
 
   worker:
     rpc:
       grpcPort: 8240
       membershipPort: 8940
       bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "temporal_standby"
 
 clusterMetadata:
   enableGlobalNamespace: true

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -168,6 +168,17 @@ global:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT "" }}
                 rootCaData:
                     - {{ default .Env.TEMPORAL_TLS_SERVER_CA_CERT_DATA "" }}
+    {{- if .Env.STATSD_ENDPOINT }}
+    metrics:
+        statsd:
+            hostPort: {{ .Env.STATSD_ENDPOINT }}
+            prefix: "frontend"
+    {{- else if .Env.PROMETHEUS_ENDPOINT }}
+    metrics:
+        prometheus:
+            timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
+            listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
+    {{- end }}
 
 {{- $temporalGrpcPort := default .Env.FRONTEND_GRPC_PORT "7233" -}}
 services:
@@ -176,68 +187,24 @@ services:
             grpcPort: {{ $temporalGrpcPort }}
             membershipPort: {{ default .Env.FRONTEND_MEMBERSHIP_PORT "6933" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
-        {{- if .Env.STATSD_ENDPOINT }}
-        metrics:
-            statsd:
-                hostPort: {{ .Env.STATSD_ENDPOINT }}
-                prefix: "frontend"
-        {{- else if .Env.PROMETHEUS_ENDPOINT }}
-        metrics:
-            prometheus:
-                timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
-                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
-        {{- end }}
 
     matching:
         rpc:
             grpcPort: {{ default .Env.MATCHING_GRPC_PORT "7235" }}
             membershipPort: {{ default .Env.MATCHING_MEMBERSHIP_PORT "6935" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
-        {{- if .Env.STATSD_ENDPOINT }}
-        metrics:
-            statsd:
-                hostPort: {{ .Env.STATSD_ENDPOINT }}
-                prefix: "matching"
-        {{- else if .Env.PROMETHEUS_ENDPOINT }}
-        metrics:
-            prometheus:
-                timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
-                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
-        {{- end }}
 
     history:
         rpc:
             grpcPort: {{ default .Env.HISTORY_GRPC_PORT "7234" }}
             membershipPort: {{ default .Env.HISTORY_MEMBERSHIP_PORT "6934" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
-        {{- if .Env.STATSD_ENDPOINT }}
-        metrics:
-            statsd:
-                hostPort: {{ .Env.STATSD_ENDPOINT }}
-                prefix: "history"
-        {{- else if .Env.PROMETHEUS_ENDPOINT }}
-        metrics:
-            prometheus:
-                timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
-                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
-        {{- end }}
 
     worker:
         rpc:
             grpcPort: {{ default .Env.WORKER_GRPC_PORT "7239" }}
             membershipPort: {{ default .Env.WORKER_MEMBERSHIP_PORT "6939" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
-        {{- if .Env.STATSD_ENDPOINT }}
-        metrics:
-            statsd:
-                hostPort: {{ .Env.STATSD_ENDPOINT }}
-                prefix: "worker"
-        {{- else if .Env.PROMETHEUS_ENDPOINT }}
-        metrics:
-            prometheus:
-                timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
-                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
-        {{- end }}
 
 clusterMetadata:
     enableGlobalNamespace: false

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -172,7 +172,7 @@ global:
     metrics:
         statsd:
             hostPort: {{ .Env.STATSD_ENDPOINT }}
-            prefix: "frontend"
+            prefix: "temporal"
     {{- else if .Env.PROMETHEUS_ENDPOINT }}
     metrics:
         prometheus:
@@ -180,7 +180,7 @@ global:
             listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
     {{- end }}
 
-{{- $temporalGrpcPort := default .Env.FRONTEND_GRPC_PORT "7233" -}}
+{{- $temporalGrpcPort := default .Env.FRONTEND_GRPC_PORT "7233" }}
 services:
     frontend:
         rpc:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
New `metrics` section was added to `global` section in `development.yml`. Old `metrics` section in `services` section is still supported but marked as deprecated. Closes #673.

<!-- Tell your future self why have you made these changes -->
**Why?**
Metrics scope should be created once per server (process), not per service.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run server locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks for now but at some point `services.metrics` needs to be removed.
