### PR TITLE
Add Attr properties to Elasticsearch GetMapping API

### DIFF
--- a/common/persistence/elasticsearch/client/client_v7.go
+++ b/common/persistence/elasticsearch/client/client_v7.go
@@ -299,6 +299,36 @@ func convertMappingBody(esMapping map[string]interface{}, indexName string) map[
 	}
 
 	for fieldName, fieldProp := range propMap {
+		if fieldName == "Attr" {
+			attrFieldMap, ok := fieldProp.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			attrFieldProp, ok := attrFieldMap["properties"]
+			if !ok {
+				continue
+			}
+			attrBodyMap, ok := attrFieldProp.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for fieldName, fieldProp := range attrBodyMap {
+				fieldPropMap, ok := fieldProp.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				tYpe, ok := fieldPropMap["type"]
+				if !ok {
+					continue
+				}
+				typeStr, ok := tYpe.(string)
+				if !ok {
+					continue
+				}
+				result["Attr."+fieldName] = typeStr
+			}
+		}
+
 		fieldPropMap, ok := fieldProp.(map[string]interface{})
 		if !ok {
 			continue

--- a/common/persistence/elasticsearch/client/client_v7.go
+++ b/common/persistence/elasticsearch/client/client_v7.go
@@ -26,11 +26,13 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/olivere/elastic/v7"
+	"go.temporal.io/server/common/searchattribute"
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
@@ -299,7 +301,7 @@ func convertMappingBody(esMapping map[string]interface{}, indexName string) map[
 	}
 
 	for fieldName, fieldProp := range propMap {
-		if fieldName == "Attr" {
+		if fieldName == searchattribute.Attr {
 			attrFieldMap, ok := fieldProp.(map[string]interface{})
 			if !ok {
 				continue
@@ -325,7 +327,7 @@ func convertMappingBody(esMapping map[string]interface{}, indexName string) map[
 				if !ok {
 					continue
 				}
-				result["Attr."+fieldName] = typeStr
+				result[fmt.Sprintf("%s.%s", searchattribute.Attr, fieldName)] = typeStr
 			}
 		}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `Attr` properties to Elasticsearch `GetMapping` API.

<!-- Tell your future self why have you made these changes -->
**Why?**
Because we are releasing the current version of search attributes storage which uses `Attr` prefix for custom search attributes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.