### PR TITLE
Remove leftover RolloutId

### DIFF
--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -28,5 +28,4 @@ frontend.validSearchAttributes:
       BinaryChecksums: "Keyword"
       CustomNamespace: "Keyword"
       Operator: "Keyword"
-      RolloutId: "Keyword"
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`RolloutId` field was removed from ES dynamic config.

<!-- Tell your future self why have you made these changes -->
**Why?**
Field is not used. Leftover after ES fields cleanup.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
