### PR TITLE
Properly handle infinite activity timeout for SDK

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -781,9 +781,9 @@ func (e *matchingEngineImpl) createPollActivityTaskQueueResponse(
 
 	// REMOVE THE CODE BELOW HERE after 1.10
 
-	// ScheduleToCloseTimeout can be 0, meaning no timeout
-	// however, SDK cannot handle ScheduleToCloseTimeout being 0
-	// so need to override
+	// TODO ScheduleToCloseTimeout can be 0, meaning no timeout
+	//  however, SDK cannot handle ScheduleToCloseTimeout being 0
+	//  so need to override
 	scheduleToCloseTimeout := timestamp.DurationValue(attributes.ScheduleToCloseTimeout)
 	if scheduleToCloseTimeout == 0 {
 		scheduleToCloseTimeout = timestamp.DurationValue(attributes.StartToCloseTimeout)

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -779,6 +779,8 @@ func (e *matchingEngineImpl) createPollActivityTaskQueueResponse(
 
 	serializedToken, _ := e.tokenSerializer.Serialize(taskToken)
 
+	// REMOVE THE CODE BELOW HERE after 1.10
+
 	// ScheduleToCloseTimeout can be 0, meaning no timeout
 	//  however, SDK cannot handle ScheduleToCloseTimeout being 0
 	//  so need to override
@@ -805,6 +807,30 @@ func (e *matchingEngineImpl) createPollActivityTaskQueueResponse(
 		WorkflowType:                historyResponse.WorkflowType,
 		WorkflowNamespace:           historyResponse.WorkflowNamespace,
 	}
+
+	// REMOVE THE CODE ABOVE HERE after 1.10
+	// UNCOMMENT THE CODE BELOW after 1.10 for original behavior
+
+	//return &matchingservice.PollActivityTaskQueueResponse{
+	//	ActivityId:                  attributes.ActivityId,
+	//	ActivityType:                attributes.ActivityType,
+	//	Header:                      attributes.Header,
+	//	Input:                       attributes.Input,
+	//	WorkflowExecution:           task.workflowExecution(),
+	//	CurrentAttemptScheduledTime: historyResponse.CurrentAttemptScheduledTime,
+	//	ScheduledTime:               scheduledEvent.EventTime,
+	//	ScheduleToCloseTimeout:      attributes.ScheduleToCloseTimeout,
+	//	StartedTime:                 historyResponse.StartedTime,
+	//	StartToCloseTimeout:         attributes.StartToCloseTimeout,
+	//	HeartbeatTimeout:            attributes.HeartbeatTimeout,
+	//	TaskToken:                   serializedToken,
+	//	Attempt:                     taskToken.ScheduleAttempt,
+	//	HeartbeatDetails:            historyResponse.HeartbeatDetails,
+	//	WorkflowType:                historyResponse.WorkflowType,
+	//	WorkflowNamespace:           historyResponse.WorkflowNamespace,
+	//}
+
+	// UNCOMMENT THE CODE ABOVE after 1.10 for original behavior
 }
 
 func (e *matchingEngineImpl) recordWorkflowTaskStarted(

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -782,8 +782,8 @@ func (e *matchingEngineImpl) createPollActivityTaskQueueResponse(
 	// REMOVE THE CODE BELOW HERE after 1.10
 
 	// ScheduleToCloseTimeout can be 0, meaning no timeout
-	//  however, SDK cannot handle ScheduleToCloseTimeout being 0
-	//  so need to override
+	// however, SDK cannot handle ScheduleToCloseTimeout being 0
+	// so need to override
 	scheduleToCloseTimeout := timestamp.DurationValue(attributes.ScheduleToCloseTimeout)
 	if scheduleToCloseTimeout == 0 {
 		scheduleToCloseTimeout = timestamp.DurationValue(attributes.StartToCloseTimeout)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Go SDK cannot handle activity schedule to close timeout being 0, adding special handling int matching service

<!-- Tell your future self why have you made these changes -->
**Why?**
See above

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
