### PR TITLE
Fix buf build warning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -257,7 +257,7 @@ buf-lint:
 
 buf-build:
 	@printf $(COLOR) "Build image.bin with buf..."
-	@(cd $(PROTO_ROOT) && buf image build -o image.bin)
+	@(cd $(PROTO_ROOT) && buf build -o image.bin)
 
 buf-breaking:
 	@printf $(COLOR) "Run buf breaking changes check against image.bin..."


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed:
```
Command "build" is deprecated, "image" sub-commands are now all implemented under the top-level "buf build" command, use "buf build" instead.
We recommend migrating, however this command continues to work.
```

<!-- Tell your future self why have you made these changes -->
**Why?**
Keep `buf` up to date.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
