### PR TITLE
Add force flag to drop command of database tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,36 +308,36 @@ ci-coverage-report: $(SUMMARY_COVER_PROFILE) coverage-report
 ##### Schema #####
 install-schema: temporal-cassandra-tool
 	@printf $(COLOR) "Install Cassandra schema..."
-	./temporal-cassandra-tool --ep 127.0.0.1 drop -k temporal
-	./temporal-cassandra-tool --ep 127.0.0.1 create -k temporal --rf 1
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal setup-schema -v 0.0
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal update-schema -d ./schema/cassandra/temporal/versioned
-	./temporal-cassandra-tool --ep 127.0.0.1 drop -k temporal_visibility
-	./temporal-cassandra-tool --ep 127.0.0.1 create -k temporal_visibility --rf 1
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility setup-schema -v 0.0
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility update-schema -d ./schema/cassandra/visibility/versioned
+	./temporal-cassandra-tool drop -k temporal -f
+	./temporal-cassandra-tool create -k temporal --rf 1
+	./temporal-cassandra-tool -k temporal setup-schema -v 0.0
+	./temporal-cassandra-tool -k temporal update-schema -d ./schema/cassandra/temporal/versioned
+	./temporal-cassandra-tool drop -k temporal_visibility -f
+	./temporal-cassandra-tool create -k temporal_visibility --rf 1
+	./temporal-cassandra-tool -k temporal_visibility setup-schema -v 0.0
+	./temporal-cassandra-tool -k temporal_visibility update-schema -d ./schema/cassandra/visibility/versioned
 
 install-schema-mysql: temporal-sql-tool
 	@printf $(COLOR) "Install MySQL schema..."
-	./temporal-sql-tool --ep 127.0.0.1 -u root --pw root drop --db temporal
-	./temporal-sql-tool --ep 127.0.0.1 -u root --pw root create --db temporal
-	./temporal-sql-tool --ep 127.0.0.1 -u root --pw root --db temporal setup-schema -v 0.0
-	./temporal-sql-tool --ep 127.0.0.1 -u root --pw root --db temporal update-schema -d ./schema/mysql/v57/temporal/versioned
-	./temporal-sql-tool --ep 127.0.0.1 -u root --pw root drop --db temporal_visibility
-	./temporal-sql-tool --ep 127.0.0.1 -u root --pw root create --db temporal_visibility
-	./temporal-sql-tool --ep 127.0.0.1 -u root --pw root --db temporal_visibility setup-schema -v 0.0
-	./temporal-sql-tool --ep 127.0.0.1 -u root --pw root --db temporal_visibility update-schema -d ./schema/mysql/v57/visibility/versioned
+	./temporal-sql-tool -u temporal --pw temporal drop --db temporal -f
+	./temporal-sql-tool -u temporal --pw temporal create --db temporal
+	./temporal-sql-tool -u temporal --pw temporal --db temporal setup-schema -v 0.0
+	./temporal-sql-tool -u temporal --pw temporal --db temporal update-schema -d ./schema/mysql/v57/temporal/versioned
+	./temporal-sql-tool -u temporal --pw temporal drop --db temporal_visibility -f
+	./temporal-sql-tool -u temporal --pw temporal create --db temporal_visibility
+	./temporal-sql-tool -u temporal --pw temporal --db temporal_visibility setup-schema -v 0.0
+	./temporal-sql-tool -u temporal --pw temporal --db temporal_visibility update-schema -d ./schema/mysql/v57/visibility/versioned
 
 install-schema-postgresql: temporal-sql-tool
 	@printf $(COLOR) "Install Postgres schema..."
-	./temporal-sql-tool --ep 127.0.0.1 -p 5432 -u temporal -pw temporal --pl postgres drop --db temporal
-	./temporal-sql-tool --ep 127.0.0.1 -p 5432 -u temporal -pw temporal --pl postgres create --db temporal
-	./temporal-sql-tool --ep 127.0.0.1 -p 5432 -u temporal -pw temporal --pl postgres --db temporal setup -v 0.0
-	./temporal-sql-tool --ep 127.0.0.1 -p 5432 -u temporal -pw temporal --pl postgres --db temporal update-schema -d ./schema/postgresql/v96/temporal/versioned
-	./temporal-sql-tool --ep 127.0.0.1 -p 5432 -u temporal -pw temporal --pl postgres drop --db temporal_visibility
-	./temporal-sql-tool --ep 127.0.0.1 -p 5432 -u temporal -pw temporal --pl postgres create --db temporal_visibility
-	./temporal-sql-tool --ep 127.0.0.1 -p 5432 -u temporal -pw temporal --pl postgres --db temporal_visibility setup-schema -v 0.0
-	./temporal-sql-tool --ep 127.0.0.1 -p 5432 -u temporal -pw temporal --pl postgres --db temporal_visibility update-schema -d ./schema/postgresql/v96/visibility/versioned
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres drop --db temporal -f
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres create --db temporal
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db temporal setup -v 0.0
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db temporal update-schema -d ./schema/postgresql/v96/temporal/versioned
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres drop --db temporal_visibility -f
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres create --db temporal_visibility
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db temporal_visibility setup-schema -v 0.0
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db temporal_visibility update-schema -d ./schema/postgresql/v96/visibility/versioned
 
 install-schema-es:
 	@printf $(COLOR) "Install Elasticsearch schema..."
@@ -346,28 +346,34 @@ install-schema-es:
 
 install-schema-cdc: temporal-cassandra-tool
 	@printf $(COLOR)  "Set up temporal_active key space..."
-	./temporal-cassandra-tool --ep 127.0.0.1 create -k temporal_active --rf 1
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_active setup-schema -v 0.0
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_active update-schema -d ./schema/cassandra/temporal/versioned
-	./temporal-cassandra-tool --ep 127.0.0.1 create -k temporal_visibility_active --rf 1
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility_active setup-schema -v 0.0
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility_active update-schema -d ./schema/cassandra/visibility/versioned
+	./temporal-cassandra-tool drop -k temporal_active -f
+	./temporal-cassandra-tool create -k temporal_active --rf 1
+	./temporal-cassandra-tool -k temporal_active setup-schema -v 0.0
+	./temporal-cassandra-tool -k temporal_active update-schema -d ./schema/cassandra/temporal/versioned
+	./temporal-cassandra-tool drop -k temporal_visibility_active -f
+	./temporal-cassandra-tool create -k temporal_visibility_active --rf 1
+	./temporal-cassandra-tool -k temporal_visibility_active setup-schema -v 0.0
+	./temporal-cassandra-tool -k temporal_visibility_active update-schema -d ./schema/cassandra/visibility/versioned
 
 	@printf $(COLOR) "Set up temporal_standby key space..."
-	./temporal-cassandra-tool --ep 127.0.0.1 create -k temporal_standby --rf 1
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_standby setup-schema -v 0.0
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_standby update-schema -d ./schema/cassandra/temporal/versioned
-	./temporal-cassandra-tool --ep 127.0.0.1 create -k temporal_visibility_standby --rf 1
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility_standby setup-schema -v 0.0
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility_standby update-schema -d ./schema/cassandra/visibility/versioned
+	./temporal-cassandra-tool drop -k temporal_standby -f
+	./temporal-cassandra-tool create -k temporal_standby --rf 1
+	./temporal-cassandra-tool -k temporal_standby setup-schema -v 0.0
+	./temporal-cassandra-tool -k temporal_standby update-schema -d ./schema/cassandra/temporal/versioned
+	./temporal-cassandra-tool drop -k temporal_visibility_standby -f
+	./temporal-cassandra-tool create -k temporal_visibility_standby --rf 1
+	./temporal-cassandra-tool -k temporal_visibility_standby setup-schema -v 0.0
+	./temporal-cassandra-tool -k temporal_visibility_standby update-schema -d ./schema/cassandra/visibility/versioned
 
 	@printf $(COLOR) "Set up temporal_other key space..."
-	./temporal-cassandra-tool --ep 127.0.0.1 create -k temporal_other --rf 1
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_other setup-schema -v 0.0
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_other update-schema -d ./schema/cassandra/temporal/versioned
-	./temporal-cassandra-tool --ep 127.0.0.1 create -k temporal_visibility_other --rf 1
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility_other setup-schema -v 0.0
-	./temporal-cassandra-tool --ep 127.0.0.1 -k temporal_visibility_other update-schema -d ./schema/cassandra/visibility/versioned
+	./temporal-cassandra-tool drop -k temporal_other -f
+	./temporal-cassandra-tool create -k temporal_other --rf 1
+	./temporal-cassandra-tool -k temporal_other setup-schema -v 0.0
+	./temporal-cassandra-tool -k temporal_other update-schema -d ./schema/cassandra/temporal/versioned
+	./temporal-cassandra-tool drop -k temporal_visibility_other -f
+	./temporal-cassandra-tool create -k temporal_visibility_other --rf 1
+	./temporal-cassandra-tool -k temporal_visibility_other setup-schema -v 0.0
+	./temporal-cassandra-tool -k temporal_visibility_other update-schema -d ./schema/cassandra/visibility/versioned
 
 ##### Run server #####
 start-dependencies:

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/urfave/cli"
@@ -234,9 +235,25 @@ func buildCLIOptions() *cli.App {
 					Value: "",
 					Usage: "enable NetworkTopologyStrategy by providing datacenter name",
 				},
+				cli.BoolFlag{
+					Name:  schema.CLIFlagForce,
+					Usage: "don't prompt for confirmation",
+				},
 			},
 			Action: func(c *cli.Context) {
-				cliHandler(c, dropKeyspace)
+				drop := c.Bool(schema.CLIOptForce)
+				if !drop {
+					keyspace := c.String(schema.CLIOptKeyspace)
+					fmt.Printf("Are you sure you want to drop keyspace %q (y/N)? ", keyspace)
+					y := ""
+					_, _ = fmt.Scanln(&y)
+					if y == "y" || y == "Y" {
+						drop = true
+					}
+				}
+				if drop {
+					cliHandler(c, dropKeyspace)
+				}
 			},
 		},
 		{

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -110,6 +110,8 @@ const (
 	CLIOptDatacenter = "datacenter"
 	// CLIOptQuiet is the cli option for quiet mode
 	CLIOptQuiet = "quiet"
+	// CLIOptForce is the cli option for force mode
+	CLIOptForce = "force"
 
 	// CLIFlagEndpoint is the cli flag for endpoint
 	CLIFlagEndpoint = CLIOptEndpoint + ", ep"
@@ -149,6 +151,8 @@ const (
 	CLIFlagDatacenter = CLIOptDatacenter + ", dc"
 	// CLIFlagQuiet is the cli flag for quiet mode
 	CLIFlagQuiet = CLIOptQuiet + ", q"
+	// CLIFlagForce is the cli flag for force mode
+	CLIFlagForce = CLIOptForce + ", f"
 
 	// CLIFlagEnableTLS enables cassandra client TLS
 	CLIFlagEnableTLS = "tls"

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -25,6 +25,7 @@
 package sql
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/urfave/cli"
@@ -202,9 +203,25 @@ func BuildCLIOptions() *cli.App {
 					Name:  schema.CLIFlagDatabase,
 					Usage: "name of the database",
 				},
+				cli.BoolFlag{
+					Name:  schema.CLIFlagForce,
+					Usage: "don't prompt for confirmation",
+				},
 			},
 			Action: func(c *cli.Context) {
-				cliHandler(c, dropDatabase)
+				drop := c.Bool(schema.CLIOptForce)
+				if !drop {
+					database := c.String(schema.CLIOptDatabase)
+					fmt.Printf("Are you sure you want to drop database %q (y/N)? ", database)
+					y := ""
+					_, _ = fmt.Scanln(&y)
+					if y == "y" || y == "Y" {
+						drop = true
+					}
+				}
+				if drop {
+					cliHandler(c, dropDatabase)
+				}
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added database/keyspace drop confirmation and `--force` flag (and `-f` alias) to sql and cassandra db tools. Modified `Makefile` accordingly.

<!-- Tell your future self why have you made these changes -->
**Why?**
To protect developers from accidental database/keyspace drop.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
