### PR TITLE
Remove TTL from open_executions Cassandra visibility table

### DIFF
--- a/common/persistence/cassandra/cassandraVisibilityPersistence.go
+++ b/common/persistence/cassandra/cassandraVisibilityPersistence.go
@@ -38,19 +38,13 @@ import (
 
 // Fixed namespace values for now
 const (
-	namespacePartition     = 0
-	defaultCloseTTLSeconds = 86400
-	openExecutionTTLBuffer = int64(86400) // setting it to a day to account for shard going down
+	namespacePartition = 0
 
 	// ref: https://docs.datastax.com/en/dse-trblshoot/doc/troubleshooting/recoveringTtlYear2038Problem.html
 	maxCassandraTTL = int64(315360000) // Cassandra max support time is 2038-01-19T03:14:06+00:00. Updated this to 10 years to support until year 2028
 )
 
 const (
-	templateCreateWorkflowExecutionStartedWithTTL = `INSERT INTO open_executions (` +
-		`namespace_id, namespace_partition, workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, task_queue) ` +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?) using TTL ?`
-
 	templateCreateWorkflowExecutionStarted = `INSERT INTO open_executions (` +
 		`namespace_id, namespace_partition, workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, task_queue) ` +
 		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
@@ -159,37 +153,22 @@ func (v *cassandraVisibilityPersistence) Close() {
 
 func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionStarted(
 	request *p.InternalRecordWorkflowExecutionStartedRequest) error {
-	ttl := request.RunTimeout + openExecutionTTLBuffer
-	var query gocql.Query
 
-	if ttl > maxCassandraTTL {
-		query = v.session.Query(templateCreateWorkflowExecutionStarted,
-			request.NamespaceID,
-			namespacePartition,
-			request.WorkflowID,
-			request.RunID,
-			p.UnixNanoToDBTimestamp(request.StartTimestamp),
-			p.UnixNanoToDBTimestamp(request.ExecutionTimestamp),
-			request.WorkflowTypeName,
-			request.Memo.Data,
-			request.Memo.EncodingType.String(),
-			request.TaskQueue,
-		)
-	} else {
-		query = v.session.Query(templateCreateWorkflowExecutionStartedWithTTL,
-			request.NamespaceID,
-			namespacePartition,
-			request.WorkflowID,
-			request.RunID,
-			p.UnixNanoToDBTimestamp(request.StartTimestamp),
-			p.UnixNanoToDBTimestamp(request.ExecutionTimestamp),
-			request.WorkflowTypeName,
-			request.Memo.Data,
-			request.Memo.EncodingType.String(),
-			request.TaskQueue,
-			ttl,
-		)
-	}
+	query := v.session.Query(templateCreateWorkflowExecutionStarted,
+		request.NamespaceID,
+		namespacePartition,
+		request.WorkflowID,
+		request.RunID,
+		p.UnixNanoToDBTimestamp(request.StartTimestamp),
+		p.UnixNanoToDBTimestamp(request.ExecutionTimestamp),
+		request.WorkflowTypeName,
+		request.Memo.Data,
+		request.Memo.EncodingType.String(),
+		request.TaskQueue,
+	)
+	// It is important to specify timestamp for all `open_executions` queries because
+	// we are using milliseconds instead of default microseconds. If custom timestamp collides with
+	// default timestamp, default one will always win because they are 1000 times bigger.
 	query = query.WithTimestamp(p.UnixNanoToDBTimestamp(request.StartTimestamp))
 	err := query.Exec()
 	return gocql.ConvertError("RecordWorkflowExecutionStarted", err)
@@ -215,12 +194,14 @@ func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionClosedV2(
 	// Next, add a row in the closed table.
 
 	// Find how long to keep the row
-	retention := request.RetentionSeconds
-	if retention == 0 {
-		retention = defaultCloseTTLSeconds
+	var retentionSeconds int64
+	if request.Retention != nil {
+		retentionSeconds = int64(request.Retention.Seconds())
+	} else {
+		retentionSeconds = maxCassandraTTL + 1
 	}
 
-	if retention > maxCassandraTTL {
+	if retentionSeconds > maxCassandraTTL {
 		batch.Query(templateCreateWorkflowExecutionClosed,
 			request.NamespaceID,
 			namespacePartition,
@@ -251,21 +232,23 @@ func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionClosedV2(
 			request.Memo.Data,
 			request.Memo.EncodingType.String(),
 			request.TaskQueue,
-			retention,
+			retentionSeconds,
 		)
 	}
 
-	// RecordWorkflowExecutionStarted is using StartTimestamp as
-	// the timestamp to issue query to Cassandra
-	// due to the fact that cross DC using mutable state creation time as workflow start time
-	// and visibility using event time instead of last update time (#1501)
-	// CloseTimestamp can be before StartTimestamp, meaning using CloseTimestamp
-	// can cause the deletion of open visibility record to be ignored.
-	queryTimeStamp := request.CloseTimestamp
-	if queryTimeStamp < request.StartTimestamp {
-		queryTimeStamp = request.StartTimestamp + time.Second.Nanoseconds()
+	// RecordWorkflowExecutionStarted is using StartTimestamp as the timestamp for every query in `open_executions` table.
+	// Due to the fact that cross DC using mutable state creation time as workflow start time and visibility using event time
+	// instead of last update time (https://github.com/uber/cadence/pull/1501) CloseTimestamp can be before StartTimestamp.
+	// Using CloseTimestamp can cause the deletion of open visibility record to be ignored.
+
+	var queryTimestamp int64
+	if request.CloseTimestamp-request.StartTimestamp < time.Millisecond.Nanoseconds() {
+		queryTimestamp = request.StartTimestamp + time.Millisecond.Nanoseconds()
+	} else {
+		queryTimestamp = request.CloseTimestamp
 	}
-	batch = batch.WithTimestamp(p.UnixNanoToDBTimestamp(queryTimeStamp))
+
+	batch = batch.WithTimestamp(p.UnixNanoToDBTimestamp(queryTimestamp))
 	err := v.session.ExecuteBatch(batch)
 	return gocql.ConvertError("RecordWorkflowExecutionClosed", err)
 }

--- a/common/persistence/persistence-tests/visibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/visibilityPersistenceTest.go
@@ -746,7 +746,6 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 					},
 					Status: enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 				},
-				WorkflowTimeout: 0,
 			},
 			expected: nil,
 		},
@@ -764,7 +763,6 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 					SearchAttributes:   nil,
 					Status:             enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 				},
-				WorkflowTimeout: 0,
 			},
 			// To avoid blocking the task queue processors on non-ElasticSearch visibility stores
 			// we simply treat any attempts to perform Upserts as "no-ops"

--- a/common/persistence/persistence-tests/visibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/visibilityPersistenceTest.go
@@ -33,6 +33,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/server/common/persistence/cassandra"
 
 	"go.temporal.io/server/common/payload"
 	p "go.temporal.io/server/common/persistence"
@@ -239,11 +240,15 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityShortWorkflow() {
 }
 
 func (s *VisibilityPersistenceSuite) TestVisibilityRetention() {
+	if _, ok := s.VisibilityTestCluster.(*cassandra.TestCluster); !ok {
+		return
+	}
+
 	testNamespaceUUID := uuid.New()
 
 	workflowExecution := commonpb.WorkflowExecution{
-		WorkflowId: "visibility-workflow-test-short-workflow",
-		RunId:      "3c095198-0c33-4136-939a-c29fbbb6a80b",
+		WorkflowId: "visibility-workflow-test-visibility-retention",
+		RunId:      "3c095198-0c33-4136-939a-c29fbbb6a802",
 	}
 
 	startTime := time.Now().UTC().Add(-1 * time.Hour).UnixNano()

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -479,22 +479,19 @@ type (
 	// InternalRecordWorkflowExecutionStartedRequest request to RecordWorkflowExecutionStarted
 	InternalRecordWorkflowExecutionStartedRequest struct {
 		*InternalVisibilityRequestBase
-		RunTimeout int64
 	}
 
 	// InternalRecordWorkflowExecutionClosedRequest is request to RecordWorkflowExecutionClosed
 	InternalRecordWorkflowExecutionClosedRequest struct {
 		*InternalVisibilityRequestBase
-		CloseTimestamp   int64
-		HistoryLength    int64
-		RetentionSeconds int64
+		CloseTimestamp int64
+		HistoryLength  int64
+		Retention      *time.Duration
 	}
 
 	// InternalUpsertWorkflowExecutionRequest is request to UpsertWorkflowExecution
 	InternalUpsertWorkflowExecutionRequest struct {
 		*InternalVisibilityRequestBase
-		// TODO (alex): not used, remove
-		WorkflowTimeout int64
 	}
 
 	// InternalCreateNamespaceRequest is used to create the namespace

--- a/common/persistence/visibilityInterfaces.go
+++ b/common/persistence/visibilityInterfaces.go
@@ -28,6 +28,8 @@
 package persistence
 
 import (
+	"time"
+
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -58,21 +60,19 @@ type (
 	// RecordWorkflowExecutionStartedRequest is used to add a record of a newly started execution
 	RecordWorkflowExecutionStartedRequest struct {
 		*VisibilityRequestBase
-		RunTimeout int64 // not persisted, used for cassandra ttl
 	}
 
 	// RecordWorkflowExecutionClosedRequest is used to add a record of a closed execution
 	RecordWorkflowExecutionClosedRequest struct {
 		*VisibilityRequestBase
-		CloseTimestamp   int64
-		HistoryLength    int64
-		RetentionSeconds int64 // not persisted, used for cassandra ttl
+		CloseTimestamp int64
+		HistoryLength  int64
+		Retention      *time.Duration // not persisted, used for cassandra ttl
 	}
 
 	// UpsertWorkflowExecutionRequest is used to upsert workflow execution
 	UpsertWorkflowExecutionRequest struct {
 		*VisibilityRequestBase
-		WorkflowTimeout int64 // not persisted, used for cassandra ttl
 	}
 
 	// ListWorkflowExecutionsRequest is used to list executions in a namespace

--- a/common/persistence/visibilityStore.go
+++ b/common/persistence/visibilityStore.go
@@ -70,7 +70,6 @@ func (v *visibilityManagerImpl) GetName() string {
 func (v *visibilityManagerImpl) RecordWorkflowExecutionStarted(request *RecordWorkflowExecutionStartedRequest) error {
 	req := &InternalRecordWorkflowExecutionStartedRequest{
 		InternalVisibilityRequestBase: v.newInternalVisibilityRequestBase(request.VisibilityRequestBase),
-		RunTimeout:                    request.RunTimeout,
 	}
 	return v.persistence.RecordWorkflowExecutionStarted(req)
 }
@@ -80,7 +79,7 @@ func (v *visibilityManagerImpl) RecordWorkflowExecutionClosed(request *RecordWor
 		InternalVisibilityRequestBase: v.newInternalVisibilityRequestBase(request.VisibilityRequestBase),
 		CloseTimestamp:                request.CloseTimestamp,
 		HistoryLength:                 request.HistoryLength,
-		RetentionSeconds:              request.RetentionSeconds,
+		Retention:                     request.Retention,
 	}
 	return v.persistence.RecordWorkflowExecutionClosed(req)
 }
@@ -88,7 +87,6 @@ func (v *visibilityManagerImpl) RecordWorkflowExecutionClosed(request *RecordWor
 func (v *visibilityManagerImpl) UpsertWorkflowExecution(request *UpsertWorkflowExecutionRequest) error {
 	req := &InternalUpsertWorkflowExecutionRequest{
 		InternalVisibilityRequestBase: v.newInternalVisibilityRequestBase(request.VisibilityRequestBase),
-		WorkflowTimeout:               request.WorkflowTimeout,
 	}
 	return v.persistence.UpsertWorkflowExecution(req)
 }

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -1982,7 +1982,6 @@ func (s *transferQueueActiveTaskExecutorSuite) createRecordWorkflowExecutionStar
 			TaskID:             task.GetTaskId(),
 			TaskQueue:          task.TaskQueue,
 		},
-		RunTimeout: int64(timestamp.DurationValue(executionInfo.WorkflowRunTimeout).Round(time.Second).Seconds()),
 	}
 }
 
@@ -2115,7 +2114,6 @@ func (s *transferQueueActiveTaskExecutorSuite) createUpsertWorkflowSearchAttribu
 			Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 			TaskQueue:        task.TaskQueue,
 		},
-		WorkflowTimeout: int64(timestamp.DurationValue(executionInfo.WorkflowRunTimeout).Round(time.Second).Seconds()),
 	}
 }
 

--- a/service/history/transferQueueStandbyTaskExecutor_test.go
+++ b/service/history/transferQueueStandbyTaskExecutor_test.go
@@ -1155,7 +1155,6 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessRecordWorkflowStarted
 			TaskID:           taskID,
 			TaskQueue:        taskQueueName,
 		},
-		RunTimeout: int64(timestamp.DurationValue(executionInfo.WorkflowRunTimeout).Round(time.Second).Seconds()),
 	}).Return(nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, *now)
@@ -1223,7 +1222,6 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchA
 			TaskQueue:        taskQueueName,
 			Status:           enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING,
 		},
-		WorkflowTimeout: int64(timestamp.DurationValue(executionInfo.WorkflowRunTimeout).Round(time.Second).Seconds()),
 	}).Return(nil)
 
 	s.mockShard.SetCurrentTime(s.clusterName, *now)

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -42,7 +42,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/shard"
@@ -196,7 +195,6 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowStarted(
 			TaskQueue:          taskQueue,
 			SearchAttributes:   searchAttributes,
 		},
-		RunTimeout: int64(timestamp.DurationValue(runTimeout).Round(time.Second).Seconds()),
 	}
 	return t.visibilityMgr.RecordWorkflowExecutionStarted(request)
 }
@@ -243,7 +241,6 @@ func (t *transferQueueTaskExecutorBase) upsertWorkflowExecution(
 			TaskQueue:          taskQueue,
 			SearchAttributes:   searchAttributes,
 		},
-		WorkflowTimeout: int64(timestamp.DurationValue(workflowTimeout).Round(time.Second).Seconds()),
 	}
 
 	return t.visibilityMgr.UpsertWorkflowExecution(request)
@@ -319,6 +316,7 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowClosed(
 	return nil
 }
 
+// TODO: remove
 func isWorkflowNotExistError(err error) bool {
 	_, ok := err.(*serviceerror.NotFound)
 	return ok

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -162,7 +162,6 @@ func (t *visibilityQueueTaskExecutor) processStartOrUpsertExecution(
 
 	executionInfo := mutableState.GetExecutionInfo()
 	executionState := mutableState.GetExecutionState()
-	runTimeout := executionInfo.WorkflowRunTimeout
 	wfTypeName := executionInfo.WorkflowTypeName
 
 	startEvent, err := mutableState.GetStartEvent()
@@ -189,7 +188,6 @@ func (t *visibilityQueueTaskExecutor) processStartOrUpsertExecution(
 			wfTypeName,
 			startTimestamp.UnixNano(),
 			executionTimestamp.UnixNano(),
-			runTimeout,
 			task.GetTaskId(),
 			executionStatus,
 			taskQueue,
@@ -204,7 +202,6 @@ func (t *visibilityQueueTaskExecutor) processStartOrUpsertExecution(
 		wfTypeName,
 		startTimestamp.UnixNano(),
 		executionTimestamp.UnixNano(),
-		runTimeout,
 		task.GetTaskId(),
 		executionStatus,
 		taskQueue,
@@ -219,7 +216,6 @@ func (t *visibilityQueueTaskExecutor) recordStartExecution(
 	workflowTypeName string,
 	startTimeUnixNano int64,
 	executionTimeUnixNano int64,
-	runTimeout *time.Duration,
 	taskID int64,
 	status enumspb.WorkflowExecutionStatus,
 	taskQueue string,
@@ -260,7 +256,6 @@ func (t *visibilityQueueTaskExecutor) recordStartExecution(
 			TaskQueue:          taskQueue,
 			SearchAttributes:   searchAttributes,
 		},
-		RunTimeout: int64(timestamp.DurationValue(runTimeout).Round(time.Second).Seconds()),
 	}
 	return t.visibilityMgr.RecordWorkflowExecutionStarted(request)
 }
@@ -272,7 +267,6 @@ func (t *visibilityQueueTaskExecutor) upsertExecution(
 	workflowTypeName string,
 	startTimeUnixNano int64,
 	executionTimeUnixNano int64,
-	workflowTimeout *time.Duration,
 	taskID int64,
 	status enumspb.WorkflowExecutionStatus,
 	taskQueue string,
@@ -308,7 +302,6 @@ func (t *visibilityQueueTaskExecutor) upsertExecution(
 			TaskQueue:          taskQueue,
 			SearchAttributes:   searchAttributes,
 		},
-		WorkflowTimeout: int64(timestamp.DurationValue(workflowTimeout).Round(time.Second).Seconds()),
 	}
 
 	return t.visibilityMgr.UpsertWorkflowExecution(request)
@@ -407,19 +400,20 @@ func (t *visibilityQueueTaskExecutor) recordCloseExecution(
 	searchAttributes *commonpb.SearchAttributes,
 ) error {
 
-	// Record closing in visibility store
-	retentionSeconds := int64(0)
+	namespaceEntry, err := t.shard.GetNamespaceCache().GetNamespaceByID(namespaceID)
+	if err != nil {
+		if _, notFound := err.(*serviceerror.NotFound); !notFound {
+			return err
+		}
+	}
+
+	var retention *time.Duration
 	namespace := defaultNamespace
 	recordWorkflowClose := true
 
-	namespaceEntry, err := t.shard.GetNamespaceCache().GetNamespaceByID(namespaceID)
-	if err != nil && !isWorkflowNotExistError(err) {
-		return err
-	}
-
-	if err == nil {
-		// retention in namespace config is in days, convert to seconds
-		retentionSeconds = int64(timestamp.DurationFromDays(namespaceEntry.GetRetentionDays(workflowID)).Seconds())
+	if namespaceEntry != nil {
+		// retention in namespace config is in days, convert to time.Duration.
+		retention = timestamp.DurationFromDays(namespaceEntry.GetRetentionDays(workflowID))
 		namespace = namespaceEntry.GetInfo().Name
 		// if sampled for longer retention is enabled, only record those sampled events
 		if namespaceEntry.IsSampledForLongerRetentionEnabled(workflowID) &&
@@ -447,9 +441,9 @@ func (t *visibilityQueueTaskExecutor) recordCloseExecution(
 				TaskQueue:          taskQueue,
 				SearchAttributes:   searchAttributes,
 			},
-			CloseTimestamp:   endTime.UnixNano(),
-			HistoryLength:    historyLength,
-			RetentionSeconds: retentionSeconds,
+			CloseTimestamp: endTime.UnixNano(),
+			HistoryLength:  historyLength,
+			Retention:      retention,
 		})
 	}
 

--- a/service/history/visibilityQueueTaskExecutor_test.go
+++ b/service/history/visibilityQueueTaskExecutor_test.go
@@ -361,7 +361,6 @@ func (s *visibilityQueueTaskExecutorSuite) createRecordWorkflowExecutionStartedR
 			ShardID:            s.mockShard.GetShardID(),
 			TaskQueue:          taskQueueName,
 		},
-		RunTimeout: int64(timestamp.DurationValue(executionInfo.WorkflowRunTimeout).Round(time.Second).Seconds()),
 	}
 }
 
@@ -391,7 +390,6 @@ func (s *visibilityQueueTaskExecutorSuite) createUpsertWorkflowSearchAttributesR
 			TaskQueue:        taskQueueName,
 			ShardID:          s.mockShard.GetShardID(),
 		},
-		WorkflowTimeout: int64(timestamp.DurationValue(executionInfo.WorkflowRunTimeout).Round(time.Second).Seconds()),
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove TTL from `open_executions` Cassandra visibility table.

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously TTL was set to workflow timeout as an extra protection in case of close workflow execution task lost. Also there was a bug in this protection which set this TTL to 1 day in case of `nil` (unlimited timeout). This protection is not needed with new visibility queue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Current tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.