### PR TITLE
Fix metrics namespace tagging issue for matching & history service

### DIFF
--- a/common/rpc/interceptor/namespace.go
+++ b/common/rpc/interceptor/namespace.go
@@ -28,6 +28,8 @@ import (
 	"go.temporal.io/server/common/cache"
 )
 
+// gRPC method request must implement either NamespaceNameGetter or NamespaceIDGetter
+// for namespace specific metrics to be reported properly
 type (
 	NamespaceNameGetter interface {
 		GetNamespace() string

--- a/common/rpc/interceptor/namespace.go
+++ b/common/rpc/interceptor/namespace.go
@@ -24,16 +24,37 @@
 
 package interceptor
 
+import (
+	"go.temporal.io/server/common/cache"
+)
+
 type (
-	NamespaceGetter interface {
+	NamespaceNameGetter interface {
 		GetNamespace() string
+	}
+
+	NamespaceIDGetter interface {
+		GetNamespaceId() string
 	}
 )
 
-func GetNamespace(req interface{}) string {
-	if namespaceGetter, ok := req.(NamespaceGetter); ok {
-		return namespaceGetter.GetNamespace()
-	}
+func GetNamespace(
+	namespaceCache cache.NamespaceCache,
+	req interface{},
+) string {
+	switch request := req.(type) {
+	case NamespaceNameGetter:
+		return request.GetNamespace()
 
-	return ""
+	case NamespaceIDGetter:
+		namespaceID := request.GetNamespaceId()
+		namespaceEntry, err := namespaceCache.GetNamespaceByID(namespaceID)
+		if err != nil {
+			return ""
+		}
+		return namespaceEntry.GetInfo().Name
+
+	default:
+		return ""
+	}
 }

--- a/common/rpc/interceptor/namespace_test.go
+++ b/common/rpc/interceptor/namespace_test.go
@@ -1,0 +1,156 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package interceptor
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/api/workflowservice/v1"
+
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+)
+
+type (
+	nameepaceSuite struct {
+		suite.Suite
+		*require.Assertions
+	}
+)
+
+var (
+	frontendAPIExcluded = map[string]struct{}{
+		"GetClusterInfo":      {},
+		"GetSearchAttributes": {},
+		"ListNamespaces":      {},
+	}
+
+	matchingAPIExcluded = map[string]struct{}{
+		"ListTaskQueuePartitions": {},
+	}
+
+	historyAPIExcluded = map[string]struct{}{
+		"CloseShard":                {},
+		"GetDLQMessages":            {},
+		"GetDLQReplicationMessages": {},
+		"GetReplicationMessages":    {},
+		"MergeDLQMessages":          {},
+		"PurgeDLQMessages":          {},
+		"RemoveTask":                {},
+		"SyncShardStatus":           {},
+	}
+)
+
+func TestNameepaceSuite(t *testing.T) {
+	s := new(nameepaceSuite)
+	suite.Run(t, s)
+}
+
+func (s *nameepaceSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *nameepaceSuite) TearDownTest() {
+
+}
+
+func (s *nameepaceSuite) TestFrontendAPIMetrics() {
+	namespaceNameGetter := reflect.TypeOf((*NamespaceNameGetter)(nil)).Elem()
+
+	var service workflowservice.WorkflowServiceServer
+	t := reflect.TypeOf(&service).Elem()
+	for i := 0; i < t.NumMethod(); i++ {
+		method := t.Method(i)
+		methodName := method.Name
+		methodType := method.Type
+
+		// 0th parameter is context.Context
+		// 1th parameter is the request
+		if _, ok := frontendAPIExcluded[methodName]; ok {
+			continue
+		}
+		if methodType.NumIn() < 2 {
+			continue
+		}
+		request := methodType.In(1)
+		if !request.Implements(namespaceNameGetter) {
+			s.Fail(fmt.Sprintf("API: %v not implementing NamespaceNameGetter", methodName))
+		}
+	}
+}
+
+func (s *nameepaceSuite) TestMatchingAPIMetrics() {
+	namespaceIDGetter := reflect.TypeOf((*NamespaceIDGetter)(nil)).Elem()
+
+	var service matchingservice.MatchingServiceServer
+	t := reflect.TypeOf(&service).Elem()
+	for i := 0; i < t.NumMethod(); i++ {
+		method := t.Method(i)
+		methodName := method.Name
+		methodType := method.Type
+
+		// 0th parameter is context.Context
+		// 1th parameter is the request
+		if _, ok := matchingAPIExcluded[methodName]; ok {
+			continue
+		}
+		if methodType.NumIn() < 2 {
+			continue
+		}
+		request := methodType.In(1)
+		if !request.Implements(namespaceIDGetter) {
+			s.Fail(fmt.Sprintf("API: %v not implementing NamespaceIDGetter", methodName))
+		}
+	}
+}
+
+func (s *nameepaceSuite) TestHistoryAPIMetrics() {
+	namespaceIDGetter := reflect.TypeOf((*NamespaceIDGetter)(nil)).Elem()
+
+	var service historyservice.HistoryServiceServer
+	t := reflect.TypeOf(&service).Elem()
+	for i := 0; i < t.NumMethod(); i++ {
+		method := t.Method(i)
+		methodName := method.Name
+		methodType := method.Type
+
+		// 0th parameter is context.Context
+		// 1th parameter is the request
+		if _, ok := historyAPIExcluded[methodName]; ok {
+			continue
+		}
+		if methodType.NumIn() < 2 {
+			continue
+		}
+		request := methodType.In(1)
+		if !request.Implements(namespaceIDGetter) {
+			s.Fail(fmt.Sprintf("API: %v not implementing NamespaceIDGetter", methodName))
+		}
+	}
+}

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -245,6 +245,7 @@ func (s *Service) Start() {
 	}
 
 	metricsInterceptor := interceptor.NewTelemetryInterceptor(
+		s.Resource.GetNamespaceCache(),
 		s.Resource.GetMetricsClient(),
 		metrics.FrontendAPIMetricsScopes(),
 		s.Resource.GetLogger(),
@@ -254,12 +255,14 @@ func (s *Service) Start() {
 		APIRateLimitOverride,
 	)
 	namespaceRateLimiterInterceptor := interceptor.NewNamespaceRateLimitInterceptor(
+		s.Resource.GetNamespaceCache(),
 		func(namespace string) float64 {
 			return float64(s.config.MaxNamespaceRPSPerInstance(namespace))
 		},
 		APIRateLimitOverride,
 	)
 	namespaceCountLimiterInterceptor := interceptor.NewNamespaceCountLimitInterceptor(
+		s.Resource.GetNamespaceCache(),
 		s.config.MaxNamespaceCountPerInstance,
 		APICountLimitOverride,
 	)

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -150,6 +150,7 @@ func (s *Service) Start() {
 	s.handler.Start()
 
 	metricsInterceptor := interceptor.NewTelemetryInterceptor(
+		s.Resource.GetNamespaceCache(),
 		s.Resource.GetMetricsClient(),
 		metrics.HistoryAPIMetricsScopes(),
 		s.Resource.GetLogger(),

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -103,6 +103,7 @@ func (s *Service) Start() {
 	s.handler.Start()
 
 	metricsInterceptor := interceptor.NewTelemetryInterceptor(
+		s.Resource.GetNamespaceCache(),
 		s.Resource.GetMetricsClient(),
 		metrics.MatchingAPIMetricsScopes(),
 		s.Resource.GetLogger(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Fix namespace name metrics extraction issue for matching & history service

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously, the namespace attribute extraction only works for frontend service (request comes with namespace name).
Internal request only contains namespace ID, which were not processed correctly

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes