### PR TITLE
Switch integration tests to disable Kafka for visibility

### DIFF
--- a/host/testdata/clientintegrationtestcluster.yaml
+++ b/host/testdata/clientintegrationtestcluster.yaml
@@ -5,7 +5,7 @@ messagingclientconfig:
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
-  disablekafkaforvisibility: false
+  disablekafkaforvisibility: true
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/host/testdata/integration_elasticsearch_cluster.yaml
+++ b/host/testdata/integration_elasticsearch_cluster.yaml
@@ -19,7 +19,7 @@ messagingclientconfig:
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
-  disablekafkaforvisibility: false
+  disablekafkaforvisibility: true
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/host/testdata/integration_sizelimit_cluster.yaml
+++ b/host/testdata/integration_sizelimit_cluster.yaml
@@ -7,7 +7,7 @@ historyconfig:
   numhistoryhosts: 1
   historycountlimiterror: 20
   historycountlimitwarn: 10
-  disablekafkaforvisibility: false
+  disablekafkaforvisibility: true
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/host/testdata/integration_test_cluster.yaml
+++ b/host/testdata/integration_test_cluster.yaml
@@ -5,7 +5,7 @@ messagingclientconfig:
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
-  disablekafkaforvisibility: false
+  disablekafkaforvisibility: true
 workerconfig:
   enablearchiver: true
   enablereplicator: true

--- a/host/testdata/ndc_integration_test_clusters.yaml
+++ b/host/testdata/ndc_integration_test_clusters.yaml
@@ -41,7 +41,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: false
+    disablekafkaforvisibility: true
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -116,7 +116,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: false
+    disablekafkaforvisibility: true
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -191,7 +191,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: false
+    disablekafkaforvisibility: true
   messagingclientconfig:
     usemock: false
     kafkaconfig:

--- a/host/testdata/xdc_integration_es_clusters.yaml
+++ b/host/testdata/xdc_integration_es_clusters.yaml
@@ -36,7 +36,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: false
+    disablekafkaforvisibility: true
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -113,7 +113,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: false
+    disablekafkaforvisibility: true
   messagingclientconfig:
     usemock: false
     kafkaconfig:

--- a/host/testdata/xdc_integration_test_clusters.yaml
+++ b/host/testdata/xdc_integration_test_clusters.yaml
@@ -36,7 +36,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: false
+    disablekafkaforvisibility: true
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -99,7 +99,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: false
+    disablekafkaforvisibility: true
   messagingclientconfig:
     usemock: false
     kafkaconfig:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Integration tests are configured to use internal visibility queue instead of Kafka for visibility.

<!-- Tell your future self why have you made these changes -->
**Why?**
As part of Kafka deprecation effort.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks, changes are in tests only.
