### PR TITLE
Fix TaskWriter panic when shutdown

### DIFF
--- a/internal/goro/goro.go
+++ b/internal/goro/goro.go
@@ -1,0 +1,86 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goro
+
+import (
+	"context"
+	"sync/atomic"
+)
+
+type (
+	// Handle is a threadsafe and multi-stop safe handle to a running goroutine.
+	Handle struct {
+		context context.Context
+		cancel  context.CancelFunc
+		done    chan struct{}
+		err     atomic.Value
+	}
+)
+
+// Go launches the supplied function in its own goroutine and returns back a
+// *Handle that serves as a handle to the goroutine itself.
+func Go(ctx context.Context, f func(context.Context) error) *Handle {
+	ctx, cancel := context.WithCancel(ctx)
+	h := &Handle{
+		context: ctx,
+		cancel:  cancel,
+		done:    make(chan struct{}),
+	}
+	go func() {
+		// use defer here so that the channel is closed even if the func calls
+		// runtime.Goexit()
+		defer close(h.done)
+		if err := f(h.context); err != nil {
+			h.err.Store(err)
+		}
+	}()
+	return h
+}
+
+// Done exposes a channel that allows outside goroutines to block on this
+// goroutine's completion. Whatever time passes between a call to Cancel() and
+// the Done() channel closing is the time taken by the goroutine to shut itself
+// down.
+func (h *Handle) Done() <-chan struct{} {
+	return h.done
+}
+
+// Cancel requests that this goroutine stop by cancelling the associated context
+// object. This function is threadsafe and idempotent. Note that this function
+// _requests_ termination, it does not forcefully kill the goroutine.
+func (h *Handle) Cancel() {
+	h.cancel()
+}
+
+// Error observes the error returned by the func passed to Go (if any). There is
+// nevery any error (i.e. this function returns nil) while the goroutine is
+// running.
+func (h *Handle) Err() error {
+	v := h.err.Load()
+	if v == nil {
+		return nil
+	}
+	return v.(error)
+}

--- a/internal/goro/goro_test.go
+++ b/internal/goro/goro_test.go
@@ -1,0 +1,104 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package goro_test
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/internal/goro"
+)
+
+func blockOnCtxReturnErr(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func blockOnCtxReturnNil(ctx context.Context) error {
+	<-ctx.Done()
+	return nil
+}
+
+func TestGoroParentTimeout(t *testing.T) {
+	pctx, pcancel := context.WithTimeout(context.TODO(), 5*time.Microsecond)
+	defer pcancel()
+	g := goro.Go(pctx, blockOnCtxReturnErr)
+	<-g.Done()
+	require.Equal(t, pctx.Err(), g.Err())
+}
+
+func TestGoroCancelParentCtx(t *testing.T) {
+	pctx, pcancel := context.WithCancel(context.TODO())
+	g := goro.Go(pctx, blockOnCtxReturnErr)
+	pcancel()
+	<-g.Done()
+	require.Equal(t, pctx.Err(), g.Err())
+}
+
+func TestGoroCancel(t *testing.T) {
+	pctx := context.Background()
+	g := goro.Go(pctx, blockOnCtxReturnErr)
+	g.Cancel()
+	<-g.Done()
+	require.ErrorIs(t, context.Canceled, g.Err())
+	require.Nil(t, pctx.Err())
+}
+
+func TestGoroMultiCancel(t *testing.T) {
+	g := goro.Go(context.TODO(), blockOnCtxReturnErr)
+	g.Cancel()
+	require.NotPanics(t, g.Cancel)
+	require.NotPanics(t, g.Cancel)
+	require.NotPanics(t, g.Cancel)
+	<-g.Done()
+	require.NotPanics(t, g.Cancel)
+	require.NotPanics(t, g.Cancel)
+	require.NotPanics(t, g.Cancel)
+}
+
+func TestGoroDoneNoErr(t *testing.T) {
+	g := goro.Go(context.TODO(), blockOnCtxReturnNil)
+	g.Cancel()
+	<-g.Done()
+	require.NoError(t, g.Err())
+}
+
+func TestGoroSimpleReturn(t *testing.T) {
+	g := goro.Go(context.TODO(), func(context.Context) error {
+		return nil
+	})
+	<-g.Done()
+}
+
+func TestGoroGoexit(t *testing.T) {
+	g := goro.Go(context.TODO(), func(context.Context) error {
+		runtime.Goexit()
+		return nil
+	})
+	<-g.Done()
+}

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -25,6 +25,7 @@
 package matching
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 	"time"
@@ -39,6 +40,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/internal/goro"
 )
 
 type (
@@ -68,7 +70,7 @@ type (
 		taskIDBlock  taskIDBlock
 		maxReadLevel int64
 		logger       log.Logger
-		shutdownChan chan struct{}
+		writeLoop    *goro.Handle
 		idAlloc      idBlockAllocator
 	}
 )
@@ -90,7 +92,6 @@ func newTaskWriter(
 		taskIDBlock:  noTaskIDs,
 		maxReadLevel: noTaskIDs.start - 1,
 		logger:       tlMgr.logger,
-		shutdownChan: make(chan struct{}),
 		idAlloc:      tlMgr.db,
 	}
 }
@@ -103,7 +104,7 @@ func (w *taskWriter) Start() {
 	) {
 		return
 	}
-	go w.taskWriterLoop()
+	w.writeLoop = goro.Go(context.Background(), w.taskWriterLoop)
 }
 
 // Stop stops the taskWriter
@@ -115,28 +116,24 @@ func (w *taskWriter) Stop() {
 	) {
 		return
 	}
-	close(w.shutdownChan)
+	w.writeLoop.Cancel()
 }
 
-func (w *taskWriter) initReadWriteState() {
+func (w *taskWriter) initReadWriteState(ctx context.Context) error {
 	retryForever := backoff.NewExponentialRetryPolicy(1 * time.Second)
 	retryForever.SetMaximumInterval(10 * time.Second)
 	retryForever.SetExpirationInterval(backoff.NoInterval)
 
 	state, err := w.renewLeaseWithRetry(
-		retryForever, common.IsPersistenceTransientError)
+		ctx, retryForever, common.IsPersistenceTransientError)
 	if err != nil {
-		// because we're retrying transient storage errors forever,
-		// anything else that comes out of here is fatal
-		close(w.shutdownChan)
-		atomic.StoreInt32(&w.status, common.DaemonStatusStopped)
-		w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID)
-		return
+		return err
 	}
 	w.taskIDBlock = rangeIDToTaskIDBlock(state.rangeID, w.config.RangeSize)
 	atomic.StoreInt64(&w.maxReadLevel, w.taskIDBlock.start-1)
 	w.tlMgr.taskAckManager.setAckLevel(state.ackLevel)
 	w.tlMgr.taskReader.Signal()
+	return nil
 }
 
 func (w *taskWriter) appendTask(
@@ -145,7 +142,7 @@ func (w *taskWriter) appendTask(
 ) (*persistence.CreateTasksResponse, error) {
 
 	select {
-	case <-w.shutdownChan:
+	case <-w.writeLoop.Done():
 		return nil, errShutdown
 	default:
 		// noop
@@ -163,7 +160,7 @@ func (w *taskWriter) appendTask(
 		select {
 		case r := <-ch:
 			return r.persistenceResponse, r.err
-		case <-w.shutdownChan:
+		case <-w.writeLoop.Done():
 			// if we are shutting down, this request will never make
 			// it to cassandra, just bail out and fail this request
 			return nil, errShutdown
@@ -177,12 +174,12 @@ func (w *taskWriter) GetMaxReadLevel() int64 {
 	return atomic.LoadInt64(&w.maxReadLevel)
 }
 
-func (w *taskWriter) allocTaskIDs(count int) ([]int64, error) {
+func (w *taskWriter) allocTaskIDs(ctx context.Context, count int) ([]int64, error) {
 	result := make([]int64, count)
 	for i := 0; i < count; i++ {
 		if w.taskIDBlock.start > w.taskIDBlock.end {
 			// we ran out of current allocation block
-			newBlock, err := w.allocTaskIDBlock(w.taskIDBlock.end)
+			newBlock, err := w.allocTaskIDBlock(ctx, w.taskIDBlock.end)
 			if err != nil {
 				return nil, err
 			}
@@ -204,7 +201,7 @@ func (w *taskWriter) appendTasks(
 		return resp, nil
 
 	case *persistence.ConditionFailedError:
-		w.tlMgr.Stop()
+		w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID)
 		return nil, err
 
 	default:
@@ -218,8 +215,14 @@ func (w *taskWriter) appendTasks(
 	}
 }
 
-func (w *taskWriter) taskWriterLoop() {
-	w.initReadWriteState()
+func (w *taskWriter) taskWriterLoop(ctx context.Context) error {
+	err := w.initReadWriteState(ctx)
+	if err != nil {
+		if w.tlMgr.errShouldUnload(err) {
+			w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID)
+		}
+		return err
+	}
 writerLoop:
 	for {
 		select {
@@ -231,7 +234,7 @@ writerLoop:
 
 			maxReadLevel := int64(0)
 
-			taskIDs, err := w.allocTaskIDs(batchSize)
+			taskIDs, err := w.allocTaskIDs(ctx, batchSize)
 			if err != nil {
 				w.sendWriteResponse(reqs, nil, err)
 				continue writerLoop
@@ -253,8 +256,8 @@ writerLoop:
 				atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
 			}
 
-		case <-w.shutdownChan:
-			return
+		case <-ctx.Done():
+			return ctx.Err()
 		}
 	}
 }
@@ -288,16 +291,17 @@ func (w *taskWriter) sendWriteResponse(
 }
 
 func (w *taskWriter) renewLeaseWithRetry(
+	ctx context.Context,
 	retryPolicy backoff.RetryPolicy,
 	retryErrors backoff.IsRetryable,
 ) (taskQueueState, error) {
 	var newState taskQueueState
-	op := func() (err error) {
+	op := func(context.Context) (err error) {
 		newState, err = w.idAlloc.RenewLease()
 		return
 	}
 	w.tlMgr.metricScope().IncCounter(metrics.LeaseRequestPerTaskQueueCounter)
-	err := backoff.Retry(op, retryPolicy, retryErrors)
+	err := backoff.RetryContext(ctx, op, retryPolicy, retryErrors)
 	if err != nil {
 		w.tlMgr.metricScope().IncCounter(metrics.LeaseFailurePerTaskQueueCounter)
 		return newState, err
@@ -305,16 +309,17 @@ func (w *taskWriter) renewLeaseWithRetry(
 	return newState, nil
 }
 
-func (w *taskWriter) allocTaskIDBlock(prevBlockEnd int64) (taskIDBlock, error) {
+func (w *taskWriter) allocTaskIDBlock(ctx context.Context, prevBlockEnd int64) (taskIDBlock, error) {
 	currBlock := rangeIDToTaskIDBlock(w.idAlloc.RangeID(), w.config.RangeSize)
 	if currBlock.end != prevBlockEnd {
 		return taskIDBlock{},
 			fmt.Errorf("allocTaskIDBlock: invalid state: prevBlockEnd:%v != currTaskIDBlock:%+v", prevBlockEnd, currBlock)
 	}
-	state, err := w.renewLeaseWithRetry(persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	state, err := w.renewLeaseWithRetry(ctx, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
 	if err != nil {
 		if w.tlMgr.errShouldUnload(err) {
 			w.tlMgr.signalFatalProblem(w.taskQueueID)
+			return taskIDBlock{}, errShutdown
 		}
 		return taskIDBlock{}, err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Shift from using a raw channel for shutdown to a `*goro.Handle`, which can be safely shut down multiple times.
- Switch from `backoff.Retry` to `backoff.RetryContext` so that the initial loading of `taskWriter` read/write state from persistence is interruptible

<!-- Tell your future self why have you made these changes -->
**Why?**
- With the right concurrency, `taskWriter` can panic due to closing the internal shutdown channel twice
- The initial read/write state load could not be interrupted (i.e. did not pay attention to `taskWriter.Stop()`)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests for new code, existing unit tests for the matching package.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Concurrency so deadlocks, races.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes