### PR TITLE
Fix error type if query task already gone

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -371,7 +371,7 @@ pollLoop:
 			})
 			if err != nil {
 				// will notify query client that the query task failed
-				e.deliverQueryResult(task.query.taskID, &queryResult{internalError: err}) // nolint:errcheck
+				_ = e.deliverQueryResult(task.query.taskID, &queryResult{internalError: err})
 				return emptyPollWorkflowTaskQueueResponse, nil
 			}
 
@@ -548,7 +548,7 @@ func (e *matchingEngineImpl) RespondQueryTaskCompleted(
 func (e *matchingEngineImpl) deliverQueryResult(taskID string, queryResult *queryResult) error {
 	queryResultCh, ok := e.lockableQueryTaskMap.get(taskID)
 	if !ok {
-		return serviceerror.NewInternal("query task not found, or already expired")
+		return serviceerror.NewNotFound("query task not found, or already expired")
 	}
 	queryResultCh <- queryResult
 	return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* If query task is gone, return not found instead of internal server error

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix error type

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No