### PR TITLE
Add tctl-authorization-plugin to docker images (#1832)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY docker/entrypoint.sh /etc/temporal/entrypoint.sh
 COPY docker/start-temporal.sh /etc/temporal/start-temporal.sh
 
 COPY --from=temporal-builder /temporal/tctl /usr/local/bin
+COPY --from=temporal-builder /temporal/tctl-authorization-plugin /usr/local/bin
 COPY --from=temporal-builder /temporal/temporal-server /usr/local/bin
 
 ##### Auto setup Temporal server #####
@@ -55,6 +56,7 @@ FROM ${BASE_SERVER_IMAGE} AS temporal-tctl
 WORKDIR /etc/temporal
 ENTRYPOINT ["tctl"]
 COPY --from=temporal-builder /temporal/tctl /usr/local/bin
+COPY --from=temporal-builder /temporal/tctl-authorization-plugin /usr/local/bin
 
 ##### Temporal admin tools #####
 FROM ${BASE_ADMIN_TOOLS_IMAGE} as temporal-admin-tools
@@ -66,6 +68,7 @@ COPY --from=temporal-builder /temporal/schema /etc/temporal/schema
 COPY --from=temporal-builder /temporal/temporal-cassandra-tool /usr/local/bin
 COPY --from=temporal-builder /temporal/temporal-sql-tool /usr/local/bin
 COPY --from=temporal-builder /temporal/tctl /usr/local/bin
+COPY --from=temporal-builder /temporal/tctl-authorization-plugin /usr/local/bin
 
 ##### Build requested image #####
 FROM temporal-${TARGET}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added the `tctl-authorization-plugin` to the docker images that currently contain the `tctl`binary.


<!-- Tell your future self why have you made these changes -->
To be able to easily enable the authorization plugin using just the environment variable.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I have tested this locally


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None, other that potentially unused code beeing shipped.


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
No
