### PR TITLE
Use mysql.Config for mysql connection string management

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/dsn_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/dsn_test.go
@@ -149,5 +149,6 @@ func buildExpectedURLParams(attrs map[string]string, isolationKey string, isolat
 	for k, v := range dsnAttrOverrides {
 		result[k] = []string{v}
 	}
+	result["rejectReadOnly"] = []string{"true"}
 	return result
 }

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -125,8 +125,13 @@ func buildDSN(cfg *config.SQL, r resolver.ServiceResolver) string {
 	mysqlConfig.Addr = r.Resolve(cfg.ConnectAddr)[0]
 	mysqlConfig.DBName = cfg.DatabaseName
 	mysqlConfig.Net = cfg.ConnectProtocol
-
 	mysqlConfig.Params = buildDSNAttrs(cfg)
+
+	// https://github.com/go-sql-driver/mysql/blob/v1.5.0/dsn.go#L104-L106
+	// https://github.com/go-sql-driver/mysql/blob/v1.5.0/dsn.go#L182-L189
+	if mysqlConfig.Net == "" {
+		mysqlConfig.Net = "tcp"
+	}
 
 	// https://github.com/go-sql-driver/mysql#rejectreadonly
 	// https://github.com/temporalio/temporal/issues/1703


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Use mysql.Config for mysql connection string management
* Set mysql.Config.RejectReadOnly = true in case mysql encounters automatic failover event

<!-- Tell your future self why have you made these changes -->
**Why?**
Do not use read only mysql instance
Close #1703

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests && CICD

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No