### PR TITLE
Set default ES bulk processor ack timeout to 1 minute

### DIFF
--- a/common/persistence/elasticsearch/esVisibilityStore_test.go
+++ b/common/persistence/elasticsearch/esVisibilityStore_test.go
@@ -112,7 +112,7 @@ func (s *ESVisibilitySuite) SetupTest() {
 	cfg := &config.VisibilityConfig{
 		ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(3),
 		ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-		ESProcessorAckTimeout:  dynamicconfig.GetDurationPropertyFn(5 * time.Second),
+		ESProcessorAckTimeout:  dynamicconfig.GetDurationPropertyFn(1 * time.Minute),
 	}
 
 	s.mockMetricsClient = &metricsmocks.Client{}

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -182,7 +182,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 			VisibilityListMaxQPS:   dynamicconfig.GetIntPropertyFilteredByNamespace(2000),
 			ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(defaultTestValueOfESIndexMaxResultWindow),
 			ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
-			ESProcessorAckTimeout:  dynamicconfig.GetDurationPropertyFn(5 * time.Second),
+			ESProcessorAckTimeout:  dynamicconfig.GetDurationPropertyFn(1 * time.Minute),
 		}
 		indexName := options.ESConfig.Indices[common.VisibilityAppName]
 		esVisibilityStore := pes.NewElasticSearchVisibilityStore(esClient, indexName, nil, esProcessor, visConfig, logger, &metricsmocks.Client{})

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -447,7 +447,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		ESProcessorBulkActions:            dc.GetIntProperty(dynamicconfig.WorkerESProcessorBulkActions, 1000),
 		ESProcessorBulkSize:               dc.GetIntProperty(dynamicconfig.WorkerESProcessorBulkSize, 2<<24), // 16MB
 		ESProcessorFlushInterval:          dc.GetDurationProperty(dynamicconfig.WorkerESProcessorFlushInterval, 1*time.Second),
-		ESProcessorAckTimeout:             dc.GetDurationProperty(dynamicconfig.WorkerESProcessorAckTimeout, 5*time.Second),
+		ESProcessorAckTimeout:             dc.GetDurationProperty(dynamicconfig.WorkerESProcessorAckTimeout, 1*time.Minute),
 	}
 
 	return cfg

--- a/tools/cli/namespaceUtils.go
+++ b/tools/cli/namespaceUtils.go
@@ -293,7 +293,7 @@ func initializeMetadataMgr(
 	pConfig.VisibilityConfig = &config.VisibilityConfig{
 		VisibilityListMaxQPS:  dynamicconfig.GetIntPropertyFilteredByNamespace(dependencyMaxQPS),
 		EnableSampling:        dynamicconfig.GetBoolPropertyFn(false), // not used by namespace operation
-		ESProcessorAckTimeout: dynamicconfig.GetDurationPropertyFn(5 * time.Second),
+		ESProcessorAckTimeout: dynamicconfig.GetDurationPropertyFn(1 * time.Minute),
 	}
 	pFactory := client.NewFactory(
 		&pConfig,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed default ES bulk processor ack timeout to 1 minute.

<!-- Tell your future self why have you made these changes -->
**Why?**
This timeout includes all possible retries bulk processor might do. In case of transient ES failures 5 seconds is too low.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
