### PR TITLE
Fix match task queue rate calculation issue

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -26,6 +26,7 @@ package matching
 
 import (
 	"context"
+	"math"
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -304,11 +305,7 @@ func (tm *TaskMatcher) UpdateRatelimit(rps *float64) {
 		// divide the rate equally across all partitions
 		rate = rate / nPartitions
 	}
-
-	burst := int(rate)
-	if 0 < rate && rate < 1 {
-		burst = 1
-	}
+	burst := int(math.Ceil(rate))
 
 	minTaskThrottlingBurstSize := tm.config.MinTaskThrottlingBurstSize()
 	if burst < minTaskThrottlingBurstSize {

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -300,12 +300,16 @@ func (tm *TaskMatcher) UpdateRatelimit(rps *float64) {
 
 	rate := *rps
 	nPartitions := float64(tm.numPartitions())
-	if rate > nPartitions {
+	if nPartitions > 0 {
 		// divide the rate equally across all partitions
 		rate = rate / nPartitions
 	}
 
 	burst := int(rate)
+	if *rps > 0 && burst < 1 {
+		burst = 1
+	}
+
 	minTaskThrottlingBurstSize := tm.config.MinTaskThrottlingBurstSize()
 	if burst < minTaskThrottlingBurstSize {
 		burst = minTaskThrottlingBurstSize

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -306,7 +306,7 @@ func (tm *TaskMatcher) UpdateRatelimit(rps *float64) {
 	}
 
 	burst := int(rate)
-	if *rps > 0 && burst < 1 {
+	if 0 < rate && rate < 1 {
 		burst = 1
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Correctly handle matching task queue rate / burst calculation

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously, Cadence's rate limiter only support rate as int, this caused some rounding issue.
Temporal's version support rate as float.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A