### PR TITLE
Update event blob size warning message

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -564,7 +564,7 @@ func CheckEventBlobSizeLimit(
 
 	if actualSize > warnLimit {
 		if logger != nil {
-			logger.Warn("Blob size exceeds limit.",
+			logger.Warn("Blob data size exceeds the warning limit.",
 				tag.WorkflowNamespaceID(namespaceID),
 				tag.WorkflowID(workflowID),
 				tag.WorkflowRunID(runID),


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

Updates the event blog size warning message text to be clearer