### PR TITLE
Add DisableTransferQueueProcessForVisibility dynamic config flag

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -726,7 +726,7 @@ const (
 
 	// key for worker
 
-	// WorkerPersistenceMaxQPS is the max qps worker host can query DBDisableTransferQueueProcessForVisibility
+	// WorkerPersistenceMaxQPS is the max qps worker host can query DB
 	WorkerPersistenceMaxQPS
 	// WorkerPersistenceGlobalMaxQPS is the max qps worker cluster can query DB
 	WorkerPersistenceGlobalMaxQPS

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -278,6 +278,7 @@ var keys = map[Key]string{
 	DefaultActivityRetryPolicy:                             "history.defaultActivityRetryPolicy",
 	DefaultWorkflowRetryPolicy:                             "history.defaultWorkflowRetryPolicy",
 	DisableKafkaForVisibility:                              "history.disableKafkaForVisibility",
+	DisableTransferQueueProcessForVisibility:               "history.disableTransferQueueProcessForVisibility",
 
 	WorkerPersistenceMaxQPS:                         "worker.persistenceMaxQPS",
 	WorkerPersistenceGlobalMaxQPS:                   "worker.persistenceGlobalMaxQPS",
@@ -720,10 +721,12 @@ const (
 
 	// DisableKafkaForVisibility is to indicate if Kafka or internal visibility queue should be used for visibility.
 	DisableKafkaForVisibility
+	// DisableTransferQueueProcessForVisibility is to indicate if transfer queue processor should be used for visibility.
+	DisableTransferQueueProcessForVisibility
 
 	// key for worker
 
-	// WorkerPersistenceMaxQPS is the max qps worker host can query DB
+	// WorkerPersistenceMaxQPS is the max qps worker host can query DBDisableTransferQueueProcessForVisibility
 	WorkerPersistenceMaxQPS
 	// WorkerPersistenceGlobalMaxQPS is the max qps worker cluster can query DB
 	WorkerPersistenceGlobalMaxQPS

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -736,6 +736,8 @@ func (c *temporalImpl) overrideHistoryDynamicConfig(client *dynamicClient) {
 	}
 
 	client.OverrideValue(dynamicconfig.DisableKafkaForVisibility, c.historyConfig.DisableKafkaForVisibility)
+	// It is ok to use the same value for DisableTransferQueueProcessForVisibility in integration tests.
+	client.OverrideValue(dynamicconfig.DisableTransferQueueProcessForVisibility, c.historyConfig.DisableKafkaForVisibility)
 }
 
 // copyPersistenceConfig makes a deepcopy of persistence config.

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -249,7 +249,8 @@ type Config struct {
 	VisibilityProcessorEnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
 	VisibilityProcessorVisibilityArchivalTimeLimit         dynamicconfig.DurationPropertyFn
 
-	DisableKafkaForVisibility dynamicconfig.BoolPropertyFn
+	DisableKafkaForVisibility                dynamicconfig.BoolPropertyFn
+	DisableTransferQueueProcessForVisibility dynamicconfig.BoolPropertyFn
 
 	// ValidSearchAttributes is legal indexed keys that can be used in list APIs
 	ValidSearchAttributes             dynamicconfig.MapPropertyFn
@@ -440,7 +441,8 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		VisibilityProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnablePriorityTaskProcessor, false),
 		VisibilityProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.VisibilityProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
-		DisableKafkaForVisibility: dc.GetBoolProperty(dynamicconfig.DisableKafkaForVisibility, false),
+		DisableKafkaForVisibility:                dc.GetBoolProperty(dynamicconfig.DisableKafkaForVisibility, false),
+		DisableTransferQueueProcessForVisibility: dc.GetBoolProperty(dynamicconfig.DisableTransferQueueProcessForVisibility, false),
 
 		ValidSearchAttributes:             dc.GetMapProperty(dynamicconfig.ValidSearchAttributes, definition.GetDefaultIndexedKeys()),
 		SearchAttributesNumberOfKeysLimit: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.SearchAttributesNumberOfKeysLimit, 100),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -249,6 +249,7 @@ type Config struct {
 	VisibilityProcessorEnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
 	VisibilityProcessorVisibilityArchivalTimeLimit         dynamicconfig.DurationPropertyFn
 
+	// TODO: See https://github.com/temporalio/temporal/pull/1096 on how to remove these fields.
 	DisableKafkaForVisibility                dynamicconfig.BoolPropertyFn
 	DisableTransferQueueProcessForVisibility dynamicconfig.BoolPropertyFn
 

--- a/service/history/transferQueueActiveTaskExecutorV2_test.go
+++ b/service/history/transferQueueActiveTaskExecutorV2_test.go
@@ -155,6 +155,7 @@ func (s *transferQueueActiveTaskExecutorSuiteV2) SetupTest() {
 
 	config := NewDynamicConfigForTest()
 	config.DisableKafkaForVisibility = dc.GetBoolPropertyFn(true)
+	config.DisableTransferQueueProcessForVisibility = dc.GetBoolPropertyFn(true)
 	s.mockShard = shard.NewTestContext(
 		s.controller,
 		&persistence.ShardInfoWithFailover{

--- a/service/history/transferQueueStandbyTaskExecutor_test.go
+++ b/service/history/transferQueueStandbyTaskExecutor_test.go
@@ -107,6 +107,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) SetupTest() {
 
 	config := configs.NewDynamicConfigForTest()
 	config.DisableKafkaForVisibility = dc.GetBoolPropertyFn(true)
+	config.DisableTransferQueueProcessForVisibility = dc.GetBoolPropertyFn(true)
 
 	s.namespaceID = testNamespaceID
 	s.namespaceEntry = testGlobalNamespaceEntry

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -290,10 +290,6 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowClosed(
 		archiveVisibility = clusterConfiguredForVisibilityArchival && namespaceConfiguredForVisibilityArchival
 	}
 
-	// Backward compatibility upgrade plan:
-	// 1. Next release: no config change, DisableKafkaForVisibility: false, DisableTransferQueueProcessForVisibility: false,
-	// 2. Next+1 release: disable publishing to transfer queue and Kafka: DisableKafkaForVisibility: true,
-	// 3. Next+2 release: disable processing of transfer queue and Kafka: DisableTransferQueueProcessForVisibility: true, EnableIndexer: false,
 	if (!t.config.DisableKafkaForVisibility() || !t.config.DisableTransferQueueProcessForVisibility()) && recordWorkflowClose {
 		if err := t.visibilityMgr.RecordWorkflowExecutionClosed(&persistence.RecordWorkflowExecutionClosedRequest{
 			VisibilityRequestBase: &persistence.VisibilityRequestBase{

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -290,7 +290,11 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowClosed(
 		archiveVisibility = clusterConfiguredForVisibilityArchival && namespaceConfiguredForVisibilityArchival
 	}
 
-	if !t.config.DisableKafkaForVisibility() && recordWorkflowClose {
+	// Backward compatibility upgrade plan:
+	// 1. Next release: no config change, DisableKafkaForVisibility: false, DisableTransferQueueProcessForVisibility: false,
+	// 2. Next+1 release: disable publishing to transfer queue and Kafka: DisableKafkaForVisibility: true,
+	// 3. Next+2 release: disable processing of transfer queue and Kafka: DisableTransferQueueProcessForVisibility: true, EnableIndexer: false,
+	if (!t.config.DisableKafkaForVisibility() || !t.config.DisableTransferQueueProcessForVisibility()) && recordWorkflowClose {
 		if err := t.visibilityMgr.RecordWorkflowExecutionClosed(&persistence.RecordWorkflowExecutionClosedRequest{
 			VisibilityRequestBase: &persistence.VisibilityRequestBase{
 				NamespaceID: namespaceID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`history.disableTransferQueueProcessForVisibility` dynamic config flag was added to cover possible edge case during migration to Kafka free mode.

<!-- Tell your future self why have you made these changes -->
**Why?**
Backward compatibility upgrade plan:
1. Next release: no config change, `DisableKafkaForVisibility`: `false`, `DisableTransferQueueProcessForVisibility`: `false` (current defaults),
2. Next+1 release: disable publishing to transfer queue and Kafka: `DisableKafkaForVisibility`: `true`,
3. Next+2 release: disable processing of transfer queue and Kafka: `DisableTransferQueueProcessForVisibility`: `true`, `EnableIndexer`: `false`,
4. Next+3 release: Kafka and indexer code are completely removed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
I don't see any risks.
