### PR TITLE
Add build-test target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bins: clean-bins temporal-server tctl temporal-cassandra-tool temporal-sql-tool
 all: update-tools clean proto bins check test
 
 # Used by Buildkite.
-ci-build: bins update-tools check proto mocks gomodtidy ensure-no-changes
+ci-build: bins build-test update-tools check proto mocks gomodtidy ensure-no-changes
 
 # Delete all build artefacts.
 clean: clean-bins clean-test-results

--- a/Makefile
+++ b/Makefile
@@ -244,6 +244,9 @@ clean-test-results:
 	@rm -f test.log
 	@go clean -testcache
 
+build-test:
+	@go test -exec="true" -count=0 $(TEST_DIRS)
+
 unit-test: clean-test-results
 	@printf $(COLOR) "Run unit tests..."
 	$(foreach UNIT_TEST_DIR,$(UNIT_TEST_DIRS),\

--- a/Makefile
+++ b/Makefile
@@ -245,6 +245,7 @@ clean-test-results:
 	@go clean -testcache
 
 build-test:
+	@printf $(COLOR) "Build tests..."
 	@go test -exec="true" -count=0 $(TEST_DIRS)
 
 unit-test: clean-test-results


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `build-test` target which only build tests but don't run them.

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve developer experience. Currently if there are compile errors in tests, `staticcheck` will fail and it is not easy to find root cause.
Inspired by https://github.com/skipor/go-test-compile.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run it locally and as part of `ci-build` target on Buildkite.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
