### PR TITLE
Change prometheus log level to error only

### DIFF
--- a/.development/docker-compose/docker-compose.yml
+++ b/.development/docker-compose/docker-compose.yml
@@ -81,6 +81,12 @@ services:
     # Use http://localhost:9090/ to access Prometheus.
     image: prom/prometheus
     container_name: temporal-dev-prometheus
+    command:
+      - "--log.level=error"
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
   grafana:
     # Use http://localhost:3000/ to access Grafana (admin/admin).
     image: grafana/grafana


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change development docker-compose prometheus error loeve to `error` only.

<!-- Tell your future self why have you made these changes -->
**Why?**
To suppress noise `warn` level logs when server is down and prometheus can scrape metrics.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
