### PR TITLE
Fix workflow reset reapply current workflow events behavior

### DIFF
--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -64,7 +64,7 @@ func TestDeliverBufferTasks(t *testing.T) {
 			tlm.taskReader.taskBuffer <- &persistencespb.AllocatedTaskInfo{}
 			err := tlm.matcher.rateLimiter.Wait(context.Background()) // consume the token
 			assert.NoError(t, err)
-			tlm.taskReader.cancelFunc()
+			tlm.taskReader.Stop()
 		},
 	}
 	for _, test := range tests {
@@ -94,7 +94,7 @@ func TestDeliverBufferTasks_NoPollers(t *testing.T) {
 		wg.Done()
 	}()
 	time.Sleep(100 * time.Millisecond) // let go routine run first and block on tasksForPoll
-	tlm.taskReader.cancelFunc()
+	tlm.taskReader.Stop()
 	wg.Wait()
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Only reapply current workflow events if current workflow is part of continue as new chain
* Fix matching service unit tests

<!-- Tell your future self why have you made these changes -->
**Why?**
Workflow reset should only re-apply events if events are part of the continue as new chain

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No