### PR TITLE
Add config parameters for selecting authorizer and claim mapper

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -130,7 +130,7 @@ func buildCLI() *cli.App {
 					temporal.ForServices(services),
 					temporal.WithConfig(cfg),
 					temporal.InterruptOn(temporal.InterruptCh()),
-					temporal.WithAuthorizer(authorization.NewNopAuthorizer()),
+					temporal.WithAuthorizer(authorization.NewNoopAuthorizer()),
 					temporal.WithClaimMapper(func(cfg *config.Config) authorization.ClaimMapper {
 						return authorization.NewNoopClaimMapper(cfg)
 					}),

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -126,13 +126,22 @@ func buildCLI() *cli.App {
 					return cli.Exit(fmt.Sprintf("Unable to load configuration: %v.", err), 1)
 				}
 
+				authorizer, err := authorization.GetAuthorizerFromConfig(&cfg.Global.Authorization)
+				if err != nil {
+					cli.Exit(fmt.Sprintf("Unable to instantiate authorizer: %v.", err), 1)
+				}
+				claimMapper, err := authorization.GetClaimMapperFromConfig(cfg)
+				if err != nil {
+					cli.Exit(fmt.Sprintf("Unable to instantiate claim mapper: %v.", err), 1)
+				}
+
 				s := temporal.NewServer(
 					temporal.ForServices(services),
 					temporal.WithConfig(cfg),
 					temporal.InterruptOn(temporal.InterruptCh()),
-					temporal.WithAuthorizer(authorization.NewNoopAuthorizer()),
+					temporal.WithAuthorizer(authorizer),
 					temporal.WithClaimMapper(func(cfg *config.Config) authorization.ClaimMapper {
-						return authorization.NewNoopClaimMapper(cfg)
+						return claimMapper
 					}),
 				)
 

--- a/common/authorization/authorizer.go
+++ b/common/authorization/authorizer.go
@@ -26,7 +26,13 @@
 
 package authorization
 
-import "context"
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.temporal.io/server/common/service/config"
+)
 
 const (
 	// DecisionDeny means auth decision is deny
@@ -68,4 +74,15 @@ type Authorizer interface {
 
 type requestWithNamespace interface {
 	GetNamespace() string
+}
+
+func GetAuthorizerFromConfig(config *config.Authorization) (Authorizer, error) {
+
+	switch strings.ToLower(config.Authorizer) {
+	case "":
+		return NewNoopAuthorizer(), nil
+	case "default":
+		return NewDefaultAuthorizer(), nil
+	}
+	return nil, fmt.Errorf("unknown authorizer: %s", config.Authorizer)
 }

--- a/common/authorization/claimMapper.go
+++ b/common/authorization/claimMapper.go
@@ -28,6 +28,8 @@ package authorization
 
 import (
 	"crypto/x509/pkix"
+	"fmt"
+	"strings"
 
 	"google.golang.org/grpc/credentials"
 
@@ -64,4 +66,15 @@ func NewNoopClaimMapper(_ *config.Config) ClaimMapper {
 
 func (*noopClaimMapper) GetClaims(_ *AuthInfo) (*Claims, error) {
 	return &Claims{System: RoleAdmin}, nil
+}
+
+func GetClaimMapperFromConfig(config *config.Config) (ClaimMapper, error) {
+
+	switch strings.ToLower(config.Global.Authorization.ClaimMapper) {
+	case "":
+		return NewNoopClaimMapper(config), nil
+	case "default":
+		return NewDefaultJWTClaimMapper(NewDefaultTokenKeyProvider(config), config), nil
+	}
+	return nil, fmt.Errorf("unknown claim mapper: %s", config.Global.Authorization.ClaimMapper)
 }

--- a/common/authorization/defaultAuthorizer.go
+++ b/common/authorization/defaultAuthorizer.go
@@ -56,3 +56,5 @@ func (a *defaultAuthorizer) Authorize(_ context.Context, claims *Claims, target 
 	}
 	return Result{Decision: DecisionAllow}, nil
 }
+
+var _ Authorizer = (*defaultAuthorizer)(nil)

--- a/common/authorization/nopAuthorizer.go
+++ b/common/authorization/nopAuthorizer.go
@@ -28,7 +28,7 @@ import "context"
 
 type noopAuthorizer struct{}
 
-// NewNoopAuthorizer creates a no-op authority
+// NewNoopAuthorizer creates a no-op authorizer
 func NewNoopAuthorizer() Authorizer {
 	return &noopAuthorizer{}
 }

--- a/common/authorization/nopAuthorizer.go
+++ b/common/authorization/nopAuthorizer.go
@@ -26,13 +26,13 @@ package authorization
 
 import "context"
 
-type nopAuthority struct{}
+type noopAuthorizer struct{}
 
-// NewNopAuthorizer creates a no-op authority
-func NewNopAuthorizer() Authorizer {
-	return &nopAuthority{}
+// NewNoopAuthorizer creates a no-op authority
+func NewNoopAuthorizer() Authorizer {
+	return &noopAuthorizer{}
 }
 
-func (a *nopAuthority) Authorize(_ context.Context, _ *Claims, _ *CallTarget) (Result, error) {
+func (a *noopAuthorizer) Authorize(_ context.Context, _ *Claims, _ *CallTarget) (Result, error) {
 	return Result{Decision: DecisionAllow}, nil
 }

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -510,6 +510,10 @@ type (
 		// Signing key provider for validating JWT tokens
 		JWTKeyProvider       JWTKeyProvider `yaml:"jwtKeyProvider"`
 		PermissionsClaimName string         `yaml:"permissionsClaimName"`
+		// Empty string for noopAuthorizer or "default" for defaultAuthorizer
+		Authorizer string `yaml:"authorizer"`
+		// Empty string for noopClaimMapper or "default" for defaultJWTClaimMapper
+		ClaimMapper string `yaml:"claimMapper"`
 	}
 
 	// @@@SNIPSTART temporal-common-service-config-jwtkeyprovider

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -184,6 +184,15 @@ global:
             timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
             listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
     {{- end }}
+    authorization:
+        jwtKeyProvider:
+            keySourceURIs:
+                - {{ default .Env.TEMPORAL_JWT_KEY_SOURCE1 "" }}
+                - {{ default .Env.TEMPORAL_JWT_KEY_SOURCE2 "" }}
+            refreshInterval: {{ default .Env.TEMPORAL_JWT_KEY_REFRESH "1m" }}
+        permissionsClaimName: {{ default .Env.TEMPORAL_JWT_PERMISSIONS_CLAIM "permissions" }}
+        authorizer: {{ default .Env.TEMPORAL_AUTH_AUTHORIZER "" }}
+        claimMapper: {{ default .Env.TEMPORAL_AUTH_CLAIM_MAPPER "" }}
 
 {{- $temporalGrpcPort := default .Env.FRONTEND_GRPC_PORT "7233" }}
 services:

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -389,7 +389,7 @@ func (c *temporalImpl) startFrontend(hosts map[string][]string, startWG *sync.Wa
 	params.ArchiverProvider = c.archiverProvider
 	params.ESConfig = c.esConfig
 	params.ESClient = c.esClient
-	params.Authorizer = authorization.NewNopAuthorizer()
+	params.Authorizer = authorization.NewNoopAuthorizer()
 
 	var err error
 	params.PersistenceConfig, err = copyPersistenceConfig(c.persistenceConfig)

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -347,7 +347,7 @@ func (s *Server) getServiceParams(
 	if s.so.authorizer != nil {
 		params.Authorizer = s.so.authorizer
 	} else {
-		params.Authorizer = authorization.NewNopAuthorizer()
+		params.Authorizer = authorization.NewNoopAuthorizer()
 	}
 	if s.so.claimMapper != nil {
 		params.ClaimMapper = s.so.claimMapper


### PR DESCRIPTION
**What changed?**
Added config switches and logic for selecting authorizer and claim mapper via config.

**Why?**
People that use our docker images need a way to select authorizer and claim mapper without resorting to building their own images (to use Server Options).

**How did you test it?**
Manually and unit tests.

**Potential risks**
I see no real risk here as the default behavior stayed unchanged.
