### PR TITLE
Fix NDC events reapplication potential deadlock issue

### DIFF
--- a/service/history/nDCTransactionMgrForNewWorkflow.go
+++ b/service/history/nDCTransactionMgrForNewWorkflow.go
@@ -221,6 +221,11 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) createAsZombie(
 		return serviceerror.NewInternal("nDCTransactionMgrForNewWorkflow createAsZombie encounter target workflow policy not being passive")
 	}
 
+	// release lock on current workflow, since current cluster maybe the active cluster
+	// and events maybe reapplied to current workflow
+	currentWorkflow.getReleaseFn()(nil)
+	currentWorkflow = nil
+
 	targetWorkflowSnapshot, targetWorkflowEventsSeq, err := targetWorkflow.getMutableState().CloseTransactionAsSnapshot(
 		now,
 		targetWorkflowPolicy,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* When doing events reapplication, release current workflow lock earlier in case of deadlock

<!-- Tell your future self why have you made these changes -->
**Why?**
Cherry pick https://github.com/uber/cadence/pull/4085

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No