### PR TITLE
Added TLS config for only server name if it's only option provided.

### DIFF
--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -192,6 +192,15 @@ func (b *clientFactory) createTLSConfig(c *cli.Context) (*tls.Config, error) {
 
 		return tlsConfig, nil
 	}
+	// If we are given a server name, set the TLS server name for DNS resolution
+	if serverName != "" {
+		host = serverName
+		// If server name is provided, we enable host verification
+		// because that's the only reason for providing server name
+		hostNameVerification = true
+		tlsConfig := auth.NewTLSConfigForServer(host, hostNameVerification)
+		return tlsConfig, nil
+	}
 
 	return nil, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- If the server name was provided but not any cert paths, initialize TLS with the server name only for DNS resolution.

<!-- Tell your future self why have you made these changes -->
**Why?**

- We have Temporal frontend running behind a domain name and this allows us to hit it from `tctl` without needing to provide a certificate.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- Tested in Kubernetes with Temporal frontend behind a domain name.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

- Nothing will be broken because if cert paths are provided, the TLS config is returned before this has a chance to get called.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

- Probably not, but we need this for our developers to be able to hit Temporal from `tctl` on their developer machines without having to use admin tools or pod ip:port.