### PR TITLE
Add incarnation ID to taskQueueManager fatal signal

### DIFF
--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 
@@ -207,7 +207,7 @@ func (t *ForwarderTestSuite) TestForwardPollError() {
 func (t *ForwarderTestSuite) TestForwardPollWorkflowTaskQueue() {
 	t.usingTaskqueuePartition(enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 
-	pollerID := uuid.New()
+	pollerID := uuid.NewString()
 	ctx := context.WithValue(context.Background(), pollerIDKey, pollerID)
 	ctx = context.WithValue(ctx, identityKey, "id1")
 	resp := &matchingservice.PollWorkflowTaskQueueResponse{}
@@ -235,7 +235,7 @@ func (t *ForwarderTestSuite) TestForwardPollWorkflowTaskQueue() {
 func (t *ForwarderTestSuite) TestForwardPollForActivity() {
 	t.usingTaskqueuePartition(enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 
-	pollerID := uuid.New()
+	pollerID := uuid.NewString()
 	ctx := context.WithValue(context.Background(), pollerIDKey, pollerID)
 	ctx = context.WithValue(ctx, identityKey, "id1")
 	resp := &matchingservice.PollActivityTaskQueueResponse{}

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -32,7 +32,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/pborman/uuid"
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	querypb "go.temporal.io/api/query/v1"
@@ -67,7 +67,7 @@ func (t *MatcherTestSuite) SetupTest() {
 	t.controller = gomock.NewController(t.T())
 	t.client = matchingservicemock.NewMockMatchingServiceClient(t.controller)
 	cfg := NewConfig(dynamicconfig.NewNoopCollection())
-	t.taskQueue = newTestTaskQueueID(uuid.New(), taskQueuePartitionPrefix+"tl0/1", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
+	t.taskQueue = newTestTaskQueueID(uuid.NewString(), taskQueuePartitionPrefix+"tl0/1", enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	tlCfg, err := newTaskQueueConfig(t.taskQueue, cfg, t.newNamespaceCache())
 	t.NoError(err)
 	tlCfg.forwarderConfig = forwarderConfig{
@@ -227,7 +227,7 @@ func (t *MatcherTestSuite) TestQueryLocalSyncMatch() {
 
 	<-pollStarted
 	time.Sleep(10 * time.Millisecond)
-	task := newInternalQueryTask(uuid.New(), &matchingservice.QueryWorkflowRequest{})
+	task := newInternalQueryTask(uuid.NewString(), &matchingservice.QueryWorkflowRequest{})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	resp, err := t.matcher.OfferQuery(ctx, task)
 	cancel()
@@ -266,7 +266,7 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatch() {
 		},
 	).Return(&remotePollResp, remotePollErr).AnyTimes()
 
-	task := newInternalQueryTask(uuid.New(), &matchingservice.QueryWorkflowRequest{})
+	task := newInternalQueryTask(uuid.NewString(), &matchingservice.QueryWorkflowRequest{})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 
 	var req *matchingservice.QueryWorkflowRequest
@@ -312,7 +312,7 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatchError() {
 		}
 	}()
 
-	task := newInternalQueryTask(uuid.New(), &matchingservice.QueryWorkflowRequest{})
+	task := newInternalQueryTask(uuid.NewString(), &matchingservice.QueryWorkflowRequest{})
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 
 	var req *matchingservice.QueryWorkflowRequest
@@ -491,9 +491,9 @@ func randomTaskInfo() *persistencespb.AllocatedTaskInfo {
 
 	return &persistencespb.AllocatedTaskInfo{
 		Data: &persistencespb.TaskInfo{
-			NamespaceId: uuid.New(),
-			WorkflowId:  uuid.New(),
-			RunId:       uuid.New(),
+			NamespaceId: uuid.NewString(),
+			WorkflowId:  uuid.NewString(),
+			RunId:       uuid.NewString(),
 			ScheduleId:  rand.Int63(),
 			CreateTime:  &rt1,
 			ExpiryTime:  &rt2,

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -201,7 +201,7 @@ func (w *taskWriter) appendTasks(
 		return resp, nil
 
 	case *persistence.ConditionFailedError:
-		w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID)
+		w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID, w.tlMgr.IncarnationID())
 		return nil, err
 
 	default:
@@ -219,7 +219,7 @@ func (w *taskWriter) taskWriterLoop(ctx context.Context) error {
 	err := w.initReadWriteState(ctx)
 	if err != nil {
 		if w.tlMgr.errShouldUnload(err) {
-			w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID)
+			w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID, w.tlMgr.IncarnationID())
 		}
 		return err
 	}
@@ -318,7 +318,7 @@ func (w *taskWriter) allocTaskIDBlock(ctx context.Context, prevBlockEnd int64) (
 	state, err := w.renewLeaseWithRetry(ctx, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
 	if err != nil {
 		if w.tlMgr.errShouldUnload(err) {
-			w.tlMgr.signalFatalProblem(w.taskQueueID)
+			w.tlMgr.signalFatalProblem(w.taskQueueID, w.tlMgr.IncarnationID())
 			return taskIDBlock{}, errShutdown
 		}
 		return taskIDBlock{}, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
A taskQueueManager shutting down can result in multiple upcalls to
unload the queue on different goroutines. We want only the first of
those calls to succeed and for later calls to have no effect. If the
later calls are allowed to run, they will unload a successor to the
taskQueueManager that emitted the signal in the first place.

Also uses github.com/google/uuid for UUIDs as this library is
maintained and more featureful than the pborman one. In fact, it's
maintained by pborman.

<!-- Tell your future self why have you made these changes -->
**Why?**
With enough activity and failure, the fatal signals can become self-sustaining

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minimal. The unload call now performs an unload in strictly _fewer_ scenarios.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No