### PR TITLE
Add custom logger option to schema tool

### DIFF
--- a/tools/common/schema/handler.go
+++ b/tools/common/schema/handler.go
@@ -60,6 +60,7 @@ func newUpdateConfig(cli *cli.Context) (*UpdateConfig, error) {
 	config := new(UpdateConfig)
 	config.SchemaDir = cli.String(CLIOptSchemaDir)
 	config.TargetVersion = cli.String(CLIOptTargetVersion)
+	config.Logger = log.NewCLILogger()
 
 	if err := validateUpdateConfig(config); err != nil {
 		return nil, err
@@ -97,6 +98,9 @@ func validateSetupConfig(config *SetupConfig) error {
 		}
 		config.InitialVersion = ver
 	}
+	if config.Logger == nil {
+		return NewConfigError("missing logger")
+	}
 	return nil
 }
 
@@ -110,6 +114,9 @@ func validateUpdateConfig(config *UpdateConfig) error {
 			return NewConfigError("invalid " + flag(CLIOptTargetVersion) + " argument:" + err.Error())
 		}
 		config.TargetVersion = ver
+	}
+	if config.Logger == nil {
+		return NewConfigError("missing logger")
 	}
 	return nil
 }

--- a/tools/common/schema/handler.go
+++ b/tools/common/schema/handler.go
@@ -26,6 +26,8 @@ package schema
 
 import (
 	"github.com/urfave/cli"
+
+	"go.temporal.io/server/common/log"
 )
 
 // SetupFromConfig sets up schema tables based on the given config
@@ -71,6 +73,7 @@ func newSetupConfig(cli *cli.Context) (*SetupConfig, error) {
 	config.InitialVersion = cli.String(CLIOptVersion)
 	config.DisableVersioning = cli.Bool(CLIOptDisableVersioning)
 	config.Overwrite = cli.Bool(CLIOptOverwrite)
+	config.Logger = log.NewCLILogger()
 
 	if err := validateSetupConfig(config); err != nil {
 		return nil, err

--- a/tools/common/schema/handler_test.go
+++ b/tools/common/schema/handler_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/common/log"
 )
 
 type (
@@ -49,6 +50,9 @@ func (s *HandlerTestSuite) SetupTest() {
 func (s *HandlerTestSuite) TestValidateSetupConfig() {
 
 	config := new(SetupConfig)
+	s.assertValidateSetupFails(config)
+
+	config.Logger = log.NewNoopLogger()
 	s.assertValidateSetupFails(config)
 
 	config.InitialVersion = "0.1"
@@ -85,6 +89,9 @@ func (s *HandlerTestSuite) TestValidateSetupConfig() {
 func (s *HandlerTestSuite) TestValidateUpdateConfig() {
 
 	config := new(UpdateConfig)
+	s.assertValidateUpdateFails(config)
+
+	config.Logger = log.NewNoopLogger()
 	s.assertValidateUpdateFails(config)
 
 	config.SchemaDir = "/tmp"

--- a/tools/common/schema/setuptask.go
+++ b/tools/common/schema/setuptask.go
@@ -25,10 +25,12 @@
 package schema
 
 import (
-	"log"
+	"fmt"
 	"path/filepath"
 
 	"github.com/blang/semver/v4"
+
+	"go.temporal.io/server/common/log/tag"
 )
 
 // SetupTask represents a task
@@ -49,7 +51,7 @@ func newSetupSchemaTask(db DB, config *SetupConfig) *SetupTask {
 // Run executes the task
 func (task *SetupTask) Run() error {
 	config := task.config
-	log.Printf("Starting schema setup, config=%+v\n", config)
+	config.Logger.Info("Starting schema setup", tag.NewAnyTag("config", config))
 
 	if config.Overwrite {
 		err := task.db.DropAllTables()
@@ -59,7 +61,7 @@ func (task *SetupTask) Run() error {
 	}
 
 	if !config.DisableVersioning {
-		log.Printf("Setting up version tables\n")
+		config.Logger.Debug("Setting up version tables")
 		if err := task.db.CreateSchemaVersionTables(); err != nil {
 			return err
 		}
@@ -75,14 +77,14 @@ func (task *SetupTask) Run() error {
 			return err
 		}
 
-		log.Println("----- Creating types and tables -----")
+		config.Logger.Debug("----- Creating types and tables -----")
 		for _, stmt := range stmts {
-			log.Println(rmspaceRegex.ReplaceAllString(stmt, " "))
+			config.Logger.Debug(rmspaceRegex.ReplaceAllString(stmt, " "))
 			if err := task.db.Exec(stmt); err != nil {
 				return err
 			}
 		}
-		log.Println("----- Done -----")
+		config.Logger.Debug("----- Done -----")
 	}
 
 	if !config.DisableVersioning {
@@ -93,23 +95,29 @@ func (task *SetupTask) Run() error {
 
 		currVerParsed, err := semver.ParseTolerant(currVer)
 		if err != nil {
-			log.Fatalf("Unable to parse current version %s: %v\n", currVer, err)
+			config.Logger.Fatal("Unable to parse current version",
+				tag.NewStringTag("current version", currVer),
+				tag.Error(err),
+			)
 		}
 
 		initialVersionParsed, err := semver.ParseTolerant(config.InitialVersion)
 		if err != nil {
-			log.Fatalf("Unable to parse initial version %s: %v\n", config.InitialVersion, err)
+			config.Logger.Fatal("Unable to parse initial version",
+				tag.NewStringTag("initial version", config.InitialVersion),
+				tag.Error(err),
+			)
 		}
 
 		if currVerParsed.GT(initialVersionParsed) {
-			log.Printf("Current database schema version %v is greater than initial schema version %v. Skip version upgrade\n", currVer, config.InitialVersion)
+			config.Logger.Debug(fmt.Sprintf("Current database schema version %v is greater than initial schema version %v. Skip version upgrade", currVer, config.InitialVersion))
 		} else {
-			log.Printf("Setting initial schema version to %v\n", config.InitialVersion)
+			config.Logger.Debug(fmt.Sprintf("Setting initial schema version to %v", config.InitialVersion))
 			err := task.db.UpdateSchemaVersion(config.InitialVersion, config.InitialVersion)
 			if err != nil {
 				return err
 			}
-			log.Printf("Updating schema update log\n")
+			config.Logger.Debug("Updating schema update log")
 			err = task.db.WriteSchemaUpdateLog("0", config.InitialVersion, "", "initial version")
 			if err != nil {
 				return err
@@ -117,7 +125,7 @@ func (task *SetupTask) Run() error {
 		}
 	}
 
-	log.Println("Schema setup complete")
+	config.Logger.Info("Schema setup complete")
 
 	return nil
 }

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -27,6 +27,8 @@ package schema
 import (
 	"fmt"
 	"regexp"
+
+	"go.temporal.io/server/common/log"
 )
 
 type (
@@ -50,6 +52,7 @@ type (
 		InitialVersion    string
 		Overwrite         bool // overwrite previous data
 		DisableVersioning bool // do not use schema versioning
+		Logger            log.Logger
 	}
 
 	// DB is the database interface that's required to be implemented

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -44,6 +44,7 @@ type (
 		TargetVersion string
 		SchemaDir     string
 		IsDryRun      bool
+		Logger        log.Logger
 	}
 	// SetupConfig holds the config
 	// params need by the SetupTask


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added a logger configuration option to the schema migration tool. This enables filtering and reformatting of migration logs.

<!-- Tell your future self why have you made these changes -->
**Why?**

The existing schema migration logs can be noisy, particularly when they are mixed in with test logs (as is the case in `temporalite`). This also makes it possible to output structured logs, which are typically easier to integrate with third party log aggregation services.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Validated by adding a local override for `go.temporal.io/server` in the go.mod of `temporalite` and running migrations against sqlite.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

The logs produced by the schema tool now default to a different format. This format is determined by the `log.NewCLILogger()` function.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

no