### PR TITLE
Use point in time with Elasticsearch v7 only if it is available

### DIFF
--- a/common/persistence/visibility/elasticsearch/client/client.go
+++ b/common/persistence/visibility/elasticsearch/client/client.go
@@ -23,7 +23,6 @@
 // THE SOFTWARE.
 
 //go:generate mockgen -copyright_file ../../../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination client_mock.go
-//go:generate mockgen -copyright_file ../../../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination client_mock.go
 
 package client
 

--- a/common/persistence/visibility/elasticsearch/client/client.go
+++ b/common/persistence/visibility/elasticsearch/client/client.go
@@ -23,6 +23,7 @@
 // THE SOFTWARE.
 
 //go:generate mockgen -copyright_file ../../../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination client_mock.go
+//go:generate mockgen -copyright_file ../../../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination client_mock.go
 
 package client
 
@@ -41,13 +42,15 @@ const (
 )
 
 type (
-	// Client is a wrapper around ElasticSearch client library.
-	// It simplifies the interface and enables mocking. We intentionally let implementation details of the elastic library
-	// bleed through, as the main purpose is testability not abstraction.
+	// Client is a wrapper around Elasticsearch client library.
 	Client interface {
 		Search(ctx context.Context, p *SearchParameters) (*elastic.SearchResult, error)
 		Count(ctx context.Context, index string, query elastic.Query) (int64, error)
 		RunBulkProcessor(ctx context.Context, p *BulkProcessorParameters) (BulkProcessor, error)
+
+		OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error)
+		Scroll(ctx context.Context, scrollID string, keepAliveInterval string) (*elastic.SearchResult, error)
+		CloseScroll(ctx context.Context, id string) error
 
 		// TODO (alex): move this to some admin client (and join with IntegrationTestsClient)
 		PutMapping(ctx context.Context, index string, mapping map[string]enumspb.IndexedValueType) (bool, error)
@@ -58,17 +61,9 @@ type (
 	// Combine ClientV7 with Client interface after ES v6 support removal.
 	ClientV7 interface {
 		Client
+		IsPointInTimeSupported(ctx context.Context) bool
 		OpenPointInTime(ctx context.Context, index string, keepAliveInterval string) (string, error)
 		ClosePointInTime(ctx context.Context, id string) (bool, error)
-	}
-
-	// Deprecated. Remove after ES v6 support removal.
-	ClientV6 interface {
-		Client
-		// Deprecated. Remove after ES v6 support removal.
-		Scroll(ctx context.Context, scrollID string) (*elastic.SearchResult, ScrollService, error)
-		// Deprecated. Remove after ES v6 support removal.
-		ScrollFirstPage(ctx context.Context, p *SearchParameters) (*elastic.SearchResult, ScrollService, error)
 	}
 
 	CLIClient interface {
@@ -87,18 +82,13 @@ type (
 		IndexGetSettings(ctx context.Context, indexName string) (map[string]*elastic.IndicesGetSettingsResponse, error)
 	}
 
-	// ScrollService is an interface for elastic.ScrollService.
-	// Deprecated. Remove after ES v6 support removal.
-	ScrollService interface {
-		Clear(ctx context.Context) error
-	}
-
 	// SearchParameters holds all required and optional parameters for executing a search.
 	SearchParameters struct {
-		Index       string
-		Query       elastic.Query
-		PageSize    int
-		Sorter      []elastic.Sorter
+		Index    string
+		Query    elastic.Query
+		PageSize int
+		Sorter   []elastic.Sorter
+
 		SearchAfter []interface{}
 		PointInTime *elastic.PointInTime
 	}

--- a/common/persistence/visibility/elasticsearch/client/client_mock.go
+++ b/common/persistence/visibility/elasticsearch/client/client_mock.go
@@ -60,6 +60,20 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
+// CloseScroll mocks base method.
+func (m *MockClient) CloseScroll(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseScroll", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseScroll indicates an expected call of CloseScroll.
+func (mr *MockClientMockRecorder) CloseScroll(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseScroll", reflect.TypeOf((*MockClient)(nil).CloseScroll), ctx, id)
+}
+
 // Count mocks base method.
 func (m *MockClient) Count(ctx context.Context, index string, query v7.Query) (int64, error) {
 	m.ctrl.T.Helper()
@@ -90,6 +104,21 @@ func (mr *MockClientMockRecorder) GetMapping(ctx, index interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMapping", reflect.TypeOf((*MockClient)(nil).GetMapping), ctx, index)
 }
 
+// OpenScroll mocks base method.
+func (m *MockClient) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenScroll", ctx, p, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenScroll indicates an expected call of OpenScroll.
+func (mr *MockClientMockRecorder) OpenScroll(ctx, p, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenScroll", reflect.TypeOf((*MockClient)(nil).OpenScroll), ctx, p, keepAliveInterval)
+}
+
 // PutMapping mocks base method.
 func (m *MockClient) PutMapping(ctx context.Context, index string, mapping map[string]v1.IndexedValueType) (bool, error) {
 	m.ctrl.T.Helper()
@@ -118,6 +147,21 @@ func (m *MockClient) RunBulkProcessor(ctx context.Context, p *BulkProcessorParam
 func (mr *MockClientMockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockClient)(nil).RunBulkProcessor), ctx, p)
+}
+
+// Scroll mocks base method.
+func (m *MockClient) Scroll(ctx context.Context, scrollID, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Scroll", ctx, scrollID, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Scroll indicates an expected call of Scroll.
+func (mr *MockClientMockRecorder) Scroll(ctx, scrollID, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockClient)(nil).Scroll), ctx, scrollID, keepAliveInterval)
 }
 
 // Search mocks base method.
@@ -188,6 +232,20 @@ func (mr *MockClientV7MockRecorder) ClosePointInTime(ctx, id interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePointInTime", reflect.TypeOf((*MockClientV7)(nil).ClosePointInTime), ctx, id)
 }
 
+// CloseScroll mocks base method.
+func (m *MockClientV7) CloseScroll(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseScroll", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseScroll indicates an expected call of CloseScroll.
+func (mr *MockClientV7MockRecorder) CloseScroll(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseScroll", reflect.TypeOf((*MockClientV7)(nil).CloseScroll), ctx, id)
+}
+
 // Count mocks base method.
 func (m *MockClientV7) Count(ctx context.Context, index string, query v7.Query) (int64, error) {
 	m.ctrl.T.Helper()
@@ -218,6 +276,20 @@ func (mr *MockClientV7MockRecorder) GetMapping(ctx, index interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMapping", reflect.TypeOf((*MockClientV7)(nil).GetMapping), ctx, index)
 }
 
+// IsPointInTimeSupported mocks base method.
+func (m *MockClientV7) IsPointInTimeSupported(ctx context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPointInTimeSupported", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPointInTimeSupported indicates an expected call of IsPointInTimeSupported.
+func (mr *MockClientV7MockRecorder) IsPointInTimeSupported(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPointInTimeSupported", reflect.TypeOf((*MockClientV7)(nil).IsPointInTimeSupported), ctx)
+}
+
 // OpenPointInTime mocks base method.
 func (m *MockClientV7) OpenPointInTime(ctx context.Context, index, keepAliveInterval string) (string, error) {
 	m.ctrl.T.Helper()
@@ -231,6 +303,21 @@ func (m *MockClientV7) OpenPointInTime(ctx context.Context, index, keepAliveInte
 func (mr *MockClientV7MockRecorder) OpenPointInTime(ctx, index, keepAliveInterval interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPointInTime", reflect.TypeOf((*MockClientV7)(nil).OpenPointInTime), ctx, index, keepAliveInterval)
+}
+
+// OpenScroll mocks base method.
+func (m *MockClientV7) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenScroll", ctx, p, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenScroll indicates an expected call of OpenScroll.
+func (mr *MockClientV7MockRecorder) OpenScroll(ctx, p, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenScroll", reflect.TypeOf((*MockClientV7)(nil).OpenScroll), ctx, p, keepAliveInterval)
 }
 
 // PutMapping mocks base method.
@@ -263,6 +350,21 @@ func (mr *MockClientV7MockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockClientV7)(nil).RunBulkProcessor), ctx, p)
 }
 
+// Scroll mocks base method.
+func (m *MockClientV7) Scroll(ctx context.Context, scrollID, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Scroll", ctx, scrollID, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Scroll indicates an expected call of Scroll.
+func (mr *MockClientV7MockRecorder) Scroll(ctx, scrollID, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockClientV7)(nil).Scroll), ctx, scrollID, keepAliveInterval)
+}
+
 // Search mocks base method.
 func (m *MockClientV7) Search(ctx context.Context, p *SearchParameters) (*v7.SearchResult, error) {
 	m.ctrl.T.Helper()
@@ -291,151 +393,6 @@ func (m *MockClientV7) WaitForYellowStatus(ctx context.Context, index string) (s
 func (mr *MockClientV7MockRecorder) WaitForYellowStatus(ctx, index interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForYellowStatus", reflect.TypeOf((*MockClientV7)(nil).WaitForYellowStatus), ctx, index)
-}
-
-// MockClientV6 is a mock of ClientV6 interface.
-type MockClientV6 struct {
-	ctrl     *gomock.Controller
-	recorder *MockClientV6MockRecorder
-}
-
-// MockClientV6MockRecorder is the mock recorder for MockClientV6.
-type MockClientV6MockRecorder struct {
-	mock *MockClientV6
-}
-
-// NewMockClientV6 creates a new mock instance.
-func NewMockClientV6(ctrl *gomock.Controller) *MockClientV6 {
-	mock := &MockClientV6{ctrl: ctrl}
-	mock.recorder = &MockClientV6MockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockClientV6) EXPECT() *MockClientV6MockRecorder {
-	return m.recorder
-}
-
-// Count mocks base method.
-func (m *MockClientV6) Count(ctx context.Context, index string, query v7.Query) (int64, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Count", ctx, index, query)
-	ret0, _ := ret[0].(int64)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Count indicates an expected call of Count.
-func (mr *MockClientV6MockRecorder) Count(ctx, index, query interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockClientV6)(nil).Count), ctx, index, query)
-}
-
-// GetMapping mocks base method.
-func (m *MockClientV6) GetMapping(ctx context.Context, index string) (map[string]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMapping", ctx, index)
-	ret0, _ := ret[0].(map[string]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMapping indicates an expected call of GetMapping.
-func (mr *MockClientV6MockRecorder) GetMapping(ctx, index interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMapping", reflect.TypeOf((*MockClientV6)(nil).GetMapping), ctx, index)
-}
-
-// PutMapping mocks base method.
-func (m *MockClientV6) PutMapping(ctx context.Context, index string, mapping map[string]v1.IndexedValueType) (bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutMapping", ctx, index, mapping)
-	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PutMapping indicates an expected call of PutMapping.
-func (mr *MockClientV6MockRecorder) PutMapping(ctx, index, mapping interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutMapping", reflect.TypeOf((*MockClientV6)(nil).PutMapping), ctx, index, mapping)
-}
-
-// RunBulkProcessor mocks base method.
-func (m *MockClientV6) RunBulkProcessor(ctx context.Context, p *BulkProcessorParameters) (BulkProcessor, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunBulkProcessor", ctx, p)
-	ret0, _ := ret[0].(BulkProcessor)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RunBulkProcessor indicates an expected call of RunBulkProcessor.
-func (mr *MockClientV6MockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockClientV6)(nil).RunBulkProcessor), ctx, p)
-}
-
-// Scroll mocks base method.
-func (m *MockClientV6) Scroll(ctx context.Context, scrollID string) (*v7.SearchResult, ScrollService, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Scroll", ctx, scrollID)
-	ret0, _ := ret[0].(*v7.SearchResult)
-	ret1, _ := ret[1].(ScrollService)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// Scroll indicates an expected call of Scroll.
-func (mr *MockClientV6MockRecorder) Scroll(ctx, scrollID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockClientV6)(nil).Scroll), ctx, scrollID)
-}
-
-// ScrollFirstPage mocks base method.
-func (m *MockClientV6) ScrollFirstPage(ctx context.Context, p *SearchParameters) (*v7.SearchResult, ScrollService, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScrollFirstPage", ctx, p)
-	ret0, _ := ret[0].(*v7.SearchResult)
-	ret1, _ := ret[1].(ScrollService)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ScrollFirstPage indicates an expected call of ScrollFirstPage.
-func (mr *MockClientV6MockRecorder) ScrollFirstPage(ctx, p interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScrollFirstPage", reflect.TypeOf((*MockClientV6)(nil).ScrollFirstPage), ctx, p)
-}
-
-// Search mocks base method.
-func (m *MockClientV6) Search(ctx context.Context, p *SearchParameters) (*v7.SearchResult, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Search", ctx, p)
-	ret0, _ := ret[0].(*v7.SearchResult)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Search indicates an expected call of Search.
-func (mr *MockClientV6MockRecorder) Search(ctx, p interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Search", reflect.TypeOf((*MockClientV6)(nil).Search), ctx, p)
-}
-
-// WaitForYellowStatus mocks base method.
-func (m *MockClientV6) WaitForYellowStatus(ctx context.Context, index string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WaitForYellowStatus", ctx, index)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// WaitForYellowStatus indicates an expected call of WaitForYellowStatus.
-func (mr *MockClientV6MockRecorder) WaitForYellowStatus(ctx, index interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitForYellowStatus", reflect.TypeOf((*MockClientV6)(nil).WaitForYellowStatus), ctx, index)
 }
 
 // MockCLIClient is a mock of CLIClient interface.
@@ -490,6 +447,20 @@ func (mr *MockCLIClientMockRecorder) CatIndices(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CatIndices", reflect.TypeOf((*MockCLIClient)(nil).CatIndices), ctx)
 }
 
+// CloseScroll mocks base method.
+func (m *MockCLIClient) CloseScroll(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseScroll", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseScroll indicates an expected call of CloseScroll.
+func (mr *MockCLIClientMockRecorder) CloseScroll(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseScroll", reflect.TypeOf((*MockCLIClient)(nil).CloseScroll), ctx, id)
+}
+
 // Count mocks base method.
 func (m *MockCLIClient) Count(ctx context.Context, index string, query v7.Query) (int64, error) {
 	m.ctrl.T.Helper()
@@ -534,6 +505,21 @@ func (mr *MockCLIClientMockRecorder) GetMapping(ctx, index interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMapping", reflect.TypeOf((*MockCLIClient)(nil).GetMapping), ctx, index)
 }
 
+// OpenScroll mocks base method.
+func (m *MockCLIClient) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenScroll", ctx, p, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenScroll indicates an expected call of OpenScroll.
+func (mr *MockCLIClientMockRecorder) OpenScroll(ctx, p, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenScroll", reflect.TypeOf((*MockCLIClient)(nil).OpenScroll), ctx, p, keepAliveInterval)
+}
+
 // PutMapping mocks base method.
 func (m *MockCLIClient) PutMapping(ctx context.Context, index string, mapping map[string]v1.IndexedValueType) (bool, error) {
 	m.ctrl.T.Helper()
@@ -562,6 +548,21 @@ func (m *MockCLIClient) RunBulkProcessor(ctx context.Context, p *BulkProcessorPa
 func (mr *MockCLIClientMockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockCLIClient)(nil).RunBulkProcessor), ctx, p)
+}
+
+// Scroll mocks base method.
+func (m *MockCLIClient) Scroll(ctx context.Context, scrollID, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Scroll", ctx, scrollID, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Scroll indicates an expected call of Scroll.
+func (mr *MockCLIClientMockRecorder) Scroll(ctx, scrollID, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockCLIClient)(nil).Scroll), ctx, scrollID, keepAliveInterval)
 }
 
 // Search mocks base method.
@@ -705,41 +706,4 @@ func (m *MockIntegrationTestsClient) IndexPutTemplate(ctx context.Context, templ
 func (mr *MockIntegrationTestsClientMockRecorder) IndexPutTemplate(ctx, templateName, bodyString interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IndexPutTemplate", reflect.TypeOf((*MockIntegrationTestsClient)(nil).IndexPutTemplate), ctx, templateName, bodyString)
-}
-
-// MockScrollService is a mock of ScrollService interface.
-type MockScrollService struct {
-	ctrl     *gomock.Controller
-	recorder *MockScrollServiceMockRecorder
-}
-
-// MockScrollServiceMockRecorder is the mock recorder for MockScrollService.
-type MockScrollServiceMockRecorder struct {
-	mock *MockScrollService
-}
-
-// NewMockScrollService creates a new mock instance.
-func NewMockScrollService(ctrl *gomock.Controller) *MockScrollService {
-	mock := &MockScrollService{ctrl: ctrl}
-	mock.recorder = &MockScrollServiceMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockScrollService) EXPECT() *MockScrollServiceMockRecorder {
-	return m.recorder
-}
-
-// Clear mocks base method.
-func (m *MockScrollService) Clear(ctx context.Context) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Clear", ctx)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Clear indicates an expected call of Clear.
-func (mr *MockScrollServiceMockRecorder) Clear(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Clear", reflect.TypeOf((*MockScrollService)(nil).Clear), ctx)
 }

--- a/common/persistence/visibility/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/elasticsearch/client/client_v7.go
@@ -49,7 +49,7 @@ type (
 )
 
 const (
-	pointInTimeSupportedFlavor = "default" // the other flavor is "OSS".
+	pointInTimeSupportedFlavor = "default" // the other flavor is "oss".
 )
 
 var (
@@ -195,7 +195,7 @@ func (c *clientV7) queryPointInTimeSupported(ctx context.Context) bool {
 	if err != nil {
 		return false
 	}
-	if result.Version.BuildFlavor != pointInTimeSupportedFlavor {
+	if result == nil || result.Version.BuildFlavor != pointInTimeSupportedFlavor {
 		return false
 	}
 	esVersion, err := semver.ParseTolerant(result.Version.Number)

--- a/common/persistence/visibility/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/elasticsearch/client/client_v7.go
@@ -27,9 +27,12 @@ package client
 import (
 	"context"
 	"net/http"
+	"net/url"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/olivere/elastic/v7"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/server/common/config"
@@ -39,11 +42,20 @@ import (
 type (
 	// clientV7 implements Client
 	clientV7 struct {
-		esClient *elastic.Client
+		esClient               *elastic.Client
+		url                    url.URL
+		isPointInTimeSupported atomic.Value
 	}
 )
 
-var _ Client = (*clientV7)(nil)
+const (
+	pointInTimeSupportedFlavor = "default" // the other flavor is "OSS".
+)
+
+var (
+	pointInTimeSupportedIn = semver.MustParseRange(">=7.10.0")
+)
+
 var _ ClientV7 = (*clientV7)(nil)
 
 // newClientV7 create a ES client
@@ -98,7 +110,10 @@ func newClientV7(cfg *config.Elasticsearch, httpClient *http.Client, logger log.
 		client.Start()
 	}
 
-	return &clientV7{esClient: client}, nil
+	return &clientV7{
+		esClient: client,
+		url:      cfg.URL,
+	}, nil
 }
 
 func newSimpleClientV7(url string) (*clientV7, error) {
@@ -138,6 +153,56 @@ func (c *clientV7) Search(ctx context.Context, p *SearchParameters) (*elastic.Se
 	}
 
 	return searchService.Do(ctx)
+}
+
+func (c *clientV7) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error) {
+	scrollService := elastic.NewScrollService(c.esClient).
+		Index(p.Index).
+		Query(p.Query).
+		SortBy(p.Sorter...).
+		KeepAlive(keepAliveInterval)
+
+	if p.PageSize != 0 {
+		scrollService.Size(p.PageSize)
+	}
+
+	searchResult, err := scrollService.Do(ctx)
+	return searchResult, err
+}
+
+func (c *clientV7) Scroll(ctx context.Context, scrollID string, keepAliveInterval string) (*elastic.SearchResult, error) {
+	scrollService := elastic.NewScrollService(c.esClient)
+	result, err := scrollService.ScrollId(scrollID).KeepAlive(keepAliveInterval).Do(ctx)
+	return result, err
+}
+
+func (c *clientV7) CloseScroll(ctx context.Context, id string) error {
+	err := elastic.NewScrollService(c.esClient).ScrollId(id).Clear(ctx)
+	return err
+}
+
+func (c *clientV7) IsPointInTimeSupported(ctx context.Context) bool {
+	isPointInTimeSupported := c.isPointInTimeSupported.Load()
+	if isPointInTimeSupported == nil {
+		isPointInTimeSupported = c.queryPointInTimeSupported(ctx)
+		c.isPointInTimeSupported.Store(isPointInTimeSupported)
+	}
+	return isPointInTimeSupported.(bool)
+}
+
+func (c *clientV7) queryPointInTimeSupported(ctx context.Context) bool {
+	result, _, err := c.esClient.Ping(c.url.String()).Do(ctx)
+	if err != nil {
+		return false
+	}
+	if result.Version.BuildFlavor != pointInTimeSupportedFlavor {
+		return false
+	}
+	esVersion, err := semver.ParseTolerant(result.Version.Number)
+	if err != nil {
+		return false
+	}
+	return pointInTimeSupportedIn(esVersion)
 }
 
 func (c *clientV7) OpenPointInTime(ctx context.Context, index string, keepAliveInterval string) (string, error) {

--- a/common/persistence/visibility/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store.go
@@ -55,6 +55,7 @@ const (
 
 	delimiter                    = "~"
 	pointInTimeKeepAliveInterval = "1m"
+	scrollKeepAliveInterval      = "1m"
 	defaultPageSize              = 1000
 )
 
@@ -73,9 +74,9 @@ type (
 		SearchAfter []interface{}
 
 		// For ScanWorkflowExecutions API.
-		// Deprecated. Remove after ES v6 support removal.
+		// For ES<7.10.0 and "oss" flavor.
 		ScrollID string
-		// Not supported in ES v6.
+		// For ES>=7.10.0 and "default" flavor.
 		PointInTimeID string
 	}
 )
@@ -388,10 +389,18 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(request *visibili
 }
 
 func (s *visibilityStore) ListWorkflowExecutions(request *visibility.ListWorkflowExecutionsRequestV2) (*visibility.InternalListWorkflowExecutionsResponse, error) {
-
 	p, err := s.buildSearchParametersV2(request)
 	if err != nil {
 		return nil, err
+	}
+
+	token, err := s.deserializePageToken(request.NextPageToken)
+	if err != nil {
+		return nil, err
+	}
+
+	if token != nil && len(token.SearchAfter) > 0 {
+		p.SearchAfter = token.SearchAfter
 	}
 
 	ctx := context.Background()
@@ -404,77 +413,106 @@ func (s *visibilityStore) ListWorkflowExecutions(request *visibility.ListWorkflo
 }
 
 func (s *visibilityStore) ScanWorkflowExecutions(request *visibility.ListWorkflowExecutionsRequestV2) (*visibility.InternalListWorkflowExecutionsResponse, error) {
-
 	ctx := context.Background()
-	switch esClient := s.esClient.(type) {
-	case client.ClientV7:
-		// Elasticsearch V7 uses "point in time" (PIT) instead of scroll to scan over all workflows without skipping them.
-		// https://www.elastic.co/guide/en/elasticsearch/reference/7.13/point-in-time-api.html
 
+	if esClientV7, isV7 := s.esClient.(client.ClientV7); isV7 {
+		// Elasticsearch 7.10+ can use "point in time" (PIT) instead of scroll to scan over all workflows without skipping or duplicating them.
+		// https://www.elastic.co/guide/en/elasticsearch/reference/7.10/point-in-time-api.html
+		if esClientV7.IsPointInTimeSupported(ctx) {
+			return s.scanWorkflowExecutionsWithPit(ctx, request, esClientV7)
+		}
+	}
+
+	return s.scanWorkflowExecutionsWithScroll(ctx, request)
+}
+
+func (s *visibilityStore) scanWorkflowExecutionsWithPit(ctx context.Context, request *visibility.ListWorkflowExecutionsRequestV2, esClient client.ClientV7) (*visibility.InternalListWorkflowExecutionsResponse, error) {
+	p, err := s.buildSearchParametersV2(request)
+	if err != nil {
+		return nil, err
+	}
+
+	// First call doesn't have token with PointInTimeID.
+	if len(request.NextPageToken) == 0 {
+		pitID, err := esClient.OpenPointInTime(ctx, s.index, pointInTimeKeepAliveInterval)
+		if err != nil {
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to create point in time: %s", detailedErrorMessage(err)))
+		}
+		p.PointInTime = elastic.NewPointInTimeWithKeepAlive(pitID, pointInTimeKeepAliveInterval)
+	} else {
+		token, err := s.deserializePageToken(request.NextPageToken)
+		if err != nil {
+			return nil, err
+		}
+		if token.PointInTimeID == "" {
+			return nil, serviceerror.NewInvalidArgument("pointInTimeId must present in pagination token")
+		}
+		p.SearchAfter = token.SearchAfter
+		p.PointInTime = elastic.NewPointInTimeWithKeepAlive(token.PointInTimeID, pointInTimeKeepAliveInterval)
+	}
+
+	searchResult, err := esClient.Search(ctx, p)
+	if err != nil {
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
+	}
+
+	if len(searchResult.Hits.Hits) < request.PageSize {
+		// It is the last page, close PIT.
+		_, err = esClient.ClosePointInTime(ctx, searchResult.PitId)
+		if err != nil {
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to close point in time: %s", detailedErrorMessage(err)))
+		}
+	}
+
+	results, err := s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
+	if err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+func (s *visibilityStore) scanWorkflowExecutionsWithScroll(ctx context.Context, request *visibility.ListWorkflowExecutionsRequestV2) (*visibility.InternalListWorkflowExecutionsResponse, error) {
+	var (
+		searchResult *elastic.SearchResult
+		scrollErr    error
+	)
+
+	// First call doesn't have token with ScrollID.
+	if len(request.NextPageToken) == 0 {
+		// First page.
 		p, err := s.buildSearchParametersV2(request)
 		if err != nil {
 			return nil, err
 		}
-
-		// First call doesn't have token with PointInTimeID.
-		if p.PointInTime == nil {
-			pointInTimeID, err := esClient.OpenPointInTime(ctx, s.index, pointInTimeKeepAliveInterval)
-			if err != nil {
-				return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to create point in time: %s", detailedErrorMessage(err)))
-			}
-			p.PointInTime = elastic.NewPointInTimeWithKeepAlive(pointInTimeID, pointInTimeKeepAliveInterval)
-		}
-
-		searchResult, err := esClient.Search(ctx, p)
+		searchResult, scrollErr = s.esClient.OpenScroll(ctx, p, scrollKeepAliveInterval)
+	} else {
+		token, err := s.deserializePageToken(request.NextPageToken)
 		if err != nil {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(err)))
+			return nil, err
 		}
-
-		if len(searchResult.Hits.Hits) < request.PageSize {
-			// It is the last page, close PIT.
-			_, err = esClient.ClosePointInTime(ctx, searchResult.PitId)
-			if err != nil {
-				return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to close point in time: %s", detailedErrorMessage(err)))
-			}
+		if token.ScrollID == "" {
+			return nil, serviceerror.NewInvalidArgument("scrollId must present in pagination token")
 		}
-		return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
-	case client.ClientV6:
-		var (
-			searchResult  *elastic.SearchResult
-			scrollService esclient.ScrollService
-			scrollErr     error
-		)
-
-		// First call doesn't have token with ScrollID.
-		if len(request.NextPageToken) == 0 {
-			// First page.
-			p, err := s.buildSearchParametersV2(request)
-			if err != nil {
-				return nil, err
-			}
-			searchResult, scrollService, scrollErr = esClient.ScrollFirstPage(ctx, p)
-		} else {
-			token, err := s.deserializePageToken(request.NextPageToken)
-			if err != nil {
-				return nil, err
-			}
-			if token.ScrollID == "" {
-				return nil, serviceerror.NewInvalidArgument("scrollId must present in pagination token")
-			}
-			searchResult, scrollService, scrollErr = esClient.Scroll(ctx, token.ScrollID)
-		}
-
-		isLastPage := false
-		if scrollErr == io.EOF { // no more result
-			isLastPage = true
-			_ = scrollService.Clear(context.Background())
-		} else if scrollErr != nil {
-			return nil, serviceerror.NewUnavailable(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(scrollErr)))
-		}
-		return s.getScrollWorkflowExecutionsResponse(searchResult.Hits, request.Namespace, request.PageSize, searchResult.ScrollId, isLastPage)
-	default:
-		panic("esClient has unsupported type")
+		searchResult, scrollErr = s.esClient.Scroll(ctx, token.ScrollID, scrollKeepAliveInterval)
 	}
+
+	if scrollErr == io.EOF {
+		// It is the last page, close scroll.
+		_ = s.esClient.CloseScroll(ctx, searchResult.ScrollId)
+	} else if scrollErr != nil {
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ScanWorkflowExecutions failed. Error: %s", detailedErrorMessage(scrollErr)))
+	}
+
+	results, err := s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if scrollErr == io.EOF {
+		// It is the last page, close scroll and clear token.
+		results.NextPageToken = nil
+	}
+	return results, nil
 }
 
 func (s *visibilityStore) CountWorkflowExecutions(request *visibility.CountWorkflowExecutionsRequest) (*visibility.CountWorkflowExecutionsResponse, error) {
@@ -554,11 +592,6 @@ func (s *visibilityStore) buildSearchParametersV2(
 	request *visibility.ListWorkflowExecutionsRequestV2,
 ) (*client.SearchParameters, error) {
 
-	token, err := s.deserializePageToken(request.NextPageToken)
-	if err != nil {
-		return nil, err
-	}
-
 	boolQuery, fieldSorts, err := s.convertQuery(request.Namespace, request.NamespaceID, request.Query)
 	if err != nil {
 		return nil, err
@@ -573,15 +606,6 @@ func (s *visibilityStore) buildSearchParametersV2(
 
 	if request.PageSize == 0 {
 		params.PageSize = defaultPageSize
-	}
-
-	if token != nil {
-		if len(token.SearchAfter) > 0 {
-			params.SearchAfter = token.SearchAfter
-		}
-		if token.PointInTimeID != "" {
-			params.PointInTime = elastic.NewPointInTimeWithKeepAlive(token.PointInTimeID, pointInTimeKeepAliveInterval)
-		}
 	}
 
 	return params, nil
@@ -633,40 +657,6 @@ func (s *visibilityStore) setDefaultFieldSort(fieldSorts []*elastic.FieldSort) [
 	return res
 }
 
-func (s *visibilityStore) getScrollWorkflowExecutionsResponse(
-	searchHits *elastic.SearchHits,
-	namespace string,
-	pageSize int,
-	scrollID string,
-	isLastPage bool,
-) (*visibility.InternalListWorkflowExecutionsResponse, error) {
-
-	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
-	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to read search attribute types: %v", err))
-	}
-
-	response := &visibility.InternalListWorkflowExecutionsResponse{}
-	response.Executions = make([]*visibility.VisibilityWorkflowExecutionInfo, len(searchHits.Hits))
-	for i := 0; i < len(searchHits.Hits); i++ {
-		response.Executions[i], err = s.parseESDoc(searchHits.Hits[i], typeMap, namespace)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	if len(searchHits.Hits) == pageSize && !isLastPage {
-		response.NextPageToken, err = s.serializePageToken(&visibilityPageToken{
-			ScrollID: scrollID,
-		})
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return response, nil
-}
-
 func (s *visibilityStore) getListWorkflowExecutionsResponse(
 	searchResult *elastic.SearchResult,
 	namespace string,
@@ -702,6 +692,7 @@ func (s *visibilityStore) getListWorkflowExecutionsResponse(
 		response.NextPageToken, err = s.serializePageToken(&visibilityPageToken{
 			SearchAfter:   lastHitSort,
 			PointInTimeID: searchResult.PitId,
+			ScrollID:      searchResult.ScrollId,
 		})
 		if err != nil {
 			return nil, err
@@ -957,4 +948,8 @@ func detailedErrorMessage(err error) string {
 		}
 	}
 	return sb.String()
+}
+
+func isPointInTimeAvailable() {
+
 }

--- a/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
@@ -29,6 +29,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"strings"
 	"testing"
@@ -1062,6 +1063,12 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 
+	// test io.EOF error
+	mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(testSearchResult, io.EOF)
+	mockESClientV6.EXPECT().CloseScroll(gomock.Any(), gomock.Any()).Return(nil)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.NoError(err)
+
 	// test unavailable error
 	mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
@@ -1118,6 +1125,12 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_Scroll() {
 	tokenBytes, err := s.visibilityStore.serializePageToken(token)
 	s.NoError(err)
 	request.NextPageToken = tokenBytes
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.NoError(err)
+
+	// test io.EOF error
+	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(testSearchResult, io.EOF)
+	s.mockESClient.EXPECT().CloseScroll(gomock.Any(), gomock.Any()).Return(nil)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 

--- a/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
@@ -57,8 +57,7 @@ type (
 		*require.Assertions
 		controller                 *gomock.Controller
 		visibilityStore            *visibilityStore
-		mockESClientV6             *esclient.MockClientV6
-		mockESClientV7             *esclient.MockClientV7
+		mockESClient               *esclient.MockClientV7
 		mockProcessor              *MockProcessor
 		mockMetricsClient          *metrics.MockClient
 		mockSearchAttributesMapper *searchattribute.MockMapper
@@ -115,10 +114,9 @@ func (s *ESVisibilitySuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockMetricsClient = metrics.NewMockClient(s.controller)
 	s.mockProcessor = NewMockProcessor(s.controller)
-	s.mockESClientV6 = esclient.NewMockClientV6(s.controller)
-	s.mockESClientV7 = esclient.NewMockClientV7(s.controller)
+	s.mockESClient = esclient.NewMockClientV7(s.controller)
 	s.mockSearchAttributesMapper = searchattribute.NewMockMapper(s.controller)
-	s.visibilityStore = NewVisibilityStore(s.mockESClientV7, testIndex, searchattribute.NewTestProvider(), nil, s.mockProcessor, cfg, s.mockMetricsClient)
+	s.visibilityStore = NewVisibilityStore(s.mockESClient, testIndex, searchattribute.NewTestProvider(), nil, s.mockProcessor, cfg, s.mockMetricsClient)
 }
 
 func (s *ESVisibilitySuite) TearDownTest() {
@@ -126,7 +124,7 @@ func (s *ESVisibilitySuite) TearDownTest() {
 }
 
 func (s *ESVisibilitySuite) TestListOpenWorkflowExecutions() {
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, input *esclient.SearchParameters) (*elastic.SearchResult, error) {
 			source, _ := input.Query.Source()
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterOpen))
@@ -135,7 +133,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutions() {
 	_, err := s.visibilityStore.ListOpenWorkflowExecutions(createTestRequest())
 	s.NoError(err)
 
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListOpenWorkflowExecutions(createTestRequest())
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
@@ -144,7 +142,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutions() {
 }
 
 func (s *ESVisibilitySuite) TestListClosedWorkflowExecutions() {
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, input *esclient.SearchParameters) (*elastic.SearchResult, error) {
 			source, _ := input.Query.Source()
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterClose))
@@ -153,7 +151,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutions() {
 	_, err := s.visibilityStore.ListClosedWorkflowExecutions(createTestRequest())
 	s.NoError(err)
 
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListClosedWorkflowExecutions(createTestRequest())
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
@@ -162,7 +160,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutions() {
 }
 
 func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, input *esclient.SearchParameters) (*elastic.SearchResult, error) {
 			source, _ := input.Query.Source()
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterOpen))
@@ -178,7 +176,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
 	_, err := s.visibilityStore.ListOpenWorkflowExecutionsByType(request)
 	s.NoError(err)
 
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByType(request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
@@ -187,7 +185,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
 }
 
 func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, input *esclient.SearchParameters) (*elastic.SearchResult, error) {
 			source, _ := input.Query.Source()
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterClose))
@@ -203,7 +201,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
 	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByType(request)
 	s.NoError(err)
 
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByType(request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
@@ -212,7 +210,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
 }
 
 func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, input *esclient.SearchParameters) (*elastic.SearchResult, error) {
 			source, _ := input.Query.Source()
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterOpen))
@@ -228,7 +226,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 	_, err := s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(request)
 	s.NoError(err)
 
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
@@ -237,7 +235,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 }
 
 func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, input *esclient.SearchParameters) (*elastic.SearchResult, error) {
 			source, _ := input.Query.Source()
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterClose))
@@ -253,7 +251,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
 	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(request)
 	s.NoError(err)
 
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
@@ -262,7 +260,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
 }
 
 func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByStatus() {
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, input *esclient.SearchParameters) (*elastic.SearchResult, error) {
 			source, _ := input.Query.Source()
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterByExecutionStatus))
@@ -277,7 +275,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByStatus() {
 	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByStatus(request)
 	s.NoError(err)
 
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByStatus(request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
@@ -466,30 +464,6 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	}, p)
 	request.Query = ""
 
-	// test for search after and pid
-	token := &visibilityPageToken{
-		SearchAfter:   []interface{}{json.Number("1528358645123456789"), "qwe"},
-		PointInTimeID: "pid",
-	}
-	request.NextPageToken, err = s.visibilityStore.serializePageToken(token)
-	s.NoError(err)
-
-	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery)
-	p, err = s.visibilityStore.buildSearchParametersV2(request)
-	s.NoError(err)
-	s.Equal(&esclient.SearchParameters{
-		Index:       testIndex,
-		Query:       boolQuery,
-		SearchAfter: []interface{}{json.Number("1528358645123456789"), "qwe"},
-		PointInTime: elastic.NewPointInTimeWithKeepAlive("pid", "1m"),
-		PageSize:    testPageSize,
-		Sorter: []elastic.Sorter{
-			elastic.NewFieldSort(searchattribute.StartTime).Desc(),
-			elastic.NewFieldSort(searchattribute.RunID).Desc(),
-		},
-	}, p)
-	request.NextPageToken = nil
-
 	// test for default page size
 	request.PageSize = 0
 	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery)
@@ -514,13 +488,6 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	s.Nil(p)
 	s.Error(err)
 	request.Query = ""
-
-	// test for wrong token
-	request.NextPageToken = []byte{1}
-	p, err = s.visibilityStore.buildSearchParametersV2(request)
-	s.Nil(p)
-	s.Error(err)
-	request.NextPageToken = nil
 }
 
 func (s *ESVisibilitySuite) queryToJSON(q elastic.Query) string {
@@ -1011,7 +978,7 @@ func (s *ESVisibilitySuite) TestParseESDoc_SearchAttributes_WithMapper() {
 }
 
 func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(ctx context.Context, p *esclient.SearchParameters) (*elastic.SearchResult, error) {
 			s.Equal(testIndex, p.Index)
 			s.Equal(
@@ -1032,7 +999,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 	_, err := s.visibilityStore.ListWorkflowExecutions(request)
 	s.NoError(err)
 
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ListWorkflowExecutions(request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
@@ -1049,10 +1016,12 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 
 func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 	// Set v6 client for test.
-	s.visibilityStore.esClient = s.mockESClientV6
+	mockESClientV6 := esclient.NewMockClient(s.controller)
+	s.visibilityStore.esClient = mockESClientV6
+
 	// test first page
-	s.mockESClientV6.EXPECT().ScrollFirstPage(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(ctx context.Context, p *esclient.SearchParameters) (*elastic.SearchResult, esclient.ScrollService, error) {
+	mockESClientV6.EXPECT().OpenScroll(gomock.Any(), gomock.Any(), "1m").DoAndReturn(
+		func(ctx context.Context, p *esclient.SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error) {
 			s.Equal(testIndex, p.Index)
 			s.Equal(
 				elastic.NewBoolQuery().Filter(
@@ -1060,7 +1029,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 					elastic.NewBoolQuery().Filter(elastic.NewMatchPhraseQuery("ExecutionStatus", "Terminated"))),
 				p.Query,
 			)
-			return testSearchResult, nil, nil
+			return testSearchResult, nil
 		})
 
 	request := &visibility.ListWorkflowExecutionsRequestV2{
@@ -1082,7 +1051,8 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 
 	// test scroll
 	scrollID := "scrollID-1"
-	s.mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID).Return(testSearchResult, nil, nil)
+	testSearchResult.ScrollId = scrollID
+	mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(testSearchResult, nil)
 
 	token := &visibilityPageToken{ScrollID: scrollID}
 	tokenBytes, err := s.visibilityStore.serializePageToken(token)
@@ -1092,14 +1062,13 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 	s.NoError(err)
 
 	// test last page
-	mockScroll := esclient.NewMockScrollService(s.controller)
-	s.mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID).Return(testSearchResult, mockScroll, io.EOF)
-	mockScroll.EXPECT().Clear(gomock.Any()).Return(nil)
+	mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(testSearchResult, io.EOF)
+	mockESClientV6.EXPECT().CloseScroll(gomock.Any(), scrollID).Return(nil)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 
 	// test internal error
-	s.mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID).Return(nil, nil, errTestESSearch)
+	mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.Error(err)
 	_, ok = err.(*serviceerror.Unavailable)
@@ -1107,10 +1076,71 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 	s.True(strings.Contains(err.Error(), "ScanWorkflowExecutions failed"))
 
 	// Restore v7 client.
-	s.visibilityStore.esClient = s.mockESClientV7
+	s.visibilityStore.esClient = s.mockESClient
+	testSearchResult.ScrollId = ""
 }
 
-func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7() {
+func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_Scroll() {
+	// test first page
+	s.mockESClient.EXPECT().OpenScroll(gomock.Any(), gomock.Any(), "1m").DoAndReturn(
+		func(ctx context.Context, p *esclient.SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error) {
+			s.Equal(testIndex, p.Index)
+			s.Equal(
+				elastic.NewBoolQuery().Filter(
+					elastic.NewTermQuery(searchattribute.NamespaceID, testNamespaceID),
+					elastic.NewBoolQuery().Filter(elastic.NewMatchPhraseQuery("ExecutionStatus", "Terminated"))),
+				p.Query,
+			)
+			return testSearchResult, nil
+		})
+	s.mockESClient.EXPECT().IsPointInTimeSupported(gomock.Any()).Return(false).AnyTimes()
+
+	request := &visibility.ListWorkflowExecutionsRequestV2{
+		NamespaceID: testNamespaceID,
+		Namespace:   testNamespace,
+		PageSize:    10,
+		Query:       `ExecutionStatus = "Terminated"`,
+	}
+	_, err := s.visibilityStore.ScanWorkflowExecutions(request)
+	s.NoError(err)
+
+	// test bad request
+	request.Query = `invalid query`
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.Error(err)
+	_, ok := err.(*serviceerror.InvalidArgument)
+	s.True(ok)
+	s.True(strings.HasPrefix(err.Error(), "unable to parse query"))
+
+	// test scroll
+	scrollID := "scrollID-1"
+	testSearchResult.ScrollId = scrollID
+	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(testSearchResult, nil)
+
+	token := &visibilityPageToken{ScrollID: scrollID}
+	tokenBytes, err := s.visibilityStore.serializePageToken(token)
+	s.NoError(err)
+	request.NextPageToken = tokenBytes
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.NoError(err)
+
+	// test last page
+	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(testSearchResult, io.EOF)
+	s.mockESClient.EXPECT().CloseScroll(gomock.Any(), scrollID).Return(nil)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.NoError(err)
+
+	// test internal error
+	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(nil, errTestESSearch)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	s.Error(err)
+	_, ok = err.(*serviceerror.Internal)
+	s.True(ok)
+	s.True(strings.Contains(err.Error(), "ScanWorkflowExecutions failed"))
+
+}
+
+func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_PIT() {
 	// test first page
 	pitID := "pitID"
 
@@ -1137,12 +1167,14 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7() {
 			Hits: []*elastic.SearchHit{
 				{
 					Source: source,
+					Sort:   []interface{}{json.Number("123"), "runId"},
 				},
 			},
 		},
 	}
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(searchResult, nil)
-	s.mockESClientV7.EXPECT().OpenPointInTime(gomock.Any(), testIndex, gomock.Any()).Return(pitID, nil)
+	s.mockESClient.EXPECT().IsPointInTimeSupported(gomock.Any()).Return(true).AnyTimes()
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(searchResult, nil)
+	s.mockESClient.EXPECT().OpenPointInTime(gomock.Any(), testIndex, gomock.Any()).Return(pitID, nil)
 	_, err := s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 
@@ -1156,14 +1188,20 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7() {
 
 	// test search
 	request.Query = `ExecutionStatus = "Terminated"`
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(searchResult, nil)
+	searchResult.PitId = pitID
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(searchResult, nil)
 
-	token := &visibilityPageToken{PointInTimeID: pitID, SearchAfter: []interface{}{2208, "qwe"}}
+	token := &visibilityPageToken{PointInTimeID: pitID, SearchAfter: []interface{}{json.Number("1528358645123456789"), "qwe"}}
 	tokenBytes, err := s.visibilityStore.serializePageToken(token)
 	s.NoError(err)
 	request.NextPageToken = tokenBytes
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	result, err := s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
+	responseToken, err := s.visibilityStore.deserializePageToken(result.NextPageToken)
+	s.NoError(err)
+	s.Equal([]interface{}{json.Number("123"), "runId"}, responseToken.SearchAfter)
+	s.Equal(pitID, responseToken.PointInTimeID)
+	searchResult.PitId = ""
 
 	// test last page
 	searchResult = &elastic.SearchResult{
@@ -1172,13 +1210,13 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7() {
 		},
 		PitId: pitID,
 	}
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(searchResult, nil)
-	s.mockESClientV7.EXPECT().ClosePointInTime(gomock.Any(), pitID).Return(true, nil)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(searchResult, nil)
+	s.mockESClient.EXPECT().ClosePointInTime(gomock.Any(), pitID).Return(true, nil)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 
 	// test internal error
-	s.mockESClientV7.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
+	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.Error(err)
 	_, ok = err.(*serviceerror.Unavailable)
@@ -1187,7 +1225,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7() {
 }
 
 func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
-	s.mockESClientV7.EXPECT().Count(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Count(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
 		func(ctx context.Context, index string, query elastic.Query) (int64, error) {
 			s.Equal(
 				elastic.NewBoolQuery().Filter(
@@ -1208,7 +1246,7 @@ func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 	s.Equal(int64(1), resp.Count)
 
 	// test internal error
-	s.mockESClientV7.EXPECT().Count(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
+	s.mockESClient.EXPECT().Count(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
 		func(ctx context.Context, index string, query elastic.Query) (int64, error) {
 			s.Equal(
 				elastic.NewBoolQuery().Filter(

--- a/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/elasticsearch/visibility_store_read_test.go
@@ -1067,7 +1067,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 
-	// test internal error
+	// test unavailable error
 	mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.Error(err)
@@ -1130,11 +1130,11 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_Scroll() {
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 
-	// test internal error
+	// test unavailable error
 	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.Error(err)
-	_, ok = err.(*serviceerror.Internal)
+	_, ok = err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ScanWorkflowExecutions failed"))
 
@@ -1215,7 +1215,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_PIT() {
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.NoError(err)
 
-	// test internal error
+	// test unavailable error
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
 	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
 	s.Error(err)
@@ -1245,7 +1245,7 @@ func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 	s.NoError(err)
 	s.Equal(int64(1), resp.Count)
 
-	// test internal error
+	// test unavailable error
 	s.mockESClient.EXPECT().Count(gomock.Any(), testIndex, gomock.Any()).DoAndReturn(
 		func(ctx context.Context, index string, query elastic.Query) (int64, error) {
 			s.Equal(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use point in time with Elasticsearch v7 only if it is available.

<!-- Tell your future self why have you made these changes -->
**Why?**
It turned out that "point in time" APIs are not available in open source version of Elasticsearch: https://github.com/elastic/elasticsearch/issues/65906. Fall back to scroll APIs if PIT is not available.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified existing and added new tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.