### PR TITLE
Remove Kafka message usage from admin ES index command

### DIFF
--- a/common/elasticsearch/bulk_processor_v6.go
+++ b/common/elasticsearch/bulk_processor_v6.go
@@ -45,7 +45,12 @@ func newBulkProcessorV6(esBulkProcessor *elastic6.BulkProcessor) *bulkProcessorV
 }
 
 func (p *bulkProcessorV6) Stop() error {
-	return p.esBulkProcessor.Stop()
+	errF := p.esBulkProcessor.Flush()
+	errS := p.esBulkProcessor.Stop()
+	if errF != nil {
+		return errF
+	}
+	return errS
 }
 
 func (p *bulkProcessorV6) Add(request *BulkableRequest) {

--- a/common/elasticsearch/bulk_processor_v7.go
+++ b/common/elasticsearch/bulk_processor_v7.go
@@ -44,7 +44,12 @@ func newBulkProcessorV7(esBulkProcessor *elastic.BulkProcessor) *bulkProcessorV7
 }
 
 func (p *bulkProcessorV7) Stop() error {
-	return p.esBulkProcessor.Stop()
+	errF := p.esBulkProcessor.Flush()
+	errS := p.esBulkProcessor.Stop()
+	if errF != nil {
+		return errF
+	}
+	return errS
 }
 
 func (p *bulkProcessorV7) Add(request *BulkableRequest) {

--- a/common/elasticsearch/client.go
+++ b/common/elasticsearch/client.go
@@ -52,8 +52,8 @@ type (
 	}
 
 	CLIClient interface {
+		Client
 		CatIndices(ctx context.Context) (elastic.CatIndicesResponse, error)
-		SearchWithDSL(ctx context.Context, index, query string) (*elastic.SearchResult, error)
 		Bulk() BulkService
 	}
 

--- a/common/elasticsearch/client_mock.go
+++ b/common/elasticsearch/client_mock.go
@@ -217,6 +217,97 @@ func (mr *MockCLIClientMockRecorder) CatIndices(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CatIndices", reflect.TypeOf((*MockCLIClient)(nil).CatIndices), ctx)
 }
 
+// Count mocks base method.
+func (m *MockCLIClient) Count(ctx context.Context, index, query string) (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Count", ctx, index, query)
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Count indicates an expected call of Count.
+func (mr *MockCLIClientMockRecorder) Count(ctx, index, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockCLIClient)(nil).Count), ctx, index, query)
+}
+
+// PutMapping mocks base method.
+func (m *MockCLIClient) PutMapping(ctx context.Context, index, root, key, valueType string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutMapping", ctx, index, root, key, valueType)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutMapping indicates an expected call of PutMapping.
+func (mr *MockCLIClientMockRecorder) PutMapping(ctx, index, root, key, valueType interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutMapping", reflect.TypeOf((*MockCLIClient)(nil).PutMapping), ctx, index, root, key, valueType)
+}
+
+// RunBulkProcessor mocks base method.
+func (m *MockCLIClient) RunBulkProcessor(ctx context.Context, p *BulkProcessorParameters) (BulkProcessor, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunBulkProcessor", ctx, p)
+	ret0, _ := ret[0].(BulkProcessor)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunBulkProcessor indicates an expected call of RunBulkProcessor.
+func (mr *MockCLIClientMockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockCLIClient)(nil).RunBulkProcessor), ctx, p)
+}
+
+// Scroll mocks base method.
+func (m *MockCLIClient) Scroll(ctx context.Context, scrollID string) (*v7.SearchResult, ScrollService, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Scroll", ctx, scrollID)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(ScrollService)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Scroll indicates an expected call of Scroll.
+func (mr *MockCLIClientMockRecorder) Scroll(ctx, scrollID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockCLIClient)(nil).Scroll), ctx, scrollID)
+}
+
+// ScrollFirstPage mocks base method.
+func (m *MockCLIClient) ScrollFirstPage(ctx context.Context, index, query string) (*v7.SearchResult, ScrollService, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ScrollFirstPage", ctx, index, query)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(ScrollService)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ScrollFirstPage indicates an expected call of ScrollFirstPage.
+func (mr *MockCLIClientMockRecorder) ScrollFirstPage(ctx, index, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrollFirstPage", reflect.TypeOf((*MockCLIClient)(nil).ScrollFirstPage), ctx, index, query)
+}
+
+// Search mocks base method.
+func (m *MockCLIClient) Search(ctx context.Context, p *SearchParameters) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Search", ctx, p)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Search indicates an expected call of Search.
+func (mr *MockCLIClientMockRecorder) Search(ctx, p interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockCLIClient)(nil).Search), ctx, p)
+}
+
 // SearchWithDSL mocks base method.
 func (m *MockCLIClient) SearchWithDSL(ctx context.Context, index, query string) (*v7.SearchResult, error) {
 	m.ctrl.T.Helper()

--- a/common/metrics/noop_metrics_client.go
+++ b/common/metrics/noop_metrics_client.go
@@ -22,34 +22,39 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package host
+package metrics
 
 import (
 	"time"
 
 	"github.com/uber-go/tally"
-
-	"go.temporal.io/server/common/metrics"
 )
 
 type (
-	noopMetricsClient struct{}
+	NoopMetricsClient struct{}
 )
 
-func (m noopMetricsClient) IncCounter(scope int, counter int) {}
-
-func (m noopMetricsClient) AddCounter(scope int, counter int, delta int64) {}
-
-func (m noopMetricsClient) StartTimer(scope int, timer int) tally.Stopwatch {
-	panic("Unexpected call to NoopMetricsClient StartTimer")
+func NewNoopMetricsClient() *NoopMetricsClient {
+	return &NoopMetricsClient{}
 }
 
-func (m noopMetricsClient) RecordTimer(scope int, timer int, d time.Duration) {}
+func (m NoopMetricsClient) IncCounter(scope int, counter int) {}
 
-func (m noopMetricsClient) RecordDistribution(scope int, timer int, d int) {}
+func (m NoopMetricsClient) AddCounter(scope int, counter int, delta int64) {}
 
-func (m noopMetricsClient) UpdateGauge(scope int, gauge int, value float64) {}
+func (m NoopMetricsClient) StartTimer(scope int, timer int) tally.Stopwatch {
+	return NopStopwatch()
+}
 
-func (m noopMetricsClient) Scope(scope int, tags ...metrics.Tag) metrics.Scope {
-	panic("Unexpected call to NoopMetricsClient Scope")
+func (m NoopMetricsClient) RecordTimer(scope int, timer int, d time.Duration) {}
+
+func (m NoopMetricsClient) RecordDistribution(scope int, timer int, d int) {}
+
+func (m NoopMetricsClient) UpdateGauge(scope int, gauge int, value float64) {}
+
+func (m NoopMetricsClient) Scope(scope int, tags ...Tag) Scope {
+	return &metricsScope{
+		scope:     tally.NoopScope,
+		rootScope: tally.NoopScope,
+	}
 }

--- a/common/persistence/visibilityInterfaces.go
+++ b/common/persistence/visibilityInterfaces.go
@@ -63,7 +63,7 @@ type (
 		*VisibilityRequestBase
 		CloseTimestamp   int64
 		HistoryLength    int64
-		RetentionSeconds int64
+		RetentionSeconds int64 // not persisted, used for cassandra ttl
 	}
 
 	// UpsertWorkflowExecutionRequest is used to upsert workflow execution

--- a/common/searchattribute/defs.go
+++ b/common/searchattribute/defs.go
@@ -38,16 +38,20 @@ const (
 	ExecutionTime   = "ExecutionTime"
 	CloseTime       = "CloseTime"
 	ExecutionStatus = "ExecutionStatus"
-	HistoryLength   = "HistoryLength"
-	KafkaKey        = "KafkaKey"
-	Encoding        = "Encoding"
-	BinaryChecksums = "BinaryChecksums"
-	TaskQueue       = "TaskQueue"
 
+	// TODO (alex): move these 3 to non-indexed.
+	HistoryLength = "HistoryLength"
+	TaskQueue     = "TaskQueue"
+	Encoding      = "Encoding"
+
+	// Valid non-indexed fields on ES.
+	Memo              = "Memo"
 	VisibilityTaskKey = "VisibilityTaskKey"
+	KafkaKey          = "KafkaKey"
 
 	// Attr is prefix of custom search attributes.
-	Attr                  = "Attr"
+	Attr = "Attr"
+	// Custom search attributes.
 	CustomStringField     = "CustomStringField"
 	CustomKeywordField    = "CustomKeywordField"
 	CustomIntField        = "CustomIntField"
@@ -55,11 +59,9 @@ const (
 	CustomBoolField       = "CustomBoolField"
 	CustomDatetimeField   = "CustomDatetimeField"
 	TemporalChangeVersion = "TemporalChangeVersion"
+	BinaryChecksums       = "BinaryChecksums"
 	CustomNamespace       = "CustomNamespace"
 	Operator              = "Operator"
-
-	// Valid non-indexed fields on ES.
-	Memo = "Memo"
 )
 
 var (

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/messaging"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/mocks"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
@@ -174,7 +175,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 			ESProcessorFlushInterval: dynamicconfig.GetDurationPropertyFn(1 * time.Minute),
 			ValidSearchAttributes:    dynamicconfig.GetMapPropertyFn(searchattribute.GetDefaultTypeMap()),
 		}
-		esProcessor := pes.NewProcessor(esProcessorConfig, esClient, logger, &noopMetricsClient{})
+		esProcessor := pes.NewProcessor(esProcessorConfig, esClient, logger, &metrics.NoopMetricsClient{})
 		esProcessor.Start()
 
 		visConfig := &config.VisibilityConfig{
@@ -185,7 +186,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 		}
 		indexName := options.ESConfig.Indices[common.VisibilityAppName]
 		esVisibilityStore := pes.NewElasticSearchVisibilityStore(
-			esClient, indexName, nil, esProcessor, visConfig, logger, &noopMetricsClient{},
+			esClient, indexName, nil, esProcessor, visConfig, logger, &metrics.NoopMetricsClient{},
 		)
 		esVisibilityMgr = persistence.NewVisibilityManagerImpl(esVisibilityStore, visConfig.ValidSearchAttributes, logger)
 	}

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -603,7 +603,7 @@ func newAdminElasticSearchCommands() []cli.Command {
 				cli.IntFlag{
 					Name:  FlagBatchSizeWithAlias,
 					Usage: "Optional batch size of actions for bulk operations",
-					Value: 1000,
+					Value: 10,
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/adminElasticSearchCommands.go
+++ b/tools/cli/adminElasticSearchCommands.go
@@ -33,17 +33,23 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
+	"go.uber.org/atomic"
 
-	enumsspb "go.temporal.io/server/api/enums/v1"
-	indexerspb "go.temporal.io/server/api/indexer/v1"
-	"go.temporal.io/server/common/codec"
 	es "go.temporal.io/server/common/elasticsearch"
 	"go.temporal.io/server/common/elasticsearch/esql"
+	"go.temporal.io/server/common/log/loggerimpl"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	espersistence "go.temporal.io/server/common/persistence/elasticsearch"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/service/config"
+	dc "go.temporal.io/server/common/service/dynamicconfig"
 )
 
 const (
@@ -56,9 +62,9 @@ const (
 )
 
 var timeKeys = map[string]bool{
-	"StartTime":     true,
-	"CloseTime":     true,
-	"ExecutionTime": true,
+	searchattribute.StartTime:     true,
+	searchattribute.CloseTime:     true,
+	searchattribute.ExecutionTime: true,
 }
 
 func timeKeyFilter(key string) bool {
@@ -122,63 +128,67 @@ func AdminCatIndices(c *cli.Context) {
 	table.Render()
 }
 
-// AdminIndex used to bulk insert message from kafka parse
+// AdminIndex used to bulk insert message to ES.
+// Sample JSON line:
+// {"NamespaceID": "namespace-id", "Namespace": "namespace-name", "Execution": {"workflow_id": "workflow-id1", "run_id": "run-id" }, "WorkflowTypeName": "workflow-type", "StartTimestamp": 1234, "Status": 1, "ExecutionTimestamp": 5678, "TaskID": 2208, "ShardID": 1978, "Memo": {"fields": {"memo-1": {"metadata": {"encoding": "anNvbi9wbGFpbg==" }, "data": "MQ==" } } }, "TaskQueue": "task-queue", "CloseTimestamp": 9012, "HistoryLength": 2203, "SearchAttributes": {"indexed_fields": {"CustomKeywordField": {"metadata": {"encoding": "anNvbi9wbGFpbg==" }, "data": "ImtleXdvcmQiCg==" } } } }
 func AdminIndex(c *cli.Context) {
 	esClient := newESClient(c)
 	indexName := getRequiredOption(c, FlagIndex)
 	inputFileName := getRequiredOption(c, FlagInputFile)
-	batchSize := c.Int(FlagBatchSize)
+	numOfBatches := c.Int(FlagBatchSize)
 
 	messages, err := parseIndexerMessage(inputFileName)
 	if err != nil {
-		ErrorAndExit("Unable to parse indexer message", err)
+		ErrorAndExit("Unable to parse RecordWorkflowExecutionClosedRequest message", err)
 	}
 
-	bulkRequest := esClient.Bulk()
-	bulkConductFn := func() {
-		err := bulkRequest.Do(context.Background())
-		if err != nil {
-			ErrorAndExit("Bulk failed", err)
-		}
-		if bulkRequest.NumberOfActions() != 0 {
-			ErrorAndExit(fmt.Sprintf("Bulk request not done, %d", bulkRequest.NumberOfActions()), nil)
-		}
+	esProcessorConfig := &espersistence.ProcessorConfig{
+		IndexerConcurrency:       dc.GetIntPropertyFn(100),
+		ESProcessorNumOfWorkers:  dc.GetIntPropertyFn(1),
+		ESProcessorBulkActions:   dc.GetIntPropertyFn(numOfBatches),
+		ESProcessorBulkSize:      dc.GetIntPropertyFn(2 << 20),
+		ESProcessorFlushInterval: dc.GetDurationPropertyFn(1 * time.Second),
+		ValidSearchAttributes:    dc.GetMapPropertyFn(searchattribute.GetDefaultTypeMap()),
 	}
-	for i, message := range messages {
-		docID := message.GetWorkflowId() + esDocIDDelimiter + message.GetRunId()
-		var req *es.BulkableRequest
-		switch message.GetMessageType() {
-		case enumsspb.MESSAGE_TYPE_INDEX:
-			doc := generateESDoc(message)
-			req = &es.BulkableRequest{
-				Index:       indexName,
-				ID:          docID,
-				Version:     message.GetVersion(),
-				RequestType: es.BulkableRequestTypeIndex,
-				Doc:         doc,
-			}
-		case enumsspb.MESSAGE_TYPE_DELETE:
-			req = &es.BulkableRequest{
-				Index:       indexName,
-				ID:          docID,
-				Version:     message.GetVersion(),
-				RequestType: es.BulkableRequestTypeDelete,
-			}
-		default:
-			ErrorAndExit("Unknown message type", nil)
-		}
-		bulkRequest.Add(req)
 
-		if i%batchSize == batchSize-1 {
-			bulkConductFn()
-		}
+	logger, err := loggerimpl.NewDevelopment()
+	if err != nil {
+		ErrorAndExit("Unable to create logger", err)
 	}
-	if bulkRequest.NumberOfActions() != 0 {
-		bulkConductFn()
+
+	esProcessor := espersistence.NewProcessor(esProcessorConfig, esClient, logger, metrics.NewNoopMetricsClient())
+	esProcessor.Start()
+
+	visibilityConfigForES := &config.VisibilityConfig{
+		ESIndexMaxResultWindow: dc.GetIntPropertyFn(10000),
+		ValidSearchAttributes:  dc.GetMapPropertyFn(searchattribute.GetDefaultTypeMap()),
+		ESProcessorAckTimeout:  dc.GetDurationPropertyFn(1 * time.Minute),
 	}
+	visibilityManager := espersistence.NewESVisibilityManager(indexName, esClient, visibilityConfigForES, nil, esProcessor, metrics.NewNoopMetricsClient(), logger)
+
+	successLines := &atomic.Int32{}
+	wg := &sync.WaitGroup{}
+	wg.Add(numOfBatches)
+	for i := 0; i < numOfBatches; i++ {
+		go func(batchNum int) {
+			for line := batchNum; line < len(messages); line += numOfBatches {
+				err1 := visibilityManager.RecordWorkflowExecutionClosedV2(messages[line])
+				if err1 != nil {
+					fmt.Printf("Unable to save row at line %d: %v", line, err1)
+				} else {
+					successLines.Inc()
+				}
+			}
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+	visibilityManager.Close()
+	fmt.Println("ES processor stopped.", successLines, "lines were saved successfully")
 }
 
-// AdminDelete used to delete documents from ElasticSearch with input of list result
+// AdminDelete used to delete documents from Elasticsearch with input of list result
 func AdminDelete(c *cli.Context) {
 	esClient := newESClient(c)
 	indexName := getRequiredOption(c, FlagIndex)
@@ -233,18 +243,15 @@ func AdminDelete(c *cli.Context) {
 	}
 }
 
-func parseIndexerMessage(fileName string) (messages []*indexerspb.Message, err error) {
-	// Executed from the CLI to parse existing elasticsearch files
-	// #nosec
+func parseIndexerMessage(fileName string) (messages []*persistence.RecordWorkflowExecutionClosedRequest, err error) {
 	file, err := os.Open(fileName)
 	if err != nil {
 		return nil, err
 	}
-	defer file.Close()
+	defer func() { _ = file.Close() }()
 
 	scanner := bufio.NewScanner(file)
 	idx := 0
-	encoder := codec.NewJSONPBEncoder()
 	for scanner.Scan() {
 		idx++
 		line := strings.TrimSpace(scanner.Text())
@@ -253,10 +260,10 @@ func parseIndexerMessage(fileName string) (messages []*indexerspb.Message, err e
 			continue
 		}
 
-		msg := &indexerspb.Message{}
-		err := encoder.Decode([]byte(line), msg)
+		msg := &persistence.RecordWorkflowExecutionClosedRequest{}
+		err := json.Unmarshal([]byte(line), msg)
 		if err != nil {
-			fmt.Printf("line %v cannot be deserialized to indexer message: %v.\n", idx, line)
+			fmt.Printf("line %v cannot be deserialized to RecordWorkflowExecutionClosedRequest: %v.\n", idx, line)
 			return nil, err
 		}
 		messages = append(messages, msg)
@@ -266,29 +273,6 @@ func parseIndexerMessage(fileName string) (messages []*indexerspb.Message, err e
 		return nil, err
 	}
 	return messages, nil
-}
-
-func generateESDoc(msg *indexerspb.Message) map[string]interface{} {
-	doc := make(map[string]interface{})
-	doc[es.NamespaceID] = msg.GetNamespaceId()
-	doc[es.WorkflowID] = msg.GetWorkflowId()
-	doc[es.RunID] = msg.GetRunId()
-
-	for k, v := range msg.Fields {
-		switch v.GetType() {
-		case enumsspb.FIELD_TYPE_STRING:
-			doc[k] = v.GetStringData()
-		case enumsspb.FIELD_TYPE_INT:
-			doc[k] = v.GetIntData()
-		case enumsspb.FIELD_TYPE_BOOL:
-			doc[k] = v.GetBoolData()
-		case enumsspb.FIELD_TYPE_BINARY:
-			doc[k] = v.GetBinaryData()
-		default:
-			ErrorAndExit("Unknown field type", nil)
-		}
-	}
-	return doc
 }
 
 // This function is used to trim unnecessary tag in returned json for table header


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`persistence.RecordWorkflowExecutionClosedRequest` is used instead of `indexerspb.Message` in `tctl admin es index` command.

<!-- Tell your future self why have you made these changes -->
**Why?**
Prepare to remove Kafka and `indexerspb.Message` from the code.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run `tctl` manually locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
`tctl admin es index` input file format is changed.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.