### PR TITLE
Fix typo on availability zone env key

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -80,7 +80,7 @@ func buildCLI() *cli.App {
 			Name:    "zone",
 			Aliases: []string{"az"},
 			Usage:   "availability zone",
-			EnvVars: []string{config.EnvKeyAvailabilityZone},
+			EnvVars: []string{config.EnvKeyAvailabilityZone, config.EnvKeyAvailabilityZoneTypo},
 		},
 	}
 

--- a/common/service/config/loader.go
+++ b/common/service/config/loader.go
@@ -42,7 +42,7 @@ const (
 	// EnvKeyEnvironment is the environment variable key for environment
 	EnvKeyEnvironment = "TEMPORAL_ENVIRONMENT"
 	// EnvKeyAvailabilityZone is the environment variable key for AZ
-	EnvKeyAvailabilityZone = "TEMPORAL_AVAILABILTY_ZONE"
+	EnvKeyAvailabilityZone = "TEMPORAL_AVAILABILITY_ZONE"
 )
 
 const (

--- a/common/service/config/loader.go
+++ b/common/service/config/loader.go
@@ -43,6 +43,10 @@ const (
 	EnvKeyEnvironment = "TEMPORAL_ENVIRONMENT"
 	// EnvKeyAvailabilityZone is the environment variable key for AZ
 	EnvKeyAvailabilityZone = "TEMPORAL_AVAILABILITY_ZONE"
+	// EnvKeyAvailabilityZoneTypo is the old environment variable key for AZ that
+	// included a typo. This is deprecated and only here to support backwards
+	// compatibility.
+	EnvKeyAvailabilityZoneTypo = "TEMPORAL_AVAILABILTY_ZONE"
 )
 
 const (


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

`EnvKeyAvailabilityZone` was changed from `TEMPORAL_AVAILABILTY_ZONE` to `TEMPORAL_AVAILABILITY_ZONE`.

This also adds backwards compatibility for the incorrectly spelt env key.

<!-- Tell your future self why have you made these changes -->
**Why?**

This corrects a typo that was a gotcha for me while trying to make use of this.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I've tried searching for existing references to this typo in this repo and could not find any. I assumed it's an indication that there are no tests around this, but I have run the full suite via `make test` and everything looks green locally.

I've manually verified by building the `server` bin and checking that both env vars are considered, with the correctly spelt version taking priority.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

There shouldn't be any. This should be communicated in the release that includes the change so people can be made aware of this change. Similar communications are needed when backwards compatibility is dropped entirely.