### PR TITLE
Adds flag to tell Temporal to avoid trying to connect to unreachable Cassandra Nodes

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -283,6 +283,8 @@ type (
 		TLS *auth.TLS `yaml:"tls"`
 		// Consistency configuration (defaults to LOCAL_QUORUM / LOCAL_SERIAL for all stores if this field not set)
 		Consistency *CassandraStoreConsistency `yaml:"consistency"`
+		// EnableContactPointHostFilter filters out any hosts returned from a cassandra node that are not reachable
+		EnableContactPointHostFilter bool `yaml:"enableContactPointHostFilter"`
 	}
 
 	// CassandraStoreConsistency enables you to set the consistency settings for each Cassandra Persistence Store for Temporal

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -48,15 +48,16 @@ type (
 	}
 	// CQLClientConfig contains the configuration for cql client
 	CQLClientConfig struct {
-		Hosts       string
-		Port        int
-		User        string
-		Password    string
-		Keyspace    string
-		Timeout     int
-		numReplicas int
-		Datacenter  string
-		TLS         *auth.TLS
+		Hosts                        string
+		Port                         int
+		User                         string
+		Password                     string
+		Keyspace                     string
+		Timeout                      int
+		numReplicas                  int
+		Datacenter                   string
+		EnableContactPointHostFilter bool
+		TLS                          *auth.TLS
 	}
 )
 
@@ -125,13 +126,14 @@ func newCQLClient(cfg *CQLClientConfig) (*cqlClient, error) {
 
 func (cfg *CQLClientConfig) toCassandraConfig() *config.Cassandra {
 	cassandraConfig := config.Cassandra{
-		Hosts:      cfg.Hosts,
-		Port:       cfg.Port,
-		User:       cfg.User,
-		Password:   cfg.Password,
-		Keyspace:   cfg.Keyspace,
-		TLS:        cfg.TLS,
-		Datacenter: cfg.Datacenter,
+		Hosts:                        cfg.Hosts,
+		Port:                         cfg.Port,
+		User:                         cfg.User,
+		Password:                     cfg.Password,
+		Keyspace:                     cfg.Keyspace,
+		TLS:                          cfg.TLS,
+		Datacenter:                   cfg.Datacenter,
+		EnableContactPointHostFilter: cfg.EnableContactPointHostFilter,
 	}
 
 	return &cassandraConfig

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -163,6 +163,7 @@ func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
 	config.Keyspace = cli.GlobalString(schema.CLIOptKeyspace)
 	config.numReplicas = cli.Int(schema.CLIOptReplicationFactor)
 	config.Datacenter = cli.String(schema.CLIOptDatacenter)
+	config.EnableContactPointHostFilter = cli.GlobalBool(schema.CLIEnableContactPointHostFilter)
 
 	if cli.GlobalBool(schema.CLIFlagEnableTLS) {
 		config.TLS = &auth.TLS{

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -147,6 +147,11 @@ func buildCLIOptions() *cli.App {
 			Usage:  "disable tls host name verification (tls must be enabled)",
 			EnvVar: "CASSANDRA_TLS_DISABLE_HOST_VERIFICATION",
 		},
+		cli.BoolFlag{
+			Name:   schema.CLIEnableContactPointHostFilter,
+			Usage:  "validates temporal is able to reach any discovered cassandra nodes",
+			EnvVar: "CASSANDRA_ENABLE_CONTACT_POINT_HOST_FILTER",
+		},
 	}
 
 	app.Commands = []cli.Command{

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -111,6 +111,8 @@ const (
 	CLIOptQuiet = "quiet"
 	// CLIOptForce is the cli option for force mode
 	CLIOptForce = "force"
+	// CLIEnableContactPointHostFilter filters out cassandra hosts that are initially unreachable
+	CLIEnableContactPointHostFilter = "enable-contact-point-host-filter"
 
 	// CLIFlagEndpoint is the cli flag for endpoint
 	CLIFlagEndpoint = CLIOptEndpoint + ", ep"


### PR DESCRIPTION
This PR filters out any hosts returned from a Cassandra Node that Temporal knows it cannot reach. This speeds up overall session creation time as Temporal will not waste time attempting to connect to unreachable nodes.

We noticed that when connecting to certain Cassandra clusters, they would return endpoint addresses for all nodes in the cluster, including that were only accessible internally from within the cluster. As a result, during session establishment, Temporal would waste time attempting to access these internal nodes, slowing down overall startup.

Tested changes via the temporal-cassandra-tool to ensure that unreachable hosts are filtered out before being used by gocql.

This is a low-risk change as it requires the user to opt-in to using it. It is not a hotfix candidate as it is a performance optimization for startup.
