### PR TITLE
Fix: history_size and event_blob_size metrics should have same tags

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -24,7 +24,9 @@
 
 package metrics
 
-import "github.com/uber-go/tally"
+import (
+	"github.com/uber-go/tally"
+)
 
 // types used/defined by the package
 type (

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -86,6 +86,10 @@ type (
 	serviceRoleTag struct {
 		value string
 	}
+
+	statsTypeTag struct {
+		value string
+	}
 )
 
 // NamespaceTag returns a new namespace tag. For timers, this also ensures that we
@@ -258,5 +262,23 @@ func (d serviceRoleTag) Key() string {
 
 // Value returns the value of the service role tag
 func (d serviceRoleTag) Value() string {
+	return d.value
+}
+
+// Returns a new stats type tag
+func StatsTypeTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return statsTypeTag{value}
+}
+
+// Key returns the key of the stats type tag
+func (d statsTypeTag) Key() string {
+	return StatsTypeTagName
+}
+
+// Value returns the value of the stats type tag
+func (d statsTypeTag) Value() string {
 	return d.value
 }

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -443,8 +443,11 @@ func (adh *AdminHandler) GetWorkflowExecutionRawHistoryV2(ctx context.Context, r
 	size := rawHistoryResponse.Size
 	// N.B. - Dual emit is required here so that we can see aggregate timer stats across all
 	// namespaces along with the individual namespaces stats
-	adh.GetMetricsClient().RecordTimer(metrics.AdminGetWorkflowExecutionRawHistoryScope, metrics.HistorySize, time.Duration(size))
-	scope.RecordTimer(metrics.HistorySize, time.Duration(size))
+	adh.GetMetricsClient().
+		Scope(metrics.AdminGetWorkflowExecutionRawHistoryScope, metrics.StatsTypeTag(metrics.SizeStatsTypeTagValue)).
+		RecordTimer(metrics.HistorySize, time.Duration(size))
+	scope.Tagged(metrics.StatsTypeTag(metrics.SizeStatsTypeTagValue)).
+		RecordTimer(metrics.HistorySize, time.Duration(size))
 
 	result := &adminservice.GetWorkflowExecutionRawHistoryV2Response{
 		HistoryBatches: rawHistoryResponse.HistoryEventBlobs,

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -505,7 +505,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(ctx context.Context, request *
 		namespaceID,
 		request.GetWorkflowId(),
 		"",
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("StartWorkflowExecution"),
 	); err != nil {
@@ -1022,7 +1022,7 @@ func (wh *WorkflowHandler) RespondWorkflowTaskFailed(ctx context.Context, reques
 		namespaceId,
 		taskToken.GetWorkflowId(),
 		taskToken.GetRunId(),
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RespondWorkflowTaskFailed"),
 	); err != nil {
@@ -1201,7 +1201,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(ctx context.Context, requ
 		namespaceId,
 		taskToken.GetWorkflowId(),
 		taskToken.GetRunId(),
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RecordActivityTaskHeartbeat"),
 	); err != nil {
@@ -1308,7 +1308,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatById(ctx context.Context, 
 		namespaceID,
 		taskToken.GetWorkflowId(),
 		taskToken.GetRunId(),
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RecordActivityTaskHeartbeatById"),
 	); err != nil {
@@ -1404,7 +1404,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(ctx context.Context, req
 		namespaceId,
 		taskToken.GetWorkflowId(),
 		taskToken.GetRunId(),
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskCompleted"),
 	); err != nil {
@@ -1513,7 +1513,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedById(ctx context.Context,
 		namespaceID,
 		taskToken.GetWorkflowId(),
 		runID,
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskCompletedById"),
 	); err != nil {
@@ -1614,7 +1614,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(ctx context.Context, reques
 		namespaceID,
 		taskToken.GetWorkflowId(),
 		taskToken.GetRunId(),
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskFailed"),
 	); err != nil {
@@ -1711,7 +1711,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedById(ctx context.Context, re
 		namespaceID,
 		taskToken.GetWorkflowId(),
 		runID,
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskFailedById"),
 	); err != nil {
@@ -1799,7 +1799,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(ctx context.Context, requ
 		namespaceID,
 		taskToken.GetWorkflowId(),
 		taskToken.GetRunId(),
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskCanceled"),
 	); err != nil {
@@ -1907,7 +1907,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledById(ctx context.Context, 
 		namespaceID,
 		taskToken.GetWorkflowId(),
 		runID,
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskCanceledById"),
 	); err != nil {
@@ -2055,7 +2055,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context, request 
 		namespaceID,
 		request.GetWorkflowExecution().GetWorkflowId(),
 		request.GetWorkflowExecution().GetRunId(),
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("SignalWorkflowExecution"),
 	); err != nil {
@@ -2173,7 +2173,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		namespaceID,
 		request.GetWorkflowId(),
 		"",
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("SignalWithStartWorkflowExecution"),
 	); err != nil {
@@ -2187,7 +2187,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		namespaceID,
 		request.GetWorkflowId(),
 		"",
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("SignalWithStartWorkflowExecution"),
 	); err != nil {
@@ -2868,7 +2868,7 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(ctx context.Context, reques
 		queryTaskToken.GetNamespaceId(),
 		"",
 		"",
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("RespondQueryTaskCompleted"),
 	); err != nil {
@@ -2997,7 +2997,7 @@ func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context, request *workflows
 		namespaceID,
 		request.GetExecution().GetWorkflowId(),
 		request.GetExecution().GetRunId(),
-		scope,
+		scope.Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
 		wh.GetThrottledLogger(),
 		tag.BlobSizeViolationOperation("QueryWorkflow")); err != nil {
 		return nil, wh.error(err, scope)
@@ -3283,7 +3283,8 @@ func (wh *WorkflowHandler) getHistory(
 		return nil, nil, err
 	}
 
-	scope.RecordTimer(metrics.HistorySize, time.Duration(size))
+	scope.Tagged(metrics.StatsTypeTag(metrics.SizeStatsTypeTagValue)).
+		RecordTimer(metrics.HistorySize, time.Duration(size))
 
 	isLastPage := len(nextPageToken) == 0
 	if err := wh.verifyHistoryIsComplete(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
history_size and event_blob_size metrics now have same set of tags when reported.

<!-- Tell your future self why have you made these changes -->
**Why?**
Prometheus doesn't support report metrics with same name, but different tag sets.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local unit/integration/canary tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Mistagged history_size and/or event_blob_size metrics.
