### PR TITLE
Bugfix: close execution request goes to Kafka even when visibility queue type is set to internalWithDualProcessor

### DIFF
--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -290,7 +290,7 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowClosed(
 		archiveVisibility = clusterConfiguredForVisibilityArchival && namespaceConfiguredForVisibilityArchival
 	}
 
-	if (t.config.VisibilityQueue() == common.VisibilityQueueKafka || t.config.VisibilityQueue() == common.VisibilityQueueInternalWithDualProcessor) && recordWorkflowClose {
+	if t.config.VisibilityQueue() == common.VisibilityQueueKafka && recordWorkflowClose {
 		if err := t.visibilityMgr.RecordWorkflowExecutionClosed(&persistence.RecordWorkflowExecutionClosedRequest{
 			VisibilityRequestBase: &persistence.VisibilityRequestBase{
 				NamespaceID: namespaceID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Bugfix: close execution request goes to Kafka even when visibility queue type is set to `internalWithDualProcessor`.

<!-- Tell your future self why have you made these changes -->
**Why?**
When visibility queue type is set to `internalWithDualProcessor` no write requests should go to the Kafka.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
