### PR TITLE
Remove openssl from base server image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG TARGET=server
 ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.4.0
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.2.0
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.3.0
 ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.2.0
 ARG GOPROXY
 

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -18,6 +18,7 @@ RUN mkdir -p /xsrc && \
 FROM alpine:3.13 AS base-server
 
 RUN apk add --update --no-cache \
+    ca-certificates \
     bash \
     curl \
     vim

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -18,8 +18,6 @@ RUN mkdir -p /xsrc && \
 FROM alpine:3.13 AS base-server
 
 RUN apk add --update --no-cache \
-    ca-certificates \
-    openssl \
     bash \
     curl \
     vim


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove `openssl` from base server image.

<!-- Tell your future self why have you made these changes -->
**Why?**
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-3711

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Build and run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If someone uses `openssl` from server image to generate certificates, they need to install it manually now.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No because `openssl` is not used in any production code path.