### PR TITLE
Adjust GetHistoryMaxPageSize default size

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -64,7 +64,7 @@ const (
 
 const (
 	// GetHistoryMaxPageSize is the max page size for get history
-	GetHistoryMaxPageSize = 100
+	GetHistoryMaxPageSize = 256
 	// ReadDLQMessagesPageSize is the max page size for read DLQ messages
 	ReadDLQMessagesPageSize = 1000
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Change GetHistoryMaxPageSize from 100 to 256

<!-- Tell your future self why have you made these changes -->
**Why?**
GetHistoryMaxPageSize being too small will increase the history replay time on SDK

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
