### PR TITLE
Adds flag to tctl db-based commands to override TLS ServerName setting

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -645,6 +645,10 @@ func getDBFlags() []cli.Flag {
 			Name:  FlagTLSCaPath,
 			Usage: "DB tls client ca path (tls must be enabled)",
 		},
+		cli.StringFlag{
+			Name:  FlagTLSServerName,
+			Usage: "DB tls server name (tls must be enabled)",
+		},
 		cli.BoolFlag{
 			Name:  FlagTLSDisableHostVerification,
 			Usage: "DB tls verify hostname and server cert (tls must be enabled)",


### PR DESCRIPTION
Adds support for the following flag:
--tls_server_name value          DB tls server name (tls must be enabled)

This is needed if we want to run tctl admin commands against a DB with TLS enabled where we still want host verification but the certificate subject and dns entry are not aligned.