### PR TITLE
Fix tctl start workflow command with empty search attributes

### DIFF
--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -695,14 +695,6 @@ func validateJSONs(str string) error {
 	}
 }
 
-func trimSpace(strs []string) []string {
-	result := make([]string, len(strs))
-	for i, v := range strs {
-		result[i] = strings.TrimSpace(v)
-	}
-	return result
-}
-
 func truncate(str string) string {
 	if len(str) > maxOutputStringLength {
 		return str[:maxOutputStringLength]

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -282,24 +282,34 @@ func startWorkflowHelper(c *cli.Context, shouldPrintProgress bool) {
 }
 
 func processSearchAttr(c *cli.Context) *commonpb.SearchAttributes {
-	rawSearchAttrKey := c.String(FlagSearchAttributesKey)
-	searchAttrKeys := trimSpace(strings.Split(rawSearchAttrKey, searchAttrInputSeparator))
+	sanitize := func(val string) []string {
+		trimmedVal := strings.TrimSpace(val)
+		if len(trimmedVal) == 0 {
+			return nil
+		}
+		splitVal := strings.Split(trimmedVal, searchAttrInputSeparator)
+		result := make([]string, len(splitVal))
+		for i, v := range splitVal {
+			result[i] = strings.TrimSpace(v)
+		}
+		return result
+	}
+
+	searchAttrKeys := sanitize(c.String(FlagSearchAttributesKey))
 	if len(searchAttrKeys) == 0 {
 		return nil
 	}
-
-	rawSearchAttrVal := c.String(FlagSearchAttributesVal)
-	searchAttrStrVals := trimSpace(strings.Split(rawSearchAttrVal, searchAttrInputSeparator))
-	if len(searchAttrStrVals) == 0 {
+	searchAttrVals := sanitize(c.String(FlagSearchAttributesVal))
+	if len(searchAttrVals) == 0 {
 		return nil
 	}
 
-	if len(searchAttrKeys) != len(searchAttrStrVals) {
-		ErrorAndExit("Number of search attributes keys and values are not equal.", nil)
+	if len(searchAttrKeys) != len(searchAttrVals) {
+		ErrorAndExit(fmt.Sprintf("Uneven number of search attributes keys (%d): %v and values(%d): %v.", len(searchAttrKeys), searchAttrKeys, len(searchAttrVals), searchAttrVals), nil)
 	}
 
 	searchAttributesStr := make(map[string]string, len(searchAttrKeys))
-	for i, searchAttrVal := range searchAttrStrVals {
+	for i, searchAttrVal := range searchAttrVals {
 		searchAttributesStr[searchAttrKeys[i]] = searchAttrVal
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix `tctl` `start workflow` command with empty search attributes.

<!-- Tell your future self why have you made these changes -->
**Why?**
W/o fix, start command treats empty search attributes list as list with one empty item, which is wrong and doesn't pass server validation.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run different combinations manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.