### PR TITLE
Fix auto-setup.sh for PostgreSQL

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -177,11 +177,16 @@ setup_postgres_schema() {
     { export SQL_PASSWORD=${POSTGRES_PWD}; } 2> /dev/null
 
     SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/temporal/versioned
-    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${DBNAME}"
+    # Create database only if its name different from user name. Otherwise PostgreSQL container will create db itself.
+    if [ "${DBNAME}" != "${POSTGRES_USER}" ]; then
+        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${DBNAME}"
+    fi
     temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" setup-schema -v 0.0
     temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${DBNAME}" update-schema -d "${SCHEMA_DIR}"
     VISIBILITY_SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/visibility/versioned
-    temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${VISIBILITY_DBNAME}"
+    if [ "${VISIBILITY_DBNAME}" != "${POSTGRES_USER}" ]; then
+        temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${VISIBILITY_DBNAME}"
+    fi
     temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" setup-schema -v 0.0
     temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" --db "${VISIBILITY_DBNAME}" update-schema -d "${VISIBILITY_SCHEMA_DIR}"
 }

--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -177,7 +177,7 @@ setup_postgres_schema() {
     { export SQL_PASSWORD=${POSTGRES_PWD}; } 2> /dev/null
 
     SCHEMA_DIR=${TEMPORAL_HOME}/schema/postgresql/v96/temporal/versioned
-    # Create database only if its name different from user name. Otherwise PostgreSQL container will create db itself.
+    # Create database only if its name is different from the user name. Otherwise PostgreSQL container itself will create database.
     if [ "${DBNAME}" != "${POSTGRES_USER}" ]; then
         temporal-sql-tool --plugin postgres --ep "${POSTGRES_SEEDS}" -u "${POSTGRES_USER}" -p "${DB_PORT}" create --db "${DBNAME}"
     fi


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix auto-setup.sh for PostgreSQL. Extra check added.

<!-- Tell your future self why have you made these changes -->
**Why?**
PostgreSQL container automatically creates a database with `POSTGRES_USER` name. Another attempt to create this database fails the `auto-setup.sh` script.

Closes #1613.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Built image locally and run it with docker-compose.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Partially. Worth to pick it up for the next patch release but doesn't worth to create patch release with just this change.