### PR TITLE
Adding CLI Authorization Token support

### DIFF
--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -94,6 +94,12 @@ func NewCliApp() *cli.App {
 			Usage:  "override for target server name",
 			EnvVar: "TEMPORAL_CLI_TLS_SERVER_NAME",
 		},
+		cli.StringFlag{
+			Name:   FlagAuthorizationToken,
+			Value:  "",
+			Usage:  "token to provide in Authorization header to server",
+			EnvVar: "TEMPORAL_CLI_AUTHORIZATION_TOKEN",
+		},
 	}
 	app.Commands = []cli.Command{
 		{

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -229,6 +229,7 @@ const (
 	FlagInputDirectory                   = "input_directory"
 	FlagAutoConfirm                      = "auto_confirm"
 	FlagVersion                          = "version"
+	FlagAuthorizationToken               = "auth_token"
 
 	FlagProtoType  = "type"
 	FlagHexData    = "hex_data"

--- a/tools/cli/token_auth_provider.go
+++ b/tools/cli/token_auth_provider.go
@@ -1,0 +1,43 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli
+
+import (
+	"context"
+
+	"github.com/urfave/cli"
+)
+
+type tokenAuthProvider struct {
+	cliContext *cli.Context
+}
+
+func (p tokenAuthProvider) GetHeaders(context.Context) (map[string]string, error) {
+	headers := map[string]string{}
+	if authToken := p.cliContext.GlobalString(FlagAuthorizationToken); authToken != "" {
+		headers["authorization"] = authToken
+	}
+	return headers, nil
+}


### PR DESCRIPTION
We are currently using a customized claims mapper and authorizer, and need to be able to provide an authorization bearer token to the cluster when using tctl.  This allows for passing that token through an `auth_token` command line flag, or the `TEMPORAL_CLI_AUTHORIZATION_TOKEN` environment variable.

May need some assistance adding tests to this.