### PR TITLE
Fix LastFirstEventTxnId not being properly propagated to DB

### DIFF
--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -165,6 +165,7 @@ func (m *executionManagerImpl) DeserializeExecutionInfo(
 		VersionHistories:                  info.VersionHistories,
 		WorkflowRunExpirationTime:         info.WorkflowRunExpirationTime,
 		WorkflowExecutionExpirationTime:   info.WorkflowExecutionExpirationTime,
+		LastFirstEventTxnId:               info.LastFirstEventTxnId,
 	}
 
 	if newInfo.AutoResetPoints == nil {
@@ -280,6 +281,7 @@ func (m *executionManagerImpl) SerializeExecutionInfo(
 		SearchAttributes:                  info.SearchAttributes,
 		WorkflowRunExpirationTime:         info.WorkflowRunExpirationTime,
 		WorkflowExecutionExpirationTime:   info.WorkflowExecutionExpirationTime,
+		LastFirstEventTxnId:               info.LastFirstEventTxnId,
 
 		ExecutionStats:       info.ExecutionStats,
 		VersionHistories:     info.VersionHistories,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Properly propagate LastFirstEventTxnId when doing serialization / deserialization to / from DB

<!-- Tell your future self why have you made these changes -->
**Why?**
Value not copy pasted

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No