### PR TITLE
Support plugins for dataconverters

### DIFF
--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -263,7 +263,7 @@ func KillPlugins(ctx *cli.Context) error {
 var (
 	pluginClient *plugin.Client
 	pluginMap    = map[string]plugin.Plugin{
-		"DataConverter": &converter.DataConverterPlugin{},
+		"DataConverter": &DataConverterPlugin{},
 	}
 	handshakeConfig = plugin.HandshakeConfig{
 		ProtocolVersion:  1,

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -31,6 +31,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/sdk/converter"
 )
 
 const (
@@ -125,4 +126,8 @@ var (
 		"cont":      enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW,
 		"timeout":   enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT,
 	}
+)
+
+var (
+	cliDataConverter = converter.GetDefaultDataConverter()
 )

--- a/tools/cli/plugin.go
+++ b/tools/cli/plugin.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"net/rpc"
+
+	"github.com/hashicorp/go-plugin"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/sdk/converter"
+)
+
+type DataConverterRPC struct {
+	client *rpc.Client
+}
+
+func (g *DataConverterRPC) FromPayload(payload *commonpb.Payload, valuePtr interface{}) error {
+	err := g.client.Call("Plugin.FromPayload", payload, valuePtr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *DataConverterRPC) FromPayloads(payloads *commonpb.Payloads, valuePtr ...interface{}) error {
+	err := g.client.Call("Plugin.FromPayloads", payloads, valuePtr)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (g *DataConverterRPC) ToPayload(value interface{}) (*commonpb.Payload, error) {
+	var payload commonpb.Payload
+	err := g.client.Call("Plugin.ToPayload", value, &payload)
+	if err != nil {
+		return nil, err
+	}
+
+	return &payload, nil
+}
+
+func (g *DataConverterRPC) ToPayloads(values ...interface{}) (*commonpb.Payloads, error) {
+	var payloads commonpb.Payloads
+	err := g.client.Call("Plugin.ToPayloads", values, &payloads)
+	if err != nil {
+		return nil, err
+	}
+
+	return &payloads, nil
+}
+
+func (g *DataConverterRPC) ToString(input *commonpb.Payload) string {
+	var resp string
+	err := g.client.Call("Plugin.ToString", input, &resp)
+	if err != nil {
+		return err.Error()
+	}
+
+	return resp
+}
+
+func (g *DataConverterRPC) ToStrings(input *commonpb.Payloads) []string {
+	var resp []string
+	err := g.client.Call("Plugin.ToStrings", input, &resp)
+	if err != nil {
+		return []string{err.Error()}
+	}
+
+	return resp
+}
+
+type DataConverterRPCServer struct {
+	Impl converter.DataConverter
+}
+
+func (s *DataConverterRPCServer) FromPayload(input *commonpb.Payload, resp *interface{}) error {
+	var result interface{}
+	err := s.Impl.FromPayload(input, result)
+	resp = &result
+	return err
+}
+
+func (s *DataConverterRPCServer) FromPayloads(input *commonpb.Payloads, resp *[]interface{}) error {
+	var results []interface{}
+	err := s.Impl.FromPayloads(input, results)
+	resp = &results
+	return err
+}
+
+func (s *DataConverterRPCServer) ToPayload(value interface{}, resp *commonpb.Payload) error {
+	resp, err := s.Impl.ToPayload(value)
+	return err
+}
+
+func (s *DataConverterRPCServer) ToPayloads(values []interface{}, resp *commonpb.Payloads) error {
+	resp, err := s.Impl.ToPayloads(values)
+	return err
+}
+
+func (s *DataConverterRPCServer) ToString(input *commonpb.Payload, resp *string) error {
+	*resp = s.Impl.ToString(input)
+	return nil
+}
+
+func (s *DataConverterRPCServer) ToStrings(input *commonpb.Payloads, resp *[]string) error {
+	*resp = s.Impl.ToStrings(input)
+	return nil
+}
+
+type DataConverterPlugin struct {
+	Impl converter.DataConverter
+}
+
+func (p *DataConverterPlugin) Server(*plugin.MuxBroker) (interface{}, error) {
+	return &DataConverterRPCServer{Impl: p.Impl}, nil
+}
+
+func (DataConverterPlugin) Client(b *plugin.MuxBroker, c *rpc.Client) (interface{}, error) {
+	return &DataConverterRPC{client: c}, nil
+}

--- a/tools/cli/stringify/stringify_test.go
+++ b/tools/cli/stringify/stringify_test.go
@@ -36,10 +36,15 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/sdk/converter"
 
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
+)
+
+var (
+	dataConverter = converter.GetDefaultDataConverter()
 )
 
 type stringifySuite struct {
@@ -83,7 +88,7 @@ func (s *stringifySuite) TestAnyToString() {
 			Input:               payloads.EncodeString(arg),
 		}},
 	}
-	res := AnyToString(event, false, 500)
+	res := AnyToString(event, false, 500, dataConverter)
 	ss, l := tablewriter.WrapString(res, 10)
 	s.Equal(6, len(ss))
 	s.Equal(120, l)
@@ -97,49 +102,49 @@ func (s *stringifySuite) TestAnyToString_DecodeMapValues() {
 		Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 		Memo:   &commonpb.Memo{Fields: fields},
 	}
-	s.Equal(`{Status:Running, HistoryLength:0, Memo:{Fields:map{TestKey:"testValue"}}}`, AnyToString(execution, true, 0))
+	s.Equal(`{Status:Running, HistoryLength:0, Memo:{Fields:map{TestKey:"testValue"}}}`, AnyToString(execution, true, 0, dataConverter))
 
 	fields["TestKey2"] = payload.EncodeString("anotherTestValue")
 	execution.Memo = &commonpb.Memo{Fields: fields}
-	got := AnyToString(execution, true, 0)
+	got := AnyToString(execution, true, 0, dataConverter)
 	expected := `{Status:Running, HistoryLength:0, Memo:{Fields:map{TestKey:"testValue", TestKey2:"anotherTestValue"}}}`
 	s.Equal(expected, got)
 }
 
 func (s *stringifySuite) TestAnyToString_Slice() {
 	var fields []string
-	got := AnyToString(fields, true, 0)
+	got := AnyToString(fields, true, 0, dataConverter)
 	s.Equal("[]", got)
 
 	fields = make([]string, 0)
-	got = AnyToString(fields, true, 0)
+	got = AnyToString(fields, true, 0, dataConverter)
 	s.Equal("[]", got)
 
 	fields = make([]string, 1)
-	got = AnyToString(fields, true, 0)
+	got = AnyToString(fields, true, 0, dataConverter)
 	s.Equal("[]", got)
 
 	fields[0] = "qwe"
-	got = AnyToString(fields, true, 0)
+	got = AnyToString(fields, true, 0, dataConverter)
 	s.Equal("[qwe]", got)
-	got = AnyToString(fields, false, 0)
+	got = AnyToString(fields, false, 0, dataConverter)
 	s.Equal("[qwe]", got)
 
 	fields = make([]string, 2)
 	fields[0] = "asd"
 	fields[1] = "zxc"
-	got = AnyToString(fields, true, 0)
+	got = AnyToString(fields, true, 0, dataConverter)
 	s.Equal("[asd,zxc]", got)
-	got = AnyToString(fields, false, 0)
+	got = AnyToString(fields, false, 0, dataConverter)
 	s.Equal("[asd,...1 more]", got)
 
 	fields = make([]string, 3)
 	fields[0] = "0"
 	fields[1] = "1"
 	fields[2] = "2"
-	got = AnyToString(fields, true, 0)
+	got = AnyToString(fields, true, 0, dataConverter)
 	s.Equal("[0,1,2]", got)
-	got = AnyToString(fields, false, 0)
+	got = AnyToString(fields, false, 0, dataConverter)
 	s.Equal("[0,...2 more]", got)
 
 }

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -77,7 +77,7 @@ func GetHistory(ctx context.Context, workflowClient sdkclient.Client, workflowID
 // HistoryEventToString convert HistoryEvent to string
 func HistoryEventToString(e *historypb.HistoryEvent, printFully bool, maxFieldLength int) string {
 	data := getEventAttributes(e)
-	return stringify.AnyToString(data, printFully, maxFieldLength)
+	return stringify.AnyToString(data, printFully, maxFieldLength, cliDataConverter)
 }
 
 // ColorEvent takes an event and return string with color

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -119,7 +119,7 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 				}
 				prevEvent = *e
 			}
-			fmt.Println(stringify.AnyToString(e, true, maxFieldLength))
+			fmt.Println(stringify.AnyToString(e, true, maxFieldLength, cliDataConverter))
 		}
 	} else if c.IsSet(FlagEventID) { // only dump that event
 		eventID := c.Int(FlagEventID)
@@ -127,7 +127,7 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 			ErrorAndExit("EventId out of range.", fmt.Errorf("number should be 1 - %d inclusive", len(history.Events)))
 		}
 		e := history.Events[eventID-1]
-		fmt.Println(stringify.AnyToString(e, true, 0))
+		fmt.Println(stringify.AnyToString(e, true, 0, cliDataConverter))
 	} else { // use table to pretty output, will trim long text
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetBorder(false)
@@ -1339,9 +1339,9 @@ func printListResults(executions []*workflowpb.WorkflowExecutionInfo, inJSON boo
 			}
 		} else {
 			if more || i < len(executions)-1 {
-				fmt.Println(stringify.AnyToString(execution, true, 0) + ",")
+				fmt.Println(stringify.AnyToString(execution, true, 0, cliDataConverter) + ",")
 			} else {
-				fmt.Println(stringify.AnyToString(execution, true, 0))
+				fmt.Println(stringify.AnyToString(execution, true, 0, cliDataConverter))
 			}
 		}
 	}


### PR DESCRIPTION
**What changed?**
A plugin interface was added for data converters.

**Why?**
This allows tctl to locally decrypt payloads or handle any custom encoding that a user's workers perform but that tctl doesn't natively know about.

Previously there was no way for a user to customise the data converter used in tctl.

**How did you test it?**
This has been tested using a combination of https://github.com/temporalio/sdk-go/pull/393 and https://github.com/temporalio/samples-go/pull/87. Tested by running the workflow from the sample and then confirming that `tctl workflow show` displays unencrypted inputs/results while the web UI shows snippets of the cipher text.

**Open questions**
  - [ ] Do we want to use an environment variable here, or rather a flag?
  - [ ] Is there a wider-reaching way set the data converter that the cli tools should use? Currently most code assumes converter.GetDefaultConverter() is the right thing and it caches this to a var at load time which makes dependency injection impossible without adjusting all the call signatures.