### PR TITLE
Remove internode keep alive pings

### DIFF
--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -31,15 +31,13 @@ import (
 
 	"github.com/gogo/status"
 	"go.temporal.io/api/serviceerror"
-	"google.golang.org/grpc"
-	"google.golang.org/grpc/backoff"
-	"google.golang.org/grpc/credentials"
-	"google.golang.org/grpc/keepalive"
-
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
+	"google.golang.org/grpc/credentials"
 )
 
 const (
@@ -62,7 +60,7 @@ const (
 // The hostName syntax is defined in
 // https://github.com/grpc/grpc/blob/master/doc/naming.md.
 // e.g. to use dns resolver, a "dns:///" prefix should be applied to the target.
-func Dial(hostName string, tlsConfig *tls.Config, logger log.Logger, enableKeepAlive bool) (*grpc.ClientConn, error) {
+func Dial(hostName string, tlsConfig *tls.Config, logger log.Logger) (*grpc.ClientConn, error) {
 	// Default to insecure
 	grpcSecureOpt := grpc.WithInsecure()
 	if tlsConfig != nil {
@@ -91,14 +89,6 @@ func Dial(hostName string, tlsConfig *tls.Config, logger log.Logger, enableKeepA
 		grpc.WithDefaultServiceConfig(DefaultServiceConfig),
 		grpc.WithDisableServiceConfig(),
 		grpc.WithConnectParams(cp),
-	}
-
-	if enableKeepAlive {
-		dialOptions = append(dialOptions, grpc.WithKeepaliveParams(
-			keepalive.ClientParameters{
-				Time: 10 * time.Second,
-			},
-		))
 	}
 
 	return grpc.Dial(

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -204,7 +204,7 @@ func (d *RPCFactory) CreateFrontendGRPCConnection(hostName string) *grpc.ClientC
 		}
 	}
 
-	return d.dial(hostName, tlsClientConfig, false)
+	return d.dial(hostName, tlsClientConfig)
 }
 
 // CreateInternodeGRPCConnection creates connection for gRPC calls
@@ -218,24 +218,16 @@ func (d *RPCFactory) CreateInternodeGRPCConnection(hostName string) *grpc.Client
 		}
 	}
 
-	return d.dial(hostName, tlsClientConfig, true)
+	return d.dial(hostName, tlsClientConfig)
 }
 
-func (d *RPCFactory) dial(hostName string, tlsClientConfig *tls.Config, enableKeepAlive bool) *grpc.ClientConn {
-	connection, err := Dial(hostName, tlsClientConfig, d.logger, enableKeepAlive)
+func (d *RPCFactory) dial(hostName string, tlsClientConfig *tls.Config) *grpc.ClientConn {
+	connection, err := Dial(hostName, tlsClientConfig, d.logger)
 	if err != nil {
 		d.logger.Fatal("Failed to create gRPC connection", tag.Error(err))
 	}
 
 	return connection
-}
-
-func getBroadcastAddressFromConfig(serverCfg *config.Global, cfg *config.RPC, logger log.Logger) string {
-	if serverCfg.Membership.BroadcastAddress != "" {
-		return serverCfg.Membership.BroadcastAddress
-	} else {
-		return getListenIP(cfg, logger).String()
-	}
 }
 
 func (d *RPCFactory) GetTLSConfigProvider() encryption.TLSConfigProvider {

--- a/common/rpc/test/rpc_common_test.go
+++ b/common/rpc/test/rpc_common_test.go
@@ -173,7 +173,7 @@ func dialHelloAndGetTLSInfo(
 	}
 
 	s.NoError(err)
-	clientConn, err := rpc.Dial(hostport, cfg, logger, false)
+	clientConn, err := rpc.Dial(hostport, cfg, logger)
 	s.NoError(err)
 	client := helloworld.NewGreeterClient(clientConn)
 

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -78,7 +78,7 @@ func (s *IntegrationBase) setupSuite(defaultClusterConfigFile string) {
 	if clusterConfig.FrontendAddress != "" {
 		s.Logger.Info("Running integration test against specified frontend", tag.Address(TestFlags.FrontendAddr))
 
-		connection, err := rpc.Dial(TestFlags.FrontendAddr, nil, s.Logger, false)
+		connection, err := rpc.Dial(TestFlags.FrontendAddr, nil, s.Logger)
 		if err != nil {
 			s.Require().NoError(err)
 		}

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -499,7 +499,7 @@ func (c *temporalImpl) startHistory(
 		// However current interface for getting history client doesn't specify which client it needs and the tests that use this API
 		// depends on the fact that there's only one history host.
 		// Need to change those tests and modify the interface for getting history client.
-		historyConnection, err := rpc.Dial(c.HistoryServiceAddress(3)[0], nil, c.logger, false)
+		historyConnection, err := rpc.Dial(c.HistoryServiceAddress(3)[0], nil, c.logger)
 		if err != nil {
 			c.logger.Fatal("Failed to create connection for history", tag.Error(err))
 		}
@@ -829,7 +829,7 @@ func (c *rpcFactoryImpl) GetRingpopChannel() *tchannel.Channel {
 
 // CreateGRPCConnection creates connection for gRPC calls
 func (c *rpcFactoryImpl) CreateGRPCConnection(hostName string) *grpc.ClientConn {
-	connection, err := rpc.Dial(hostName, nil, c.logger, false)
+	connection, err := rpc.Dial(hostName, nil, c.logger)
 	if err != nil {
 		c.logger.Fatal("Failed to create gRPC connection", tag.Error(err))
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove internode keep alive pings.

<!-- Tell your future self why have you made these changes -->
**Why?**
Internode pings were added in #1654. Unfortunately 10 seconds interval is very aggressive and server part on both matching and history services are not configured properly (minimum allowed interval is 5 minutes by default).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.