### PR TITLE
Remove params field from service and handler objects

### DIFF
--- a/common/resource/bootstrapParams.go
+++ b/common/resource/bootstrapParams.go
@@ -62,7 +62,7 @@ type (
 		MetricsClient                metrics.Client
 		ESClient                     client.Client
 		ESConfig                     *config.Elasticsearch
-		DynamicConfig                dynamicconfig.Client
+		DynamicConfigClient          dynamicconfig.Client
 		DCRedirectionPolicy          config.DCRedirectionPolicy
 		PublicClient                 sdkclient.Client
 		ArchivalMetadata             archiver.ArchivalMetadata

--- a/common/resource/bootstrapParams.go
+++ b/common/resource/bootstrapParams.go
@@ -64,7 +64,7 @@ type (
 		ESConfig                     *config.Elasticsearch
 		DynamicConfigClient          dynamicconfig.Client
 		DCRedirectionPolicy          config.DCRedirectionPolicy
-		PublicClient                 sdkclient.Client
+		SdkClient                    sdkclient.Client
 		ArchivalMetadata             archiver.ArchivalMetadata
 		ArchiverProvider             provider.ArchiverProvider
 		Authorizer                   authorization.Authorizer

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -327,7 +327,7 @@ func New(
 
 		// internal services clients
 
-		sdkClient:         params.PublicClient,
+		sdkClient:         params.SdkClient,
 		frontendRawClient: frontendRawClient,
 		frontendClient:    frontendClient,
 		matchingRawClient: matchingRawClient,

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -201,7 +201,7 @@ func New(
 		return nil, err
 	}
 
-	dynamicCollection := dynamicconfig.NewCollection(params.DynamicConfig, logger)
+	dynamicCollection := dynamicconfig.NewCollection(params.DynamicConfigClient, logger)
 	clientBean, err := client.NewClientBean(
 		client.NewRPCClientFactory(
 			params.RPCFactory,

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -446,7 +446,7 @@ func (c *temporalImpl) startHistory(
 		params.DynamicConfigClient = integrationClient
 
 		var err error
-		params.PublicClient, err = sdkclient.NewClient(sdkclient.Options{
+		params.SdkClient, err = sdkclient.NewClient(sdkclient.Options{
 			HostPort:     c.FrontendGRPCAddress(),
 			Namespace:    common.SystemLocalNamespace,
 			MetricsScope: params.MetricsScope,
@@ -578,7 +578,7 @@ func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.Wait
 	}
 	params.PersistenceServiceResolver = resolver.NewNoopResolver()
 
-	params.PublicClient, err = sdkclient.NewClient(sdkclient.Options{
+	params.SdkClient, err = sdkclient.NewClient(sdkclient.Options{
 		HostPort:     c.FrontendGRPCAddress(),
 		Namespace:    common.SystemLocalNamespace,
 		MetricsScope: params.MetricsScope,
@@ -663,7 +663,7 @@ func (c *temporalImpl) startWorkerClientWorker(params *resource.BootstrapParams,
 	workerConfig.ArchiverConfig.ArchiverConcurrency = dynamicconfig.GetIntPropertyFn(10)
 
 	bc := &archiver.BootstrapContainer{
-		PublicClient:     params.PublicClient,
+		SdkClient:        params.SdkClient,
 		MetricsClient:    service.GetMetricsClient(),
 		Logger:           c.logger,
 		HistoryV2Manager: c.historyV2Mgr,

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -364,7 +364,7 @@ func (c *temporalImpl) GetHistoryClient() historyservice.HistoryServiceClient {
 }
 
 func (c *temporalImpl) startFrontend(hosts map[string][]string, startWG *sync.WaitGroup) {
-	params := new(resource.BootstrapParams)
+	params := &resource.BootstrapParams{}
 	params.DCRedirectionPolicy = config.DCRedirectionPolicy{}
 	params.Name = common.FrontendServiceName
 	params.Logger = c.logger
@@ -377,7 +377,7 @@ func (c *temporalImpl) startFrontend(hosts map[string][]string, startWG *sync.Wa
 	}
 	params.ClusterMetadataConfig = c.clusterMetadataConfig
 	params.MetricsClient = metrics.NewClient(params.MetricsScope, metrics.GetMetricsServiceIdx(params.Name, c.logger))
-	params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNoopClient())
+	params.DynamicConfigClient = newIntegrationConfigClient(dynamicconfig.NewNoopClient())
 	params.ArchivalMetadata = c.archiverMetadata
 	params.ArchiverProvider = c.archiverProvider
 	params.ESConfig = c.esConfig
@@ -430,7 +430,7 @@ func (c *temporalImpl) startHistory(
 ) {
 	membershipPorts := c.HistoryServiceAddress(2)
 	for i, grpcPort := range c.HistoryServiceAddress(3) {
-		params := new(resource.BootstrapParams)
+		params := &resource.BootstrapParams{}
 		params.Name = common.HistoryServiceName
 		params.Logger = c.logger
 		params.ThrottledLogger = c.logger
@@ -443,7 +443,7 @@ func (c *temporalImpl) startHistory(
 		params.MetricsClient = metrics.NewClient(params.MetricsScope, metrics.GetMetricsServiceIdx(params.Name, c.logger))
 		integrationClient := newIntegrationConfigClient(dynamicconfig.NewNoopClient())
 		c.overrideHistoryDynamicConfig(integrationClient)
-		params.DynamicConfig = integrationClient
+		params.DynamicConfigClient = integrationClient
 
 		var err error
 		params.PublicClient, err = sdkclient.NewClient(sdkclient.Options{
@@ -513,7 +513,7 @@ func (c *temporalImpl) startHistory(
 
 func (c *temporalImpl) startMatching(hosts map[string][]string, startWG *sync.WaitGroup) {
 
-	params := new(resource.BootstrapParams)
+	params := &resource.BootstrapParams{}
 	params.Name = common.MatchingServiceName
 	params.Logger = c.logger
 	params.ThrottledLogger = c.logger
@@ -524,7 +524,7 @@ func (c *temporalImpl) startMatching(hosts map[string][]string, startWG *sync.Wa
 	}
 	params.ClusterMetadataConfig = c.clusterMetadataConfig
 	params.MetricsClient = metrics.NewClient(params.MetricsScope, metrics.GetMetricsServiceIdx(params.Name, c.logger))
-	params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNoopClient())
+	params.DynamicConfigClient = newIntegrationConfigClient(dynamicconfig.NewNoopClient())
 	params.ArchivalMetadata = c.archiverMetadata
 	params.ArchiverProvider = c.archiverProvider
 
@@ -556,7 +556,7 @@ func (c *temporalImpl) startMatching(hosts map[string][]string, startWG *sync.Wa
 }
 
 func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.WaitGroup) {
-	params := new(resource.BootstrapParams)
+	params := &resource.BootstrapParams{}
 	params.Name = common.WorkerServiceName
 	params.Logger = c.logger
 	params.ThrottledLogger = c.logger
@@ -567,7 +567,7 @@ func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.Wait
 	}
 	params.ClusterMetadataConfig = c.clusterMetadataConfig
 	params.MetricsClient = metrics.NewClient(params.MetricsScope, metrics.GetMetricsServiceIdx(params.Name, c.logger))
-	params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNoopClient())
+	params.DynamicConfigClient = newIntegrationConfigClient(dynamicconfig.NewNoopClient())
 	params.ArchivalMetadata = c.archiverMetadata
 	params.ArchiverProvider = c.archiverProvider
 

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -65,7 +65,7 @@ type Service struct {
 func NewService(
 	params *resource.BootstrapParams,
 ) (resource.Resource, error) {
-	serviceConfig := configs.NewConfig(dynamicconfig.NewCollection(params.DynamicConfig, params.Logger),
+	serviceConfig := configs.NewConfig(dynamicconfig.NewCollection(params.DynamicConfigClient, params.Logger),
 		params.PersistenceConfig.NumHistoryShards,
 		params.PersistenceConfig.IsAdvancedVisibilityConfigExist())
 

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -63,7 +63,7 @@ type Service struct {
 // NewService builds a new history service
 func NewService(
 	params *resource.BootstrapParams,
-) (resource.Resource, error) {
+) (*Service, error) {
 	logger := params.Logger
 
 	serviceConfig := configs.NewConfig(dynamicconfig.NewCollection(params.DynamicConfigClient, params.Logger),

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -58,7 +58,7 @@ type Service struct {
 // NewService builds a new matching service
 func NewService(
 	params *resource.BootstrapParams,
-) (resource.Resource, error) {
+) (*Service, error) {
 	logger := params.Logger
 
 	serviceConfig := NewConfig(dynamicconfig.NewCollection(params.DynamicConfigClient, params.Logger))

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -61,7 +61,7 @@ func NewService(
 	params *resource.BootstrapParams,
 ) (resource.Resource, error) {
 
-	serviceConfig := NewConfig(dynamicconfig.NewCollection(params.DynamicConfig, params.Logger))
+	serviceConfig := NewConfig(dynamicconfig.NewCollection(params.DynamicConfigClient, params.Logger))
 	serviceResource, err := resource.New(
 		params,
 		common.MatchingServiceName,

--- a/service/worker/archiver/client_worker.go
+++ b/service/worker/archiver/client_worker.go
@@ -57,7 +57,7 @@ type (
 
 	// BootstrapContainer contains everything need for bootstrapping
 	BootstrapContainer struct {
-		PublicClient     sdkclient.Client
+		SdkClient        sdkclient.Client
 		MetricsClient    metrics.Client
 		Logger           log.Logger
 		HistoryV2Manager persistence.HistoryManager
@@ -104,7 +104,7 @@ func NewClientWorker(container *BootstrapContainer) ClientWorker {
 		BackgroundActivityContext: actCtx,
 	}
 	clientWorker := &clientWorker{
-		worker:         worker.New(container.PublicClient, workflowTaskQueue, wo),
+		worker:         worker.New(container.SdkClient, workflowTaskQueue, wo),
 		namespaceCache: container.NamespaceCache,
 	}
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -76,7 +76,7 @@ type (
 // NewService builds a new worker service
 func NewService(
 	params *resource.BootstrapParams,
-) (resource.Resource, error) {
+) (*Service, error) {
 
 	serviceConfig := NewConfig(params)
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -107,7 +107,7 @@ func NewService(
 
 // NewConfig builds the new Config for worker service
 func NewConfig(params *resource.BootstrapParams) *Config {
-	dc := dynamicconfig.NewCollection(params.DynamicConfig, params.Logger)
+	dc := dynamicconfig.NewCollection(params.DynamicConfigClient, params.Logger)
 	config := &Config{
 		ReplicationCfg: &replicator.Config{
 			PersistenceMaxQPS:                  dc.GetIntProperty(dynamicconfig.WorkerPersistenceMaxQPS, 500),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"go.temporal.io/api/serviceerror"
+	sdkclient "go.temporal.io/sdk/client"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -53,10 +54,10 @@ type (
 	Service struct {
 		resource.Resource
 
-		status int32
-		stopC  chan struct{}
-		params *resource.BootstrapParams
-		config *Config
+		status    int32
+		stopC     chan struct{}
+		sdkClient sdkclient.Client
+		config    *Config
 	}
 
 	// Config contains all the service config for worker
@@ -97,11 +98,11 @@ func NewService(
 	}
 
 	return &Service{
-		Resource: serviceResource,
-		status:   common.DaemonStatusInitialized,
-		config:   serviceConfig,
-		params:   params,
-		stopC:    make(chan struct{}),
+		Resource:  serviceResource,
+		status:    common.DaemonStatusInitialized,
+		config:    serviceConfig,
+		sdkClient: params.SdkClient,
+		stopC:     make(chan struct{}),
 	}, nil
 }
 
@@ -175,6 +176,7 @@ func (s *Service) Start() {
 
 // Stop is called to stop the service
 func (s *Service) Stop() {
+	logger := s.GetLogger()
 	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
@@ -183,12 +185,12 @@ func (s *Service) Stop() {
 
 	s.Resource.Stop()
 
-	s.params.Logger.Info("worker stopped", tag.ComponentWorker)
+	logger.Info("worker stopped", tag.ComponentWorker)
 }
 
 func (s *Service) startParentClosePolicyProcessor() {
 	params := &parentclosepolicy.BootstrapParams{
-		ServiceClient: s.params.PublicClient,
+		ServiceClient: s.sdkClient,
 		MetricsClient: s.GetMetricsClient(),
 		Logger:        s.GetLogger(),
 		ClientBean:    s.GetClientBean(),
@@ -202,7 +204,7 @@ func (s *Service) startParentClosePolicyProcessor() {
 func (s *Service) startBatcher() {
 	params := &batcher.BootstrapParams{
 		Config:        *s.config.BatcherCfg,
-		ServiceClient: s.params.PublicClient,
+		ServiceClient: s.sdkClient,
 		MetricsClient: s.GetMetricsClient(),
 		Logger:        s.GetLogger(),
 		ClientBean:    s.GetClientBean(),
@@ -242,7 +244,7 @@ func (s *Service) startReplicator() {
 
 func (s *Service) startArchiver() {
 	bc := &archiver.BootstrapContainer{
-		PublicClient:     s.GetSDKClient(),
+		SdkClient:        s.GetSDKClient(),
 		MetricsClient:    s.GetMetricsClient(),
 		Logger:           s.GetLogger(),
 		HistoryV2Manager: s.GetHistoryManager(),

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -276,7 +276,7 @@ func (s *Server) newBootstrapParams(
 		return nil, fmt.Errorf("unable to load frontend TLS configuration: %w", err)
 	}
 
-	params.PublicClient, err = sdkclient.NewClient(sdkclient.Options{
+	params.SdkClient, err = sdkclient.NewClient(sdkclient.Options{
 		HostPort:     s.so.config.PublicClient.HostPort,
 		Namespace:    common.SystemLocalNamespace,
 		MetricsScope: metricsScope,

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -237,7 +237,7 @@ func (s *Server) newBootstrapParams(
 	params.Name = svcName
 	params.Logger = s.logger
 	params.PersistenceConfig = s.so.config.Persistence
-	params.DynamicConfig = s.so.dynamicConfigClient
+	params.DynamicConfigClient = s.so.dynamicConfigClient
 	params.ClusterMetadataConfig = s.so.config.ClusterMetadata
 
 	svcCfg := s.so.config.Services[svcName]


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove `params` field from service and handler objects.
Move some service and handler initialization logic to constructor from `Start()` method.

<!-- Tell your future self why have you made these changes -->
**Why?**
`params` object is to pass params to constructors but not to be stored as a field inside object itself.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Build, run current tests, run canary locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.