### PR TITLE
Bugfix: messaging client not set when advanced visibility is used

### DIFF
--- a/temporal/server.go
+++ b/temporal/server.go
@@ -296,6 +296,8 @@ func (s *Server) getServiceParams(
 		if params.ClusterMetadata.GetReplicationConsumerConfig().Type == config.ReplicationConsumerTypeKafka ||
 			params.ClusterMetadata.GetReplicationConsumerConfig().Type == config.ReplicationConsumerTypeKafkaToRPC {
 			params.MessagingClient = messaging.NewKafkaClient(&s.so.config.Kafka, metricsClient, zap.NewNop(), s.logger, metricsScope, true, isAdvancedVisEnabled)
+		} else if isAdvancedVisEnabled {
+			params.MessagingClient = messaging.NewKafkaClient(&s.so.config.Kafka, metricsClient, zap.NewNop(), s.logger, metricsScope, false, isAdvancedVisEnabled)
 		} else {
 			params.MessagingClient = nil
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Bugfix: messaging client not set when advanced visibility is used

<!-- Tell your future self why have you made these changes -->
**Why?**
When advanced visibility is enabled, messaging client should be initialized

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
