### PR TITLE
Set workflow start time within business logic

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -400,7 +400,6 @@ func createExecution(
 	runID := executionState.RunId
 
 	// TODO we should set the start time and last update time on business logic layer
-	executionInfo.StartTime = timestamp.UnixOrZeroTimePtr(p.DBTimestampToUnixNano(cqlNowTimestampMillis))
 	executionInfo.LastUpdateTime = timestamp.UnixOrZeroTimePtr(p.DBTimestampToUnixNano(cqlNowTimestampMillis))
 
 	executionDatablob, err := serialization.WorkflowExecutionInfoToBlob(executionInfo)

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -138,6 +138,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionDeDup() {
 				LastFirstEventId:           common.FirstEventID,
 				LastProcessedEvent:         lastProcessedEventID,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -211,6 +212,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionStateStatus() {
 				LastFirstEventId:           common.FirstEventID,
 				LastProcessedEvent:         lastProcessedEventID,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -332,6 +334,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionWithZombieState() {
 				DefaultWorkflowTaskTimeout: workflowTaskTimeout,
 				LastProcessedEvent:         lastProcessedEventID,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -420,6 +423,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 				LastFirstEventId:           common.FirstEventID,
 				LastProcessedEvent:         lastProcessedEventID,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -601,6 +605,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithZombieState() {
 				DefaultWorkflowTaskTimeout: workflowTaskTimeout,
 				LastProcessedEvent:         lastProcessedEventID,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -735,6 +740,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionBrandNew() {
 				LastFirstEventId:           common.FirstEventID,
 				LastProcessedEvent:         lastProcessedEventID,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -789,6 +795,7 @@ func (s *ExecutionManagerSuite) TestUpsertWorkflowActivity() {
 				LastFirstEventId:           common.FirstEventID,
 				LastProcessedEvent:         lastProcessedEventID,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -916,6 +923,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionRunIDReuseWithoutRepl
 				LastFirstEventId:           common.FirstEventID,
 				LastProcessedEvent:         lastProcessedEventID,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -1028,6 +1036,7 @@ func (s *ExecutionManagerSuite) TestPersistenceStartWorkflow() {
 				WorkflowTaskStartedId:      common.EmptyEventID,
 				WorkflowTaskTimeout:        timestamp.DurationFromSeconds(1),
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			ExecutionState: &persistencespb.WorkflowExecutionState{
 				RunId:           workflowExecution.GetRunId(),
@@ -1119,6 +1128,7 @@ func (s *ExecutionManagerSuite) TestGetWorkflow() {
 				ExecutionStats: &persistencespb.ExecutionStats{
 					HistorySize: int64(rand.Int31()),
 				},
+				StartTime: timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: rand.Int63(),
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -3164,7 +3174,6 @@ func copyWorkflowExecutionInfo(sourceInfo *persistencespb.WorkflowExecutionInfo)
 		DefaultWorkflowTaskTimeout: sourceInfo.DefaultWorkflowTaskTimeout,
 		LastFirstEventId:           sourceInfo.LastFirstEventId,
 		LastProcessedEvent:         sourceInfo.LastProcessedEvent,
-		LastUpdateTime:             sourceInfo.LastUpdateTime,
 		WorkflowTaskVersion:        sourceInfo.WorkflowTaskVersion,
 		WorkflowTaskScheduleId:     sourceInfo.WorkflowTaskScheduleId,
 		WorkflowTaskStartedId:      sourceInfo.WorkflowTaskStartedId,
@@ -3175,6 +3184,8 @@ func copyWorkflowExecutionInfo(sourceInfo *persistencespb.WorkflowExecutionInfo)
 		ExecutionStats: &persistencespb.ExecutionStats{
 			HistorySize: sourceInfo.ExecutionStats.HistorySize,
 		},
+		StartTime:      sourceInfo.StartTime,
+		LastUpdateTime: sourceInfo.LastUpdateTime,
 	}
 }
 

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -335,6 +335,7 @@ func (s *TestBase) CreateWorkflowExecutionWithBranchToken(namespaceID string, wo
 				WorkflowTaskTimeout:        timestamp.DurationFromSeconds(1),
 				EventBranchToken:           branchToken,
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			ExecutionState: &persistencespb.WorkflowExecutionState{
 				RunId:           workflowExecution.GetRunId(),
@@ -405,6 +406,7 @@ func (s *TestBase) CreateWorkflowExecutionManyTasks(namespaceID string, workflow
 				WorkflowTaskStartedId:  common.EmptyEventID,
 				WorkflowTaskTimeout:    timestamp.DurationFromSeconds(1),
 				ExecutionStats:         &persistencespb.ExecutionStats{},
+				StartTime:              timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{
@@ -447,6 +449,7 @@ func (s *TestBase) CreateChildWorkflowExecution(namespaceID string, workflowExec
 				WorkflowTaskStartedId:      common.EmptyEventID,
 				WorkflowTaskTimeout:        timestamp.DurationFromSeconds(1),
 				ExecutionStats:             &persistencespb.ExecutionStats{},
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			ExecutionState: &persistencespb.WorkflowExecutionState{State: enumsspb.WORKFLOW_EXECUTION_STATE_CREATED,
 				RunId:           workflowExecution.GetRunId(),
@@ -549,6 +552,7 @@ func (s *TestBase) ContinueAsNewExecution(updatedInfo *persistencespb.WorkflowEx
 				WorkflowTaskStartedId:      common.EmptyEventID,
 				WorkflowTaskTimeout:        timestamp.DurationFromSeconds(1),
 				AutoResetPoints:            prevResetPoints,
+				StartTime:                  timestamp.TimeNowPtrUtc(),
 			},
 			NextEventID: nextEventID,
 			ExecutionState: &persistencespb.WorkflowExecutionState{

--- a/common/persistence/sql/sqlExecutionManagerUtil.go
+++ b/common/persistence/sql/sqlExecutionManagerUtil.go
@@ -1188,7 +1188,6 @@ func (m *sqlExecutionManager) createExecution(
 	}
 
 	// TODO we should set the start time and last update time on business logic layer
-	executionInfo.StartTime = timestamp.TimeNowPtrUtc()
 	executionInfo.LastUpdateTime = executionInfo.StartTime
 
 	row, err := buildExecutionRow(

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -451,6 +451,7 @@ func (e *historyEngineImpl) createMutableState(
 		e.shard.GetEventsCache(),
 		e.logger,
 		namespaceEntry,
+		e.shard.GetTimeSource().Now(),
 	)
 
 	if err := newMutableState.SetHistoryTree(runID); err != nil {

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -5259,7 +5259,7 @@ func newMutableStateBuilderWithEventV2(
 	runID string,
 ) *mutableStateBuilder {
 
-	msBuilder := newMutableStateBuilderWithVersionHistories(shard, eventsCache, logger, testLocalNamespaceEntry)
+	msBuilder := newMutableStateBuilderWithVersionHistories(shard, eventsCache, logger, testLocalNamespaceEntry, time.Now().UTC())
 	_ = msBuilder.SetHistoryTree(runID)
 
 	return msBuilder
@@ -5273,7 +5273,7 @@ func newMutableStateBuilderWithVersionHistoriesForTest(
 	runID string,
 ) *mutableStateBuilder {
 
-	msBuilder := newMutableStateBuilderWithVersionHistories(shard, eventsCache, logger, testLocalNamespaceEntry)
+	msBuilder := newMutableStateBuilderWithVersionHistories(shard, eventsCache, logger, testLocalNamespaceEntry, time.Now().UTC())
 	msBuilder.UpdateCurrentVersion(version, false)
 	_ = msBuilder.SetHistoryTree(runID)
 

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -255,11 +255,13 @@ func newMutableStateBuilderWithVersionHistories(
 	eventsCache events.Cache,
 	logger log.Logger,
 	namespaceEntry *cache.NamespaceCacheEntry,
-	now time.Time,
+	startTime time.Time,
 ) *mutableStateBuilder {
 
 	s := newMutableStateBuilder(shard, eventsCache, logger, namespaceEntry)
-	s.executionInfo.StartTime = timestamp.TimePtr(now)
+	// start time should be set for workflow timeout calculation
+	// NOTE: workflow reset case, this start time is the reset time
+	s.executionInfo.StartTime = timestamp.TimePtr(startTime)
 	s.executionInfo.VersionHistories = versionhistory.NewVersionHistories(&historyspb.VersionHistory{})
 	return s
 }

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -40,6 +40,7 @@ import (
 	history "go.temporal.io/api/history/v1"
 	taskqueue "go.temporal.io/api/taskqueue/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
+
 	enums0 "go.temporal.io/server/api/enums/v1"
 	historyservice "go.temporal.io/server/api/historyservice/v1"
 	persistence "go.temporal.io/server/api/persistence/v1"

--- a/service/history/nDCConflictResolver.go
+++ b/service/history/nDCConflictResolver.go
@@ -35,6 +35,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/versionhistory"
+	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/service/history/shard"
 )
 
@@ -144,7 +145,7 @@ func (r *nDCConflictResolverImpl) rebuild(
 
 	rebuildMutableState, rebuiltHistorySize, err := r.stateRebuilder.rebuild(
 		ctx,
-		executionInfo.StartTime,
+		timestamp.TimeValue(executionInfo.StartTime),
 		workflowIdentifier,
 		replayVersionHistory.GetBranchToken(),
 		lastItem.GetEventId(),

--- a/service/history/nDCStateRebuilder_mock.go
+++ b/service/history/nDCStateRebuilder_mock.go
@@ -34,6 +34,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
+
 	definition "go.temporal.io/server/common/definition"
 )
 
@@ -61,7 +62,7 @@ func (m *MocknDCStateRebuilder) EXPECT() *MocknDCStateRebuilderMockRecorder {
 }
 
 // rebuild mocks base method.
-func (m *MocknDCStateRebuilder) rebuild(ctx context.Context, now *time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseLastEventID, baseLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchToken []byte, requestID string) (mutableState, int64, error) {
+func (m *MocknDCStateRebuilder) rebuild(ctx context.Context, now time.Time, baseWorkflowIdentifier definition.WorkflowIdentifier, baseBranchToken []byte, baseLastEventID, baseLastEventVersion int64, targetWorkflowIdentifier definition.WorkflowIdentifier, targetBranchToken []byte, requestID string) (mutableState, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "rebuild", ctx, now, baseWorkflowIdentifier, baseBranchToken, baseLastEventID, baseLastEventVersion, targetWorkflowIdentifier, targetBranchToken, requestID)
 	ret0, _ := ret[0].(mutableState)

--- a/service/history/nDCWorkflowResetter.go
+++ b/service/history/nDCWorkflowResetter.go
@@ -50,7 +50,7 @@ type (
 	nDCWorkflowResetter interface {
 		resetWorkflow(
 			ctx context.Context,
-			now *time.Time,
+			now time.Time,
 			baseLastEventID int64,
 			baseLastEventVersion int64,
 			incomingFirstEventID int64,
@@ -104,7 +104,7 @@ func newNDCWorkflowResetter(
 
 func (r *nDCWorkflowResetterImpl) resetWorkflow(
 	ctx context.Context,
-	now *time.Time,
+	now time.Time,
 	baseLastEventID int64,
 	baseLastEventVersion int64,
 	incomingFirstEventID int64,

--- a/service/history/nDCWorkflowResetter_mock.go
+++ b/service/history/nDCWorkflowResetter_mock.go
@@ -60,7 +60,7 @@ func (m *MocknDCWorkflowResetter) EXPECT() *MocknDCWorkflowResetterMockRecorder 
 }
 
 // resetWorkflow mocks base method.
-func (m *MocknDCWorkflowResetter) resetWorkflow(ctx context.Context, now *time.Time, baseLastEventID, baseLastEventVersion, incomingFirstEventID, incomingFirstEventVersion int64) (mutableState, error) {
+func (m *MocknDCWorkflowResetter) resetWorkflow(ctx context.Context, now time.Time, baseLastEventID, baseLastEventVersion, incomingFirstEventID, incomingFirstEventVersion int64) (mutableState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "resetWorkflow", ctx, now, baseLastEventID, baseLastEventVersion, incomingFirstEventID, incomingFirstEventVersion)
 	ret0, _ := ret[0].(mutableState)

--- a/service/history/nDCWorkflowResetter_test.go
+++ b/service/history/nDCWorkflowResetter_test.go
@@ -27,6 +27,7 @@ package history
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
@@ -42,7 +43,6 @@ import (
 	"go.temporal.io/server/common/mocks"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
-	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/shard"
 )
@@ -131,7 +131,7 @@ func (s *nDCWorkflowResetterSuite) TearDownTest() {
 
 func (s *nDCWorkflowResetterSuite) TestResetWorkflow_NoError() {
 	ctx := context.Background()
-	now := timestamp.TimeNowPtrUtc()
+	now := time.Now().UTC()
 
 	branchToken := []byte("some random branch token")
 	lastEventID := int64(500)
@@ -211,7 +211,7 @@ func (s *nDCWorkflowResetterSuite) TestResetWorkflow_NoError() {
 
 func (s *nDCWorkflowResetterSuite) TestResetWorkflow_Error() {
 	ctx := context.Background()
-	now := timestamp.TimeNowPtrUtc()
+	now := time.Now().UTC()
 
 	branchToken := []byte("some random branch token")
 	lastEventID := int64(500)

--- a/service/history/stateBuilder.go
+++ b/service/history/stateBuilder.go
@@ -598,6 +598,7 @@ func (b *stateBuilderImpl) applyEvents(
 					b.shard.GetEventsCache(),
 					b.logger,
 					b.mutableState.GetNamespaceEntry(),
+					timestamp.TimeValue(newRunHistory[0].GetEventTime()),
 				)
 
 				newRunStateBuilder := newStateBuilder(b.shard, b.logger, newRunMutableStateBuilder, b.taskGeneratorProvider)

--- a/service/history/workflowResetter.go
+++ b/service/history/workflowResetter.go
@@ -345,7 +345,7 @@ func (r *workflowResetterImpl) replayResetWorkflow(
 	)
 	resetMutableState, resetHistorySize, err := r.newStateRebuilder().rebuild(
 		ctx,
-		timestamp.TimePtr(r.shard.GetTimeSource().Now()),
+		r.shard.GetTimeSource().Now(),
 		definition.NewWorkflowIdentifier(
 			namespaceID,
 			workflowID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Set workflow start time within business logic (mutable state initialization) instead of within persistence layer

<!-- Tell your future self why have you made these changes -->
**Why?**
Persistence layer should not initialize variable related to business logic

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
