### PR TITLE
Elasticsearch template tuning

### DIFF
--- a/schema/elasticsearch/visibility/versioned/v0/index_template_v6.json
+++ b/schema/elasticsearch/visibility/versioned/v0/index_template_v6.json
@@ -5,8 +5,9 @@
   ],
   "settings": {
     "index": {
-      "number_of_shards": "5",
-      "number_of_replicas": "0"
+      "number_of_shards": "1",
+      "number_of_replicas": "0",
+      "auto_expand_replicas": "0-2"
     }
   },
   "mappings": {

--- a/schema/elasticsearch/visibility/versioned/v0/index_template_v7.json
+++ b/schema/elasticsearch/visibility/versioned/v0/index_template_v7.json
@@ -5,8 +5,9 @@
   ],
   "settings": {
     "index": {
-      "number_of_shards": "5",
+      "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-2",
       "search.idle.after": "365d"
     }
   },

--- a/schema/elasticsearch/visibility/versioned/v1/index_template_v6.json
+++ b/schema/elasticsearch/visibility/versioned/v1/index_template_v6.json
@@ -5,8 +5,9 @@
   ],
   "settings": {
     "index": {
-      "number_of_shards": "5",
-      "number_of_replicas": "0"
+      "number_of_shards": "1",
+      "number_of_replicas": "0",
+      "auto_expand_replicas": "0-2"
     }
   },
   "mappings": {

--- a/schema/elasticsearch/visibility/versioned/v1/index_template_v7.json
+++ b/schema/elasticsearch/visibility/versioned/v1/index_template_v7.json
@@ -5,8 +5,9 @@
   ],
   "settings": {
     "index": {
-      "number_of_shards": "5",
+      "number_of_shards": "1",
       "number_of_replicas": "0",
+      "auto_expand_replicas": "0-2",
       "search.idle.after": "365d"
     }
   },


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Visibility schema templates used in Elasticsearch.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Since Elasticsearch 7.x it is advised to use one primary shard for performance reasons. It is also advisable in previous Elasticsearch versions. In general, default shard 5 was resulting in shard explosion and cluster collapse especially when using shared Elasticsearch cluster.
- Set auto expand replicas from 0 to 2, this allows to set up system even on single node and it will automatically adjust itself is more nodes are available.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
We use our custom Temporal `admin-tools` container with custom template.
Tested under Elasticsearch 7.9.x only, but in general auto-expand was tested on other datasets under Elasticsearch 6.x as well.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- does not work well with already existing indices, you would have to reindex/delete+recreate.
- this change is preferred when creating new cluster.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.