### PR TITLE
Remove forced namespace cache refresh (#1014)

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -45,7 +45,8 @@ const (
 	// below are templates for history_tree table
 	addHistoryTreeQuery = `INSERT INTO history_tree (` +
 		`shard_id, tree_id, branch_id, data, data_encoding) ` +
-		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) `
+		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) ` +
+		`ON DUPLICATE KEY UPDATE data=VALUES(data), data_encoding=VALUES(data_encoding)`
 
 	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = ? AND tree_id = ? `
 

--- a/common/persistence/sql/sqlplugin/postgresql/events.go
+++ b/common/persistence/sql/sqlplugin/postgresql/events.go
@@ -45,7 +45,9 @@ const (
 	// below are templates for history_tree table
 	addHistoryTreeQuery = `INSERT INTO history_tree (` +
 		`shard_id, tree_id, branch_id, data, data_encoding) ` +
-		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) `
+		`VALUES (:shard_id, :tree_id, :branch_id, :data, :data_encoding) ` +
+		`ON CONFLICT (shard_id, tree_id, branch_id) DO UPDATE ` +
+		`SET data = excluded.data, data_encoding = excluded.data_encoding`
 
 	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = $1 AND tree_id = $2 `
 

--- a/common/persistence/sql/sqlplugin/tests/history_tree_test.go
+++ b/common/persistence/sql/sqlplugin/tests/history_tree_test.go
@@ -92,7 +92,7 @@ func (s *historyTreeSuite) TestInsert_Success() {
 	s.Equal(1, int(rowsAffected))
 }
 
-func (s *historyTreeSuite) TestInsert_Fail_Duplicate() {
+func (s *historyTreeSuite) TestInsert_Duplicate_Success() {
 	shardID := rand.Int31()
 	treeID := primitives.NewUUID()
 	branchID := primitives.NewUUID()
@@ -105,8 +105,12 @@ func (s *historyTreeSuite) TestInsert_Fail_Duplicate() {
 	s.Equal(1, int(rowsAffected))
 
 	node = s.newRandomTreeRow(shardID, treeID, branchID)
-	_, err = s.store.InsertIntoHistoryTree(newExecutionContext(), &node)
-	s.Error(err) // TODO persistence layer should do proper error translation
+	result, err = s.store.InsertIntoHistoryTree(newExecutionContext(), &node)
+	s.NoError(err)
+	_, err = result.RowsAffected()
+	s.NoError(err)
+	// TODO cannot assert on the number of rows affect
+	//  since MySQL and PostgreSQL have different behavior
 }
 
 func (s *historyTreeSuite) TestInsertSelect() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Remove forced namespace cache refresh
* Make SQL insert into history tree idempotent

<!-- Tell your future self why have you made these changes -->
**Why?**
NOTE: Previously, if a namespace is newly created and not loaded
in cache, the namespace cache can do forced cache refresh reducing
the wait time for caller. This forced cache refreshment may able
to trigger a new callback for failover. Now, if a task with deleted
namespace is processed, namespace cache will trigger the above
cache refreshment and causing a deadlock. The only solution now is
to remove the namespace cache forced refreshment logic.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

