### PR TITLE
Add ES_VERSION parameter to reindex.sh

### DIFF
--- a/schema/elasticsearch/visibility/versioned/v1/reindex.sh
+++ b/schema/elasticsearch/visibility/versioned/v1/reindex.sh
@@ -36,11 +36,11 @@ if [ "${CUSTOM_SEARCH_ATTRIBUTES}" != "[]" ]; then
     fi
     CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(curl --silent --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/${ES_VIS_INDEX_V0}${DOC_TYPE}/_mapping" | jq --compact-output '.. | .Attr? | select(.!=null) | .properties | with_entries(select(.key == ($customSA[]))) | {properties:.}' --argjson customSA "${CUSTOM_SEARCH_ATTRIBUTES}")
     if [ "${ES_VERSION}" == "v7" ]; then
-        # Replace "date" type with "date_nanos" for Elasticsearch v7.
+        # Replace "date" type with "date_nanos" only for Elasticsearch v7.
         CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(jq '(.properties[].type | select(. == "date")) = "date_nanos"' <<< "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}")
-        # Replace "double" type with "scaled_float" for Elasticsearch v7.
-        CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(jq '(.properties[] | select(.type == "double")) = {"type":"scaled_float","scaling_factor":10000}' <<< "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}")
     fi
+    # Replace "double" type with "scaled_float".
+    CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(jq '(.properties[] | select(.type == "double")) = {"type":"scaled_float","scaling_factor":10000}' <<< "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}")
 
     jq <<< "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}"
     if [ -z "${AUTO_CONFIRM}" ]; then

--- a/schema/elasticsearch/visibility/versioned/v1/reindex.sh
+++ b/schema/elasticsearch/visibility/versioned/v1/reindex.sh
@@ -26,6 +26,8 @@ CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(curl --silent --user "${ES_USER}":"${ES_PWD}"
 if [ "${ES_VERSION}" == "v7" ]; then
     # Replace "date" type with "date_nanos" for Elasticsearch v7.
     CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(jq '(.properties[].type | select(. == "date")) = "date_nanos"' <<< "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}")
+    # Replace "double" type with "scaled_float" for Elasticsearch v7.
+    CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(jq '(.properties[] | select(.type == "double")) = {"type":"scaled_float","scaling_factor":10000}' <<< "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}")
 fi
 jq -n "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}"
 if [ -z "${AUTO_CONFIRM}" ]; then

--- a/schema/elasticsearch/visibility/versioned/v1/reindex.sh
+++ b/schema/elasticsearch/visibility/versioned/v1/reindex.sh
@@ -24,12 +24,12 @@ ES_ENDPOINT="${ES_SCHEME}://${ES_SERVER}:${ES_PORT}"
 DIR_NAME="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 echo "=== Step 0. Sanity check if both Elasticsearch indices are accessible. ==="
-if ! curl --silent --fail --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/${ES_VIS_INDEX_V0}/_stats/docs"; then
+if ! curl --silent --fail --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/${ES_VIS_INDEX_V0}/_stats/docs" --write-out "\n"; then
     echo "Elasticsearch index ${ES_VIS_INDEX_V0} is not accessible at ${ES_ENDPOINT}."
     exit 1
 fi
 
-if ! curl --silent --fail --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/${ES_VIS_INDEX_V1}/_stats/docs"; then
+if ! curl --silent --fail --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/${ES_VIS_INDEX_V1}/_stats/docs" --write-out "\n"; then
     echo "Elasticsearch index ${ES_VIS_INDEX_V1} is not accessible at ${ES_ENDPOINT}."
     exit 1
 fi
@@ -56,7 +56,7 @@ if jq --exit-status '.properties[]? | length > 0' <<< "${CUSTOM_SEARCH_ATTRIBUTE
         REPLY="y"
     fi
     if [ "${REPLY}" = "y" ]; then
-        curl --silent --user "${ES_USER}":"${ES_PWD}" -X PUT "${ES_ENDPOINT}/${ES_VIS_INDEX_V1}${DOC_TYPE}/_mapping" -H "Content-Type: application/json" --data-binary "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}" --write-out "\n" | jq
+        curl --silent --user "${ES_USER}":"${ES_PWD}" -X PUT "${ES_ENDPOINT}/${ES_VIS_INDEX_V1}${DOC_TYPE}/_mapping" -H "Content-Type: application/json" --data-binary "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}" | jq
         # Wait for mapping changes to go through.
         until curl --silent --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/_cluster/health/${ES_VIS_INDEX_V1}" | jq --exit-status '.status=="green" | .'; do
             echo "Waiting for Elasticsearch index ${ES_VIS_INDEX_V1} become green."

--- a/schema/elasticsearch/visibility/versioned/v1/reindex.sh
+++ b/schema/elasticsearch/visibility/versioned/v1/reindex.sh
@@ -8,6 +8,7 @@ ES_SERVER="${ES_SERVER:-127.0.0.1}"
 ES_PORT="${ES_PORT:-9200}"
 ES_USER="${ES_USER:-}"
 ES_PWD="${ES_PWD:-}"
+ES_VERSION="${ES_VERSION:-v7}"
 ES_VIS_INDEX_V0="${ES_VIS_INDEX_V0:-temporal-visibility-dev}"
 ES_VIS_INDEX_V1="${ES_VIS_INDEX_V1:-temporal_visibility_v1_dev}"
 CUSTOM_SEARCH_ATTRIBUTES="${CUSTOM_SEARCH_ATTRIBUTES:-[\"CustomKeywordField\",\"CustomStringField\",\"CustomIntField\",\"CustomDatetimeField\",\"CustomDoubleField\",\"CustomBoolField\"]}"
@@ -17,8 +18,15 @@ ES_ENDPOINT="${ES_SCHEME}://${ES_SERVER}:${ES_PORT}"
 DIR_NAME="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
 echo "=== Step 1. Add custom search attributes to the new index. ==="
-# _doc and ?include_type_name=true for compatibility with ES6.
-CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(curl --silent --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/${ES_VIS_INDEX_V0}/_doc/_mapping?include_type_name=true" | jq -c '.. | .Attr? | select(.!=null) | .properties | with_entries(select(.key == ($customSA[]))) | {properties:.}' --argjson customSA "${CUSTOM_SEARCH_ATTRIBUTES}")
+DOC_TYPE=""
+if [ "${ES_VERSION}" != "v7" ]; then
+    DOC_TYPE="/_doc"
+fi
+CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(curl --silent --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/${ES_VIS_INDEX_V0}${DOC_TYPE}/_mapping" | jq -c '.. | .Attr? | select(.!=null) | .properties | with_entries(select(.key == ($customSA[]))) | {properties:.}' --argjson customSA "${CUSTOM_SEARCH_ATTRIBUTES}")
+if [ "${ES_VERSION}" == "v7" ]; then
+    # Replace "date" type with "date_nanos" for Elasticsearch v7.
+    CUSTOM_SEARCH_ATTRIBUTES_MAPPING=$(jq '(.properties[].type | select(. == "date")) = "date_nanos"' <<< "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}")
+fi
 jq -n "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}"
 if [ -z "${AUTO_CONFIRM}" ]; then
     read -p "Add custom search attributes above to the index ${ES_VIS_INDEX_V1}? (N/y)" -n 1 -r
@@ -27,14 +35,13 @@ else
     REPLY="y"
 fi
 if [ "${REPLY}" = "y" ]; then
-    curl --silent --user "${ES_USER}":"${ES_PWD}" -X PUT "${ES_ENDPOINT}/${ES_VIS_INDEX_V1}/_doc/_mapping?include_type_name=true" -H "Content-Type: application/json" --data-binary "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}" --write-out "\n" | jq
+    curl --silent --user "${ES_USER}":"${ES_PWD}" -X PUT "${ES_ENDPOINT}/${ES_VIS_INDEX_V1}${DOC_TYPE}/_mapping" -H "Content-Type: application/json" --data-binary "${CUSTOM_SEARCH_ATTRIBUTES_MAPPING}" --write-out "\n" | jq
     # Wait for mapping changes to go through.
     until curl --silent --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/_cluster/health/${ES_VIS_INDEX_V1}" | jq  --exit-status '.status=="green" | .'; do
         echo "Waiting for Elasticsearch index ${ES_VIS_INDEX_V1} become green."
         sleep 1
     done
 fi
-
 
 echo "=== Step 2. Reindex old index to the new index. ==="
 # Convert multiline script to single line, remove repeated spaces, and replace / with \/.

--- a/schema/elasticsearch/visibility/versioned/v1/reindex.sh
+++ b/schema/elasticsearch/visibility/versioned/v1/reindex.sh
@@ -23,7 +23,7 @@ AUTO_CONFIRM="${AUTO_CONFIRM:-}"
 ES_ENDPOINT="${ES_SCHEME}://${ES_SERVER}:${ES_PORT}"
 DIR_NAME="$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
 
-if ! curl --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}"; then
+if ! curl --silent --user "${ES_USER}":"${ES_PWD}" "${ES_ENDPOINT}/_cluster/health" | jq --exit-status '.status=="green" | .'; then
     echo "Elasticsearch is not accessible at ${ES_ENDPOINT}."
     exit 1
 fi

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -215,7 +215,7 @@ func (adh *AdminHandler) AddSearchAttributes(ctx context.Context, request *admin
 	return &adminservice.AddSearchAttributesResponse{}, nil
 }
 
-// RemoveSearchAttributes add search attribute to the cluster.
+// RemoveSearchAttributes remove search attribute from the cluster.
 func (adh *AdminHandler) RemoveSearchAttributes(ctx context.Context, request *adminservice.RemoveSearchAttributesRequest) (_ *adminservice.RemoveSearchAttributesResponse, retError error) {
 	defer log.CapturePanic(adh.GetLogger(), &retError)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `ES_VERSION` parameter to `reindex.sh`.

<!-- Tell your future self why have you made these changes -->
**Why?**
`date` type needs to be converted to `date_nanos` for Elasticsearch 7 when migrating custom search attributes.
`double` type always needs to be converted to `scaled_float` when migrating custom search attributes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.