### PR TITLE
Pass logger from server options instead of calling log.NewDefaultLogger()

### DIFF
--- a/common/rpc/encryption/localStoreCertProvider.go
+++ b/common/rpc/encryption/localStoreCertProvider.go
@@ -89,14 +89,15 @@ func NewLocalStoreCertProvider(
 	tlsSettings *config.GroupTLS,
 	workerTlsSettings *config.WorkerTLS,
 	legacyWorkerSettings *config.ClientTLS,
-	refreshInterval time.Duration) CertProvider {
+	refreshInterval time.Duration,
+	logger log.Logger) CertProvider {
 
 	provider := &localStoreCertProvider{
 		tlsSettings:          tlsSettings,
 		workerTLSSettings:    workerTlsSettings,
 		legacyWorkerSettings: legacyWorkerSettings,
 		isLegacyWorkerConfig: legacyWorkerSettings != nil,
-		logger:               log.NewDefaultLogger(),
+		logger:               logger,
 		refreshInterval:      refreshInterval,
 	}
 	provider.initialize()

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -29,6 +29,7 @@ import (
 	"time"
 
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 )
 
 var _ PerHostCertProviderMap = (*localStorePerHostCertProviderMap)(nil)
@@ -40,7 +41,10 @@ type localStorePerHostCertProviderMap struct {
 }
 
 func newLocalStorePerHostCertProviderMap(
-	overrides map[string]config.ServerTLS, certProviderFactory CertProviderFactory, refreshInterval time.Duration,
+	overrides map[string]config.ServerTLS,
+	certProviderFactory CertProviderFactory,
+	refreshInterval time.Duration,
+	logger log.Logger,
 ) *localStorePerHostCertProviderMap {
 
 	providerMap := &localStorePerHostCertProviderMap{}
@@ -54,7 +58,7 @@ func newLocalStorePerHostCertProviderMap(
 	for host, settings := range overrides {
 		lcHost := strings.ToLower(host)
 
-		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil, refreshInterval)
+		provider := certProviderFactory(&config.GroupTLS{Server: settings}, nil, nil, refreshInterval, logger)
 		providerMap.certProviderCache[lcHost] = provider
 		providerMap.clientAuthCache[lcHost] = settings.RequireClientAuth
 	}

--- a/common/rpc/encryption/localStorePerHostCertProviderMap.go
+++ b/common/rpc/encryption/localStorePerHostCertProviderMap.go
@@ -95,3 +95,11 @@ func (f *localStorePerHostCertProviderMap) GetExpiringCerts(timeWindow time.Dura
 	}
 	return expiring, expired, err
 }
+
+func (f *localStorePerHostCertProviderMap) NumberOfHosts() int {
+
+	if f.certProviderCache != nil {
+		return len(f.certProviderCache)
+	}
+	return 0
+}

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -252,9 +252,9 @@ func newServerTLSConfig(
 	tlsConfig.GetConfigForClient = func(c *tls.ClientHelloInfo) (*tls.Config, error) {
 
 		remoteAddress := c.Conn.RemoteAddr().String()
-		logger.Info("attempted incoming TLS connection", tag.Address(remoteAddress), tag.HostID(c.ServerName))
+		logger.Debug("attempted incoming TLS connection", tag.Address(remoteAddress), tag.HostID(c.ServerName))
 
-		if perHostCertProviderMap != nil {
+		if perHostCertProviderMap != nil && perHostCertProviderMap.NumberOfHosts() > 0 {
 			perHostCertProvider, hostClientAuthRequired, err := perHostCertProviderMap.GetCertProvider(c.ServerName)
 			if err != nil {
 				logger.Error("error while looking up per-host provider for attempted incoming TLS connection",

--- a/common/rpc/encryption/testDynamicCertProvider.go
+++ b/common/rpc/encryption/testDynamicCertProvider.go
@@ -105,3 +105,7 @@ func (t *TestDynamicCertProvider) GetExpiringCerts(_ time.Duration,
 func (t *TestDynamicCertProvider) Initialize(refreshInterval time.Duration) {
 	panic("implement me")
 }
+
+func (t *TestDynamicCertProvider) NumberOfHosts() int {
+	return 1
+}

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -57,6 +57,7 @@ type (
 	PerHostCertProviderMap interface {
 		GetCertProvider(hostName string) (provider CertProvider, clientAuthRequired bool, err error)
 		GetExpiringCerts(timeWindow time.Duration) (expiring CertExpirationMap, expired CertExpirationMap, err error)
+		NumberOfHosts() int
 	}
 
 	CertThumbprint [16]byte

--- a/common/rpc/encryption/tlsFactory.go
+++ b/common/rpc/encryption/tlsFactory.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/uber-go/tally"
+	"go.temporal.io/server/common/log"
 
 	"go.temporal.io/server/common/config"
 )
@@ -84,11 +85,12 @@ type (
 func NewTLSConfigProviderFromConfig(
 	encryptionSettings config.RootTLS,
 	scope tally.Scope,
+	logger log.Logger,
 	certProviderFactory CertProviderFactory,
 ) (TLSConfigProvider, error) {
 
 	if certProviderFactory == nil {
 		certProviderFactory = NewLocalStoreCertProvider
 	}
-	return NewLocalStoreTlsProvider(&encryptionSettings, scope, certProviderFactory)
+	return NewLocalStoreTlsProvider(&encryptionSettings, scope, logger, certProviderFactory)
 }

--- a/common/rpc/test/rpc_localstore_tls_test.go
+++ b/common/rpc/test/rpc_localstore_tls_test.go
@@ -126,7 +126,7 @@ func (s *localStoreRPCSuite) SetupSuite() {
 	s.Assertions = require.New(s.T())
 	s.logger = log.NewDefaultLogger()
 
-	provider, err := encryption.NewTLSConfigProviderFromConfig(serverCfgInsecure.TLS, nil, nil)
+	provider, err := encryption.NewTLSConfigProviderFromConfig(serverCfgInsecure.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	insecureFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(insecureFactory)
@@ -304,22 +304,22 @@ func (s *localStoreRPCSuite) setupFrontend() {
 		},
 	}
 
-	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, nil, nil)
+	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	frontendMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(frontendMutualTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, nil, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	frontendServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(frontendServerTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSSystemWorker.TLS, nil, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSSystemWorker.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	frontendSystemWorkerMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(frontendSystemWorkerMutualTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSWithRefresh.TLS, nil, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSWithRefresh.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	frontendMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(frontendMutualTLSRefreshFactory)
@@ -371,22 +371,22 @@ func (s *localStoreRPCSuite) setupInternode() {
 	localStoreMutualTLSWithRefresh.TLS.Internode = s.internodeConfigMutualTLSRefresh
 	localStoreMutualTLSWithRefresh.TLS.RefreshInterval = time.Second
 
-	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, nil, nil)
+	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	internodeMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(internodeMutualTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, nil, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	internodeServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(internodeServerTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreAltMutualTLS.TLS, nil, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreAltMutualTLS.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	internodeMutualAltTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(internodeMutualAltTLSFactory)
 
-	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSWithRefresh.TLS, nil, nil)
+	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSWithRefresh.TLS, nil, s.logger, nil)
 	s.NoError(err)
 	internodeMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider)
 	s.NotNil(internodeMutualTLSRefreshFactory)

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -172,7 +172,7 @@ func (s *Server) Start() error {
 
 	if s.so.tlsConfigProvider == nil {
 		s.so.tlsConfigProvider, err = encryption.NewTLSConfigProviderFromConfig(
-			s.so.config.Global.TLS, globalMetricsScope, s.so.logger, nil)
+			s.so.config.Global.TLS, globalMetricsScope, s.logger, nil)
 		if err != nil {
 			return fmt.Errorf("TLS provider initialization error: %w", err)
 		}

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -171,7 +171,8 @@ func (s *Server) Start() error {
 	}
 
 	if s.so.tlsConfigProvider == nil {
-		s.so.tlsConfigProvider, err = encryption.NewTLSConfigProviderFromConfig(s.so.config.Global.TLS, globalMetricsScope, nil)
+		s.so.tlsConfigProvider, err = encryption.NewTLSConfigProviderFromConfig(
+			s.so.config.Global.TLS, globalMetricsScope, s.so.logger, nil)
 		if err != nil {
 			return fmt.Errorf("TLS provider initialization error: %w", err)
 		}


### PR DESCRIPTION
**What changed?**
Replaced instantiations of new logger in TLS provider code with passing it all the way from server options.

**Why?**
Multiple logger instances create undesirable effects when used concurrently.

**How did you test it?**
Unit tests

**Potential risks**
No risk

**Is hotfix candidate?**
No