### PR TITLE
Add support for periodic refreshing of TLS certs loaded from files

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -129,6 +129,9 @@ type (
 		// specific hostname. Host names are case insensitive. Optional. If not present,
 		// uses configuration supplied by Server field.
 		PerHostOverrides map[string]ServerTLS `yaml:"hostOverrides"`
+
+		// Interval between refreshes of certificates loaded from files
+		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// ServerTLS contains items to load server TLS configuration
@@ -185,6 +188,9 @@ type (
 
 		// Client TLS settings for system workers
 		Client ClientTLS `yaml:"client"`
+
+		// Interval between refreshes of certificates loaded from files
+		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// CertExpirationValidation contains settings for periodic checks of TLS certificate expiration

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -115,6 +115,8 @@ type (
 		SystemWorker WorkerTLS `yaml:"systemWorker"`
 		// ExpirationChecks defines settings for periodic checks for expiration of certificates
 		ExpirationChecks CertExpirationValidation `yaml:"expirationChecks"`
+		// Interval between refreshes of certificates loaded from files
+		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// GroupTLS contains an instance client and server TLS settings
@@ -129,9 +131,6 @@ type (
 		// specific hostname. Host names are case insensitive. Optional. If not present,
 		// uses configuration supplied by Server field.
 		PerHostOverrides map[string]ServerTLS `yaml:"hostOverrides"`
-
-		// Interval between refreshes of certificates loaded from files
-		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// ServerTLS contains items to load server TLS configuration
@@ -188,9 +187,6 @@ type (
 
 		// Client TLS settings for system workers
 		Client ClientTLS `yaml:"client"`
-
-		// Interval between refreshes of certificates loaded from files
-		RefreshInterval time.Duration `yaml:"refreshInterval"`
 	}
 
 	// CertExpirationValidation contains settings for periodic checks of TLS certificate expiration

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -817,16 +817,17 @@ func BootstrapHostPorts(s string) ZapTag {
 	return NewStringTag("bootstrap-hostports", s)
 }
 
-// CertFile returns tag for RequestRunID
+// TLSCertFile returns tag for TLS cert file name
 func TLSCertFile(filePath string) ZapTag {
 	return NewStringTag("tls-cert-file", filePath)
 }
 
-// CertFile returns tag for RequestRunID
+// TLSKeyFile returns tag for TLS key file
 func TLSKeyFile(filePath string) ZapTag {
 	return NewStringTag("tls-key-file", filePath)
 }
 
+// TLSCertFiles returns tag for TLS cert file names
 func TLSCertFiles(filePaths []string) ZapTag {
-	return NewStringsTag("tls-cert-file", filePaths)
+	return NewStringsTag("tls-cert-files", filePaths)
 }

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -816,3 +816,17 @@ func MaxQueryLevel(s time.Time) ZapTag {
 func BootstrapHostPorts(s string) ZapTag {
 	return NewStringTag("bootstrap-hostports", s)
 }
+
+// CertFile returns tag for RequestRunID
+func TLSCertFile(filePath string) ZapTag {
+	return NewStringTag("tls-cert-file", filePath)
+}
+
+// CertFile returns tag for RequestRunID
+func TLSKeyFile(filePath string) ZapTag {
+	return NewStringTag("tls-key-file", filePath)
+}
+
+func TLSCertFiles(filePaths []string) ZapTag {
+	return NewStringsTag("tls-cert-file", filePaths)
+}

--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -72,20 +72,13 @@ type x509CertFetcher func() (*x509.Certificate, error)
 type x509CertPoolFetcher func() (*x509.CertPool, error)
 type tlsCertFetcher func() (*tls.Certificate, error)
 
-func (s *localStoreCertProvider) Initialize() {
+func (s *localStoreCertProvider) Initialize(refreshInterval time.Duration) {
 
 	s.logger = log.NewDefaultLogger()
-	var period time.Duration
 
-	if s.tlsSettings != nil {
-		period = s.tlsSettings.RefreshInterval
-	} else if s.workerTLSSettings != nil {
-		period = s.workerTLSSettings.RefreshInterval
-	}
-
-	if period != 0 {
+	if refreshInterval != 0 {
 		s.stop = make(chan bool)
-		s.ticker = time.NewTicker(period)
+		s.ticker = time.NewTicker(refreshInterval)
 		go s.refreshCerts()
 	}
 }

--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -544,8 +544,9 @@ func (c *certCache) isEqual(other *certCache) bool {
 	if c == nil || other == nil {
 		return false
 	}
-	if !equal(c.serverCert.Certificate, other.serverCert.Certificate) ||
-		!equal(c.workerCert.Certificate, other.workerCert.Certificate) ||
+
+	if !equalTLSCerts(c.serverCert, other.serverCert) ||
+		!equalTLSCerts(c.workerCert, other.workerCert) ||
 		!equalX509(c.clientCACerts, other.clientCACerts) ||
 		!equalX509(c.serverCACerts, other.serverCACerts) ||
 		!equalX509(c.serverCACertsWorker, other.serverCACertsWorker) {
@@ -572,6 +573,19 @@ func equalX509(a, b []*x509.Certificate) bool {
 	}
 	for i := range a {
 		if !a[i].Equal(b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func equalTLSCerts(a, b *tls.Certificate) bool {
+	if a != nil {
+		if b == nil || !equal(a.Certificate, b.Certificate) {
+			return false
+		}
+	} else {
+		if b != nil {
 			return false
 		}
 	}

--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -489,13 +489,20 @@ func appendError(aggregatedErr error, err error) error {
 
 func (s *localStoreCertProvider) refreshCerts() {
 
-	s.logger.Info("resetting cached TLS certs to refresh them")
-	s.serverCert = nil
-	s.clientCert = nil
-	s.clientCAPool = nil
-	s.serverCAPool = nil
-	s.serverCAsWorkerPool = nil
-	s.clientCACerts = nil
-	s.serverCACerts = nil
-	s.serverCACertsWorker = nil
+	for {
+		select {
+		case <-s.stop:
+			break
+		case <-s.ticker.C:
+		}
+		s.logger.Info("resetting cached TLS certs to refresh them")
+		s.serverCert = nil
+		s.clientCert = nil
+		s.clientCAPool = nil
+		s.serverCAPool = nil
+		s.serverCAsWorkerPool = nil
+		s.clientCACerts = nil
+		s.serverCACerts = nil
+		s.serverCACertsWorker = nil
+	}
 }

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -52,7 +52,10 @@ func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS, 
 
 	for host, settings := range overrides {
 		lcHost := strings.ToLower(host)
-		providerMap.certProviderCache[lcHost] = certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
+
+		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
+		providerMap.certProviderCache[lcHost] = provider
+		provider.Initialize()
 		providerMap.clientAuthCache[lcHost] = settings.RequireClientAuth
 	}
 

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -54,9 +54,8 @@ func newLocalStorePerHostCertProviderMap(
 	for host, settings := range overrides {
 		lcHost := strings.ToLower(host)
 
-		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
+		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil, refreshInterval)
 		providerMap.certProviderCache[lcHost] = provider
-		provider.Initialize(refreshInterval)
 		providerMap.clientAuthCache[lcHost] = settings.RequireClientAuth
 	}
 

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -39,7 +39,8 @@ type localStorePerHostCertProviderMap struct {
 	clientAuthCache   map[string]bool
 }
 
-func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS, certProviderFactory CertProviderFactory,
+func newLocalStorePerHostCertProviderMap(
+	overrides map[string]config.ServerTLS, certProviderFactory CertProviderFactory, refreshInterval time.Duration,
 ) *localStorePerHostCertProviderMap {
 
 	providerMap := &localStorePerHostCertProviderMap{}
@@ -55,7 +56,7 @@ func newLocalStorePerHostCertProviderMap(overrides map[string]config.ServerTLS, 
 
 		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil)
 		providerMap.certProviderCache[lcHost] = provider
-		provider.Initialize()
+		provider.Initialize(refreshInterval)
 		providerMap.clientAuthCache[lcHost] = settings.RequireClientAuth
 	}
 

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -82,6 +82,7 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		internodeWorkerProvider := certProviderFactory(&tlsConfig.Internode, nil, &tlsConfig.Frontend.Client)
 		workerProvider = internodeWorkerProvider
 	}
+	workerProvider.Initialize()
 
 	provider := &localStoreTlsProvider{
 		internodeCertProvider:       internodeProvider,
@@ -94,11 +95,14 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		settings: tlsConfig,
 		scope:    scope,
 	}
-	provider.initialize()
+	provider.internodeCertProvider.Initialize()
+	provider.frontendCertProvider.Initialize()
+	provider.workerCertProvider.Initialize()
+	provider.Initialize()
 	return provider, nil
 }
 
-func (s *localStoreTlsProvider) initialize() {
+func (s *localStoreTlsProvider) Initialize() {
 
 	period := s.settings.ExpirationChecks.CheckInterval
 	if period != 0 {

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -43,7 +43,11 @@ const (
 	metricCertsExpiring = "certificates_expiring"
 )
 
-type CertProviderFactory func(tlsSettings *config.GroupTLS, workerTlsSettings *config.WorkerTLS, legacyWorkerSettings *config.ClientTLS) CertProvider
+type CertProviderFactory func(
+	tlsSettings *config.GroupTLS,
+	workerTlsSettings *config.WorkerTLS,
+	legacyWorkerSettings *config.ClientTLS,
+	refreshInterval time.Duration) CertProvider
 
 type localStoreTlsProvider struct {
 	sync.RWMutex
@@ -74,20 +78,19 @@ var _ CertExpirationChecker = (*localStoreTlsProvider)(nil)
 func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, certProviderFactory CertProviderFactory,
 ) (TLSConfigProvider, error) {
 
-	internodeProvider := certProviderFactory(&tlsConfig.Internode, nil, nil)
+	internodeProvider := certProviderFactory(&tlsConfig.Internode, nil, nil, tlsConfig.RefreshInterval)
 	var workerProvider CertProvider
 	if tlsConfig.SystemWorker.CertFile != "" || tlsConfig.SystemWorker.CertData != "" { // explicit system worker config
-		workerProvider = certProviderFactory(nil, &tlsConfig.SystemWorker, nil)
+		workerProvider = certProviderFactory(nil, &tlsConfig.SystemWorker, nil, tlsConfig.RefreshInterval)
 	} else { // legacy implicit system worker config case
-		internodeWorkerProvider := certProviderFactory(&tlsConfig.Internode, nil, &tlsConfig.Frontend.Client)
+		internodeWorkerProvider := certProviderFactory(&tlsConfig.Internode, nil, &tlsConfig.Frontend.Client, tlsConfig.RefreshInterval)
 		workerProvider = internodeWorkerProvider
 	}
-	workerProvider.Initialize(tlsConfig.RefreshInterval)
 
 	provider := &localStoreTlsProvider{
 		internodeCertProvider:       internodeProvider,
 		internodeClientCertProvider: internodeProvider,
-		frontendCertProvider:        certProviderFactory(&tlsConfig.Frontend, nil, nil),
+		frontendCertProvider:        certProviderFactory(&tlsConfig.Frontend, nil, nil, tlsConfig.RefreshInterval),
 		workerCertProvider:          workerProvider,
 		frontendPerHostCertProviderMap: newLocalStorePerHostCertProviderMap(
 			tlsConfig.Frontend.PerHostOverrides, certProviderFactory, tlsConfig.RefreshInterval),
@@ -95,14 +98,11 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		settings: tlsConfig,
 		scope:    scope,
 	}
-	provider.internodeCertProvider.Initialize(tlsConfig.RefreshInterval)
-	provider.frontendCertProvider.Initialize(tlsConfig.RefreshInterval)
-	provider.workerCertProvider.Initialize(tlsConfig.RefreshInterval)
-	provider.Initialize()
+	provider.initialize()
 	return provider, nil
 }
 
-func (s *localStoreTlsProvider) Initialize() {
+func (s *localStoreTlsProvider) initialize() {
 
 	period := s.settings.ExpirationChecks.CheckInterval
 	if period != 0 {

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -82,7 +82,7 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		internodeWorkerProvider := certProviderFactory(&tlsConfig.Internode, nil, &tlsConfig.Frontend.Client)
 		workerProvider = internodeWorkerProvider
 	}
-	workerProvider.Initialize()
+	workerProvider.Initialize(tlsConfig.RefreshInterval)
 
 	provider := &localStoreTlsProvider{
 		internodeCertProvider:       internodeProvider,
@@ -90,14 +90,14 @@ func NewLocalStoreTlsProvider(tlsConfig *config.RootTLS, scope tally.Scope, cert
 		frontendCertProvider:        certProviderFactory(&tlsConfig.Frontend, nil, nil),
 		workerCertProvider:          workerProvider,
 		frontendPerHostCertProviderMap: newLocalStorePerHostCertProviderMap(
-			tlsConfig.Frontend.PerHostOverrides, certProviderFactory),
+			tlsConfig.Frontend.PerHostOverrides, certProviderFactory, tlsConfig.RefreshInterval),
 		RWMutex:  sync.RWMutex{},
 		settings: tlsConfig,
 		scope:    scope,
 	}
-	provider.internodeCertProvider.Initialize()
-	provider.frontendCertProvider.Initialize()
-	provider.workerCertProvider.Initialize()
+	provider.internodeCertProvider.Initialize(tlsConfig.RefreshInterval)
+	provider.frontendCertProvider.Initialize(tlsConfig.RefreshInterval)
+	provider.workerCertProvider.Initialize(tlsConfig.RefreshInterval)
 	provider.Initialize()
 	return provider, nil
 }

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -102,6 +102,6 @@ func (t *TestDynamicCertProvider) GetExpiringCerts(_ time.Duration,
 	panic("not implemented")
 }
 
-func (t *TestDynamicCertProvider) Initialize() {
+func (t *TestDynamicCertProvider) Initialize(refreshInterval time.Duration) {
 	panic("implement me")
 }

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -101,3 +101,7 @@ func (t *TestDynamicCertProvider) GetExpiringCerts(_ time.Duration,
 ) (expiring CertExpirationMap, expired CertExpirationMap, err error) {
 	panic("not implemented")
 }
+
+func (t *TestDynamicCertProvider) Initialize() {
+	panic("implement me")
+}

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -51,7 +51,7 @@ type (
 		FetchClientCertificate(isWorker bool) (*tls.Certificate, error)
 		FetchServerRootCAsForClient(isWorker bool) (*x509.CertPool, error)
 		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
-		Initialize()
+		Initialize(refreshInterval time.Duration)
 	}
 
 	// PerHostCertProviderMap returns a CertProvider for a given host name.

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -51,6 +51,7 @@ type (
 		FetchClientCertificate(isWorker bool) (*tls.Certificate, error)
 		FetchServerRootCAsForClient(isWorker bool) (*x509.CertPool, error)
 		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
+		Initialize()
 	}
 
 	// PerHostCertProviderMap returns a CertProvider for a given host name.


### PR DESCRIPTION
This is a replacement for #1395 that I'm unable to reopen now.

What changed?
Added support for periodic refreshing of TLS certs loaded from files.

Why?
To allow for refreshing TLS certs without restarting server.

How did you test it?
Unit tests.

Potential risks
If a previously loaded cert disappears from the file system, TLS connections will get broken after a refresh period.

Is hotfix candidate?
No.