### PR TITLE
Reverts Reconnection Policy specified on gocql client

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -149,13 +149,6 @@ func NewCassandraCluster(
 	cluster.ProtoVersion = 4
 	cluster.Consistency = cfg.Consistency.GetConsistency()
 	cluster.SerialConsistency = cfg.Consistency.GetSerialConsistency()
-
-	cluster.ReconnectionPolicy = &gocql.ExponentialReconnectionPolicy{
-		MaxRetries:      30,
-		InitialInterval: time.Second,
-		MaxInterval:     10 * time.Second,
-	}
-
 	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
 	return cluster, nil
 }


### PR DESCRIPTION
Setting this policy can cause Temporal to fail when connecting to certain implementations of Cassandra. Until this is root-caused, it is safer to remove it for now.