### PR TITLE
Convert Elasticsearch ExecutionStatus field to keyword

### DIFF
--- a/common/persistence/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/elasticsearch/visibility_store_read_test.go
@@ -922,6 +922,39 @@ func (s *ESVisibilitySuite) TestTimeProcessFunc() {
 	}
 }
 
+func (s *ESVisibilitySuite) TestStatusProcessFunc() {
+	cases := []struct {
+		key   string
+		value string
+	}{
+		{key: "query", value: "Completed"},
+		{key: "query", value: "1"},
+		{key: "query", value: "100"},
+		{key: "query", value: "BadStatus"},
+		{key: "unrelatedKey", value: "should not be modified"},
+	}
+	expected := []struct {
+		value     string
+		returnErr bool
+	}{
+		{value: `"Completed"`, returnErr: false},
+		{value: `"Running"`, returnErr: false},
+		{value: `""`, returnErr: false},
+		{value: `"BadStatus"`, returnErr: false},
+		{value: `"should not be modified"`, returnErr: false},
+	}
+
+	for i, testCase := range cases {
+		value := fastjson.MustParse(fmt.Sprintf(`{"%s": "%s"}`, testCase.key, testCase.value))
+		err := statusProcessFunc(nil, "", value)
+		if expected[i].returnErr {
+			s.Error(err)
+			continue
+		}
+		s.Equal(expected[i].value, value.Get(testCase.key).String())
+	}
+}
+
 func (s *ESVisibilitySuite) TestProcessAllValuesForKey() {
 	testJSONStr := `{
 		"arrayKey": [

--- a/common/persistence/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/elasticsearch/visibility_store_read_test.go
@@ -82,12 +82,12 @@ var (
 	}
 	errTestESSearch = errors.New("ES error")
 
-	filterOpen              = fmt.Sprintf("map[match:map[ExecutionStatus:map[query:%d]]]", enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
-	filterClose             = fmt.Sprintf("map[match:map[ExecutionStatus:map[query:%d]]]", enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
+	filterOpen              = fmt.Sprintf("map[match:map[ExecutionStatus:map[query:%s]]]", enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String())
+	filterClose             = fmt.Sprintf("map[match:map[ExecutionStatus:map[query:%s]]]", enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String())
 	filterByType            = fmt.Sprintf("map[match:map[WorkflowType:map[query:%s]]]", testWorkflowType)
 	filterByWID             = fmt.Sprintf("map[match:map[WorkflowId:map[query:%s]]]", testWorkflowID)
 	filterByRunID           = fmt.Sprintf("map[match:map[RunId:map[query:%s]]]", testRunID)
-	filterByExecutionStatus = fmt.Sprintf("map[match:map[ExecutionStatus:map[query:%d]]]", testStatus)
+	filterByExecutionStatus = fmt.Sprintf("map[match:map[ExecutionStatus:map[query:%s]]]", testStatus.String())
 )
 
 func createTestRequest() *persistence.ListWorkflowExecutionsRequest {
@@ -430,7 +430,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	s.Equal(0, len(resp.Executions))
 
 	// test for one hits
-	data := []byte(`{"ExecutionStatus": 1,
+	data := []byte(`{"ExecutionStatus": "Running",
           "CloseTime": "2021-06-11T16:04:07.980-07:00",
           "NamespaceId": "bfd5c907-f899-4baf-a7b2-2ab85e623ebd",
           "HistoryLength": 29,
@@ -543,7 +543,7 @@ func (s *ESVisibilitySuite) TestSerializePageToken() {
 
 func (s *ESVisibilitySuite) TestParseESDoc() {
 	searchHit := &elastic.SearchHit{
-		Source: []byte(`{"ExecutionStatus": 1,
+		Source: []byte(`{"ExecutionStatus": "Running",
           "NamespaceId": "bfd5c907-f899-4baf-a7b2-2ab85e623ebd",
           "HistoryLength": 29,
           "VisibilityTaskKey": "7-619",
@@ -565,7 +565,7 @@ func (s *ESVisibilitySuite) TestParseESDoc() {
 
 	// test for close
 	searchHit = &elastic.SearchHit{
-		Source: []byte(`{"ExecutionStatus": 2,
+		Source: []byte(`{"ExecutionStatus": "Completed",
           "CloseTime": "2021-06-11T16:04:07Z",
           "NamespaceId": "bfd5c907-f899-4baf-a7b2-2ab85e623ebd",
           "HistoryLength": 29,
@@ -777,7 +777,7 @@ func (s *ESVisibilitySuite) TestAddNamespaceToQuery() {
 func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 	s.mockESClient.EXPECT().SearchWithDSL(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, index, input string) (*elastic.SearchResult, error) {
-			s.True(strings.Contains(input, `{"match_phrase":{"ExecutionStatus":{"query":"5"}}}`))
+			s.True(strings.Contains(input, `{"match_phrase":{"ExecutionStatus":{"query":"Terminated"}}}`))
 			return testSearchResult, nil
 		})
 
@@ -785,7 +785,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 		NamespaceID: testNamespaceID,
 		Namespace:   testNamespace,
 		PageSize:    10,
-		Query:       `ExecutionStatus = 5`,
+		Query:       `ExecutionStatus = "Terminated"`,
 	}
 	_, err := s.visibilityStore.ListWorkflowExecutions(request)
 	s.NoError(err)
@@ -809,7 +809,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 	// test first page
 	s.mockESClient.EXPECT().ScrollFirstPage(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
 		func(ctx context.Context, index, input string) (*elastic.SearchResult, client.ScrollService, error) {
-			s.True(strings.Contains(input, `{"match_phrase":{"ExecutionStatus":{"query":"5"}}}`))
+			s.True(strings.Contains(input, `{"match_phrase":{"ExecutionStatus":{"query":"Terminated"}}}`))
 			return testSearchResult, nil, nil
 		})
 
@@ -817,7 +817,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 		NamespaceID: testNamespaceID,
 		Namespace:   testNamespace,
 		PageSize:    10,
-		Query:       `ExecutionStatus = 5`,
+		Query:       `ExecutionStatus = "Terminated"`,
 	}
 	_, err := s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
@@ -860,14 +860,14 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 	s.mockESClient.EXPECT().Count(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
 		func(ctx context.Context, index, input string) (int64, error) {
-			s.True(strings.Contains(input, `{"match_phrase":{"ExecutionStatus":{"query":"5"}}}`))
+			s.True(strings.Contains(input, `{"match_phrase":{"ExecutionStatus":{"query":"Terminated"}}}`))
 			return int64(1), nil
 		})
 
 	request := &persistence.CountWorkflowExecutionsRequest{
 		NamespaceID: testNamespaceID,
 		Namespace:   testNamespace,
-		Query:       `ExecutionStatus = 5`,
+		Query:       `ExecutionStatus = "Terminated"`,
 	}
 	resp, err := s.visibilityStore.CountWorkflowExecutions(request)
 	s.NoError(err)

--- a/common/persistence/elasticsearch/visibility_store_write_test.go
+++ b/common/persistence/elasticsearch/visibility_store_write_test.go
@@ -79,7 +79,7 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionStarted() {
 			s.EqualValues(request.StartTimestamp, body[searchattribute.StartTime])
 			s.EqualValues(request.ExecutionTimestamp, body[searchattribute.ExecutionTime])
 			s.Equal(request.TaskQueue, body[searchattribute.TaskQueue])
-			s.EqualValues(request.Status, body[searchattribute.ExecutionStatus])
+			s.EqualValues(request.Status.String(), body[searchattribute.ExecutionStatus])
 
 			s.Equal(request.Memo.Data, body[searchattribute.Memo])
 			s.Equal(enumspb.ENCODING_TYPE_PROTO3.String(), body[searchattribute.MemoEncoding])
@@ -177,7 +177,7 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionClosed() {
 			s.Equal(request.Memo.Data, body[searchattribute.Memo])
 			s.Equal(enumspb.ENCODING_TYPE_PROTO3.String(), body[searchattribute.MemoEncoding])
 			s.EqualValues(request.CloseTimestamp, body[searchattribute.CloseTime])
-			s.EqualValues(request.Status, body[searchattribute.ExecutionStatus])
+			s.EqualValues(request.Status.String(), body[searchattribute.ExecutionStatus])
 			s.EqualValues(request.HistoryLength, body[searchattribute.HistoryLength])
 
 			s.Equal(client.BulkableRequestTypeIndex, bulkRequest.RequestType)

--- a/common/searchattribute/defs.go
+++ b/common/searchattribute/defs.go
@@ -79,7 +79,7 @@ var (
 		StartTime:             enumspb.INDEXED_VALUE_TYPE_DATETIME,
 		ExecutionTime:         enumspb.INDEXED_VALUE_TYPE_DATETIME,
 		CloseTime:             enumspb.INDEXED_VALUE_TYPE_DATETIME,
-		ExecutionStatus:       enumspb.INDEXED_VALUE_TYPE_INT,
+		ExecutionStatus:       enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		TaskQueue:             enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		HistoryLength:         enumspb.INDEXED_VALUE_TYPE_INT,
 		TemporalChangeVersion: enumspb.INDEXED_VALUE_TYPE_KEYWORD,

--- a/host/testdata/es_v6_index_template.json
+++ b/host/testdata/es_v6_index_template.json
@@ -35,7 +35,7 @@
           "type": "date"
         },
         "ExecutionStatus": {
-          "type": "integer"
+          "type": "keyword"
         },
         "HistoryLength": {
           "type": "long"

--- a/host/testdata/es_v7_index_template.json
+++ b/host/testdata/es_v7_index_template.json
@@ -34,7 +34,7 @@
         "type": "date_nanos"
       },
       "ExecutionStatus": {
-        "type": "integer"
+        "type": "keyword"
       },
       "HistoryLength": {
         "type": "long"

--- a/schema/elasticsearch/visibility/index_template_v6.json
+++ b/schema/elasticsearch/visibility/index_template_v6.json
@@ -35,7 +35,7 @@
           "type": "date"
         },
         "ExecutionStatus": {
-          "type": "long"
+          "type": "keyword"
         },
         "TaskQueue": {
           "type": "keyword"

--- a/schema/elasticsearch/visibility/index_template_v7.json
+++ b/schema/elasticsearch/visibility/index_template_v7.json
@@ -35,7 +35,7 @@
         "type": "date_nanos"
       },
       "ExecutionStatus": {
-        "type": "long"
+        "type": "keyword"
       },
       "TaskQueue": {
         "type": "keyword"

--- a/schema/elasticsearch/visibility/versioned/v1/index_template_v6.json
+++ b/schema/elasticsearch/visibility/versioned/v1/index_template_v6.json
@@ -35,7 +35,7 @@
           "type": "date"
         },
         "ExecutionStatus": {
-          "type": "long"
+          "type": "keyword"
         },
         "TaskQueue": {
           "type": "keyword"

--- a/schema/elasticsearch/visibility/versioned/v1/index_template_v7.json
+++ b/schema/elasticsearch/visibility/versioned/v1/index_template_v7.json
@@ -35,7 +35,7 @@
         "type": "date_nanos"
       },
       "ExecutionStatus": {
-        "type": "long"
+        "type": "keyword"
       },
       "TaskQueue": {
         "type": "keyword"

--- a/schema/elasticsearch/visibility/versioned/v1/reindex.painless
+++ b/schema/elasticsearch/visibility/versioned/v1/reindex.painless
@@ -32,18 +32,18 @@ if (ctx._source.CloseTime != null){
 }
 
 if (ctx._source.ExecutionStatus == 1)
-    ctx._source.ExecutionStatus = "Running";
+    ctx._source.ExecutionStatus = 'Running';
 else if (ctx._source.ExecutionStatus == 2)
-    ctx._source.ExecutionStatus = "Completed";
+    ctx._source.ExecutionStatus = 'Completed';
 else if (ctx._source.ExecutionStatus == 3)
-    ctx._source.ExecutionStatus = "Failed";
+    ctx._source.ExecutionStatus = 'Failed';
 else if (ctx._source.ExecutionStatus == 4)
-    ctx._source.ExecutionStatus = "Canceled";
+    ctx._source.ExecutionStatus = 'Canceled';
 else if (ctx._source.ExecutionStatus == 5)
-    ctx._source.ExecutionStatus = "Terminated";
+    ctx._source.ExecutionStatus = 'Terminated';
 else if (ctx._source.ExecutionStatus == 6)
-    ctx._source.ExecutionStatus = "ContinuedAsNew";
+    ctx._source.ExecutionStatus = 'ContinuedAsNew';
 else if (ctx._source.ExecutionStatus == 7)
-    ctx._source.ExecutionStatus = "TimedOut";
+    ctx._source.ExecutionStatus = 'TimedOut';
 else
-    ctx._source.ExecutionStatus = "Unspecified";
+    ctx._source.ExecutionStatus = 'Unspecified';

--- a/schema/elasticsearch/visibility/versioned/v1/reindex.painless
+++ b/schema/elasticsearch/visibility/versioned/v1/reindex.painless
@@ -31,3 +31,19 @@ if (ctx._source.CloseTime != null){
     ctx._source.CloseTime = Instant.ofEpochSecond(ctx._source.CloseTime / nanos, ctx._source.CloseTime % nanos);
 }
 
+if (ctx._source.ExecutionStatus == 1)
+    ctx._source.ExecutionStatus = "Running";
+else if (ctx._source.ExecutionStatus == 2)
+    ctx._source.ExecutionStatus = "Completed";
+else if (ctx._source.ExecutionStatus == 3)
+    ctx._source.ExecutionStatus = "Failed";
+else if (ctx._source.ExecutionStatus == 4)
+    ctx._source.ExecutionStatus = "Canceled";
+else if (ctx._source.ExecutionStatus == 5)
+    ctx._source.ExecutionStatus = "Terminated";
+else if (ctx._source.ExecutionStatus == 6)
+    ctx._source.ExecutionStatus = "ContinuedAsNew";
+else if (ctx._source.ExecutionStatus == 7)
+    ctx._source.ExecutionStatus = "TimedOut";
+else
+    ctx._source.ExecutionStatus = "Unspecified";


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Convert Elasticsearch `ExecutionStatus` field to `keyword` data type instead of `long`.

<!-- Tell your future self why have you made these changes -->
**Why?**
To support queries like `ExecutionStatus = 'Completed'` and improve internal index structure.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New and existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Some queries with `ExecutionStatus` might stop to work. Also if someone uses Elasticsearch directly, they need to modify queries accordinally.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.