### PR TITLE
dynamicconfig: Make Keys public for use in extension clients

### DIFF
--- a/common/dynamicconfig/config_test.go
+++ b/common/dynamicconfig/config_test.go
@@ -273,7 +273,7 @@ func (s *configSuite) TestUpdateConfig() {
 
 func TestDynamicConfigKeyIsMapped(t *testing.T) {
 	for i := unknownKey; i < lastKeyForTest; i++ {
-		key, ok := keys[i]
+		key, ok := Keys[i]
 		require.True(t, ok, fmt.Sprintf("key %d is not mapped", i))
 		require.NotEmpty(t, key)
 	}

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -32,15 +32,15 @@ import (
 type Key int
 
 func (k Key) String() string {
-	keyName, ok := keys[k]
+	keyName, ok := Keys[k]
 	if !ok {
-		return keys[unknownKey]
+		return Keys[unknownKey]
 	}
 	return keyName
 }
 
-// Mapping from Key to keyName, where keyName are used dynamic config source.
-var keys = map[Key]string{
+// Keys represents a mapping from Key to keyName, where keyName are used dynamic config source.
+var Keys = map[Key]string{
 	unknownKey: "unknownKey",
 
 	// tests keys

--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -190,7 +190,7 @@ func (fc *fileBasedClient) GetDurationValue(
 }
 
 func (fc *fileBasedClient) UpdateValue(name Key, value interface{}) error {
-	keyName := keys[name]
+	keyName := Keys[name]
 	currentValues := make(map[string][]*constrainedValue)
 
 	confContent, err := ioutil.ReadFile(fc.config.Filepath)
@@ -264,7 +264,7 @@ func (fc *fileBasedClient) storeValues(newValues map[string][]*constrainedValue)
 }
 
 func (fc *fileBasedClient) getValueWithFilters(key Key, filters map[Filter]interface{}, defaultValue interface{}) (interface{}, error) {
-	keyName := keys[key]
+	keyName := Keys[key]
 	values := fc.values.Load().(map[string][]*constrainedValue)
 	found := false
 	for _, constrainedValue := range values[keyName] {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed the visibility of the `keys` mapping in dynamicconfig to public.

<!-- Tell your future self why have you made these changes -->
**Why?**
Dynamic config client extensions may want to reuse the same keys as upstream. Making it public will reduce copy/paste synchronization between version changes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No