### PR TITLE
Add server option for custom Elasticsearch HTTP client

### DIFF
--- a/common/elasticsearch/aws.go
+++ b/common/elasticsearch/aws.go
@@ -36,11 +36,15 @@ import (
 	elasticaws "github.com/olivere/elastic/aws/v4"
 )
 
-func newAWSElasticsearchHTTPClient(config AWSRequestSigningConfig) (*http.Client, error) {
+func NewAwsHttpClient(config AWSRequestSigningConfig) (*http.Client, error) {
+	if !config.Enabled {
+		return nil, nil
+	}
+
 	if config.Region == "" {
 		config.Region = os.Getenv("AWS_REGION")
 		if config.Region == "" {
-			return nil, fmt.Errorf("unable to resolve aws region for obtaining aws es signing credentials")
+			return nil, fmt.Errorf("unable to resolve AWS region for obtaining AWS Elastic signing credentials")
 		}
 	}
 
@@ -66,7 +70,7 @@ func newAWSElasticsearchHTTPClient(config AWSRequestSigningConfig) (*http.Client
 
 		awsCredentials = awsSession.Config.Credentials
 	default:
-		return nil, fmt.Errorf("unknown aws credential provider specified: %+v. Accepted options are 'static', 'environment' or 'session'", config.CredentialProvider)
+		return nil, fmt.Errorf("unknown AWS credential provider specified: %+v. Accepted options are 'static', 'environment' or 'session'", config.CredentialProvider)
 	}
 
 	return elasticaws.NewV4SigningClient(awsCredentials, config.Region), nil

--- a/common/elasticsearch/client_factory.go
+++ b/common/elasticsearch/client_factory.go
@@ -26,16 +26,17 @@ package elasticsearch
 
 import (
 	"fmt"
+	"net/http"
 
 	"go.temporal.io/server/common/log"
 )
 
-func NewClient(config *Config, logger log.Logger) (Client, error) {
+func NewClient(config *Config, httpClient *http.Client, logger log.Logger) (Client, error) {
 	switch config.Version {
 	case "v6", "":
-		return newClientV6(config, logger)
+		return newClientV6(config, httpClient, logger)
 	case "v7":
-		return newClientV7(config, logger)
+		return newClientV7(config, httpClient, logger)
 	default:
 		return nil, fmt.Errorf("not supported ElasticSearch version: %v", config.Version)
 	}

--- a/common/elasticsearch/client_v6.go
+++ b/common/elasticsearch/client_v6.go
@@ -52,7 +52,6 @@ func newClientV6(config *Config, httpClient *http.Client, logger log.Logger) (*c
 		elastic6.SetURL(config.URL.String()),
 		elastic6.SetSniff(false),
 		elastic6.SetBasicAuth(config.Username, config.Password),
-		elastic6.SetHttpClient(httpClient),
 
 		// Disable health check so we don't block client creation (and thus temporal server startup)
 		// if the ES instance happens to be down.
@@ -65,6 +64,10 @@ func newClientV6(config *Config, httpClient *http.Client, logger log.Logger) (*c
 	}
 
 	options = append(options, getLoggerOptionsV6(config.LogLevel, logger)...)
+
+	if httpClient != nil {
+		options = append(options, elastic6.SetHttpClient(httpClient))
+	}
 
 	client, err := elastic6.NewClient(options...)
 	if err != nil {

--- a/common/elasticsearch/client_v7.go
+++ b/common/elasticsearch/client_v7.go
@@ -50,7 +50,6 @@ func newClientV7(config *Config, httpClient *http.Client, logger log.Logger) (*c
 		elastic.SetURL(config.URL.String()),
 		elastic.SetSniff(false),
 		elastic.SetBasicAuth(config.Username, config.Password),
-		elastic.SetHttpClient(httpClient),
 
 		// Disable health check so we don't block client creation (and thus temporal server startup)
 		// if the ES instance happens to be down.
@@ -63,6 +62,10 @@ func newClientV7(config *Config, httpClient *http.Client, logger log.Logger) (*c
 	}
 
 	options = append(options, getLoggerOptions(config.LogLevel, logger)...)
+
+	if httpClient != nil {
+		options = append(options, elastic.SetHttpClient(httpClient))
+	}
 
 	client, err := elastic.NewClient(options...)
 	if err != nil {

--- a/common/elasticsearch/client_v7.go
+++ b/common/elasticsearch/client_v7.go
@@ -26,6 +26,7 @@ package elasticsearch
 
 import (
 	"context"
+	"net/http"
 	"strings"
 	"time"
 
@@ -44,11 +45,12 @@ type (
 var _ Client = (*clientV7)(nil)
 
 // newClientV7 create a ES client
-func newClientV7(config *Config, logger log.Logger) (*clientV7, error) {
+func newClientV7(config *Config, httpClient *http.Client, logger log.Logger) (*clientV7, error) {
 	options := []elastic.ClientOptionFunc{
 		elastic.SetURL(config.URL.String()),
 		elastic.SetSniff(false),
 		elastic.SetBasicAuth(config.Username, config.Password),
+		elastic.SetHttpClient(httpClient),
 
 		// Disable health check so we don't block client creation (and thus temporal server startup)
 		// if the ES instance happens to be down.
@@ -61,14 +63,6 @@ func newClientV7(config *Config, logger log.Logger) (*clientV7, error) {
 	}
 
 	options = append(options, getLoggerOptions(config.LogLevel, logger)...)
-
-	if config.AWSRequestSigning.Enabled {
-		httpClient, err := newAWSElasticsearchHTTPClient(config.AWSRequestSigning)
-		if err != nil {
-			return nil, err
-		}
-		options = append(options, elastic.SetHttpClient(httpClient))
-	}
 
 	client, err := elastic.NewClient(options...)
 	if err != nil {

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -162,7 +162,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	if options.WorkerConfig.EnableIndexer {
 		advancedVisibilityWritingMode = dynamicconfig.GetStringPropertyFn(common.AdvancedVisibilityWritingModeOn)
 		var err error
-		esClient, err = elasticsearch.NewClient(options.ESConfig, logger)
+		esClient, err = elasticsearch.NewClient(options.ESConfig, nil, logger)
 		if err != nil {
 			return nil, err
 		}

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -25,6 +25,8 @@
 package temporal
 
 import (
+	"net/http"
+
 	"github.com/uber-go/tally"
 
 	"go.temporal.io/server/common/authorization"
@@ -97,5 +99,12 @@ func WithCustomMetricsReporter(reporter tally.BaseStatsReporter) ServerOption {
 func WithPersistenceServiceResolver(r resolver.ServiceResolver) ServerOption {
 	return newApplyFuncContainer(func(s *serverOptions) {
 		s.persistenceServiceResolver = r
+	})
+}
+
+// Set custom persistence service resolver which will convert service name or address value from config to another a....
+func WithElasticsearchHttpClient(c *http.Client) ServerOption {
+	return newApplyFuncContainer(func(s *serverOptions) {
+		s.elasticseachHttpClient = c
 	})
 }

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -26,6 +26,7 @@ package temporal
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/uber-go/tally"
 
@@ -37,20 +38,22 @@ import (
 
 type (
 	serverOptions struct {
-		config                     *config.Config
+		serviceNames []string
+
+		config    *config.Config
+		configDir string
+		env       string
+		zone      string
+
+		interruptCh   <-chan interface{}
+		blockingStart bool
+
 		authorizer                 authorization.Authorizer
 		tlsConfigProvider          encryption.TLSConfigProvider
 		claimMapper                authorization.ClaimMapper
 		metricsReporter            tally.BaseStatsReporter
 		persistenceServiceResolver resolver.ServiceResolver
-		configDir                  string
-		env                        string
-		zone                       string
-
-		serviceNames []string
-
-		interruptCh   <-chan interface{}
-		blockingStart bool
+		elasticseachHttpClient     *http.Client
 	}
 )
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add ability to pass custom HTTP client used for Elasticsearch using `ServerOption`.

<!-- Tell your future self why have you made these changes -->
**Why?**
To be able to inject any customer HTTP client for custom builds.
https://community.temporal.io/t/passing-in-custom-http-client-for-signing-elasticsearch-requests/1339

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk, default behaviour stays the same.
