### PR TITLE
Update Cassandra cli consistency settings

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -52,8 +52,8 @@ import (
 // R represents row type in executions table, valid values are:
 // R = {Shard = 1, Execution = 2, Transfer = 3, Timer = 4, Replication = 5}
 const (
-	// ProtoVersion is the protocol version used to communicate with Cassandra cluster
-	ProtoVersion = 4
+	// ProtocolVersion is the protocol version used to communicate with Cassandra cluster
+	ProtocolVersion = 4
 
 	defaultSessionTimeout = 10 * time.Second
 	// Special Namespaces related constants

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -52,7 +52,9 @@ import (
 // R represents row type in executions table, valid values are:
 // R = {Shard = 1, Execution = 2, Transfer = 3, Timer = 4, Replication = 5}
 const (
-	cassandraProtoVersion = 4
+	// ProtoVersion is the protocol version used to communicate with Cassandra cluster
+	ProtoVersion = 4
+
 	defaultSessionTimeout = 10 * time.Second
 	// Special Namespaces related constants
 	emptyNamespaceID = "10000000-0000-f000-f000-000000000000"

--- a/common/persistence/cassandra/session.go
+++ b/common/persistence/cassandra/session.go
@@ -43,7 +43,7 @@ func NewSession(
 		return nil, fmt.Errorf("create cassandra cluster from config: %w", err)
 	}
 
-	cluster.ProtoVersion = cassandraProtoVersion
+	cluster.ProtoVersion = ProtoVersion
 	cluster.Consistency = cfg.Consistency.GetConsistency()
 	cluster.SerialConsistency = cfg.Consistency.GetSerialConsistency()
 	cluster.Timeout = defaultSessionTimeout

--- a/common/persistence/cassandra/session.go
+++ b/common/persistence/cassandra/session.go
@@ -43,7 +43,7 @@ func NewSession(
 		return nil, fmt.Errorf("create cassandra cluster from config: %w", err)
 	}
 
-	cluster.ProtoVersion = ProtoVersion
+	cluster.ProtoVersion = ProtocolVersion
 	cluster.Consistency = cfg.Consistency.GetConsistency()
 	cluster.SerialConsistency = cfg.Consistency.GetSerialConsistency()
 	cluster.Timeout = defaultSessionTimeout

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -65,10 +65,9 @@ var errNoHosts = errors.New("Cassandra Hosts list is empty or malformed")
 var errGetSchemaVersion = errors.New("Failed to get current schema version from cassandra")
 
 const (
-	defaultTimeout     = 30    // Timeout in seconds
-	cqlProtoVersion    = 4     // default CQL protocol version
-	defaultConsistency = "ALL" // schema updates must always be ALL
-	systemKeyspace     = "system"
+	defaultTimeout  = 30 // Timeout in seconds
+	cqlProtoVersion = 4  // default CQL protocol version
+	systemKeyspace  = "system"
 )
 
 const (
@@ -116,7 +115,8 @@ func NewCassandraCluster(cfg *config.Cassandra, timeoutSeconds int) (*gocql.Clus
 	timeout := time.Duration(timeoutSeconds) * time.Second
 	clusterCfg.Timeout = timeout
 	clusterCfg.ProtoVersion = cqlProtoVersion
-	clusterCfg.Consistency = gocql.ParseConsistency(defaultConsistency)
+	clusterCfg.Consistency = cfg.Consistency.GetConsistency()
+	clusterCfg.SerialConsistency = cfg.Consistency.GetSerialConsistency()
 	return clusterCfg, nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Update Cassandra cli consistency settings, with default to local quorum

<!-- Tell your future self why have you made these changes -->
**Why?**
AwaitSchemaAgreement is being used

Solves #1168 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
