### PR TITLE
Add checks for nil claims to defaultAuthorizer

### DIFF
--- a/common/authorization/defaultAuthorizer.go
+++ b/common/authorization/defaultAuthorizer.go
@@ -50,9 +50,6 @@ func (a *defaultAuthorizer) Authorize(_ context.Context, claims *Claims, target 
 	if claims.System == RoleAdmin || claims.System == RoleWriter {
 		return Result{Decision: DecisionAllow}, nil
 	}
-	if claims.Namespaces == nil {
-		return Result{Decision: DecisionDeny}, nil
-	}
 	roles, found := claims.Namespaces[target.Namespace]
 	if !found || roles == RoleUndefined {
 		return Result{Decision: DecisionDeny}, nil

--- a/common/authorization/defaultAuthorizer.go
+++ b/common/authorization/defaultAuthorizer.go
@@ -43,12 +43,16 @@ func (a *defaultAuthorizer) Authorize(_ context.Context, claims *Claims, target 
 	if target.Namespace == "temporal-system" || target.Namespace == "" {
 		return Result{Decision: DecisionAllow}, nil
 	}
-
+	if claims == nil {
+		return Result{Decision: DecisionDeny}, nil
+	}
 	// Check system level permissions
 	if claims.System == RoleAdmin || claims.System == RoleWriter {
 		return Result{Decision: DecisionAllow}, nil
 	}
-
+	if claims.Namespaces == nil {
+		return Result{Decision: DecisionDeny}, nil
+	}
 	roles, found := claims.Namespaces[target.Namespace]
 	if !found || roles == RoleUndefined {
 		return Result{Decision: DecisionDeny}, nil


### PR DESCRIPTION
**What changed?**
Added nil checks for claims and namespaces within it.

**Why?**
The current code could cause NREs if claim mapper isn't configured. While nobody is expected to do that in production, it's a potential hurdle for initial development.

**How did you test it?**
Unit tests.

**Potential risks**
No risk. This authorizer isn't enabled by default.
