### PR TITLE
Postgres docker compose fix

### DIFF
--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: temporal
       POSTGRES_PASSWORD: temporal
   temporal:
-    image: temporalio/auto-setup:${SERVER_TAG:-1.1.1}
+    image: temporalio/auto-setup:${SERVER_TAG:-1.2.0}
     ports:
       - "7233:7233"
     volumes:
@@ -23,7 +23,7 @@ services:
     depends_on:
       - postgresql
   temporal-admin-tools:
-    image: temporalio/admin-tools:${SERVER_TAG:-1.1.0}
+    image: temporalio/admin-tools:${SERVER_TAG:-1.2.0}
     stdin_open: true
     tty: true
     environment:

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: temporal
       POSTGRES_PASSWORD: temporal
   temporal:
-    image: temporalio/auto-setup:${SERVER_TAG:-1.1.0}
+    image: temporalio/auto-setup:${SERVER_TAG:-1.1.1}
     ports:
       - "7233:7233"
     volumes:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Update SERVER_TAG to one that can handle the updated `DB=postgresql` environment passed by the docker-compose file.

<!-- Tell your future self why have you made these changes -->
**Why?**

In 1.2.0 the start script was adjusted to expect `DB=postgresql` instead of `DB=postgres` to decide which service to configure/wait for. The compose file was updated to `postgresql` instead of `postgres` but the default tag is of an older version whose `start.sh` still expects `postgres`.

For people using this compose file without setting `SERVER_TAG` this will result in temporal hanging, mistakenly waiting for cassandra instead of postgres.

```
+ DB=postgresql
+ ENABLE_ES=false
+ ES_PORT=9200
+ ES_SCHEME=http
+ RF=1
+ DEFAULT_NAMESPACE=default
+ DEFAULT_NAMESPACE_RETENTION=1
+ export TEMPORAL_CLI_ADDRESS=172.30.2.7:7233
+ TEMPORAL_CLI_ADDRESS=172.30.2.7:7233
+ export KEYSPACE=temporal
+ KEYSPACE=temporal
+ export VISIBILITY_KEYSPACE=temporal_visibility
+ VISIBILITY_KEYSPACE=temporal_visibility
+ export DBNAME=temporal
+ DBNAME=temporal
+ export VISIBILITY_DBNAME=temporal_visibility
+ VISIBILITY_DBNAME=temporal_visibility
+ export DB_PORT=5432
+ DB_PORT=5432
+ '[' autosetup = autosetup ']'
+ auto_setup
+ wait_for_db
+ '[' postgresql == mysql ']'
+ '[' postgresql == postgres ']'
+ wait_for_cassandra
++ awk -F , '{print $1}'
++ echo
+ server=
+ cqlsh --cqlversion=3.4.4
Connection error: ('Unable to connect to any servers', {'127.0.0.1:9042': error(111, "Tried connecting to [('127.0.0.1', 9042)]. Last error: Connection refused")})
waiting for cassandra to start up
+ echo 'waiting for cassandra to start up'
+ sleep 1
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Updated the compose file and started temporal, confirmed it came up ok.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

