### PR TITLE
Change parseESDoc and generateESDoc to return error instead of logging

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1755,6 +1755,7 @@ const (
 	AddSearchAttributesWorkflowFailuresCount
 
 	ElasticsearchDocumentParseFailuresCount
+	ElasticsearchDocumentGenerateFailuresCount
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -2208,7 +2209,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ServiceErrAuthorizeFailedPerTaskQueueCounter: {
 			metricName: "service_errors_authorize_failed_per_tl", metricRollupName: "service_errors_authorize_failed", metricType: Counter,
 		},
-		ElasticsearchDocumentParseFailuresCount: {metricName: "elasticsearch_document_parse_failures_counter", metricType: Counter},
+		ElasticsearchDocumentParseFailuresCount:    {metricName: "elasticsearch_document_parse_failures_counter", metricType: Counter},
+		ElasticsearchDocumentGenerateFailuresCount: {metricName: "elasticsearch_document_generate_failures_counter", metricType: Counter},
 	},
 	History: {
 		TaskRequests: {metricName: "task_requests", metricType: Counter},
@@ -2387,7 +2389,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		MutableStateChecksumInvalidated:                   {metricName: "mutable_state_checksum_invalidated", metricType: Counter},
 
 		ElasticsearchBulkProcessorRequests:       {metricName: "elasticsearch_bulk_processor_requests"},
-		ElasticsearchBulkProcessorQueuedRequests: {metricName: "elasticsearch_bulk_processor_queued_requests"},
+		ElasticsearchBulkProcessorQueuedRequests: {metricName: "elasticsearch_bulk_processor_queued_requests", metricType: Timer},
 		ElasticsearchBulkProcessorRetries:        {metricName: "elasticsearch_bulk_processor_retries"},
 		ElasticsearchBulkProcessorFailures:       {metricName: "elasticsearch_bulk_processor_errors"},
 		ElasticsearchBulkProcessorCorruptedData:  {metricName: "elasticsearch_bulk_processor_corrupted_data"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1754,7 +1754,7 @@ const (
 	AddSearchAttributesWorkflowSuccessCount
 	AddSearchAttributesWorkflowFailuresCount
 
-	ElasticsearchInvalidSearchAttributeCount
+	ElasticsearchDocumentParseFailuresCount
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -2208,7 +2208,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ServiceErrAuthorizeFailedPerTaskQueueCounter: {
 			metricName: "service_errors_authorize_failed_per_tl", metricRollupName: "service_errors_authorize_failed", metricType: Counter,
 		},
-		ElasticsearchInvalidSearchAttributeCount: {metricName: "elasticsearch_invalid_search_attribute_counter", metricType: Counter},
+		ElasticsearchDocumentParseFailuresCount: {metricName: "elasticsearch_document_parse_failures_counter", metricType: Counter},
 	},
 	History: {
 		TaskRequests: {metricName: "task_requests", metricType: Counter},

--- a/common/persistence/visibility/elasticsearch/visibility_manager.go
+++ b/common/persistence/visibility/elasticsearch/visibility_manager.go
@@ -47,7 +47,7 @@ func NewVisibilityManager(
 	log log.Logger,
 ) visibility.VisibilityManager {
 
-	visStore := NewVisibilityStore(esClient, indexName, searchAttributesProvider, processor, cfg, log, metricsClient)
+	visStore := NewVisibilityStore(esClient, indexName, searchAttributesProvider, processor, cfg, metricsClient)
 	visManager := visibility.NewVisibilityManagerImpl(visStore, searchAttributesProvider, indexName, log)
 
 	if cfg != nil {

--- a/common/persistence/visibility/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store.go
@@ -745,12 +745,14 @@ func (s *visibilityStore) generateESDoc(request *visibility.InternalVisibilityRe
 
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
+		s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentGenerateFailuresCount)
 		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to read search attribute types: %v", err))
 	}
 
 	searchAttributes, err := searchattribute.Decode(request.SearchAttributes, &typeMap)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to read search attribute types: %v", err))
+		s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentGenerateFailuresCount)
+		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to decode search attributes: %v", err))
 	}
 	for saName, saValue := range searchAttributes {
 		doc[saName] = saValue

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -177,7 +177,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 		}
 		indexName := options.ESConfig.GetVisibilityIndex()
 		esVisibilityStore := elasticsearch.NewVisibilityStore(
-			esClient, indexName, searchattribute.NewTestProvider(), esProcessor, visConfig, logger, &metrics.NoopMetricsClient{},
+			esClient, indexName, searchattribute.NewTestProvider(), esProcessor, visConfig, &metrics.NoopMetricsClient{},
 		)
 		esVisibilityMgr = visibility.NewVisibilityManagerImpl(esVisibilityStore, searchattribute.NewTestProvider(), indexName, logger)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change `parseESDoc` and `generateESDoc` to return error instead of logging.

<!-- Tell your future self why have you made these changes -->
**Why?**
More errors is about to be added and they can't be just logged but needs to be returned. Changing only existing ones in this PR.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Exiting tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Previously minor errors in Elasticsearch document was just logged but incomplete data was returned by visibility read API. In some cases this incomplete data might be good enough and users might not even notice that there is an error without checking server logs and metrics. Now, any error in any field in any document will fail visibility API read request.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.