### PR TITLE
Fix to use the configured token.

### DIFF
--- a/cmd/tools/cli/plugins/authorization/main.go
+++ b/cmd/tools/cli/plugins/authorization/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	var pluginMap = map[string]plugin.Plugin{
 		cliplugin.HeadersProviderPluginType: &cliplugin.HeadersProviderPlugin{
-			Impl: &provider{},
+			Impl: &p,
 		},
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
The plugin is now set to use the configured provider.

<!-- Tell your future self why have you made these changes -->
Previously the provider configuration was being ignored as we were using an empty provider rather than the one we'd configured.