### PR TITLE
Fix typo in encryption algorithm name ec256 -> es256

### DIFF
--- a/common/authorization/default_token_key_provider.go
+++ b/common/authorization/default_token_key_provider.go
@@ -97,7 +97,7 @@ func (a *defaultTokenKeyProvider) RsaKey(alg string, kid string) (*rsa.PublicKey
 }
 
 func (a *defaultTokenKeyProvider) EcdsaKey(alg string, kid string) (*ecdsa.PublicKey, error) {
-	if !strings.EqualFold(alg, "ec256") {
+	if !strings.EqualFold(alg, "es256") {
 		return nil, fmt.Errorf("unexpected signing algorithm: %s", alg)
 	}
 


### PR DESCRIPTION
**What changed?**
Fixed typo in encryption algorithm name "ec256" -> "es256".

**Why?**
To support elliptic curves.
Fixes #1662.

**How did you test it?**
Added unit tests.

**Potential risks**
None

**Is hotfix candidate?**
Yes