### PR TITLE
Adds counter that increments when a matching poll request is canceled

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1756,6 +1756,8 @@ const (
 
 	ElasticsearchInvalidSearchAttributeCount
 
+	CanceledMatchingPollTaskQueueCounter
+
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1034,6 +1034,10 @@ func (wh *WorkflowHandler) PollActivityTaskQueue(ctx context.Context, request *w
 	if err != nil {
 		contextWasCanceled := wh.cancelOutstandingPoll(ctx, namespaceID, enumspb.TASK_QUEUE_TYPE_ACTIVITY, request.TaskQueue, pollerID)
 		if contextWasCanceled {
+			wh.metricsScope(ctx).Tagged(
+				metrics.TaskQueueTag(request.TaskQueue.Name),
+			).IncCounter(metrics.CanceledMatchingPollTaskQueueCounter)
+
 			// Clear error as we don't want to report context cancellation error to count against our SLA.
 			// It doesn't matter what to return here, client has already gone. But (nil,nil) is invalid gogo return pair.
 			return &workflowservice.PollActivityTaskQueueResponse{}, nil


### PR DESCRIPTION
This enables an operator to track how often matching poll requests are canceled due to an issue outside of Temporal Server