### PR TITLE
Fix TaskQueueLock starvation

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1046,7 +1046,6 @@ func acquireShard(
 		}
 		_, ok := err.(*persistence.ShardAlreadyExistError)
 		return ok
-
 	}
 
 	getShard := func() error {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -205,14 +205,16 @@ func (e *matchingEngineImpl) getTaskQueueManager(taskQueue *taskQueueID, taskQue
 		return nil, err
 	}
 	e.logger.Info("", tag.LifeCycleStarting, tag.WorkflowTaskQueueName(taskQueue.name), tag.WorkflowTaskQueueType(taskQueue.taskType))
+	e.taskQueues[*taskQueue] = mgr
+	e.taskQueuesLock.Unlock()
+
 	err = mgr.Start()
 	if err != nil {
-		e.taskQueuesLock.Unlock()
+		e.removeTaskQueueManager(taskQueue)
 		e.logger.Info("", tag.LifeCycleStartFailed, tag.WorkflowTaskQueueName(taskQueue.name), tag.WorkflowTaskQueueType(taskQueue.taskType), tag.Error(err))
 		return nil, err
 	}
-	e.taskQueues[*taskQueue] = mgr
-	e.taskQueuesLock.Unlock()
+
 	e.logger.Info("", tag.LifeCycleStarted, tag.WorkflowTaskQueueName(taskQueue.name), tag.WorkflowTaskQueueType(taskQueue.taskType))
 	return mgr, nil
 }

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1585,6 +1585,8 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch_ReadBatchDone() {
 	tlMgr, ok := tlMgr0.(*taskQueueManagerImpl)
 	s.True(ok)
 
+	tlMgr.Start()
+
 	tlMgr.taskAckManager.setReadLevel(0)
 	atomic.StoreInt64(&tlMgr.taskWriter.maxReadLevel, maxReadLevel)
 	tasks, readLevel, isReadBatchDone, err := tlMgr.taskReader.getTaskBatch()

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -141,7 +141,7 @@ type (
 		outstandingPollsMap  map[string]context.CancelFunc
 		shutdownCh           chan struct{} // Delivers stop to the pump that populates taskBuffer
 		signalFatalProblem   func(id *taskQueueID)
-		startGate            sync.WaitGroup
+		startGate            *sync.WaitGroup
 	}
 )
 
@@ -172,7 +172,7 @@ func newTaskQueueManager(
 
 	db := newTaskQueueDB(e.taskManager, taskQueue.namespaceID, taskQueue.name, taskQueue.taskType, taskQueueKind, e.logger)
 
-	startGate := sync.WaitGroup{}
+	startGate := &sync.WaitGroup{}
 	startGate.Add(1)
 	tlMgr := &taskQueueManagerImpl{
 		status:              common.DaemonStatusInitialized,

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -141,6 +141,7 @@ type (
 		outstandingPollsMap  map[string]context.CancelFunc
 		shutdownCh           chan struct{} // Delivers stop to the pump that populates taskBuffer
 		signalFatalProblem   func(id *taskQueueID)
+		startGate            sync.WaitGroup
 	}
 )
 
@@ -171,6 +172,8 @@ func newTaskQueueManager(
 
 	db := newTaskQueueDB(e.taskManager, taskQueue.namespaceID, taskQueue.name, taskQueue.taskType, taskQueueKind, e.logger)
 
+	startGate := sync.WaitGroup{}
+	startGate.Add(1)
 	tlMgr := &taskQueueManagerImpl{
 		status:              common.DaemonStatusInitialized,
 		namespaceCache:      e.namespaceCache,
@@ -188,6 +191,7 @@ func newTaskQueueManager(
 		pollerHistory:       newPollerHistory(),
 		outstandingPollsMap: make(map[string]context.CancelFunc),
 		signalFatalProblem:  e.unloadTaskQueue,
+		startGate:           startGate,
 	}
 
 	tlMgr.namespaceValue.Store("")
@@ -248,6 +252,7 @@ func (c *taskQueueManagerImpl) Start() error {
 	c.liveness.Start()
 	c.taskWriter.Start(idblock)
 	c.taskReader.Start()
+	c.startGate.Done()
 	return nil
 }
 
@@ -280,6 +285,7 @@ func (c *taskQueueManagerImpl) AddTask(
 	ctx context.Context,
 	params addTaskParams,
 ) (bool, error) {
+	c.startGate.Wait()
 	if params.forwardedFrom == "" {
 		// request sent by history service
 		c.liveness.markAlive(time.Now())
@@ -327,6 +333,7 @@ func (c *taskQueueManagerImpl) GetTask(
 	ctx context.Context,
 	maxDispatchPerSecond *float64,
 ) (*internalTask, error) {
+	c.startGate.Wait()
 	c.liveness.markAlive(time.Now())
 
 	// We need to set a shorter timeout than the original ctx; otherwise, by the time ctx deadline is
@@ -388,6 +395,7 @@ func (c *taskQueueManagerImpl) DispatchTask(
 	ctx context.Context,
 	task *internalTask,
 ) error {
+	c.startGate.Wait()
 	return c.matcher.MustOffer(ctx, task)
 }
 
@@ -398,16 +406,19 @@ func (c *taskQueueManagerImpl) DispatchQueryTask(
 	taskID string,
 	request *matchingservice.QueryWorkflowRequest,
 ) (*matchingservice.QueryWorkflowResponse, error) {
+	c.startGate.Wait()
 	task := newInternalQueryTask(taskID, request)
 	return c.matcher.OfferQuery(ctx, task)
 }
 
 // GetAllPollerInfo returns all pollers that polled from this taskqueue in last few minutes
 func (c *taskQueueManagerImpl) GetAllPollerInfo() []*taskqueuepb.PollerInfo {
+	c.startGate.Wait()
 	return c.pollerHistory.getAllPollerInfo()
 }
 
 func (c *taskQueueManagerImpl) CancelPoller(pollerID string) {
+	c.startGate.Wait()
 	c.outstandingPollsLock.Lock()
 	cancel, ok := c.outstandingPollsMap[pollerID]
 	c.outstandingPollsLock.Unlock()
@@ -421,6 +432,7 @@ func (c *taskQueueManagerImpl) CancelPoller(pollerID string) {
 // pollers which polled this taskqueue in last few minutes and status of taskqueue's ackManager
 // (readLevel, ackLevel, backlogCountHint and taskIDBlock).
 func (c *taskQueueManagerImpl) DescribeTaskQueue(includeTaskQueueStatus bool) *matchingservice.DescribeTaskQueueResponse {
+	c.startGate.Wait()
 	response := &matchingservice.DescribeTaskQueueResponse{Pollers: c.GetAllPollerInfo()}
 	if !includeTaskQueueStatus {
 		return response
@@ -442,6 +454,7 @@ func (c *taskQueueManagerImpl) DescribeTaskQueue(includeTaskQueueStatus bool) *m
 }
 
 func (c *taskQueueManagerImpl) String() string {
+	c.startGate.Wait()
 	buf := new(bytes.Buffer)
 	if c.taskQueueID.taskType == enumspb.TASK_QUEUE_TYPE_ACTIVITY {
 		buf.WriteString("Activity")

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -324,6 +324,7 @@ func createTestTaskQueueManagerWithConfig(
 		return nil, err
 	}
 	me.taskQueues[*tlID] = tlMgr
+	tlMgr.Start()
 	return tlMgr.(*taskQueueManagerImpl), nil
 }
 

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -57,7 +57,7 @@ func TestDeliverBufferTasks(t *testing.T) {
 
 	tests := []func(tlm *taskQueueManagerImpl){
 		func(tlm *taskQueueManagerImpl) { close(tlm.taskReader.taskBuffer) },
-		func(tlm *taskQueueManagerImpl) { close(tlm.taskReader.shutdownChan) },
+		func(tlm *taskQueueManagerImpl) { tlm.taskReader.Stop() },
 		func(tlm *taskQueueManagerImpl) {
 			rps := 0.1
 			tlm.matcher.UpdateRatelimit(&rps)
@@ -211,11 +211,12 @@ func TestStartFailureWithForeignPartitionOwner(t *testing.T) {
 	cc := dynamicconfig.NewMutableEphemeralClient(
 		dynamicconfig.Set(dynamicconfig.ResilientSyncMatch, true))
 	cfg := NewConfig(dynamicconfig.NewCollection(cc, log.NewTestLogger()))
-	tqm := mustCreateTestTaskQueueManagerWithConfig(t, gomock.NewController(t), cfg,
+	tqm, err1 := createTestTaskQueueManagerWithConfigAndStart(gomock.NewController(t), cfg, false,
 		makeTestBlocAlloc(func() (taskQueueState, error) {
 			// ConditionFailedError indicates foreign partition owner
 			return taskQueueState{}, &persistence.ConditionFailedError{}
 		}))
+	require.NoError(t, err1)
 	var err *persistence.ConditionFailedError
 	require.ErrorAs(t, tqm.Start(), &err)
 }
@@ -308,6 +309,15 @@ func createTestTaskQueueManagerWithConfig(
 	cfg *Config,
 	opts ...taskQueueManagerOpt,
 ) (*taskQueueManagerImpl, error) {
+	return createTestTaskQueueManagerWithConfigAndStart(controller, cfg, true, opts...)
+}
+
+func createTestTaskQueueManagerWithConfigAndStart(
+	controller *gomock.Controller,
+	cfg *Config,
+	start bool,
+	opts ...taskQueueManagerOpt,
+) (*taskQueueManagerImpl, error) {
 	logger := log.NewTestLogger()
 	tm := newTestTaskManager(logger)
 	mockNamespaceCache := cache.NewMockNamespaceCache(controller)
@@ -324,7 +334,9 @@ func createTestTaskQueueManagerWithConfig(
 		return nil, err
 	}
 	me.taskQueues[*tlID] = tlMgr
-	tlMgr.Start()
+	if start {
+		tlMgr.Start()
+	}
 	return tlMgr.(*taskQueueManagerImpl), nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move tqm.Start() out of global lock scope

<!-- Tell your future self why have you made these changes -->
**Why?**
The tqm.Start() would try to renew lease which could fail and it would retry. The process could take more than 30s.
Doing this within global taskQueueLock would block entire matching service.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test with a setup that I can fail some task queue renew.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.