### PR TITLE
Add PostgreSQL support to tctl admin commands

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -588,7 +588,7 @@ func getDBFlags() []cli.Flag {
 		cli.StringFlag{
 			Name:  FlagDBEngine,
 			Value: "cassandra",
-			Usage: "Type of the DB engine to use (cassandra, mysql..)",
+			Usage: "Type of the DB engine to use (cassandra, mysql, postgres..)",
 		},
 		cli.StringFlag{
 			Name:  FlagDBAddress,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added PostgreSQL support to tctl admin commands (newer commands that use persistenceUtil.go). Some older commands don't use this util and don't support PostgreSQL yet. There is a separate task that tracks refactoring of older commands 

<!-- Tell your future self why have you made these changes -->
**Why?**
Adds tctl admin visibility into temporal setups based on PostgreSQL db

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
ran `admin namespace list` with PostgreSQL and Cassandra setups

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
-- testing--