### PR TITLE
ExecutionStore/ExecutionManager without ShardID as member field

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -722,7 +722,6 @@ type (
 	// Implements ExecutionManager, ShardManager and TaskManager
 	cassandraPersistence struct {
 		cassandraStore
-		//shardID            int32
 		currentClusterName string
 	}
 )

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1441,6 +1441,7 @@ func (d *cassandraPersistence) assertNotCurrentExecution(
 ) error {
 
 	if resp, err := d.GetCurrentExecution(&p.GetCurrentExecutionRequest{
+		ShardID: d.shardID,
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	}); err != nil {

--- a/common/persistence/cassandra/factory.go
+++ b/common/persistence/cassandra/factory.go
@@ -87,8 +87,8 @@ func (f *Factory) NewClusterMetadataStore() (p.ClusterMetadataStore, error) {
 }
 
 // NewExecutionStore returns an ExecutionStore for a given shardID
-func (f *Factory) NewExecutionStore(shardID int32) (p.ExecutionStore, error) {
-	return NewExecutionStore(shardID, f.session, f.logger), nil
+func (f *Factory) NewExecutionStore() (p.ExecutionStore, error) {
+	return NewExecutionStore(f.session, f.logger), nil
 }
 
 // NewQueue returns a new queue backed by cassandra

--- a/common/persistence/client/bean.go
+++ b/common/persistence/client/bean.go
@@ -69,6 +69,8 @@ type (
 		historyManager            persistence.HistoryManager
 		executionManager          persistence.ExecutionManager
 
+		factory Factory
+
 		sync.RWMutex
 	}
 )
@@ -115,6 +117,7 @@ func NewBeanFromFactory(
 	}
 
 	return NewBean(
+		factory,
 		clusterMetadataMgr,
 		metadataMgr,
 		taskMgr,
@@ -127,6 +130,7 @@ func NewBeanFromFactory(
 
 // NewBean create a new store bean
 func NewBean(
+	factory Factory,
 	clusterMetadataManager persistence.ClusterMetadataManager,
 	metadataManager persistence.MetadataManager,
 	taskManager persistence.TaskManager,
@@ -136,6 +140,7 @@ func NewBean(
 	executionManager persistence.ExecutionManager,
 ) *BeanImpl {
 	return &BeanImpl{
+		factory:                   factory,
 		clusterMetadataManager:    clusterMetadataManager,
 		metadataManager:           metadataManager,
 		taskManager:               taskManager,
@@ -297,4 +302,6 @@ func (s *BeanImpl) Close() {
 	s.shardManager.Close()
 	s.historyManager.Close()
 	s.executionManager.Close()
+
+	s.factory.Close()
 }

--- a/common/persistence/client/bean.go
+++ b/common/persistence/client/bean.go
@@ -70,7 +70,6 @@ type (
 		executionManager          persistence.ExecutionManager
 
 		sync.RWMutex
-		shardIDToExecutionManager map[int32]persistence.ExecutionManager
 	}
 )
 
@@ -144,8 +143,6 @@ func NewBean(
 		shardManager:              shardManager,
 		historyManager:            historyManager,
 		executionManager:          executionManager,
-
-		shardIDToExecutionManager: make(map[int32]persistence.ExecutionManager),
 	}
 }
 
@@ -300,7 +297,4 @@ func (s *BeanImpl) Close() {
 	s.shardManager.Close()
 	s.historyManager.Close()
 	s.executionManager.Close()
-	for _, executionMgr := range s.shardIDToExecutionManager {
-		executionMgr.Close()
-	}
 }

--- a/common/persistence/client/bean_mock.go
+++ b/common/persistence/client/bean_mock.go
@@ -85,18 +85,17 @@ func (mr *MockBeanMockRecorder) GetClusterMetadataManager() *gomock.Call {
 }
 
 // GetExecutionManager mocks base method.
-func (m *MockBean) GetExecutionManager(arg0 int32) (persistence.ExecutionManager, error) {
+func (m *MockBean) GetExecutionManager() persistence.ExecutionManager {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetExecutionManager", arg0)
+	ret := m.ctrl.Call(m, "GetExecutionManager")
 	ret0, _ := ret[0].(persistence.ExecutionManager)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetExecutionManager indicates an expected call of GetExecutionManager.
-func (mr *MockBeanMockRecorder) GetExecutionManager(arg0 interface{}) *gomock.Call {
+func (mr *MockBeanMockRecorder) GetExecutionManager() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecutionManager", reflect.TypeOf((*MockBean)(nil).GetExecutionManager), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecutionManager", reflect.TypeOf((*MockBean)(nil).GetExecutionManager))
 }
 
 // GetHistoryManager mocks base method.
@@ -182,15 +181,15 @@ func (mr *MockBeanMockRecorder) SetClusterMetadataManager(arg0 interface{}) *gom
 }
 
 // SetExecutionManager mocks base method.
-func (m *MockBean) SetExecutionManager(arg0 int32, arg1 persistence.ExecutionManager) {
+func (m *MockBean) SetExecutionManager(arg0 persistence.ExecutionManager) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetExecutionManager", arg0, arg1)
+	m.ctrl.Call(m, "SetExecutionManager", arg0)
 }
 
 // SetExecutionManager indicates an expected call of SetExecutionManager.
-func (mr *MockBeanMockRecorder) SetExecutionManager(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockBeanMockRecorder) SetExecutionManager(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExecutionManager", reflect.TypeOf((*MockBean)(nil).SetExecutionManager), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetExecutionManager", reflect.TypeOf((*MockBean)(nil).SetExecutionManager), arg0)
 }
 
 // SetHistoryManager mocks base method.

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -71,7 +71,7 @@ type (
 		NewShardStore() (p.ShardStore, error)
 		// NewMetadataStore returns a new metadata store
 		NewMetadataStore() (p.MetadataStore, error)
-		// NewExecutionStore returns a workflow store
+		// NewExecutionStore returns a execution store
 		NewExecutionStore() (p.ExecutionStore, error)
 		NewQueue(queueType p.QueueType) (p.Queue, error)
 		// NewClusterMetadataStore returns a new metadata store

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -276,8 +276,9 @@ func (f *factoryImpl) NewNamespaceReplicationQueue() (p.NamespaceReplicationQueu
 
 // Close closes this factory
 func (f *factoryImpl) Close() {
-	ds := f.datastores[storeTypeExecution]
-	ds.factory.Close()
+	for _, ds := range f.datastores {
+		ds.factory.Close()
+	}
 }
 
 func (f *factoryImpl) isCassandra() bool {

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -53,8 +53,8 @@ type (
 		NewHistoryManager() (p.HistoryManager, error)
 		// NewMetadataManager returns a new metadata manager
 		NewMetadataManager() (p.MetadataManager, error)
-		// NewExecutionManager returns a new execution manager for a given shardID
-		NewExecutionManager(shardID int32) (p.ExecutionManager, error)
+		// NewExecutionManager returns a new execution manager
+		NewExecutionManager() (p.ExecutionManager, error)
 		// NewNamespaceReplicationQueue returns a new queue for namespace replication
 		NewNamespaceReplicationQueue() (p.NamespaceReplicationQueue, error)
 		// NewClusterMetadataManager returns a new manager for cluster specific metadata
@@ -71,8 +71,8 @@ type (
 		NewShardStore() (p.ShardStore, error)
 		// NewMetadataStore returns a new metadata store
 		NewMetadataStore() (p.MetadataStore, error)
-		// NewExecutionStore returns a workflow store for given shardID
-		NewExecutionStore(shardID int32) (p.ExecutionStore, error)
+		// NewExecutionStore returns a workflow store
+		NewExecutionStore() (p.ExecutionStore, error)
 		NewQueue(queueType p.QueueType) (p.Queue, error)
 		// NewClusterMetadataStore returns a new metadata store
 		NewClusterMetadataStore() (p.ClusterMetadataStore, error)
@@ -186,7 +186,7 @@ func (f *factoryImpl) NewShardManager() (p.ShardManager, error) {
 // NewHistoryManager returns a new history manager
 func (f *factoryImpl) NewHistoryManager() (p.HistoryManager, error) {
 	ds := f.datastores[storeTypeHistory]
-	store, err := ds.factory.NewExecutionStore(-1)
+	store, err := ds.factory.NewExecutionStore()
 	if err != nil {
 		return nil, err
 	}
@@ -241,12 +241,10 @@ func (f *factoryImpl) NewClusterMetadataManager() (p.ClusterMetadataManager, err
 }
 
 // NewExecutionManager returns a new execution manager for a given shardID
-func (f *factoryImpl) NewExecutionManager(
-	shardID int32,
-) (p.ExecutionManager, error) {
+func (f *factoryImpl) NewExecutionManager() (p.ExecutionManager, error) {
 
 	ds := f.datastores[storeTypeExecution]
-	store, err := ds.factory.NewExecutionStore(shardID)
+	store, err := ds.factory.NewExecutionStore()
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -411,6 +411,7 @@ type (
 
 	// AddTasksRequest is used to write new tasks
 	AddTasksRequest struct {
+		ShardID int32
 		RangeID int64
 
 		NamespaceID string
@@ -425,6 +426,7 @@ type (
 
 	// CreateWorkflowExecutionRequest is used to write a new workflow execution
 	CreateWorkflowExecutionRequest struct {
+		ShardID int32
 		RangeID int64
 
 		Mode CreateWorkflowMode
@@ -441,7 +443,7 @@ type (
 
 	// GetWorkflowExecutionRequest is used to retrieve the info of a workflow execution
 	GetWorkflowExecutionRequest struct {
-		ShardID int32
+		ShardID     int32
 		NamespaceID string
 		Execution   commonpb.WorkflowExecution
 	}
@@ -455,13 +457,14 @@ type (
 
 	// GetCurrentExecutionRequest is used to retrieve the current RunId for an execution
 	GetCurrentExecutionRequest struct {
-		ShardID int32
+		ShardID     int32
 		NamespaceID string
 		WorkflowID  string
 	}
 
 	// ListConcreteExecutionsRequest is request to ListConcreteExecutions
 	ListConcreteExecutionsRequest struct {
+		ShardID   int32
 		PageSize  int
 		PageToken []byte
 	}
@@ -483,6 +486,7 @@ type (
 
 	// UpdateWorkflowExecutionRequest is used to update a workflow execution
 	UpdateWorkflowExecutionRequest struct {
+		ShardID int32
 		RangeID int64
 
 		Mode UpdateWorkflowMode
@@ -494,6 +498,7 @@ type (
 
 	// ConflictResolveWorkflowExecutionRequest is used to reset workflow execution state for a single run
 	ConflictResolveWorkflowExecutionRequest struct {
+		ShardID int32
 		RangeID int64
 
 		Mode ConflictResolveWorkflowMode
@@ -598,7 +603,7 @@ type (
 
 	// DeleteWorkflowExecutionRequest is used to delete a workflow execution
 	DeleteWorkflowExecutionRequest struct {
-		ShardID int32
+		ShardID     int32
 		NamespaceID string
 		WorkflowID  string
 		RunID       string
@@ -606,7 +611,7 @@ type (
 
 	// DeleteCurrentWorkflowExecutionRequest is used to delete the current workflow execution
 	DeleteCurrentWorkflowExecutionRequest struct {
-		ShardID int32
+		ShardID     int32
 		NamespaceID string
 		WorkflowID  string
 		RunID       string
@@ -625,6 +630,7 @@ type (
 
 	// GetTransferTasksRequest is used to read tasks from the transfer task queue
 	GetTransferTasksRequest struct {
+		ShardID       int32
 		ReadLevel     int64
 		MaxReadLevel  int64
 		BatchSize     int
@@ -650,6 +656,7 @@ type (
 
 	// GetVisibilityTasksRequest is used to read tasks from the visibility task queue
 	GetVisibilityTasksRequest struct {
+		ShardID       int32
 		ReadLevel     int64
 		MaxReadLevel  int64
 		BatchSize     int
@@ -675,6 +682,7 @@ type (
 
 	// GetReplicationTasksRequest is used to read tasks from the replication task queue
 	GetReplicationTasksRequest struct {
+		ShardID       int32
 		MinTaskID     int64
 		MaxTaskID     int64
 		BatchSize     int
@@ -689,56 +697,66 @@ type (
 
 	// CompleteTransferTaskRequest is used to complete a task in the transfer task queue
 	CompleteTransferTaskRequest struct {
-		TaskID int64
+		ShardID int32
+		TaskID  int64
 	}
 
 	// RangeCompleteTransferTaskRequest is used to complete a range of tasks in the transfer task queue
 	RangeCompleteTransferTaskRequest struct {
+		ShardID              int32
 		ExclusiveBeginTaskID int64
 		InclusiveEndTaskID   int64
 	}
 
 	// CompleteVisibilityTaskRequest is used to complete a task in the visibility task queue
 	CompleteVisibilityTaskRequest struct {
-		TaskID int64
+		ShardID int32
+		TaskID  int64
 	}
 
 	// RangeCompleteVisibilityTaskRequest is used to complete a range of tasks in the visibility task queue
 	RangeCompleteVisibilityTaskRequest struct {
+		ShardID              int32
 		ExclusiveBeginTaskID int64
 		InclusiveEndTaskID   int64
 	}
 
 	// CompleteReplicationTaskRequest is used to complete a task in the replication task queue
 	CompleteReplicationTaskRequest struct {
-		TaskID int64
+		ShardID int32
+		TaskID  int64
 	}
 
 	// RangeCompleteReplicationTaskRequest is used to complete a range of task in the replication task queue
 	RangeCompleteReplicationTaskRequest struct {
+		ShardID            int32
 		InclusiveEndTaskID int64
 	}
 
 	// PutReplicationTaskToDLQRequest is used to put a replication task to dlq
 	PutReplicationTaskToDLQRequest struct {
+		ShardID           int32
 		SourceClusterName string
 		TaskInfo          *persistencespb.ReplicationTaskInfo
 	}
 
 	// GetReplicationTasksFromDLQRequest is used to get replication tasks from dlq
 	GetReplicationTasksFromDLQRequest struct {
+		ShardID           int32
 		SourceClusterName string
 		GetReplicationTasksRequest
 	}
 
 	// DeleteReplicationTaskFromDLQRequest is used to delete replication task from DLQ
 	DeleteReplicationTaskFromDLQRequest struct {
+		ShardID           int32
 		SourceClusterName string
 		TaskID            int64
 	}
 
 	// RangeDeleteReplicationTaskFromDLQRequest is used to delete replication tasks from DLQ
 	RangeDeleteReplicationTaskFromDLQRequest struct {
+		ShardID              int32
 		SourceClusterName    string
 		ExclusiveBeginTaskID int64
 		InclusiveEndTaskID   int64
@@ -749,12 +767,14 @@ type (
 
 	// RangeCompleteTimerTaskRequest is used to complete a range of tasks in the timer task queue
 	RangeCompleteTimerTaskRequest struct {
+		ShardID                 int32
 		InclusiveBeginTimestamp time.Time
 		ExclusiveEndTimestamp   time.Time
 	}
 
 	// CompleteTimerTaskRequest is used to complete a task in the timer task queue
 	CompleteTimerTaskRequest struct {
+		ShardID             int32
 		VisibilityTimestamp time.Time
 		TaskID              int64
 	}
@@ -861,6 +881,7 @@ type (
 	// GetTimerIndexTasksRequest is the request for GetTimerIndexTasks
 	// TODO: replace this with an iterator that can configure min and max index.
 	GetTimerIndexTasksRequest struct {
+		ShardID       int32
 		MinTimestamp  time.Time
 		MaxTimestamp  time.Time
 		BatchSize     int
@@ -1227,7 +1248,6 @@ type (
 	ExecutionManager interface {
 		Closeable
 		GetName() string
-		GetShardID() int32
 
 		CreateWorkflowExecution(request *CreateWorkflowExecutionRequest) (*CreateWorkflowExecutionResponse, error)
 		GetWorkflowExecution(request *GetWorkflowExecutionRequest) (*GetWorkflowExecutionResponse, error)
@@ -1276,12 +1296,6 @@ type (
 		GetVisibilityTasks(request *GetVisibilityTasksRequest) (*GetVisibilityTasksResponse, error)
 		CompleteVisibilityTask(request *CompleteVisibilityTaskRequest) error
 		RangeCompleteVisibilityTask(request *RangeCompleteVisibilityTaskRequest) error
-	}
-
-	// ExecutionManagerFactory creates an instance of ExecutionManager for a given shard
-	ExecutionManagerFactory interface {
-		Closeable
-		NewExecutionManager(shardID int32) (ExecutionManager, error)
 	}
 
 	// TaskManager is used to manage tasks
@@ -2169,6 +2183,7 @@ func SplitHistoryGarbageCleanupInfo(info string) (namespaceID, workflowID, runID
 
 // NewGetReplicationTasksFromDLQRequest creates a new GetReplicationTasksFromDLQRequest
 func NewGetReplicationTasksFromDLQRequest(
+	shardID int32,
 	sourceClusterName string,
 	readLevel int64,
 	maxReadLevel int64,
@@ -2176,6 +2191,7 @@ func NewGetReplicationTasksFromDLQRequest(
 	nextPageToken []byte,
 ) *GetReplicationTasksFromDLQRequest {
 	return &GetReplicationTasksFromDLQRequest{
+		ShardID:           shardID,
 		SourceClusterName: sourceClusterName,
 		GetReplicationTasksRequest: GetReplicationTasksRequest{
 			MinTaskID:     readLevel,

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -441,6 +441,7 @@ type (
 
 	// GetWorkflowExecutionRequest is used to retrieve the info of a workflow execution
 	GetWorkflowExecutionRequest struct {
+		ShardID int32
 		NamespaceID string
 		Execution   commonpb.WorkflowExecution
 	}
@@ -454,6 +455,7 @@ type (
 
 	// GetCurrentExecutionRequest is used to retrieve the current RunId for an execution
 	GetCurrentExecutionRequest struct {
+		ShardID int32
 		NamespaceID string
 		WorkflowID  string
 	}
@@ -596,6 +598,7 @@ type (
 
 	// DeleteWorkflowExecutionRequest is used to delete a workflow execution
 	DeleteWorkflowExecutionRequest struct {
+		ShardID int32
 		NamespaceID string
 		WorkflowID  string
 		RunID       string
@@ -603,6 +606,7 @@ type (
 
 	// DeleteCurrentWorkflowExecutionRequest is used to delete the current workflow execution
 	DeleteCurrentWorkflowExecutionRequest struct {
+		ShardID int32
 		NamespaceID string
 		WorkflowID  string
 		RunID       string

--- a/common/persistence/dataInterfaces_mock.go
+++ b/common/persistence/dataInterfaces_mock.go
@@ -528,20 +528,6 @@ func (mr *MockExecutionManagerMockRecorder) GetReplicationTasksFromDLQ(request i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTasksFromDLQ", reflect.TypeOf((*MockExecutionManager)(nil).GetReplicationTasksFromDLQ), request)
 }
 
-// GetShardID mocks base method.
-func (m *MockExecutionManager) GetShardID() int32 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShardID")
-	ret0, _ := ret[0].(int32)
-	return ret0
-}
-
-// GetShardID indicates an expected call of GetShardID.
-func (mr *MockExecutionManagerMockRecorder) GetShardID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardID", reflect.TypeOf((*MockExecutionManager)(nil).GetShardID))
-}
-
 // GetTimerIndexTasks mocks base method.
 func (m *MockExecutionManager) GetTimerIndexTasks(request *GetTimerIndexTasksRequest) (*GetTimerIndexTasksResponse, error) {
 	m.ctrl.T.Helper()
@@ -759,56 +745,6 @@ func (m *MockExecutionManager) UpdateWorkflowExecution(request *UpdateWorkflowEx
 func (mr *MockExecutionManagerMockRecorder) UpdateWorkflowExecution(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecution", reflect.TypeOf((*MockExecutionManager)(nil).UpdateWorkflowExecution), request)
-}
-
-// MockExecutionManagerFactory is a mock of ExecutionManagerFactory interface.
-type MockExecutionManagerFactory struct {
-	ctrl     *gomock.Controller
-	recorder *MockExecutionManagerFactoryMockRecorder
-}
-
-// MockExecutionManagerFactoryMockRecorder is the mock recorder for MockExecutionManagerFactory.
-type MockExecutionManagerFactoryMockRecorder struct {
-	mock *MockExecutionManagerFactory
-}
-
-// NewMockExecutionManagerFactory creates a new mock instance.
-func NewMockExecutionManagerFactory(ctrl *gomock.Controller) *MockExecutionManagerFactory {
-	mock := &MockExecutionManagerFactory{ctrl: ctrl}
-	mock.recorder = &MockExecutionManagerFactoryMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockExecutionManagerFactory) EXPECT() *MockExecutionManagerFactoryMockRecorder {
-	return m.recorder
-}
-
-// Close mocks base method.
-func (m *MockExecutionManagerFactory) Close() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Close")
-}
-
-// Close indicates an expected call of Close.
-func (mr *MockExecutionManagerFactoryMockRecorder) Close() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockExecutionManagerFactory)(nil).Close))
-}
-
-// NewExecutionManager mocks base method.
-func (m *MockExecutionManagerFactory) NewExecutionManager(shardID int32) (ExecutionManager, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewExecutionManager", shardID)
-	ret0, _ := ret[0].(ExecutionManager)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewExecutionManager indicates an expected call of NewExecutionManager.
-func (mr *MockExecutionManagerFactoryMockRecorder) NewExecutionManager(shardID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewExecutionManager", reflect.TypeOf((*MockExecutionManagerFactory)(nil).NewExecutionManager), shardID)
 }
 
 // MockTaskManager is a mock of TaskManager interface.

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -148,6 +148,7 @@ func (m *executionManagerImpl) UpdateWorkflowExecution(
 	}
 
 	newRequest := &InternalUpdateWorkflowExecutionRequest{
+		ShardID: m.GetShardID(),
 		RangeID: request.RangeID,
 
 		Mode: request.Mode,
@@ -196,6 +197,7 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 	}
 
 	newRequest := &InternalConflictResolveWorkflowExecutionRequest{
+		ShardID: m.GetShardID(),
 		RangeID: request.RangeID,
 
 		Mode: request.Mode,
@@ -233,6 +235,7 @@ func (m *executionManagerImpl) CreateWorkflowExecution(
 	}
 
 	newRequest := &InternalCreateWorkflowExecutionRequest{
+		ShardID: m.GetShardID(),
 		RangeID:                  request.RangeID,
 		Mode:                     request.Mode,
 		PreviousRunID:            request.PreviousRunID,

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -69,10 +69,6 @@ func (m *executionManagerImpl) GetName() string {
 	return m.persistence.GetName()
 }
 
-func (m *executionManagerImpl) GetShardID() int32 {
-	return m.persistence.GetShardID()
-}
-
 // The below three APIs are related to serialization/deserialization
 func (m *executionManagerImpl) GetWorkflowExecution(
 	request *GetWorkflowExecutionRequest,
@@ -148,7 +144,7 @@ func (m *executionManagerImpl) UpdateWorkflowExecution(
 	}
 
 	newRequest := &InternalUpdateWorkflowExecutionRequest{
-		ShardID: m.GetShardID(),
+		ShardID: request.ShardID,
 		RangeID: request.RangeID,
 
 		Mode: request.Mode,
@@ -197,7 +193,7 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 	}
 
 	newRequest := &InternalConflictResolveWorkflowExecutionRequest{
-		ShardID: m.GetShardID(),
+		ShardID: request.ShardID,
 		RangeID: request.RangeID,
 
 		Mode: request.Mode,
@@ -235,7 +231,7 @@ func (m *executionManagerImpl) CreateWorkflowExecution(
 	}
 
 	newRequest := &InternalCreateWorkflowExecutionRequest{
-		ShardID: m.GetShardID(),
+		ShardID:                  request.ShardID,
 		RangeID:                  request.RangeID,
 		Mode:                     request.Mode,
 		PreviousRunID:            request.PreviousRunID,

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -946,20 +946,6 @@ func (mr *MockExecutionStoreMockRecorder) GetReplicationTasksFromDLQ(request int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTasksFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).GetReplicationTasksFromDLQ), request)
 }
 
-// GetShardID mocks base method.
-func (m *MockExecutionStore) GetShardID() int32 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShardID")
-	ret0, _ := ret[0].(int32)
-	return ret0
-}
-
-// GetShardID indicates an expected call of GetShardID.
-func (mr *MockExecutionStoreMockRecorder) GetShardID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardID", reflect.TypeOf((*MockExecutionStore)(nil).GetShardID))
-}
-
 // GetTimerIndexTasks mocks base method.
 func (m *MockExecutionStore) GetTimerIndexTasks(request *persistence.GetTimerIndexTasksRequest) (*persistence.GetTimerIndexTasksResponse, error) {
 	m.ctrl.T.Helper()

--- a/common/persistence/namespaceReplicationQueue.go
+++ b/common/persistence/namespaceReplicationQueue.go
@@ -128,7 +128,6 @@ func (q *namespaceReplicationQueueImpl) Stop() {
 		return
 	}
 	close(q.done)
-	q.queue.Close()
 }
 
 func (q *namespaceReplicationQueueImpl) Publish(message interface{}) error {

--- a/common/persistence/namespaceReplicationQueue.go
+++ b/common/persistence/namespaceReplicationQueue.go
@@ -128,6 +128,7 @@ func (q *namespaceReplicationQueueImpl) Stop() {
 		return
 	}
 	close(q.done)
+	q.queue.Close()
 }
 
 func (q *namespaceReplicationQueueImpl) Publish(message interface{}) error {

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -126,6 +126,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionDeDup() {
 	csum := s.newRandomChecksum()
 
 	req := &p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -162,6 +163,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionDeDup() {
 	updatedState.State = enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED
 	updatedState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -201,6 +203,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionStateStatus() {
 	csum := s.newRandomChecksum()
 
 	req := &p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -323,6 +326,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionWithZombieState() {
 	csum := s.newRandomChecksum()
 
 	req := &p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -411,6 +415,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 	csum := s.newRandomChecksum()
 
 	req := &p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -451,6 +456,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 	updatedState.State = enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING
 	updatedState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -474,6 +480,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 	for _, status := range statuses {
 		updatedState.Status = status
 		_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+			ShardID: s.ShardInfo.GetShardId(),
 			UpdateWorkflowMutation: p.WorkflowMutation{
 				ExecutionInfo:  updatedInfo,
 				ExecutionState: updatedState,
@@ -491,6 +498,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 	updatedState.State = enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED
 	updatedState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -505,6 +513,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 	for _, status := range statuses {
 		updatedState.Status = status
 		_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+			ShardID: s.ShardInfo.GetShardId(),
 			UpdateWorkflowMutation: p.WorkflowMutation{
 				ExecutionInfo:  updatedInfo,
 				ExecutionState: updatedState,
@@ -542,6 +551,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 	updatedState.State = enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE
 	updatedState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -563,6 +573,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 	for _, status := range statuses {
 		updatedState.Status = status
 		_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+			ShardID: s.ShardInfo.GetShardId(),
 			UpdateWorkflowMutation: p.WorkflowMutation{
 				ExecutionInfo:  updatedInfo,
 				ExecutionState: updatedState,
@@ -594,6 +605,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithZombieState() {
 
 	// create and update a workflow to make it completed
 	req := &p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -634,6 +646,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithZombieState() {
 	updatedState.State = enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE
 	updatedState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -651,6 +664,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithZombieState() {
 	updatedState.State = enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED
 	updatedState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -691,6 +705,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithZombieState() {
 	updatedState.State = enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE
 	updatedState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -728,6 +743,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionBrandNew() {
 	nextEventID := int64(3)
 
 	req := &p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -783,6 +799,7 @@ func (s *ExecutionManagerSuite) TestUpsertWorkflowActivity() {
 
 	// create and update a workflow to make it completed
 	req := &p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -822,6 +839,7 @@ func (s *ExecutionManagerSuite) TestUpsertWorkflowActivity() {
 	updatedInfo := copyWorkflowExecutionInfo(info.ExecutionInfo)
 	updatedState := copyWorkflowExecutionState(info.ExecutionState)
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -848,6 +866,7 @@ func (s *ExecutionManagerSuite) TestUpsertWorkflowActivity() {
 
 	// upsert the previous activity
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  updatedInfo,
 			ExecutionState: updatedState,
@@ -911,6 +930,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionRunIDReuseWithoutRepl
 	// this create should work since we are relying the business logic in history engine
 	// to check whether the existing running workflow has finished
 	_, err3 := s.ExecutionManager.CreateWorkflowExecution(&p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -1021,6 +1041,7 @@ func (s *ExecutionManagerSuite) TestPersistenceStartWorkflow() {
 	s.Empty(task1, "Expected empty task identifier.")
 
 	response, err2 := s.ExecutionManager.CreateWorkflowExecution(&p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -1092,6 +1113,7 @@ func (s *ExecutionManagerSuite) TestGetWorkflow() {
 	csum := s.newRandomChecksum()
 
 	createReq := &p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                     uuid.New(),
@@ -1655,6 +1677,7 @@ func (s *ExecutionManagerSuite) TestCleanupCorruptedWorkflow() {
 	// mark it as corrupted
 	info0.ExecutionState.State = enumsspb.WORKFLOW_EXECUTION_STATE_CORRUPTED
 	_, err6 := s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:  info0.ExecutionInfo,
 			ExecutionState: info0.ExecutionState,
@@ -1699,7 +1722,7 @@ func (s *ExecutionManagerSuite) TestGetCurrentWorkflow() {
 	s.NotNil(task0, "Expected non empty task identifier.")
 
 	response, err := s.ExecutionManager.GetCurrentExecution(&p.GetCurrentExecutionRequest{
-		ShardID: s.ShardInfo.GetShardId(),
+		ShardID:     s.ShardInfo.GetShardId(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowExecution.GetWorkflowId(),
 	})

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1699,6 +1699,7 @@ func (s *ExecutionManagerSuite) TestGetCurrentWorkflow() {
 	s.NotNil(task0, "Expected non empty task identifier.")
 
 	response, err := s.ExecutionManager.GetCurrentExecution(&p.GetCurrentExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowExecution.GetWorkflowId(),
 	})

--- a/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
+++ b/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
@@ -114,6 +114,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowCreation() {
 	csum := s.newRandomChecksum()
 
 	_, err0 := s.ExecutionManager.CreateWorkflowExecution(&p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
 				NamespaceId:                namespaceID,
@@ -212,6 +213,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowCreationWithVersionHistor
 	csum := s.newRandomChecksum()
 
 	_, err0 := s.ExecutionManager.CreateWorkflowExecution(&p.CreateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		RangeID: s.ShardInfo.GetRangeId(),
 		NewWorkflowSnapshot: p.WorkflowSnapshot{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
@@ -325,6 +327,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestContinueAsNew() {
 	}
 
 	_, err2 := s.ExecutionManager.UpdateWorkflowExecution(&p.UpdateWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		UpdateWorkflowMutation: p.WorkflowMutation{
 			ExecutionInfo:       updatedInfo,
 			ExecutionState:      updatedState,

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1298,7 +1298,7 @@ func (s *TestBase) TearDownWorkflowStore() {
 	s.HistoryV2Mgr.Close()
 	s.ClusterMetadataManager.Close()
 	s.MetadataManager.Close()
-	s.VisibilityMgr.Close()
+	s.NamespaceReplicationQueue.Stop()
 
 	// TODO VisibilityMgr/Store is created with a separated code path, this is incorrect and may cause leaking connection
 	// And Postgres requires all connection to be closed before dropping a database

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1295,6 +1295,13 @@ func (s *TestBase) CompleteTask(namespaceID string, taskQueue string, taskType e
 
 // TearDownWorkflowStore to cleanup
 func (s *TestBase) TearDownWorkflowStore() {
+	s.TaskMgr.Close()
+	s.ClusterMetadataManager.Close()
+	s.MetadataManager.Close()
+	s.HistoryV2Mgr.Close()
+	s.ShardMgr.Close()
+	s.ExecutionManager.Close()
+	s.NamespaceReplicationQueue.Stop()
 	s.Factory.Close()
 
 	// TODO VisibilityMgr/Store is created with a separated code path, this is incorrect and may cause leaking connection

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -476,6 +476,7 @@ func (s *TestBase) CreateChildWorkflowExecution(namespaceID string, workflowExec
 func (s *TestBase) GetWorkflowExecutionInfoWithStats(namespaceID string, workflowExecution commonpb.WorkflowExecution) (
 	*persistence.MutableStateStats, *persistencespb.WorkflowMutableState, error) {
 	response, err := s.ExecutionManager.GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NamespaceID: namespaceID,
 		Execution:   workflowExecution,
 	})
@@ -490,6 +491,7 @@ func (s *TestBase) GetWorkflowExecutionInfoWithStats(namespaceID string, workflo
 func (s *TestBase) GetWorkflowMutableState(namespaceID string, workflowExecution commonpb.WorkflowExecution) (
 	*persistencespb.WorkflowMutableState, error) {
 	response, err := s.ExecutionManager.GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
+		ShardID:  s.ShardInfo.GetShardId(),
 		NamespaceID: namespaceID,
 		Execution:   workflowExecution,
 	})
@@ -502,6 +504,7 @@ func (s *TestBase) GetWorkflowMutableState(namespaceID string, workflowExecution
 // GetCurrentWorkflowRunID returns the workflow run ID for the given params
 func (s *TestBase) GetCurrentWorkflowRunID(namespaceID, workflowID string) (string, error) {
 	response, err := s.ExecutionManager.GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	})
@@ -932,6 +935,7 @@ func (s *TestBase) ConflictResolveWorkflowExecution(prevRunID string, prevLastWr
 // DeleteWorkflowExecution is a utility method to delete a workflow execution
 func (s *TestBase) DeleteWorkflowExecution(info *persistencespb.WorkflowExecutionInfo, state *persistencespb.WorkflowExecutionState) error {
 	return s.ExecutionManager.DeleteWorkflowExecution(&persistence.DeleteWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NamespaceID: info.NamespaceId,
 		WorkflowID:  info.WorkflowId,
 		RunID:       state.GetRunId(),
@@ -941,6 +945,7 @@ func (s *TestBase) DeleteWorkflowExecution(info *persistencespb.WorkflowExecutio
 // DeleteCurrentWorkflowExecution is a utility method to delete the workflow current execution
 func (s *TestBase) DeleteCurrentWorkflowExecution(info *persistencespb.WorkflowExecutionInfo, state *persistencespb.WorkflowExecutionState) error {
 	return s.ExecutionManager.DeleteCurrentWorkflowExecution(&persistence.DeleteCurrentWorkflowExecutionRequest{
+		ShardID: s.ShardInfo.GetShardId(),
 		NamespaceID: info.NamespaceId,
 		WorkflowID:  info.WorkflowId,
 		RunID:       state.GetRunId(),

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -90,6 +90,7 @@ type (
 		suite.Suite
 		ShardMgr                  persistence.ShardManager
 		AbstractDataStoreFactory  client.AbstractDataStoreFactory
+		Factory                   client.Factory
 		ExecutionManager          persistence.ExecutionManager
 		TaskMgr                   persistence.TaskManager
 		HistoryV2Mgr              persistence.HistoryManager
@@ -238,6 +239,8 @@ func (s *TestBase) Setup(clusterMetadataConfig *config.ClusterMetadata) {
 
 	s.ExecutionManager, err = factory.NewExecutionManager()
 	s.fatalOnError("NewExecutionManager", err)
+
+	s.Factory = factory
 
 	// SQL currently doesn't have support for visibility manager
 	vCfg := s.VisibilityTestCluster.Config()
@@ -1292,13 +1295,7 @@ func (s *TestBase) CompleteTask(namespaceID string, taskQueue string, taskType e
 
 // TearDownWorkflowStore to cleanup
 func (s *TestBase) TearDownWorkflowStore() {
-	s.ShardMgr.Close()
-	s.ExecutionManager.Close()
-	s.TaskMgr.Close()
-	s.HistoryV2Mgr.Close()
-	s.ClusterMetadataManager.Close()
-	s.MetadataManager.Close()
-	s.NamespaceReplicationQueue.Stop()
+	s.Factory.Close()
 
 	// TODO VisibilityMgr/Store is created with a separated code path, this is incorrect and may cause leaking connection
 	// And Postgres requires all connection to be closed before dropping a database

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -104,7 +104,6 @@ type (
 	ExecutionStore interface {
 		Closeable
 		GetName() string
-		GetShardID() int32
 		// The below three APIs are related to serialization/deserialization
 		GetWorkflowExecution(request *GetWorkflowExecutionRequest) (*InternalGetWorkflowExecutionResponse, error)
 		UpdateWorkflowExecution(request *InternalUpdateWorkflowExecutionRequest) error

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -295,6 +295,7 @@ type (
 
 	// InternalCreateWorkflowExecutionRequest is used to write a new workflow execution
 	InternalCreateWorkflowExecutionRequest struct {
+		ShardID int32
 		RangeID int64
 
 		Mode CreateWorkflowMode
@@ -323,6 +324,7 @@ type (
 
 	// InternalUpdateWorkflowExecutionRequest is used to update a workflow execution for Persistence Interface
 	InternalUpdateWorkflowExecutionRequest struct {
+		ShardID int32
 		RangeID int64
 
 		Mode UpdateWorkflowMode
@@ -334,6 +336,7 @@ type (
 
 	// InternalConflictResolveWorkflowExecutionRequest is used to reset workflow execution state for Persistence Interface
 	InternalConflictResolveWorkflowExecutionRequest struct {
+		ShardID int32
 		RangeID int64
 
 		Mode ConflictResolveWorkflowMode

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -220,10 +220,6 @@ func (p *workflowExecutionPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *workflowExecutionPersistenceClient) GetShardID() int32 {
-	return p.persistence.GetShardID()
-}
-
 func (p *workflowExecutionPersistenceClient) CreateWorkflowExecution(request *CreateWorkflowExecutionRequest) (*CreateWorkflowExecutionResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceCreateWorkflowExecutionScope, metrics.PersistenceRequests)
 
@@ -658,7 +654,7 @@ func (p *workflowExecutionPersistenceClient) updateErrorMetric(scope int, err er
 		p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
 	default:
 		p.logger.Error("Operation failed with internal error.",
-			tag.Error(err), tag.MetricScope(scope), tag.ShardID(p.GetShardID()))
+			tag.Error(err), tag.MetricScope(scope))
 		p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
 	}
 }

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -192,10 +192,6 @@ func (p *workflowExecutionRateLimitedPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *workflowExecutionRateLimitedPersistenceClient) GetShardID() int32 {
-	return p.persistence.GetShardID()
-}
-
 func (p *workflowExecutionRateLimitedPersistenceClient) CreateWorkflowExecution(request *CreateWorkflowExecutionRequest) (*CreateWorkflowExecutionResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -118,12 +118,12 @@ func (f *Factory) NewClusterMetadataStore() (p.ClusterMetadataStore, error) {
 }
 
 // NewExecutionStore returns a ExecutionStore for a given shardID
-func (f *Factory) NewExecutionStore(shardID int32) (p.ExecutionStore, error) {
+func (f *Factory) NewExecutionStore() (p.ExecutionStore, error) {
 	conn, err := f.mainDBConn.Get()
 	if err != nil {
 		return nil, err
 	}
-	return NewSQLExecutionStore(conn, f.logger, shardID)
+	return NewSQLExecutionStore(conn, f.logger)
 }
 
 // NewQueue returns a new queue backed by sql

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -68,7 +68,7 @@ func TestCassandraHistoryStoreSuite(t *testing.T) {
 		testCassandraClusterName,
 		logger,
 	)
-	store, err := factory.NewExecutionStore(-1)
+	store, err := factory.NewExecutionStore()
 	if err != nil {
 		t.Fatalf("unable to create Cassandra DB: %v", err)
 	}

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -71,7 +71,7 @@ func TestMySQLHistoryStoreSuite(t *testing.T) {
 		testMySQLClusterName,
 		logger,
 	)
-	store, err := factory.NewExecutionStore(-1)
+	store, err := factory.NewExecutionStore()
 	if err != nil {
 		t.Fatalf("unable to create MySQL DB: %v", err)
 	}

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -71,7 +71,7 @@ func TestPostgreSQLHistoryStoreSuite(t *testing.T) {
 		testPostgreSQLClusterName,
 		logger,
 	)
-	store, err := factory.NewExecutionStore(-1)
+	store, err := factory.NewExecutionStore()
 	if err != nil {
 		t.Fatalf("unable to create PostgreSQL DB: %v", err)
 	}

--- a/common/resource/resource.go
+++ b/common/resource/resource.go
@@ -104,7 +104,7 @@ type (
 		GetNamespaceReplicationQueue() persistence.NamespaceReplicationQueue
 		GetShardManager() persistence.ShardManager
 		GetHistoryManager() persistence.HistoryManager
-		GetExecutionManager(int32) (persistence.ExecutionManager, error)
+		GetExecutionManager() persistence.ExecutionManager
 		GetPersistenceBean() persistenceClient.Bean
 
 		// loggers

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -604,12 +604,9 @@ func (h *Impl) GetHistoryManager() persistence.HistoryManager {
 	return h.persistenceBean.GetHistoryManager()
 }
 
-// GetExecutionManager return execution manager for given shard ID
-func (h *Impl) GetExecutionManager(
-	shardID int32,
-) (persistence.ExecutionManager, error) {
-
-	return h.persistenceBean.GetExecutionManager(shardID)
+// GetExecutionManager return execution manager
+func (h *Impl) GetExecutionManager() persistence.ExecutionManager {
+	return h.persistenceBean.GetExecutionManager()
 }
 
 // GetPersistenceBean return persistence bean

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -154,7 +154,7 @@ func NewTest(
 	persistenceBean.EXPECT().GetTaskManager().Return(taskMgr).AnyTimes()
 	persistenceBean.EXPECT().GetHistoryManager().Return(historyMgr).AnyTimes()
 	persistenceBean.EXPECT().GetShardManager().Return(shardMgr).AnyTimes()
-	persistenceBean.EXPECT().GetExecutionManager(gomock.Any()).Return(executionMgr, nil).AnyTimes()
+	persistenceBean.EXPECT().GetExecutionManager().Return(executionMgr).AnyTimes()
 	persistenceBean.EXPECT().GetNamespaceReplicationQueue().Return(namespaceReplicationQueue).AnyTimes()
 	persistenceBean.EXPECT().GetClusterMetadataManager().Return(clusterMetadataManager).AnyTimes()
 
@@ -410,11 +410,8 @@ func (s *Test) GetHistoryManager() persistence.HistoryManager {
 }
 
 // GetExecutionManager for testing
-func (s *Test) GetExecutionManager(
-	shardID int32,
-) (persistence.ExecutionManager, error) {
-
-	return s.ExecutionMgr, nil
+func (s *Test) GetExecutionManager() persistence.ExecutionManager {
+	return s.ExecutionMgr
 }
 
 // GetPersistenceBean for testing

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -204,7 +204,10 @@ func (s *integrationSuite) isHistoryDeleted(execution *commonpb.WorkflowExecutio
 }
 
 func (s *integrationSuite) isMutableStateDeleted(namespaceID string, execution *commonpb.WorkflowExecution) bool {
+	shardID := common.WorkflowIDToHistoryShard(namespaceID, execution.GetWorkflowId(),
+		s.testClusterConfig.HistoryConfig.NumHistoryShards)
 	request := &persistence.GetWorkflowExecutionRequest{
+		ShardID: shardID,
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: execution.WorkflowId,

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -207,7 +207,7 @@ func (s *integrationSuite) isMutableStateDeleted(namespaceID string, execution *
 	shardID := common.WorkflowIDToHistoryShard(namespaceID, execution.GetWorkflowId(),
 		s.testClusterConfig.HistoryConfig.NumHistoryShards)
 	request := &persistence.GetWorkflowExecutionRequest{
-		ShardID: shardID,
+		ShardID:     shardID,
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: execution.WorkflowId,

--- a/host/ndc/replication_integration_test.go
+++ b/host/ndc/replication_integration_test.go
@@ -80,7 +80,7 @@ func (s *nDCIntegrationTestSuite) TestReplicationMessageApplication() {
 }
 
 func (s *nDCIntegrationTestSuite) TestReplicationMessageDLQ() {
-
+	var shardID int32 = 1
 	workflowID := "replication-message-dlq-test" + uuid.New()
 	runID := uuid.New()
 	workflowType := "event-generator-workflow-type"
@@ -110,10 +110,7 @@ func (s *nDCIntegrationTestSuite) TestReplicationMessageDLQ() {
 		historyBatch,
 	)
 
-	execMgrFactory := s.active.GetExecutionManagerFactory()
-	executionManager, err := execMgrFactory.NewExecutionManager(1)
-	s.NoError(err)
-
+	executionManager := s.active.GetExecutionManager()
 	expectedDLQMsgs := map[int64]bool{}
 	for _, batch := range historyBatch {
 		firstEventID := batch.Events[0].GetEventId()
@@ -128,7 +125,7 @@ Loop:
 
 		actualDLQMsgs := map[int64]bool{}
 		request := persistence.NewGetReplicationTasksFromDLQRequest(
-			"standby", -1, math.MaxInt64, math.MaxInt64, nil,
+			shardID, "standby", -1, math.MaxInt64, math.MaxInt64, nil,
 		)
 		var token []byte
 		for doPaging := true; doPaging; doPaging = len(token) > 0 {

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -75,7 +75,7 @@ type Temporal interface {
 	GetAdminClient() adminservice.AdminServiceClient
 	GetFrontendClient() workflowservice.WorkflowServiceClient
 	GetHistoryClient() historyservice.HistoryServiceClient
-	GetExecutionManagerFactory() persistence.ExecutionManagerFactory
+	GetExecutionManager() persistence.ExecutionManager
 }
 
 type (
@@ -97,7 +97,7 @@ type (
 		historyV2Mgr                     persistence.HistoryManager
 		taskMgr                          persistence.TaskManager
 		visibilityMgr                    visibility.VisibilityManager
-		executionMgrFactory              persistence.ExecutionManagerFactory
+		executionManager                 persistence.ExecutionManager
 		namespaceReplicationQueue        persistence.NamespaceReplicationQueue
 		shutdownCh                       chan struct{}
 		shutdownWG                       sync.WaitGroup
@@ -130,7 +130,7 @@ type (
 		ClusterMetadataManager           persistence.ClusterMetadataManager
 		ShardMgr                         persistence.ShardManager
 		HistoryV2Mgr                     persistence.HistoryManager
-		ExecutionMgrFactory              persistence.ExecutionManagerFactory
+		ExecutionManager                 persistence.ExecutionManager
 		TaskMgr                          persistence.TaskManager
 		VisibilityMgr                    visibility.VisibilityManager
 		NamespaceReplicationQueue        persistence.NamespaceReplicationQueue
@@ -165,7 +165,7 @@ func NewTemporal(params *TemporalParams) Temporal {
 		shardMgr:                         params.ShardMgr,
 		historyV2Mgr:                     params.HistoryV2Mgr,
 		taskMgr:                          params.TaskMgr,
-		executionMgrFactory:              params.ExecutionMgrFactory,
+		executionManager:                 params.ExecutionManager,
 		namespaceReplicationQueue:        params.NamespaceReplicationQueue,
 		shutdownCh:                       make(chan struct{}),
 		clusterNo:                        params.ClusterNo,
@@ -702,8 +702,8 @@ func (c *temporalImpl) createSystemNamespace() error {
 	return nil
 }
 
-func (c *temporalImpl) GetExecutionManagerFactory() persistence.ExecutionManagerFactory {
-	return c.executionMgrFactory
+func (c *temporalImpl) GetExecutionManager() persistence.ExecutionManager {
+	return c.executionManager
 }
 
 func (c *temporalImpl) overrideHistoryDynamicConfig(client *dynamicClient) {

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -209,7 +209,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 		ClusterMetadataManager:           testBase.ClusterMetadataManager,
 		ShardMgr:                         testBase.ShardMgr,
 		HistoryV2Mgr:                     testBase.HistoryV2Mgr,
-		ExecutionMgrFactory:              testBase.ExecutionMgrFactory,
+		ExecutionManager:                 testBase.ExecutionManager,
 		NamespaceReplicationQueue:        testBase.NamespaceReplicationQueue,
 		TaskMgr:                          testBase.TaskMgr,
 		VisibilityMgr:                    visibilityMgr,
@@ -328,7 +328,7 @@ func (tc *TestCluster) GetHistoryClient() HistoryClient {
 	return tc.host.GetHistoryClient()
 }
 
-// GetExecutionManagerFactory returns an execution manager factory from the test cluster
-func (tc *TestCluster) GetExecutionManagerFactory() persistence.ExecutionManagerFactory {
-	return tc.host.GetExecutionManagerFactory()
+// GetExecutionManager returns an execution manager factory from the test cluster
+func (tc *TestCluster) GetExecutionManager() persistence.ExecutionManager {
+	return tc.host.GetExecutionManager()
 }

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -587,28 +587,30 @@ func (h *Handler) DescribeHistoryHost(_ context.Context, _ *historyservice.Descr
 
 // RemoveTask returns information about the internal states of a history host
 func (h *Handler) RemoveTask(_ context.Context, request *historyservice.RemoveTaskRequest) (_ *historyservice.RemoveTaskResponse, retError error) {
-	executionMgr, err := h.GetExecutionManager(request.GetShardId())
-	if err != nil {
-		return nil, err
-	}
+	executionMgr := h.GetExecutionManager()
 
+	var err error
 	switch request.GetCategory() {
 	case enumsspb.TASK_CATEGORY_TRANSFER:
 		err = executionMgr.CompleteTransferTask(&persistence.CompleteTransferTaskRequest{
-			TaskID: request.GetTaskId(),
+			ShardID: request.GetShardId(),
+			TaskID:  request.GetTaskId(),
 		})
 	case enumsspb.TASK_CATEGORY_VISIBILITY:
 		err = executionMgr.CompleteVisibilityTask(&persistence.CompleteVisibilityTaskRequest{
-			TaskID: request.GetTaskId(),
+			ShardID: request.GetShardId(),
+			TaskID:  request.GetTaskId(),
 		})
 	case enumsspb.TASK_CATEGORY_TIMER:
 		err = executionMgr.CompleteTimerTask(&persistence.CompleteTimerTaskRequest{
+			ShardID:             request.GetShardId(),
 			VisibilityTimestamp: timestamp.TimeValue(request.GetVisibilityTime()),
 			TaskID:              request.GetTaskId(),
 		})
 	case enumsspb.TASK_CATEGORY_REPLICATION:
 		err = executionMgr.CompleteReplicationTask(&persistence.CompleteReplicationTaskRequest{
-			TaskID: request.GetTaskId(),
+			ShardID: request.GetShardId(),
+			TaskID:  request.GetTaskId(),
 		})
 	default:
 		err = errInvalidTaskType

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -3219,6 +3219,7 @@ func (e *historyEngineImpl) loadWorkflow(
 		// workflow not running, need to check current record
 		resp, err := e.shard.GetExecutionManager().GetCurrentExecution(
 			&persistence.GetCurrentExecutionRequest{
+				ShardID:     e.shard.GetShardID(),
 				NamespaceID: namespaceID,
 				WorkflowID:  workflowID,
 			},

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2310,6 +2310,7 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 
 	// also load the current run of the workflow, it can be different from the base runID
 	resp, err := e.executionManager.GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+		ShardID:     e.shard.GetShardID(),
 		NamespaceID: namespaceID,
 		WorkflowID:  request.WorkflowExecution.GetWorkflowId(),
 	})

--- a/service/history/nDCActivityReplicator_test.go
+++ b/service/history/nDCActivityReplicator_test.go
@@ -606,7 +606,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_WorkflowNotFound() {
 		RunId:       runID,
 	}
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
-		ShardID: s.mockShard.GetShardID(),
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: workflowID,

--- a/service/history/nDCActivityReplicator_test.go
+++ b/service/history/nDCActivityReplicator_test.go
@@ -606,6 +606,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_WorkflowNotFound() {
 		RunId:       runID,
 	}
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
+		ShardID: s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: workflowID,

--- a/service/history/nDCTransactionMgr.go
+++ b/service/history/nDCTransactionMgr.go
@@ -392,6 +392,7 @@ func (r *nDCTransactionMgrImpl) checkWorkflowExists(
 
 	_, err := r.shard.GetExecutionManager().GetWorkflowExecution(
 		&persistence.GetWorkflowExecutionRequest{
+			ShardID:  r.shard.GetShardID(),
 			NamespaceID: namespaceID,
 			Execution: commonpb.WorkflowExecution{
 				WorkflowId: workflowID,

--- a/service/history/nDCTransactionMgr.go
+++ b/service/history/nDCTransactionMgr.go
@@ -392,7 +392,7 @@ func (r *nDCTransactionMgrImpl) checkWorkflowExists(
 
 	_, err := r.shard.GetExecutionManager().GetWorkflowExecution(
 		&persistence.GetWorkflowExecutionRequest{
-			ShardID:  r.shard.GetShardID(),
+			ShardID:     r.shard.GetShardID(),
 			NamespaceID: namespaceID,
 			Execution: commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
@@ -419,6 +419,7 @@ func (r *nDCTransactionMgrImpl) getCurrentWorkflowRunID(
 
 	resp, err := r.shard.GetExecutionManager().GetCurrentExecution(
 		&persistence.GetCurrentExecutionRequest{
+			ShardID:     r.shard.GetShardID(),
 			NamespaceID: namespaceID,
 			WorkflowID:  workflowID,
 		},

--- a/service/history/nDCTransactionMgr_test.go
+++ b/service/history/nDCTransactionMgr_test.go
@@ -241,6 +241,7 @@ func (s *nDCTransactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Clo
 	).Return(nil)
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil)
@@ -325,6 +326,7 @@ func (s *nDCTransactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_Cl
 	}).AnyTimes()
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil)
@@ -382,6 +384,7 @@ func (s *nDCTransactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active(
 	}).AnyTimes()
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil)
@@ -438,6 +441,7 @@ func (s *nDCTransactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passive
 	}).AnyTimes()
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil)
@@ -458,7 +462,7 @@ func (s *nDCTransactionMgrSuite) TestCheckWorkflowExists_DoesNotExists() {
 	runID := "some random run ID"
 
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
-		ShardID: s.mockShard.GetShardID(),
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
@@ -478,7 +482,7 @@ func (s *nDCTransactionMgrSuite) TestCheckWorkflowExists_DoesExists() {
 	runID := "some random run ID"
 
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
-		ShardID: s.mockShard.GetShardID(),
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
@@ -497,6 +501,7 @@ func (s *nDCTransactionMgrSuite) TestGetWorkflowCurrentRunID_Missing() {
 	workflowID := "some random workflow ID"
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	}).Return(nil, serviceerror.NewNotFound(""))
@@ -513,6 +518,7 @@ func (s *nDCTransactionMgrSuite) TestGetWorkflowCurrentRunID_Exists() {
 	runID := "some random run ID"
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil)

--- a/service/history/nDCTransactionMgr_test.go
+++ b/service/history/nDCTransactionMgr_test.go
@@ -458,6 +458,7 @@ func (s *nDCTransactionMgrSuite) TestCheckWorkflowExists_DoesNotExists() {
 	runID := "some random run ID"
 
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
+		ShardID: s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
@@ -477,6 +478,7 @@ func (s *nDCTransactionMgrSuite) TestCheckWorkflowExists_DoesExists() {
 	runID := "some random run ID"
 
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
+		ShardID: s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: workflowID,

--- a/service/history/replicationDLQHandler.go
+++ b/service/history/replicationDLQHandler.go
@@ -115,6 +115,7 @@ func (r *replicationDLQHandlerImpl) readMessagesWithAckLevel(
 
 	ackLevel := r.shard.GetReplicatorDLQAckLevel(sourceCluster)
 	resp, err := r.shard.GetExecutionManager().GetReplicationTasksFromDLQ(&persistence.GetReplicationTasksFromDLQRequest{
+		ShardID:           r.shard.GetShardID(),
 		SourceClusterName: sourceCluster,
 		GetReplicationTasksRequest: persistence.GetReplicationTasksRequest{
 			MinTaskID:     ackLevel,
@@ -169,6 +170,7 @@ func (r *replicationDLQHandlerImpl) purgeMessages(
 	ackLevel := r.shard.GetReplicatorDLQAckLevel(sourceCluster)
 	err := r.shard.GetExecutionManager().RangeDeleteReplicationTaskFromDLQ(
 		&persistence.RangeDeleteReplicationTaskFromDLQRequest{
+			ShardID:              r.shard.GetShardID(),
 			SourceClusterName:    sourceCluster,
 			ExclusiveBeginTaskID: ackLevel,
 			InclusiveEndTaskID:   lastMessageID,
@@ -219,6 +221,7 @@ func (r *replicationDLQHandlerImpl) mergeMessages(
 
 	err = r.shard.GetExecutionManager().RangeDeleteReplicationTaskFromDLQ(
 		&persistence.RangeDeleteReplicationTaskFromDLQRequest{
+			ShardID:              r.shard.GetShardID(),
 			SourceClusterName:    sourceCluster,
 			ExclusiveBeginTaskID: ackLevel,
 			InclusiveEndTaskID:   lastMessageID,

--- a/service/history/replicationDLQHandler_test.go
+++ b/service/history/replicationDLQHandler_test.go
@@ -171,6 +171,7 @@ func (s *replicationDLQHandlerSuite) TestReadMessages_OK() {
 	}
 
 	s.executionManager.EXPECT().GetReplicationTasksFromDLQ(&persistence.GetReplicationTasksFromDLQRequest{
+		ShardID:           s.mockShard.GetShardID(),
 		SourceClusterName: s.sourceCluster,
 		GetReplicationTasksRequest: persistence.GetReplicationTasksRequest{
 			MinTaskID:     persistence.EmptyQueueMessageID,
@@ -196,6 +197,7 @@ func (s *replicationDLQHandlerSuite) TestPurgeMessages() {
 
 	s.executionManager.EXPECT().RangeDeleteReplicationTaskFromDLQ(
 		&persistence.RangeDeleteReplicationTaskFromDLQRequest{
+			ShardID:              s.mockShard.GetShardID(),
 			SourceClusterName:    s.sourceCluster,
 			ExclusiveBeginTaskID: persistence.EmptyQueueMessageID,
 			InclusiveEndTaskID:   lastMessageID,
@@ -254,6 +256,7 @@ func (s *replicationDLQHandlerSuite) TestMergeMessages() {
 	}
 
 	s.executionManager.EXPECT().GetReplicationTasksFromDLQ(&persistence.GetReplicationTasksFromDLQRequest{
+		ShardID:           s.mockShard.GetShardID(),
 		SourceClusterName: s.sourceCluster,
 		GetReplicationTasksRequest: persistence.GetReplicationTasksRequest{
 			MinTaskID:     persistence.EmptyQueueMessageID,
@@ -270,6 +273,7 @@ func (s *replicationDLQHandlerSuite) TestMergeMessages() {
 		}, nil)
 	s.taskExecutor.EXPECT().execute(remoteTask, true).Return(0, nil)
 	s.executionManager.EXPECT().RangeDeleteReplicationTaskFromDLQ(&persistence.RangeDeleteReplicationTaskFromDLQRequest{
+		ShardID:              s.mockShard.GetShardID(),
 		SourceClusterName:    s.sourceCluster,
 		ExclusiveBeginTaskID: persistence.EmptyQueueMessageID,
 		InclusiveEndTaskID:   lastMessageID,

--- a/service/history/replicationTaskProcessor.go
+++ b/service/history/replicationTaskProcessor.go
@@ -371,6 +371,7 @@ func (p *ReplicationTaskProcessorImpl) convertTaskToDLQTask(
 	case enumsspb.REPLICATION_TASK_TYPE_SYNC_ACTIVITY_TASK:
 		taskAttributes := replicationTask.GetSyncActivityTaskAttributes()
 		return &persistence.PutReplicationTaskToDLQRequest{
+			ShardID:           p.shard.GetShardID(),
 			SourceClusterName: p.sourceCluster,
 			TaskInfo: &persistencespb.ReplicationTaskInfo{
 				NamespaceId: taskAttributes.GetNamespaceId(),
@@ -401,6 +402,7 @@ func (p *ReplicationTaskProcessorImpl) convertTaskToDLQTask(
 		nextEventID := lastEvent.GetEventId() + 1
 
 		return &persistence.PutReplicationTaskToDLQRequest{
+			ShardID:           p.shard.GetShardID(),
 			SourceClusterName: p.sourceCluster,
 			TaskInfo: &persistencespb.ReplicationTaskInfo{
 				NamespaceId:  taskAttributes.GetNamespaceId(),

--- a/service/history/replicationTaskProcessor_test.go
+++ b/service/history/replicationTaskProcessor_test.go
@@ -240,6 +240,7 @@ func (s *replicationTaskProcessorSuite) TestHandleReplicationDLQTask_SyncActivit
 	workflowID := uuid.New()
 	runID := uuid.NewRandom().String()
 	request := &persistence.PutReplicationTaskToDLQRequest{
+		ShardID:           s.mockShard.GetShardID(),
 		SourceClusterName: cluster.TestAlternativeClusterName,
 		TaskInfo: &persistencespb.ReplicationTaskInfo{
 			NamespaceId: namespaceID,
@@ -260,6 +261,7 @@ func (s *replicationTaskProcessorSuite) TestHandleReplicationDLQTask_History() {
 	runID := uuid.NewRandom().String()
 
 	request := &persistence.PutReplicationTaskToDLQRequest{
+		ShardID:           s.mockShard.GetShardID(),
 		SourceClusterName: cluster.TestAlternativeClusterName,
 		TaskInfo: &persistencespb.ReplicationTaskInfo{
 			NamespaceId:  namespaceID,
@@ -291,6 +293,7 @@ func (s *replicationTaskProcessorSuite) TestConvertTaskToDLQTask_SyncActivity() 
 		}},
 	}
 	request := &persistence.PutReplicationTaskToDLQRequest{
+		ShardID:           s.mockShard.GetShardID(),
 		SourceClusterName: cluster.TestAlternativeClusterName,
 		TaskInfo: &persistencespb.ReplicationTaskInfo{
 			NamespaceId: namespaceID,
@@ -337,6 +340,7 @@ func (s *replicationTaskProcessorSuite) TestConvertTaskToDLQTask_History() {
 		},
 	}
 	request := &persistence.PutReplicationTaskToDLQRequest{
+		ShardID:           s.mockShard.GetShardID(),
 		SourceClusterName: cluster.TestAlternativeClusterName,
 		TaskInfo: &persistencespb.ReplicationTaskInfo{
 			NamespaceId:  namespaceID,
@@ -373,6 +377,7 @@ func (s *replicationTaskProcessorSuite) TestCleanupReplicationTask_Cleanup() {
 
 	s.replicationTaskProcessor.minTxAckedTaskID = ackedTaskID - 1
 	s.mockExecutionManager.EXPECT().RangeCompleteReplicationTask(&persistence.RangeCompleteReplicationTaskRequest{
+		ShardID:            s.mockShard.GetShardID(),
 		InclusiveEndTaskID: ackedTaskID,
 	}).Return(nil)
 	err = s.replicationTaskProcessor.cleanupReplicationTasks()

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -191,6 +191,7 @@ func (p *replicatorQueueProcessorImpl) getTasks(
 	tasks := make([]*replicationspb.ReplicationTask, 0, batchSize)
 	for {
 		response, err := p.executionMgr.GetReplicationTasks(&persistence.GetReplicationTasksRequest{
+			ShardID:       p.shard.GetShardID(),
 			MinTaskID:     minTaskID,
 			MaxTaskID:     maxTaskID,
 			BatchSize:     batchSize,

--- a/service/history/replicatorQueueProcessor_test.go
+++ b/service/history/replicatorQueueProcessor_test.go
@@ -223,6 +223,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowMissing() {
 		ScheduledId: scheduleID,
 	}
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
+		ShardID: s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: workflowID,

--- a/service/history/replicatorQueueProcessor_test.go
+++ b/service/history/replicatorQueueProcessor_test.go
@@ -223,7 +223,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowMissing() {
 		ScheduledId: scheduleID,
 	}
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
-		ShardID: s.mockShard.GetShardID(),
+		ShardID:     s.mockShard.GetShardID(),
 		NamespaceID: namespaceID,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: workflowID,

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1103,7 +1103,7 @@ func acquireShard(
 		timerMaxReadLevelMap[clusterName] = timerMaxReadLevelMap[clusterName].Truncate(time.Millisecond)
 	}
 
-	executionMgr, err := shardItem.GetExecutionManager(shardItem.shardID)
+	executionMgr := shardItem.GetExecutionManager()
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -118,6 +118,7 @@ func (s *contextSuite) TestAddTasks_Success() {
 	visibilityTasks := []persistence.Task{&persistence.DeleteExecutionVisibilityTask{}}
 
 	addTasksRequest := &persistence.AddTasksRequest{
+		ShardID:     s.shardContext.GetShardID(),
 		NamespaceID: task.GetNamespaceId(),
 		WorkflowID:  task.GetWorkflowId(),
 		RunID:       task.GetRunId(),

--- a/service/history/timerQueueAckMgr.go
+++ b/service/history/timerQueueAckMgr.go
@@ -410,6 +410,7 @@ MoveAckLevelLoop:
 // all timer tasks are in this queue and filter will be applied.
 func (t *timerQueueAckMgrImpl) getTimerTasks(minTimestamp time.Time, maxTimestamp time.Time, batchSize int, pageToken []byte) ([]*persistencespb.TimerTaskInfo, []byte, error) {
 	request := &persistence.GetTimerIndexTasksRequest{
+		ShardID:       t.shard.GetShardID(),
 		MinTimestamp:  minTimestamp,
 		MaxTimestamp:  maxTimestamp,
 		BatchSize:     batchSize,

--- a/service/history/timerQueueAckMgr_test.go
+++ b/service/history/timerQueueAckMgr_test.go
@@ -176,6 +176,7 @@ func (s *timerQueueAckMgrSuite) TestGetTimerTasks_More() {
 	batchSize := 10
 
 	request := &persistence.GetTimerIndexTasksRequest{
+		ShardID:       s.mockShard.GetShardID(),
 		MinTimestamp:  minTimestamp,
 		MaxTimestamp:  maxTimestamp,
 		BatchSize:     batchSize,
@@ -213,6 +214,7 @@ func (s *timerQueueAckMgrSuite) TestGetTimerTasks_NoMore() {
 	batchSize := 10
 
 	request := &persistence.GetTimerIndexTasksRequest{
+		ShardID:       s.mockShard.GetShardID(),
 		MinTimestamp:  minTimestamp,
 		MaxTimestamp:  maxTimestamp,
 		BatchSize:     batchSize,

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -325,6 +325,7 @@ func (t *timerQueueProcessorImpl) completeTimers() error {
 
 	if lowerAckLevel.VisibilityTimestamp.Before(upperAckLevel.VisibilityTimestamp) {
 		err := t.shard.GetExecutionManager().RangeCompleteTimerTask(&persistence.RangeCompleteTimerTaskRequest{
+			ShardID:                 t.shard.GetShardID(),
 			InclusiveBeginTimestamp: lowerAckLevel.VisibilityTimestamp,
 			ExclusiveEndTimestamp:   upperAckLevel.VisibilityTimestamp,
 		})

--- a/service/history/timerQueueStandbyTaskExecutor_test.go
+++ b/service/history/timerQueueStandbyTaskExecutor_test.go
@@ -742,6 +742,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple
 			mutableState.GetExecutionInfo().ExecutionStats = &persistencespb.ExecutionStats{}
 
 			s.Equal(&persistence.UpdateWorkflowExecutionRequest{
+				ShardID: s.mockShard.GetShardID(),
 				UpdateWorkflowMutation: persistence.WorkflowMutation{
 					ExecutionInfo:             mutableState.GetExecutionInfo(),
 					ExecutionState:            mutableState.GetExecutionState(),

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -243,7 +243,7 @@ func (t *timerQueueTaskExecutorBase) deleteWorkflowExecution(
 
 	op := func() error {
 		return t.shard.GetExecutionManager().DeleteWorkflowExecution(&persistence.DeleteWorkflowExecutionRequest{
-			ShardID: t.shard.GetShardID(),
+			ShardID:     t.shard.GetShardID(),
 			NamespaceID: task.GetNamespaceId(),
 			WorkflowID:  task.GetWorkflowId(),
 			RunID:       task.GetRunId(),
@@ -258,7 +258,7 @@ func (t *timerQueueTaskExecutorBase) deleteCurrentWorkflowExecution(
 
 	op := func() error {
 		return t.shard.GetExecutionManager().DeleteCurrentWorkflowExecution(&persistence.DeleteCurrentWorkflowExecutionRequest{
-			ShardID: t.shard.GetShardID(),
+			ShardID:     t.shard.GetShardID(),
 			NamespaceID: task.GetNamespaceId(),
 			WorkflowID:  task.GetWorkflowId(),
 			RunID:       task.GetRunId(),
@@ -291,8 +291,8 @@ func (t *timerQueueTaskExecutorBase) deleteWorkflowVisibility(
 ) error {
 
 	return t.shard.AddTasks(&persistence.AddTasksRequest{
+		ShardID: t.shard.GetShardID(),
 		// RangeID is set by shard
-
 		NamespaceID: task.GetNamespaceId(),
 		WorkflowID:  task.GetWorkflowId(),
 		RunID:       task.GetRunId(),

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -243,6 +243,7 @@ func (t *timerQueueTaskExecutorBase) deleteWorkflowExecution(
 
 	op := func() error {
 		return t.shard.GetExecutionManager().DeleteWorkflowExecution(&persistence.DeleteWorkflowExecutionRequest{
+			ShardID: t.shard.GetShardID(),
 			NamespaceID: task.GetNamespaceId(),
 			WorkflowID:  task.GetWorkflowId(),
 			RunID:       task.GetRunId(),
@@ -257,6 +258,7 @@ func (t *timerQueueTaskExecutorBase) deleteCurrentWorkflowExecution(
 
 	op := func() error {
 		return t.shard.GetExecutionManager().DeleteCurrentWorkflowExecution(&persistence.DeleteCurrentWorkflowExecutionRequest{
+			ShardID: t.shard.GetShardID(),
 			NamespaceID: task.GetNamespaceId(),
 			WorkflowID:  task.GetWorkflowId(),
 			RunID:       task.GetRunId(),

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -724,6 +724,7 @@ func (t *transferQueueActiveTaskExecutor) processResetWorkflow(
 		// it means this this might not be current anymore, we need to check
 		var resp *persistence.GetCurrentExecutionResponse
 		resp, err = t.shard.GetExecutionManager().GetCurrentExecution(&persistence.GetCurrentExecutionRequest{
+			ShardID:     t.shard.GetShardID(),
 			NamespaceID: task.GetNamespaceId(),
 			WorkflowID:  task.GetWorkflowId(),
 		})

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -331,6 +331,7 @@ func (t *transferQueueProcessorImpl) completeTransfer() error {
 
 	if lowerAckLevel < upperAckLevel {
 		err := t.shard.GetExecutionManager().RangeCompleteTransferTask(&persistence.RangeCompleteTransferTaskRequest{
+			ShardID:              t.shard.GetShardID(),
 			ExclusiveBeginTaskID: lowerAckLevel,
 			InclusiveEndTaskID:   upperAckLevel,
 		})

--- a/service/history/transferQueueProcessorBase.go
+++ b/service/history/transferQueueProcessorBase.go
@@ -74,6 +74,7 @@ func (t *transferQueueProcessorBase) readTasks(
 ) ([]queueTaskInfo, bool, error) {
 
 	response, err := t.executionManager.GetTransferTasks(&persistence.GetTransferTasksRequest{
+		ShardID:      t.shard.GetShardID(),
 		ReadLevel:    readLevel,
 		MaxReadLevel: t.maxReadAckLevel(),
 		BatchSize:    t.options.BatchSize(),

--- a/service/history/visibilityQueueProcessor.go
+++ b/service/history/visibilityQueueProcessor.go
@@ -276,6 +276,7 @@ func (t *visibilityQueueProcessorImpl) completeTask() error {
 
 	if lowerAckLevel < upperAckLevel {
 		err := t.shard.GetExecutionManager().RangeCompleteVisibilityTask(&persistence.RangeCompleteVisibilityTaskRequest{
+			ShardID:              t.shard.GetShardID(),
 			ExclusiveBeginTaskID: lowerAckLevel,
 			InclusiveEndTaskID:   upperAckLevel,
 		})
@@ -321,6 +322,7 @@ func (t *visibilityQueueProcessorImpl) readTasks(
 ) ([]queueTaskInfo, bool, error) {
 
 	response, err := t.executionManager.GetVisibilityTasks(&persistence.GetVisibilityTasksRequest{
+		ShardID:      t.shard.GetShardID(),
 		ReadLevel:    readLevel,
 		MaxReadLevel: t.maxReadAckLevel(),
 		BatchSize:    t.options.BatchSize(),

--- a/service/history/workflow/cache.go
+++ b/service/history/workflow/cache.go
@@ -216,6 +216,7 @@ func (c *Cache) validateWorkflowExecutionInfo(
 	// RunID is not provided, lets try to retrieve the RunID for current active execution
 	if execution.GetRunId() == "" {
 		response, err := c.getCurrentExecutionWithRetry(&persistence.GetCurrentExecutionRequest{
+			ShardID:     c.shard.GetShardID(),
 			NamespaceID: namespaceID,
 			WorkflowID:  execution.GetWorkflowId(),
 		})

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -259,7 +259,7 @@ func (c *ContextImpl) LoadWorkflowExecutionForReplication(
 
 	if c.MutableState == nil {
 		response, err := getWorkflowExecutionWithRetry(c.shard, &persistence.GetWorkflowExecutionRequest{
-			ShardID: c.shard.GetShardID(),
+			ShardID:     c.shard.GetShardID(),
 			NamespaceID: c.namespaceID,
 			Execution:   c.workflowExecution,
 		})
@@ -341,7 +341,7 @@ func (c *ContextImpl) LoadWorkflowExecution() (MutableState, error) {
 
 	if c.MutableState == nil {
 		response, err := getWorkflowExecutionWithRetry(c.shard, &persistence.GetWorkflowExecutionRequest{
-			ShardID: c.shard.GetShardID(),
+			ShardID:     c.shard.GetShardID(),
 			NamespaceID: c.namespaceID,
 			Execution:   c.workflowExecution,
 		})
@@ -426,6 +426,7 @@ func (c *ContextImpl) CreateWorkflowExecution(
 	}()
 
 	createRequest := &persistence.CreateWorkflowExecutionRequest{
+		ShardID: c.shard.GetShardID(),
 		// workflow create mode & prev run ID & version
 		Mode:                     createMode,
 		PreviousRunID:            prevRunID,

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -259,6 +259,7 @@ func (c *ContextImpl) LoadWorkflowExecutionForReplication(
 
 	if c.MutableState == nil {
 		response, err := getWorkflowExecutionWithRetry(c.shard, &persistence.GetWorkflowExecutionRequest{
+			ShardID: c.shard.GetShardID(),
 			NamespaceID: c.namespaceID,
 			Execution:   c.workflowExecution,
 		})
@@ -340,6 +341,7 @@ func (c *ContextImpl) LoadWorkflowExecution() (MutableState, error) {
 
 	if c.MutableState == nil {
 		response, err := getWorkflowExecutionWithRetry(c.shard, &persistence.GetWorkflowExecutionRequest{
+			ShardID: c.shard.GetShardID(),
 			NamespaceID: c.namespaceID,
 			Execution:   c.workflowExecution,
 		})

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -75,6 +75,7 @@ func (t *TransactionImpl) CreateWorkflowExecution(
 	newWorkflowSnapshot.ExecutionInfo.ExecutionStats.HistorySize += newWorkflowHistorySizeDiff
 
 	if err := createWorkflowExecutionWithRetry(t.shard, &persistence.CreateWorkflowExecutionRequest{
+		ShardID: t.shard.GetShardID(),
 		// RangeID , this is set by shard context
 		Mode:                createMode,
 		NewWorkflowSnapshot: *newWorkflowSnapshot,
@@ -137,6 +138,7 @@ func (t *TransactionImpl) ConflictResolveWorkflowExecution(
 	}
 
 	if err := t.shard.ConflictResolveWorkflowExecution(&persistence.ConflictResolveWorkflowExecutionRequest{
+		ShardID: t.shard.GetShardID(),
 		// RangeID , this is set by shard context
 		Mode:                    conflictResolveMode,
 		ResetWorkflowSnapshot:   *resetWorkflowSnapshot,
@@ -195,6 +197,7 @@ func (t *TransactionImpl) UpdateWorkflowExecution(
 	}
 
 	if err := updateWorkflowExecutionWithRetry(t.shard, &persistence.UpdateWorkflowExecutionRequest{
+		ShardID: t.shard.GetShardID(),
 		// RangeID , this is set by shard context
 		Mode:                   updateMode,
 		UpdateWorkflowMutation: *currentWorkflowMutation,

--- a/service/worker/scanner/executions/history_event_id_validator.go
+++ b/service/worker/scanner/executions/history_event_id_validator.go
@@ -90,6 +90,7 @@ func (v *historyEventIDValidator) Validate(
 	case *serviceerror.NotFound, *serviceerror.DataLoss:
 		// additionally validate mutable state is still present in DB
 		_, err = v.executionManager.GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
+			ShardID: v.shardID,
 			NamespaceID: mutableState.GetExecutionInfo().NamespaceId,
 			Execution: commonpb.WorkflowExecution{
 				WorkflowId: mutableState.GetExecutionInfo().WorkflowId,

--- a/service/worker/scanner/executions/history_event_id_validator.go
+++ b/service/worker/scanner/executions/history_event_id_validator.go
@@ -90,7 +90,7 @@ func (v *historyEventIDValidator) Validate(
 	case *serviceerror.NotFound, *serviceerror.DataLoss:
 		// additionally validate mutable state is still present in DB
 		_, err = v.executionManager.GetWorkflowExecution(&persistence.GetWorkflowExecutionRequest{
-			ShardID: v.shardID,
+			ShardID:     v.shardID,
 			NamespaceID: mutableState.GetExecutionInfo().NamespaceId,
 			Execution: commonpb.WorkflowExecution{
 				WorkflowId: mutableState.GetExecutionInfo().WorkflowId,

--- a/service/worker/scanner/executions/task.go
+++ b/service/worker/scanner/executions/task.go
@@ -166,6 +166,7 @@ func (t *task) validate(
 func (t *task) getPaginationFn() collection.PaginationFn {
 	return func(paginationToken []byte) ([]interface{}, []byte, error) {
 		req := &persistence.ListConcreteExecutionsRequest{
+			ShardID:   t.shardID,
 			PageSize:  executionsPageSize,
 			PageToken: paginationToken,
 		}

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -51,8 +51,8 @@ type (
 
 func (s scannerCtxExecMgrFactory) Close() {}
 
-func (s scannerCtxExecMgrFactory) NewExecutionManager(shardID int32) (persistence.ExecutionManager, error) {
-	return s.ctx.GetExecutionManager(shardID)
+func (s scannerCtxExecMgrFactory) NewExecutionManager() persistence.ExecutionManager {
+	return s.ctx.GetExecutionManager()
 }
 
 const (
@@ -202,7 +202,7 @@ func ExecutionsScavengerActivity(
 	metricsClient := ctx.GetMetricsClient()
 	scavenger := executions.NewScavenger(
 		ctx.cfg.Persistence.NumHistoryShards,
-		scannerCtxExecMgrFactory{ctx}, // as persistence.ExecutionManagerFactory
+		ctx.GetExecutionManager(),
 		ctx.GetHistoryManager(),
 		metricsClient,
 		ctx.GetLogger(),

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -257,6 +257,7 @@ func AdminDeleteWorkflow(c *cli.Context) {
 
 	exeStore := cassandra.NewExecutionStore(int32(shardIDInt), session, log.NewNoopLogger())
 	req := &persistence.DeleteWorkflowExecutionRequest{
+		ShardID: int32(shardIDInt),
 		NamespaceID: namespaceID,
 		WorkflowID:  getRequiredOption(c, FlagWorkflowID),
 		RunID:       runID,
@@ -273,6 +274,7 @@ func AdminDeleteWorkflow(c *cli.Context) {
 	}
 
 	deleteCurrentReq := &persistence.DeleteCurrentWorkflowExecutionRequest{
+		ShardID: int32(shardIDInt),
 		NamespaceID: namespaceID,
 		WorkflowID:  getRequiredOption(c, FlagWorkflowID),
 		RunID:       runID,

--- a/tools/cli/adminDBCleanCommand.go
+++ b/tools/cli/adminDBCleanCommand.go
@@ -176,7 +176,7 @@ func cleanShard(
 		return report
 	}
 	defer shardCorruptedFile.Close()
-	execStore := cassp.NewExecutionStore(shardID, session, log.NewNoopLogger())
+	execStore := cassp.NewExecutionStore(session, log.NewNoopLogger())
 
 	scanner := bufio.NewScanner(shardCorruptedFile)
 	for scanner.Scan() {
@@ -196,7 +196,7 @@ func cleanShard(
 		}
 
 		deleteConcreteReq := &persistence.DeleteWorkflowExecutionRequest{
-			ShardID: shardID,
+			ShardID:     shardID,
 			NamespaceID: ce.NamespaceID,
 			WorkflowID:  ce.WorkflowID,
 			RunID:       ce.RunID,
@@ -212,7 +212,7 @@ func cleanShard(
 		successfullyCleanWriter.Add(&ce)
 		if ce.CorruptedExceptionMetadata.CorruptionType != OpenExecutionInvalidCurrentExecution {
 			deleteCurrentReq := &persistence.DeleteCurrentWorkflowExecutionRequest{
-				ShardID: shardID,
+				ShardID:     shardID,
 				NamespaceID: ce.NamespaceID,
 				WorkflowID:  ce.WorkflowID,
 				RunID:       ce.RunID,

--- a/tools/cli/adminDBCleanCommand.go
+++ b/tools/cli/adminDBCleanCommand.go
@@ -196,6 +196,7 @@ func cleanShard(
 		}
 
 		deleteConcreteReq := &persistence.DeleteWorkflowExecutionRequest{
+			ShardID: shardID,
 			NamespaceID: ce.NamespaceID,
 			WorkflowID:  ce.WorkflowID,
 			RunID:       ce.RunID,
@@ -211,6 +212,7 @@ func cleanShard(
 		successfullyCleanWriter.Add(&ce)
 		if ce.CorruptedExceptionMetadata.CorruptionType != OpenExecutionInvalidCurrentExecution {
 			deleteCurrentReq := &persistence.DeleteCurrentWorkflowExecutionRequest{
+				ShardID: shardID,
 				NamespaceID: ce.NamespaceID,
 				WorkflowID:  ce.WorkflowID,
 				RunID:       ce.RunID,

--- a/tools/cli/adminDBScanCommand.go
+++ b/tools/cli/adminDBScanCommand.go
@@ -291,7 +291,7 @@ func scanShard(
 		deleteEmptyFiles(outputFiles.CorruptedExecutionFile, outputFiles.ExecutionCheckFailureFile, outputFiles.ShardScanReportFile)
 		closeFn()
 	}()
-	workflowStore := cassp.NewExecutionStore(shardID, session, log.NewNoopLogger())
+	workflowStore := cassp.NewExecutionStore(session, log.NewNoopLogger())
 	execMan := persistence.NewExecutionManager(workflowStore, log.NewNoopLogger())
 
 	var token []byte
@@ -299,6 +299,7 @@ func scanShard(
 	for isFirstIteration || len(token) != 0 {
 		isFirstIteration = false
 		req := &persistence.ListConcreteExecutionsRequest{
+			ShardID:   shardID,
 			PageSize:  executionsPageSize,
 			PageToken: token,
 		}
@@ -640,6 +641,7 @@ func verifyCurrentExecution(
 		return VerificationResultNoCorruption
 	}
 	getCurrentExecutionRequest := &persistence.GetCurrentExecutionRequest{
+		ShardID:     shardID,
 		NamespaceID: executionInfo.NamespaceId,
 		WorkflowID:  executionInfo.WorkflowId,
 	}
@@ -714,7 +716,7 @@ func concreteExecutionStillExists(
 	totalDBRequests *int64,
 ) (*ExecutionCheckFailure, bool) {
 	getConcreteExecution := &persistence.GetWorkflowExecutionRequest{
-		ShardID: shardID,
+		ShardID:     shardID,
 		NamespaceID: executionInfo.NamespaceId,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: executionInfo.WorkflowId,
@@ -751,7 +753,7 @@ func concreteExecutionStillOpen(
 	totalDBRequests *int64,
 ) (*ExecutionCheckFailure, bool) {
 	getConcreteExecution := &persistence.GetWorkflowExecutionRequest{
-		ShardID: shardID,
+		ShardID:     shardID,
 		NamespaceID: executionInfo.NamespaceId,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: executionInfo.WorkflowId,

--- a/tools/cli/adminDBScanCommand.go
+++ b/tools/cli/adminDBScanCommand.go
@@ -714,6 +714,7 @@ func concreteExecutionStillExists(
 	totalDBRequests *int64,
 ) (*ExecutionCheckFailure, bool) {
 	getConcreteExecution := &persistence.GetWorkflowExecutionRequest{
+		ShardID: shardID,
 		NamespaceID: executionInfo.NamespaceId,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: executionInfo.WorkflowId,
@@ -750,6 +751,7 @@ func concreteExecutionStillOpen(
 	totalDBRequests *int64,
 ) (*ExecutionCheckFailure, bool) {
 	getConcreteExecution := &persistence.GetWorkflowExecutionRequest{
+		ShardID: shardID,
 		NamespaceID: executionInfo.NamespaceId,
 		Execution: commonpb.WorkflowExecution{
 			WorkflowId: executionInfo.WorkflowId,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor ExecutionManager/ExecutionStore to not require shardID as field.

<!-- Tell your future self why have you made these changes -->
**Why?**
ExecutionManager/ExecutionManager does not need to tie to a particular shard. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test, integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No