### PR TITLE
Improve PostgreSQL config

### DIFF
--- a/common/persistence/cassandra/factory.go
+++ b/common/persistence/cassandra/factory.go
@@ -55,7 +55,12 @@ type (
 
 // NewFactory returns an instance of a factory object which can be used to create
 // datastores that are backed by cassandra
-func NewFactory(cfg config.Cassandra, r resolver.ServiceResolver, clusterName string, logger log.Logger) *Factory {
+func NewFactory(
+	cfg config.Cassandra,
+	r resolver.ServiceResolver,
+	clusterName string,
+	logger log.Logger,
+) *Factory {
 	session, err := NewSession(cfg, r)
 	if err != nil {
 		logger.Fatal("unable to initialize cassandra session", tag.Error(err))

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -65,7 +65,12 @@ type (
 
 // NewFactory returns an instance of a factory object which can be used to create
 // datastores backed by any kind of SQL store
-func NewFactory(cfg config.SQL, r resolver.ServiceResolver, clusterName string, logger log.Logger) *Factory {
+func NewFactory(
+	cfg config.SQL,
+	r resolver.ServiceResolver,
+	clusterName string,
+	logger log.Logger,
+) *Factory {
 	return &Factory{
 		cfg:         cfg,
 		clusterName: clusterName,

--- a/common/persistence/sql/sqlplugin/postgresql/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/plugin.go
@@ -98,7 +98,7 @@ func (d *plugin) createDBConnection(cfg *config.SQL, r resolver.ServiceResolver)
 }
 
 func buildDSN(cfg *config.SQL, r resolver.ServiceResolver) string {
-	tlsAttrs := dsnTSL(cfg).Encode()
+	tlsAttrs := buildDSNAttr(cfg).Encode()
 	resolvedAddr := r.Resolve(cfg.ConnectAddr)[0]
 	dsn := fmt.Sprintf(
 		dsnFmt,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Include connectAttributes as part of connection string

<!-- Tell your future self why have you made these changes -->
**Why?**
`connectAttributes` was not used

Closes #1208

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test locally

```yaml
persistence:
  defaultStore: postgres-default
  visibilityStore: postgres-visibility
  numHistoryShards: 4
  datastores:
    postgres-default:
      sql:
        pluginName: "postgres"
        databaseName: "temporal"
        connectAddr: "127.0.0.1:5432"
        connectProtocol: "tcp"
        connectAttributes:
          application_name: temporaltest
    postgres-visibility:
      sql:
        pluginName: "postgres"
        databaseName: "temporal_visibility"
        connectAddr: "127.0.0.1:5432"
        connectProtocol: "tcp"
        connectAttributes:
          application_name: temporaltest
```

```sql
postgres=# SELECT application_name FROM pg_stat_activity limit 1;
 application_name 
------------------
 temporaltest
(1 row)
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
