### PR TITLE
Fix pip installer download path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN apk add --update --no-cache \
     mysql-client \
     postgresql-client \
     python2 \
-    && curl https://bootstrap.pypa.io/2.7/get-pip.py | python \
+    && curl https://bootstrap.pypa.io/pip/2.7/get-pip.py | python \
     && pip install cqlsh
 
 ENV TEMPORAL_HOME /etc/temporal


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix pip installer download path.

<!-- Tell your future self why have you made these changes -->
**Why?**
`pip` download path was changed on Python side and it broke Temporal `docker build`:
```
The URL you are using to fetch this script has changed, and this one will no
longer work. Please use get-pip.py from the following URL instead:

    https://bootstrap.pypa.io/pip/2.7/get-pip.py

Sorry if this change causes any inconvenience for you!
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Build image locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.