### PR TITLE
Adds additional logging around connection validation to temporal-cassandra-tool

### DIFF
--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -105,10 +105,14 @@ func newCQLClient(cfg *CQLClientConfig) (*cqlClient, error) {
 
 	cassandraConfig := cfg.toCassandraConfig()
 	cassandraConfig.ConnectTimeout = time.Duration(cfg.Timeout) * time.Second
+
+	log.Println("validating connection to cassandra cluster")
 	session, err := gocql.NewSession(*cassandraConfig, resolver.NewNoopResolver())
 	if err != nil {
+		log.Printf("connection validation failed: %+v\r\n", err)
 		return nil, err
 	}
+	log.Println("connection validation succeeded")
 
 	return &cqlClient{
 		keyspace:   cfg.Keyspace,


### PR DESCRIPTION
We noticed a few instances where the temporal-cassandra-tool is taking a long time to apply schema updates. We suspect this is because testing connection establishment is taking quite a while, but we do not have any logs around this. This PR adds logs to better diagnose this.