### PR TITLE
Use Prometheus as default metrics provider for all configs

### DIFF
--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -18,9 +18,9 @@ global:
   pprof:
     port: 7936
   metrics:
-    statsd:
-      hostPort: "127.0.0.1:8125"
-      prefix: "temporal_active"
+    prometheus:
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
 
 services:
   frontend:

--- a/config/development_archival.yaml
+++ b/config/development_archival.yaml
@@ -18,9 +18,9 @@ global:
   pprof:
     port: 7936
   metrics:
-    statsd:
-      hostPort: "127.0.0.1:8125"
-      prefix: "temporal"
+    prometheus:
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
 
 services:
   frontend:

--- a/config/development_es.yaml
+++ b/config/development_es.yaml
@@ -25,9 +25,9 @@ global:
   pprof:
       port: 7936
   metrics:
-    statsd:
-      hostPort: "127.0.0.1:8125"
-      prefix: "temporal"
+    prometheus:
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
 
 services:
   frontend:

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -32,9 +32,9 @@ global:
   pprof:
     port: 7936
   metrics:
-    statsd:
-      hostPort: "127.0.0.1:8125"
-      prefix: "temporal"
+    prometheus:
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
 
 services:
   frontend:

--- a/config/development_other.yaml
+++ b/config/development_other.yaml
@@ -18,9 +18,9 @@ global:
   pprof:
     port: 9936
   metrics:
-    statsd:
-      hostPort: "127.0.0.1:8125"
-      prefix: "temporal_other"
+    prometheus:
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
 
 services:
   frontend:

--- a/config/development_postgres.yaml
+++ b/config/development_postgres.yaml
@@ -32,9 +32,9 @@ global:
   pprof:
     port: 7936
   metrics:
-    statsd:
-      hostPort: "127.0.0.1:8125"
-      prefix: "temporal"
+    prometheus:
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
 
 services:
   frontend:

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -18,9 +18,9 @@ global:
   pprof:
     port: 8936
   metrics:
-    statsd:
-      hostPort: "127.0.0.1:8125"
-      prefix: "temporal_standby"
+    prometheus:
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
 
 services:
   frontend:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Prometheus is used by default for metrics instead of `statsd`.

<!-- Tell your future self why have you made these changes -->
**Why?**
For consistency with main `development.yml` config.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
