### PR TITLE
Use proto.Clone instead of custom serializer

### DIFF
--- a/common/persistence/serialization/blob.go
+++ b/common/persistence/serialization/blob.go
@@ -82,15 +82,6 @@ func NamespaceDetailFromBlob(blob []byte, encoding string) (*persistencespb.Name
 	return result, proto3Decode(blob, encoding, result)
 }
 
-func WorkflowMutableStateToBlob(info *persistencespb.WorkflowMutableState) (commonpb.DataBlob, error) {
-	return proto3Encode(info)
-}
-
-func WorkflowMutableStateFromBlob(blob []byte, encoding string) (*persistencespb.WorkflowMutableState, error) {
-	result := &persistencespb.WorkflowMutableState{}
-	return result, proto3Decode(blob, encoding, result)
-}
-
 func HistoryTreeInfoToBlob(info *persistencespb.HistoryTreeInfo) (commonpb.DataBlob, error) {
 	return proto3Encode(info)
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1078,10 +1078,7 @@ func (e *historyEngineImpl) DescribeMutableState(
 
 	if cacheHit && cacheCtx.(*workflowExecutionContextImpl).mutableState != nil {
 		msb := cacheCtx.(*workflowExecutionContextImpl).mutableState
-		response.CacheMutableState, err = msb.CloneProto()
-		if err != nil {
-			return nil, err
-		}
+		response.CacheMutableState = msb.CloneToProto()
 	}
 
 	msb, err := dbCtx.loadWorkflowExecution()
@@ -1089,10 +1086,7 @@ func (e *historyEngineImpl) DescribeMutableState(
 		return nil, err
 	}
 
-	response.DatabaseMutableState, err = msb.CloneProto()
-	if err != nil {
-		return nil, err
-	}
+	response.DatabaseMutableState = msb.CloneToProto()
 	return response, nil
 }
 

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -114,7 +114,7 @@ type (
 		AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details *commonpb.Payloads, identity string) (*historypb.HistoryEvent, error)
 		ClearStickyness()
 		CheckResettable() error
-		CloneProto() (*persistencespb.WorkflowMutableState, error)
+		CloneToProto() *persistencespb.WorkflowMutableState
 		RetryActivity(ai *persistencespb.ActivityInfo, failure *failurepb.Failure) (enumspb.RetryState, error)
 		CreateNewHistoryEvent(eventType enumspb.EventType) *historypb.HistoryEvent
 		CreateNewHistoryEventWithTime(eventType enumspb.EventType, time time.Time) *historypb.HistoryEvent

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -29,6 +29,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/pborman/uuid"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
@@ -56,7 +57,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
@@ -268,7 +268,7 @@ func newMutableStateBuilderWithVersionHistories(
 	return s
 }
 
-func (e *mutableStateBuilder) CloneProto() (*persistencespb.WorkflowMutableState, error) {
+func (e *mutableStateBuilder) CloneToProto() *persistencespb.WorkflowMutableState {
 	ms := &persistencespb.WorkflowMutableState{
 		ActivityInfos:       e.pendingActivityInfoIDs,
 		TimerInfos:          e.pendingTimerInfoIDs,
@@ -283,11 +283,7 @@ func (e *mutableStateBuilder) CloneProto() (*persistencespb.WorkflowMutableState
 		Checksum:            e.checksum,
 	}
 
-	blob, err := serialization.WorkflowMutableStateToBlob(ms)
-	if err != nil {
-		return nil, err
-	}
-	return serialization.WorkflowMutableStateFromBlob(blob.Data, blob.String())
+	return proto.Clone(ms).(*persistencespb.WorkflowMutableState)
 }
 
 func (e *mutableStateBuilder) Load(

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -809,19 +809,18 @@ func (mr *MockmutableStateMockRecorder) ClearStickyness() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClearStickyness", reflect.TypeOf((*MockmutableState)(nil).ClearStickyness))
 }
 
-// CloneProto mocks base method.
-func (m *MockmutableState) CloneProto() (*persistence.WorkflowMutableState, error) {
+// CloneToProto mocks base method.
+func (m *MockmutableState) CloneToProto() *persistence.WorkflowMutableState {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CloneProto")
+	ret := m.ctrl.Call(m, "CloneToProto")
 	ret0, _ := ret[0].(*persistence.WorkflowMutableState)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
-// CloneProto indicates an expected call of CloneProto.
-func (mr *MockmutableStateMockRecorder) CloneProto() *gomock.Call {
+// CloneToProto indicates an expected call of CloneToProto.
+func (mr *MockmutableStateMockRecorder) CloneToProto() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloneProto", reflect.TypeOf((*MockmutableState)(nil).CloneProto))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloneToProto", reflect.TypeOf((*MockmutableState)(nil).CloneToProto))
 }
 
 // CloseTransactionAsMutation mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use `proto.Clone` instead of custom serializer.

<!-- Tell your future self why have you made these changes -->
**Why?**
Recently potential data race was fixed in #1360. This PR slightly simply the fix by leavereging pregenerated `proto.Clone()` func.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.