### PR TITLE
Enforce daemon at most once start / stop logic within matching service

### DIFF
--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -220,10 +220,6 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueuesEmptyResultWithShortCont
 }
 
 func (s *matchingEngineSuite) TestPollWorkflowTaskQueues() {
-	s.PollWorkflowTaskQueuesResultTest()
-}
-
-func (s *matchingEngineSuite) PollWorkflowTaskQueuesResultTest() {
 	namespaceID := uuid.NewRandom().String()
 	tl := "makeToast"
 	stickyTl := "makeStickyToast"
@@ -611,6 +607,7 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	scope := tally.NewTestScope("test", nil)
 	s.matchingEngine.metricsClient = metrics.NewClient(scope, metrics.Matching)
 
+	s.taskManager.getTaskQueueManager(tlID).rangeID = initialRangeID
 	mgr, err := newTaskQueueManager(s.matchingEngine, tlID, tlKind, s.matchingEngine.config)
 	s.NoError(err)
 
@@ -631,8 +628,8 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 		RateLimiterImpl: mgrImpl.matcher.rateLimiter.(*quotas.RateLimiterImpl),
 	}
 	s.matchingEngine.updateTaskQueue(tlID, mgr)
-	s.taskManager.getTaskQueueManager(tlID).rangeID = initialRangeID
-	s.NoError(mgr.Start())
+
+	mgr.Start()
 
 	taskQueue := &taskqueuepb.TaskQueue{Name: tl}
 	activityTypeName := "activity1"
@@ -804,7 +801,10 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeActivitiesWithZeroDisp
 }
 
 func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
-	workerCount int, taskCount int64, dispatchLimitFn func(int, int64) float64) int64 {
+	workerCount int,
+	taskCount int64,
+	dispatchLimitFn func(int, int64) float64,
+) int64 {
 	scope := tally.NewTestScope("test", nil)
 	s.matchingEngine.metricsClient = metrics.NewClient(scope, metrics.Matching)
 	runID := uuid.NewRandom().String()
@@ -820,6 +820,7 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	tlKind := enumspb.TASK_QUEUE_KIND_NORMAL
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
+	s.taskManager.getTaskQueueManager(tlID).rangeID = initialRangeID
 	mgr, err := newTaskQueueManager(s.matchingEngine, tlID, tlKind, s.matchingEngine.config)
 	s.NoError(err)
 
@@ -838,8 +839,7 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 		RateLimiterImpl: mgrImpl.matcher.rateLimiter.(*quotas.RateLimiterImpl),
 	}
 	s.matchingEngine.updateTaskQueue(tlID, mgr)
-	s.taskManager.getTaskQueueManager(tlID).rangeID = initialRangeID
-	s.NoError(mgr.Start())
+	mgr.Start()
 
 	taskQueue := &taskqueuepb.TaskQueue{Name: tl}
 	var wg sync.WaitGroup
@@ -1484,11 +1484,7 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 
 	// stop all goroutines that read / write tasks in the background
 	// remainder of this test works with the in-memory buffer
-	if !atomic.CompareAndSwapInt32(&tlMgr.stopped, 0, 1) {
-		return
-	}
-	close(tlMgr.shutdownCh)
-	tlMgr.taskWriter.Stop()
+	tlMgr.Stop()
 
 	// setReadLevel should NEVER be called without updating ackManager.outstandingTasks
 	// This is only for unit test purpose

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -31,6 +31,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/persistence"
@@ -55,47 +56,62 @@ type (
 
 	// taskWriter writes tasks sequentially to persistence
 	taskWriter struct {
+		status       int32
 		tlMgr        *taskQueueManagerImpl
 		config       *taskQueueConfig
 		taskQueueID  *taskQueueID
 		appendCh     chan *writeTaskRequest
 		taskIDBlock  taskIDBlock
 		maxReadLevel int64
-		stopped      int64 // set to 1 if the writer is stopped or is shutting down
 		logger       log.Logger
-		stopCh       chan struct{} // shutdown signal for all routines in this class
+		shutdownChan chan struct{}
 	}
 )
 
 // errShutdown indicates that the task queue is shutting down
 var errShutdown = &persistence.ConditionFailedError{Msg: "task queue shutting down"}
 
-func newTaskWriter(tlMgr *taskQueueManagerImpl) *taskWriter {
+func newTaskWriter(
+	tlMgr *taskQueueManagerImpl,
+	block taskIDBlock,
+) *taskWriter {
 	return &taskWriter{
-		tlMgr:       tlMgr,
-		config:      tlMgr.config,
-		taskQueueID: tlMgr.taskQueueID,
-		stopCh:      make(chan struct{}),
-		appendCh:    make(chan *writeTaskRequest, tlMgr.config.OutstandingTaskAppendsThreshold()),
-		logger:      tlMgr.logger,
+		status:       common.DaemonStatusInitialized,
+		tlMgr:        tlMgr,
+		config:       tlMgr.config,
+		taskQueueID:  tlMgr.taskQueueID,
+		appendCh:     make(chan *writeTaskRequest, tlMgr.config.OutstandingTaskAppendsThreshold()),
+		taskIDBlock:  block,
+		maxReadLevel: block.start - 1,
+		logger:       tlMgr.logger,
+
+		shutdownChan: make(chan struct{}),
 	}
 }
 
-func (w *taskWriter) Start(block taskIDBlock) {
-	w.taskIDBlock = block
-	w.maxReadLevel = block.start - 1
+func (w *taskWriter) Start() {
+	if !atomic.CompareAndSwapInt32(
+		&w.status,
+		common.DaemonStatusInitialized,
+		common.DaemonStatusStarted,
+	) {
+		return
+	}
+
 	go w.taskWriterLoop()
 }
 
 // Stop stops the taskWriter
 func (w *taskWriter) Stop() {
-	if atomic.CompareAndSwapInt64(&w.stopped, 0, 1) {
-		close(w.stopCh)
+	if !atomic.CompareAndSwapInt32(
+		&w.status,
+		common.DaemonStatusStarted,
+		common.DaemonStatusStopped,
+	) {
+		return
 	}
-}
 
-func (w *taskWriter) isStopped() bool {
-	return atomic.LoadInt64(&w.stopped) == 1
+	close(w.shutdownChan)
 }
 
 func (w *taskWriter) appendTask(
@@ -103,8 +119,11 @@ func (w *taskWriter) appendTask(
 	taskInfo *persistencespb.TaskInfo,
 ) (*persistence.CreateTasksResponse, error) {
 
-	if w.isStopped() {
+	select {
+	case <-w.shutdownChan:
 		return nil, errShutdown
+	default:
+		// noop
 	}
 
 	ch := make(chan *writeTaskResponse)
@@ -119,7 +138,7 @@ func (w *taskWriter) appendTask(
 		select {
 		case r := <-ch:
 			return r.persistenceResponse, r.err
-		case <-w.stopCh:
+		case <-w.shutdownChan:
 			// if we are shutting down, this request will never make
 			// it to cassandra, just bail out and fail this request
 			return nil, errShutdown
@@ -179,41 +198,37 @@ writerLoop:
 	for {
 		select {
 		case request := <-w.appendCh:
-			{
-				// read a batch of requests from the channel
-				reqs := []*writeTaskRequest{request}
-				reqs = w.getWriteBatch(reqs)
-				batchSize := len(reqs)
+			// read a batch of requests from the channel
+			reqs := []*writeTaskRequest{request}
+			reqs = w.getWriteBatch(reqs)
+			batchSize := len(reqs)
 
-				maxReadLevel := int64(0)
+			maxReadLevel := int64(0)
 
-				taskIDs, err := w.allocTaskIDs(batchSize)
-				if err != nil {
-					w.sendWriteResponse(reqs, nil, err)
-					continue writerLoop
-				}
-
-				var tasks []*persistencespb.AllocatedTaskInfo
-				for i, req := range reqs {
-					tasks = append(tasks, &persistencespb.AllocatedTaskInfo{
-						TaskId: taskIDs[i],
-						Data:   req.taskInfo,
-					})
-					maxReadLevel = taskIDs[i]
-				}
-
-				resp, err := w.appendTasks(tasks)
-				w.sendWriteResponse(reqs, resp, err)
-				// Update the maxReadLevel after the writes are completed.
-				if maxReadLevel > 0 {
-					atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
-				}
+			taskIDs, err := w.allocTaskIDs(batchSize)
+			if err != nil {
+				w.sendWriteResponse(reqs, nil, err)
+				continue writerLoop
 			}
-		case <-w.stopCh:
-			// we don't close the appendCh here
-			// because that can cause on a send on closed
-			// channel panic on the appendTask()
-			break writerLoop
+
+			var tasks []*persistencespb.AllocatedTaskInfo
+			for i, req := range reqs {
+				tasks = append(tasks, &persistencespb.AllocatedTaskInfo{
+					TaskId: taskIDs[i],
+					Data:   req.taskInfo,
+				})
+				maxReadLevel = taskIDs[i]
+			}
+
+			resp, err := w.appendTasks(tasks)
+			w.sendWriteResponse(reqs, resp, err)
+			// Update the maxReadLevel after the writes are completed.
+			if maxReadLevel > 0 {
+				atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
+			}
+
+		case <-w.shutdownChan:
+			return
 		}
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Enforce daemon coroutine at most once start / stop logic within matching engine
* Enforce daemon coroutine at most once start / stop logic within task queue manager
* Enforce daemon coroutine at most once start / stop logic within task queue reader
* Enforce daemon coroutine at most once start / stop logic within task queue writer

<!-- Tell your future self why have you made these changes -->
**Why?**
Better guarantee

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No