### PR TITLE
Handle unreliable gocql close function stuck issue

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -26,7 +26,6 @@ package gocql
 
 import (
 	"context"
-
 	"sync"
 	"sync/atomic"
 	"time"
@@ -104,7 +103,7 @@ func (s *session) refresh() {
 	s.sessionInitTime = time.Now().UTC()
 	oldSession := s.Value.Load().(*gocql.Session)
 	s.Value.Store(newSession)
-	oldSession.Close()
+	go oldSession.Close()
 	s.logger.Warn("successfully refreshed cql session")
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Start a new goroutine when closing gocql session

<!-- Tell your future self why have you made these changes -->
**Why?**
gocql session.Close is not reliable, sometimes there can be deadlock issue, details see below
1. stack trace proving that gocql session.Close is stuck
```bash
goroutine 700966 [chan send, 61 minutes]:
github.com/gocql/gocql.(*controlConn).close(0xc0026b8c80)
	/go/pkg/mod/github.com/gocql/gocql@v0.0.0-20210621133426-d83b80dfb480/control.go:488 +0xbb
github.com/gocql/gocql.(*Session).Close(0xc0015c2a80)
	/go/pkg/mod/github.com/gocql/gocql@v0.0.0-20210621133426-d83b80dfb480/session.go:464 +0x15f
go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql.(*session).refresh(0xc001daeb60)
	/go/pkg/mod/go.temporal.io/server@v1.11.1-0.20210801055905-ea5caf1c1ea1/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go:107 +0x5cd
go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql.(*query).handleError(...)
	/go/pkg/mod/go.temporal.io/server@v1.11.1-0.20210801055905-ea5caf1c1ea1/common/persistence/nosql/nosqlplugin/cassandra/gocql/query.go:133
```
2. call stack which triggered the above deadlock (from caller to callee)
  a. https://github.com/gocql/gocql/blob/d83b80dfb4800e8761487e2a0c86cf6864824a8e/session.go#L464
  b. https://github.com/gocql/gocql/blob/d83b80dfb4800e8761487e2a0c86cf6864824a8e/control.go#L488
  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No