### PR TITLE
Disable sniffing on ES7 client used in CLI

### DIFF
--- a/common/persistence/visibility/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/elasticsearch/client/client_v7.go
@@ -91,6 +91,7 @@ func newSimpleClientV7(url string) (*clientV7, error) {
 	var err error
 	if client, err = elastic.NewClient(
 		elastic.SetURL(url),
+		elastic.SetSniff(false),
 		elastic.SetRetrier(retrier),
 	); err != nil {
 		return nil, err


### PR DESCRIPTION
**What changed?**

This MR disables sniffing on the Elasticsearch Client (version 7) used by CLI commands.
This is needed for Elasticsearch Servers not supporting sniffing, eg. AWS Elasticsearch Service.
See the following issue for more details:
* https://github.com/temporalio/temporal/issues/621
* https://github.com/temporalio/temporal/issues/551

**Why?**

Without this setting you can't use the CLI commands using AWS Elasticsearch service eg.
```
$ TEMPORAL_CLI_SHOW_STACKS=1 tctl admin es catIndex --url https://my-temporal-1234567.eu-central-1.es.amazonaws.com:443/ --version v7
Error: Unable to create Elasticsearch client
Error Details: context deadline exceeded
Stack trace:
....
```

**How did you test it?**

This was verified by compiling tctl with this change and running the command again:
```
$ TEMPORAL_CLI_SHOW_STACKS=1 tctl admin es catIndex --url https://my-temporal-1234567.eu-central-1.es.amazonaws.com:443/ --version v7
+--------+--------+-----------------------------+-----+-----+------------+--------------+------------+----------------+
| HEALTH | STATUS |            INDEX            | PRI | REP | DOCS COUNT | DOCS DELETED | STORE SIZE | PRI STORE SIZE |
+--------+--------+-----------------------------+-----+-----+------------+--------------+------------+----------------+
| green  | open   | temporal_visibility_v1_dev  |   5 |   0 |          0 |            0 | 1kb        | 1kb            |
| green  | open   | .kibana_1                   |   1 |   1 |          1 |            0 | 10.1kb     | 5kb            |
+--------+--------+-----------------------------+-----+-----+------------+--------------+------------+----------------+
```

**Potential risks**

Don't see any risk for this.

**Is hotfix candidate?**

No