### PR TITLE
Log details of authorization errors and return a generic unauthorized error to the caller

### DIFF
--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -35,6 +35,8 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 )
 
@@ -90,7 +92,7 @@ func (a *interceptor) Interceptor(
 			}
 			mappedClaims, err := a.claimMapper.GetClaims(&authInfo)
 			if err != nil {
-				return nil, err
+				return nil, a.logAuthError(err)
 			}
 			claims = mappedClaims
 			ctx = context.WithValue(ctx, ContextKeyMappedClaims, mappedClaims)
@@ -113,7 +115,7 @@ func (a *interceptor) Interceptor(
 		result, err := a.authorizer.Authorize(ctx, claims, &CallTarget{Namespace: namespace, APIName: apiName})
 		if err != nil {
 			scope.IncCounter(metrics.ServiceErrAuthorizeFailedCounter)
-			return nil, err
+			return nil, a.logAuthError(err)
 		}
 		if result.Decision != DecisionAllow {
 			scope.IncCounter(metrics.ServiceErrUnauthorizedCounter)
@@ -123,10 +125,16 @@ func (a *interceptor) Interceptor(
 	return handler(ctx, req)
 }
 
+func (a *interceptor) logAuthError(err error) error {
+	a.logger.Error("authorization error", tag.Error(err))
+	return errUnauthorized // return a generic error to the caller without disclosing details
+}
+
 type interceptor struct {
 	authorizer    Authorizer
 	claimMapper   ClaimMapper
 	metricsClient metrics.Client
+	logger        log.Logger
 }
 
 // GetAuthorizationInterceptor creates an authorization interceptor and return a func that points to its Interceptor method
@@ -134,8 +142,14 @@ func NewAuthorizationInterceptor(
 	claimMapper ClaimMapper,
 	authorizer Authorizer,
 	metrics metrics.Client,
+	logger log.Logger,
 ) grpc.UnaryServerInterceptor {
-	return (&interceptor{claimMapper: claimMapper, authorizer: authorizer, metricsClient: metrics}).Interceptor
+	return (&interceptor{
+		claimMapper:   claimMapper,
+		authorizer:    authorizer,
+		metricsClient: metrics,
+		logger:        logger,
+	}).Interceptor
 }
 
 // getMetricsScopeWithNamespace return metrics scope with namespace tag

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -33,8 +33,10 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/api/workflowservicemock/v1"
+	"go.uber.org/zap"
 	"google.golang.org/grpc"
 
+	"go.temporal.io/server/common/log/loggerimpl"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/metrics/mocks"
 )
@@ -90,7 +92,11 @@ func (s *authorizerInterceptorSuite) SetupTest() {
 	s.mockMetricsScope.On("StartTimer", metrics.ServiceAuthorizationLatency).
 		Return(metrics.Stopwatch{}).Once()
 	s.mockClaimMapper = NewMockClaimMapper(s.controller)
-	s.interceptor = NewAuthorizationInterceptor(s.mockClaimMapper, s.mockAuthorizer, s.mockMetricsClient)
+	s.interceptor = NewAuthorizationInterceptor(
+		s.mockClaimMapper,
+		s.mockAuthorizer,
+		s.mockMetricsClient,
+		loggerimpl.NewLogger(zap.NewNop()))
 	s.handler = func(ctx context.Context, req interface{}) (interface{}, error) { return true, nil }
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -274,7 +274,8 @@ func (s *Service) Start() {
 			authorization.NewAuthorizationInterceptor(
 				s.params.ClaimMapper,
 				s.params.Authorizer,
-				s.Resource.GetMetricsClient())))
+				s.Resource.GetMetricsClient(),
+				s.GetLogger())))
 	s.server = grpc.NewServer(opts...)
 
 	wfHandler := NewWorkflowHandler(s, s.config, replicationMessageSink)


### PR DESCRIPTION
**What changed?**
Stop sending details of authorization errors to the caller, log them on the server, and return a generic unauthorized error with no details. 

**Why?**
Returning details of authorization errors may inadvertently disclose information that could help a malicious caller. 

**How did you test it?**
Unit tests

**Potential risks**
No risk
