### PR TITLE
Replace bool visibility queue dynamic configs with single string config

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -134,3 +134,10 @@ const (
 	// AdvancedVisibilityWritingModeDual means write to both normal visibility and advanced visibility store
 	AdvancedVisibilityWritingModeDual = "dual"
 )
+
+// enum for dynamic config VisibilityQueue
+const (
+	VisibilityQueueKafka                     = "kafka"
+	VisibilityQueueInternalWithDualProcessor = "internalWithDualProcessor"
+	VisibilityQueueInternal                  = "internal"
+)

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -71,7 +71,6 @@ var keys = map[Key]string{
 	MinRetentionDays:                       "system.minRetentionDays",
 	DisallowQuery:                          "system.disallowQuery",
 	EnableBatcher:                          "worker.enableBatcher",
-	EnableIndexer:                          "worker.enableIndexer",
 	EnableParentClosePolicyWorker:          "system.enableParentClosePolicyWorker",
 	EnableStickyQuery:                      "system.enableStickyQuery",
 	EnablePriorityTaskProcessor:            "system.enablePriorityTaskProcessor",
@@ -277,8 +276,7 @@ var keys = map[Key]string{
 	SkipReapplicationByNamespaceId:                         "history.SkipReapplicationByNamespaceId",
 	DefaultActivityRetryPolicy:                             "history.defaultActivityRetryPolicy",
 	DefaultWorkflowRetryPolicy:                             "history.defaultWorkflowRetryPolicy",
-	DisableKafkaForVisibility:                              "history.disableKafkaForVisibility",
-	DisableTransferQueueProcessForVisibility:               "history.disableTransferQueueProcessForVisibility",
+	VisibilityQueue:                                        "history.visibilityQueue",
 
 	WorkerPersistenceMaxQPS:                         "worker.persistenceMaxQPS",
 	WorkerPersistenceGlobalMaxQPS:                   "worker.persistenceGlobalMaxQPS",
@@ -719,10 +717,8 @@ const (
 	// SkipReapplicationByNameSpaceId is whether skipping a event re-application for a namespace
 	SkipReapplicationByNamespaceId
 
-	// DisableKafkaForVisibility is to indicate if Kafka or internal visibility queue should be used for visibility.
-	DisableKafkaForVisibility
-	// DisableTransferQueueProcessForVisibility is to indicate if transfer queue processor should be used for visibility.
-	DisableTransferQueueProcessForVisibility
+	// VisibilityQueue is to indicate which visibility queue to use: "Kafka", "InternalWithDualProcessor", "Internal".
+	VisibilityQueue
 
 	// key for worker
 
@@ -789,8 +785,6 @@ const (
 	ExecutionsScannerEnabled
 	// EnableBatcher decides whether start batcher in our worker
 	EnableBatcher
-	// EnableIndexer decides whether start indexer in our worker
-	EnableIndexer
 	// EnableParentClosePolicyWorker decides whether or not enable system workers for processing parent close policy task
 	EnableParentClosePolicyWorker
 	// EnableStickyQuery indicates if sticky query should be enabled per namespace

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -117,11 +117,11 @@ type (
 
 	// HistoryConfig contains configs for history service
 	HistoryConfig struct {
-		NumHistoryShards          int32
-		NumHistoryHosts           int
-		HistoryCountLimitError    int
-		HistoryCountLimitWarn     int
-		DisableKafkaForVisibility bool
+		NumHistoryShards       int32
+		NumHistoryHosts        int
+		HistoryCountLimitError int
+		HistoryCountLimitWarn  int
+		VisibilityQueue        string
 	}
 
 	// TemporalParams contains everything needed to bootstrap Temporal
@@ -735,9 +735,7 @@ func (c *temporalImpl) overrideHistoryDynamicConfig(client *dynamicClient) {
 		client.OverrideValue(dynamicconfig.HistoryCountLimitError, c.historyConfig.HistoryCountLimitError)
 	}
 
-	client.OverrideValue(dynamicconfig.DisableKafkaForVisibility, c.historyConfig.DisableKafkaForVisibility)
-	// It is ok to use the same value for DisableTransferQueueProcessForVisibility in integration tests.
-	client.OverrideValue(dynamicconfig.DisableTransferQueueProcessForVisibility, c.historyConfig.DisableKafkaForVisibility)
+	client.OverrideValue(dynamicconfig.VisibilityQueue, c.historyConfig.VisibilityQueue)
 }
 
 // copyPersistenceConfig makes a deepcopy of persistence config.

--- a/host/testdata/clientintegrationtestcluster.yaml
+++ b/host/testdata/clientintegrationtestcluster.yaml
@@ -5,7 +5,7 @@ messagingclientconfig:
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
-  disablekafkaforvisibility: true
+  visibilityqueue: internal
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/host/testdata/integration_elasticsearch_cluster.yaml
+++ b/host/testdata/integration_elasticsearch_cluster.yaml
@@ -19,7 +19,7 @@ messagingclientconfig:
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
-  disablekafkaforvisibility: true
+  visibilityqueue: internal
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/host/testdata/integration_sizelimit_cluster.yaml
+++ b/host/testdata/integration_sizelimit_cluster.yaml
@@ -7,7 +7,7 @@ historyconfig:
   numhistoryhosts: 1
   historycountlimiterror: 20
   historycountlimitwarn: 10
-  disablekafkaforvisibility: true
+  visibilityqueue: internal
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/host/testdata/integration_test_cluster.yaml
+++ b/host/testdata/integration_test_cluster.yaml
@@ -5,7 +5,7 @@ messagingclientconfig:
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
-  disablekafkaforvisibility: true
+  visibilityqueue: internal
 workerconfig:
   enablearchiver: true
   enablereplicator: true

--- a/host/testdata/ndc_integration_test_clusters.yaml
+++ b/host/testdata/ndc_integration_test_clusters.yaml
@@ -41,7 +41,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: true
+    visibilityqueue: internal
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -116,7 +116,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: true
+    visibilityqueue: internal
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -191,7 +191,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: true
+    visibilityqueue: internal
   messagingclientconfig:
     usemock: false
     kafkaconfig:

--- a/host/testdata/xdc_integration_es_clusters.yaml
+++ b/host/testdata/xdc_integration_es_clusters.yaml
@@ -36,7 +36,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: true
+    visibilityqueue: internal
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -113,7 +113,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: true
+    visibilityqueue: internal
   messagingclientconfig:
     usemock: false
     kafkaconfig:

--- a/host/testdata/xdc_integration_test_clusters.yaml
+++ b/host/testdata/xdc_integration_test_clusters.yaml
@@ -36,7 +36,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: true
+    visibilityqueue: internal
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -99,7 +99,7 @@
   historyconfig:
     numhistoryshards: 1
     numhistoryhosts: 1
-    disablekafkaforvisibility: true
+    visibilityqueue: internal
   messagingclientconfig:
     usemock: false
     kafkaconfig:

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -249,9 +249,7 @@ type Config struct {
 	VisibilityProcessorEnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
 	VisibilityProcessorVisibilityArchivalTimeLimit         dynamicconfig.DurationPropertyFn
 
-	// TODO: See https://github.com/temporalio/temporal/pull/1096 on how to remove these fields.
-	DisableKafkaForVisibility                dynamicconfig.BoolPropertyFn
-	DisableTransferQueueProcessForVisibility dynamicconfig.BoolPropertyFn
+	VisibilityQueue dynamicconfig.StringPropertyFn
 
 	// ValidSearchAttributes is legal indexed keys that can be used in list APIs
 	ValidSearchAttributes             dynamicconfig.MapPropertyFn
@@ -442,8 +440,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		VisibilityProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnablePriorityTaskProcessor, false),
 		VisibilityProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.VisibilityProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
-		DisableKafkaForVisibility:                dc.GetBoolProperty(dynamicconfig.DisableKafkaForVisibility, false),
-		DisableTransferQueueProcessForVisibility: dc.GetBoolProperty(dynamicconfig.DisableTransferQueueProcessForVisibility, false),
+		VisibilityQueue: dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueKafka),
 
 		ValidSearchAttributes:             dc.GetMapProperty(dynamicconfig.ValidSearchAttributes, definition.GetDefaultIndexedKeys()),
 		SearchAttributesNumberOfKeysLimit: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.SearchAttributesNumberOfKeysLimit, 100),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -224,7 +224,7 @@ func NewEngineWithShardContext(
 
 	historyEngImpl.txProcessor = newTransferQueueProcessor(shard, historyEngImpl, visibilityMgr, matching, historyClient, queueTaskProcessor, logger)
 	historyEngImpl.timerProcessor = newTimerQueueProcessor(shard, historyEngImpl, matching, queueTaskProcessor, logger)
-	if config.DisableKafkaForVisibility() {
+	if config.VisibilityQueue() == common.VisibilityQueueInternal || config.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor {
 		historyEngImpl.visibilityProcessor = newVisibilityQueueProcessor(shard, historyEngImpl, visibilityMgr, matching, historyClient, queueTaskProcessor, logger)
 	}
 	historyEngImpl.eventsReapplier = newNDCEventsReapplier(shard.GetMetricsClient(), logger)

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -85,7 +85,7 @@ func NewService(
 
 			var visibilityProducer messaging.Producer
 			var esProcessor espersistence.Processor
-			if serviceConfig.DisableKafkaForVisibility() {
+			if serviceConfig.VisibilityQueue() == common.VisibilityQueueInternal || serviceConfig.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor {
 				esProcessorConfig := &espersistence.ProcessorConfig{
 					IndexerConcurrency:       serviceConfig.IndexerConcurrency,
 					ESProcessorNumOfWorkers:  serviceConfig.ESProcessorNumOfWorkers,

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -266,7 +266,7 @@ func (t *timerQueueTaskExecutorBase) deleteWorkflowVisibility(
 	task *persistencespb.TimerTaskInfo,
 ) error {
 
-	if !t.config.DisableKafkaForVisibility() {
+	if t.config.VisibilityQueue() == common.VisibilityQueueKafka {
 		op := func() error {
 			request := &persistence.VisibilityDeleteWorkflowExecutionRequest{
 				NamespaceID: task.GetNamespaceId(),

--- a/service/history/timerQueueTaskExecutorBaseV2_test.go
+++ b/service/history/timerQueueTaskExecutorBaseV2_test.go
@@ -88,7 +88,7 @@ func (s *timerQueueTaskExecutorBaseSuiteV2) SetupTest() {
 	s.mockMutableState = NewMockmutableState(s.controller)
 
 	config := NewDynamicConfigForTest()
-	config.DisableKafkaForVisibility = dc.GetBoolPropertyFn(true)
+	config.VisibilityQueue = dc.GetStringPropertyFn(common.VisibilityQueueInternal)
 	s.mockShard = shard.NewTestContext(
 		s.controller,
 		&persistence.ShardInfoWithFailover{

--- a/service/history/transferQueueActiveTaskExecutorV2_test.go
+++ b/service/history/transferQueueActiveTaskExecutorV2_test.go
@@ -154,8 +154,7 @@ func (s *transferQueueActiveTaskExecutorSuiteV2) SetupTest() {
 	s.mockTimerProcessor.EXPECT().NotifyNewTimers(gomock.Any(), gomock.Any()).AnyTimes()
 
 	config := NewDynamicConfigForTest()
-	config.DisableKafkaForVisibility = dc.GetBoolPropertyFn(true)
-	config.DisableTransferQueueProcessForVisibility = dc.GetBoolPropertyFn(true)
+	config.VisibilityQueue = dc.GetStringPropertyFn(common.VisibilityQueueInternal)
 	s.mockShard = shard.NewTestContext(
 		s.controller,
 		&persistence.ShardInfoWithFailover{

--- a/service/history/transferQueueStandbyTaskExecutor_test.go
+++ b/service/history/transferQueueStandbyTaskExecutor_test.go
@@ -106,8 +106,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 
 	config := configs.NewDynamicConfigForTest()
-	config.DisableKafkaForVisibility = dc.GetBoolPropertyFn(true)
-	config.DisableTransferQueueProcessForVisibility = dc.GetBoolPropertyFn(true)
+	config.VisibilityQueue = dc.GetStringPropertyFn(common.VisibilityQueueInternal)
 
 	s.namespaceID = testNamespaceID
 	s.namespaceEntry = testGlobalNamespaceEntry

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -290,7 +290,7 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowClosed(
 		archiveVisibility = clusterConfiguredForVisibilityArchival && namespaceConfiguredForVisibilityArchival
 	}
 
-	if (!t.config.DisableKafkaForVisibility() || !t.config.DisableTransferQueueProcessForVisibility()) && recordWorkflowClose {
+	if (t.config.VisibilityQueue() == common.VisibilityQueueKafka || t.config.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor) && recordWorkflowClose {
 		if err := t.visibilityMgr.RecordWorkflowExecutionClosed(&persistence.RecordWorkflowExecutionClosedRequest{
 			VisibilityRequestBase: &persistence.VisibilityRequestBase{
 				NamespaceID: namespaceID,

--- a/service/history/visibilityQueueTaskExecutor_test.go
+++ b/service/history/visibilityQueueTaskExecutor_test.go
@@ -106,7 +106,7 @@ func (s *visibilityQueueTaskExecutorSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 
 	config := NewDynamicConfigForTest()
-	config.DisableKafkaForVisibility = dc.GetBoolPropertyFn(true)
+	config.VisibilityQueue = dc.GetStringPropertyFn(common.VisibilityQueueInternal)
 	s.mockShard = shard.NewTestContext(
 		s.controller,
 		&persistence.ShardInfoWithFailover{

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -71,7 +71,7 @@ type (
 		ThrottledLogRPS               dynamicconfig.IntPropertyFn
 		PersistenceGlobalMaxQPS       dynamicconfig.IntPropertyFn
 		EnableBatcher                 dynamicconfig.BoolPropertyFn
-		EnableIndexer                 dynamicconfig.BoolPropertyFn
+		VisibilityQueue               dynamicconfig.StringPropertyFn
 		EnableParentClosePolicyWorker dynamicconfig.BoolPropertyFn
 	}
 )
@@ -143,7 +143,7 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 			ClusterMetadata:     params.ClusterMetadata,
 		},
 		EnableBatcher:                 dc.GetBoolProperty(dynamicconfig.EnableBatcher, true),
-		EnableIndexer:                 dc.GetBoolProperty(dynamicconfig.EnableIndexer, true),
+		VisibilityQueue:               dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueKafka),
 		EnableParentClosePolicyWorker: dc.GetBoolProperty(dynamicconfig.EnableParentClosePolicyWorker, true),
 		ThrottledLogRPS:               dc.GetIntProperty(dynamicconfig.WorkerThrottledLogRPS, 20),
 		PersistenceGlobalMaxQPS:       dc.GetIntProperty(dynamicconfig.WorkerPersistenceGlobalMaxQPS, 0),
@@ -152,7 +152,7 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 		dynamicconfig.AdvancedVisibilityWritingMode,
 		common.GetDefaultAdvancedVisibilityWritingMode(params.PersistenceConfig.IsAdvancedVisibilityConfigExist()),
 	)
-	if config.EnableIndexer() && advancedVisWritingMode() != common.AdvancedVisibilityWritingModeOff {
+	if (config.VisibilityQueue() == common.VisibilityQueueKafka || config.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor) && advancedVisWritingMode() != common.AdvancedVisibilityWritingModeOff {
 		config.IndexerCfg = &indexer.Config{
 			IndexerConcurrency:       dc.GetIntProperty(dynamicconfig.WorkerIndexerConcurrency, 100),
 			ESProcessorNumOfWorkers:  dc.GetIntProperty(dynamicconfig.WorkerESProcessorNumOfWorkers, 1),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`history.disableKafkaForVisibility`, `history.disableTransferQueueProcessForVisibility`, and `worker.enableIndexer` were replaced with single `history.visibilityQueue` setting with 3 possible values: `kafka`, `internalWithDualProcessor`, and `internal`.

<!-- Tell your future self why have you made these changes -->
**Why?**
To simplify upgrade experience. Current upgrade plan is the following:
1. Next release: default value for `history.visibilityQueue` is `kafka`.
  * after rollout the release users change its value to `internalWithDualProcessor` and waits for Kafka queue to get drained and all previously created transfer queue tasks to be processed.
  * when is is done (should be within seconds), value needs to be changed to `internal`.
2. Next+1 release: default value for `history.visibilityQueue` is `internal`. Kafka code path is not used.
3. Next+2 release: `history.visibilityQueue` setting, Kafka and indexer code are completely removed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
