### PR TITLE
Add option to disable visibility queue processor

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -275,6 +275,7 @@ var keys = map[Key]string{
 	DefaultActivityRetryPolicy:                             "history.defaultActivityRetryPolicy",
 	DefaultWorkflowRetryPolicy:                             "history.defaultWorkflowRetryPolicy",
 	VisibilityQueue:                                        "history.visibilityQueue",
+	VisibilityProcessorEnabled:                             "history.visibilityProcessorEnabled",
 
 	WorkerPersistenceMaxQPS:                         "worker.persistenceMaxQPS",
 	WorkerPersistenceGlobalMaxQPS:                   "worker.persistenceGlobalMaxQPS",
@@ -713,6 +714,9 @@ const (
 
 	// VisibilityQueue is to indicate which visibility queue to use: "Kafka", "InternalWithDualProcessor", "Internal".
 	VisibilityQueue
+
+	// VisibilityProcessorEnabled is to indicate if visibility processor should be enabled or not.
+	VisibilityProcessorEnabled
 
 	// key for worker
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -244,7 +244,8 @@ type Config struct {
 	VisibilityProcessorEnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
 	VisibilityProcessorVisibilityArchivalTimeLimit         dynamicconfig.DurationPropertyFn
 
-	VisibilityQueue dynamicconfig.StringPropertyFn
+	VisibilityQueue            dynamicconfig.StringPropertyFn
+	VisibilityProcessorEnabled dynamicconfig.BoolPropertyFn
 
 	// ValidSearchAttributes is legal indexed keys that can be used in list APIs
 	ValidSearchAttributes             dynamicconfig.MapPropertyFn
@@ -432,7 +433,8 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		VisibilityProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnablePriorityTaskProcessor, false),
 		VisibilityProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.VisibilityProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
-		VisibilityQueue: dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternalWithDualProcessor),
+		VisibilityQueue:            dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternalWithDualProcessor),
+		VisibilityProcessorEnabled: dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnabled, true),
 
 		ValidSearchAttributes:             dc.GetMapProperty(dynamicconfig.ValidSearchAttributes, definition.GetDefaultIndexedKeys()),
 		SearchAttributesNumberOfKeysLimit: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.SearchAttributesNumberOfKeysLimit, 100),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -219,7 +219,8 @@ func NewEngineWithShardContext(
 
 	historyEngImpl.txProcessor = newTransferQueueProcessor(shard, historyEngImpl, visibilityMgr, matching, historyClient, queueTaskProcessor, logger)
 	historyEngImpl.timerProcessor = newTimerQueueProcessor(shard, historyEngImpl, matching, queueTaskProcessor, logger)
-	if config.VisibilityQueue() == common.VisibilityQueueInternal || config.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor {
+	if (config.VisibilityQueue() == common.VisibilityQueueInternal || config.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor) &&
+		config.VisibilityProcessorEnabled() {
 		historyEngImpl.visibilityProcessor = newVisibilityQueueProcessor(shard, historyEngImpl, visibilityMgr, matching, historyClient, queueTaskProcessor, logger)
 	}
 	historyEngImpl.eventsReapplier = newNDCEventsReapplier(shard.GetMetricsClient(), logger)

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -72,6 +72,7 @@ type (
 		PersistenceGlobalMaxQPS       dynamicconfig.IntPropertyFn
 		EnableBatcher                 dynamicconfig.BoolPropertyFn
 		VisibilityQueue               dynamicconfig.StringPropertyFn
+		VisibilityProcessorEnabled    dynamicconfig.BoolPropertyFn
 		EnableParentClosePolicyWorker dynamicconfig.BoolPropertyFn
 	}
 )
@@ -144,6 +145,7 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 		},
 		EnableBatcher:                 dc.GetBoolProperty(dynamicconfig.EnableBatcher, true),
 		VisibilityQueue:               dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternalWithDualProcessor),
+		VisibilityProcessorEnabled:    dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnabled, true),
 		EnableParentClosePolicyWorker: dc.GetBoolProperty(dynamicconfig.EnableParentClosePolicyWorker, true),
 		ThrottledLogRPS:               dc.GetIntProperty(dynamicconfig.WorkerThrottledLogRPS, 20),
 		PersistenceGlobalMaxQPS:       dc.GetIntProperty(dynamicconfig.WorkerPersistenceGlobalMaxQPS, 0),
@@ -152,7 +154,9 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 		dynamicconfig.AdvancedVisibilityWritingMode,
 		common.GetDefaultAdvancedVisibilityWritingMode(params.PersistenceConfig.IsAdvancedVisibilityConfigExist()),
 	)
-	if (config.VisibilityQueue() == common.VisibilityQueueKafka || config.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor) && advancedVisWritingMode() != common.AdvancedVisibilityWritingModeOff {
+	if (config.VisibilityQueue() == common.VisibilityQueueKafka || config.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor) &&
+		advancedVisWritingMode() != common.AdvancedVisibilityWritingModeOff &&
+		config.VisibilityProcessorEnabled() {
 		config.IndexerCfg = &indexer.Config{
 			IndexerConcurrency:       dc.GetIntProperty(dynamicconfig.WorkerIndexerConcurrency, 100),
 			ESProcessorNumOfWorkers:  dc.GetIntProperty(dynamicconfig.WorkerESProcessorNumOfWorkers, 1),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added dynamic config option to completely disable visibility processor (both internal and legacy Kafka).

<!-- Tell your future self why have you made these changes -->
**Why?**
To support smooth migration from ES6 to ES7.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests. Local run with different values (`true`/`false`).

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
