### PR TITLE
Use an SDK client to start workflows

### DIFF
--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -277,8 +277,7 @@ func (s *cliAppSuite) TestShowHistory_PrintDateTime() {
 }
 
 func (s *cliAppSuite) TestStartWorkflow() {
-	resp := &workflowservice.StartWorkflowExecutionResponse{RunId: uuid.New()}
-	s.frontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(resp, nil).Times(2)
+	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	// start with wid
 	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-w", "wid", "-wrp", "AllowDuplicateFailedOnly"})
 	s.Nil(err)
@@ -288,16 +287,14 @@ func (s *cliAppSuite) TestStartWorkflow() {
 }
 
 func (s *cliAppSuite) TestStartWorkflow_Failed() {
-	resp := &workflowservice.StartWorkflowExecutionResponse{RunId: uuid.New()}
-	s.frontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(resp, serviceerror.NewInvalidArgument("faked error"))
+	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), serviceerror.NewInvalidArgument("faked error"))
 	// start with wid
 	errorCode := s.RunErrorExitCode([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-w", "wid"})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestRunWorkflow() {
-	resp := &workflowservice.StartWorkflowExecutionResponse{RunId: uuid.New()}
-	s.frontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(resp, nil).Times(2)
+	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", mock.Anything, mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
 
 	// start with wid
@@ -305,6 +302,7 @@ func (s *cliAppSuite) TestRunWorkflow() {
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 
+	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
 	// start without wid
 	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "run", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "wrp", "2"})
@@ -313,9 +311,9 @@ func (s *cliAppSuite) TestRunWorkflow() {
 }
 
 func (s *cliAppSuite) TestRunWorkflow_Failed() {
-	resp := &workflowservice.StartWorkflowExecutionResponse{RunId: uuid.New()}
-	s.frontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(resp, serviceerror.NewInvalidArgument("faked error"))
-	s.sdkClient.On("GetWorkflowHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
+	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), serviceerror.NewInvalidArgument("fake error"))
+	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", mock.Anything, mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
+
 	// start with wid
 	errorCode := s.RunErrorExitCode([]string{"", "--ns", cliTestNamespace, "workflow", "run", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-w", "wid"})
 	s.Equal(1, errorCode)

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -99,6 +99,7 @@ func (b *clientFactory) SDKClient(c *cli.Context, namespace string) sdkclient.Cl
 		HostPort:  hostPort,
 		Namespace: namespace,
 		Logger:    log.NewSdkLogger(b.logger),
+		Identity:  getCliIdentity(),
 		ConnectionOptions: sdkclient.ConnectionOptions{
 			DisableHealthCheck: true,
 			TLS:                tlsConfig,

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -628,7 +628,7 @@ func processJSONInput(c *cli.Context) *commonpb.Payloads {
 		} else {
 			var j interface{}
 			if err := json.Unmarshal(jsonRaw, &j); err != nil {
-				ErrorAndExit("Input is not a valid JSON.", err)
+				ErrorAndExit("Input is not valid JSON.", err)
 			}
 			jsons = append(jsons, j)
 		}

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -322,20 +322,16 @@ func unmarshalSearchAttrFromCLI(c *cli.Context) map[string]interface{} {
 		ErrorAndExit(fmt.Sprintf("Uneven number of search attributes keys (%d): %v and values(%d): %v.", len(searchAttrKeys), searchAttrKeys, len(rawSearchAttrVals), rawSearchAttrVals), nil)
 	}
 
-	var searchAttrValues []interface{}
+	fields := make(map[string]interface{}, len(searchAttrKeys))
 
-	for _, v := range rawSearchAttrVals {
+	for i, v := range rawSearchAttrVals {
 		var j interface{}
 		if err := json.Unmarshal([]byte(v), &j); err != nil {
 			ErrorAndExit("Search attribute JSON parse error.", err)
 		}
-		searchAttrValues = append(searchAttrValues, j)
+		fields[searchAttrKeys[i]] = j
 	}
 
-	fields := make(map[string]interface{}, len(searchAttrKeys))
-	for i, key := range searchAttrKeys {
-		fields[key] = searchAttrValues[i]
-	}
 	return fields
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
tctl now uses an SDK client rather than a service client to start workflows.

<!-- Tell your future self why have you made these changes -->
**Why?**

Using the SDK client brings the tctl code more inline with standard way
for users to start workflows and makes it easier for contributors to
adjust tctl and make use of SDK features such as interceptors/context
propagation.

This will also be useful in future if we wish to provide more plugin
APIs to control the SDK client.

This also avoids using more complex code paths for parsing memo and
search attributes given that we can only be receiving untyped JSON
inputs from the command line anyway.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tests were updated. Also manually tested error handling for invalid memo/search inputs.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No.