### PR TITLE
Fix Elasticsearch metrics and memo encoding

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -684,6 +684,9 @@ const (
 	// BlobstoreClientDirectoryExistsScope tracks DirectoryExists calls to blobstore
 	BlobstoreClientDirectoryExistsScope
 
+	// ElasticSearchVisibility is scope used by all metric emitted by esProcessor
+	ElasticSearchVisibility
+
 	NumCommonScopes
 )
 
@@ -1028,9 +1031,6 @@ const (
 	ReplicationTaskCleanupScope
 	// ReplicationDLQStatsScope is scope used by all metrics emitted related to replication DLQ
 	ReplicationDLQStatsScope
-
-	// ElasticSearchVisibility is scope used by all metric emitted by esProcessor
-	ElasticSearchVisibility
 
 	NumHistoryScopes
 )
@@ -1384,6 +1384,8 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		BlobstoreClientExistsScope:          {operation: "BlobstoreClientExists", tags: map[string]string{ServiceRoleTagName: BlobstoreRoleTagValue}},
 		BlobstoreClientDeleteScope:          {operation: "BlobstoreClientDelete", tags: map[string]string{ServiceRoleTagName: BlobstoreRoleTagValue}},
 		BlobstoreClientDirectoryExistsScope: {operation: "BlobstoreClientDirectoryExists", tags: map[string]string{ServiceRoleTagName: BlobstoreRoleTagValue}},
+
+		ElasticSearchVisibility: {operation: "ElasticSearchVisibility"},
 	},
 	// Frontend Scope Names
 	Frontend: {
@@ -1556,7 +1558,6 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ReplicationTaskFetcherScope:               {operation: "ReplicationTaskFetcher"},
 		ReplicationTaskCleanupScope:               {operation: "ReplicationTaskCleanup"},
 		ReplicationDLQStatsScope:                  {operation: "ReplicationDLQStats"},
-		ElasticSearchVisibility:                   {operation: "ElasticSearchVisibility"},
 		SyncShardTaskScope:                        {operation: "SyncShardTask"},
 		SyncActivityTaskScope:                     {operation: "SyncActivityTask"},
 		HistoryMetadataReplicationTaskScope:       {operation: "HistoryMetadataReplicationTask"},
@@ -1747,6 +1748,9 @@ const (
 
 	AddSearchAttributesWorkflowSuccessCount
 	AddSearchAttributesWorkflowFailuresCount
+
+	ESInvalidSearchAttribute
+
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
 
@@ -1926,7 +1930,6 @@ const (
 	ESBulkProcessorFailures
 	ESBulkProcessorCorruptedData
 	ESBulkProcessorRequestLatency
-	ESInvalidSearchAttribute
 
 	NumHistoryMetrics
 )
@@ -2197,6 +2200,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ServiceErrAuthorizeFailedPerTaskQueueCounter: {
 			metricName: "service_errors_authorize_failed_per_tl", metricRollupName: "service_errors_authorize_failed", metricType: Counter,
 		},
+		ESInvalidSearchAttribute: {metricName: "es_invalid_search_attribute"},
 	},
 	History: {
 		TaskRequests:                                      {metricName: "task_requests", metricType: Counter},
@@ -2370,7 +2374,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ESBulkProcessorFailures:       {metricName: "es_bulk_processor_errors"},
 		ESBulkProcessorCorruptedData:  {metricName: "es_bulk_processor_corrupted_data"},
 		ESBulkProcessorRequestLatency: {metricName: "es_bulk_processor_request_latency", metricType: Timer},
-		ESInvalidSearchAttribute:      {metricName: "es_invalid_search_attribute"},
 	},
 	Matching: {
 		PollSuccessPerTaskQueueCounter:            {metricName: "poll_success_per_tl", metricRollupName: "poll_success"},

--- a/common/persistence/elasticsearch/visibility_store.go
+++ b/common/persistence/elasticsearch/visibility_store.go
@@ -27,6 +27,7 @@ package elasticsearch
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -904,6 +905,10 @@ func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchatt
 		s.logger.Error("Unable to parse JSON date while parsing Elasticsearch document.", tag.Name(fieldName), tag.ValueType(fieldValue), tag.Error(err), tag.ESDocID(docID))
 		s.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESInvalidSearchAttribute)
 	}
+	logMemoDecodeError := func(err error, docID string) {
+		s.logger.Error("Unable to base64 decode Memo field while parsing Elasticsearch document.", tag.Error(err), tag.ESDocID(docID))
+		s.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESInvalidSearchAttribute)
+	}
 
 	var sourceMap map[string]interface{}
 	d := json.NewDecoder(bytes.NewReader(hit.Source))
@@ -964,8 +969,13 @@ func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchatt
 				logDateParseError(fieldName, closeTime, err, hit.Id)
 			}
 		case searchattribute.Memo:
-			if memo, isValidType = fieldValue.([]byte); !isValidType {
+			var memoStr string
+			if memoStr, isValidType = fieldValue.(string); !isValidType {
 				logUnexpectedType(fieldName, fieldValue, hit.Id)
+			}
+			var err error
+			if memo, err = base64.StdEncoding.DecodeString(memoStr); err != nil {
+				logMemoDecodeError(err, hit.Id)
 			}
 		case searchattribute.Encoding:
 			if memoEncoding, isValidType = fieldValue.(string); !isValidType {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix Elasticsearch metrics and memo encoding.

<!-- Tell your future self why have you made these changes -->
**Why?**
ES metrics definitions were places incorrectly and didn't properly work for "read" path. Also memo is returned as `string` not `[]byte` and require custom `base64` decoding.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.