### PR TITLE
Fix namespace registration response

### DIFF
--- a/common/namespace/handler.go
+++ b/common/namespace/handler.go
@@ -280,7 +280,7 @@ func (d *HandlerImpl) RegisterNamespace(
 		tag.WorkflowNamespaceID(namespaceResponse.ID),
 	)
 
-	return nil, nil
+	return &workflowservice.RegisterNamespaceResponse{}, nil
 }
 
 // ListNamespaces list all namespaces

--- a/common/namespace/handler_GlobalNamespaceDisabled_test.go
+++ b/common/namespace/handler_GlobalNamespaceDisabled_test.go
@@ -196,7 +196,7 @@ func (s *namespaceHandlerGlobalNamespaceDisabledSuite) TestRegisterGetNamespace_
 		WorkflowExecutionRetentionPeriod: &retention,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	resp, err := s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -261,7 +261,7 @@ func (s *namespaceHandlerGlobalNamespaceDisabledSuite) TestRegisterGetNamespace_
 		IsGlobalNamespace:                isGlobalNamespace,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	resp, err := s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -317,7 +317,7 @@ func (s *namespaceHandlerGlobalNamespaceDisabledSuite) TestUpdateGetNamespace_No
 		Data:                             data,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	fnTest := func(info *namespacepb.NamespaceInfo, config *namespacepb.NamespaceConfig,
 		replicationConfig *replicationpb.NamespaceReplicationConfig, isGlobalNamespace bool, failoverVersion int64) {
@@ -379,7 +379,7 @@ func (s *namespaceHandlerGlobalNamespaceDisabledSuite) TestUpdateGetNamespace_Al
 		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(1 * time.Hour * 24),
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	description := "some random description"
 	email := "some random email"

--- a/common/namespace/handler_GlobalNamespaceEnabled_MasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_MasterCluster_test.go
@@ -170,7 +170,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestRegisterG
 		WorkflowExecutionRetentionPeriod: &retention,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	resp, err := s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -235,7 +235,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestRegisterG
 		IsGlobalNamespace:                isGlobalNamespace,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	resp, err := s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -293,7 +293,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestUpdateGet
 		IsGlobalNamespace:                isGlobalNamespace,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	fnTest := func(info *namespacepb.NamespaceInfo, config *namespacepb.NamespaceConfig,
 		replicationConfig *replicationpb.NamespaceReplicationConfig, isGlobalNamespace bool, failoverVersion int64) {
@@ -357,7 +357,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestUpdateGet
 		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(1 * time.Hour * 24),
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	description := "some random description"
 	email := "some random email"
@@ -459,7 +459,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestRegisterG
 		WorkflowExecutionRetentionPeriod: &retention,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	resp, err := s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -525,7 +525,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestRegisterG
 		IsGlobalNamespace:                isGlobalNamespace,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	resp, err := s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -591,7 +591,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestUpdateGet
 		IsGlobalNamespace:                isGlobalNamespace,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	fnTest := func(info *namespacepb.NamespaceInfo, config *namespacepb.NamespaceConfig,
 		replicationConfig *replicationpb.NamespaceReplicationConfig, isGlobalNamespace bool, failoverVersion int64) {
@@ -672,7 +672,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestUpdateGet
 		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(1 * time.Hour * 24),
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	description := "some random description"
 	email := "some random email"
@@ -783,7 +783,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestUpdateGet
 		IsGlobalNamespace:                isGlobalNamespace,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	fnTest := func(info *namespacepb.NamespaceInfo, config *namespacepb.NamespaceConfig,
 		replicationConfig *replicationpb.NamespaceReplicationConfig, isGlobalNamespace bool, failoverVersion int64) {

--- a/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
@@ -142,7 +142,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestRegist
 		WorkflowExecutionRetentionPeriod: &retention,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	resp, err := s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -207,7 +207,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestRegist
 		IsGlobalNamespace:                isGlobalNamespace,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	resp, err := s.handler.DescribeNamespace(context.Background(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -266,7 +266,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 		IsGlobalNamespace:                isGlobalNamespace,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	fnTest := func(info *namespacepb.NamespaceInfo, config *namespacepb.NamespaceConfig,
 		replicationConfig *replicationpb.NamespaceReplicationConfig, isGlobalNamespace bool, failoverVersion int64) {
@@ -330,7 +330,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(1 * time.Hour * 24),
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	description := "some random description"
 	email := "some random email"

--- a/common/namespace/handler_test.go
+++ b/common/namespace/handler_test.go
@@ -286,7 +286,7 @@ func (s *namespaceHandlerCommonSuite) TestListNamespace() {
 		IsGlobalNamespace:                isGlobalNamespace1,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	namespace2 := s.getRandomNamespace()
 	description2 := "some random description 2"
@@ -316,7 +316,7 @@ func (s *namespaceHandlerCommonSuite) TestListNamespace() {
 		IsGlobalNamespace:                isGlobalNamespace2,
 	})
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	namespaces := map[string]*workflowservice.DescribeNamespaceResponse{}
 	pagesize := int32(1)
@@ -410,7 +410,7 @@ func (s *namespaceHandlerCommonSuite) TestUpdateNamespace_InvalidRetentionPeriod
 	}
 	registerResp, err := s.handler.RegisterNamespace(context.Background(), registerRequest)
 	s.NoError(err)
-	s.Nil(registerResp)
+	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
 	updateRequest := &workflowservice.UpdateNamespaceRequest{
 		Namespace: namespace,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Return RegisterNamespaceResponse instead of nil if API call is a success

<!-- Tell your future self why have you made these changes -->
**Why?**
API should not return nil if call is a success

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
