### PR TITLE
Change default value of worker.ESProcessorFlushInterval from 200ms to 1s

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -448,9 +448,8 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		ESProcessorBulkActions: dc.GetIntProperty(dynamicconfig.WorkerESProcessorBulkActions, 500),
 		// 16MB - just a sanity check. With ES document size ~1Kb it should never be reached.
 		ESProcessorBulkSize: dc.GetIntProperty(dynamicconfig.WorkerESProcessorBulkSize, 16*1024*1024),
-		// Under high load bulk processor should flush due to number of BulkActions reached.
-		// Although, under small load it would never be the case and bulk processor will flush every this interval.
-		ESProcessorFlushInterval: dc.GetDurationProperty(dynamicconfig.WorkerESProcessorFlushInterval, 200*time.Millisecond),
+		// Bulk processor will flush every this interval regardless of last flush due to bulk actions.
+		ESProcessorFlushInterval: dc.GetDurationProperty(dynamicconfig.WorkerESProcessorFlushInterval, 1*time.Second),
 		ESProcessorAckTimeout:    dc.GetDurationProperty(dynamicconfig.WorkerESProcessorAckTimeout, 1*time.Minute),
 
 		EnableCrossNamespaceCommands: dc.GetBoolProperty(dynamicconfig.EnableCrossNamespaceCommands, true),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change default value of `worker.ESProcessorFlushInterval` from 200ms to 1s.

<!-- Tell your future self why have you made these changes -->
**Why?**
It turned out that bulk processor doesn't work as expected. It flushes every flush interval even if the last flush due to number of actions was 1ms ago. 200ms is too aggressive and can overload Elasticsearch server. 1 second is reasonable compromise between flush delay and Elasticsearch load. Proper fix for bulk processor is needed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tests and load on test cluster.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Visibility update delay increased to 1 second also.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.