### PR TITLE
Refactor cert provider interfaces and make cert provider injectable

### DIFF
--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -72,7 +72,7 @@ func (s *localStoreCertProvider) FetchServerCertificate() (*tls.Certificate, err
 	if s.tlsSettings == nil {
 		return nil, nil
 	}
-	return s.FetchCertificate(&s.serverCert, s.tlsSettings.Server.CertFile, s.tlsSettings.Server.CertData,
+	return s.fetchCertificate(&s.serverCert, s.tlsSettings.Server.CertFile, s.tlsSettings.Server.CertData,
 		s.tlsSettings.Server.KeyFile, s.tlsSettings.Server.KeyData)
 }
 
@@ -172,24 +172,24 @@ func (s *localStoreCertProvider) FetchClientCertificate(isWorker bool) (*tls.Cer
 	if s.tlsSettings == nil {
 		return nil, nil
 	}
-	return s.FetchCertificate(&s.clientCert, s.tlsSettings.Server.CertFile, s.tlsSettings.Server.CertData,
+	return s.fetchCertificate(&s.clientCert, s.tlsSettings.Server.CertFile, s.tlsSettings.Server.CertData,
 		s.tlsSettings.Server.KeyFile, s.tlsSettings.Server.KeyData)
 }
 
 func (s *localStoreCertProvider) fetchWorkerCertificate() (*tls.Certificate, error) {
 	if s.isLegacyWorkerConfig {
-		return s.FetchCertificate(&s.clientCert, s.tlsSettings.Server.CertFile, s.tlsSettings.Server.CertData,
+		return s.fetchCertificate(&s.clientCert, s.tlsSettings.Server.CertFile, s.tlsSettings.Server.CertData,
 			s.tlsSettings.Server.KeyFile, s.tlsSettings.Server.KeyData)
 	} else {
 		if s.workerTLSSettings != nil {
-			return s.FetchCertificate(&s.clientCert, s.workerTLSSettings.CertFile, s.workerTLSSettings.CertData,
+			return s.fetchCertificate(&s.clientCert, s.workerTLSSettings.CertFile, s.workerTLSSettings.CertData,
 				s.workerTLSSettings.KeyFile, s.workerTLSSettings.KeyData)
 		}
 		return nil, nil
 	}
 }
 
-func (s *localStoreCertProvider) FetchCertificate(cachedCert **tls.Certificate,
+func (s *localStoreCertProvider) fetchCertificate(cachedCert **tls.Certificate,
 	certFile string, certData string,
 	keyFile string, keyData string) (*tls.Certificate, error) {
 	if certFile == "" && certData == "" {

--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -40,7 +40,6 @@ import (
 )
 
 var _ CertProvider = (*localStoreCertProvider)(nil)
-var _ ClientCertProvider = (*localStoreCertProvider)(nil)
 var _ CertExpirationChecker = (*localStoreCertProvider)(nil)
 
 type localStoreCertProvider struct {

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -35,27 +35,24 @@ var _ PerHostCertProviderMap = (*localStorePerHostCertProviderMap)(nil)
 var _ CertExpirationChecker = (*localStorePerHostCertProviderMap)(nil)
 
 type localStorePerHostCertProviderMap struct {
-	certProviderCache map[string]*localStoreCertProvider
+	certProviderCache map[string]CertProvider
 	clientAuthCache   map[string]bool
 }
 
-func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS) *localStorePerHostCertProviderMap {
+func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS, certProviderFactory CertProviderFactory,
+) *localStorePerHostCertProviderMap {
 
 	factory := &localStorePerHostCertProviderMap{}
 	if overrides == nil {
 		return factory
 	}
 
-	factory.certProviderCache = make(map[string]*localStoreCertProvider, len(overrides))
+	factory.certProviderCache = make(map[string]CertProvider, len(overrides))
 	factory.clientAuthCache = make(map[string]bool, len(overrides))
 
 	for host, settings := range overrides {
 		lcHost := strings.ToLower(host)
-		factory.certProviderCache[lcHost] = &localStoreCertProvider{
-			tlsSettings: &config.GroupTLS{
-				Server: settings,
-			},
-		}
+		factory.certProviderCache[lcHost] = certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
 		factory.clientAuthCache[lcHost] = settings.RequireClientAuth
 	}
 

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -42,21 +42,21 @@ type localStorePerHostCertProviderMap struct {
 func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS, certProviderFactory CertProviderFactory,
 ) *localStorePerHostCertProviderMap {
 
-	factory := &localStorePerHostCertProviderMap{}
+	providerMap := &localStorePerHostCertProviderMap{}
 	if overrides == nil {
-		return factory
+		return providerMap
 	}
 
-	factory.certProviderCache = make(map[string]CertProvider, len(overrides))
-	factory.clientAuthCache = make(map[string]bool, len(overrides))
+	providerMap.certProviderCache = make(map[string]CertProvider, len(overrides))
+	providerMap.clientAuthCache = make(map[string]bool, len(overrides))
 
 	for host, settings := range overrides {
 		lcHost := strings.ToLower(host)
-		factory.certProviderCache[lcHost] = certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
-		factory.clientAuthCache[lcHost] = settings.RequireClientAuth
+		providerMap.certProviderCache[lcHost] = certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
+		providerMap.clientAuthCache[lcHost] = settings.RequireClientAuth
 	}
 
-	return factory
+	return providerMap
 }
 
 // GetCertProvider for a given host name returns a cert provider (nil if not found) and if client authentication is required

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -84,14 +84,15 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 	}
 
 	provider := &localStoreTlsProvider{
-		internodeCertProvider:          internodeProvider,
-		internodeClientCertProvider:    internodeProvider,
-		frontendCertProvider:           certProviderFactory(&tlsConfig.Frontend, nil, nil),
-		workerCertProvider:             workerProvider,
-		frontendPerHostCertProviderMap: newLocalStorePerHostCertProviderMap(tlsConfig.Frontend.PerHostOverrides),
-		RWMutex:                        sync.RWMutex{},
-		settings:                       tlsConfig,
-		scope:                          scope,
+		internodeCertProvider:       internodeProvider,
+		internodeClientCertProvider: internodeProvider,
+		frontendCertProvider:        certProviderFactory(&tlsConfig.Frontend, nil, nil),
+		workerCertProvider:          workerProvider,
+		frontendPerHostCertProviderMap: newLocalStorePerHostCertProviderMap(
+			tlsConfig.Frontend.PerHostOverrides, certProviderFactory),
+		RWMutex:  sync.RWMutex{},
+		settings: tlsConfig,
+		scope:    scope,
 	}
 	provider.initialize()
 	return provider, nil

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -48,10 +48,10 @@ type localStoreTlsProvider struct {
 
 	settings *config.RootTLS
 
-	internodeCertProvider       *localStoreCertProvider
-	internodeClientCertProvider *localStoreCertProvider
-	frontendCertProvider        *localStoreCertProvider
-	workerCertProvider          *localStoreCertProvider
+	internodeCertProvider       CertProvider
+	internodeClientCertProvider CertProvider
+	frontendCertProvider        CertProvider
+	workerCertProvider          CertProvider
 
 	frontendPerHostCertProviderMap *localStorePerHostCertProviderMap
 
@@ -288,7 +288,7 @@ func getServerTLSConfigFromCertProvider(certProvider CertProvider, requireClient
 		clientCaPool), nil
 }
 
-func newClientTLSConfig(clientProvider ClientCertProvider, serverName string, isAuthRequired bool,
+func newClientTLSConfig(clientProvider CertProvider, serverName string, isAuthRequired bool,
 	isWorker bool, enableHostVerification bool) (*tls.Config, error) {
 	// Optional ServerCA for client if not already trusted by host
 	serverCa, err := clientProvider.FetchServerRootCAsForClient(isWorker)

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -27,6 +27,7 @@ package encryption
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"time"
 
 	"go.temporal.io/server/common/config"
 )
@@ -42,7 +43,6 @@ type TestDynamicCertProvider struct {
 }
 
 var _ CertProvider = (*TestDynamicCertProvider)(nil)
-var _ ClientCertProvider = (*TestDynamicCertProvider)(nil)
 var _ PerHostCertProviderMap = (*TestDynamicCertProvider)(nil)
 
 func NewTestDynamicCertProvider(
@@ -95,4 +95,9 @@ func (t *TestDynamicCertProvider) SwitchToWrongServerRootCACerts() {
 
 func (t *TestDynamicCertProvider) SetServerName(serverName string) {
 	t.serverName = serverName
+}
+
+func (t *TestDynamicCertProvider) GetExpiringCerts(_ time.Duration,
+) (expiring CertExpirationMap, expired CertExpirationMap, err error) {
+	panic("not implemented")
 }

--- a/common/rpc/encryption/testDynamicTLSConfigProvider.go
+++ b/common/rpc/encryption/testDynamicTLSConfigProvider.go
@@ -27,6 +27,7 @@ package encryption
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"time"
 
 	"go.temporal.io/server/common/config"
 )
@@ -62,6 +63,10 @@ func (t *TestDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, e
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendClientConfig() (*tls.Config, error) {
 	return newClientTLSConfig(t.WorkerCertProvider, t.settings.Frontend.Client.ServerName, true, false, true)
+}
+
+func (t *TestDynamicTLSConfigProvider) GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error) {
+	panic("implement me")
 }
 
 var _ TLSConfigProvider = (*TestDynamicTLSConfigProvider)(nil)

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -56,6 +56,7 @@ type (
 	// PerHostCertProviderMap returns a CertProvider for a given host name.
 	PerHostCertProviderMap interface {
 		GetCertProvider(hostName string) (provider CertProvider, clientAuthRequired bool, err error)
+		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
 	}
 
 	CertThumbprint [16]byte

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -41,6 +41,7 @@ type (
 		GetInternodeClientConfig() (*tls.Config, error)
 		GetFrontendServerConfig() (*tls.Config, error)
 		GetFrontendClientConfig() (*tls.Config, error)
+		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
 	}
 
 	// CertProvider is a common interface to load raw TLS/X509 primitives.
@@ -69,10 +70,7 @@ type (
 	CertExpirationMap map[CertThumbprint]CertExpirationData
 
 	CertExpirationChecker interface {
-		GetExpiringCerts(timeWindow time.Duration) (
-			expiring CertExpirationMap,
-			expired CertExpirationMap,
-			err error)
+		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
 	}
 
 	tlsConfigConstructor func() (*tls.Config, error)

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -47,12 +47,9 @@ type (
 	CertProvider interface {
 		FetchServerCertificate() (*tls.Certificate, error)
 		FetchClientCAs() (*x509.CertPool, error)
-	}
-
-	// ClientCertProvider is an interface to load raw TLS/X509 primitives for configuring clients.
-	ClientCertProvider interface {
 		FetchClientCertificate(isWorker bool) (*tls.Certificate, error)
 		FetchServerRootCAsForClient(isWorker bool) (*x509.CertPool, error)
+		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
 	}
 
 	// PerHostCertProviderMap returns a CertProvider for a given host name.

--- a/common/rpc/test/rpc_localstore_tls_test.go
+++ b/common/rpc/test/rpc_localstore_tls_test.go
@@ -545,9 +545,7 @@ func (s *localStoreRPCSuite) TestCertExpiration() {
 }
 
 func (s *localStoreRPCSuite) testCertExpiration(factory *TestFactory, timeWindow time.Duration, nExpiring int) {
-	provider, ok := factory.GetTLSConfigProvider().(encryption.CertExpirationChecker)
-	s.True(ok)
-	expiring, expired, err := provider.GetExpiringCerts(timeWindow)
+	expiring, expired, err := factory.GetTLSConfigProvider().GetExpiringCerts(timeWindow)
 	if len(expired) > 0 {
 	}
 	s.NotNil(expiring)

--- a/common/rpc/test/rpc_localstore_tls_test.go
+++ b/common/rpc/test/rpc_localstore_tls_test.go
@@ -111,7 +111,7 @@ func (s *localStoreRPCSuite) SetupSuite() {
 	s.Assertions = require.New(s.T())
 	s.logger = log.NewDefaultLogger()
 
-	provider, err := encryption.NewTLSConfigProviderFromConfig(serverCfgInsecure.TLS, nil)
+	provider, err := encryption.NewTLSConfigProviderFromConfig(serverCfgInsecure.TLS, nil, nil)
 	s.NoError(err)
 	insecureFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(insecureFactory)
@@ -249,17 +249,17 @@ func (s *localStoreRPCSuite) setupFrontend() {
 		},
 	}
 
-	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, nil)
+	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, nil, nil)
 	s.NoError(err)
 	frontendMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(frontendMutualTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, nil, nil)
 	s.NoError(err)
 	frontendServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(frontendServerTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSSystemWorker.TLS, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSSystemWorker.TLS, nil, nil)
 	s.NoError(err)
 	frontendSystemWorkerMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(frontendSystemWorkerMutualTLSFactory)
@@ -305,17 +305,17 @@ func (s *localStoreRPCSuite) setupInternode() {
 		},
 	}
 
-	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, nil)
+	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, nil, nil)
 	s.NoError(err)
 	internodeMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(internodeMutualTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, nil, nil)
 	s.NoError(err)
 	internodeServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(internodeServerTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreAltMutualTLS.TLS, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreAltMutualTLS.TLS, nil, nil)
 	s.NoError(err)
 	internodeMutualAltTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(internodeMutualAltTLSFactory)

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -150,7 +150,7 @@ func (s *Server) Start() error {
 	if s.so.tlsConfigProvider != nil {
 		tlsFactory = s.so.tlsConfigProvider
 	} else {
-		tlsFactory, err = encryption.NewTLSConfigProviderFromConfig(s.so.config.Global.TLS, globalMetricsScope)
+		tlsFactory, err = encryption.NewTLSConfigProviderFromConfig(s.so.config.Global.TLS, globalMetricsScope, nil)
 		if err != nil {
 			return fmt.Errorf("TLS provider initialization error: %w", err)
 		}


### PR DESCRIPTION
**What changed?**
Removed `ClientCertProvider` interface and consolidated all cert provider methods in `CertProvider` interface.
Added `GetExpiringCerts()` to all cert provider interfaces.
Refactored `localStoreTlsProvider` to support injection of cert provider implementation instead of the hardcoded `localStoreCertProvider`.

**Why?**
This enables injection of cert provider implementation with a clean interface it needs to implement.

**How did you test it?**
Unit tests.

**Potential risks**
No risk. The change is backward compatible expect for the GetExpiringCerts() method added to `TLSConfigProvider` interface. People who inject their custom TLS config providers would need to implement it.

**Is hotfix candidate?**
No