### PR TITLE
Export encryption.NewLocalStoreCertProvider()

### DIFF
--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -85,6 +85,24 @@ func (s *localStoreCertProvider) initialize() {
 	}
 }
 
+func NewLocalStoreCertProvider(
+	tlsSettings *config.GroupTLS,
+	workerTlsSettings *config.WorkerTLS,
+	legacyWorkerSettings *config.ClientTLS,
+	refreshInterval time.Duration) CertProvider {
+
+	provider := &localStoreCertProvider{
+		tlsSettings:          tlsSettings,
+		workerTLSSettings:    workerTlsSettings,
+		legacyWorkerSettings: legacyWorkerSettings,
+		isLegacyWorkerConfig: legacyWorkerSettings != nil,
+		logger:               log.NewDefaultLogger(),
+		refreshInterval:      refreshInterval,
+	}
+	provider.initialize()
+	return provider
+}
+
 func (s *localStoreCertProvider) Close() {
 
 	if s.ticker != nil {

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -32,7 +32,6 @@ import (
 	"github.com/uber-go/tally"
 
 	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/log"
 )
 
 type (
@@ -88,25 +87,7 @@ func NewTLSConfigProviderFromConfig(
 ) (TLSConfigProvider, error) {
 
 	if certProviderFactory == nil {
-		certProviderFactory = newLocalStoreCertProvider
+		certProviderFactory = NewLocalStoreCertProvider
 	}
 	return NewLocalStoreTlsProvider(&encryptionSettings, scope, certProviderFactory)
-}
-
-func newLocalStoreCertProvider(
-	tlsSettings *config.GroupTLS,
-	workerTlsSettings *config.WorkerTLS,
-	legacyWorkerSettings *config.ClientTLS,
-	refreshInterval time.Duration) CertProvider {
-
-	provider := &localStoreCertProvider{
-		tlsSettings:          tlsSettings,
-		workerTLSSettings:    workerTlsSettings,
-		legacyWorkerSettings: legacyWorkerSettings,
-		isLegacyWorkerConfig: legacyWorkerSettings != nil,
-		logger:               log.NewDefaultLogger(),
-		refreshInterval:      refreshInterval,
-	}
-	provider.initialize()
-	return provider
 }


### PR DESCRIPTION
**What changed?**
Exported `encryption.NewLocalStoreCertProvider()`.

**Why?**
`NewLocalStoreCertProvider()` is currently only used from within `NewTLSConfigProviderFromConfig()`. This change will allow it to be leveraged from other implementations of `TLSConfigProvider`.

**How did you test it?**
Unit test.

**Potential risks**
No risk.

**Is hotfix candidate?**
No.