### PR TITLE
Add support for periodic refreshing of TLS certs loaded from files

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -129,6 +129,9 @@ type (
 		// specific hostname. Host names are case insensitive. Optional. If not present,
 		// uses configuration supplied by Server field.
 		PerHostOverrides map[string]ServerTLS `yaml:"hostOverrides"`
+
+		// Interval between refreshes of certificates loaded from files
+		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// ServerTLS contains items to load server TLS configuration
@@ -185,6 +188,9 @@ type (
 
 		// Client TLS settings for system workers
 		Client ClientTLS `yaml:"client"`
+
+		// Interval between refreshes of certificates loaded from files
+		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// CertExpirationValidation contains settings for periodic checks of TLS certificate expiration

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -115,6 +115,8 @@ type (
 		SystemWorker WorkerTLS `yaml:"systemWorker"`
 		// ExpirationChecks defines settings for periodic checks for expiration of certificates
 		ExpirationChecks CertExpirationValidation `yaml:"expirationChecks"`
+		// Interval between refreshes of certificates loaded from files
+		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// GroupTLS contains an instance client and server TLS settings
@@ -129,9 +131,6 @@ type (
 		// specific hostname. Host names are case insensitive. Optional. If not present,
 		// uses configuration supplied by Server field.
 		PerHostOverrides map[string]ServerTLS `yaml:"hostOverrides"`
-
-		// Interval between refreshes of certificates loaded from files
-		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// ServerTLS contains items to load server TLS configuration
@@ -188,9 +187,6 @@ type (
 
 		// Client TLS settings for system workers
 		Client ClientTLS `yaml:"client"`
-
-		// Interval between refreshes of certificates loaded from files
-		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// CertExpirationValidation contains settings for periodic checks of TLS certificate expiration

--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -72,20 +72,13 @@ type x509CertFetcher func() (*x509.Certificate, error)
 type x509CertPoolFetcher func() (*x509.CertPool, error)
 type tlsCertFetcher func() (*tls.Certificate, error)
 
-func (s *localStoreCertProvider) Initialize() {
+func (s *localStoreCertProvider) Initialize(refreshInterval time.Duration) {
 
 	s.logger = log.NewDefaultLogger()
-	var period time.Duration
 
-	if s.tlsSettings != nil {
-		period = s.tlsSettings.RefreshInterval
-	} else if s.workerTLSSettings != nil {
-		period = s.workerTLSSettings.RefreshInterval
-	}
-
-	if period != 0 {
+	if refreshInterval != 0 {
 		s.stop = make(chan bool)
-		s.ticker = time.NewTicker(period)
+		s.ticker = time.NewTicker(refreshInterval)
 		go s.refreshCerts()
 	}
 }

--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -489,13 +489,20 @@ func appendError(aggregatedErr error, err error) error {
 
 func (s *localStoreCertProvider) refreshCerts() {
 
-	s.logger.Info("resetting cached TLS certs to refresh them")
-	s.serverCert = nil
-	s.clientCert = nil
-	s.clientCAPool = nil
-	s.serverCAPool = nil
-	s.serverCAsWorkerPool = nil
-	s.clientCACerts = nil
-	s.serverCACerts = nil
-	s.serverCACertsWorker = nil
+	for {
+		select {
+		case <-s.stop:
+			break
+		case <-s.ticker.C:
+		}
+		s.logger.Info("resetting cached TLS certs to refresh them")
+		s.serverCert = nil
+		s.clientCert = nil
+		s.clientCAPool = nil
+		s.serverCAPool = nil
+		s.serverCAsWorkerPool = nil
+		s.clientCACerts = nil
+		s.serverCACerts = nil
+		s.serverCACertsWorker = nil
+	}
 }

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -52,7 +52,10 @@ func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS, 
 
 	for host, settings := range overrides {
 		lcHost := strings.ToLower(host)
-		providerMap.certProviderCache[lcHost] = certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
+
+		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
+		providerMap.certProviderCache[lcHost] = provider
+		provider.Initialize()
 		providerMap.clientAuthCache[lcHost] = settings.RequireClientAuth
 	}
 

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -39,7 +39,8 @@ type localStorePerHostCertProviderMap struct {
 	clientAuthCache   map[string]bool
 }
 
-func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS, certProviderFactory CertProviderFactory,
+func newLocalStorePerHostCertProviderMap(
+	overrides map[string]config.ServerTLS, certProviderFactory CertProviderFactory, refreshInterval time.Duration,
 ) *localStorePerHostCertProviderMap {
 
 	providerMap := &localStorePerHostCertProviderMap{}
@@ -55,7 +56,7 @@ func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS, 
 
 		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
 		providerMap.certProviderCache[lcHost] = provider
-		provider.Initialize()
+		provider.Initialize(refreshInterval)
 		providerMap.clientAuthCache[lcHost] = settings.RequireClientAuth
 	}
 

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -82,6 +82,7 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		internodeWorkerProvider := certProviderFactory(&tlsConfig.Internode, nil, &tlsConfig.Frontend.Client)
 		workerProvider = internodeWorkerProvider
 	}
+	workerProvider.Initialize()
 
 	provider := &localStoreTlsProvider{
 		internodeCertProvider:       internodeProvider,
@@ -94,11 +95,14 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		settings: tlsConfig,
 		scope:    scope,
 	}
-	provider.initialize()
+	provider.internodeCertProvider.Initialize()
+	provider.frontendCertProvider.Initialize()
+	provider.workerCertProvider.Initialize()
+	provider.Initialize()
 	return provider, nil
 }
 
-func (s *localStoreTlsProvider) initialize() {
+func (s *localStoreTlsProvider) Initialize() {
 
 	period := s.settings.ExpirationChecks.CheckInterval
 	if period != 0 {

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -82,7 +82,7 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		internodeWorkerProvider := certProviderFactory(&tlsConfig.Internode, nil, &tlsConfig.Frontend.Client)
 		workerProvider = internodeWorkerProvider
 	}
-	workerProvider.Initialize()
+	workerProvider.Initialize(tlsConfig.RefreshInterval)
 
 	provider := &localStoreTlsProvider{
 		internodeCertProvider:       internodeProvider,
@@ -90,14 +90,14 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		frontendCertProvider:        certProviderFactory(&tlsConfig.Frontend, nil, nil),
 		workerCertProvider:          workerProvider,
 		frontendPerHostCertProviderMap: newLocalStorePerHostCertProviderMap(
-			tlsConfig.Frontend.PerHostOverrides, certProviderFactory),
+			tlsConfig.Frontend.PerHostOverrides, certProviderFactory, tlsConfig.RefreshInterval),
 		RWMutex:  sync.RWMutex{},
 		settings: tlsConfig,
 		scope:    scope,
 	}
-	provider.internodeCertProvider.Initialize()
-	provider.frontendCertProvider.Initialize()
-	provider.workerCertProvider.Initialize()
+	provider.internodeCertProvider.Initialize(tlsConfig.RefreshInterval)
+	provider.frontendCertProvider.Initialize(tlsConfig.RefreshInterval)
+	provider.workerCertProvider.Initialize(tlsConfig.RefreshInterval)
 	provider.Initialize()
 	return provider, nil
 }

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -102,6 +102,6 @@ func (t *TestDynamicCertProvider) GetExpiringCerts(_ time.Duration,
 	panic("not implemented")
 }
 
-func (t *TestDynamicCertProvider) Initialize() {
+func (t *TestDynamicCertProvider) Initialize(refreshInterval time.Duration) {
 	panic("implement me")
 }

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -101,3 +101,7 @@ func (t *TestDynamicCertProvider) GetExpiringCerts(_ time.Duration,
 ) (expiring CertExpirationMap, expired CertExpirationMap, err error) {
 	panic("not implemented")
 }
+
+func (t *TestDynamicCertProvider) Initialize() {
+	panic("implement me")
+}

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -51,7 +51,7 @@ type (
 		FetchClientCertificate(isWorker bool) (*tls.Certificate, error)
 		FetchServerRootCAsForClient(isWorker bool) (*x509.CertPool, error)
 		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
-		Initialize()
+		Initialize(refreshInterval time.Duration)
 	}
 
 	// PerHostCertProviderMap returns a CertProvider for a given host name.

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -51,6 +51,7 @@ type (
 		FetchClientCertificate(isWorker bool) (*tls.Certificate, error)
 		FetchServerRootCAsForClient(isWorker bool) (*x509.CertPool, error)
 		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
+		Initialize()
 	}
 
 	// PerHostCertProviderMap returns a CertProvider for a given host name.


### PR DESCRIPTION
**What changed?**
Added support for periodic refreshing of TLS certs loaded from files.

**Why?**
To allow for refreshing TLS certs without restarting server.

**How did you test it?**
Unit tests.

**Potential risks**
If a previously loaded cert disappears from the file system, TLS connections will get broken after a refresh period.

**Is hotfix candidate?**
No.