### PR TITLE
Handle mutable state version migration edge case

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -222,6 +222,7 @@ const (
 		`, execution_state = ? ` +
 		`, execution_state_encoding = ? ` +
 		`, next_event_id = ? ` +
+		`, db_record_version = ? ` +
 		`, checksum = ? ` +
 		`, checksum_encoding = ? ` +
 		`WHERE shard_id = ? ` +
@@ -1264,7 +1265,7 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(
 			updateWorkflow.ExecutionState.RunId,
 			[]executionCASCondition{{
 				runID:       updateWorkflow.ExecutionState.RunId,
-				dbVersion:   updateWorkflow.DBRecordVersion,
+				dbVersion:   updateWorkflow.DBRecordVersion - 1,
 				nextEventID: updateWorkflow.Condition,
 			}},
 		)
@@ -1403,13 +1404,13 @@ func (d *cassandraPersistence) ConflictResolveWorkflowExecution(
 	if !applied {
 		executionCASConditions := []executionCASCondition{{
 			runID:       resetWorkflow.RunID,
-			dbVersion:   resetWorkflow.DBRecordVersion,
+			dbVersion:   resetWorkflow.DBRecordVersion - 1,
 			nextEventID: resetWorkflow.Condition,
 		}}
 		if currentWorkflow != nil {
 			executionCASConditions = append(executionCASConditions, executionCASCondition{
 				runID:       currentWorkflow.RunID,
-				dbVersion:   currentWorkflow.DBRecordVersion,
+				dbVersion:   currentWorkflow.DBRecordVersion - 1,
 				nextEventID: currentWorkflow.Condition,
 			})
 		}

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1264,7 +1264,9 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(
 			request.RangeID,
 			updateWorkflow.ExecutionState.RunId,
 			[]executionCASCondition{{
-				runID:       updateWorkflow.ExecutionState.RunId,
+				runID: updateWorkflow.ExecutionState.RunId,
+				// dbVersion is for CAS, so the db record version will be set to `updateWorkflow.DBRecordVersion`
+				// while CAS on `updateWorkflow.DBRecordVersion - 1`
 				dbVersion:   updateWorkflow.DBRecordVersion - 1,
 				nextEventID: updateWorkflow.Condition,
 			}},
@@ -1403,13 +1405,17 @@ func (d *cassandraPersistence) ConflictResolveWorkflowExecution(
 
 	if !applied {
 		executionCASConditions := []executionCASCondition{{
-			runID:       resetWorkflow.RunID,
+			runID: resetWorkflow.RunID,
+			// dbVersion is for CAS, so the db record version will be set to `resetWorkflow.DBRecordVersion`
+			// while CAS on `resetWorkflow.DBRecordVersion - 1`
 			dbVersion:   resetWorkflow.DBRecordVersion - 1,
 			nextEventID: resetWorkflow.Condition,
 		}}
 		if currentWorkflow != nil {
 			executionCASConditions = append(executionCASConditions, executionCASCondition{
-				runID:       currentWorkflow.RunID,
+				runID: currentWorkflow.RunID,
+				// dbVersion is for CAS, so the db record version will be set to `currentWorkflow.DBRecordVersion`
+				// while CAS on `currentWorkflow.DBRecordVersion - 1`
 				dbVersion:   currentWorkflow.DBRecordVersion - 1,
 				nextEventID: currentWorkflow.Condition,
 			})

--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -445,6 +445,7 @@ func updateExecution(
 			executionStateBlob.Data,
 			executionStateBlob.EncodingType.String(),
 			nextEventID,
+			dbRecordVersion,
 			checksumBlob.Data,
 			checksumBlob.EncodingType.String(),
 			shardID,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -235,6 +235,7 @@ func NewMutableState(
 		metricsClient:   shard.GetMetricsClient(),
 	}
 
+	// making new workflow to use db record version for CAS instead of next event ID
 	if migration.IsDBVersionEnabled() {
 		s.dbRecordVersion = 1
 	}

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -234,6 +234,11 @@ func NewMutableState(
 		logger:          logger,
 		metricsClient:   shard.GetMetricsClient(),
 	}
+
+	if migration.IsDBVersionEnabled() {
+		s.dbRecordVersion = 1
+	}
+
 	s.executionInfo = &persistencespb.WorkflowExecutionInfo{
 		WorkflowTaskVersion:    common.EmptyVersion,
 		WorkflowTaskScheduleId: common.EmptyEventID,
@@ -3653,7 +3658,7 @@ func (e *MutableStateImpl) CloseTransactionAsMutation(
 	// impact the checksum calculation
 	checksum := e.generateChecksum()
 
-	if e.dbRecordVersion == 0 && !migration.IsDBVersionEnabled() {
+	if e.dbRecordVersion == 0 {
 		// noop, existing behavior
 	} else {
 		e.dbRecordVersion += 1
@@ -3742,7 +3747,7 @@ func (e *MutableStateImpl) CloseTransactionAsSnapshot(
 	// impact the checksum calculation
 	checksum := e.generateChecksum()
 
-	if e.dbRecordVersion == 0 && !migration.IsDBVersionEnabled() {
+	if e.dbRecordVersion == 0 {
 		// noop, existing behavior
 	} else {
 		e.dbRecordVersion += 1


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Old version of mutable state `db_record_version` will be `null` on Cassandra, but gocql `MapScan` function will return `0` instead of `null`. This makes conditional update on `db_record_version` impossible due to business logic unable to tell the difference between `null` vs `0`. Solution is to continue using CAS on `next_event_id` for old version of mutable state; using CAS on `db_record_version` for new version of mutable state.

<!-- Tell your future self why have you made these changes -->
**Why?**
See above

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests & manual tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No