### PR TITLE
Use scaled_float instead of double for Double search attributes

### DIFF
--- a/common/persistence/elasticsearch/client/client_v7.go
+++ b/common/persistence/elasticsearch/client/client_v7.go
@@ -256,9 +256,13 @@ func getLoggerOptions(logLevel string, logger log.Logger) []elastic.ClientOption
 func buildMappingBody(mapping map[string]string) map[string]interface{} {
 	properties := make(map[string]interface{}, len(mapping))
 	for fieldName, fieldType := range mapping {
-		properties[fieldName] = map[string]interface{}{
+		typeMap := map[string]interface{}{
 			"type": fieldType,
 		}
+		if fieldType == "scaled_float" {
+			typeMap["scaling_factor"] = 10000
+		}
+		properties[fieldName] = typeMap
 	}
 
 	body := map[string]interface{}{

--- a/common/searchattribute/search_attirbute.go
+++ b/common/searchattribute/search_attirbute.go
@@ -103,7 +103,7 @@ func MapESType(t enumspb.IndexedValueType, dateFieldType string) string {
 	case enumspb.INDEXED_VALUE_TYPE_INT:
 		return "long"
 	case enumspb.INDEXED_VALUE_TYPE_DOUBLE:
-		return "double"
+		return "scaled_float"
 	case enumspb.INDEXED_VALUE_TYPE_BOOL:
 		return "boolean"
 	case enumspb.INDEXED_VALUE_TYPE_DATETIME:

--- a/common/searchattribute/search_attribute_test.go
+++ b/common/searchattribute/search_attribute_test.go
@@ -190,7 +190,7 @@ func Test_MapESType(t *testing.T) {
 		{
 			input:         enumspb.INDEXED_VALUE_TYPE_DOUBLE,
 			dateFieldType: "",
-			expected:      "double",
+			expected:      "scaled_float",
 		},
 		{
 			input:         enumspb.INDEXED_VALUE_TYPE_BOOL,

--- a/host/testdata/es_v6_index_template.json
+++ b/host/testdata/es_v6_index_template.json
@@ -56,7 +56,8 @@
           "type": "long"
         },
         "CustomDoubleField": {
-          "type": "double"
+          "type": "scaled_float",
+          "scaling_factor": 10000
         },
         "CustomBoolField": {
           "type": "boolean"

--- a/host/testdata/es_v7_index_template.json
+++ b/host/testdata/es_v7_index_template.json
@@ -55,7 +55,8 @@
         "type": "long"
       },
       "CustomDoubleField": {
-        "type": "double"
+        "type": "scaled_float",
+        "scaling_factor": 10000
       },
       "CustomBoolField": {
         "type": "boolean"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use `scaled_float` instead of `double` for `Double` search attributes.

<!-- Tell your future self why have you made these changes -->
**Why?**
`scaled_float` is more suitable for search fields.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.