### PR TITLE
Add metrics to bulk processor

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1940,10 +1940,14 @@ const (
 	ElasticsearchBulkProcessorRetries
 	ElasticsearchBulkProcessorFailures
 	ElasticsearchBulkProcessorCorruptedData
+
 	ElasticsearchBulkProcessorRequestLatency
 	ElasticsearchBulkProcessorCommitLatency
-	ElasticsearchBulkProcessorWaitLatency
+	ElasticsearchBulkProcessorWaitAddLatency
+	ElasticsearchBulkProcessorWaitStartLatency
+
 	ElasticsearchBulkProcessorBulkSize
+
 	ElasticsearchBulkProcessorDeadlock
 
 	NumHistoryMetrics
@@ -2388,16 +2392,17 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		MutableStateChecksumMismatch:                      {metricName: "mutable_state_checksum_mismatch", metricType: Counter},
 		MutableStateChecksumInvalidated:                   {metricName: "mutable_state_checksum_invalidated", metricType: Counter},
 
-		ElasticsearchBulkProcessorRequests:       {metricName: "elasticsearch_bulk_processor_requests"},
-		ElasticsearchBulkProcessorQueuedRequests: {metricName: "elasticsearch_bulk_processor_queued_requests", metricType: Timer},
-		ElasticsearchBulkProcessorRetries:        {metricName: "elasticsearch_bulk_processor_retries"},
-		ElasticsearchBulkProcessorFailures:       {metricName: "elasticsearch_bulk_processor_errors"},
-		ElasticsearchBulkProcessorCorruptedData:  {metricName: "elasticsearch_bulk_processor_corrupted_data"},
-		ElasticsearchBulkProcessorRequestLatency: {metricName: "elasticsearch_bulk_processor_request_latency", metricType: Timer},
-		ElasticsearchBulkProcessorCommitLatency:  {metricName: "elasticsearch_bulk_processor_commit_latency", metricType: Timer},
-		ElasticsearchBulkProcessorWaitLatency:    {metricName: "elasticsearch_bulk_processor_wait_latency", metricType: Timer},
-		ElasticsearchBulkProcessorBulkSize:       {metricName: "elasticsearch_bulk_processor_bulk_size", metricType: Timer},
-		ElasticsearchBulkProcessorDeadlock:       {metricName: "elasticsearch_bulk_processor_deadlock"},
+		ElasticsearchBulkProcessorRequests:         {metricName: "elasticsearch_bulk_processor_requests"},
+		ElasticsearchBulkProcessorQueuedRequests:   {metricName: "elasticsearch_bulk_processor_queued_requests", metricType: Timer},
+		ElasticsearchBulkProcessorRetries:          {metricName: "elasticsearch_bulk_processor_retries"},
+		ElasticsearchBulkProcessorFailures:         {metricName: "elasticsearch_bulk_processor_errors"},
+		ElasticsearchBulkProcessorCorruptedData:    {metricName: "elasticsearch_bulk_processor_corrupted_data"},
+		ElasticsearchBulkProcessorRequestLatency:   {metricName: "elasticsearch_bulk_processor_request_latency", metricType: Timer},
+		ElasticsearchBulkProcessorCommitLatency:    {metricName: "elasticsearch_bulk_processor_commit_latency", metricType: Timer},
+		ElasticsearchBulkProcessorWaitAddLatency:   {metricName: "elasticsearch_bulk_processor_wait_add_latency", metricType: Timer},
+		ElasticsearchBulkProcessorWaitStartLatency: {metricName: "elasticsearch_bulk_processor_wait_start_latency", metricType: Timer},
+		ElasticsearchBulkProcessorBulkSize:         {metricName: "elasticsearch_bulk_processor_bulk_size", metricType: Timer},
+		ElasticsearchBulkProcessorDeadlock:         {metricName: "elasticsearch_bulk_processor_deadlock"},
 	},
 	Matching: {
 		PollSuccessPerTaskQueueCounter:            {metricName: "poll_success_per_tl", metricRollupName: "poll_success"},

--- a/common/persistence/visibility/elasticsearch/processor.go
+++ b/common/persistence/visibility/elasticsearch/processor.go
@@ -180,8 +180,8 @@ func (p *processorImpl) Add(request *esclient.BulkableRequest, visibilityTaskKey
 		return nil
 	})
 	if !isDup {
-		p.bulkProcessor.Add(request)
 		ackCh.add(p.metricsClient)
+		p.bulkProcessor.Add(request)
 	}
 	return ackCh.ackChInternal
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Split `elasticsearch_bulk_processor_wait_latency` into `elasticsearch_bulk_processor_wait_add_latency` and `elasticsearch_bulk_processor_wait_start_latency`,
- In case of duplicates, acknowledge new instead of existing tasks. It actually doesn't matter, but might cause some concurrency problem.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve and analyze performance under high load.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Fixed exiting tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.