### PR TITLE
Add authorization header to context

### DIFF
--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -46,6 +46,7 @@ var (
 
 const (
 	ContextKeyMappedClaims = "auth-mappedClaims"
+	ContextAuthHeader      = "auth-header"
 )
 
 func (a *interceptor) Interceptor(
@@ -103,6 +104,9 @@ func (a *interceptor) Interceptor(
 			}
 			claims = mappedClaims
 			ctx = context.WithValue(ctx, ContextKeyMappedClaims, mappedClaims)
+			if authHeader != "" {
+				ctx = context.WithValue(ctx, ContextAuthHeader, authHeader)
+			}
 		}
 	}
 


### PR DESCRIPTION
**What changed?**
Added content of "authorization" header to context.

**Why?**
This gives workflows and activities access to the JWT auth token (if passed).
Addresses #1135.

**How did you test it?**
Unit tests.

**Potential risks**
No risk. This only adds data to context.
