### PR TITLE
Ack existing visibility task in case of duplicates

### DIFF
--- a/common/persistence/visibility/elasticsearch/processor.go
+++ b/common/persistence/visibility/elasticsearch/processor.go
@@ -175,8 +175,8 @@ func (p *processorImpl) Add(request *esclient.BulkableRequest, visibilityTaskKey
 
 		p.logger.Warn("Adding duplicate ES request for visibility task key.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID), tag.Value(request.Doc))
 
-		// Nack existing visibility task.
-		ackChExisting.done(false, p.metricsClient)
+		// Ack existing visibility task as if it is processed successfully.
+		ackChExisting.done(true, p.metricsClient)
 
 		// Replace existing dictionary item with new item.
 		// Note: request won't be added to bulk processor.

--- a/common/persistence/visibility/elasticsearch/processor_test.go
+++ b/common/persistence/visibility/elasticsearch/processor_test.go
@@ -150,9 +150,9 @@ func (s *processorSuite) TestAdd() {
 	s.Equal(1, s.esProcessor.mapToAckChan.Len())
 	select {
 	case ack := <-ackCh1:
-		s.False(ack)
+		s.True(ack)
 	default:
-		s.Fail("1st (existing) request should be nacked due to duplicate key")
+		s.Fail("1st (existing) request should be acked due to duplicate key")
 	}
 
 	select {
@@ -212,13 +212,13 @@ func (s *processorSuite) TestAdd_ConcurrentAdd_Duplicates() {
 	for i := 0; i < duplicates; i++ {
 		select {
 		case ack := <-ackChs[i]:
-			s.False(ack)
+			s.True(ack)
 		default:
 			pendingRequestsCount++
 		}
 	}
 
-	s.Equal(1, pendingRequestsCount, "only one request should not be nacked")
+	s.Equal(1, pendingRequestsCount, "only one request should not be acked")
 	s.Equal(1, s.esProcessor.mapToAckChan.Len(), "only one request should be in the bulk")
 }
 

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -137,10 +137,6 @@ func (t *timerQueueTaskExecutorBase) deleteWorkflow(
 	msBuilder workflow.MutableState,
 ) error {
 
-	if err := t.deleteWorkflowVisibility(task); err != nil {
-		return err
-	}
-
 	if err := t.deleteCurrentWorkflowExecution(task); err != nil {
 		return err
 	}
@@ -150,6 +146,10 @@ func (t *timerQueueTaskExecutorBase) deleteWorkflow(
 	}
 
 	if err := t.deleteWorkflowHistory(task, msBuilder); err != nil {
+		return err
+	}
+
+	if err := t.deleteWorkflowVisibility(task); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ack existing visibility task in case of duplicates. It was nack before.
Also changed order of operation while deleting workflow because delete from visibility is asynchronous anyway.

<!-- Tell your future self why have you made these changes -->
**Why?**
If visibility tasks are duplicated for some reason, nacking them leads to retris and more duplicates. Existing task should be acked instead, as if it is successfully processed. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Fixed existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.