### PR TITLE
Correctly set current version if workflow is finished

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -451,6 +451,12 @@ func (e *MutableStateImpl) UpdateCurrentVersion(
 
 	if state, _ := e.GetWorkflowStateStatus(); state == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
 		// do not update current version only when workflow is completed
+		// always set current version to last write version when workflow is completed
+		lastWriteVersion, err := e.GetLastWriteVersion()
+		if err != nil {
+			return err
+		}
+		e.currentVersion = lastWriteVersion
 		return nil
 	}
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -450,7 +450,6 @@ func (e *MutableStateImpl) UpdateCurrentVersion(
 ) error {
 
 	if state, _ := e.GetWorkflowStateStatus(); state == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
-		// do not update current version only when workflow is completed
 		// always set current version to last write version when workflow is completed
 		lastWriteVersion, err := e.GetLastWriteVersion()
 		if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Correctly set the in memory current version if workflow is finished

<!-- Tell your future self why have you made these changes -->
**Why?**
In case future logic use current version, [reference](https://github.com/uber/cadence/pull/4431)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No