### PR TITLE
Move search attributes validator from frontend to history

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -95,7 +95,6 @@ type (
 		versionChecker                  headers.VersionChecker
 		namespaceHandler                namespace.Handler
 		visibilityQueryValidator        *validator.VisibilityQueryValidator
-		searchAttributesValidator       *validator.SearchAttributesValidator
 		getDefaultWorkflowRetrySettings dynamicconfig.MapPropertyFnWithNamespaceFilter
 	}
 
@@ -131,14 +130,7 @@ func NewWorkflowHandler(
 			resource.GetArchivalMetadata(),
 			resource.GetArchiverProvider(),
 		),
-		visibilityQueryValidator: validator.NewQueryValidator(config.ValidSearchAttributes),
-		searchAttributesValidator: validator.NewSearchAttributesValidator(
-			resource.GetLogger(),
-			config.ValidSearchAttributes,
-			config.SearchAttributesNumberOfKeysLimit,
-			config.SearchAttributesSizeOfValueLimit,
-			config.SearchAttributesTotalSizeLimit,
-		),
+		visibilityQueryValidator:        validator.NewQueryValidator(config.ValidSearchAttributes),
 		getDefaultWorkflowRetrySettings: config.DefaultWorkflowRetryPolicy,
 	}
 
@@ -453,10 +445,6 @@ func (wh *WorkflowHandler) StartWorkflowExecution(ctx context.Context, request *
 
 	if len(request.GetRequestId()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errRequestIDTooLong, scope)
-	}
-
-	if err := wh.searchAttributesValidator.ValidateSearchAttributes(request.SearchAttributes, namespace); err != nil {
-		return nil, wh.error(err, scope)
 	}
 
 	enums.SetDefaultWorkflowIdReusePolicy(&request.WorkflowIdReusePolicy)
@@ -2171,10 +2159,6 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 	}
 
 	if err := backoff.ValidateSchedule(request.GetCronSchedule()); err != nil {
-		return nil, wh.error(err, scope)
-	}
-
-	if err := wh.searchAttributesValidator.ValidateSearchAttributes(request.SearchAttributes, namespace); err != nil {
 		return nil, wh.error(err, scope)
 	}
 

--- a/service/history/commandChecker_test.go
+++ b/service/history/commandChecker_test.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/elasticsearch/validator"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
@@ -96,8 +97,13 @@ func (s *commandAttrValidatorSuite) SetupTest() {
 	s.validator = newCommandAttrValidator(
 		s.mockNamespaceCache,
 		config,
-		log.NewNoop(),
-	)
+		validator.NewSearchAttributesValidator(
+			log.NewNoop(),
+			config.ValidSearchAttributes,
+			config.SearchAttributesNumberOfKeysLimit,
+			config.SearchAttributesSizeOfValueLimit,
+			config.SearchAttributesTotalSizeLimit,
+		))
 }
 
 func (s *commandAttrValidatorSuite) TearDownTest() {

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -1176,7 +1176,7 @@ func (s *engineSuite) TestValidateSignalRequest() {
 		WorkflowTaskTimeout:      timestamp.DurationPtr(10 * time.Second),
 		Identity:                 "identity",
 	}
-	err := validateStartWorkflowExecutionRequest(startRequest, 999)
+	err := s.mockHistoryEngine.validateStartWorkflowExecutionRequest(startRequest, 999, testLocalNamespaceEntry.GetInfo().GetName())
 	s.Error(err, "startRequest doesn't have request id, it should error out")
 }
 

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -101,7 +101,7 @@ func newWorkflowTaskHandlerCallback(historyEngine *historyEngineImpl) *workflowT
 		commandAttrValidator: newCommandAttrValidator(
 			historyEngine.shard.GetNamespaceCache(),
 			historyEngine.config,
-			historyEngine.logger,
+			historyEngine.searchAttributesValidator,
 		),
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move search attributes validator from frontend to history.

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Internal requests might bypass frontend.
2. All validation logic is already in history, so it is more natural to validate search attributes there too.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.
