### PR TITLE
Ignore InvalidArgument error for unknown custom search attributes

### DIFF
--- a/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
@@ -1000,7 +1000,7 @@ func (s *ESVisibilitySuite) TestParseESDoc_SearchAttributes_WithMapper() {
 
 	s.mockSearchAttributesMapper.EXPECT().GetAlias(gomock.Any(), testNamespace).DoAndReturn(
 		func(fieldName string, namespace string) (string, error) {
-			return "", serviceerror.NewInvalidArgument("error")
+			return "", serviceerror.NewInternal("error")
 		})
 	info, err = s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap, testNamespace)
 	s.Error(err)

--- a/common/searchattribute/mapper.go
+++ b/common/searchattribute/mapper.go
@@ -28,6 +28,7 @@ package searchattribute
 
 import (
 	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/serviceerror"
 )
 
 type (
@@ -55,6 +56,10 @@ func ApplyAliases(mapper Mapper, searchAttributes *commonpb.SearchAttributes, na
 
 		aliasName, err := mapper.GetAlias(saName, namespace)
 		if err != nil {
+			if _, isInvalidArgument := err.(*serviceerror.InvalidArgument); isInvalidArgument {
+				// Silently ignore serviceerror.InvalidArgument because it indicates unmapped field (alias was deleted, for example).
+				continue
+			}
 			return err
 		}
 		newIndexedFields[aliasName] = saPayload

--- a/common/searchattribute/mapper_test.go
+++ b/common/searchattribute/mapper_test.go
@@ -39,11 +39,14 @@ type (
 )
 
 func (t *TestMapper) GetAlias(fieldName string, namespace string) (string, error) {
+	if fieldName == "wrong_field" {
+		return "", serviceerror.NewInvalidArgument("unmapped field")
+	}
 	if namespace == "test" {
 		return "alias_of_" + fieldName, nil
 	}
 	if namespace == "error" {
-		return "", serviceerror.NewInvalidArgument("mapper error")
+		return "", serviceerror.NewInternal("mapper error")
 	}
 	return fieldName, nil
 }
@@ -53,7 +56,7 @@ func (t *TestMapper) GetFieldName(alias string, namespace string) (string, error
 		return strings.TrimPrefix(alias, "alias_of_"), nil
 	}
 	if namespace == "error" {
-		return "", serviceerror.NewInvalidArgument("mapper error")
+		return "", serviceerror.NewInternal("mapper error")
 	}
 	return alias, nil
 }
@@ -61,13 +64,14 @@ func (t *TestMapper) GetFieldName(alias string, namespace string) (string, error
 func Test_ApplyAliases(t *testing.T) {
 	sa := &commonpb.SearchAttributes{
 		IndexedFields: map[string]*commonpb.Payload{
-			"field1": {Data: []byte("data1")},
-			"field2": {Data: []byte("data2")},
+			"field1":      {Data: []byte("data1")},
+			"field2":      {Data: []byte("data2")},
+			"wrong_field": {Data: []byte("data23")},
 		},
 	}
 	err := ApplyAliases(&TestMapper{}, sa, "error")
 	assert.Error(t, err)
-	var invalidArgumentErr *serviceerror.InvalidArgument
+	var invalidArgumentErr *serviceerror.Internal
 	assert.ErrorAs(t, err, &invalidArgumentErr)
 
 	err = ApplyAliases(&TestMapper{}, sa, "namespace1")
@@ -92,7 +96,7 @@ func Test_SubstituteAliases(t *testing.T) {
 	}
 	err := SubstituteAliases(&TestMapper{}, sa, "error")
 	assert.Error(t, err)
-	var invalidArgumentErr *serviceerror.InvalidArgument
+	var invalidArgumentErr *serviceerror.Internal
 	assert.ErrorAs(t, err, &invalidArgumentErr)
 
 	err = SubstituteAliases(&TestMapper{}, sa, "namespace1")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ignore `InvalidArgument` error for unknown custom search attributes.

<!-- Tell your future self why have you made these changes -->
**Why?**
To support search attribute alias deletion.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.