### PR TITLE
Set timeout for TestCluster

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceTest.go
+++ b/common/persistence/cassandra/cassandraPersistenceTest.go
@@ -30,9 +30,8 @@ import (
 	"strings"
 	"time"
 
-	"go.temporal.io/server/common/config"
-
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -77,7 +76,7 @@ func NewTestCluster(keyspace, username, password, host string, port int, schemaD
 		Hosts:          host,
 		Port:           port,
 		MaxConns:       2,
-		ConnectTimeout: 600 * time.Millisecond,
+		ConnectTimeout: 30 * time.Second,
 		Keyspace:       keyspace,
 	}
 	result.faultInjection = faultInjection
@@ -151,6 +150,7 @@ func (s *TestCluster) CreateSession(
 					Consistency: "ONE",
 				},
 			},
+			ConnectTimeout: s.cfg.ConnectTimeout,
 		},
 		resolver.NewNoopResolver(),
 		log.NewNoopLogger(),


### PR DESCRIPTION
**What changed?**
Set longer timeout for integration tests.

**Why?**
Avoid flakiness of integration test due to timeout.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No