### PR TITLE
Add minimum date validation

### DIFF
--- a/common/persistence/elasticsearch/visibility_store.go
+++ b/common/persistence/elasticsearch/visibility_store.go
@@ -719,24 +719,31 @@ func (s *visibilityStore) getNextPageToken(token []byte) (*visibilityPageToken, 
 func (s *visibilityStore) getSearchResult(request *persistence.ListWorkflowExecutionsRequest, token *visibilityPageToken,
 	boolQuery *elastic.BoolQuery, overStartTime bool) (*elastic.SearchResult, error) {
 
-	matchNamespaceQuery := elastic.NewMatchQuery(searchattribute.NamespaceID, request.NamespaceID)
-	var rangeQuery *elastic.RangeQuery
-	if overStartTime {
-		rangeQuery = elastic.NewRangeQuery(searchattribute.StartTime)
-	} else {
-		rangeQuery = elastic.NewRangeQuery(searchattribute.CloseTime)
-	}
-
-	rangeQuery = rangeQuery.
-		Gte(request.EarliestStartTime).
-		Lte(request.LatestStartTime)
-
 	query := elastic.NewBoolQuery()
 	if boolQuery != nil {
 		*query = *boolQuery
 	}
 
-	query = query.Must(matchNamespaceQuery).Filter(rangeQuery)
+	matchNamespaceQuery := elastic.NewMatchQuery(searchattribute.NamespaceID, request.NamespaceID)
+	query = query.Must(matchNamespaceQuery)
+
+	if !request.EarliestStartTime.IsZero() && !request.LatestStartTime.IsZero() {
+		var rangeQuery *elastic.RangeQuery
+		if overStartTime {
+			rangeQuery = elastic.NewRangeQuery(searchattribute.StartTime)
+		} else {
+			rangeQuery = elastic.NewRangeQuery(searchattribute.CloseTime)
+		}
+
+		if !request.EarliestStartTime.IsZero() {
+			rangeQuery = rangeQuery.Gte(request.EarliestStartTime)
+		}
+
+		if !request.LatestStartTime.IsZero() {
+			rangeQuery = rangeQuery.Lte(request.LatestStartTime)
+		}
+		query = query.Filter(rangeQuery)
+	}
 
 	ctx := context.Background()
 	params := &client.SearchParameters{

--- a/common/persistence/elasticsearch/visibility_store.go
+++ b/common/persistence/elasticsearch/visibility_store.go
@@ -727,7 +727,7 @@ func (s *visibilityStore) getSearchResult(request *persistence.ListWorkflowExecu
 	matchNamespaceQuery := elastic.NewMatchQuery(searchattribute.NamespaceID, request.NamespaceID)
 	query = query.Must(matchNamespaceQuery)
 
-	if !request.EarliestStartTime.IsZero() && !request.LatestStartTime.IsZero() {
+	if !request.EarliestStartTime.IsZero() || !request.LatestStartTime.IsZero() {
 		var rangeQuery *elastic.RangeQuery
 		if overStartTime {
 			rangeQuery = elastic.NewRangeQuery(searchattribute.StartTime)

--- a/host/testdata/es_v7_index_template.json
+++ b/host/testdata/es_v7_index_template.json
@@ -61,7 +61,7 @@
         "type": "boolean"
       },
       "CustomDatetimeField": {
-        "type": "date"
+        "type": "date_nanos"
       },
       "CustomNamespace": {
         "type": "keyword"

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -78,6 +78,7 @@ const (
 var _ Handler = (*WorkflowHandler)(nil)
 
 var (
+	minTime = time.Unix(0, 0).UTC()
 	maxTime = time.Date(2100, 1, 1, 1, 0, 0, 0, time.UTC)
 )
 
@@ -2187,6 +2188,10 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context, reque
 		request.StartTimeFilter = &filterpb.StartTimeFilter{}
 	}
 
+	if timestamp.TimeValue(request.GetStartTimeFilter().GetEarliestTime()).IsZero() {
+		request.GetStartTimeFilter().EarliestTime = &minTime
+	}
+
 	if timestamp.TimeValue(request.GetStartTimeFilter().GetLatestTime()).IsZero() {
 		request.GetStartTimeFilter().LatestTime = &maxTime
 	}
@@ -2278,6 +2283,10 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context, req
 
 	if request.StartTimeFilter == nil {
 		request.StartTimeFilter = &filterpb.StartTimeFilter{}
+	}
+
+	if timestamp.TimeValue(request.GetStartTimeFilter().GetEarliestTime()).IsZero() {
+		request.GetStartTimeFilter().EarliestTime = &minTime
 	}
 
 	if timestamp.TimeValue(request.GetStartTimeFilter().GetLatestTime()).IsZero() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add minimum date validation on both front end and persistence level.

<!-- Tell your future self why have you made these changes -->
**Why?**
Without this validation empty dates (`time.Time{}`) cause Elasticsearch to fail the query. `date_nanos` doesn't support dates bellow Unix epoch.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests and manual queries.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.