### PR TITLE
Make ResilientSyncMatch the default behavior

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -153,7 +153,6 @@ var Keys = map[Key]string{
 	MatchingForwarderMaxOutstandingTasks:    "matching.forwarderMaxOutstandingTasks",
 	MatchingForwarderMaxRatePerSecond:       "matching.forwarderMaxRatePerSecond",
 	MatchingForwarderMaxChildrenPerNode:     "matching.forwarderMaxChildrenPerNode",
-	ResilientSyncMatch:                      "matching.resilientSyncMatch",
 	MatchingShutdownDrainDuration:           "matching.shutdownDrainDuration",
 
 	// history settings
@@ -538,8 +537,6 @@ const (
 	MatchingForwarderMaxRatePerSecond
 	// MatchingForwarderMaxChildrenPerNode is the max number of children per node in the task queue partition tree
 	MatchingForwarderMaxChildrenPerNode
-	// ResilientSyncMatch enables or disables sync-matching while queue persistence is unavailable
-	ResilientSyncMatch
 	// MatchingShutdownDrainDuration is the duration of traffic drain during shutdown
 	MatchingShutdownDrainDuration
 

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -54,7 +54,6 @@ type (
 		ForwarderMaxOutstandingTasks dynamicconfig.IntPropertyFnWithTaskQueueInfoFilters
 		ForwarderMaxRatePerSecond    dynamicconfig.IntPropertyFnWithTaskQueueInfoFilters
 		ForwarderMaxChildrenPerNode  dynamicconfig.IntPropertyFnWithTaskQueueInfoFilters
-		ResilientSyncMatch           dynamicconfig.BoolPropertyFn
 
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskQueueInfoFilters
@@ -100,10 +99,6 @@ type (
 		AdminNamespaceToPartitionDispatchRate func() float64
 		// partition qps = AdminNamespaceTaskQueueToPartitionDispatchRate(namespace, task_queue)
 		AdminNamespaceTaskQueueToPartitionDispatchRate func() float64
-
-		// ResilientSyncMatch enables or disables sync-matching while
-		// persistence is unavailable
-		ResilientSyncMatch func() bool
 	}
 )
 
@@ -131,7 +126,6 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 		ForwarderMaxOutstandingTasks:    dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingForwarderMaxOutstandingTasks, 1),
 		ForwarderMaxRatePerSecond:       dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingForwarderMaxRatePerSecond, 10),
 		ForwarderMaxChildrenPerNode:     dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingForwarderMaxChildrenPerNode, 20),
-		ResilientSyncMatch:              dc.GetBoolProperty(dynamicconfig.ResilientSyncMatch, false),
 		ShutdownDrainDuration:           dc.GetDurationProperty(dynamicconfig.MatchingShutdownDrainDuration, 0),
 
 		AdminNamespaceToPartitionDispatchRate:          dc.GetFloatPropertyFilteredByNamespace(dynamicconfig.AdminMatchingNamespaceToPartitionDispatchRate, 10000),
@@ -209,9 +203,6 @@ func newTaskQueueConfig(id *taskQueueID, config *Config, namespaceCache namespac
 			ForwarderMaxChildrenPerNode: func() int {
 				return common.MaxInt(1, config.ForwarderMaxChildrenPerNode(namespace, taskQueueName, taskType))
 			},
-		},
-		ResilientSyncMatch: func() bool {
-			return config.ResilientSyncMatch()
 		},
 	}, nil
 }

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -212,13 +212,9 @@ func (c *taskQueueManagerImpl) signalIfFatal(err error) bool {
 	if err == nil {
 		return false
 	}
-	foreignLessee := false
 	var condfail *persistence.ConditionFailedError
 	if errors.As(err, &condfail) {
 		c.metricScope().IncCounter(metrics.ConditionFailedErrorPerTaskQueueCounter)
-		foreignLessee = true
-	}
-	if foreignLessee || !c.config.ResilientSyncMatch() {
 		c.signalFatalProblem(c)
 		return true
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Make ResilientSyncMatch the default behavior

<!-- Tell your future self why have you made these changes -->
**Why?**
Continues to do some matching during persistence outages

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This has been in the product behind a feature flag for several weeks. Has seen multiple flavors of persistence outages through scale testing.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No