### PR TITLE
Report aggregated metrics under explicit metric name

### DIFF
--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -87,8 +87,10 @@ func (m *metricsScope) StartTimer(id int) Stopwatch {
 	case !def.metricRollupName.Empty():
 		return NewStopwatch(timer, m.rootScope.Timer(def.metricRollupName.String()))
 	case m.isNamespaceTagged:
-		timerAll := m.scope.Tagged(map[string]string{namespace: namespaceAllValue}).Timer(def.metricName.String())
-		return NewStopwatch(timer, timerAll)
+		// remove next line in v1.20.0
+		timerAllDeprecated := m.scope.Tagged(map[string]string{namespace: namespaceAllValue}).Timer(def.metricName.String())
+		timerAll := m.rootScope.Timer(def.metricName.String() + totalMetricSuffix)
+		return NewStopwatch(timer, timerAll, timerAllDeprecated)
 	default:
 		return NewStopwatch(timer)
 	}
@@ -101,7 +103,9 @@ func (m *metricsScope) RecordTimer(id int, d time.Duration) {
 	case !def.metricRollupName.Empty():
 		m.rootScope.Timer(def.metricRollupName.String()).Record(d)
 	case m.isNamespaceTagged:
+		// remove next line in v1.20.0
 		m.scope.Tagged(map[string]string{namespace: namespaceAllValue}).Timer(def.metricName.String()).Record(d)
+		m.rootScope.Timer(def.metricName.String() + totalMetricSuffix).Record(d)
 	}
 }
 
@@ -113,7 +117,9 @@ func (m *metricsScope) RecordDistribution(id int, d int) {
 	case !def.metricRollupName.Empty():
 		m.rootScope.Timer(def.metricRollupName.String()).Record(dist)
 	case m.isNamespaceTagged:
+		// remove next line in v1.20.0
 		m.scope.Tagged(map[string]string{namespace: namespaceAllValue}).Timer(def.metricName.String()).Record(dist)
+		m.rootScope.Timer(def.metricName.String() + totalMetricSuffix).Record(dist)
 	}
 }
 

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -43,6 +43,7 @@ const (
 
 	namespaceAllValue = "all"
 	unknownValue      = "_unknown_"
+	totalMetricSuffix = "_total"
 )
 
 // Tag is an interface to define metrics tags


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Before: Aggregated metrics are reported as "<metric_name>" metric name and namespace="all" label.
After: Aggregated metrics are reported as "<metric_name>_total" metric name.

Note: dashboards will have to be changed if they were showing old metric type.

<!-- Tell your future self why have you made these changes -->
**Why?**
It is inconvenient for user to aggregate and display metrics.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manual testing, automated tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Name collision on prometheus server when reporting metrics.
Automation based on old metric format will stop working.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No