### PR TITLE
Add support for authorization of read-only frontend calls

### DIFF
--- a/common/authorization/default_authorizer.go
+++ b/common/authorization/default_authorizer.go
@@ -41,6 +41,9 @@ func NewDefaultAuthorizer() Authorizer {
 	return &defaultAuthorizer{}
 }
 
+var resultAllow = Result{Decision: DecisionAllow}
+var resultDeny = Result{Decision: DecisionDeny}
+
 func (a *defaultAuthorizer) Authorize(_ context.Context, claims *Claims, target *CallTarget) (Result, error) {
 
 	// TODO: This is a temporary workaround to allow calls to system namespace and
@@ -49,19 +52,42 @@ func (a *defaultAuthorizer) Authorize(_ context.Context, claims *Claims, target 
 	// no namespace will need to be performed at the API level, so that data would
 	// be filtered based of caller's permissions to namespaces and system.
 	if target.Namespace == "temporal-system" || target.Namespace == "" {
-		return Result{Decision: DecisionAllow}, nil
+		return resultAllow, nil
 	}
 	if claims == nil {
-		return Result{Decision: DecisionDeny}, nil
+		return resultDeny, nil
 	}
 	// Check system level permissions
-	if claims.System == RoleAdmin || claims.System == RoleWriter {
-		return Result{Decision: DecisionAllow}, nil
-	}
-	roles, found := claims.Namespaces[strings.ToLower(target.Namespace)]
-	if !found || roles == RoleUndefined {
-		return Result{Decision: DecisionDeny}, nil
+	if claims.System >= RoleWriter {
+		return resultAllow, nil
 	}
 
-	return Result{Decision: DecisionAllow}, nil
+	api := ApiName(target.APIName)
+	readOnlyNamespaceAPI := IsReadOnlyNamespaceAPI(api)
+	readOnlyGlobalAPI := IsReadOnlyGlobalAPI(api)
+	if claims.System >= RoleReader && (readOnlyNamespaceAPI || readOnlyGlobalAPI) {
+		return resultAllow, nil
+	}
+
+	role, found := claims.Namespaces[strings.ToLower(target.Namespace)]
+	if !found || role == RoleUndefined {
+		return resultDeny, nil
+	}
+	if role >= RoleWriter {
+		return resultAllow, nil
+	}
+	if role >= RoleReader && readOnlyNamespaceAPI {
+		return resultAllow, nil
+	}
+
+	return resultDeny, nil
+}
+
+func ApiName(api string) string {
+
+	index := strings.LastIndex(api, "/")
+	if index > -1 {
+		return api[index+1:]
+	}
+	return api
 }

--- a/common/authorization/default_authorizer.go
+++ b/common/authorization/default_authorizer.go
@@ -84,7 +84,6 @@ func (a *defaultAuthorizer) Authorize(_ context.Context, claims *Claims, target 
 }
 
 func ApiName(api string) string {
-
 	index := strings.LastIndex(api, "/")
 	if index > -1 {
 		return api[index+1:]

--- a/common/authorization/default_authorizer_test.go
+++ b/common/authorization/default_authorizer_test.go
@@ -66,6 +66,14 @@ var (
 		APIName:   "Foo",
 		Namespace: "BAR",
 	}
+	targetListNamespaces = CallTarget{
+		APIName:   "/temporal.api.workflowservice.v1.WorkflowService/ListNamespaces",
+		Namespace: "BAR",
+	}
+	targetDescribeNamespace = CallTarget{
+		APIName:   "/temporal.api.workflowservice.v1.WorkflowService/DescribeNamespace",
+		Namespace: "BAR",
+	}
 )
 
 type (
@@ -116,13 +124,44 @@ func (s *defaultAuthorizerSuite) TestSystemReaderBarUndefinedAuthZ() {
 func (s *defaultAuthorizerSuite) TestSystemUndefinedNamespaceReaderAuthZ() {
 	result, err := s.authorizer.Authorize(nil, &claimsSystemUndefinedNamespaceReader, &targetFooBar)
 	s.NoError(err)
-	s.Equal(DecisionAllow, result.Decision)
+	s.Equal(DecisionDeny, result.Decision)
 }
 func (s *defaultAuthorizerSuite) TestSystemUndefinedNamespaceCaseMismatch() {
 	result, err := s.authorizer.Authorize(nil, &claimsSystemUndefinedNamespaceReader, &targetFooBAR)
 	s.NoError(err)
+	s.Equal(DecisionDeny, result.Decision)
+}
+func (s *defaultAuthorizerSuite) TestSystemUndefinedNamespaceReaderListNamespaces() {
+	result, err := s.authorizer.Authorize(nil, &claimsSystemUndefinedNamespaceReader, &targetListNamespaces)
+	s.NoError(err)
+	s.Equal(DecisionDeny, result.Decision)
+}
+func (s *defaultAuthorizerSuite) TestSystemUndefinedNamespaceReaderDescribeNamespace() {
+	result, err := s.authorizer.Authorize(nil, &claimsSystemUndefinedNamespaceReader, &targetDescribeNamespace)
+	s.NoError(err)
 	s.Equal(DecisionAllow, result.Decision)
 }
+func (s *defaultAuthorizerSuite) TestSystemWriterDescribeNamespace() {
+	result, err := s.authorizer.Authorize(nil, &claimsSystemWriter, &targetDescribeNamespace)
+	s.NoError(err)
+	s.Equal(DecisionAllow, result.Decision)
+}
+func (s *defaultAuthorizerSuite) TestSystemWriterListNamespaces() {
+	result, err := s.authorizer.Authorize(nil, &claimsSystemWriter, &targetListNamespaces)
+	s.NoError(err)
+	s.Equal(DecisionAllow, result.Decision)
+}
+func (s *defaultAuthorizerSuite) TestSystemAdminDescribeNamespace() {
+	result, err := s.authorizer.Authorize(nil, &claimsSystemAdmin, &targetDescribeNamespace)
+	s.NoError(err)
+	s.Equal(DecisionAllow, result.Decision)
+}
+func (s *defaultAuthorizerSuite) TestSystemAdminListNamespaces() {
+	result, err := s.authorizer.Authorize(nil, &claimsSystemAdmin, &targetListNamespaces)
+	s.NoError(err)
+	s.Equal(DecisionAllow, result.Decision)
+}
+
 func (s *defaultAuthorizerSuite) TestGetAuthorizerFromConfigNoop() {
 	s.testGetAuthorizerFromConfig("", true, reflect.TypeOf(&noopAuthorizer{}))
 }

--- a/common/authorization/frontend_api.go
+++ b/common/authorization/frontend_api.go
@@ -25,34 +25,32 @@
 package authorization
 
 var readOnlyNamespaceAPI = map[string]struct{}{
-	"DescribeNamespace":              struct{},
-	"GetWorkflowExecutionHistory":    nil,
-	"ListOpenWorkflowExecutions":     nil,
-	"ListClosedWorkflowExecutions":   nil,
-	"ListWorkflowExecutions":         nil,
-	"ListArchivedWorkflowExecutions": nil,
-	"ScanWorkflowExecutions":         nil,
-	"CountWorkflowExecutions":        nil,
-	"QueryWorkflow":                  nil,
-	"DescribeWorkflowExecution":      nil,
-	"DescribeTaskQueue":              nil,
-	"ListTaskQueuePartitions":        nil,
+	"DescribeNamespace":              {},
+	"GetWorkflowExecutionHistory":    {},
+	"ListOpenWorkflowExecutions":     {},
+	"ListClosedWorkflowExecutions":   {},
+	"ListWorkflowExecutions":         {},
+	"ListArchivedWorkflowExecutions": {},
+	"ScanWorkflowExecutions":         {},
+	"CountWorkflowExecutions":        {},
+	"QueryWorkflow":                  {},
+	"DescribeWorkflowExecution":      {},
+	"DescribeTaskQueue":              {},
+	"ListTaskQueuePartitions":        {},
 }
 
-var readOnlyGlobalAPI = map[string]interface{}{
-	"ListNamespaces":      nil,
-	"GetSearchAttributes": nil,
-	"GetClusterInfo":      nil,
+var readOnlyGlobalAPI = map[string]struct{}{
+	"ListNamespaces":      {},
+	"GetSearchAttributes": {},
+	"GetClusterInfo":      {},
 }
 
 func IsReadOnlyNamespaceAPI(api string) bool {
-
 	_, found := readOnlyNamespaceAPI[api]
 	return found
 }
 
 func IsReadOnlyGlobalAPI(api string) bool {
-
 	_, found := readOnlyGlobalAPI[api]
 	return found
 }

--- a/common/authorization/frontend_api.go
+++ b/common/authorization/frontend_api.go
@@ -24,8 +24,8 @@
 
 package authorization
 
-var readOnlyNamespaceAPI = map[string]interface{}{
-	"DescribeNamespace":              nil,
+var readOnlyNamespaceAPI = map[string]struct{}{
+	"DescribeNamespace":              struct{},
 	"GetWorkflowExecutionHistory":    nil,
 	"ListOpenWorkflowExecutions":     nil,
 	"ListClosedWorkflowExecutions":   nil,

--- a/common/authorization/frontend_api.go
+++ b/common/authorization/frontend_api.go
@@ -1,0 +1,58 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package authorization
+
+var readOnlyNamespaceAPI = map[string]interface{}{
+	"DescribeNamespace":              nil,
+	"GetWorkflowExecutionHistory":    nil,
+	"ListOpenWorkflowExecutions":     nil,
+	"ListClosedWorkflowExecutions":   nil,
+	"ListWorkflowExecutions":         nil,
+	"ListArchivedWorkflowExecutions": nil,
+	"ScanWorkflowExecutions":         nil,
+	"CountWorkflowExecutions":        nil,
+	"QueryWorkflow":                  nil,
+	"DescribeWorkflowExecution":      nil,
+	"DescribeTaskQueue":              nil,
+	"ListTaskQueuePartitions":        nil,
+}
+
+var readOnlyGlobalAPI = map[string]interface{}{
+	"ListNamespaces":      nil,
+	"GetSearchAttributes": nil,
+	"GetClusterInfo":      nil,
+}
+
+func IsReadOnlyNamespaceAPI(api string) bool {
+
+	_, found := readOnlyNamespaceAPI[api]
+	return found
+}
+
+func IsReadOnlyGlobalAPI(api string) bool {
+
+	_, found := readOnlyGlobalAPI[api]
+	return found
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added definitions of read-only APIs at namespace and global level.
Updated `defaultAuthorizer` to allow read-only calls through if the caller has Reader permissions.
Custom authorizer plugins can leverage the same `IsReadOnlyNamespaceAPI` and `IsReadOnlyGlobalAPI` helper methods
Fixes #1688.

<!-- Tell your future self why have you made these changes -->
**Why?**
To support read-only access to Temporal.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
I don't see any

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No