### PR TITLE
Remove search attributes errors logs

### DIFF
--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -32,16 +32,12 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payload"
 )
 
 type (
 	// Validator is used to validate search attributes
 	Validator struct {
-		logger log.Logger
-
 		searchAttributesProvider          Provider
 		searchAttributesNumberOfKeysLimit dynamicconfig.IntPropertyFnWithNamespaceFilter
 		searchAttributesSizeOfValueLimit  dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -55,28 +51,17 @@ var (
 
 // NewValidator create Validator
 func NewValidator(
-	logger log.Logger,
 	searchAttributesProvider Provider,
 	searchAttributesNumberOfKeysLimit dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	searchAttributesSizeOfValueLimit dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	searchAttributesTotalSizeLimit dynamicconfig.IntPropertyFnWithNamespaceFilter,
 ) *Validator {
 	return &Validator{
-		logger:                            logger,
 		searchAttributesProvider:          searchAttributesProvider,
 		searchAttributesNumberOfKeysLimit: searchAttributesNumberOfKeysLimit,
 		searchAttributesSizeOfValueLimit:  searchAttributesSizeOfValueLimit,
 		searchAttributesTotalSizeLimit:    searchAttributesTotalSizeLimit,
 	}
-}
-
-// ValidateAndLog validate search attributes are valid for writing and not exceed limits
-func (v *Validator) ValidateAndLog(searchAttributes *commonpb.SearchAttributes, namespace string, indexName string) error {
-	err := v.Validate(searchAttributes, namespace, indexName)
-	if err != nil {
-		v.logger.Warn("Search attributes are invalid.", tag.Error(err), tag.WorkflowNamespace(namespace), tag.ESIndex(indexName))
-	}
-	return err
 }
 
 // Validate validate search attributes are valid for writing.

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -31,7 +31,6 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payload"
 )
 
@@ -49,7 +48,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	sizeOfValueLimit := 5
 	sizeOfTotalLimit := 20
 
-	saValidator := NewValidator(log.NewNoopLogger(),
+	saValidator := NewValidator(
 		NewTestProvider(),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
@@ -122,7 +121,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 	sizeOfValueLimit := 5
 	sizeOfTotalLimit := 20
 
-	saValidator := NewValidator(log.NewNoopLogger(),
+	saValidator := NewValidator(
 		NewTestProvider(),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -524,7 +524,7 @@ func (v *commandAttrValidator) validateUpsertWorkflowSearchAttributes(
 		return serviceerror.NewInvalidArgument("IndexedFields is empty on command.")
 	}
 
-	return v.searchAttributesValidator.ValidateAndLog(attributes.GetSearchAttributes(), namespace, visibilityIndexName)
+	return v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), namespace, visibilityIndexName)
 }
 
 func (v *commandAttrValidator) validateContinueAsNewWorkflowExecutionAttributes(
@@ -574,7 +574,7 @@ func (v *commandAttrValidator) validateContinueAsNewWorkflowExecutionAttributes(
 		attributes.WorkflowTaskTimeout = timestamp.DurationPtr(timestamp.DurationValue(executionInfo.DefaultWorkflowTaskTimeout))
 	}
 
-	return v.searchAttributesValidator.ValidateAndLog(attributes.GetSearchAttributes(), namespace, visibilityIndexName)
+	return v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), namespace, visibilityIndexName)
 }
 
 func (v *commandAttrValidator) validateStartChildExecutionAttributes(
@@ -638,7 +638,7 @@ func (v *commandAttrValidator) validateStartChildExecutionAttributes(
 		return err
 	}
 
-	if err := v.searchAttributesValidator.ValidateAndLog(attributes.GetSearchAttributes(), targetNamespace, visibilityIndexName); err != nil {
+	if err := v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), targetNamespace, visibilityIndexName); err != nil {
 		return err
 	}
 

--- a/service/history/commandChecker_test.go
+++ b/service/history/commandChecker_test.go
@@ -43,7 +43,6 @@ import (
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
@@ -97,7 +96,6 @@ func (s *commandAttrValidatorSuite) SetupTest() {
 		s.mockNamespaceCache,
 		config,
 		searchattribute.NewValidator(
-			log.NewNoopLogger(),
 			searchattribute.NewTestProvider(),
 			config.SearchAttributesNumberOfKeysLimit,
 			config.SearchAttributesSizeOfValueLimit,

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -196,7 +196,6 @@ func NewEngineWithShardContext(
 	)
 
 	historyEngImpl.searchAttributesValidator = searchattribute.NewValidator(
-		logger,
 		shard.GetService().GetSearchAttributesProvider(),
 		config.SearchAttributesNumberOfKeysLimit,
 		config.SearchAttributesSizeOfValueLimit,
@@ -2613,11 +2612,9 @@ func (e *historyEngineImpl) validateStartWorkflowExecutionRequest(
 		return err
 	}
 	if err := e.searchAttributesValidator.Validate(request.SearchAttributes, namespace, e.config.DefaultVisibilityIndexName); err != nil {
-		e.logger.Warn("Search attributes are invalid.", tag.Error(err), tag.WorkflowNamespace(namespace))
 		return err
 	}
 	if err := e.searchAttributesValidator.ValidateSize(request.SearchAttributes, namespace); err != nil {
-		e.logger.Warn("Search attributes are invalid.", tag.Error(err), tag.WorkflowNamespace(namespace))
 		return err
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove search attributes errors logs.

<!-- Tell your future self why have you made these changes -->
**Why?**
Search attributes validation errors are user errors which shouldn't go to server log. They are returned to the caller (as other validation errors) and caller can react appropriately.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.