### PR TITLE
Refactor Elasticsearch visibility store

### DIFF
--- a/common/persistence/visibility/elasticsearch/query/converter.go
+++ b/common/persistence/visibility/elasticsearch/query/converter.go
@@ -103,7 +103,7 @@ func (c *Converter) convertSelect(sel *sqlparser.Select) (*elastic.BoolQuery, []
 	if sel.Where != nil {
 		q, err := c.convertWhere(sel.Where.Expr)
 		if err != nil {
-			return nil, nil, NewConverterError(fmt.Sprintf("unable to convert filter expression: %s", err))
+			return nil, nil, wrapConverterError("unable to convert filter expression", err)
 		}
 		// Result must be BoolQuery.
 		var isBoolQuery bool
@@ -116,7 +116,7 @@ func (c *Converter) convertSelect(sel *sqlparser.Select) (*elastic.BoolQuery, []
 	for _, orderByExpr := range sel.OrderBy {
 		colName, err := c.convertColName(orderByExpr.Expr, FieldNameSorter)
 		if err != nil {
-			return nil, nil, NewConverterError(fmt.Sprintf("unable to convert 'order by' column name: %s", err))
+			return nil, nil, wrapConverterError("unable to convert 'order by' column name", err)
 		}
 		fieldSort := elastic.NewFieldSort(colName)
 		if orderByExpr.Direction == sqlparser.DescScr {
@@ -216,7 +216,7 @@ func (c *Converter) convertOrExpr(expr *sqlparser.OrExpr) (elastic.Query, error)
 func (c *Converter) convertRangeCondExpr(expr *sqlparser.RangeCond) (elastic.Query, error) {
 	colName, err := c.convertColName(expr.Left, FieldNameFilter)
 	if err != nil {
-		return nil, NewConverterError(fmt.Sprintf("unable to convert left part of 'between' expression: %s", err))
+		return nil, wrapConverterError("unable to convert left part of 'between' expression", err)
 	}
 
 	fromValue, err := c.parseSqlValue(sqlparser.String(expr.From))
@@ -230,7 +230,7 @@ func (c *Converter) convertRangeCondExpr(expr *sqlparser.RangeCond) (elastic.Que
 
 	values, err := c.fvInterceptor.Values(colName, fromValue, toValue)
 	if err != nil {
-		return nil, NewConverterError(fmt.Sprintf("unable to convert values of 'between' expression: %s", err))
+		return nil, wrapConverterError("unable to convert values of 'between' expression", err)
 	}
 	fromValue = values[0]
 	toValue = values[1]
@@ -250,7 +250,7 @@ func (c *Converter) convertRangeCondExpr(expr *sqlparser.RangeCond) (elastic.Que
 func (c *Converter) convertIsExpr(expr *sqlparser.IsExpr) (elastic.Query, error) {
 	colName, err := c.convertColName(expr.Expr, FieldNameFilter)
 	if err != nil {
-		return nil, NewConverterError(fmt.Sprintf("unable to convert left part of 'is' expression: %s", err))
+		return nil, wrapConverterError("unable to convert left part of 'is' expression", err)
 	}
 
 	var query elastic.Query
@@ -269,12 +269,12 @@ func (c *Converter) convertIsExpr(expr *sqlparser.IsExpr) (elastic.Query, error)
 func (c *Converter) convertComparisonExpr(expr *sqlparser.ComparisonExpr) (elastic.Query, error) {
 	colName, err := c.convertColName(expr.Left, FieldNameFilter)
 	if err != nil {
-		return nil, NewConverterError(fmt.Sprintf("unable to convert left part of comparison expression: %s", err))
+		return nil, wrapConverterError("unable to convert left part of comparison expression", err)
 	}
 
 	colValue, err := c.convertComparisonExprValue(expr.Right)
 	if err != nil {
-		return nil, NewConverterError(fmt.Sprintf("unable to convert right part of comparison expression: %s", err))
+		return nil, wrapConverterError("unable to convert right part of comparison expression", err)
 	}
 
 	if expr.Operator == "like" || expr.Operator == "not like" {
@@ -292,7 +292,7 @@ func (c *Converter) convertComparisonExpr(expr *sqlparser.ComparisonExpr) (elast
 
 	colValues, err = c.fvInterceptor.Values(colName, colValues...)
 	if err != nil {
-		return nil, NewConverterError(fmt.Sprintf("unable to convert values of comparison expression: %s", err))
+		return nil, wrapConverterError("unable to convert values of comparison expression", err)
 	}
 
 	var query elastic.Query

--- a/common/persistence/visibility/elasticsearch/query/errors.go
+++ b/common/persistence/visibility/elasticsearch/query/errors.go
@@ -24,6 +24,11 @@
 
 package query
 
+import (
+	"errors"
+	"fmt"
+)
+
 type (
 	ConverterError struct {
 		text string
@@ -42,4 +47,12 @@ func NewConverterError(text string) error {
 
 func (c *ConverterError) Error() string {
 	return c.text
+}
+
+func wrapConverterError(message string, err error) error {
+	var converterErr *ConverterError
+	if errors.As(err, &converterErr) {
+		return NewConverterError(fmt.Sprintf("%s: %v", message, converterErr))
+	}
+	return err
 }

--- a/common/persistence/visibility/elasticsearch/query/interceptors.go
+++ b/common/persistence/visibility/elasticsearch/query/interceptors.go
@@ -44,7 +44,7 @@ const (
 	FieldNameSorter
 )
 
-func (n *nopFieldNameInterceptor) Name(name string, usage FieldNameUsage) (string, error) {
+func (n *nopFieldNameInterceptor) Name(name string, _ FieldNameUsage) (string, error) {
 	return name, nil
 }
 

--- a/common/persistence/visibility/elasticsearch/query_interceptors.go
+++ b/common/persistence/visibility/elasticsearch/query_interceptors.go
@@ -37,19 +37,19 @@ import (
 
 type (
 	nameInterceptor struct {
-		index                    string
-		searchAttributesProvider searchattribute.Provider
+		index                   string
+		searchAttributesTypeMap searchattribute.NameTypeMap
 	}
 	valuesInterceptor struct{}
 )
 
 func newNameInterceptor(
 	index string,
-	searchAttributesProvider searchattribute.Provider,
+	saTypeMap searchattribute.NameTypeMap,
 ) *nameInterceptor {
 	return &nameInterceptor{
-		index:                    index,
-		searchAttributesProvider: searchAttributesProvider,
+		index:                   index,
+		searchAttributesTypeMap: saTypeMap,
 	}
 }
 
@@ -58,23 +58,20 @@ func newValuesInterceptor() *valuesInterceptor {
 }
 
 func (ni *nameInterceptor) Name(name string, usage query.FieldNameUsage) (string, error) {
-	searchAttributes, err := ni.searchAttributesProvider.GetSearchAttributes(ni.index, false)
-	if err != nil {
-		return "", fmt.Errorf("unable to read search attribute types: %v", err)
-	}
+	fieldName := name
 
-	if !searchAttributes.IsDefined(name) {
-		return "", fmt.Errorf("invalid search attribute: %s", name)
+	fieldType, err := ni.searchAttributesTypeMap.GetType(fieldName)
+	if err != nil {
+		return "", query.NewConverterError(fmt.Sprintf("invalid search attribute: %s", name))
 	}
 
 	if usage == query.FieldNameSorter {
-		fieldType, _ := searchAttributes.GetType(name)
 		if fieldType == enumspb.INDEXED_VALUE_TYPE_STRING {
-			return "", errors.New("unable to sort by field of String type, use field of type Keyword")
+			return "", query.NewConverterError(fmt.Sprintf("unable to sort by field of %s type, use field of type %s", enumspb.INDEXED_VALUE_TYPE_STRING.String(), enumspb.INDEXED_VALUE_TYPE_KEYWORD.String()))
 		}
 	}
 
-	return name, nil
+	return fieldName, nil
 }
 
 func (vi *valuesInterceptor) Values(name string, values ...interface{}) ([]interface{}, error) {
@@ -84,7 +81,7 @@ func (vi *valuesInterceptor) Values(name string, values ...interface{}) ([]inter
 		switch name {
 		case searchattribute.StartTime, searchattribute.CloseTime, searchattribute.ExecutionTime:
 			if nanos, isNumber := value.(int64); isNumber {
-				value = time.Unix(0, int64(nanos)).UTC().Format(time.RFC3339Nano)
+				value = time.Unix(0, nanos).UTC().Format(time.RFC3339Nano)
 			}
 		case searchattribute.ExecutionStatus:
 			if status, isNumber := value.(int64); isNumber {
@@ -100,8 +97,9 @@ func (vi *valuesInterceptor) Values(name string, values ...interface{}) ([]inter
 				} else {
 					// To support "hh:mm:ss" durations.
 					durationNanos, err := vi.parseHHMMSSDuration(durationStr)
-					if errors.Is(err, ErrInvalidDuration) {
-						return nil, err
+					var converterErr *query.ConverterError
+					if errors.As(err, &converterErr) {
+						return nil, converterErr
 					}
 					if err == nil {
 						value = durationNanos
@@ -120,16 +118,16 @@ func (vi *valuesInterceptor) parseHHMMSSDuration(d string) (int64, error) {
 	var hours, minutes, seconds, nanos int64
 	_, err := fmt.Sscanf(d, "%d:%d:%d", &hours, &minutes, &seconds)
 	if err != nil {
-		return 0, err
+		return 0, errors.New("value is not a duration")
 	}
 	if hours < 0 {
-		return 0, fmt.Errorf("%w: hours must be positive number", ErrInvalidDuration)
+		return 0, query.NewConverterError("invalid duration: hours must be positive number")
 	}
 	if minutes < 0 || minutes > 59 {
-		return 0, fmt.Errorf("%w: minutes must be from 0 to 59", ErrInvalidDuration)
+		return 0, query.NewConverterError("invalid duration: minutes must be from 0 to 59")
 	}
 	if seconds < 0 || seconds > 59 {
-		return 0, fmt.Errorf("%w: seconds must be from 0 to 59", ErrInvalidDuration)
+		return 0, query.NewConverterError("invalid duration: seconds must be from 0 to 59")
 	}
 
 	return hours*int64(time.Hour) + minutes*int64(time.Minute) + seconds*int64(time.Second) + nanos, nil

--- a/common/persistence/visibility/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store.go
@@ -65,7 +65,6 @@ type (
 		config                   *config.VisibilityConfig
 		metricsClient            metrics.Client
 		processor                Processor
-		queryConverter           *query.Converter
 	}
 
 	visibilityPageToken struct {
@@ -82,7 +81,6 @@ type (
 var _ visibility.VisibilityStore = (*visibilityStore)(nil)
 
 var (
-	ErrInvalidDuration         = errors.New("invalid duration format")
 	errUnexpectedJSONFieldType = errors.New("unexpected JSON field type")
 )
 
@@ -103,10 +101,6 @@ func NewVisibilityStore(
 		processor:                processor,
 		config:                   cfg,
 		metricsClient:            metricsClient,
-		queryConverter: query.NewConverter(
-			newNameInterceptor(index, searchAttributesProvider),
-			newValuesInterceptor(),
-		),
 	}
 }
 
@@ -242,7 +236,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutions(request *visibility.ListWor
 		return !rec.StartTime.Before(request.EarliestStartTime) && !rec.StartTime.After(request.LatestStartTime)
 	}
 
-	return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, isRecordValid)
+	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutions(request *visibility.ListWorkflowExecutionsRequest) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -265,7 +259,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutions(request *visibility.ListW
 		return !rec.CloseTime.Before(request.EarliestStartTime) && !rec.CloseTime.After(request.LatestStartTime)
 	}
 
-	return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, isRecordValid)
+	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
 func (s *visibilityStore) ListOpenWorkflowExecutionsByType(request *visibility.ListWorkflowExecutionsByTypeRequest) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -290,7 +284,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByType(request *visibility.L
 		return !rec.StartTime.Before(request.EarliestStartTime) && !rec.StartTime.After(request.LatestStartTime)
 	}
 
-	return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, isRecordValid)
+	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByType(request *visibility.ListWorkflowExecutionsByTypeRequest) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -314,7 +308,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByType(request *visibility
 		return !rec.CloseTime.Before(request.EarliestStartTime) && !rec.CloseTime.After(request.LatestStartTime)
 	}
 
-	return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, isRecordValid)
+	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
 func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(request *visibility.ListWorkflowExecutionsByWorkflowIDRequest) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -339,7 +333,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(request *visibi
 		return !rec.StartTime.Before(request.EarliestStartTime) && !rec.StartTime.After(request.LatestStartTime)
 	}
 
-	return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, isRecordValid)
+	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(request *visibility.ListWorkflowExecutionsByWorkflowIDRequest) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -363,7 +357,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(request *visi
 		return !rec.CloseTime.Before(request.EarliestStartTime) && !rec.CloseTime.After(request.LatestStartTime)
 	}
 
-	return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, isRecordValid)
+	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(request *visibility.ListClosedWorkflowExecutionsByStatusRequest) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -386,7 +380,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(request *visibili
 		return !rec.CloseTime.Before(request.EarliestStartTime) && !rec.CloseTime.After(request.LatestStartTime)
 	}
 
-	return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, isRecordValid)
+	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
 func (s *visibilityStore) ListWorkflowExecutions(request *visibility.ListWorkflowExecutionsRequestV2) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -402,7 +396,7 @@ func (s *visibilityStore) ListWorkflowExecutions(request *visibility.ListWorkflo
 		return nil, serviceerror.NewInternal(fmt.Sprintf("ListWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
 	}
 
-	return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, nil)
+	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
 }
 
 func (s *visibilityStore) ScanWorkflowExecutions(request *visibility.ListWorkflowExecutionsRequestV2) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -439,7 +433,7 @@ func (s *visibilityStore) ScanWorkflowExecutions(request *visibility.ListWorkflo
 				return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to close point in time: %s", detailedErrorMessage(err)))
 			}
 		}
-		return s.getListWorkflowExecutionsResponse(searchResult, request.PageSize, nil)
+		return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
 	case client.ClientV6:
 		var (
 			searchResult  *elastic.SearchResult
@@ -473,23 +467,16 @@ func (s *visibilityStore) ScanWorkflowExecutions(request *visibility.ListWorkflo
 		} else if scrollErr != nil {
 			return nil, serviceerror.NewInternal(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(scrollErr)))
 		}
-		return s.getScrollWorkflowExecutionsResponse(searchResult.Hits, request.PageSize, searchResult.ScrollId, isLastPage)
+		return s.getScrollWorkflowExecutionsResponse(searchResult.Hits, request.Namespace, request.PageSize, searchResult.ScrollId, isLastPage)
 	default:
 		panic("esClient has unsupported type")
 	}
 }
 
 func (s *visibilityStore) CountWorkflowExecutions(request *visibility.CountWorkflowExecutionsRequest) (*visibility.CountWorkflowExecutionsResponse, error) {
-
-	requestQuery, _, err := s.queryConverter.ConvertWhereOrderBy(request.Query)
+	boolQuery, _, err := s.convertQuery(request.Namespace, request.NamespaceID, request.Query)
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("unable to parse query: %v", err))
-	}
-
-	// Create new bool query because request query might have only "should" (="or") queries.
-	boolQuery := elastic.NewBoolQuery().Filter(elastic.NewTermQuery(searchattribute.NamespaceID, request.NamespaceID))
-	if requestQuery != nil {
-		boolQuery.Filter(requestQuery)
+		return nil, err
 	}
 
 	ctx := context.Background()
@@ -568,15 +555,9 @@ func (s *visibilityStore) buildSearchParametersV2(
 		return nil, err
 	}
 
-	requestQuery, fieldSorts, err := s.queryConverter.ConvertWhereOrderBy(request.Query)
+	boolQuery, fieldSorts, err := s.convertQuery(request.Namespace, request.NamespaceID, request.Query)
 	if err != nil {
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("unable to parse query: %v", err))
-	}
-
-	// Create new bool query because request query might have only "should" (="or") queries.
-	boolQuery := elastic.NewBoolQuery().Filter(elastic.NewTermQuery(searchattribute.NamespaceID, request.NamespaceID))
-	if requestQuery != nil {
-		boolQuery.Filter(requestQuery)
+		return nil, err
 	}
 
 	params := &esclient.SearchParameters{
@@ -601,6 +582,33 @@ func (s *visibilityStore) buildSearchParametersV2(
 
 	return params, nil
 }
+func (s *visibilityStore) convertQuery(namespace string, namespaceID string, requestQueryStr string) (*elastic.BoolQuery, []*elastic.FieldSort, error) {
+	saTypeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
+	if err != nil {
+		return nil, nil, serviceerror.NewInternal(fmt.Sprintf("Unable to read search attribute types: %v", err))
+	}
+	queryConverter := query.NewConverter(
+		newNameInterceptor(s.index, saTypeMap),
+		newValuesInterceptor(),
+	)
+	requestQuery, fieldSorts, err := queryConverter.ConvertWhereOrderBy(requestQueryStr)
+	if err != nil {
+		// Convert query.ConverterError to serviceerror.InvalidArgument and pass through all other errors (which should be only mapper errors).
+		var converterErr *query.ConverterError
+		if errors.As(err, &converterErr) {
+			return nil, nil, serviceerror.NewInvalidArgument(fmt.Sprintf("unable to parse query: %v", converterErr))
+		}
+		return nil, nil, err
+	}
+
+	// Create new bool query because request query might have only "should" (="or") queries.
+	namespaceFilterQuery := elastic.NewBoolQuery().Filter(elastic.NewTermQuery(searchattribute.NamespaceID, namespaceID))
+	if requestQuery != nil {
+		namespaceFilterQuery.Filter(requestQuery)
+	}
+
+	return namespaceFilterQuery, fieldSorts, nil
+}
 
 func (s *visibilityStore) setDefaultFieldSort(fieldSorts []*elastic.FieldSort) []elastic.Sorter {
 	if len(fieldSorts) == 0 {
@@ -623,6 +631,7 @@ func (s *visibilityStore) setDefaultFieldSort(fieldSorts []*elastic.FieldSort) [
 
 func (s *visibilityStore) getScrollWorkflowExecutionsResponse(
 	searchHits *elastic.SearchHits,
+	namespace string,
 	pageSize int,
 	scrollID string,
 	isLastPage bool,
@@ -636,7 +645,7 @@ func (s *visibilityStore) getScrollWorkflowExecutionsResponse(
 	response := &visibility.InternalListWorkflowExecutionsResponse{}
 	response.Executions = make([]*visibility.VisibilityWorkflowExecutionInfo, len(searchHits.Hits))
 	for i := 0; i < len(searchHits.Hits); i++ {
-		response.Executions[i], err = s.parseESDoc(searchHits.Hits[i], typeMap)
+		response.Executions[i], err = s.parseESDoc(searchHits.Hits[i], typeMap, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -656,6 +665,7 @@ func (s *visibilityStore) getScrollWorkflowExecutionsResponse(
 
 func (s *visibilityStore) getListWorkflowExecutionsResponse(
 	searchResult *elastic.SearchResult,
+	namespace string,
 	pageSize int,
 	isRecordValid func(rec *visibility.VisibilityWorkflowExecutionInfo) bool,
 ) (*visibility.InternalListWorkflowExecutionsResponse, error) {
@@ -670,7 +680,7 @@ func (s *visibilityStore) getListWorkflowExecutionsResponse(
 	}
 	var lastHitSort []interface{}
 	for _, hit := range searchResult.Hits.Hits {
-		workflowExecutionInfo, err := s.parseESDoc(hit, typeMap)
+		workflowExecutionInfo, err := s.parseESDoc(hit, typeMap, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -761,7 +771,7 @@ func (s *visibilityStore) generateESDoc(request *visibility.InternalVisibilityRe
 	return doc, nil
 }
 
-func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchattribute.NameTypeMap) (*visibility.VisibilityWorkflowExecutionInfo, error) {
+func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchattribute.NameTypeMap, namespace string) (*visibility.VisibilityWorkflowExecutionInfo, error) {
 	logParseError := func(fieldName string, fieldValue interface{}, err error, docID string) error {
 		s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentParseFailuresCount)
 		return serviceerror.NewInternal(fmt.Sprintf("Unable to parse Elasticsearch document(%s) %q field value %q: %v", docID, fieldName, fieldValue, err))
@@ -844,7 +854,7 @@ func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchatt
 		case searchattribute.StateTransitionCount:
 			record.StateTransitionCount = fieldValueParsed.(int64)
 		default:
-			// All custom search attributes are handled here.
+			// All custom and predefined search attributes are handled here.
 			if customSearchAttributes == nil {
 				customSearchAttributes = map[string]interface{}{}
 			}

--- a/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
@@ -638,7 +638,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 		Hits: &elastic.SearchHits{
 			TotalHits: &elastic.TotalHits{},
 		}}
-	resp, err := s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, 1, nil)
+	resp, err := s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, testNamespace, 1, nil)
 	s.NoError(err)
 	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(0, len(resp.Executions))
@@ -661,14 +661,14 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	}
 	searchResult.Hits.Hits = []*elastic.SearchHit{searchHit}
 	searchResult.Hits.TotalHits.Value = 1
-	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, 1, nil)
+	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, testNamespace, 1, nil)
 	s.NoError(err)
 	serializedToken, _ := s.visibilityStore.serializePageToken(&visibilityPageToken{SearchAfter: []interface{}{1547596872371234567, "e481009e-14b3-45ae-91af-dce6e2a88365"}})
 	s.Equal(serializedToken, resp.NextPageToken)
 	s.Equal(1, len(resp.Executions))
 
 	// test for last page hits
-	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, 2, nil)
+	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, testNamespace, 2, nil)
 	s.NoError(err)
 	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(1, len(resp.Executions))
@@ -679,7 +679,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 		searchResult.Hits.Hits = append(searchResult.Hits.Hits, searchHit)
 	}
 	numOfHits := len(searchResult.Hits.Hits)
-	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, numOfHits, nil)
+	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, testNamespace, numOfHits, nil)
 	s.NoError(err)
 	s.Equal(numOfHits, len(resp.Executions))
 	nextPageToken, err := s.visibilityStore.deserializePageToken(resp.NextPageToken)
@@ -689,7 +689,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	s.Equal(int64(1547596872371234567), resultSortValue)
 	s.Equal("e481009e-14b3-45ae-91af-dce6e2a88365", nextPageToken.SearchAfter[1])
 	// for last page
-	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, numOfHits+1, nil)
+	resp, err = s.visibilityStore.getListWorkflowExecutionsResponse(searchResult, testNamespace, numOfHits+1, nil)
 	s.NoError(err)
 	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(numOfHits, len(resp.Executions))
@@ -753,7 +753,7 @@ func (s *ESVisibilitySuite) TestParseESDoc() {
           "WorkflowType": "TestWorkflowExecute"}`),
 	}
 	// test for open
-	info, err := s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap)
+	info, err := s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap, testNamespace)
 	s.NoError(err)
 	s.NotNil(info)
 	s.Equal("6bfbc1e5-6ce4-4e22-bbfb-e0faa9a7a604-1-2256", info.WorkflowID)
@@ -779,7 +779,7 @@ func (s *ESVisibilitySuite) TestParseESDoc() {
           "WorkflowId": "6bfbc1e5-6ce4-4e22-bbfb-e0faa9a7a604-1-2256",
           "WorkflowType": "TestWorkflowExecute"}`),
 	}
-	info, err = s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap)
+	info, err = s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap, testNamespace)
 	s.NoError(err)
 	s.NotNil(info)
 	s.Equal("6bfbc1e5-6ce4-4e22-bbfb-e0faa9a7a604-1-2256", info.WorkflowID)
@@ -801,7 +801,7 @@ func (s *ESVisibilitySuite) TestParseESDoc() {
 		Source: []byte(`corrupted data`),
 	}
 	s.mockMetricsClient.EXPECT().IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentParseFailuresCount)
-	info, err = s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap)
+	info, err = s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap, testNamespace)
 	s.Error(err)
 	s.Nil(info)
 }
@@ -818,7 +818,7 @@ func (s *ESVisibilitySuite) TestParseESDoc_SearchAttributes() {
           "UnknownField": "random"}`),
 	}
 	// test for open
-	info, err := s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap)
+	info, err := s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap, testNamespace)
 	s.NoError(err)
 	s.NotNil(info)
 	customSearchAttributes, err := searchattribute.Decode(info.SearchAttributes, &searchattribute.TestNameTypeMap)

--- a/common/persistence/visibility/visibility_manager.go
+++ b/common/persistence/visibility/visibility_manager.go
@@ -87,7 +87,7 @@ type (
 	// ListWorkflowExecutionsRequestV2 is used to list executions in a namespace
 	ListWorkflowExecutionsRequestV2 struct {
 		NamespaceID string
-		Namespace   string // namespace name is not persisted, but used as config filter key
+		Namespace   string // namespace name is not persisted
 		PageSize    int    // Maximum number of workflow executions per page
 		// Token to continue reading next page of workflow executions.
 		// Pass in empty slice for first page.
@@ -106,7 +106,7 @@ type (
 	// CountWorkflowExecutionsRequest is request from CountWorkflowExecutions
 	CountWorkflowExecutionsRequest struct {
 		NamespaceID string
-		Namespace   string // namespace name is not persisted, but used as config filter key
+		Namespace   string // namespace name is not persisted
 		Query       string
 	}
 

--- a/common/persistence/visibility/visibility_store.go
+++ b/common/persistence/visibility/visibility_store.go
@@ -60,7 +60,7 @@ type (
 		NextPageToken []byte
 	}
 
-	// InternalRecordWorkflowExecutionStartedRequest request to RecordWorkflowExecutionStarted
+	// InternalVisibilityRequestBase is a base request to visibility APIs.
 	InternalVisibilityRequestBase struct {
 		NamespaceID          string
 		WorkflowID           string

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -247,7 +247,6 @@ func New(
 	}
 
 	saProvider := persistence.NewSearchAttributesManager(clock.NewRealTimeSource(), persistenceBean.GetClusterMetadataManager())
-
 	saManager := persistence.NewSearchAttributesManager(clock.NewRealTimeSource(), persistenceBean.GetClusterMetadataManager())
 
 	visibilityMgr, err := visibilityManagerInitializer(

--- a/common/searchattribute/defs.go
+++ b/common/searchattribute/defs.go
@@ -89,16 +89,16 @@ var (
 	}
 )
 
-// IsReserved return true if field name is system reserved and can't be used as custom search attribute name.
-func IsReserved(fieldName string) bool {
-	if _, ok := system[fieldName]; ok {
+// IsReserved returns true if name is system reserved and can't be used as custom search attribute name.
+func IsReserved(name string) bool {
+	if _, ok := system[name]; ok {
 		return true
 	}
-	if _, ok := predefined[fieldName]; ok {
+	if _, ok := predefined[name]; ok {
 		return true
 	}
-	if _, ok := reserved[fieldName]; ok {
+	if _, ok := reserved[name]; ok {
 		return true
 	}
-	return strings.HasPrefix(fieldName, ReservedPrefix)
+	return strings.HasPrefix(name, ReservedPrefix)
 }

--- a/common/searchattribute/encode.go
+++ b/common/searchattribute/encode.go
@@ -31,7 +31,7 @@ import (
 )
 
 // Encode encodes map of search attribute values to search attributes.
-// typeMap can be nil (MetadataType field won't be set).
+// typeMap can be nil (then MetadataType field won't be set).
 // In case of error, it will continue to next search attribute and return last error.
 func Encode(searchAttributes map[string]interface{}, typeMap *NameTypeMap) (*commonpb.SearchAttributes, error) {
 	if len(searchAttributes) == 0 {

--- a/common/searchattribute/name_type_map.go
+++ b/common/searchattribute/name_type_map.go
@@ -72,7 +72,7 @@ func (m NameTypeMap) Custom() map[string]enumspb.IndexedValueType {
 }
 
 func (m NameTypeMap) All() map[string]enumspb.IndexedValueType {
-	allSearchAttributes := make(map[string]enumspb.IndexedValueType, len(system)+len(m.customSearchAttributes)+len(reserved))
+	allSearchAttributes := make(map[string]enumspb.IndexedValueType, len(system)+len(m.customSearchAttributes)+len(predefined))
 	for saName, saType := range system {
 		allSearchAttributes[saName] = saType
 	}

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/common/dynamicconfig"
@@ -64,7 +65,7 @@ func NewValidator(
 	}
 }
 
-// Validate validate search attributes are valid for writing.
+// Validate search attributes are valid for writing.
 func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namespace string, indexName string) error {
 	if searchAttributes == nil {
 		return nil
@@ -75,28 +76,29 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		return serviceerror.NewInvalidArgument(fmt.Sprintf("number of search attributes %d exceeds limit %d", lengthOfFields, v.searchAttributesNumberOfKeysLimit(namespace)))
 	}
 
-	typeMap, err := v.searchAttributesProvider.GetSearchAttributes(indexName, false)
+	saTypeMap, err := v.searchAttributesProvider.GetSearchAttributes(indexName, false)
 	if err != nil {
 		return serviceerror.NewInvalidArgument(fmt.Sprintf("unable to get search attributes from cluster metadata: %v", err))
 	}
 
 	for saName, saPayload := range searchAttributes.GetIndexedFields() {
-		if _, err := typeMap.getType(saName, systemCategory); err == nil {
+		if _, err = saTypeMap.getType(saName, systemCategory); err == nil {
 			return serviceerror.NewInvalidArgument(fmt.Sprintf("%s attribute can't be set in SearchAttributes", saName))
 		}
 
-		saType, err := typeMap.getType(saName, customCategory|predefinedCategory)
-		if err != nil {
+		fieldName := saName
+
+		var saType enumspb.IndexedValueType
+		if saType, err = saTypeMap.getType(fieldName, customCategory|predefinedCategory); err != nil {
 			if errors.Is(err, ErrInvalidName) {
 				return serviceerror.NewInvalidArgument(fmt.Sprintf("%s is not a valid search attribute name", saName))
 			}
 			return serviceerror.NewInvalidArgument(fmt.Sprintf("unable to get %s search attribute type: %v", saName, err))
 		}
 
-		_, err = DecodeValue(saPayload, saType)
-		if err != nil {
+		if _, err = DecodeValue(saPayload, saType); err != nil {
 			var invalidValue interface{}
-			if err := payload.Decode(saPayload, &invalidValue); err != nil {
+			if err = payload.Decode(saPayload, &invalidValue); err != nil {
 				invalidValue = fmt.Sprintf("value from <%s>", saPayload.String())
 			}
 			return serviceerror.NewInvalidArgument(fmt.Sprintf("%v is not a valid value for search attribute %s of type %s", invalidValue, saName, saType))

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -1052,6 +1052,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
 
 func (s *workflowHandlerSuite) TestGetHistory() {
 	namespaceID := uuid.New()
+	namespace := "namespace"
 	firstEventID := int64(100)
 	nextEventID := int64(102)
 	branchToken := []byte{1}
@@ -1099,6 +1100,7 @@ func (s *workflowHandlerSuite) TestGetHistory() {
 	history, token, err := wh.getHistory(
 		metrics.NoopScope(metrics.Frontend),
 		namespaceID,
+		namespace,
 		we,
 		firstEventID,
 		nextEventID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor Elasticsearch visibility store:
1. Query converter returns `ConverterError` if query is invalid and pass through all other errors from interceptors.
2. Move query converter from visibility store level to `func` level.
3. Minor renames and bug fixes.

<!-- Tell your future self why have you made these changes -->
**Why?**
Prepare to add custom search attribute mapper interface.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.