### PR TITLE
Add persistence mutable state mutation / snapshot binary size util

### DIFF
--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -32,6 +32,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 )
 
@@ -394,6 +395,31 @@ type (
 		Condition int64
 
 		Checksum *commonpb.DataBlob
+	}
+
+	InternalWorkflowStatus struct {
+		TotalSize int
+
+		// Breakdown of size into more granular stats
+		ExecutionInfoSize  int
+		ExecutionStateSize int
+
+		ActivityInfoSize      int
+		TimerInfoSize         int
+		ChildInfoSize         int
+		RequestCancelInfoSize int
+		SignalInfoSize        int
+		SignalRequestIDSize   int
+		BufferedEventsSize    int
+
+		// Item count for various information captured within mutable state
+		ActivityInfoCount      int
+		TimerInfoCount         int
+		ChildInfoCount         int
+		RequestCancelInfoCount int
+		SignalInfoCount        int
+		SignalRequestIDCount   int
+		BufferedEventsCount    int
 	}
 
 	// InternalWorkflowSnapshot is used as generic workflow execution state snapshot for Persistence Interface

--- a/common/persistence/size.go
+++ b/common/persistence/size.go
@@ -1,0 +1,242 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package persistence
+
+func statusOfInternalWorkflow(
+	state *InternalWorkflowMutableState,
+) InternalWorkflowStatus {
+	executionInfoSize := sizeOfExecutionInfo(state.ExecutionInfo)
+	executionStateSize := sizeOfExecutionState(state.ExecutionState)
+
+	activityInfoCount := len(state.ActivityInfos)
+	activityInfoSize := sizeOfActivityInfos(state.ActivityInfos)
+
+	timerInfoCount := len(state.TimerInfos)
+	timerInfoSize := sizeOfTimerInfos(state.TimerInfos)
+
+	childExecutionInfoCount := len(state.ChildExecutionInfos)
+	childExecutionInfoSize := sizeOfChildWorkflowInfos(state.ChildExecutionInfos)
+
+	requestCancelInfoCount := len(state.RequestCancelInfos)
+	requestCancelInfoSize := sizeOfRequestCancelInfos(state.RequestCancelInfos)
+
+	signalInfoCount := len(state.SignalInfos)
+	signalInfoSize := sizeOfSignalInfos(state.SignalInfos)
+
+	signalRequestIDCount := len(state.SignalRequestedIDs)
+	signalRequestIDSize := sizeOfStringSlice(state.SignalRequestedIDs)
+
+	bufferedEventsCount := len(state.BufferedEvents)
+	bufferedEventsSize := sizeOfBlobSlice(state.BufferedEvents)
+
+	totalSize := executionInfoSize
+	totalSize += executionStateSize
+	totalSize += activityInfoSize
+	totalSize += timerInfoSize
+	totalSize += childExecutionInfoSize
+	totalSize += requestCancelInfoSize
+	totalSize += signalInfoSize
+	totalSize += signalRequestIDSize
+	totalSize += bufferedEventsSize
+
+	return InternalWorkflowStatus{
+		TotalSize: totalSize,
+
+		ExecutionInfoSize:  executionInfoSize,
+		ExecutionStateSize: executionStateSize,
+
+		ActivityInfoSize:  activityInfoSize,
+		ActivityInfoCount: activityInfoCount,
+
+		TimerInfoSize:  timerInfoSize,
+		TimerInfoCount: timerInfoCount,
+
+		ChildInfoSize:  childExecutionInfoSize,
+		ChildInfoCount: childExecutionInfoCount,
+
+		RequestCancelInfoSize:  requestCancelInfoSize,
+		RequestCancelInfoCount: requestCancelInfoCount,
+
+		SignalInfoSize:  signalInfoSize,
+		SignalInfoCount: signalInfoCount,
+
+		SignalRequestIDSize:  signalRequestIDSize,
+		SignalRequestIDCount: signalRequestIDCount,
+
+		BufferedEventsSize:  bufferedEventsSize,
+		BufferedEventsCount: bufferedEventsCount,
+	}
+}
+
+func statusOfInternalWorkflowMutation(
+	mutation *InternalWorkflowMutation,
+) InternalWorkflowStatus {
+	executionInfoSize := sizeOfExecutionInfo(mutation.ExecutionInfo)
+	executionStateSize := sizeOfExecutionState(mutation.ExecutionStateBlob)
+
+	activityInfoCount := len(mutation.UpsertActivityInfos)
+	activityInfoCount += len(mutation.DeleteActivityInfos)
+	activityInfoSize := sizeOfActivityInfos(mutation.UpsertActivityInfos)
+	activityInfoSize += sizeOfActivityInfoIDs(mutation.DeleteActivityInfos)
+
+	timerInfoCount := len(mutation.UpsertTimerInfos)
+	timerInfoCount += len(mutation.DeleteTimerInfos)
+	timerInfoSize := sizeOfTimerInfos(mutation.UpsertTimerInfos)
+	timerInfoSize += sizeOfTimerInfoIDs(mutation.DeleteTimerInfos)
+
+	childExecutionInfoCount := len(mutation.UpsertChildExecutionInfos)
+	childExecutionInfoCount += len(mutation.DeleteChildExecutionInfos)
+	childExecutionInfoSize := sizeOfChildWorkflowInfos(mutation.UpsertChildExecutionInfos)
+	childExecutionInfoSize += sizeOfChildWorkflowInfoIDs(mutation.DeleteChildExecutionInfos)
+
+	requestCancelInfoCount := len(mutation.UpsertRequestCancelInfos)
+	requestCancelInfoCount += len(mutation.DeleteRequestCancelInfos)
+	requestCancelInfoSize := sizeOfRequestCancelInfos(mutation.UpsertRequestCancelInfos)
+	requestCancelInfoSize += sizeOfRequestCancelInfoIDs(mutation.DeleteRequestCancelInfos)
+
+	signalInfoCount := len(mutation.UpsertSignalInfos)
+	signalInfoCount += len(mutation.DeleteSignalInfos)
+	signalInfoSize := sizeOfSignalInfos(mutation.UpsertSignalInfos)
+	signalInfoSize += sizeOfSignalInfoIDs(mutation.DeleteSignalInfos)
+
+	signalRequestIDCount := len(mutation.UpsertSignalRequestedIDs)
+	signalRequestIDCount += len(mutation.DeleteSignalRequestedIDs)
+	signalRequestIDSize := sizeOfStringSet(mutation.UpsertSignalRequestedIDs)
+	signalRequestIDSize += sizeOfStringSet(mutation.DeleteSignalRequestedIDs)
+
+	bufferedEventsCount := 0
+	bufferedEventsSize := 0
+	if mutation.NewBufferedEvents != nil {
+		bufferedEventsCount = 1
+		bufferedEventsSize = mutation.NewBufferedEvents.Size()
+	}
+
+	// TODO what about tasks?
+	// TODO what about checksum?
+
+	totalSize := executionInfoSize
+	totalSize += executionStateSize
+	totalSize += activityInfoSize
+	totalSize += timerInfoSize
+	totalSize += childExecutionInfoSize
+	totalSize += requestCancelInfoSize
+	totalSize += signalInfoSize
+	totalSize += signalRequestIDSize
+	totalSize += bufferedEventsSize
+
+	return InternalWorkflowStatus{
+		TotalSize: totalSize,
+
+		ExecutionInfoSize:  executionInfoSize,
+		ExecutionStateSize: executionStateSize,
+
+		ActivityInfoSize:  activityInfoSize,
+		ActivityInfoCount: activityInfoCount,
+
+		TimerInfoSize:  timerInfoSize,
+		TimerInfoCount: timerInfoCount,
+
+		ChildInfoSize:  childExecutionInfoSize,
+		ChildInfoCount: childExecutionInfoCount,
+
+		RequestCancelInfoSize:  requestCancelInfoSize,
+		RequestCancelInfoCount: requestCancelInfoCount,
+
+		SignalInfoSize:  signalInfoSize,
+		SignalInfoCount: signalInfoCount,
+
+		SignalRequestIDSize:  signalRequestIDSize,
+		SignalRequestIDCount: signalRequestIDCount,
+
+		BufferedEventsSize:  bufferedEventsSize,
+		BufferedEventsCount: bufferedEventsCount,
+	}
+}
+
+func statusOfInternalWorkflowSnapshot(
+	snapshot *InternalWorkflowSnapshot,
+) InternalWorkflowStatus {
+	executionInfoSize := sizeOfExecutionInfo(snapshot.ExecutionInfo)
+	executionStateSize := sizeOfExecutionState(snapshot.ExecutionStateBlob)
+
+	activityInfoCount := len(snapshot.ActivityInfos)
+	activityInfoSize := sizeOfActivityInfos(snapshot.ActivityInfos)
+
+	timerInfoCount := len(snapshot.TimerInfos)
+	timerInfoSize := sizeOfTimerInfos(snapshot.TimerInfos)
+
+	childExecutionInfoCount := len(snapshot.ChildExecutionInfos)
+	childExecutionInfoSize := sizeOfChildWorkflowInfos(snapshot.ChildExecutionInfos)
+
+	requestCancelInfoCount := len(snapshot.RequestCancelInfos)
+	requestCancelInfoSize := sizeOfRequestCancelInfos(snapshot.RequestCancelInfos)
+
+	signalInfoCount := len(snapshot.SignalInfos)
+	signalInfoSize := sizeOfSignalInfos(snapshot.SignalInfos)
+
+	signalRequestIDCount := len(snapshot.SignalRequestedIDs)
+	signalRequestIDSize := sizeOfStringSet(snapshot.SignalRequestedIDs)
+
+	bufferedEventsCount := 0
+	bufferedEventsSize := 0
+
+	totalSize := executionInfoSize
+	totalSize += executionStateSize
+	totalSize += activityInfoSize
+	totalSize += timerInfoSize
+	totalSize += childExecutionInfoSize
+	totalSize += requestCancelInfoSize
+	totalSize += signalInfoSize
+	totalSize += signalRequestIDSize
+	totalSize += bufferedEventsSize
+
+	return InternalWorkflowStatus{
+		TotalSize: totalSize,
+
+		ExecutionInfoSize:  executionInfoSize,
+		ExecutionStateSize: executionStateSize,
+
+		ActivityInfoSize:  activityInfoSize,
+		ActivityInfoCount: activityInfoCount,
+
+		TimerInfoSize:  timerInfoSize,
+		TimerInfoCount: timerInfoCount,
+
+		ChildInfoSize:  childExecutionInfoSize,
+		ChildInfoCount: childExecutionInfoCount,
+
+		RequestCancelInfoSize:  requestCancelInfoSize,
+		RequestCancelInfoCount: requestCancelInfoCount,
+
+		SignalInfoSize:  signalInfoSize,
+		SignalInfoCount: signalInfoCount,
+
+		SignalRequestIDSize:  signalRequestIDSize,
+		SignalRequestIDCount: signalRequestIDCount,
+
+		BufferedEventsSize:  bufferedEventsSize,
+		BufferedEventsCount: bufferedEventsCount,
+	}
+}

--- a/common/persistence/size.go
+++ b/common/persistence/size.go
@@ -27,23 +27,23 @@ package persistence
 func statusOfInternalWorkflow(
 	state *InternalWorkflowMutableState,
 ) InternalWorkflowStatus {
-	executionInfoSize := sizeOfExecutionInfo(state.ExecutionInfo)
-	executionStateSize := sizeOfExecutionState(state.ExecutionState)
+	executionInfoSize := sizeOfBlob(state.ExecutionInfo)
+	executionStateSize := sizeOfBlob(state.ExecutionState)
 
 	activityInfoCount := len(state.ActivityInfos)
-	activityInfoSize := sizeOfActivityInfos(state.ActivityInfos)
+	activityInfoSize := sizeOfInt64BlobMap(state.ActivityInfos)
 
 	timerInfoCount := len(state.TimerInfos)
-	timerInfoSize := sizeOfTimerInfos(state.TimerInfos)
+	timerInfoSize := sizeOfStringBlobMap(state.TimerInfos)
 
 	childExecutionInfoCount := len(state.ChildExecutionInfos)
-	childExecutionInfoSize := sizeOfChildWorkflowInfos(state.ChildExecutionInfos)
+	childExecutionInfoSize := sizeOfInt64BlobMap(state.ChildExecutionInfos)
 
 	requestCancelInfoCount := len(state.RequestCancelInfos)
-	requestCancelInfoSize := sizeOfRequestCancelInfos(state.RequestCancelInfos)
+	requestCancelInfoSize := sizeOfInt64BlobMap(state.RequestCancelInfos)
 
 	signalInfoCount := len(state.SignalInfos)
-	signalInfoSize := sizeOfSignalInfos(state.SignalInfos)
+	signalInfoSize := sizeOfInt64BlobMap(state.SignalInfos)
 
 	signalRequestIDCount := len(state.SignalRequestedIDs)
 	signalRequestIDSize := sizeOfStringSlice(state.SignalRequestedIDs)
@@ -93,33 +93,33 @@ func statusOfInternalWorkflow(
 func statusOfInternalWorkflowMutation(
 	mutation *InternalWorkflowMutation,
 ) InternalWorkflowStatus {
-	executionInfoSize := sizeOfExecutionInfo(mutation.ExecutionInfo)
-	executionStateSize := sizeOfExecutionState(mutation.ExecutionStateBlob)
+	executionInfoSize := sizeOfBlob(mutation.ExecutionInfo)
+	executionStateSize := sizeOfBlob(mutation.ExecutionStateBlob)
 
 	activityInfoCount := len(mutation.UpsertActivityInfos)
 	activityInfoCount += len(mutation.DeleteActivityInfos)
-	activityInfoSize := sizeOfActivityInfos(mutation.UpsertActivityInfos)
-	activityInfoSize += sizeOfActivityInfoIDs(mutation.DeleteActivityInfos)
+	activityInfoSize := sizeOfInt64BlobMap(mutation.UpsertActivityInfos)
+	activityInfoSize += sizeOfInt64Set(mutation.DeleteActivityInfos)
 
 	timerInfoCount := len(mutation.UpsertTimerInfos)
 	timerInfoCount += len(mutation.DeleteTimerInfos)
-	timerInfoSize := sizeOfTimerInfos(mutation.UpsertTimerInfos)
-	timerInfoSize += sizeOfTimerInfoIDs(mutation.DeleteTimerInfos)
+	timerInfoSize := sizeOfStringBlobMap(mutation.UpsertTimerInfos)
+	timerInfoSize += sizeOfStringSet(mutation.DeleteTimerInfos)
 
 	childExecutionInfoCount := len(mutation.UpsertChildExecutionInfos)
 	childExecutionInfoCount += len(mutation.DeleteChildExecutionInfos)
-	childExecutionInfoSize := sizeOfChildWorkflowInfos(mutation.UpsertChildExecutionInfos)
-	childExecutionInfoSize += sizeOfChildWorkflowInfoIDs(mutation.DeleteChildExecutionInfos)
+	childExecutionInfoSize := sizeOfInt64BlobMap(mutation.UpsertChildExecutionInfos)
+	childExecutionInfoSize += sizeOfInt64Set(mutation.DeleteChildExecutionInfos)
 
 	requestCancelInfoCount := len(mutation.UpsertRequestCancelInfos)
 	requestCancelInfoCount += len(mutation.DeleteRequestCancelInfos)
-	requestCancelInfoSize := sizeOfRequestCancelInfos(mutation.UpsertRequestCancelInfos)
-	requestCancelInfoSize += sizeOfRequestCancelInfoIDs(mutation.DeleteRequestCancelInfos)
+	requestCancelInfoSize := sizeOfInt64BlobMap(mutation.UpsertRequestCancelInfos)
+	requestCancelInfoSize += sizeOfInt64Set(mutation.DeleteRequestCancelInfos)
 
 	signalInfoCount := len(mutation.UpsertSignalInfos)
 	signalInfoCount += len(mutation.DeleteSignalInfos)
-	signalInfoSize := sizeOfSignalInfos(mutation.UpsertSignalInfos)
-	signalInfoSize += sizeOfSignalInfoIDs(mutation.DeleteSignalInfos)
+	signalInfoSize := sizeOfInt64BlobMap(mutation.UpsertSignalInfos)
+	signalInfoSize += sizeOfInt64Set(mutation.DeleteSignalInfos)
 
 	signalRequestIDCount := len(mutation.UpsertSignalRequestedIDs)
 	signalRequestIDCount += len(mutation.DeleteSignalRequestedIDs)
@@ -178,23 +178,23 @@ func statusOfInternalWorkflowMutation(
 func statusOfInternalWorkflowSnapshot(
 	snapshot *InternalWorkflowSnapshot,
 ) InternalWorkflowStatus {
-	executionInfoSize := sizeOfExecutionInfo(snapshot.ExecutionInfo)
-	executionStateSize := sizeOfExecutionState(snapshot.ExecutionStateBlob)
+	executionInfoSize := sizeOfBlob(snapshot.ExecutionInfo)
+	executionStateSize := sizeOfBlob(snapshot.ExecutionStateBlob)
 
 	activityInfoCount := len(snapshot.ActivityInfos)
-	activityInfoSize := sizeOfActivityInfos(snapshot.ActivityInfos)
+	activityInfoSize := sizeOfInt64BlobMap(snapshot.ActivityInfos)
 
 	timerInfoCount := len(snapshot.TimerInfos)
-	timerInfoSize := sizeOfTimerInfos(snapshot.TimerInfos)
+	timerInfoSize := sizeOfStringBlobMap(snapshot.TimerInfos)
 
 	childExecutionInfoCount := len(snapshot.ChildExecutionInfos)
-	childExecutionInfoSize := sizeOfChildWorkflowInfos(snapshot.ChildExecutionInfos)
+	childExecutionInfoSize := sizeOfInt64BlobMap(snapshot.ChildExecutionInfos)
 
 	requestCancelInfoCount := len(snapshot.RequestCancelInfos)
-	requestCancelInfoSize := sizeOfRequestCancelInfos(snapshot.RequestCancelInfos)
+	requestCancelInfoSize := sizeOfInt64BlobMap(snapshot.RequestCancelInfos)
 
 	signalInfoCount := len(snapshot.SignalInfos)
-	signalInfoSize := sizeOfSignalInfos(snapshot.SignalInfos)
+	signalInfoSize := sizeOfInt64BlobMap(snapshot.SignalInfos)
 
 	signalRequestIDCount := len(snapshot.SignalRequestedIDs)
 	signalRequestIDSize := sizeOfStringSet(snapshot.SignalRequestedIDs)

--- a/common/persistence/size_util.go
+++ b/common/persistence/size_util.go
@@ -1,0 +1,163 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package persistence
+
+import (
+	commonpb "go.temporal.io/api/common/v1"
+)
+
+func sizeOfExecutionInfo(
+	executionInfo *commonpb.DataBlob,
+) int {
+	return executionInfo.Size()
+}
+
+func sizeOfExecutionState(
+	executionState *commonpb.DataBlob,
+) int {
+	return executionState.Size()
+}
+
+func sizeOfActivityInfoIDs(
+	activityInfoIDs map[int64]struct{},
+) int {
+	return sizeOfInt64Set(activityInfoIDs)
+}
+
+func sizeOfActivityInfos(
+	activityInfos map[int64]*commonpb.DataBlob,
+) int {
+	return sizeOfInt64BlobMap(activityInfos)
+}
+
+func sizeOfTimerInfoIDs(
+	timerInfoIDs map[string]struct{},
+) int {
+	size := 0
+	for id := range timerInfoIDs {
+		size += len(id)
+	}
+	return size
+}
+
+func sizeOfTimerInfos(
+	timerInfos map[string]*commonpb.DataBlob,
+) int {
+	size := 0
+	for id, blob := range timerInfos {
+		size += len(id) + blob.Size()
+	}
+	return size
+}
+
+func sizeOfChildWorkflowInfoIDs(
+	childWorkflowInfoIDs map[int64]struct{},
+) int {
+	return sizeOfInt64Set(childWorkflowInfoIDs)
+}
+
+func sizeOfChildWorkflowInfos(
+	childWorkflowInfos map[int64]*commonpb.DataBlob,
+) int {
+	return sizeOfInt64BlobMap(childWorkflowInfos)
+}
+
+func sizeOfRequestCancelInfoIDs(
+	requestCancelInfoIDs map[int64]struct{},
+) int {
+	return sizeOfInt64Set(requestCancelInfoIDs)
+}
+
+func sizeOfRequestCancelInfos(
+	requestCancelInfos map[int64]*commonpb.DataBlob,
+) int {
+	return sizeOfInt64BlobMap(requestCancelInfos)
+}
+
+func sizeOfSignalInfoIDs(
+	signalInfoIDs map[int64]struct{},
+) int {
+	return sizeOfInt64Set(signalInfoIDs)
+}
+
+func sizeOfSignalInfos(
+	signalInfos map[int64]*commonpb.DataBlob,
+) int {
+	return sizeOfInt64BlobMap(signalInfos)
+}
+
+func sizeOfSignalRequestIDs(
+	signalRequestIDs map[string]struct{},
+) int {
+	return sizeOfStringSet(signalRequestIDs)
+}
+
+func sizeOfInt64Set(
+	int64Set map[int64]struct{},
+) int {
+	// 8 == 64 bit / 8 bit per byte
+	return 8 * len(int64Set)
+}
+
+func sizeOfStringSet(
+	stringSet map[string]struct{},
+) int {
+	size := 0
+	for requestID := range stringSet {
+		size += len(requestID)
+	}
+	return size
+}
+
+func sizeOfInt64BlobMap(
+	kvBlob map[int64]*commonpb.DataBlob,
+) int {
+	size := 0
+	for _, blob := range kvBlob {
+		// 8 == 64 bit / 8 bit per byte
+		size += 8 + blob.Size()
+	}
+	return size
+}
+
+func sizeOfStringSlice(
+	stringSlice []string,
+) int {
+	size := 0
+	for _, str := range stringSlice {
+		size += len(str)
+	}
+	return size
+}
+
+func sizeOfBlobSlice(
+	blobSlice []*commonpb.DataBlob,
+) int {
+	size := 0
+	for _, blob := range blobSlice {
+		size += blob.Size()
+	}
+	return size
+}

--- a/common/persistence/size_util.go
+++ b/common/persistence/size_util.go
@@ -54,10 +54,10 @@ func sizeOfStringSet(
 func sizeOfInt64BlobMap(
 	kvBlob map[int64]*commonpb.DataBlob,
 ) int {
-	size := 0
+	// 8 == 64 bit / 8 bit per byte
+	size := 8 * len(kvBlob)
 	for _, blob := range kvBlob {
-		// 8 == 64 bit / 8 bit per byte
-		size += 8 + blob.Size()
+		size += blob.Size()
 	}
 	return size
 }

--- a/common/persistence/size_util.go
+++ b/common/persistence/size_util.go
@@ -28,90 +28,10 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 )
 
-func sizeOfExecutionInfo(
-	executionInfo *commonpb.DataBlob,
+func sizeOfBlob(
+	blob *commonpb.DataBlob,
 ) int {
-	return executionInfo.Size()
-}
-
-func sizeOfExecutionState(
-	executionState *commonpb.DataBlob,
-) int {
-	return executionState.Size()
-}
-
-func sizeOfActivityInfoIDs(
-	activityInfoIDs map[int64]struct{},
-) int {
-	return sizeOfInt64Set(activityInfoIDs)
-}
-
-func sizeOfActivityInfos(
-	activityInfos map[int64]*commonpb.DataBlob,
-) int {
-	return sizeOfInt64BlobMap(activityInfos)
-}
-
-func sizeOfTimerInfoIDs(
-	timerInfoIDs map[string]struct{},
-) int {
-	size := 0
-	for id := range timerInfoIDs {
-		size += len(id)
-	}
-	return size
-}
-
-func sizeOfTimerInfos(
-	timerInfos map[string]*commonpb.DataBlob,
-) int {
-	size := 0
-	for id, blob := range timerInfos {
-		size += len(id) + blob.Size()
-	}
-	return size
-}
-
-func sizeOfChildWorkflowInfoIDs(
-	childWorkflowInfoIDs map[int64]struct{},
-) int {
-	return sizeOfInt64Set(childWorkflowInfoIDs)
-}
-
-func sizeOfChildWorkflowInfos(
-	childWorkflowInfos map[int64]*commonpb.DataBlob,
-) int {
-	return sizeOfInt64BlobMap(childWorkflowInfos)
-}
-
-func sizeOfRequestCancelInfoIDs(
-	requestCancelInfoIDs map[int64]struct{},
-) int {
-	return sizeOfInt64Set(requestCancelInfoIDs)
-}
-
-func sizeOfRequestCancelInfos(
-	requestCancelInfos map[int64]*commonpb.DataBlob,
-) int {
-	return sizeOfInt64BlobMap(requestCancelInfos)
-}
-
-func sizeOfSignalInfoIDs(
-	signalInfoIDs map[int64]struct{},
-) int {
-	return sizeOfInt64Set(signalInfoIDs)
-}
-
-func sizeOfSignalInfos(
-	signalInfos map[int64]*commonpb.DataBlob,
-) int {
-	return sizeOfInt64BlobMap(signalInfos)
-}
-
-func sizeOfSignalRequestIDs(
-	signalRequestIDs map[string]struct{},
-) int {
-	return sizeOfStringSet(signalRequestIDs)
+	return blob.Size()
 }
 
 func sizeOfInt64Set(
@@ -138,6 +58,17 @@ func sizeOfInt64BlobMap(
 	for _, blob := range kvBlob {
 		// 8 == 64 bit / 8 bit per byte
 		size += 8 + blob.Size()
+	}
+	return size
+}
+
+func sizeOfStringBlobMap(
+	kvBlob map[string]*commonpb.DataBlob,
+) int {
+	size := 0
+	for id, blob := range kvBlob {
+		// 8 == 64 bit / 8 bit per byte
+		size += len(id) + blob.Size()
 	}
 	return size
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Add function to extract count / size info from
  * InternalWorkflowSnapshot
  * InternalWorkflowMutation
  * InternalWorkflowMutableState

<!-- Tell your future self why have you made these changes -->
**Why?**
Existing size calculation util is [not accurate](https://github.com/temporalio/temporal/blob/v1.12.0/common/persistence/statsComputer.go#L180-L246)
Size / count calculation is missing some attributes, e.g. request cancel info

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No