### PR TITLE
Use local quorum for Cassandra when querying schema version

### DIFF
--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -189,6 +189,10 @@ func (client *cqlClient) CreateSchemaVersionTables() error {
 // ReadSchemaVersion returns the current schema version for the Keyspace
 func (client *cqlClient) ReadSchemaVersion() (string, error) {
 	query := client.session.Query(readSchemaVersionCQL, client.clusterConfig.Keyspace)
+	// when querying the DB schema version, override to local quorum
+	// in case Cassandra node down (compared to using ALL)
+	query.SetConsistency(gocql.LocalQuorum)
+
 	iter := query.Iter()
 	var version string
 	if !iter.Scan(&version) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Make Cassandra DB layer ReadSchemaVersion use LocalQuorum

<!-- Tell your future self why have you made these changes -->
**Why?**
In case Cassandra hosts down for maintenance

Solves #1085 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
