### PR TITLE
Remove CLI flags for security tokens

### DIFF
--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -1562,7 +1562,6 @@ func registerNamespaceRequest(
 		},
 		ActiveClusterName:       cluster.TestCurrentClusterName,
 		Data:                    make(map[string]string),
-		SecurityToken:           "token",
 		HistoryArchivalState:    historyArchivalState,
 		HistoryArchivalUri:      historyArchivalURI,
 		VisibilityArchivalState: visibilityArchivalState,

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -164,8 +164,6 @@ const (
 	FlagActivityIDWithAlias                   = FlagActivityID + ", aid"
 	FlagMaxFieldLength                        = "max_field_length"
 	FlagMaxFieldLengthWithAlias               = FlagMaxFieldLength + ", maxl"
-	FlagSecurityToken                         = "security_token"
-	FlagSecurityTokenWithAlias                = FlagSecurityToken + ", st"
 	FlagSkipErrorMode                         = "skip_errors"
 	FlagSkipErrorModeWithAlias                = FlagSkipErrorMode + ", serr"
 	FlagHeadersMode                           = "headers"

--- a/tools/cli/namespaceCommands.go
+++ b/tools/cli/namespaceCommands.go
@@ -84,7 +84,6 @@ func (d *namespaceCLIImpl) RegisterNamespace(c *cli.Context) {
 	if c.IsSet(FlagRetentionDays) {
 		retentionDays = c.Int(FlagRetentionDays)
 	}
-	securityToken := c.String(FlagSecurityToken)
 	var err error
 
 	var isGlobalNamespace bool
@@ -136,7 +135,6 @@ func (d *namespaceCLIImpl) RegisterNamespace(c *cli.Context) {
 		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(time.Duration(retentionDays) * time.Hour * 24),
 		Clusters:                         clusters,
 		ActiveClusterName:                activeClusterName,
-		SecurityToken:                    securityToken,
 		HistoryArchivalState:             archivalState(c, FlagHistoryArchivalState),
 		HistoryArchivalUri:               c.String(FlagHistoryArchivalURI),
 		VisibilityArchivalState:          archivalState(c, FlagVisibilityArchivalState),
@@ -271,8 +269,6 @@ func (d *namespaceCLIImpl) UpdateNamespace(c *cli.Context) {
 		}
 	}
 
-	securityToken := c.String(FlagSecurityToken)
-	updateRequest.SecurityToken = securityToken
 	err := d.updateNamespace(ctx, updateRequest)
 	if err != nil {
 		if _, ok := err.(*serviceerror.NotFound); !ok {

--- a/tools/cli/namespaceUtils.go
+++ b/tools/cli/namespaceUtils.go
@@ -85,10 +85,6 @@ var (
 			Usage: "Namespace data of key value pairs, in format of k1:v1,k2:v2,k3:v3",
 		},
 		cli.StringFlag{
-			Name:  FlagSecurityTokenWithAlias,
-			Usage: "Optional token for security check",
-		},
-		cli.StringFlag{
 			Name:  FlagHistoryArchivalStateWithAlias,
 			Usage: "Flag to set history archival state, valid values are \"disabled\" and \"enabled\"",
 		},
@@ -133,10 +129,6 @@ var (
 		cli.StringFlag{
 			Name:  FlagNamespaceDataWithAlias,
 			Usage: "Namespace data of key value pairs, in format of k1:v1,k2:v2,k3:v3 ",
-		},
-		cli.StringFlag{
-			Name:  FlagSecurityTokenWithAlias,
-			Usage: "Optional token for security check",
 		},
 		cli.StringFlag{
 			Name:  FlagHistoryArchivalStateWithAlias,


### PR DESCRIPTION
**What changed?**
Removed CLI flags for security tokens.

**Why?**
They aren't actually used anywhere and only confuse users.

**How did you test it?**
Unit tests.

**Potential risks**
I don't see any.

**Is hotfix candidate?**
No.