### PR TITLE
Fix db scan admin command

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -217,7 +217,7 @@ const (
 		`and visibility_ts = ? ` +
 		`and task_id = ?`
 
-	templateListWorkflowExecutionQuery = `SELECT run_id, execution, execution_encoding, execution_state, execution_state_encoding,next_event_id ` +
+	templateListWorkflowExecutionQuery = `SELECT run_id, execution, execution_encoding, execution_state, execution_state_encoding, next_event_id ` +
 		`FROM executions ` +
 		`WHERE shard_id = ? ` +
 		`and type = ?`

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -217,7 +217,7 @@ const (
 		`and visibility_ts = ? ` +
 		`and task_id = ?`
 
-	templateListWorkflowExecutionQuery = `SELECT run_id, execution, execution_encoding, next_event_id ` +
+	templateListWorkflowExecutionQuery = `SELECT run_id, execution, execution_encoding, execution_state, execution_state_encoding,next_event_id ` +
 		`FROM executions ` +
 		`WHERE shard_id = ? ` +
 		`and type = ?`

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -289,13 +289,11 @@ func readOneRow(query *gocql.Query) (map[string]interface{}, error) {
 
 func connectToCassandra(c *cli.Context) *gocql.Session {
 	host := getRequiredOption(c, FlagDBAddress)
-	if !c.IsSet(FlagDBPort) {
-		ErrorAndExit("cassandra port is required", nil)
-	}
+	port := c.Int(FlagDBPort)
 
 	cassandraConfig := &config.Cassandra{
 		Hosts:    host,
-		Port:     c.Int(FlagDBPort),
+		Port:     port,
 		User:     c.String(FlagUsername),
 		Password: c.String(FlagPassword),
 		Keyspace: getRequiredOption(c, FlagKeyspace),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed DBScan admin commands which checks for corruptions in the db

<!-- Tell your future self why have you made these changes -->
**Why?**
DBScan command was broken as ListConcreteExecutions API was not working.  Fixed
ListConcreteExecutions API on cassandra persistence and also fixed logic to correctly
decode `BranchToken` in admin command handler.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally by manually corrupting workflow executions.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk.
