### PR TITLE
Make sync match wait time configurable

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -137,7 +137,7 @@ var Keys = map[Key]string{
 	MatchingMinTaskThrottlingBurstSize:      "matching.minTaskThrottlingBurstSize",
 	MatchingGetTasksBatchSize:               "matching.getTasksBatchSize",
 	MatchingLongPollExpirationInterval:      "matching.longPollExpirationInterval",
-	MatchingEnableSyncMatch:                 "matching.enableSyncMatch",
+	MatchingSyncMatchWaitDuration:           "matching.syncMatchWaitDuration",
 	MatchingUpdateAckInterval:               "matching.updateAckInterval",
 	MatchingIdleTaskqueueCheckInterval:      "matching.idleTaskqueueCheckInterval",
 	MaxTaskqueueIdleTime:                    "matching.maxTaskqueueIdleTime",
@@ -498,8 +498,8 @@ const (
 	MatchingGetTasksBatchSize
 	// MatchingLongPollExpirationInterval is the long poll expiration interval in the matching service
 	MatchingLongPollExpirationInterval
-	// MatchingEnableSyncMatch is to enable sync match
-	MatchingEnableSyncMatch
+	// MatchingSyncMatchWaitDuration is to wait time for sync match
+	MatchingSyncMatchWaitDuration
 	// MatchingUpdateAckInterval is the interval for update ack
 	MatchingUpdateAckInterval
 	// MatchingIdleTaskqueueCheckInterval is the IdleTaskqueueCheckInterval

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -124,11 +124,6 @@ type (
 	}
 )
 
-const (
-	// maxSyncMatchWaitTime is the max amount of time that we are willing to wait for a sync match to happen
-	maxSyncMatchWaitTime = 200 * time.Millisecond
-)
-
 var _ taskQueueManager = (*taskQueueManagerImpl)(nil)
 
 var errRemoteSyncMatchFailed = serviceerror.NewCanceled("remote sync match failed")
@@ -495,7 +490,7 @@ func (c *taskQueueManagerImpl) executeWithRetry(
 }
 
 func (c *taskQueueManagerImpl) trySyncMatch(ctx context.Context, params addTaskParams) (bool, error) {
-	childCtx, cancel := c.newChildContext(ctx, maxSyncMatchWaitTime, time.Second)
+	childCtx, cancel := c.newChildContext(ctx, c.config.SyncMatchWaitDuration(), time.Second)
 
 	// Mocking out TaskId for syncmatch as it hasn't been allocated yet
 	fakeTaskIdWrapper := &persistencespb.AllocatedTaskInfo{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Make sync match wait time configurable, dynamic config key: `matching.syncMatchWaitDuration`
* Remove unused MatchingEnableSyncMatch dynamic config since sync match should always be enabled

<!-- Tell your future self why have you made these changes -->
**Why?**
Make sync match wait time configurable

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A