### PR TITLE
Improve compatibility with Aiven DB

### DIFF
--- a/tools/sql/clitest/connTest.go
+++ b/tools/sql/clitest/connTest.go
@@ -79,7 +79,7 @@ func (s *SQLConnTestSuite) SetupSuite() {
 	conn, err := newTestConn("", s.host, s.port, s.pluginName)
 	if err != nil {
 		logger := log.NewDefaultLogger()
-		logger.Fatal("error creating sql conn, ", tag.Error(err))
+		logger.Fatal("error creating sql conn", tag.Error(err))
 	}
 	s.SetupSuiteBase(conn)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Try using a set of default database names when initializing admin DB connection

<!-- Tell your future self why have you made these changes -->
**Why?**
Aiven DB is a PostgreSQL compatible DB, but comes with a different default DB name
Close #1389

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No