### PR TITLE
Remove visibility sampling for ES

### DIFF
--- a/common/elasticsearch/bulk_processor_v6.go
+++ b/common/elasticsearch/bulk_processor_v6.go
@@ -51,14 +51,14 @@ func (p *bulkProcessorV6) Stop() error {
 func (p *bulkProcessorV6) Add(request *BulkableRequest) {
 	switch request.RequestType {
 	case BulkableRequestTypeIndex:
-		bulkDeleteRequest := elastic.NewBulkIndexRequest().
+		bulkIndexRequest := elastic.NewBulkIndexRequest().
 			Index(request.Index).
 			Type(docTypeV6).
 			Id(request.ID).
 			VersionType(versionTypeExternal).
 			Version(request.Version).
 			Doc(request.Doc)
-		p.esBulkProcessor.Add(bulkDeleteRequest)
+		p.esBulkProcessor.Add(bulkIndexRequest)
 	case BulkableRequestTypeDelete:
 		bulkDeleteRequest := elastic.NewBulkDeleteRequest().
 			Index(request.Index).

--- a/common/elasticsearch/bulk_processor_v7.go
+++ b/common/elasticsearch/bulk_processor_v7.go
@@ -50,13 +50,13 @@ func (p *bulkProcessorV7) Stop() error {
 func (p *bulkProcessorV7) Add(request *BulkableRequest) {
 	switch request.RequestType {
 	case BulkableRequestTypeIndex:
-		bulkDeleteRequest := elastic.NewBulkIndexRequest().
+		bulkIndexRequest := elastic.NewBulkIndexRequest().
 			Index(request.Index).
 			Id(request.ID).
 			VersionType(versionTypeExternal).
 			Version(request.Version).
 			Doc(request.Doc)
-		p.esBulkProcessor.Add(bulkDeleteRequest)
+		p.esBulkProcessor.Add(bulkIndexRequest)
 	case BulkableRequestTypeDelete:
 		bulkDeleteRequest := elastic.NewBulkDeleteRequest().
 			Index(request.Index).

--- a/common/persistence/elasticsearch/esVisibilityManager.go
+++ b/common/persistence/elasticsearch/esVisibilityManager.go
@@ -58,9 +58,6 @@ func NewESVisibilityManager(
 			)
 			visibilityManager = p.NewVisibilityPersistenceRateLimitedClient(visibilityManager, esRateLimiter, log)
 		}
-		if cfg.EnableSampling != nil && cfg.EnableSampling() {
-			visibilityManager = p.NewVisibilitySamplingClient(visibilityManager, cfg, metricsClient, log)
-		}
 	}
 	if metricsClient != nil {
 		// wrap with metrics

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -174,6 +174,8 @@ func (t *visibilityQueueTaskExecutor) processStartOrUpsertExecution(
 	visibilityMemo := getWorkflowMemo(executionInfo.Memo)
 	// TODO (alex): remove copy?
 	searchAttr := copySearchAttributes(executionInfo.SearchAttributes)
+	executionStatus := executionState.GetStatus()
+	taskQueue := executionInfo.TaskQueue
 
 	// release the context lock since we no longer need mutable state builder and
 	// the rest of logic is making RPC call, which takes time.
@@ -189,8 +191,8 @@ func (t *visibilityQueueTaskExecutor) processStartOrUpsertExecution(
 			executionTimestamp.UnixNano(),
 			runTimeout,
 			task.GetTaskId(),
-			executionState.GetStatus(),
-			executionInfo.TaskQueue,
+			executionStatus,
+			taskQueue,
 			visibilityMemo,
 			searchAttr,
 		)
@@ -204,8 +206,8 @@ func (t *visibilityQueueTaskExecutor) processStartOrUpsertExecution(
 		executionTimestamp.UnixNano(),
 		runTimeout,
 		task.GetTaskId(),
-		executionState.GetStatus(),
-		executionInfo.TaskQueue,
+		executionStatus,
+		taskQueue,
 		visibilityMemo,
 		searchAttr,
 	)
@@ -366,6 +368,7 @@ func (t *visibilityQueueTaskExecutor) processCloseExecution(
 	workflowExecutionTime := getWorkflowExecutionTime(mutableState, startEvent)
 	visibilityMemo := getWorkflowMemo(executionInfo.Memo)
 	searchAttr := executionInfo.SearchAttributes
+	taskQueue := executionInfo.TaskQueue
 
 	// release the context lock since we no longer need mutable state builder and
 	// the rest of logic is making RPC call, which takes time.
@@ -382,7 +385,7 @@ func (t *visibilityQueueTaskExecutor) processCloseExecution(
 		workflowHistoryLength,
 		task.GetTaskId(),
 		visibilityMemo,
-		executionInfo.TaskQueue,
+		taskQueue,
 		searchAttr,
 	)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Sampling for enhanced visibility is removed.

<!-- Tell your future self why have you made these changes -->
**Why?**
Sampling was designed for Cassandra and MySQL implementation but not for Elasticsearch. Elasticsearch should store all visibility data.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
