### PR TITLE
Use document Id to match request and response in ES processor afterFunc callback

### DIFF
--- a/common/persistence/elasticsearch/esProcessor.go
+++ b/common/persistence/elasticsearch/esProcessor.go
@@ -299,7 +299,9 @@ func (p *esProcessorImpl) extractVisibilityTaskKey(request elastic.BulkableReque
 
 		k, ok := body[definition.VisibilityTaskKey]
 		if !ok {
-			panic("VisibilityTaskKey not found")
+			p.logger.Error("Unable to extract VisibilityTaskKey from ES request.", tag.ESRequest(request.String()))
+			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorCorruptedData)
+			return ""
 		}
 		return k.(string)
 	} else { // delete requests

--- a/common/persistence/elasticsearch/esProcessor.go
+++ b/common/persistence/elasticsearch/esProcessor.go
@@ -71,7 +71,6 @@ type (
 	ackChanWithStopwatch struct { // value of esProcessorImpl.mapToAckChan
 		ackCh                 chan<- bool
 		addToProcessStopwatch *tally.Stopwatch // Used to report metrics: interval between visibility task being added to bulk processor and it is processed (ack/nack).
-		//uniqueID              string
 	}
 )
 
@@ -381,10 +380,5 @@ func newAckChanWithStopwatch(ackCh chan<- bool, stopwatch *tally.Stopwatch) *ack
 	return &ackChanWithStopwatch{
 		ackCh:                 ackCh,
 		addToProcessStopwatch: stopwatch,
-		//uniqueID:              uniqueID,
 	}
-}
-
-func uniqueDocID(index, id string) string {
-	return fmt.Sprintf("%s%s%s", index, delimiter, id)
 }

--- a/common/persistence/elasticsearch/esProcessor.go
+++ b/common/persistence/elasticsearch/esProcessor.go
@@ -211,6 +211,15 @@ func (p *esProcessorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRe
 		if visibilityTaskKey == "" {
 			continue
 		}
+		if i >= len(response.Items) {
+			p.logger.Error("ES request failed. Request item doesn't have corresponding response item.",
+				tag.Value(i),
+				tag.Key(visibilityTaskKey),
+				tag.ESRequest(request.String()))
+			p.sendToAckChan(visibilityTaskKey, false)
+			continue
+		}
+
 		responseItem := response.Items[i]
 		for _, resp := range responseItem {
 			switch {

--- a/common/persistence/elasticsearch/esProcessor.go
+++ b/common/persistence/elasticsearch/esProcessor.go
@@ -241,6 +241,8 @@ func (p *esProcessorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRe
 			p.logger.Error("ES request failed.",
 				tag.ESResponseStatus(responseItem.Status),
 				tag.ESResponseError(extractErrorReason(responseItem)),
+				tag.Key(visibilityTaskKey),
+				tag.ESDocID(docID),
 				tag.ESRequest(request.String()))
 			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorFailures)
 			p.sendToAckChan(visibilityTaskKey, false)
@@ -248,6 +250,8 @@ func (p *esProcessorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRe
 			p.logger.Warn("ES request retried.",
 				tag.ESResponseStatus(responseItem.Status),
 				tag.ESResponseError(extractErrorReason(responseItem)),
+				tag.Key(visibilityTaskKey),
+				tag.ESDocID(docID),
 				tag.ESRequest(request.String()))
 			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorRetries)
 		}

--- a/common/persistence/elasticsearch/esProcessor_test.go
+++ b/common/persistence/elasticsearch/esProcessor_test.go
@@ -266,6 +266,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Nack() {
 	ackCh := make(chan bool, 1)
 	mapVal := newAckChanWithStopwatch(ackCh, &testStopWatch)
 	s.esProcessor.mapToAckChan.Put(testKey, mapVal)
+	s.mockMetricClient.On("IncCounter", metrics.ElasticSearchVisibility, metrics.ESBulkProcessorFailures).Once()
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
 	select {
 	case ack := <-ackCh:

--- a/common/persistence/elasticsearch/esProcessor_test.go
+++ b/common/persistence/elasticsearch/esProcessor_test.go
@@ -389,22 +389,22 @@ func (s *esProcessorSuite) TestGetKeyForKafkaMsg_Delete() {
 
 func (s *esProcessorSuite) TestIsResponseSuccess() {
 	for i := 200; i < 300; i++ {
-		s.True(isResponseSuccess(i))
+		s.True(isSuccessStatus(i))
 	}
 	status := []int{409, 404}
 	for _, code := range status {
-		s.True(isResponseSuccess(code))
+		s.True(isSuccessStatus(code))
 	}
 	status = []int{100, 199, 300, 400, 500, 408, 429, 503, 507}
 	for _, code := range status {
-		s.False(isResponseSuccess(code))
+		s.False(isSuccessStatus(code))
 	}
 }
 
 func (s *esProcessorSuite) TestIsResponseRetryable() {
 	status := []int{408, 429, 500, 503, 507}
 	for _, code := range status {
-		s.True(isResponseRetryable(code))
+		s.True(isRetryableStatus(code))
 	}
 }
 

--- a/common/persistence/elasticsearch/esProcessor_test.go
+++ b/common/persistence/elasticsearch/esProcessor_test.go
@@ -352,18 +352,18 @@ func (s *esProcessorSuite) TestHashFn() {
 
 func (s *esProcessorSuite) TestGetVisibilityTaskKey() {
 	request := elastic.NewBulkIndexRequest()
-	s.PanicsWithValue("VisibilityTaskKey not found", func() { s.esProcessor.getVisibilityTaskKey(request) })
+	s.PanicsWithValue("VisibilityTaskKey not found", func() { s.esProcessor.extractVisibilityTaskKey(request) })
 
 	m := map[string]interface{}{
 		definition.VisibilityTaskKey: 1,
 	}
 	request.Doc(m)
-	s.PanicsWithValue("VisibilityTaskKey is not string", func() { s.esProcessor.getVisibilityTaskKey(request) })
+	s.PanicsWithValue("VisibilityTaskKey is not string", func() { s.esProcessor.extractVisibilityTaskKey(request) })
 
 	testKey := "test-key"
 	m[definition.VisibilityTaskKey] = testKey
 	request.Doc(m)
-	s.Equal(testKey, s.esProcessor.getVisibilityTaskKey(request))
+	s.Equal(testKey, s.esProcessor.extractVisibilityTaskKey(request))
 }
 
 func (s *esProcessorSuite) TestGetKeyForKafkaMsg_Delete() {
@@ -379,11 +379,11 @@ func (s *esProcessorSuite) TestGetKeyForKafkaMsg_Delete() {
 	_, ok := body["delete"]
 	s.True(ok)
 
-	s.PanicsWithValue("_id not found in request opMap", func() { s.esProcessor.getVisibilityTaskKey(request) })
+	s.PanicsWithValue("_id not found in request opMap", func() { s.esProcessor.extractVisibilityTaskKey(request) })
 
 	id := "id"
 	request.Id(id)
-	key := s.esProcessor.getVisibilityTaskKey(request)
+	key := s.esProcessor.extractVisibilityTaskKey(request)
 	s.Equal(id, key)
 }
 
@@ -408,10 +408,10 @@ func (s *esProcessorSuite) TestIsResponseRetryable() {
 	}
 }
 
-func (s *esProcessorSuite) TestGetErrorMsgFromESResp() {
+func (s *esProcessorSuite) TestErrorReasonFromResponse() {
 	reason := "error reason"
 	resp := &elastic.BulkResponseItem{Status: 400}
-	s.Equal("", getErrorMsgFromESResp(resp))
+	s.Equal("", extractErrorReason(resp))
 	resp.Error = &elastic.ErrorDetails{Reason: reason}
-	s.Equal(reason, getErrorMsgFromESResp(resp))
+	s.Equal(reason, extractErrorReason(resp))
 }

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -287,7 +287,7 @@ func (v *esVisibilityStore) addBulkRequestAndWait(bulkRequest *es.BulkableReques
 
 func (v *esVisibilityStore) generateESDoc(request *p.InternalVisibilityRequestBase, visibilityTaskKey string) map[string]interface{} {
 	doc := map[string]interface{}{
-		definition.VisibilityTaskKey: visibilityTaskKey, // processor will panic if this field is missing.
+		definition.VisibilityTaskKey: visibilityTaskKey,
 		definition.NamespaceID:       request.NamespaceID,
 		definition.WorkflowID:        request.WorkflowID,
 		definition.RunID:             request.RunID,

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -287,7 +287,7 @@ func (v *esVisibilityStore) addBulkRequestAndWait(bulkRequest *es.BulkableReques
 
 func (v *esVisibilityStore) generateESDoc(request *p.InternalVisibilityRequestBase, visibilityTaskKey string) map[string]interface{} {
 	doc := map[string]interface{}{
-		definition.VisibilityTaskKey: visibilityTaskKey,
+		definition.VisibilityTaskKey: visibilityTaskKey, // processor will panic if this field is missing.
 		definition.NamespaceID:       request.NamespaceID,
 		definition.WorkflowID:        request.WorkflowID,
 		definition.RunID:             request.RunID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use document Id to match request and response in ES processor `afterFunc` callback.

<!-- Tell your future self why have you made these changes -->
**Why?**
Request and response sizes are not guarantee to be the same and can be unordered in `afterFunc` handler of ES `BulkProcessorService`. Using document Id which is unique (it has `runID`) to match request and response items.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
