### PR TITLE
Remove CacheEntry.GetReplicationConfig

### DIFF
--- a/common/namespace/cache.go
+++ b/common/namespace/cache.go
@@ -44,7 +44,6 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
-	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -81,6 +80,18 @@ const (
 )
 
 type (
+	ClusterInfo interface {
+		IsGlobalNamespaceEnabled() bool
+		GetCurrentClusterName() string
+	}
+
+	Persistence interface {
+		ListNamespaces(
+			*persistence.ListNamespacesRequest,
+		) (*persistence.ListNamespacesResponse, error)
+		GetMetadata() (*persistence.GetMetadataResponse, error)
+	}
+
 	// PrepareCallbackFn is function to be called before CallbackFn is called,
 	// it is guaranteed that PrepareCallbackFn and CallbackFn pair will be both called or non will be called
 	PrepareCallbackFn func()
@@ -109,15 +120,15 @@ type (
 	}
 
 	namespaceCache struct {
-		status          int32
-		shutdownChan    chan struct{}
-		cacheNameToID   *atomic.Value
-		cacheByID       *atomic.Value
-		metadataMgr     persistence.MetadataManager
-		clusterMetadata cluster.Metadata
-		timeSource      clock.TimeSource
-		metricsClient   metrics.Client
-		logger          log.Logger
+		status        int32
+		shutdownChan  chan struct{}
+		cacheNameToID *atomic.Value
+		cacheByID     *atomic.Value
+		persistence   Persistence
+		thisCluster   ClusterInfo
+		timeSource    clock.TimeSource
+		metricsClient metrics.Client
+		logger        log.Logger
 
 		// refresh lock is used to guarantee at most one
 		// coroutine is doing namespace refreshment
@@ -137,7 +148,7 @@ type (
 
 	// CacheEntry contains the info and config for a namespace
 	CacheEntry struct {
-		clusterMetadata cluster.Metadata
+		thisCluster ClusterInfo
 		sync.RWMutex
 		info                        *persistencespb.NamespaceInfo
 		config                      *persistencespb.NamespaceConfig
@@ -153,8 +164,8 @@ type (
 
 // NewNamespaceCache creates a new instance of cache for holding onto namespace information to reduce the load on persistence
 func NewNamespaceCache(
-	metadataMgr persistence.MetadataManager,
-	clusterMetadata cluster.Metadata,
+	persistence Persistence,
+	thisCluster ClusterInfo,
 	metricsClient metrics.Client,
 	logger log.Logger,
 ) Cache {
@@ -164,8 +175,8 @@ func NewNamespaceCache(
 		shutdownChan:     make(chan struct{}),
 		cacheNameToID:    &atomic.Value{},
 		cacheByID:        &atomic.Value{},
-		metadataMgr:      metadataMgr,
-		clusterMetadata:  clusterMetadata,
+		persistence:      persistence,
+		thisCluster:      thisCluster,
 		timeSource:       clock.NewRealTimeSource(),
 		metricsClient:    metricsClient,
 		logger:           logger,
@@ -187,73 +198,11 @@ func newCache() cache.Cache {
 	return cache.New(namespaceCacheMaxSize, opts)
 }
 
-func newCacheEntry(
-	clusterMetadata cluster.Metadata,
-) *CacheEntry {
+func newCacheEntry(thisCluster ClusterInfo) *CacheEntry {
 
 	return &CacheEntry{
-		clusterMetadata: clusterMetadata,
-		initialized:     false,
-	}
-}
-
-// NewGlobalCacheEntryForTest returns an entry with test data
-func NewGlobalCacheEntryForTest(
-	info *persistencespb.NamespaceInfo,
-	config *persistencespb.NamespaceConfig,
-	repConfig *persistencespb.NamespaceReplicationConfig,
-	failoverVersion int64,
-	clusterMetadata cluster.Metadata,
-) *CacheEntry {
-
-	return &CacheEntry{
-		info:              info,
-		config:            config,
-		isGlobalNamespace: true,
-		replicationConfig: repConfig,
-		failoverVersion:   failoverVersion,
-		clusterMetadata:   clusterMetadata,
-	}
-}
-
-// NewLocalCacheEntryForTest returns an entry with test data
-func NewLocalCacheEntryForTest(
-	info *persistencespb.NamespaceInfo,
-	config *persistencespb.NamespaceConfig,
-	targetCluster string,
-	clusterMetadata cluster.Metadata,
-) *CacheEntry {
-
-	return &CacheEntry{
-		info:              info,
-		config:            config,
-		isGlobalNamespace: false,
-		replicationConfig: &persistencespb.NamespaceReplicationConfig{
-			ActiveClusterName: targetCluster,
-			Clusters:          []string{targetCluster},
-		},
-		failoverVersion: common.EmptyVersion,
-		clusterMetadata: clusterMetadata,
-	}
-}
-
-// NewNamespaceCacheEntryForTest returns an entry with test data
-func NewNamespaceCacheEntryForTest(
-	info *persistencespb.NamespaceInfo,
-	config *persistencespb.NamespaceConfig,
-	isGlobalNamespace bool,
-	repConfig *persistencespb.NamespaceReplicationConfig,
-	failoverVersion int64,
-	clusterMetadata cluster.Metadata,
-) *CacheEntry {
-
-	return &CacheEntry{
-		info:              info,
-		config:            config,
-		isGlobalNamespace: isGlobalNamespace,
-		replicationConfig: repConfig,
-		failoverVersion:   failoverVersion,
-		clusterMetadata:   clusterMetadata,
+		thisCluster: thisCluster,
+		initialized: false,
 	}
 }
 
@@ -456,7 +405,7 @@ func (c *namespaceCache) refreshNamespacesLocked() error {
 
 	// first load the metadata record, then load namespaces
 	// this can guarantee that namespaces in the cache are not updated more than metadata record
-	metadata, err := c.metadataMgr.GetMetadata()
+	metadata, err := c.persistence.GetMetadata()
 	if err != nil {
 		return err
 	}
@@ -469,13 +418,13 @@ func (c *namespaceCache) refreshNamespacesLocked() error {
 
 	for continuePage {
 		request.NextPageToken = token
-		response, err := c.metadataMgr.ListNamespaces(request)
+		response, err := c.persistence.ListNamespaces(request)
 		if err != nil {
 			return err
 		}
 		token = response.NextPageToken
 		for _, namespace := range response.Namespaces {
-			namespaces = append(namespaces, c.buildEntryFromRecord(namespace))
+			namespaces = append(namespaces, FromPersistentState(c.thisCluster, namespace))
 		}
 		continuePage = len(token) != 0
 	}
@@ -547,7 +496,7 @@ func (c *namespaceCache) updateIDToNamespaceCache(
 	record *CacheEntry,
 ) (*CacheEntry, *CacheEntry, error) {
 
-	elem, err := cacheByID.PutIfNotExist(id, newCacheEntry(c.clusterMetadata))
+	elem, err := cacheByID.PutIfNotExist(id, newCacheEntry(c.thisCluster))
 	if err != nil {
 		return nil, nil, err
 	}
@@ -557,7 +506,7 @@ func (c *namespaceCache) updateIDToNamespaceCache(
 	defer entry.Unlock()
 
 	var prevNamespace *CacheEntry
-	triggerCallback := c.clusterMetadata.IsGlobalNamespaceEnabled() &&
+	triggerCallback := c.thisCluster.IsGlobalNamespaceEnabled() &&
 		// initialized will be true when the entry contains valid data
 		entry.initialized &&
 		record.notificationVersion > entry.notificationVersion
@@ -632,35 +581,61 @@ func (c *namespaceCache) triggerNamespaceChangeCallbackLocked(
 	}
 }
 
-func (c *namespaceCache) buildEntryFromRecord(
+func FromPersistentState(
+	thisCluster ClusterInfo,
 	record *persistence.GetNamespaceResponse,
 ) *CacheEntry {
+	return &CacheEntry{
+		thisCluster:                 thisCluster,
+		info:                        record.Namespace.Info,
+		config:                      record.Namespace.Config,
+		replicationConfig:           record.Namespace.ReplicationConfig,
+		configVersion:               record.Namespace.ConfigVersion,
+		failoverVersion:             record.Namespace.FailoverVersion,
+		isGlobalNamespace:           record.IsGlobalNamespace,
+		failoverNotificationVersion: record.Namespace.FailoverNotificationVersion,
+		notificationVersion:         record.NotificationVersion,
+		initialized:                 true,
+	}
+}
 
-	// this is a shallow copy, but since the record is generated by persistence
-	// and only accessible here, it would be fine
-	newEntry := newCacheEntry(c.clusterMetadata)
-	newEntry.info = record.Namespace.Info
-	newEntry.config = record.Namespace.Config
-	newEntry.replicationConfig = record.Namespace.ReplicationConfig
-	newEntry.configVersion = record.Namespace.ConfigVersion
-	newEntry.failoverVersion = record.Namespace.FailoverVersion
-	newEntry.isGlobalNamespace = record.IsGlobalNamespace
-	newEntry.failoverNotificationVersion = record.Namespace.FailoverNotificationVersion
-	newEntry.notificationVersion = record.NotificationVersion
-	newEntry.initialized = true
-	return newEntry
+type EntryMutation func(*persistence.GetNamespaceResponse)
+
+func (entry *CacheEntry) CloneWith(ms ...EntryMutation) *CacheEntry {
+	newEntry := entry.duplicate()
+	r := persistence.GetNamespaceResponse{
+		Namespace: &persistencespb.NamespaceDetail{
+			Info:                        newEntry.info,
+			Config:                      newEntry.config,
+			ReplicationConfig:           newEntry.replicationConfig,
+			ConfigVersion:               newEntry.configVersion,
+			FailoverNotificationVersion: newEntry.failoverNotificationVersion,
+			FailoverVersion:             newEntry.failoverVersion,
+		},
+		IsGlobalNamespace:   newEntry.isGlobalNamespace,
+		NotificationVersion: newEntry.notificationVersion,
+	}
+	for _, m := range ms {
+		m(&r)
+	}
+	return FromPersistentState(entry.thisCluster, &r)
 }
 
 func (entry *CacheEntry) duplicate() *CacheEntry {
 	// this is a deep copy
-	result := newCacheEntry(entry.clusterMetadata)
+	result := newCacheEntry(entry.thisCluster)
 	result.info = proto.Clone(entry.info).(*persistencespb.NamespaceInfo)
 	if result.info.Data == nil {
 		result.info.Data = make(map[string]string, 0)
 	}
 
 	result.config = proto.Clone(entry.config).(*persistencespb.NamespaceConfig)
-	if result.config.BadBinaries == nil || result.config.BadBinaries.Binaries == nil {
+	if result.config.BadBinaries == nil {
+		result.config.BadBinaries = &namespacepb.BadBinaries{
+			Binaries: make(map[string]*namespacepb.BadBinaryInfo, 0),
+		}
+	}
+	if result.config.BadBinaries.Binaries == nil {
 		result.config.BadBinaries.Binaries = make(map[string]*namespacepb.BadBinaryInfo, 0)
 	}
 
@@ -684,9 +659,19 @@ func (entry *CacheEntry) GetConfig() *persistencespb.NamespaceConfig {
 	return entry.config
 }
 
-// GetReplicationConfig return the namespace replication config
-func (entry *CacheEntry) GetReplicationConfig() *persistencespb.NamespaceReplicationConfig {
-	return entry.replicationConfig
+// ActiveClusterName observes the name of the cluster that is currently active
+// for this namspace.
+func (entry *CacheEntry) ActiveClusterName() string {
+	return entry.replicationConfig.ActiveClusterName
+}
+
+// ClusterNames observes the names of the clusters to which this namespace is
+// replicated.
+func (entry *CacheEntry) ClusterNames() []string {
+	// copy slice to preserve immutability
+	out := make([]string, len(entry.replicationConfig.Clusters))
+	copy(out, entry.replicationConfig.Clusters)
+	return out
 }
 
 // GetConfigVersion return the namespace config version
@@ -720,7 +705,7 @@ func (entry *CacheEntry) IsNamespaceActive() bool {
 		// namespace is not a global namespace, meaning namespace is always "active" within each cluster
 		return true
 	}
-	return entry.clusterMetadata.GetCurrentClusterName() == entry.replicationConfig.ActiveClusterName
+	return entry.thisCluster.GetCurrentClusterName() == entry.replicationConfig.ActiveClusterName
 }
 
 // GetReplicationPolicy return the derived workflow replication policy
@@ -741,7 +726,7 @@ func (entry *CacheEntry) GetNamespaceNotActiveErr() error {
 	}
 	return serviceerror.NewNamespaceNotActive(
 		entry.info.Name,
-		entry.clusterMetadata.GetCurrentClusterName(),
+		entry.thisCluster.GetCurrentClusterName(),
 		entry.replicationConfig.ActiveClusterName,
 	)
 }

--- a/common/namespace/cache_mock.go
+++ b/common/namespace/cache_mock.go
@@ -35,6 +35,41 @@ import (
 	persistence "go.temporal.io/server/common/persistence"
 )
 
+// MockEntryMutation is a mock of EntryMutation interface.
+type MockEntryMutation struct {
+	ctrl     *gomock.Controller
+	recorder *MockEntryMutationMockRecorder
+}
+
+// MockEntryMutationMockRecorder is the mock recorder for MockEntryMutation.
+type MockEntryMutationMockRecorder struct {
+	mock *MockEntryMutation
+}
+
+// NewMockEntryMutation creates a new mock instance.
+func NewMockEntryMutation(ctrl *gomock.Controller) *MockEntryMutation {
+	mock := &MockEntryMutation{ctrl: ctrl}
+	mock.recorder = &MockEntryMutationMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockEntryMutation) EXPECT() *MockEntryMutationMockRecorder {
+	return m.recorder
+}
+
+// apply mocks base method.
+func (m *MockEntryMutation) apply(arg0 *persistence.GetNamespaceResponse) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "apply", arg0)
+}
+
+// apply indicates an expected call of apply.
+func (mr *MockEntryMutationMockRecorder) apply(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "apply", reflect.TypeOf((*MockEntryMutation)(nil).apply), arg0)
+}
+
 // MockClusterInfo is a mock of ClusterInfo interface.
 type MockClusterInfo struct {
 	ctrl     *gomock.Controller

--- a/common/namespace/cache_mock.go
+++ b/common/namespace/cache_mock.go
@@ -32,7 +32,112 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	persistence "go.temporal.io/server/common/persistence"
 )
+
+// MockClusterInfo is a mock of ClusterInfo interface.
+type MockClusterInfo struct {
+	ctrl     *gomock.Controller
+	recorder *MockClusterInfoMockRecorder
+}
+
+// MockClusterInfoMockRecorder is the mock recorder for MockClusterInfo.
+type MockClusterInfoMockRecorder struct {
+	mock *MockClusterInfo
+}
+
+// NewMockClusterInfo creates a new mock instance.
+func NewMockClusterInfo(ctrl *gomock.Controller) *MockClusterInfo {
+	mock := &MockClusterInfo{ctrl: ctrl}
+	mock.recorder = &MockClusterInfoMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockClusterInfo) EXPECT() *MockClusterInfoMockRecorder {
+	return m.recorder
+}
+
+// GetCurrentClusterName mocks base method.
+func (m *MockClusterInfo) GetCurrentClusterName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentClusterName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetCurrentClusterName indicates an expected call of GetCurrentClusterName.
+func (mr *MockClusterInfoMockRecorder) GetCurrentClusterName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentClusterName", reflect.TypeOf((*MockClusterInfo)(nil).GetCurrentClusterName))
+}
+
+// IsGlobalNamespaceEnabled mocks base method.
+func (m *MockClusterInfo) IsGlobalNamespaceEnabled() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsGlobalNamespaceEnabled")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsGlobalNamespaceEnabled indicates an expected call of IsGlobalNamespaceEnabled.
+func (mr *MockClusterInfoMockRecorder) IsGlobalNamespaceEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsGlobalNamespaceEnabled", reflect.TypeOf((*MockClusterInfo)(nil).IsGlobalNamespaceEnabled))
+}
+
+// MockPersistence is a mock of Persistence interface.
+type MockPersistence struct {
+	ctrl     *gomock.Controller
+	recorder *MockPersistenceMockRecorder
+}
+
+// MockPersistenceMockRecorder is the mock recorder for MockPersistence.
+type MockPersistenceMockRecorder struct {
+	mock *MockPersistence
+}
+
+// NewMockPersistence creates a new mock instance.
+func NewMockPersistence(ctrl *gomock.Controller) *MockPersistence {
+	mock := &MockPersistence{ctrl: ctrl}
+	mock.recorder = &MockPersistenceMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPersistence) EXPECT() *MockPersistenceMockRecorder {
+	return m.recorder
+}
+
+// GetMetadata mocks base method.
+func (m *MockPersistence) GetMetadata() (*persistence.GetMetadataResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetadata")
+	ret0, _ := ret[0].(*persistence.GetMetadataResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMetadata indicates an expected call of GetMetadata.
+func (mr *MockPersistenceMockRecorder) GetMetadata() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockPersistence)(nil).GetMetadata))
+}
+
+// ListNamespaces mocks base method.
+func (m *MockPersistence) ListNamespaces(arg0 *persistence.ListNamespacesRequest) (*persistence.ListNamespacesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListNamespaces", arg0)
+	ret0, _ := ret[0].(*persistence.ListNamespacesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListNamespaces indicates an expected call of ListNamespaces.
+func (mr *MockPersistenceMockRecorder) ListNamespaces(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockPersistence)(nil).ListNamespaces), arg0)
+}
 
 // MockCache is a mock of Cache interface.
 type MockCache struct {

--- a/common/namespace/namespacetest/mutate.go
+++ b/common/namespace/namespacetest/mutate.go
@@ -1,0 +1,36 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package namespacetest
+
+import (
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+)
+
+func SetActiveCluster(name string) namespace.EntryMutation {
+	return func(ns *persistence.GetNamespaceResponse) {
+		ns.Namespace.ReplicationConfig.ActiveClusterName = name
+	}
+}

--- a/common/namespace/testconstructors.go
+++ b/common/namespace/testconstructors.go
@@ -1,0 +1,92 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package namespace
+
+import (
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
+)
+
+//TODO: delete this whole file and transition usages to FromPersistentState
+
+// NewLocalCacheEntryForTest returns an entry with test data
+func NewLocalCacheEntryForTest(
+	info *persistencespb.NamespaceInfo,
+	config *persistencespb.NamespaceConfig,
+	targetCluster string,
+	thisCluster ClusterInfo,
+) *CacheEntry {
+
+	return &CacheEntry{
+		info:              info,
+		config:            config,
+		isGlobalNamespace: false,
+		replicationConfig: &persistencespb.NamespaceReplicationConfig{
+			ActiveClusterName: targetCluster,
+			Clusters:          []string{targetCluster},
+		},
+		failoverVersion: common.EmptyVersion,
+		thisCluster:     thisCluster,
+	}
+}
+
+// NewNamespaceCacheEntryForTest returns an entry with test data
+func NewNamespaceCacheEntryForTest(
+	info *persistencespb.NamespaceInfo,
+	config *persistencespb.NamespaceConfig,
+	isGlobalNamespace bool,
+	repConfig *persistencespb.NamespaceReplicationConfig,
+	failoverVersion int64,
+	thisCluster ClusterInfo,
+) *CacheEntry {
+
+	return &CacheEntry{
+		info:              info,
+		config:            config,
+		isGlobalNamespace: isGlobalNamespace,
+		replicationConfig: repConfig,
+		failoverVersion:   failoverVersion,
+		thisCluster:       thisCluster,
+	}
+}
+
+// newGlobalCacheEntryForTest returns an entry with test data
+func NewGlobalCacheEntryForTest(
+	info *persistencespb.NamespaceInfo,
+	config *persistencespb.NamespaceConfig,
+	repConfig *persistencespb.NamespaceReplicationConfig,
+	failoverVersion int64,
+	thisCluster ClusterInfo,
+) *CacheEntry {
+
+	return &CacheEntry{
+		info:              info,
+		config:            config,
+		isGlobalNamespace: true,
+		replicationConfig: repConfig,
+		failoverVersion:   failoverVersion,
+		thisCluster:       thisCluster,
+	}
+}

--- a/service/frontend/dcRedirectionPolicy.go
+++ b/service/frontend/dcRedirectionPolicy.go
@@ -170,7 +170,7 @@ func (policy *SelectedAPIsForwardingRedirectionPolicy) getTargetClusterAndIsName
 		return policy.currentClusterName, false
 	}
 
-	if len(namespaceEntry.GetReplicationConfig().Clusters) == 1 {
+	if len(namespaceEntry.ClusterNames()) == 1 {
 		// do not do dc redirection if namespace is only targeting at 1 dc (effectively local namespace)
 		return policy.currentClusterName, false
 	}
@@ -186,5 +186,5 @@ func (policy *SelectedAPIsForwardingRedirectionPolicy) getTargetClusterAndIsName
 		return policy.currentClusterName, false
 	}
 
-	return namespaceEntry.GetReplicationConfig().ActiveClusterName, true
+	return namespaceEntry.ActiveClusterName(), true
 }

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -757,8 +757,8 @@ func (v *commandAttrValidator) validateCrossNamespaceCall(
 		return nil
 	}
 
-	namespaceClusters := namespaceEntry.GetReplicationConfig().Clusters
-	targetNamespaceClusters := targetNamespaceEntry.GetReplicationConfig().Clusters
+	namespaceClusters := namespaceEntry.ClusterNames()
+	targetNamespaceClusters := targetNamespaceEntry.ClusterNames()
 
 	// one is local namespace, another one is global namespace or both global namespace
 	// treat global namespace with one replication cluster as local namespace

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -352,7 +352,7 @@ func (e *historyEngineImpl) registerNamespaceFailoverCallback() {
 
 	failoverPredicate := func(shardNotificationVersion int64, nextNamespace *namespace.CacheEntry, action func()) {
 		namespaceFailoverNotificationVersion := nextNamespace.GetFailoverNotificationVersion()
-		namespaceActiveCluster := nextNamespace.GetReplicationConfig().ActiveClusterName
+		namespaceActiveCluster := nextNamespace.ActiveClusterName()
 
 		if nextNamespace.IsGlobalNamespace() &&
 			namespaceFailoverNotificationVersion >= shardNotificationVersion &&

--- a/service/history/replicationTaskExecutor.go
+++ b/service/history/replicationTaskExecutor.go
@@ -251,7 +251,7 @@ func (e *replicationTaskExecutorImpl) filterTask(
 
 	shouldProcessTask := false
 FilterLoop:
-	for _, targetCluster := range namespaceEntry.GetReplicationConfig().Clusters {
+	for _, targetCluster := range namespaceEntry.ClusterNames() {
 		if e.currentCluster == targetCluster {
 			shouldProcessTask = true
 			break FilterLoop

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -920,7 +920,7 @@ func (s *ContextImpl) allocateTimerIDsLocked(
 			// cannot use version to determine the corresponding cluster for timer task
 			// this is because during failover, timer task should be created as active
 			// or otherwise, failover + active processing logic may not pick up the task.
-			currentCluster = namespaceEntry.GetReplicationConfig().ActiveClusterName
+			currentCluster = namespaceEntry.ActiveClusterName()
 		}
 		readCursorTS := s.timerMaxReadLevelMap[currentCluster]
 		if ts.Before(readCursorTS) {

--- a/service/history/taskAllocator.go
+++ b/service/history/taskAllocator.go
@@ -80,7 +80,7 @@ func (t *taskAllocatorImpl) verifyActiveTask(taskNamespaceID string, task interf
 		t.logger.Warn("Cannot find namespace, default to process task.", tag.WorkflowNamespaceID(taskNamespaceID), tag.Value(task))
 		return true, nil
 	}
-	if namespaceEntry.IsGlobalNamespace() && t.currentClusterName != namespaceEntry.GetReplicationConfig().ActiveClusterName {
+	if namespaceEntry.IsGlobalNamespace() && t.currentClusterName != namespaceEntry.ActiveClusterName() {
 		// timer task does not belong to cluster name
 		t.logger.Debug("Namespace is not active, skip task.", tag.WorkflowNamespaceID(taskNamespaceID), tag.Value(task))
 		return false, nil
@@ -120,7 +120,7 @@ func (t *taskAllocatorImpl) verifyStandbyTask(standbyCluster string, taskNamespa
 		// non global namespace, timer task does not belong here
 		t.logger.Debug("Namespace is not global, skip task.", tag.WorkflowNamespaceID(taskNamespaceID), tag.Value(task))
 		return false, nil
-	} else if namespaceEntry.IsGlobalNamespace() && namespaceEntry.GetReplicationConfig().ActiveClusterName != standbyCluster {
+	} else if namespaceEntry.IsGlobalNamespace() && namespaceEntry.ActiveClusterName() != standbyCluster {
 		// timer task does not belong here
 		t.logger.Debug("Namespace is not standby, skip task.", tag.WorkflowNamespaceID(taskNamespaceID), tag.Value(task))
 		return false, nil

--- a/service/history/taskPriorityAssigner.go
+++ b/service/history/taskPriorityAssigner.go
@@ -128,7 +128,7 @@ func (a *taskPriorityAssignerImpl) getNamespaceInfo(
 		return "", true, nil
 	}
 
-	if namespaceEntry.IsGlobalNamespace() && a.currentClusterName != namespaceEntry.GetReplicationConfig().ActiveClusterName {
+	if namespaceEntry.IsGlobalNamespace() && a.currentClusterName != namespaceEntry.ActiveClusterName() {
 		return namespaceEntry.GetInfo().Name, false, nil
 	}
 	return namespaceEntry.GetInfo().Name, true, nil

--- a/service/history/taskPriorityAssigner_test.go
+++ b/service/history/taskPriorityAssigner_test.go
@@ -39,7 +39,6 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/namespace/namespacetest"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/tests"
 )
@@ -96,8 +95,8 @@ func (s *taskPriorityAssignerSuite) TestGetNamespaceInfo_Success_Active() {
 }
 
 func (s *taskPriorityAssignerSuite) TestGetNamespaceInfo_Success_Passive() {
-	entry := tests.GlobalNamespaceEntry.CloneWith(
-		namespacetest.SetActiveCluster(cluster.TestAlternativeClusterName))
+	entry := tests.GlobalNamespaceEntry.Clone(
+		namespace.WithActiveCluster(cluster.TestAlternativeClusterName))
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(entry, nil)
 
 	namespace, isActive, err := s.priorityAssigner.getNamespaceInfo(tests.NamespaceID)
@@ -149,8 +148,8 @@ func (s *taskPriorityAssignerSuite) TestAssign_ReplicationTask() {
 }
 
 func (s *taskPriorityAssignerSuite) TestAssign_StandbyTask() {
-	entry := tests.GlobalChildNamespaceEntry.CloneWith(
-		namespacetest.SetActiveCluster(cluster.TestAlternativeClusterName))
+	entry := tests.GlobalChildNamespaceEntry.Clone(
+		namespace.WithActiveCluster(cluster.TestAlternativeClusterName))
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(entry, nil)
 
 	mockTask := NewMockqueueTask(s.controller)

--- a/service/history/taskPriorityAssigner_test.go
+++ b/service/history/taskPriorityAssigner_test.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/namespace/namespacetest"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/tests"
 )
@@ -95,11 +96,9 @@ func (s *taskPriorityAssignerSuite) TestGetNamespaceInfo_Success_Active() {
 }
 
 func (s *taskPriorityAssignerSuite) TestGetNamespaceInfo_Success_Passive() {
-	tests.GlobalNamespaceEntry.GetReplicationConfig().ActiveClusterName = cluster.TestAlternativeClusterName
-	defer func() {
-		tests.GlobalNamespaceEntry.GetReplicationConfig().ActiveClusterName = cluster.TestCurrentClusterName
-	}()
-	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(tests.GlobalNamespaceEntry, nil)
+	entry := tests.GlobalNamespaceEntry.CloneWith(
+		namespacetest.SetActiveCluster(cluster.TestAlternativeClusterName))
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(entry, nil)
 
 	namespace, isActive, err := s.priorityAssigner.getNamespaceInfo(tests.NamespaceID)
 	s.NoError(err)
@@ -150,11 +149,9 @@ func (s *taskPriorityAssignerSuite) TestAssign_ReplicationTask() {
 }
 
 func (s *taskPriorityAssignerSuite) TestAssign_StandbyTask() {
-	tests.GlobalNamespaceEntry.GetReplicationConfig().ActiveClusterName = cluster.TestAlternativeClusterName
-	defer func() {
-		tests.GlobalNamespaceEntry.GetReplicationConfig().ActiveClusterName = cluster.TestCurrentClusterName
-	}()
-	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(tests.GlobalNamespaceEntry, nil)
+	entry := tests.GlobalChildNamespaceEntry.CloneWith(
+		namespacetest.SetActiveCluster(cluster.TestAlternativeClusterName))
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(entry, nil)
 
 	mockTask := NewMockqueueTask(s.controller)
 	mockTask.EXPECT().GetQueueType().Return(transferQueueType)

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -847,7 +847,7 @@ func (c *ContextImpl) ReapplyEvents(
 	ctx, cancel := context.WithTimeout(context.Background(), defaultRemoteCallTimeout)
 	defer cancel()
 
-	activeCluster := namespaceEntry.GetReplicationConfig().ActiveClusterName
+	activeCluster := namespaceEntry.ActiveClusterName()
 	if activeCluster == c.shard.GetClusterMetadata().GetCurrentClusterName() {
 		return c.shard.GetEngine().ReapplyEvents(
 			ctx,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove CacheEntry.GetReplicationConfig and fixups to dependent code for the same.

<!-- Tell your future self why have you made these changes -->
**Why?**
Part of a larger refactoring to make CacheEntry immutable by prohibiting
access to its internal NamespaceInfo, NamespaceConfig, and
NamespaceReplicationConfig.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No