### PR TITLE
Start Kafka producer in dual mode

### DIFF
--- a/service/history/service.go
+++ b/service/history/service.go
@@ -97,7 +97,8 @@ func NewService(
 
 				esProcessor = espersistence.NewProcessor(esProcessorConfig, params.ESClient, logger, params.MetricsClient)
 				esProcessor.Start()
-			} else {
+			}
+			if serviceConfig.VisibilityQueue() == common.VisibilityQueueKafka || serviceConfig.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor {
 				var err error
 				visibilityProducer, err = params.MessagingClient.NewProducer(common.VisibilityAppName)
 				if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Kafka producer didn't start in `internalWithDualProcessor` mode.

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fix.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
