### PR TITLE
Do not exit CLI if task queue has no poller

### DIFF
--- a/tools/cli/taskQueueCommands.go
+++ b/tools/cli/taskQueueCommands.go
@@ -51,10 +51,6 @@ func DescribeTaskQueue(c *cli.Context) {
 	}
 
 	pollers := response.Pollers
-	if len(pollers) == 0 {
-		ErrorAndExit(colorMagenta("No poller for taskqueue: "+taskQueue), nil)
-	}
-
 	table := tablewriter.NewWriter(os.Stdout)
 	table.SetBorder(false)
 	table.SetColumnSeparator("|")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Do not exit CLI if task queue has no poller

<!-- Tell your future self why have you made these changes -->
**Why?**
This is not an error case

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual tests
Before:
```bash
tctl --ns canary taskqueue describe --tq canary-task-queue                                    
Error: No poller for taskqueue: canary-task-queue
```

After:
```bash
./tctl --ns canary taskqueue describe --tq canary-task-queue
  WORKFLOW POLLER IDENTITY | LAST ACCESS TIME
  ```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No