### PR TITLE
Increases number of go-routines that acquire history shards

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -277,7 +277,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		EventsCacheTTL:                       dc.GetDurationProperty(dynamicconfig.EventsCacheTTL, time.Hour),
 		RangeSizeBits:                        20, // 20 bits for sequencer, 2^20 sequence number for any range
 		AcquireShardInterval:                 dc.GetDurationProperty(dynamicconfig.AcquireShardInterval, time.Minute),
-		AcquireShardConcurrency:              dc.GetIntProperty(dynamicconfig.AcquireShardConcurrency, 1),
+		AcquireShardConcurrency:              dc.GetIntProperty(dynamicconfig.AcquireShardConcurrency, 10),
 		StandbyClusterDelay:                  dc.GetDurationProperty(dynamicconfig.StandbyClusterDelay, 5*time.Minute),
 		StandbyTaskMissingEventsResendDelay:  dc.GetDurationProperty(dynamicconfig.StandbyTaskMissingEventsResendDelay, 10*time.Minute),
 		StandbyTaskMissingEventsDiscardDelay: dc.GetDurationProperty(dynamicconfig.StandbyTaskMissingEventsDiscardDelay, 15*time.Minute),


### PR DESCRIPTION
For Temporal clusters with a large number of shards, a single go-routine that acquires all the shards causes significant latency when a history node is starting up as it loads the shards one-by-one.

This fix increases the number of goroutines to "10" as that should not cause any issues for existing clusters, but will yield a significant benefit to clusters with a larger number of shards.

Ideally, the number of goroutines should be calculated based on a ratio of the total number of shards to make this slightly more flexible.