### PR TITLE
Check shard status before workflow modification

### DIFF
--- a/service/history/shard/context_util.go
+++ b/service/history/shard/context_util.go
@@ -55,7 +55,6 @@ func NewTestContext(
 	shard := &ContextImpl{
 		Resource:                  resource,
 		shardID:                   shardInfo.GetShardId(),
-		rangeID:                   shardInfo.GetRangeId(),
 		shardInfo:                 shardInfo,
 		metricsClient:             resource.MetricsClient,
 		executionManager:          resource.ExecutionMgr,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Check shard status guarantee shard not being used after close for following operations:
  * CreateWorkflowExecution
  * UpdateWorkflowExecution
  * ConflictResolveWorkflowExecution
  * AddTasks
  * AppendHistoryEvents
* Rewrite error handling logic
* Remove unused range ID var within shard context

<!-- Tell your future self why have you made these changes -->
**Why?**
Guarantee do not reuse shard after shard close
Existing logic already set the range ID to -1 so DB CAS will fail, this PR add check prior to making DB call for better understanding

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests & CICD

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No