### PR TITLE
Use valid input for wfClient.GetSearchAttributes

### DIFF
--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -947,7 +947,7 @@ func convertSearchAttributes(searchAttributes *commonpb.SearchAttributes,
 	}
 	ctx, cancel := newContext(c)
 	defer cancel()
-	validSearchAttributes, err := wfClient.GetSearchAttributes(ctx, nil)
+	validSearchAttributes, err := wfClient.GetSearchAttributes(ctx, &workflowservice.GetSearchAttributesRequest{})
 	if err != nil {
 		ErrorAndExit("Error when get search attributes", err)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* CLI use valid input for wfClient.GetSearchAttributes

<!-- Tell your future self why have you made these changes -->
**Why?**
We should use valid input, not nil

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
