### PR TITLE
Remove taskQueueManager by instance rather than queue ID

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -217,10 +217,15 @@ func (e *matchingEngineImpl) updateTaskQueue(taskQueue *taskQueueID, mgr taskQue
 	e.taskQueues[*taskQueue] = mgr
 }
 
-func (e *matchingEngineImpl) removeTaskQueueManager(id *taskQueueID) {
+func (e *matchingEngineImpl) removeTaskQueueManager(delTQM taskQueueManager) {
+	queueID := delTQM.QueueID()
 	e.taskQueuesLock.Lock()
 	defer e.taskQueuesLock.Unlock()
-	delete(e.taskQueues, *id)
+	foundTQM, ok := e.taskQueues[*queueID]
+	if !ok || foundTQM != delTQM {
+		return
+	}
+	delete(e.taskQueues, *queueID)
 }
 
 // AddWorkflowTask either delivers task directly to waiting poller or save it into task queue persistence.

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1602,8 +1602,6 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 	s.Nil(err)
 	s.True(0 < len(tasks) && len(tasks) <= rangeSize)
 	s.True(isReadBatchDone)
-
-	tlMgr.engine.removeTaskQueueManager(tlMgr.taskQueueID)
 }
 
 func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch_ReadBatchDone() {

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -256,7 +256,7 @@ func (c *taskQueueManagerImpl) Stop() {
 	c.liveness.Stop()
 	c.taskWriter.Stop()
 	c.taskReader.Stop()
-	c.engine.removeTaskQueueManager(c.taskQueueID)
+	c.engine.removeTaskQueueManager(c)
 	c.logger.Info("", tag.LifeCycleStopped)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Makes the logic in removeTaskQueueManager consistent with the update to
unloadQueue. I.e. remove a specific instance of taskQueueManager rather
than whatever instance happens to be associated with that taskQueueID at
the time.


<!-- Tell your future self why have you made these changes -->
**Why?**
A simplified version of a previous PR that was more aggressive in eliminating these calls but which is still being investigated as it does not pass integration testing

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit & integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minimal - we remove TQM in fewer cases

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
