### PR TITLE
Set longer task timeout to avoid stampede on history service

### DIFF
--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	transferActiveTaskDefaultTimeout = 60 * time.Second
+	transferActiveTaskDefaultTimeout = 30 * time.Second
 )
 
 type (

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	transferActiveTaskDefaultTimeout = 3 * time.Second
+	transferActiveTaskDefaultTimeout = 60 * time.Second
 )
 
 type (

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	transferActiveTaskDefaultTimeout = 30 * time.Second
+	transferActiveTaskDefaultTimeout = 20 * time.Second
 )
 
 type (


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Default timeout for background task processing.

<!-- Tell your future self why have you made these changes -->
**Why?**
When history service has large latency, the short timeout and retry policy would cause transfer queue to keep initiate more and more requests causing them to pile up on history service side.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Deployed to test cluster where we have this issue, and see the issue resolved with the fix.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.