### PR TITLE
Merge serialization methods into new Serializer

### DIFF
--- a/common/persistence/serialization/serializer.go
+++ b/common/persistence/serialization/serializer.go
@@ -1,0 +1,704 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package serialization
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/codec"
+)
+
+type (
+	// Serializer is used by persistence to serialize/deserialize objects
+	// It will only be used inside persistence, so that serialize/deserialize is transparent for application
+	Serializer interface {
+		// serialize/deserialize history events
+		SerializeEvents(batch []*historypb.HistoryEvent, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		DeserializeEvents(data *commonpb.DataBlob) ([]*historypb.HistoryEvent, error)
+
+		// serialize/deserialize a single history event
+		SerializeEvent(event *historypb.HistoryEvent, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		DeserializeEvent(data *commonpb.DataBlob) (*historypb.HistoryEvent, error)
+
+		// serialize/deserialize visibility memo fields
+		SerializeVisibilityMemo(memo *commonpb.Memo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		DeserializeVisibilityMemo(data *commonpb.DataBlob) (*commonpb.Memo, error)
+
+		// serialize/deserialize reset points
+		SerializeResetPoints(event *workflowpb.ResetPoints, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		DeserializeResetPoints(data *commonpb.DataBlob) (*workflowpb.ResetPoints, error)
+
+		// serialize/deserialize bad binaries
+		SerializeBadBinaries(event *namespacepb.BadBinaries, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		DeserializeBadBinaries(data *commonpb.DataBlob) (*namespacepb.BadBinaries, error)
+
+		// serialize/deserialize mutable cluster metadata
+		SerializeClusterMetadata(icm *persistencespb.ClusterMetadata, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		DeserializeClusterMetadata(data *commonpb.DataBlob) (*persistencespb.ClusterMetadata, error)
+
+		ShardInfoToBlob(info *persistencespb.ShardInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		ShardInfoFromBlob(data *commonpb.DataBlob, clusterName string) (*persistencespb.ShardInfo, error)
+
+		NamespaceDetailToBlob(info *persistencespb.NamespaceDetail, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		NamespaceDetailFromBlob(data *commonpb.DataBlob) (*persistencespb.NamespaceDetail, error)
+
+		HistoryTreeInfoToBlob(info *persistencespb.HistoryTreeInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		HistoryTreeInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.HistoryTreeInfo, error)
+
+		HistoryBranchToBlob(info *persistencespb.HistoryBranch, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		HistoryBranchFromBlob(data *commonpb.DataBlob) (*persistencespb.HistoryBranch, error)
+
+		WorkflowExecutionInfoToBlob(info *persistencespb.WorkflowExecutionInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		WorkflowExecutionInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.WorkflowExecutionInfo, error)
+
+		WorkflowExecutionStateToBlob(info *persistencespb.WorkflowExecutionState, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		WorkflowExecutionStateFromBlob(data *commonpb.DataBlob) (*persistencespb.WorkflowExecutionState, error)
+
+		ActivityInfoToBlob(info *persistencespb.ActivityInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		ActivityInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.ActivityInfo, error)
+
+		ChildExecutionInfoToBlob(info *persistencespb.ChildExecutionInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		ChildExecutionInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.ChildExecutionInfo, error)
+
+		SignalInfoToBlob(info *persistencespb.SignalInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		SignalInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.SignalInfo, error)
+
+		RequestCancelInfoToBlob(info *persistencespb.RequestCancelInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		RequestCancelInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.RequestCancelInfo, error)
+
+		TimerInfoToBlob(info *persistencespb.TimerInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		TimerInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.TimerInfo, error)
+
+		TaskInfoToBlob(info *persistencespb.AllocatedTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		TaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.AllocatedTaskInfo, error)
+
+		TaskQueueInfoToBlob(info *persistencespb.TaskQueueInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		TaskQueueInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.TaskQueueInfo, error)
+
+		TransferTaskInfoToBlob(info *persistencespb.TransferTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		TransferTaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.TransferTaskInfo, error)
+
+		TimerTaskInfoToBlob(info *persistencespb.TimerTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		TimerTaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.TimerTaskInfo, error)
+
+		ReplicationTaskInfoToBlob(info *persistencespb.ReplicationTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		ReplicationTaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.ReplicationTaskInfo, error)
+
+		VisibilityTaskInfoToBlob(info *persistencespb.VisibilityTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		VisibilityTaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.VisibilityTaskInfo, error)
+
+		ChecksumToBlob(checksum *persistencespb.Checksum, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		ChecksumFromBlob(data *commonpb.DataBlob) (*persistencespb.Checksum, error)
+
+		QueueMetadataToBlob(metadata *persistencespb.QueueMetadata, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		QueueMetadataFromBlob(data *commonpb.DataBlob) (*persistencespb.QueueMetadata, error)
+
+		ReplicationTaskToBlob(replicationTask *replicationspb.ReplicationTask, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
+		ReplicationTaskFromBlob(data *commonpb.DataBlob) (*replicationspb.ReplicationTask, error)
+	}
+
+	// SerializationError is an error type for serialization
+	SerializationError struct {
+		msg string
+	}
+
+	// DeserializationError is an error type for deserialization
+	DeserializationError struct {
+		msg string
+	}
+
+	// UnknownEncodingTypeError is an error type for unknown or unsupported encoding type
+	UnknownEncodingTypeError struct {
+		encodingType enumspb.EncodingType
+	}
+
+	serializerImpl struct{}
+)
+
+// NewSerializer returns a PayloadSerializer
+func NewSerializer() Serializer {
+	return &serializerImpl{}
+}
+
+func (t *serializerImpl) SerializeEvents(events []*historypb.HistoryEvent, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return t.serialize(&historypb.History{Events: events}, encodingType)
+}
+
+func (t *serializerImpl) DeserializeEvents(data *commonpb.DataBlob) ([]*historypb.HistoryEvent, error) {
+	if data == nil {
+		return nil, nil
+	}
+	if len(data.Data) == 0 {
+		return nil, nil
+	}
+
+	events := &historypb.History{}
+	var err error
+	switch data.EncodingType {
+	case enumspb.ENCODING_TYPE_PROTO3:
+		// Client API currently specifies encodingType on requests which span multiple of these objects
+		err = events.Unmarshal(data.Data)
+	default:
+		return nil, NewDeserializationError("DeserializeEvents invalid encoding")
+	}
+	if err != nil {
+		return nil, err
+	}
+	return events.Events, nil
+}
+
+func (t *serializerImpl) SerializeEvent(event *historypb.HistoryEvent, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	if event == nil {
+		return nil, nil
+	}
+	return t.serialize(event, encodingType)
+}
+
+func (t *serializerImpl) DeserializeEvent(data *commonpb.DataBlob) (*historypb.HistoryEvent, error) {
+	if data == nil {
+		return nil, nil
+	}
+	if len(data.Data) == 0 {
+		return nil, nil
+	}
+
+	event := &historypb.HistoryEvent{}
+	var err error
+	switch data.EncodingType {
+	case enumspb.ENCODING_TYPE_PROTO3:
+		// Client API currently specifies encodingType on requests which span multiple of these objects
+		err = event.Unmarshal(data.Data)
+	default:
+		return nil, NewDeserializationError("DeserializeEvent invalid encoding")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return event, err
+}
+
+func (t *serializerImpl) SerializeResetPoints(rp *workflowpb.ResetPoints, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	if rp == nil {
+		rp = &workflowpb.ResetPoints{}
+	}
+	return t.serialize(rp, encodingType)
+}
+
+func (t *serializerImpl) DeserializeResetPoints(data *commonpb.DataBlob) (*workflowpb.ResetPoints, error) {
+	if data == nil {
+		return &workflowpb.ResetPoints{}, nil
+	}
+	if len(data.Data) == 0 {
+		return &workflowpb.ResetPoints{}, nil
+	}
+
+	memo := &workflowpb.ResetPoints{}
+	var err error
+	switch data.EncodingType {
+	case enumspb.ENCODING_TYPE_PROTO3:
+		// Thrift == Proto for this object so that we can maintain test behavior until thrift is gone
+		// Client API currently specifies encodingType on requests which span multiple of these objects
+		err = memo.Unmarshal(data.Data)
+	default:
+		return nil, NewDeserializationError("DeserializeResetPoints invalid encoding")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return memo, err
+}
+
+func (t *serializerImpl) SerializeBadBinaries(bb *namespacepb.BadBinaries, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	if bb == nil {
+		bb = &namespacepb.BadBinaries{}
+	}
+	return t.serialize(bb, encodingType)
+}
+
+func (t *serializerImpl) DeserializeBadBinaries(data *commonpb.DataBlob) (*namespacepb.BadBinaries, error) {
+	if data == nil {
+		return &namespacepb.BadBinaries{}, nil
+	}
+	if len(data.Data) == 0 {
+		return &namespacepb.BadBinaries{}, nil
+	}
+
+	memo := &namespacepb.BadBinaries{}
+	var err error
+	switch data.EncodingType {
+	case enumspb.ENCODING_TYPE_PROTO3:
+		// Thrift == Proto for this object so that we can maintain test behavior until thrift is gone
+		// Client API currently specifies encodingType on requests which span multiple of these objects
+		err = memo.Unmarshal(data.Data)
+	default:
+		return nil, NewDeserializationError("DeserializeBadBinaries invalid encoding")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return memo, err
+}
+
+func (t *serializerImpl) SerializeVisibilityMemo(memo *commonpb.Memo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	if memo == nil {
+		// Return nil here to be consistent with Event
+		// This check is not duplicate as check in following serialize
+		return nil, nil
+	}
+	return t.serialize(memo, encodingType)
+}
+
+func (t *serializerImpl) DeserializeVisibilityMemo(data *commonpb.DataBlob) (*commonpb.Memo, error) {
+	if data == nil {
+		return &commonpb.Memo{}, nil
+	}
+	if len(data.Data) == 0 {
+		return &commonpb.Memo{}, nil
+	}
+
+	memo := &commonpb.Memo{}
+	var err error
+	switch data.EncodingType {
+	case enumspb.ENCODING_TYPE_PROTO3:
+		// Thrift == Proto for this object so that we can maintain test behavior until thrift is gone
+		// Client API currently specifies encodingType on requests which span multiple of these objects
+		err = memo.Unmarshal(data.Data)
+	default:
+		return nil, NewDeserializationError("DeserializeVisibilityMemo invalid encoding")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return memo, err
+}
+
+func (t *serializerImpl) SerializeClusterMetadata(cm *persistencespb.ClusterMetadata, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	if cm == nil {
+		cm = &persistencespb.ClusterMetadata{}
+	}
+	return t.serialize(cm, encodingType)
+}
+
+func (t *serializerImpl) DeserializeClusterMetadata(data *commonpb.DataBlob) (*persistencespb.ClusterMetadata, error) {
+	if data == nil {
+		return nil, nil
+	}
+	if len(data.Data) == 0 {
+		return nil, nil
+	}
+
+	cm := &persistencespb.ClusterMetadata{}
+	var err error
+	switch data.EncodingType {
+	case enumspb.ENCODING_TYPE_PROTO3:
+		// Thrift == Proto for this object so that we can maintain test behavior until thrift is gone
+		// Client API currently specifies encodingType on requests which span multiple of these objects
+		err = cm.Unmarshal(data.Data)
+	default:
+		return nil, NewDeserializationError("DeserializeClusterMetadata invalid encoding")
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cm, err
+}
+
+func (t *serializerImpl) serialize(p proto.Marshaler, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	if p == nil {
+		return nil, nil
+	}
+
+	var data []byte
+	var err error
+
+	switch encodingType {
+	case enumspb.ENCODING_TYPE_PROTO3:
+		// Client API currently specifies encodingType on requests which span multiple of these objects
+		data, err = p.Marshal()
+	default:
+		return nil, NewUnknownEncodingTypeError(encodingType)
+	}
+
+	if err != nil {
+		return nil, NewSerializationError(err.Error())
+	}
+
+	// Shouldn't happen, but keeping
+	if data == nil {
+		return nil, nil
+	}
+
+	return &commonpb.DataBlob{
+		Data:         data,
+		EncodingType: encodingType,
+	}, nil
+}
+
+// NewUnknownEncodingTypeError returns a new instance of encoding type error
+func NewUnknownEncodingTypeError(encodingType enumspb.EncodingType) error {
+	return &UnknownEncodingTypeError{encodingType: encodingType}
+}
+
+func (e *UnknownEncodingTypeError) Error() string {
+	return fmt.Sprintf("unknown or unsupported encoding type %v", e.encodingType)
+}
+
+// NewSerializationError returns a SerializationError
+func NewSerializationError(msg string) error {
+	return &SerializationError{msg: msg}
+}
+
+func (e *SerializationError) Error() string {
+	return fmt.Sprintf("serialization error: %v", e.msg)
+}
+
+// NewDeserializationError returns a DeserializationError
+func NewDeserializationError(msg string) error {
+	return &DeserializationError{msg: msg}
+}
+
+func (e *DeserializationError) Error() string {
+	return fmt.Sprintf("deserialization error: %v", e.msg)
+}
+
+
+func (t *serializerImpl) ShardInfoToBlob(info *persistencespb.ShardInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) ShardInfoFromBlob(data *commonpb.DataBlob, clusterName string) (*persistencespb.ShardInfo, error) {
+	shardInfo := &persistencespb.ShardInfo{}
+	err := proto3DecodeBlob(data, shardInfo)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if len(shardInfo.GetClusterTransferAckLevel()) == 0 {
+		shardInfo.ClusterTransferAckLevel = map[string]int64{
+			clusterName: shardInfo.GetTransferAckLevel(),
+		}
+	}
+
+	if len(shardInfo.GetClusterTimerAckLevel()) == 0 {
+		shardInfo.ClusterTimerAckLevel = map[string]*time.Time{
+			clusterName: shardInfo.GetTimerAckLevelTime(),
+		}
+	}
+
+	if shardInfo.GetClusterReplicationLevel() == nil {
+		shardInfo.ClusterReplicationLevel = make(map[string]int64)
+	}
+
+	if shardInfo.GetReplicationDlqAckLevel() == nil {
+		shardInfo.ReplicationDlqAckLevel = make(map[string]int64)
+	}
+
+	return shardInfo, nil
+}
+
+func (t *serializerImpl) NamespaceDetailToBlob(info *persistencespb.NamespaceDetail, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) NamespaceDetailFromBlob(data *commonpb.DataBlob) (*persistencespb.NamespaceDetail, error) {
+	result := &persistencespb.NamespaceDetail{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) HistoryTreeInfoToBlob(info *persistencespb.HistoryTreeInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) HistoryTreeInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.HistoryTreeInfo, error) {
+	result := &persistencespb.HistoryTreeInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) HistoryBranchToBlob(info *persistencespb.HistoryBranch, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) HistoryBranchFromBlob(data *commonpb.DataBlob) (*persistencespb.HistoryBranch, error) {
+	result := &persistencespb.HistoryBranch{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) WorkflowExecutionInfoToBlob(info *persistencespb.WorkflowExecutionInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) WorkflowExecutionInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.WorkflowExecutionInfo, error) {
+	result := &persistencespb.WorkflowExecutionInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) WorkflowExecutionStateToBlob(info *persistencespb.WorkflowExecutionState, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) WorkflowExecutionStateFromBlob(data *commonpb.DataBlob) (*persistencespb.WorkflowExecutionState, error) {
+	result := &persistencespb.WorkflowExecutionState{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) ActivityInfoToBlob(info *persistencespb.ActivityInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl)ActivityInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.ActivityInfo, error) {
+	result := &persistencespb.ActivityInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl)ChildExecutionInfoToBlob(info *persistencespb.ChildExecutionInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) ChildExecutionInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.ChildExecutionInfo, error) {
+	result := &persistencespb.ChildExecutionInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func(t *serializerImpl) SignalInfoToBlob(info *persistencespb.SignalInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) SignalInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.SignalInfo, error) {
+	result := &persistencespb.SignalInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func(t *serializerImpl) RequestCancelInfoToBlob(info *persistencespb.RequestCancelInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) RequestCancelInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.RequestCancelInfo, error) {
+	result := &persistencespb.RequestCancelInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) TimerInfoToBlob(info *persistencespb.TimerInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) TimerInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.TimerInfo, error) {
+	result := &persistencespb.TimerInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) TaskInfoToBlob(info *persistencespb.AllocatedTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) TaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.AllocatedTaskInfo, error) {
+	result := &persistencespb.AllocatedTaskInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) TaskQueueInfoToBlob(info *persistencespb.TaskQueueInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) TaskQueueInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.TaskQueueInfo, error) {
+	result := &persistencespb.TaskQueueInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) TransferTaskInfoToBlob(info *persistencespb.TransferTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) TransferTaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.TransferTaskInfo, error) {
+	result := &persistencespb.TransferTaskInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) TimerTaskInfoToBlob(info *persistencespb.TimerTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) TimerTaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.TimerTaskInfo, error) {
+	result := &persistencespb.TimerTaskInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) ReplicationTaskInfoToBlob(info *persistencespb.ReplicationTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) ReplicationTaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.ReplicationTaskInfo, error) {
+	result := &persistencespb.ReplicationTaskInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func (t *serializerImpl) VisibilityTaskInfoToBlob(info *persistencespb.VisibilityTaskInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(info, encodingType)
+}
+
+func (t *serializerImpl) VisibilityTaskInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.VisibilityTaskInfo, error) {
+	result := &persistencespb.VisibilityTaskInfo{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func(t *serializerImpl) ChecksumToBlob(checksum *persistencespb.Checksum, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	// nil is replaced with empty object because it is not supported for "checksum" field in DB.
+	if checksum == nil {
+		checksum = &persistencespb.Checksum{}
+	}
+	return proto3EncodeBlob(checksum, encodingType)
+}
+
+func (t *serializerImpl) ChecksumFromBlob(data *commonpb.DataBlob) (*persistencespb.Checksum, error) {
+	result := &persistencespb.Checksum{}
+	err := proto3DecodeBlob(data, result)
+	if err != nil || result.GetFlavor() == enumsspb.CHECKSUM_FLAVOR_UNSPECIFIED {
+		// If result is an empty struct (Flavor is unspecified), replace it with nil, because everywhere in the code checksum is pointer type.
+		return nil, err
+	}
+	return result, nil
+}
+
+func (t *serializerImpl) QueueMetadataToBlob(metadata *persistencespb.QueueMetadata, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return encodeBlob(metadata, encodingType)
+}
+
+func(t *serializerImpl) QueueMetadataFromBlob(data *commonpb.DataBlob) (*persistencespb.QueueMetadata, error) {
+	result := &persistencespb.QueueMetadata{}
+	return result, decodeBlob(data, result)
+}
+
+func(t *serializerImpl) ReplicationTaskToBlob(replicationTask *replicationspb.ReplicationTask, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	return proto3EncodeBlob(replicationTask, encodingType)
+}
+
+func (t *serializerImpl) ReplicationTaskFromBlob(data *commonpb.DataBlob) (*replicationspb.ReplicationTask, error) {
+	result := &replicationspb.ReplicationTask{}
+	return result, proto3DecodeBlob(data, result)
+}
+
+func proto3DecodeBlob(data *commonpb.DataBlob, result proto.Message) error {
+	if data == nil {
+		// TODO: should we return nil or error?
+		return fmt.Errorf("cannot decode nil")
+	}
+
+	if data.EncodingType != enumspb.ENCODING_TYPE_PROTO3 {
+		return NewDeserializationError(fmt.Sprintf("encoding %v doesn't match expected encoding %v", data.EncodingType, enumspb.ENCODING_TYPE_PROTO3))
+	}
+
+	if err := proto.Unmarshal(data.Data, result); err != nil {
+		return NewDeserializationError(fmt.Sprintf("error deserializing blob using %v encoding: %s", enumspb.ENCODING_TYPE_PROTO3, err))
+	}
+	return nil
+}
+
+func decodeBlob(data *commonpb.DataBlob, result proto.Message) error {
+	if data == nil {
+		// TODO: should we return nil or error?
+		return fmt.Errorf("cannot decode nil")
+	}
+
+	if data.Data == nil {
+		return nil
+	}
+
+	switch data.EncodingType {
+	case enumspb.ENCODING_TYPE_JSON:
+		return codec.NewJSONPBEncoder().Decode(data.Data, result)
+	case enumspb.ENCODING_TYPE_PROTO3:
+		return proto3DecodeBlob(data, result)
+	default:
+		return NewUnknownEncodingTypeError(data.EncodingType)
+	}
+}
+
+func encodeBlob(o proto.Message, encoding enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	if o == nil || (reflect.ValueOf(o).Kind() == reflect.Ptr && reflect.ValueOf(o).IsNil()) {
+		return &commonpb.DataBlob{
+			Data:         nil,
+			EncodingType: encoding,
+		}, nil
+	}
+
+	switch encoding {
+	case enumspb.ENCODING_TYPE_JSON:
+		blob, err := codec.NewJSONPBEncoder().Encode(o.(proto.Message))
+		if err != nil {
+			return nil, err
+		}
+		return &commonpb.DataBlob{
+			Data:         blob,
+			EncodingType: enumspb.ENCODING_TYPE_JSON,
+		}, nil
+	case enumspb.ENCODING_TYPE_PROTO3:
+		return proto3EncodeBlob(o, enumspb.ENCODING_TYPE_PROTO3)
+	default:
+		return nil, fmt.Errorf("unknown encoding type: %v", encoding)
+	}
+}
+
+func proto3EncodeBlob(m proto.Message, encoding enumspb.EncodingType) (*commonpb.DataBlob, error) {
+	if encoding != enumspb.ENCODING_TYPE_PROTO3 {
+		return nil, NewUnknownEncodingTypeError(encoding)
+	}
+
+	if m == nil || (reflect.ValueOf(m).Kind() == reflect.Ptr && reflect.ValueOf(m).IsNil()){
+		// TODO: is this expected?
+		return &commonpb.DataBlob{
+			Data:         nil,
+			EncodingType: encoding,
+		}, nil
+	}
+
+	blob := &commonpb.DataBlob{EncodingType: enumspb.ENCODING_TYPE_PROTO3}
+	data, err := proto.Marshal(m)
+	if err != nil {
+		return nil, fmt.Errorf("error serializing struct to blob using %v encoding: %w", enumspb.ENCODING_TYPE_PROTO3, err)
+	}
+	blob.Data = data
+	return blob, nil
+}

--- a/common/persistence/serialization/serializer.go
+++ b/common/persistence/serialization/serializer.go
@@ -404,7 +404,6 @@ func (e *DeserializationError) Error() string {
 	return fmt.Sprintf("deserialization error: %v", e.msg)
 }
 
-
 func (t *serializerImpl) ShardInfoToBlob(info *persistencespb.ShardInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
 	return proto3EncodeBlob(info, encodingType)
 }
@@ -489,12 +488,12 @@ func (t *serializerImpl) ActivityInfoToBlob(info *persistencespb.ActivityInfo, e
 	return proto3EncodeBlob(info, encodingType)
 }
 
-func (t *serializerImpl)ActivityInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.ActivityInfo, error) {
+func (t *serializerImpl) ActivityInfoFromBlob(data *commonpb.DataBlob) (*persistencespb.ActivityInfo, error) {
 	result := &persistencespb.ActivityInfo{}
 	return result, proto3DecodeBlob(data, result)
 }
 
-func (t *serializerImpl)ChildExecutionInfoToBlob(info *persistencespb.ChildExecutionInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+func (t *serializerImpl) ChildExecutionInfoToBlob(info *persistencespb.ChildExecutionInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
 	return proto3EncodeBlob(info, encodingType)
 }
 
@@ -503,7 +502,7 @@ func (t *serializerImpl) ChildExecutionInfoFromBlob(data *commonpb.DataBlob) (*p
 	return result, proto3DecodeBlob(data, result)
 }
 
-func(t *serializerImpl) SignalInfoToBlob(info *persistencespb.SignalInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+func (t *serializerImpl) SignalInfoToBlob(info *persistencespb.SignalInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
 	return proto3EncodeBlob(info, encodingType)
 }
 
@@ -512,7 +511,7 @@ func (t *serializerImpl) SignalInfoFromBlob(data *commonpb.DataBlob) (*persisten
 	return result, proto3DecodeBlob(data, result)
 }
 
-func(t *serializerImpl) RequestCancelInfoToBlob(info *persistencespb.RequestCancelInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+func (t *serializerImpl) RequestCancelInfoToBlob(info *persistencespb.RequestCancelInfo, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
 	return proto3EncodeBlob(info, encodingType)
 }
 
@@ -584,7 +583,7 @@ func (t *serializerImpl) VisibilityTaskInfoFromBlob(data *commonpb.DataBlob) (*p
 	return result, proto3DecodeBlob(data, result)
 }
 
-func(t *serializerImpl) ChecksumToBlob(checksum *persistencespb.Checksum, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+func (t *serializerImpl) ChecksumToBlob(checksum *persistencespb.Checksum, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
 	// nil is replaced with empty object because it is not supported for "checksum" field in DB.
 	if checksum == nil {
 		checksum = &persistencespb.Checksum{}
@@ -606,12 +605,12 @@ func (t *serializerImpl) QueueMetadataToBlob(metadata *persistencespb.QueueMetad
 	return encodeBlob(metadata, encodingType)
 }
 
-func(t *serializerImpl) QueueMetadataFromBlob(data *commonpb.DataBlob) (*persistencespb.QueueMetadata, error) {
+func (t *serializerImpl) QueueMetadataFromBlob(data *commonpb.DataBlob) (*persistencespb.QueueMetadata, error) {
 	result := &persistencespb.QueueMetadata{}
 	return result, decodeBlob(data, result)
 }
 
-func(t *serializerImpl) ReplicationTaskToBlob(replicationTask *replicationspb.ReplicationTask, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
+func (t *serializerImpl) ReplicationTaskToBlob(replicationTask *replicationspb.ReplicationTask, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error) {
 	return proto3EncodeBlob(replicationTask, encodingType)
 }
 
@@ -686,7 +685,7 @@ func proto3EncodeBlob(m proto.Message, encoding enumspb.EncodingType) (*commonpb
 		return nil, NewUnknownEncodingTypeError(encoding)
 	}
 
-	if m == nil || (reflect.ValueOf(m).Kind() == reflect.Ptr && reflect.ValueOf(m).IsNil()){
+	if m == nil || (reflect.ValueOf(m).Kind() == reflect.Ptr && reflect.ValueOf(m).IsNil()) {
 		// TODO: is this expected?
 		return &commonpb.DataBlob{
 			Data:         nil,

--- a/common/persistence/serialization/serializer_test.go
+++ b/common/persistence/serialization/serializer_test.go
@@ -25,12 +25,13 @@
 package serialization
 
 import (
-	v14 "go.temporal.io/server/api/enums/v1"
-	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"reflect"
 	"sync"
 	"testing"
 	"time"
+
+	v14 "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -125,12 +126,12 @@ func (s *temporalSerializerSuite) TestSerializer() {
 	}
 
 	visibilityTaskInfo0 := &persistencespb.VisibilityTaskInfo{
-		NamespaceId: "test-namespace-id",
-		WorkflowId: "test-workflow-id",
-		RunId: "test-run-id",
+		NamespaceId:    "test-namespace-id",
+		WorkflowId:     "test-workflow-id",
+		RunId:          "test-run-id",
 		TaskType:       v14.TASK_TYPE_VISIBILITY_START_EXECUTION,
-		Version: 0,
-		TaskId: 123,
+		Version:        0,
+		TaskId:         123,
 		VisibilityTime: timestamp.TimePtr(time.Date(2020, 8, 22, 0, 0, 0, 0, time.UTC)),
 	}
 

--- a/common/persistence/serialization/serializer_test.go
+++ b/common/persistence/serialization/serializer_test.go
@@ -1,0 +1,297 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package serialization
+
+import (
+	v14 "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/primitives/timestamp"
+)
+
+type (
+	temporalSerializerSuite struct {
+		suite.Suite
+		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
+		// not merely log an error
+		*require.Assertions
+		logger log.Logger
+	}
+)
+
+func TestTemporalSerializerSuite(t *testing.T) {
+	s := new(temporalSerializerSuite)
+	suite.Run(t, s)
+}
+
+func (s *temporalSerializerSuite) SetupTest() {
+	s.logger = log.NewTestLogger()
+	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
+	s.Assertions = require.New(s.T())
+}
+
+func (s *temporalSerializerSuite) TestSerializer() {
+
+	concurrency := 1
+	startWG := sync.WaitGroup{}
+	doneWG := sync.WaitGroup{}
+
+	startWG.Add(1)
+	doneWG.Add(concurrency)
+
+	serializer := NewSerializer()
+
+	eventType := enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED
+	event0 := &historypb.HistoryEvent{
+		EventId:   999,
+		EventTime: timestamp.TimePtr(time.Date(2020, 8, 22, 0, 0, 0, 0, time.UTC)),
+		EventType: eventType,
+		Attributes: &historypb.HistoryEvent_ActivityTaskCompletedEventAttributes{
+			ActivityTaskCompletedEventAttributes: &historypb.ActivityTaskCompletedEventAttributes{
+				Result:           payloads.EncodeString("result-1-event-1"),
+				ScheduledEventId: 4,
+				StartedEventId:   5,
+				Identity:         "event-1",
+			},
+		},
+	}
+
+	history0 := &historypb.History{Events: []*historypb.HistoryEvent{event0, event0}}
+
+	memoFields := map[string]*commonpb.Payload{
+		"TestField": payload.EncodeString("Test binary"),
+	}
+	memo0 := &commonpb.Memo{Fields: memoFields}
+
+	resetPoints0 := &workflowpb.ResetPoints{
+		Points: []*workflowpb.ResetPointInfo{
+			{
+				BinaryChecksum:               "bad-binary-cs",
+				RunId:                        "test-run-id",
+				FirstWorkflowTaskCompletedId: 123,
+				CreateTime:                   timestamp.TimePtr(time.Date(2020, 8, 22, 0, 0, 0, 0, time.UTC)),
+				Resettable:                   true,
+				ExpireTime:                   timestamp.TimePtr(time.Date(2020, 8, 22, 0, 0, 0, 0, time.UTC)),
+			},
+		},
+	}
+
+	badBinaries0 := &namespacepb.BadBinaries{
+		Binaries: map[string]*namespacepb.BadBinaryInfo{
+			"bad-binary-cs": {
+				CreateTime: timestamp.TimePtr(time.Date(2020, 8, 22, 0, 0, 0, 0, time.UTC)),
+				Operator:   "test-operattor",
+				Reason:     "test-reason",
+			},
+		},
+	}
+
+	visibilityTaskInfo0 := &persistencespb.VisibilityTaskInfo{
+		NamespaceId: "test-namespace-id",
+		WorkflowId: "test-workflow-id",
+		RunId: "test-run-id",
+		TaskType:       v14.TASK_TYPE_VISIBILITY_START_EXECUTION,
+		Version: 0,
+		TaskId: 123,
+		VisibilityTime: timestamp.TimePtr(time.Date(2020, 8, 22, 0, 0, 0, 0, time.UTC)),
+	}
+
+	for i := 0; i < concurrency; i++ {
+
+		go func() {
+
+			startWG.Wait()
+			defer doneWG.Done()
+
+			// serialize event
+
+			nilEvent, err := serializer.SerializeEvent(nil, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.Nil(nilEvent)
+
+			_, err = serializer.SerializeEvent(event0, enumspb.ENCODING_TYPE_UNSPECIFIED)
+			s.NotNil(err)
+			_, ok := err.(*UnknownEncodingTypeError)
+			s.True(ok)
+
+			dProto, err := serializer.SerializeEvent(event0, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(dProto)
+
+			// serialize batch events
+
+			nilEvents, err := serializer.SerializeEvents(nil, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(nilEvents)
+
+			_, err = serializer.SerializeEvents(history0.Events, enumspb.ENCODING_TYPE_UNSPECIFIED)
+			s.NotNil(err)
+			_, ok = err.(*UnknownEncodingTypeError)
+			s.True(ok)
+
+			dsProto, err := serializer.SerializeEvents(history0.Events, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(dsProto)
+
+			_, err = serializer.SerializeVisibilityMemo(memo0, enumspb.ENCODING_TYPE_UNSPECIFIED)
+			s.NotNil(err)
+			_, ok = err.(*UnknownEncodingTypeError)
+			s.True(ok)
+
+			// serialize visibility memo
+
+			nilMemo, err := serializer.SerializeVisibilityMemo(nil, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.Nil(nilMemo)
+
+			mProto, err := serializer.SerializeVisibilityMemo(memo0, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(mProto)
+
+			// deserialize event
+
+			dNilEvent, err := serializer.DeserializeEvent(nilEvent)
+			s.Nil(err)
+			s.Nil(dNilEvent)
+
+			event2, err := serializer.DeserializeEvent(dProto)
+			s.Nil(err)
+			s.True(reflect.DeepEqual(event0, event2))
+
+			// deserialize events
+
+			dNilEvents, err := serializer.DeserializeEvents(nilEvents)
+			s.Nil(err)
+			s.Nil(dNilEvents)
+
+			events, err := serializer.DeserializeEvents(dsProto)
+			history2 := &historypb.History{Events: events}
+			s.Nil(err)
+			s.True(reflect.DeepEqual(history0, history2))
+
+			// deserialize visibility memo
+
+			dNilMemo, err := serializer.DeserializeVisibilityMemo(nilMemo)
+			s.Nil(err)
+			s.Equal(&commonpb.Memo{}, dNilMemo)
+
+			memo2, err := serializer.DeserializeVisibilityMemo(mProto)
+			s.Nil(err)
+			s.True(reflect.DeepEqual(memo0, memo2))
+
+			// serialize reset points
+
+			nilResetPoints, err := serializer.SerializeResetPoints(nil, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(nilResetPoints)
+
+			_, err = serializer.SerializeResetPoints(resetPoints0, enumspb.ENCODING_TYPE_UNSPECIFIED)
+			s.NotNil(err)
+			_, ok = err.(*UnknownEncodingTypeError)
+			s.True(ok)
+
+			resetPointsProto, err := serializer.SerializeResetPoints(resetPoints0, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(resetPointsProto)
+
+			// deserialize reset points
+
+			dNilResetPoints1, err := serializer.DeserializeResetPoints(nil)
+			s.Nil(err)
+			s.Equal(&workflowpb.ResetPoints{}, dNilResetPoints1)
+
+			dNilResetPoints2, err := serializer.DeserializeResetPoints(nilResetPoints)
+			s.Nil(err)
+			s.Equal(&workflowpb.ResetPoints{}, dNilResetPoints2)
+
+			resetPoints2, err := serializer.DeserializeResetPoints(resetPointsProto)
+			s.Nil(err)
+			s.True(reflect.DeepEqual(resetPoints2, resetPoints0))
+
+			// serialize bad binaries
+
+			nilBadBinaries, err := serializer.SerializeBadBinaries(nil, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(nilBadBinaries)
+
+			_, err = serializer.SerializeBadBinaries(badBinaries0, enumspb.ENCODING_TYPE_UNSPECIFIED)
+			s.NotNil(err)
+			_, ok = err.(*UnknownEncodingTypeError)
+			s.True(ok)
+
+			badBinariesProto, err := serializer.SerializeBadBinaries(badBinaries0, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(badBinariesProto)
+
+			// deserialize bad binaries
+
+			dNilBadBinaries1, err := serializer.DeserializeBadBinaries(nil)
+			s.Nil(err)
+			s.Equal(&namespacepb.BadBinaries{}, dNilBadBinaries1)
+
+			dNilBadBinaries2, err := serializer.DeserializeBadBinaries(nilBadBinaries)
+			s.Nil(err)
+			s.Equal(&namespacepb.BadBinaries{}, dNilBadBinaries2)
+
+			badBinaries2, err := serializer.DeserializeBadBinaries(badBinariesProto)
+			s.Nil(err)
+			s.True(reflect.DeepEqual(badBinaries2, badBinaries0))
+
+			// VisibilityTaskInfo
+			nilVisibilityTaskInfo, err := serializer.VisibilityTaskInfoToBlob(nil, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(nilVisibilityTaskInfo)
+
+			_, err = serializer.VisibilityTaskInfoToBlob(visibilityTaskInfo0, enumspb.ENCODING_TYPE_UNSPECIFIED)
+			s.NotNil(err)
+			_, ok = err.(*UnknownEncodingTypeError)
+			s.True(ok)
+
+			visibilityTaskInfoProto, err := serializer.VisibilityTaskInfoToBlob(visibilityTaskInfo0, enumspb.ENCODING_TYPE_PROTO3)
+			s.Nil(err)
+			s.NotNil(visibilityTaskInfoProto)
+		}()
+	}
+
+	startWG.Done()
+	succ := common.AwaitWaitGroup(&doneWG, 10*time.Second)
+	s.True(succ, "test timed out")
+}

--- a/go.mod
+++ b/go.mod
@@ -69,9 +69,9 @@ require (
 	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.16.0
 	golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b // indirect
-	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
+	golang.org/x/tools v0.1.1 // indirect
 	google.golang.org/api v0.45.0
 	google.golang.org/grpc v1.37.0
 	google.golang.org/grpc/examples v0.0.0-20210426212906-52a707c0dafe

--- a/go.sum
+++ b/go.sum
@@ -398,6 +398,7 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
+github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=
 go.opencensus.io v0.22.2/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
@@ -514,6 +515,7 @@ golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
+golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -586,10 +588,12 @@ golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210317225723-c4fcb01b228e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210412220455-f1c623a9e750/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210426230700-d19ff857e887 h1:dXfMednGJh/SUUFjTLsWJz3P+TQt9qnR11GgeI3vWKs=
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007 h1:gG67DSER+11cZvqIMb8S8bt0vZtiN6xWYARwirrOSfE=
+golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -658,8 +662,9 @@ golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
+golang.org/x/tools v0.1.1 h1:wGiQel/hW0NnEkJUk8lbzkX2gFJU6PFxf1v5OlCfuOs=
+golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added a new interface Serializer that contains all methods defined in PayloadSerializer and methods defined in common/persistence/seraliazation/blob.go.

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to move all seralization/deseralization logic to the layer above persistence. The data layer will then use this new interface to do seralization/deseralization, and persistence layer will only deal with DataBlob. This will enforce abstract layering. Follow up PRs will convert existing persistence layer code to avoid doing seralization/deseralization.

Also related to #1531 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This is new separated code that is not hooked up with system yet. Tested in unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.