### PR TITLE
Properly dedup signal request ID

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1830,19 +1830,22 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 		namespaceID,
 		execution,
 		func(context workflowExecutionContext, mutableState mutableState) (*updateWorkflowAction, error) {
-			executionInfo := mutableState.GetExecutionInfo()
-			createWorkflowTask := true
-			// Do not create workflow task when the workflow is cron and the cron has not been started yet
-			if mutableState.GetExecutionInfo().CronSchedule != "" && !mutableState.HasProcessedOrPendingWorkflowTask() {
-				createWorkflowTask = false
-			}
-			postActions := &updateWorkflowAction{
-				noop:               false,
-				createWorkflowTask: createWorkflowTask,
+			if request.GetRequestId() != "" && mutableState.IsSignalRequested(request.GetRequestId()) {
+				return &updateWorkflowAction{
+					noop:               true,
+					createWorkflowTask: false,
+				}, nil
 			}
 
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, ErrWorkflowCompleted
+			}
+
+			executionInfo := mutableState.GetExecutionInfo()
+			createWorkflowTask := true
+			// Do not create workflow task when the workflow is cron and the cron has not been started yet
+			if executionInfo.CronSchedule != "" && !mutableState.HasProcessedOrPendingWorkflowTask() {
+				createWorkflowTask = false
 			}
 
 			maxAllowedSignals := e.config.MaximumSignalsPerExecution(namespaceEntry.GetInfo().Name)
@@ -1863,14 +1866,9 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 				}
 			}
 
-			// deduplicate by request id for signal workflow task
-			if requestID := request.GetRequestId(); requestID != "" {
-				if mutableState.IsSignalRequested(requestID) {
-					return postActions, nil
-				}
-				mutableState.AddSignalRequested(requestID)
+			if request.GetRequestId() != "" {
+				mutableState.AddSignalRequested(request.GetRequestId())
 			}
-
 			if _, err := mutableState.AddWorkflowExecutionSignaled(
 				request.GetSignalName(),
 				request.GetInput(),
@@ -1878,7 +1876,10 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 				return nil, serviceerror.NewInternal("Unable to signal workflow execution.")
 			}
 
-			return postActions, nil
+			return &updateWorkflowAction{
+				noop:               false,
+				createWorkflowTask: createWorkflowTask,
+			}, nil
 		})
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Dedup signal request ID before checking workflow mutability, in case workflow is signaled by finished

<!-- Tell your future self why have you made these changes -->
**Why?**
Business logic should check request ID for deduping purpose first.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No