### PR TITLE
Ignore goveralls exit code

### DIFF
--- a/develop/buildkite/pipeline.yml
+++ b/develop/buildkite/pipeline.yml
@@ -173,7 +173,7 @@ steps:
           run: integration-test-xdc-postgresql
           config: ./develop/buildkite/docker-compose.yml
 
-  - label: ":golang: fossa"
+  - label: ":tiger2: fossa"
     agents:
       queue: "default"
       docker: "*"
@@ -188,14 +188,14 @@ steps:
 
   - wait
 
-  - label: ":golang: coverage-report"
+  - label: ":coverage: coverage-report"
     agents:
       queue: "default"
       docker: "*"
     command: "./develop/buildkite/scripts/coverage-report.sh"
     artifact_paths:
-      - ".coverage/summary_coverprofile.out"
-      - ".coverage/summary_coverprofile.out.html"
+      - ".coverage/summary.out"
+      - ".coverage/summary.out.html"
     retry:
       automatic:
         limit: 2


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ignore goveralls exit code.

<!-- Tell your future self why have you made these changes -->
**Why?**
Don't block the build in case if [coveralls.io](https://coveralls.io/) is down. `goveralls` doesn't report actual coverage status right away anyway so there is no point blocking build on its exit code.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.