### PR TITLE
Seperate liveness of task queue into a dedicated entity

### DIFF
--- a/service/matching/liveness.go
+++ b/service/matching/liveness.go
@@ -1,0 +1,127 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/clock"
+)
+
+type (
+	liveness struct {
+		status     int32
+		timeSource clock.TimeSource
+		ttl        time.Duration
+		// internal shutdown channel
+		shutdownChan chan struct{}
+
+		// broadcast shutdown functions
+		broadcastShutdownFn func()
+
+		sync.Mutex
+		lastEventTime time.Time
+	}
+)
+
+var _ common.Daemon = (*liveness)(nil)
+
+func newLiveness(
+	timeSource clock.TimeSource,
+	ttl time.Duration,
+	broadcastShutdownFn func(),
+) *liveness {
+	return &liveness{
+		status:       common.DaemonStatusInitialized,
+		timeSource:   timeSource,
+		ttl:          ttl,
+		shutdownChan: make(chan struct{}),
+
+		broadcastShutdownFn: broadcastShutdownFn,
+
+		lastEventTime: timeSource.Now(),
+	}
+}
+
+func (l *liveness) Start() {
+	if !atomic.CompareAndSwapInt32(
+		&l.status,
+		common.DaemonStatusInitialized,
+		common.DaemonStatusStarted,
+	) {
+		return
+	}
+
+	go l.eventLoop()
+}
+
+func (l *liveness) Stop() {
+	if !atomic.CompareAndSwapInt32(
+		&l.status,
+		common.DaemonStatusStarted,
+		common.DaemonStatusStopped,
+	) {
+		return
+	}
+
+	close(l.shutdownChan)
+	l.broadcastShutdownFn()
+}
+
+func (l *liveness) eventLoop() {
+	ttlTimer := time.NewTicker(l.ttl)
+	defer ttlTimer.Stop()
+
+	for {
+		select {
+		case <-ttlTimer.C:
+			if !l.isAlive() {
+				l.Stop()
+			}
+
+		case <-l.shutdownChan:
+			return
+		}
+	}
+}
+
+func (l *liveness) isAlive() bool {
+	l.Lock()
+	defer l.Unlock()
+	return l.lastEventTime.Add(l.ttl).After(l.timeSource.Now())
+}
+
+func (l *liveness) markAlive(
+	now time.Time,
+) {
+	l.Lock()
+	defer l.Unlock()
+	if l.lastEventTime.Before(now) {
+		l.lastEventTime = now.UTC()
+	}
+}

--- a/service/matching/liveness_test.go
+++ b/service/matching/liveness_test.go
@@ -1,0 +1,125 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"go.temporal.io/server/common/clock"
+)
+
+type (
+	livenessSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		timeSource   *clock.EventTimeSource
+		ttl          time.Duration
+		shutdownFlag bool
+	}
+)
+
+func TestLivenessSuite(t *testing.T) {
+	s := new(livenessSuite)
+	suite.Run(t, s)
+}
+
+func (s *livenessSuite) SetupSuite() {
+}
+
+func (s *livenessSuite) TearDownSuite() {
+}
+
+func (s *livenessSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.ttl = 2 * time.Second
+	s.timeSource = clock.NewEventTimeSource()
+	s.timeSource.Update(time.Now())
+	s.shutdownFlag = false
+}
+
+func (s *livenessSuite) TearDownTest() {
+
+}
+
+func (s *livenessSuite) TestIsAlive_No() {
+	liveness := newLiveness(s.timeSource, s.ttl, func() { s.shutdownFlag = true })
+	s.timeSource.Update(time.Now().Add(s.ttl * 2))
+	alive := liveness.isAlive()
+	s.False(alive)
+}
+
+func (s *livenessSuite) TestIsAlive_Yes() {
+	liveness := newLiveness(s.timeSource, s.ttl, func() { s.shutdownFlag = true })
+	s.timeSource.Update(time.Now().Add(s.ttl / 2))
+	alive := liveness.isAlive()
+	s.True(alive)
+}
+
+func (s *livenessSuite) TestMarkAlive_Noop() {
+	liveness := newLiveness(s.timeSource, s.ttl, func() { s.shutdownFlag = true })
+	lastEventTime := liveness.lastEventTime
+	newEventTime := s.timeSource.Now().Add(-1)
+	liveness.markAlive(newEventTime)
+	s.Equal(lastEventTime, liveness.lastEventTime)
+}
+
+func (s *livenessSuite) TestMarkAlive_Updated() {
+	liveness := newLiveness(s.timeSource, s.ttl, func() { s.shutdownFlag = true })
+	newEventTime := s.timeSource.Now().Add(1)
+	liveness.markAlive(newEventTime)
+	s.Equal(newEventTime, liveness.lastEventTime)
+}
+
+func (s *livenessSuite) TestEventLoop_Noop() {
+	liveness := newLiveness(s.timeSource, s.ttl, func() { s.shutdownFlag = true })
+	liveness.Start()
+
+	now := time.Now().Add(s.ttl * 4)
+	s.timeSource.Update(now)
+	liveness.markAlive(now)
+
+	timer := time.NewTimer(s.ttl * 2)
+	select {
+	case <-liveness.shutdownChan:
+		s.Fail("should not shutdown")
+	case <-timer.C:
+		s.False(s.shutdownFlag)
+	}
+}
+
+func (s *livenessSuite) TestEventLoop_Shutdown() {
+	liveness := newLiveness(s.timeSource, s.ttl, func() { s.shutdownFlag = true })
+	liveness.Start()
+
+	s.timeSource.Update(time.Now().Add(s.ttl * 4))
+	<-liveness.shutdownChan
+	s.True(s.shutdownFlag)
+}

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1584,7 +1584,7 @@ func (s *matchingEngineSuite) TestTaskExpiryAndCompletion() {
 	s.matchingEngine.config.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskQueueInfo(2)
 	// set idle timer check to a really small value to assert that we don't accidentally drop tasks while blocking
 	// on enqueuing a task to task buffer
-	s.matchingEngine.config.IdleTaskqueueCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(time.Microsecond)
+	s.matchingEngine.config.IdleTaskqueueCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(time.Millisecond)
 
 	testCases := []struct {
 		batchSize          int

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1587,11 +1587,10 @@ func (s *matchingEngineSuite) TestTaskExpiryAndCompletion() {
 	s.matchingEngine.config.IdleTaskqueueCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(time.Millisecond)
 
 	testCases := []struct {
-		batchSize          int
 		maxTimeBtwnDeletes time.Duration
 	}{
-		{2, time.Minute},       // test taskGC deleting due to size threshold
-		{100, time.Nanosecond}, // test taskGC deleting due to time condition
+		{time.Minute},     // test taskGC deleting due to size threshold
+		{time.Nanosecond}, // test taskGC deleting due to time condition
 	}
 
 	for _, tc := range testCases {
@@ -1622,7 +1621,6 @@ func (s *matchingEngineSuite) TestTaskExpiryAndCompletion() {
 		s.True(s.awaitCondition(func() bool { return len(tlMgr.taskReader.taskBuffer) >= (taskCount/2 - 1) }, time.Second))
 
 		maxTimeBetweenTaskDeletes = tc.maxTimeBtwnDeletes
-		s.matchingEngine.config.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskQueueInfo(tc.batchSize)
 
 		s.setupRecordActivityTaskStartedMock(tl)
 

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -39,6 +39,7 @@ import (
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/common/clock"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
@@ -101,6 +102,7 @@ type (
 		engine           *matchingEngineImpl
 		taskWriter       *taskWriter
 		taskReader       *taskReader // reads tasks from db and async matches it with poller
+		liveness         *liveness
 		taskGC           *taskGC
 		taskAckManager   ackManager   // tracks ackLevel for delivered messages
 		matcher          *TaskMatcher // for matching a task producer with a poller
@@ -176,8 +178,10 @@ func newTaskQueueManager(
 	}
 
 	tlMgr.taskAckManager.setAckLevel(state.ackLevel)
+	tlMgr.liveness = newLiveness(clock.NewRealTimeSource(), taskQueueConfig.IdleTaskqueueCheckInterval(), tlMgr.Stop)
 	tlMgr.taskWriter = newTaskWriter(tlMgr, tlMgr.rangeIDToTaskIDBlock(state.rangeID))
 	tlMgr.taskReader = newTaskReader(tlMgr)
+
 	var fwdr *Forwarder
 	if tlMgr.isFowardingAllowed(taskQueue, taskQueueKind) {
 		fwdr = newForwarder(&taskQueueConfig.forwarderConfig, taskQueue, taskQueueKind, e.matchingClient)
@@ -197,6 +201,7 @@ func (c *taskQueueManagerImpl) Start() {
 		return
 	}
 
+	c.liveness.Start()
 	c.taskWriter.Start()
 	c.taskReader.Start()
 }
@@ -212,6 +217,11 @@ func (c *taskQueueManagerImpl) Stop() {
 	}
 
 	close(c.shutdownCh)
+
+	_ = c.db.UpdateState(c.taskAckManager.getAckLevel())
+	c.taskGC.RunNow(c.taskAckManager.getAckLevel())
+
+	c.liveness.Stop()
 	c.taskWriter.Stop()
 	c.taskReader.Stop()
 	c.engine.removeTaskQueueManager(c.taskQueueID)
@@ -221,7 +231,15 @@ func (c *taskQueueManagerImpl) Stop() {
 // AddTask adds a task to the task queue. This method will first attempt a synchronous
 // match with a poller. When there are no pollers or if ratelimit is exceeded, task will
 // be written to database and later asynchronously matched with a poller
-func (c *taskQueueManagerImpl) AddTask(ctx context.Context, params addTaskParams) (bool, error) {
+func (c *taskQueueManagerImpl) AddTask(
+	ctx context.Context,
+	params addTaskParams,
+) (bool, error) {
+	if params.forwardedFrom == "" {
+		// request sent by history service
+		c.liveness.markAlive(time.Now())
+	}
+
 	var syncMatch bool
 	_, err := c.executeWithRetry(func() (interface{}, error) {
 		td := params.taskInfo
@@ -256,24 +274,6 @@ func (c *taskQueueManagerImpl) AddTask(ctx context.Context, params addTaskParams
 	return syncMatch, err
 }
 
-// DispatchTask dispatches a task to a poller. When there are no pollers to pick
-// up the task or if rate limit is exceeded, this method will return error. Task
-// *will not* be persisted to db
-func (c *taskQueueManagerImpl) DispatchTask(ctx context.Context, task *internalTask) error {
-	return c.matcher.MustOffer(ctx, task)
-}
-
-// DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,
-// if dispatched to local poller then nil and nil is returned.
-func (c *taskQueueManagerImpl) DispatchQueryTask(
-	ctx context.Context,
-	taskID string,
-	request *matchingservice.QueryWorkflowRequest,
-) (*matchingservice.QueryWorkflowResponse, error) {
-	task := newInternalQueryTask(taskID, request)
-	return c.matcher.OfferQuery(ctx, task)
-}
-
 // GetTask blocks waiting for a task.
 // Returns error when context deadline is exceeded
 // maxDispatchPerSecond is the max rate at which tasks are allowed
@@ -282,16 +282,8 @@ func (c *taskQueueManagerImpl) GetTask(
 	ctx context.Context,
 	maxDispatchPerSecond *float64,
 ) (*internalTask, error) {
-	task, err := c.getTask(ctx, maxDispatchPerSecond)
-	if err != nil {
-		return nil, err
-	}
-	task.namespace = c.namespace()
-	task.backlogCountHint = c.taskAckManager.getBacklogCountHint()
-	return task, nil
-}
+	c.liveness.markAlive(time.Now())
 
-func (c *taskQueueManagerImpl) getTask(ctx context.Context, maxDispatchPerSecond *float64) (*internalTask, error) {
 	// We need to set a shorter timeout than the original ctx; otherwise, by the time ctx deadline is
 	// reached, instead of emptyTask, context timeout error is returned to the frontend by the rpc stack,
 	// which counts against our SLO. By shortening the timeout by a very small amount, the emptyTask can be
@@ -334,7 +326,35 @@ func (c *taskQueueManagerImpl) getTask(ctx context.Context, maxDispatchPerSecond
 		return c.matcher.PollForQuery(childCtx)
 	}
 
-	return c.matcher.Poll(childCtx)
+	task, err := c.matcher.Poll(childCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	task.namespace = c.namespace()
+	task.backlogCountHint = c.taskAckManager.getBacklogCountHint()
+	return task, nil
+}
+
+// DispatchTask dispatches a task to a poller. When there are no pollers to pick
+// up the task or if rate limit is exceeded, this method will return error. Task
+// *will not* be persisted to db
+func (c *taskQueueManagerImpl) DispatchTask(
+	ctx context.Context,
+	task *internalTask,
+) error {
+	return c.matcher.MustOffer(ctx, task)
+}
+
+// DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,
+// if dispatched to local poller then nil and nil is returned.
+func (c *taskQueueManagerImpl) DispatchQueryTask(
+	ctx context.Context,
+	taskID string,
+	request *matchingservice.QueryWorkflowRequest,
+) (*matchingservice.QueryWorkflowResponse, error) {
+	task := newInternalQueryTask(taskID, request)
+	return c.matcher.OfferQuery(ctx, task)
 }
 
 // GetAllPollerInfo returns all pollers that polled from this taskqueue in last few minutes

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -122,7 +122,7 @@ func TestReadLevelForAllExpiredTasksInBatch(t *testing.T) {
 		},
 	}
 
-	require.True(t, tlm.taskReader.addTasksToBuffer(tasks, time.Now().UTC(), time.NewTimer(time.Minute)))
+	require.True(t, tlm.taskReader.addTasksToBuffer(tasks))
 	require.Equal(t, int64(0), tlm.taskAckManager.getAckLevel())
 	require.Equal(t, int64(12), tlm.taskAckManager.getReadLevel())
 
@@ -142,7 +142,7 @@ func TestReadLevelForAllExpiredTasksInBatch(t *testing.T) {
 			},
 			TaskId: 14,
 		},
-	}, time.Now().UTC(), time.NewTimer(time.Minute)))
+	}))
 	require.Equal(t, int64(0), tlm.taskAckManager.getAckLevel())
 	require.Equal(t, int64(14), tlm.taskAckManager.getReadLevel())
 }
@@ -248,13 +248,13 @@ func TestCheckIdleTaskQueue(t *testing.T) {
 	defer controller.Finish()
 
 	cfg := NewConfig(dynamicconfig.NewNoopCollection())
-	cfg.IdleTaskqueueCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(10 * time.Millisecond)
+	cfg.IdleTaskqueueCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(2 * time.Second)
 
 	// Idle
 	tlm := createTestTaskQueueManagerWithConfig(controller, cfg)
 	tlm.Start()
 	tlMgrStartWithoutNotifyEvent(tlm)
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
 
 	// Active poll-er
@@ -263,7 +263,7 @@ func TestCheckIdleTaskQueue(t *testing.T) {
 	tlm.pollerHistory.updatePollerInfo(pollerIdentity("test-poll"), nil)
 	require.Equal(t, 1, len(tlm.GetAllPollerInfo()))
 	tlMgrStartWithoutNotifyEvent(tlm)
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
 	tlm.Stop()
 	require.Equal(t, common.DaemonStatusStopped, atomic.LoadInt32(&tlm.status))
@@ -274,7 +274,7 @@ func TestCheckIdleTaskQueue(t *testing.T) {
 	require.Equal(t, 0, len(tlm.GetAllPollerInfo()))
 	tlMgrStartWithoutNotifyEvent(tlm)
 	tlm.taskReader.Signal()
-	time.Sleep(20 * time.Millisecond)
+	time.Sleep(1 * time.Second)
 	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
 	tlm.Stop()
 	require.Equal(t, common.DaemonStatusStopped, atomic.LoadInt32(&tlm.status))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Mark liveness when adding new tasks from history service
* Mark liveness when polling tasks from frontend service
* Unit test

<!-- Tell your future self why have you made these changes -->
**Why?**
Try to guarantee to unload a task queue if not new tasks added && no poller polling

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New tests && manual tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No