### PR TITLE
Modify add-search-attributes tctl command to add only missing search attributes 

### DIFF
--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -259,18 +259,14 @@ register_default_namespace() {
 }
 
 add_custom_search_attributes() {
-    if ! tctl cluster get-search-attributes | grep CustomKeywordField; then
-        echo "Adding Custom*Field search attributes."
-        tctl --auto_confirm admin cluster add-search-attributes \
-            --name CustomKeywordField --type Keyword \
-            --name CustomStringField --type String \
-            --name CustomIntField --type Int \
-            --name CustomDatetimeField --type Datetime \
-            --name CustomDoubleField --type Double \
-            --name CustomBoolField --type Bool
-    else
-        echo "CustomKeywordField search attribute already exist. Skip search attributes creation."
-    fi
+      echo "Adding Custom*Field search attributes."
+      tctl --auto_confirm admin cluster add-search-attributes --idempotent \
+          --name CustomKeywordField --type Keyword \
+          --name CustomStringField --type String \
+          --name CustomIntField --type Int \
+          --name CustomDatetimeField --type Datetime \
+          --name CustomDoubleField --type Double \
+          --name CustomBoolField --type Bool
 }
 
 setup_server(){

--- a/docker/auto-setup.sh
+++ b/docker/auto-setup.sh
@@ -260,7 +260,7 @@ register_default_namespace() {
 
 add_custom_search_attributes() {
       echo "Adding Custom*Field search attributes."
-      tctl --auto_confirm admin cluster add-search-attributes --idempotent \
+      tctl --auto_confirm admin cluster add-search-attributes \
           --name CustomKeywordField --type Keyword \
           --name CustomStringField --type String \
           --name CustomIntField --type Int \

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -597,6 +597,10 @@ func newAdminClusterCommands() []cli.Command {
 					Usage:  "ES index name (optional)",
 					Hidden: true, // don't show it for now
 				},
+				cli.BoolFlag{
+					Name:  FlagIdempotent,
+					Usage: "Add only missing attributes",
+				},
 				cli.StringSliceFlag{
 					Name:  FlagNameWithAlias,
 					Usage: "Search attribute name",

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -597,17 +597,13 @@ func newAdminClusterCommands() []cli.Command {
 					Usage:  "ES index name (optional)",
 					Hidden: true, // don't show it for now
 				},
-				cli.BoolFlag{
-					Name:  FlagIdempotent,
-					Usage: "Add only missing attributes",
-				},
 				cli.StringSliceFlag{
 					Name:  FlagNameWithAlias,
-					Usage: "Search attribute name",
+					Usage: "Search attribute name (multiply values are supported)",
 				},
 				cli.StringSliceFlag{
 					Name:  FlagTypeWithAlias,
-					Usage: fmt.Sprintf("Search attribute type: %v", allowedEnumValues(enumspb.IndexedValueType_name)),
+					Usage: fmt.Sprintf("Search attribute type: %v (multiply values are supported)", allowedEnumValues(enumspb.IndexedValueType_name)),
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -556,7 +556,8 @@ func (s *cliAppSuite) TestAdminAddSearchAttributes() {
 	s.serverAdminClient.EXPECT().AddSearchAttributes(gomock.Any(), request)
 
 	getRequest := &adminservice.GetSearchAttributesRequest{}
-	s.serverAdminClient.EXPECT().GetSearchAttributes(gomock.Any(), getRequest)
+	getResponse := &adminservice.GetSearchAttributesResponse{}
+	s.serverAdminClient.EXPECT().GetSearchAttributes(gomock.Any(), getRequest).Return(getResponse, nil).Times(2)
 
 	err := s.app.Run([]string{"", "--auto_confirm", "--ns", cliTestNamespace, "admin", "cl", "asa", "--name", "testKey", "--type", "keyword"})
 	s.Nil(err)

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -237,6 +237,7 @@ const (
 	FlagType                                  = "type"
 	FlagTypeWithAlias                         = FlagType + ", t"
 	FlagVersion                               = "version"
+	FlagIdempotent                            = "idempotent"
 
 	FlagProtoType  = "type"
 	FlagHexData    = "hex_data"

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -237,7 +237,6 @@ const (
 	FlagType                                  = "type"
 	FlagTypeWithAlias                         = FlagType + ", t"
 	FlagVersion                               = "version"
-	FlagIdempotent                            = "idempotent"
 
 	FlagProtoType  = "type"
 	FlagHexData    = "hex_data"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Modify add-search-attributes tctl command to add only missing search attributes.

<!-- Tell your future self why have you made these changes -->
**Why?**
There are scenarios (such as `auto-setup.sh`) when only missing attributes should be added to the cluster.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.