### PR TITLE
Add a length check to protect from possible panic

### DIFF
--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -438,7 +438,7 @@ func parseCert(bytes []byte) (*x509.Certificate, error) {
 		}
 	}
 
-	if len(certBytes[0]) == 0 {
+	if len(certBytes) == 0 || len(certBytes[0]) == 0 {
 		return nil, fmt.Errorf("failed to decode PEM certificate data")
 	}
 	return x509.ParseCertificate(certBytes[0])

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -65,17 +65,16 @@ func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS) 
 // GetCertProvider for a given host name returns a cert provider (nil if not found) and if client authentication is required
 func (f *localStorePerHostCertProviderMap) GetCertProvider(hostName string) (CertProvider, bool, error) {
 
-	clientAuthRequired := true
 	lcHostName := strings.ToLower(hostName)
 
 	if f.certProviderCache == nil {
-		return nil, clientAuthRequired, nil
+		return nil, true, nil
 	}
 	cachedCertProvider, ok := f.certProviderCache[lcHostName]
 	if !ok {
-		return nil, clientAuthRequired, nil
+		return nil, true, nil
 	}
-	clientAuthRequired = f.clientAuthCache[lcHostName]
+	clientAuthRequired := f.clientAuthCache[lcHostName]
 	return cachedCertProvider, clientAuthRequired, nil
 }
 


### PR DESCRIPTION
**What changed?**
Add a length check to protect from possible panic

**Why?**
To protect from an NRE panic in case certificate data is malformed.

**How did you test it?**
Unit tests

**Potential risks**
None

**Is hotfix candidate?**
No