### PR TITLE
Add logging for attempted and successful TLS connections to server

### DIFF
--- a/common/auth/tlsConfigHelper.go
+++ b/common/auth/tlsConfigHelper.go
@@ -27,6 +27,9 @@ package auth
 import (
 	"crypto/tls"
 	"crypto/x509"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 )
 
 // Helper methods for creating tls.Config structs to ensure MinVersion is 1.3
@@ -72,10 +75,15 @@ func NewTLSConfigWithCertsAndCAs(
 	clientAuth tls.ClientAuthType,
 	certificates []tls.Certificate,
 	clientCAs *x509.CertPool,
+	logger log.Logger,
 ) *tls.Config {
 	c := NewEmptyTLSConfig()
 	c.ClientAuth = clientAuth
 	c.Certificates = certificates
 	c.ClientCAs = clientCAs
+	c.VerifyConnection = func(state tls.ConnectionState) error {
+		logger.Info("successfully established incoming TLS connection", tag.HostID(state.ServerName))
+		return nil
+	}
 	return c
 }

--- a/common/auth/tlsConfigHelper.go
+++ b/common/auth/tlsConfigHelper.go
@@ -82,8 +82,16 @@ func NewTLSConfigWithCertsAndCAs(
 	c.Certificates = certificates
 	c.ClientCAs = clientCAs
 	c.VerifyConnection = func(state tls.ConnectionState) error {
-		logger.Debug("successfully established incoming TLS connection", tag.HostID(state.ServerName))
+		logger.Debug("successfully established incoming TLS connection", tag.HostID(state.ServerName), tag.Name(tlsCN(state)))
 		return nil
 	}
 	return c
+}
+
+func tlsCN(state tls.ConnectionState) string {
+
+	if len(state.PeerCertificates) == 0 {
+		return ""
+	}
+	return state.PeerCertificates[0].Subject.CommonName
 }

--- a/common/auth/tlsConfigHelper.go
+++ b/common/auth/tlsConfigHelper.go
@@ -82,7 +82,7 @@ func NewTLSConfigWithCertsAndCAs(
 	c.Certificates = certificates
 	c.ClientCAs = clientCAs
 	c.VerifyConnection = func(state tls.ConnectionState) error {
-		logger.Info("successfully established incoming TLS connection", tag.HostID(state.ServerName))
+		logger.Debug("successfully established incoming TLS connection", tag.HostID(state.ServerName))
 		return nil
 	}
 	return c

--- a/common/rpc/encryption/testDynamicTLSConfigProvider.go
+++ b/common/rpc/encryption/testDynamicTLSConfigProvider.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 )
 
 type TestDynamicTLSConfigProvider struct {
@@ -47,10 +48,12 @@ type TestDynamicTLSConfigProvider struct {
 	internodeClientConfig *tls.Config
 	frontendServerConfig  *tls.Config
 	frontendClientConfig  *tls.Config
+
+	logger log.Logger
 }
 
 func (t *TestDynamicTLSConfigProvider) GetInternodeServerConfig() (*tls.Config, error) {
-	return newServerTLSConfig(t.InternodeCertProvider, nil, &t.settings.Internode)
+	return newServerTLSConfig(t.InternodeCertProvider, nil, &t.settings.Internode, t.logger)
 }
 
 func (t *TestDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, error) {
@@ -58,7 +61,7 @@ func (t *TestDynamicTLSConfigProvider) GetInternodeClientConfig() (*tls.Config, 
 }
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendServerConfig() (*tls.Config, error) {
-	return newServerTLSConfig(t.FrontendCertProvider, t.FrontendPerHostCertProviderMap, &t.settings.Frontend)
+	return newServerTLSConfig(t.FrontendCertProvider, t.FrontendPerHostCertProviderMap, &t.settings.Frontend, t.logger)
 }
 
 func (t *TestDynamicTLSConfigProvider) GetFrontendClientConfig() (*tls.Config, error) {
@@ -91,5 +94,6 @@ func NewTestDynamicTLSConfigProvider(
 		WorkerCertProvider:             frontendProvider,
 		FrontendPerHostCertProviderMap: frontendProvider,
 		settings:                       tlsConfig,
+		logger:                         log.NewDefaultLogger(),
 	}, nil
 }


### PR DESCRIPTION
**What changed?**
Added logging of attempted and successfully established TLS connections to server

**Why?**
To have records in the log of all attempted TLS connections to server and remote IP addresses of parties trying to connect.

**How did you test it?**
Unit tests.

**Potential risks**
No risks.

**Is hotfix candidate?**
No.