### PR TITLE
Emit dedicated metrics for context cancelled

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1616,6 +1616,7 @@ const (
 	ServiceErrNamespaceAlreadyExistsCounter
 	ServiceErrCancellationAlreadyRequestedCounter
 	ServiceErrQueryFailedCounter
+	ServiceErrContextCancelledCounter
 	ServiceErrContextTimeoutCounter
 	ServiceErrRetryTaskCounter
 	ServiceErrBadBinaryCounter
@@ -2044,6 +2045,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ServiceErrNamespaceAlreadyExistsCounter:             {metricName: "service_errors_namespace_already_exists", metricType: Counter},
 		ServiceErrCancellationAlreadyRequestedCounter:       {metricName: "service_errors_cancellation_already_requested", metricType: Counter},
 		ServiceErrQueryFailedCounter:                        {metricName: "service_errors_query_failed", metricType: Counter},
+		ServiceErrContextCancelledCounter:                   {metricName: "service_errors_context_cancelled", metricType: Counter},
 		ServiceErrContextTimeoutCounter:                     {metricName: "service_errors_context_timeout", metricType: Counter},
 		ServiceErrRetryTaskCounter:                          {metricName: "service_errors_retry_task", metricType: Counter},
 		ServiceErrBadBinaryCounter:                          {metricName: "service_errors_bad_binary", metricType: Counter},

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -145,8 +145,12 @@ func (ti *TelemetryInterceptor) handleError(
 	err error,
 ) {
 
-	if common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err) {
+	if common.IsContextDeadlineExceededErr(err) {
 		scope.IncCounter(metrics.ServiceErrContextTimeoutCounter)
+		return
+	}
+	if common.IsContextCanceledErr(err) {
+		scope.IncCounter(metrics.ServiceErrContextCancelledCounter)
 		return
 	}
 

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -410,7 +410,7 @@ pollLoop:
 	}
 }
 
-// pollForActivityTaskOperation takes one task from the task manager, update workflow execution history, mark task as
+// PollActivityTaskQueue takes one task from the task manager, update workflow execution history, mark task as
 // completed and return it to user. If a task from task manager is already started, return an empty response, without
 // error. Timeouts handled by the timer queue.
 func (e *matchingEngineImpl) PollActivityTaskQueue(

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -181,7 +181,7 @@ func newTaskQueueManager(
 	return tlMgr, nil
 }
 
-// Starts reading pump for the given task queue.
+// Start reading pump for the given task queue.
 // The pump fills up taskBuffer from persistence.
 func (c *taskQueueManagerImpl) Start() error {
 	defer c.startWG.Done()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Split ServiceErrContextTimeoutCounter metrics into ServiceErrContextTimeoutCounter and ServiceErrContextCancelledCounter
* ServiceErrContextCancelledCounter metrics indicates request being cancelled
* ServiceErrContextTimeoutCounter metrics indicates timeout

<!-- Tell your future self why have you made these changes -->
**Why?**
Use dedicated metrics for dedicated error.
Matching to matching task forwarding will return `*serviceerror.Canceled` which will emit `ServiceErrContextCancelledCounter` metrics
ref: https://github.com/temporalio/temporal/blob/v1.10.2/service/matching/taskQueueManager.go#L129

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A