### PR TITLE
nil check reporters when stopping

### DIFF
--- a/temporal/server.go
+++ b/temporal/server.go
@@ -263,8 +263,13 @@ func (s *Server) Stop() {
 	}
 	wg.Wait()
 
-	s.sdkReporter.Stop(s.logger)
-	s.serverReporter.Stop(s.logger)
+	if s.sdkReporter != nil {
+		s.sdkReporter.Stop(s.logger)
+	}
+
+	if s.serverReporter != nil {
+		s.serverReporter.Stop(s.logger)
+	}
 }
 
 // Populates parameters for a service


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
nil check reporters when stopping

<!-- Tell your future self why have you made these changes -->
**Why?**
The configuration allows these to be optional. https://github.com/temporalio/temporal/blob/3c427e6a2d5e7bcdda5868f379a26f6eb578871f/temporal/server.go#L177-L180

If they were not set, I was getting a panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x1d54ba7]

goroutine 1 [running]:
go.temporal.io/server/temporal.(*Server).Stop(0xc0004b4280)
	/home/jaym/workspace/godev/pkg/mod/go.temporal.io/server@v1.10.2/temporal/server.go:254 +0x1c7
go.temporal.io/server/temporal.(*Server).Start(0xc0004b4280, 0xc0004b4280, 0x3)
	/home/jaym/workspace/godev/pkg/mod/go.temporal.io/server@v1.10.2/temporal/server.go:229 +0xf7e
...
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
