### PR TITLE
Fix potential data race DescribeMutableState API

### DIFF
--- a/common/persistence/serialization/blob.go
+++ b/common/persistence/serialization/blob.go
@@ -82,6 +82,15 @@ func NamespaceDetailFromBlob(blob []byte, encoding string) (*persistencespb.Name
 	return result, proto3Decode(blob, encoding, result)
 }
 
+func WorkflowMutableStateToBlob(info *persistencespb.WorkflowMutableState) (commonpb.DataBlob, error) {
+	return proto3Encode(info)
+}
+
+func WorkflowMutableStateFromBlob(blob []byte, encoding string) (*persistencespb.WorkflowMutableState, error) {
+	result := &persistencespb.WorkflowMutableState{}
+	return result, proto3Decode(blob, encoding, result)
+}
+
 func HistoryTreeInfoToBlob(info *persistencespb.HistoryTreeInfo) (commonpb.DataBlob, error) {
 	return proto3Encode(info)
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1078,7 +1078,7 @@ func (e *historyEngineImpl) DescribeMutableState(
 
 	if cacheHit && cacheCtx.(*workflowExecutionContextImpl).mutableState != nil {
 		msb := cacheCtx.(*workflowExecutionContextImpl).mutableState
-		response.CacheMutableState, err = msb.Clone()
+		response.CacheMutableState, err = msb.CloneProto()
 		if err != nil {
 			return nil, err
 		}
@@ -1089,7 +1089,7 @@ func (e *historyEngineImpl) DescribeMutableState(
 		return nil, err
 	}
 
-	response.DatabaseMutableState, err = msb.Clone()
+	response.DatabaseMutableState, err = msb.CloneProto()
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1078,7 +1078,10 @@ func (e *historyEngineImpl) DescribeMutableState(
 
 	if cacheHit && cacheCtx.(*workflowExecutionContextImpl).mutableState != nil {
 		msb := cacheCtx.(*workflowExecutionContextImpl).mutableState
-		response.CacheMutableState = msb.ToProto()
+		response.CacheMutableState, err = msb.Clone()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	msb, err := dbCtx.loadWorkflowExecution()
@@ -1086,7 +1089,10 @@ func (e *historyEngineImpl) DescribeMutableState(
 		return nil, err
 	}
 
-	response.DatabaseMutableState = msb.ToProto()
+	response.DatabaseMutableState, err = msb.Clone()
+	if err != nil {
+		return nil, err
+	}
 	return response, nil
 }
 

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -114,7 +114,7 @@ type (
 		AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *commonpb.Payloads, identity string) (*historypb.HistoryEvent, error)
 		ClearStickyness()
 		CheckResettable() error
-		ToProto() *persistencespb.WorkflowMutableState
+		Clone() (*persistencespb.WorkflowMutableState, error)
 		RetryActivity(ai *persistencespb.ActivityInfo, failure *failurepb.Failure) (enumspb.RetryState, error)
 		CreateNewHistoryEvent(eventType enumspb.EventType) *historypb.HistoryEvent
 		CreateNewHistoryEventWithTime(eventType enumspb.EventType, time time.Time) *historypb.HistoryEvent

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -114,7 +114,7 @@ type (
 		AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *commonpb.Payloads, identity string) (*historypb.HistoryEvent, error)
 		ClearStickyness()
 		CheckResettable() error
-		Clone() (*persistencespb.WorkflowMutableState, error)
+		CloneProto() (*persistencespb.WorkflowMutableState, error)
 		RetryActivity(ai *persistencespb.ActivityInfo, failure *failurepb.Failure) (enumspb.RetryState, error)
 		CreateNewHistoryEvent(eventType enumspb.EventType) *historypb.HistoryEvent
 		CreateNewHistoryEventWithTime(eventType enumspb.EventType, time time.Time) *historypb.HistoryEvent

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -268,7 +268,7 @@ func newMutableStateBuilderWithVersionHistories(
 	return s
 }
 
-func (e *mutableStateBuilder) Clone() (*persistencespb.WorkflowMutableState, error) {
+func (e *mutableStateBuilder) CloneProto() (*persistencespb.WorkflowMutableState, error) {
 	ms := &persistencespb.WorkflowMutableState{
 		ActivityInfos:       e.pendingActivityInfoIDs,
 		TimerInfos:          e.pendingTimerInfoIDs,

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -56,6 +56,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
@@ -267,8 +268,8 @@ func newMutableStateBuilderWithVersionHistories(
 	return s
 }
 
-func (e *mutableStateBuilder) ToProto() *persistencespb.WorkflowMutableState {
-	return &persistencespb.WorkflowMutableState{
+func (e *mutableStateBuilder) Clone() (*persistencespb.WorkflowMutableState, error) {
+	ms := &persistencespb.WorkflowMutableState{
 		ActivityInfos:       e.pendingActivityInfoIDs,
 		TimerInfos:          e.pendingTimerInfoIDs,
 		ChildExecutionInfos: e.pendingChildExecutionInfoIDs,
@@ -281,6 +282,12 @@ func (e *mutableStateBuilder) ToProto() *persistencespb.WorkflowMutableState {
 		BufferedEvents:      e.bufferedEvents,
 		Checksum:            e.checksum,
 	}
+
+	blob, err := serialization.WorkflowMutableStateToBlob(ms)
+	if err != nil {
+		return nil, err
+	}
+	return serialization.WorkflowMutableStateFromBlob(blob.Data, blob.String())
 }
 
 func (e *mutableStateBuilder) Load(

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -40,6 +40,7 @@ import (
 	history "go.temporal.io/api/history/v1"
 	taskqueue "go.temporal.io/api/taskqueue/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
+
 	enums0 "go.temporal.io/server/api/enums/v1"
 	historyservice "go.temporal.io/server/api/historyservice/v1"
 	persistence "go.temporal.io/server/api/persistence/v1"
@@ -810,9 +811,9 @@ func (mr *MockmutableStateMockRecorder) ClearStickyness() *gomock.Call {
 }
 
 // Clone mocks base method.
-func (m *MockmutableState) Clone() (*persistence.WorkflowMutableState, error) {
+func (m *MockmutableState) CloneProto() (*persistence.WorkflowMutableState, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clone")
+	ret := m.ctrl.Call(m, "CloneProto")
 	ret0, _ := ret[0].(*persistence.WorkflowMutableState)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
@@ -821,7 +822,7 @@ func (m *MockmutableState) Clone() (*persistence.WorkflowMutableState, error) {
 // Clone indicates an expected call of Clone.
 func (mr *MockmutableStateMockRecorder) Clone() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockmutableState)(nil).Clone))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloneProto", reflect.TypeOf((*MockmutableState)(nil).CloneProto))
 }
 
 // CloseTransactionAsMutation mocks base method.

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -809,6 +809,21 @@ func (mr *MockmutableStateMockRecorder) ClearStickyness() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearStickyness", reflect.TypeOf((*MockmutableState)(nil).ClearStickyness))
 }
 
+// Clone mocks base method.
+func (m *MockmutableState) Clone() (*persistence.WorkflowMutableState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Clone")
+	ret0, _ := ret[0].(*persistence.WorkflowMutableState)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Clone indicates an expected call of Clone.
+func (mr *MockmutableStateMockRecorder) Clone() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clone", reflect.TypeOf((*MockmutableState)(nil).Clone))
+}
+
 // CloseTransactionAsMutation mocks base method.
 func (m *MockmutableState) CloseTransactionAsMutation(now time.Time, transactionPolicy transactionPolicy) (*persistence0.WorkflowMutation, []*persistence0.WorkflowEvents, error) {
 	m.ctrl.T.Helper()
@@ -2328,20 +2343,6 @@ func (m *MockmutableState) StartTransactionSkipWorkflowTaskFail(entry *cache.Nam
 func (mr *MockmutableStateMockRecorder) StartTransactionSkipWorkflowTaskFail(entry interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartTransactionSkipWorkflowTaskFail", reflect.TypeOf((*MockmutableState)(nil).StartTransactionSkipWorkflowTaskFail), entry)
-}
-
-// ToProto mocks base method.
-func (m *MockmutableState) ToProto() *persistence.WorkflowMutableState {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ToProto")
-	ret0, _ := ret[0].(*persistence.WorkflowMutableState)
-	return ret0
-}
-
-// ToProto indicates an expected call of ToProto.
-func (mr *MockmutableStateMockRecorder) ToProto() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ToProto", reflect.TypeOf((*MockmutableState)(nil).ToProto))
 }
 
 // UpdateActivity mocks base method.

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -40,7 +40,6 @@ import (
 	history "go.temporal.io/api/history/v1"
 	taskqueue "go.temporal.io/api/taskqueue/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
-
 	enums0 "go.temporal.io/server/api/enums/v1"
 	historyservice "go.temporal.io/server/api/historyservice/v1"
 	persistence "go.temporal.io/server/api/persistence/v1"
@@ -810,7 +809,7 @@ func (mr *MockmutableStateMockRecorder) ClearStickyness() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearStickyness", reflect.TypeOf((*MockmutableState)(nil).ClearStickyness))
 }
 
-// Clone mocks base method.
+// CloneProto mocks base method.
 func (m *MockmutableState) CloneProto() (*persistence.WorkflowMutableState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CloneProto")
@@ -819,8 +818,8 @@ func (m *MockmutableState) CloneProto() (*persistence.WorkflowMutableState, erro
 	return ret0, ret1
 }
 
-// Clone indicates an expected call of Clone.
-func (mr *MockmutableStateMockRecorder) Clone() *gomock.Call {
+// CloneProto indicates an expected call of CloneProto.
+func (mr *MockmutableStateMockRecorder) CloneProto() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloneProto", reflect.TypeOf((*MockmutableState)(nil).CloneProto))
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Rename mutable state `ToProto` function to `CloneProto`
* Make `CloneProto` function do deep copy of mutable state

<!-- Tell your future self why have you made these changes -->
**Why?**
`ToProto` function was doing shallow copy of mutable state, which means pointer to mutable state is still valid after mutable state lock is released.
Ref:
https://github.com/temporalio/temporal/blob/v1.7.0/service/history/mutableStateBuilder.go#L270-L284
https://github.com/temporalio/temporal/blob/v1.7.0/service/history/historyEngine.go#L1076
https://github.com/temporalio/temporal/blob/v1.7.0/service/history/historyEngine.go#L1084

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
See why

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No