### PR TITLE
Add proper index to SQL visibility store

### DIFF
--- a/schema/mysql/v57/visibility/schema.sql
+++ b/schema/mysql/v57/visibility/schema.sql
@@ -21,3 +21,4 @@ CREATE INDEX by_status_by_start_time ON executions_visibility (namespace_id, sta
 CREATE INDEX by_type_close_time ON executions_visibility (namespace_id, workflow_type_name, status, close_time DESC, run_id);
 CREATE INDEX by_workflow_id_close_time ON executions_visibility (namespace_id, workflow_id, status, close_time DESC, run_id);
 CREATE INDEX by_status_by_close_time ON executions_visibility (namespace_id, status, close_time DESC, run_id);
+CREATE INDEX by_close_time_by_status ON executions_visibility (namespace_id, close_time DESC, run_id, status);

--- a/schema/mysql/v57/visibility/versioned/v1.1/index.sql
+++ b/schema/mysql/v57/visibility/versioned/v1.1/index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX by_close_time_by_status ON executions_visibility (namespace_id, close_time DESC, run_id, status);

--- a/schema/mysql/v57/visibility/versioned/v1.1/manifest.json
+++ b/schema/mysql/v57/visibility/versioned/v1.1/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.1",
+  "MinCompatibleVersion": "0.1",
+  "Description": "add close time & status index",
+  "SchemaUpdateCqlFiles": [
+    "index.sql"
+  ]
+}

--- a/schema/mysql/version.go
+++ b/schema/mysql/version.go
@@ -30,4 +30,4 @@ package mysql
 const Version = "1.3"
 
 // VisibilityVersion is the MySQL visibility database release version
-const VisibilityVersion = "1.0"
+const VisibilityVersion = "1.1"

--- a/schema/postgresql/v96/visibility/schema.sql
+++ b/schema/postgresql/v96/visibility/schema.sql
@@ -21,5 +21,6 @@ CREATE INDEX by_status_by_start_time ON executions_visibility (namespace_id, sta
 CREATE INDEX by_type_close_time ON executions_visibility (namespace_id, workflow_type_name, status, close_time DESC, run_id);
 CREATE INDEX by_workflow_id_close_time ON executions_visibility (namespace_id, workflow_id, status, close_time DESC, run_id);
 CREATE INDEX by_status_by_close_time ON executions_visibility (namespace_id, status, close_time DESC, run_id);
+CREATE INDEX by_close_time_by_status ON executions_visibility (namespace_id, close_time DESC, run_id, status);
 
 

--- a/schema/postgresql/v96/visibility/versioned/v1.1/index.sql
+++ b/schema/postgresql/v96/visibility/versioned/v1.1/index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX by_close_time_by_status ON executions_visibility (namespace_id, close_time DESC, run_id, status);

--- a/schema/postgresql/v96/visibility/versioned/v1.1/manifest.json
+++ b/schema/postgresql/v96/visibility/versioned/v1.1/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.1",
+  "MinCompatibleVersion": "0.1",
+  "Description": "add close time & status index",
+  "SchemaUpdateCqlFiles": [
+    "index.sql"
+  ]
+}

--- a/schema/postgresql/version.go
+++ b/schema/postgresql/version.go
@@ -32,4 +32,4 @@ const Version = "1.3"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres
-const VisibilityVersion = "1.0"
+const VisibilityVersion = "1.1"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Add new index to MySQL & PostgreSQL visibility table

NOTE: `The table remains available for read and write operations while the index is being created.`
Ref: https://dev.mysql.com/doc/refman/5.7/en/innodb-online-ddl-operations.html#online-ddl-index-operations

<!-- Tell your future self why have you made these changes -->
**Why?**
SQL side table schema lacks index on close time & run ID & status

Solves #1106

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
