### PR TITLE
Remove missing keyword support in visibility queries

### DIFF
--- a/common/persistence/visibility/elasticsearch/query/converter_test.go
+++ b/common/persistence/visibility/elasticsearch/query/converter_test.go
@@ -78,8 +78,6 @@ var supportedWhereCases = map[string]string{
 	"id not IN (1, 2,3)":                           `{"bool":{"must_not":{"terms":{"id":[1,2,3]}}}}`,
 	"id iS not null":                               `{"bool":{"filter":{"exists":{"field":"id"}}}}`,
 	"id is NULL":                                   `{"bool":{"must_not":{"exists":{"field":"id"}}}}`,
-	"id != missing":                                `{"bool":{"filter":{"exists":{"field":"id"}}}}`,
-	"id = missing":                                 `{"bool":{"must_not":{"exists":{"field":"id"}}}}`,
 	"value = '1'":                                  `{"bool":{"filter":{"match_phrase":{"value":{"query":"1"}}}}}`,
 	"value = 'true'":                               `{"bool":{"filter":{"match_phrase":{"value":{"query":"true"}}}}}`,
 	"value = 'True'":                               `{"bool":{"filter":{"match_phrase":{"value":{"query":"True"}}}}}`,

--- a/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
@@ -561,19 +561,19 @@ func (s *ESVisibilitySuite) Test_convertQuery() {
 	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":{"match_phrase":{"WorkflowId":{"query":"wid"}}}}}]}}`, s.queryToJSON(qry))
 	s.Equal(`[{"StartTime":{"order":"desc"}}]`, s.sorterToJSON(srt))
 
-	query = `WorkflowId = 'wid' and CloseTime = missing`
+	query = `WorkflowId = 'wid' and CloseTime is null`
 	qry, srt, err = s.visibilityStore.convertQuery(testNamespace, testNamespaceID, query)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"filter":[{"match_phrase":{"WorkflowId":{"query":"wid"}}},{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}]}}]}}`, s.queryToJSON(qry))
 	s.Nil(srt)
 
-	query = `WorkflowId = 'wid' or CloseTime = missing`
+	query = `WorkflowId = 'wid' or CloseTime is null`
 	qry, srt, err = s.visibilityStore.convertQuery(testNamespace, testNamespaceID, query)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"should":[{"match_phrase":{"WorkflowId":{"query":"wid"}}},{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}]}}]}}`, s.queryToJSON(qry))
 	s.Nil(srt)
 
-	query = `CloseTime = missing order by CloseTime desc`
+	query = `CloseTime is null order by CloseTime desc`
 	qry, srt, err = s.visibilityStore.convertQuery(testNamespace, testNamespaceID, query)
 	s.NoError(err)
 	s.Equal(`{"bool":{"filter":[{"term":{"NamespaceId":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}},{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}]}}`, s.queryToJSON(qry))

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -515,7 +515,7 @@ func (s *cliAppSuite) TestCountWorkflow() {
 	s.sdkClient.AssertExpectations(s.T())
 
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{}, nil).Once()
-	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "count", "-q", "'CloseTime = missing'"})
+	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "count", "-q", "'CloseTime is null'"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }
@@ -523,7 +523,7 @@ func (s *cliAppSuite) TestCountWorkflow() {
 func (s *cliAppSuite) TestCountWorkflowDeadlineExceeded() {
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(nil, context.DeadlineExceeded).Once()
 	s.sdkClient.On("CountWorkflow", mock.Anything, mock.Anything).Return(&workflowservice.CountWorkflowExecutionsResponse{}, nil).Once()
-	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "count", "-q", "'CloseTime = missing'"})
+	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "count", "-q", "'CloseTime is null'"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -523,7 +523,7 @@ func getFlagsForCount() []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:  FlagListQueryWithAlias,
-			Usage: "Optional SQL like query. e.g count all open workflows 'CloseTime = missing'; 'WorkflowType=\"wtype\" and CloseTime > 0'",
+			Usage: "Optional SQL like query. e.g count all open workflows \"ExecutionStatus='Running'\"; 'WorkflowType=\"wtype\" and CloseTime > 0'",
 		},
 	}
 }

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -35,7 +35,6 @@ import (
 	"math/rand"
 	"os"
 	"reflect"
-	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -697,9 +696,8 @@ func ScanAllWorkflow(c *cli.Context) {
 		return
 	}
 
-	isQueryOpen := isQueryOpen(c.String(FlagListQuery))
-	table := createTableForListWorkflow(c, true, isQueryOpen)
-	prepareTable := scanWorkflow(c, table, isQueryOpen)
+	table := createTableForListWorkflow(c, true, true)
+	prepareTable := scanWorkflow(c, table, true)
 	var nextPageToken []byte
 	for {
 		nextPageToken, _ = prepareTable(nextPageToken)
@@ -708,11 +706,6 @@ func ScanAllWorkflow(c *cli.Context) {
 		}
 	}
 	table.Render()
-}
-
-func isQueryOpen(query string) bool {
-	var openWFPattern = regexp.MustCompile(`CloseTime[ ]*=[ ]*missing`)
-	return openWFPattern.MatchString(query)
 }
 
 // CountWorkflow count number of workflows


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove `missing` keyword support in visibility queries.

<!-- Tell your future self why have you made these changes -->
**Why?**
`missing` support was deprecated in 1.12 release and is removed in 1.13. Use `ExecutionStatus="Running"` to filter only running workflows or `CloseTime is null` to filter workflows with missed field.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Queries which are still using `missing` keywords (like `CloseTime=missing`) will fail.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.