### PR TITLE
Validate ids in event cache

### DIFF
--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -32,6 +32,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -120,12 +121,24 @@ func newEventKey(namespaceID, workflowID, runID string, eventID int64) eventKey 
 	}
 }
 
+func (e *CacheImpl) validateIds(namespaceID, workflowID, runID string, eventID int64) {
+	if len(namespaceID) == 0 || len(workflowID) == 0 || len(runID) == 0 || eventID < common.FirstEventID {
+		// This is definitely a bug, but just warn and don't crash so we can find anywhere this happens.
+		e.logger.Warn("one or more ids is invalid in event cache",
+			tag.WorkflowID(workflowID),
+			tag.WorkflowRunID(runID),
+			tag.WorkflowNamespaceID(namespaceID),
+			tag.WorkflowEventID(eventID))
+	}
+}
+
 func (e *CacheImpl) GetEvent(namespaceID, workflowID, runID string, firstEventID, eventID int64,
 	branchToken []byte) (*historypb.HistoryEvent, error) {
 	e.metricsClient.IncCounter(metrics.EventsCacheGetEventScope, metrics.CacheRequests)
 	sw := e.metricsClient.StartTimer(metrics.EventsCacheGetEventScope, metrics.CacheLatency)
 	defer sw.Stop()
 
+	e.validateIds(namespaceID, workflowID, runID, eventID)
 	key := newEventKey(namespaceID, workflowID, runID, eventID)
 	// Test hook for disabling cache
 	if !e.disabled {
@@ -157,6 +170,7 @@ func (e *CacheImpl) PutEvent(namespaceID, workflowID, runID string, eventID int6
 	sw := e.metricsClient.StartTimer(metrics.EventsCachePutEventScope, metrics.CacheLatency)
 	defer sw.Stop()
 
+	e.validateIds(namespaceID, workflowID, runID, eventID)
 	key := newEventKey(namespaceID, workflowID, runID, eventID)
 	e.Put(key, event)
 }
@@ -166,6 +180,7 @@ func (e *CacheImpl) DeleteEvent(namespaceID, workflowID, runID string, eventID i
 	sw := e.metricsClient.StartTimer(metrics.EventsCacheDeleteEventScope, metrics.CacheLatency)
 	defer sw.Stop()
 
+	e.validateIds(namespaceID, workflowID, runID, eventID)
 	key := newEventKey(namespaceID, workflowID, runID, eventID)
 	e.Delete(key)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Logs if any id that goes into the event cache key are missing/invalid. Don't allow events to be cached under those keys, but allow `GetEvent` to return them.

<!-- Tell your future self why have you made these changes -->
**Why?**

We found one site where this happened (#1836) and would like to identify any others.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Ran unit tests and integration tests with `Warn` changed to `Fatal` to ensure tests would fail if it hit.

New unit test for change in behavior.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

If there is buggy code calling the event cache with invalid ids, this will cause more lookups since it will stop caching those events. But it shouldn't make the code any more buggy, only reveal bugs.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
