### PR TITLE
Add an ExtraData field to Claims struct 

### DIFF
--- a/common/authorization/roles.go
+++ b/common/authorization/roles.go
@@ -54,7 +54,7 @@ type Claims struct {
 	// Roles within specific namespaces
 	Namespaces map[string]Role
 	// Free form bucket for extra data
-	ExtraData interface{}
+	Extensions interface{}
 }
 
 // @@@SNIPEND

--- a/common/authorization/roles.go
+++ b/common/authorization/roles.go
@@ -53,6 +53,8 @@ type Claims struct {
 	System Role
 	// Roles within specific namespaces
 	Namespaces map[string]Role
+	// Free form bucket for extra data
+	ExtraData interface{}
 }
 
 // @@@SNIPEND


### PR DESCRIPTION
**What changed?**
Added a field to `Claims` struct for passing additional data between ClaimMapper and Authorizer.

**Why?**
To enable extensibility for authorization scenarios.

**How did you test it?**
No test is needed

**Potential risks**
None

**Is hotfix candidate?**
No