### PR TITLE
Switch visibility queue to dual processor mode

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -440,7 +440,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		VisibilityProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnablePriorityTaskProcessor, false),
 		VisibilityProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.VisibilityProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
-		VisibilityQueue: dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternal),
+		VisibilityQueue: dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternalWithDualProcessor),
 
 		ValidSearchAttributes:             dc.GetMapProperty(dynamicconfig.ValidSearchAttributes, definition.GetDefaultIndexedKeys()),
 		SearchAttributesNumberOfKeysLimit: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.SearchAttributesNumberOfKeysLimit, 100),

--- a/service/history/transferQueueActiveTaskExecutorV2_test.go
+++ b/service/history/transferQueueActiveTaskExecutorV2_test.go
@@ -154,6 +154,7 @@ func (s *transferQueueActiveTaskExecutorSuiteV2) SetupTest() {
 	s.mockTimerProcessor.EXPECT().NotifyNewTimers(gomock.Any(), gomock.Any()).AnyTimes()
 
 	config := NewDynamicConfigForTest()
+	config.VisibilityQueue = dc.GetStringPropertyFn(common.VisibilityQueueInternal)
 	s.mockShard = shard.NewTestContext(
 		s.controller,
 		&persistence.ShardInfoWithFailover{

--- a/service/history/transferQueueStandbyTaskExecutor_test.go
+++ b/service/history/transferQueueStandbyTaskExecutor_test.go
@@ -55,6 +55,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
+	dc "go.temporal.io/server/common/service/dynamicconfig"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/events"
@@ -105,6 +106,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 
 	config := configs.NewDynamicConfigForTest()
+	config.VisibilityQueue = dc.GetStringPropertyFn(common.VisibilityQueueInternal)
 
 	s.namespaceID = testNamespaceID
 	s.namespaceEntry = testGlobalNamespaceEntry

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -143,7 +143,7 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 			ClusterMetadata:     params.ClusterMetadata,
 		},
 		EnableBatcher:                 dc.GetBoolProperty(dynamicconfig.EnableBatcher, true),
-		VisibilityQueue:               dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternal),
+		VisibilityQueue:               dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternalWithDualProcessor),
 		EnableParentClosePolicyWorker: dc.GetBoolProperty(dynamicconfig.EnableParentClosePolicyWorker, true),
 		ThrottledLogRPS:               dc.GetIntProperty(dynamicconfig.WorkerThrottledLogRPS, 20),
 		PersistenceGlobalMaxQPS:       dc.GetIntProperty(dynamicconfig.WorkerPersistenceGlobalMaxQPS, 0),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
#1140 switched default value to `internal` which is not backward compatible. With dual processor mode users can install next release w/o any changes in config files. 

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve upgrade experience.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
