### PR TITLE
Adjust system worker poller number

### DIFF
--- a/service/worker/parentclosepolicy/processor.go
+++ b/service/worker/parentclosepolicy/processor.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	maxConcurrentActivityTaskPollers = 16
-	maxConcurrentWorkflowTaskPollers = 16
+	maxConcurrentActivityTaskPollers = 8
+	maxConcurrentWorkflowTaskPollers = 8
 )
 
 type (

--- a/service/worker/parentclosepolicy/processor.go
+++ b/service/worker/parentclosepolicy/processor.go
@@ -40,10 +40,8 @@ import (
 )
 
 const (
-	maxConcurrentActivityExecutionSize = 10
-	maxConcurrentWorkflowExecutionSize = 10
-	maxConcurrentActivityTaskPollers   = 16
-	maxConcurrentWorkflowTaskPollers   = 16
+	maxConcurrentActivityTaskPollers = 16
+	maxConcurrentWorkflowTaskPollers = 16
 )
 
 type (
@@ -83,11 +81,9 @@ func New(params *BootstrapParams) *Processor {
 func (s *Processor) Start() error {
 	ctx := context.WithValue(context.Background(), processorContextKey, s)
 	workerOpts := worker.Options{
-		MaxConcurrentActivityExecutionSize:     maxConcurrentActivityExecutionSize,
-		MaxConcurrentWorkflowTaskExecutionSize: maxConcurrentWorkflowExecutionSize,
-		MaxConcurrentActivityTaskPollers:       maxConcurrentActivityTaskPollers,
-		MaxConcurrentWorkflowTaskPollers:       maxConcurrentWorkflowTaskPollers,
-		BackgroundActivityContext:              ctx,
+		MaxConcurrentActivityTaskPollers: maxConcurrentActivityTaskPollers,
+		MaxConcurrentWorkflowTaskPollers: maxConcurrentWorkflowTaskPollers,
+		BackgroundActivityContext:        ctx,
 	}
 	processorWorker := worker.New(s.svcClient, processorTaskQueueName, workerOpts)
 

--- a/service/worker/parentclosepolicy/processor.go
+++ b/service/worker/parentclosepolicy/processor.go
@@ -39,6 +39,13 @@ import (
 	"go.temporal.io/server/common/metrics"
 )
 
+const (
+	maxConcurrentActivityExecutionSize = 10
+	maxConcurrentWorkflowExecutionSize = 10
+	maxConcurrentActivityTaskPollers   = 16
+	maxConcurrentWorkflowTaskPollers   = 16
+)
+
 type (
 	// BootstrapParams contains the set of params needed to bootstrap
 	// the sub-system
@@ -76,7 +83,11 @@ func New(params *BootstrapParams) *Processor {
 func (s *Processor) Start() error {
 	ctx := context.WithValue(context.Background(), processorContextKey, s)
 	workerOpts := worker.Options{
-		BackgroundActivityContext: ctx,
+		MaxConcurrentActivityExecutionSize:     maxConcurrentActivityExecutionSize,
+		MaxConcurrentWorkflowTaskExecutionSize: maxConcurrentWorkflowExecutionSize,
+		MaxConcurrentActivityTaskPollers:       maxConcurrentActivityTaskPollers,
+		MaxConcurrentWorkflowTaskPollers:       maxConcurrentWorkflowTaskPollers,
+		BackgroundActivityContext:              ctx,
 	}
 	processorWorker := worker.New(s.svcClient, processorTaskQueueName, workerOpts)
 

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -108,7 +108,9 @@ func New(
 func (s *Scanner) Start() error {
 	workerOpts := worker.Options{
 		MaxConcurrentActivityExecutionSize:     maxConcurrentActivityExecutionSize,
-		MaxConcurrentWorkflowTaskExecutionSize: maxConcurrentWorkflowTaskExecutionSize,
+		MaxConcurrentWorkflowTaskExecutionSize: maxConcurrentWorkflowExecutionSize,
+		MaxConcurrentActivityTaskPollers:       maxConcurrentActivityTaskPollers,
+		MaxConcurrentWorkflowTaskPollers:       maxConcurrentWorkflowTaskPollers,
 		BackgroundActivityContext:              context.WithValue(context.Background(), scannerContextKey, s.context),
 	}
 

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -60,8 +60,8 @@ const (
 
 	maxConcurrentActivityExecutionSize = 10
 	maxConcurrentWorkflowExecutionSize = 10
-	maxConcurrentActivityTaskPollers   = 16
-	maxConcurrentWorkflowTaskPollers   = 16
+	maxConcurrentActivityTaskPollers   = 8
+	maxConcurrentWorkflowTaskPollers   = 8
 	infiniteDuration                   = 20 * 365 * 24 * time.Hour
 
 	tqScannerWFID                  = "temporal-sys-tq-scanner"

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -58,9 +58,11 @@ func (s scannerCtxExecMgrFactory) NewExecutionManager(shardID int32) (persistenc
 const (
 	scannerContextKey = contextKey(0)
 
-	maxConcurrentActivityExecutionSize     = 10
-	maxConcurrentWorkflowTaskExecutionSize = 10
-	infiniteDuration                       = 20 * 365 * 24 * time.Hour
+	maxConcurrentActivityExecutionSize = 10
+	maxConcurrentWorkflowExecutionSize = 10
+	maxConcurrentActivityTaskPollers   = 16
+	maxConcurrentWorkflowTaskPollers   = 16
+	infiniteDuration                   = 20 * 365 * 24 * time.Hour
 
 	tqScannerWFID                  = "temporal-sys-tq-scanner"
 	tqScannerWFTypeName            = "temporal-sys-tq-scanner-workflow"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Use 8 for activity / workflow task poller count instead of default 2

<!-- Tell your future self why have you made these changes -->
**Why?**
2 as poller count is probably only suitable for dev env

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No