### PR TITLE
Change CLI default TLS host name verification behavior

### DIFF
--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -170,7 +170,7 @@ func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
 			CertFile:               cli.GlobalString(schema.CLIFlagTLSCertFile),
 			KeyFile:                cli.GlobalString(schema.CLIFlagTLSKeyFile),
 			CaFile:                 cli.GlobalString(schema.CLIFlagTLSCaFile),
-			EnableHostVerification: cli.GlobalBool(schema.CLIFlagTLSEnableHostVerification),
+			EnableHostVerification: !cli.GlobalBool(schema.CLIFlagTLSDisableHostVerification),
 		}
 	}
 

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -138,7 +138,7 @@ func buildCLIOptions() *cli.App {
 		},
 		cli.BoolFlag{
 			Name:   schema.CLIFlagTLSDisableHostVerification,
-			Usage:  "Cassandra tls verify server hostname",
+			Usage:  "disable tls host name verification (tls must be enabled)",
 			EnvVar: "CASSANDRA_TLS_DISABLE_HOST_VERIFICATION",
 		},
 	}

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -137,9 +137,9 @@ func buildCLIOptions() *cli.App {
 			EnvVar: "CASSANDRA_TLS_CA",
 		},
 		cli.BoolFlag{
-			Name:   schema.CLIFlagTLSEnableHostVerification,
-			Usage:  "TLS host verification",
-			EnvVar: "CASSANDRA_TLS_VERIFY_HOST",
+			Name:   schema.CLIFlagTLSDisableHostVerification,
+			Usage:  "Cassandra tls verify server hostname",
+			EnvVar: "CASSANDRA_TLS_DISABLE_HOST_VERIFICATION",
 		},
 	}
 

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -306,7 +306,7 @@ func connectToCassandra(c *cli.Context) gocql.Session {
 			CertFile:               c.String(FlagTLSCertPath),
 			KeyFile:                c.String(FlagTLSKeyPath),
 			CaFile:                 c.String(FlagTLSCaPath),
-			EnableHostVerification: c.Bool(FlagTLSEnableHostVerification),
+			EnableHostVerification: !c.Bool(FlagTLSDisableHostVerification),
 		}
 	}
 

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -85,7 +85,7 @@ func NewCliApp() *cli.App {
 		},
 		cli.BoolFlag{
 			Name:   FlagTLSDisableHostVerification,
-			Usage:  "whether to validates hostname of temporal cluster against server certificate",
+			Usage:  "disable tls host name verification (tls must be enabled)",
 			EnvVar: "TEMPORAL_CLI_TLS_DISABLE_HOST_VERIFICATION",
 		},
 		cli.StringFlag{

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -84,9 +84,9 @@ func NewCliApp() *cli.App {
 			EnvVar: "TEMPORAL_CLI_TLS_CA",
 		},
 		cli.BoolFlag{
-			Name:   FlagTLSEnableHostVerification,
-			Usage:  "validates hostname of temporal cluster against server certificate",
-			EnvVar: "TEMPORAL_CLI_TLS_ENABLE_HOST_VERIFICATION",
+			Name:   FlagTLSDisableHostVerification,
+			Usage:  "whether to validates hostname of temporal cluster against server certificate",
+			EnvVar: "TEMPORAL_CLI_TLS_DISABLE_HOST_VERIFICATION",
 		},
 		cli.StringFlag{
 			Name:   FlagTLSServerName,

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -144,7 +144,7 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 	certPath := c.GlobalString(FlagTLSCertPath)
 	keyPath := c.GlobalString(FlagTLSKeyPath)
 	caPath := c.GlobalString(FlagTLSCaPath)
-	hostNameVerification := c.GlobalBool(FlagTLSEnableHostVerification)
+	hostNameVerification := !c.GlobalBool(FlagTLSDisableHostVerification)
 	serverName := c.GlobalString(FlagTLSServerName)
 
 	var host string

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -215,14 +215,13 @@ const (
 	FlagTLSCertPath                      = "tls_cert_path"
 	FlagTLSKeyPath                       = "tls_key_path"
 	FlagTLSCaPath                        = "tls_ca_path"
-	FlagTLSEnableHostVerification        = "tls_enable_host_verification"
+	FlagTLSDisableHostVerification       = "tls_disable_host_verification"
 	FlagTLSServerName                    = "tls_server_name"
 	FlagDLQType                          = "dlq_type"
 	FlagDLQTypeWithAlias                 = FlagDLQType + ", dt"
 	FlagMaxMessageCount                  = "max_message_count"
 	FlagMaxMessageCountWithAlias         = FlagMaxMessageCount + ", mmc"
 	FlagLastMessageID                    = "last_message_id"
-	FlagLastMessageIDWithAlias           = FlagLastMessageID + ", lm"
 	FlagConcurrency                      = "concurrency"
 	FlagReportRate                       = "report_rate"
 	FlagLowerShardBound                  = "lower_shard_bound"
@@ -637,7 +636,7 @@ func getDBFlags() []cli.Flag {
 			Usage: "DB tls client ca path (tls must be enabled)",
 		},
 		cli.BoolFlag{
-			Name:  FlagTLSEnableHostVerification,
+			Name:  FlagTLSDisableHostVerification,
 			Usage: "DB tls verify hostname and server cert (tls must be enabled)",
 		},
 	}

--- a/tools/cli/persistenceUtil.go
+++ b/tools/cli/persistenceUtil.go
@@ -85,7 +85,7 @@ func CreateDefaultDBConfig(c *cli.Context) (config.DataStore, error) {
 			CertFile:               c.String(FlagTLSCertPath),
 			KeyFile:                c.String(FlagTLSKeyPath),
 			CaFile:                 c.String(FlagTLSCaPath),
-			EnableHostVerification: c.Bool(FlagTLSEnableHostVerification),
+			EnableHostVerification: !c.Bool(FlagTLSDisableHostVerification),
 		}
 	}
 

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -159,8 +159,8 @@ const (
 	CLIFlagTLSKeyFile = "tls-key-file"
 	// CLIFlagTLSCaFile is the optional tls CA file (tls must be enabled)
 	CLIFlagTLSCaFile = "tls-ca-file"
-	// CLIFlagTLSEnableHostVerification enables tls host verification (tls must be enabled)
-	CLIFlagTLSEnableHostVerification = "tls-enable-host-verification"
+	// CLIFlagTLSDisableHostVerification disable tls host verification (tls must be enabled)
+	CLIFlagTLSDisableHostVerification = "tls-disable-host-verification"
 )
 
 var rmspaceRegex = regexp.MustCompile(`\s+`)

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -167,7 +167,7 @@ func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 			CertFile:               cli.GlobalString(schema.CLIFlagTLSCertFile),
 			KeyFile:                cli.GlobalString(schema.CLIFlagTLSKeyFile),
 			CaFile:                 cli.GlobalString(schema.CLIFlagTLSCaFile),
-			EnableHostVerification: cli.GlobalBool(schema.CLIFlagTLSEnableHostVerification),
+			EnableHostVerification: !cli.GlobalBool(schema.CLIFlagTLSDisableHostVerification),
 		}
 	}
 

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -126,7 +126,7 @@ func BuildCLIOptions() *cli.App {
 		},
 		cli.BoolFlag{
 			Name:   schema.CLIFlagTLSDisableHostVerification,
-			Usage:  "sql tls verify hostname and server cert (tls must be enabled)",
+			Usage:  "disable tls host name verification (tls must be enabled)",
 			EnvVar: "SQL_TLS_DISABLE_HOST_VERIFICATION",
 		},
 	}

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -125,9 +125,9 @@ func BuildCLIOptions() *cli.App {
 			EnvVar: "SQL_TLS_CA_FILE",
 		},
 		cli.BoolFlag{
-			Name:   schema.CLIFlagTLSEnableHostVerification,
+			Name:   schema.CLIFlagTLSDisableHostVerification,
 			Usage:  "sql tls verify hostname and server cert (tls must be enabled)",
-			EnvVar: "SQL_TLS_ENABLE_HOST_VERIFICATION",
+			EnvVar: "SQL_TLS_DISABLE_HOST_VERIFICATION",
 		},
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* CLI TLS default to perform host name verification
* Remove CLI TLS enable host verification flag, `tls_enable_host_verification` and `tls-enable-host-verification`
* Add CLI TLS disable host verification flag `tls_disable_host_verification` and `tls-disable-host-verification`

<!-- Tell your future self why have you made these changes -->
**Why?**
Changing the default behavior for better security reasons

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual tests & CICD

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
CLI behavior breaking change

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No