### PR TITLE
Sets Reconnection policy on gocql.ClusterObject

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -153,7 +153,7 @@ func NewCassandraCluster(
 	cluster.ReconnectionPolicy = &gocql.ExponentialReconnectionPolicy{
 		MaxRetries:      30,
 		InitialInterval: time.Second,
-		MaxInterval:     time.Minute,
+		MaxInterval:     10 * time.Second,
 	}
 
 	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -150,6 +150,12 @@ func NewCassandraCluster(
 	cluster.Consistency = cfg.Consistency.GetConsistency()
 	cluster.SerialConsistency = cfg.Consistency.GetSerialConsistency()
 
+	cluster.ReconnectionPolicy = &gocql.ExponentialReconnectionPolicy{
+		MaxRetries:      30,
+		InitialInterval: time.Second,
+		MaxInterval:     time.Minute,
+	}
+
 	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
 	return cluster, nil
 }


### PR DESCRIPTION
Enabling a Reconnection policy will enable better resiliency in the event that Cassandra nodes happen to churn for a given cluster. We have seen situations where nodes churned, and the only way to recover Temporal was by initiating a reboot. This should address this.

Validated change in a deployed test environment. This is a low-risk change.
