### PR TITLE
Refactor Elasticsearch metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -658,6 +658,12 @@ const (
 	// ElasticsearchDeleteWorkflowExecutionsScope tracks DeleteWorkflowExecution calls made by service to persistence layer
 	ElasticsearchDeleteWorkflowExecutionsScope
 
+	// ElasticsearchBulkProcessor is scope used by all metric emitted by Elasticsearch bulk processor
+	ElasticsearchBulkProcessor
+
+	// ElasticsearchVisibility is scope used by all Elasticsearch visibility metrics
+	ElasticsearchVisibility
+
 	// SequentialTaskProcessingScope is used by sequential task processing logic
 	SequentialTaskProcessingScope
 	// ParallelTaskProcessingScope is used by parallel task processing logic
@@ -685,9 +691,6 @@ const (
 	BlobstoreClientDeleteScope
 	// BlobstoreClientDirectoryExistsScope tracks DirectoryExists calls to blobstore
 	BlobstoreClientDirectoryExistsScope
-
-	// ElasticsearchVisibility is scope used by all metric emitted by esProcessor
-	ElasticsearchVisibility
 
 	NumCommonScopes
 )
@@ -1376,9 +1379,12 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ElasticsearchScanWorkflowExecutionsScope:                   {operation: "ScanWorkflowExecutions"},
 		ElasticsearchCountWorkflowExecutionsScope:                  {operation: "CountWorkflowExecutions"},
 		ElasticsearchDeleteWorkflowExecutionsScope:                 {operation: "DeleteWorkflowExecution"},
-		SequentialTaskProcessingScope:                              {operation: "SequentialTaskProcessing"},
-		ParallelTaskProcessingScope:                                {operation: "ParallelTaskProcessing"},
-		TaskSchedulerScope:                                         {operation: "TaskScheduler"},
+		ElasticsearchBulkProcessor:                                 {operation: "ElasticsearchBulkProcessor"},
+		ElasticsearchVisibility:                                    {operation: "ElasticsearchVisibility"},
+
+		SequentialTaskProcessingScope: {operation: "SequentialTaskProcessing"},
+		ParallelTaskProcessingScope:   {operation: "ParallelTaskProcessing"},
+		TaskSchedulerScope:            {operation: "TaskScheduler"},
 
 		HistoryArchiverScope:    {operation: "HistoryArchiver"},
 		VisibilityArchiverScope: {operation: "VisibilityArchiver"},
@@ -1389,8 +1395,6 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		BlobstoreClientExistsScope:          {operation: "BlobstoreClientExists", tags: map[string]string{ServiceRoleTagName: BlobstoreRoleTagValue}},
 		BlobstoreClientDeleteScope:          {operation: "BlobstoreClientDelete", tags: map[string]string{ServiceRoleTagName: BlobstoreRoleTagValue}},
 		BlobstoreClientDirectoryExistsScope: {operation: "BlobstoreClientDirectoryExists", tags: map[string]string{ServiceRoleTagName: BlobstoreRoleTagValue}},
-
-		ElasticsearchVisibility: {operation: "ElasticsearchVisibility"},
 	},
 	// Frontend Scope Names
 	Frontend: {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -686,8 +686,8 @@ const (
 	// BlobstoreClientDirectoryExistsScope tracks DirectoryExists calls to blobstore
 	BlobstoreClientDirectoryExistsScope
 
-	// ElasticSearchVisibility is scope used by all metric emitted by esProcessor
-	ElasticSearchVisibility
+	// ElasticsearchVisibility is scope used by all metric emitted by esProcessor
+	ElasticsearchVisibility
 
 	NumCommonScopes
 )
@@ -1390,7 +1390,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		BlobstoreClientDeleteScope:          {operation: "BlobstoreClientDelete", tags: map[string]string{ServiceRoleTagName: BlobstoreRoleTagValue}},
 		BlobstoreClientDirectoryExistsScope: {operation: "BlobstoreClientDirectoryExists", tags: map[string]string{ServiceRoleTagName: BlobstoreRoleTagValue}},
 
-		ElasticSearchVisibility: {operation: "ElasticSearchVisibility"},
+		ElasticsearchVisibility: {operation: "ElasticsearchVisibility"},
 	},
 	// Frontend Scope Names
 	Frontend: {
@@ -1755,7 +1755,7 @@ const (
 	AddSearchAttributesWorkflowSuccessCount
 	AddSearchAttributesWorkflowFailuresCount
 
-	ESInvalidSearchAttribute
+	ElasticsearchInvalidSearchAttributeCount
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -1931,11 +1931,14 @@ const (
 	MutableStateChecksumMismatch
 	MutableStateChecksumInvalidated
 
-	ESBulkProcessorRequests
-	ESBulkProcessorRetries
-	ESBulkProcessorFailures
-	ESBulkProcessorCorruptedData
-	ESBulkProcessorRequestLatency
+	ElasticsearchBulkProcessorRequests
+	ElasticsearchBulkProcessorRetries
+	ElasticsearchBulkProcessorFailures
+	ElasticsearchBulkProcessorCorruptedData
+	ElasticsearchBulkProcessorRequestLatency
+	ElasticsearchBulkProcessorCommitLatency
+	ElasticsearchBulkProcessorWaitLatency
+	ElasticsearchBulkProcessorBulkSize
 
 	NumHistoryMetrics
 )
@@ -1979,13 +1982,6 @@ const (
 	ReplicatorMessagesDropped
 	ReplicatorLatency
 	ReplicatorDLQFailures
-	ESProcessorRequests
-	ESProcessorRetries
-	ESProcessorFailures
-	ESProcessorCorruptedData
-	ESProcessorProcessMsgLatency
-	IndexProcessorCorruptedData
-	IndexProcessorProcessMsgLatency
 	ArchiverNonRetryableErrorCount
 	ArchiverStartedCount
 	ArchiverStoppedCount
@@ -2206,7 +2202,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ServiceErrAuthorizeFailedPerTaskQueueCounter: {
 			metricName: "service_errors_authorize_failed_per_tl", metricRollupName: "service_errors_authorize_failed", metricType: Counter,
 		},
-		ESInvalidSearchAttribute: {metricName: "es_invalid_search_attribute"},
+		ElasticsearchInvalidSearchAttributeCount: {metricName: "elasticsearch_invalid_search_attribute_counter", metricType: Counter},
 	},
 	History: {
 		TaskRequests:                                      {metricName: "task_requests", metricType: Counter},
@@ -2375,11 +2371,14 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		MutableStateChecksumMismatch:                      {metricName: "mutable_state_checksum_mismatch", metricType: Counter},
 		MutableStateChecksumInvalidated:                   {metricName: "mutable_state_checksum_invalidated", metricType: Counter},
 
-		ESBulkProcessorRequests:       {metricName: "es_bulk_processor_requests"},
-		ESBulkProcessorRetries:        {metricName: "es_bulk_processor_retries"},
-		ESBulkProcessorFailures:       {metricName: "es_bulk_processor_errors"},
-		ESBulkProcessorCorruptedData:  {metricName: "es_bulk_processor_corrupted_data"},
-		ESBulkProcessorRequestLatency: {metricName: "es_bulk_processor_request_latency", metricType: Timer},
+		ElasticsearchBulkProcessorRequests:       {metricName: "elasticsearch_bulk_processor_requests"},
+		ElasticsearchBulkProcessorRetries:        {metricName: "elasticsearch_bulk_processor_retries"},
+		ElasticsearchBulkProcessorFailures:       {metricName: "elasticsearch_bulk_processor_errors"},
+		ElasticsearchBulkProcessorCorruptedData:  {metricName: "elasticsearch_bulk_processor_corrupted_data"},
+		ElasticsearchBulkProcessorRequestLatency: {metricName: "elasticsearch_bulk_processor_request_latency", metricType: Timer},
+		ElasticsearchBulkProcessorCommitLatency:  {metricName: "elasticsearch_bulk_processor_commit_latency", metricType: Timer},
+		ElasticsearchBulkProcessorWaitLatency:    {metricName: "elasticsearch_bulk_processor_wait_latency", metricType: Timer},
+		ElasticsearchBulkProcessorBulkSize:       {metricName: "elasticsearch_bulk_processor_bulk_size", metricType: Timer},
 	},
 	Matching: {
 		PollSuccessPerTaskQueueCounter:            {metricName: "poll_success_per_tl", metricRollupName: "poll_success"},
@@ -2415,13 +2414,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ReplicatorMessagesDropped:                     {metricName: "replicator_messages_dropped"},
 		ReplicatorLatency:                             {metricName: "replicator_latency"},
 		ReplicatorDLQFailures:                         {metricName: "replicator_dlq_enqueue_fails", metricType: Counter},
-		ESProcessorRequests:                           {metricName: "es_processor_requests"},
-		ESProcessorRetries:                            {metricName: "es_processor_retries"},
-		ESProcessorFailures:                           {metricName: "es_processor_errors"},
-		ESProcessorCorruptedData:                      {metricName: "es_processor_corrupted_data"},
-		ESProcessorProcessMsgLatency:                  {metricName: "es_processor_process_msg_latency", metricType: Timer},
-		IndexProcessorCorruptedData:                   {metricName: "index_processor_corrupted_data"},
-		IndexProcessorProcessMsgLatency:               {metricName: "index_processor_process_msg_latency", metricType: Timer},
 		ArchiverNonRetryableErrorCount:                {metricName: "archiver_non_retryable_error"},
 		ArchiverStartedCount:                          {metricName: "archiver_started"},
 		ArchiverStoppedCount:                          {metricName: "archiver_stopped"},

--- a/common/persistence/elasticsearch/processor.go
+++ b/common/persistence/elasticsearch/processor.go
@@ -167,6 +167,7 @@ func (p *processorImpl) hashFn(key interface{}) uint32 {
 // Add request to the bulk and return ack channel which will receive ack signal when request is processed.
 func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
 	ackCh := newAckChan()
+	retCh := ackCh.ackChInternal
 	_, isDup, _ := p.mapToAckChan.PutOrDo(visibilityTaskKey, ackCh, func(key interface{}, value interface{}) error {
 		ackChExisting, ok := value.(*ackChan)
 		if !ok {
@@ -188,7 +189,7 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 	if !isDup {
 		p.bulkProcessor.Add(request)
 	}
-	return ackCh.ackChInternal
+	return retCh
 }
 
 // bulkBeforeAction is triggered before bulk processor commit

--- a/common/persistence/elasticsearch/processor.go
+++ b/common/persistence/elasticsearch/processor.go
@@ -52,7 +52,7 @@ type (
 		common.Daemon
 
 		// Add request to bulk processor.
-		Add(request *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool)
+		Add(request *client.BulkableRequest, visibilityTaskKey string) <-chan bool
 	}
 
 	// processorImpl implements Processor, it's an agent of elastic.BulkProcessor
@@ -76,9 +76,10 @@ type (
 		ESProcessorFlushInterval dynamicconfig.DurationPropertyFn
 	}
 
-	ackChanWithStopwatch struct { // value of processorImpl.mapToAckChan
-		ackCh                 chan<- bool
-		addToProcessStopwatch metrics.Stopwatch // Used to report metrics: interval between visibility task being added to bulk processor and it is processed (ack/nack).
+	ackChan struct { // value of processorImpl.mapToAckChan
+		ackChInternal chan bool
+		addedAt       time.Time // Time when request was added to bulk processor (used to report metrics).
+		startedAt     time.Time // Time when request was sent to Elasticsearch by bulk processor (used to report metrics).
 	}
 )
 
@@ -163,40 +164,52 @@ func (p *processorImpl) hashFn(key interface{}) uint32 {
 	return hash % p.indexerConcurrency
 }
 
-// Add request to bulk, and record ack channel message in map with provided key
-func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool) {
-	if cap(ackCh) < 1 {
-		panic("ackCh must be buffered channel (length should be 1 or more)")
-	}
-	sw := p.metricsClient.StartTimer(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorRequestLatency)
-	ackChWithStopwatch := newAckChanWithStopwatch(ackCh, sw)
-	_, isDup, _ := p.mapToAckChan.PutOrDo(visibilityTaskKey, ackChWithStopwatch, func(key interface{}, value interface{}) error {
-		ackChWithStopwatchExisting, ok := value.(*ackChanWithStopwatch)
+// Add request to the bulk and return ack channel which will receive ack signal when request is processed.
+func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
+	ackCh := newAckChan()
+	_, isDup, _ := p.mapToAckChan.PutOrDo(visibilityTaskKey, ackCh, func(key interface{}, value interface{}) error {
+		ackChExisting, ok := value.(*ackChan)
 		if !ok {
-			p.logger.Fatal(fmt.Sprintf("mapToAckChan has item of a wrong type %T (%T expected).", value, &ackChanWithStopwatch{}), tag.Value(key))
+			p.logger.Fatal(fmt.Sprintf("mapToAckChan has item of a wrong type %T (%T expected).", value, &ackChan{}), tag.Value(key))
 		}
 
 		p.logger.Warn("Adding duplicate ES request for visibility task key.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID), tag.Value(request.Doc))
 
 		// Nack existing visibility task.
-		ackChWithStopwatchExisting.addToProcessStopwatch.Stop()
-		ackChWithStopwatchExisting.ackCh <- false
+		ackChExisting.Done(false, p.metricsClient)
 
 		// Replace existing dictionary item with new item.
 		// Note: request won't be added to bulk processor.
-		ackChWithStopwatchExisting.addToProcessStopwatch = ackChWithStopwatch.addToProcessStopwatch
-		ackChWithStopwatchExisting.ackCh = ackChWithStopwatch.ackCh
+		ackChExisting.addedAt = ackCh.addedAt
+		ackChExisting.startedAt = ackCh.startedAt
+		ackChExisting.ackChInternal = ackCh.ackChInternal
 		return nil
 	})
-	if isDup {
-		return
+	if !isDup {
+		p.bulkProcessor.Add(request)
 	}
-	p.bulkProcessor.Add(request)
+	return ackCh.ackChInternal
 }
 
 // bulkBeforeAction is triggered before bulk processor commit
 func (p *processorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableRequest) {
-	p.metricsClient.AddCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorRequests, int64(len(requests)))
+	p.metricsClient.AddCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorRequests, int64(len(requests)))
+	p.metricsClient.RecordDistribution(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorBulkSize, len(requests))
+
+	for _, request := range requests {
+		visibilityTaskKey := p.extractVisibilityTaskKey(request)
+		if visibilityTaskKey == "" {
+			continue
+		}
+		_, _, _ = p.mapToAckChan.GetAndDo(visibilityTaskKey, func(key interface{}, value interface{}) error {
+			ackCh, ok := value.(*ackChan)
+			if !ok {
+				p.logger.Fatal(fmt.Sprintf("mapToAckChan has item of a wrong type %T (%T expected).", value, &ackChan{}), tag.Value(key))
+			}
+			ackCh.Start(p.metricsClient)
+			return nil
+		})
+	}
 }
 
 // bulkAfterAction is triggered after bulk processor commit
@@ -209,7 +222,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 		p.logger.Error("Unable to commit bulk ES request.", tag.Error(err), tag.Bool(isRetryable))
 		for _, request := range requests {
 			p.logger.Error("ES request failed.", tag.ESRequest(request.String()))
-			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorFailures)
+			p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorFailures)
 
 			if !isRetryable {
 				visibilityTaskKey := p.extractVisibilityTaskKey(request)
@@ -237,7 +250,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 				tag.Key(visibilityTaskKey),
 				tag.ESDocID(docID),
 				tag.ESRequest(request.String()))
-			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorCorruptedData)
+			p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorCorruptedData)
 			p.sendToAckChan(visibilityTaskKey, false)
 			continue
 		}
@@ -252,7 +265,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 				tag.Key(visibilityTaskKey),
 				tag.ESDocID(docID),
 				tag.ESRequest(request.String()))
-			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorFailures)
+			p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorFailures)
 			p.sendToAckChan(visibilityTaskKey, false)
 		default: // bulk processor will retry
 			p.logger.Warn("ES request retried.",
@@ -261,7 +274,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 				tag.Key(visibilityTaskKey),
 				tag.ESDocID(docID),
 				tag.ESRequest(request.String()))
-			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorRetries)
+			p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorRetries)
 		}
 	}
 }
@@ -285,13 +298,12 @@ func (p *processorImpl) buildResponseIndex(response *elastic.BulkResponse) map[s
 func (p *processorImpl) sendToAckChan(visibilityTaskKey string, ack bool) {
 	// Use RemoveIf here to prevent race condition with de-dup logic in Add method.
 	_ = p.mapToAckChan.RemoveIf(visibilityTaskKey, func(key interface{}, value interface{}) bool {
-		ackChWithStopwatch, ok := value.(*ackChanWithStopwatch)
+		ackCh, ok := value.(*ackChan)
 		if !ok {
-			p.logger.Fatal(fmt.Sprintf("mapToAckChan has item of a wrong type %T (%T expected).", value, &ackChanWithStopwatch{}), tag.ESKey(visibilityTaskKey))
+			p.logger.Fatal(fmt.Sprintf("mapToAckChan has item of a wrong type %T (%T expected).", value, &ackChan{}), tag.ESKey(visibilityTaskKey))
 		}
 
-		ackChWithStopwatch.addToProcessStopwatch.Stop()
-		ackChWithStopwatch.ackCh <- ack
+		ackCh.Done(ack, p.metricsClient)
 		return true
 	})
 }
@@ -300,7 +312,7 @@ func (p *processorImpl) extractVisibilityTaskKey(request elastic.BulkableRequest
 	req, err := request.Source()
 	if err != nil {
 		p.logger.Error("Unable to get ES request source.", tag.Error(err), tag.ESRequest(request.String()))
-		p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorCorruptedData)
+		p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorCorruptedData)
 		return ""
 	}
 
@@ -308,14 +320,14 @@ func (p *processorImpl) extractVisibilityTaskKey(request elastic.BulkableRequest
 		var body map[string]interface{}
 		if err = json.Unmarshal([]byte(req[1]), &body); err != nil {
 			p.logger.Error("Unable to unmarshal ES request body.", tag.Error(err))
-			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorCorruptedData)
+			p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorCorruptedData)
 			return ""
 		}
 
 		k, ok := body[searchattribute.VisibilityTaskKey]
 		if !ok {
 			p.logger.Error("Unable to extract VisibilityTaskKey from ES request.", tag.ESRequest(request.String()))
-			p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorCorruptedData)
+			p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorCorruptedData)
 			return ""
 		}
 		return k.(string)
@@ -328,14 +340,14 @@ func (p *processorImpl) extractDocID(request elastic.BulkableRequest) string {
 	req, err := request.Source()
 	if err != nil {
 		p.logger.Error("Unable to get ES request source.", tag.Error(err), tag.ESRequest(request.String()))
-		p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorCorruptedData)
+		p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorCorruptedData)
 		return ""
 	}
 
 	var body map[string]map[string]interface{}
 	if err = json.Unmarshal([]byte(req[0]), &body); err != nil {
 		p.logger.Error("Unable to unmarshal ES request body.", tag.Error(err), tag.ESRequest(request.String()))
-		p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorCorruptedData)
+		p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorCorruptedData)
 		return ""
 	}
 
@@ -348,7 +360,7 @@ func (p *processorImpl) extractDocID(request elastic.BulkableRequest) string {
 	}
 
 	p.logger.Error("Unable to extract _id from ES request.", tag.ESRequest(request.String()))
-	p.metricsClient.IncCounter(metrics.ElasticSearchVisibility, metrics.ESBulkProcessorCorruptedData)
+	p.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorCorruptedData)
 	return ""
 }
 
@@ -368,9 +380,23 @@ func extractErrorReason(resp *elastic.BulkResponseItem) string {
 	return ""
 }
 
-func newAckChanWithStopwatch(ackCh chan<- bool, stopwatch metrics.Stopwatch) *ackChanWithStopwatch {
-	return &ackChanWithStopwatch{
-		ackCh:                 ackCh,
-		addToProcessStopwatch: stopwatch,
+func newAckChan() *ackChan {
+	return &ackChan{
+		ackChInternal: make(chan bool, 1),
+		addedAt:       time.Now().UTC(),
+	}
+}
+
+func (a *ackChan) Start(metricsClient metrics.Client) {
+	metricsClient.RecordTimer(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorWaitLatency, time.Now().UTC().Sub(a.addedAt))
+	a.startedAt = time.Now().UTC()
+}
+
+func (a *ackChan) Done(ack bool, metricsClient metrics.Client) {
+	a.ackChInternal <- ack
+
+	metricsClient.RecordTimer(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorRequestLatency, time.Now().UTC().Sub(a.addedAt))
+	if !a.startedAt.IsZero() {
+		metricsClient.RecordTimer(metrics.ElasticsearchVisibility, metrics.ElasticsearchBulkProcessorCommitLatency, time.Now().UTC().Sub(a.startedAt))
 	}
 }

--- a/common/persistence/elasticsearch/processor_mock.go
+++ b/common/persistence/elasticsearch/processor_mock.go
@@ -59,15 +59,17 @@ func (m *MockProcessor) EXPECT() *MockProcessorMockRecorder {
 }
 
 // Add mocks base method.
-func (m *MockProcessor) Add(request *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool) {
+func (m *MockProcessor) Add(request *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Add", request, visibilityTaskKey, ackCh)
+	ret := m.ctrl.Call(m, "Add", request, visibilityTaskKey)
+	ret0, _ := ret[0].(<-chan bool)
+	return ret0
 }
 
 // Add indicates an expected call of Add.
-func (mr *MockProcessorMockRecorder) Add(request, visibilityTaskKey, ackCh interface{}) *gomock.Call {
+func (mr *MockProcessorMockRecorder) Add(request, visibilityTaskKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockProcessor)(nil).Add), request, visibilityTaskKey, ackCh)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockProcessor)(nil).Add), request, visibilityTaskKey)
 }
 
 // Start mocks base method.

--- a/common/persistence/elasticsearch/visibility_store_write_test.go
+++ b/common/persistence/elasticsearch/visibility_store_write_test.go
@@ -61,13 +61,8 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionStarted() {
 		},
 	}
 
-	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool) {
-			s.NotNil(ackCh)
-			s.Equal(1, cap(ackCh))
-			s.Equal(0, len(ackCh))
-			ackCh <- true
-
+	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
 			s.Equal("2208~111", visibilityTaskKey)
 
 			body := bulkRequest.Doc
@@ -92,6 +87,10 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionStarted() {
 			s.EqualValues(request.TaskID, bulkRequest.Version)
 			s.Equal("wid~rid", bulkRequest.ID)
 			s.Equal("test-index", bulkRequest.Index)
+
+			ackCh := make(chan bool, 1)
+			ackCh <- true
+			return ackCh
 		})
 
 	err := s.visibilityStore.RecordWorkflowExecutionStarted(request)
@@ -106,13 +105,8 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionStarted_EmptyRequest() {
 		},
 	}
 
-	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool) {
-			s.NotNil(ackCh)
-			s.Equal(1, cap(ackCh))
-			s.Equal(0, len(ackCh))
-			ackCh <- true
-
+	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
 			s.Equal("0~0", visibilityTaskKey)
 
 			body := bulkRequest.Doc
@@ -126,6 +120,10 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionStarted_EmptyRequest() {
 			s.EqualValues(request.TaskID, bulkRequest.Version)
 			s.Equal("~", bulkRequest.ID)
 			s.Equal("test-index", bulkRequest.Index)
+
+			ackCh := make(chan bool, 1)
+			ackCh <- true
+			return ackCh
 		})
 
 	err := s.visibilityStore.RecordWorkflowExecutionStarted(request)
@@ -157,13 +155,8 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionClosed() {
 		HistoryLength: int64(20),
 	}
 
-	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool) {
-			s.NotNil(ackCh)
-			s.Equal(1, cap(ackCh))
-			s.Equal(0, len(ackCh))
-			ackCh <- true
-
+	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
 			s.Equal("2208~111", visibilityTaskKey)
 
 			body := bulkRequest.Doc
@@ -184,6 +177,10 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionClosed() {
 			s.EqualValues(request.TaskID, bulkRequest.Version)
 			s.Equal("wid~rid", bulkRequest.ID)
 			s.Equal("test-index", bulkRequest.Index)
+
+			ackCh := make(chan bool, 1)
+			ackCh <- true
+			return ackCh
 		})
 
 	err := s.visibilityStore.RecordWorkflowExecutionClosed(request)
@@ -198,13 +195,8 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionClosed_EmptyRequest() {
 		},
 	}
 
-	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool) {
-			s.NotNil(ackCh)
-			s.Equal(1, cap(ackCh))
-			s.Equal(0, len(ackCh))
-			ackCh <- true
-
+	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
 			s.Equal("0~0", visibilityTaskKey)
 
 			body := bulkRequest.Doc
@@ -218,6 +210,10 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionClosed_EmptyRequest() {
 			s.EqualValues(request.TaskID, bulkRequest.Version)
 			s.Equal("~", bulkRequest.ID)
 			s.Equal("test-index", bulkRequest.Index)
+
+			ackCh := make(chan bool, 1)
+			ackCh <- true
+			return ackCh
 		})
 
 	err := s.visibilityStore.RecordWorkflowExecutionClosed(request)
@@ -233,19 +229,18 @@ func (s *ESVisibilitySuite) TestDeleteExecution() {
 		TaskID:      int64(111),
 	}
 
-	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool) {
-			s.NotNil(ackCh)
-			s.Equal(1, cap(ackCh))
-			s.Equal(0, len(ackCh))
-			ackCh <- true
-
+	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
 			s.Equal("wid~rid", visibilityTaskKey)
 
 			s.Equal(client.BulkableRequestTypeDelete, bulkRequest.RequestType)
 			s.EqualValues(request.TaskID, bulkRequest.Version)
 			s.Equal("wid~rid", bulkRequest.ID)
 			s.Equal("test-index", bulkRequest.Index)
+
+			ackCh := make(chan bool, 1)
+			ackCh <- true
+			return ackCh
 		})
 
 	err := s.visibilityStore.DeleteWorkflowExecution(request)
@@ -256,18 +251,17 @@ func (s *ESVisibilitySuite) TestDeleteExecution_EmptyRequest() {
 	// test empty request
 	request := &persistence.VisibilityDeleteWorkflowExecutionRequest{}
 
-	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any(), gomock.Any()).
-		Do(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string, ackCh chan<- bool) {
-			s.NotNil(ackCh)
-			s.Equal(1, cap(ackCh))
-			s.Equal(0, len(ackCh))
-			ackCh <- true
-
+	s.mockProcessor.EXPECT().Add(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(bulkRequest *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
 			s.Equal("~", visibilityTaskKey)
 
 			s.Equal(client.BulkableRequestTypeDelete, bulkRequest.RequestType)
 			s.Equal("~", bulkRequest.ID)
 			s.Equal("test-index", bulkRequest.Index)
+
+			ackCh := make(chan bool, 1)
+			ackCh <- true
+			return ackCh
 		})
 
 	err := s.visibilityStore.DeleteWorkflowExecution(request)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor Elasticsearch related metrics. Renamed them to have `elasticsearch` prefix and arranged other definitions.
Also moved ack channel creation into `processor.go`.


<!-- Tell your future self why have you made these changes -->
**Why?**
Unify metrics.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified existing and added new unit tests. Local canary run.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Few Elasticsearch metrics are renamed and dashboards need to be updated.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.