### PR TITLE
Relax the constraint on which event ID is allow for ResetWorkflow API

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -567,6 +567,10 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
+	if len(newWorkflowEventsSeq) != 1 {
+		return nil, serviceerror.NewInternal("unable to create 1st event batch")
+	}
+
 	historySize, err := weContext.persistFirstWorkflowEvents(newWorkflowEventsSeq[0])
 	if err != nil {
 		return nil, err
@@ -1989,6 +1993,10 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
+	if len(newWorkflowEventsSeq) != 1 {
+		return nil, serviceerror.NewInternal("unable to create 1st event batch")
+	}
+
 	historySize, err := context.persistFirstWorkflowEvents(newWorkflowEventsSeq[0])
 	if err != nil {
 		return nil, err

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -5027,10 +5027,12 @@ func addWorkflowTaskStartedEvent(builder mutableState, scheduleID int64, taskQue
 
 func addWorkflowTaskStartedEventWithRequestID(builder mutableState, scheduleID int64, requestID string,
 	taskQueue, identity string) *historypb.HistoryEvent {
-	event, _, _ := builder.AddWorkflowTaskStartedEvent(scheduleID, requestID, &workflowservice.PollWorkflowTaskQueueRequest{
-		TaskQueue: &taskqueuepb.TaskQueue{Name: taskQueue},
-		Identity:  identity,
-	})
+	event, _, _ := builder.AddWorkflowTaskStartedEvent(
+		scheduleID,
+		requestID,
+		&taskqueuepb.TaskQueue{Name: taskQueue},
+		identity,
+	)
 
 	return event
 }

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -90,7 +90,7 @@ type (
 		AddFirstWorkflowTaskScheduled(*historypb.HistoryEvent) error
 		AddWorkflowTaskScheduledEvent(bypassTaskGeneration bool) (*workflowTaskInfo, error)
 		AddWorkflowTaskScheduledEventAsHeartbeat(bypassTaskGeneration bool, originalScheduledTimestamp *time.Time) (*workflowTaskInfo, error)
-		AddWorkflowTaskStartedEvent(int64, string, *workflowservice.PollWorkflowTaskQueueRequest) (*historypb.HistoryEvent, *workflowTaskInfo, error)
+		AddWorkflowTaskStartedEvent(int64, string, *taskqueuepb.TaskQueue, string) (*historypb.HistoryEvent, *workflowTaskInfo, error)
 		AddWorkflowTaskTimedOutEvent(int64, int64) (*historypb.HistoryEvent, error)
 		AddExternalWorkflowExecutionCancelRequested(int64, string, string, string) (*historypb.HistoryEvent, error)
 		AddExternalWorkflowExecutionSignaled(int64, string, string, string, string) (*historypb.HistoryEvent, error)

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1526,13 +1526,14 @@ func (e *mutableStateBuilder) ReplicateWorkflowTaskScheduledEvent(
 func (e *mutableStateBuilder) AddWorkflowTaskStartedEvent(
 	scheduleEventID int64,
 	requestID string,
-	request *workflowservice.PollWorkflowTaskQueueRequest,
+	taskQueue *taskqueuepb.TaskQueue,
+	identity string,
 ) (*historypb.HistoryEvent, *workflowTaskInfo, error) {
 	opTag := tag.WorkflowActionWorkflowTaskStarted
 	if err := e.checkMutability(opTag); err != nil {
 		return nil, nil, err
 	}
-	return e.workflowTaskManager.AddWorkflowTaskStartedEvent(scheduleEventID, requestID, request)
+	return e.workflowTaskManager.AddWorkflowTaskStartedEvent(scheduleEventID, requestID, taskQueue, identity)
 }
 
 func (e *mutableStateBuilder) ReplicateWorkflowTaskStartedEvent(
@@ -3697,9 +3698,6 @@ func (e *mutableStateBuilder) CloseTransactionAsSnapshot(
 		return nil, nil, err
 	}
 
-	if len(workflowEventsSeq) > 1 {
-		return nil, nil, serviceerror.NewInternal("cannot generate workflow snapshot with transient events")
-	}
 	if len(bufferEvents) > 0 {
 		// TODO do we need the functionality to generate snapshot with buffered events?
 		return nil, nil, serviceerror.NewInternal("cannot generate workflow snapshot with buffered events")

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -37,7 +37,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
-	"go.temporal.io/api/workflowservice/v1"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
@@ -410,7 +409,8 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskStart_CurrentVersionChanged
 	_, _, err = s.msBuilder.AddWorkflowTaskStartedEvent(
 		s.msBuilder.GetNextEventID(),
 		uuid.New(),
-		&workflowservice.PollWorkflowTaskQueueRequest{},
+		&taskqueuepb.TaskQueue{},
+		"random identity",
 	)
 	s.NoError(err)
 	s.Equal(0, s.msBuilder.hBuilder.BufferEventSize())

--- a/service/history/mutableStateWorkflowTaskManager_mock.go
+++ b/service/history/mutableStateWorkflowTaskManager_mock.go
@@ -153,9 +153,9 @@ func (mr *MockmutableStateWorkflowTaskManagerMockRecorder) AddWorkflowTaskSchedu
 }
 
 // AddWorkflowTaskStartedEvent mocks base method.
-func (m *MockmutableStateWorkflowTaskManager) AddWorkflowTaskStartedEvent(scheduleEventID int64, requestID string, request *workflowservice.PollWorkflowTaskQueueRequest) (*history.HistoryEvent, *workflowTaskInfo, error) {
+func (m *MockmutableStateWorkflowTaskManager) AddWorkflowTaskStartedEvent(scheduleEventID int64, requestID string, taskQueue *taskqueue.TaskQueue, identity string) (*history.HistoryEvent, *workflowTaskInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWorkflowTaskStartedEvent", scheduleEventID, requestID, request)
+	ret := m.ctrl.Call(m, "AddWorkflowTaskStartedEvent", scheduleEventID, requestID, taskQueue, identity)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(*workflowTaskInfo)
 	ret2, _ := ret[2].(error)
@@ -163,9 +163,9 @@ func (m *MockmutableStateWorkflowTaskManager) AddWorkflowTaskStartedEvent(schedu
 }
 
 // AddWorkflowTaskStartedEvent indicates an expected call of AddWorkflowTaskStartedEvent.
-func (mr *MockmutableStateWorkflowTaskManagerMockRecorder) AddWorkflowTaskStartedEvent(scheduleEventID, requestID, request interface{}) *gomock.Call {
+func (mr *MockmutableStateWorkflowTaskManagerMockRecorder) AddWorkflowTaskStartedEvent(scheduleEventID, requestID, taskQueue, identity interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowTaskStartedEvent", reflect.TypeOf((*MockmutableStateWorkflowTaskManager)(nil).AddWorkflowTaskStartedEvent), scheduleEventID, requestID, request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowTaskStartedEvent", reflect.TypeOf((*MockmutableStateWorkflowTaskManager)(nil).AddWorkflowTaskStartedEvent), scheduleEventID, requestID, taskQueue, identity)
 }
 
 // AddWorkflowTaskTimedOutEvent mocks base method.

--- a/service/history/mutableState_mock.go
+++ b/service/history/mutableState_mock.go
@@ -754,9 +754,9 @@ func (mr *MockmutableStateMockRecorder) AddWorkflowTaskScheduledEventAsHeartbeat
 }
 
 // AddWorkflowTaskStartedEvent mocks base method.
-func (m *MockmutableState) AddWorkflowTaskStartedEvent(arg0 int64, arg1 string, arg2 *workflowservice.PollWorkflowTaskQueueRequest) (*history.HistoryEvent, *workflowTaskInfo, error) {
+func (m *MockmutableState) AddWorkflowTaskStartedEvent(arg0 int64, arg1 string, arg2 *taskqueue.TaskQueue, arg3 string) (*history.HistoryEvent, *workflowTaskInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddWorkflowTaskStartedEvent", arg0, arg1, arg2)
+	ret := m.ctrl.Call(m, "AddWorkflowTaskStartedEvent", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*history.HistoryEvent)
 	ret1, _ := ret[1].(*workflowTaskInfo)
 	ret2, _ := ret[2].(error)
@@ -764,9 +764,9 @@ func (m *MockmutableState) AddWorkflowTaskStartedEvent(arg0 int64, arg1 string, 
 }
 
 // AddWorkflowTaskStartedEvent indicates an expected call of AddWorkflowTaskStartedEvent.
-func (mr *MockmutableStateMockRecorder) AddWorkflowTaskStartedEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
+func (mr *MockmutableStateMockRecorder) AddWorkflowTaskStartedEvent(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowTaskStartedEvent", reflect.TypeOf((*MockmutableState)(nil).AddWorkflowTaskStartedEvent), arg0, arg1, arg2)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowTaskStartedEvent", reflect.TypeOf((*MockmutableState)(nil).AddWorkflowTaskStartedEvent), arg0, arg1, arg2, arg3)
 }
 
 // AddWorkflowTaskTimedOutEvent mocks base method.

--- a/service/history/nDCTransactionMgrForNewWorkflow.go
+++ b/service/history/nDCTransactionMgrForNewWorkflow.go
@@ -162,6 +162,9 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) createAsCurrent(
 	if err != nil {
 		return err
 	}
+	if len(targetWorkflowEventsSeq) != 1 {
+		return serviceerror.NewInternal("unable to create 1st event batch")
+	}
 
 	targetWorkflowHistorySize, err := r.persistNewNDCWorkflowEvents(
 		targetWorkflow,
@@ -232,6 +235,9 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) createAsZombie(
 	)
 	if err != nil {
 		return err
+	}
+	if len(targetWorkflowEventsSeq) != 1 {
+		return serviceerror.NewInternal("unable to create 1st event batch")
 	}
 
 	targetWorkflowHistorySize, err := r.persistNewNDCWorkflowEvents(

--- a/service/history/timerQueueStandbyTaskExecutor_test.go
+++ b/service/history/timerQueueStandbyTaskExecutor_test.go
@@ -690,7 +690,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple
 	activityType2 := "activity type 2"
 	timerTimeout2 := 20 * time.Second
 	scheduledEvent2, _ := addActivityTaskScheduledEvent(mutableState, event.GetEventId(), activityID2, activityType2, taskqueue, nil,
-		timerTimeout2, timerTimeout2, timerTimeout2, timerTimeout2)
+		timerTimeout2, timerTimeout2, timerTimeout2, 10*time.Second)
 	addActivityTaskStartedEvent(mutableState, scheduledEvent2.GetEventId(), identity)
 	activityInfo2 := mutableState.pendingActivityInfoIDs[scheduledEvent2.GetEventId()]
 	activityInfo2.TimerTaskStatus |= timerTaskStatusCreatedHeartbeat

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -477,12 +477,13 @@ func (c *workflowExecutionContextImpl) conflictResolveWorkflowExecution(
 			return err
 		}
 		newWorkflowSizeSize := newContext.getHistorySize()
-		startEvents := newWorkflowEventsSeq[0]
-		eventsSize, err := c.persistNewWorkflowEvents(startEvents)
-		if err != nil {
-			return err
+		for _, workflowEvents := range newWorkflowEventsSeq {
+			eventsSize, err := c.persistNewWorkflowEvents(workflowEvents)
+			if err != nil {
+				return err
+			}
+			newWorkflowSizeSize += eventsSize
 		}
-		newWorkflowSizeSize += eventsSize
 		newContext.setHistorySize(newWorkflowSizeSize)
 		newWorkflow.ExecutionInfo.ExecutionStats = &persistencespb.ExecutionStats{
 			HistorySize: newWorkflowSizeSize,
@@ -721,12 +722,13 @@ func (c *workflowExecutionContextImpl) updateWorkflowExecutionWithNew(
 			return err
 		}
 		newWorkflowSizeSize := newContext.getHistorySize()
-		startEvents := newWorkflowEventsSeq[0]
-		eventsSize, err := c.persistNewWorkflowEvents(startEvents)
-		if err != nil {
-			return err
+		for _, workflowEvents := range newWorkflowEventsSeq {
+			eventsSize, err := c.persistNewWorkflowEvents(workflowEvents)
+			if err != nil {
+				return err
+			}
+			newWorkflowSizeSize += eventsSize
 		}
-		newWorkflowSizeSize += eventsSize
 		newContext.setHistorySize(newWorkflowSizeSize)
 		newWorkflow.ExecutionInfo.ExecutionStats = &persistencespb.ExecutionStats{
 			HistorySize: newWorkflowSizeSize,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Allow reset workflow with event ID in range [workflow task schedule ID+1, workflow task start ID+1]
* Add UT & integration test

<!-- Tell your future self why have you made these changes -->
**Why?**
Allow more reset points for ResetWorkflow API
Close #1358

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No