### PR TITLE
Fix broken DescribeHistoryHost API / CLI

### DIFF
--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -270,8 +270,22 @@ func (adh *AdminHandler) DescribeHistoryHost(ctx context.Context, request *admin
 	scope, sw := adh.startRequestProfile(metrics.AdminDescribeHistoryHostScope)
 	defer sw.Stop()
 
-	if request == nil || request.WorkflowExecution == nil {
+	if request == nil {
 		return nil, adh.error(errRequestNotSet, scope)
+	}
+
+	flagsCount := 0
+	if request.ShardId != 0 {
+		flagsCount++
+	}
+	if len(request.Namespace) != 0 && request.WorkflowExecution != nil {
+		flagsCount++
+	}
+	if len(request.GetHostAddress()) > 0 {
+		flagsCount++
+	}
+	if flagsCount != 1 {
+		return nil, serviceerror.NewInvalidArgument("must provide one and only one: shard id or namespace & workflow id or host address")
 	}
 
 	var err error


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Fix CLI / server admin handler bug

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix bug

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```zsh
./tctl --address 127.0.0.1:7233 admin history_host describe --shard_id 4
./tctl --address 127.0.0.1:7233 admin history_host describe --history_address 127.0.0.1:7234
./tctl --address 127.0.0.1:7233 --namespace canary admin history_host describe --workflow_id ff
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
