### PR TITLE
Enable NetworkTopologyStrategy for cassandra

### DIFF
--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -78,13 +78,14 @@ func checkCompatibleVersion(
 ) error {
 
 	client, err := newCQLClient(&CQLClientConfig{
-		Hosts:    cfg.Hosts,
-		Port:     cfg.Port,
-		User:     cfg.User,
-		Password: cfg.Password,
-		Keyspace: cfg.Keyspace,
-		Timeout:  defaultTimeout,
-		TLS:      cfg.TLS,
+		Hosts:      cfg.Hosts,
+		Port:       cfg.Port,
+		User:       cfg.User,
+		Password:   cfg.Password,
+		Keyspace:   cfg.Keyspace,
+		Timeout:    defaultTimeout,
+		Datacenter: cfg.Datacenter,
+		TLS:        cfg.TLS,
 	})
 	if err != nil {
 		return fmt.Errorf("unable to create CQL Client: %v", err.Error())
@@ -204,6 +205,7 @@ func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
 	config.Timeout = cli.GlobalInt(schema.CLIOptTimeout)
 	config.Keyspace = cli.GlobalString(schema.CLIOptKeyspace)
 	config.numReplicas = cli.Int(schema.CLIOptReplicationFactor)
+	config.Datacenter = cli.String(schema.CLIOptDatacenter)
 
 	if cli.GlobalBool(schema.CLIFlagEnableTLS) {
 		config.TLS = &auth.TLS{

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -104,6 +104,12 @@ func buildCLIOptions() *cli.App {
 			Usage:  "name of the cassandra Keyspace",
 			EnvVar: "CASSANDRA_KEYSPACE",
 		},
+		cli.StringFlag{
+			Name:   schema.CLIFlagDatacenter,
+			Value:  "",
+			Usage:  "enable NetworkTopologyStrategy by providing datacenter name",
+			EnvVar: "CASSANDRA_DATACENTER",
+		},
 		cli.BoolFlag{
 			Name:  schema.CLIFlagQuiet,
 			Usage: "Don't set exit status to 1 on error",
@@ -188,7 +194,7 @@ func buildCLIOptions() *cli.App {
 		{
 			Name:    "create-Keyspace",
 			Aliases: []string{"create"},
-			Usage:   "creates a Keyspace with simple strategy",
+			Usage:   "creates a Keyspace with simple strategy or network topology if datacenter name is provided",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  schema.CLIFlagKeyspace,
@@ -198,6 +204,11 @@ func buildCLIOptions() *cli.App {
 					Name:  schema.CLIFlagReplicationFactor,
 					Value: 1,
 					Usage: "replication factor for the Keyspace",
+				},
+				cli.StringFlag{
+					Name:  schema.CLIFlagDatacenter,
+					Value: "",
+					Usage: "enable NetworkTopologyStrategy by providing datacenter name",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -106,6 +106,8 @@ const (
 	CLIOptSchemaDir = "schema-dir"
 	// CLIOptReplicationFactor is the cli option for replication factor
 	CLIOptReplicationFactor = "replication-factor"
+	// CLIOptDatacenter is the cli option for NetworkTopologyStrategy datacenter
+	CLIOptDatacenter = "datacenter"
 	// CLIOptQuiet is the cli option for quiet mode
 	CLIOptQuiet = "quiet"
 
@@ -143,6 +145,8 @@ const (
 	CLIFlagSchemaDir = CLIOptSchemaDir + ", d"
 	// CLIFlagReplicationFactor is the cli flag for replication factor
 	CLIFlagReplicationFactor = CLIOptReplicationFactor + ", rf"
+	// CLIFlagDatacenter is the cli option for NetworkTopologyStrategy datacenter
+	CLIFlagDatacenter = CLIOptDatacenter + ", dc"
 	// CLIFlagQuiet is the cli flag for quiet mode
 	CLIFlagQuiet = CLIOptQuiet + ", q"
 


### PR DESCRIPTION
**What changed?**
Adds a `--datacenter` flag to temporal-cassandra-tool on create that will use NetworkTopologyStrategy for replication with the specified replication factor.

**Why?**
This is highly useful for clusters with topologies more complex than either single node or single node per rack with number of racks equal to replication factor. Any other layout will benefit from this.

**How did you test it?**
Manual test:
```
temporal-cassandra-tool create --keyspace temporal_derek_net_top --rf 3 --datacenter dc1
``` 
Result: 
```
cluster1-superuser@cqlsh> DESC KEYSPACE temporal_derek_net_top 

CREATE KEYSPACE temporal_derek_net_top WITH replication = {'class': 'NetworkTopologyStrategy', 'dc1': '3'}  AND durable_writes = true;
```

**Potential risks**
None known, but no unit tests added for this.