### PR TITLE
Remove forced namespace cache refresh

### DIFF
--- a/common/cache/namespaceCache_test.go
+++ b/common/cache/namespaceCache_test.go
@@ -202,93 +202,6 @@ func (s *namespaceCacheSuite) TestListNamespace() {
 	}, allNamespaces)
 }
 
-func (s *namespaceCacheSuite) TestGetNamespace_NonLoaded_GetByName() {
-	s.clusterMetadata.On("IsGlobalNamespaceEnabled").Return(true)
-	namespaceNotificationVersion := int64(999999) // make this notification version really large for test
-	s.metadataMgr.On("GetMetadata").Return(&persistence.GetMetadataResponse{NotificationVersion: namespaceNotificationVersion}, nil)
-	namespaceRecord := &persistence.GetNamespaceResponse{
-		Namespace: &persistenceblobs.NamespaceDetail{
-			Info: &persistenceblobs.NamespaceInfo{Id: uuid.New(), Name: "some random namespace name", Data: make(map[string]string)},
-			Config: &persistenceblobs.NamespaceConfig{
-				Retention: timestamp.DurationFromDays(1),
-				BadBinaries: &namespacepb.BadBinaries{
-					Binaries: map[string]*namespacepb.BadBinaryInfo{
-						"abc": {
-							Reason:     "test reason",
-							Operator:   "test operator",
-							CreateTime: timestamp.TimePtr(time.Unix(0, 123).UTC()),
-						},
-					},
-				}},
-			ReplicationConfig: &persistenceblobs.NamespaceReplicationConfig{
-				ActiveClusterName: cluster.TestCurrentClusterName,
-				Clusters: []string{
-					cluster.TestCurrentClusterName,
-					cluster.TestAlternativeClusterName,
-				},
-			},
-		},
-	}
-	entry := s.buildEntryFromRecord(namespaceRecord)
-
-	s.metadataMgr.On("GetNamespace", &persistence.GetNamespaceRequest{Name: entry.info.Name}).Return(namespaceRecord, nil).Once()
-	s.metadataMgr.On("ListNamespaces", &persistence.ListNamespacesRequest{
-		PageSize:      namespaceCacheRefreshPageSize,
-		NextPageToken: nil,
-	}).Return(&persistence.ListNamespacesResponse{
-		Namespaces:    []*persistence.GetNamespaceResponse{namespaceRecord},
-		NextPageToken: nil,
-	}, nil).Once()
-
-	entryByName, err := s.namespaceCache.GetNamespace(namespaceRecord.Namespace.Info.Name)
-	s.Nil(err)
-	s.Equal(entry, entryByName)
-	entryByName, err = s.namespaceCache.GetNamespace(namespaceRecord.Namespace.Info.Name)
-	s.Nil(err)
-	s.Equal(entry, entryByName)
-}
-
-func (s *namespaceCacheSuite) TestGetNamespace_NonLoaded_GetByID() {
-	s.clusterMetadata.On("IsGlobalNamespaceEnabled").Return(true)
-	namespaceNotificationVersion := int64(999999) // make this notification version really large for test
-	s.metadataMgr.On("GetMetadata").Return(&persistence.GetMetadataResponse{NotificationVersion: namespaceNotificationVersion}, nil)
-	namespaceRecord := &persistence.GetNamespaceResponse{
-		Namespace: &persistenceblobs.NamespaceDetail{
-			Info: &persistenceblobs.NamespaceInfo{Id: uuid.New(), Name: "some random namespace name", Data: make(map[string]string)},
-			Config: &persistenceblobs.NamespaceConfig{
-				Retention: timestamp.DurationFromDays(1),
-				BadBinaries: &namespacepb.BadBinaries{
-					Binaries: map[string]*namespacepb.BadBinaryInfo{},
-				},
-			},
-			ReplicationConfig: &persistenceblobs.NamespaceReplicationConfig{
-				ActiveClusterName: cluster.TestCurrentClusterName,
-				Clusters: []string{
-					cluster.TestCurrentClusterName,
-					cluster.TestAlternativeClusterName,
-				},
-			},
-		},
-	}
-	entry := s.buildEntryFromRecord(namespaceRecord)
-
-	s.metadataMgr.On("GetNamespace", &persistence.GetNamespaceRequest{ID: entry.info.Id}).Return(namespaceRecord, nil).Once()
-	s.metadataMgr.On("ListNamespaces", &persistence.ListNamespacesRequest{
-		PageSize:      namespaceCacheRefreshPageSize,
-		NextPageToken: nil,
-	}).Return(&persistence.ListNamespacesResponse{
-		Namespaces:    []*persistence.GetNamespaceResponse{namespaceRecord},
-		NextPageToken: nil,
-	}, nil).Once()
-
-	entryByID, err := s.namespaceCache.GetNamespaceByID(namespaceRecord.Namespace.Info.Id)
-	s.Nil(err)
-	s.Equal(entry, entryByID)
-	entryByID, err = s.namespaceCache.GetNamespaceByID(namespaceRecord.Namespace.Info.Id)
-	s.Nil(err)
-	s.Equal(entry, entryByID)
-}
-
 func (s *namespaceCacheSuite) TestRegisterCallback_CatchUp() {
 	namespaceNotificationVersion := int64(0)
 	namespaceRecord1 := &persistence.GetNamespaceResponse{
@@ -544,7 +457,6 @@ func (s *namespaceCacheSuite) TestGetTriggerListAndUpdateCache_ConcurrentAccess(
 	}
 	entryOld := s.buildEntryFromRecord(namespaceRecordOld)
 
-	s.metadataMgr.On("GetNamespace", &persistence.GetNamespaceRequest{ID: id}).Return(namespaceRecordOld, nil).Maybe()
 	s.metadataMgr.On("ListNamespaces", &persistence.ListNamespacesRequest{
 		PageSize:      namespaceCacheRefreshPageSize,
 		NextPageToken: nil,
@@ -552,6 +464,10 @@ func (s *namespaceCacheSuite) TestGetTriggerListAndUpdateCache_ConcurrentAccess(
 		Namespaces:    []*persistence.GetNamespaceResponse{namespaceRecordOld},
 		NextPageToken: nil,
 	}, nil).Once()
+
+	// load namespaces
+	s.namespaceCache.Start()
+	defer s.namespaceCache.Stop()
 
 	coroutineCountGet := 1000
 	waitGroup := &sync.WaitGroup{}

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -44,7 +44,8 @@ const (
 	// below are templates for history_tree table
 	addHistoryTreeQuery = `INSERT INTO history_tree (` +
 		`shard_id, tree_id, branch_id, data, data_encoding) ` +
-		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) `
+		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) ` +
+		`ON DUPLICATE KEY UPDATE data=VALUES(data), data_encoding=VALUES(data_encoding)`
 
 	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = ? AND tree_id = ? `
 

--- a/common/persistence/sql/sqlplugin/postgresql/events.go
+++ b/common/persistence/sql/sqlplugin/postgresql/events.go
@@ -44,7 +44,9 @@ const (
 	// below are templates for history_tree table
 	addHistoryTreeQuery = `INSERT INTO history_tree (` +
 		`shard_id, tree_id, branch_id, data, data_encoding) ` +
-		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) `
+		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) ` +
+		`ON CONFLICT (shard_id, tree_id, branch_id) DO UPDATE ` +
+		`SET data = excluded.data, data_encoding = excluded.data_encoding`
 
 	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = $1 AND tree_id = $2 `
 

--- a/common/persistence/sql/sqlplugin/tests/history_tree_test.go
+++ b/common/persistence/sql/sqlplugin/tests/history_tree_test.go
@@ -92,7 +92,7 @@ func (s *historyTreeSuite) TestInsert_Success() {
 	s.Equal(1, int(rowsAffected))
 }
 
-func (s *historyTreeSuite) TestInsert_Fail_Duplicate() {
+func (s *historyTreeSuite) TestInsert_Duplicate_Success() {
 	shardID := rand.Int31()
 	treeID := primitives.NewUUID()
 	branchID := primitives.NewUUID()
@@ -105,8 +105,12 @@ func (s *historyTreeSuite) TestInsert_Fail_Duplicate() {
 	s.Equal(1, int(rowsAffected))
 
 	node = s.newRandomTreeRow(shardID, treeID, branchID)
-	_, err = s.store.InsertIntoHistoryTree(&node)
-	s.Error(err) // TODO persistence layer should do proper error translation
+	result, err = s.store.InsertIntoHistoryTree(&node)
+	s.NoError(err)
+	_, err = result.RowsAffected()
+	s.NoError(err)
+	// TODO cannot assert on the number of rows affect
+	//  since MySQL and PostgreSQL have different behavior
 }
 
 func (s *historyTreeSuite) TestInsertSelect() {

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -163,7 +163,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int32, enableReadF
 		DisallowQuery:                          dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.DisallowQuery, false),
 		SendRawWorkflowHistory:                 dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.SendRawWorkflowHistory, false),
 		EnableRPCReplication:                   dc.GetBoolProperty(dynamicconfig.FrontendEnableRPCReplication, false),
-		EnableCleanupReplicationTask:           dc.GetBoolProperty(dynamicconfig.FrontendEnableCleanupReplicationTask, true),
+		EnableCleanupReplicationTask:           dc.GetBoolProperty(dynamicconfig.FrontendEnableCleanupReplicationTask, false),
 		DefaultWorkflowRetryPolicy:             dc.GetMapPropertyFnWithNamespaceFilter(dynamicconfig.DefaultWorkflowRetryPolicy, common.GetDefaultRetryPolicyConfigOptions()),
 		DefaultWorkflowExecutionTimeout:        dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.DefaultWorkflowExecutionTimeout, common.DefaultWorkflowExecutionTimeout),
 		DefaultWorkflowRunTimeout:              dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.DefaultWorkflowRunTimeout, common.DefaultWorkflowRunTimeout),

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -410,7 +410,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		ReplicationTaskProcessorCleanupJitterCoefficient: dc.GetFloat64PropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorCleanupJitterCoefficient, 0.15),
 		EnableRPCReplication:                             dc.GetBoolProperty(dynamicconfig.HistoryEnableRPCReplication, false),
 		EnableKafkaReplication:                           dc.GetBoolProperty(dynamicconfig.HistoryEnableKafkaReplication, true),
-		EnableCleanupReplicationTask:                     dc.GetBoolProperty(dynamicconfig.HistoryEnableCleanupReplicationTask, true),
+		EnableCleanupReplicationTask:                     dc.GetBoolProperty(dynamicconfig.HistoryEnableCleanupReplicationTask, false),
 
 		MaxBufferedQueryCount:                 dc.GetIntProperty(dynamicconfig.MaxBufferedQueryCount, 1),
 		MutableStateChecksumGenProbability:    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateChecksumGenProbability, 0),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -124,7 +124,7 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 			ReplicationTaskContextTimeout:      dc.GetDurationProperty(dynamicconfig.WorkerReplicationTaskContextDuration, 30*time.Second),
 			ReReplicationContextTimeout:        dc.GetDurationPropertyFilteredByNamespaceID(dynamicconfig.WorkerReReplicationContextTimeout, 0*time.Second),
 			EnableRPCReplication:               dc.GetBoolProperty(dynamicconfig.WorkerEnableRPCReplication, false),
-			EnableKafkaReplication:             dc.GetBoolProperty(dynamicconfig.WorkerEnableKafkaReplication, false),
+			EnableKafkaReplication:             dc.GetBoolProperty(dynamicconfig.WorkerEnableKafkaReplication, true),
 		},
 		ArchiverConfig: &archiver.Config{
 			ArchiverConcurrency:           dc.GetIntProperty(dynamicconfig.WorkerArchiverConcurrency, 50),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Remove forced namespace cache refresh
* Make SQL insert into history tree idempotent

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously, if a namespace is newly created and not loaded
in cache, the namespace cache can do forced cache refresh reducing
the wait time for caller. This forced cache refreshment may able
to trigger a new callback for failover. Now, if a task with deleted
namespace is processed, namespace cache will trigger the above
cache refreshment and causing a deadlock. The only solution now is
to remove the namespace cache forced refreshment logic.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
