### PR TITLE
Fix reset workflow pending activity schedule time

### DIFF
--- a/service/history/workflowResetter.go
+++ b/service/history/workflowResetter.go
@@ -29,6 +29,7 @@ package history
 import (
 	"context"
 	"fmt"
+	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -228,7 +229,11 @@ func (r *workflowResetterImpl) prepareResetWorkflow(
 		return nil, err
 	}
 
-	if err := r.failInflightActivity(resetMutableState, resetReason); err != nil {
+	if err := r.failInflightActivity(
+		*resetMutableState.GetExecutionInfo().StartTime,
+		resetMutableState,
+		resetReason,
+	); err != nil {
 		return nil, err
 	}
 
@@ -419,6 +424,7 @@ func (r *workflowResetterImpl) failWorkflowTask(
 }
 
 func (r *workflowResetterImpl) failInflightActivity(
+	now time.Time,
 	mutableState mutableState,
 	terminateReason string,
 ) error {
@@ -427,10 +433,17 @@ func (r *workflowResetterImpl) failInflightActivity(
 		switch ai.StartedId {
 		case common.EmptyEventID:
 			// activity not started, noop
+			// override the activity time to now
+			ai.ScheduledTime = timestamp.TimePtr(now)
+			if err := mutableState.UpdateActivity(ai); err != nil {
+				return err
+			}
+
 		case common.TransientEventID:
 			// activity is started (with retry policy)
 			// should not encounter this case when rebuilding mutable state
 			return serviceerror.NewInternal("workflowResetter encounter transient activity")
+
 		default:
 			if _, err := mutableState.AddActivityTaskFailedEvent(
 				ai.ScheduleId,

--- a/service/history/workflowResetter_test.go
+++ b/service/history/workflowResetter_test.go
@@ -27,6 +27,7 @@ package history
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
@@ -35,6 +36,8 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+
+	"go.temporal.io/server/common/primitives/timestamp"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
@@ -381,6 +384,7 @@ func (s *workflowResetterSuite) TestFailWorkflowTask_WorkflowTaskStarted() {
 }
 
 func (s *workflowResetterSuite) TestFailInflightActivity() {
+	now := time.Now().UTC()
 	terminateReason := "some random termination reason"
 
 	mutableState := NewMockmutableState(s.controller)
@@ -388,14 +392,16 @@ func (s *workflowResetterSuite) TestFailInflightActivity() {
 	activity1 := &persistencespb.ActivityInfo{
 		Version:              12,
 		ScheduleId:           123,
+		ScheduledTime:        timestamp.TimePtr(now.Add(-10 * time.Second)),
 		StartedId:            124,
 		LastHeartbeatDetails: payloads.EncodeString("some random activity 1 details"),
 		StartedIdentity:      "some random activity 1 started identity",
 	}
 	activity2 := &persistencespb.ActivityInfo{
-		Version:    12,
-		ScheduleId: 456,
-		StartedId:  common.EmptyEventID,
+		Version:       12,
+		ScheduleId:    456,
+		ScheduledTime: timestamp.TimePtr(now.Add(-10 * time.Second)),
+		StartedId:     common.EmptyEventID,
 	}
 	mutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{
 		activity1.ScheduleId: activity1,
@@ -410,7 +416,14 @@ func (s *workflowResetterSuite) TestFailInflightActivity() {
 		activity1.StartedIdentity,
 	).Return(&historypb.HistoryEvent{}, nil)
 
-	err := s.workflowResetter.failInflightActivity(mutableState, terminateReason)
+	mutableState.EXPECT().UpdateActivity(&persistencespb.ActivityInfo{
+		Version:       activity2.Version,
+		ScheduleId:    activity2.ScheduleId,
+		ScheduledTime: timestamp.TimePtr(now),
+		StartedId:     activity2.StartedId,
+	}).Return(nil)
+
+	err := s.workflowResetter.failInflightActivity(now, mutableState, terminateReason)
 	s.NoError(err)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Override activity schedule time to reset time

<!-- Tell your future self why have you made these changes -->
**Why?**
Valid activities after workflow reset should be assigned with `now` schedule time, not time from activity schedule event, which can be long time ago.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No