### PR TITLE
Use serviceerror.Unavailable error type instead of serviceerror.Internal

### DIFF
--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -206,7 +206,7 @@ func (h *historyArchiver) Get(
 	dirPath := URI.Path()
 	exists, err := directoryExists(dirPath)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 	if !exists {
 		return nil, serviceerror.NewInvalidArgument(archiver.ErrHistoryNotExist.Error())
@@ -226,7 +226,7 @@ func (h *historyArchiver) Get(
 	} else {
 		highestVersion, err := getHighestVersion(dirPath, request)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		token = &getHistoryToken{
 			CloseFailoverVersion: *highestVersion,
@@ -238,7 +238,7 @@ func (h *historyArchiver) Get(
 	filepath := path.Join(dirPath, filename)
 	exists, err = fileExists(filepath)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 	if !exists {
 		return nil, serviceerror.NewNotFound(archiver.ErrHistoryNotExist.Error())
@@ -246,13 +246,13 @@ func (h *historyArchiver) Get(
 
 	encodedHistoryBatches, err := readFile(filepath)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 
 	encoder := codec.NewJSONPBEncoder()
 	historyBatches, err := encoder.DecodeHistories(encodedHistoryBatches)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 	historyBatches = historyBatches[token.NextBatchIdx:]
 
@@ -272,7 +272,7 @@ func (h *historyArchiver) Get(
 		token.NextBatchIdx += numOfBatches
 		nextToken, err := serializeToken(token)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		response.NextPageToken = nextToken
 	}

--- a/common/archiver/filestore/visibilityArchiver.go
+++ b/common/archiver/filestore/visibilityArchiver.go
@@ -194,7 +194,7 @@ func (v *visibilityArchiver) query(
 	dirPath := path.Join(URI.Path(), request.namespaceID)
 	exists, err := directoryExists(dirPath)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 	if !exists {
 		return &archiver.QueryVisibilityResponse{}, nil
@@ -202,12 +202,12 @@ func (v *visibilityArchiver) query(
 
 	files, err := listFiles(dirPath)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 
 	files, err = sortAndFilterFiles(files, token)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 	if len(files) == 0 {
 		return &archiver.QueryVisibilityResponse{}, nil
@@ -217,12 +217,12 @@ func (v *visibilityArchiver) query(
 	for idx, file := range files {
 		encodedRecord, err := readFile(path.Join(dirPath, file))
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 
 		record, err := decodeVisibilityRecord(encodedRecord)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 
 		if record.CloseTime.Before(request.parsedQuery.earliestCloseTime) {
@@ -232,7 +232,7 @@ func (v *visibilityArchiver) query(
 		if matchQuery(record, request.parsedQuery) {
 			executionInfo, err := convertToExecutionInfo(record, saTypeMap)
 			if err != nil {
-				return nil, serviceerror.NewInternal(err.Error())
+				return nil, serviceerror.NewUnavailable(err.Error())
 			}
 
 			response.Executions = append(response.Executions, executionInfo)
@@ -244,7 +244,7 @@ func (v *visibilityArchiver) query(
 					}
 					encodedToken, err := serializeToken(newToken)
 					if err != nil {
-						return nil, serviceerror.NewInternal(err.Error())
+						return nil, serviceerror.NewUnavailable(err.Error())
 					}
 					response.NextPageToken = encodedToken
 				}

--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -215,7 +215,7 @@ func (h *historyArchiver) Get(ctx context.Context, URI archiver.URI, request *ar
 	} else {
 		highestVersion, historyhighestPart, historyCurrentPart, err := h.getHighestVersion(ctx, URI, request)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		token = &getHistoryToken{
 			CloseFailoverVersion: *highestVersion,
@@ -237,16 +237,16 @@ outer:
 		encodedHistoryBatches, err := h.gcloudStorage.Get(ctx, URI, filename)
 
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 
 		if encodedHistoryBatches == nil {
-			return nil, serviceerror.NewInternal("Fail retrieving history file: " + URI.String() + "/" + filename)
+			return nil, serviceerror.NewUnavailable("Fail retrieving history file: " + URI.String() + "/" + filename)
 		}
 
 		batches, err := encoder.DecodeHistories(encodedHistoryBatches)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		// trim the batches in the beginning based on token.BatchIdxOffset
 		batches = batches[token.BatchIdxOffset:]
@@ -275,7 +275,7 @@ outer:
 	if token.CurrentPart <= token.HighestPart {
 		nextToken, err := serializeToken(token)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		response.NextPageToken = nextToken
 	}

--- a/common/archiver/gcloud/visibilityArchiver.go
+++ b/common/archiver/gcloud/visibilityArchiver.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/searchattribute"
 
 	archiverspb "go.temporal.io/server/api/archiver/v1"
@@ -248,7 +249,7 @@ func (v *visibilityArchiver) query(
 
 		executionInfo, err := convertToExecutionInfo(record, saTypeMap)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		response.Executions = append(response.Executions, executionInfo)
 	}

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -303,20 +303,20 @@ func (h *historyArchiver) Get(
 		encodedRecord, err := download(ctx, h.s3cli, URI, key)
 		if err != nil {
 			if isRetryableError(err) {
-				return nil, &serviceerror.Internal{Message: err.Error()}
+				return nil, serviceerror.NewUnavailable(err.Error())
 			}
 			switch err.(type) {
-			case *serviceerror.InvalidArgument, *serviceerror.Internal, *serviceerror.NotFound:
+			case *serviceerror.InvalidArgument, *serviceerror.Unavailable, *serviceerror.NotFound:
 				return nil, err
 			default:
-				return nil, &serviceerror.Internal{Message: err.Error()}
+				return nil, serviceerror.NewUnavailable(err.Error())
 			}
 		}
 
 		historyBlob := archiverspb.HistoryBlob{}
 		err = encoder.Decode(encodedRecord, &historyBlob)
 		if err != nil {
-			return nil, &serviceerror.Internal{Message: err.Error()}
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 
 		for _, batch := range historyBlob.Body {
@@ -333,7 +333,7 @@ func (h *historyArchiver) Get(
 	if isTruncated {
 		nextToken, err := serializeToken(token)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		response.NextPageToken = nextToken
 	}

--- a/common/archiver/s3store/visibilityArchiver.go
+++ b/common/archiver/s3store/visibilityArchiver.go
@@ -33,6 +33,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/searchattribute"
 
 	archiverspb "go.temporal.io/server/api/archiver/v1"
@@ -230,7 +231,7 @@ func (v *visibilityArchiver) query(
 	})
 	if err != nil {
 		if isRetryableError(err) {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		return nil, serviceerror.NewInvalidArgument(err.Error())
 	}
@@ -245,16 +246,16 @@ func (v *visibilityArchiver) query(
 	for _, item := range results.Contents {
 		encodedRecord, err := download(ctx, v.s3cli, URI, *item.Key)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 
 		record, err := decodeVisibilityRecord(encodedRecord)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		executionInfo, err := convertToExecutionInfo(record, saTypeMap)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 		response.Executions = append(response.Executions, executionInfo)
 	}

--- a/common/log/panic.go
+++ b/common/log/panic.go
@@ -50,6 +50,6 @@ func CapturePanic(logger Logger, retError *error) {
 
 		logger.Error("Panic is captured", tag.SysStackTrace(st), tag.Error(err))
 
-		*retError = serviceerror.NewInternal(err.Error())
+		*retError = serviceerror.NewUnavailable(err.Error())
 	}
 }

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -38,7 +38,7 @@ import (
 var ErrUnknownService = errors.New("Service not tracked by Monitor")
 
 // ErrInsufficientHosts is thrown when there are not enough hosts to serve the request
-var ErrInsufficientHosts = serviceerror.NewInternal("Not enough hosts to serve the request")
+var ErrInsufficientHosts = serviceerror.NewUnavailable("Not enough hosts to serve the request")
 
 // ErrListenerAlreadyExist is thrown on a duplicate AddListener call from the same listener
 var ErrListenerAlreadyExist = errors.New("Listener already exist for the service")

--- a/common/namespace/dlqMessageHandler.go
+++ b/common/namespace/dlqMessageHandler.go
@@ -135,7 +135,7 @@ func (d *dlqMessageHandlerImpl) Merge(
 	for _, message := range messages {
 		namespaceTask := message.GetNamespaceTaskAttributes()
 		if namespaceTask == nil {
-			return nil, serviceerror.NewInternal("Encounter non namespace replication task in namespace replication queue.")
+			return nil, serviceerror.NewUnavailable("Encounter non namespace replication task in namespace replication queue.")
 		}
 
 		if err := d.replicationHandler.Execute(

--- a/common/persistence/cassandra/cassandraClusterMetadata.go
+++ b/common/persistence/cassandra/cassandraClusterMetadata.go
@@ -133,7 +133,7 @@ func (m *cassandraClusterMetadata) SaveClusterMetadata(request *p.InternalSaveCl
 		return false, gocql.ConvertError("SaveClusterMetadata", err)
 	}
 	if !applied {
-		return false, serviceerror.NewInternal("SaveClusterMetadata operation encountered concurrent write.")
+		return false, serviceerror.NewUnavailable("SaveClusterMetadata operation encountered concurrent write.")
 	}
 	return true, nil
 }

--- a/common/persistence/cassandra/cassandraHistoryPersistence.go
+++ b/common/persistence/cassandra/cassandraHistoryPersistence.go
@@ -30,6 +30,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
@@ -147,12 +148,12 @@ func (h *cassandraPersistence) ReadHistoryBranch(
 
 	treeID, err := primitives.ValidateUUID(request.TreeID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err))
 	}
 
 	branchID, err := primitives.ValidateUUID(request.BranchID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch - Gocql BranchId UUID cast failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadHistoryBranch - Gocql BranchId UUID cast failed. Error: %v", err))
 	}
 
 	var queryString string
@@ -174,7 +175,7 @@ func (h *cassandraPersistence) ReadHistoryBranch(
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch. Close operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadHistoryBranch. Close operation failed. Error: %v", err))
 	}
 
 	return &p.InternalReadHistoryBranchResponse{
@@ -236,12 +237,12 @@ func (h *cassandraPersistence) ForkHistoryBranch(
 
 	cqlTreeID, err := primitives.ValidateUUID(forkB.TreeId)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("ForkHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("ForkHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err))
 	}
 
 	cqlNewBranchID, err := primitives.ValidateUUID(request.NewBranchID)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("ForkHistoryBranch - Gocql NewBranchID UUID cast failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("ForkHistoryBranch - Gocql NewBranchID UUID cast failed. Error: %v", err))
 	}
 	query := h.session.Query(v2templateInsertTree, cqlTreeID, cqlNewBranchID, datablob.Data, datablob.EncodingType.String())
 	err = query.Exec()
@@ -316,7 +317,7 @@ func (h *cassandraPersistence) GetAllHistoryTreeBranches(
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetAllHistoryTreeBranches. Close operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetAllHistoryTreeBranches. Close operation failed. Error: %v", err))
 	}
 
 	response := &p.InternalGetAllHistoryTreeBranchesResponse{
@@ -334,7 +335,7 @@ func (h *cassandraPersistence) GetHistoryTree(
 
 	treeID, err := primitives.ValidateUUID(request.TreeID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch. Gocql TreeId UUID cast failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadHistoryBranch. Gocql TreeId UUID cast failed. Error: %v", err))
 	}
 	query := h.session.Query(v2templateReadAllBranches, treeID)
 

--- a/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
+++ b/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
@@ -124,7 +124,7 @@ func (m *cassandraMetadataPersistenceV2) CreateNamespace(request *p.InternalCrea
 	query := m.session.Query(templateCreateNamespaceQuery, request.ID, request.Name)
 	applied, err := query.MapScanCAS(make(map[string]interface{}))
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err))
 	}
 	if !applied {
 		return nil, serviceerror.NewNamespaceAlreadyExists("CreateNamespace operation failed because of uuid collision.")
@@ -161,7 +161,7 @@ func (m *cassandraMetadataPersistenceV2) CreateNamespaceInV2Table(request *p.Int
 	}()
 
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("CreateNamespace operation failed. Inserting into namespaces table. Error: %v", err))
 	}
 
 	if !applied {
@@ -201,10 +201,10 @@ func (m *cassandraMetadataPersistenceV2) UpdateNamespace(request *p.InternalUpda
 	}()
 
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("UpdateNamespace operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("UpdateNamespace operation failed. Error: %v", err))
 	}
 	if !applied {
-		return serviceerror.NewInternal(fmt.Sprintf("UpdateNamespace operation failed because of conditional failure."))
+		return serviceerror.NewUnavailable(fmt.Sprintf("UpdateNamespace operation failed because of conditional failure."))
 	}
 
 	return nil
@@ -232,7 +232,7 @@ func (m *cassandraMetadataPersistenceV2) GetNamespace(request *p.GetNamespaceReq
 			}
 			return serviceerror.NewNotFound(fmt.Sprintf("Namespace %s does not exist.", identity))
 		}
-		return serviceerror.NewInternal(fmt.Sprintf("GetNamespace operation failed. Error %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("GetNamespace operation failed. Error %v", err))
 	}
 
 	namespace := request.Name
@@ -302,7 +302,7 @@ func (m *cassandraMetadataPersistenceV2) ListNamespaces(request *p.ListNamespace
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListNamespaces operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListNamespaces operation failed. Error: %v", err))
 	}
 
 	return response, nil
@@ -375,12 +375,12 @@ func (m *cassandraMetadataPersistenceV2) updateMetadataBatch(
 func (m *cassandraMetadataPersistenceV2) deleteNamespace(name string, ID []byte) error {
 	query := m.session.Query(templateDeleteNamespaceByNameQueryV2, constNamespacePartition, name)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("DeleteNamespaceByName operation failed. Error %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteNamespaceByName operation failed. Error %v", err))
 	}
 
 	query = m.session.Query(templateDeleteNamespaceQuery, ID)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("DeleteNamespace operation failed. Error %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteNamespace operation failed. Error %v", err))
 	}
 
 	return nil

--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -594,7 +594,7 @@ func createTransferTasks(
 			// No explicit property needs to be set
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("Unknow transfer type: %v", task.GetType()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Unknow transfer type: %v", task.GetType()))
 		}
 
 		transferTaskInfo := &persistencespb.TransferTaskInfo{
@@ -663,7 +663,7 @@ func createReplicationTasks(
 			activityScheduleID = task.(*p.SyncActivityTask).ScheduledID
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("Unknow replication type: %v", task.GetType()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Unknow replication type: %v", task.GetType()))
 		}
 
 		datablob, err := serialization.ReplicationTaskInfoToBlob(&persistencespb.ReplicationTaskInfo{
@@ -736,7 +736,7 @@ func createVisibilityTasks(
 			// noop
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("createVisibilityTasks failed. Unknow visibility type: %v", task.GetType()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("createVisibilityTasks failed. Unknow visibility type: %v", task.GetType()))
 		}
 
 		batch.Query(templateCreateVisibilityTaskQuery,
@@ -798,7 +798,7 @@ func createTimerTasks(
 			// noop
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("Unknow timer type: %v", task.GetType()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Unknow timer type: %v", task.GetType()))
 		}
 
 		// Ignoring possible type cast errors.

--- a/common/persistence/cassandra/cassandraQueue.go
+++ b/common/persistence/cassandra/cassandraQueue.go
@@ -31,6 +31,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
@@ -173,7 +174,7 @@ func (q *cassandraQueue) ReadMessages(
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadMessages operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadMessages operation failed. Error: %v", err))
 	}
 
 	return result, nil
@@ -206,7 +207,7 @@ func (q *cassandraQueue) ReadMessagesFromDLQ(
 	newPageToken := make([]byte, len(nextPageToken))
 	copy(newPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		return nil, nil, serviceerror.NewInternal(fmt.Sprintf("ReadMessagesFromDLQ operation failed. Error: %v", err))
+		return nil, nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadMessagesFromDLQ operation failed. Error: %v", err))
 	}
 
 	return result, newPageToken, nil
@@ -218,7 +219,7 @@ func (q *cassandraQueue) DeleteMessagesBefore(
 
 	query := q.session.Query(templateDeleteMessagesBeforeQuery, q.queueType, messageID)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("DeleteMessagesBefore operation failed. Error %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteMessagesBefore operation failed. Error %v", err))
 	}
 	return nil
 }
@@ -230,7 +231,7 @@ func (q *cassandraQueue) DeleteMessageFromDLQ(
 	// Use negative queue type as the dlq type
 	query := q.session.Query(templateDeleteMessageQuery, q.getDLQTypeFromQueueType(), messageID)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("DeleteMessageFromDLQ operation failed. Error %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteMessageFromDLQ operation failed. Error %v", err))
 	}
 
 	return nil
@@ -244,7 +245,7 @@ func (q *cassandraQueue) RangeDeleteMessagesFromDLQ(
 	// Use negative queue type as the dlq type
 	query := q.session.Query(templateDeleteMessagesQuery, q.getDLQTypeFromQueueType(), firstMessageID, lastMessageID)
 	if err := query.Exec(); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("RangeDeleteMessagesFromDLQ operation failed. Error %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("RangeDeleteMessagesFromDLQ operation failed. Error %v", err))
 	}
 
 	return nil

--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -29,6 +29,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/persistence"
 )
@@ -88,7 +89,7 @@ type (
 var defaultErrors = []FaultWeight{
 	{
 		errFactory: func(msg string) error {
-			return serviceerror.NewInternal(msg)
+			return serviceerror.NewUnavailable(msg)
 		},
 		weight: 1,
 	},

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -730,9 +730,9 @@ func (m *executionManagerImpl) filterHistoryNodes(
 
 		switch {
 		case node.NodeID < lastNodeID:
-			return nil, serviceerror.NewInternal(fmt.Sprintf("corrupted data, nodeID cannot decrease"))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("corrupted data, nodeID cannot decrease"))
 		case node.NodeID == lastNodeID:
-			return nil, serviceerror.NewInternal(fmt.Sprintf("corrupted data, same nodeID must have smaller txnID"))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("corrupted data, same nodeID must have smaller txnID"))
 		default: // row.NodeID > lastNodeID:
 			// NOTE: when row.nodeID > lastNodeID, we expect the one with largest txnID comes first
 			lastTransactionID = node.TransactionID

--- a/common/persistence/history_node_util.go
+++ b/common/persistence/history_node_util.go
@@ -96,7 +96,7 @@ func reverselyLinkNode(
 	node, ok := transactionIDToNode[transactionID]
 	// sanity check node ID <-> transaction ID being unique
 	if !ok || node.nodeID != tailNodeID {
-		return nil, serviceerror.NewInternal(
+		return nil, serviceerror.NewUnavailable(
 			fmt.Sprintf("unable to find or verify the tail history node, node ID: %v, transaction ID: %v",
 				tailNodeID,
 				tailTransactionID,
@@ -108,7 +108,7 @@ func reverselyLinkNode(
 	nodes = append(nodes, node)
 	for node.nodeID > common.FirstEventID {
 		if prevNode, ok := transactionIDToNode[node.prevTransactionID]; !ok {
-			return nil, serviceerror.NewInternal(
+			return nil, serviceerror.NewUnavailable(
 				fmt.Sprintf("unable to back trace history node, node ID: %v, transaction ID: %v, prev transaction ID: %v",
 					node.nodeID,
 					node.transactionID,
@@ -125,7 +125,7 @@ func reverselyLinkNode(
 	// node.nodeID == common.FirstEventID
 	// node.prevTransactionID == 0
 	if node.nodeID != common.FirstEventID || node.prevTransactionID != 0 {
-		return nil, serviceerror.NewInternal(
+		return nil, serviceerror.NewUnavailable(
 			fmt.Sprintf("unable to back trace history node, node ID: %v, transaction ID: %v, prev transaction ID: %v",
 				node.nodeID,
 				node.transactionID,

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/errors.go
@@ -55,9 +55,9 @@ func ConvertError(
 		if v.Code() == 0x1001 {
 			return serviceerror.NewResourceExhausted(fmt.Sprintf("operation %v encounter %v", operation, err.Error()))
 		}
-		return serviceerror.NewInternal(fmt.Sprintf("operation %v encounter %v", operation, err.Error()))
+		return serviceerror.NewUnavailable(fmt.Sprintf("operation %v encounter %v", operation, err.Error()))
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("operation %v encounter %v", operation, err.Error()))
+		return serviceerror.NewUnavailable(fmt.Sprintf("operation %v encounter %v", operation, err.Error()))
 	}
 }
 

--- a/common/persistence/operationModeValidator.go
+++ b/common/persistence/operationModeValidator.go
@@ -73,7 +73,7 @@ func ValidateCreateWorkflowModeState(
 		return nil
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown mode: %v", mode))
+		return serviceerror.NewUnavailable(fmt.Sprintf("unknown mode: %v", mode))
 	}
 }
 
@@ -154,7 +154,7 @@ func ValidateUpdateWorkflowModeState(
 		return nil
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown mode: %v", mode))
+		return serviceerror.NewUnavailable(fmt.Sprintf("unknown mode: %v", mode))
 	}
 }
 
@@ -277,7 +277,7 @@ func ValidateConflictResolveWorkflowModeState(
 
 		// precondition
 		if currentWorkflowMutation != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Invalid workflow conflict resolve mode %v, encounter current workflow", mode))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Invalid workflow conflict resolve mode %v, encounter current workflow", mode))
 		}
 
 		// case 1
@@ -308,7 +308,7 @@ func ValidateConflictResolveWorkflowModeState(
 		return nil
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown mode: %v", mode))
+		return serviceerror.NewUnavailable(fmt.Sprintf("unknown mode: %v", mode))
 	}
 }
 
@@ -321,7 +321,7 @@ func checkWorkflowState(state enumsspb.WorkflowExecutionState) error {
 		enumsspb.WORKFLOW_EXECUTION_STATE_CORRUPTED:
 		return nil
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+		return serviceerror.NewUnavailable(fmt.Sprintf("unknown workflow state: %v", state))
 	}
 }
 
@@ -329,7 +329,7 @@ func newInvalidCreateWorkflowMode(
 	mode CreateWorkflowMode,
 	workflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewUnavailable(fmt.Sprintf(
 		"Invalid workflow create mode %v, state: %v",
 		mode,
 		workflowState,
@@ -341,7 +341,7 @@ func newInvalidUpdateWorkflowMode(
 	mode UpdateWorkflowMode,
 	currentWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewUnavailable(fmt.Sprintf(
 		"Invalid workflow update mode %v, state: %v",
 		mode,
 		currentWorkflowState,
@@ -354,7 +354,7 @@ func newInvalidUpdateWorkflowWithNewMode(
 	currentWorkflowState enumsspb.WorkflowExecutionState,
 	newWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewUnavailable(fmt.Sprintf(
 		"Invalid workflow update mode %v, current state: %v, new state: %v",
 		mode,
 		currentWorkflowState,
@@ -367,7 +367,7 @@ func newInvalidConflictResolveWorkflowMode(
 	mode ConflictResolveWorkflowMode,
 	resetWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewUnavailable(fmt.Sprintf(
 		"Invalid workflow conflict resolve mode %v, reset state: %v",
 		mode,
 		resetWorkflowState,
@@ -380,7 +380,7 @@ func newInvalidConflictResolveWorkflowWithNewMode(
 	resetWorkflowState enumsspb.WorkflowExecutionState,
 	newWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewUnavailable(fmt.Sprintf(
 		"Invalid workflow conflict resolve mode %v, reset state: %v, new state: %v",
 		mode,
 		resetWorkflowState,
@@ -394,7 +394,7 @@ func newInvalidConflictResolveWorkflowWithCurrentMode(
 	resetWorkflowState enumsspb.WorkflowExecutionState,
 	currentWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewUnavailable(fmt.Sprintf(
 		"Invalid workflow conflict resolve mode %v, reset state: %v, current state: %v",
 		mode,
 		resetWorkflowState,
@@ -409,7 +409,7 @@ func newInvalidConflictResolveWorkflowWithCurrentWithNewMode(
 	newWorkflowState enumsspb.WorkflowExecutionState,
 	currentWorkflowState enumsspb.WorkflowExecutionState,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(
+	return serviceerror.NewUnavailable(fmt.Sprintf(
 		"Invalid workflow conflict resolve mode %v, reset state: %v, new state: %v, current state: %v",
 		mode,
 		resetWorkflowState,

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -236,7 +236,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionStateStatus() {
 	for _, invalidStatus := range invalidStatuses {
 		req.NewWorkflowSnapshot.ExecutionState.Status = invalidStatus
 		_, err := s.ExecutionManager.CreateWorkflowExecution(req)
-		s.IsType(&serviceerror.Internal{}, err)
+		s.IsType(&serviceerror.Unavailable{}, err)
 	}
 	req.NewWorkflowSnapshot.ExecutionState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err := s.ExecutionManager.CreateWorkflowExecution(req)
@@ -257,7 +257,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionStateStatus() {
 	for _, invalidStatus := range invalidStatuses {
 		req.NewWorkflowSnapshot.ExecutionState.Status = invalidStatus
 		_, err := s.ExecutionManager.CreateWorkflowExecution(req)
-		s.IsType(&serviceerror.Internal{}, err)
+		s.IsType(&serviceerror.Unavailable{}, err)
 	}
 	req.NewWorkflowSnapshot.ExecutionState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err = s.ExecutionManager.CreateWorkflowExecution(req)
@@ -278,11 +278,11 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionStateStatus() {
 	for _, invalidStatus := range invalidStatuses {
 		req.NewWorkflowSnapshot.ExecutionState.Status = invalidStatus
 		_, err := s.ExecutionManager.CreateWorkflowExecution(req)
-		s.IsType(&serviceerror.Internal{}, err)
+		s.IsType(&serviceerror.Unavailable{}, err)
 	}
 	req.NewWorkflowSnapshot.ExecutionState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err = s.ExecutionManager.CreateWorkflowExecution(req)
-	s.IsType(&serviceerror.Internal{}, err)
+	s.IsType(&serviceerror.Unavailable{}, err)
 
 	// for zombie workflow creation, we must use existing workflow ID which got created
 	// since we do not allow creation of zombie workflow without current record
@@ -297,7 +297,7 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionStateStatus() {
 	for _, invalidStatus := range invalidStatuses {
 		req.NewWorkflowSnapshot.ExecutionState.Status = invalidStatus
 		_, err := s.ExecutionManager.CreateWorkflowExecution(req)
-		s.IsType(&serviceerror.Internal{}, err)
+		s.IsType(&serviceerror.Unavailable{}, err)
 	}
 	req.NewWorkflowSnapshot.ExecutionState.Status = enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 	_, err = s.ExecutionManager.CreateWorkflowExecution(req)
@@ -490,7 +490,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 			RangeID: s.ShardInfo.GetRangeId(),
 			Mode:    p.UpdateWorkflowModeUpdateCurrent,
 		})
-		s.IsType(&serviceerror.Internal{}, err)
+		s.IsType(&serviceerror.Unavailable{}, err)
 	}
 
 	updatedInfo = copyWorkflowExecutionInfo(state.ExecutionInfo)
@@ -508,7 +508,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 		RangeID: s.ShardInfo.GetRangeId(),
 		Mode:    p.UpdateWorkflowModeUpdateCurrent,
 	})
-	s.IsType(&serviceerror.Internal{}, err)
+	s.IsType(&serviceerror.Unavailable{}, err)
 
 	for _, status := range statuses {
 		updatedState.Status = status
@@ -583,7 +583,7 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionStateStatus() {
 			RangeID: s.ShardInfo.GetRangeId(),
 			Mode:    p.UpdateWorkflowModeBypassCurrent,
 		})
-		s.IsType(&serviceerror.Internal{}, err)
+		s.IsType(&serviceerror.Unavailable{}, err)
 	}
 }
 

--- a/common/persistence/sql/cluster_metadata.go
+++ b/common/persistence/sql/cluster_metadata.go
@@ -66,13 +66,13 @@ func (s *sqlClusterMetadataManager) SaveClusterMetadata(request *p.InternalSaveC
 		var lastVersion int64
 		if err != nil {
 			if err != sql.ErrNoRows {
-				return serviceerror.NewInternal(fmt.Sprintf("SaveClusterMetadata operation failed. Error %v", err))
+				return serviceerror.NewUnavailable(fmt.Sprintf("SaveClusterMetadata operation failed. Error %v", err))
 			}
 		} else {
 			lastVersion = oldClusterMetadata.Version
 		}
 		if request.Version != lastVersion {
-			return serviceerror.NewInternal(fmt.Sprintf("SaveClusterMetadata encountered version mismatch, expected %v but got %v.",
+			return serviceerror.NewUnavailable(fmt.Sprintf("SaveClusterMetadata encountered version mismatch, expected %v but got %v.",
 				request.Version, oldClusterMetadata.Version))
 		}
 		_, err = tx.SaveClusterMetadata(ctx, &sqlplugin.ClusterMetadataRow{
@@ -87,7 +87,7 @@ func (s *sqlClusterMetadataManager) SaveClusterMetadata(request *p.InternalSaveC
 	})
 
 	if err != nil {
-		return false, serviceerror.NewInternal(err.Error())
+		return false, serviceerror.NewUnavailable(err.Error())
 	}
 	return true, nil
 }
@@ -99,7 +99,7 @@ func (s *sqlClusterMetadataManager) GetClusterMembers(request *p.GetClusterMembe
 	if len(request.NextPageToken) == 16 {
 		lastSeenHostId = request.NextPageToken
 	} else if len(request.NextPageToken) > 0 {
-		return nil, serviceerror.NewInternal("page token is corrupted.")
+		return nil, serviceerror.NewUnavailable("page token is corrupted.")
 	}
 
 	now := time.Now().UTC()

--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -66,7 +66,7 @@ func (m *SqlStore) Close() {
 func (m *SqlStore) txExecute(ctx context.Context, operation string, f func(tx sqlplugin.Tx) error) error {
 	tx, err := m.Db.BeginTx(ctx)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("%s failed. Failed to start transaction. Error: %v", operation, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("%s failed. Failed to start transaction. Error: %v", operation, err))
 	}
 	err = f(tx)
 	if err != nil {
@@ -81,14 +81,14 @@ func (m *SqlStore) txExecute(ctx context.Context, operation string, f func(tx sq
 			*persistence.WorkflowConditionFailedError,
 			*serviceerror.NamespaceAlreadyExists,
 			*persistence.ShardOwnershipLostError,
-			*serviceerror.Internal:
+			*serviceerror.Unavailable:
 			return err
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("%v: %v", operation, err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("%v: %v", operation, err))
 		}
 	}
 	if err := tx.Commit(); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("%s operation failed. Failed to commit transaction. Error: %v", operation, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("%s operation failed. Failed to commit transaction. Error: %v", operation, err))
 	}
 	return nil
 }
@@ -98,7 +98,7 @@ func gobSerialize(x interface{}) ([]byte, error) {
 	e := gob.NewEncoder(&b)
 	err := e.Encode(x)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Error in serialization: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Error in serialization: %v", err))
 	}
 	return b.Bytes(), nil
 }
@@ -109,7 +109,7 @@ func gobDeserialize(a []byte, x interface{}) error {
 	err := d.Decode(x)
 
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Error in deserialization: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Error in deserialization: %v", err))
 	}
 	return nil
 }
@@ -135,5 +135,5 @@ func convertCommonErrors(
 		return serviceerror.NewNotFound(fmt.Sprintf("%v failed. Error: %v ", operation, err))
 	}
 
-	return serviceerror.NewInternal(fmt.Sprintf("%v operation failed. Error: %v", operation, err))
+	return serviceerror.NewUnavailable(fmt.Sprintf("%v operation failed. Error: %v", operation, err))
 }

--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -213,7 +213,7 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 		}
 
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("CreteWorkflowExecution: unknown mode: %v", request.Mode))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("CreteWorkflowExecution: unknown mode: %v", request.Mode))
 	}
 
 	if err := createOrUpdateCurrentExecution(ctx,
@@ -262,7 +262,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	case sql.ErrNoRows:
 		return nil, serviceerror.NewNotFound(fmt.Sprintf("Workflow executionsRow not found.  WorkflowId: %v, RunId: %v", request.Execution.GetWorkflowId(), request.Execution.GetRunId()))
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed. Error: %v", err))
 	}
 
 	state := &p.InternalWorkflowMutableState{
@@ -281,7 +281,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed to get activity info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get activity info. Error: %v", err))
 	}
 
 	state.TimerInfos, err = getTimerInfoMap(ctx,
@@ -292,7 +292,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed to get timer info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get timer info. Error: %v", err))
 	}
 
 	state.ChildExecutionInfos, err = getChildExecutionInfoMap(ctx,
@@ -303,7 +303,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed to get child executionsRow info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get child executionsRow info. Error: %v", err))
 	}
 
 	state.RequestCancelInfos, err = getRequestCancelInfoMap(ctx,
@@ -314,7 +314,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed to get request cancel info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get request cancel info. Error: %v", err))
 	}
 
 	state.SignalInfos, err = getSignalInfoMap(ctx,
@@ -325,7 +325,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed to get signal info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get signal info. Error: %v", err))
 	}
 
 	state.BufferedEvents, err = getBufferedEvents(ctx,
@@ -336,7 +336,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed to get buffered events. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get buffered events. Error: %v", err))
 	}
 
 	state.SignalRequestedIDs, err = getSignalsRequested(ctx,
@@ -347,7 +347,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 		runID,
 	)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetWorkflowExecution: failed to get signals requested. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetWorkflowExecution: failed to get signals requested. Error: %v", err))
 	}
 
 	return &p.InternalGetWorkflowExecutionResponse{
@@ -416,7 +416,7 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 			newRunID := primitives.MustParseUUID(newWorkflow.ExecutionState.RunId)
 
 			if !bytes.Equal(namespaceID, newNamespaceID) {
-				return serviceerror.NewInternal(fmt.Sprintf("UpdateWorkflowExecution: cannot continue as new to another namespace"))
+				return serviceerror.NewUnavailable(fmt.Sprintf("UpdateWorkflowExecution: cannot continue as new to another namespace"))
 			}
 
 			if err := assertRunIDAndUpdateCurrentExecution(ctx,
@@ -432,7 +432,7 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 				newWorkflow.StartVersion,
 				lastWriteVersion,
 			); err != nil {
-				return serviceerror.NewInternal(fmt.Sprintf("UpdateWorkflowExecution: failed to continue as new current execution. Error: %v", err))
+				return serviceerror.NewUnavailable(fmt.Sprintf("UpdateWorkflowExecution: failed to continue as new current execution. Error: %v", err))
 			}
 		} else {
 			lastWriteVersion := updateWorkflow.LastWriteVersion
@@ -450,12 +450,12 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 				updateWorkflow.StartVersion,
 				lastWriteVersion,
 			); err != nil {
-				return serviceerror.NewInternal(fmt.Sprintf("UpdateWorkflowExecution: failed to update current execution. Error: %v", err))
+				return serviceerror.NewUnavailable(fmt.Sprintf("UpdateWorkflowExecution: failed to update current execution. Error: %v", err))
 			}
 		}
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("UpdateWorkflowExecution: unknown mode: %v", request.Mode))
+		return serviceerror.NewUnavailable(fmt.Sprintf("UpdateWorkflowExecution: unknown mode: %v", request.Mode))
 	}
 
 	if err := applyWorkflowMutationTx(ctx,
@@ -549,7 +549,7 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 				startVersion,
 				lastWriteVersion,
 			); err != nil {
-				return serviceerror.NewInternal(fmt.Sprintf("ConflictResolveWorkflowExecution. Failed to comare and swap the current record. Error: %v", err))
+				return serviceerror.NewUnavailable(fmt.Sprintf("ConflictResolveWorkflowExecution. Failed to comare and swap the current record. Error: %v", err))
 			}
 		} else {
 			// reset workflow is current
@@ -568,12 +568,12 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 				startVersion,
 				lastWriteVersion,
 			); err != nil {
-				return serviceerror.NewInternal(fmt.Sprintf("ConflictResolveWorkflowExecution. Failed to comare and swap the current record. Error: %v", err))
+				return serviceerror.NewUnavailable(fmt.Sprintf("ConflictResolveWorkflowExecution. Failed to comare and swap the current record. Error: %v", err))
 			}
 		}
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("ConflictResolveWorkflowExecution: unknown mode: %v", request.Mode))
+		return serviceerror.NewUnavailable(fmt.Sprintf("ConflictResolveWorkflowExecution: unknown mode: %v", request.Mode))
 	}
 
 	if err := applyWorkflowSnapshotTxAsReset(ctx,
@@ -656,7 +656,7 @@ func (m *sqlExecutionStore) GetCurrentExecution(
 		if err == sql.ErrNoRows {
 			return nil, serviceerror.NewNotFound(err.Error())
 		}
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetCurrentExecution operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetCurrentExecution operation failed. Error: %v", err))
 	}
 
 	return &p.InternalGetCurrentExecutionResponse{

--- a/common/persistence/sql/execution_state_map.go
+++ b/common/persistence/sql/execution_state_map.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
+
 	"go.temporal.io/server/common/persistence"
 
 	"go.temporal.io/api/serviceerror"
@@ -65,7 +66,7 @@ func updateActivityInfos(
 		}
 
 		if _, err := tx.ReplaceIntoActivityInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update activity info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update activity info. Failed to execute update query. Error: %v", err))
 		}
 	}
 
@@ -77,7 +78,7 @@ func updateActivityInfos(
 			RunID:       runID,
 			ScheduleIDs: convert.Int64SetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update activity info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update activity info. Failed to execute delete query. Error: %v", err))
 		}
 	}
 	return nil
@@ -99,7 +100,7 @@ func getActivityInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Failed to get activity info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get activity info. Error: %v", err))
 	}
 
 	ret := make(map[int64]*commonpb.DataBlob)
@@ -125,7 +126,7 @@ func deleteActivityInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to delete activity info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete activity info map. Error: %v", err))
 	}
 	return nil
 }
@@ -155,7 +156,7 @@ func updateTimerInfos(
 			})
 		}
 		if _, err := tx.ReplaceIntoTimerInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update timer info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update timer info. Failed to execute update query. Error: %v", err))
 		}
 	}
 
@@ -167,7 +168,7 @@ func updateTimerInfos(
 			RunID:       runID,
 			TimerIDs:    convert.StringSetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update timer info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update timer info. Failed to execute delete query. Error: %v", err))
 		}
 	}
 	return nil
@@ -189,7 +190,7 @@ func getTimerInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Failed to get timer info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get timer info. Error: %v", err))
 	}
 	ret := make(map[string]*commonpb.DataBlob)
 	for _, row := range rows {
@@ -214,7 +215,7 @@ func deleteTimerInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to delete timer info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete timer info map. Error: %v", err))
 	}
 	return nil
 }
@@ -244,7 +245,7 @@ func updateChildExecutionInfos(
 			})
 		}
 		if _, err := tx.ReplaceIntoChildExecutionInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update child execution info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update child execution info. Failed to execute update query. Error: %v", err))
 		}
 	}
 
@@ -256,7 +257,7 @@ func updateChildExecutionInfos(
 			RunID:        runID,
 			InitiatedIDs: convert.Int64SetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update child execution info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update child execution info. Failed to execute delete query. Error: %v", err))
 		}
 	}
 	return nil
@@ -278,7 +279,7 @@ func getChildExecutionInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Failed to get timer info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get timer info. Error: %v", err))
 	}
 
 	ret := make(map[int64]*commonpb.DataBlob)
@@ -304,7 +305,7 @@ func deleteChildExecutionInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to delete timer info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete timer info map. Error: %v", err))
 	}
 	return nil
 }
@@ -335,7 +336,7 @@ func updateRequestCancelInfos(
 		}
 
 		if _, err := tx.ReplaceIntoRequestCancelInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update request cancel info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update request cancel info. Failed to execute update query. Error: %v", err))
 		}
 	}
 
@@ -347,7 +348,7 @@ func updateRequestCancelInfos(
 			RunID:        runID,
 			InitiatedIDs: convert.Int64SetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update request cancel info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update request cancel info. Failed to execute delete query. Error: %v", err))
 		}
 	}
 	return nil
@@ -369,7 +370,7 @@ func getRequestCancelInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Failed to get request cancel info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get request cancel info. Error: %v", err))
 	}
 
 	ret := make(map[int64]*commonpb.DataBlob)
@@ -395,7 +396,7 @@ func deleteRequestCancelInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to delete request cancel info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete request cancel info map. Error: %v", err))
 	}
 	return nil
 }
@@ -426,7 +427,7 @@ func updateSignalInfos(
 		}
 
 		if _, err := tx.ReplaceIntoSignalInfoMaps(ctx, rows); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update signal info. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update signal info. Failed to execute update query. Error: %v", err))
 		}
 	}
 
@@ -438,7 +439,7 @@ func updateSignalInfos(
 			RunID:        runID,
 			InitiatedIDs: convert.Int64SetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update signal info. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update signal info. Failed to execute delete query. Error: %v", err))
 		}
 	}
 	return nil
@@ -460,7 +461,7 @@ func getSignalInfoMap(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Failed to get signal info. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get signal info. Error: %v", err))
 	}
 
 	ret := make(map[int64]*commonpb.DataBlob)
@@ -486,7 +487,7 @@ func deleteSignalInfoMap(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to delete signal info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete signal info map. Error: %v", err))
 	}
 	return nil
 }

--- a/common/persistence/sql/execution_state_non_map.go
+++ b/common/persistence/sql/execution_state_non_map.go
@@ -61,7 +61,7 @@ func updateSignalsRequested(
 			})
 		}
 		if _, err := tx.ReplaceIntoSignalsRequestedSets(ctx, rows); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update signals requested. Failed to execute update query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update signals requested. Failed to execute update query. Error: %v", err))
 		}
 	}
 
@@ -73,7 +73,7 @@ func updateSignalsRequested(
 			RunID:       runID,
 			SignalIDs:   convert.StringSetToSlice(deleteIDs),
 		}); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Failed to update signals requested. Failed to execute delete query. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update signals requested. Failed to execute delete query. Error: %v", err))
 		}
 	}
 	return nil
@@ -95,7 +95,7 @@ func getSignalsRequested(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Failed to get signals requested. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to get signals requested. Error: %v", err))
 	}
 	var ret = make([]string, len(rows))
 	for i, s := range rows {
@@ -119,7 +119,7 @@ func deleteSignalsRequestedSet(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to delete signals requested set. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to delete signals requested set. Error: %v", err))
 	}
 	return nil
 }
@@ -147,7 +147,7 @@ func updateBufferedEvents(
 	}
 
 	if _, err := tx.InsertIntoBufferedEvents(ctx, []sqlplugin.BufferedEventsRow{row}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("updateBufferedEvents operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("updateBufferedEvents operation failed. Error: %v", err))
 	}
 	return nil
 }
@@ -168,7 +168,7 @@ func getBufferedEvents(
 		RunID:       runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("getBufferedEvents operation failed. Select failed: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("getBufferedEvents operation failed. Select failed: %v", err))
 	}
 	var result []*commonpb.DataBlob
 	for _, row := range rows {
@@ -192,7 +192,7 @@ func deleteBufferedEvents(
 		WorkflowID:  workflowID,
 		RunID:       runID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("updateBufferedEvents delete operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("updateBufferedEvents delete operation failed. Error: %v", err))
 	}
 	return nil
 }

--- a/common/persistence/sql/execution_tasks.go
+++ b/common/persistence/sql/execution_tasks.go
@@ -78,11 +78,11 @@ func (m *sqlExecutionStore) GetTransferTask(
 		if err == sql.ErrNoRows {
 			return nil, serviceerror.NewNotFound(fmt.Sprintf("GetTransferTask operation failed. Task with ID %v not found. Error: %v", request.TaskID, err))
 		}
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetTransferTask operation failed. Failed to get record. TaskId: %v. Error: %v", request.TaskID, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTransferTask operation failed. Failed to get record. TaskId: %v. Error: %v", request.TaskID, err))
 	}
 
 	if len(rows) == 0 {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetTransferTask operation failed. Failed to get record. TaskId: %v", request.TaskID))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTransferTask operation failed. Failed to get record. TaskId: %v", request.TaskID))
 	}
 
 	transferRow := rows[0]
@@ -108,7 +108,7 @@ func (m *sqlExecutionStore) GetTransferTasks(
 	})
 	if err != nil {
 		if err != sql.ErrNoRows {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("GetTransferTasks operation failed. Select failed. Error: %v", err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTransferTasks operation failed. Select failed. Error: %v", err))
 		}
 	}
 	resp := &p.GetTransferTasksResponse{Tasks: make([]*persistencespb.TransferTaskInfo, len(rows))}
@@ -132,7 +132,7 @@ func (m *sqlExecutionStore) CompleteTransferTask(
 		ShardID: request.ShardID,
 		TaskID:  request.TaskID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("CompleteTransferTask operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("CompleteTransferTask operation failed. Error: %v", err))
 	}
 	return nil
 }
@@ -147,7 +147,7 @@ func (m *sqlExecutionStore) RangeCompleteTransferTask(
 		MinTaskID: request.ExclusiveBeginTaskID,
 		MaxTaskID: request.InclusiveEndTaskID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("RangeCompleteTransferTask operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("RangeCompleteTransferTask operation failed. Error: %v", err))
 	}
 	return nil
 }
@@ -166,11 +166,11 @@ func (m *sqlExecutionStore) GetTimerTask(
 		if err == sql.ErrNoRows {
 			return nil, serviceerror.NewNotFound(fmt.Sprintf("GetTimerTask operation failed. Task with ID %v not found. Error: %v", request.TaskID, err))
 		}
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetTimerTask operation failed. Failed to get record. TaskId: %v. Error: %v", request.TaskID, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTimerTask operation failed. Failed to get record. TaskId: %v. Error: %v", request.TaskID, err))
 	}
 
 	if len(rows) == 0 {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetTimerTask operation failed. Failed to get record. TaskId: %v", request.TaskID))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTimerTask operation failed. Failed to get record. TaskId: %v", request.TaskID))
 	}
 
 	timerRow := rows[0]
@@ -192,7 +192,7 @@ func (m *sqlExecutionStore) GetTimerIndexTasks(
 	pageToken := &timerTaskPageToken{TaskID: math.MinInt64, Timestamp: request.MinTimestamp}
 	if len(request.NextPageToken) > 0 {
 		if err := pageToken.deserialize(request.NextPageToken); err != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("error deserializing timerTaskPageToken: %v", err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("error deserializing timerTaskPageToken: %v", err))
 		}
 	}
 
@@ -205,7 +205,7 @@ func (m *sqlExecutionStore) GetTimerIndexTasks(
 	})
 
 	if err != nil && err != sql.ErrNoRows {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetTimerTasks operation failed. Select failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTimerTasks operation failed. Select failed. Error: %v", err))
 	}
 
 	resp := &p.GetTimerIndexTasksResponse{Timers: make([]*persistencespb.TimerTaskInfo, len(rows))}
@@ -220,7 +220,7 @@ func (m *sqlExecutionStore) GetTimerIndexTasks(
 	if len(resp.Timers) > request.BatchSize {
 		goVisibilityTimestamp := resp.Timers[request.BatchSize].VisibilityTime
 		if goVisibilityTimestamp == nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("GetTimerTasks: time for page token is nil - TaskId '%v'", resp.Timers[request.BatchSize].TaskId))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTimerTasks: time for page token is nil - TaskId '%v'", resp.Timers[request.BatchSize].TaskId))
 		}
 
 		pageToken = &timerTaskPageToken{
@@ -230,7 +230,7 @@ func (m *sqlExecutionStore) GetTimerIndexTasks(
 		resp.Timers = resp.Timers[:request.BatchSize]
 		nextToken, err := pageToken.serialize()
 		if err != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("GetTimerTasks: error serializing page token: %v", err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTimerTasks: error serializing page token: %v", err))
 		}
 		resp.NextPageToken = nextToken
 	}
@@ -248,7 +248,7 @@ func (m *sqlExecutionStore) CompleteTimerTask(
 		VisibilityTimestamp: request.VisibilityTimestamp,
 		TaskID:              request.TaskID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("CompleteTimerTask operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("CompleteTimerTask operation failed. Error: %v", err))
 	}
 	return nil
 }
@@ -265,7 +265,7 @@ func (m *sqlExecutionStore) RangeCompleteTimerTask(
 		MinVisibilityTimestamp: start,
 		MaxVisibilityTimestamp: end,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("CompleteTimerTask operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("CompleteTimerTask operation failed. Error: %v", err))
 	}
 	return nil
 }
@@ -283,11 +283,11 @@ func (m *sqlExecutionStore) GetReplicationTask(
 		if err == sql.ErrNoRows {
 			return nil, serviceerror.NewNotFound(fmt.Sprintf("GetReplicationTask operation failed. Task with ID %v not found. Error: %v", request.TaskID, err))
 		}
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetReplicationTask operation failed. Failed to get record. TaskId: %v. Error: %v", request.TaskID, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetReplicationTask operation failed. Failed to get record. TaskId: %v. Error: %v", request.TaskID, err))
 	}
 
 	if len(rows) == 0 {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetReplicationTask operation failed. Failed to get record. TaskId: %v", request.TaskID))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetReplicationTask operation failed. Failed to get record. TaskId: %v", request.TaskID))
 	}
 
 	replicationRow := rows[0]
@@ -324,7 +324,7 @@ func (m *sqlExecutionStore) GetReplicationTasks(
 	case sql.ErrNoRows:
 		return &p.GetReplicationTasksResponse{}, nil
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetReplicationTasks operation failed. Select failed: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetReplicationTasks operation failed. Select failed: %v", err))
 	}
 }
 
@@ -408,7 +408,7 @@ func (m *sqlExecutionStore) CompleteReplicationTask(
 		ShardID: request.ShardID,
 		TaskID:  request.TaskID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("CompleteReplicationTask operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("CompleteReplicationTask operation failed. Error: %v", err))
 	}
 	return nil
 }
@@ -423,7 +423,7 @@ func (m *sqlExecutionStore) RangeCompleteReplicationTask(
 		MinTaskID: 0,
 		MaxTaskID: request.InclusiveEndTaskID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("RangeCompleteReplicationTask operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("RangeCompleteReplicationTask operation failed. Error: %v", err))
 	}
 	return nil
 }
@@ -451,7 +451,7 @@ func (m *sqlExecutionStore) PutReplicationTaskToDLQ(
 	// Tasks are immutable. So it's fine if we already persisted it before.
 	// This can happen when tasks are retried (ack and cleanup can have lag on source side).
 	if err != nil && !m.Db.IsDupEntryError(err) {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to create replication tasks. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to create replication tasks. Error: %v", err))
 	}
 
 	return nil
@@ -481,7 +481,7 @@ func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 	case sql.ErrNoRows:
 		return &p.GetReplicationTasksResponse{}, nil
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetReplicationTasks operation failed. Select failed: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetReplicationTasks operation failed. Select failed: %v", err))
 	}
 }
 
@@ -529,11 +529,11 @@ func (m *sqlExecutionStore) GetVisibilityTask(
 		if err == sql.ErrNoRows {
 			return nil, serviceerror.NewNotFound(fmt.Sprintf("GetVisibilityTask operation failed. Task with ID %v not found. Error: %v", request.TaskID, err))
 		}
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetVisibilityTask operation failed. Failed to get record. TaskId: %v. Error: %v", request.TaskID, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetVisibilityTask operation failed. Failed to get record. TaskId: %v. Error: %v", request.TaskID, err))
 	}
 
 	if len(rows) == 0 {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetVisibilityTask operation failed. Failed to get record. TaskId: %v", request.TaskID))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetVisibilityTask operation failed. Failed to get record. TaskId: %v", request.TaskID))
 	}
 
 	visibilityRow := rows[0]
@@ -559,7 +559,7 @@ func (m *sqlExecutionStore) GetVisibilityTasks(
 	})
 	if err != nil {
 		if err != sql.ErrNoRows {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("GetVisibilityTasks operation failed. Select failed. Error: %v", err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetVisibilityTasks operation failed. Select failed. Error: %v", err))
 		}
 	}
 	resp := &p.GetVisibilityTasksResponse{Tasks: make([]*persistencespb.VisibilityTaskInfo, len(rows))}
@@ -583,7 +583,7 @@ func (m *sqlExecutionStore) CompleteVisibilityTask(
 		ShardID: request.ShardID,
 		TaskID:  request.TaskID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("CompleteVisibilityTask operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("CompleteVisibilityTask operation failed. Error: %v", err))
 	}
 	return nil
 }
@@ -598,7 +598,7 @@ func (m *sqlExecutionStore) RangeCompleteVisibilityTask(
 		MinTaskID: request.ExclusiveBeginTaskID,
 		MaxTaskID: request.InclusiveEndTaskID,
 	}); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("RangeCompleteVisibilityTask operation failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("RangeCompleteVisibilityTask operation failed. Error: %v", err))
 	}
 	return nil
 }

--- a/common/persistence/sql/execution_util.go
+++ b/common/persistence/sql/execution_util.go
@@ -57,12 +57,12 @@ func applyWorkflowMutationTx(
 
 	namespaceIDBytes, err := primitives.ParseUUID(namespaceID)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("uuid parse failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("uuid parse failed. Error: %v", err))
 	}
 
 	runIDBytes, err := primitives.ParseUUID(runID)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("uuid parse failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("uuid parse failed. Error: %v", err))
 	}
 
 	// TODO Remove me if UPDATE holds the lock to the end of a transaction
@@ -79,7 +79,7 @@ func applyWorkflowMutationTx(
 		case *p.WorkflowConditionFailedError:
 			return err
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Failed to lock executions row. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Failed to lock executions row. Error: %v", err))
 		}
 	}
 
@@ -94,7 +94,7 @@ func applyWorkflowMutationTx(
 		workflowMutation.DBRecordVersion,
 		shardID,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Failed to update executions row. Erorr: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Failed to update executions row. Erorr: %v", err))
 	}
 
 	if err := applyTasks(ctx,
@@ -120,7 +120,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 	}
 
 	if err := updateTimerInfos(ctx,
@@ -132,7 +132,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 	}
 
 	if err := updateChildExecutionInfos(ctx,
@@ -144,7 +144,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 	}
 
 	if err := updateRequestCancelInfos(ctx,
@@ -156,7 +156,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 	}
 
 	if err := updateSignalInfos(ctx,
@@ -168,7 +168,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 	}
 
 	if err := updateSignalsRequested(ctx,
@@ -179,7 +179,7 @@ func applyWorkflowMutationTx(
 		namespaceIDBytes,
 		workflowID,
 		runIDBytes); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 	}
 
 	if workflowMutation.ClearBufferedEvents {
@@ -190,7 +190,7 @@ func applyWorkflowMutationTx(
 			workflowID,
 			runIDBytes,
 		); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 		}
 	}
 
@@ -202,7 +202,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err))
 	}
 	return nil
 }
@@ -241,7 +241,7 @@ func applyWorkflowSnapshotTxAsReset(
 		case *p.WorkflowConditionFailedError:
 			return err
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to lock executions row. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to lock executions row. Error: %v", err))
 		}
 	}
 
@@ -256,7 +256,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowSnapshot.DBRecordVersion,
 		shardID,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to update executions row. Erorr: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to update executions row. Erorr: %v", err))
 	}
 
 	if err := applyTasks(ctx,
@@ -280,7 +280,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear activity info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear activity info map. Error: %v", err))
 	}
 
 	if err := updateActivityInfos(ctx,
@@ -292,7 +292,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err))
 	}
 
 	if err := deleteTimerInfoMap(ctx,
@@ -302,7 +302,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear timer info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear timer info map. Error: %v", err))
 	}
 
 	if err := updateTimerInfos(ctx,
@@ -314,7 +314,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into timer info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into timer info map after clearing. Error: %v", err))
 	}
 
 	if err := deleteChildExecutionInfoMap(ctx,
@@ -324,7 +324,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear child execution info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear child execution info map. Error: %v", err))
 	}
 
 	if err := updateChildExecutionInfos(ctx,
@@ -336,7 +336,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err))
 	}
 
 	if err := deleteRequestCancelInfoMap(ctx,
@@ -346,7 +346,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear request cancel info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear request cancel info map. Error: %v", err))
 	}
 
 	if err := updateRequestCancelInfos(ctx,
@@ -358,7 +358,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into request cancel info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into request cancel info map after clearing. Error: %v", err))
 	}
 
 	if err := deleteSignalInfoMap(ctx,
@@ -368,7 +368,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear signal info map. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear signal info map. Error: %v", err))
 	}
 
 	if err := updateSignalInfos(ctx,
@@ -380,7 +380,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signal info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signal info map after clearing. Error: %v", err))
 	}
 
 	if err := deleteSignalsRequestedSet(ctx,
@@ -389,7 +389,7 @@ func applyWorkflowSnapshotTxAsReset(
 		namespaceIDBytes,
 		workflowID,
 		runIDBytes); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear signals requested set. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear signals requested set. Error: %v", err))
 	}
 
 	if err := updateSignalsRequested(ctx,
@@ -401,7 +401,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signals requested set after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signals requested set after clearing. Error: %v", err))
 	}
 
 	if err := deleteBufferedEvents(ctx,
@@ -411,7 +411,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear buffered events. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear buffered events. Error: %v", err))
 	}
 	return nil
 }
@@ -473,7 +473,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err))
 	}
 
 	if err := updateTimerInfos(ctx,
@@ -485,7 +485,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into timer info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into timer info map after clearing. Error: %v", err))
 	}
 
 	if err := updateChildExecutionInfos(ctx,
@@ -497,7 +497,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err))
 	}
 
 	if err := updateRequestCancelInfos(ctx,
@@ -509,7 +509,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into request cancel info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into request cancel info map after clearing. Error: %v", err))
 	}
 
 	if err := updateSignalInfos(ctx,
@@ -521,7 +521,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signal info map after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signal info map after clearing. Error: %v", err))
 	}
 
 	if err := updateSignalsRequested(ctx,
@@ -533,7 +533,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runIDBytes,
 	); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signals requested set after clearing. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signals requested set after clearing. Error: %v", err))
 	}
 
 	return nil
@@ -559,7 +559,7 @@ func applyTasks(
 		namespaceID,
 		workflowID,
 		runID); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyTasks failed. Failed to create transfer tasks. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyTasks failed. Failed to create transfer tasks. Error: %v", err))
 	}
 
 	if err := createReplicationTasks(ctx,
@@ -569,7 +569,7 @@ func applyTasks(
 		namespaceID,
 		workflowID,
 		runID); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyTasks failed. Failed to create replication tasks. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyTasks failed. Failed to create replication tasks. Error: %v", err))
 	}
 
 	if err := createTimerTasks(ctx,
@@ -579,7 +579,7 @@ func applyTasks(
 		namespaceID,
 		workflowID,
 		runID); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyTasks failed. Failed to create timer tasks. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyTasks failed. Failed to create timer tasks. Error: %v", err))
 	}
 
 	if err := createVisibilityTasks(ctx,
@@ -589,7 +589,7 @@ func applyTasks(
 		namespaceID,
 		workflowID,
 		runID); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("applyTasks failed. Failed to create timer tasks. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("applyTasks failed. Failed to create timer tasks. Error: %v", err))
 	}
 
 	return nil
@@ -609,12 +609,12 @@ func lockCurrentExecutionIfExists(
 	})
 	if err != nil {
 		if err != sql.ErrNoRows {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("lockCurrentExecutionIfExists failed. Failed to get current_executions row for (shard,namespace,workflow) = (%v, %v, %v). Error: %v", shardID, namespaceID, workflowID, err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("lockCurrentExecutionIfExists failed. Failed to get current_executions row for (shard,namespace,workflow) = (%v, %v, %v). Error: %v", shardID, namespaceID, workflowID, err))
 		}
 	}
 	size := len(rows)
 	if size > 1 {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("lockCurrentExecutionIfExists failed. Multiple current_executions rows for (shard,namespace,workflow) = (%v, %v, %v).", shardID, namespaceID, workflowID))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("lockCurrentExecutionIfExists failed. Multiple current_executions rows for (shard,namespace,workflow) = (%v, %v, %v).", shardID, namespaceID, workflowID))
 	}
 	if size == 0 {
 		return nil, nil
@@ -662,7 +662,7 @@ func createOrUpdateCurrentExecution(
 			status,
 			row.StartVersion,
 			row.LastWriteVersion); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to continue as new. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to continue as new. Error: %v", err))
 		}
 	case p.CreateWorkflowModeWorkflowIDReuse:
 		if err := updateCurrentExecution(ctx,
@@ -676,11 +676,11 @@ func createOrUpdateCurrentExecution(
 			status,
 			row.StartVersion,
 			row.LastWriteVersion); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to reuse workflow ID. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to reuse workflow ID. Error: %v", err))
 		}
 	case p.CreateWorkflowModeBrandNew:
 		if _, err := tx.InsertIntoCurrentExecutions(ctx, &row); err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to insert into current_executions table. Error: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to insert into current_executions table. Error: %v", err))
 		}
 	case p.CreateWorkflowModeZombie:
 		// noop
@@ -752,7 +752,7 @@ func lockExecution(
 				workflowID,
 				runID))
 		}
-		return 0, 0, serviceerror.NewInternal(fmt.Sprintf("lockNextEventID failed. Error: %v", err))
+		return 0, 0, serviceerror.NewUnavailable(fmt.Sprintf("lockNextEventID failed. Error: %v", err))
 	}
 	return dbRecordVersion, nextEventID, nil
 }
@@ -825,7 +825,7 @@ func createTransferTasks(
 			// No explicit property needs to be set
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("createTransferTasks failed. Unknow transfer type: %v", task.GetType()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Unknow transfer type: %v", task.GetType()))
 		}
 
 		blob, err := serialization.TransferTaskInfoToBlob(info)
@@ -841,16 +841,16 @@ func createTransferTasks(
 
 	result, err := tx.InsertIntoTransferTasks(ctx, transferTasksRows)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createTransferTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Error: %v", err))
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createTransferTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Could not verify number of rows inserted. Error: %v", err))
 	}
 
 	if int(rowsAffected) != len(transferTasks) {
-		return serviceerror.NewInternal(fmt.Sprintf("createTransferTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(transferTasks), err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(transferTasks), err))
 	}
 	return nil
 }
@@ -889,7 +889,7 @@ func createReplicationTasks(
 		case enumsspb.TASK_TYPE_REPLICATION_HISTORY:
 			historyReplicationTask, ok := task.(*p.HistoryReplicationTask)
 			if !ok {
-				return serviceerror.NewInternal(fmt.Sprintf("createReplicationTasks failed. Failed to cast %v to HistoryReplicationTask", task))
+				return serviceerror.NewUnavailable(fmt.Sprintf("createReplicationTasks failed. Failed to cast %v to HistoryReplicationTask", task))
 			}
 			info.FirstEventId = historyReplicationTask.FirstEventID
 			info.NextEventId = historyReplicationTask.NextEventID
@@ -902,7 +902,7 @@ func createReplicationTasks(
 			info.ScheduledId = task.(*p.SyncActivityTask).ScheduledID
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("Unknown replication task: %v", task.GetType()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Unknown replication task: %v", task.GetType()))
 		}
 
 		blob, err := serialization.ReplicationTaskInfoToBlob(info)
@@ -918,16 +918,16 @@ func createReplicationTasks(
 
 	result, err := tx.InsertIntoReplicationTasks(ctx, replicationTasksRows)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createReplicationTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createReplicationTasks failed. Error: %v", err))
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createReplicationTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createReplicationTasks failed. Could not verify number of rows inserted. Error: %v", err))
 	}
 
 	if int(rowsAffected) != len(replicationTasks) {
-		return serviceerror.NewInternal(fmt.Sprintf("createReplicationTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(replicationTasks), err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createReplicationTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(replicationTasks), err))
 	}
 	return nil
 }
@@ -986,7 +986,7 @@ func createTimerTasks(
 			// noop
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("createTimerTasks failed. Unknown timer task: %v", task.GetType()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("createTimerTasks failed. Unknown timer task: %v", task.GetType()))
 		}
 
 		blob, err := serialization.TimerTaskInfoToBlob(info)
@@ -1003,15 +1003,15 @@ func createTimerTasks(
 
 	result, err := tx.InsertIntoTimerTasks(ctx, timerTasksRows)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createTimerTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTimerTasks failed. Error: %v", err))
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createTimerTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTimerTasks failed. Could not verify number of rows inserted. Error: %v", err))
 	}
 
 	if int(rowsAffected) != len(timerTasks) {
-		return serviceerror.NewInternal(fmt.Sprintf("createTimerTasks failed. Inserted %v instead of %v rows into timer_tasks. Error: %v", rowsAffected, len(timerTasks), err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTimerTasks failed. Inserted %v instead of %v rows into timer_tasks. Error: %v", rowsAffected, len(timerTasks), err))
 	}
 	return nil
 }
@@ -1056,7 +1056,7 @@ func createVisibilityTasks(
 			// noop
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("createVisibilityTasks failed. Unknow visibility type: %v", task.GetType()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("createVisibilityTasks failed. Unknow visibility type: %v", task.GetType()))
 		}
 
 		blob, err := serialization.VisibilityTaskInfoToBlob(info)
@@ -1072,16 +1072,16 @@ func createVisibilityTasks(
 
 	result, err := tx.InsertIntoVisibilityTasks(ctx, visibilityTasksRows)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createTransferTasks failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Error: %v", err))
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createTransferTasks failed. Could not verify number of rows inserted. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Could not verify number of rows inserted. Error: %v", err))
 	}
 
 	if int(rowsAffected) != len(visibilityTasksRows) {
-		return serviceerror.NewInternal(fmt.Sprintf("createTransferTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(visibilityTasksRows), err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createTransferTasks failed. Inserted %v instead of %v rows into transfer_tasks. Error: %v", rowsAffected, len(visibilityTasksRows), err))
 	}
 	return nil
 }
@@ -1104,7 +1104,7 @@ func assertNotCurrentExecution(
 			// allow bypassing no current record
 			return nil
 		}
-		return serviceerror.NewInternal(fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err))
 	}
 	return assertRunIDMismatch(runID, currentRow)
 }
@@ -1180,7 +1180,7 @@ func assertCurrentExecution(
 		WorkflowID:  workflowID,
 	})
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err))
 	}
 	return assertFn(currentRow)
 }
@@ -1229,14 +1229,14 @@ func updateCurrentExecution(
 		LastWriteVersion: lastWriteVersion,
 	})
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("updateCurrentExecution failed. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("updateCurrentExecution failed. Error: %v", err))
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("updateCurrentExecution failed. Failed to check number of rows updated in current_executions table. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("updateCurrentExecution failed. Failed to check number of rows updated in current_executions table. Error: %v", err))
 	}
 	if rowsAffected != 1 {
-		return serviceerror.NewInternal(fmt.Sprintf("updateCurrentExecution failed. %v rows of current_executions updated instead of 1.", rowsAffected))
+		return serviceerror.NewUnavailable(fmt.Sprintf("updateCurrentExecution failed. %v rows of current_executions updated instead of 1.", rowsAffected))
 	}
 	return nil
 }
@@ -1317,11 +1317,11 @@ func (m *sqlExecutionStore) createExecution(
 				DBRecordVersion: 0,
 			}
 		}
-		return serviceerror.NewInternal(fmt.Sprintf("createExecution failed. Erorr: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createExecution failed. Erorr: %v", err))
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("createExecution failed. Failed to verify number of rows affected. Erorr: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("createExecution failed. Failed to verify number of rows affected. Erorr: %v", err))
 	}
 	if rowsAffected != 1 {
 		return serviceerror.NewNotFound(fmt.Sprintf("createExecution failed. Affected %v rows updated instead of 1.", rowsAffected))
@@ -1357,11 +1357,11 @@ func updateExecution(
 	}
 	result, err := tx.UpdateExecutions(ctx, row)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("updateExecution failed. Erorr: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("updateExecution failed. Erorr: %v", err))
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("updateExecution failed. Failed to verify number of rows affected. Erorr: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("updateExecution failed. Failed to verify number of rows affected. Erorr: %v", err))
 	}
 	if rowsAffected != 1 {
 		return serviceerror.NewNotFound(fmt.Sprintf("updateExecution failed. Affected %v rows updated instead of 1.", rowsAffected))

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -31,6 +31,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/primitives"
@@ -76,7 +77,7 @@ func (m *sqlExecutionStore) AppendHistoryNodes(
 			if m.Db.IsDupEntryError(err) {
 				return &p.ConditionFailedError{Msg: fmt.Sprintf("AppendHistoryNodes: row already exist: %v", err)}
 			}
-			return serviceerror.NewInternal(fmt.Sprintf("AppendHistoryNodes: %v", err))
+			return serviceerror.NewUnavailable(fmt.Sprintf("AppendHistoryNodes: %v", err))
 		}
 		return nil
 	}
@@ -153,7 +154,7 @@ func (m *sqlExecutionStore) DeleteHistoryNodes(
 
 	_, err = m.Db.DeleteFromHistoryNode(ctx, nodeRow)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("DeleteHistoryNodes: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("DeleteHistoryNodes: %v", err))
 	}
 	return nil
 }

--- a/common/persistence/sql/metadata.go
+++ b/common/persistence/sql/metadata.go
@@ -128,7 +128,7 @@ func (m *sqlMetadataManagerV2) GetNamespace(
 
 			return nil, serviceerror.NewNotFound(fmt.Sprintf("Namespace %s does not exist.", identity))
 		default:
-			return nil, serviceerror.NewInternal(fmt.Sprintf("GetNamespace operation failed. Error %v", err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetNamespace operation failed. Error %v", err))
 		}
 	}
 
@@ -221,7 +221,7 @@ func (m *sqlMetadataManagerV2) GetMetadata() (*persistence.GetMetadataResponse, 
 	defer cancel()
 	row, err := m.Db.SelectFromNamespaceMetadata(ctx)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetMetadata operation failed. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetMetadata operation failed. Error: %v", err))
 	}
 	return &persistence.GetMetadataResponse{NotificationVersion: row.NotificationVersion}, nil
 }
@@ -242,7 +242,7 @@ func (m *sqlMetadataManagerV2) ListNamespaces(request *persistence.ListNamespace
 		if err == sql.ErrNoRows {
 			return &persistence.InternalListNamespacesResponse{}, nil
 		}
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListNamespaces operation failed. Failed to get namespace rows. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListNamespaces operation failed. Failed to get namespace rows. Error: %v", err))
 	}
 
 	var namespaces []*persistence.InternalGetNamespaceResponse
@@ -271,14 +271,14 @@ func updateMetadata(
 		NotificationVersion: oldNotificationVersion,
 	})
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to update namespace metadata. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update namespace metadata. Error: %v", err))
 	}
 
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Could not verify whether namespace metadata update occurred. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Could not verify whether namespace metadata update occurred. Error: %v", err))
 	} else if rowsAffected != 1 {
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to update namespace metadata. <>1 rows affected. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to update namespace metadata. <>1 rows affected. Error: %v", err))
 	}
 
 	return nil
@@ -290,7 +290,7 @@ func lockMetadata(
 ) (*sqlplugin.NamespaceMetadataRow, error) {
 	row, err := tx.LockNamespaceMetadata(ctx)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Failed to lock namespace metadata. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock namespace metadata. Error: %v", err))
 	}
 	return row, nil
 }

--- a/common/persistence/sql/shard.go
+++ b/common/persistence/sql/shard.go
@@ -78,7 +78,7 @@ func (m *sqlShardStore) CreateShard(
 	}
 
 	if _, err := m.Db.InsertIntoShards(ctx, row); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("CreateShard operation failed. Failed to insert into shards table. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("CreateShard operation failed. Failed to insert into shards table. Error: %v", err))
 	}
 
 	return nil
@@ -100,7 +100,7 @@ func (m *sqlShardStore) GetShard(
 	case sql.ErrNoRows:
 		return nil, serviceerror.NewNotFound(fmt.Sprintf("GetShard operation failed. Shard with ID %v not found. Error: %v", request.ShardID, err))
 	default:
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetShard operation failed. Failed to get record. ShardId: %v. Error: %v", request.ShardID, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetShard operation failed. Failed to get record. ShardId: %v. Error: %v", request.ShardID, err))
 	}
 }
 
@@ -158,9 +158,9 @@ func lockShard(
 		}
 		return nil
 	case sql.ErrNoRows:
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to lock shard with ID %v that does not exist.", shardID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock shard with ID %v that does not exist.", shardID))
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to lock shard with ID: %v. Error: %v", shardID, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock shard with ID: %v. Error: %v", shardID, err))
 	}
 }
 
@@ -184,8 +184,8 @@ func readLockShard(
 		}
 		return nil
 	case sql.ErrNoRows:
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to lock shard with ID %v that does not exist.", shardID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock shard with ID %v that does not exist.", shardID))
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to lock shard with ID: %v. Error: %v", shardID, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock shard with ID: %v. Error: %v", shardID, err))
 	}
 }

--- a/common/persistence/sql/sqlplugin/mysql/namespace.go
+++ b/common/persistence/sql/sqlplugin/mysql/namespace.go
@@ -105,7 +105,7 @@ func (mdb *db) SelectFromNamespace(
 	switch {
 	case filter.ID != nil || filter.Name != nil:
 		if filter.ID != nil && filter.Name != nil {
-			return nil, serviceerror.NewInternal("only ID or name filter can be specified for selection")
+			return nil, serviceerror.NewUnavailable("only ID or name filter can be specified for selection")
 		}
 		return mdb.selectFromNamespace(ctx, filter)
 	case filter.PageSize != nil && *filter.PageSize > 0:

--- a/common/persistence/sql/sqlplugin/mysql/task.go
+++ b/common/persistence/sql/sqlplugin/mysql/task.go
@@ -187,18 +187,18 @@ func (mdb *db) SelectFromTaskQueues(
 	switch {
 	case filter.TaskQueueID != nil:
 		if filter.RangeHashLessThanEqualTo != 0 || filter.RangeHashGreaterThanEqualTo != 0 {
-			return nil, serviceerror.NewInternal("range of hashes not supported for specific selection")
+			return nil, serviceerror.NewUnavailable("range of hashes not supported for specific selection")
 		}
 		return mdb.selectFromTaskQueues(ctx, filter)
 	case filter.RangeHashLessThanEqualTo != 0 && filter.PageSize != nil:
 		if filter.RangeHashLessThanEqualTo < filter.RangeHashGreaterThanEqualTo {
-			return nil, serviceerror.NewInternal("range of hashes bound is invalid")
+			return nil, serviceerror.NewUnavailable("range of hashes bound is invalid")
 		}
 		return mdb.rangeSelectFromTaskQueues(ctx, filter)
 	case filter.TaskQueueIDGreaterThan != nil && filter.PageSize != nil:
 		return mdb.rangeSelectFromTaskQueues(ctx, filter)
 	default:
-		return nil, serviceerror.NewInternal("invalid set of query filter params")
+		return nil, serviceerror.NewUnavailable("invalid set of query filter params")
 	}
 }
 

--- a/common/persistence/sql/sqlplugin/postgresql/namespace.go
+++ b/common/persistence/sql/sqlplugin/postgresql/namespace.go
@@ -89,7 +89,7 @@ func (pdb *db) SelectFromNamespace(
 	switch {
 	case filter.ID != nil || filter.Name != nil:
 		if filter.ID != nil && filter.Name != nil {
-			return nil, serviceerror.NewInternal("only ID or name filter can be specified for selection")
+			return nil, serviceerror.NewUnavailable("only ID or name filter can be specified for selection")
 		}
 		return pdb.selectFromNamespace(ctx, filter)
 	case filter.PageSize != nil && *filter.PageSize > 0:

--- a/common/persistence/sql/sqlplugin/postgresql/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/plugin.go
@@ -135,7 +135,7 @@ func (d *plugin) tryConnect(
 			errors = append(errors, err)
 		}
 	}
-	return nil, serviceerror.NewInternal(
+	return nil, serviceerror.NewUnavailable(
 		fmt.Sprintf("unable to connect to DB, tried default DB names: %v, errors: %v", strings.Join(defaultDatabaseNames, ","), errors),
 	)
 }

--- a/common/persistence/sql/sqlplugin/postgresql/task.go
+++ b/common/persistence/sql/sqlplugin/postgresql/task.go
@@ -187,18 +187,18 @@ func (pdb *db) SelectFromTaskQueues(
 	switch {
 	case filter.TaskQueueID != nil:
 		if filter.RangeHashLessThanEqualTo != 0 || filter.RangeHashGreaterThanEqualTo != 0 {
-			return nil, serviceerror.NewInternal("shardID range not supported for specific selection")
+			return nil, serviceerror.NewUnavailable("shardID range not supported for specific selection")
 		}
 		return pdb.selectFromTaskQueues(ctx, filter)
 	case filter.RangeHashLessThanEqualTo != 0 && filter.PageSize != nil:
 		if filter.RangeHashLessThanEqualTo < filter.RangeHashGreaterThanEqualTo {
-			return nil, serviceerror.NewInternal("range of hashes bound is invalid")
+			return nil, serviceerror.NewUnavailable("range of hashes bound is invalid")
 		}
 		return pdb.rangeSelectFromTaskQueues(ctx, filter)
 	case filter.TaskQueueIDGreaterThan != nil && filter.PageSize != nil:
 		return pdb.rangeSelectFromTaskQueues(ctx, filter)
 	default:
-		return nil, serviceerror.NewInternal("invalid set of query filter params")
+		return nil, serviceerror.NewUnavailable("invalid set of query filter params")
 	}
 }
 

--- a/common/persistence/sql/task.go
+++ b/common/persistence/sql/task.go
@@ -35,6 +35,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
@@ -75,7 +76,7 @@ func (m *sqlTaskManager) CreateTaskQueue(request *persistence.InternalCreateTask
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return serviceerror.NewInternal(err.Error())
+		return serviceerror.NewUnavailable(err.Error())
 	}
 	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType)
 
@@ -87,7 +88,7 @@ func (m *sqlTaskManager) CreateTaskQueue(request *persistence.InternalCreateTask
 		DataEncoding: request.TaskQueueInfo.EncodingType.String(),
 	}
 	if _, err := m.Db.InsertIntoTaskQueues(ctx, &row); err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("CreateTaskQueue operation failed. Failed to make task queue %v of type %v. Error: %v", request.TaskQueue, request.TaskType, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("CreateTaskQueue operation failed. Failed to make task queue %v of type %v. Error: %v", request.TaskQueue, request.TaskType, err))
 	}
 
 	return nil
@@ -98,7 +99,7 @@ func (m *sqlTaskManager) GetTaskQueue(request *persistence.InternalGetTaskQueueR
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType)
 	rows, err := m.Db.SelectFromTaskQueues(ctx, sqlplugin.TaskQueuesFilter{
@@ -109,7 +110,7 @@ func (m *sqlTaskManager) GetTaskQueue(request *persistence.InternalGetTaskQueueR
 	switch err {
 	case nil:
 		if len(rows) != 1 {
-			return nil, serviceerror.NewInternal(
+			return nil, serviceerror.NewUnavailable(
 				fmt.Sprintf("GetTaskQueue operation failed. Expect exactly one result row, but got %d for task queue %v of type %v",
 					len(rows), request.TaskQueue, request.TaskType))
 		}
@@ -123,7 +124,7 @@ func (m *sqlTaskManager) GetTaskQueue(request *persistence.InternalGetTaskQueueR
 			fmt.Sprintf("GetTaskQueue operation failed. TaskQueue: %v, TaskType: %v, Error: %v",
 				request.TaskQueue, request.TaskType, err))
 	default:
-		return nil, serviceerror.NewInternal(
+		return nil, serviceerror.NewUnavailable(
 			fmt.Sprintf("GetTaskQueue operation failed. Failed to check if task queue %v of type %v existed. Error: %v",
 				request.TaskQueue, request.TaskType, err))
 	}
@@ -136,7 +137,7 @@ func (m *sqlTaskManager) ExtendLease(
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return serviceerror.NewInternal(err.Error())
+		return serviceerror.NewUnavailable(err.Error())
 	}
 	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType)
 
@@ -182,7 +183,7 @@ func (m *sqlTaskManager) UpdateTaskQueue(
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 
 	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType)
@@ -225,7 +226,7 @@ func (m *sqlTaskManager) ListTaskQueue(request *persistence.ListTaskQueueRequest
 	pageToken := taskQueuePageToken{MinTaskQueueId: minTaskQueueId}
 	if request.PageToken != nil {
 		if err := gobDeserialize(request.PageToken, &pageToken); err != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("error deserializing page token: %v", err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("error deserializing page token: %v", err))
 		}
 	}
 	var err error
@@ -265,7 +266,7 @@ func (m *sqlTaskManager) ListTaskQueue(request *persistence.ListTaskQueueRequest
 
 		rows, err = m.Db.SelectFromTaskQueues(ctx, filter)
 		if err != nil {
-			return nil, serviceerror.NewInternal(err.Error())
+			return nil, serviceerror.NewUnavailable(err.Error())
 		}
 
 		if len(rows) > 0 {
@@ -313,7 +314,7 @@ func (m *sqlTaskManager) ListTaskQueue(request *persistence.ListTaskQueueRequest
 	}
 
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("error serializing nextPageToken:%v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("error serializing nextPageToken:%v", err))
 	}
 
 	resp.NextPageToken = nextPageToken
@@ -356,7 +357,7 @@ func (m *sqlTaskManager) DeleteTaskQueue(
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.TaskQueue.NamespaceID)
 	if err != nil {
-		return serviceerror.NewInternal(err.Error())
+		return serviceerror.NewUnavailable(err.Error())
 	}
 	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue.Name, request.TaskQueue.TaskType)
 	result, err := m.Db.DeleteFromTaskQueues(ctx, sqlplugin.TaskQueuesFilter{
@@ -365,14 +366,14 @@ func (m *sqlTaskManager) DeleteTaskQueue(
 		RangeID:     &request.RangeID,
 	})
 	if err != nil {
-		return serviceerror.NewInternal(err.Error())
+		return serviceerror.NewUnavailable(err.Error())
 	}
 	nRows, err := result.RowsAffected()
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("rowsAffected returned error:%v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("rowsAffected returned error:%v", err))
 	}
 	if nRows != 1 {
-		return serviceerror.NewInternal(fmt.Sprintf("delete failed: %v rows affected instead of 1", nRows))
+		return serviceerror.NewUnavailable(fmt.Sprintf("delete failed: %v rows affected instead of 1", nRows))
 	}
 	return nil
 }
@@ -384,7 +385,7 @@ func (m *sqlTaskManager) CreateTasks(
 
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType)
 
@@ -425,7 +426,7 @@ func (m *sqlTaskManager) GetTasks(
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return nil, serviceerror.NewInternal(err.Error())
+		return nil, serviceerror.NewUnavailable(err.Error())
 	}
 
 	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueue, request.TaskType)
@@ -437,7 +438,7 @@ func (m *sqlTaskManager) GetTasks(
 		PageSize:    &request.BatchSize,
 	})
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("GetTasks operation failed. Failed to get rows. Error: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetTasks operation failed. Failed to get rows. Error: %v", err))
 	}
 
 	var tasks = make([]*commonpb.DataBlob, len(rows))
@@ -455,7 +456,7 @@ func (m *sqlTaskManager) CompleteTask(
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.TaskQueue.NamespaceID)
 	if err != nil {
-		return serviceerror.NewInternal(err.Error())
+		return serviceerror.NewUnavailable(err.Error())
 	}
 
 	taskID := request.TaskID
@@ -465,7 +466,7 @@ func (m *sqlTaskManager) CompleteTask(
 		TaskQueueID: tqId,
 		TaskID:      &taskID})
 	if err != nil && err != sql.ErrNoRows {
-		return serviceerror.NewInternal(err.Error())
+		return serviceerror.NewUnavailable(err.Error())
 	}
 	return nil
 }
@@ -477,7 +478,7 @@ func (m *sqlTaskManager) CompleteTasksLessThan(
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
-		return 0, serviceerror.NewInternal(err.Error())
+		return 0, serviceerror.NewUnavailable(err.Error())
 	}
 	tqId, tqHash := m.taskQueueIdAndHash(nidBytes, request.TaskQueueName, request.TaskType)
 	result, err := m.Db.DeleteFromTasks(ctx, sqlplugin.TasksFilter{
@@ -487,11 +488,11 @@ func (m *sqlTaskManager) CompleteTasksLessThan(
 		Limit:                &request.Limit,
 	})
 	if err != nil {
-		return 0, serviceerror.NewInternal(err.Error())
+		return 0, serviceerror.NewUnavailable(err.Error())
 	}
 	nRows, err := result.RowsAffected()
 	if err != nil {
-		return 0, serviceerror.NewInternal(fmt.Sprintf("rowsAffected returned error: %v", err))
+		return 0, serviceerror.NewUnavailable(fmt.Sprintf("rowsAffected returned error: %v", err))
 	}
 	return int(nRows), nil
 }
@@ -551,6 +552,6 @@ func lockTaskQueue(
 		return &persistence.ConditionFailedError{Msg: "Task queue does not exists"}
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("Failed to lock task queue. Error: %v", err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Failed to lock task queue. Error: %v", err))
 	}
 }

--- a/common/persistence/visibility/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store.go
@@ -38,6 +38,7 @@ import (
 	"github.com/olivere/elastic/v7"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/persistence/visibility"
 	"go.temporal.io/server/common/persistence/visibility/elasticsearch/client"
 	esclient "go.temporal.io/server/common/persistence/visibility/elasticsearch/client"
@@ -232,7 +233,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutions(request *visibility.ListWor
 	ctx := context.Background()
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListOpenWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListOpenWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	isRecordValid := func(rec *visibility.VisibilityWorkflowExecutionInfo) bool {
@@ -255,7 +256,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutions(request *visibility.ListW
 	ctx := context.Background()
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListClosedWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListClosedWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	isRecordValid := func(rec *visibility.VisibilityWorkflowExecutionInfo) bool {
@@ -280,7 +281,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByType(request *visibility.L
 	ctx := context.Background()
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListOpenWorkflowExecutionsByType failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListOpenWorkflowExecutionsByType failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	isRecordValid := func(rec *visibility.VisibilityWorkflowExecutionInfo) bool {
@@ -304,7 +305,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByType(request *visibility
 	ctx := context.Background()
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListClosedWorkflowExecutionsByType failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListClosedWorkflowExecutionsByType failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	isRecordValid := func(rec *visibility.VisibilityWorkflowExecutionInfo) bool {
@@ -329,7 +330,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(request *visibi
 	ctx := context.Background()
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListOpenWorkflowExecutionsByWorkflowID failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListOpenWorkflowExecutionsByWorkflowID failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	isRecordValid := func(rec *visibility.VisibilityWorkflowExecutionInfo) bool {
@@ -353,7 +354,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(request *visi
 	ctx := context.Background()
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	isRecordValid := func(rec *visibility.VisibilityWorkflowExecutionInfo) bool {
@@ -376,7 +377,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(request *visibili
 	ctx := context.Background()
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListClosedWorkflowExecutionsByStatus failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListClosedWorkflowExecutionsByStatus failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	isRecordValid := func(rec *visibility.VisibilityWorkflowExecutionInfo) bool {
@@ -396,7 +397,7 @@ func (s *visibilityStore) ListWorkflowExecutions(request *visibility.ListWorkflo
 	ctx := context.Background()
 	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("ListWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
@@ -419,21 +420,21 @@ func (s *visibilityStore) ScanWorkflowExecutions(request *visibility.ListWorkflo
 		if p.PointInTime == nil {
 			pointInTimeID, err := esClient.OpenPointInTime(ctx, s.index, pointInTimeKeepAliveInterval)
 			if err != nil {
-				return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to create point in time: %s", detailedErrorMessage(err)))
+				return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to create point in time: %s", detailedErrorMessage(err)))
 			}
 			p.PointInTime = elastic.NewPointInTimeWithKeepAlive(pointInTimeID, pointInTimeKeepAliveInterval)
 		}
 
 		searchResult, err := esClient.Search(ctx, p)
 		if err != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
 		}
 
 		if len(searchResult.Hits.Hits) < request.PageSize {
 			// It is the last page, close PIT.
 			_, err = esClient.ClosePointInTime(ctx, searchResult.PitId)
 			if err != nil {
-				return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to close point in time: %s", detailedErrorMessage(err)))
+				return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to close point in time: %s", detailedErrorMessage(err)))
 			}
 		}
 		return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
@@ -468,7 +469,7 @@ func (s *visibilityStore) ScanWorkflowExecutions(request *visibility.ListWorkflo
 			isLastPage = true
 			_ = scrollService.Clear(context.Background())
 		} else if scrollErr != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(scrollErr)))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(scrollErr)))
 		}
 		return s.getScrollWorkflowExecutionsResponse(searchResult.Hits, request.Namespace, request.PageSize, searchResult.ScrollId, isLastPage)
 	default:
@@ -485,7 +486,7 @@ func (s *visibilityStore) CountWorkflowExecutions(request *visibility.CountWorkf
 	ctx := context.Background()
 	count, err := s.esClient.Count(ctx, s.index, boolQuery)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("CountWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("CountWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
 	}
 
 	response := &visibility.CountWorkflowExecutionsResponse{Count: count}
@@ -588,7 +589,7 @@ func (s *visibilityStore) buildSearchParametersV2(
 func (s *visibilityStore) convertQuery(namespace string, namespaceID string, requestQueryStr string) (*elastic.BoolQuery, []*elastic.FieldSort, error) {
 	saTypeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		return nil, nil, serviceerror.NewInternal(fmt.Sprintf("Unable to read search attribute types: %v", err))
+		return nil, nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to read search attribute types: %v", err))
 	}
 	queryConverter := query.NewConverter(
 		newNameInterceptor(namespace, s.index, saTypeMap, s.searchAttributesMapper),
@@ -642,7 +643,7 @@ func (s *visibilityStore) getScrollWorkflowExecutionsResponse(
 
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to read search attribute types: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to read search attribute types: %v", err))
 	}
 
 	response := &visibility.InternalListWorkflowExecutionsResponse{}
@@ -675,7 +676,7 @@ func (s *visibilityStore) getListWorkflowExecutionsResponse(
 
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to read search attribute types: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to read search attribute types: %v", err))
 	}
 
 	response := &visibility.InternalListWorkflowExecutionsResponse{
@@ -759,13 +760,13 @@ func (s *visibilityStore) generateESDoc(request *visibility.InternalVisibilityRe
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
 		s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentGenerateFailuresCount)
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to read search attribute types: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to read search attribute types: %v", err))
 	}
 
 	searchAttributes, err := searchattribute.Decode(request.SearchAttributes, &typeMap)
 	if err != nil {
 		s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentGenerateFailuresCount)
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to decode search attributes: %v", err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to decode search attributes: %v", err))
 	}
 	for saName, saValue := range searchAttributes {
 		doc[saName] = saValue
@@ -777,7 +778,7 @@ func (s *visibilityStore) generateESDoc(request *visibility.InternalVisibilityRe
 func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchattribute.NameTypeMap, namespace string) (*visibility.VisibilityWorkflowExecutionInfo, error) {
 	logParseError := func(fieldName string, fieldValue interface{}, err error, docID string) error {
 		s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentParseFailuresCount)
-		return serviceerror.NewInternal(fmt.Sprintf("Unable to parse Elasticsearch document(%s) %q field value %q: %v", docID, fieldName, fieldValue, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Unable to parse Elasticsearch document(%s) %q field value %q: %v", docID, fieldName, fieldValue, err))
 	}
 
 	var sourceMap map[string]interface{}
@@ -786,7 +787,7 @@ func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchatt
 	d.UseNumber()
 	if err := d.Decode(&sourceMap); err != nil {
 		s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentParseFailuresCount)
-		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to unmarshal JSON from Elasticsearch document(%s): %v", hit.Id, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to unmarshal JSON from Elasticsearch document(%s): %v", hit.Id, err))
 	}
 
 	var (
@@ -827,7 +828,7 @@ func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchatt
 				continue
 			}
 			s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentParseFailuresCount)
-			return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to get type for Elasticsearch document(%s) field %q: %v", hit.Id, fieldName, err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to get type for Elasticsearch document(%s) field %q: %v", hit.Id, fieldName, err))
 		}
 
 		fieldValueParsed, err := finishParseJSONValue(fieldValue, fieldType)
@@ -870,7 +871,7 @@ func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchatt
 		record.SearchAttributes, err = searchattribute.Encode(customSearchAttributes, &saTypeMap)
 		if err != nil {
 			s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentParseFailuresCount)
-			return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to encode custom search attributes of Elasticsearch document(%s): %v", hit.Id, err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to encode custom search attributes of Elasticsearch document(%s): %v", hit.Id, err))
 		}
 		err = searchattribute.ApplyAliases(s.searchAttributesMapper, record.SearchAttributes, namespace)
 		if err != nil {
@@ -882,7 +883,7 @@ func (s *visibilityStore) parseESDoc(hit *elastic.SearchHit, saTypeMap searchatt
 		record.Memo = persistence.NewDataBlob(memo, memoEncoding)
 	} else if memo != nil {
 		s.metricsClient.IncCounter(metrics.ElasticsearchVisibility, metrics.ElasticsearchDocumentParseFailuresCount)
-		return nil, serviceerror.NewInternal(fmt.Sprintf("%q field is missing in Elasticsearch document(%s)", searchattribute.MemoEncoding, hit.Id))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("%q field is missing in Elasticsearch document(%s)", searchattribute.MemoEncoding, hit.Id))
 	}
 
 	return record, nil

--- a/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
@@ -41,6 +41,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
@@ -137,7 +138,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutions() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListOpenWorkflowExecutions(createTestRequest())
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutions failed"))
 }
@@ -155,7 +156,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutions() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListClosedWorkflowExecutions(createTestRequest())
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutions failed"))
 }
@@ -180,7 +181,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByType(request)
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutionsByType failed"))
 }
@@ -205,7 +206,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByType(request)
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByType failed"))
 }
@@ -230,7 +231,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(request)
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutionsByWorkflowID failed"))
 }
@@ -255,7 +256,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(request)
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByWorkflowID failed"))
 }
@@ -279,7 +280,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByStatus() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByStatus(request)
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByStatus failed"))
 }
@@ -1000,7 +1001,7 @@ func (s *ESVisibilitySuite) TestParseESDoc_SearchAttributes_WithMapper() {
 
 	s.mockSearchAttributesMapper.EXPECT().GetAlias(gomock.Any(), testNamespace).DoAndReturn(
 		func(fieldName string, namespace string) (string, error) {
-			return "", serviceerror.NewInternal("error")
+			return "", serviceerror.NewUnavailable("error")
 		})
 	info, err = s.visibilityStore.parseESDoc(searchHit, searchattribute.TestNameTypeMap, testNamespace)
 	s.Error(err)
@@ -1034,7 +1035,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListWorkflowExecutions(request)
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListWorkflowExecutions failed"))
 
@@ -1101,7 +1102,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 	s.mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID).Return(nil, nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.Error(err)
-	_, ok = err.(*serviceerror.Internal)
+	_, ok = err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ScanWorkflowExecutions failed"))
 
@@ -1180,7 +1181,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7() {
 	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.Error(err)
-	_, ok = err.(*serviceerror.Internal)
+	_, ok = err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ScanWorkflowExecutions failed"))
 }
@@ -1220,7 +1221,7 @@ func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 
 	_, err = s.visibilityStore.CountWorkflowExecutions(request)
 	s.Error(err)
-	_, ok := err.(*serviceerror.Internal)
+	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "CountWorkflowExecutions failed"))
 

--- a/common/persistence/visibility/sql/visibility_store.go
+++ b/common/persistence/visibility/sql/visibility_store.go
@@ -32,6 +32,7 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
@@ -310,7 +311,7 @@ func (s *visibilityStore) DeleteWorkflowExecution(
 		RunID:       request.RunID,
 	})
 	if err != nil {
-		return serviceerror.NewInternal(err.Error())
+		return serviceerror.NewUnavailable(err.Error())
 	}
 	return nil
 }
@@ -378,7 +379,7 @@ func (s *visibilityStore) listWorkflowExecutions(
 	}
 	rows, err := selectOp(readLevel)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf("%v operation failed. Select failed: %v", opName, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("%v operation failed. Select failed: %v", opName, err))
 	}
 	if len(rows) == 0 {
 		return &visibility.InternalListWorkflowExecutionsResponse{}, nil

--- a/common/persistence/visibility/visibility_manager_dual_write.go
+++ b/common/persistence/visibility/visibility_manager_dual_write.go
@@ -84,7 +84,7 @@ func (v *visibilityManagerWrapper) RecordWorkflowExecutionStarted(request *Recor
 		}
 		return v.visibilityManager.RecordWorkflowExecutionStarted(request)
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("Unknown advanced visibility writing mode: %s", v.advancedVisWritingMode()))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Unknown advanced visibility writing mode: %s", v.advancedVisWritingMode()))
 	}
 }
 
@@ -100,7 +100,7 @@ func (v *visibilityManagerWrapper) RecordWorkflowExecutionClosed(request *Record
 		}
 		return v.visibilityManager.RecordWorkflowExecutionClosed(request)
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("Unknown advanced visibility writing mode: %s", v.advancedVisWritingMode()))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Unknown advanced visibility writing mode: %s", v.advancedVisWritingMode()))
 	}
 }
 
@@ -118,7 +118,7 @@ func (v *visibilityManagerWrapper) UpsertWorkflowExecution(request *UpsertWorkfl
 		// no op on SQL/Cassandra persistence.
 		return v.visibilityManager.UpsertWorkflowExecution(request)
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("Unknown advanced visibility writing mode: %s", v.advancedVisWritingMode()))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Unknown advanced visibility writing mode: %s", v.advancedVisWritingMode()))
 	}
 }
 
@@ -169,7 +169,7 @@ func (v *visibilityManagerWrapper) DeleteWorkflowExecution(request *VisibilityDe
 		}
 		return v.visibilityManager.DeleteWorkflowExecution(request)
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("Unknown advanced visibility writing mode: %s", v.advancedVisWritingMode()))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Unknown advanced visibility writing mode: %s", v.advancedVisWritingMode()))
 	}
 }
 

--- a/common/persistence/workflowStateStatusValidator.go
+++ b/common/persistence/workflowStateStatusValidator.go
@@ -68,7 +68,7 @@ func ValidateCreateWorkflowStateStatus(
 
 	// validate workflow state & status
 	if state == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED || status != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
-		return serviceerror.NewInternal(fmt.Sprintf("Create workflow with invalid state: %v or status: %v", state, status))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Create workflow with invalid state: %v or status: %v", state, status))
 	}
 	return nil
 }
@@ -89,7 +89,7 @@ func ValidateUpdateWorkflowStateStatus(
 	// validate workflow state & status
 	if status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
 		if state == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
-			return serviceerror.NewInternal(fmt.Sprintf("Update workflow with invalid state: %v or status: %v", state, status))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Update workflow with invalid state: %v or status: %v", state, status))
 		}
 	} else {
 		// enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED
@@ -99,7 +99,7 @@ func ValidateUpdateWorkflowStateStatus(
 		// enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW
 		// enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT
 		if state != enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
-			return serviceerror.NewInternal(fmt.Sprintf("Update workflow with invalid state: %v or status: %v", state, status))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Update workflow with invalid state: %v or status: %v", state, status))
 		}
 	}
 	return nil
@@ -111,7 +111,7 @@ func validateWorkflowState(
 ) error {
 
 	if _, ok := validWorkflowStates[state]; !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("Invalid workflow state: %v", state))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Invalid workflow state: %v", state))
 	}
 
 	return nil
@@ -123,7 +123,7 @@ func validateWorkflowStatus(
 ) error {
 
 	if _, ok := validWorkflowStatuses[status]; !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("Invalid workflow status: %v", status))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Invalid workflow status: %v", status))
 	}
 
 	return nil

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -181,10 +181,10 @@ func (ti *TelemetryInterceptor) handleError(
 		scope.IncCounter(metrics.ServiceErrClientVersionNotSupportedCounter)
 	case *serviceerror.DataLoss:
 		scope.IncCounter(metrics.ServiceFailures)
-		ti.logger.Error("internal service error, data loss", append(logTags, tag.Error(err))...)
-	case *serviceerror.Internal:
+		ti.logger.Error("unavailable error, data loss", append(logTags, tag.Error(err))...)
+	case *serviceerror.Unavailable:
 		scope.IncCounter(metrics.ServiceFailures)
-		ti.logger.Error("internal service error", append(logTags, tag.Error(err))...)
+		ti.logger.Error("unavailable error", append(logTags, tag.Error(err))...)
 	default:
 		scope.IncCounter(metrics.ServiceFailures)
 		ti.logger.Error("uncategorized error", append(logTags, tag.Error(err))...)

--- a/common/searchattribute/mapper_test.go
+++ b/common/searchattribute/mapper_test.go
@@ -46,7 +46,7 @@ func (t *TestMapper) GetAlias(fieldName string, namespace string) (string, error
 		return "alias_of_" + fieldName, nil
 	}
 	if namespace == "error" {
-		return "", serviceerror.NewInternal("mapper error")
+		return "", serviceerror.NewUnavailable("mapper error")
 	}
 	return fieldName, nil
 }
@@ -56,7 +56,7 @@ func (t *TestMapper) GetFieldName(alias string, namespace string) (string, error
 		return strings.TrimPrefix(alias, "alias_of_"), nil
 	}
 	if namespace == "error" {
-		return "", serviceerror.NewInternal("mapper error")
+		return "", serviceerror.NewUnavailable("mapper error")
 	}
 	return alias, nil
 }
@@ -71,8 +71,8 @@ func Test_ApplyAliases(t *testing.T) {
 	}
 	err := ApplyAliases(&TestMapper{}, sa, "error")
 	assert.Error(t, err)
-	var invalidArgumentErr *serviceerror.Internal
-	assert.ErrorAs(t, err, &invalidArgumentErr)
+	var unavailableErr *serviceerror.Unavailable
+	assert.ErrorAs(t, err, &unavailableErr)
 
 	err = ApplyAliases(&TestMapper{}, sa, "namespace1")
 	assert.NoError(t, err)
@@ -96,8 +96,8 @@ func Test_SubstituteAliases(t *testing.T) {
 	}
 	err := SubstituteAliases(&TestMapper{}, sa, "error")
 	assert.Error(t, err)
-	var invalidArgumentErr *serviceerror.Internal
-	assert.ErrorAs(t, err, &invalidArgumentErr)
+	var unavailablErr *serviceerror.Unavailable
+	assert.ErrorAs(t, err, &unavailablErr)
 
 	err = SubstituteAliases(&TestMapper{}, sa, "namespace1")
 	assert.NoError(t, err)

--- a/common/util.go
+++ b/common/util.go
@@ -207,7 +207,7 @@ func CreateReplicationServiceBusyRetryPolicy() backoff.RetryPolicy {
 // IsPersistenceTransientError checks if the error is a transient persistence error
 func IsPersistenceTransientError(err error) bool {
 	switch err.(type) {
-	case *serviceerror.Internal,
+	case *serviceerror.Unavailable,
 		*serviceerror.ResourceExhausted:
 		return true
 	}

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -73,7 +73,7 @@ var (
 	errFailureMustHaveApplicationFailureInfo              = serviceerror.NewInvalidArgument("Failure must have ApplicationFailureInfo.")
 	errStatusFilterMustBeNotRunning                       = serviceerror.NewInvalidArgument("StatusFilter must be specified and must be not Running.")
 	errTokenNamespaceMismatch                             = serviceerror.NewInvalidArgument("Operation requested with a token from a different namespace.")
-	errShuttingDown                                       = serviceerror.NewInternal("Shutting down")
+	errShuttingDown                                       = serviceerror.NewUnavailable("Shutting down")
 
 	errPageSizeTooBigMessage = "PageSize is larger than allowed %d."
 

--- a/service/frontend/versionChecker.go
+++ b/service/frontend/versionChecker.go
@@ -159,7 +159,7 @@ func (vc *VersionChecker) saveVersionInfo(resp *check.VersionCheckResponse) erro
 		return err
 	}
 	if !saved {
-		return serviceerror.NewInternal("version info update hasn't been applied")
+		return serviceerror.NewUnavailable("version info update hasn't been applied")
 	}
 	return nil
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2071,7 +2071,7 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context, request *
 	case enumspb.RESET_REAPPLY_TYPE_NONE:
 		// noop
 	default:
-		return nil, serviceerror.NewInternal("unknown reset type")
+		return nil, serviceerror.NewUnavailable("unknown reset type")
 	}
 
 	namespaceID, err := wh.GetNamespaceCache().GetNamespaceID(request.GetNamespace())
@@ -2457,7 +2457,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 
 	searchAttributes, err := wh.Resource.GetSearchAttributesProvider().GetSearchAttributes(wh.config.ESIndexName, false)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}
 
 	archiverResponse, err := visibilityArchiver.Query(
@@ -2591,7 +2591,7 @@ func (wh *WorkflowHandler) GetSearchAttributes(ctx context.Context, _ *workflows
 
 	searchAttributes, err := wh.GetSearchAttributesProvider().GetSearchAttributes(wh.config.ESIndexName, false)
 	if err != nil {
-		return nil, serviceerror.NewInternal(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}
 	resp := &workflowservice.GetSearchAttributesResponse{
 		Keys: searchAttributes.All(),
@@ -2833,7 +2833,7 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, reques
 	if response.GetWorkflowExecutionInfo().GetSearchAttributes() != nil {
 		saTypeMap, err := wh.GetSearchAttributesProvider().GetSearchAttributes(wh.config.ESIndexName, false)
 		if err != nil {
-			return nil, serviceerror.NewInternal(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 		}
 		searchattribute.ApplyTypeMap(response.GetWorkflowExecutionInfo().GetSearchAttributes(), saTypeMap)
 		err = searchattribute.ApplyAliases(wh.GetSearchAttributesMapper(), response.GetWorkflowExecutionInfo().GetSearchAttributes(), request.GetNamespace())
@@ -3101,7 +3101,7 @@ func (wh *WorkflowHandler) getHistory(
 func (wh *WorkflowHandler) processSearchAttributes(events []*historypb.HistoryEvent, namespace string) error {
 	saTypeMap, err := wh.GetSearchAttributesProvider().GetSearchAttributes(wh.config.ESIndexName, false)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}
 	for _, event := range events {
 		var searchAttributes *commonpb.SearchAttributes

--- a/service/history/consts/const.go
+++ b/service/history/consts/const.go
@@ -61,11 +61,11 @@ var (
 	// ErrSignalsLimitExceeded is the error indicating limit reached for maximum number of signal events
 	ErrSignalsLimitExceeded = serviceerror.NewResourceExhausted("exceeded workflow execution limit for signal events")
 	// ErrEventsAterWorkflowFinish is the error indicating server error trying to write events after workflow finish event
-	ErrEventsAterWorkflowFinish = serviceerror.NewInternal("error validating last event being workflow finish event")
+	ErrEventsAterWorkflowFinish = serviceerror.NewUnavailable("error validating last event being workflow finish event")
 	// ErrQueryEnteredInvalidState is error indicating query entered invalid state
 	ErrQueryEnteredInvalidState = serviceerror.NewInvalidArgument("query entered invalid state, this should be impossible")
 	// ErrConsistentQueryBufferExceeded is error indicating that too many consistent queries have been buffered and until buffered queries are finished new consistent queries cannot be buffered
-	ErrConsistentQueryBufferExceeded = serviceerror.NewInternal("consistent query buffer is full, cannot accept new consistent queries")
+	ErrConsistentQueryBufferExceeded = serviceerror.NewUnavailable("consistent query buffer is full, cannot accept new consistent queries")
 	// ErrEmptyHistoryRawEventBatch indicate that one single batch of history raw events is of size 0
 	ErrEmptyHistoryRawEventBatch = serviceerror.NewInvalidArgument("encounter empty history batch")
 	// ErrSizeExceedsLimit is error indicating workflow execution has exceeded system defined limit

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -66,7 +66,7 @@ type (
 )
 
 var (
-	errEventNotFoundInBatch = serviceerror.NewInternal("History event not found within expected batch")
+	errEventNotFoundInBatch = serviceerror.NewUnavailable("History event not found within expected batch")
 )
 
 var _ Cache = (*CacheImpl)(nil)

--- a/service/history/events/notifier.go
+++ b/service/history/events/notifier.go
@@ -155,7 +155,7 @@ func (notifier *NotifierImpl) WatchHistoryEvent(
 
 		if _, ok := subscribers[subscriberID]; ok {
 			// UUID collision
-			return serviceerror.NewInternal("Unable to watch on workflow execution.")
+			return serviceerror.NewUnavailable("Unable to watch on workflow execution.")
 		}
 		subscribers[subscriberID] = channel
 		return nil
@@ -187,7 +187,7 @@ func (notifier *NotifierImpl) UnwatchHistoryEvent(
 
 	if !success {
 		// cannot find the subscribe ID, which means there is a bug
-		return serviceerror.NewInternal("Unable to unwatch on workflow execution.")
+		return serviceerror.NewUnavailable("Unable to unwatch on workflow execution.")
 	}
 
 	return nil

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -93,7 +93,7 @@ var (
 
 	errDeserializeTaskTokenMessage = "Error to deserialize task token. Error: %v."
 
-	errShuttingDown = serviceerror.NewInternal("Shutting down")
+	errShuttingDown = serviceerror.NewUnavailable("Shutting down")
 )
 
 // NewHandler creates a thrift handler for the history service
@@ -1434,9 +1434,9 @@ func (h *Handler) convertError(err error) error {
 		}
 		return serviceerrors.NewShardOwnershipLost(h.GetHostInfo().GetAddress(), "<unknown>")
 	case *persistence.WorkflowConditionFailedError:
-		return serviceerror.NewInternal(err.Msg)
+		return serviceerror.NewUnavailable(err.Msg)
 	case *persistence.CurrentWorkflowConditionFailedError:
-		return serviceerror.NewInternal(err.Msg)
+		return serviceerror.NewUnavailable(err.Msg)
 	case *persistence.TransactionSizeLimitError:
 		return serviceerror.NewInvalidArgument(err.Msg)
 	}

--- a/service/history/nDCConflictResolver.go
+++ b/service/history/nDCConflictResolver.go
@@ -167,7 +167,7 @@ func (r *nDCConflictResolverImpl) rebuild(
 	}
 
 	if !rebuildVersionHistory.Equal(replayVersionHistory) {
-		return nil, serviceerror.NewInternal("nDCConflictResolver encounter mismatch version history after rebuild")
+		return nil, serviceerror.NewUnavailable("nDCConflictResolver encounter mismatch version history after rebuild")
 	}
 
 	// set the current branch index to target branch index

--- a/service/history/nDCEventsReapplier.go
+++ b/service/history/nDCEventsReapplier.go
@@ -92,7 +92,7 @@ func (r *nDCEventsReapplierImpl) reapplyEvents(
 
 	// sanity check workflow still running
 	if !msBuilder.IsWorkflowExecutionRunning() {
-		return nil, serviceerror.NewInternal("unable to reapply events to closed workflow.")
+		return nil, serviceerror.NewUnavailable("unable to reapply events to closed workflow.")
 	}
 
 	for _, event := range reappliedEvents {

--- a/service/history/nDCHistoryReplicator.go
+++ b/service/history/nDCHistoryReplicator.go
@@ -120,7 +120,7 @@ type (
 	}
 )
 
-var errPanic = serviceerror.NewInternal("encounter panic")
+var errPanic = serviceerror.NewUnavailable("encounter panic")
 
 func newNDCHistoryReplicator(
 	shard shard.Context,
@@ -268,7 +268,7 @@ func (r *nDCHistoryReplicatorImpl) applyEvents(
 		case nil:
 			// Sanity check to make only 3DC mutable state here
 			if mutableState.GetExecutionInfo().GetVersionHistories() == nil {
-				return serviceerror.NewInternal("The mutable state does not support 3DC.")
+				return serviceerror.NewUnavailable("The mutable state does not support 3DC.")
 			}
 
 			doContinue, branchIndex, err := r.applyNonStartEventsPrepareBranch(ctx, context, mutableState, task)

--- a/service/history/nDCTransactionMgrForExistingWorkflow.go
+++ b/service/history/nDCTransactionMgrForExistingWorkflow.go
@@ -108,12 +108,12 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) dispatchForExistingWorkflow(
 	}
 	if currentRunID == "" {
 		// this means a bug in our code or DB is inconsistent...
-		return serviceerror.NewInternal("nDCTransactionMgr: unable to locate current workflow during update")
+		return serviceerror.NewUnavailable("nDCTransactionMgr: unable to locate current workflow during update")
 	}
 
 	if currentRunID == targetRunID {
 		if !isWorkflowRebuilt {
-			return serviceerror.NewInternal("nDCTransactionMgr: encounter workflow not rebuilt & current workflow not guaranteed")
+			return serviceerror.NewUnavailable("nDCTransactionMgr: encounter workflow not rebuilt & current workflow not guaranteed")
 		}
 
 		// update to current record, since target workflow is pointed by current record
@@ -258,7 +258,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) updateAsZombie(
 		return err
 	}
 	if targetPolicy != workflow.TransactionPolicyPassive {
-		return serviceerror.NewInternal("nDCTransactionMgrForExistingWorkflow updateAsZombie encounter target workflow policy not being passive")
+		return serviceerror.NewUnavailable("nDCTransactionMgrForExistingWorkflow updateAsZombie encounter target workflow policy not being passive")
 	}
 
 	var newContext workflow.Context
@@ -272,7 +272,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) updateAsZombie(
 			return err
 		}
 		if newWorkflowPolicy != workflow.TransactionPolicyPassive {
-			return serviceerror.NewInternal("nDCTransactionMgrForExistingWorkflow updateAsZombie encounter new workflow policy not being passive")
+			return serviceerror.NewUnavailable("nDCTransactionMgrForExistingWorkflow updateAsZombie encounter new workflow policy not being passive")
 		}
 
 		// sanity check if new workflow is already created
@@ -402,7 +402,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) conflictResolveAsZombie(
 		return err
 	}
 	if targetWorkflowPolicy != workflow.TransactionPolicyPassive {
-		return serviceerror.NewInternal("nDCTransactionMgrForExistingWorkflow conflictResolveAsZombie encounter target workflow policy not being passive")
+		return serviceerror.NewUnavailable("nDCTransactionMgrForExistingWorkflow conflictResolveAsZombie encounter target workflow policy not being passive")
 	}
 
 	var newContext workflow.Context
@@ -415,7 +415,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) conflictResolveAsZombie(
 			return err
 		}
 		if newWorkflowPolicy != workflow.TransactionPolicyPassive {
-			return serviceerror.NewInternal("nDCTransactionMgrForExistingWorkflow conflictResolveAsZombie encounter new workflow policy not being passive")
+			return serviceerror.NewUnavailable("nDCTransactionMgrForExistingWorkflow conflictResolveAsZombie encounter new workflow policy not being passive")
 		}
 
 		// sanity check if new workflow is already created
@@ -522,7 +522,7 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) executeTransaction(
 		)
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("nDCTransactionMgr: encounter unknown transaction type: %v", transactionPolicy))
+		return serviceerror.NewUnavailable(fmt.Sprintf("nDCTransactionMgr: encounter unknown transaction type: %v", transactionPolicy))
 	}
 }
 

--- a/service/history/nDCTransactionMgrForNewWorkflow.go
+++ b/service/history/nDCTransactionMgrForNewWorkflow.go
@@ -163,7 +163,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) createAsCurrent(
 		return err
 	}
 	if len(targetWorkflowEventsSeq) != 1 {
-		return serviceerror.NewInternal("unable to create 1st event batch")
+		return serviceerror.NewUnavailable("unable to create 1st event batch")
 	}
 
 	// target workflow to be created as current
@@ -215,7 +215,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) createAsZombie(
 		return err
 	}
 	if targetWorkflowPolicy != workflow.TransactionPolicyPassive {
-		return serviceerror.NewInternal("nDCTransactionMgrForNewWorkflow createAsZombie encounter target workflow policy not being passive")
+		return serviceerror.NewUnavailable("nDCTransactionMgrForNewWorkflow createAsZombie encounter target workflow policy not being passive")
 	}
 
 	// release lock on current workflow, since current cluster maybe the active cluster
@@ -231,7 +231,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) createAsZombie(
 		return err
 	}
 	if len(targetWorkflowEventsSeq) != 1 {
-		return serviceerror.NewInternal("unable to create 1st event batch")
+		return serviceerror.NewUnavailable("unable to create 1st event batch")
 	}
 
 	if err := targetWorkflow.getContext().ReapplyEvents(
@@ -333,7 +333,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) executeTransaction(
 		)
 
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("nDCTransactionMgr: encounter unknown transaction type: %v", transactionPolicy))
+		return serviceerror.NewUnavailable(fmt.Sprintf("nDCTransactionMgr: encounter unknown transaction type: %v", transactionPolicy))
 	}
 }
 

--- a/service/history/nDCWorkflow.go
+++ b/service/history/nDCWorkflow.go
@@ -175,7 +175,7 @@ func (r *nDCWorkflowImpl) suppressBy(
 		incomingLastWriteVersion,
 		incomingLastEventTaskID,
 	) {
-		return workflow.TransactionPolicyActive, serviceerror.NewInternal("nDCWorkflow cannot suppress workflow by older workflow")
+		return workflow.TransactionPolicyActive, serviceerror.NewUnavailable("nDCWorkflow cannot suppress workflow by older workflow")
 	}
 
 	// if workflow is in zombie or finished state, keep as is
@@ -211,7 +211,7 @@ func (r *nDCWorkflowImpl) flushBufferedEvents() error {
 	currentCluster := r.clusterMetadata.GetCurrentClusterName()
 
 	if lastWriteCluster != currentCluster {
-		return serviceerror.NewInternal("nDCWorkflow encounter workflow with buffered events but last write not from current cluster")
+		return serviceerror.NewUnavailable("nDCWorkflow encounter workflow with buffered events but last write not from current cluster")
 	}
 
 	return r.failWorkflowTask(lastWriteVersion)

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -481,7 +481,7 @@ func (p *replicatorQueueProcessorImpl) getEventsBlob(
 	}
 
 	if len(eventBatchBlobs) != 1 {
-		return nil, serviceerror.NewInternal("replicatorQueueProcessor encounter more than 1 NDC raw event batch")
+		return nil, serviceerror.NewUnavailable("replicatorQueueProcessor encounter more than 1 NDC raw event batch")
 	}
 
 	return eventBatchBlobs[0], nil
@@ -495,7 +495,7 @@ func (p *replicatorQueueProcessorImpl) getVersionHistoryItems(
 
 	versionHistories := mutableState.GetExecutionInfo().GetVersionHistories()
 	if versionHistories == nil {
-		return nil, nil, serviceerror.NewInternal("replicatorQueueProcessor encounter workflow without version histories")
+		return nil, nil, serviceerror.NewUnavailable("replicatorQueueProcessor encounter workflow without version histories")
 	}
 
 	versionHistoryIndex, err := versionhistory.FindFirstVersionHistoryIndexByVersionHistoryItem(

--- a/service/history/timerQueueActiveTaskExecutor.go
+++ b/service/history/timerQueueActiveTaskExecutor.go
@@ -150,7 +150,7 @@ Loop:
 		if !ok {
 			errString := fmt.Sprintf("failed to find in user timer event ID: %v", timerSequenceID.EventID)
 			t.logger.Error(errString)
-			return serviceerror.NewInternal(errString)
+			return serviceerror.NewUnavailable(errString)
 		}
 
 		if expired := timerSequence.IsExpired(referenceTime, timerSequenceID); !expired {
@@ -470,7 +470,7 @@ func (t *timerQueueActiveTaskExecutor) executeActivityRetryTimerTask(
 		if scheduledEvent.GetActivityTaskScheduledEventAttributes().GetNamespace() != "" {
 			namespaceEntry, err := t.shard.GetNamespaceCache().GetNamespace(scheduledEvent.GetActivityTaskScheduledEventAttributes().GetNamespace())
 			if err != nil {
-				return serviceerror.NewInternal("unable to re-schedule activity across namespace.")
+				return serviceerror.NewUnavailable("unable to re-schedule activity across namespace.")
 			}
 			targetNamespaceID = namespaceEntry.GetInfo().Id
 		}

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -136,7 +136,7 @@ func (t *timerQueueStandbyTaskExecutor) executeUserTimerTimeoutTask(
 			if !ok {
 				errString := fmt.Sprintf("failed to find in user timer event ID: %v", timerSequenceID.EventID)
 				t.logger.Error(errString)
-				return nil, serviceerror.NewInternal(errString)
+				return nil, serviceerror.NewUnavailable(errString)
 			}
 
 			if isExpired := timerSequence.IsExpired(
@@ -196,7 +196,7 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 			if !ok {
 				errString := fmt.Sprintf("failed to find in memory activity timer: %v", timerSequenceID.EventID)
 				t.logger.Error(errString)
-				return nil, serviceerror.NewInternal(errString)
+				return nil, serviceerror.NewUnavailable(errString)
 			}
 
 			if isExpired := timerSequence.IsExpired(
@@ -504,7 +504,7 @@ func (t *timerQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 			common.EmptyVersion,
 		)
 	} else {
-		err = serviceerror.NewInternal("timerQueueStandbyProcessor encounter empty historyResendInfo")
+		err = serviceerror.NewUnavailable("timerQueueStandbyProcessor encounter empty historyResendInfo")
 	}
 
 	if err != nil {

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -1399,9 +1399,9 @@ func (t *transferQueueActiveTaskExecutor) applyParentClosePolicy(
 		return err
 
 	default:
-		return &serviceerror.Internal{
-			Message: fmt.Sprintf("unknown parent close policy: %v", childInfo.ParentClosePolicy),
-		}
+		return serviceerror.NewUnavailable(
+			fmt.Sprintf("unknown parent close policy: %v", childInfo.ParentClosePolicy),
+		)
 	}
 }
 

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -537,9 +537,9 @@ func (t *transferQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 			0,
 		)
 	} else {
-		err = &serviceerror.Internal{
-			Message: "transferQueueStandbyProcessor encounter empty historyResendInfo",
-		}
+		err = serviceerror.NewUnavailable(
+			"transferQueueStandbyProcessor encounter empty historyResendInfo",
+		)
 	}
 
 	if err != nil {

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -326,7 +326,7 @@ func (c *ContextImpl) LoadWorkflowExecutionForReplication(
 			return nil, err
 		}
 		if flushBeforeReady {
-			return nil, serviceerror.NewInternal("Context counter flushBeforeReady status after loading mutable state from DB")
+			return nil, serviceerror.NewUnavailable("Context counter flushBeforeReady status after loading mutable state from DB")
 		}
 	}
 	return c.MutableState, nil
@@ -397,7 +397,7 @@ func (c *ContextImpl) LoadWorkflowExecution() (MutableState, error) {
 		return nil, err
 	}
 	if flushBeforeReady {
-		return nil, serviceerror.NewInternal("Context counter flushBeforeReady status after loading mutable state from DB")
+		return nil, serviceerror.NewUnavailable("Context counter flushBeforeReady status after loading mutable state from DB")
 	}
 
 	return c.MutableState, nil
@@ -758,7 +758,7 @@ func (c *ContextImpl) mergeContinueAsNewReplicationTasks(
 	}
 
 	if newWorkflowSnapshot == nil || len(newWorkflowSnapshot.ReplicationTasks) != 1 {
-		return serviceerror.NewInternal("unable to find replication task from new workflow for continue as new replication")
+		return serviceerror.NewUnavailable("unable to find replication task from new workflow for continue as new replication")
 	}
 
 	// merge the new run first event batch replication task
@@ -775,7 +775,7 @@ func (c *ContextImpl) mergeContinueAsNewReplicationTasks(
 		}
 	}
 	if !taskUpdated {
-		return serviceerror.NewInternal("unable to find replication task from current workflow for continue as new replication")
+		return serviceerror.NewUnavailable("unable to find replication task from current workflow for continue as new replication")
 	}
 	return nil
 }
@@ -830,7 +830,7 @@ func (c *ContextImpl) ReapplyEvents(
 	for _, events := range eventBatches {
 		if events.NamespaceID != namespaceID ||
 			events.WorkflowID != workflowID {
-			return serviceerror.NewInternal("Context encounter mismatch namespaceID / workflowID in events reapplication.")
+			return serviceerror.NewUnavailable("Context encounter mismatch namespaceID / workflowID in events reapplication.")
 		}
 
 		for _, e := range events.Events {
@@ -884,7 +884,7 @@ func (c *ContextImpl) ReapplyEvents(
 	// Reapplication only happens in active cluster
 	sourceCluster := clientBean.GetRemoteAdminClient(activeCluster)
 	if sourceCluster == nil {
-		return serviceerror.NewInternal(fmt.Sprintf("cannot find cluster config %v to do reapply", activeCluster))
+		return serviceerror.NewUnavailable(fmt.Sprintf("cannot find cluster config %v to do reapply", activeCluster))
 	}
 	ctx2, cancel2 := rpc.NewContextWithTimeoutAndHeaders(defaultRemoteCallTimeout)
 	defer cancel2()

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -101,7 +101,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 ) (MutableState, error) {
 
 	if len(history) == 0 {
-		return nil, serviceerror.NewInternal(ErrMessageHistorySizeZero)
+		return nil, serviceerror.NewUnavailable(ErrMessageHistorySizeZero)
 	}
 	firstEvent := history[0]
 	lastEvent := history[len(history)-1]

--- a/service/history/workflow/mutable_state_state_status.go
+++ b/service/history/workflow/mutable_state_state_status.go
@@ -73,7 +73,7 @@ func setStateStatus(
 			}
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+			return serviceerror.NewUnavailable(fmt.Sprintf("unknown workflow state: %v", state))
 		}
 	case enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING:
 		switch state {
@@ -96,7 +96,7 @@ func setStateStatus(
 			}
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+			return serviceerror.NewUnavailable(fmt.Sprintf("unknown workflow state: %v", state))
 		}
 	case enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED:
 		switch state {
@@ -115,7 +115,7 @@ func setStateStatus(
 			return invalidStateTransitionErr(e.GetState(), state, status)
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+			return serviceerror.NewUnavailable(fmt.Sprintf("unknown workflow state: %v", state))
 		}
 	case enumsspb.WORKFLOW_EXECUTION_STATE_ZOMBIE:
 		switch state {
@@ -140,10 +140,10 @@ func setStateStatus(
 			}
 
 		default:
-			return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+			return serviceerror.NewUnavailable(fmt.Sprintf("unknown workflow state: %v", state))
 		}
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown workflow state: %v", state))
+		return serviceerror.NewUnavailable(fmt.Sprintf("unknown workflow state: %v", state))
 	}
 
 	e.State = state
@@ -156,5 +156,5 @@ func invalidStateTransitionErr(
 	targetState enumsspb.WorkflowExecutionState,
 	targetStatus enumspb.WorkflowExecutionStatus,
 ) error {
-	return serviceerror.NewInternal(fmt.Sprintf(invalidStateTransitionMsg, currentState, targetState, targetStatus))
+	return serviceerror.NewUnavailable(fmt.Sprintf(invalidStateTransitionMsg, currentState, targetState, targetStatus))
 }

--- a/service/history/workflow/query.go
+++ b/service/history/workflow/query.go
@@ -40,9 +40,9 @@ const (
 )
 
 var (
-	errTerminationStateInvalid = serviceerror.NewInternal("query termination state invalid")
-	errAlreadyInTerminalState  = serviceerror.NewInternal("query already in terminal state")
-	errQueryNotInTerminalState = serviceerror.NewInternal("query not in terminal state")
+	errTerminationStateInvalid = serviceerror.NewUnavailable("query termination state invalid")
+	errAlreadyInTerminalState  = serviceerror.NewUnavailable("query already in terminal state")
+	errQueryNotInTerminalState = serviceerror.NewUnavailable("query not in terminal state")
 )
 
 type (

--- a/service/history/workflow/query_registry.go
+++ b/service/history/workflow/query_registry.go
@@ -32,7 +32,7 @@ import (
 )
 
 var (
-	errQueryNotExists = serviceerror.NewInternal("query does not exist")
+	errQueryNotExists = serviceerror.NewUnavailable("query does not exist")
 )
 
 type (

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -252,7 +252,7 @@ func SetupNewWorkflowForRetryOrCron(
 		firstRunID,
 	)
 	if err != nil {
-		return serviceerror.NewInternal("Failed to add workflow execution started event.")
+		return serviceerror.NewUnavailable("Failed to add workflow execution started event.")
 	}
 	if err = newMutableState.AddFirstWorkflowTaskScheduled(event); err != nil {
 		return err

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -209,7 +209,7 @@ func (r *TaskGeneratorImpl) GenerateDelayedWorkflowTasks(
 	case enumspb.CONTINUE_AS_NEW_INITIATOR_CRON_SCHEDULE, enumspb.CONTINUE_AS_NEW_INITIATOR_WORKFLOW:
 		workflowBackoffType = enumsspb.WORKFLOW_BACKOFF_TYPE_CRON
 	default:
-		return serviceerror.NewInternal(fmt.Sprintf("unknown initiator: %v", startAttr.GetInitiator()))
+		return serviceerror.NewUnavailable(fmt.Sprintf("unknown initiator: %v", startAttr.GetInitiator()))
 	}
 
 	r.mutableState.AddTimerTasks(&persistence.WorkflowBackoffTimerTask{
@@ -247,7 +247,7 @@ func (r *TaskGeneratorImpl) GenerateScheduleWorkflowTaskTasks(
 		workflowTaskScheduleID,
 	)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending workflow task: %v", workflowTaskScheduleID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("it could be a bug, cannot get pending workflow task: %v", workflowTaskScheduleID))
 	}
 
 	r.mutableState.AddTransferTasks(&persistence.WorkflowTask{
@@ -285,7 +285,7 @@ func (r *TaskGeneratorImpl) GenerateStartWorkflowTaskTasks(
 		workflowTaskScheduleID,
 	)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending workflowTaskInfo: %v", workflowTaskScheduleID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("it could be a bug, cannot get pending workflowTaskInfo: %v", workflowTaskScheduleID))
 	}
 
 	startedTime := timestamp.TimeValue(workflowTask.StartedTime)
@@ -313,7 +313,7 @@ func (r *TaskGeneratorImpl) GenerateActivityTransferTasks(
 
 	activityInfo, ok := r.mutableState.GetActivityInfo(activityScheduleID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending activity: %v", activityScheduleID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("it could be a bug, cannot get pending activity: %v", activityScheduleID))
 	}
 
 	var targetNamespaceID string
@@ -349,7 +349,7 @@ func (r *TaskGeneratorImpl) GenerateActivityRetryTasks(
 
 	ai, ok := r.mutableState.GetActivityInfo(activityScheduleID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending activity: %v", activityScheduleID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("it could be a bug, cannot get pending activity: %v", activityScheduleID))
 	}
 
 	r.mutableState.AddTimerTasks(&persistence.ActivityRetryTimerTask{
@@ -373,7 +373,7 @@ func (r *TaskGeneratorImpl) GenerateChildWorkflowTasks(
 
 	childWorkflowInfo, ok := r.mutableState.GetChildExecutionInfo(childWorkflowScheduleID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending child workflow: %v", childWorkflowScheduleID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("it could be a bug, cannot get pending child workflow: %v", childWorkflowScheduleID))
 	}
 
 	targetNamespaceID, err := r.getTargetNamespaceID(childWorkflowTargetNamespace)
@@ -408,7 +408,7 @@ func (r *TaskGeneratorImpl) GenerateRequestCancelExternalTasks(
 
 	_, ok := r.mutableState.GetRequestCancelInfo(scheduleID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending request cancel external workflow: %v", scheduleID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("it could be a bug, cannot get pending request cancel external workflow: %v", scheduleID))
 	}
 
 	targetNamespaceID, err := r.getTargetNamespaceID(targetNamespace)
@@ -445,7 +445,7 @@ func (r *TaskGeneratorImpl) GenerateSignalExternalTasks(
 
 	_, ok := r.mutableState.GetSignalInfo(scheduleID)
 	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending signal external workflow: %v", scheduleID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("it could be a bug, cannot get pending signal external workflow: %v", scheduleID))
 	}
 
 	targetNamespaceID, err := r.getTargetNamespaceID(targetNamespace)

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -249,7 +249,7 @@ func (r *TaskRefresherImpl) refreshWorkflowTaskTasks(
 
 	workflowTask, ok := mutableState.GetPendingWorkflowTask()
 	if !ok {
-		return serviceerror.NewInternal("it could be a bug, cannot get pending workflow task")
+		return serviceerror.NewUnavailable("it could be a bug, cannot get pending workflow task")
 	}
 
 	// workflowTask already started

--- a/service/history/workflow/timer_sequence.go
+++ b/service/history/workflow/timer_sequence.go
@@ -128,7 +128,7 @@ func (t *timerSequenceImpl) CreateNextUserTimer() (bool, error) {
 
 	timerInfo, ok := t.mutableState.GetUserTimerInfoByEventID(firstTimerTask.EventID)
 	if !ok {
-		return false, serviceerror.NewInternal(fmt.Sprintf("unable to load activity info %v", firstTimerTask.EventID))
+		return false, serviceerror.NewUnavailable(fmt.Sprintf("unable to load activity info %v", firstTimerTask.EventID))
 	}
 	// mark timer task mask as indication that timer task is generated
 	// here TaskID is misleading attr, should be called timer created flag or something
@@ -167,7 +167,7 @@ func (t *timerSequenceImpl) CreateNextActivityTimer() (bool, error) {
 
 	activityInfo, ok := t.mutableState.GetActivityInfo(firstTimerTask.EventID)
 	if !ok {
-		return false, serviceerror.NewInternal(fmt.Sprintf("unable to load activity info %v", firstTimerTask.EventID))
+		return false, serviceerror.NewUnavailable(fmt.Sprintf("unable to load activity info %v", firstTimerTask.EventID))
 	}
 	// mark timer task mask as indication that timer task is generated
 	activityInfo.TimerTaskStatus |= timerTypeToTimerMask(firstTimerTask.TimerType)

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -72,7 +72,7 @@ func ScheduleWorkflowTask(
 
 	_, err := mutableState.AddWorkflowTaskScheduledEvent(false)
 	if err != nil {
-		return serviceerror.NewInternal("Failed to add workflow task scheduled event.")
+		return serviceerror.NewUnavailable("Failed to add workflow task scheduled event.")
 	}
 	return nil
 }

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -134,7 +134,7 @@ func (m *workflowTaskStateMachine) ReplicateWorkflowTaskStartedEvent(
 	if workflowTask == nil {
 		workflowTask, ok = m.GetWorkflowTaskInfo(scheduleID)
 		if !ok {
-			return nil, serviceerror.NewInternal(fmt.Sprintf("unable to find workflow task: %v", scheduleID))
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("unable to find workflow task: %v", scheduleID))
 		}
 		// setting workflow task attempt to 1 for workflow task replication
 		// this mainly handles transient workflow task completion

--- a/service/history/workflowResetter.go
+++ b/service/history/workflowResetter.go
@@ -276,7 +276,7 @@ func (r *workflowResetterImpl) prepareResetWorkflow(
 	}
 
 	if resetMutableState.GetCurrentVersion() > resetWorkflowVersion {
-		return nil, serviceerror.NewInternal("workflowResetter encounter version mismatch.")
+		return nil, serviceerror.NewUnavailable("workflowResetter encounter version mismatch.")
 	}
 	if err := resetMutableState.UpdateCurrentVersion(
 		resetWorkflowVersion,
@@ -525,7 +525,7 @@ func (r *workflowResetterImpl) failInflightActivity(
 		case common.TransientEventID:
 			// activity is started (with retry policy)
 			// should not encounter this case when rebuilding mutable state
-			return serviceerror.NewInternal("workflowResetter encounter transient activity")
+			return serviceerror.NewUnavailable("workflowResetter encounter transient activity")
 
 		default:
 			if _, err := mutableState.AddActivityTaskFailedEvent(

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -34,6 +34,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/searchattribute"
 
 	"go.temporal.io/server/common"
@@ -200,7 +201,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandScheduleActivity(
 	if attr.GetNamespace() != "" {
 		targetNamespaceEntry, err := handler.namespaceCache.GetNamespace(attr.GetNamespace())
 		if err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Unable to schedule activity across namespace %v.", attr.GetNamespace()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to schedule activity across namespace %v.", attr.GetNamespace()))
 		}
 		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
 	}
@@ -377,7 +378,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCompleteWorkflow(
 	// Always add workflow completed event to this one
 	_, err = handler.mutableState.AddCompletedWorkflowEvent(handler.workflowTaskCompletedID, attr, newExecutionRunID)
 	if err != nil {
-		return serviceerror.NewInternal("Unable to add complete workflow event.")
+		return serviceerror.NewUnavailable("Unable to add complete workflow event.")
 	}
 
 	// Check if this workflow has a cron schedule
@@ -560,7 +561,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandRequestCancelExternalWorkfl
 	if attr.GetNamespace() != "" {
 		targetNamespaceEntry, err := handler.namespaceCache.GetNamespace(attr.GetNamespace())
 		if err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Unable to cancel workflow across namespace: %v.", attr.GetNamespace()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to cancel workflow across namespace: %v.", attr.GetNamespace()))
 		}
 		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
 	}
@@ -739,7 +740,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 	if attr.GetNamespace() != "" {
 		targetNamespaceEntry, err := handler.namespaceCache.GetNamespace(attr.GetNamespace())
 		if err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Unable to schedule child execution across namespace %v.", attr.GetNamespace()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to schedule child execution across namespace %v.", attr.GetNamespace()))
 		}
 		targetNamespace = targetNamespaceEntry.GetInfo().Name
 		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
@@ -834,7 +835,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandSignalExternalWorkflow(
 	if attr.GetNamespace() != "" {
 		targetNamespaceEntry, err := handler.namespaceCache.GetNamespace(attr.GetNamespace())
 		if err != nil {
-			return serviceerror.NewInternal(fmt.Sprintf("Unable to signal workflow across namespace: %v.", attr.GetNamespace()))
+			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to signal workflow across namespace: %v.", attr.GetNamespace()))
 		}
 		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
 	}
@@ -883,7 +884,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandUpsertWorkflowSearchAttribu
 	namespaceID := executionInfo.NamespaceId
 	namespaceEntry, err := handler.namespaceCache.GetNamespaceByID(namespaceID)
 	if err != nil {
-		return serviceerror.NewInternal(fmt.Sprintf("Unable to get namespace for namespaceID: %v.", namespaceID))
+		return serviceerror.NewUnavailable(fmt.Sprintf("Unable to get namespace for namespaceID: %v.", namespaceID))
 	}
 	namespace := namespaceEntry.GetInfo().Name
 

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -34,6 +34,7 @@ import (
 	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+
 	"go.temporal.io/server/common/searchattribute"
 
 	historyspb "go.temporal.io/server/api/history/v1"
@@ -229,7 +230,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 			)
 			if err != nil {
 				// Unable to add WorkflowTaskStarted event to history
-				return nil, serviceerror.NewInternal("Unable to add WorkflowTaskStarted event to history.")
+				return nil, serviceerror.NewUnavailable("Unable to add WorkflowTaskStarted event to history.")
 			}
 
 			resp, err = handler.createRecordWorkflowTaskStartedResponse(namespaceID, mutableState, workflowTask, req.PollRequest.GetIdentity())
@@ -379,19 +380,19 @@ Update_History_Loop:
 				scope.IncCounter(metrics.WorkflowTaskHeartbeatTimeoutCounter)
 				completedEvent, err = msBuilder.AddWorkflowTaskTimedOutEvent(currentWorkflowTask.ScheduleID, currentWorkflowTask.StartedID)
 				if err != nil {
-					return nil, serviceerror.NewInternal("Failed to add workflow task timeout event.")
+					return nil, serviceerror.NewUnavailable("Failed to add workflow task timeout event.")
 				}
 				msBuilder.ClearStickyness()
 			} else {
 				completedEvent, err = msBuilder.AddWorkflowTaskCompletedEvent(scheduleID, startedID, request, maxResetPoints)
 				if err != nil {
-					return nil, serviceerror.NewInternal("Unable to add WorkflowTaskCompleted event to history.")
+					return nil, serviceerror.NewUnavailable("Unable to add WorkflowTaskCompleted event to history.")
 				}
 			}
 		} else {
 			completedEvent, err = msBuilder.AddWorkflowTaskCompletedEvent(scheduleID, startedID, request, maxResetPoints)
 			if err != nil {
-				return nil, serviceerror.NewInternal("Unable to add WorkflowTaskCompleted event to history.")
+				return nil, serviceerror.NewUnavailable("Unable to add WorkflowTaskCompleted event to history.")
 			}
 		}
 
@@ -500,7 +501,7 @@ Update_History_Loop:
 				)
 			}
 			if err != nil {
-				return nil, serviceerror.NewInternal("Failed to add workflow task scheduled event.")
+				return nil, serviceerror.NewUnavailable("Failed to add workflow task scheduled event.")
 			}
 
 			newWorkflowTaskScheduledID = newWorkflowTask.ScheduleID

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -536,7 +536,7 @@ func (e *matchingEngineImpl) QueryWorkflow(
 		case enumspb.QUERY_RESULT_TYPE_FAILED:
 			return nil, serviceerror.NewQueryFailed(workerResponse.GetCompletedRequest().GetErrorMessage())
 		default:
-			return nil, serviceerror.NewInternal("unknown query completed type")
+			return nil, serviceerror.NewUnavailable("unknown query completed type")
 		}
 	case <-hCtx.Done():
 		return nil, hCtx.Err()

--- a/service/worker/replicator/namespace_replication_message_processor.go
+++ b/service/worker/replicator/namespace_replication_message_processor.go
@@ -191,9 +191,9 @@ func (p *namespaceReplicationMessageProcessor) putNamespaceReplicationTaskToDLQ(
 
 	namespaceAttribute := task.GetNamespaceTaskAttributes()
 	if namespaceAttribute == nil {
-		return &serviceerror.Internal{
-			Message: "Namespace replication task does not set namespace task attribute",
-		}
+		return serviceerror.NewUnavailable(
+			"Namespace replication task does not set namespace task attribute",
+		)
 	}
 	p.metricsClient.Scope(
 		metrics.NamespaceReplicationTaskScope,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Use serviceerror.Unavailable error type instead of serviceerror.Internal
  * serviceerror.Unavailable indicates errors like service's dependency is down, retryable
  * serviceerror.Internal indicates errors like NPE in service logic, non-retryable

<!-- Tell your future self why have you made these changes -->
**Why?**
Let SDK do better error handling

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
SDKs (go & java) currently does not differentiate the different between Unavailable & Internal, both are retried.
SDKs in the future should only retry on Unavailable, and try not to retry on Internal

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A