### PR TITLE
Fix protoc-gen-gogoslick plugin installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,7 +137,7 @@ update-mockgen:
 
 update-proto-plugins:
 	@printf $(COLOR) "Install/update proto plugins..."
-	cd && GO111MODULE=on go get github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick
+	GO111MODULE=off go get github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick
 	cd && GO111MODULE=on go get google.golang.org/grpc@v1.34.0
 
 update-tools: update-checkers update-mockgen update-proto-plugins


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`GOMODULE111` turned `off` for github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick plugin.

<!-- Tell your future self why have you made these changes -->
**Why?**
Sources of this plugin are needed to build proto files. With `GOMODULE111=on` go will only install binaries. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run with empty cache.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A.
