### PR TITLE
Always return nil value for NextPageToken if there are no more pages

### DIFF
--- a/common/persistence/cassandra/cassandraClusterMetadata.go
+++ b/common/persistence/cassandra/cassandraClusterMetadata.go
@@ -199,19 +199,17 @@ func (m *cassandraClusterMetadata) GetClusterMembers(request *p.GetClusterMember
 		clusterMembers = append(clusterMembers, &member)
 	}
 
-	pagingToken := iter.PageState()
-	var pagingTokenCopy []byte
+	var pagingToken []byte
 	// contract of this API expect nil as pagination token instead of empty byte array
-	if len(pagingToken) > 0 {
-		pagingTokenCopy = make([]byte, len(pagingToken))
-		copy(pagingTokenCopy, pagingToken)
+	if len(iter.PageState()) > 0 {
+		pagingToken = iter.PageState()
 	}
 
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("GetClusterMembers", err)
 	}
 
-	return &p.GetClusterMembersResponse{ActiveMembers: clusterMembers, NextPageToken: pagingTokenCopy}, nil
+	return &p.GetClusterMembersResponse{ActiveMembers: clusterMembers, NextPageToken: pagingToken}, nil
 }
 
 func (m *cassandraClusterMetadata) UpsertClusterMembership(request *p.UpsertClusterMembershipRequest) error {

--- a/common/persistence/cassandra/cassandraHistoryPersistence.go
+++ b/common/persistence/cassandra/cassandraHistoryPersistence.go
@@ -165,7 +165,10 @@ func (h *cassandraPersistence) ReadHistoryBranch(
 	query := h.session.Query(queryString, treeID, branchID, request.MinNodeID, request.MaxNodeID)
 
 	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
-	pagingToken := iter.PageState()
+	var pagingToken []byte
+	if len(iter.PageState()) > 0 {
+		pagingToken = iter.PageState()
+	}
 
 	nodes := make([]p.InternalHistoryNode, 0, request.PageSize)
 	message := make(map[string]interface{})
@@ -293,7 +296,10 @@ func (h *cassandraPersistence) GetAllHistoryTreeBranches(
 
 	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
 
-	pagingToken := iter.PageState()
+	var pagingToken []byte
+	if len(iter.PageState()) > 0 {
+		pagingToken = iter.PageState()
+	}
 
 	branches := make([]p.InternalHistoryBranchDetail, 0, request.PageSize)
 	treeUUID := ""

--- a/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
+++ b/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
@@ -298,9 +298,9 @@ func (m *cassandraMetadataPersistenceV2) ListNamespaces(request *p.ListNamespace
 		}
 	}
 
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf("ListNamespaces operation failed. Error: %v", err))
 	}

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1529,9 +1529,9 @@ func (d *cassandraPersistence) ListConcreteExecutions(
 		}
 		result = make(map[string]interface{})
 	}
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	return response, nil
 }
 
@@ -1647,9 +1647,9 @@ func (d *cassandraPersistence) GetTransferTasks(
 
 		response.Tasks = append(response.Tasks, t)
 	}
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("GetTransferTasks", err)
@@ -1716,9 +1716,9 @@ func (d *cassandraPersistence) GetVisibilityTasks(
 
 		response.Tasks = append(response.Tasks, t)
 	}
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("GetVisibilityTasks", err)
@@ -1794,9 +1794,9 @@ func (d *cassandraPersistence) populateGetReplicationTasksResponse(
 
 		response.Tasks = append(response.Tasks, t)
 	}
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError(operation, err)
@@ -2361,9 +2361,9 @@ func (d *cassandraPersistence) GetTimerIndexTasks(
 
 		response.Timers = append(response.Timers, t)
 	}
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("GetTimerIndexTasks", err)

--- a/common/persistence/cassandra/cassandraQueue.go
+++ b/common/persistence/cassandra/cassandraQueue.go
@@ -203,14 +203,15 @@ func (q *cassandraQueue) ReadMessagesFromDLQ(
 		message = make(map[string]interface{})
 	}
 
-	nextPageToken := iter.PageState()
-	newPageToken := make([]byte, len(nextPageToken))
-	copy(newPageToken, nextPageToken)
+	var nextPageToken []byte
+	if len(iter.PageState()) > 0 {
+		nextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, nil, serviceerror.NewUnavailable(fmt.Sprintf("ReadMessagesFromDLQ operation failed. Error: %v", err))
 	}
 
-	return result, newPageToken, nil
+	return result, nextPageToken, nil
 }
 
 func (q *cassandraQueue) DeleteMessagesBefore(

--- a/common/persistence/visibility/cassandra/visibility_store.go
+++ b/common/persistence/visibility/cassandra/visibility_store.go
@@ -277,9 +277,9 @@ func (v *visibilityStore) ListOpenWorkflowExecutions(
 		wfexecution, has = readOpenWorkflowExecutionRecord(iter)
 	}
 
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("ListOpenWorkflowExecutions", err)
 	}
@@ -306,9 +306,9 @@ func (v *visibilityStore) ListOpenWorkflowExecutionsByType(
 		wfexecution, has = readOpenWorkflowExecutionRecord(iter)
 	}
 
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("ListOpenWorkflowExecutionsByType", err)
 	}
@@ -335,9 +335,9 @@ func (v *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
 		wfexecution, has = readOpenWorkflowExecutionRecord(iter)
 	}
 
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("ListOpenWorkflowExecutionsByWorkflowID", err)
 	}
@@ -363,9 +363,9 @@ func (v *visibilityStore) ListClosedWorkflowExecutions(
 		wfexecution, has = readClosedWorkflowExecutionRecord(iter)
 	}
 
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("ListClosedWorkflowExecutions", err)
 	}
@@ -392,9 +392,9 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByType(
 		wfexecution, has = readClosedWorkflowExecutionRecord(iter)
 	}
 
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("ListClosedWorkflowExecutionsByType", err)
 	}
@@ -421,9 +421,9 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
 		wfexecution, has = readClosedWorkflowExecutionRecord(iter)
 	}
 
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("ListClosedWorkflowExecutionsByWorkflowID", err)
 	}
@@ -450,9 +450,9 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByStatus(
 		wfexecution, has = readClosedWorkflowExecutionRecord(iter)
 	}
 
-	nextPageToken := iter.PageState()
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
+	if len(iter.PageState()) > 0 {
+		response.NextPageToken = iter.PageState()
+	}
 	if err := iter.Close(); err != nil {
 		return nil, gocql.ConvertError("ListClosedWorkflowExecutionsByStatus", err)
 	}

--- a/host/elasticsearch_test.go
+++ b/host/elasticsearch_test.go
@@ -138,6 +138,7 @@ func (s *elasticsearchIntegrationSuite) TestListOpenWorkflow() {
 		s.NoError(err)
 		if len(resp.GetExecutions()) == 1 {
 			openExecution = resp.GetExecutions()[0]
+			s.Nil(resp.NextPageToken)
 			break
 		}
 		time.Sleep(waitTimeInMs * time.Millisecond)
@@ -469,7 +470,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_MaxWindowSize() {
 	resp, err := s.engine.ListWorkflowExecutions(NewContext(), listRequest)
 	s.NoError(err)
 	s.True(len(resp.GetExecutions()) == 0)
-	s.True(len(resp.GetNextPageToken()) == 0)
+	s.Nil(resp.GetNextPageToken())
 }
 
 func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrderBy() {
@@ -715,6 +716,7 @@ func (s *elasticsearchIntegrationSuite) testHelperForReadOnce(expectedRunID stri
 			s.NoError(err)
 			if len(scanResponse.GetExecutions()) == 1 {
 				openExecution = scanResponse.GetExecutions()[0]
+				s.Nil(scanResponse.NextPageToken)
 				break
 			}
 		} else {
@@ -722,6 +724,7 @@ func (s *elasticsearchIntegrationSuite) testHelperForReadOnce(expectedRunID stri
 			s.NoError(err)
 			if len(listResponse.GetExecutions()) == 1 {
 				openExecution = listResponse.GetExecutions()[0]
+				s.Nil(listResponse.NextPageToken)
 				break
 			}
 		}
@@ -1025,6 +1028,7 @@ func (s *elasticsearchIntegrationSuite) testListResultForUpsertSearchAttributes(
 		resp, err := s.engine.ListWorkflowExecutions(NewContext(), listRequest)
 		s.NoError(err)
 		if len(resp.GetExecutions()) == 1 {
+			s.Nil(resp.NextPageToken)
 			execution := resp.GetExecutions()[0]
 			retrievedSearchAttr := execution.SearchAttributes
 			if retrievedSearchAttr != nil && len(retrievedSearchAttr.GetIndexedFields()) == 4 {

--- a/host/workflow_visibility_test.go
+++ b/host/workflow_visibility_test.go
@@ -145,6 +145,7 @@ func (s *integrationSuite) TestVisibility() {
 		closedCount = len(resp.Executions)
 		if closedCount == 1 {
 			historyLength = resp.Executions[0].HistoryLength
+			s.Nil(resp.NextPageToken)
 			break
 		}
 		s.Logger.Info("Closed WorkflowExecution is not yet visible")
@@ -162,6 +163,7 @@ func (s *integrationSuite) TestVisibility() {
 		s.NoError(err4)
 		openCount = len(resp.Executions)
 		if openCount == 1 {
+			s.Nil(resp.NextPageToken)
 			break
 		}
 		s.Logger.Info("Open WorkflowExecution is not yet visible")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Always return `nil` value for `NextPageToken` if there are no more pages. Previously some implementation returned `nil`, some zero length slice.

<!-- Tell your future self why have you made these changes -->
**Why?**
For consistency between different persistence implementations.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified existing test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there are explicit checks for zero-length slice (w/o checking for `nil`/`null` first) in user code in other languages it will fail.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.