### PR TITLE
Disallow fetching CA cert over HTTP in tctl commands

### DIFF
--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -241,7 +241,11 @@ func fetchCACert(pathOrUrl string) (caPool *x509.CertPool, err error) {
 	caPool = x509.NewCertPool()
 	var caBytes []byte
 
-	if strings.HasPrefix(pathOrUrl, "http://") || strings.HasPrefix(pathOrUrl, "https://") {
+	if strings.HasPrefix(pathOrUrl, "http://") {
+		return nil, errors.New("HTTP is not supported for CA cert URLs. Provide HTTPS URL")
+	}
+
+	if strings.HasPrefix(pathOrUrl, "https://") {
 		resp, err := netClient.Get(pathOrUrl)
 		if err != nil {
 			return nil, err

--- a/tools/cli/factory_test.go
+++ b/tools/cli/factory_test.go
@@ -74,6 +74,11 @@ func Test_fetchCACertFromUrl(t *testing.T) {
 			args:    args{path: "https://example.com/testdata/notfound"},
 			wantErr: true,
 		},
+		{
+			name:    "example cert that is passed over http",
+			args:    args{path: "http://example.com/testdata/notfound"},
+			wantErr: true,
+		},
 	}
 	// generate a test server so we can capture and inspect the request
 	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Disallows fetching CA Cert over HTTP. Returns an error message suggesting to provide HTTPS 
- adds unit test to cover HTTP URLs

<!-- Tell your future self why have you made these changes -->
**Why?**
Addressing security request to only support HTTPS https://github.com/temporalio/temporal/pull/1773#discussion_r681205844

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests (including new one)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risk (the feature is not yet released)

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no