### PR TITLE
Do not persist to DB when resetting sticky task queue

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1104,13 +1104,20 @@ func (e *historyEngineImpl) ResetStickyTaskQueue(
 		return nil, err
 	}
 
-	err = e.updateWorkflowExecution(ctx, namespaceID, *resetRequest.Execution, false,
-		func(context workflowExecutionContext, mutableState mutableState) error {
+	err = e.updateWorkflowExecution(
+		ctx,
+		namespaceID,
+		*resetRequest.Execution,
+		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return ErrWorkflowCompleted
+				return nil, ErrWorkflowCompleted
 			}
+
 			mutableState.ClearStickyness()
-			return nil
+			return &updateWorkflowAction{
+				noop:               true,
+				createWorkflowTask: false,
+			}, nil
 		},
 	)
 
@@ -1281,10 +1288,13 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 	}
 
 	response := &historyservice.RecordActivityTaskStartedResponse{}
-	err = e.updateWorkflowExecution(ctx, namespaceID, execution, false,
-		func(context workflowExecutionContext, mutableState mutableState) error {
+	err = e.updateWorkflowExecution(
+		ctx,
+		namespaceID,
+		execution,
+		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return ErrWorkflowCompleted
+				return nil, ErrWorkflowCompleted
 			}
 
 			scheduleID := request.GetScheduleId()
@@ -1295,7 +1305,7 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduleID >= mutableState.GetNextEventID() {
 				e.metricsClient.IncCounter(metrics.HistoryRecordActivityTaskStartedScope, metrics.StaleMutableStateCounter)
-				return ErrStaleState
+				return nil, ErrStaleState
 			}
 
 			// Check execution state to make sure task is in the list of outstanding tasks and it is not yet started.  If
@@ -1304,12 +1314,12 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 				// Looks like ActivityTask already completed as a result of another call.
 				// It is OK to drop the task at this point.
 				e.logger.Debug("Potentially duplicate task.", tag.TaskID(request.GetTaskId()), tag.WorkflowScheduleID(scheduleID), tag.TaskType(enumsspb.TASK_TYPE_TRANSFER_ACTIVITY_TASK))
-				return ErrActivityTaskNotFound
+				return nil, ErrActivityTaskNotFound
 			}
 
 			scheduledEvent, err := mutableState.GetActivityScheduledEvent(scheduleID)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			response.ScheduledEvent = scheduledEvent
 			response.CurrentAttemptScheduledTime = ai.ScheduledTime
@@ -1319,19 +1329,22 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 				if ai.RequestId == requestID {
 					response.StartedTime = ai.StartedTime
 					response.Attempt = ai.Attempt
-					return nil
+					return &updateWorkflowAction{
+						noop:               false,
+						createWorkflowTask: false,
+					}, nil
 				}
 
 				// Looks like ActivityTask already started as a result of another call.
 				// It is OK to drop the task at this point.
 				e.logger.Debug("Potentially duplicate task.", tag.TaskID(request.GetTaskId()), tag.WorkflowScheduleID(scheduleID), tag.TaskType(enumsspb.TASK_TYPE_TRANSFER_ACTIVITY_TASK))
-				return serviceerrors.NewTaskAlreadyStarted("Activity")
+				return nil, serviceerrors.NewTaskAlreadyStarted("Activity")
 			}
 
 			if _, err := mutableState.AddActivityTaskStartedEvent(
 				ai, scheduleID, requestID, request.PollRequest.GetIdentity(),
 			); err != nil {
-				return err
+				return nil, err
 			}
 
 			response.StartedTime = ai.StartedTime
@@ -1341,7 +1354,10 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 			response.WorkflowType = mutableState.GetWorkflowType()
 			response.WorkflowNamespace = namespace
 
-			return nil
+			return &updateWorkflowAction{
+				noop:               false,
+				createWorkflowTask: false,
+			}, nil
 		})
 
 	if err != nil {
@@ -1410,17 +1426,20 @@ func (e *historyEngineImpl) RespondActivityTaskCompleted(
 	var activityStartedTime time.Time
 	var taskQueue string
 	var workflowTypeName string
-	err = e.updateWorkflowExecution(ctx, namespaceID, workflowExecution, true,
-		func(context workflowExecutionContext, mutableState mutableState) error {
+	err = e.updateWorkflowExecution(
+		ctx,
+		namespaceID,
+		workflowExecution,
+		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
 			workflowTypeName = mutableState.GetWorkflowType().GetName()
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return ErrWorkflowCompleted
+				return nil, ErrWorkflowCompleted
 			}
 			scheduleID := token.GetScheduleId()
 			if scheduleID == common.EmptyEventID { // client call CompleteActivityById, so get scheduleID by activityID
 				scheduleID, err0 = getScheduleID(token.GetActivityId(), mutableState)
 				if err0 != nil {
-					return err0
+					return nil, err0
 				}
 			}
 			ai, isRunning := mutableState.GetActivityInfo(scheduleID)
@@ -1429,22 +1448,26 @@ func (e *historyEngineImpl) RespondActivityTaskCompleted(
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduleID >= mutableState.GetNextEventID() {
 				e.metricsClient.IncCounter(metrics.HistoryRespondActivityTaskCompletedScope, metrics.StaleMutableStateCounter)
-				return ErrStaleState
+				return nil, ErrStaleState
 			}
 
 			if !isRunning || ai.StartedId == common.EmptyEventID ||
 				(token.GetScheduleId() != common.EmptyEventID && token.ScheduleAttempt != ai.Attempt) {
-				return ErrActivityTaskNotFound
+				return nil, ErrActivityTaskNotFound
 			}
 
 			if _, err := mutableState.AddActivityTaskCompletedEvent(scheduleID, ai.StartedId, request); err != nil {
 				// Unable to add ActivityTaskCompleted event to history
-				return serviceerror.NewInternal("Unable to add ActivityTaskCompleted event to history.")
+				return nil, serviceerror.NewInternal("Unable to add ActivityTaskCompleted event to history.")
 			}
 			activityStartedTime = *ai.StartedTime
 			taskQueue = ai.TaskQueue
-			return nil
+			return &updateWorkflowAction{
+				noop:               false,
+				createWorkflowTask: true,
+			}, nil
 		})
+
 	if err == nil && !activityStartedTime.IsZero() {
 		scope := e.metricsClient.Scope(metrics.HistoryRespondActivityTaskCompletedScope).
 			Tagged(
@@ -1485,7 +1508,7 @@ func (e *historyEngineImpl) RespondActivityTaskFailed(
 	var activityStartedTime time.Time
 	var taskQueue string
 	var workflowTypeName string
-	err = e.updateWorkflowExecutionWithAction(ctx, namespaceID, workflowExecution,
+	err = e.updateWorkflowExecution(ctx, namespaceID, workflowExecution,
 		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
 			workflowTypeName = mutableState.GetWorkflowType().GetName()
 			if !mutableState.IsWorkflowExecutionRunning() {
@@ -1572,18 +1595,21 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(
 	var activityStartedTime time.Time
 	var taskQueue string
 	var workflowTypeName string
-	err = e.updateWorkflowExecution(ctx, namespaceID, workflowExecution, true,
-		func(context workflowExecutionContext, mutableState mutableState) error {
+	err = e.updateWorkflowExecution(
+		ctx,
+		namespaceID,
+		workflowExecution,
+		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
 			workflowTypeName = mutableState.GetWorkflowType().GetName()
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return ErrWorkflowCompleted
+				return nil, ErrWorkflowCompleted
 			}
 
 			scheduleID := token.GetScheduleId()
 			if scheduleID == common.EmptyEventID { // client call CompleteActivityById, so get scheduleID by activityID
 				scheduleID, err0 = getScheduleID(token.GetActivityId(), mutableState)
 				if err0 != nil {
-					return err0
+					return nil, err0
 				}
 			}
 			ai, isRunning := mutableState.GetActivityInfo(scheduleID)
@@ -1592,12 +1618,12 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduleID >= mutableState.GetNextEventID() {
 				e.metricsClient.IncCounter(metrics.HistoryRespondActivityTaskCanceledScope, metrics.StaleMutableStateCounter)
-				return ErrStaleState
+				return nil, ErrStaleState
 			}
 
 			if !isRunning || ai.StartedId == common.EmptyEventID ||
 				(token.GetScheduleId() != common.EmptyEventID && token.ScheduleAttempt != ai.Attempt) {
-				return ErrActivityTaskNotFound
+				return nil, ErrActivityTaskNotFound
 			}
 
 			if _, err := mutableState.AddActivityTaskCanceledEvent(
@@ -1607,13 +1633,17 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(
 				request.Details,
 				request.Identity); err != nil {
 				// Unable to add ActivityTaskCanceled event to history
-				return serviceerror.NewInternal("Unable to add ActivityTaskCanceled event to history.")
+				return nil, serviceerror.NewInternal("Unable to add ActivityTaskCanceled event to history.")
 			}
 
 			activityStartedTime = *ai.StartedTime
 			taskQueue = ai.TaskQueue
-			return nil
+			return &updateWorkflowAction{
+				noop:               false,
+				createWorkflowTask: true,
+			}, nil
 		})
+
 	if err == nil && !activityStartedTime.IsZero() {
 		scope := e.metricsClient.Scope(metrics.HistoryRespondActivityTaskCanceledScope).
 			Tagged(
@@ -1654,18 +1684,21 @@ func (e *historyEngineImpl) RecordActivityTaskHeartbeat(
 	}
 
 	var cancelRequested bool
-	err = e.updateWorkflowExecution(ctx, namespaceID, workflowExecution, false,
-		func(context workflowExecutionContext, mutableState mutableState) error {
+	err = e.updateWorkflowExecution(
+		ctx,
+		namespaceID,
+		workflowExecution,
+		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				e.logger.Debug("Heartbeat failed")
-				return ErrWorkflowCompleted
+				return nil, ErrWorkflowCompleted
 			}
 
 			scheduleID := token.GetScheduleId()
 			if scheduleID == common.EmptyEventID { // client call RecordActivityHeartbeatByID, so get scheduleID by activityID
 				scheduleID, err0 = getScheduleID(token.GetActivityId(), mutableState)
 				if err0 != nil {
-					return err0
+					return nil, err0
 				}
 			}
 			ai, isRunning := mutableState.GetActivityInfo(scheduleID)
@@ -1674,12 +1707,12 @@ func (e *historyEngineImpl) RecordActivityTaskHeartbeat(
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduleID >= mutableState.GetNextEventID() {
 				e.metricsClient.IncCounter(metrics.HistoryRecordActivityTaskHeartbeatScope, metrics.StaleMutableStateCounter)
-				return ErrStaleState
+				return nil, ErrStaleState
 			}
 
 			if !isRunning || ai.StartedId == common.EmptyEventID ||
 				(token.GetScheduleId() != common.EmptyEventID && token.ScheduleAttempt != ai.Attempt) {
-				return ErrActivityTaskNotFound
+				return nil, ErrActivityTaskNotFound
 			}
 
 			cancelRequested = ai.CancelRequested
@@ -1689,7 +1722,10 @@ func (e *historyEngineImpl) RecordActivityTaskHeartbeat(
 			// Save progress and last HB reported time.
 			mutableState.UpdateActivityProgress(ai, request)
 
-			return nil
+			return &updateWorkflowAction{
+				noop:               false,
+				createWorkflowTask: false,
+			}, nil
 		})
 
 	if err != nil {
@@ -1729,7 +1765,10 @@ func (e *historyEngineImpl) RequestCancelWorkflowExecution(
 			if !mutableState.IsWorkflowExecutionRunning() {
 				// the request to cancel this workflow is a success even
 				// if the target workflow has already finished
-				return &updateWorkflowAction{noop: true}, nil
+				return &updateWorkflowAction{
+					noop:               true,
+					createWorkflowTask: false,
+				}, nil
 			}
 
 			// There is a workflow execution currently running with the WorkflowID.
@@ -1753,7 +1792,10 @@ func (e *historyEngineImpl) RequestCancelWorkflowExecution(
 			isCancelRequested := mutableState.IsCancelRequested()
 			if isCancelRequested {
 				// since cancellation is idempotent
-				return &updateWorkflowAction{noop: true}, nil
+				return &updateWorkflowAction{
+					noop:               true,
+					createWorkflowTask: false,
+				}, nil
 			}
 
 			if _, err := mutableState.AddWorkflowExecutionCancelRequestedEvent(req); err != nil {
@@ -1795,6 +1837,7 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 				createWorkflowTask = false
 			}
 			postActions := &updateWorkflowAction{
+				noop:               false,
 				createWorkflowTask: createWorkflowTask,
 			}
 
@@ -2074,15 +2117,20 @@ func (e *historyEngineImpl) RemoveSignalMutableState(
 		RunId:      request.WorkflowExecution.RunId,
 	}
 
-	return e.updateWorkflowExecution(ctx, namespaceID, execution, false,
-		func(context workflowExecutionContext, mutableState mutableState) error {
+	return e.updateWorkflowExecution(
+		ctx,
+		namespaceID,
+		execution,
+		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return ErrWorkflowCompleted
+				return nil, ErrWorkflowCompleted
 			}
 
 			mutableState.DeleteSignalRequested(request.GetRequestId())
-
-			return nil
+			return &updateWorkflowAction{
+				noop:               false,
+				createWorkflowTask: false,
+			}, nil
 		})
 }
 
@@ -2154,10 +2202,13 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(
 		RunId:      completionRequest.WorkflowExecution.RunId,
 	}
 
-	return e.updateWorkflowExecution(ctx, namespaceID, execution, true,
-		func(context workflowExecutionContext, mutableState mutableState) error {
+	return e.updateWorkflowExecution(
+		ctx,
+		namespaceID,
+		execution,
+		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return ErrWorkflowCompleted
+				return nil, ErrWorkflowCompleted
 			}
 
 			initiatedID := completionRequest.InitiatedId
@@ -2167,10 +2218,10 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(
 			// Check mutable state to make sure child execution is in pending child executions
 			ci, isRunning := mutableState.GetChildExecutionInfo(initiatedID)
 			if !isRunning || ci.StartedId == common.EmptyEventID {
-				return serviceerror.NewNotFound("Pending child execution not found.")
+				return nil, serviceerror.NewNotFound("Pending child execution not found.")
 			}
 			if ci.GetStartedWorkflowId() != completedExecution.GetWorkflowId() {
-				return serviceerror.NewNotFound("Pending child execution not found.")
+				return nil, serviceerror.NewNotFound("Pending child execution not found.")
 			}
 
 			switch completionEvent.GetEventType() {
@@ -2191,7 +2242,13 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(
 				_, err = mutableState.AddChildWorkflowExecutionTimedOutEvent(initiatedID, completedExecution, attributes)
 			}
 
-			return err
+			if err != nil {
+				return nil, err
+			}
+			return &updateWorkflowAction{
+				noop:               false,
+				createWorkflowTask: true,
+			}, err
 		})
 }
 
@@ -2370,7 +2427,7 @@ func (e *historyEngineImpl) updateWorkflow(
 	return e.updateWorkflowHelper(workflowContext, action)
 }
 
-func (e *historyEngineImpl) updateWorkflowExecutionWithAction(
+func (e *historyEngineImpl) updateWorkflowExecution(
 	ctx context.Context,
 	namespaceID string,
 	execution commonpb.WorkflowExecution,
@@ -2442,40 +2499,6 @@ UpdateHistoryLoop:
 		return err
 	}
 	return ErrMaxAttemptsExceeded
-}
-
-// TODO: remove and use updateWorkflowExecutionWithAction
-func (e *historyEngineImpl) updateWorkflowExecution(
-	ctx context.Context,
-	namespaceID string,
-	execution commonpb.WorkflowExecution,
-	createWorkflowTask bool,
-	action func(context workflowExecutionContext, mutableState mutableState) error,
-) error {
-
-	return e.updateWorkflowExecutionWithAction(
-		ctx,
-		namespaceID,
-		execution,
-		getUpdateWorkflowActionFunc(createWorkflowTask, action),
-	)
-}
-
-func getUpdateWorkflowActionFunc(
-	createWorkflowTask bool,
-	action func(context workflowExecutionContext, mutableState mutableState) error,
-) updateWorkflowActionFunc {
-
-	return func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
-		err := action(context, mutableState)
-		if err != nil {
-			return nil, err
-		}
-		postActions := &updateWorkflowAction{
-			createWorkflowTask: createWorkflowTask,
-		}
-		return postActions, nil
-	}
 }
 
 func (e *historyEngineImpl) failWorkflowTask(
@@ -2893,7 +2916,7 @@ func (e *historyEngineImpl) ReapplyEvents(
 		WorkflowId: workflowID,
 	}
 
-	return e.updateWorkflowExecutionWithAction(
+	return e.updateWorkflowExecution(
 		ctx,
 		namespaceID,
 		currentExecution,
@@ -2918,7 +2941,8 @@ func (e *historyEngineImpl) ReapplyEvents(
 			}
 			if len(toReapplyEvents) == 0 {
 				return &updateWorkflowAction{
-					noop: true,
+					noop:               true,
+					createWorkflowTask: false,
 				}, nil
 			}
 
@@ -2937,7 +2961,10 @@ func (e *historyEngineImpl) ReapplyEvents(
 						tag.WorkflowID(currentExecution.GetWorkflowId()),
 					)
 					e.metricsClient.IncCounter(metrics.HistoryReapplyEventsScope, metrics.EventReapplySkippedCount)
-					return &updateWorkflowAction{noop: true}, nil
+					return &updateWorkflowAction{
+						noop:               true,
+						createWorkflowTask: false,
+					}, nil
 				}
 
 				baseVersionHistories := mutableState.GetExecutionInfo().GetVersionHistories()
@@ -2977,11 +3004,13 @@ func (e *historyEngineImpl) ReapplyEvents(
 					return nil, err
 				}
 				return &updateWorkflowAction{
-					noop: true,
+					noop:               true,
+					createWorkflowTask: false,
 				}, nil
 			}
 
 			postActions := &updateWorkflowAction{
+				noop:               false,
 				createWorkflowTask: true,
 			}
 			// Do not create workflow task when the workflow is cron and the cron has not been started yet
@@ -3000,7 +3029,8 @@ func (e *historyEngineImpl) ReapplyEvents(
 			}
 			if len(reappliedEvents) == 0 {
 				return &updateWorkflowAction{
-					noop: true,
+					noop:               true,
+					createWorkflowTask: false,
 				}, nil
 			}
 			return postActions, nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Do not persist to DB when resetting sticky task queue
* Use updateWorkflowExecutionWithAction instead of updateWorkflowExecution
* Rename updateWorkflowExecutionWithAction to updateWorkflowExecution

<!-- Tell your future self why have you made these changes -->
**Why?**
Reduce unnecessary DB write

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No