### PR TITLE
Remove Custom*Field search attributes from index template

### DIFF
--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -194,6 +194,8 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	}
 
 	if advancedVisibilityWritingMode() != common.AdvancedVisibilityWritingModeOff {
+		// This will save custom test search attributes to cluster metadata.
+		// Actual Elasticsearch fields are created from index template (testdata/es_v7_index_template.json).
 		err = testBase.SearchAttributesManager.SaveSearchAttributes(
 			options.ESConfig.GetVisibilityIndex(),
 			searchattribute.TestNameTypeMap.Custom(),

--- a/schema/elasticsearch/v6/visibility/index_template.json
+++ b/schema/elasticsearch/v6/visibility/index_template.json
@@ -44,12 +44,6 @@
         "Attr": {
           "properties": {
             "TemporalChangeVersion":  { "type": "keyword" },
-            "CustomStringField":  { "type": "text" },
-            "CustomKeywordField": { "type": "keyword"},
-            "CustomIntField": { "type": "long"},
-            "CustomDoubleField": { "type": "double"},
-            "CustomBoolField": { "type": "boolean"},
-            "CustomDatetimeField": { "type": "date"},
             "CustomNamespace": { "type": "keyword"},
             "Operator": { "type": "keyword"},
             "BinaryChecksums": { "type": "keyword"}

--- a/schema/elasticsearch/v7/visibility/index_template.json
+++ b/schema/elasticsearch/v7/visibility/index_template.json
@@ -46,24 +46,6 @@
           "TemporalChangeVersion": {
             "type": "keyword"
           },
-          "CustomStringField": {
-            "type": "text"
-          },
-          "CustomKeywordField": {
-            "type": "keyword"
-          },
-          "CustomIntField": {
-            "type": "long"
-          },
-          "CustomDoubleField": {
-            "type": "double"
-          },
-          "CustomBoolField": {
-            "type": "boolean"
-          },
-          "CustomDatetimeField": {
-            "type": "date"
-          },
           "CustomNamespace": {
             "type": "keyword"
           },


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove `Custom*Field` search attributes from index template.

<!-- Tell your future self why have you made these changes -->
**Why?**
In #1540 `Custom*Field`s were removed from dynamic config but not from index template itself.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.