### PR TITLE
WorkflowStore interface

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -727,7 +727,7 @@ type (
 	}
 )
 
-var _ p.ExecutionStore = (*cassandraPersistence)(nil)
+var _ p.WorkflowStore = (*cassandraPersistence)(nil)
 
 // newShardPersistence is used to create an instance of ShardManager implementation
 func newShardPersistence(
@@ -742,16 +742,16 @@ func newShardPersistence(
 	}, nil
 }
 
-// NewWorkflowExecutionPersistence is used to create an instance of workflowExecutionManager implementation
-func NewWorkflowExecutionPersistence(
+// NewWorkflowStore is used to create an instance of workflowExecutionManager implementation
+func NewWorkflowStore(
 	shardID int32,
 	session gocql.Session,
 	logger log.Logger,
-) (p.ExecutionStore, error) {
+) p.WorkflowStore {
 	return &cassandraPersistence{
 		cassandraStore: cassandraStore{session: session, logger: logger},
 		shardID:        shardID,
-	}, nil
+	}
 }
 
 // newTaskPersistence is used to create an instance of TaskManager implementation

--- a/common/persistence/cassandra/factory.go
+++ b/common/persistence/cassandra/factory.go
@@ -39,16 +39,10 @@ type (
 	// Factory vends datastore implementations backed by cassandra
 	Factory struct {
 		sync.RWMutex
-		cfg              config.Cassandra
-		clusterName      string
-		logger           log.Logger
-		execStoreFactory *executionStoreFactory
-		session          gocql.Session
-	}
-
-	executionStoreFactory struct {
-		session gocql.Session
-		logger  log.Logger
+		cfg         config.Cassandra
+		clusterName string
+		logger      log.Logger
+		session     gocql.Session
 	}
 )
 
@@ -82,11 +76,6 @@ func (f *Factory) NewShardStore() (p.ShardStore, error) {
 	return newShardPersistence(f.session, f.clusterName, f.logger)
 }
 
-// NewHistoryStore returns a new history store
-func (f *Factory) NewHistoryStore() (p.HistoryStore, error) {
-	return newHistoryPersistence(f.session, f.logger)
-}
-
 // NewMetadataStore returns a metadata store that understands only v2
 func (f *Factory) NewMetadataStore() (p.MetadataStore, error) {
 	return newMetadataPersistence(f.session, f.clusterName, f.logger)
@@ -97,13 +86,9 @@ func (f *Factory) NewClusterMetadataStore() (p.ClusterMetadataStore, error) {
 	return newClusterMetadataInstance(f.session, f.logger)
 }
 
-// NewExecutionStore returns an ExecutionStore for a given shardID
-func (f *Factory) NewExecutionStore(shardID int32) (p.ExecutionStore, error) {
-	factory, err := f.executionStoreFactory()
-	if err != nil {
-		return nil, err
-	}
-	return factory.new(shardID)
+// NewWorkflowStore returns an WorkflowStore for a given shardID
+func (f *Factory) NewWorkflowStore(shardID int32) (p.WorkflowStore, error) {
+	return NewWorkflowStore(shardID, f.session, f.logger), nil
 }
 
 // NewQueue returns a new queue backed by cassandra
@@ -115,57 +100,5 @@ func (f *Factory) NewQueue(queueType p.QueueType) (p.Queue, error) {
 func (f *Factory) Close() {
 	f.Lock()
 	defer f.Unlock()
-	if f.execStoreFactory != nil {
-		f.execStoreFactory.close()
-	}
-}
-
-func (f *Factory) executionStoreFactory() (*executionStoreFactory, error) {
-	f.RLock()
-	if f.execStoreFactory != nil {
-		f.RUnlock()
-		return f.execStoreFactory, nil
-	}
-	f.RUnlock()
-
-	f.Lock()
-	defer f.Unlock()
-
-	if f.execStoreFactory != nil {
-		return f.execStoreFactory, nil
-	}
-
-	factory, err := newExecutionStoreFactory(f.session, f.logger)
-	if err != nil {
-		return nil, err
-	}
-
-	f.execStoreFactory = factory
-	return f.execStoreFactory, nil
-}
-
-// newExecutionStoreFactory is used to create an instance of ExecutionStoreFactory implementation
-func newExecutionStoreFactory(
-	session gocql.Session,
-	logger log.Logger,
-) (*executionStoreFactory, error) {
-	return &executionStoreFactory{
-		session: session,
-		logger:  logger,
-	}, nil
-}
-
-func (f *executionStoreFactory) close() {
 	f.session.Close()
-}
-
-// new implements ExecutionStoreFactory interface
-func (f *executionStoreFactory) new(
-	shardID int32,
-) (p.ExecutionStore, error) {
-	pmgr, err := NewWorkflowExecutionPersistence(shardID, f.session, f.logger)
-	if err != nil {
-		return nil, err
-	}
-	return pmgr, nil
 }

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -69,12 +69,10 @@ type (
 		NewTaskStore() (p.TaskStore, error)
 		// NewShardStore returns a new shard store
 		NewShardStore() (p.ShardStore, error)
-		// NewHistoryStore returns a new history store
-		NewHistoryStore() (p.HistoryStore, error)
 		// NewMetadataStore returns a new metadata store
 		NewMetadataStore() (p.MetadataStore, error)
-		// NewExecutionStore returns an execution store for given shardID
-		NewExecutionStore(shardID int32) (p.ExecutionStore, error)
+		// NewWorkflowStore returns a workflow store for given shardID
+		NewWorkflowStore(shardID int32) (p.WorkflowStore, error)
 		NewQueue(queueType p.QueueType) (p.Queue, error)
 		// NewClusterMetadataStore returns a new metadata store
 		NewClusterMetadataStore() (p.ClusterMetadataStore, error)
@@ -188,7 +186,7 @@ func (f *factoryImpl) NewShardManager() (p.ShardManager, error) {
 // NewHistoryManager returns a new history manager
 func (f *factoryImpl) NewHistoryManager() (p.HistoryManager, error) {
 	ds := f.datastores[storeTypeHistory]
-	store, err := ds.factory.NewHistoryStore()
+	store, err := ds.factory.NewWorkflowStore(-1)
 	if err != nil {
 		return nil, err
 	}
@@ -248,7 +246,7 @@ func (f *factoryImpl) NewExecutionManager(
 ) (p.ExecutionManager, error) {
 
 	ds := f.datastores[storeTypeExecution]
-	store, err := ds.factory.NewExecutionStore(shardID)
+	store, err := ds.factory.NewWorkflowStore(shardID)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -40,10 +40,10 @@ import (
 )
 
 type (
-	// executionManagerImpl implements ExecutionManager based on ExecutionStore, statsComputer and Serializer
+	// executionManagerImpl implements ExecutionManager based on WorkflowStore, statsComputer and Serializer
 	executionManagerImpl struct {
 		serializer    serialization.Serializer
-		persistence   ExecutionStore
+		persistence   WorkflowStore
 		statsComputer statsComputer
 		logger        log.Logger
 	}
@@ -53,7 +53,7 @@ var _ ExecutionManager = (*executionManagerImpl)(nil)
 
 // NewExecutionManager returns new ExecutionManager
 func NewExecutionManager(
-	persistence ExecutionStore,
+	persistence WorkflowStore,
 	logger log.Logger,
 ) ExecutionManager {
 

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -43,10 +43,10 @@ import (
 )
 
 type (
-	// historyManagerImpl implements HistoryManager based on HistoryStore and Serializer
+	// historyManagerImpl implements HistoryManager based on WorkflowStore and Serializer
 	historyV2ManagerImpl struct {
 		historySerializer     serialization.Serializer
-		persistence           HistoryStore
+		persistence           WorkflowStore
 		logger                log.Logger
 		pagingTokenSerializer *jsonHistoryTokenSerializer
 		transactionSizeLimit  dynamicconfig.IntPropertyFn
@@ -65,7 +65,7 @@ var _ HistoryManager = (*historyV2ManagerImpl)(nil)
 
 // NewHistoryV2ManagerImpl returns new HistoryManager
 func NewHistoryV2ManagerImpl(
-	persistence HistoryStore,
+	persistence WorkflowStore,
 	logger log.Logger,
 	transactionSizeLimit dynamicconfig.IntPropertyFn,
 ) HistoryManager {

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -610,31 +610,31 @@ func (mr *MockClusterMetadataStoreMockRecorder) UpsertClusterMembership(request 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertClusterMembership", reflect.TypeOf((*MockClusterMetadataStore)(nil).UpsertClusterMembership), request)
 }
 
-// MockExecutionStore is a mock of ExecutionStore interface.
-type MockExecutionStore struct {
+// MockWorkflowStore is a mock of WorkflowStore interface.
+type MockWorkflowStore struct {
 	ctrl     *gomock.Controller
-	recorder *MockExecutionStoreMockRecorder
+	recorder *MockWorkflowStoreMockRecorder
 }
 
-// MockExecutionStoreMockRecorder is the mock recorder for MockExecutionStore.
-type MockExecutionStoreMockRecorder struct {
-	mock *MockExecutionStore
+// MockWorkflowStoreMockRecorder is the mock recorder for MockWorkflowStore.
+type MockWorkflowStoreMockRecorder struct {
+	mock *MockWorkflowStore
 }
 
-// NewMockExecutionStore creates a new mock instance.
-func NewMockExecutionStore(ctrl *gomock.Controller) *MockExecutionStore {
-	mock := &MockExecutionStore{ctrl: ctrl}
-	mock.recorder = &MockExecutionStoreMockRecorder{mock}
+// NewMockWorkflowStore creates a new mock instance.
+func NewMockWorkflowStore(ctrl *gomock.Controller) *MockWorkflowStore {
+	mock := &MockWorkflowStore{ctrl: ctrl}
+	mock.recorder = &MockWorkflowStoreMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockExecutionStore) EXPECT() *MockExecutionStoreMockRecorder {
+func (m *MockWorkflowStore) EXPECT() *MockWorkflowStoreMockRecorder {
 	return m.recorder
 }
 
 // AddTasks mocks base method.
-func (m *MockExecutionStore) AddTasks(request *persistence.AddTasksRequest) error {
+func (m *MockWorkflowStore) AddTasks(request *persistence.AddTasksRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddTasks", request)
 	ret0, _ := ret[0].(error)
@@ -642,25 +642,39 @@ func (m *MockExecutionStore) AddTasks(request *persistence.AddTasksRequest) erro
 }
 
 // AddTasks indicates an expected call of AddTasks.
-func (mr *MockExecutionStoreMockRecorder) AddTasks(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) AddTasks(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTasks", reflect.TypeOf((*MockExecutionStore)(nil).AddTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTasks", reflect.TypeOf((*MockWorkflowStore)(nil).AddTasks), request)
+}
+
+// AppendHistoryNodes mocks base method.
+func (m *MockWorkflowStore) AppendHistoryNodes(request *persistence.InternalAppendHistoryNodesRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppendHistoryNodes", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AppendHistoryNodes indicates an expected call of AppendHistoryNodes.
+func (mr *MockWorkflowStoreMockRecorder) AppendHistoryNodes(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendHistoryNodes", reflect.TypeOf((*MockWorkflowStore)(nil).AppendHistoryNodes), request)
 }
 
 // Close mocks base method.
-func (m *MockExecutionStore) Close() {
+func (m *MockWorkflowStore) Close() {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Close")
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockExecutionStoreMockRecorder) Close() *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockExecutionStore)(nil).Close))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockWorkflowStore)(nil).Close))
 }
 
 // CompleteReplicationTask mocks base method.
-func (m *MockExecutionStore) CompleteReplicationTask(request *persistence.CompleteReplicationTaskRequest) error {
+func (m *MockWorkflowStore) CompleteReplicationTask(request *persistence.CompleteReplicationTaskRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompleteReplicationTask", request)
 	ret0, _ := ret[0].(error)
@@ -668,13 +682,13 @@ func (m *MockExecutionStore) CompleteReplicationTask(request *persistence.Comple
 }
 
 // CompleteReplicationTask indicates an expected call of CompleteReplicationTask.
-func (mr *MockExecutionStoreMockRecorder) CompleteReplicationTask(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) CompleteReplicationTask(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteReplicationTask", reflect.TypeOf((*MockExecutionStore)(nil).CompleteReplicationTask), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteReplicationTask", reflect.TypeOf((*MockWorkflowStore)(nil).CompleteReplicationTask), request)
 }
 
 // CompleteTimerTask mocks base method.
-func (m *MockExecutionStore) CompleteTimerTask(request *persistence.CompleteTimerTaskRequest) error {
+func (m *MockWorkflowStore) CompleteTimerTask(request *persistence.CompleteTimerTaskRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompleteTimerTask", request)
 	ret0, _ := ret[0].(error)
@@ -682,13 +696,13 @@ func (m *MockExecutionStore) CompleteTimerTask(request *persistence.CompleteTime
 }
 
 // CompleteTimerTask indicates an expected call of CompleteTimerTask.
-func (mr *MockExecutionStoreMockRecorder) CompleteTimerTask(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) CompleteTimerTask(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTimerTask", reflect.TypeOf((*MockExecutionStore)(nil).CompleteTimerTask), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTimerTask", reflect.TypeOf((*MockWorkflowStore)(nil).CompleteTimerTask), request)
 }
 
 // CompleteTransferTask mocks base method.
-func (m *MockExecutionStore) CompleteTransferTask(request *persistence.CompleteTransferTaskRequest) error {
+func (m *MockWorkflowStore) CompleteTransferTask(request *persistence.CompleteTransferTaskRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompleteTransferTask", request)
 	ret0, _ := ret[0].(error)
@@ -696,13 +710,13 @@ func (m *MockExecutionStore) CompleteTransferTask(request *persistence.CompleteT
 }
 
 // CompleteTransferTask indicates an expected call of CompleteTransferTask.
-func (mr *MockExecutionStoreMockRecorder) CompleteTransferTask(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) CompleteTransferTask(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTransferTask", reflect.TypeOf((*MockExecutionStore)(nil).CompleteTransferTask), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTransferTask", reflect.TypeOf((*MockWorkflowStore)(nil).CompleteTransferTask), request)
 }
 
 // CompleteVisibilityTask mocks base method.
-func (m *MockExecutionStore) CompleteVisibilityTask(request *persistence.CompleteVisibilityTaskRequest) error {
+func (m *MockWorkflowStore) CompleteVisibilityTask(request *persistence.CompleteVisibilityTaskRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CompleteVisibilityTask", request)
 	ret0, _ := ret[0].(error)
@@ -710,13 +724,13 @@ func (m *MockExecutionStore) CompleteVisibilityTask(request *persistence.Complet
 }
 
 // CompleteVisibilityTask indicates an expected call of CompleteVisibilityTask.
-func (mr *MockExecutionStoreMockRecorder) CompleteVisibilityTask(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) CompleteVisibilityTask(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteVisibilityTask", reflect.TypeOf((*MockExecutionStore)(nil).CompleteVisibilityTask), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteVisibilityTask", reflect.TypeOf((*MockWorkflowStore)(nil).CompleteVisibilityTask), request)
 }
 
 // ConflictResolveWorkflowExecution mocks base method.
-func (m *MockExecutionStore) ConflictResolveWorkflowExecution(request *persistence.InternalConflictResolveWorkflowExecutionRequest) error {
+func (m *MockWorkflowStore) ConflictResolveWorkflowExecution(request *persistence.InternalConflictResolveWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ConflictResolveWorkflowExecution", request)
 	ret0, _ := ret[0].(error)
@@ -724,13 +738,13 @@ func (m *MockExecutionStore) ConflictResolveWorkflowExecution(request *persisten
 }
 
 // ConflictResolveWorkflowExecution indicates an expected call of ConflictResolveWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) ConflictResolveWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) ConflictResolveWorkflowExecution(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConflictResolveWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).ConflictResolveWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConflictResolveWorkflowExecution", reflect.TypeOf((*MockWorkflowStore)(nil).ConflictResolveWorkflowExecution), request)
 }
 
 // CreateWorkflowExecution mocks base method.
-func (m *MockExecutionStore) CreateWorkflowExecution(request *persistence.InternalCreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error) {
+func (m *MockWorkflowStore) CreateWorkflowExecution(request *persistence.InternalCreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateWorkflowExecution", request)
 	ret0, _ := ret[0].(*persistence.CreateWorkflowExecutionResponse)
@@ -739,13 +753,13 @@ func (m *MockExecutionStore) CreateWorkflowExecution(request *persistence.Intern
 }
 
 // CreateWorkflowExecution indicates an expected call of CreateWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) CreateWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) CreateWorkflowExecution(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).CreateWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockWorkflowStore)(nil).CreateWorkflowExecution), request)
 }
 
 // DeleteCurrentWorkflowExecution mocks base method.
-func (m *MockExecutionStore) DeleteCurrentWorkflowExecution(request *persistence.DeleteCurrentWorkflowExecutionRequest) error {
+func (m *MockWorkflowStore) DeleteCurrentWorkflowExecution(request *persistence.DeleteCurrentWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteCurrentWorkflowExecution", request)
 	ret0, _ := ret[0].(error)
@@ -753,396 +767,13 @@ func (m *MockExecutionStore) DeleteCurrentWorkflowExecution(request *persistence
 }
 
 // DeleteCurrentWorkflowExecution indicates an expected call of DeleteCurrentWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) DeleteCurrentWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) DeleteCurrentWorkflowExecution(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCurrentWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).DeleteCurrentWorkflowExecution), request)
-}
-
-// DeleteReplicationTaskFromDLQ mocks base method.
-func (m *MockExecutionStore) DeleteReplicationTaskFromDLQ(request *persistence.DeleteReplicationTaskFromDLQRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteReplicationTaskFromDLQ", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteReplicationTaskFromDLQ indicates an expected call of DeleteReplicationTaskFromDLQ.
-func (mr *MockExecutionStoreMockRecorder) DeleteReplicationTaskFromDLQ(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteReplicationTaskFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).DeleteReplicationTaskFromDLQ), request)
-}
-
-// DeleteWorkflowExecution mocks base method.
-func (m *MockExecutionStore) DeleteWorkflowExecution(request *persistence.DeleteWorkflowExecutionRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) DeleteWorkflowExecution(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).DeleteWorkflowExecution), request)
-}
-
-// GetCurrentExecution mocks base method.
-func (m *MockExecutionStore) GetCurrentExecution(request *persistence.GetCurrentExecutionRequest) (*persistence.InternalGetCurrentExecutionResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentExecution", request)
-	ret0, _ := ret[0].(*persistence.InternalGetCurrentExecutionResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCurrentExecution indicates an expected call of GetCurrentExecution.
-func (mr *MockExecutionStoreMockRecorder) GetCurrentExecution(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentExecution", reflect.TypeOf((*MockExecutionStore)(nil).GetCurrentExecution), request)
-}
-
-// GetName mocks base method.
-func (m *MockExecutionStore) GetName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetName indicates an expected call of GetName.
-func (mr *MockExecutionStoreMockRecorder) GetName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockExecutionStore)(nil).GetName))
-}
-
-// GetReplicationTask mocks base method.
-func (m *MockExecutionStore) GetReplicationTask(request *persistence.GetReplicationTaskRequest) (*persistence.GetReplicationTaskResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReplicationTask", request)
-	ret0, _ := ret[0].(*persistence.GetReplicationTaskResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetReplicationTask indicates an expected call of GetReplicationTask.
-func (mr *MockExecutionStoreMockRecorder) GetReplicationTask(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTask", reflect.TypeOf((*MockExecutionStore)(nil).GetReplicationTask), request)
-}
-
-// GetReplicationTasks mocks base method.
-func (m *MockExecutionStore) GetReplicationTasks(request *persistence.GetReplicationTasksRequest) (*persistence.GetReplicationTasksResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReplicationTasks", request)
-	ret0, _ := ret[0].(*persistence.GetReplicationTasksResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetReplicationTasks indicates an expected call of GetReplicationTasks.
-func (mr *MockExecutionStoreMockRecorder) GetReplicationTasks(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTasks", reflect.TypeOf((*MockExecutionStore)(nil).GetReplicationTasks), request)
-}
-
-// GetReplicationTasksFromDLQ mocks base method.
-func (m *MockExecutionStore) GetReplicationTasksFromDLQ(request *persistence.GetReplicationTasksFromDLQRequest) (*persistence.GetReplicationTasksFromDLQResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReplicationTasksFromDLQ", request)
-	ret0, _ := ret[0].(*persistence.GetReplicationTasksFromDLQResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetReplicationTasksFromDLQ indicates an expected call of GetReplicationTasksFromDLQ.
-func (mr *MockExecutionStoreMockRecorder) GetReplicationTasksFromDLQ(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTasksFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).GetReplicationTasksFromDLQ), request)
-}
-
-// GetShardID mocks base method.
-func (m *MockExecutionStore) GetShardID() int32 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShardID")
-	ret0, _ := ret[0].(int32)
-	return ret0
-}
-
-// GetShardID indicates an expected call of GetShardID.
-func (mr *MockExecutionStoreMockRecorder) GetShardID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardID", reflect.TypeOf((*MockExecutionStore)(nil).GetShardID))
-}
-
-// GetTimerIndexTasks mocks base method.
-func (m *MockExecutionStore) GetTimerIndexTasks(request *persistence.GetTimerIndexTasksRequest) (*persistence.GetTimerIndexTasksResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTimerIndexTasks", request)
-	ret0, _ := ret[0].(*persistence.GetTimerIndexTasksResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTimerIndexTasks indicates an expected call of GetTimerIndexTasks.
-func (mr *MockExecutionStoreMockRecorder) GetTimerIndexTasks(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimerIndexTasks", reflect.TypeOf((*MockExecutionStore)(nil).GetTimerIndexTasks), request)
-}
-
-// GetTimerTask mocks base method.
-func (m *MockExecutionStore) GetTimerTask(request *persistence.GetTimerTaskRequest) (*persistence.GetTimerTaskResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTimerTask", request)
-	ret0, _ := ret[0].(*persistence.GetTimerTaskResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTimerTask indicates an expected call of GetTimerTask.
-func (mr *MockExecutionStoreMockRecorder) GetTimerTask(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimerTask", reflect.TypeOf((*MockExecutionStore)(nil).GetTimerTask), request)
-}
-
-// GetTransferTask mocks base method.
-func (m *MockExecutionStore) GetTransferTask(request *persistence.GetTransferTaskRequest) (*persistence.GetTransferTaskResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTransferTask", request)
-	ret0, _ := ret[0].(*persistence.GetTransferTaskResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTransferTask indicates an expected call of GetTransferTask.
-func (mr *MockExecutionStoreMockRecorder) GetTransferTask(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransferTask", reflect.TypeOf((*MockExecutionStore)(nil).GetTransferTask), request)
-}
-
-// GetTransferTasks mocks base method.
-func (m *MockExecutionStore) GetTransferTasks(request *persistence.GetTransferTasksRequest) (*persistence.GetTransferTasksResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTransferTasks", request)
-	ret0, _ := ret[0].(*persistence.GetTransferTasksResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTransferTasks indicates an expected call of GetTransferTasks.
-func (mr *MockExecutionStoreMockRecorder) GetTransferTasks(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransferTasks", reflect.TypeOf((*MockExecutionStore)(nil).GetTransferTasks), request)
-}
-
-// GetVisibilityTask mocks base method.
-func (m *MockExecutionStore) GetVisibilityTask(request *persistence.GetVisibilityTaskRequest) (*persistence.GetVisibilityTaskResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVisibilityTask", request)
-	ret0, _ := ret[0].(*persistence.GetVisibilityTaskResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVisibilityTask indicates an expected call of GetVisibilityTask.
-func (mr *MockExecutionStoreMockRecorder) GetVisibilityTask(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVisibilityTask", reflect.TypeOf((*MockExecutionStore)(nil).GetVisibilityTask), request)
-}
-
-// GetVisibilityTasks mocks base method.
-func (m *MockExecutionStore) GetVisibilityTasks(request *persistence.GetVisibilityTasksRequest) (*persistence.GetVisibilityTasksResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetVisibilityTasks", request)
-	ret0, _ := ret[0].(*persistence.GetVisibilityTasksResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetVisibilityTasks indicates an expected call of GetVisibilityTasks.
-func (mr *MockExecutionStoreMockRecorder) GetVisibilityTasks(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVisibilityTasks", reflect.TypeOf((*MockExecutionStore)(nil).GetVisibilityTasks), request)
-}
-
-// GetWorkflowExecution mocks base method.
-func (m *MockExecutionStore) GetWorkflowExecution(request *persistence.GetWorkflowExecutionRequest) (*persistence.InternalGetWorkflowExecutionResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkflowExecution", request)
-	ret0, _ := ret[0].(*persistence.InternalGetWorkflowExecutionResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetWorkflowExecution indicates an expected call of GetWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) GetWorkflowExecution(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).GetWorkflowExecution), request)
-}
-
-// ListConcreteExecutions mocks base method.
-func (m *MockExecutionStore) ListConcreteExecutions(request *persistence.ListConcreteExecutionsRequest) (*persistence.InternalListConcreteExecutionsResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListConcreteExecutions", request)
-	ret0, _ := ret[0].(*persistence.InternalListConcreteExecutionsResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListConcreteExecutions indicates an expected call of ListConcreteExecutions.
-func (mr *MockExecutionStoreMockRecorder) ListConcreteExecutions(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConcreteExecutions", reflect.TypeOf((*MockExecutionStore)(nil).ListConcreteExecutions), request)
-}
-
-// PutReplicationTaskToDLQ mocks base method.
-func (m *MockExecutionStore) PutReplicationTaskToDLQ(request *persistence.PutReplicationTaskToDLQRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutReplicationTaskToDLQ", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// PutReplicationTaskToDLQ indicates an expected call of PutReplicationTaskToDLQ.
-func (mr *MockExecutionStoreMockRecorder) PutReplicationTaskToDLQ(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutReplicationTaskToDLQ", reflect.TypeOf((*MockExecutionStore)(nil).PutReplicationTaskToDLQ), request)
-}
-
-// RangeCompleteReplicationTask mocks base method.
-func (m *MockExecutionStore) RangeCompleteReplicationTask(request *persistence.RangeCompleteReplicationTaskRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeCompleteReplicationTask", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RangeCompleteReplicationTask indicates an expected call of RangeCompleteReplicationTask.
-func (mr *MockExecutionStoreMockRecorder) RangeCompleteReplicationTask(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteReplicationTask", reflect.TypeOf((*MockExecutionStore)(nil).RangeCompleteReplicationTask), request)
-}
-
-// RangeCompleteTimerTask mocks base method.
-func (m *MockExecutionStore) RangeCompleteTimerTask(request *persistence.RangeCompleteTimerTaskRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeCompleteTimerTask", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RangeCompleteTimerTask indicates an expected call of RangeCompleteTimerTask.
-func (mr *MockExecutionStoreMockRecorder) RangeCompleteTimerTask(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteTimerTask", reflect.TypeOf((*MockExecutionStore)(nil).RangeCompleteTimerTask), request)
-}
-
-// RangeCompleteTransferTask mocks base method.
-func (m *MockExecutionStore) RangeCompleteTransferTask(request *persistence.RangeCompleteTransferTaskRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeCompleteTransferTask", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RangeCompleteTransferTask indicates an expected call of RangeCompleteTransferTask.
-func (mr *MockExecutionStoreMockRecorder) RangeCompleteTransferTask(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteTransferTask", reflect.TypeOf((*MockExecutionStore)(nil).RangeCompleteTransferTask), request)
-}
-
-// RangeCompleteVisibilityTask mocks base method.
-func (m *MockExecutionStore) RangeCompleteVisibilityTask(request *persistence.RangeCompleteVisibilityTaskRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeCompleteVisibilityTask", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RangeCompleteVisibilityTask indicates an expected call of RangeCompleteVisibilityTask.
-func (mr *MockExecutionStoreMockRecorder) RangeCompleteVisibilityTask(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteVisibilityTask", reflect.TypeOf((*MockExecutionStore)(nil).RangeCompleteVisibilityTask), request)
-}
-
-// RangeDeleteReplicationTaskFromDLQ mocks base method.
-func (m *MockExecutionStore) RangeDeleteReplicationTaskFromDLQ(request *persistence.RangeDeleteReplicationTaskFromDLQRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeDeleteReplicationTaskFromDLQ", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RangeDeleteReplicationTaskFromDLQ indicates an expected call of RangeDeleteReplicationTaskFromDLQ.
-func (mr *MockExecutionStoreMockRecorder) RangeDeleteReplicationTaskFromDLQ(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeDeleteReplicationTaskFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).RangeDeleteReplicationTaskFromDLQ), request)
-}
-
-// UpdateWorkflowExecution mocks base method.
-func (m *MockExecutionStore) UpdateWorkflowExecution(request *persistence.InternalUpdateWorkflowExecutionRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateWorkflowExecution", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateWorkflowExecution indicates an expected call of UpdateWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) UpdateWorkflowExecution(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).UpdateWorkflowExecution), request)
-}
-
-// MockHistoryStore is a mock of HistoryStore interface.
-type MockHistoryStore struct {
-	ctrl     *gomock.Controller
-	recorder *MockHistoryStoreMockRecorder
-}
-
-// MockHistoryStoreMockRecorder is the mock recorder for MockHistoryStore.
-type MockHistoryStoreMockRecorder struct {
-	mock *MockHistoryStore
-}
-
-// NewMockHistoryStore creates a new mock instance.
-func NewMockHistoryStore(ctrl *gomock.Controller) *MockHistoryStore {
-	mock := &MockHistoryStore{ctrl: ctrl}
-	mock.recorder = &MockHistoryStoreMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockHistoryStore) EXPECT() *MockHistoryStoreMockRecorder {
-	return m.recorder
-}
-
-// AppendHistoryNodes mocks base method.
-func (m *MockHistoryStore) AppendHistoryNodes(request *persistence.InternalAppendHistoryNodesRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendHistoryNodes", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AppendHistoryNodes indicates an expected call of AppendHistoryNodes.
-func (mr *MockHistoryStoreMockRecorder) AppendHistoryNodes(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendHistoryNodes", reflect.TypeOf((*MockHistoryStore)(nil).AppendHistoryNodes), request)
-}
-
-// Close mocks base method.
-func (m *MockHistoryStore) Close() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close")
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockHistoryStoreMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockHistoryStore)(nil).Close))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCurrentWorkflowExecution", reflect.TypeOf((*MockWorkflowStore)(nil).DeleteCurrentWorkflowExecution), request)
 }
 
 // DeleteHistoryBranch mocks base method.
-func (m *MockHistoryStore) DeleteHistoryBranch(request *persistence.InternalDeleteHistoryBranchRequest) error {
+func (m *MockWorkflowStore) DeleteHistoryBranch(request *persistence.InternalDeleteHistoryBranchRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteHistoryBranch", request)
 	ret0, _ := ret[0].(error)
@@ -1150,13 +781,13 @@ func (m *MockHistoryStore) DeleteHistoryBranch(request *persistence.InternalDele
 }
 
 // DeleteHistoryBranch indicates an expected call of DeleteHistoryBranch.
-func (mr *MockHistoryStoreMockRecorder) DeleteHistoryBranch(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) DeleteHistoryBranch(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHistoryBranch", reflect.TypeOf((*MockHistoryStore)(nil).DeleteHistoryBranch), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHistoryBranch", reflect.TypeOf((*MockWorkflowStore)(nil).DeleteHistoryBranch), request)
 }
 
 // DeleteHistoryNodes mocks base method.
-func (m *MockHistoryStore) DeleteHistoryNodes(request *persistence.InternalDeleteHistoryNodesRequest) error {
+func (m *MockWorkflowStore) DeleteHistoryNodes(request *persistence.InternalDeleteHistoryNodesRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteHistoryNodes", request)
 	ret0, _ := ret[0].(error)
@@ -1164,13 +795,41 @@ func (m *MockHistoryStore) DeleteHistoryNodes(request *persistence.InternalDelet
 }
 
 // DeleteHistoryNodes indicates an expected call of DeleteHistoryNodes.
-func (mr *MockHistoryStoreMockRecorder) DeleteHistoryNodes(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) DeleteHistoryNodes(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHistoryNodes", reflect.TypeOf((*MockHistoryStore)(nil).DeleteHistoryNodes), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHistoryNodes", reflect.TypeOf((*MockWorkflowStore)(nil).DeleteHistoryNodes), request)
+}
+
+// DeleteReplicationTaskFromDLQ mocks base method.
+func (m *MockWorkflowStore) DeleteReplicationTaskFromDLQ(request *persistence.DeleteReplicationTaskFromDLQRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteReplicationTaskFromDLQ", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteReplicationTaskFromDLQ indicates an expected call of DeleteReplicationTaskFromDLQ.
+func (mr *MockWorkflowStoreMockRecorder) DeleteReplicationTaskFromDLQ(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteReplicationTaskFromDLQ", reflect.TypeOf((*MockWorkflowStore)(nil).DeleteReplicationTaskFromDLQ), request)
+}
+
+// DeleteWorkflowExecution mocks base method.
+func (m *MockWorkflowStore) DeleteWorkflowExecution(request *persistence.DeleteWorkflowExecutionRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
+func (mr *MockWorkflowStoreMockRecorder) DeleteWorkflowExecution(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockWorkflowStore)(nil).DeleteWorkflowExecution), request)
 }
 
 // ForkHistoryBranch mocks base method.
-func (m *MockHistoryStore) ForkHistoryBranch(request *persistence.InternalForkHistoryBranchRequest) error {
+func (m *MockWorkflowStore) ForkHistoryBranch(request *persistence.InternalForkHistoryBranchRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ForkHistoryBranch", request)
 	ret0, _ := ret[0].(error)
@@ -1178,13 +837,13 @@ func (m *MockHistoryStore) ForkHistoryBranch(request *persistence.InternalForkHi
 }
 
 // ForkHistoryBranch indicates an expected call of ForkHistoryBranch.
-func (mr *MockHistoryStoreMockRecorder) ForkHistoryBranch(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) ForkHistoryBranch(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForkHistoryBranch", reflect.TypeOf((*MockHistoryStore)(nil).ForkHistoryBranch), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForkHistoryBranch", reflect.TypeOf((*MockWorkflowStore)(nil).ForkHistoryBranch), request)
 }
 
 // GetAllHistoryTreeBranches mocks base method.
-func (m *MockHistoryStore) GetAllHistoryTreeBranches(request *persistence.GetAllHistoryTreeBranchesRequest) (*persistence.InternalGetAllHistoryTreeBranchesResponse, error) {
+func (m *MockWorkflowStore) GetAllHistoryTreeBranches(request *persistence.GetAllHistoryTreeBranchesRequest) (*persistence.InternalGetAllHistoryTreeBranchesResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAllHistoryTreeBranches", request)
 	ret0, _ := ret[0].(*persistence.InternalGetAllHistoryTreeBranchesResponse)
@@ -1193,13 +852,28 @@ func (m *MockHistoryStore) GetAllHistoryTreeBranches(request *persistence.GetAll
 }
 
 // GetAllHistoryTreeBranches indicates an expected call of GetAllHistoryTreeBranches.
-func (mr *MockHistoryStoreMockRecorder) GetAllHistoryTreeBranches(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) GetAllHistoryTreeBranches(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllHistoryTreeBranches", reflect.TypeOf((*MockHistoryStore)(nil).GetAllHistoryTreeBranches), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllHistoryTreeBranches", reflect.TypeOf((*MockWorkflowStore)(nil).GetAllHistoryTreeBranches), request)
+}
+
+// GetCurrentExecution mocks base method.
+func (m *MockWorkflowStore) GetCurrentExecution(request *persistence.GetCurrentExecutionRequest) (*persistence.InternalGetCurrentExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentExecution", request)
+	ret0, _ := ret[0].(*persistence.InternalGetCurrentExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCurrentExecution indicates an expected call of GetCurrentExecution.
+func (mr *MockWorkflowStoreMockRecorder) GetCurrentExecution(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentExecution", reflect.TypeOf((*MockWorkflowStore)(nil).GetCurrentExecution), request)
 }
 
 // GetHistoryTree mocks base method.
-func (m *MockHistoryStore) GetHistoryTree(request *persistence.GetHistoryTreeRequest) (*persistence.InternalGetHistoryTreeResponse, error) {
+func (m *MockWorkflowStore) GetHistoryTree(request *persistence.GetHistoryTreeRequest) (*persistence.InternalGetHistoryTreeResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHistoryTree", request)
 	ret0, _ := ret[0].(*persistence.InternalGetHistoryTreeResponse)
@@ -1208,13 +882,13 @@ func (m *MockHistoryStore) GetHistoryTree(request *persistence.GetHistoryTreeReq
 }
 
 // GetHistoryTree indicates an expected call of GetHistoryTree.
-func (mr *MockHistoryStoreMockRecorder) GetHistoryTree(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) GetHistoryTree(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTree", reflect.TypeOf((*MockHistoryStore)(nil).GetHistoryTree), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTree", reflect.TypeOf((*MockWorkflowStore)(nil).GetHistoryTree), request)
 }
 
 // GetName mocks base method.
-func (m *MockHistoryStore) GetName() string {
+func (m *MockWorkflowStore) GetName() string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetName")
 	ret0, _ := ret[0].(string)
@@ -1222,13 +896,276 @@ func (m *MockHistoryStore) GetName() string {
 }
 
 // GetName indicates an expected call of GetName.
-func (mr *MockHistoryStoreMockRecorder) GetName() *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) GetName() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockHistoryStore)(nil).GetName))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockWorkflowStore)(nil).GetName))
+}
+
+// GetReplicationTask mocks base method.
+func (m *MockWorkflowStore) GetReplicationTask(request *persistence.GetReplicationTaskRequest) (*persistence.GetReplicationTaskResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReplicationTask", request)
+	ret0, _ := ret[0].(*persistence.GetReplicationTaskResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetReplicationTask indicates an expected call of GetReplicationTask.
+func (mr *MockWorkflowStoreMockRecorder) GetReplicationTask(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTask", reflect.TypeOf((*MockWorkflowStore)(nil).GetReplicationTask), request)
+}
+
+// GetReplicationTasks mocks base method.
+func (m *MockWorkflowStore) GetReplicationTasks(request *persistence.GetReplicationTasksRequest) (*persistence.GetReplicationTasksResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReplicationTasks", request)
+	ret0, _ := ret[0].(*persistence.GetReplicationTasksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetReplicationTasks indicates an expected call of GetReplicationTasks.
+func (mr *MockWorkflowStoreMockRecorder) GetReplicationTasks(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTasks", reflect.TypeOf((*MockWorkflowStore)(nil).GetReplicationTasks), request)
+}
+
+// GetReplicationTasksFromDLQ mocks base method.
+func (m *MockWorkflowStore) GetReplicationTasksFromDLQ(request *persistence.GetReplicationTasksFromDLQRequest) (*persistence.GetReplicationTasksFromDLQResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReplicationTasksFromDLQ", request)
+	ret0, _ := ret[0].(*persistence.GetReplicationTasksFromDLQResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetReplicationTasksFromDLQ indicates an expected call of GetReplicationTasksFromDLQ.
+func (mr *MockWorkflowStoreMockRecorder) GetReplicationTasksFromDLQ(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTasksFromDLQ", reflect.TypeOf((*MockWorkflowStore)(nil).GetReplicationTasksFromDLQ), request)
+}
+
+// GetShardID mocks base method.
+func (m *MockWorkflowStore) GetShardID() int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetShardID")
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetShardID indicates an expected call of GetShardID.
+func (mr *MockWorkflowStoreMockRecorder) GetShardID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardID", reflect.TypeOf((*MockWorkflowStore)(nil).GetShardID))
+}
+
+// GetTimerIndexTasks mocks base method.
+func (m *MockWorkflowStore) GetTimerIndexTasks(request *persistence.GetTimerIndexTasksRequest) (*persistence.GetTimerIndexTasksResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTimerIndexTasks", request)
+	ret0, _ := ret[0].(*persistence.GetTimerIndexTasksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTimerIndexTasks indicates an expected call of GetTimerIndexTasks.
+func (mr *MockWorkflowStoreMockRecorder) GetTimerIndexTasks(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimerIndexTasks", reflect.TypeOf((*MockWorkflowStore)(nil).GetTimerIndexTasks), request)
+}
+
+// GetTimerTask mocks base method.
+func (m *MockWorkflowStore) GetTimerTask(request *persistence.GetTimerTaskRequest) (*persistence.GetTimerTaskResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTimerTask", request)
+	ret0, _ := ret[0].(*persistence.GetTimerTaskResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTimerTask indicates an expected call of GetTimerTask.
+func (mr *MockWorkflowStoreMockRecorder) GetTimerTask(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimerTask", reflect.TypeOf((*MockWorkflowStore)(nil).GetTimerTask), request)
+}
+
+// GetTransferTask mocks base method.
+func (m *MockWorkflowStore) GetTransferTask(request *persistence.GetTransferTaskRequest) (*persistence.GetTransferTaskResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTransferTask", request)
+	ret0, _ := ret[0].(*persistence.GetTransferTaskResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransferTask indicates an expected call of GetTransferTask.
+func (mr *MockWorkflowStoreMockRecorder) GetTransferTask(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransferTask", reflect.TypeOf((*MockWorkflowStore)(nil).GetTransferTask), request)
+}
+
+// GetTransferTasks mocks base method.
+func (m *MockWorkflowStore) GetTransferTasks(request *persistence.GetTransferTasksRequest) (*persistence.GetTransferTasksResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTransferTasks", request)
+	ret0, _ := ret[0].(*persistence.GetTransferTasksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransferTasks indicates an expected call of GetTransferTasks.
+func (mr *MockWorkflowStoreMockRecorder) GetTransferTasks(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransferTasks", reflect.TypeOf((*MockWorkflowStore)(nil).GetTransferTasks), request)
+}
+
+// GetVisibilityTask mocks base method.
+func (m *MockWorkflowStore) GetVisibilityTask(request *persistence.GetVisibilityTaskRequest) (*persistence.GetVisibilityTaskResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVisibilityTask", request)
+	ret0, _ := ret[0].(*persistence.GetVisibilityTaskResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVisibilityTask indicates an expected call of GetVisibilityTask.
+func (mr *MockWorkflowStoreMockRecorder) GetVisibilityTask(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVisibilityTask", reflect.TypeOf((*MockWorkflowStore)(nil).GetVisibilityTask), request)
+}
+
+// GetVisibilityTasks mocks base method.
+func (m *MockWorkflowStore) GetVisibilityTasks(request *persistence.GetVisibilityTasksRequest) (*persistence.GetVisibilityTasksResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVisibilityTasks", request)
+	ret0, _ := ret[0].(*persistence.GetVisibilityTasksResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetVisibilityTasks indicates an expected call of GetVisibilityTasks.
+func (mr *MockWorkflowStoreMockRecorder) GetVisibilityTasks(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVisibilityTasks", reflect.TypeOf((*MockWorkflowStore)(nil).GetVisibilityTasks), request)
+}
+
+// GetWorkflowExecution mocks base method.
+func (m *MockWorkflowStore) GetWorkflowExecution(request *persistence.GetWorkflowExecutionRequest) (*persistence.InternalGetWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowExecution", request)
+	ret0, _ := ret[0].(*persistence.InternalGetWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkflowExecution indicates an expected call of GetWorkflowExecution.
+func (mr *MockWorkflowStoreMockRecorder) GetWorkflowExecution(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockWorkflowStore)(nil).GetWorkflowExecution), request)
+}
+
+// ListConcreteExecutions mocks base method.
+func (m *MockWorkflowStore) ListConcreteExecutions(request *persistence.ListConcreteExecutionsRequest) (*persistence.InternalListConcreteExecutionsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListConcreteExecutions", request)
+	ret0, _ := ret[0].(*persistence.InternalListConcreteExecutionsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListConcreteExecutions indicates an expected call of ListConcreteExecutions.
+func (mr *MockWorkflowStoreMockRecorder) ListConcreteExecutions(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConcreteExecutions", reflect.TypeOf((*MockWorkflowStore)(nil).ListConcreteExecutions), request)
+}
+
+// PutReplicationTaskToDLQ mocks base method.
+func (m *MockWorkflowStore) PutReplicationTaskToDLQ(request *persistence.PutReplicationTaskToDLQRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutReplicationTaskToDLQ", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PutReplicationTaskToDLQ indicates an expected call of PutReplicationTaskToDLQ.
+func (mr *MockWorkflowStoreMockRecorder) PutReplicationTaskToDLQ(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutReplicationTaskToDLQ", reflect.TypeOf((*MockWorkflowStore)(nil).PutReplicationTaskToDLQ), request)
+}
+
+// RangeCompleteReplicationTask mocks base method.
+func (m *MockWorkflowStore) RangeCompleteReplicationTask(request *persistence.RangeCompleteReplicationTaskRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RangeCompleteReplicationTask", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RangeCompleteReplicationTask indicates an expected call of RangeCompleteReplicationTask.
+func (mr *MockWorkflowStoreMockRecorder) RangeCompleteReplicationTask(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteReplicationTask", reflect.TypeOf((*MockWorkflowStore)(nil).RangeCompleteReplicationTask), request)
+}
+
+// RangeCompleteTimerTask mocks base method.
+func (m *MockWorkflowStore) RangeCompleteTimerTask(request *persistence.RangeCompleteTimerTaskRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RangeCompleteTimerTask", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RangeCompleteTimerTask indicates an expected call of RangeCompleteTimerTask.
+func (mr *MockWorkflowStoreMockRecorder) RangeCompleteTimerTask(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteTimerTask", reflect.TypeOf((*MockWorkflowStore)(nil).RangeCompleteTimerTask), request)
+}
+
+// RangeCompleteTransferTask mocks base method.
+func (m *MockWorkflowStore) RangeCompleteTransferTask(request *persistence.RangeCompleteTransferTaskRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RangeCompleteTransferTask", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RangeCompleteTransferTask indicates an expected call of RangeCompleteTransferTask.
+func (mr *MockWorkflowStoreMockRecorder) RangeCompleteTransferTask(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteTransferTask", reflect.TypeOf((*MockWorkflowStore)(nil).RangeCompleteTransferTask), request)
+}
+
+// RangeCompleteVisibilityTask mocks base method.
+func (m *MockWorkflowStore) RangeCompleteVisibilityTask(request *persistence.RangeCompleteVisibilityTaskRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RangeCompleteVisibilityTask", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RangeCompleteVisibilityTask indicates an expected call of RangeCompleteVisibilityTask.
+func (mr *MockWorkflowStoreMockRecorder) RangeCompleteVisibilityTask(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteVisibilityTask", reflect.TypeOf((*MockWorkflowStore)(nil).RangeCompleteVisibilityTask), request)
+}
+
+// RangeDeleteReplicationTaskFromDLQ mocks base method.
+func (m *MockWorkflowStore) RangeDeleteReplicationTaskFromDLQ(request *persistence.RangeDeleteReplicationTaskFromDLQRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RangeDeleteReplicationTaskFromDLQ", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RangeDeleteReplicationTaskFromDLQ indicates an expected call of RangeDeleteReplicationTaskFromDLQ.
+func (mr *MockWorkflowStoreMockRecorder) RangeDeleteReplicationTaskFromDLQ(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeDeleteReplicationTaskFromDLQ", reflect.TypeOf((*MockWorkflowStore)(nil).RangeDeleteReplicationTaskFromDLQ), request)
 }
 
 // ReadHistoryBranch mocks base method.
-func (m *MockHistoryStore) ReadHistoryBranch(request *persistence.InternalReadHistoryBranchRequest) (*persistence.InternalReadHistoryBranchResponse, error) {
+func (m *MockWorkflowStore) ReadHistoryBranch(request *persistence.InternalReadHistoryBranchRequest) (*persistence.InternalReadHistoryBranchResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReadHistoryBranch", request)
 	ret0, _ := ret[0].(*persistence.InternalReadHistoryBranchResponse)
@@ -1237,9 +1174,23 @@ func (m *MockHistoryStore) ReadHistoryBranch(request *persistence.InternalReadHi
 }
 
 // ReadHistoryBranch indicates an expected call of ReadHistoryBranch.
-func (mr *MockHistoryStoreMockRecorder) ReadHistoryBranch(request interface{}) *gomock.Call {
+func (mr *MockWorkflowStoreMockRecorder) ReadHistoryBranch(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadHistoryBranch", reflect.TypeOf((*MockHistoryStore)(nil).ReadHistoryBranch), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadHistoryBranch", reflect.TypeOf((*MockWorkflowStore)(nil).ReadHistoryBranch), request)
+}
+
+// UpdateWorkflowExecution mocks base method.
+func (m *MockWorkflowStore) UpdateWorkflowExecution(request *persistence.InternalUpdateWorkflowExecutionRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateWorkflowExecution", request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateWorkflowExecution indicates an expected call of UpdateWorkflowExecution.
+func (mr *MockWorkflowStoreMockRecorder) UpdateWorkflowExecution(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecution", reflect.TypeOf((*MockWorkflowStore)(nil).UpdateWorkflowExecution), request)
 }
 
 // MockQueue is a mock of Queue interface.

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -100,8 +100,8 @@ type (
 		PruneClusterMembership(request *PruneClusterMembershipRequest) error
 	}
 
-	// ExecutionStore is used to manage workflow executions for Persistence layer
-	ExecutionStore interface {
+	// WorkflowStore is used to manage workflow including execution's mutable states / history / tasks.
+	WorkflowStore interface {
 		Closeable
 		GetName() string
 		GetShardID() int32
@@ -148,12 +148,6 @@ type (
 		GetVisibilityTasks(request *GetVisibilityTasksRequest) (*GetVisibilityTasksResponse, error)
 		CompleteVisibilityTask(request *CompleteVisibilityTaskRequest) error
 		RangeCompleteVisibilityTask(request *RangeCompleteVisibilityTaskRequest) error
-	}
-
-	// HistoryStore is to manager workflow history events
-	HistoryStore interface {
-		Closeable
-		GetName() string
 
 		// The below are history V2 APIs
 		// V2 regards history events growing as a tree, decoupled from workflow concepts

--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -40,28 +40,28 @@ import (
 	"go.temporal.io/server/common/primitives"
 )
 
-type sqlExecutionStore struct {
+type sqlWorkflowStore struct {
 	SqlStore
 	shardID int32
 }
 
-var _ p.ExecutionStore = (*sqlExecutionStore)(nil)
+var _ p.WorkflowStore = (*sqlWorkflowStore)(nil)
 
-// NewSQLExecutionStore creates an instance of ExecutionStore
-func NewSQLExecutionStore(
+// NewSQLWorkflowStore creates an instance of WorkflowStore
+func NewSQLWorkflowStore(
 	db sqlplugin.DB,
 	logger log.Logger,
 	shardID int32,
-) (p.ExecutionStore, error) {
+) (p.WorkflowStore, error) {
 
-	return &sqlExecutionStore{
+	return &sqlWorkflowStore{
 		shardID:  shardID,
 		SqlStore: NewSqlStore(db, logger),
 	}, nil
 }
 
 // txExecuteShardLocked executes f under transaction and with read lock on shard row
-func (m *sqlExecutionStore) txExecuteShardLocked(
+func (m *sqlWorkflowStore) txExecuteShardLocked(
 	ctx context.Context,
 	operation string,
 	rangeID int64,
@@ -80,11 +80,11 @@ func (m *sqlExecutionStore) txExecuteShardLocked(
 	})
 }
 
-func (m *sqlExecutionStore) GetShardID() int32 {
+func (m *sqlWorkflowStore) GetShardID() int32 {
 	return m.shardID
 }
 
-func (m *sqlExecutionStore) CreateWorkflowExecution(
+func (m *sqlWorkflowStore) CreateWorkflowExecution(
 	request *p.InternalCreateWorkflowExecutionRequest,
 ) (response *p.CreateWorkflowExecutionResponse, err error) {
 	ctx, cancel := newExecutionContext()
@@ -99,7 +99,7 @@ func (m *sqlExecutionStore) CreateWorkflowExecution(
 	return
 }
 
-func (m *sqlExecutionStore) createWorkflowExecutionTx(
+func (m *sqlWorkflowStore) createWorkflowExecutionTx(
 	ctx context.Context,
 	tx sqlplugin.Tx,
 	request *p.InternalCreateWorkflowExecutionRequest,
@@ -224,7 +224,7 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 	return &p.CreateWorkflowExecutionResponse{}, nil
 }
 
-func (m *sqlExecutionStore) GetWorkflowExecution(
+func (m *sqlWorkflowStore) GetWorkflowExecution(
 	request *p.GetWorkflowExecutionRequest,
 ) (*p.InternalGetWorkflowExecutionResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -338,7 +338,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	}, nil
 }
 
-func (m *sqlExecutionStore) UpdateWorkflowExecution(
+func (m *sqlWorkflowStore) UpdateWorkflowExecution(
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -351,7 +351,7 @@ func (m *sqlExecutionStore) UpdateWorkflowExecution(
 		})
 }
 
-func (m *sqlExecutionStore) updateWorkflowExecutionTx(
+func (m *sqlWorkflowStore) updateWorkflowExecutionTx(
 	ctx context.Context,
 	tx sqlplugin.Tx,
 	request *p.InternalUpdateWorkflowExecutionRequest,
@@ -446,7 +446,7 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 	return nil
 }
 
-func (m *sqlExecutionStore) ConflictResolveWorkflowExecution(
+func (m *sqlWorkflowStore) ConflictResolveWorkflowExecution(
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -459,7 +459,7 @@ func (m *sqlExecutionStore) ConflictResolveWorkflowExecution(
 		})
 }
 
-func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
+func (m *sqlWorkflowStore) conflictResolveWorkflowExecutionTx(
 	ctx context.Context,
 	tx sqlplugin.Tx,
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
@@ -573,7 +573,7 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 	return nil
 }
 
-func (m *sqlExecutionStore) DeleteWorkflowExecution(
+func (m *sqlWorkflowStore) DeleteWorkflowExecution(
 	request *p.DeleteWorkflowExecutionRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -593,7 +593,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 // here was finished. In that case, current_executions table will have the same workflowID but different
 // runID. The following code will delete the row from current_executions if and only if the runID is
 // same as the one we are trying to delete here
-func (m *sqlExecutionStore) DeleteCurrentWorkflowExecution(
+func (m *sqlWorkflowStore) DeleteCurrentWorkflowExecution(
 	request *p.DeleteCurrentWorkflowExecutionRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -609,7 +609,7 @@ func (m *sqlExecutionStore) DeleteCurrentWorkflowExecution(
 	return err
 }
 
-func (m *sqlExecutionStore) GetCurrentExecution(
+func (m *sqlWorkflowStore) GetCurrentExecution(
 	request *p.GetCurrentExecutionRequest,
 ) (*p.InternalGetCurrentExecutionResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -637,7 +637,7 @@ func (m *sqlExecutionStore) GetCurrentExecution(
 	}, nil
 }
 
-func (m *sqlExecutionStore) ListConcreteExecutions(
+func (m *sqlWorkflowStore) ListConcreteExecutions(
 	_ *p.ListConcreteExecutionsRequest,
 ) (*p.InternalListConcreteExecutionsResponse, error) {
 	return nil, serviceerror.NewUnimplemented("ListConcreteExecutions is not implemented")

--- a/common/persistence/sql/execution_tasks.go
+++ b/common/persistence/sql/execution_tasks.go
@@ -41,7 +41,7 @@ import (
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
 
-func (m *sqlExecutionStore) AddTasks(
+func (m *sqlWorkflowStore) AddTasks(
 	request *p.AddTasksRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -64,7 +64,7 @@ func (m *sqlExecutionStore) AddTasks(
 		})
 }
 
-func (m *sqlExecutionStore) GetTransferTask(
+func (m *sqlWorkflowStore) GetTransferTask(
 	request *persistence.GetTransferTaskRequest,
 ) (*persistence.GetTransferTaskResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -95,7 +95,7 @@ func (m *sqlExecutionStore) GetTransferTask(
 	return resp, nil
 }
 
-func (m *sqlExecutionStore) GetTransferTasks(
+func (m *sqlWorkflowStore) GetTransferTasks(
 	request *p.GetTransferTasksRequest,
 ) (*p.GetTransferTasksResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -122,7 +122,7 @@ func (m *sqlExecutionStore) GetTransferTasks(
 	return resp, nil
 }
 
-func (m *sqlExecutionStore) CompleteTransferTask(
+func (m *sqlWorkflowStore) CompleteTransferTask(
 	request *p.CompleteTransferTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -136,7 +136,7 @@ func (m *sqlExecutionStore) CompleteTransferTask(
 	return nil
 }
 
-func (m *sqlExecutionStore) RangeCompleteTransferTask(
+func (m *sqlWorkflowStore) RangeCompleteTransferTask(
 	request *p.RangeCompleteTransferTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -151,7 +151,7 @@ func (m *sqlExecutionStore) RangeCompleteTransferTask(
 	return nil
 }
 
-func (m *sqlExecutionStore) GetTimerTask(
+func (m *sqlWorkflowStore) GetTimerTask(
 	request *persistence.GetTimerTaskRequest,
 ) (*persistence.GetTimerTaskResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -183,7 +183,7 @@ func (m *sqlExecutionStore) GetTimerTask(
 	return resp, nil
 }
 
-func (m *sqlExecutionStore) GetTimerIndexTasks(
+func (m *sqlWorkflowStore) GetTimerIndexTasks(
 	request *p.GetTimerIndexTasksRequest,
 ) (*p.GetTimerIndexTasksResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -237,7 +237,7 @@ func (m *sqlExecutionStore) GetTimerIndexTasks(
 	return resp, nil
 }
 
-func (m *sqlExecutionStore) CompleteTimerTask(
+func (m *sqlWorkflowStore) CompleteTimerTask(
 	request *p.CompleteTimerTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -252,7 +252,7 @@ func (m *sqlExecutionStore) CompleteTimerTask(
 	return nil
 }
 
-func (m *sqlExecutionStore) RangeCompleteTimerTask(
+func (m *sqlWorkflowStore) RangeCompleteTimerTask(
 	request *p.RangeCompleteTimerTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -269,7 +269,7 @@ func (m *sqlExecutionStore) RangeCompleteTimerTask(
 	return nil
 }
 
-func (m *sqlExecutionStore) GetReplicationTask(
+func (m *sqlWorkflowStore) GetReplicationTask(
 	request *persistence.GetReplicationTaskRequest,
 ) (*persistence.GetReplicationTaskResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -300,7 +300,7 @@ func (m *sqlExecutionStore) GetReplicationTask(
 	return resp, nil
 }
 
-func (m *sqlExecutionStore) GetReplicationTasks(
+func (m *sqlWorkflowStore) GetReplicationTasks(
 	request *p.GetReplicationTasksRequest,
 ) (*p.GetReplicationTasksResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -342,7 +342,7 @@ func getReadLevels(
 	return readLevel, maxReadLevelInclusive, nil
 }
 
-func (m *sqlExecutionStore) populateGetReplicationTasksResponse(
+func (m *sqlWorkflowStore) populateGetReplicationTasksResponse(
 	rows []sqlplugin.ReplicationTasksRow,
 	requestMaxReadLevel int64,
 ) (*p.GetReplicationTasksResponse, error) {
@@ -370,7 +370,7 @@ func (m *sqlExecutionStore) populateGetReplicationTasksResponse(
 	}, nil
 }
 
-func (m *sqlExecutionStore) populateGetReplicationDLQTasksResponse(
+func (m *sqlWorkflowStore) populateGetReplicationDLQTasksResponse(
 	rows []sqlplugin.ReplicationDLQTasksRow,
 	requestMaxReadLevel int64,
 ) (*p.GetReplicationTasksResponse, error) {
@@ -398,7 +398,7 @@ func (m *sqlExecutionStore) populateGetReplicationDLQTasksResponse(
 	}, nil
 }
 
-func (m *sqlExecutionStore) CompleteReplicationTask(
+func (m *sqlWorkflowStore) CompleteReplicationTask(
 	request *p.CompleteReplicationTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -412,7 +412,7 @@ func (m *sqlExecutionStore) CompleteReplicationTask(
 	return nil
 }
 
-func (m *sqlExecutionStore) RangeCompleteReplicationTask(
+func (m *sqlWorkflowStore) RangeCompleteReplicationTask(
 	request *p.RangeCompleteReplicationTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -427,7 +427,7 @@ func (m *sqlExecutionStore) RangeCompleteReplicationTask(
 	return nil
 }
 
-func (m *sqlExecutionStore) PutReplicationTaskToDLQ(
+func (m *sqlWorkflowStore) PutReplicationTaskToDLQ(
 	request *p.PutReplicationTaskToDLQRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -456,7 +456,7 @@ func (m *sqlExecutionStore) PutReplicationTaskToDLQ(
 	return nil
 }
 
-func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
+func (m *sqlWorkflowStore) GetReplicationTasksFromDLQ(
 	request *p.GetReplicationTasksFromDLQRequest,
 ) (*p.GetReplicationTasksFromDLQResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -484,7 +484,7 @@ func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 	}
 }
 
-func (m *sqlExecutionStore) DeleteReplicationTaskFromDLQ(
+func (m *sqlWorkflowStore) DeleteReplicationTaskFromDLQ(
 	request *p.DeleteReplicationTaskFromDLQRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -499,7 +499,7 @@ func (m *sqlExecutionStore) DeleteReplicationTaskFromDLQ(
 	return nil
 }
 
-func (m *sqlExecutionStore) RangeDeleteReplicationTaskFromDLQ(
+func (m *sqlWorkflowStore) RangeDeleteReplicationTaskFromDLQ(
 	request *p.RangeDeleteReplicationTaskFromDLQRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -515,7 +515,7 @@ func (m *sqlExecutionStore) RangeDeleteReplicationTaskFromDLQ(
 	return nil
 }
 
-func (m *sqlExecutionStore) GetVisibilityTask(
+func (m *sqlWorkflowStore) GetVisibilityTask(
 	request *persistence.GetVisibilityTaskRequest,
 ) (*persistence.GetVisibilityTaskResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -546,7 +546,7 @@ func (m *sqlExecutionStore) GetVisibilityTask(
 	return resp, nil
 }
 
-func (m *sqlExecutionStore) GetVisibilityTasks(
+func (m *sqlWorkflowStore) GetVisibilityTasks(
 	request *p.GetVisibilityTasksRequest,
 ) (*p.GetVisibilityTasksResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -573,7 +573,7 @@ func (m *sqlExecutionStore) GetVisibilityTasks(
 	return resp, nil
 }
 
-func (m *sqlExecutionStore) CompleteVisibilityTask(
+func (m *sqlWorkflowStore) CompleteVisibilityTask(
 	request *p.CompleteVisibilityTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -587,7 +587,7 @@ func (m *sqlExecutionStore) CompleteVisibilityTask(
 	return nil
 }
 
-func (m *sqlExecutionStore) RangeCompleteVisibilityTask(
+func (m *sqlWorkflowStore) RangeCompleteVisibilityTask(
 	request *p.RangeCompleteVisibilityTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()

--- a/common/persistence/sql/execution_util.go
+++ b/common/persistence/sql/execution_util.go
@@ -416,7 +416,7 @@ func applyWorkflowSnapshotTxAsReset(
 	return nil
 }
 
-func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
+func (m *sqlWorkflowStore) applyWorkflowSnapshotTxAsNew(
 	ctx context.Context,
 	tx sqlplugin.Tx,
 	shardID int32,
@@ -1265,7 +1265,7 @@ func buildExecutionRow(
 	}, nil
 }
 
-func (m *sqlExecutionStore) createExecution(
+func (m *sqlWorkflowStore) createExecution(
 	ctx context.Context,
 	tx sqlplugin.Tx,
 	namespaceID string,

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -99,15 +99,6 @@ func (f *Factory) NewShardStore() (p.ShardStore, error) {
 	return newShardPersistence(conn, f.clusterName, f.logger)
 }
 
-// NewHistoryStore returns a new history store
-func (f *Factory) NewHistoryStore() (p.HistoryStore, error) {
-	conn, err := f.mainDBConn.Get()
-	if err != nil {
-		return nil, err
-	}
-	return newHistoryV2Persistence(conn, f.logger)
-}
-
 // NewMetadataStore returns a new metadata store
 func (f *Factory) NewMetadataStore() (p.MetadataStore, error) {
 	conn, err := f.mainDBConn.Get()
@@ -126,13 +117,13 @@ func (f *Factory) NewClusterMetadataStore() (p.ClusterMetadataStore, error) {
 	return newClusterMetadataPersistence(conn, f.logger)
 }
 
-// NewExecutionStore returns an ExecutionStore for a given shardID
-func (f *Factory) NewExecutionStore(shardID int32) (p.ExecutionStore, error) {
+// NewWorkflowStore returns a WorkflowStore for a given shardID
+func (f *Factory) NewWorkflowStore(shardID int32) (p.WorkflowStore, error) {
 	conn, err := f.mainDBConn.Get()
 	if err != nil {
 		return nil, err
 	}
-	return NewSQLExecutionStore(conn, f.logger, shardID)
+	return NewSQLWorkflowStore(conn, f.logger, shardID)
 }
 
 // NewQueue returns a new queue backed by sql

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -30,19 +30,10 @@ import (
 	"math"
 
 	commonpb "go.temporal.io/api/common/v1"
-
 	"go.temporal.io/api/serviceerror"
-
-	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/primitives"
-)
-
-type (
-	sqlHistoryV2Manager struct {
-		SqlStore
-	}
 )
 
 const (
@@ -50,19 +41,8 @@ const (
 	MinTxnID = math.MaxInt64
 )
 
-// newHistoryV2Persistence creates an instance of HistoryManager
-func newHistoryV2Persistence(
-	db sqlplugin.DB,
-	logger log.Logger,
-) (p.HistoryStore, error) {
-
-	return &sqlHistoryV2Manager{
-		SqlStore: NewSqlStore(db, logger),
-	}, nil
-}
-
 // AppendHistoryNodes add(or override) a node to a history branch
-func (m *sqlHistoryV2Manager) AppendHistoryNodes(
+func (m *sqlWorkflowStore) AppendHistoryNodes(
 	request *p.InternalAppendHistoryNodesRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -138,7 +118,7 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(
 	})
 }
 
-func (m *sqlHistoryV2Manager) DeleteHistoryNodes(
+func (m *sqlWorkflowStore) DeleteHistoryNodes(
 	request *p.InternalDeleteHistoryNodesRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -179,7 +159,7 @@ func (m *sqlHistoryV2Manager) DeleteHistoryNodes(
 }
 
 // ReadHistoryBranch returns history node data for a branch
-func (m *sqlHistoryV2Manager) ReadHistoryBranch(
+func (m *sqlWorkflowStore) ReadHistoryBranch(
 	request *p.InternalReadHistoryBranchRequest,
 ) (*p.InternalReadHistoryBranchResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -303,7 +283,7 @@ func (m *sqlHistoryV2Manager) ReadHistoryBranch(
 //       \
 //       8[8,9]
 //
-func (m *sqlHistoryV2Manager) ForkHistoryBranch(
+func (m *sqlWorkflowStore) ForkHistoryBranch(
 	request *p.InternalForkHistoryBranchRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -343,7 +323,7 @@ func (m *sqlHistoryV2Manager) ForkHistoryBranch(
 }
 
 // DeleteHistoryBranch removes a branch
-func (m *sqlHistoryV2Manager) DeleteHistoryBranch(
+func (m *sqlWorkflowStore) DeleteHistoryBranch(
 	request *p.InternalDeleteHistoryBranchRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -390,7 +370,7 @@ func (m *sqlHistoryV2Manager) DeleteHistoryBranch(
 	})
 }
 
-func (m *sqlHistoryV2Manager) GetAllHistoryTreeBranches(
+func (m *sqlWorkflowStore) GetAllHistoryTreeBranches(
 	request *p.GetAllHistoryTreeBranchesRequest,
 ) (*p.InternalGetAllHistoryTreeBranchesResponse, error) {
 
@@ -400,7 +380,7 @@ func (m *sqlHistoryV2Manager) GetAllHistoryTreeBranches(
 }
 
 // GetHistoryTree returns all branch information of a tree
-func (m *sqlHistoryV2Manager) GetHistoryTree(
+func (m *sqlWorkflowStore) GetHistoryTree(
 	request *p.GetHistoryTreeRequest,
 ) (*p.InternalGetHistoryTreeResponse, error) {
 	ctx, cancel := newExecutionContext()

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -68,7 +68,7 @@ func TestCassandraHistoryStoreSuite(t *testing.T) {
 		testCassandraClusterName,
 		logger,
 	)
-	store, err := factory.NewHistoryStore()
+	store, err := factory.NewWorkflowStore(-1)
 	if err != nil {
 		t.Fatalf("unable to create Cassandra DB: %v", err)
 	}

--- a/common/persistence/tests/history_store_test.go
+++ b/common/persistence/tests/history_store_test.go
@@ -65,7 +65,7 @@ type (
 
 func newHistoryEventsSuite(
 	t *testing.T,
-	store p.HistoryStore,
+	store p.WorkflowStore,
 	logger log.Logger,
 ) *historyEventsSuite {
 	return &historyEventsSuite{

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -71,7 +71,7 @@ func TestMySQLHistoryStoreSuite(t *testing.T) {
 		testMySQLClusterName,
 		logger,
 	)
-	store, err := factory.NewHistoryStore()
+	store, err := factory.NewWorkflowStore(-1)
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -71,7 +71,7 @@ func TestPostgreSQLHistoryStoreSuite(t *testing.T) {
 		testPostgreSQLClusterName,
 		logger,
 	)
-	store, err := factory.NewHistoryStore()
+	store, err := factory.NewWorkflowStore(-1)
 	if err != nil {
 		t.Fatalf("unable to create PostgreSQL DB: %v", err)
 	}

--- a/common/persistence/visibility/sql/visibility_store.go
+++ b/common/persistence/visibility/sql/visibility_store.go
@@ -65,7 +65,7 @@ func newVisibilityContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(ctx, visibilityTimeout)
 }
 
-// NewSQLVisibilityStore creates an instance of ExecutionStore
+// NewSQLVisibilityStore creates an instance of VisibilityStore
 func NewSQLVisibilityStore(
 	cfg config.SQL,
 	r resolver.ServiceResolver,

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -73,7 +73,7 @@ func AdminShowWorkflow(c *cli.Context) {
 	serializer := serialization.NewSerializer()
 	var history []*commonpb.DataBlob
 	if len(tid) != 0 {
-		histV2 := cassandra.NewHistoryV2PersistenceFromSession(session, log.NewNoopLogger())
+		histV2 := cassandra.NewWorkflowStore(-1, session, log.NewNoopLogger())
 		resp, err := histV2.ReadHistoryBranch(&persistence.InternalReadHistoryBranchRequest{
 			TreeID:    tid,
 			BranchID:  bid,
@@ -240,7 +240,7 @@ func AdminDeleteWorkflow(c *cli.Context) {
 		}
 		fmt.Println("Deleting history events for:")
 		prettyPrintJSONObject(branchInfo)
-		histV2 := cassandra.NewHistoryV2PersistenceFromSession(session, log.NewNoopLogger())
+		histV2 := cassandra.NewWorkflowStore(-1, session, log.NewNoopLogger())
 		histMgr := persistence.NewHistoryV2ManagerImpl(histV2, log.NewNoopLogger(), dynamicconfig.GetIntPropertyFn(common.DefaultTransactionSizeLimit))
 		err = histMgr.DeleteHistoryBranch(&persistence.DeleteHistoryBranchRequest{
 			BranchToken: branchToken,
@@ -255,7 +255,7 @@ func AdminDeleteWorkflow(c *cli.Context) {
 		}
 	}
 
-	exeStore, _ := cassandra.NewWorkflowExecutionPersistence(int32(shardIDInt), session, log.NewNoopLogger())
+	exeStore := cassandra.NewWorkflowStore(int32(shardIDInt), session, log.NewNoopLogger())
 	req := &persistence.DeleteWorkflowExecutionRequest{
 		NamespaceID: namespaceID,
 		WorkflowID:  getRequiredOption(c, FlagWorkflowID),

--- a/tools/cli/adminDBCleanCommand.go
+++ b/tools/cli/adminDBCleanCommand.go
@@ -176,14 +176,7 @@ func cleanShard(
 		return report
 	}
 	defer shardCorruptedFile.Close()
-	execStore, err := cassp.NewWorkflowExecutionPersistence(shardID, session, log.NewNoopLogger())
-	if err != nil {
-		report.Failure = &ShardCleanReportFailure{
-			Note:    "failed to create execution store",
-			Details: err.Error(),
-		}
-		return report
-	}
+	execStore := cassp.NewWorkflowStore(shardID, session, log.NewNoopLogger())
 
 	scanner := bufio.NewScanner(shardCorruptedFile)
 	for scanner.Scan() {

--- a/tools/cli/adminDBScanCommand.go
+++ b/tools/cli/adminDBScanCommand.go
@@ -236,7 +236,6 @@ func AdminDBScan(c *cli.Context) {
 	rateLimiter := getRateLimiter(startingRPS, targetRPS)
 	session := connectToCassandra(c)
 	defer session.Close()
-	historyStore := cassp.NewHistoryV2PersistenceFromSession(session, log.NewNoopLogger())
 	scanOutputDirectories := createScanOutputDirectories()
 
 	reports := make(chan *ShardScanReport)
@@ -250,8 +249,7 @@ func AdminDBScan(c *cli.Context) {
 						scanOutputDirectories,
 						rateLimiter,
 						executionsPageSize,
-						payloadSerializer,
-						historyStore)
+						payloadSerializer)
 				}
 			}
 		}(i)
@@ -279,7 +277,6 @@ func scanShard(
 	limiter quotas.RateLimiter,
 	executionsPageSize int,
 	payloadSerializer serialization.Serializer,
-	historyStore persistence.HistoryStore,
 ) *ShardScanReport {
 	outputFiles, closeFn := createShardScanOutputFiles(shardID, scanOutputDirectories)
 	report := &ShardScanReport{
@@ -294,15 +291,8 @@ func scanShard(
 		deleteEmptyFiles(outputFiles.CorruptedExecutionFile, outputFiles.ExecutionCheckFailureFile, outputFiles.ShardScanReportFile)
 		closeFn()
 	}()
-	execStore, err := cassp.NewWorkflowExecutionPersistence(shardID, session, log.NewNoopLogger())
-	if err != nil {
-		report.Failure = &ShardScanReportFailure{
-			Note:    "failed to create execution store",
-			Details: err.Error(),
-		}
-		return report
-	}
-	execMan := persistence.NewExecutionManager(execStore, log.NewNoopLogger())
+	workflowStore := cassp.NewWorkflowStore(shardID, session, log.NewNoopLogger())
+	execMan := persistence.NewExecutionManager(workflowStore, log.NewNoopLogger())
 
 	var token []byte
 	isFirstIteration := true
@@ -335,9 +325,8 @@ func scanShard(
 				checkFailureWriter,
 				shardID,
 				limiter,
-				historyStore,
+				workflowStore,
 				&report.TotalDBRequests,
-				execStore,
 			)
 			switch historyVerificationResult {
 			case VerificationResultNoCorruption:
@@ -440,9 +429,8 @@ func fetchAndVerifyHistoryExists(
 	checkFailureWriter BufferedWriter,
 	shardID int32,
 	limiter quotas.RateLimiter,
-	historyStore persistence.HistoryStore,
+	workflowStore persistence.WorkflowStore,
 	totalDBRequests *int64,
-	execStore persistence.ExecutionStore,
 ) (VerificationResult, *persistence.InternalReadHistoryBranchResponse, *persistencespb.HistoryBranch) {
 	var branch *persistencespb.HistoryBranch
 	currentVersionHistory, err := versionhistory.GetCurrentVersionHistory(executionInfo.VersionHistories)
@@ -473,9 +461,9 @@ func fetchAndVerifyHistoryExists(
 		PageSize:  historyPageSize,
 	}
 	preconditionForDBCall(totalDBRequests, limiter)
-	history, err := historyStore.ReadHistoryBranch(readHistoryBranchReq)
+	history, err := workflowStore.ReadHistoryBranch(readHistoryBranchReq)
 
-	ecf, stillExists := concreteExecutionStillExists(executionInfo, executionState, shardID, execStore, limiter, totalDBRequests)
+	ecf, stillExists := concreteExecutionStillExists(executionInfo, executionState, shardID, workflowStore, limiter, totalDBRequests)
 	if ecf != nil {
 		checkFailureWriter.Add(ecf)
 		return VerificationResultCheckFailure, nil, nil
@@ -721,7 +709,7 @@ func concreteExecutionStillExists(
 	executionInfo *persistencespb.WorkflowExecutionInfo,
 	executionState *persistencespb.WorkflowExecutionState,
 	shardID int32,
-	execStore persistence.ExecutionStore,
+	workflowStore persistence.WorkflowStore,
 	limiter quotas.RateLimiter,
 	totalDBRequests *int64,
 ) (*ExecutionCheckFailure, bool) {
@@ -733,7 +721,7 @@ func concreteExecutionStillExists(
 		},
 	}
 	preconditionForDBCall(totalDBRequests, limiter)
-	_, err := execStore.GetWorkflowExecution(getConcreteExecution)
+	_, err := workflowStore.GetWorkflowExecution(getConcreteExecution)
 	if err == nil {
 		return nil, true
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This is part 1 of a long series changes to unify the persistence interface for workflow.
WorkflowStore is combined interfaces of ExecutionStore and HistoryStore.
Expect no behavior change in this PR.

<!-- Tell your future self why have you made these changes -->
**Why?**
The operations to append history, update mutable state and add tasks are the result of one workflow update.
These operations should be treated as one operation at upper layer. The current implementation is greatly
influenced by the fact that Cassandra does not support transaction across multiple tables. 
Follow up changes will combine ExecutionManager and HistoryManager into WorkflowManager.
And the operation to create/update workflow will be combined with append history.
Then will wire the combined create/update with upper layer.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests, integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
