### PR TITLE
Optimize matching ack manager loop perf

### DIFF
--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -197,6 +197,40 @@ func (s *matchingEngineSuite) TestAckManager() {
 	s.EqualValues(t5, m.getReadLevel())
 }
 
+func (s *matchingEngineSuite) TestAckManager_Sort() {
+	m := newAckManager(s.logger)
+	const t0 = 100
+	m.setAckLevel(t0)
+	s.EqualValues(t0, m.getAckLevel())
+	s.EqualValues(t0, m.getReadLevel())
+	const t1 = 200
+	const t2 = 220
+	const t3 = 320
+	const t4 = 340
+	const t5 = 360
+
+	m.addTask(t1)
+	m.addTask(t2)
+	m.addTask(t3)
+	m.addTask(t4)
+	m.addTask(t5)
+
+	m.completeTask(t2)
+	s.EqualValues(t0, m.getAckLevel())
+
+	m.completeTask(t1)
+	s.EqualValues(t2, m.getAckLevel())
+
+	m.completeTask(t5)
+	s.EqualValues(t2, m.getAckLevel())
+
+	m.completeTask(t4)
+	s.EqualValues(t2, m.getAckLevel())
+
+	m.completeTask(t3)
+	s.EqualValues(t5, m.getAckLevel())
+}
+
 func (s *matchingEngineSuite) TestPollActivityTaskQueuesEmptyResult() {
 	s.PollForTasksEmptyResultTest(context.Background(), enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 }

--- a/service/matching/tasks.go
+++ b/service/matching/tasks.go
@@ -1,0 +1,45 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+type (
+	// taskIDs is used for sorting task IDs
+	taskIDs []int64
+)
+
+// Len implements sort.Interace
+func (t taskIDs) Len() int {
+	return len(t)
+}
+
+// Swap implements sort.Interface.
+func (t taskIDs) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+// Less implements sort.Interface
+func (t taskIDs) Less(i, j int) bool {
+	return t[i] < t[j]
+}

--- a/service/matching/tasks_test.go
+++ b/service/matching/tasks_test.go
@@ -1,0 +1,93 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"math/rand"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type (
+	taskIDSuite struct {
+		suite.Suite
+		*require.Assertions
+	}
+)
+
+func TestTaskIDSuite(t *testing.T) {
+	s := new(taskIDSuite)
+	suite.Run(t, s)
+}
+
+func (s *taskIDSuite) SetupSuite() {
+}
+
+func (s *taskIDSuite) TearDownSuite() {
+}
+
+func (s *taskIDSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *taskIDSuite) TearDownTest() {
+
+}
+
+func (s *taskIDSuite) TestSort_Sorted() {
+	expectedTaskIDs := []int64{1, 3, 5, 10001, 10005, 10008, 100001, 100007, 200017}
+
+	taskIDSlice := make([]int64, len(expectedTaskIDs))
+	copy(taskIDSlice, expectedTaskIDs)
+	actualTaskIDs := taskIDs(taskIDSlice)
+	sort.Sort(actualTaskIDs)
+
+	s.Equal(expectedTaskIDs, []int64(actualTaskIDs))
+}
+
+func (s *taskIDSuite) TestSort_ReverseSorted() {
+	expectedTaskIDs := []int64{1, 3, 5, 10001, 10005, 10008, 100001, 100007, 200017}
+	actualTaskIDs := taskIDs([]int64{200017, 100007, 100001, 10008, 10005, 10001, 5, 3, 1})
+
+	sort.Sort(actualTaskIDs)
+
+	s.Equal(expectedTaskIDs, []int64(actualTaskIDs))
+}
+
+func (s *taskIDSuite) TestSort_Random() {
+	totalNum := 4096
+	var actualTaskIDs taskIDs
+	for i := 0; i < totalNum; i++ {
+		actualTaskIDs = append(actualTaskIDs, rand.Int63())
+	}
+	sort.Sort(actualTaskIDs)
+
+	for i := 1; i < totalNum; i++ {
+		s.True(actualTaskIDs[i-1] <= actualTaskIDs[i])
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Sort matching service task IDs before advancing ack level

<!-- Tell your future self why have you made these changes -->
**Why?**
When lots of ownership movement happens to matching task queue, task IDs allocated can be sparse, e.g. millions of numbers away. This condition can cost lot of CPU cycles when advancing task ack level. 
* Short term, sort task IDs each time before advancing ack level
  * If no much backlog -> matching service is not busy, additional cost due to sort can be acceptable
  * If no lots of backlog -> matching service is busy, additional cost due to sort << looping
* Long term, logic to advance ack level should be handled by a dedicated coroutine

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New tests & existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No