### PR TITLE
Refactor cert provider interfaces to simplify them

### DIFF
--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -70,10 +70,6 @@ type x509CertFetcher func() (*x509.Certificate, error)
 type x509CertPoolFetcher func() (*x509.CertPool, error)
 type tlsCertFetcher func() (*tls.Certificate, error)
 
-func (s *localStoreCertProvider) GetSettings() *config.GroupTLS {
-	return s.tlsSettings
-}
-
 func (s *localStoreCertProvider) FetchServerCertificate() (*tls.Certificate, error) {
 
 	if s.tlsSettings == nil {
@@ -256,14 +252,6 @@ func (s *localStoreCertProvider) FetchCertificate(cachedCert **tls.Certificate,
 
 	*cachedCert = &cert
 	return *cachedCert, nil
-}
-
-func (s *localStoreCertProvider) ServerName(isWorker bool) string {
-	return s.getClientTLSSettings(isWorker).ServerName
-}
-
-func (s *localStoreCertProvider) DisableHostVerification(isWorker bool) bool {
-	return s.getClientTLSSettings(isWorker).DisableHostVerification
 }
 
 func (s *localStoreCertProvider) getClientTLSSettings(isWorker bool) *config.ClientTLS {

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -62,10 +62,10 @@ func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS) 
 	return factory
 }
 
-func (f *localStorePerHostCertProviderMap) GetCertProvider(hostName string,
-) (provider CertProvider, clientAuthRequired bool, err error) {
+// GetCertProvider for a given host name returns a cert provider (nil if not found) and if client authentication is required
+func (f *localStorePerHostCertProviderMap) GetCertProvider(hostName string) (CertProvider, bool, error) {
 
-	clientAuthRequired = true
+	clientAuthRequired := true
 	lcHostName := strings.ToLower(hostName)
 
 	if f.certProviderCache == nil {

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -36,7 +36,7 @@ var _ CertExpirationChecker = (*localStorePerHostCertProviderMap)(nil)
 
 type localStorePerHostCertProviderMap struct {
 	certProviderCache map[string]*localStoreCertProvider
-	clientAuthCache map[string] bool
+	clientAuthCache   map[string]bool
 }
 
 func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS) *localStorePerHostCertProviderMap {
@@ -73,10 +73,10 @@ func (f *localStorePerHostCertProviderMap) GetCertProvider(hostName string,
 	}
 	cachedCertProvider, ok := f.certProviderCache[lcHostName]
 	if !ok {
-		return nil, clientAuthRequired,nil
+		return nil, clientAuthRequired, nil
 	}
 	clientAuthRequired = f.clientAuthCache[lcHostName]
-	return cachedCertProvider, clientAuthRequired,nil
+	return cachedCertProvider, clientAuthRequired, nil
 }
 
 func (f *localStorePerHostCertProviderMap) GetExpiringCerts(timeWindow time.Duration,

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -55,10 +55,10 @@ type localStoreTlsProvider struct {
 
 	frontendPerHostCertProviderMap *localStorePerHostCertProviderMap
 
-	internodeServerConfig *tls.Config
-	internodeClientConfig *tls.Config
-	frontendServerConfig  *tls.Config
-	frontendClientConfig  *tls.Config
+	cachedInternodeServerConfig *tls.Config
+	cachedInternodeClientConfig *tls.Config
+	cachedFrontendServerConfig  *tls.Config
+	cachedFrontendClientConfig  *tls.Config
 
 	ticker *time.Ticker
 	logger log.Logger
@@ -118,7 +118,7 @@ func (s *localStoreTlsProvider) Close() {
 
 func (s *localStoreTlsProvider) GetInternodeClientConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(
-		&s.internodeClientConfig,
+		&s.cachedInternodeClientConfig,
 		func() (*tls.Config, error) {
 			return newClientTLSConfig(s.internodeClientCertProvider,
 				s.internodeCertProvider.GetSettings().Server.RequireClientAuth, false)
@@ -129,7 +129,7 @@ func (s *localStoreTlsProvider) GetInternodeClientConfig() (*tls.Config, error) 
 
 func (s *localStoreTlsProvider) GetFrontendClientConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(
-		&s.frontendClientConfig,
+		&s.cachedFrontendClientConfig,
 		func() (*tls.Config, error) {
 			return newClientTLSConfig(s.workerCertProvider,
 				s.frontendCertProvider.GetSettings().Server.RequireClientAuth, true)
@@ -140,7 +140,7 @@ func (s *localStoreTlsProvider) GetFrontendClientConfig() (*tls.Config, error) {
 
 func (s *localStoreTlsProvider) GetFrontendServerConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(
-		&s.frontendServerConfig,
+		&s.cachedFrontendServerConfig,
 		func() (*tls.Config, error) {
 			return newServerTLSConfig(s.frontendCertProvider, s.frontendPerHostCertProviderMap)
 		},
@@ -149,7 +149,7 @@ func (s *localStoreTlsProvider) GetFrontendServerConfig() (*tls.Config, error) {
 
 func (s *localStoreTlsProvider) GetInternodeServerConfig() (*tls.Config, error) {
 	return s.getOrCreateConfig(
-		&s.internodeServerConfig,
+		&s.cachedInternodeServerConfig,
 		func() (*tls.Config, error) {
 			return newServerTLSConfig(s.internodeCertProvider, nil)
 		},

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -240,15 +240,15 @@ func newServerTLSConfig(
 
 	tlsConfig.GetConfigForClient = func(c *tls.ClientHelloInfo) (*tls.Config, error) {
 		if perHostCertProviderMap != nil {
-			perHostCertProvider, clientAuth, err := perHostCertProviderMap.GetCertProvider(c.ServerName)
+			perHostCertProvider, hostClientAuthRequired, err := perHostCertProviderMap.GetCertProvider(c.ServerName)
 			if err != nil {
 				return nil, err
 			}
 
-			if perHostCertProvider == nil {
-				return getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired)
+			if perHostCertProvider != nil {
+				return getServerTLSConfigFromCertProvider(perHostCertProvider, hostClientAuthRequired)
 			}
-			return getServerTLSConfigFromCertProvider(perHostCertProvider, clientAuth)
+			return getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired)
 		}
 		return getServerTLSConfigFromCertProvider(certProvider, clientAuthRequired)
 	}
@@ -317,7 +317,7 @@ func newClientTLSConfig(clientProvider ClientCertProvider, serverName string, is
 		getCert,
 		serverCa,
 		serverName,
-		enableHostVerification, //!clientProvider.DisableHostVerification(isWorker),
+		enableHostVerification,
 	), nil
 }
 

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -82,14 +82,6 @@ func (t *TestDynamicCertProvider) FetchServerRootCAsForClient(_ bool) (*x509.Cer
 	return t.caCerts, nil
 }
 
-func (t *TestDynamicCertProvider) ServerName(_ bool) string {
-	return t.serverName
-}
-
-func (t *TestDynamicCertProvider) DisableHostVerification(_ bool) bool {
-	return false
-}
-
 func (t *TestDynamicCertProvider) GetCertProvider(hostName string) (CertProvider, bool, error) {
 	if hostName == "localhost" {
 		return t, false, nil

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -90,11 +90,11 @@ func (t *TestDynamicCertProvider) DisableHostVerification(_ bool) bool {
 	return false
 }
 
-func (t *TestDynamicCertProvider) GetCertProvider(hostName string) (CertProvider, error) {
+func (t *TestDynamicCertProvider) GetCertProvider(hostName string) (CertProvider, bool, error) {
 	if hostName == "localhost" {
-		return t, nil
+		return t, false, nil
 	}
-	return nil, nil
+	return nil, false, nil
 }
 
 func (t *TestDynamicCertProvider) SwitchToWrongServerRootCACerts() {

--- a/common/rpc/encryption/testDynamicTLSConfigProvider.go
+++ b/common/rpc/encryption/testDynamicTLSConfigProvider.go
@@ -49,7 +49,7 @@ type TestDynamicTLSConfigProvider struct {
 }
 
 func (t *TestDynamicTLSConfigProvider) GetInternodeServerConfig() (*tls.Config, error) {
-	return newServerTLSConfig(t.InternodeCertProvider, nil)
+	return newServerTLSConfig(t.InternodeCertProvider, nil, &t.settings.Internode)
 }
 
 func (t *TestDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, error) {
@@ -57,7 +57,7 @@ func (t *TestDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, 
 }
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, error) {
-	return newServerTLSConfig(t.FrontendCertProvider, t.FrontendPerHostCertProviderMap)
+	return newServerTLSConfig(t.FrontendCertProvider, t.FrontendPerHostCertProviderMap, &t.settings.Frontend)
 }
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendClientConfig() (*tls.Config, error) {

--- a/common/rpc/encryption/testDynamicTLSConfigProvider.go
+++ b/common/rpc/encryption/testDynamicTLSConfigProvider.go
@@ -53,7 +53,7 @@ func (t *TestDynamicTLSConfigProvider) GetInternodeServerConfig() (*tls.Config, 
 }
 
 func (t *TestDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, error) {
-	return newClientTLSConfig(t.InternodeClientCertProvider, true, false)
+	return newClientTLSConfig(t.InternodeClientCertProvider, t.settings.Internode.Client.ServerName, true, false, true)
 }
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, error) {
@@ -61,7 +61,7 @@ func (t *TestDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, e
 }
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendClientConfig() (*tls.Config, error) {
-	return newClientTLSConfig(t.WorkerCertProvider, true, false)
+	return newClientTLSConfig(t.WorkerCertProvider, t.settings.Frontend.Client.ServerName, true, false, true)
 }
 
 var _ TLSConfigProvider = (*TestDynamicTLSConfigProvider)(nil)

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -47,7 +47,6 @@ type (
 	CertProvider interface {
 		FetchServerCertificate() (*tls.Certificate, error)
 		FetchClientCAs() (*x509.CertPool, error)
-		GetSettings() *config.GroupTLS
 	}
 
 	// ClientCertProvider is an interface to load raw TLS/X509 primitives for configuring clients.
@@ -60,7 +59,7 @@ type (
 
 	// PerHostCertProviderMap returns a CertProvider for a given host name.
 	PerHostCertProviderMap interface {
-		GetCertProvider(hostName string) (CertProvider, error)
+		GetCertProvider(hostName string) (provider CertProvider, clientAuthRequired bool, err error)
 	}
 
 	CertThumbprint [16]byte

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -53,8 +53,6 @@ type (
 	ClientCertProvider interface {
 		FetchClientCertificate(isWorker bool) (*tls.Certificate, error)
 		FetchServerRootCAsForClient(isWorker bool) (*x509.CertPool, error)
-		ServerName(isWorker bool) string
-		DisableHostVerification(isWorker bool) bool
 	}
 
 	// PerHostCertProviderMap returns a CertProvider for a given host name.


### PR DESCRIPTION
**What changed?**
Removed from `CertProvider` and `ClientCertProvider` methods that are not concerned with getting certs and only return pieces of TLS configuration in a roundabout way. 

**Why?**
To make cert provider pluggable, the interfaces need to be clean from the superfluous functionality that got into them

**How did you test it?**
Unit tests

**Potential risks**
I don't see a risk as this functionality isn't pluggable yet.

**Is hotfix candidate?**
No