### PR TITLE
Remove requestWithNamespace interface that is not used anymore

### DIFF
--- a/common/authorization/authorizer.go
+++ b/common/authorization/authorizer.go
@@ -61,7 +61,3 @@ type Authorizer interface {
 type requestWithNamespace interface {
 	GetNamespace() string
 }
-
-type requestWithName interface {
-	GetName() string
-}


### PR DESCRIPTION
**What changed?**
Removed unused interface.

**Why?**
Interface `requestWithNamespace` was part of the workaround removed in #967.

**How did you test it?**
Buildkite should suffice.

**Potential risks**
No risk.
