### PR TITLE
Fix cassandra error handling edge case

### DIFF
--- a/common/persistence/cassandra/errors.go
+++ b/common/persistence/cassandra/errors.go
@@ -227,9 +227,11 @@ func extractWorkflowVersionConflictError(
 		return nil
 	}
 
+	actualNextEventID, _ := record["next_event_id"].(int64)
+	actualDBVersion, _ := record["db_version"].(int64)
+
 	// TODO remove this block once DB version comparison is the default
 	if requestDBVersion == 0 {
-		actualNextEventID := record["next_event_id"].(int64)
 		if actualNextEventID != requestNextEventID {
 			return &p.ConditionFailedError{
 				Msg: fmt.Sprintf("Encounter workflow next event ID mismatch, request next event ID: %v, actual next event ID: %v",
@@ -241,7 +243,6 @@ func extractWorkflowVersionConflictError(
 		return nil
 	}
 
-	actualDBVersion := record["db_version"].(int64)
 	if actualDBVersion != requestDBVersion {
 		return &p.ConditionFailedError{
 			Msg: fmt.Sprintf("Encounter workflow db version mismatch, request db version ID: %v, actual db version ID: %v",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Currectly handle edge case if `db_version` is not set during error extraction

<!-- Tell your future self why have you made these changes -->
**Why?**
Correctly handle if `db_version` is not set

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No