### PR TITLE
Switched to using frontend server cert as client certs for internal workers

### DIFF
--- a/common/authorization/authorizer.go
+++ b/common/authorization/authorizer.go
@@ -36,7 +36,7 @@ const (
 )
 
 type (
-	// Attributes is input for authority to make decision.
+	// CallTarget is input for authorizer to make decision.
 	// It can be extended in future if required auth on resources like WorkflowType and TaskQueue
 	CallTarget struct {
 		APIName   string

--- a/common/rpc/encryption/localStoreTlsFactory.go
+++ b/common/rpc/encryption/localStoreTlsFactory.go
@@ -74,9 +74,9 @@ func (s *localStoreTlsProvider) GetFrontendClientConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(
 		&s.frontendClientConfig,
 		func() (*tls.Config, error) {
-			return newClientTLSConfig(s.internodeCertProvider, s.frontendCertProvider)
+			return newClientTLSConfig(s.frontendCertProvider, s.frontendCertProvider)
 		},
-		s.internodeCertProvider.GetSettings().IsEnabled(),
+		s.frontendCertProvider.GetSettings().IsEnabled(),
 	)
 }
 


### PR DESCRIPTION
**What changed?**
Switched to using frontend server cert as client certs for internal workers instead of internode server certs.

**Why?**
This change enables using different certs for internode communication within the cluster and for internal workers communicating with the frontends (via SDK client), so that the internode server cert is never given by the frontend to clients trying to connect to it.  

**How did you test it?**
Unit test plus manual verification that internal workers are able to connect to the frontends with a separate cert.

**Potential risks**
This can potentially break people that run Temporal today with TLS configured. That's why we shouldn't rush this change and why I'm submitting it as a draft PR.