### PR TITLE
Adds log whenever we fetch bootstrap hosts for ringpop from DB

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -847,12 +847,12 @@ func QueryLevel(s time.Time) Tag {
 	return newTimeTag("query-level", s)
 }
 
-// QueryLevel returns tag for query level
+// MinQueryLevel returns tag for query level
 func MinQueryLevel(s time.Time) Tag {
 	return newTimeTag("min-query-level", s)
 }
 
-// QueryLevel returns tag for query level
+// MaxQueryLevel returns tag for query level
 func MaxQueryLevel(s time.Time) Tag {
 	return newTimeTag("max-query-level", s)
 }
@@ -860,4 +860,9 @@ func MaxQueryLevel(s time.Time) Tag {
 // TaskQueueInfo returns tag for task queue info
 func TaskQueueInfo(s interface{}) Tag {
 	return newObjectTag("task-queue-info", s)
+}
+
+// BootstrapHostPorts returns tag for bootstrap host ports
+func BootstrapHostPorts(s string) Tag {
+	return newStringTag("bootstrap-hostports", s)
 }

--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -118,7 +118,7 @@ func (rpo *ringpopMonitor) Start() {
 	}
 
 	rpo.rp.Start(
-		func() ([]string, error) { return fetchCurrentBootstrapHostports(rpo.metadataManager) },
+		func() ([]string, error) { return fetchCurrentBootstrapHostports(rpo.metadataManager, rpo.logger) },
 		healthyHostLastHeartbeatCutoff/2)
 
 	labels, err := rpo.rp.Labels()
@@ -230,7 +230,7 @@ func (rpo *ringpopMonitor) startHeartbeat(broadcastHostport string) error {
 	return err
 }
 
-func fetchCurrentBootstrapHostports(manager persistence.ClusterMetadataManager) ([]string, error) {
+func fetchCurrentBootstrapHostports(manager persistence.ClusterMetadataManager, log log.Logger) ([]string, error) {
 	pageSize := 1000
 	set := make(map[string]struct{})
 
@@ -259,6 +259,7 @@ func fetchCurrentBootstrapHostports(manager persistence.ClusterMetadataManager) 
 			for k := range set {
 				bootstrapHostPorts = append(bootstrapHostPorts, k)
 			}
+			log.Info(fmt.Sprintf("bootstrap hosts fetched %+v", bootstrapHostPorts))
 			return bootstrapHostPorts, nil
 		}
 

--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -259,7 +259,8 @@ func fetchCurrentBootstrapHostports(manager persistence.ClusterMetadataManager, 
 			for k := range set {
 				bootstrapHostPorts = append(bootstrapHostPorts, k)
 			}
-			log.Info(fmt.Sprintf("bootstrap hosts fetched %+v", bootstrapHostPorts))
+
+			log.Info("bootstrap hosts fetched", tag.BootstrapHostPorts(strings.Join(bootstrapHostPorts, ",")))
 			return bootstrapHostPorts, nil
 		}
 


### PR DESCRIPTION
Adds a log when we are fetching bootstrap hosts which we try to connect to via Ringpop. This can help aid debuggability of cold starts in the future.

Low risk change as it is just an additional log.



