### PR TITLE
Adds keep-alive to gRPC connections between the frontend and history/matching services

### DIFF
--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -98,8 +98,7 @@ func Dial(hostName string, tlsConfig *tls.Config, logger log.Logger, enableKeepA
 			keepalive.ClientParameters{
 				Time: 10 * time.Second,
 			},
-		),
-		)
+		))
 	}
 
 	return grpc.Dial(

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -204,7 +204,7 @@ func (d *RPCFactory) CreateFrontendGRPCConnection(hostName string) *grpc.ClientC
 		}
 	}
 
-	return d.dial(hostName, tlsClientConfig)
+	return d.dial(hostName, tlsClientConfig, false)
 }
 
 // CreateInternodeGRPCConnection creates connection for gRPC calls
@@ -218,11 +218,11 @@ func (d *RPCFactory) CreateInternodeGRPCConnection(hostName string) *grpc.Client
 		}
 	}
 
-	return d.dial(hostName, tlsClientConfig)
+	return d.dial(hostName, tlsClientConfig, true)
 }
 
-func (d *RPCFactory) dial(hostName string, tlsClientConfig *tls.Config) *grpc.ClientConn {
-	connection, err := Dial(hostName, tlsClientConfig, d.logger)
+func (d *RPCFactory) dial(hostName string, tlsClientConfig *tls.Config, enableKeepAlive bool) *grpc.ClientConn {
+	connection, err := Dial(hostName, tlsClientConfig, d.logger, enableKeepAlive)
 	if err != nil {
 		d.logger.Fatal("Failed to create gRPC connection", tag.Error(err))
 	}

--- a/common/rpc/test/rpc_common_test.go
+++ b/common/rpc/test/rpc_common_test.go
@@ -173,7 +173,7 @@ func dialHelloAndGetTLSInfo(
 	}
 
 	s.NoError(err)
-	clientConn, err := rpc.Dial(hostport, cfg, logger)
+	clientConn, err := rpc.Dial(hostport, cfg, logger, false)
 	s.NoError(err)
 	client := helloworld.NewGreeterClient(clientConn)
 

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -79,7 +79,7 @@ func (s *IntegrationBase) setupSuite(defaultClusterConfigFile string) {
 	if clusterConfig.FrontendAddress != "" {
 		s.Logger.Info("Running integration test against specified frontend", tag.Address(TestFlags.FrontendAddr))
 
-		connection, err := rpc.Dial(TestFlags.FrontendAddr, nil, s.Logger)
+		connection, err := rpc.Dial(TestFlags.FrontendAddr, nil, s.Logger, false)
 		if err != nil {
 			s.Require().NoError(err)
 		}

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -499,7 +499,7 @@ func (c *temporalImpl) startHistory(
 		// However current interface for getting history client doesn't specify which client it needs and the tests that use this API
 		// depends on the fact that there's only one history host.
 		// Need to change those tests and modify the interface for getting history client.
-		historyConnection, err := rpc.Dial(c.HistoryServiceAddress(3)[0], nil, c.logger)
+		historyConnection, err := rpc.Dial(c.HistoryServiceAddress(3)[0], nil, c.logger, false)
 		if err != nil {
 			c.logger.Fatal("Failed to create connection for history", tag.Error(err))
 		}
@@ -829,7 +829,7 @@ func (c *rpcFactoryImpl) GetRingpopChannel() *tchannel.Channel {
 
 // CreateGRPCConnection creates connection for gRPC calls
 func (c *rpcFactoryImpl) CreateGRPCConnection(hostName string) *grpc.ClientConn {
-	connection, err := rpc.Dial(hostName, nil, c.logger)
+	connection, err := rpc.Dial(hostName, nil, c.logger, false)
 	if err != nil {
 		c.logger.Fatal("Failed to create gRPC connection", tag.Error(err))
 	}

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -97,6 +97,7 @@ func NewService(
 	if err != nil {
 		logger.Fatal("creating gRPC server options failed", tag.Error(err))
 	}
+
 	grpcServerOptions = append(
 		grpcServerOptions,
 		grpc.ChainUnaryInterceptor(


### PR DESCRIPTION
This PR adds a 10-second keep-alive between the frontend and history/matching services. This will enable a request on a severed connection to fail more quickly so that it can be retried, therefore reducing recovery time if one of those services recycles.

This is a very low-risk change that is automatically validated via unit/integration testing