### PR TITLE
Unload taskQueueManager by instance, not queue ID

### DIFF
--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -108,6 +108,7 @@ type (
 		// DescribeTaskQueue returns information about the target task queue
 		DescribeTaskQueue(includeTaskQueueStatus bool) *matchingservice.DescribeTaskQueueResponse
 		String() string
+		QueueID() *taskQueueID
 	}
 
 	// Single task queue in memory state
@@ -139,7 +140,7 @@ type (
 		outstandingPollsLock sync.Mutex
 		outstandingPollsMap  map[string]context.CancelFunc
 		shutdownCh           chan struct{} // Delivers stop to the pump that populates taskBuffer
-		signalFatalProblem   func(id *taskQueueID)
+		signalFatalProblem   func(taskQueueManager)
 	}
 )
 
@@ -471,7 +472,7 @@ func (c *taskQueueManagerImpl) completeTask(task *persistencespb.AllocatedTaskIn
 				tag.Error(err),
 				tag.WorkflowTaskQueueName(c.taskQueueID.name),
 				tag.WorkflowTaskQueueType(c.taskQueueID.taskType))
-			c.signalFatalProblem(c.taskQueueID)
+			c.signalFatalProblem(c)
 			return
 		}
 		c.taskReader.Signal()
@@ -599,4 +600,8 @@ func (c *taskQueueManagerImpl) tryInitNamespaceAndScope() {
 
 	c.metricScopeValue.Store(scope)
 	c.namespaceValue.Store(namespace)
+}
+
+func (c *taskQueueManagerImpl) QueueID() *taskQueueID {
+	return c.taskQueueID
 }

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -201,7 +201,7 @@ func (w *taskWriter) appendTasks(
 		return resp, nil
 
 	case *persistence.ConditionFailedError:
-		w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID)
+		w.tlMgr.signalFatalProblem(w.tlMgr)
 		return nil, err
 
 	default:
@@ -219,7 +219,7 @@ func (w *taskWriter) taskWriterLoop(ctx context.Context) error {
 	err := w.initReadWriteState(ctx)
 	if err != nil {
 		if w.tlMgr.errShouldUnload(err) {
-			w.tlMgr.signalFatalProblem(w.tlMgr.taskQueueID)
+			w.tlMgr.signalFatalProblem(w.tlMgr)
 		}
 		return err
 	}
@@ -318,7 +318,7 @@ func (w *taskWriter) allocTaskIDBlock(ctx context.Context, prevBlockEnd int64) (
 	state, err := w.renewLeaseWithRetry(ctx, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
 	if err != nil {
 		if w.tlMgr.errShouldUnload(err) {
-			w.tlMgr.signalFatalProblem(w.taskQueueID)
+			w.tlMgr.signalFatalProblem(w.tlMgr)
 			return taskIDBlock{}, errShutdown
 		}
 		return taskIDBlock{}, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Unload taskQueueManager by instance, not queue ID

<!-- Tell your future self why have you made these changes -->
**Why?**
Matching engine can incorrectly unload a taskQueueManager instance
because the fatal signals from a previous instance are still being
delivered and reference the same queue ID. To address we unload by
taskQueueManager object instance rather than simply by queue ID.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minimal - unload occurs in strictly _fewer_ cases

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no