### PR TITLE
Begin the migration of executions table operation using atomic counter

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -63,6 +63,9 @@ var Keys = map[Key]string{
 	AdminMatchingNamespaceToPartitionDispatchRate:          "admin.matchingNamespaceToPartitionDispatchRate",
 	AdminMatchingNamespaceTaskqueueToPartitionDispatchRate: "admin.matchingNamespaceTaskqueueToPartitionDispatchRate",
 
+	// TODO remove this dynamic flag in 1.11.x
+	EnableDBVersion: "system.enableDBVersion",
+
 	// system settings
 	EnableVisibilitySampling:               "system.enableVisibilitySampling",
 	AdvancedVisibilityWritingMode:          "system.advancedVisibilityWritingMode",
@@ -340,6 +343,10 @@ const (
 	AdminMatchingNamespaceToPartitionDispatchRate
 	// AdminMatchingNamespaceTaskqueueToPartitionDispatchRate is the max qps of a task queue partition for a given namespace & task queue
 	AdminMatchingNamespaceTaskqueueToPartitionDispatchRate
+
+	// TODO remove this dynamic flag in 1.11.x
+	// EnableDBVersion is key for enable db version
+	EnableDBVersion
 
 	// EnableVisibilitySampling is key for enable visibility sampling
 	EnableVisibilitySampling

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -64,7 +64,7 @@ var Keys = map[Key]string{
 	AdminMatchingNamespaceTaskqueueToPartitionDispatchRate: "admin.matchingNamespaceTaskqueueToPartitionDispatchRate",
 
 	// TODO remove this dynamic flag in 1.11.x
-	EnableDBVersion: "system.enableDBVersion",
+	EnableDBRecordVersion: "system.enableDBRecordVersion",
 
 	// system settings
 	EnableVisibilitySampling:               "system.enableVisibilitySampling",
@@ -345,8 +345,8 @@ const (
 	AdminMatchingNamespaceTaskqueueToPartitionDispatchRate
 
 	// TODO remove this dynamic flag in 1.11.x
-	// EnableDBVersion is key for enable db version
-	EnableDBVersion
+	// EnableDBRecordVersion is key for enable db version
+	EnableDBRecordVersion
 
 	// EnableVisibilitySampling is key for enable visibility sampling
 	EnableVisibilitySampling

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -46,6 +46,11 @@ const LoggingCallAtKey = "logging-call-at"
 
 ///////////////////  Common tags defined here ///////////////////
 
+// Operation returns tag for Operation
+func Operation(operation string) ZapTag {
+	return NewStringTag("operation", operation)
+}
+
 // Error returns tag for Error
 func Error(err error) ZapTag {
 	return NewErrorTag(err)

--- a/common/migration/db_record_version.go
+++ b/common/migration/db_record_version.go
@@ -29,19 +29,19 @@ import (
 )
 
 var (
-	enableDBVersion int32
+	enableDBRecordVersion int32
 )
 
 func IsDBVersionEnabled() bool {
-	return atomic.LoadInt32(&enableDBVersion) == 1
+	return atomic.LoadInt32(&enableDBRecordVersion) == 1
 }
 
 func SetDBVersionFlag(
 	enabled bool,
 ) {
 	if enabled {
-		atomic.StoreInt32(&enableDBVersion, 1)
+		atomic.StoreInt32(&enableDBRecordVersion, 1)
 	} else {
-		atomic.StoreInt32(&enableDBVersion, 0)
+		atomic.StoreInt32(&enableDBRecordVersion, 0)
 	}
 }

--- a/common/migration/db_version.go
+++ b/common/migration/db_version.go
@@ -22,14 +22,26 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package postgresql
+package migration
 
-// NOTE: whenever there is a new data base schema update, plz update the following versions
+import (
+	"sync/atomic"
+)
 
-// Version is the Postgres database release version
-// Temporal supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres
-const Version = "1.5"
+var (
+	enableDBVersion int32
+)
 
-// VisibilityVersion is the Postgres visibility database release version
-// Temporal supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres
-const VisibilityVersion = "1.1"
+func IsDBVersionEnabled() bool {
+	return atomic.LoadInt32(&enableDBVersion) == 1
+}
+
+func SetDBVersionFlag(
+	enabled bool,
+) {
+	if enabled {
+		atomic.StoreInt32(&enableDBVersion, 1)
+	} else {
+		atomic.StoreInt32(&enableDBVersion, 0)
+	}
+}

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -218,6 +218,7 @@ const (
 		`and type = ?`
 
 	// TODO deprecate templateUpdateWorkflowExecutionQueryDeprecated in favor of templateUpdateWorkflowExecutionQuery
+	// Deprecated.
 	templateUpdateWorkflowExecutionQueryDeprecated = `UPDATE executions ` +
 		`SET execution = ? ` +
 		`, execution_encoding = ? ` +

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -159,7 +159,7 @@ const (
 
 	templateCreateWorkflowExecutionQuery = `INSERT INTO executions (` +
 		`shard_id, namespace_id, workflow_id, run_id, type, ` +
-		`execution, execution_encoding, execution_state, execution_state_encoding, next_event_id, db_version, ` +
+		`execution, execution_encoding, execution_state, execution_state_encoding, next_event_id, db_record_version, ` +
 		`visibility_ts, task_id, checksum, checksum_encoding) ` +
 		`VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS `
 
@@ -192,7 +192,7 @@ const (
 
 	templateGetWorkflowExecutionQuery = `SELECT execution, execution_encoding, execution_state, execution_state_encoding, next_event_id, activity_map, activity_map_encoding, timer_map, timer_map_encoding, ` +
 		`child_executions_map, child_executions_map_encoding, request_cancel_map, request_cancel_map_encoding, signal_map, signal_map_encoding, signal_requested, buffered_events_list, ` +
-		`checksum, checksum_encoding, db_version ` +
+		`checksum, checksum_encoding, db_record_version ` +
 		`FROM executions ` +
 		`WHERE shard_id = ? ` +
 		`and type = ? ` +
@@ -240,7 +240,7 @@ const (
 		`, execution_state = ? ` +
 		`, execution_state_encoding = ? ` +
 		`, next_event_id = ? ` +
-		`, db_version = ? ` +
+		`, db_record_version = ? ` +
 		`, checksum = ? ` +
 		`, checksum_encoding = ? ` +
 		`WHERE shard_id = ? ` +
@@ -250,7 +250,7 @@ const (
 		`and run_id = ? ` +
 		`and visibility_ts = ? ` +
 		`and task_id = ? ` +
-		`IF db_version = ? `
+		`IF db_record_version = ? `
 
 	templateUpdateActivityInfoQuery = `UPDATE executions ` +
 		`SET activity_map[ ? ] = ?, activity_map_encoding = ? ` +
@@ -1181,15 +1181,15 @@ func (d *cassandraPersistence) GetWorkflowExecution(
 	state.Checksum = cs
 
 	dbVersion := int64(0)
-	if dbRecordVersion, ok := result["db_version"]; ok {
+	if dbRecordVersion, ok := result["db_record_version"]; ok {
 		dbVersion = dbRecordVersion.(int64)
 	} else {
 		dbVersion = 0
 	}
 
 	return &p.InternalGetWorkflowExecutionResponse{
-		State:     state,
-		DBVersion: dbVersion,
+		State:           state,
+		DBRecordVersion: dbVersion,
 	}, nil
 }
 

--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -62,7 +62,7 @@ func applyWorkflowMutationBatch(
 		workflowMutation.NextEventID,
 		cqlNowTimestampMillis,
 		workflowMutation.Condition,
-		workflowMutation.DBVersion,
+		workflowMutation.DBRecordVersion,
 		workflowMutation.Checksum,
 	); err != nil {
 		return err
@@ -182,7 +182,7 @@ func applyWorkflowSnapshotBatchAsReset(
 		workflowSnapshot.NextEventID,
 		cqlNowTimestampMillis,
 		workflowSnapshot.Condition,
-		workflowSnapshot.DBVersion,
+		workflowSnapshot.DBRecordVersion,
 		workflowSnapshot.Checksum,
 	); err != nil {
 		return err
@@ -292,7 +292,7 @@ func applyWorkflowSnapshotBatchAsNew(
 		workflowSnapshot.ExecutionInfo,
 		workflowSnapshot.ExecutionState,
 		workflowSnapshot.NextEventID,
-		workflowSnapshot.DBVersion,
+		workflowSnapshot.DBRecordVersion,
 		workflowSnapshot.Checksum,
 		cqlNowTimestampMillis,
 	); err != nil {

--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -389,7 +389,7 @@ func createExecution(
 	executionInfo *persistencespb.WorkflowExecutionInfo,
 	executionState *persistencespb.WorkflowExecutionState,
 	nextEventID int64,
-	dbVersion int64,
+	dbRecordVersion int64,
 	checksum *persistencespb.Checksum,
 	cqlNowTimestampMillis int64,
 ) error {
@@ -435,7 +435,7 @@ func createExecution(
 		executionStateDatablob.Data,
 		executionStateDatablob.EncodingType.String(),
 		nextEventID,
-		dbVersion,
+		dbRecordVersion,
 		defaultVisibilityTimestamp,
 		rowTypeExecutionTaskID,
 		checksumDatablob.Data,
@@ -453,7 +453,7 @@ func updateExecution(
 	nextEventID int64,
 	cqlNowTimestampMillis int64,
 	condition int64,
-	dbVersion int64,
+	dbRecordVersion int64,
 	checksum *persistencespb.Checksum,
 ) error {
 
@@ -486,7 +486,7 @@ func updateExecution(
 		return err
 	}
 
-	if dbVersion == 0 {
+	if dbRecordVersion == 0 {
 		batch.Query(templateUpdateWorkflowExecutionQueryDeprecated,
 			executionDatablob.Data,
 			executionDatablob.EncodingType.String(),
@@ -511,7 +511,7 @@ func updateExecution(
 			executionStateDatablob.Data,
 			executionStateDatablob.EncodingType.String(),
 			nextEventID,
-			dbVersion,
+			dbRecordVersion,
 			checksumDatablob.Data,
 			checksumDatablob.EncodingType.String(),
 			shardID,
@@ -521,7 +521,7 @@ func updateExecution(
 			runID,
 			defaultVisibilityTimestamp,
 			rowTypeExecutionTaskID,
-			dbVersion-1,
+			dbRecordVersion-1,
 		)
 	}
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -448,7 +448,7 @@ type (
 	// GetWorkflowExecutionResponse is the response to GetWorkflowExecutionRequest
 	GetWorkflowExecutionResponse struct {
 		State             *persistencespb.WorkflowMutableState
-		DBVersion         int64
+		DBRecordVersion   int64
 		MutableStateStats *MutableStateStats
 	}
 
@@ -538,7 +538,7 @@ type (
 	WorkflowMutation struct {
 		ExecutionInfo  *persistencespb.WorkflowExecutionInfo
 		ExecutionState *persistencespb.WorkflowExecutionState
-		// TODO deprecate NextEventID in favor of DBVersion
+		// TODO deprecate NextEventID in favor of DBRecordVersion
 		NextEventID int64
 
 		UpsertActivityInfos       map[int64]*persistencespb.ActivityInfo
@@ -561,17 +561,17 @@ type (
 		TimerTasks       []Task
 		VisibilityTasks  []Task
 
-		// TODO deprecate Condition in favor of DBVersion
-		Condition int64
-		DBVersion int64
-		Checksum  *persistencespb.Checksum
+		// TODO deprecate Condition in favor of DBRecordVersion
+		Condition       int64
+		DBRecordVersion int64
+		Checksum        *persistencespb.Checksum
 	}
 
 	// WorkflowSnapshot is used as generic workflow execution state snapshot
 	WorkflowSnapshot struct {
 		ExecutionInfo  *persistencespb.WorkflowExecutionInfo
 		ExecutionState *persistencespb.WorkflowExecutionState
-		// TODO deprecate NextEventID in favor of DBVersion
+		// TODO deprecate NextEventID in favor of DBRecordVersion
 		NextEventID int64
 
 		ActivityInfos       map[int64]*persistencespb.ActivityInfo
@@ -586,10 +586,10 @@ type (
 		TimerTasks       []Task
 		VisibilityTasks  []Task
 
-		// TODO deprecate Condition in favor of DBVersion
-		Condition int64
-		DBVersion int64
-		Checksum  *persistencespb.Checksum
+		// TODO deprecate Condition in favor of DBRecordVersion
+		Condition       int64
+		DBRecordVersion int64
+		Checksum        *persistencespb.Checksum
 	}
 
 	// DeleteWorkflowExecutionRequest is used to delete a workflow execution

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -448,6 +448,7 @@ type (
 	// GetWorkflowExecutionResponse is the response to GetWorkflowExecutionRequest
 	GetWorkflowExecutionResponse struct {
 		State             *persistencespb.WorkflowMutableState
+		DBVersion         int64
 		MutableStateStats *MutableStateStats
 	}
 
@@ -537,7 +538,8 @@ type (
 	WorkflowMutation struct {
 		ExecutionInfo  *persistencespb.WorkflowExecutionInfo
 		ExecutionState *persistencespb.WorkflowExecutionState
-		NextEventID    int64
+		// TODO deprecate NextEventID in favor of DBVersion
+		NextEventID int64
 
 		UpsertActivityInfos       map[int64]*persistencespb.ActivityInfo
 		DeleteActivityInfos       map[int64]struct{}
@@ -559,7 +561,9 @@ type (
 		TimerTasks       []Task
 		VisibilityTasks  []Task
 
+		// TODO deprecate Condition in favor of DBVersion
 		Condition int64
+		DBVersion int64
 		Checksum  *persistencespb.Checksum
 	}
 
@@ -567,7 +571,8 @@ type (
 	WorkflowSnapshot struct {
 		ExecutionInfo  *persistencespb.WorkflowExecutionInfo
 		ExecutionState *persistencespb.WorkflowExecutionState
-		NextEventID    int64
+		// TODO deprecate NextEventID in favor of DBVersion
+		NextEventID int64
 
 		ActivityInfos       map[int64]*persistencespb.ActivityInfo
 		TimerInfos          map[string]*persistencespb.TimerInfo
@@ -581,7 +586,9 @@ type (
 		TimerTasks       []Task
 		VisibilityTasks  []Task
 
+		// TODO deprecate Condition in favor of DBVersion
 		Condition int64
+		DBVersion int64
 		Checksum  *persistencespb.Checksum
 	}
 

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -92,7 +92,7 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 			ExecutionState:      response.State.ExecutionState,
 			NextEventId:         response.State.NextEventID,
 		},
-		DBVersion: response.DBVersion,
+		DBRecordVersion: response.DBRecordVersion,
 	}
 
 	newResponse.State.BufferedEvents, err = m.DeserializeBufferedEvents(response.State.BufferedEvents)
@@ -396,9 +396,9 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 		TimerTasks:       input.TimerTasks,
 		VisibilityTasks:  input.VisibilityTasks,
 
-		Condition: input.Condition,
-		DBVersion: input.DBVersion,
-		Checksum:  input.Checksum,
+		Condition:       input.Condition,
+		DBRecordVersion: input.DBRecordVersion,
+		Checksum:        input.Checksum,
 	}, nil
 }
 
@@ -434,9 +434,9 @@ func (m *executionManagerImpl) SerializeWorkflowSnapshot(
 		TimerTasks:       input.TimerTasks,
 		VisibilityTasks:  input.VisibilityTasks,
 
-		Condition: input.Condition,
-		DBVersion: input.DBVersion,
-		Checksum:  input.Checksum,
+		Condition:       input.Condition,
+		DBRecordVersion: input.DBRecordVersion,
+		Checksum:        input.Checksum,
 	}, nil
 }
 

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -92,6 +92,7 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 			ExecutionState:      response.State.ExecutionState,
 			NextEventId:         response.State.NextEventID,
 		},
+		DBVersion: response.DBVersion,
 	}
 
 	newResponse.State.BufferedEvents, err = m.DeserializeBufferedEvents(response.State.BufferedEvents)
@@ -396,6 +397,7 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 		VisibilityTasks:  input.VisibilityTasks,
 
 		Condition: input.Condition,
+		DBVersion: input.DBVersion,
 		Checksum:  input.Checksum,
 	}, nil
 }
@@ -433,6 +435,7 @@ func (m *executionManagerImpl) SerializeWorkflowSnapshot(
 		VisibilityTasks:  input.VisibilityTasks,
 
 		Condition: input.Condition,
+		DBVersion: input.DBVersion,
 		Checksum:  input.Checksum,
 	}, nil
 }

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -228,6 +228,7 @@ type (
 
 		BufferedEvents []*commonpb.DataBlob
 		Checksum       *persistencespb.Checksum
+		DBVersion      int64
 	}
 
 	// InternalUpdateWorkflowExecutionRequest is used to update a workflow execution for Persistence Interface
@@ -263,6 +264,7 @@ type (
 		ExecutionState   *persistencespb.WorkflowExecutionState
 		NextEventID      int64
 		LastWriteVersion int64
+		DBVersion        int64
 
 		UpsertActivityInfos       map[int64]*persistencespb.ActivityInfo
 		DeleteActivityInfos       map[int64]struct{}
@@ -295,6 +297,7 @@ type (
 		ExecutionState   *persistencespb.WorkflowExecutionState
 		LastWriteVersion int64
 		NextEventID      int64
+		DBVersion        int64
 
 		ActivityInfos       map[int64]*persistencespb.ActivityInfo
 		TimerInfos          map[string]*persistencespb.TimerInfo
@@ -345,7 +348,8 @@ type (
 
 	// InternalGetWorkflowExecutionResponse is the response to GetworkflowExecution for Persistence Interface
 	InternalGetWorkflowExecutionResponse struct {
-		State *InternalWorkflowMutableState
+		State     *InternalWorkflowMutableState
+		DBVersion int64
 	}
 
 	// InternalListConcreteExecutionsResponse is the response to ListConcreteExecutions for Persistence Interface

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -226,9 +226,9 @@ type (
 		ExecutionState      *persistencespb.WorkflowExecutionState
 		NextEventID         int64
 
-		BufferedEvents []*commonpb.DataBlob
-		Checksum       *persistencespb.Checksum
-		DBVersion      int64
+		BufferedEvents  []*commonpb.DataBlob
+		Checksum        *persistencespb.Checksum
+		DBRecordVersion int64
 	}
 
 	// InternalUpdateWorkflowExecutionRequest is used to update a workflow execution for Persistence Interface
@@ -264,7 +264,7 @@ type (
 		ExecutionState   *persistencespb.WorkflowExecutionState
 		NextEventID      int64
 		LastWriteVersion int64
-		DBVersion        int64
+		DBRecordVersion  int64
 
 		UpsertActivityInfos       map[int64]*persistencespb.ActivityInfo
 		DeleteActivityInfos       map[int64]struct{}
@@ -297,7 +297,7 @@ type (
 		ExecutionState   *persistencespb.WorkflowExecutionState
 		LastWriteVersion int64
 		NextEventID      int64
-		DBVersion        int64
+		DBRecordVersion  int64
 
 		ActivityInfos       map[int64]*persistencespb.ActivityInfo
 		TimerInfos          map[string]*persistencespb.TimerInfo
@@ -348,8 +348,8 @@ type (
 
 	// InternalGetWorkflowExecutionResponse is the response to GetworkflowExecution for Persistence Interface
 	InternalGetWorkflowExecutionResponse struct {
-		State     *InternalWorkflowMutableState
-		DBVersion int64
+		State           *InternalWorkflowMutableState
+		DBRecordVersion int64
 	}
 
 	// InternalListConcreteExecutionsResponse is the response to ListConcreteExecutions for Persistence Interface

--- a/common/persistence/sql/sql_execution.go
+++ b/common/persistence/sql/sql_execution.go
@@ -227,7 +227,10 @@ func (m *sqlExecutionManager) GetWorkflowExecution(
 	runID := primitives.MustParseUUID(request.Execution.RunId)
 	wfID := request.Execution.WorkflowId
 	executionsRow, err := m.db.SelectFromExecutions(ctx, sqlplugin.ExecutionsFilter{
-		ShardID: m.shardID, NamespaceID: namespaceID, WorkflowID: wfID, RunID: runID,
+		ShardID:     m.shardID,
+		NamespaceID: namespaceID,
+		WorkflowID:  wfID,
+		RunID:       runID,
 	})
 	switch err {
 	case nil:
@@ -251,7 +254,10 @@ func (m *sqlExecutionManager) GetWorkflowExecution(
 	state := &p.InternalWorkflowMutableState{
 		ExecutionInfo:  info,
 		ExecutionState: executionState,
-		NextEventID:    executionsRow.NextEventID}
+		NextEventID:    executionsRow.NextEventID,
+
+		DBVersion: executionsRow.DBVersion,
+	}
 
 	state.ActivityInfos, err = getActivityInfoMap(ctx,
 		m.db,
@@ -330,7 +336,10 @@ func (m *sqlExecutionManager) GetWorkflowExecution(
 		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed to get signals requested. Error: %v", err))
 	}
 
-	return &p.InternalGetWorkflowExecutionResponse{State: state}, nil
+	return &p.InternalGetWorkflowExecutionResponse{
+		State:     state,
+		DBVersion: executionsRow.DBVersion,
+	}, nil
 }
 
 func (m *sqlExecutionManager) UpdateWorkflowExecution(

--- a/common/persistence/sql/sql_execution.go
+++ b/common/persistence/sql/sql_execution.go
@@ -256,7 +256,7 @@ func (m *sqlExecutionManager) GetWorkflowExecution(
 		ExecutionState: executionState,
 		NextEventID:    executionsRow.NextEventID,
 
-		DBVersion: executionsRow.DBVersion,
+		DBRecordVersion: executionsRow.DBRecordVersion,
 	}
 
 	state.ActivityInfos, err = getActivityInfoMap(ctx,
@@ -337,8 +337,8 @@ func (m *sqlExecutionManager) GetWorkflowExecution(
 	}
 
 	return &p.InternalGetWorkflowExecutionResponse{
-		State:     state,
-		DBVersion: executionsRow.DBVersion,
+		State:           state,
+		DBRecordVersion: executionsRow.DBRecordVersion,
 	}, nil
 }
 

--- a/common/persistence/sql/sql_execution_util.go
+++ b/common/persistence/sql/sql_execution_util.go
@@ -692,7 +692,7 @@ func lockAndCheckExecution(
 	workflowID string,
 	runID primitives.UUID,
 	condition int64,
-	dbVersion int64,
+	dbRecordVersion int64,
 ) error {
 
 	version, nextEventID, err := lockExecution(ctx, tx, shardID, namespaceID, workflowID, runID)
@@ -706,12 +706,12 @@ func lockAndCheckExecution(
 		}
 	}
 
-	if dbVersion != 0 {
-		dbVersion -= 1
+	if dbRecordVersion != 0 {
+		dbRecordVersion -= 1
 	}
-	if version != dbVersion {
+	if version != dbRecordVersion {
 		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("lockAndCheckExecution failed. DBRecordVersion expected: %v, actually %v.", dbVersion, version),
+			Msg: fmt.Sprintf("lockAndCheckExecution failed. DBRecordVersion expected: %v, actually %v.", dbRecordVersion, version),
 		}
 	}
 
@@ -1225,7 +1225,7 @@ func buildExecutionRow(
 	executionState *persistencespb.WorkflowExecutionState,
 	nextEventID int64,
 	lastWriteVersion int64,
-	dbVersion int64,
+	dbRecordVersion int64,
 	shardID int32,
 ) (row *sqlplugin.ExecutionsRow, err error) {
 
@@ -1260,7 +1260,7 @@ func buildExecutionRow(
 		DataEncoding:     infoBlob.EncodingType.String(),
 		State:            stateBlob.Data,
 		StateEncoding:    stateBlob.EncodingType.String(),
-		DBRecordVersion:  dbVersion,
+		DBRecordVersion:  dbRecordVersion,
 	}, nil
 }
 
@@ -1271,7 +1271,7 @@ func (m *sqlExecutionManager) createExecution(
 	executionState *persistencespb.WorkflowExecutionState,
 	nextEventID int64,
 	lastWriteVersion int64,
-	dbVersion int64,
+	dbRecordVersion int64,
 	shardID int32,
 ) error {
 
@@ -1290,7 +1290,7 @@ func (m *sqlExecutionManager) createExecution(
 		executionState,
 		nextEventID,
 		lastWriteVersion,
-		dbVersion,
+		dbRecordVersion,
 		shardID,
 	)
 	if err != nil {
@@ -1328,7 +1328,7 @@ func updateExecution(
 	executionState *persistencespb.WorkflowExecutionState,
 	nextEventID int64,
 	lastWriteVersion int64,
-	dbVersion int64,
+	dbRecordVersion int64,
 	shardID int32,
 ) error {
 
@@ -1347,7 +1347,7 @@ func updateExecution(
 		executionState,
 		nextEventID,
 		lastWriteVersion,
-		dbVersion,
+		dbRecordVersion,
 		shardID,
 	)
 	if err != nil {

--- a/common/persistence/sql/sql_execution_util.go
+++ b/common/persistence/sql/sql_execution_util.go
@@ -727,7 +727,7 @@ func lockExecution(
 	runID primitives.UUID,
 ) (int64, int64, error) {
 
-	version, nextEventID, err := tx.WriteLockExecutions(ctx, sqlplugin.ExecutionsFilter{
+	dbRecordVersion, nextEventID, err := tx.WriteLockExecutions(ctx, sqlplugin.ExecutionsFilter{
 		ShardID:     shardID,
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
@@ -743,7 +743,7 @@ func lockExecution(
 		}
 		return 0, 0, serviceerror.NewInternal(fmt.Sprintf("lockNextEventID failed. Error: %v", err))
 	}
-	return version, nextEventID, nil
+	return dbRecordVersion, nextEventID, nil
 }
 
 func createTransferTasks(

--- a/common/persistence/sql/sql_execution_util.go
+++ b/common/persistence/sql/sql_execution_util.go
@@ -72,7 +72,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 		workflowMutation.Condition,
-		workflowMutation.DBVersion,
+		workflowMutation.DBRecordVersion,
 	); err != nil {
 		switch err.(type) {
 		case *p.ConditionFailedError:
@@ -88,7 +88,7 @@ func applyWorkflowMutationTx(
 		workflowMutation.ExecutionState,
 		workflowMutation.NextEventID,
 		lastWriteVersion,
-		workflowMutation.DBVersion,
+		workflowMutation.DBRecordVersion,
 		shardID,
 	); err != nil {
 		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Failed to update executions row. Erorr: %v", err))
@@ -232,7 +232,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 		workflowSnapshot.Condition,
-		workflowSnapshot.DBVersion,
+		workflowSnapshot.DBRecordVersion,
 	); err != nil {
 		switch err.(type) {
 		case *p.ConditionFailedError:
@@ -248,7 +248,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowSnapshot.ExecutionState,
 		workflowSnapshot.NextEventID,
 		lastWriteVersion,
-		workflowSnapshot.DBVersion,
+		workflowSnapshot.DBRecordVersion,
 		shardID,
 	); err != nil {
 		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to update executions row. Erorr: %v", err))
@@ -437,7 +437,7 @@ func (m *sqlExecutionManager) applyWorkflowSnapshotTxAsNew(
 		workflowSnapshot.ExecutionState,
 		workflowSnapshot.NextEventID,
 		lastWriteVersion,
-		workflowSnapshot.DBVersion,
+		workflowSnapshot.DBRecordVersion,
 		shardID,
 	); err != nil {
 		return err
@@ -711,7 +711,7 @@ func lockAndCheckExecution(
 	}
 	if version != dbVersion {
 		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("lockAndCheckExecution failed. DBVersion expected: %v, actually %v.", dbVersion, version),
+			Msg: fmt.Sprintf("lockAndCheckExecution failed. DBRecordVersion expected: %v, actually %v.", dbVersion, version),
 		}
 	}
 
@@ -1260,7 +1260,7 @@ func buildExecutionRow(
 		DataEncoding:     infoBlob.EncodingType.String(),
 		State:            stateBlob.Data,
 		StateEncoding:    stateBlob.EncodingType.String(),
-		DBVersion:        dbVersion,
+		DBRecordVersion:  dbVersion,
 	}, nil
 }
 

--- a/common/persistence/sql/sqlplugin/history_execution.go
+++ b/common/persistence/sql/sqlplugin/history_execution.go
@@ -47,7 +47,7 @@ type (
 		DataEncoding     string
 		State            []byte
 		StateEncoding    string
-		DBVersion        int64
+		DBRecordVersion  int64
 	}
 
 	// ExecutionsFilter contains the column names within executions table that
@@ -83,8 +83,8 @@ type (
 
 	// TODO remove this block in 1.11.x
 	ExecutionVersion struct {
-		DBVersion   int64
-		NextEventID int64
+		DBRecordVersion int64
+		NextEventID     int64
 	}
 
 	// HistoryExecution is the SQL persistence interface for history executions

--- a/common/persistence/sql/sqlplugin/history_execution.go
+++ b/common/persistence/sql/sqlplugin/history_execution.go
@@ -47,6 +47,7 @@ type (
 		DataEncoding     string
 		State            []byte
 		StateEncoding    string
+		DBVersion        int64
 	}
 
 	// ExecutionsFilter contains the column names within executions table that
@@ -80,14 +81,20 @@ type (
 		RunID       primitives.UUID
 	}
 
+	// TODO remove this block in 1.11.x
+	ExecutionVersion struct {
+		DBVersion   int64
+		NextEventID int64
+	}
+
 	// HistoryExecution is the SQL persistence interface for history executions
 	HistoryExecution interface {
 		InsertIntoExecutions(ctx context.Context, row *ExecutionsRow) (sql.Result, error)
 		UpdateExecutions(ctx context.Context, row *ExecutionsRow) (sql.Result, error)
 		SelectFromExecutions(ctx context.Context, filter ExecutionsFilter) (*ExecutionsRow, error)
 		DeleteFromExecutions(ctx context.Context, filter ExecutionsFilter) (sql.Result, error)
-		ReadLockExecutions(ctx context.Context, filter ExecutionsFilter) (int64, error)
-		WriteLockExecutions(ctx context.Context, filter ExecutionsFilter) (int64, error)
+		ReadLockExecutions(ctx context.Context, filter ExecutionsFilter) (int64, int64, error)
+		WriteLockExecutions(ctx context.Context, filter ExecutionsFilter) (int64, int64, error)
 
 		LockCurrentExecutionsJoinExecutions(ctx context.Context, filter CurrentExecutionsFilter) ([]CurrentExecutionsRow, error)
 

--- a/common/persistence/sql/sqlplugin/mysql/execution.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	executionsColumns = `shard_id, namespace_id, workflow_id, run_id, next_event_id, last_write_version, data, data_encoding, state, state_encoding, db_version`
+	executionsColumns = `shard_id, namespace_id, workflow_id, run_id, next_event_id, last_write_version, data, data_encoding, state, state_encoding, db_record_version`
 
 	createExecutionQuery = `INSERT INTO executions(` + executionsColumns + `)
- VALUES(:shard_id, :namespace_id, :workflow_id, :run_id, :next_event_id, :last_write_version, :data, :data_encoding, :state, :state_encoding, :db_version)`
+ VALUES(:shard_id, :namespace_id, :workflow_id, :run_id, :next_event_id, :last_write_version, :data, :data_encoding, :state, :state_encoding, :db_record_version)`
 
 	updateExecutionQuery = `UPDATE executions SET
- db_version = :db_version, next_event_id = :next_event_id, last_write_version = :last_write_version, data = :data, data_encoding = :data_encoding, state = :state, state_encoding = :state_encoding
+ db_record_version = :db_record_version, next_event_id = :next_event_id, last_write_version = :last_write_version, data = :data, data_encoding = :data_encoding, state = :state, state_encoding = :state_encoding
  WHERE shard_id = :shard_id AND namespace_id = :namespace_id AND workflow_id = :workflow_id AND run_id = :run_id`
 
 	getExecutionQuery = `SELECT ` + executionsColumns + ` FROM executions
@@ -47,7 +47,7 @@ const (
 	deleteExecutionQuery = `DELETE FROM executions 
  WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ? AND run_id = ?`
 
-	lockExecutionQueryBase = `SELECT db_version, next_event_id FROM executions 
+	lockExecutionQueryBase = `SELECT db_record_version, next_event_id FROM executions 
  WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ? AND run_id = ?`
 
 	writeLockExecutionQuery = lockExecutionQueryBase + ` FOR UPDATE`
@@ -246,7 +246,7 @@ func (mdb *db) ReadLockExecutions(
 		filter.WorkflowID,
 		filter.RunID,
 	)
-	return executionVersion.DBVersion, executionVersion.NextEventID, err
+	return executionVersion.DBRecordVersion, executionVersion.NextEventID, err
 }
 
 // WriteLockExecutions acquires a write lock on a single row in executions table
@@ -263,7 +263,7 @@ func (mdb *db) WriteLockExecutions(
 		filter.WorkflowID,
 		filter.RunID,
 	)
-	return executionVersion.DBVersion, executionVersion.NextEventID, err
+	return executionVersion.DBRecordVersion, executionVersion.NextEventID, err
 }
 
 // InsertIntoCurrentExecutions inserts a single row into current_executions table

--- a/common/persistence/sql/sqlplugin/mysql/execution.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	executionsColumns = `shard_id, namespace_id, workflow_id, run_id, next_event_id, last_write_version, data, data_encoding, state, state_encoding`
+	executionsColumns = `shard_id, namespace_id, workflow_id, run_id, next_event_id, last_write_version, data, data_encoding, state, state_encoding, db_version`
 
 	createExecutionQuery = `INSERT INTO executions(` + executionsColumns + `)
- VALUES(:shard_id, :namespace_id, :workflow_id, :run_id, :next_event_id, :last_write_version, :data, :data_encoding, :state, :state_encoding)`
+ VALUES(:shard_id, :namespace_id, :workflow_id, :run_id, :next_event_id, :last_write_version, :data, :data_encoding, :state, :state_encoding, :db_version)`
 
 	updateExecutionQuery = `UPDATE executions SET
- next_event_id = :next_event_id, last_write_version = :last_write_version, data = :data, data_encoding = :data_encoding, state = :state, state_encoding = :state_encoding
+ db_version = :db_version, next_event_id = :next_event_id, last_write_version = :last_write_version, data = :data, data_encoding = :data_encoding, state = :state, state_encoding = :state_encoding
  WHERE shard_id = :shard_id AND namespace_id = :namespace_id AND workflow_id = :workflow_id AND run_id = :run_id`
 
 	getExecutionQuery = `SELECT ` + executionsColumns + ` FROM executions
@@ -47,7 +47,7 @@ const (
 	deleteExecutionQuery = `DELETE FROM executions 
  WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ? AND run_id = ?`
 
-	lockExecutionQueryBase = `SELECT next_event_id FROM executions 
+	lockExecutionQueryBase = `SELECT db_version, next_event_id FROM executions 
  WHERE shard_id = ? AND namespace_id = ? AND workflow_id = ? AND run_id = ?`
 
 	writeLockExecutionQuery = lockExecutionQueryBase + ` FOR UPDATE`
@@ -236,34 +236,34 @@ func (mdb *db) DeleteFromExecutions(
 func (mdb *db) ReadLockExecutions(
 	ctx context.Context,
 	filter sqlplugin.ExecutionsFilter,
-) (int64, error) {
-	var nextEventID int64
+) (int64, int64, error) {
+	var executionVersion sqlplugin.ExecutionVersion
 	err := mdb.conn.GetContext(ctx,
-		&nextEventID,
+		&executionVersion,
 		readLockExecutionQuery,
 		filter.ShardID,
 		filter.NamespaceID,
 		filter.WorkflowID,
 		filter.RunID,
 	)
-	return nextEventID, err
+	return executionVersion.DBVersion, executionVersion.NextEventID, err
 }
 
 // WriteLockExecutions acquires a write lock on a single row in executions table
 func (mdb *db) WriteLockExecutions(
 	ctx context.Context,
 	filter sqlplugin.ExecutionsFilter,
-) (int64, error) {
-	var nextEventID int64
+) (int64, int64, error) {
+	var executionVersion sqlplugin.ExecutionVersion
 	err := mdb.conn.GetContext(ctx,
-		&nextEventID,
+		&executionVersion,
 		writeLockExecutionQuery,
 		filter.ShardID,
 		filter.NamespaceID,
 		filter.WorkflowID,
 		filter.RunID,
 	)
-	return nextEventID, err
+	return executionVersion.DBVersion, executionVersion.NextEventID, err
 }
 
 // InsertIntoCurrentExecutions inserts a single row into current_executions table

--- a/common/persistence/sql/sqlplugin/postgresql/execution.go
+++ b/common/persistence/sql/sqlplugin/postgresql/execution.go
@@ -32,13 +32,13 @@ import (
 )
 
 const (
-	executionsColumns = `shard_id, namespace_id, workflow_id, run_id, next_event_id, last_write_version, data, data_encoding, state, state_encoding, db_version`
+	executionsColumns = `shard_id, namespace_id, workflow_id, run_id, next_event_id, last_write_version, data, data_encoding, state, state_encoding, db_record_version`
 
 	createExecutionQuery = `INSERT INTO executions(` + executionsColumns + `)
- VALUES(:shard_id, :namespace_id, :workflow_id, :run_id, :next_event_id, :last_write_version, :data, :data_encoding, :state, :state_encoding, :db_version)`
+ VALUES(:shard_id, :namespace_id, :workflow_id, :run_id, :next_event_id, :last_write_version, :data, :data_encoding, :state, :state_encoding, :db_record_version)`
 
 	updateExecutionQuery = `UPDATE executions SET
- db_version = :db_version, next_event_id = :next_event_id, last_write_version = :last_write_version, data = :data, data_encoding = :data_encoding, state = :state, state_encoding = :state_encoding
+ db_record_version = :db_record_version, next_event_id = :next_event_id, last_write_version = :last_write_version, data = :data, data_encoding = :data_encoding, state = :state, state_encoding = :state_encoding
  WHERE shard_id = :shard_id AND namespace_id = :namespace_id AND workflow_id = :workflow_id AND run_id = :run_id`
 
 	getExecutionQuery = `SELECT ` + executionsColumns + ` FROM executions
@@ -47,7 +47,7 @@ const (
 	deleteExecutionQuery = `DELETE FROM executions 
  WHERE shard_id = $1 AND namespace_id = $2 AND workflow_id = $3 AND run_id = $4`
 
-	lockExecutionQueryBase = `SELECT db_version, next_event_id FROM executions 
+	lockExecutionQueryBase = `SELECT db_record_version, next_event_id FROM executions 
  WHERE shard_id = $1 AND namespace_id = $2 AND workflow_id = $3 AND run_id = $4`
 
 	writeLockExecutionQuery = lockExecutionQueryBase + ` FOR UPDATE`
@@ -246,7 +246,7 @@ func (pdb *db) ReadLockExecutions(
 		filter.WorkflowID,
 		filter.RunID,
 	)
-	return executionVersion.DBVersion, executionVersion.NextEventID, err
+	return executionVersion.DBRecordVersion, executionVersion.NextEventID, err
 }
 
 // WriteLockExecutions acquires a write lock on a single row in executions table
@@ -263,7 +263,7 @@ func (pdb *db) WriteLockExecutions(
 		filter.WorkflowID,
 		filter.RunID,
 	)
-	return executionVersion.DBVersion, executionVersion.NextEventID, err
+	return executionVersion.DBRecordVersion, executionVersion.NextEventID, err
 }
 
 // InsertIntoCurrentExecutions inserts a single row into current_executions table

--- a/common/persistence/sql/sqlplugin/tests/history_execution_test.go
+++ b/common/persistence/sql/sqlplugin/tests/history_execution_test.go
@@ -291,8 +291,9 @@ func (s *historyExecutionSuite) TestReadLock() {
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}
-	rowNextEventID, err := s.store.ReadLockExecutions(newExecutionContext(), filter)
+	rowDBVersion, rowNextEventID, err := s.store.ReadLockExecutions(newExecutionContext(), filter)
 	s.NoError(err)
+	s.Equal(execution.DBVersion, rowDBVersion)
 	s.Equal(execution.NextEventID, rowNextEventID)
 }
 
@@ -317,8 +318,9 @@ func (s *historyExecutionSuite) TestWriteLock() {
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}
-	rowNextEventID, err := s.store.WriteLockExecutions(newExecutionContext(), filter)
+	rowDBVersion, rowNextEventID, err := s.store.WriteLockExecutions(newExecutionContext(), filter)
 	s.NoError(err)
+	s.Equal(execution.DBVersion, rowDBVersion)
 	s.Equal(execution.NextEventID, rowNextEventID)
 }
 

--- a/common/persistence/sql/sqlplugin/tests/history_execution_test.go
+++ b/common/persistence/sql/sqlplugin/tests/history_execution_test.go
@@ -293,7 +293,7 @@ func (s *historyExecutionSuite) TestReadLock() {
 	}
 	rowDBVersion, rowNextEventID, err := s.store.ReadLockExecutions(newExecutionContext(), filter)
 	s.NoError(err)
-	s.Equal(execution.DBVersion, rowDBVersion)
+	s.Equal(execution.DBRecordVersion, rowDBVersion)
 	s.Equal(execution.NextEventID, rowNextEventID)
 }
 
@@ -320,7 +320,7 @@ func (s *historyExecutionSuite) TestWriteLock() {
 	}
 	rowDBVersion, rowNextEventID, err := s.store.WriteLockExecutions(newExecutionContext(), filter)
 	s.NoError(err)
-	s.Equal(execution.DBVersion, rowDBVersion)
+	s.Equal(execution.DBRecordVersion, rowDBVersion)
 	s.Equal(execution.NextEventID, rowNextEventID)
 }
 

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -112,7 +112,7 @@ func (ti *TelemetryInterceptor) Intercept(
 
 	resp, err := handler(ctx, req)
 	if err != nil {
-		ti.handleError(scope, err)
+		ti.handleError(scope, methodName, err)
 		return nil, err
 	}
 	return resp, nil
@@ -120,6 +120,7 @@ func (ti *TelemetryInterceptor) Intercept(
 
 func (ti *TelemetryInterceptor) handleError(
 	scope int,
+	methodName string,
 	err error,
 ) {
 
@@ -153,13 +154,13 @@ func (ti *TelemetryInterceptor) handleError(
 		ti.metricsClient.IncCounter(scope, metrics.ServiceErrClientVersionNotSupportedCounter)
 	case *serviceerror.DataLoss:
 		ti.metricsClient.IncCounter(scope, metrics.ServiceFailures)
-		ti.logger.Error("internal service error, data loss", tag.Error(err))
+		ti.logger.Error("internal service error, data loss", tag.Operation(methodName), tag.Error(err))
 	case *serviceerror.Internal:
 		ti.metricsClient.IncCounter(scope, metrics.ServiceFailures)
-		ti.logger.Error("internal service error", tag.Error(err))
+		ti.logger.Error("internal service error", tag.Operation(methodName), tag.Error(err))
 	default:
 		ti.metricsClient.IncCounter(scope, metrics.ServiceFailures)
-		ti.logger.Error("uncategorized error", tag.Error(err))
+		ti.logger.Error("uncategorized error", tag.Operation(methodName), tag.Error(err))
 	}
 }
 

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -45,6 +45,7 @@ CREATE TABLE executions (
   workflow_state                 int,
   checksum                       blob,
   checksum_encoding              text,
+  db_version                     bigint,
   PRIMARY KEY  (shard_id, type, namespace_id, workflow_id, run_id, visibility_ts, task_id)
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -45,7 +45,7 @@ CREATE TABLE executions (
   workflow_state                 int,
   checksum                       blob,
   checksum_encoding              text,
-  db_record_version                     bigint,
+  db_record_version              bigint,
   PRIMARY KEY  (shard_id, type, namespace_id, workflow_id, run_id, visibility_ts, task_id)
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -45,7 +45,7 @@ CREATE TABLE executions (
   workflow_state                 int,
   checksum                       blob,
   checksum_encoding              text,
-  db_version                     bigint,
+  db_record_version                     bigint,
   PRIMARY KEY  (shard_id, type, namespace_id, workflow_id, run_id, visibility_ts, task_id)
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'

--- a/schema/cassandra/temporal/versioned/v1.5/executions.cql
+++ b/schema/cassandra/temporal/versioned/v1.5/executions.cql
@@ -1,0 +1,1 @@
+ALTER TABLE executions Add db_version bigint;

--- a/schema/cassandra/temporal/versioned/v1.5/executions.cql
+++ b/schema/cassandra/temporal/versioned/v1.5/executions.cql
@@ -1,1 +1,1 @@
-ALTER TABLE executions Add db_version bigint;
+ALTER TABLE executions Add db_record_version bigint;

--- a/schema/cassandra/temporal/versioned/v1.5/manifest.json
+++ b/schema/cassandra/temporal/versioned/v1.5/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.5",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for execution table version",
+  "SchemaUpdateCqlFiles": [
+    "executions.cql"
+  ]
+}

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -27,7 +27,7 @@ package cassandra
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "1.4"
+const Version = "1.5"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "1.0"

--- a/schema/mysql/v57/temporal/schema.sql
+++ b/schema/mysql/v57/temporal/schema.sql
@@ -39,7 +39,7 @@ CREATE TABLE executions(
   data_encoding VARCHAR(16) NOT NULL,
   state MEDIUMBLOB NOT NULL,
   state_encoding VARCHAR(16) NOT NULL,
-  db_version BIGINT NOT NULL DEFAULT 0,
+  db_record_version BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id)
 );
 

--- a/schema/mysql/v57/temporal/schema.sql
+++ b/schema/mysql/v57/temporal/schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE executions(
   data_encoding VARCHAR(16) NOT NULL,
   state MEDIUMBLOB NOT NULL,
   state_encoding VARCHAR(16) NOT NULL,
+  db_version BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id)
 );
 

--- a/schema/mysql/v57/temporal/versioned/v1.5/executions.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.5/executions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions ADD db_version BIGINT NOT NULL DEFAULT 0;

--- a/schema/mysql/v57/temporal/versioned/v1.5/executions.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.5/executions.sql
@@ -1,1 +1,1 @@
-ALTER TABLE executions ADD db_version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE executions ADD db_record_version BIGINT NOT NULL DEFAULT 0;

--- a/schema/mysql/v57/temporal/versioned/v1.5/manifest.json
+++ b/schema/mysql/v57/temporal/versioned/v1.5/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.5",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for execution table version",
+  "SchemaUpdateCqlFiles": [
+    "executions.sql"
+  ]
+}

--- a/schema/mysql/version.go
+++ b/schema/mysql/version.go
@@ -27,7 +27,7 @@ package mysql
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "1.4"
+const Version = "1.5"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "1.1"

--- a/schema/postgresql/v96/temporal/schema.sql
+++ b/schema/postgresql/v96/temporal/schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE executions(
   data_encoding VARCHAR(16) NOT NULL,
   state BYTEA NOT NULL,
   state_encoding VARCHAR(16) NOT NULL,
+  db_version BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id)
 );
 

--- a/schema/postgresql/v96/temporal/schema.sql
+++ b/schema/postgresql/v96/temporal/schema.sql
@@ -39,7 +39,7 @@ CREATE TABLE executions(
   data_encoding VARCHAR(16) NOT NULL,
   state BYTEA NOT NULL,
   state_encoding VARCHAR(16) NOT NULL,
-  db_version BIGINT NOT NULL DEFAULT 0,
+  db_record_version BIGINT NOT NULL DEFAULT 0,
   PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id)
 );
 

--- a/schema/postgresql/v96/temporal/versioned/v1.5/executions.sql
+++ b/schema/postgresql/v96/temporal/versioned/v1.5/executions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions ADD db_version BIGINT NOT NULL DEFAULT 0;

--- a/schema/postgresql/v96/temporal/versioned/v1.5/executions.sql
+++ b/schema/postgresql/v96/temporal/versioned/v1.5/executions.sql
@@ -1,1 +1,1 @@
-ALTER TABLE executions ADD db_version BIGINT NOT NULL DEFAULT 0;
+ALTER TABLE executions ADD db_record_version BIGINT NOT NULL DEFAULT 0;

--- a/schema/postgresql/v96/temporal/versioned/v1.5/manifest.json
+++ b/schema/postgresql/v96/temporal/versioned/v1.5/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.5",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for execution table version",
+  "SchemaUpdateCqlFiles": [
+    "executions.sql"
+  ]
+}

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -39,6 +39,9 @@ import (
 type Config struct {
 	NumberOfShards int32
 
+	// TODO remove this dynamic flag in 1.11.x
+	EnableDBVersion dynamicconfig.BoolPropertyFn
+
 	RPS                           dynamicconfig.IntPropertyFn
 	MaxIDLengthLimit              dynamicconfig.IntPropertyFn
 	PersistenceMaxQPS             dynamicconfig.IntPropertyFn
@@ -264,7 +267,11 @@ const (
 // NewConfig returns new service config with default values
 func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVisConfigExist bool) *Config {
 	cfg := &Config{
-		NumberOfShards:                       numberOfShards,
+		NumberOfShards: numberOfShards,
+
+		// TODO remove this dynamic flag in 1.11.x
+		EnableDBVersion: dc.GetBoolProperty(dynamicconfig.EnableDBVersion, false),
+
 		RPS:                                  dc.GetIntProperty(dynamicconfig.HistoryRPS, 3000),
 		MaxIDLengthLimit:                     dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		PersistenceMaxQPS:                    dc.GetIntProperty(dynamicconfig.HistoryPersistenceMaxQPS, 9000),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -40,7 +40,7 @@ type Config struct {
 	NumberOfShards int32
 
 	// TODO remove this dynamic flag in 1.11.x
-	EnableDBVersion dynamicconfig.BoolPropertyFn
+	EnableDBRecordVersion dynamicconfig.BoolPropertyFn
 
 	RPS                           dynamicconfig.IntPropertyFn
 	MaxIDLengthLimit              dynamicconfig.IntPropertyFn
@@ -270,7 +270,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		NumberOfShards: numberOfShards,
 
 		// TODO remove this dynamic flag in 1.11.x
-		EnableDBVersion: dc.GetBoolProperty(dynamicconfig.EnableDBVersion, false),
+		EnableDBRecordVersion: dc.GetBoolProperty(dynamicconfig.EnableDBRecordVersion, false),
 
 		RPS:                                  dc.GetIntProperty(dynamicconfig.HistoryRPS, 3000),
 		MaxIDLengthLimit:                     dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -171,7 +171,7 @@ type (
 		IsWorkflowExecutionRunning() bool
 		IsResourceDuplicated(resourceDedupKey definition.DeduplicationID) bool
 		UpdateDuplicatedResource(resourceDedupKey definition.DeduplicationID)
-		Load(*persistencespb.WorkflowMutableState) error
+		Load(*persistencespb.WorkflowMutableState, int64) error
 		ReplicateActivityInfo(*historyservice.SyncActivityRequest, bool) error
 		ReplicateActivityTaskCancelRequestedEvent(*historypb.HistoryEvent) error
 		ReplicateActivityTaskCanceledEvent(*historypb.HistoryEvent) error
@@ -228,8 +228,8 @@ type (
 		AddTransferTasks(transferTasks ...persistence.Task)
 		AddTimerTasks(timerTasks ...persistence.Task)
 		AddVisibilityTasks(visibilityTasks ...persistence.Task)
-		SetUpdateCondition(int64)
-		GetUpdateCondition() int64
+		SetUpdateCondition(int64, int64)
+		GetUpdateCondition() (int64, int64)
 
 		StartTransaction(entry *cache.NamespaceCacheEntry) (bool, error)
 		StartTransactionSkipWorkflowTaskFail(entry *cache.NamespaceCacheEntry) error

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -57,6 +57,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/migration"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -144,8 +145,11 @@ type (
 		// indicates the workflow state in DB, can be used to calculate
 		// whether this workflow is pointed by current workflow record
 		stateInDB enumsspb.WorkflowExecutionState
+		// TODO deprecate nextEventIDInDB in favor of dbVersion
 		// indicates the next event ID in DB, for conditional update
 		nextEventIDInDB int64
+		// indicates the DB record version, for conditional update
+		dbVersion int64
 		// namespace entry contains a snapshot of namespace
 		// NOTE: do not use the failover version inside, use currentVersion above
 		namespaceEntry *cache.NamespaceCacheEntry
@@ -219,6 +223,7 @@ func newMutableStateBuilder(
 		hasBufferedEventsInDB: false,
 		stateInDB:             enumsspb.WORKFLOW_EXECUTION_STATE_VOID,
 		nextEventIDInDB:       0,
+		dbVersion:             0,
 		namespaceEntry:        namespaceEntry,
 		appliedEvents:         make(map[string]struct{}),
 
@@ -289,6 +294,7 @@ func (e *mutableStateBuilder) CloneToProto() *persistencespb.WorkflowMutableStat
 
 func (e *mutableStateBuilder) Load(
 	state *persistencespb.WorkflowMutableState,
+	dbVersion int64,
 ) error {
 
 	e.pendingActivityInfoIDs = state.ActivityInfos
@@ -318,6 +324,7 @@ func (e *mutableStateBuilder) Load(
 	e.hasBufferedEventsInDB = len(e.bufferedEvents) > 0
 	e.stateInDB = state.ExecutionState.State
 	e.nextEventIDInDB = state.NextEventId
+	e.dbVersion = dbVersion
 	e.checksum = state.Checksum
 
 	if len(state.Checksum.GetValue()) > 0 {
@@ -3821,13 +3828,15 @@ func (e *mutableStateBuilder) AddTimerTasks(
 
 func (e *mutableStateBuilder) SetUpdateCondition(
 	nextEventIDInDB int64,
+	dbVersion int64,
 ) {
 
 	e.nextEventIDInDB = nextEventIDInDB
+	e.dbVersion = dbVersion
 }
 
-func (e *mutableStateBuilder) GetUpdateCondition() int64 {
-	return e.nextEventIDInDB
+func (e *mutableStateBuilder) GetUpdateCondition() (int64, int64) {
+	return e.nextEventIDInDB, e.dbVersion
 }
 
 func (e *mutableStateBuilder) GetWorkflowStateStatus() (enumsspb.WorkflowExecutionState, enumspb.WorkflowExecutionStatus) {
@@ -3914,6 +3923,12 @@ func (e *mutableStateBuilder) CloseTransactionAsMutation(
 	// impact the checksum calculation
 	checksum := e.generateChecksum()
 
+	if e.dbVersion == 0 && !migration.IsDBVersionEnabled() {
+		// noop, existing behavior
+	} else {
+		e.dbVersion += 1
+	}
+
 	workflowMutation := &persistence.WorkflowMutation{
 		ExecutionInfo:  e.executionInfo,
 		ExecutionState: e.executionState,
@@ -3940,6 +3955,7 @@ func (e *mutableStateBuilder) CloseTransactionAsMutation(
 		VisibilityTasks:  e.insertVisibilityTasks,
 
 		Condition: e.nextEventIDInDB,
+		DBVersion: e.dbVersion,
 		Checksum:  checksum,
 	}
 
@@ -4018,6 +4034,7 @@ func (e *mutableStateBuilder) CloseTransactionAsSnapshot(
 		VisibilityTasks:  e.insertVisibilityTasks,
 
 		Condition: e.nextEventIDInDB,
+		DBVersion: e.dbVersion,
 		Checksum:  checksum,
 	}
 
@@ -4120,6 +4137,7 @@ func (e *mutableStateBuilder) cleanupTransaction(
 	e.hasBufferedEventsInDB = len(e.bufferedEvents) > 0
 	e.stateInDB = e.executionState.State
 	e.nextEventIDInDB = e.GetNextEventID()
+	// e.dbVersion remains the same
 
 	e.insertTransferTasks = nil
 	e.insertReplicationTasks = nil

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -3954,9 +3954,9 @@ func (e *mutableStateBuilder) CloseTransactionAsMutation(
 		TimerTasks:       e.insertTimerTasks,
 		VisibilityTasks:  e.insertVisibilityTasks,
 
-		Condition: e.nextEventIDInDB,
-		DBVersion: e.dbVersion,
-		Checksum:  checksum,
+		Condition:       e.nextEventIDInDB,
+		DBRecordVersion: e.dbVersion,
+		Checksum:        checksum,
 	}
 
 	e.checksum = checksum
@@ -4033,9 +4033,9 @@ func (e *mutableStateBuilder) CloseTransactionAsSnapshot(
 		TimerTasks:       e.insertTimerTasks,
 		VisibilityTasks:  e.insertVisibilityTasks,
 
-		Condition: e.nextEventIDInDB,
-		DBVersion: e.dbVersion,
-		Checksum:  checksum,
+		Condition:       e.nextEventIDInDB,
+		DBRecordVersion: e.dbVersion,
+		Checksum:        checksum,
 	}
 
 	e.checksum = checksum

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -343,8 +343,9 @@ func (s *mutableStateSuite) TestReorderEvents() {
 		ActivityInfos:  activityInfos,
 		BufferedEvents: bufferedEvents,
 	}
+	dbVersion := int64(123)
 
-	s.msBuilder.Load(dbState)
+	_ = s.msBuilder.Load(dbState, dbVersion)
 	s.Equal(enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED, s.msBuilder.bufferedEvents[0].GetEventType())
 	s.Equal(enumspb.EVENT_TYPE_ACTIVITY_TASK_STARTED, s.msBuilder.bufferedEvents[1].GetEventType())
 
@@ -407,7 +408,7 @@ func (s *mutableStateSuite) TestChecksum() {
 
 			// create mutable state and verify checksum is generated on close
 			loadErrors = loadErrorsFunc()
-			s.msBuilder.Load(dbState)
+			_ = s.msBuilder.Load(dbState, 123)
 			s.Equal(loadErrors, loadErrorsFunc()) // no errors expected
 			s.EqualValues(dbState.Checksum, s.msBuilder.checksum)
 			s.msBuilder.namespaceEntry = s.newNamespaceCacheEntry()
@@ -420,7 +421,7 @@ func (s *mutableStateSuite) TestChecksum() {
 
 			// verify checksum is verified on Load
 			dbState.Checksum = csum
-			s.msBuilder.Load(dbState)
+			_ = s.msBuilder.Load(dbState, 123)
 			s.Equal(loadErrors, loadErrorsFunc())
 
 			// generate checksum again and verify its the same
@@ -431,7 +432,7 @@ func (s *mutableStateSuite) TestChecksum() {
 
 			// modify checksum and verify Load fails
 			dbState.Checksum.Value[0]++
-			s.msBuilder.Load(dbState)
+			_ = s.msBuilder.Load(dbState, 123)
 			s.Equal(loadErrors+1, loadErrorsFunc())
 			s.EqualValues(dbState.Checksum, s.msBuilder.checksum)
 
@@ -440,7 +441,7 @@ func (s *mutableStateSuite) TestChecksum() {
 			s.mockConfig.MutableStateChecksumInvalidateBefore = func(...dynamicconfig.FilterOption) float64 {
 				return float64((s.msBuilder.executionInfo.LastUpdateTime.UnixNano() / int64(time.Second)) + 1)
 			}
-			s.msBuilder.Load(dbState)
+			_ = s.msBuilder.Load(dbState, 123)
 			s.Equal(loadErrors, loadErrorsFunc())
 			s.Nil(s.msBuilder.checksum)
 

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -1401,11 +1401,12 @@ func (mr *MockmutableStateMockRecorder) GetStartVersion() *gomock.Call {
 }
 
 // GetUpdateCondition mocks base method.
-func (m *MockmutableState) GetUpdateCondition() int64 {
+func (m *MockmutableState) GetUpdateCondition() (int64, int64) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetUpdateCondition")
 	ret0, _ := ret[0].(int64)
-	return ret0
+	ret1, _ := ret[1].(int64)
+	return ret0, ret1
 }
 
 // GetUpdateCondition indicates an expected call of GetUpdateCondition.
@@ -1643,17 +1644,17 @@ func (mr *MockmutableStateMockRecorder) IsWorkflowExecutionRunning() *gomock.Cal
 }
 
 // Load mocks base method.
-func (m *MockmutableState) Load(arg0 *persistence.WorkflowMutableState) error {
+func (m *MockmutableState) Load(arg0 *persistence.WorkflowMutableState, arg1 int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Load", arg0)
+	ret := m.ctrl.Call(m, "Load", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Load indicates an expected call of Load.
-func (mr *MockmutableStateMockRecorder) Load(arg0 interface{}) *gomock.Call {
+func (mr *MockmutableStateMockRecorder) Load(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockmutableState)(nil).Load), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Load", reflect.TypeOf((*MockmutableState)(nil).Load), arg0, arg1)
 }
 
 // ReplicateActivityInfo mocks base method.
@@ -2304,15 +2305,15 @@ func (mr *MockmutableStateMockRecorder) SetNextEventID(nextEventID interface{}) 
 }
 
 // SetUpdateCondition mocks base method.
-func (m *MockmutableState) SetUpdateCondition(arg0 int64) {
+func (m *MockmutableState) SetUpdateCondition(arg0, arg1 int64) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetUpdateCondition", arg0)
+	m.ctrl.Call(m, "SetUpdateCondition", arg0, arg1)
 }
 
 // SetUpdateCondition indicates an expected call of SetUpdateCondition.
-func (mr *MockmutableStateMockRecorder) SetUpdateCondition(arg0 interface{}) *gomock.Call {
+func (mr *MockmutableStateMockRecorder) SetUpdateCondition(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpdateCondition", reflect.TypeOf((*MockmutableState)(nil).SetUpdateCondition), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetUpdateCondition", reflect.TypeOf((*MockmutableState)(nil).SetUpdateCondition), arg0, arg1)
 }
 
 // StartTransaction mocks base method.

--- a/service/history/nDCConflictResolver_test.go
+++ b/service/history/nDCConflictResolver_test.go
@@ -108,6 +108,7 @@ func (s *nDCConflictResolverSuite) TearDownTest() {
 func (s *nDCConflictResolverSuite) TestRebuild() {
 	ctx := context.Background()
 	updateCondition := int64(59)
+	dbVersion := int64(1444)
 	requestID := uuid.New()
 	version := int64(12)
 	historySize := int64(12345)
@@ -128,7 +129,7 @@ func (s *nDCConflictResolverSuite) TestRebuild() {
 	_, _, err := versionhistory.AddVersionHistory(versionHistories, versionHistory1)
 	s.NoError(err)
 
-	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition).AnyTimes()
+	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition, dbVersion).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		NamespaceId:      s.namespaceID,
 		WorkflowId:       s.workflowID,
@@ -154,7 +155,7 @@ func (s *nDCConflictResolverSuite) TestRebuild() {
 			),
 		},
 	).Times(2)
-	mockRebuildMutableState.EXPECT().SetUpdateCondition(updateCondition)
+	mockRebuildMutableState.EXPECT().SetUpdateCondition(updateCondition, dbVersion)
 
 	s.mockStateBuilder.EXPECT().rebuild(
 		ctx,
@@ -197,6 +198,7 @@ func (s *nDCConflictResolverSuite) TestPrepareMutableState_NoRebuild() {
 func (s *nDCConflictResolverSuite) TestPrepareMutableState_Rebuild() {
 	ctx := context.Background()
 	updateCondition := int64(59)
+	dbVersion := int64(1444)
 	version := int64(12)
 	incomingVersion := version + 1
 	historySize := int64(12345)
@@ -224,7 +226,7 @@ func (s *nDCConflictResolverSuite) TestPrepareMutableState_Rebuild() {
 	_, _, err := versionhistory.AddVersionHistory(versionHistories, versionHistory1)
 	s.Nil(err)
 
-	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition).AnyTimes()
+	s.mockMutableState.EXPECT().GetUpdateCondition().Return(updateCondition, dbVersion).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		NamespaceId:      s.namespaceID,
 		WorkflowId:       s.workflowID,
@@ -250,7 +252,7 @@ func (s *nDCConflictResolverSuite) TestPrepareMutableState_Rebuild() {
 			),
 		},
 	).Times(2)
-	mockRebuildMutableState.EXPECT().SetUpdateCondition(updateCondition)
+	mockRebuildMutableState.EXPECT().SetUpdateCondition(updateCondition, dbVersion)
 
 	s.mockStateBuilder.EXPECT().rebuild(
 		ctx,

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -169,7 +169,7 @@ func (s *Service) Start() {
 	}
 
 	// TODO remove this dynamic flag in 1.11.x
-	migration.SetDBVersionFlag(s.config.EnableDBVersion())
+	migration.SetDBVersionFlag(s.config.EnableDBRecordVersion())
 
 	logger := s.GetLogger()
 	logger.Info("history starting")

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -252,7 +252,7 @@ func (c *workflowExecutionContextImpl) loadWorkflowExecutionForReplication(
 			namespaceEntry,
 		)
 
-		if err := c.mutableState.Load(response.State); err != nil {
+		if err := c.mutableState.Load(response.State, response.DBVersion); err != nil {
 			return nil, err
 		}
 
@@ -334,7 +334,7 @@ func (c *workflowExecutionContextImpl) loadWorkflowExecution() (mutableState, er
 			namespaceEntry,
 		)
 
-		if err := c.mutableState.Load(response.State); err != nil {
+		if err := c.mutableState.Load(response.State, response.DBVersion); err != nil {
 			return nil, err
 		}
 

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -252,7 +252,7 @@ func (c *workflowExecutionContextImpl) loadWorkflowExecutionForReplication(
 			namespaceEntry,
 		)
 
-		if err := c.mutableState.Load(response.State, response.DBVersion); err != nil {
+		if err := c.mutableState.Load(response.State, response.DBRecordVersion); err != nil {
 			return nil, err
 		}
 
@@ -334,7 +334,7 @@ func (c *workflowExecutionContextImpl) loadWorkflowExecution() (mutableState, er
 			namespaceEntry,
 		)
 
-		if err := c.mutableState.Load(response.State, response.DBVersion); err != nil {
+		if err := c.mutableState.Load(response.State, response.DBRecordVersion); err != nil {
 			return nil, err
 		}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Add db version attribute to executions table for better CAS guarantee
* 1.9.x will by default use existing next event ID for CAS, but will also support the new DB version CAS
* 1.10.x will by default use DB version CAS

<!-- Tell your future self why have you made these changes -->
**Why?**
Last event ID is not enough for CAS operation protection: e.g. activity heartbeat will not generate new history event, meaning last event ID will remain the same during the CAS to DB. 
The newly introduced DB version will be increased by 1 each time execution table is updated (update to mutable state record).

Close #435 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests, randomized tests, CICD

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Some low level persistence interfaces are changed.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No