### PR TITLE
Fail workflow if search attributes size exceed limit

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1651,6 +1651,7 @@ const (
 	HistorySize
 	HistoryCount
 	EventBlobSize
+	SearchAttributesSize
 
 	ArchivalConfigFailures
 
@@ -2061,6 +2062,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		HistorySize:                                         {metricName: "history_size", metricType: Timer},
 		HistoryCount:                                        {metricName: "history_count", metricType: Timer},
 		EventBlobSize:                                       {metricName: "event_blob_size", metricType: Timer},
+		SearchAttributesSize:                                {metricName: "search_attributes_size", metricType: Timer},
 		ArchivalConfigFailures:                              {metricName: "archivalconfig_failures", metricType: Counter},
 		ElasticsearchRequests:                               {metricName: "elasticsearch_requests", metricType: Counter},
 		ElasticsearchFailures:                               {metricName: "elasticsearch_errors", metricType: Counter},

--- a/common/util.go
+++ b/common/util.go
@@ -552,6 +552,7 @@ func CheckEventBlobSizeLimit(
 	logger log.Logger,
 	blobSizeViolationOperationTag tag.ZapTag,
 ) error {
+
 	scope.RecordDistribution(metrics.EventBlobSize, actualSize)
 
 	if actualSize > warnLimit {

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2564,7 +2564,12 @@ func (e *historyEngineImpl) validateStartWorkflowExecutionRequest(
 	if err := common.ValidateRetryPolicy(request.RetryPolicy); err != nil {
 		return err
 	}
-	if err := e.searchAttributesValidator.ValidateAndLog(request.SearchAttributes, namespace); err != nil {
+	if err := e.searchAttributesValidator.Validate(request.SearchAttributes, namespace); err != nil {
+		e.logger.Warn("Search attributes are invalid.", tag.Error(err), tag.WorkflowNamespace(namespace))
+		return err
+	}
+	if err := e.searchAttributesValidator.ValidateSize(request.SearchAttributes, namespace); err != nil {
+		e.logger.Warn("Search attributes are invalid.", tag.Error(err), tag.WorkflowNamespace(namespace))
 		return err
 	}
 

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -634,9 +634,16 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 		return handler.failCommand(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
 
+	namespaceEntry, err := handler.namespaceCache.GetNamespaceByID(handler.mutableState.GetExecutionInfo().NamespaceId)
+	if err != nil {
+		return err
+	}
+	namespace := namespaceEntry.GetInfo().Name
+
 	if err := handler.validateCommandAttr(
 		func() error {
 			return handler.attrValidator.validateContinueAsNewWorkflowExecutionAttributes(
+				namespace,
 				attr,
 				handler.mutableState.GetExecutionInfo(),
 			)
@@ -650,6 +657,16 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION.String()),
 		attr.GetInput().Size(),
 		"ContinueAsNewWorkflowExecutionCommandAttributes. Input exceeds size limit.",
+	)
+	if err != nil || failWorkflow {
+		handler.stopProcessing = true
+		return err
+	}
+
+	failWorkflow, err = handler.sizeLimitChecker.failWorkflowIfSearchAttributesSizeExceedsLimit(
+		attr.GetSearchAttributes(),
+		namespace,
+		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION.String()),
 	)
 	if err != nil || failWorkflow {
 		handler.stopProcessing = true
@@ -740,6 +757,16 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION.String()),
 		attr.GetInput().Size(),
 		"StartChildWorkflowExecutionCommandAttributes.Input exceeds size limit.",
+	)
+	if err != nil || failWorkflow {
+		handler.stopProcessing = true
+		return err
+	}
+
+	failWorkflow, err = handler.sizeLimitChecker.failWorkflowIfSearchAttributesSizeExceedsLimit(
+		attr.GetSearchAttributes(),
+		parentNamespace,
+		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION.String()),
 	)
 	if err != nil || failWorkflow {
 		handler.stopProcessing = true
@@ -852,6 +879,16 @@ func (handler *workflowTaskHandlerImpl) handleCommandUpsertWorkflowSearchAttribu
 		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES.String()),
 		searchAttributesSize(attr.GetSearchAttributes().GetIndexedFields()),
 		"UpsertWorkflowSearchAttributesCommandAttributes exceeds size limit.",
+	)
+	if err != nil || failWorkflow {
+		handler.stopProcessing = true
+		return err
+	}
+
+	failWorkflow, err = handler.sizeLimitChecker.failWorkflowIfSearchAttributesSizeExceedsLimit(
+		attr.GetSearchAttributes(),
+		namespace,
+		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES.String()),
 	)
 	if err != nil || failWorkflow {
 		handler.stopProcessing = true

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -634,11 +634,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 		return handler.failCommand(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
 
-	namespaceEntry, err := handler.namespaceCache.GetNamespaceByID(handler.mutableState.GetExecutionInfo().NamespaceId)
-	if err != nil {
-		return err
-	}
-	namespace := namespaceEntry.GetInfo().Name
+	namespace := handler.mutableState.GetNamespaceEntry().GetInfo().Name
 
 	if err := handler.validateCommandAttr(
 		func() error {
@@ -765,7 +761,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 
 	failWorkflow, err = handler.sizeLimitChecker.failWorkflowIfSearchAttributesSizeExceedsLimit(
 		attr.GetSearchAttributes(),
-		parentNamespace,
+		targetNamespace,
 		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION.String()),
 	)
 	if err != nil || failWorkflow {

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -399,6 +399,7 @@ Update_History_Loop:
 				handler.config.HistoryCountLimitError(namespace),
 				completedEvent.GetEventId(),
 				msBuilder,
+				handler.historyEngine.searchAttributesValidator,
 				executionStats,
 				handler.metricsClient.Scope(metrics.HistoryRespondWorkflowTaskCompletedScope, metrics.NamespaceTag(namespace)),
 				handler.throttledLogger,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fail workflow if search attributes size exceed limit.

Split single search attributes validator into two:
1. Validate names and types.
2. Validate size of each value and total size.

<!-- Tell your future self why have you made these changes -->
**Why?**
First validator works as before: it fails workflow task and therefore leads to retries (until Workflow code is fixed or search attribute is registered).
Second validator now fails Workflow right away to prevent server overload due to exceeded size of search attributes values.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Total size limit now include attributes names and metadata size, so if total size was very close to the limit before it might start fail workflow now. Which is very unlikely though, because default total size limit is 40K.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.