### PR TITLE
Add retries for tctl visibility APIs

### DIFF
--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -25,6 +25,7 @@
 package cli
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -435,6 +436,14 @@ func (s *cliAppSuite) TestListWorkflow() {
 	s.sdkClient.AssertExpectations(s.T())
 }
 
+func (s *cliAppSuite) TestListWorkflow_DeadlineExceeded() {
+	s.sdkClient.On("ListClosedWorkflow", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded).Once()
+	s.sdkClient.On("ListClosedWorkflow", mock.Anything, mock.Anything).Return(listClosedWorkflowExecutionsResponse, nil).Once()
+	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "list"})
+	s.Nil(err)
+	s.sdkClient.AssertExpectations(s.T())
+}
+
 func (s *cliAppSuite) TestListWorkflow_WithWorkflowID() {
 	s.sdkClient.On("ListClosedWorkflow", mock.Anything, mock.Anything).Return(listClosedWorkflowExecutionsResponse, nil).Once()
 	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "list", "-wid", "nothing"})
@@ -470,6 +479,14 @@ func (s *cliAppSuite) TestListWorkflow_Open() {
 	s.sdkClient.AssertExpectations(s.T())
 }
 
+func (s *cliAppSuite) TestListWorkflow_Open_DeadlineExceeded() {
+	s.sdkClient.On("ListOpenWorkflow", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded).Once()
+	s.sdkClient.On("ListOpenWorkflow", mock.Anything, mock.Anything).Return(listOpenWorkflowExecutionsResponse, nil).Once()
+	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "list", "-op"})
+	s.Nil(err)
+	s.sdkClient.AssertExpectations(s.T())
+}
+
 func (s *cliAppSuite) TestListWorkflow_Open_WithWorkflowID() {
 	s.sdkClient.On("ListOpenWorkflow", mock.Anything, mock.Anything).Return(listOpenWorkflowExecutionsResponse, nil).Once()
 	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "list", "-op", "-wid", "nothing"})
@@ -499,6 +516,14 @@ func (s *cliAppSuite) TestCountWorkflow() {
 
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{}, nil).Once()
 	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "count", "-q", "'CloseTime = missing'"})
+	s.Nil(err)
+	s.sdkClient.AssertExpectations(s.T())
+}
+
+func (s *cliAppSuite) TestCountWorkflowDeadlineExceeded() {
+	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded).Once()
+	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{}, nil).Once()
+	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "count", "-q", "'CloseTime = missing'"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -58,7 +58,6 @@ const (
 	defaultContextTimeout                        = defaultContextTimeoutInSeconds * time.Second
 	defaultContextTimeoutForLongPoll             = 2 * time.Minute
 	defaultContextTimeoutForListArchivedWorkflow = 3 * time.Minute
-	defaultContextTimeoutForVisibility           = 10 * time.Second
 
 	defaultWorkflowTaskTimeoutInSeconds = 10
 	defaultPageSizeForList              = 500

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -592,10 +592,6 @@ func newContext(c *cli.Context) (context.Context, context.CancelFunc) {
 	return newContextWithTimeout(c, defaultContextTimeout)
 }
 
-func newContextForVisibility(c *cli.Context) (context.Context, context.CancelFunc) {
-	return newContextWithTimeout(c, defaultContextTimeoutForVisibility)
-}
-
 func newContextForLongPoll(c *cli.Context) (context.Context, context.CancelFunc) {
 	return newContextWithTimeout(c, defaultContextTimeoutForLongPoll)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added top level retries for list/count workflow APIs in tctl.

<!-- Tell your future self why have you made these changes -->
**Why?**
Our pipelines are failing with a following error:
```
++ kubectl exec -it services/temporaltest-admintools -- bash -c 'tctl --ns canary-java wf count -q ExecutionStatus=3'

command terminated with exit code 1

+ FAILED_COUNT='Error: Failed to count workflow.

Error Details: context deadline exceeded
```
After deeper inspection it turned out that this error happens because our on-prem ES pod hangs and request times out. In the meantime new ES master is elected and subsequent requests succeed. Unfortunately this issue can not be handled at the level of gRPC retry built into the client as a single API call attempt uses entire context deadline interval (because request hangs) leaving no time for retries.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
`tctl workflow list/count` APIs and most of our pipelines that rely on them.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
