### PR TITLE
V1.11.1

### DIFF
--- a/common/headers/versionChecker.go
+++ b/common/headers/versionChecker.go
@@ -38,8 +38,8 @@ const (
 	ClientNameJavaSDK = "temporal-java"
 	ClientNameCLI     = "temporal-cli"
 
-	ServerVersion = "1.11.0"
-	CLIVersion    = "1.11.0"
+	ServerVersion = "1.11.1"
+	CLIVersion    = "1.11.1"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"

--- a/common/headers/versionChecker.go
+++ b/common/headers/versionChecker.go
@@ -38,8 +38,8 @@ const (
 	ClientNameJavaSDK = "temporal-java"
 	ClientNameCLI     = "temporal-cli"
 
-	ServerVersion = "1.10.0"
-	CLIVersion    = "1.10.0"
+	ServerVersion = "1.11.0"
+	CLIVersion    = "1.11.0"
 
 	// SupportedServerVersions is used by CLI and inter role communication.
 	SupportedServerVersions = ">=1.0.0 <2.0.0"


### PR DESCRIPTION
Forget to bump version number for v1.11.0. 
Bump version to 1.11.1, will cut a patch release for this.
