### PR TITLE
Make entity with Start / Stop functions idempotent

### DIFF
--- a/common/cache/namespaceCache_test.go
+++ b/common/cache/namespaceCache_test.go
@@ -45,7 +45,6 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/service/config"
-	"go.temporal.io/server/common/service/dynamicconfig"
 )
 
 type (
@@ -611,7 +610,7 @@ func Test_IsSampledForLongerRetention(t *testing.T) {
 func Test_NamespaceCacheEntry_GetNamespaceNotActiveErr(t *testing.T) {
 	clusterMetadata := cluster.NewMetadata(
 		loggerimpl.NewNopLogger(),
-		dynamicconfig.GetBoolPropertyFn(true),
+		true,
 		int64(10),
 		cluster.TestCurrentClusterName,
 		cluster.TestCurrentClusterName,

--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -32,7 +32,6 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/service/config"
-	"go.temporal.io/server/common/service/dynamicconfig"
 )
 
 type (
@@ -62,8 +61,7 @@ type (
 	metadataImpl struct {
 		logger log.Logger
 		// EnableGlobalNamespace whether the global namespace is enabled,
-		// this attr should be discarded when cross DC is made public
-		enableGlobalNamespace dynamicconfig.BoolPropertyFn
+		enableGlobalNamespace bool
 		// failoverVersionIncrement is the increment of each cluster's version when failover happen
 		failoverVersionIncrement int64
 		// masterClusterName is the name of the master cluster, only the master cluster can register / update namespace
@@ -83,7 +81,7 @@ type (
 // NewMetadata create a new instance of Metadata
 func NewMetadata(
 	logger log.Logger,
-	enableGlobalNamespace dynamicconfig.BoolPropertyFn,
+	enableGlobalNamespace bool,
 	failoverVersionIncrement int64,
 	masterClusterName string,
 	currentClusterName string,
@@ -145,7 +143,7 @@ func NewMetadata(
 // IsGlobalNamespaceEnabled whether the global namespace is enabled,
 // this attr should be discarded when cross DC is made public
 func (metadata *metadataImpl) IsGlobalNamespaceEnabled() bool {
-	return metadata.enableGlobalNamespace()
+	return metadata.enableGlobalNamespace
 }
 
 // GetNextFailoverVersion return the next failover version based on input

--- a/common/cluster/metadataTest.go
+++ b/common/cluster/metadataTest.go
@@ -28,7 +28,6 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log/loggerimpl"
 	"go.temporal.io/server/common/service/config"
-	"go.temporal.io/server/common/service/dynamicconfig"
 )
 
 const (
@@ -90,7 +89,7 @@ func GetTestClusterMetadata(enableGlobalNamespace bool, isMasterCluster bool) Me
 	if enableGlobalNamespace {
 		return NewMetadata(
 			loggerimpl.NewNopLogger(),
-			dynamicconfig.GetBoolPropertyFn(true),
+			true,
 			TestFailoverVersionIncrement,
 			masterClusterName,
 			TestCurrentClusterName,
@@ -103,7 +102,7 @@ func GetTestClusterMetadata(enableGlobalNamespace bool, isMasterCluster bool) Me
 
 	return NewMetadata(
 		loggerimpl.NewNopLogger(),
-		dynamicconfig.GetBoolPropertyFn(false),
+		false,
 		TestFailoverVersionIncrement,
 		TestCurrentClusterName,
 		TestCurrentClusterName,

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -40,6 +40,9 @@ import (
 const (
 	// ReplicationConsumerTypeKafka means consuming replication tasks from kafka.
 	ReplicationConsumerTypeKafka = "kafka"
+	// ReplicationConsumerTypeKafkaToRPC means sending tasks to kafka while receiving from both kafka & rpc
+	//  this should be used for kafka deprecation
+	ReplicationConsumerTypeKafkaToRPC = "kafka-to-rpc"
 	// ReplicationConsumerTypeRPC means pulling source DC for replication tasks.
 	ReplicationConsumerTypeRPC = "rpc"
 )

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -59,7 +59,6 @@ var keys = map[Key]string{
 	testGetBoolPropertyFilteredByTaskQueueInfoKey:     "testGetBoolPropertyFilteredByTaskQueueInfoKey",
 
 	// system settings
-	EnableGlobalNamespace:                  "system.enableGlobalNamespace",
 	EnableVisibilitySampling:               "system.enableVisibilitySampling",
 	AdvancedVisibilityWritingMode:          "system.advancedVisibilityWritingMode",
 	EnableReadVisibilityFromES:             "system.enableReadVisibilityFromES",
@@ -106,8 +105,6 @@ var keys = map[Key]string{
 	EnableClientVersionCheck:              "frontend.enableClientVersionCheck",
 	ValidSearchAttributes:                 "frontend.validSearchAttributes",
 	SendRawWorkflowHistory:                "frontend.sendRawWorkflowHistory",
-	FrontendEnableRPCReplication:          "frontend.enableRPCReplication",
-	FrontendEnableCleanupReplicationTask:  "frontend.enableCleanupReplicationTask",
 	SearchAttributesNumberOfKeysLimit:     "frontend.searchAttributesNumberOfKeysLimit",
 	SearchAttributesSizeOfValueLimit:      "frontend.searchAttributesSizeOfValueLimit",
 	SearchAttributesTotalSizeLimit:        "frontend.searchAttributesTotalSizeLimit",
@@ -247,9 +244,6 @@ var keys = map[Key]string{
 	ReplicationTaskProcessorStartWaitJitterCoefficient:     "history.ReplicationTaskProcessorStartWaitJitterCoefficient",
 	ReplicationTaskProcessorHostQPS:                        "history.ReplicationTaskProcessorHostQPS",
 	ReplicationTaskProcessorShardQPS:                       "history.ReplicationTaskProcessorShardQPS",
-	HistoryEnableRPCReplication:                            "history.EnableRPCReplication",
-	HistoryEnableKafkaReplication:                          "history.EnableKafkaReplication",
-	HistoryEnableCleanupReplicationTask:                    "history.EnableCleanupReplicationTask",
 	MaxBufferedQueryCount:                                  "history.MaxBufferedQueryCount",
 	MutableStateChecksumGenProbability:                     "history.mutableStateChecksumGenProbability",
 	MutableStateChecksumVerifyProbability:                  "history.mutableStateChecksumVerifyProbability",
@@ -272,8 +266,6 @@ var keys = map[Key]string{
 	WorkerReplicationTaskMaxRetryDuration:           "worker.replicationTaskMaxRetryDuration",
 	WorkerReplicationTaskContextDuration:            "worker.replicationTaskContextDuration",
 	WorkerReReplicationContextTimeout:               "worker.workerReReplicationContextTimeout",
-	WorkerEnableRPCReplication:                      "worker.enableWorkerRPCReplication",
-	WorkerEnableKafkaReplication:                    "worker.enableKafkaReplication",
 	WorkerIndexerConcurrency:                        "worker.indexerConcurrency",
 	WorkerESProcessorNumOfWorkers:                   "worker.ESProcessorNumOfWorkers",
 	WorkerESProcessorBulkActions:                    "worker.ESProcessorBulkActions",
@@ -312,8 +304,6 @@ const (
 	testGetBoolPropertyFilteredByNamespaceIDKey
 	testGetBoolPropertyFilteredByTaskQueueInfoKey
 
-	// EnableGlobalNamespace is key for enable global namespace
-	EnableGlobalNamespace
 	// EnableVisibilitySampling is key for enable visibility sampling
 	EnableVisibilitySampling
 	// AdvancedVisibilityWritingMode is key for how to write to advanced visibility
@@ -402,10 +392,6 @@ const (
 	ValidSearchAttributes
 	// SendRawWorkflowHistory is whether to enable raw history retrieving
 	SendRawWorkflowHistory
-	// FrontendEnableRPCReplication is a feature flag for rpc replication
-	FrontendEnableRPCReplication
-	// FrontendEnableCleanupReplicationTask is a feature flag for rpc replication cleanup
-	FrontendEnableCleanupReplicationTask
 	// SearchAttributesNumberOfKeysLimit is the limit of number of keys
 	SearchAttributesNumberOfKeysLimit
 	// SearchAttributesSizeOfValueLimit is the size limit of each value
@@ -696,10 +682,6 @@ const (
 	WorkerReplicationTaskContextDuration
 	// WorkerReReplicationContextTimeout is the context timeout for end to end  re-replication process
 	WorkerReReplicationContextTimeout
-	// WorkerEnableRPCReplication is the feature flag for RPC replication
-	WorkerEnableRPCReplication
-	// WorkerEnableKafkaReplication is the feature flag for kafka replication
-	WorkerEnableKafkaReplication
 	// WorkerIndexerConcurrency is the max concurrent messages to be processed at any given time
 	WorkerIndexerConcurrency
 	// WorkerESProcessorNumOfWorkers is num of workers for esProcessor
@@ -769,12 +751,6 @@ const (
 	ReplicationTaskProcessorHostQPS
 	// ReplicationTaskProcessorShardQPS is the qps of task processing rate limiter on shard level
 	ReplicationTaskProcessorShardQPS
-	// HistoryEnableRPCReplication is the feature flag for RPC replication
-	HistoryEnableRPCReplication
-	// HistoryEnableKafkaReplication is the migration flag for Kafka replication
-	HistoryEnableKafkaReplication
-	// HistoryEnableCleanupReplicationTask is the migration flag for Kafka replication
-	HistoryEnableCleanupReplicationTask
 	// EnableConsistentQuery indicates if consistent query is enabled for the cluster
 	MaxBufferedQueryCount
 	// MutableStateChecksumGenProbability is the probability [0-100] that checksum will be generated for mutable state

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -50,7 +50,7 @@ services:
 clusterMetadata:
   enableGlobalNamespace: true
   replicationConsumer:
-    type: kafka
+    type: rpc
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
@@ -66,7 +66,7 @@ clusterMetadata:
       rpcName: "frontend"
       rpcAddress: "localhost:8233"
     other:
-      enabled: true
+      enabled: false
       initialFailoverVersion: 3
       rpcName: "frontend"
       rpcAddress: "localhost:9233"

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -50,7 +50,7 @@ services:
 clusterMetadata:
   enableGlobalNamespace: true
   replicationConsumer:
-    type: kafka
+    type: rpc
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "standby"
@@ -66,7 +66,7 @@ clusterMetadata:
       rpcName: "frontend"
       rpcAddress: "localhost:8233"
     other:
-      enabled: true
+      enabled: false
       initialFailoverVersion: 3
       rpcName: "frontend"
       rpcAddress: "localhost:9233"

--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -47,10 +47,6 @@ var (
 		dynamicconfig.ReplicationTaskFetcherAggregationInterval:     200 * time.Millisecond,
 		dynamicconfig.ReplicationTaskFetcherErrorRetryWait:          50 * time.Millisecond,
 		dynamicconfig.ReplicationTaskProcessorErrorRetryWait:        time.Millisecond,
-		dynamicconfig.FrontendEnableRPCReplication:                  false,
-		dynamicconfig.HistoryEnableRPCReplication:                   false,
-		dynamicconfig.HistoryEnableKafkaReplication:                 true,
-		dynamicconfig.WorkerEnableRPCReplication:                    false,
 	}
 )
 

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -116,7 +116,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	if !options.IsMasterCluster && options.ClusterMetadata.MasterClusterName != "" { // xdc cluster metadata setup
 		clusterMetadata = cluster.NewMetadata(
 			logger,
-			dynamicconfig.GetBoolPropertyFn(options.ClusterMetadata.EnableGlobalNamespace),
+			options.ClusterMetadata.EnableGlobalNamespace,
 			options.ClusterMetadata.FailoverVersionIncrement,
 			options.ClusterMetadata.MasterClusterName,
 			options.ClusterMetadata.CurrentClusterName,

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -101,8 +101,7 @@ func (s *adminHandlerSuite) SetupTest() {
 		},
 	}
 	config := &Config{
-		EnableAdminProtection:        dynamicconfig.GetBoolPropertyFn(false),
-		EnableCleanupReplicationTask: dynamicconfig.GetBoolPropertyFn(false),
+		EnableAdminProtection: dynamicconfig.GetBoolPropertyFn(false),
 	}
 	s.handler = NewAdminHandler(s.mockResource, params, config)
 	s.handler.Start()
@@ -571,9 +570,8 @@ func (s *adminHandlerSuite) Test_AddSearchAttribute_Permission() {
 	ctx := context.Background()
 	handler := s.handler
 	handler.config = &Config{
-		EnableAdminProtection:        dynamicconfig.GetBoolPropertyFn(true),
-		AdminOperationToken:          dynamicconfig.GetStringPropertyFn(common.DefaultAdminOperationToken),
-		EnableCleanupReplicationTask: dynamicconfig.GetBoolPropertyFn(false),
+		EnableAdminProtection: dynamicconfig.GetBoolPropertyFn(true),
+		AdminOperationToken:   dynamicconfig.GetStringPropertyFn(common.DefaultAdminOperationToken),
 	}
 
 	type test struct {

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -108,9 +108,6 @@ type Config struct {
 
 	SendRawWorkflowHistory dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
-	EnableRPCReplication         dynamicconfig.BoolPropertyFn
-	EnableCleanupReplicationTask dynamicconfig.BoolPropertyFn
-
 	// DefaultWorkflowTaskTimeout the default workflow task timeout
 	DefaultWorkflowTaskTimeout dynamicconfig.DurationPropertyFnWithNamespaceFilter
 
@@ -158,8 +155,6 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int32, enableReadF
 		VisibilityArchivalQueryMaxPageSize:     dc.GetIntProperty(dynamicconfig.VisibilityArchivalQueryMaxPageSize, 10000),
 		DisallowQuery:                          dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.DisallowQuery, false),
 		SendRawWorkflowHistory:                 dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.SendRawWorkflowHistory, false),
-		EnableRPCReplication:                   dc.GetBoolProperty(dynamicconfig.FrontendEnableRPCReplication, false),
-		EnableCleanupReplicationTask:           dc.GetBoolProperty(dynamicconfig.FrontendEnableCleanupReplicationTask, false),
 		DefaultWorkflowRetryPolicy:             dc.GetMapPropertyFnWithNamespaceFilter(dynamicconfig.DefaultWorkflowRetryPolicy, common.GetDefaultRetryPolicyConfigOptions()),
 		DefaultWorkflowTaskTimeout:             dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.DefaultWorkflowTaskTimeout, common.DefaultWorkflowTaskTimeout),
 		EnableServerVersionCheck:               dc.GetBoolProperty(dynamicconfig.EnableServerVersionCheck, os.Getenv("TEMPORAL_VERSION_CHECK_DISABLED") == ""),
@@ -256,9 +251,7 @@ func (s *Service) Start() {
 	clusterMetadata := s.GetClusterMetadata()
 	if clusterMetadata.IsGlobalNamespaceEnabled() {
 		consumerConfig := clusterMetadata.GetReplicationConsumerConfig()
-		if consumerConfig != nil &&
-			consumerConfig.Type == config.ReplicationConsumerTypeRPC &&
-			s.config.EnableRPCReplication() {
+		if consumerConfig.Type == config.ReplicationConsumerTypeRPC || consumerConfig.Type == config.ReplicationConsumerTypeKafkaToRPC {
 			replicationMessageSink = s.GetNamespaceReplicationQueue()
 		} else {
 			var err error

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -218,10 +218,6 @@ type Config struct {
 	ReplicationTaskProcessorHostQPS                    dynamicconfig.FloatPropertyFn
 	ReplicationTaskProcessorShardQPS                   dynamicconfig.FloatPropertyFn
 
-	EnableKafkaReplication       dynamicconfig.BoolPropertyFn
-	EnableRPCReplication         dynamicconfig.BoolPropertyFn
-	EnableCleanupReplicationTask dynamicconfig.BoolPropertyFn
-
 	// The following are used by consistent query
 	MaxBufferedQueryCount dynamicconfig.IntPropertyFn
 
@@ -385,9 +381,6 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		ReplicationTaskProcessorNoTaskRetryWait:          dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorNoTaskInitialWait, 2*time.Second),
 		ReplicationTaskProcessorCleanupInterval:          dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorCleanupInterval, 1*time.Minute),
 		ReplicationTaskProcessorCleanupJitterCoefficient: dc.GetFloat64PropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorCleanupJitterCoefficient, 0.15),
-		EnableRPCReplication:                             dc.GetBoolProperty(dynamicconfig.HistoryEnableRPCReplication, false),
-		EnableKafkaReplication:                           dc.GetBoolProperty(dynamicconfig.HistoryEnableKafkaReplication, true),
-		EnableCleanupReplicationTask:                     dc.GetBoolProperty(dynamicconfig.HistoryEnableCleanupReplicationTask, false),
 
 		MaxBufferedQueryCount:                 dc.GetIntProperty(dynamicconfig.MaxBufferedQueryCount, 1),
 		MutableStateChecksumGenProbability:    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateChecksumGenProbability, 0),

--- a/service/history/replicationTaskFetcher.go
+++ b/service/history/replicationTaskFetcher.go
@@ -99,7 +99,7 @@ func NewReplicationTaskFetchers(
 ) *ReplicationTaskFetchersImpl {
 
 	var fetchers []ReplicationTaskFetcher
-	if consumerConfig.Type == serviceConfig.ReplicationConsumerTypeRPC && config.EnableRPCReplication() {
+	if consumerConfig.Type == serviceConfig.ReplicationConsumerTypeRPC || consumerConfig.Type == serviceConfig.ReplicationConsumerTypeKafkaToRPC {
 		currentCluster := clusterMetadata.GetCurrentClusterName()
 		for clusterName, info := range clusterMetadata.GetAllClusterInfo() {
 			if !info.Enabled {

--- a/service/history/replicationTaskProcessor.go
+++ b/service/history/replicationTaskProcessor.go
@@ -210,11 +210,9 @@ func (p *ReplicationTaskProcessorImpl) eventLoop() {
 			))
 
 		case <-cleanupTimer.C:
-			if p.config.EnableCleanupReplicationTask() {
-				if err := p.cleanupReplicationTasks(); err != nil {
-					p.logger.Error("Failed to clean up replication messages.", tag.Error(err))
-					p.metricsClient.Scope(metrics.ReplicationTaskCleanupScope).IncCounter(metrics.ReplicationTaskCleanupFailure)
-				}
+			if err := p.cleanupReplicationTasks(); err != nil {
+				p.logger.Error("Failed to clean up replication messages.", tag.Error(err))
+				p.metricsClient.Scope(metrics.ReplicationTaskCleanupScope).IncCounter(metrics.ReplicationTaskCleanupFailure)
 			}
 			cleanupTimer.Reset(backoff.JitDuration(
 				p.config.ReplicationTaskProcessorCleanupInterval(shardID),

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -184,7 +184,6 @@ func (s *Service) Stop() {
 	remainingTime = s.sleep(shardOwnershipTransferDelay, remainingTime)
 
 	s.GetLogger().Info("ShutdownHandler: No longer taking rpc requests")
-	s.handler.PrepareToStop()
 	remainingTime = s.sleep(gracePeriod, remainingTime)
 
 	// TODO: Change this to GracefulStop when integration tests are refactored.

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -123,8 +123,6 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 			ReplicationTaskMaxRetryDuration:    dc.GetDurationProperty(dynamicconfig.WorkerReplicationTaskMaxRetryDuration, 15*time.Minute),
 			ReplicationTaskContextTimeout:      dc.GetDurationProperty(dynamicconfig.WorkerReplicationTaskContextDuration, 30*time.Second),
 			ReReplicationContextTimeout:        dc.GetDurationPropertyFilteredByNamespaceID(dynamicconfig.WorkerReReplicationContextTimeout, 0*time.Second),
-			EnableRPCReplication:               dc.GetBoolProperty(dynamicconfig.WorkerEnableRPCReplication, false),
-			EnableKafkaReplication:             dc.GetBoolProperty(dynamicconfig.WorkerEnableKafkaReplication, true),
 		},
 		ArchiverConfig: &archiver.Config{
 			ArchiverConcurrency:           dc.GetIntProperty(dynamicconfig.WorkerArchiverConcurrency, 50),
@@ -182,7 +180,7 @@ func (s *Service) Start() {
 		s.startIndexer()
 	}
 
-	if s.GetClusterMetadata().IsGlobalNamespaceEnabled() && s.config.ReplicationCfg.EnableKafkaReplication() {
+	if s.GetClusterMetadata().IsGlobalNamespaceEnabled() {
 		s.startReplicator()
 	}
 	if s.GetArchivalMetadata().GetHistoryConfig().ClusterConfiguredForArchival() {

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -141,7 +141,7 @@ func (s *Server) Start() error {
 
 	clusterMetadata := cluster.NewMetadata(
 		s.logger,
-		dc.GetBoolProperty(dynamicconfig.EnableGlobalNamespace, s.so.config.ClusterMetadata.EnableGlobalNamespace),
+		s.so.config.ClusterMetadata.EnableGlobalNamespace,
 		s.so.config.ClusterMetadata.FailoverVersionIncrement,
 		s.so.config.ClusterMetadata.MasterClusterName,
 		s.so.config.ClusterMetadata.CurrentClusterName,

--- a/tools/cli/namespaceUtils.go
+++ b/tools/cli/namespaceUtils.go
@@ -315,7 +315,7 @@ func initializeClusterMetadata(
 	clusterMetadata := serviceConfig.ClusterMetadata
 	return cluster.NewMetadata(
 		logger,
-		dynamicconfig.GetBoolPropertyFn(clusterMetadata.EnableGlobalNamespace),
+		clusterMetadata.EnableGlobalNamespace,
 		clusterMetadata.FailoverVersionIncrement,
 		clusterMetadata.MasterClusterName,
 		clusterMetadata.CurrentClusterName,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Make entity with Start / Stop functions idempotent
* Remove misleading / unnecessary dynamic configs related to NDC
* Minor issue fixes

NOTE: 
* when running in `kafka` replication mode, both tx and rx will use Kafka replication stack
* when running in `kafka-to-rpc` replication mode
  * tx will use RPC stack
  * rx will use both RPC stack and Kafka stack
* when running in `rpc` replication mode, both tx and rx will use RPC replication stack

<!-- Tell your future self why have you made these changes -->
**Why?**
Code logic should guarantee at most once start / stop

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally with NDC w/ Kafka & NDC w/ RPC, NDC with Kafka -> RPC needs to be tested by larger cluster 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
