### PR TITLE
Switch visibility queue default to internal

### DIFF
--- a/.development/docker-compose/docker-compose.yml
+++ b/.development/docker-compose/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     volumes:
       - ./grafana/provisioning/:/etc/grafana/provisioning/
   temporal-web:
-    image: temporalio/web:1.4.1
+    image: temporalio/web:1.6.0
     container_name: temporal-dev-web
 
 networks:

--- a/.development/docker-compose/docker-compose.yml
+++ b/.development/docker-compose/docker-compose.yml
@@ -90,7 +90,7 @@ services:
     volumes:
       - ./grafana/provisioning/:/etc/grafana/provisioning/
   temporal-web:
-    image: temporalio/web:1.6.0
+    image: temporalio/web:1.4.1
     container_name: temporal-dev-web
 
 networks:

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -433,7 +433,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		VisibilityProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnablePriorityTaskProcessor, false),
 		VisibilityProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.VisibilityProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
-		VisibilityQueue:            dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternalWithDualProcessor),
+		VisibilityQueue:            dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternal),
 		VisibilityProcessorEnabled: dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnabled, true),
 
 		ValidSearchAttributes:             dc.GetMapProperty(dynamicconfig.ValidSearchAttributes, definition.GetDefaultIndexedKeys()),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -143,7 +143,7 @@ func NewConfig(params *resource.BootstrapParams) *Config {
 			ClusterMetadata: params.ClusterMetadata,
 		},
 		EnableBatcher:                 dc.GetBoolProperty(dynamicconfig.EnableBatcher, true),
-		VisibilityQueue:               dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternalWithDualProcessor),
+		VisibilityQueue:               dc.GetStringProperty(dynamicconfig.VisibilityQueue, common.VisibilityQueueInternal),
 		VisibilityProcessorEnabled:    dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnabled, true),
 		EnableParentClosePolicyWorker: dc.GetBoolProperty(dynamicconfig.EnableParentClosePolicyWorker, true),
 		ThrottledLogRPS:               dc.GetIntProperty(dynamicconfig.WorkerThrottledLogRPS, 20),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Switch visibility queue from `internalWithDualProcessor` to `internal`.

<!-- Tell your future self why have you made these changes -->
**Why?**
As part of Kafka deprecation this will completely remove usage of Kafka (code and configuration files are still there).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tests already use `internal`. Run locally also.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Moving directly from `kafka` to `internal` may lead to some unprocessed visibility messages stuck in Kafka. Follow upgrade instruction from [v1.5.0](https://github.com/temporalio/temporal/releases/tag/v1.5.0) release to properly migrate out of Kafka.
