### PR TITLE
Cleanup metrics interface.

### DIFF
--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -64,6 +64,7 @@ type (
 		mockAuthorizer      *MockAuthorizer
 		mockMetricsClient   *metrics.MockClient
 		mockMetricsScope    *metrics.MockScope
+		mockStopwatch       *metrics.MockStopwatch
 		interceptor         grpc.UnaryServerInterceptor
 		handler             grpc.UnaryHandler
 		mockClaimMapper     *MockClaimMapper
@@ -83,9 +84,11 @@ func (s *authorizerInterceptorSuite) SetupTest() {
 	s.mockAuthorizer = NewMockAuthorizer(s.controller)
 	s.mockMetricsScope = metrics.NewMockScope(s.controller)
 	s.mockMetricsClient = metrics.NewMockClient(s.controller)
+	s.mockStopwatch = metrics.NewMockStopwatch(s.controller)
+	s.mockStopwatch.EXPECT().Stop().AnyTimes()
 	s.mockMetricsClient.EXPECT().Scope(metrics.AuthorizationScope).Return(s.mockMetricsScope)
 	s.mockMetricsScope.EXPECT().Tagged(metrics.NamespaceTag(testNamespace)).Return(s.mockMetricsScope)
-	s.mockMetricsScope.EXPECT().StartTimer(metrics.ServiceAuthorizationLatency).Return(metrics.Stopwatch{})
+	s.mockMetricsScope.EXPECT().StartTimer(metrics.ServiceAuthorizationLatency).Return(s.mockStopwatch)
 	s.mockClaimMapper = NewMockClaimMapper(s.controller)
 	s.interceptor = NewAuthorizationInterceptor(
 		s.mockClaimMapper,

--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -16,7 +16,7 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
@@ -32,10 +32,6 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/primitives"
-)
-
-const (
-	distributionToTimerRatio = int(time.Millisecond / time.Nanosecond)
 )
 
 // ClientImpl is used for reporting metrics by various Temporal services
@@ -97,9 +93,10 @@ func (m *ClientImpl) AddCounter(scopeIdx int, counterIdx int, delta int64) {
 
 // StartTimer starts a timer for the given
 // metric name
-func (m *ClientImpl) StartTimer(scopeIdx int, timerIdx int) tally.Stopwatch {
+func (m *ClientImpl) StartTimer(scopeIdx int, timerIdx int) Stopwatch {
 	name := string(m.metricDefs[timerIdx].metricName)
-	return m.childScopes[scopeIdx].Timer(name).Start()
+	timer := m.childScopes[scopeIdx].Timer(name)
+	return NewStopwatch(timer)
 }
 
 // RecordTimer record and emit a timer for the given
@@ -128,25 +125,6 @@ func (m *ClientImpl) UpdateGauge(scopeIdx int, gaugeIdx int, value float64) {
 func (m *ClientImpl) Scope(scopeIdx int, tags ...Tag) Scope {
 	scope := m.childScopes[scopeIdx]
 	return newMetricsScope(scope, scope, m.metricDefs, false).Tagged(tags...)
-}
-
-func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {
-	defs := make(map[int]metricDefinition)
-	for idx, def := range MetricDefs[Common] {
-		defs[idx] = def
-	}
-
-	for idx, def := range MetricDefs[serviceIdx] {
-		defs[idx] = def
-	}
-
-	return defs
-}
-
-func mergeMapToRight(src map[string]string, dest map[string]string) {
-	for k, v := range src {
-		dest[k] = v
-	}
 }
 
 // GetMetricsServiceIdx returns the metrics name

--- a/common/metrics/common.go
+++ b/common/metrics/common.go
@@ -24,37 +24,27 @@
 
 package metrics
 
-import (
-	"time"
+import "time"
 
-	"github.com/uber-go/tally"
+const (
+	distributionToTimerRatio = int(time.Millisecond / time.Nanosecond)
 )
 
-type (
-	NoopMetricsClient struct{}
-)
-
-func NewNoopMetricsClient() *NoopMetricsClient {
-	return &NoopMetricsClient{}
-}
-
-func (m NoopMetricsClient) IncCounter(scope int, counter int) {}
-
-func (m NoopMetricsClient) AddCounter(scope int, counter int, delta int64) {}
-
-func (m NoopMetricsClient) StartTimer(scope int, timer int) Stopwatch {
-	return NopStopwatch()
-}
-
-func (m NoopMetricsClient) RecordTimer(scope int, timer int, d time.Duration) {}
-
-func (m NoopMetricsClient) RecordDistribution(scope int, timer int, d int) {}
-
-func (m NoopMetricsClient) UpdateGauge(scope int, gauge int, value float64) {}
-
-func (m NoopMetricsClient) Scope(scope int, tags ...Tag) Scope {
-	return &metricsScope{
-		scope:     tally.NoopScope,
-		rootScope: tally.NoopScope,
+func mergeMapToRight(src map[string]string, dest map[string]string) {
+	for k, v := range src {
+		dest[k] = v
 	}
+}
+
+func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {
+	defs := make(map[int]metricDefinition)
+	for idx, def := range MetricDefs[Common] {
+		defs[idx] = def
+	}
+
+	for idx, def := range MetricDefs[serviceIdx] {
+		defs[idx] = def
+	}
+
+	return defs
 }

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package config
+package metrics
 
 import (
 	"time"
@@ -30,6 +30,7 @@ import (
 	"github.com/cactus/go-statsd-client/statsd"
 	prom "github.com/m3db/prometheus_client_golang/prometheus"
 	"github.com/uber-go/tally"
+	"github.com/uber-go/tally/m3"
 	"github.com/uber-go/tally/prometheus"
 	tallystatsdreporter "github.com/uber-go/tally/statsd"
 
@@ -37,6 +38,49 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	statsdreporter "go.temporal.io/server/common/metrics/tally/statsd"
 )
+
+type (
+	// Metrics contains the config items for metrics subsystem
+	Metrics struct {
+		// M3 is the configuration for m3 metrics reporter
+		M3 *m3.Configuration `yaml:"m3"`
+		// Statsd is the configuration for statsd reporter
+		Statsd *Statsd `yaml:"statsd"`
+		// Prometheus is the configuration for prometheus reporter
+		Prometheus *prometheus.Configuration `yaml:"prometheus"`
+		// Config for Opentelemetery Prometheus metrics
+		OTPrometheus *PrometheusConfig `yaml:"otprometheus"`
+		// Tags is the set of key-value pairs to be reported as part of every metric
+		Tags map[string]string `yaml:"tags"`
+
+		// Prefix sets the prefix to all outgoing metrics
+		Prefix string `yaml:"prefix"`
+	}
+
+	// Statsd contains the config items for statsd metrics reporter
+	Statsd struct {
+		// The host and port of the statsd server
+		HostPort string `yaml:"hostPort" validate:"nonzero"`
+		// The prefix to use in reporting to statsd
+		Prefix string `yaml:"prefix" validate:"nonzero"`
+		// FlushInterval is the maximum interval for sending packets.
+		// If it is not specified, it defaults to 1 second.
+		FlushInterval time.Duration `yaml:"flushInterval"`
+		// FlushBytes specifies the maximum udp packet size you wish to send.
+		// If FlushBytes is unspecified, it defaults  to 1432 bytes, which is
+		// considered safe for local traffic.
+		FlushBytes int `yaml:"flushBytes"`
+	}
+
+	PrometheusConfig struct {
+		// Address for prometheus to serve metrics from.
+		ListenAddress string `yaml:"listenAddress"`
+		// DefaultHistogramBoundaries defines the default histogram bucket
+		// boundaries.
+		DefaultHistogramBoundaries []float64 `yaml:"defaultHistogramBoundaries"`
+	}
+)
+
 
 const (
 	ms = float64(time.Millisecond) / float64(time.Second)

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -45,7 +45,7 @@ type (
 		// M3 is the configuration for m3 metrics reporter
 		M3 *m3.Configuration `yaml:"m3"`
 		// Statsd is the configuration for statsd reporter
-		Statsd *Statsd `yaml:"statsd"`
+		Statsd *StatsdConfig `yaml:"statsd"`
 		// Prometheus is the configuration for prometheus reporter
 		Prometheus *prometheus.Configuration `yaml:"prometheus"`
 		// Config for Opentelemetery Prometheus metrics
@@ -57,8 +57,8 @@ type (
 		Prefix string `yaml:"prefix"`
 	}
 
-	// Statsd contains the config items for statsd metrics reporter
-	Statsd struct {
+	// StatsdConfig contains the config items for statsd metrics reporter
+	StatsdConfig struct {
 		// The host and port of the statsd server
 		HostPort string `yaml:"hostPort" validate:"nonzero"`
 		// The prefix to use in reporting to statsd

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -81,7 +81,6 @@ type (
 	}
 )
 
-
 const (
 	ms = float64(time.Millisecond) / float64(time.Second)
 )

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -40,8 +40,8 @@ import (
 )
 
 type (
-	// Metrics contains the config items for metrics subsystem
-	Metrics struct {
+	// Config contains the config items for metrics subsystem
+	Config struct {
 		// M3 is the configuration for m3 metrics reporter
 		M3 *m3.Configuration `yaml:"m3"`
 		// Statsd is the configuration for statsd reporter
@@ -141,7 +141,7 @@ var (
 //
 // Current priority order is:
 // m3 > statsd > prometheus
-func (c *Metrics) NewScope(logger log.Logger) tally.Scope {
+func (c *Config) NewScope(logger log.Logger) tally.Scope {
 	if c.M3 != nil {
 		return c.newM3Scope(logger)
 	}
@@ -154,7 +154,7 @@ func (c *Metrics) NewScope(logger log.Logger) tally.Scope {
 	return tally.NoopScope
 }
 
-func (c *Metrics) NewCustomReporterScope(logger log.Logger, customReporter tally.BaseStatsReporter) tally.Scope {
+func (c *Config) NewCustomReporterScope(logger log.Logger, customReporter tally.BaseStatsReporter) tally.Scope {
 	options := tally.ScopeOptions{
 		DefaultBuckets: defaultHistogramBuckets,
 	}
@@ -178,7 +178,7 @@ func (c *Metrics) NewCustomReporterScope(logger log.Logger, customReporter tally
 
 // newM3Scope returns a new m3 scope with
 // a default reporting interval of a second
-func (c *Metrics) newM3Scope(logger log.Logger) tally.Scope {
+func (c *Config) newM3Scope(logger log.Logger) tally.Scope {
 	reporter, err := c.M3.NewReporter()
 	if err != nil {
 		logger.Fatal("error creating m3 reporter", tag.Error(err))
@@ -195,7 +195,7 @@ func (c *Metrics) newM3Scope(logger log.Logger) tally.Scope {
 
 // newM3Scope returns a new statsd scope with
 // a default reporting interval of a second
-func (c *Metrics) newStatsdScope(logger log.Logger) tally.Scope {
+func (c *Config) newStatsdScope(logger log.Logger) tally.Scope {
 	config := c.Statsd
 	if len(config.HostPort) == 0 {
 		return tally.NoopScope
@@ -219,7 +219,7 @@ func (c *Metrics) newStatsdScope(logger log.Logger) tally.Scope {
 
 // newPrometheusScope returns a new prometheus scope with
 // a default reporting interval of a second
-func (c *Metrics) newPrometheusScope(logger log.Logger) tally.Scope {
+func (c *Config) newPrometheusScope(logger log.Logger) tally.Scope {
 	if len(c.Prometheus.DefaultHistogramBuckets) == 0 {
 		for _, value := range defaultHistogramBuckets {
 			c.Prometheus.DefaultHistogramBuckets = append(

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -93,7 +93,7 @@ func (s *MetricsSuite) TestStatsd() {
 		Prefix:   "testStatsd",
 	}
 
-	config := new(Metrics)
+	config := new(Config)
 	config.Statsd = statsd
 	scope := config.NewScope(loggerimpl.NewNopLogger())
 	s.NotNil(scope)
@@ -105,7 +105,7 @@ func (s *MetricsSuite) TestM3() {
 		Service:  "testM3",
 		Env:      "devel",
 	}
-	config := new(Metrics)
+	config := new(Config)
 	config.M3 = m3
 	scope := config.NewScope(loggerimpl.NewNopLogger())
 	s.NotNil(scope)
@@ -117,34 +117,34 @@ func (s *MetricsSuite) TestPrometheus() {
 		TimerType:     "histogram",
 		ListenAddress: "127.0.0.1:0",
 	}
-	config := new(Metrics)
+	config := new(Config)
 	config.Prometheus = prom
 	scope := config.NewScope(loggerimpl.NewNopLogger())
 	s.NotNil(scope)
 }
 
 func (s *MetricsSuite) TestNoop() {
-	config := &Metrics{}
+	config := &Config{}
 	scope := config.NewScope(loggerimpl.NewNopLogger())
 	s.Equal(tally.NoopScope, scope)
 }
 
 func (s *MetricsSuite) TestCustomReporter() {
-	config := &Metrics{}
+	config := &Config{}
 	scope := config.NewCustomReporterScope(loggerimpl.NewNopLogger(), tally.NullStatsReporter)
 	s.NotNil(scope)
 	s.NotEqual(tally.NoopScope, scope)
 }
 
 func (s *MetricsSuite) TestCustomCachedReporter() {
-	config := &Metrics{}
+	config := &Config{}
 	scope := config.NewCustomReporterScope(loggerimpl.NewNopLogger(), CachedNullStatsReporter)
 	s.NotNil(scope)
 	s.NotEqual(tally.NoopScope, scope)
 }
 
 func (s *MetricsSuite) TestUnsupportedReporter() {
-	config := &Metrics{}
+	config := &Config{}
 	scope := config.NewCustomReporterScope(loggerimpl.NewNopLogger(), UnsupportedNullStatsReporter)
 	s.Equal(tally.NoopScope, scope)
 }

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -88,7 +88,7 @@ func (s *MetricsSuite) SetupTest() {
 }
 
 func (s *MetricsSuite) TestStatsd() {
-	statsd := &Statsd{
+	statsd := &StatsdConfig{
 		HostPort: "127.0.0.1:8125",
 		Prefix:   "testStatsd",
 	}

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package config
+package metrics
 
 import (
 	"testing"

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -33,6 +33,13 @@ import (
 )
 
 type (
+	// Stopwatch is a helper for simpler tracking of elapsed time, use the
+	// Stop() method to report time elapsed since its created back to the
+	// timer or histogram.
+	Stopwatch interface {
+		Stop()
+	}
+
 	// Client is the interface used to report metrics tally.
 	Client interface {
 		// IncCounter increments a counter metric
@@ -41,7 +48,7 @@ type (
 		AddCounter(scope int, counter int, delta int64)
 		// StartTimer starts a timer for the given
 		// metric name. Time will be recorded when stopwatch is stopped.
-		StartTimer(scope int, timer int) tally.Stopwatch
+		StartTimer(scope int, timer int) Stopwatch
 		// RecordTimer starts a timer for the given
 		// metric name
 		RecordTimer(scope int, timer int, d time.Duration)

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -33,7 +33,7 @@ import (
 )
 
 type (
-	// Stopwatch is a helper for simpler tracking of elapsed time, use the
+	// Stopwatch is an interface tracking of elapsed time, use the
 	// Stop() method to report time elapsed since its created back to the
 	// timer or histogram.
 	Stopwatch interface {

--- a/common/metrics/interfaces_mock.go
+++ b/common/metrics/interfaces_mock.go
@@ -33,8 +33,42 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	tally "github.com/uber-go/tally"
 )
+
+// MockStopwatch is a mock of Stopwatch interface.
+type MockStopwatch struct {
+	ctrl     *gomock.Controller
+	recorder *MockStopwatchMockRecorder
+}
+
+// MockStopwatchMockRecorder is the mock recorder for MockStopwatch.
+type MockStopwatchMockRecorder struct {
+	mock *MockStopwatch
+}
+
+// NewMockStopwatch creates a new mock instance.
+func NewMockStopwatch(ctrl *gomock.Controller) *MockStopwatch {
+	mock := &MockStopwatch{ctrl: ctrl}
+	mock.recorder = &MockStopwatchMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockStopwatch) EXPECT() *MockStopwatchMockRecorder {
+	return m.recorder
+}
+
+// Stop mocks base method.
+func (m *MockStopwatch) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockStopwatchMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockStopwatch)(nil).Stop))
+}
 
 // MockClient is a mock of Client interface.
 type MockClient struct {
@@ -127,10 +161,10 @@ func (mr *MockClientMockRecorder) Scope(scope interface{}, tags ...interface{}) 
 }
 
 // StartTimer mocks base method.
-func (m *MockClient) StartTimer(scope, timer int) tally.Stopwatch {
+func (m *MockClient) StartTimer(scope, timer int) Stopwatch {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartTimer", scope, timer)
-	ret0, _ := ret[0].(tally.Stopwatch)
+	ret0, _ := ret[0].(Stopwatch)
 	return ret0
 }
 

--- a/common/metrics/nop.go
+++ b/common/metrics/nop.go
@@ -36,6 +36,6 @@ type nopStopwatchRecorder struct{}
 func (n *nopStopwatchRecorder) RecordStopwatch(stopwatchStart time.Time) {}
 
 // NopStopwatch return a fake tally stop watch
-func NopStopwatch() tally.Stopwatch {
+func NopStopwatch() Stopwatch {
 	return tally.NewStopwatch(time.Now().UTC(), &nopStopwatchRecorder{})
 }

--- a/common/metrics/stopwatch.go
+++ b/common/metrics/stopwatch.go
@@ -50,7 +50,7 @@ func NewTestStopwatch() Stopwatch {
 }
 
 // Stop reports time elapsed since the stopwatch start to the recorder.
-func (sw* TallyStopwatch) Stop() {
+func (sw *TallyStopwatch) Stop() {
 	d := time.Since(sw.start)
 	for _, timer := range sw.timers {
 		timer.Record(d)

--- a/common/metrics/stopwatch.go
+++ b/common/metrics/stopwatch.go
@@ -33,7 +33,7 @@ import (
 // Stopwatch is a helper for simpler tracking of elapsed time, use the
 // Stop() method to report time elapsed since its created back to the
 // timer or histogram.
-type Stopwatch struct {
+type TallyStopwatch struct {
 	start  time.Time
 	timers []tally.Timer
 }
@@ -41,16 +41,16 @@ type Stopwatch struct {
 // NewStopwatch creates a new immutable stopwatch for recording the start
 // time to a stopwatch reporter.
 func NewStopwatch(timers ...tally.Timer) Stopwatch {
-	return Stopwatch{time.Now().UTC(), timers}
+	return &TallyStopwatch{time.Now().UTC(), timers}
 }
 
 // NewTestStopwatch returns a new test stopwatch
 func NewTestStopwatch() Stopwatch {
-	return Stopwatch{time.Now().UTC(), []tally.Timer{}}
+	return &TallyStopwatch{time.Now().UTC(), []tally.Timer{}}
 }
 
 // Stop reports time elapsed since the stopwatch start to the recorder.
-func (sw Stopwatch) Stop() {
+func (sw* TallyStopwatch) Stop() {
 	d := time.Since(sw.start)
 	for _, timer := range sw.timers {
 		timer.Record(d)

--- a/common/persistence/elasticsearch/processor_test.go
+++ b/common/persistence/elasticsearch/processor_test.go
@@ -56,9 +56,9 @@ type processorSuite struct {
 }
 
 var (
-	testID        = "test-doc-id"
-	testScope     = metrics.ElasticSearchVisibility
-	testMetric    = metrics.ESBulkProcessorRequestLatency
+	testID     = "test-doc-id"
+	testScope  = metrics.ElasticSearchVisibility
+	testMetric = metrics.ESBulkProcessorRequestLatency
 )
 
 func TestElasticsearchProcessorSuite(t *testing.T) {

--- a/common/persistence/elasticsearch/processor_test.go
+++ b/common/persistence/elasticsearch/processor_test.go
@@ -52,11 +52,11 @@ type processorSuite struct {
 	mockBulkProcessor *client.MockBulkProcessor
 	mockMetricClient  *metrics.MockClient
 	mockESClient      *client.MockClient
+	mockStopwatch     *metrics.MockStopwatch
 }
 
 var (
 	testID        = "test-doc-id"
-	testStopWatch = metrics.NopStopwatch()
 	testScope     = metrics.ElasticSearchVisibility
 	testMetric    = metrics.ESBulkProcessorRequestLatency
 )
@@ -84,6 +84,7 @@ func (s *processorSuite) SetupTest() {
 	}
 
 	s.mockMetricClient = metrics.NewMockClient(s.controller)
+	s.mockStopwatch = metrics.NewMockStopwatch(s.controller)
 	s.mockBulkProcessor = client.NewMockBulkProcessor(s.controller)
 	s.mockESClient = client.NewMockClient(s.controller)
 	s.esProcessor = NewProcessor(cfg, s.mockESClient, loggerimpl.NewLogger(zapLogger), s.mockMetricClient)
@@ -139,8 +140,9 @@ func (s *processorSuite) TestAdd() {
 	ackCh := make(chan bool, 1)
 	s.Equal(0, s.esProcessor.mapToAckChan.Len())
 
+	s.mockStopwatch.EXPECT().Stop()
 	s.mockBulkProcessor.EXPECT().Add(request)
-	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(testStopWatch)
+	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(s.mockStopwatch)
 
 	s.esProcessor.Add(request, visibilityTaskKey, ackCh)
 	s.Equal(1, s.esProcessor.mapToAckChan.Len())
@@ -151,7 +153,7 @@ func (s *processorSuite) TestAdd() {
 	}
 
 	// handle duplicate
-	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(testStopWatch)
+	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(s.mockStopwatch)
 	s.esProcessor.Add(request, visibilityTaskKey, ackCh)
 	s.Equal(1, s.esProcessor.mapToAckChan.Len())
 	select {
@@ -167,7 +169,8 @@ func (s *processorSuite) TestAdd_ConcurrentAdd() {
 	key := "test-key"
 	duplicates := 100
 	ackCh := make(chan bool, duplicates-1)
-	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(testStopWatch).Times(duplicates)
+	s.mockStopwatch.EXPECT().Stop().AnyTimes()
+	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(s.mockStopwatch).Times(duplicates)
 
 	addFunc := func(wg *sync.WaitGroup) {
 		s.esProcessor.Add(request, key, ackCh)
@@ -216,7 +219,8 @@ func (s *processorSuite) TestBulkAfterAction_Ack() {
 	}
 
 	ackCh := make(chan bool, 1)
-	mapVal := newAckChanWithStopwatch(ackCh, &testStopWatch)
+	s.mockStopwatch.EXPECT().Stop()
+	mapVal := newAckChanWithStopwatch(ackCh, s.mockStopwatch)
 	s.esProcessor.mapToAckChan.Put(testKey, mapVal)
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
 	select {
@@ -262,7 +266,8 @@ func (s *processorSuite) TestBulkAfterAction_Nack() {
 	}
 
 	ackCh := make(chan bool, 1)
-	mapVal := newAckChanWithStopwatch(ackCh, &testStopWatch)
+	s.mockStopwatch.EXPECT().Stop()
+	mapVal := newAckChanWithStopwatch(ackCh, s.mockStopwatch)
 	s.esProcessor.mapToAckChan.Put(testKey, mapVal)
 	s.mockMetricClient.EXPECT().IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorFailures)
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
@@ -311,7 +316,8 @@ func (s *processorSuite) TestAckChan() {
 	s.esProcessor.sendToAckChan(key, true)
 
 	request := &client.BulkableRequest{}
-	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(testStopWatch)
+	s.mockStopwatch.EXPECT().Stop()
+	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(s.mockStopwatch)
 	s.mockBulkProcessor.EXPECT().Add(request)
 	ackCh := make(chan bool, 1)
 	s.esProcessor.Add(request, key, ackCh)
@@ -334,7 +340,8 @@ func (s *processorSuite) TestNackChan() {
 
 	request := &client.BulkableRequest{}
 	s.mockBulkProcessor.EXPECT().Add(request)
-	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(testStopWatch)
+	s.mockStopwatch.EXPECT().Stop()
+	s.mockMetricClient.EXPECT().StartTimer(testScope, testMetric).Return(s.mockStopwatch)
 	ackCh := make(chan bool, 1)
 	s.esProcessor.Add(request, key, ackCh)
 	s.Equal(1, s.esProcessor.mapToAckChan.Len())

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -67,7 +67,7 @@ type (
 		// RPC is the rpc configuration
 		RPC RPC `yaml:"rpc"`
 		// Deprecated. Use Metrics in global section instead.
-		Metrics metrics.Metrics `yaml:"metrics"`
+		Metrics metrics.Config `yaml:"metrics"`
 	}
 
 	// PProf contains the config items for the pprof utility
@@ -99,7 +99,7 @@ type (
 		// TLS controls the communication encryption configuration
 		TLS RootTLS `yaml:"tls"`
 		// Metrics is the metrics subsystem configuration
-		Metrics *metrics.Metrics `yaml:"metrics"`
+		Metrics *metrics.Config `yaml:"metrics"`
 		// Settings for authentication and authorization
 		Authorization Authorization `yaml:"authorization"`
 	}

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -28,12 +28,11 @@ import (
 	"bytes"
 	"time"
 
-	"github.com/uber-go/tally/m3"
-	"github.com/uber-go/tally/prometheus"
 	"gopkg.in/yaml.v3"
 
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/masker"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/service/dynamicconfig"
 )
 
@@ -68,7 +67,7 @@ type (
 		// RPC is the rpc configuration
 		RPC RPC `yaml:"rpc"`
 		// Deprecated. Use Metrics in global section instead.
-		Metrics Metrics `yaml:"metrics"`
+		Metrics metrics.Metrics `yaml:"metrics"`
 	}
 
 	// PProf contains the config items for the pprof utility
@@ -100,7 +99,7 @@ type (
 		// TLS controls the communication encryption configuration
 		TLS RootTLS `yaml:"tls"`
 		// Metrics is the metrics subsystem configuration
-		Metrics *Metrics `yaml:"metrics"`
+		Metrics *metrics.Metrics `yaml:"metrics"`
 		// Settings for authentication and authorization
 		Authorization Authorization `yaml:"authorization"`
 	}
@@ -385,35 +384,6 @@ type (
 	DCRedirectionPolicy struct {
 		Policy string `yaml:"policy"`
 		ToDC   string `yaml:"toDC"`
-	}
-
-	// Metrics contains the config items for metrics subsystem
-	Metrics struct {
-		// M3 is the configuration for m3 metrics reporter
-		M3 *m3.Configuration `yaml:"m3"`
-		// Statsd is the configuration for statsd reporter
-		Statsd *Statsd `yaml:"statsd"`
-		// Prometheus is the configuration for prometheus reporter
-		Prometheus *prometheus.Configuration `yaml:"prometheus"`
-		// Tags is the set of key-value pairs to be reported as part of every metric
-		Tags map[string]string `yaml:"tags"`
-		// Prefix sets the prefix to all outgoing metrics
-		Prefix string `yaml:"prefix"`
-	}
-
-	// Statsd contains the config items for statsd metrics reporter
-	Statsd struct {
-		// The host and port of the statsd server
-		HostPort string `yaml:"hostPort" validate:"nonzero"`
-		// The prefix to use in reporting to statsd
-		Prefix string `yaml:"prefix" validate:"nonzero"`
-		// FlushInterval is the maximum interval for sending packets.
-		// If it is not specified, it defaults to 1 second.
-		FlushInterval time.Duration `yaml:"flushInterval"`
-		// FlushBytes specifies the maximum udp packet size you wish to send.
-		// If FlushBytes is unspecified, it defaults  to 1432 bytes, which is
-		// considered safe for local traffic.
-		FlushBytes int `yaml:"flushBytes"`
 	}
 
 	// Archival contains the config for archival

--- a/service/worker/archiver/replay_metrics_client.go
+++ b/service/worker/archiver/replay_metrics_client.go
@@ -27,8 +27,6 @@ package archiver
 import (
 	"time"
 
-	"github.com/uber-go/tally"
-
 	"go.temporal.io/sdk/workflow"
 
 	"go.temporal.io/server/common/metrics"
@@ -71,7 +69,7 @@ func (r *replayMetricsClient) AddCounter(scope int, counter int, delta int64) {
 }
 
 // StartTimer starts a timer for the given metric name. Time will be recorded when stopwatch is stopped.
-func (r *replayMetricsClient) StartTimer(scope int, timer int) tally.Stopwatch {
+func (r *replayMetricsClient) StartTimer(scope int, timer int) metrics.Stopwatch {
 	if workflow.IsReplaying(r.ctx) {
 		return metrics.NopStopwatch()
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Move metrics scope initialization logic to metrics package.
Remove Tally from metrics interface.


<!-- Tell your future self why have you made these changes -->
**Why?**
Cleaning up interface to make it easier to add support for OpenTelemetry.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No