### PR TITLE
Adds configuration flag to set DisableInitialHostLookup on gocql client driver

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -281,6 +281,8 @@ type (
 		TLS *auth.TLS `yaml:"tls"`
 		// Consistency configuration (defaults to LOCAL_QUORUM / LOCAL_SERIAL for all stores if this field not set)
 		Consistency *CassandraStoreConsistency `yaml:"consistency"`
+		// DisableInitialHostLookup instructs the gocql client to connect only using the supplied hosts
+		DisableInitialHostLookup bool `yaml:"disableInitialHostLookup"`
 	}
 
 	// CassandraStoreConsistency enables you to set the consistency settings for each Cassandra Persistence Store for Temporal

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -149,6 +149,7 @@ func NewCassandraCluster(
 	cluster.ProtoVersion = 4
 	cluster.Consistency = cfg.Consistency.GetConsistency()
 	cluster.SerialConsistency = cfg.Consistency.GetSerialConsistency()
+	cluster.DisableInitialHostLookup = cfg.DisableInitialHostLookup
 
 	cluster.ReconnectionPolicy = &gocql.ExponentialReconnectionPolicy{
 		MaxRetries:      30,


### PR DESCRIPTION
This change adds a configuration (default: false) that instructs the gocql client to only connect using the supplied hosts.

For certain Cassandra deployments, using the supplied hosts to connect is the optimal approach vs looking up all the hosts from the cluster's system.peers table. This can reduce the time to establish a cql session by an order of magnitude.

Tested against a private deployment. No risk as the default behavior is not changed - the user must explicitly opt into this.


