### PR TITLE
Preload config before setting server options

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -121,14 +121,19 @@ func buildCLI() *cli.App {
 					services = strings.Split(c.String("services"), ",")
 				}
 
+				cfg, err := config.LoadConfig(env, configDir, zone)
+				if err != nil {
+					return cli.NewExitError(fmt.Sprintf("Unable to load configuration: %v.", err), 1)
+				}
+
 				s := temporal.NewServer(
 					temporal.ForServices(services),
-					temporal.WithConfigLoader(configDir, env, zone),
+					temporal.WithConfig(cfg),
 					temporal.InterruptOn(temporal.InterruptCh()),
 					temporal.WithAuthorizer(authorization.NewNopAuthorizer()),
 				)
 
-				err := s.Start()
+				err = s.Start()
 				if err != nil {
 					return cli.NewExitError(fmt.Sprintf("Unable to start server: %v.", err), 1)
 				}

--- a/common/service/config/loader.go
+++ b/common/service/config/loader.go
@@ -102,6 +102,16 @@ func Load(env string, configDir string, zone string, config interface{}) error {
 	return validator.Validate(config)
 }
 
+// Helper function for loading configuration
+func LoadConfig(env string, configDir string, zone string) (*Config, error) {
+	config := Config{}
+	err := Load(env, configDir, zone, &config)
+	if err != nil {
+		return nil, fmt.Errorf("config file corrupted: %w", err)
+	}
+	return &config, nil
+}
+
 // getConfigFiles returns the list of config files to
 // process in the hierarchy order
 func getConfigFiles(env string, configDir string, zone string) ([]string, error) {


### PR DESCRIPTION
**What changed?**
Changed server initialization procedure to load configs before server options are set.

**Why?**
Some server options need to get configuration parameters as part of their initialization. That requires config to be already loaded. Today config gets loaded later, and hence server options cannot use it. 

**How did you test it?**
Unit tests.

**Potential risks**
I don't see any risk here.
