### PR TITLE
Fix ES processor metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1008,8 +1008,8 @@ const (
 	// ReplicationDLQStatsScope is scope used by all metrics emitted related to replication DLQ
 	ReplicationDLQStatsScope
 
-	// ESVisibility is scope used by all metric emitted by esProcessor
-	ESVisibility
+	// ElasticSearchVisibility is scope used by all metric emitted by esProcessor
+	ElasticSearchVisibility
 
 	NumHistoryScopes
 )
@@ -1533,7 +1533,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ReplicationTaskFetcherScope:               {operation: "ReplicationTaskFetcher"},
 		ReplicationTaskCleanupScope:               {operation: "ReplicationTaskCleanup"},
 		ReplicationDLQStatsScope:                  {operation: "ReplicationDLQStats"},
-		ESVisibility:                              {operation: "ESVisibility"},
+		ElasticSearchVisibility:                   {operation: "ElasticSearchVisibility"},
 	},
 	// Matching Scope Names
 	Matching: {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1008,6 +1008,9 @@ const (
 	// ReplicationDLQStatsScope is scope used by all metrics emitted related to replication DLQ
 	ReplicationDLQStatsScope
 
+	// ESVisibility is scope used by all metric emitted by esProcessor
+	ESVisibility
+
 	NumHistoryScopes
 )
 
@@ -1530,6 +1533,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ReplicationTaskFetcherScope:               {operation: "ReplicationTaskFetcher"},
 		ReplicationTaskCleanupScope:               {operation: "ReplicationTaskCleanup"},
 		ReplicationDLQStatsScope:                  {operation: "ReplicationDLQStats"},
+		ESVisibility:                              {operation: "ESVisibility"},
 	},
 	// Matching Scope Names
 	Matching: {
@@ -1871,6 +1875,13 @@ const (
 	ReplicationTaskCleanupFailure
 	MutableStateChecksumMismatch
 	MutableStateChecksumInvalidated
+
+	ESBulkProcessorRequests
+	ESBulkProcessorRetries
+	ESBulkProcessorFailures
+	ESBulkProcessorCorruptedData
+	ESBulkProcessorRequestLatency
+	ESInvalidSearchAttribute
 
 	NumHistoryMetrics
 )
@@ -2290,6 +2301,13 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ReplicationTaskCleanupFailure:                     {metricName: "replication_task_cleanup_failed", metricType: Counter},
 		MutableStateChecksumMismatch:                      {metricName: "mutable_state_checksum_mismatch", metricType: Counter},
 		MutableStateChecksumInvalidated:                   {metricName: "mutable_state_checksum_invalidated", metricType: Counter},
+
+		ESBulkProcessorRequests:       {metricName: "es_bulk_processor_requests"},
+		ESBulkProcessorRetries:        {metricName: "es_bulk_processor_retries"},
+		ESBulkProcessorFailures:       {metricName: "es_bulk_processor_errors"},
+		ESBulkProcessorCorruptedData:  {metricName: "es_bulk_processor_corrupted_data"},
+		ESBulkProcessorRequestLatency: {metricName: "es_bulk_processor_request_latency", metricType: Timer},
+		ESInvalidSearchAttribute:      {metricName: "es_invalid_search_attribute"},
 	},
 	Matching: {
 		PollSuccessPerTaskQueueCounter:            {metricName: "poll_success_per_tl", metricRollupName: "poll_success"},

--- a/common/persistence/elasticsearch/esProcessor.go
+++ b/common/persistence/elasticsearch/esProcessor.go
@@ -79,7 +79,7 @@ type (
 		indexerConcurrency      uint32
 	}
 
-	chanWithStopwatch struct { // value of esProcessorImpl.mapToAckChan
+	ackChanWithStopwatch struct { // value of esProcessorImpl.mapToAckChan
 		ackCh             chan<- bool
 		addToAckStopwatch *tally.Stopwatch // metric from message add to process, to message ack/nack
 	}
@@ -173,26 +173,31 @@ func (p *esProcessorImpl) Add(request elastic.BulkableRequest, visibilityTaskKey
 		panic("ackCh must be buffered channel (length should be 1 or more)")
 	}
 
-	actionWhenFoundDuplicates := func(key interface{}, value interface{}) error {
-		ackCh <- true
-		return nil
-	}
-
-	sw := p.metricsClient.StartTimer(metrics.ESProcessorScope, metrics.ESProcessorProcessMsgLatency)
-	chWithStopwatch := newChanWithStopwatch(ackCh, &sw)
-	_, isDup, _ := p.mapToAckChan.PutOrDo(visibilityTaskKey, chWithStopwatch, actionWhenFoundDuplicates)
+	sw := p.metricsClient.StartTimer(metrics.ESVisibility, metrics.ESBulkProcessorRequestLatency)
+	ackChWithStopwatch := newAckChanWithStopwatch(ackCh, &sw)
+	_, isDup, _ := p.mapToAckChan.PutOrDo(visibilityTaskKey, ackChWithStopwatch, p.onDuplicateAction)
 	if isDup {
 		return
 	}
 	p.bulkProcessor.Add(request)
 }
 
-// bulkBeforeAction is triggered before bulk processor commit
-func (p *esProcessorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableRequest) {
-	p.metricsClient.AddCounter(metrics.ESProcessorScope, metrics.ESProcessorRequests, int64(len(requests)))
+func (p *esProcessorImpl) onDuplicateAction(key interface{}, value interface{}) error {
+	ackChWithStopwatch, ok := value.(*ackChanWithStopwatch)
+	if !ok { // must be bug in code and bad deployment
+		p.logger.Fatal(fmt.Sprintf("Message has wrong type %T (%T expected).", value, &ackChanWithStopwatch{}), tag.Value(key))
+	}
+	ackChWithStopwatch.addToAckStopwatch.Stop()
+	ackChWithStopwatch.ackCh <- true
+	return nil
 }
 
-// bulkAfterAction is triggered after bulk processor commit
+// bulkBeforeAction is triggered before bulk processor commit
+func (p *esProcessorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableRequest) {
+	p.metricsClient.AddCounter(metrics.ESVisibility, metrics.ESBulkProcessorRequests, int64(len(requests)))
+}
+
+// bulkAfterAction is triggered eafter bulk processor commit
 func (p *esProcessorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequest, response *elastic.BulkResponse, err error) {
 	if err != nil {
 		// This happens after configured retry, which means something bad happens on cluster or index
@@ -201,7 +206,7 @@ func (p *esProcessorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRe
 
 		for _, request := range requests {
 			p.logger.Error("ES request failed.", tag.ESRequest(request.String()))
-			p.metricsClient.IncCounter(metrics.ESProcessorScope, metrics.ESProcessorFailures)
+			p.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESBulkProcessorFailures)
 		}
 		return
 	}
@@ -225,39 +230,41 @@ func (p *esProcessorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRe
 				p.sendToAckChan(visibilityTaskKey, false)
 			default: // bulk processor will retry
 				p.logger.Info("ES request retried.", tag.ESResponseStatus(resp.Status))
-				p.metricsClient.IncCounter(metrics.ESProcessorScope, metrics.ESProcessorRetries)
+				p.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESBulkProcessorRetries)
 			}
 		}
 	}
 }
 
 func (p *esProcessorImpl) sendToAckChan(visibilityTaskKey string, ack bool) {
-	ackCh, ok := p.getAckChan(visibilityTaskKey)
+	ackChWithStopwatch, ok := p.getAckChan(visibilityTaskKey)
 	if !ok {
 		return
 	}
-	ackCh <- ack
+
+	ackChWithStopwatch.addToAckStopwatch.Stop()
+	ackChWithStopwatch.ackCh <- ack
 
 	p.mapToAckChan.Remove(visibilityTaskKey)
 }
 
-func (p *esProcessorImpl) getAckChan(visibilityTaskKey string) (chan<- bool, bool) {
-	msg, ok := p.mapToAckChan.Get(visibilityTaskKey)
+func (p *esProcessorImpl) getAckChan(visibilityTaskKey string) (*ackChanWithStopwatch, bool) {
+	ackCh, ok := p.mapToAckChan.Get(visibilityTaskKey)
 	if !ok {
 		return nil, false
 	}
-	chWithStopwatch, ok := msg.(*chanWithStopwatch)
+	ackChWithStopwatch, ok := ackCh.(*ackChanWithStopwatch)
 	if !ok { // must be bug in code and bad deployment
-		p.logger.Fatal(fmt.Sprintf("Message has wrong type %T (%T expected).", msg, &chanWithStopwatch{}), tag.ESKey(visibilityTaskKey))
+		p.logger.Fatal(fmt.Sprintf("Message has wrong type %T (%T expected).", ackCh, &ackChanWithStopwatch{}), tag.ESKey(visibilityTaskKey))
 	}
-	return chWithStopwatch.ackCh, ok
+	return ackChWithStopwatch, ok
 }
 
 func (p *esProcessorImpl) getVisibilityTaskKey(request elastic.BulkableRequest) string {
 	req, err := request.Source()
 	if err != nil {
 		p.logger.Error("Get request source err.", tag.Error(err), tag.ESRequest(request.String()))
-		p.metricsClient.IncCounter(metrics.ESProcessorScope, metrics.ESProcessorCorruptedData)
+		p.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESBulkProcessorCorruptedData)
 		return ""
 	}
 
@@ -266,7 +273,7 @@ func (p *esProcessorImpl) getVisibilityTaskKey(request elastic.BulkableRequest) 
 		var body map[string]interface{}
 		if err := json.Unmarshal([]byte(req[1]), &body); err != nil {
 			p.logger.Error("Unmarshal index request body err.", tag.Error(err))
-			p.metricsClient.IncCounter(metrics.ESProcessorScope, metrics.ESProcessorCorruptedData)
+			p.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESBulkProcessorCorruptedData)
 			return ""
 		}
 
@@ -284,7 +291,7 @@ func (p *esProcessorImpl) getVisibilityTaskKey(request elastic.BulkableRequest) 
 		var body map[string]map[string]interface{}
 		if err := json.Unmarshal([]byte(req[0]), &body); err != nil {
 			p.logger.Error("Unmarshal delete request body err.", tag.Error(err))
-			p.metricsClient.IncCounter(metrics.ESProcessorScope, metrics.ESProcessorCorruptedData)
+			p.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESBulkProcessorCorruptedData)
 			return ""
 		}
 
@@ -308,7 +315,7 @@ func (p *esProcessorImpl) getDocIDs(request elastic.BulkableRequest) (workflowID
 	req, err := request.Source()
 	if err != nil {
 		p.logger.Error("Get request source err.", tag.Error(err), tag.ESRequest(request.String()))
-		p.metricsClient.IncCounter(metrics.ESProcessorScope, metrics.ESProcessorCorruptedData)
+		p.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESBulkProcessorCorruptedData)
 		return
 	}
 
@@ -316,7 +323,7 @@ func (p *esProcessorImpl) getDocIDs(request elastic.BulkableRequest) (workflowID
 		var body map[string]interface{}
 		if err := json.Unmarshal([]byte(req[1]), &body); err != nil {
 			p.logger.Error("Unmarshal index request body err.", tag.Error(err))
-			p.metricsClient.IncCounter(metrics.ESProcessorScope, metrics.ESProcessorCorruptedData)
+			p.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESBulkProcessorCorruptedData)
 			return
 		}
 
@@ -332,7 +339,7 @@ func (p *esProcessorImpl) getDocIDs(request elastic.BulkableRequest) (workflowID
 		var body map[string]map[string]interface{}
 		if err := json.Unmarshal([]byte(req[0]), &body); err != nil {
 			p.logger.Error("Unmarshal delete request body err.", tag.Error(err))
-			p.metricsClient.IncCounter(metrics.ESProcessorScope, metrics.ESProcessorCorruptedData)
+			p.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESBulkProcessorCorruptedData)
 			return
 		}
 
@@ -385,23 +392,9 @@ func getErrorMsgFromESResp(resp *elastic.BulkResponseItem) string {
 	return errMsg
 }
 
-func newChanWithStopwatch(ackCh chan<- bool, stopwatch *tally.Stopwatch) *chanWithStopwatch {
-	return &chanWithStopwatch{
+func newAckChanWithStopwatch(ackCh chan<- bool, stopwatch *tally.Stopwatch) *ackChanWithStopwatch {
+	return &ackChanWithStopwatch{
 		ackCh:             ackCh,
 		addToAckStopwatch: stopwatch,
-	}
-}
-
-func (km *chanWithStopwatch) Ack() {
-	km.ackCh <- true
-	if km.addToAckStopwatch != nil {
-		km.addToAckStopwatch.Stop()
-	}
-}
-
-func (km *chanWithStopwatch) Nack() {
-	km.ackCh <- false
-	if km.addToAckStopwatch != nil {
-		km.addToAckStopwatch.Stop()
 	}
 }

--- a/common/persistence/elasticsearch/esProcessor_test.go
+++ b/common/persistence/elasticsearch/esProcessor_test.go
@@ -59,8 +59,8 @@ var (
 	testType      = docType
 	testID        = "test-doc-id"
 	testStopWatch = metrics.NopStopwatch()
-	testScope     = metrics.ESProcessorScope
-	testMetric    = metrics.ESProcessorProcessMsgLatency
+	testScope     = metrics.ESVisibility
+	testMetric    = metrics.ESBulkProcessorRequestLatency
 )
 
 func TestESProcessorSuite(t *testing.T) {
@@ -215,7 +215,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Ack() {
 	}
 
 	ackCh := make(chan bool, 1)
-	mapVal := newChanWithStopwatch(ackCh, &testStopWatch)
+	mapVal := newAckChanWithStopwatch(ackCh, &testStopWatch)
 	s.esProcessor.mapToAckChan.Put(testKey, mapVal)
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
 	select {
@@ -264,7 +264,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Nack() {
 	}
 
 	ackCh := make(chan bool, 1)
-	mapVal := newChanWithStopwatch(ackCh, &testStopWatch)
+	mapVal := newAckChanWithStopwatch(ackCh, &testStopWatch)
 	s.esProcessor.mapToAckChan.Put(testKey, mapVal)
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
 	select {
@@ -300,7 +300,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Error() {
 		Items:  []map[string]*elastic.BulkResponseItem{mFailed},
 	}
 
-	s.mockMetricClient.On("IncCounter", metrics.ESProcessorScope, metrics.ESProcessorFailures).Once()
+	s.mockMetricClient.On("IncCounter", metrics.ESVisibility, metrics.ESBulkProcessorFailures).Once()
 	s.esProcessor.bulkAfterAction(0, requests, response, errors.New("some error"))
 }
 

--- a/common/persistence/elasticsearch/esProcessor_test.go
+++ b/common/persistence/elasticsearch/esProcessor_test.go
@@ -59,7 +59,7 @@ var (
 	testType      = docType
 	testID        = "test-doc-id"
 	testStopWatch = metrics.NopStopwatch()
-	testScope     = metrics.ESVisibility
+	testScope     = metrics.ElasticSearchVisibility
 	testMetric    = metrics.ESBulkProcessorRequestLatency
 )
 
@@ -300,7 +300,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Error() {
 		Items:  []map[string]*elastic.BulkResponseItem{mFailed},
 	}
 
-	s.mockMetricClient.On("IncCounter", metrics.ESVisibility, metrics.ESBulkProcessorFailures).Once()
+	s.mockMetricClient.On("IncCounter", metrics.ElasticSearchVisibility, metrics.ESBulkProcessorFailures).Once()
 	s.esProcessor.bulkAfterAction(0, requests, response, errors.New("some error"))
 }
 

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -309,7 +309,7 @@ func (v *esVisibilityStore) generateESDoc(request *p.InternalVisibilityRequestBa
 	for searchAttributeName, searchAttributePayload := range request.SearchAttributes {
 		if !v.isValidSearchAttribute(searchAttributeName) {
 			v.logger.Error("Unregistered field.", tag.ESField(searchAttributeName))
-			v.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESInvalidSearchAttribute)
+			v.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESInvalidSearchAttribute)
 			continue
 		}
 		var searchAttributeValue interface{}
@@ -317,7 +317,7 @@ func (v *esVisibilityStore) generateESDoc(request *p.InternalVisibilityRequestBa
 		err := payload.Decode(searchAttributePayload, &searchAttributeValue)
 		if err != nil {
 			v.logger.Error("Error when decode search attribute payload.", tag.Error(err), tag.ESField(searchAttributeName))
-			v.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESInvalidSearchAttribute)
+			v.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESInvalidSearchAttribute)
 		}
 		attr[searchAttributeName] = searchAttributeValue
 	}

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -309,7 +309,7 @@ func (v *esVisibilityStore) generateESDoc(request *p.InternalVisibilityRequestBa
 	for searchAttributeName, searchAttributePayload := range request.SearchAttributes {
 		if !v.isValidSearchAttribute(searchAttributeName) {
 			v.logger.Error("Unregistered field.", tag.ESField(searchAttributeName))
-			v.metricsClient.IncCounter(metrics.IndexProcessorScope, metrics.IndexProcessorCorruptedData)
+			v.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESInvalidSearchAttribute)
 			continue
 		}
 		var searchAttributeValue interface{}
@@ -317,7 +317,7 @@ func (v *esVisibilityStore) generateESDoc(request *p.InternalVisibilityRequestBa
 		err := payload.Decode(searchAttributePayload, &searchAttributeValue)
 		if err != nil {
 			v.logger.Error("Error when decode search attribute payload.", tag.Error(err), tag.ESField(searchAttributeName))
-			v.metricsClient.IncCounter(metrics.IndexProcessorScope, metrics.IndexProcessorCorruptedData)
+			v.metricsClient.IncCounter(metrics.ESVisibility, metrics.ESInvalidSearchAttribute)
 		}
 		attr[searchAttributeName] = searchAttributeValue
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
ES bulk processor metrics were fixed to reflect recent copy of `ESProcessor.go` to the history service.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix bugs for Kafka deprecation effort.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally and observe metrics.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
