### PR TITLE
tctl: always print first slice item and length if there are more

### DIFF
--- a/tools/cli/stringify/stringify.go
+++ b/tools/cli/stringify/stringify.go
@@ -91,13 +91,7 @@ func AnyToString(val interface{}, printFully bool, maxFieldLength int) string {
 		return ""
 	case reflect.Slice:
 		// All but []byte which is already handled.
-		if v.Len() == 0 {
-			return ""
-		}
-		if v.Len() == 1 {
-			return fmt.Sprintf("[%s]", AnyToString(v.Index(0).Interface(), printFully, maxFieldLength))
-		}
-		return fmt.Sprintf("[len=%d]", v.Len())
+		return sliceToString(v, printFully, maxFieldLength)
 	case reflect.Ptr:
 		return AnyToString(v.Elem().Interface(), printFully, maxFieldLength)
 	case reflect.Map:
@@ -198,6 +192,25 @@ func AnyToString(val interface{}, printFully bool, maxFieldLength int) string {
 	default:
 		return fmt.Sprint(val)
 	}
+}
+
+func sliceToString(slice reflect.Value, printFully bool, maxFieldLength int) string {
+	var b strings.Builder
+	b.WriteRune('[')
+	for i := 0; i < slice.Len(); i++ {
+		if i == 0 || printFully {
+			b.WriteString(AnyToString(slice.Index(i).Interface(), printFully, maxFieldLength))
+			if i < slice.Len()-1 {
+				b.WriteRune(',')
+			}
+			if !printFully && slice.Len() > 1 {
+				b.WriteString(fmt.Sprintf("...%d more]", slice.Len()-1))
+				return b.String()
+			}
+		}
+	}
+	b.WriteRune(']')
+	return b.String()
 }
 
 func bytesToString(val []byte) string {

--- a/tools/cli/stringify/stringify.go
+++ b/tools/cli/stringify/stringify.go
@@ -94,6 +94,9 @@ func AnyToString(val interface{}, printFully bool, maxFieldLength int) string {
 		if v.Len() == 0 {
 			return ""
 		}
+		if v.Len() == 1 {
+			return fmt.Sprintf("[%s]", AnyToString(v.Index(0).Interface(), printFully, maxFieldLength))
+		}
 		return fmt.Sprintf("[len=%d]", v.Len())
 	case reflect.Ptr:
 		return AnyToString(v.Elem().Interface(), printFully, maxFieldLength)

--- a/tools/cli/stringify/stringify_test.go
+++ b/tools/cli/stringify/stringify_test.go
@@ -109,11 +109,11 @@ func (s *stringifySuite) TestAnyToString_DecodeMapValues() {
 func (s *stringifySuite) TestAnyToString_Slice() {
 	var fields []string
 	got := AnyToString(fields, true, 0)
-	s.Equal("", got)
+	s.Equal("[]", got)
 
 	fields = make([]string, 0)
 	got = AnyToString(fields, true, 0)
-	s.Equal("", got)
+	s.Equal("[]", got)
 
 	fields = make([]string, 1)
 	got = AnyToString(fields, true, 0)
@@ -122,10 +122,26 @@ func (s *stringifySuite) TestAnyToString_Slice() {
 	fields[0] = "qwe"
 	got = AnyToString(fields, true, 0)
 	s.Equal("[qwe]", got)
+	got = AnyToString(fields, false, 0)
+	s.Equal("[qwe]", got)
 
 	fields = make([]string, 2)
+	fields[0] = "asd"
+	fields[1] = "zxc"
 	got = AnyToString(fields, true, 0)
-	s.Equal("[len=2]", got)
+	s.Equal("[asd,zxc]", got)
+	got = AnyToString(fields, false, 0)
+	s.Equal("[asd,...1 more]", got)
+
+	fields = make([]string, 3)
+	fields[0] = "0"
+	fields[1] = "1"
+	fields[2] = "2"
+	got = AnyToString(fields, true, 0)
+	s.Equal("[0,1,2]", got)
+	got = AnyToString(fields, false, 0)
+	s.Equal("[0,...2 more]", got)
+
 }
 
 func (s *stringifySuite) TestIsAttributeName() {

--- a/tools/cli/stringify/stringify_test.go
+++ b/tools/cli/stringify/stringify_test.go
@@ -106,6 +106,28 @@ func (s *stringifySuite) TestAnyToString_DecodeMapValues() {
 	s.Equal(expected, got)
 }
 
+func (s *stringifySuite) TestAnyToString_Slice() {
+	var fields []string
+	got := AnyToString(fields, true, 0)
+	s.Equal("", got)
+
+	fields = make([]string, 0)
+	got = AnyToString(fields, true, 0)
+	s.Equal("", got)
+
+	fields = make([]string, 1)
+	got = AnyToString(fields, true, 0)
+	s.Equal("[]", got)
+
+	fields[0] = "qwe"
+	got = AnyToString(fields, true, 0)
+	s.Equal("[qwe]", got)
+
+	fields = make([]string, 2)
+	got = AnyToString(fields, true, 0)
+	s.Equal("[len=2]", got)
+}
+
 func (s *stringifySuite) TestIsAttributeName() {
 	s.True(isAttributeName("WorkflowExecutionStartedEventAttributes"))
 	s.False(isAttributeName("workflowExecutionStartedEventAttributes"))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
In `tctl`, always print first slice item and length if there are more. (when `tctl` prints out different structures such as workflow history).
Old version:
```
  1  WorkflowExecutionStarted  {WorkflowType:{Name:cronWorkflow},                             
...
                                PrevAutoResetPoints:{Points:[len=1]},                          
                                Header:{Fields:map{_tracer-data:{}}}}  
```
New version:
```
  1  WorkflowExecutionStarted  {WorkflowType:{Name:cronWorkflow}, ParentInitiatedEventId:0,                    
...
                                PrevAutoResetPoints:{Points:[{BinaryChecksum:85f30e2356766729577cccc58382d155,  
                                RunId:e50ded41-a4b2-4d4e-935b-80c82c93983f, FirstWorkflowTaskCompletedId:4,     
                                CreateTime:2021-03-15 20:24:38.806197758 +0000 UTC,                             
                                ExpireTime:2021-03-25 20:24:43.839456587 +0000 UTC, Resettable:true}]},         
                                Header:{Fields:map{_tracer-data:{}}}}        
```

<!-- Tell your future self why have you made these changes -->
**Why?**
For better user experience.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.