### PR TITLE
feat(metrics): Add datadog statsd format compatibility

### DIFF
--- a/common/metrics/tally/dogstatsd/reporter.go
+++ b/common/metrics/tally/dogstatsd/reporter.go
@@ -1,0 +1,73 @@
+package dogstatsd
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/uber-go/tally"
+	"sort"
+	"time"
+)
+
+type tallyDogstatsdReporter struct {
+	dogstatsd *statsd.Client
+}
+
+// NewReporter is a wrapper on top of "github.com/DataDog/datadog-go/statsd"
+// The purpose is to support datadog-formatted statsd metric tagging.
+func NewReporter(client *statsd.Client) tally.StatsReporter {
+	return &tallyDogstatsdReporter{
+		dogstatsd: client,
+	}
+}
+
+func (r tallyDogstatsdReporter) Capabilities() tally.Capabilities {
+	return r
+}
+
+func (r tallyDogstatsdReporter) Reporting() bool {
+	return true
+}
+
+func (r tallyDogstatsdReporter) Tagging() bool {
+	return true
+}
+
+func (r tallyDogstatsdReporter) Flush() {
+	// no-op
+}
+
+func (r tallyDogstatsdReporter) ReportCounter(name string, tags map[string]string, value int64) {
+	_ = r.dogstatsd.Count(name, value, r.marshalTags(tags), 1)
+}
+
+func (r tallyDogstatsdReporter) ReportGauge(name string, tags map[string]string, value float64) {
+	_ = r.dogstatsd.Gauge(name, value, r.marshalTags(tags), 1)
+}
+
+func (r tallyDogstatsdReporter) ReportTimer(name string, tags map[string]string, interval time.Duration) {
+	_ = r.dogstatsd.Timing(name, interval, r.marshalTags(tags), 1)
+}
+
+func (r tallyDogstatsdReporter) ReportHistogramValueSamples(name string, tags map[string]string, buckets tally.Buckets, bucketLowerBound, bucketUpperBound float64, samples int64) {
+	// temporal's client does not expose histograms
+	panic("implement me")
+}
+
+func (r tallyDogstatsdReporter) ReportHistogramDurationSamples(name string, tags map[string]string, buckets tally.Buckets, bucketLowerBound, bucketUpperBound time.Duration, samples int64) {
+	// temporal's client does not expose histograms
+	panic("implement me")
+}
+
+func (r tallyDogstatsdReporter) marshalTags(tags map[string]string) []string {
+	var keys []string
+	for k := range tags {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var dogTags []string
+	for _, tk := range keys {
+		dogTags = append(dogTags, fmt.Sprintf("%s:%s", tk, tags[tk]))
+	}
+	return dogTags
+}

--- a/common/metrics/tally/dogstatsd/reporter_test.go
+++ b/common/metrics/tally/dogstatsd/reporter_test.go
@@ -1,0 +1,42 @@
+package dogstatsd
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCapabilities(t *testing.T) {
+	r := NewReporter(nil)
+	assert.True(t, r.Capabilities().Reporting())
+	assert.True(t, r.Capabilities().Tagging())
+}
+
+func TestTagMarshaling(t *testing.T) {
+	r := tallyDogstatsdReporter{
+		dogstatsd: nil,
+	}
+	tags := map[string]string{
+		"tag1": "123",
+		"tag2": "456",
+		"tag3": "789",
+	}
+	dogTags := r.marshalTags(tags)
+
+	assert.Equal(t, "tag1:123", dogTags[0])
+	assert.Equal(t, "tag2:456", dogTags[1])
+	assert.Equal(t, "tag3:789", dogTags[2])
+}
+
+func TestTagMarshalingStability(t *testing.T) {
+	r := tallyDogstatsdReporter{}
+
+	tags := map[string]string{
+		"tag1": "123",
+		"tag2": "456",
+		"tag3": "789",
+	}
+
+	for i := 1; i <= 16; i++ {
+		assert.Equal(t, r.marshalTags(tags), r.marshalTags(tags))
+	}
+}

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -400,6 +400,9 @@ type (
 		// If FlushBytes is unspecified, it defaults  to 1432 bytes, which is
 		// considered safe for local traffic.
 		FlushBytes int `yaml:"flushBytes"`
+		// DatadogFormat formats the statsd metric names to be compatible with
+		// the DogStatsD format: https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics
+		DatadogFormat bool `yaml:"datadogFormat"`
 	}
 
 	// Archival contains the config for archival

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c
 	github.com/cch123/elasticsql v1.0.1
 	github.com/cpuguy83/go-md2man/v2 v2.0.0 // indirect
+	github.com/DataDog/datadog-go v4.2.0+incompatible
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
 	github.com/emirpasic/gods v0.0.0-20190624094223-e689965507ab

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
+github.com/DataDog/datadog-go v4.2.0+incompatible h1:Q73jzyKHwyA04Gf4SSukRF+KR4wJEimU6tAuU0B8Y4Y=
+github.com/DataDog/datadog-go v4.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Shopify/sarama v1.27.2 h1:1EyY1dsxNDUQEv0O/4TsjosHI2CgB1uo9H/v56xzTxc=
 github.com/Shopify/sarama v1.27.2/go.mod h1:g5s5osgELxgM+Md9Qni9rzo7Rbt+vvFQI4bt/Mc93II=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added support for the [dogstatsd](https://docs.datadoghq.com/developers/dogstatsd/datagram_shell/?tab=metrics) statsd format.

<!-- Tell your future self why have you made these changes -->
**Why?**

We'd like to send metrics into [Atlas](https://github.com/Netflix/atlas). Rather than add a reporter specific to Atlas, which would have limited community usefulness, I opted for adding the Datadog statsd naming scheme, which Atlas supports. 

Dogstatsd uses an incompatible naming scheme for tags than what the existing Tally statsd extension in Temporal currently has. I don't know who is currently using the existing statsd implementation, so I kept this change behind a new config value that would require users to explicitly opt into this alternative behavior.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I've only run the unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

New users of the datadog statsd implementation would not receive metrics.