### PR TITLE
Fix ExecutionTime backfill by changing init order

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -314,6 +314,7 @@ func newMutableStateBuilderFromDB(
 	}
 
 	mutableState.pendingSignalRequestedIDs = convert.StringSliceToSet(dbRecord.SignalRequestedIds)
+	mutableState.executionState = dbRecord.ExecutionState
 	mutableState.executionInfo = dbRecord.ExecutionInfo
 
 	// Workflows created before 1.11 doesn't have ExecutionTime and it must be computed for backwards compatibility.
@@ -326,7 +327,6 @@ func newMutableStateBuilderFromDB(
 		backoffDuration := timestamp.DurationValue(startEvent.GetWorkflowExecutionStartedEventAttributes().GetFirstWorkflowTaskBackoff())
 		mutableState.executionInfo.ExecutionTime = timestamp.TimePtr(timestamp.TimeValue(mutableState.executionInfo.GetStartTime()).Add(backoffDuration))
 	}
-	mutableState.executionState = dbRecord.ExecutionState
 
 	mutableState.hBuilder = NewMutableHistoryBuilder(
 		mutableState.timeSource,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Tweak the order of initializing fields so that the backfill `ExecutionTime` logic works correctly.

<!-- Tell your future self why have you made these changes -->
**Why?**

It was calling `GetStartEvent` before initializing `executionState`, which contains the run id. Without the run id, the event cache was using a bad key and confusing events from different runs.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Mostly manual testing and observation.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

This only affects the `ExecutionTime` backfill logic, so shouldn't affect anything that doesn't depend on that.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

yes