### PR TITLE
Patch metrics reported with different tags.

### DIFF
--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -59,7 +59,7 @@ func NewClient(scope tally.Scope, serviceIdx ServiceIdx) Client {
 	for idx, def := range ScopeDefs[Common] {
 		scopeTags := map[string]string{
 			OperationTagName: def.operation,
-			"namespace":      "all",
+			namespace:        namespaceAllValue,
 		}
 		mergeMapToRight(def.tags, scopeTags)
 		metricsClient.childScopes[idx] = scope.Tagged(scopeTags)
@@ -68,7 +68,7 @@ func NewClient(scope tally.Scope, serviceIdx ServiceIdx) Client {
 	for idx, def := range ScopeDefs[serviceIdx] {
 		scopeTags := map[string]string{
 			OperationTagName: def.operation,
-			"namespace":      "all",
+			namespace:        namespaceAllValue,
 		}
 		mergeMapToRight(def.tags, scopeTags)
 		metricsClient.childScopes[idx] = scope.Tagged(scopeTags)

--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -59,6 +59,7 @@ func NewClient(scope tally.Scope, serviceIdx ServiceIdx) Client {
 	for idx, def := range ScopeDefs[Common] {
 		scopeTags := map[string]string{
 			OperationTagName: def.operation,
+			"namespace":      "all",
 		}
 		mergeMapToRight(def.tags, scopeTags)
 		metricsClient.childScopes[idx] = scope.Tagged(scopeTags)
@@ -67,6 +68,7 @@ func NewClient(scope tally.Scope, serviceIdx ServiceIdx) Client {
 	for idx, def := range ScopeDefs[serviceIdx] {
 		scopeTags := map[string]string{
 			OperationTagName: def.operation,
+			"namespace":      "all",
 		}
 		mergeMapToRight(def.tags, scopeTags)
 		metricsClient.childScopes[idx] = scope.Tagged(scopeTags)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2264,7 +2264,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		SyncThrottlePerTaskQueueCounter:           {metricName: "sync_throttle_count_per_tl", metricRollupName: "sync_throttle_count"},
 		BufferThrottlePerTaskQueueCounter:         {metricName: "buffer_throttle_count_per_tl", metricRollupName: "buffer_throttle_count"},
 		ExpiredTasksPerTaskQueueCounter:           {metricName: "tasks_expired_per_tl", metricRollupName: "tasks_expired"},
-		ForwardedPerTaskQueueCounter:              {metricName: "forwarded_per_tl", metricRollupName: "forwarded"},
+		ForwardedPerTaskQueueCounter:              {metricName: "forwarded_per_tl"},
 		ForwardTaskCallsPerTaskQueue:              {metricName: "forward_task_calls_per_tl", metricRollupName: "forward_task_calls"},
 		ForwardTaskErrorsPerTaskQueue:             {metricName: "forward_task_errors_per_tl", metricRollupName: "forward_task_errors"},
 		ForwardQueryCallsPerTaskQueue:             {metricName: "forward_query_calls_per_tl", metricRollupName: "forward_query_calls"},

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -82,6 +82,10 @@ type (
 	commandTypeTag struct {
 		value string
 	}
+
+	serviceRoleTag struct {
+		value string
+	}
 )
 
 // NamespaceTag returns a new namespace tag. For timers, this also ensures that we
@@ -236,5 +240,23 @@ func (d commandTypeTag) Key() string {
 
 // Value returns the value of the command type tag
 func (d commandTypeTag) Value() string {
+	return d.value
+}
+
+// Returns a new service role tag.
+func ServiceRoleTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return serviceRoleTag{value}
+}
+
+// Key returns the key of the service role tag
+func (d serviceRoleTag) Key() string {
+	return ServiceRoleTagName
+}
+
+// Value returns the value of the service role tag
+func (d serviceRoleTag) Value() string {
 	return d.value
 }

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -388,7 +388,7 @@ func (s *mutableStateSuite) TestChecksum() {
 	}
 
 	loadErrorsFunc := func() int64 {
-		counter := s.testScope.Snapshot().Counters()["test.mutable_state_checksum_mismatch+operation=WorkflowContext"]
+		counter := s.testScope.Snapshot().Counters()["test.mutable_state_checksum_mismatch+namespace=all,operation=WorkflowContext"]
 		if counter != nil {
 			return counter.Value()
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Most of metrics received namespace="all" tag.
"forwarded" metric always reported with namespace and service_role tags.

<!-- Tell your future self why have you made these changes -->
**Why?**
Prometheus doesn't support reporting same metric name with different tags.
This is intended as a small fix to mitigate existing bugs. More generic fix is currently under ongoing discussion.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration tests with explicit os.exit(1)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Some metrics might change reporting location.
Aggregation of metrics logic should be changed in dashboards.
