### PR TITLE
Fixes bug where intra-node client is doing retries even if the error is context cancelled

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -217,20 +217,23 @@ func IsPersistenceTransientError(err error) bool {
 
 // IsServiceTransientError checks if the error is a retryable error.
 func IsServiceTransientError(err error) bool {
-	return !IsServiceNonRetryableError(err)
-}
-
-// IsServiceNonRetryableError checks if the error is a non retryable error.
-func IsServiceNonRetryableError(err error) bool {
 	switch err.(type) {
 	case *serviceerror.NotFound,
 		*serviceerror.InvalidArgument,
 		*serviceerror.NamespaceNotActive,
 		*serviceerror.WorkflowExecutionAlreadyStarted:
-		return true
+		return false
 	}
 
-	return IsContextDeadlineExceededErr(err) || IsContextCanceledErr(err)
+	if IsContextDeadlineExceededErr(err) {
+		return false
+	}
+
+	if IsContextCanceledErr(err) {
+		return false
+	}
+
+	return true
 }
 
 // IsContextDeadlineExceededErr checks if the error is context.DeadlineExceeded or serviceerror.DeadlineExceeded error

--- a/common/util.go
+++ b/common/util.go
@@ -230,11 +230,7 @@ func IsServiceNonRetryableError(err error) bool {
 		return true
 	}
 
-	if IsContextDeadlineExceededErr(err) {
-		return true
-	}
-
-	return false
+	return IsContextDeadlineExceededErr(err) || IsContextCanceledErr(err)
 }
 
 // IsContextDeadlineExceededErr checks if the error is context.DeadlineExceeded or serviceerror.DeadlineExceeded error

--- a/host/taskpoller.go
+++ b/host/taskpoller.go
@@ -152,7 +152,7 @@ Loop:
 			Identity:  p.Identity,
 		})
 
-		if common.IsServiceNonRetryableError(err1) {
+		if !common.IsServiceTransientError(err1) {
 			return false, nil, err1
 		}
 

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -422,7 +422,7 @@ func (t *transferQueueActiveTaskExecutor) processCancelExecution(
 
 		// Check to see if the error is non-transient, in which case add RequestCancelFailed
 		// event and complete transfer task by setting the err = nil
-		if !common.IsServiceNonRetryableError(err) || common.IsContextDeadlineExceededErr(err) {
+		if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
 			// for retryable error just return
 			return err
 		}
@@ -518,7 +518,7 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 
 		// Check to see if the error is non-transient, in which case add SignalFailed
 		// event and complete transfer task by setting the err = nil
-		if !common.IsServiceNonRetryableError(err) || common.IsContextDeadlineExceededErr(err) {
+		if common.IsServiceTransientError(err) || common.IsContextDeadlineExceededErr(err) {
 			// for retryable error just return
 			return err
 		}


### PR DESCRIPTION
We add "context canceled" as a blacklist for determining if an error is transient or not.

We are proposing this change because otherwise a single poll getting canceled results in 7x the attempts with an already canceled context.

Verified on one-box.

Could be risky as there may be cases where we DO want to retry on a context canceled error (however, we already don't retry on context deadline exceeded, so why are we doing it on context cancelled)?

Not a hotfix. Main impact will be to reduce resource usage for non-retryable errors and fix up metrics reporting.
