### PR TITLE
Fix enabled flag for TLS-FrontendClientConfig

### DIFF
--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -149,7 +149,7 @@ func (s *localStoreTlsProvider) GetFrontendClientConfig() (*tls.Config, error) {
 			return newClientTLSConfig(s.workerCertProvider, client.ServerName,
 				s.settings.Frontend.Server.RequireClientAuth, true, !client.DisableHostVerification)
 		},
-		s.settings.Internode.IsEnabled(),
+		s.settings.Frontend.IsEnabled(),
 	)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The frontend client config must be considered if TLS has been configured for the frontend and not if the internode TLS has been configured.

<!-- Tell your future self why have you made these changes -->
**Why?**
If it’s checked against internode it’s not possible to enable TLS only for frontend communication. And as a result the worker service is unable to communicate with the frontend service if TLS is enabled for the frontend only.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested Locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Should have no impact.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.