### PR TITLE
Set search.idle.after to 365 days

### DIFF
--- a/schema/elasticsearch/v7/visibility/index_template.json
+++ b/schema/elasticsearch/v7/visibility/index_template.json
@@ -6,7 +6,8 @@
   "settings": {
     "index": {
       "number_of_shards": "5",
-      "number_of_replicas": "0"
+      "number_of_replicas": "0",
+      "search.idle.after": "365d"
     }
   },
   "mappings": {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set `search.idle.after` parameter in ES7 index schema to 365 days.

<!-- Tell your future self why have you made these changes -->
**Why?**
We see some latency spikes for `_search` requests. After [investigation](https://discuss.elastic.co/t/bug-elasticsearch-7-after-upgrade-from-6-7-slow-search-during-3-5-seconds-every-60-seconds/177017/35) it turn out that it is because ES shard got [parked](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-7.0.html#_skipped_background_refresh_on_search_idle_shards) after 30 seconds of default timeout.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually uploaded configuration to the test cluster and observed latency.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
