### PR TITLE
Bugfix: activity heartbeat timeout

### DIFF
--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -260,7 +260,7 @@ func (v *commandAttrValidator) validateActivityScheduleAttributes(
 			attributes.HeartbeatTimeout = &runTimeout
 		}
 	}
-	attributes.HeartbeatTimeout = timestamp.MinDurationPtr(attributes.GetHeartbeatTimeout(), attributes.GetScheduleToCloseTimeout())
+	attributes.HeartbeatTimeout = timestamp.MinDurationPtr(attributes.GetHeartbeatTimeout(), attributes.GetStartToCloseTimeout())
 
 	return nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Activity heartbeat timeout can be override by start to close timeout, not schedule to close timeout

<!-- Tell your future self why have you made these changes -->
**Why?**
Bugfix

Close #1218 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
