### PR TITLE
Set timeout for all Elasticsearch read calls

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -109,9 +109,8 @@ func NewVisibilityStore(
 	}
 }
 
-func newReadContext() context.Context {
-	ctx, _ := context.WithTimeout(context.Background(), readTimeout)
-	return ctx
+func newReadContext() (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.Background(), readTimeout)
 }
 
 func (s *visibilityStore) Close() {
@@ -236,7 +235,9 @@ func (s *visibilityStore) ListOpenWorkflowExecutions(request *manager.ListWorkfl
 		return nil, err
 	}
 
-	searchResult, err := s.esClient.Search(newReadContext(), p)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
 		return nil, convertElasticsearchClientError("ListOpenWorkflowExecutions failed", err)
 	}
@@ -258,7 +259,9 @@ func (s *visibilityStore) ListClosedWorkflowExecutions(request *manager.ListWork
 		return nil, err
 	}
 
-	searchResult, err := s.esClient.Search(newReadContext(), p)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
 		return nil, convertElasticsearchClientError("ListClosedWorkflowExecutions failed", err)
 	}
@@ -282,7 +285,9 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByType(request *manager.List
 		return nil, err
 	}
 
-	searchResult, err := s.esClient.Search(newReadContext(), p)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
 		return nil, convertElasticsearchClientError("ListOpenWorkflowExecutionsByType failed", err)
 	}
@@ -305,7 +310,9 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByType(request *manager.Li
 		return nil, err
 	}
 
-	searchResult, err := s.esClient.Search(newReadContext(), p)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
 		return nil, convertElasticsearchClientError("ListClosedWorkflowExecutionsByType failed", err)
 	}
@@ -329,7 +336,9 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(request *manage
 		return nil, err
 	}
 
-	searchResult, err := s.esClient.Search(newReadContext(), p)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
 		return nil, convertElasticsearchClientError("ListOpenWorkflowExecutionsByWorkflowID failed", err)
 	}
@@ -352,7 +361,9 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(request *mana
 		return nil, err
 	}
 
-	searchResult, err := s.esClient.Search(newReadContext(), p)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
 		return nil, convertElasticsearchClientError("ListClosedWorkflowExecutionsByWorkflowID failed", err)
 	}
@@ -374,7 +385,9 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(request *manager.
 		return nil, err
 	}
 
-	searchResult, err := s.esClient.Search(newReadContext(), p)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
 		return nil, convertElasticsearchClientError("ListClosedWorkflowExecutionsByStatus failed", err)
 	}
@@ -401,7 +414,9 @@ func (s *visibilityStore) ListWorkflowExecutions(request *manager.ListWorkflowEx
 		p.SearchAfter = token.SearchAfter
 	}
 
-	searchResult, err := s.esClient.Search(newReadContext(), p)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	searchResult, err := s.esClient.Search(ctx, p)
 	if err != nil {
 		return nil, convertElasticsearchClientError("ListWorkflowExecutions failed", err)
 	}
@@ -410,7 +425,8 @@ func (s *visibilityStore) ListWorkflowExecutions(request *manager.ListWorkflowEx
 }
 
 func (s *visibilityStore) ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*store.InternalListWorkflowExecutionsResponse, error) {
-	ctx := newReadContext()
+	ctx, cancel := newReadContext()
+	defer cancel()
 
 	if esClientV7, isV7 := s.esClient.(client.ClientV7); isV7 {
 		// Elasticsearch 7.10+ can use "point in time" (PIT) instead of scroll to scan over all workflows without skipping or duplicating them.
@@ -511,7 +527,9 @@ func (s *visibilityStore) CountWorkflowExecutions(request *manager.CountWorkflow
 		return nil, err
 	}
 
-	count, err := s.esClient.Count(newReadContext(), s.index, boolQuery)
+	ctx, cancel := newReadContext()
+	defer cancel()
+	count, err := s.esClient.Count(ctx, s.index, boolQuery)
 	if err != nil {
 		return nil, convertElasticsearchClientError("CountWorkflowExecutions failed", err)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set timeout (16 seconds) for all Elasticsearch read calls.

<!-- Tell your future self why have you made these changes -->
**Why?**
Closes #581.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Calls to Elasticsearch longer than 16 seconds will start to fail. But our RPC timeout is shorter so no real calls should be affected.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.