### PR TITLE
Fix history service metrics double emission issue

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -134,6 +134,7 @@ const (
 	UnknownScope = iota
 
 	// -- Common Operation scopes --
+
 	// PersistenceCreateShardScope tracks CreateShard calls made by service to persistence layer
 	PersistenceCreateShardScope
 	// PersistenceGetShardScope tracks GetShard calls made by service to persistence layer
@@ -344,9 +345,9 @@ const (
 	HistoryClientScheduleWorkflowTaskScope
 	// HistoryClientRecordChildExecutionCompletedScope tracks RPC calls to history service
 	HistoryClientRecordChildExecutionCompletedScope
-	// HistoryClientSyncShardStatusScope tracks RPC calls to history service
+	// HistoryClientReplicateEventsV2Scope tracks RPC calls to history service
 	HistoryClientReplicateEventsV2Scope
-	// HistoryClientReplicateRawEventsV2Scope tracks RPC calls to history service
+	// HistoryClientSyncShardStatusScope tracks RPC calls to history service
 	HistoryClientSyncShardStatusScope
 	// HistoryClientSyncActivityScope tracks RPC calls to history service
 	HistoryClientSyncActivityScope
@@ -575,9 +576,9 @@ const (
 	// DCRedirectionListTaskQueuePartitionsScope tracks RPC calls for dc redirection
 	DCRedirectionListTaskQueuePartitionsScope
 
-	// MessagingPublishScope tracks Publish calls made by service to messaging layer
+	// MessagingClientPublishScope tracks Publish calls made by service to messaging layer
 	MessagingClientPublishScope
-	// MessagingPublishBatchScope tracks Publish calls made by service to messaging layer
+	// MessagingClientPublishBatchScope tracks Publish calls made by service to messaging layer
 	MessagingClientPublishBatchScope
 
 	// NamespaceCacheScope tracks namespace cache callbacks
@@ -721,7 +722,7 @@ const (
 const (
 	// FrontendStartWorkflowExecutionScope is the metric scope for frontend.StartWorkflowExecution
 	FrontendStartWorkflowExecutionScope = iota + NumAdminScopes
-	// PollWorkflowTaskQueueScope is the metric scope for frontend.PollWorkflowTaskQueue
+	// FrontendPollWorkflowTaskQueueScope is the metric scope for frontend.PollWorkflowTaskQueue
 	FrontendPollWorkflowTaskQueueScope
 	// FrontendPollActivityTaskQueueScope is the metric scope for frontend.PollActivityTaskQueue
 	FrontendPollActivityTaskQueueScope
@@ -741,15 +742,15 @@ const (
 	FrontendRespondActivityTaskFailedScope
 	// FrontendRespondActivityTaskCanceledScope is the metric scope for frontend.RespondActivityTaskCanceled
 	FrontendRespondActivityTaskCanceledScope
-	// FrontendRespondActivityTaskCompletedScope is the metric scope for frontend.RespondActivityTaskCompletedById
+	// FrontendRespondActivityTaskCompletedByIdScope is the metric scope for frontend.RespondActivityTaskCompletedById
 	FrontendRespondActivityTaskCompletedByIdScope
-	// FrontendRespondActivityTaskFailedScope is the metric scope for frontend.RespondActivityTaskFailedById
+	// FrontendRespondActivityTaskFailedByIdScope is the metric scope for frontend.RespondActivityTaskFailedById
 	FrontendRespondActivityTaskFailedByIdScope
-	// FrontendRespondActivityTaskCanceledScope is the metric scope for frontend.RespondActivityTaskCanceledById
+	// FrontendRespondActivityTaskCanceledByIdScope is the metric scope for frontend.RespondActivityTaskCanceledById
 	FrontendRespondActivityTaskCanceledByIdScope
 	// FrontendGetWorkflowExecutionHistoryScope is the metric scope for non-long-poll frontend.GetWorkflowExecutionHistory
 	FrontendGetWorkflowExecutionHistoryScope
-	// FrontendGetWorkflowExecutionHistoryScope is the metric scope for long poll case of frontend.GetWorkflowExecutionHistory
+	// FrontendPollWorkflowExecutionHistoryScope is the metric scope for long poll case of frontend.GetWorkflowExecutionHistory
 	FrontendPollWorkflowExecutionHistoryScope
 	// FrontendGetWorkflowExecutionRawHistoryScope is the metric scope for frontend.GetWorkflowExecutionRawHistory
 	FrontendGetWorkflowExecutionRawHistoryScope
@@ -789,7 +790,7 @@ const (
 	FrontendDescribeWorkflowExecutionScope
 	// FrontendDescribeTaskQueueScope is the metric scope for frontend.DescribeTaskQueue
 	FrontendDescribeTaskQueueScope
-	// FrontendResetStickyTaskQueueScope is the metric scope for frontend.ResetStickyTaskQueue
+	// FrontendListTaskQueuePartitionsScope is the metric scope for frontend.ResetStickyTaskQueue
 	FrontendListTaskQueuePartitionsScope
 	// FrontendResetStickyTaskQueueScope is the metric scope for frontend.ResetStickyTaskQueue
 	FrontendResetStickyTaskQueueScope
@@ -858,7 +859,7 @@ const (
 	HistorySyncActivityScope
 	// HistoryDescribeMutableStateScope tracks HistoryActivity API calls received by service
 	HistoryDescribeMutableStateScope
-	// GetReplicationMessages tracks GetReplicationMessages API calls received by service
+	// HistoryGetReplicationMessagesScope tracks GetReplicationMessages API calls received by service
 	HistoryGetReplicationMessagesScope
 	// HistoryGetDLQReplicationMessagesScope tracks GetReplicationMessages API calls received by service
 	HistoryGetDLQReplicationMessagesScope
@@ -938,7 +939,7 @@ const (
 	TimerQueueProcessorScope
 	// TimerActiveQueueProcessorScope is the scope used by all metric emitted by timer queue processor
 	TimerActiveQueueProcessorScope
-	// TimerQueueProcessorScope is the scope used by all metric emitted by timer queue processor
+	// TimerStandbyQueueProcessorScope is the scope used by all metric emitted by timer queue processor
 	TimerStandbyQueueProcessorScope
 	// TimerActiveTaskActivityTimeoutScope is the scope used by metric emitted by timer queue processor for processing activity timeouts
 	TimerActiveTaskActivityTimeoutScope
@@ -1031,9 +1032,9 @@ const (
 
 // -- Operation scopes for Matching service --
 const (
-	// PollWorkflowTaskQueueScope tracks PollWorkflowTaskQueue API calls received by service
+	// MatchingPollWorkflowTaskQueueScope tracks PollWorkflowTaskQueue API calls received by service
 	MatchingPollWorkflowTaskQueueScope = iota + NumHistoryScopes
-	// PollActivityTaskQueueScope tracks PollActivityTaskQueue API calls received by service
+	// MatchingPollActivityTaskQueueScope tracks PollActivityTaskQueue API calls received by service
 	MatchingPollActivityTaskQueueScope
 	// MatchingAddActivityTaskScope tracks AddActivityTask API calls received by service
 	MatchingAddActivityTaskScope
@@ -1057,7 +1058,7 @@ const (
 
 // -- Operation scopes for Worker service --
 const (
-	// ReplicationScope is the scope used by all metric emitted by replicator
+	// ReplicatorScope is the scope used by all metric emitted by replicator
 	ReplicatorScope = iota + NumMatchingScopes
 	// NamespaceReplicationTaskScope is the scope used by namespace task replication processing
 	NamespaceReplicationTaskScope
@@ -1679,6 +1680,7 @@ const (
 
 	// The following metrics are only used by internal history archiver implemention.
 	// TODO: move them to internal repo once temporal plugin model is in place.
+
 	HistoryArchiverBlobExistsCount
 	HistoryArchiverBlobSize
 	HistoryArchiverRunningDeterministicConstructionCheckCount
@@ -1699,6 +1701,7 @@ const (
 	NamespaceReplicationDLQMaxLevelGauge
 
 	// common metrics that are emitted per task queue
+
 	ServiceRequestsPerTaskQueue
 	ServiceFailuresPerTaskQueue
 	ServiceLatencyPerTaskQueue

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -49,7 +49,6 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/resource"
@@ -630,11 +629,6 @@ func (h *Handler) DescribeMutableState(ctx context.Context, request *historyserv
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
-	scope := metrics.HistoryRecordActivityTaskHeartbeatScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
-
 	namespaceID := request.GetNamespaceId()
 	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
@@ -658,11 +652,6 @@ func (h *Handler) DescribeMutableState(ctx context.Context, request *historyserv
 func (h *Handler) GetMutableState(ctx context.Context, request *historyservice.GetMutableStateRequest) (_ *historyservice.GetMutableStateResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-
-	scope := metrics.HistoryGetMutableStateScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
 
 	namespaceID := request.GetNamespaceId()
 	if namespaceID == "" {
@@ -688,11 +677,6 @@ func (h *Handler) PollMutableState(ctx context.Context, request *historyservice.
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
-	scope := metrics.HistoryPollMutableStateScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
-
 	namespaceID := request.GetNamespaceId()
 	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
@@ -717,11 +701,6 @@ func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *histor
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
-	scope := metrics.HistoryDescribeWorkflowExecutionScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
-
 	namespaceID := request.GetNamespaceId()
 	if namespaceID == "" {
 		return nil, h.convertError(errNamespaceNotSet)
@@ -745,11 +724,6 @@ func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *histor
 func (h *Handler) RequestCancelWorkflowExecution(ctx context.Context, request *historyservice.RequestCancelWorkflowExecutionRequest) (_ *historyservice.RequestCancelWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-
-	scope := metrics.HistoryRequestCancelWorkflowExecutionScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
 
 	if h.isStopped() {
 		return nil, errShuttingDown
@@ -787,11 +761,6 @@ func (h *Handler) SignalWorkflowExecution(ctx context.Context, request *historys
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
-	scope := metrics.HistorySignalWorkflowExecutionScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
-
 	if h.isStopped() {
 		return nil, errShuttingDown
 	}
@@ -824,11 +793,6 @@ func (h *Handler) SignalWorkflowExecution(ctx context.Context, request *historys
 func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context, request *historyservice.SignalWithStartWorkflowExecutionRequest) (_ *historyservice.SignalWithStartWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-
-	scope := metrics.HistorySignalWithStartWorkflowExecutionScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
 
 	if h.isStopped() {
 		return nil, errShuttingDown
@@ -886,11 +850,6 @@ func (h *Handler) RemoveSignalMutableState(ctx context.Context, request *history
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
-	scope := metrics.HistoryRemoveSignalMutableStateScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
-
 	if h.isStopped() {
 		return nil, errShuttingDown
 	}
@@ -920,11 +879,6 @@ func (h *Handler) RemoveSignalMutableState(ctx context.Context, request *history
 func (h *Handler) TerminateWorkflowExecution(ctx context.Context, request *historyservice.TerminateWorkflowExecutionRequest) (_ *historyservice.TerminateWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-
-	scope := metrics.HistoryTerminateWorkflowExecutionScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
 
 	if h.isStopped() {
 		return nil, errShuttingDown
@@ -956,11 +910,6 @@ func (h *Handler) ResetWorkflowExecution(ctx context.Context, request *historyse
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
-	scope := metrics.HistoryResetWorkflowExecutionScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
-
 	if h.isStopped() {
 		return nil, errShuttingDown
 	}
@@ -989,11 +938,6 @@ func (h *Handler) ResetWorkflowExecution(ctx context.Context, request *historyse
 func (h *Handler) QueryWorkflow(ctx context.Context, request *historyservice.QueryWorkflowRequest) (_ *historyservice.QueryWorkflowResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-
-	scope := metrics.HistoryQueryWorkflowScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
 
 	if h.isStopped() {
 		return nil, errShuttingDown
@@ -1025,11 +969,6 @@ func (h *Handler) QueryWorkflow(ctx context.Context, request *historyservice.Que
 func (h *Handler) ScheduleWorkflowTask(ctx context.Context, request *historyservice.ScheduleWorkflowTaskRequest) (_ *historyservice.ScheduleWorkflowTaskResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-
-	scope := metrics.HistoryScheduleWorkflowTaskScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
 
 	if h.isStopped() {
 		return nil, errShuttingDown
@@ -1064,11 +1003,6 @@ func (h *Handler) ScheduleWorkflowTask(ctx context.Context, request *historyserv
 func (h *Handler) RecordChildExecutionCompleted(ctx context.Context, request *historyservice.RecordChildExecutionCompletedRequest) (_ *historyservice.RecordChildExecutionCompletedResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-
-	scope := metrics.HistoryRecordChildExecutionCompletedScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
 
 	if h.isStopped() {
 		return nil, errShuttingDown
@@ -1106,11 +1040,6 @@ func (h *Handler) ResetStickyTaskQueue(ctx context.Context, request *historyserv
 
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-
-	scope := metrics.HistoryResetStickyTaskQueueScope
-	h.GetMetricsClient().IncCounter(scope, metrics.ServiceRequests)
-	sw := h.GetMetricsClient().StartTimer(scope, metrics.ServiceLatency)
-	defer sw.Stop()
 
 	if h.isStopped() {
 		return nil, errShuttingDown

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2810,10 +2810,6 @@ func (e *historyEngineImpl) GetReplicationMessages(
 	queryMessageID int64,
 ) (*replicationspb.ReplicationMessages, error) {
 
-	scope := metrics.HistoryGetReplicationMessagesScope
-	sw := e.metricsClient.StartTimer(scope, metrics.GetReplicationMessagesForShardLatency)
-	defer sw.Stop()
-
 	if ackMessageID != persistence.EmptyQueueMessageID {
 		if err := e.shard.UpdateClusterReplicationLevel(
 			pollingCluster,
@@ -2840,10 +2836,6 @@ func (e *historyEngineImpl) GetDLQReplicationMessages(
 	ctx context.Context,
 	taskInfos []*replicationspb.ReplicationTaskInfo,
 ) ([]*replicationspb.ReplicationTask, error) {
-
-	scope := metrics.HistoryGetDLQReplicationMessagesScope
-	sw := e.metricsClient.StartTimer(scope, metrics.GetDLQReplicationMessagesLatency)
-	defer sw.Stop()
 
 	tasks := make([]*replicationspb.ReplicationTask, 0, len(taskInfos))
 	for _, taskInfo := range taskInfos {

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -513,8 +513,10 @@ func (handler *workflowTaskHandlerImpl) handleCommandCancelWorkflow(
 	attr *commandpb.CancelWorkflowExecutionCommandAttributes,
 ) error {
 
-	handler.metricsClient.IncCounter(metrics.HistoryRespondWorkflowTaskCompletedScope,
-		metrics.CommandTypeCancelWorkflowCounter)
+	handler.metricsClient.IncCounter(
+		metrics.HistoryRespondWorkflowTaskCompletedScope,
+		metrics.CommandTypeCancelWorkflowCounter,
+	)
 
 	if handler.hasBufferedEvents {
 		return handler.failCommand(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Fix double metrics emission for history service RecordActivityTaskHeartbeat API
* Fix double metrics emission for history service GetMutableState API
* Fix double metrics emission for history service PollMutableState API
* Fix double metrics emission for history service DescribeWorkflowExecution API
* Fix double metrics emission for history service SignalWorkflowExecution API
* Fix double metrics emission for history service SignalWithStartWorkflowExecution API
* Fix double metrics emission for history service RemoveSignalMutableState API
* Fix double metrics emission for history service TerminateWorkflowExecution API
* Fix double metrics emission for history service ResetWorkflowExecution API
* Fix double metrics emission for history service QueryWorkflow API
* Fix double metrics emission for history service ScheduleWorkflowTask API
* Fix double metrics emission for history service RecordChildExecutionCompleted API
* Fix double metrics emission for history service ResetStickyTaskQueue API

<!-- Tell your future self why have you made these changes -->
**Why?**
Some metrics in history service are double emitted

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No