### PR TITLE
Remove deprecated metrics config code as per release 1.11 note

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -67,8 +67,6 @@ type (
 	Service struct {
 		// RPC is the rpc configuration
 		RPC RPC `yaml:"rpc"`
-		// Deprecated. Use Metrics in global section instead.
-		Metrics metrics.Config `yaml:"metrics"`
 	}
 
 	// PProf contains the config items for the pprof utility

--- a/common/resource/bootstrapParams.go
+++ b/common/resource/bootstrapParams.go
@@ -62,8 +62,6 @@ type (
 		PersistenceConfig            config.Persistence
 		ClusterMetadataConfig        *config.ClusterMetadata
 		ReplicatorConfig             config.Replicator
-		ServerMetricsReporter        metrics.Reporter
-		SDKMetricsReporter           metrics.Reporter
 		MetricsClient                metrics.Client
 		ESClient                     esclient.Client
 		ESConfig                     *config.Elasticsearch

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -310,19 +310,6 @@ func (s *Server) newBootstrapParams(
 			)
 		}
 
-	// todo: Replace this hack with actually using sdkReporter, Client or Scope.
-	if serverReporter == nil {
-		var err error
-		serverReporter, sdkReporter, err = svcCfg.Metrics.InitMetricReporters(s.logger, nil)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"unable to initialize per-service metric client. "+
-					"This is deprecated behavior used as fallback, please use global metric config. Error: %w", err)
-		}
-		params.ServerMetricsReporter = serverReporter
-		params.SDKMetricsReporter = sdkReporter
-	}
-
 	globalTallyScope, err := s.extractTallyScopeForSDK(sdkReporter)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed deprecated per-service metrics config.
Deprecation not see https://github.com/temporalio/temporal/releases/tag/v1.11.0

<!-- Tell your future self why have you made these changes -->
**Why?**
Remove deprecated code.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
automated tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
deprecated configuration will not work.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
