### PR TITLE
Emits warning/error logs when Temporal tries/fails to establish a new GoCQL session

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceTest.go
+++ b/common/persistence/cassandra/cassandraPersistenceTest.go
@@ -151,6 +151,7 @@ func (s *TestCluster) CreateSession(
 			},
 		},
 		resolver.NewNoopResolver(),
+		log.NewNoopLogger(),
 	)
 	if err != nil {
 		s.logger.Fatal("CreateSession", tag.Error(err))

--- a/common/persistence/cassandra/factory.go
+++ b/common/persistence/cassandra/factory.go
@@ -60,7 +60,7 @@ func NewFactory(
 	clusterName string,
 	logger log.Logger,
 ) *Factory {
-	session, err := gocql.NewSession(cfg, r)
+	session, err := gocql.NewSession(cfg, r, logger)
 	if err != nil {
 		logger.Fatal("unable to initialize cassandra session", tag.Error(err))
 	}

--- a/common/persistence/cassandra/version_checker.go
+++ b/common/persistence/cassandra/version_checker.go
@@ -26,6 +26,7 @@ package cassandra
 
 import (
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/persistence/schema"
 	"go.temporal.io/server/common/resolver"
@@ -81,7 +82,7 @@ func checkCompatibleVersion(
 	expectedVersion string,
 ) error {
 
-	session, err := gocql.NewSession(cfg, r)
+	session, err := gocql.NewSession(cfg, r, log.NewNoopLogger())
 	if err != nil {
 		return err
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go
@@ -130,7 +130,7 @@ func (q *query) handleError(
 ) {
 	switch err {
 	case gocql.ErrNoConnections:
-		_ = q.session.refresh()
+		q.session.refresh()
 	default:
 		// noop
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -105,7 +105,7 @@ func (s *session) refresh() {
 	oldSession := s.Value.Load().(*gocql.Session)
 	s.Value.Store(newSession)
 	oldSession.Close()
-	s.logger.Warn("successfully refresshed cql session")
+	s.logger.Warn("successfully refreshed cql session")
 }
 
 func initSession(
@@ -127,6 +127,7 @@ func (s *session) Query(
 	if q == nil {
 		return nil
 	}
+
 	return &query{
 		session:    s,
 		gocqlQuery: q,

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -97,7 +97,7 @@ func SetupCassandraDatabase(cfg *config.Cassandra) {
 	// NOTE need to connect with empty name to create new database
 	adminCfg.Keyspace = "system"
 
-	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver())
+	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver(), log.NewNoopLogger())
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}
@@ -115,7 +115,7 @@ func SetupCassandraDatabase(cfg *config.Cassandra) {
 }
 
 func SetupCassandraSchema(cfg *config.Cassandra) {
-	session, err := gocql.NewSession(*cfg, resolver.NewNoopResolver())
+	session, err := gocql.NewSession(*cfg, resolver.NewNoopResolver(), log.NewNoopLogger())
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}
@@ -159,7 +159,7 @@ func TearDownCassandraKeyspace(cfg *config.Cassandra) {
 	// NOTE need to connect with empty name to create new database
 	adminCfg.Keyspace = "system"
 
-	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver())
+	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver(), log.NewNoopLogger())
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}

--- a/tests/integration/cassandra_test.go
+++ b/tests/integration/cassandra_test.go
@@ -84,7 +84,7 @@ func SetupCassandraDatabase(cfg *config.Cassandra) {
 	// NOTE need to connect with empty name to create new database
 	adminCfg.Keyspace = "system"
 
-	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver())
+	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver(), log.NewNoopLogger())
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}
@@ -102,7 +102,7 @@ func SetupCassandraDatabase(cfg *config.Cassandra) {
 }
 
 func SetupCassandraSchema(cfg *config.Cassandra) {
-	session, err := gocql.NewSession(*cfg, resolver.NewNoopResolver())
+	session, err := gocql.NewSession(*cfg, resolver.NewNoopResolver(), log.NewNoopLogger())
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}
@@ -146,7 +146,7 @@ func TearDownCassandraKeyspace(cfg *config.Cassandra) {
 	// NOTE need to connect with empty name to create new database
 	adminCfg.Keyspace = "system"
 
-	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver())
+	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver(), log.NewNoopLogger())
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -33,6 +33,7 @@ import (
 
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
+	tlog "go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/tools/common/schema"
@@ -107,7 +108,7 @@ func newCQLClient(cfg *CQLClientConfig) (*cqlClient, error) {
 	cassandraConfig.ConnectTimeout = time.Duration(cfg.Timeout) * time.Second
 
 	log.Println("validating connection to cassandra cluster")
-	session, err := gocql.NewSession(*cassandraConfig, resolver.NewNoopResolver())
+	session, err := gocql.NewSession(*cassandraConfig, resolver.NewNoopResolver(), tlog.NewNoopLogger())
 	if err != nil {
 		log.Printf("connection validation failed: %+v\r\n", err)
 		return nil, err

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -312,7 +312,7 @@ func connectToCassandra(c *cli.Context) gocql.Session {
 		}
 	}
 
-	session, err := gocql.NewSession(cassandraConfig, resolver.NewNoopResolver())
+	session, err := gocql.NewSession(cassandraConfig, resolver.NewNoopResolver(), log.NewNoopLogger())
 	if err != nil {
 		ErrorAndExit("connect to Cassandra failed", err)
 	}


### PR DESCRIPTION
Adds additional logging on GoCQL session refresh attempts, failures and successes. This will help us diagnose instances where we've seen Temporal unable to re-establish a connection to a rolled Cassandra cluster by giving us more logging information. This is a low-risk change as it is just adding more logging.

