### PR TITLE
Set Temporal internode comm max recv payload size to 128MB

### DIFF
--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -79,7 +79,7 @@ func Dial(hostName string, tlsConfig *tls.Config) (*grpc.ClientConn, error) {
 
 	return grpc.Dial(hostName,
 		grpcSecureOpt,
-		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxInternodeRecvPayloadSize)),
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(maxInternodeRecvPayloadSize)),
 		grpc.WithChainUnaryInterceptor(
 			versionHeadersInterceptor,
 			errorInterceptor,

--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -51,8 +51,8 @@ const (
 	// minConnectTimeout is the minimum amount of time we are willing to give a connection to complete.
 	minConnectTimeout = 20 * time.Second
 
-	// MaxInternodeRecvPayloadSize indicates the internode max receive payload size
-	MaxInternodeRecvPayloadSize = 128 * 1024 * 1024
+	// maxInternodeRecvPayloadSize indicates the internode max receive payload size.
+	maxInternodeRecvPayloadSize = 128 * 1024 * 1024 // 128 Mb
 )
 
 // Dial creates a client connection to the given target with default options.

--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -50,6 +50,9 @@ const (
 
 	// minConnectTimeout is the minimum amount of time we are willing to give a connection to complete.
 	minConnectTimeout = 20 * time.Second
+
+	// MaxInternodeRecvPayloadSize indicates the internode max receive payload size
+	MaxInternodeRecvPayloadSize = 128 * 1024 * 1024
 )
 
 // Dial creates a client connection to the given target with default options.
@@ -76,9 +79,11 @@ func Dial(hostName string, tlsConfig *tls.Config) (*grpc.ClientConn, error) {
 
 	return grpc.Dial(hostName,
 		grpcSecureOpt,
+		grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(MaxInternodeRecvPayloadSize)),
 		grpc.WithChainUnaryInterceptor(
 			versionHeadersInterceptor,
-			errorInterceptor),
+			errorInterceptor,
+		),
 		grpc.WithDefaultServiceConfig(DefaultServiceConfig),
 		grpc.WithDisableServiceConfig(),
 		grpc.WithConnectParams(cp),

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -192,7 +192,7 @@ func getListenIP(cfg *config.RPC, logger log.Logger) net.IP {
 	return ip
 }
 
-// CreateGRPCConnection creates connection for gRPC calls
+// CreateFrontendGRPCConnection creates connection for gRPC calls
 func (d *RPCFactory) CreateFrontendGRPCConnection(hostName string) *grpc.ClientConn {
 	var tlsClientConfig *tls.Config
 	var err error
@@ -206,7 +206,7 @@ func (d *RPCFactory) CreateFrontendGRPCConnection(hostName string) *grpc.ClientC
 	return d.dial(hostName, tlsClientConfig)
 }
 
-// CreateGRPCConnection creates connection for gRPC calls
+// CreateInternodeGRPCConnection creates connection for gRPC calls
 func (d *RPCFactory) CreateInternodeGRPCConnection(hostName string) *grpc.ClientConn {
 	var tlsClientConfig *tls.Config
 	var err error


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Set Temporal internode comm max recv payload size to 128MB

<!-- Tell your future self why have you made these changes -->
**Why?**
Temporal internode communication should not be limited to 4MB default gRPC size limit (receiver side)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No