### PR TITLE
Enable dynamic update of TLS certificates

### DIFF
--- a/common/auth/tlsConfigHelper.go
+++ b/common/auth/tlsConfigHelper.go
@@ -50,19 +50,25 @@ func NewTLSConfigForServer(
 	return c
 }
 
-func NewTLSConfigWithCertsAndCAs(
-	certificates []tls.Certificate,
+func NewDynamicTLSClientConfig(
+	getCert func() (*tls.Certificate, error),
 	rootCAs *x509.CertPool,
 	serverName string,
 	enableHostVerification bool,
 ) *tls.Config {
 	c := NewTLSConfigForServer(serverName, enableHostVerification)
-	c.Certificates = certificates
+
+	if getCert != nil {
+		c.GetClientCertificate = func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			return getCert()
+		}
+	}
 	c.RootCAs = rootCAs
+
 	return c
 }
 
-func NewTLSConfigWithClientAuthAndCAs(
+func NewTLSConfigWithCertsAndCAs(
 	clientAuth tls.ClientAuthType,
 	certificates []tls.Certificate,
 	clientCAs *x509.CertPool,

--- a/common/messaging/kafkaClient.go
+++ b/common/messaging/kafkaClient.go
@@ -309,5 +309,11 @@ func CreateTLSConfig(tlsConfig auth.TLS) (*tls.Config, error) {
 		caCertPool.AppendCertsFromPEM(pemData)
 	}
 
-	return auth.NewTLSConfigWithCertsAndCAs([]tls.Certificate{cert}, caCertPool, "", tlsConfig.EnableHostVerification), nil
+	return auth.NewDynamicTLSClientConfig(
+		func() (*tls.Certificate, error) {
+			return &cert, nil
+		},
+		caCertPool,
+		"",
+		tlsConfig.EnableHostVerification), nil
 }

--- a/common/rpc/encryption/certificate.go
+++ b/common/rpc/encryption/certificate.go
@@ -93,10 +93,16 @@ func GenerateSelfSignedX509CA(commonName string, extUsage []x509.ExtKeyUsage, ke
 }
 
 // GenerateServerX509UsingCA generates a TLS serverCert that is self-signed
-func GenerateServerX509UsingCA(commonName string, ca *tls.Certificate) (*tls.Certificate, *rsa.PrivateKey, error) {
+func GenerateServerX509UsingCAAndSerialNumber(commonName string, serialNumber int64, ca *tls.Certificate) (*tls.Certificate, *rsa.PrivateKey, error) {
 	now := time.Now().UTC()
 
-	i := mathrand.Int63n(100000000000000000)
+	var i int64
+	if serialNumber == 0 {
+		i = mathrand.Int63n(100000000000000000)
+	} else {
+		i = serialNumber
+	}
+
 	template := &x509.Certificate{
 		SerialNumber: big.NewInt(i),
 		Subject: pkix.Name{
@@ -144,4 +150,9 @@ func GenerateServerX509UsingCA(commonName string, ca *tls.Certificate) (*tls.Cer
 	tlsCert.PrivateKey = privateKey
 
 	return &tlsCert, privateKey, err
+}
+
+// GenerateServerX509UsingCA generates a TLS serverCert that is self-signed
+func GenerateServerX509UsingCA(commonName string, ca *tls.Certificate) (*tls.Certificate, *rsa.PrivateKey, error) {
+	return GenerateServerX509UsingCAAndSerialNumber(commonName, 0, ca)
 }

--- a/common/rpc/encryption/certificate.go
+++ b/common/rpc/encryption/certificate.go
@@ -96,11 +96,9 @@ func GenerateSelfSignedX509CA(commonName string, extUsage []x509.ExtKeyUsage, ke
 func GenerateServerX509UsingCAAndSerialNumber(commonName string, serialNumber int64, ca *tls.Certificate) (*tls.Certificate, *rsa.PrivateKey, error) {
 	now := time.Now().UTC()
 
-	var i int64
-	if serialNumber == 0 {
+	i := serialNumber
+	if i == 0 {
 		i = mathrand.Int63n(100000000000000000)
-	} else {
-		i = serialNumber
 	}
 
 	template := &x509.Certificate{

--- a/common/rpc/encryption/localStoreTlsFactory.go
+++ b/common/rpc/encryption/localStoreTlsFactory.go
@@ -154,13 +154,11 @@ func newServerTLSConfig(
 	certProvider CertProvider,
 	perHostCertProviderFactory PerHostCertProviderFactory,
 ) (*tls.Config, error) {
-	tlsConfig, err := getServerTLSConfigFromCertProvider(certProvider)
-	if err != nil {
-		return nil, err
-	}
 
-	if tlsConfig != nil && perHostCertProviderFactory != nil {
-		tlsConfig.GetConfigForClient = func(c *tls.ClientHelloInfo) (*tls.Config, error) {
+	var callback func(c *tls.ClientHelloInfo) (*tls.Config, error)
+
+	if perHostCertProviderFactory != nil {
+		callback = func(c *tls.ClientHelloInfo) (*tls.Config, error) {
 			perHostCertProvider, err := perHostCertProviderFactory.GetCertProvider(c.ServerName)
 			if err != nil {
 				return nil, err
@@ -169,13 +167,22 @@ func newServerTLSConfig(
 			// If there are no special TLS settings for the specific host name being requested,
 			// returning nil here will fallback to the default, top-level TLS config
 			if perHostCertProvider == nil {
-				return nil, nil
+				return getServerTLSConfigFromCertProvider(certProvider)
 			}
-
 			return getServerTLSConfigFromCertProvider(perHostCertProvider)
+		}
+	} else {
+		callback = func(c *tls.ClientHelloInfo) (*tls.Config, error) {
+			return getServerTLSConfigFromCertProvider(certProvider)
 		}
 	}
 
+	tlsConfig, err := getServerTLSConfigFromCertProvider(certProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	tlsConfig.GetConfigForClient = callback
 	return tlsConfig, nil
 }
 
@@ -206,8 +213,10 @@ func getServerTLSConfigFromCertProvider(certProvider CertProvider) (*tls.Config,
 
 		clientCaPool = ca
 	}
-
-	return auth.NewTLSConfigWithClientAuthAndCAs(clientAuthType, []tls.Certificate{*serverCert}, clientCaPool), nil
+	return auth.NewTLSConfigWithCertsAndCAs(
+		clientAuthType,
+		[]tls.Certificate{*serverCert},
+		clientCaPool), nil
 }
 
 func newClientTLSConfig(clientProvider ClientCertProvider, isAuthRequired bool, isWorker bool) (*tls.Config, error) {
@@ -217,22 +226,25 @@ func newClientTLSConfig(clientProvider ClientCertProvider, isAuthRequired bool, 
 		return nil, fmt.Errorf("failed to load client ca: %v", err)
 	}
 
-	// mTLS enabled, present certificate
-	var clientCerts []tls.Certificate
-	if isAuthRequired {
-		cert, err := clientProvider.FetchClientCertificate(isWorker)
-		if err != nil {
-			return nil, err
-		}
+	var getCert func() (*tls.Certificate, error)
 
-		if cert == nil {
-			return nil, fmt.Errorf("client auth required, but no certificate provided")
+	// mTLS enabled, present certificate
+	if isAuthRequired {
+		getCert = func() (*tls.Certificate, error) {
+			cert, err := clientProvider.FetchClientCertificate(isWorker)
+			if err != nil {
+				return nil, err
+			}
+
+			if cert == nil {
+				return nil, fmt.Errorf("client auth required, but no certificate provided")
+			}
+			return cert, nil
 		}
-		clientCerts = []tls.Certificate{*cert}
 	}
 
-	return auth.NewTLSConfigWithCertsAndCAs(
-		clientCerts,
+	return auth.NewDynamicTLSClientConfig(
+		getCert,
 		serverCa,
 		clientProvider.ServerName(isWorker),
 		!clientProvider.DisableHostVerification(isWorker),

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -38,6 +38,7 @@ type TestDynamicCertProvider struct {
 	serverCertIndex int
 	caCertIndex     int
 	config          *config.GroupTLS
+	serverName      string
 }
 
 var _ CertProvider = (*TestDynamicCertProvider)(nil)
@@ -55,6 +56,7 @@ func NewTestDynamicCertProvider(
 		caCerts:      caCerts,
 		wrongCACerts: wrongCACerts,
 		config:       &config,
+		serverName:   "127.0.0.1",
 	}
 }
 
@@ -81,7 +83,7 @@ func (t *TestDynamicCertProvider) FetchServerRootCAsForClient(_ bool) (*x509.Cer
 }
 
 func (t *TestDynamicCertProvider) ServerName(_ bool) string {
-	return "localhost"
+	return t.serverName
 }
 
 func (t *TestDynamicCertProvider) DisableHostVerification(_ bool) bool {
@@ -89,9 +91,16 @@ func (t *TestDynamicCertProvider) DisableHostVerification(_ bool) bool {
 }
 
 func (t *TestDynamicCertProvider) GetCertProvider(hostName string) (CertProvider, error) {
-	return t, nil
+	if hostName == "localhost" {
+		return t, nil
+	}
+	return nil, nil
 }
 
 func (t *TestDynamicCertProvider) SwitchToWrongServerRootCACerts() {
 	t.caCerts = t.wrongCACerts
+}
+
+func (t *TestDynamicCertProvider) SetServerName(serverName string) {
+	t.serverName = serverName
 }

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -31,7 +31,7 @@ import (
 	"go.temporal.io/server/common/service/config"
 )
 
-type testDynamicCertProvider struct {
+type TestDynamicCertProvider struct {
 	serverCerts     []*tls.Certificate
 	caCerts         *x509.CertPool
 	wrongCACerts    *x509.CertPool
@@ -40,17 +40,17 @@ type testDynamicCertProvider struct {
 	config          *config.GroupTLS
 }
 
-var _ CertProvider = (*testDynamicCertProvider)(nil)
-var _ ClientCertProvider = (*testDynamicCertProvider)(nil)
-var _ PerHostCertProviderFactory = (*testDynamicCertProvider)(nil)
+var _ CertProvider = (*TestDynamicCertProvider)(nil)
+var _ ClientCertProvider = (*TestDynamicCertProvider)(nil)
+var _ PerHostCertProviderFactory = (*TestDynamicCertProvider)(nil)
 
 func NewTestDynamicCertProvider(
 	serverCerts []*tls.Certificate,
 	caCerts *x509.CertPool,
 	wrongCACerts *x509.CertPool,
-	config config.GroupTLS) *testDynamicCertProvider {
+	config config.GroupTLS) *TestDynamicCertProvider {
 
-	return &testDynamicCertProvider{
+	return &TestDynamicCertProvider{
 		serverCerts:  serverCerts,
 		caCerts:      caCerts,
 		wrongCACerts: wrongCACerts,
@@ -58,40 +58,40 @@ func NewTestDynamicCertProvider(
 	}
 }
 
-func (t *testDynamicCertProvider) FetchServerCertificate() (*tls.Certificate, error) {
+func (t *TestDynamicCertProvider) FetchServerCertificate() (*tls.Certificate, error) {
 	i := t.serverCertIndex % len(t.serverCerts)
 	t.serverCertIndex++
 	return t.serverCerts[i], nil
 }
 
-func (t *testDynamicCertProvider) FetchClientCAs() (*x509.CertPool, error) {
+func (t *TestDynamicCertProvider) FetchClientCAs() (*x509.CertPool, error) {
 	panic("not implemented")
 }
 
-func (t *testDynamicCertProvider) GetSettings() *config.GroupTLS {
+func (t *TestDynamicCertProvider) GetSettings() *config.GroupTLS {
 	return t.config
 }
 
-func (t *testDynamicCertProvider) FetchClientCertificate(_ bool) (*tls.Certificate, error) {
+func (t *TestDynamicCertProvider) FetchClientCertificate(_ bool) (*tls.Certificate, error) {
 	panic("not implemented")
 }
 
-func (t *testDynamicCertProvider) FetchServerRootCAsForClient(_ bool) (*x509.CertPool, error) {
-	t.caCertIndex++
-	if t.caCertIndex == 3 {
-		return t.wrongCACerts, nil
-	}
+func (t *TestDynamicCertProvider) FetchServerRootCAsForClient(_ bool) (*x509.CertPool, error) {
 	return t.caCerts, nil
 }
 
-func (t *testDynamicCertProvider) ServerName(_ bool) string {
+func (t *TestDynamicCertProvider) ServerName(_ bool) string {
 	return "localhost"
 }
 
-func (t *testDynamicCertProvider) DisableHostVerification(_ bool) bool {
+func (t *TestDynamicCertProvider) DisableHostVerification(_ bool) bool {
 	return false
 }
 
-func (t *testDynamicCertProvider) GetCertProvider(hostName string) (CertProvider, error) {
+func (t *TestDynamicCertProvider) GetCertProvider(hostName string) (CertProvider, error) {
 	return t, nil
+}
+
+func (t *TestDynamicCertProvider) SwitchToWrongServerRootCACerts() {
+	t.caCerts = t.wrongCACerts
 }

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -1,0 +1,97 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encryption
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"go.temporal.io/server/common/service/config"
+)
+
+type testDynamicCertProvider struct {
+	serverCerts     []*tls.Certificate
+	caCerts         *x509.CertPool
+	wrongCACerts    *x509.CertPool
+	serverCertIndex int
+	caCertIndex     int
+	config          *config.GroupTLS
+}
+
+var _ CertProvider = (*testDynamicCertProvider)(nil)
+var _ ClientCertProvider = (*testDynamicCertProvider)(nil)
+var _ PerHostCertProviderFactory = (*testDynamicCertProvider)(nil)
+
+func NewTestDynamicCertProvider(
+	serverCerts []*tls.Certificate,
+	caCerts *x509.CertPool,
+	wrongCACerts *x509.CertPool,
+	config config.GroupTLS) *testDynamicCertProvider {
+
+	return &testDynamicCertProvider{
+		serverCerts:  serverCerts,
+		caCerts:      caCerts,
+		wrongCACerts: wrongCACerts,
+		config:       &config,
+	}
+}
+
+func (t *testDynamicCertProvider) FetchServerCertificate() (*tls.Certificate, error) {
+	i := t.serverCertIndex % len(t.serverCerts)
+	t.serverCertIndex++
+	return t.serverCerts[i], nil
+}
+
+func (t *testDynamicCertProvider) FetchClientCAs() (*x509.CertPool, error) {
+	panic("not implemented")
+}
+
+func (t *testDynamicCertProvider) GetSettings() *config.GroupTLS {
+	return t.config
+}
+
+func (t *testDynamicCertProvider) FetchClientCertificate(_ bool) (*tls.Certificate, error) {
+	panic("not implemented")
+}
+
+func (t *testDynamicCertProvider) FetchServerRootCAsForClient(_ bool) (*x509.CertPool, error) {
+	t.caCertIndex++
+	if t.caCertIndex == 3 {
+		return t.wrongCACerts, nil
+	}
+	return t.caCerts, nil
+}
+
+func (t *testDynamicCertProvider) ServerName(_ bool) string {
+	return "localhost"
+}
+
+func (t *testDynamicCertProvider) DisableHostVerification(_ bool) bool {
+	return false
+}
+
+func (t *testDynamicCertProvider) GetCertProvider(hostName string) (CertProvider, error) {
+	return t, nil
+}

--- a/common/rpc/encryption/testDynamicTLSConfigProvider.go
+++ b/common/rpc/encryption/testDynamicTLSConfigProvider.go
@@ -1,0 +1,88 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package encryption
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+
+	"go.temporal.io/server/common/service/config"
+)
+
+type testDynamicTLSConfigProvider struct {
+	settings *config.RootTLS
+
+	internodeCertProvider       CertProvider
+	internodeClientCertProvider ClientCertProvider
+	frontendCertProvider        CertProvider
+	workerCertProvider          ClientCertProvider
+
+	frontendPerHostCertProviderFactory PerHostCertProviderFactory
+
+	internodeServerConfig *tls.Config
+	internodeClientConfig *tls.Config
+	frontendServerConfig  *tls.Config
+	frontendClientConfig  *tls.Config
+}
+
+func (t *testDynamicTLSConfigProvider) GetInternodeServerConfig() (*tls.Config, error) {
+	return newServerTLSConfig(t.internodeCertProvider, nil)
+}
+
+func (t *testDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, error) {
+	return newClientTLSConfig(t.internodeClientCertProvider, true, false)
+}
+
+func (t *testDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, error) {
+	return newServerTLSConfig(t.frontendCertProvider, t.frontendPerHostCertProviderFactory)
+}
+
+func (t *testDynamicTLSConfigProvider) GetFrontendClientConfig() (*tls.Config, error) {
+	return newClientTLSConfig(t.workerCertProvider, true, false)
+}
+
+var _ TLSConfigProvider = (*testDynamicTLSConfigProvider)(nil)
+
+func NewTestDynamicTLSConfigProvider(
+	tlsConfig *config.RootTLS,
+	internodeCerts []*tls.Certificate,
+	internodeCACerts *x509.CertPool,
+	frontendCerts []*tls.Certificate,
+	frontendCACerts *x509.CertPool,
+	wrongCACerts *x509.CertPool,
+) (TLSConfigProvider, error) {
+
+	internodeProvider := NewTestDynamicCertProvider(internodeCerts, internodeCACerts, wrongCACerts, tlsConfig.Internode)
+	frontendProvider := NewTestDynamicCertProvider(frontendCerts, frontendCACerts, wrongCACerts, tlsConfig.Frontend)
+
+	return &testDynamicTLSConfigProvider{
+		internodeCertProvider:              internodeProvider,
+		internodeClientCertProvider:        internodeProvider,
+		frontendCertProvider:               frontendProvider,
+		workerCertProvider:                 frontendProvider,
+		frontendPerHostCertProviderFactory: frontendProvider,
+		settings:                           tlsConfig,
+	}, nil
+}

--- a/common/rpc/encryption/testDynamicTLSConfigProvider.go
+++ b/common/rpc/encryption/testDynamicTLSConfigProvider.go
@@ -31,15 +31,15 @@ import (
 	"go.temporal.io/server/common/service/config"
 )
 
-type testDynamicTLSConfigProvider struct {
+type TestDynamicTLSConfigProvider struct {
 	settings *config.RootTLS
 
-	internodeCertProvider       CertProvider
-	internodeClientCertProvider ClientCertProvider
-	frontendCertProvider        CertProvider
-	workerCertProvider          ClientCertProvider
+	InternodeCertProvider       *TestDynamicCertProvider
+	InternodeClientCertProvider *TestDynamicCertProvider
+	FrontendCertProvider        *TestDynamicCertProvider
+	WorkerCertProvider          *TestDynamicCertProvider
 
-	frontendPerHostCertProviderFactory PerHostCertProviderFactory
+	FrontendPerHostCertProviderFactory PerHostCertProviderFactory
 
 	internodeServerConfig *tls.Config
 	internodeClientConfig *tls.Config
@@ -47,23 +47,23 @@ type testDynamicTLSConfigProvider struct {
 	frontendClientConfig  *tls.Config
 }
 
-func (t *testDynamicTLSConfigProvider) GetInternodeServerConfig() (*tls.Config, error) {
-	return newServerTLSConfig(t.internodeCertProvider, nil)
+func (t *TestDynamicTLSConfigProvider) GetInternodeServerConfig() (*tls.Config, error) {
+	return newServerTLSConfig(t.InternodeCertProvider, nil)
 }
 
-func (t *testDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, error) {
-	return newClientTLSConfig(t.internodeClientCertProvider, true, false)
+func (t *TestDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, error) {
+	return newClientTLSConfig(t.InternodeClientCertProvider, true, false)
 }
 
-func (t *testDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, error) {
-	return newServerTLSConfig(t.frontendCertProvider, t.frontendPerHostCertProviderFactory)
+func (t *TestDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, error) {
+	return newServerTLSConfig(t.FrontendCertProvider, t.FrontendPerHostCertProviderFactory)
 }
 
-func (t *testDynamicTLSConfigProvider) GetFrontendClientConfig() (*tls.Config, error) {
-	return newClientTLSConfig(t.workerCertProvider, true, false)
+func (t *TestDynamicTLSConfigProvider) GetFrontendClientConfig() (*tls.Config, error) {
+	return newClientTLSConfig(t.WorkerCertProvider, true, false)
 }
 
-var _ TLSConfigProvider = (*testDynamicTLSConfigProvider)(nil)
+var _ TLSConfigProvider = (*TestDynamicTLSConfigProvider)(nil)
 
 func NewTestDynamicTLSConfigProvider(
 	tlsConfig *config.RootTLS,
@@ -72,17 +72,17 @@ func NewTestDynamicTLSConfigProvider(
 	frontendCerts []*tls.Certificate,
 	frontendCACerts *x509.CertPool,
 	wrongCACerts *x509.CertPool,
-) (TLSConfigProvider, error) {
+) (*TestDynamicTLSConfigProvider, error) {
 
 	internodeProvider := NewTestDynamicCertProvider(internodeCerts, internodeCACerts, wrongCACerts, tlsConfig.Internode)
 	frontendProvider := NewTestDynamicCertProvider(frontendCerts, frontendCACerts, wrongCACerts, tlsConfig.Frontend)
 
-	return &testDynamicTLSConfigProvider{
-		internodeCertProvider:              internodeProvider,
-		internodeClientCertProvider:        internodeProvider,
-		frontendCertProvider:               frontendProvider,
-		workerCertProvider:                 frontendProvider,
-		frontendPerHostCertProviderFactory: frontendProvider,
+	return &TestDynamicTLSConfigProvider{
+		InternodeCertProvider:              internodeProvider,
+		InternodeClientCertProvider:        internodeProvider,
+		FrontendCertProvider:               frontendProvider,
+		WorkerCertProvider:                 frontendProvider,
+		FrontendPerHostCertProviderFactory: frontendProvider,
 		settings:                           tlsConfig,
 	}, nil
 }

--- a/common/rpc/encryption/testDynamicTLSConfigProvider.go
+++ b/common/rpc/encryption/testDynamicTLSConfigProvider.go
@@ -37,6 +37,7 @@ type TestDynamicTLSConfigProvider struct {
 	InternodeCertProvider       *TestDynamicCertProvider
 	InternodeClientCertProvider *TestDynamicCertProvider
 	FrontendCertProvider        *TestDynamicCertProvider
+	FrontendClientCertProvider  *TestDynamicCertProvider
 	WorkerCertProvider          *TestDynamicCertProvider
 
 	FrontendPerHostCertProviderFactory PerHostCertProviderFactory
@@ -81,6 +82,7 @@ func NewTestDynamicTLSConfigProvider(
 		InternodeCertProvider:              internodeProvider,
 		InternodeClientCertProvider:        internodeProvider,
 		FrontendCertProvider:               frontendProvider,
+		FrontendClientCertProvider:         frontendProvider,
 		WorkerCertProvider:                 frontendProvider,
 		FrontendPerHostCertProviderFactory: frontendProvider,
 		settings:                           tlsConfig,

--- a/common/rpc/test/rpc_localstore_tls_test.go
+++ b/common/rpc/test/rpc_localstore_tls_test.go
@@ -495,6 +495,8 @@ func (s *localStoreRPCSuite) testDynamicServerTLS(host string, frontend bool) {
 
 	server, client := s.getTestFactory(frontend)
 	var index int
+	s.dynamicConfigProvider.InternodeClientCertProvider.SetServerName(host)
+	s.dynamicConfigProvider.FrontendClientCertProvider.SetServerName(host)
 	runHelloWorldMultipleDials(s.Suite, host, server, client, 5,
 		func(tlsInfo *credentials.TLSInfo, err error) {
 			s.NoError(err)


### PR DESCRIPTION
**What changed?**
Switched retrieval of all certs to be performed for each connection.

**Why?**
Before this change, TLS configuration is static. That is, a certificate is retrieved from the cert provider only once, and then is reused by gRPC until server restarts except for the per-host frontend certs. This change switches retrieval of all certs to be performed for each connection, which enables updating of cert without restarting server.

**How did you test it?**
Added unit tests.

**Potential risks**
Establishment of new TLS connections can be slightly slower, but that should be negligible compared how long it TLS negotiation takes.
