### PR TITLE
Fix PostgreSQL EnableHostVerification behavior

### DIFF
--- a/common/persistence/sql/sqlplugin/postgresql/tls.go
+++ b/common/persistence/sql/sqlplugin/postgresql/tls.go
@@ -31,10 +31,10 @@ import (
 )
 
 const (
-	postgreSQLSSLMode     = "sslmode"
-	postgreSQLSSLModeNoop = "disable"
-	postgreSQLSSLModeCA   = "verify-ca"
-	postgreSQLSSLModeFull = "verify-full"
+	postgreSQLSSLMode        = "sslmode"
+	postgreSQLSSLModeNoop    = "disable"
+	postgreSQLSSLModeRequire = "require"
+	postgreSQLSSLModeFull    = "verify-full"
 
 	postgreSQLSSLHost = "host"
 
@@ -47,7 +47,7 @@ func dsnTSL(cfg *config.SQL) url.Values {
 	sslParams := url.Values{}
 	if cfg.TLS != nil && cfg.TLS.Enabled {
 		if !cfg.TLS.EnableHostVerification {
-			sslParams.Set(postgreSQLSSLMode, postgreSQLSSLModeCA)
+			sslParams.Set(postgreSQLSSLMode, postgreSQLSSLModeRequire)
 		} else {
 			sslParams.Set(postgreSQLSSLMode, postgreSQLSSLModeFull)
 			sslParams.Set(postgreSQLSSLHost, cfg.TLS.ServerName)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Fix PostgreSQL EnableHostVerification behavior

<!-- Tell your future self why have you made these changes -->
**Why?**
TLS with EnableHostVerification == false means do not verify hostname and server cert
The definition of `EnableHostVerification` is `EnableHostVerification = !InsecureSkipVerify`
see `InsecureSkipVerify`: https://golang.org/pkg/crypto/tls/
PostgreSQL: https://www.postgresql.org/docs/9.6/libpq-ssl.html

Fix: #1047 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
