### PR TITLE
Use PIT instead of scroll for Scan API

### DIFF
--- a/common/persistence/elasticsearch/client/client.go
+++ b/common/persistence/elasticsearch/client/client.go
@@ -45,10 +45,6 @@ type (
 	Client interface {
 		Search(ctx context.Context, p *SearchParameters) (*elastic.SearchResult, error)
 		SearchWithDSL(ctx context.Context, index, query string) (*elastic.SearchResult, error)
-		// Deprecated. Remove after ES v6 support removal.
-		Scroll(ctx context.Context, scrollID string) (*elastic.SearchResult, ScrollService, error)
-		// Deprecated. Remove after ES v6 support removal.
-		ScrollFirstPage(ctx context.Context, index, query string) (*elastic.SearchResult, ScrollService, error)
 		Count(ctx context.Context, index, query string) (int64, error)
 		RunBulkProcessor(ctx context.Context, p *BulkProcessorParameters) (BulkProcessor, error)
 
@@ -63,6 +59,14 @@ type (
 		OpenPointInTime(ctx context.Context, index string, keepAliveInterval string) (string, error)
 		ClosePointInTime(ctx context.Context, id string) (bool, error)
 		SearchWithDSLWithPIT(ctx context.Context, query string) (*elastic.SearchResult, error)
+	}
+
+	// Deprecated. Remove after ES v6 support removal.
+	ClientV6 interface {
+		// Deprecated. Remove after ES v6 support removal.
+		Scroll(ctx context.Context, scrollID string) (*elastic.SearchResult, ScrollService, error)
+		// Deprecated. Remove after ES v6 support removal.
+		ScrollFirstPage(ctx context.Context, index, query string) (*elastic.SearchResult, ScrollService, error)
 	}
 
 	CLIClient interface {

--- a/common/persistence/elasticsearch/client/client.go
+++ b/common/persistence/elasticsearch/client/client.go
@@ -45,7 +45,9 @@ type (
 	Client interface {
 		Search(ctx context.Context, p *SearchParameters) (*elastic.SearchResult, error)
 		SearchWithDSL(ctx context.Context, index, query string) (*elastic.SearchResult, error)
+		// Deprecated. Remove after ES v6 support removal.
 		Scroll(ctx context.Context, scrollID string) (*elastic.SearchResult, ScrollService, error)
+		// Deprecated. Remove after ES v6 support removal.
 		ScrollFirstPage(ctx context.Context, index, query string) (*elastic.SearchResult, ScrollService, error)
 		Count(ctx context.Context, index, query string) (int64, error)
 		RunBulkProcessor(ctx context.Context, p *BulkProcessorParameters) (BulkProcessor, error)
@@ -54,6 +56,13 @@ type (
 		PutMapping(ctx context.Context, index string, mapping map[string]enumspb.IndexedValueType) (bool, error)
 		WaitForYellowStatus(ctx context.Context, index string) (string, error)
 		GetMapping(ctx context.Context, index string) (map[string]string, error)
+	}
+
+	// Combine ClientV7 with Client interface after ES v6 support removal.
+	ClientV7 interface {
+		OpenPointInTime(ctx context.Context, index string, keepAliveInterval string) (string, error)
+		ClosePointInTime(ctx context.Context, id string) (bool, error)
+		SearchWithDSLWithPIT(ctx context.Context, query string) (*elastic.SearchResult, error)
 	}
 
 	CLIClient interface {
@@ -73,11 +82,12 @@ type (
 	}
 
 	// ScrollService is a interface for elastic.ScrollService
+	// Deprecated. Remove after ES v6 support removal.
 	ScrollService interface {
 		Clear(ctx context.Context) error
 	}
 
-	// SearchParameters holds all required and optional parameters for executing a search
+	// SearchParameters holds all required and optional parameters for executing a search.
 	SearchParameters struct {
 		Index       string
 		Query       elastic.Query

--- a/common/persistence/elasticsearch/client/client_mock.go
+++ b/common/persistence/elasticsearch/client/client_mock.go
@@ -120,38 +120,6 @@ func (mr *MockClientMockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockClient)(nil).RunBulkProcessor), ctx, p)
 }
 
-// Scroll mocks base method.
-func (m *MockClient) Scroll(ctx context.Context, scrollID string) (*v7.SearchResult, ScrollService, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Scroll", ctx, scrollID)
-	ret0, _ := ret[0].(*v7.SearchResult)
-	ret1, _ := ret[1].(ScrollService)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// Scroll indicates an expected call of Scroll.
-func (mr *MockClientMockRecorder) Scroll(ctx, scrollID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockClient)(nil).Scroll), ctx, scrollID)
-}
-
-// ScrollFirstPage mocks base method.
-func (m *MockClient) ScrollFirstPage(ctx context.Context, index, query string) (*v7.SearchResult, ScrollService, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScrollFirstPage", ctx, index, query)
-	ret0, _ := ret[0].(*v7.SearchResult)
-	ret1, _ := ret[1].(ScrollService)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ScrollFirstPage indicates an expected call of ScrollFirstPage.
-func (mr *MockClientMockRecorder) ScrollFirstPage(ctx, index, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrollFirstPage", reflect.TypeOf((*MockClient)(nil).ScrollFirstPage), ctx, index, query)
-}
-
 // Search mocks base method.
 func (m *MockClient) Search(ctx context.Context, p *SearchParameters) (*v7.SearchResult, error) {
 	m.ctrl.T.Helper()
@@ -263,6 +231,61 @@ func (m *MockClientV7) SearchWithDSLWithPIT(ctx context.Context, query string) (
 func (mr *MockClientV7MockRecorder) SearchWithDSLWithPIT(ctx, query interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchWithDSLWithPIT", reflect.TypeOf((*MockClientV7)(nil).SearchWithDSLWithPIT), ctx, query)
+}
+
+// MockClientV6 is a mock of ClientV6 interface.
+type MockClientV6 struct {
+	ctrl     *gomock.Controller
+	recorder *MockClientV6MockRecorder
+}
+
+// MockClientV6MockRecorder is the mock recorder for MockClientV6.
+type MockClientV6MockRecorder struct {
+	mock *MockClientV6
+}
+
+// NewMockClientV6 creates a new mock instance.
+func NewMockClientV6(ctrl *gomock.Controller) *MockClientV6 {
+	mock := &MockClientV6{ctrl: ctrl}
+	mock.recorder = &MockClientV6MockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockClientV6) EXPECT() *MockClientV6MockRecorder {
+	return m.recorder
+}
+
+// Scroll mocks base method.
+func (m *MockClientV6) Scroll(ctx context.Context, scrollID string) (*v7.SearchResult, ScrollService, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Scroll", ctx, scrollID)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(ScrollService)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// Scroll indicates an expected call of Scroll.
+func (mr *MockClientV6MockRecorder) Scroll(ctx, scrollID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockClientV6)(nil).Scroll), ctx, scrollID)
+}
+
+// ScrollFirstPage mocks base method.
+func (m *MockClientV6) ScrollFirstPage(ctx context.Context, index, query string) (*v7.SearchResult, ScrollService, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ScrollFirstPage", ctx, index, query)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(ScrollService)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ScrollFirstPage indicates an expected call of ScrollFirstPage.
+func (mr *MockClientV6MockRecorder) ScrollFirstPage(ctx, index, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrollFirstPage", reflect.TypeOf((*MockClientV6)(nil).ScrollFirstPage), ctx, index, query)
 }
 
 // MockCLIClient is a mock of CLIClient interface.
@@ -389,38 +412,6 @@ func (m *MockCLIClient) RunBulkProcessor(ctx context.Context, p *BulkProcessorPa
 func (mr *MockCLIClientMockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockCLIClient)(nil).RunBulkProcessor), ctx, p)
-}
-
-// Scroll mocks base method.
-func (m *MockCLIClient) Scroll(ctx context.Context, scrollID string) (*v7.SearchResult, ScrollService, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Scroll", ctx, scrollID)
-	ret0, _ := ret[0].(*v7.SearchResult)
-	ret1, _ := ret[1].(ScrollService)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// Scroll indicates an expected call of Scroll.
-func (mr *MockCLIClientMockRecorder) Scroll(ctx, scrollID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockCLIClient)(nil).Scroll), ctx, scrollID)
-}
-
-// ScrollFirstPage mocks base method.
-func (m *MockCLIClient) ScrollFirstPage(ctx context.Context, index, query string) (*v7.SearchResult, ScrollService, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScrollFirstPage", ctx, index, query)
-	ret0, _ := ret[0].(*v7.SearchResult)
-	ret1, _ := ret[1].(ScrollService)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ScrollFirstPage indicates an expected call of ScrollFirstPage.
-func (mr *MockCLIClientMockRecorder) ScrollFirstPage(ctx, index, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrollFirstPage", reflect.TypeOf((*MockCLIClient)(nil).ScrollFirstPage), ctx, index, query)
 }
 
 // Search mocks base method.

--- a/common/persistence/elasticsearch/client/client_mock.go
+++ b/common/persistence/elasticsearch/client/client_mock.go
@@ -197,6 +197,74 @@ func (mr *MockClientMockRecorder) WaitForYellowStatus(ctx, index interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForYellowStatus", reflect.TypeOf((*MockClient)(nil).WaitForYellowStatus), ctx, index)
 }
 
+// MockClientV7 is a mock of ClientV7 interface.
+type MockClientV7 struct {
+	ctrl     *gomock.Controller
+	recorder *MockClientV7MockRecorder
+}
+
+// MockClientV7MockRecorder is the mock recorder for MockClientV7.
+type MockClientV7MockRecorder struct {
+	mock *MockClientV7
+}
+
+// NewMockClientV7 creates a new mock instance.
+func NewMockClientV7(ctrl *gomock.Controller) *MockClientV7 {
+	mock := &MockClientV7{ctrl: ctrl}
+	mock.recorder = &MockClientV7MockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockClientV7) EXPECT() *MockClientV7MockRecorder {
+	return m.recorder
+}
+
+// ClosePointInTime mocks base method.
+func (m *MockClientV7) ClosePointInTime(ctx context.Context, id string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ClosePointInTime", ctx, id)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ClosePointInTime indicates an expected call of ClosePointInTime.
+func (mr *MockClientV7MockRecorder) ClosePointInTime(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePointInTime", reflect.TypeOf((*MockClientV7)(nil).ClosePointInTime), ctx, id)
+}
+
+// OpenPointInTime mocks base method.
+func (m *MockClientV7) OpenPointInTime(ctx context.Context, index, keepAliveInterval string) (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenPointInTime", ctx, index, keepAliveInterval)
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenPointInTime indicates an expected call of OpenPointInTime.
+func (mr *MockClientV7MockRecorder) OpenPointInTime(ctx, index, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPointInTime", reflect.TypeOf((*MockClientV7)(nil).OpenPointInTime), ctx, index, keepAliveInterval)
+}
+
+// SearchWithDSLWithPIT mocks base method.
+func (m *MockClientV7) SearchWithDSLWithPIT(ctx context.Context, query string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SearchWithDSLWithPIT", ctx, query)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SearchWithDSLWithPIT indicates an expected call of SearchWithDSLWithPIT.
+func (mr *MockClientV7MockRecorder) SearchWithDSLWithPIT(ctx, query interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SearchWithDSLWithPIT", reflect.TypeOf((*MockClientV7)(nil).SearchWithDSLWithPIT), ctx, query)
+}
+
 // MockCLIClient is a mock of CLIClient interface.
 type MockCLIClient struct {
 	ctrl     *gomock.Controller

--- a/common/persistence/elasticsearch/client/client_v6.go
+++ b/common/persistence/elasticsearch/client/client_v6.go
@@ -275,6 +275,7 @@ func convertV6SearchResultToV7(result *elastic6.SearchResult) *elastic.SearchRes
 		Error:           convertV6ErrorDetailsToV7(result.Error),
 		Status:          result.Status,
 		Aggregations:    convertV6AggregationsToV7(result.Aggregations),
+		PitId:           "",
 
 		// TODO (alex): these complex structs are not converted. Add conversion funcs before using them in caller code.
 		Suggest: nil, // result.Suggest,

--- a/common/persistence/elasticsearch/client/client_v7.go
+++ b/common/persistence/elasticsearch/client/client_v7.go
@@ -142,18 +142,6 @@ func (c *clientV7) SearchWithDSL(ctx context.Context, index, query string) (*ela
 	return searchResult, err
 }
 
-func (c *clientV7) Scroll(ctx context.Context, scrollID string) (*elastic.SearchResult, ScrollService, error) {
-	scrollService := elastic.NewScrollService(c.esClient)
-	result, err := scrollService.ScrollId(scrollID).Do(ctx)
-	return result, scrollService, err
-}
-
-func (c *clientV7) ScrollFirstPage(ctx context.Context, index, query string) (*elastic.SearchResult, ScrollService, error) {
-	scrollService := elastic.NewScrollService(c.esClient)
-	result, err := scrollService.Index(index).Body(query).Do(ctx)
-	return result, scrollService, err
-}
-
 func (c *clientV7) Count(ctx context.Context, index, query string) (int64, error) {
 	return c.esClient.Count(index).BodyString(query).Do(ctx)
 }

--- a/common/persistence/elasticsearch/client/client_v7.go
+++ b/common/persistence/elasticsearch/client/client_v7.go
@@ -44,6 +44,7 @@ type (
 )
 
 var _ Client = (*clientV7)(nil)
+var _ ClientV7 = (*clientV7)(nil)
 
 // newClientV7 create a ES client
 func newClientV7(config *config.Elasticsearch, httpClient *http.Client, logger log.Logger) (*clientV7, error) {
@@ -112,6 +113,28 @@ func (c *clientV7) Search(ctx context.Context, p *SearchParameters) (*elastic.Se
 	}
 
 	return searchService.Do(ctx)
+}
+
+func (c *clientV7) OpenPointInTime(ctx context.Context, index string, keepAliveInterval string) (string, error) {
+	resp, err := c.esClient.OpenPointInTime(index).KeepAlive(keepAliveInterval).Do(ctx)
+	if err != nil {
+		return "", err
+	}
+	return resp.Id, nil
+}
+
+func (c *clientV7) ClosePointInTime(ctx context.Context, id string) (bool, error) {
+	resp, err := c.esClient.ClosePointInTime(id).Do(ctx)
+	if err != nil {
+		return false, err
+	}
+	return resp.Succeeded, nil
+}
+
+func (c *clientV7) SearchWithDSLWithPIT(ctx context.Context, query string) (*elastic.SearchResult, error) {
+	// When pit.id is specified index must not be used.
+	searchResult, err := c.esClient.Search().Source(query).Do(ctx)
+	return searchResult, err
 }
 
 func (c *clientV7) SearchWithDSL(ctx context.Context, index, query string) (*elastic.SearchResult, error) {

--- a/common/persistence/elasticsearch/visibility_store.go
+++ b/common/persistence/elasticsearch/visibility_store.go
@@ -445,7 +445,7 @@ func (s *visibilityStore) ScanWorkflowExecutions(
 		if token.PointInTimeID == "" {
 			token.PointInTimeID, err = esClient.OpenPointInTime(ctx, s.index, pointInTimeKeepAliveInterval)
 			if err != nil {
-				return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to create point in time: %v", err))
+				return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to create point in time: %s", detailedErrorMessage(err)))
 			}
 		}
 
@@ -457,14 +457,14 @@ func (s *visibilityStore) ScanWorkflowExecutions(
 
 		searchResult, err := esClient.SearchWithDSLWithPIT(ctx, queryDSL)
 		if err != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %v", err))
+			return nil, serviceerror.NewInternal(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
 		}
 
 		if len(searchResult.Hits.Hits) < request.PageSize {
 			// It is the last page, close PIT.
 			_, err = esClient.ClosePointInTime(ctx, token.PointInTimeID)
 			if err != nil {
-				return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to close point in time: %v", err))
+				return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to close point in time: %s", detailedErrorMessage(err)))
 			}
 		}
 		return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, nil)

--- a/common/persistence/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/elasticsearch/visibility_store_read_test.go
@@ -60,8 +60,20 @@ type (
 		controller        *gomock.Controller
 		visibilityStore   *visibilityStore
 		mockESClient      *client.MockClient
+		mockESClientV6    *client.MockClientV6
+		mockESClientV7    *client.MockClientV7
 		mockProcessor     *MockProcessor
 		mockMetricsClient *metrics.MockClient
+	}
+
+	mockESClientV7 struct {
+		*client.MockClient
+		*client.MockClientV7
+	}
+
+	mockESClientV6 struct {
+		*client.MockClient
+		*client.MockClientV6
 	}
 )
 
@@ -116,7 +128,13 @@ func (s *ESVisibilitySuite) SetupTest() {
 	s.mockMetricsClient = metrics.NewMockClient(s.controller)
 	s.mockProcessor = NewMockProcessor(s.controller)
 	s.mockESClient = client.NewMockClient(s.controller)
-	s.visibilityStore = NewVisibilityStore(s.mockESClient, testIndex, searchattribute.NewTestProvider(), s.mockProcessor, cfg, log.NewNoopLogger(), s.mockMetricsClient)
+	s.mockESClientV6 = client.NewMockClientV6(s.controller)
+	s.mockESClientV7 = client.NewMockClientV7(s.controller)
+	mClientV7 := &mockESClientV7{
+		MockClient:   s.mockESClient,
+		MockClientV7: s.mockESClientV7,
+	}
+	s.visibilityStore = NewVisibilityStore(mClientV7, testIndex, searchattribute.NewTestProvider(), s.mockProcessor, cfg, log.NewNoopLogger(), s.mockMetricsClient)
 }
 
 func (s *ESVisibilitySuite) TearDownTest() {
@@ -821,9 +839,14 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 	s.True(strings.Contains(err.Error(), "Error when parse query"))
 }
 
-func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
+func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
+	// Set v6 client for test.
+	s.visibilityStore.esClient = &mockESClientV6{
+		MockClient:   s.mockESClient,
+		MockClientV6: s.mockESClientV6,
+	}
 	// test first page
-	s.mockESClient.EXPECT().ScrollFirstPage(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
+	s.mockESClientV6.EXPECT().ScrollFirstPage(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
 		func(ctx context.Context, index, input string) (*elastic.SearchResult, client.ScrollService, error) {
 			s.True(strings.Contains(input, `{"match_phrase":{"ExecutionStatus":{"query":"Terminated"}}}`))
 			return testSearchResult, nil, nil
@@ -848,7 +871,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 
 	// test scroll
 	scrollID := "scrollID-1"
-	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID).Return(testSearchResult, nil, nil)
+	s.mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID).Return(testSearchResult, nil, nil)
 
 	token := &visibilityPageToken{ScrollID: scrollID}
 	tokenBytes, err := s.visibilityStore.serializePageToken(token)
@@ -859,13 +882,95 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 
 	// test last page
 	mockScroll := client.NewMockScrollService(s.controller)
-	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID).Return(testSearchResult, mockScroll, io.EOF)
+	s.mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID).Return(testSearchResult, mockScroll, io.EOF)
 	mockScroll.EXPECT().Clear(gomock.Any()).Return(nil)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 
 	// test internal error
-	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID).Return(nil, nil, errTestESSearch)
+	s.mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID).Return(nil, nil, errTestESSearch)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.Error(err)
+	_, ok = err.(*serviceerror.Internal)
+	s.True(ok)
+	s.True(strings.Contains(err.Error(), "ScanWorkflowExecutions failed"))
+
+	// Restore v7 client.
+	s.visibilityStore.esClient = &mockESClientV7{
+		MockClient:   s.mockESClient,
+		MockClientV7: s.mockESClientV7,
+	}
+}
+
+func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7() {
+	// test first page
+	pitID := "pitID"
+
+	request := &persistence.ListWorkflowExecutionsRequestV2{
+		NamespaceID: testNamespaceID,
+		Namespace:   testNamespace,
+		PageSize:    1,
+		Query:       `ExecutionStatus = "Terminated"`,
+	}
+
+	data := []byte(`{"ExecutionStatus": "Running",
+          "CloseTime": "2021-06-11T16:04:07.980-07:00",
+          "NamespaceId": "bfd5c907-f899-4baf-a7b2-2ab85e623ebd",
+          "HistoryLength": 29,
+          "StateTransitionCount": 22,
+          "VisibilityTaskKey": "7-619",
+          "RunId": "e481009e-14b3-45ae-91af-dce6e2a88365",
+          "StartTime": "2021-06-11T15:04:07.980-07:00",
+          "WorkflowId": "6bfbc1e5-6ce4-4e22-bbfb-e0faa9a7a604-1-2256",
+          "WorkflowType": "basic.stressWorkflowExecute"}`)
+	source := json.RawMessage(data)
+	searchResult := &elastic.SearchResult{
+		Hits: &elastic.SearchHits{
+			Hits: []*elastic.SearchHit{
+				{
+					Source: source,
+				},
+			},
+		},
+	}
+	s.mockESClientV7.EXPECT().SearchWithDSLWithPIT(gomock.Any(), gomock.Any()).Return(searchResult, nil)
+	s.mockESClientV7.EXPECT().OpenPointInTime(gomock.Any(), testIndex, gomock.Any()).Return(pitID, nil)
+	_, err := s.visibilityStore.ScanWorkflowExecutions(request)
+	s.NoError(err)
+
+	// test bad request
+	request.Query = `invalid query`
+	s.mockESClientV7.EXPECT().OpenPointInTime(gomock.Any(), testIndex, gomock.Any()).Return(pitID, nil)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.Error(err)
+	_, ok := err.(*serviceerror.InvalidArgument)
+	s.True(ok)
+	s.True(strings.Contains(err.Error(), "Error when parse query"))
+
+	// test search
+	request.Query = `ExecutionStatus = "Terminated"`
+	s.mockESClientV7.EXPECT().SearchWithDSLWithPIT(gomock.Any(), gomock.Any()).Return(searchResult, nil)
+
+	token := &visibilityPageToken{PointInTimeID: pitID}
+	tokenBytes, err := s.visibilityStore.serializePageToken(token)
+	s.NoError(err)
+	request.NextPageToken = tokenBytes
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.NoError(err)
+
+	// test last page
+	searchResult = &elastic.SearchResult{
+		Hits: &elastic.SearchHits{
+			Hits: []*elastic.SearchHit{},
+		},
+	}
+	s.mockESClientV7.EXPECT().SearchWithDSLWithPIT(gomock.Any(), gomock.Any()).Return(searchResult, nil)
+	s.mockESClientV7.EXPECT().ClosePointInTime(gomock.Any(), pitID).Return(true, nil)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.NoError(err)
+
+	// test internal error
+	s.mockESClientV7.EXPECT().SearchWithDSLWithPIT(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.Error(err)
 	_, ok = err.(*serviceerror.Internal)

--- a/common/persistence/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/elasticsearch/visibility_store_read_test.go
@@ -420,10 +420,11 @@ func (s *ESVisibilitySuite) TestGetSearchResult() {
 
 func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	// test for empty hits
-	searchHits := &elastic.SearchHits{
-		TotalHits: &elastic.TotalHits{},
-	}
-	resp, err := s.visibilityStore.getListWorkflowExecutionsResponse(searchHits, 1, nil)
+	searchResult := &elastic.SearchResult{
+		Hits: &elastic.SearchHits{
+			TotalHits: &elastic.TotalHits{},
+		}}
+	resp, err := s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, 1, nil)
 	s.NoError(err)
 	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(0, len(resp.Executions))
@@ -444,27 +445,27 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 		Source: source,
 		Sort:   []interface{}{1547596872371000000, "e481009e-14b3-45ae-91af-dce6e2a88365"},
 	}
-	searchHits.Hits = []*elastic.SearchHit{searchHit}
-	searchHits.TotalHits.Value = 1
-	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchHits, 1, nil)
+	searchResult.Hits.Hits = []*elastic.SearchHit{searchHit}
+	searchResult.Hits.TotalHits.Value = 1
+	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, 1, nil)
 	s.NoError(err)
 	serializedToken, _ := s.visibilityStore.serializePageToken(&visibilityPageToken{SortValue: 1547596872371000000, TieBreaker: "e481009e-14b3-45ae-91af-dce6e2a88365"})
 	s.Equal(serializedToken, resp.NextPageToken)
 	s.Equal(1, len(resp.Executions))
 
 	// test for last page hits
-	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchHits, 2, nil)
+	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, 2, nil)
 	s.NoError(err)
 	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(1, len(resp.Executions))
 
 	// test for search after
-	searchHits.Hits = []*elastic.SearchHit{}
-	for i := int64(0); i < searchHits.TotalHits.Value; i++ {
-		searchHits.Hits = append(searchHits.Hits, searchHit)
+	searchResult.Hits.Hits = []*elastic.SearchHit{}
+	for i := int64(0); i < searchResult.Hits.TotalHits.Value; i++ {
+		searchResult.Hits.Hits = append(searchResult.Hits.Hits, searchHit)
 	}
-	numOfHits := len(searchHits.Hits)
-	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchHits, numOfHits, nil)
+	numOfHits := len(searchResult.Hits.Hits)
+	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, numOfHits, nil)
 	s.NoError(err)
 	s.Equal(numOfHits, len(resp.Executions))
 	nextPageToken, err := s.visibilityStore.deserializePageToken(resp.NextPageToken)
@@ -474,7 +475,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	s.Equal(int64(1547596872371000000), resultSortValue)
 	s.Equal("e481009e-14b3-45ae-91af-dce6e2a88365", nextPageToken.TieBreaker)
 	// for last page
-	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchHits, numOfHits+1, nil)
+	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, numOfHits+1, nil)
 	s.NoError(err)
 	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(numOfHits, len(resp.Executions))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use [point in time](https://www.elastic.co/guide/en/elasticsearch/reference/7.13/point-in-time-api.html) instead of [scroll](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/paginate-search-results.html#scroll-search-results) for `ScanWorkflowExecutions` API.

<!-- Tell your future self why have you made these changes -->
**Why?**
Recommendations for Elasticsearch v7 has changed:
> We no longer recommend using the scroll API for deep pagination. If you need to preserve the index state while paging through more than 10,000 hits, use the search_after parameter with a point in time (PIT).

PIT consumes less Elasticsearch resources and has better limitations.

Elasticsearch v6 still uses scroll.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit and integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.