### PR TITLE
Remove default page size from Elasticsearch visibility store

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -55,7 +55,6 @@ const (
 	delimiter                    = "~"
 	pointInTimeKeepAliveInterval = "1m"
 	scrollKeepAliveInterval      = "1m"
-	defaultPageSize              = 1000
 )
 
 type (
@@ -564,10 +563,6 @@ func (s *visibilityStore) buildSearchParameters(
 		params.SearchAfter = token.SearchAfter
 	}
 
-	if request.PageSize == 0 {
-		params.PageSize = defaultPageSize
-	}
-
 	if overStartTime {
 		params.Sorter = append(params.Sorter, elastic.NewFieldSort(searchattribute.StartTime).Desc())
 	} else {
@@ -594,10 +589,6 @@ func (s *visibilityStore) buildSearchParametersV2(
 		Query:    boolQuery,
 		PageSize: request.PageSize,
 		Sorter:   s.setDefaultFieldSort(fieldSorts),
-	}
-
-	if request.PageSize == 0 {
-		params.PageSize = defaultPageSize
 	}
 
 	return params, nil

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -379,24 +379,6 @@ func (s *ESVisibilitySuite) TestBuildSearchParameters() {
 	}, p)
 	request = createTestRequest() // revert
 
-	// test for default page size
-	request.PageSize = 0
-	rangeQuery = elastic.NewRangeQuery(searchattribute.StartTime).Gte(request.EarliestStartTime).Lte(request.LatestStartTime)
-	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery).Filter(rangeQuery)
-	p, err = s.visibilityStore.buildSearchParameters(request, elastic.NewBoolQuery(), true)
-	s.NoError(err)
-	s.Equal(&client.SearchParameters{
-		Index:       testIndex,
-		Query:       boolQuery,
-		SearchAfter: nil,
-		PageSize:    1000,
-		Sorter: []elastic.Sorter{
-			elastic.NewFieldSort(searchattribute.StartTime).Desc(),
-			elastic.NewFieldSort(searchattribute.RunID).Desc(),
-		},
-	}, p)
-	request = createTestRequest() // revert
-
 	// test for nil token
 	rangeQuery = elastic.NewRangeQuery(searchattribute.StartTime).Gte(request.EarliestStartTime).Lte(request.LatestStartTime)
 	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery).Filter(rangeQuery)
@@ -460,24 +442,6 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 		},
 	}, p)
 	request.Query = ""
-
-	// test for default page size
-	request.PageSize = 0
-	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery)
-	p, err = s.visibilityStore.buildSearchParametersV2(request)
-	s.NoError(err)
-	s.Equal(&client.SearchParameters{
-		Index:       testIndex,
-		Query:       boolQuery,
-		SearchAfter: nil,
-		PointInTime: nil,
-		PageSize:    1000,
-		Sorter: []elastic.Sorter{
-			elastic.NewFieldSort(searchattribute.StartTime).Desc(),
-			elastic.NewFieldSort(searchattribute.RunID).Desc(),
-		},
-	}, p)
-	request.PageSize = testPageSize
 
 	// test for wrong query
 	request.Query = "invalid query"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove default page size from Elasticsearch visibility store.

<!-- Tell your future self why have you made these changes -->
**Why?**
Elasticsearch page size is set on a frontend so it shouldn't be set on store level. Also other stores don't have it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.