### PR TITLE
Fix issue that namespace replication name is not set in req

### DIFF
--- a/common/persistence/cassandra/cassandraQueue.go
+++ b/common/persistence/cassandra/cassandraQueue.go
@@ -373,11 +373,11 @@ func (q *cassandraQueue) updateAckLevel(
 
 	queueMetadata, err := q.getQueueMetadata(queueType)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("UpdateDLQAckLevel operation failed. Error %v", err))
+		return serviceerror.NewInternal(fmt.Sprintf("updateAckLevel operation failed. Error %v", err))
 	}
 
 	// Ignore possibly delayed message
-	if queueMetadata.clusterAckLevels[clusterName] > messageID {
+	if ack, ok := queueMetadata.clusterAckLevels[clusterName]; ok && ack > messageID {
 		return nil
 	}
 

--- a/common/persistence/cassandra/cassandraQueue.go
+++ b/common/persistence/cassandra/cassandraQueue.go
@@ -381,6 +381,10 @@ func (q *cassandraQueue) updateAckLevel(
 		return nil
 	}
 
+	// TODO remove this block in 1.12.x
+	delete(queueMetadata.clusterAckLevels, "")
+	// TODO remove this block in 1.12.x
+
 	queueMetadata.clusterAckLevels[clusterName] = messageID
 	queueMetadata.version++
 

--- a/common/persistence/sql/queue.go
+++ b/common/persistence/sql/queue.go
@@ -171,6 +171,11 @@ func (q *sqlQueue) UpdateAckLevel(
 		if ack, ok := queueMetadata.ClusterAckLevels[clusterName]; ok && ack > messageID {
 			return nil
 		}
+
+		// TODO remove this block in 1.12.x
+		delete(queueMetadata.ClusterAckLevels, "")
+		// TODO remove this block in 1.12.x
+
 		queueMetadata.ClusterAckLevels[clusterName] = messageID
 
 		blob, err := serialization.QueueMetadataToBlob(queueMetadata)
@@ -356,6 +361,11 @@ func (q *sqlQueue) UpdateDLQAckLevel(
 		if ack, ok := queueMetadata.ClusterAckLevels[clusterName]; ok && ack > messageID {
 			return nil
 		}
+
+		// TODO remove this block in 1.12.x
+		delete(queueMetadata.ClusterAckLevels, "")
+		// TODO remove this block in 1.12.x
+
 		queueMetadata.ClusterAckLevels[clusterName] = messageID
 
 		blob, err := serialization.QueueMetadataToBlob(queueMetadata)

--- a/common/persistence/sql/queue.go
+++ b/common/persistence/sql/queue.go
@@ -168,7 +168,7 @@ func (q *sqlQueue) UpdateAckLevel(
 		}
 
 		// Ignore possibly delayed message
-		if queueMetadata.ClusterAckLevels[clusterName] > messageID {
+		if ack, ok := queueMetadata.ClusterAckLevels[clusterName]; ok && ack > messageID {
 			return nil
 		}
 		queueMetadata.ClusterAckLevels[clusterName] = messageID
@@ -353,7 +353,7 @@ func (q *sqlQueue) UpdateDLQAckLevel(
 		}
 
 		// Ignore possibly delayed message
-		if queueMetadata.ClusterAckLevels[clusterName] > messageID {
+		if ack, ok := queueMetadata.ClusterAckLevels[clusterName]; ok && ack > messageID {
 			return nil
 		}
 		queueMetadata.ClusterAckLevels[clusterName] = messageID

--- a/service/worker/replicator/namespace_replication_message_processor.go
+++ b/service/worker/replicator/namespace_replication_message_processor.go
@@ -53,6 +53,7 @@ const (
 )
 
 func newNamespaceReplicationMessageProcessor(
+	currentCluster string,
 	sourceCluster string,
 	logger log.Logger,
 	remotePeer adminservice.AdminServiceClient,
@@ -70,6 +71,7 @@ func newNamespaceReplicationMessageProcessor(
 		hostInfo:                  hostInfo,
 		serviceResolver:           serviceResolver,
 		status:                    common.DaemonStatusInitialized,
+		currentCluster:            currentCluster,
 		sourceCluster:             sourceCluster,
 		logger:                    logger,
 		remotePeer:                remotePeer,
@@ -88,6 +90,7 @@ type (
 		hostInfo                  *membership.HostInfo
 		serviceResolver           membership.ServiceResolver
 		status                    int32
+		currentCluster            string
 		sourceCluster             string
 		logger                    log.Logger
 		remotePeer                adminservice.AdminServiceClient
@@ -143,6 +146,7 @@ func (p *namespaceReplicationMessageProcessor) getAndHandleNamespaceReplicationT
 
 	ctx, cancel := rpc.NewContextWithTimeoutAndHeaders(fetchTaskRequestTimeout)
 	request := &adminservice.GetNamespaceReplicationMessagesRequest{
+		ClusterName:            p.currentCluster,
 		LastRetrievedMessageId: p.lastRetrievedMessageID,
 		LastProcessedMessageId: p.lastProcessedMessageID,
 	}

--- a/service/worker/replicator/replicator.go
+++ b/service/worker/replicator/replicator.go
@@ -86,16 +86,17 @@ func NewReplicator(
 	logger = log.With(logger, tag.ComponentReplicator)
 	var namespaceReplicationMessageProcessors []*namespaceReplicationMessageProcessor
 	currentClusterName := clusterMetadata.GetCurrentClusterName()
-	for clusterName, info := range clusterMetadata.GetAllClusterInfo() {
+	for targetClusterName, info := range clusterMetadata.GetAllClusterInfo() {
 		if !info.Enabled {
 			continue
 		}
 
-		if clusterName != currentClusterName {
+		if targetClusterName != currentClusterName {
 			namespaceReplicationMessageProcessors = append(namespaceReplicationMessageProcessors, newNamespaceReplicationMessageProcessor(
-				clusterName,
-				log.With(logger, tag.ComponentReplicationTaskProcessor, tag.SourceCluster(clusterName)),
-				clientBean.GetRemoteAdminClient(clusterName),
+				currentClusterName,
+				targetClusterName,
+				log.With(logger, tag.ComponentReplicationTaskProcessor, tag.SourceCluster(targetClusterName)),
+				clientBean.GetRemoteAdminClient(targetClusterName),
 				metricsClient,
 				namespaceReplicationTaskExecutor,
 				hostInfo,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Correctly set the cluster name in replication namespace request

<!-- Tell your future self why have you made these changes -->
**Why?**
Bugfix, ref: https://github.com/uber/cadence/pull/4212

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No