### PR TITLE
Bugfix: Allow enabling TLS for sql tool without requiring key/cert.

### DIFF
--- a/tools/sql/clitest/handlerTest.go
+++ b/tools/sql/clitest/handlerTest.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/service/config"
 	"go.temporal.io/server/environment"
 	"go.temporal.io/server/tools/common/schema"
@@ -85,11 +84,6 @@ func (s *HandlerTestSuite) TestValidateConnectConfig() {
 	cfg.DatabaseName = "foobar"
 	s.Nil(sql.ValidateConnectConfig(cfg, false))
 	s.Nil(sql.ValidateConnectConfig(cfg, true))
-
-	cfg.TLS = &auth.TLS{}
-	cfg.TLS.Enabled = true
-	s.NotNil(sql.ValidateConnectConfig(cfg, false))
-	s.NotNil(sql.ValidateConnectConfig(cfg, true))
 
 	cfg.TLS.CaFile = "ca.pem"
 	s.Nil(sql.ValidateConnectConfig(cfg, false))

--- a/tools/sql/clitest/handler_test.go
+++ b/tools/sql/clitest/handler_test.go
@@ -84,23 +84,4 @@ func (s *HandlerTestSuite) TestValidateConnectConfig() {
 	cfg.DatabaseName = "foobar"
 	s.Nil(sql.ValidateConnectConfig(cfg, false))
 	s.Nil(sql.ValidateConnectConfig(cfg, true))
-
-	cfg.TLS.CaFile = "ca.pem"
-	s.Nil(sql.ValidateConnectConfig(cfg, false))
-	s.Nil(sql.ValidateConnectConfig(cfg, true))
-
-	cfg.TLS.KeyFile = "key_file"
-	cfg.TLS.CertFile = ""
-	s.NotNil(sql.ValidateConnectConfig(cfg, false))
-	s.NotNil(sql.ValidateConnectConfig(cfg, true))
-
-	cfg.TLS.KeyFile = ""
-	cfg.TLS.CertFile = "cert_file"
-	s.NotNil(sql.ValidateConnectConfig(cfg, false))
-	s.NotNil(sql.ValidateConnectConfig(cfg, true))
-
-	cfg.TLS.KeyFile = "key_file"
-	cfg.TLS.CertFile = "cert_file"
-	s.Nil(sql.ValidateConnectConfig(cfg, false))
-	s.Nil(sql.ValidateConnectConfig(cfg, true))
 }

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -265,14 +265,7 @@ func ValidateConnectConfig(cfg *config.SQL, isDryRun bool) error {
 		}
 		cfg.DatabaseName = schema.DryrunDBName
 	}
-	if cfg.TLS != nil && cfg.TLS.Enabled {
-		enabledCertFile := cfg.TLS.CertFile != ""
-		enabledKeyFile := cfg.TLS.KeyFile != ""
 
-		if (enabledCertFile && !enabledKeyFile) || (!enabledCertFile && enabledKeyFile) {
-			return schema.NewConfigError("must have both CertFile and KeyFile set")
-		}
-	}
 	return nil
 }
 

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -266,16 +266,11 @@ func ValidateConnectConfig(cfg *config.SQL, isDryRun bool) error {
 		cfg.DatabaseName = schema.DryrunDBName
 	}
 	if cfg.TLS != nil && cfg.TLS.Enabled {
-		enabledCaFile := cfg.TLS.CaFile != ""
 		enabledCertFile := cfg.TLS.CertFile != ""
 		enabledKeyFile := cfg.TLS.KeyFile != ""
 
 		if (enabledCertFile && !enabledKeyFile) || (!enabledCertFile && enabledKeyFile) {
 			return schema.NewConfigError("must have both CertFile and KeyFile set")
-		}
-
-		if !enabledCaFile && !enabledCertFile && !enabledKeyFile {
-			return schema.NewConfigError("must provide tls certs to use")
 		}
 	}
 	return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
This allows using TLS for transport but not authentication for the sql tool, consistent with temporal server.

<!-- Tell your future self why have you made these changes -->
Prior to this fix it was not possible to use the SQL tool to connect to Postgres which required TLS for transport
security but was not setup to use TLS for authentication.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Tested by running modified sql tool locally against an Postgres instance configured to require TLS for transport security but not authentication.

