### PR TITLE
Remove namespace.CacheEntry.GetInfo()

### DIFF
--- a/common/namespace/cache.go
+++ b/common/namespace/cache.go
@@ -691,9 +691,14 @@ func (entry *CacheEntry) VerifyBinaryChecksum(cksum string) error {
 	return nil
 }
 
-// GetInfo return the namespace info
-func (entry *CacheEntry) GetInfo() *persistencespb.NamespaceInfo {
-	return entry.info
+// ID observes this namespace's permanent unique identifier in string form.
+func (entry *CacheEntry) ID() string {
+	return entry.info.Id
+}
+
+// Name observes this namespace's configured name.
+func (entry *CacheEntry) Name() string {
+	return entry.info.Name
 }
 
 // ActiveClusterName observes the name of the cluster that is currently active

--- a/common/namespace/cache_test.go
+++ b/common/namespace/cache_test.go
@@ -197,8 +197,8 @@ func (s *namespaceCacheSuite) TestListNamespace() {
 
 	allNamespaces := s.namespaceCache.GetAllNamespace()
 	s.Equal(map[string]*CacheEntry{
-		entry1.GetInfo().Id: entry1,
-		entry2.GetInfo().Id: entry2,
+		entry1.ID(): entry1,
+		entry2.ID(): entry2,
 	}, allNamespaces)
 }
 

--- a/common/rpc/interceptor/namespace.go
+++ b/common/rpc/interceptor/namespace.go
@@ -54,7 +54,7 @@ func GetNamespace(
 		if err != nil {
 			return ""
 		}
-		return namespaceEntry.GetInfo().Name
+		return namespaceEntry.Name()
 
 	default:
 		return ""

--- a/common/xdc/nDCHistoryResender.go
+++ b/common/xdc/nDCHistoryResender.go
@@ -263,7 +263,7 @@ func (n *NDCHistoryResenderImpl) getHistory(
 		logger.Error("error getting namespace", tag.Error(err))
 		return nil, err
 	}
-	namespace := namespaceEntry.GetInfo().Name
+	namespace := namespaceEntry.Name()
 
 	ctx, cancel := rpc.NewContextFromParentWithTimeoutAndHeaders(ctx, resendContextTimeout)
 	defer cancel()

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -761,7 +761,7 @@ func (adh *AdminHandler) ReapplyEvents(ctx context.Context, request *adminservic
 	}
 
 	_, err = adh.GetHistoryClient().ReapplyEvents(ctx, &historyservice.ReapplyEventsRequest{
-		NamespaceId: namespaceEntry.GetInfo().Id,
+		NamespaceId: namespaceEntry.ID(),
 		Request:     request,
 	})
 	if err != nil {
@@ -983,7 +983,7 @@ func (adh *AdminHandler) RefreshWorkflowTasks(
 	}
 
 	_, err = adh.GetHistoryClient().RefreshWorkflowTasks(ctx, &historyservice.RefreshWorkflowTasksRequest{
-		NamespaceId: namespaceEntry.GetInfo().Id,
+		NamespaceId: namespaceEntry.ID(),
 		Request:     request,
 	})
 	if err != nil {

--- a/service/frontend/dcRedirectionPolicy.go
+++ b/service/frontend/dcRedirectionPolicy.go
@@ -175,7 +175,7 @@ func (policy *SelectedAPIsForwardingRedirectionPolicy) getTargetClusterAndIsName
 		return policy.currentClusterName, false
 	}
 
-	if !policy.config.EnableNamespaceNotActiveAutoForwarding(namespaceEntry.GetInfo().Name) {
+	if !policy.config.EnableNamespaceNotActiveAutoForwarding(namespaceEntry.Name()) {
 		// do not do dc redirection if auto-forwarding dynamic config flag is not enabled
 		return policy.currentClusterName, false
 	}

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -776,7 +776,7 @@ func (wh *WorkflowHandler) PollWorkflowTaskQueue(ctx context.Context, request *w
 	if err != nil {
 		return nil, err
 	}
-	namespaceID := namespaceEntry.GetInfo().Id
+	namespaceID := namespaceEntry.ID()
 
 	wh.GetLogger().Debug("Poll workflow task queue.", tag.WorkflowNamespace(namespace), tag.WorkflowNamespaceID(namespaceID))
 	if err := wh.checkBadBinary(namespaceEntry, request.GetBinaryChecksum()); err != nil {
@@ -862,7 +862,7 @@ func (wh *WorkflowHandler) RespondWorkflowTaskCompleted(
 		return nil, err
 	}
 
-	namespaceName := namespaceEntry.GetInfo().Name
+	namespaceName := namespaceEntry.Name()
 
 	if wh.isStopped() {
 		return nil, errShuttingDown
@@ -946,7 +946,7 @@ func (wh *WorkflowHandler) RespondWorkflowTaskFailed(
 		return nil, err
 	}
 
-	namespaceName := namespaceEntry.GetInfo().Name
+	namespaceName := namespaceEntry.Name()
 
 	if wh.isStopped() {
 		return nil, errShuttingDown
@@ -960,8 +960,8 @@ func (wh *WorkflowHandler) RespondWorkflowTaskFailed(
 		return nil, errIdentityTooLong
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetFailure().Size(),
@@ -1140,8 +1140,8 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(ctx context.Context, requ
 		return nil, errShuttingDown
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetDetails().Size(),
@@ -1238,8 +1238,8 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatById(ctx context.Context, 
 		return nil, err
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetDetails().Size(),
@@ -1324,7 +1324,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 		return nil, errIdentityTooLong
 	}
 
-	namespaceName := namespaceEntry.GetInfo().Name
+	namespaceName := namespaceEntry.Name()
 
 	if wh.isStopped() {
 		return nil, errShuttingDown
@@ -1334,8 +1334,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 		return nil, err
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetResult().Size(),
@@ -1434,8 +1434,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedById(ctx context.Context,
 		return nil, err
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetResult().Size(),
@@ -1521,7 +1521,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 		return nil, errFailureMustHaveApplicationFailureInfo
 	}
 
-	namespaceName := namespaceEntry.GetInfo().Name
+	namespaceName := namespaceEntry.Name()
 
 	if wh.isStopped() {
 		return nil, errShuttingDown
@@ -1535,8 +1535,8 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 		return nil, errIdentityTooLong
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetFailure().Size(),
@@ -1623,8 +1623,8 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedById(ctx context.Context, re
 		return nil, err
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetFailure().Size(),
@@ -1693,7 +1693,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(ctx context.Context, requ
 		return nil, err
 	}
 
-	namespaceName := namespaceEntry.GetInfo().Name
+	namespaceName := namespaceEntry.Name()
 
 	if wh.isStopped() {
 		return nil, errShuttingDown
@@ -1707,8 +1707,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(ctx context.Context, requ
 		return nil, errIdentityTooLong
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetDetails().Size(),
@@ -1806,8 +1806,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledById(ctx context.Context, 
 		return nil, err
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetDetails().Size(),
@@ -2481,7 +2481,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 	}
 
 	archiverRequest := &archiver.QueryVisibilityRequest{
-		NamespaceID:   entry.GetInfo().Id,
+		NamespaceID:   entry.ID(),
 		PageSize:      int(request.GetPageSize()),
 		NextPageToken: request.NextPageToken,
 		Query:         request.GetQuery(),
@@ -2665,7 +2665,7 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 		return nil, err
 	}
 
-	namespaceName := namespaceEntry.GetInfo().Name
+	namespaceName := namespaceEntry.Name()
 
 	if wh.isStopped() {
 		return nil, errShuttingDown
@@ -2675,8 +2675,8 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 		return nil, err
 	}
 
-	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.GetInfo().Name)
-	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.GetInfo().Name)
+	sizeLimitError := wh.config.BlobSizeLimitError(namespaceEntry.Name())
+	sizeLimitWarn := wh.config.BlobSizeLimitWarn(namespaceEntry.Name())
 
 	if err := common.CheckEventBlobSizeLimit(
 		request.GetQueryResult().Size(),
@@ -3242,11 +3242,11 @@ func (wh *WorkflowHandler) createPollWorkflowTaskQueueResponse(
 		history, persistenceToken, err = wh.getHistory(
 			wh.metricsScope(ctx),
 			namespaceID,
-			namespace.GetInfo().GetName(),
+			namespace.Name(),
 			*matchingResp.GetWorkflowExecution(),
 			firstEventID,
 			nextEventID,
-			int32(wh.config.HistoryMaxPageSize(namespace.GetInfo().GetName())),
+			int32(wh.config.HistoryMaxPageSize(namespace.Name())),
 			nil,
 			matchingResp.GetWorkflowTaskInfo(),
 			branchToken,

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -775,5 +775,5 @@ func (v *commandAttrValidator) createCrossNamespaceCallError(
 	namespaceEntry *namespace.CacheEntry,
 	targetNamespaceEntry *namespace.CacheEntry,
 ) error {
-	return serviceerror.NewInvalidArgument(fmt.Sprintf("unable to process cross namespace command between %v and %v", namespaceEntry.GetInfo().Name, targetNamespaceEntry.GetInfo().Name))
+	return serviceerror.NewInvalidArgument(fmt.Sprintf("unable to process cross namespace command between %v and %v", namespaceEntry.Name(), targetNamespaceEntry.Name()))
 }

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -1083,7 +1083,7 @@ func (s *engineSuite) TestValidateSignalRequest() {
 		Identity:                 "identity",
 	}
 	err := s.mockHistoryEngine.validateStartWorkflowExecutionRequest(
-		context.Background(), startRequest, tests.LocalNamespaceEntry.GetInfo().GetName(), "SignalWithStartWorkflowExecution")
+		context.Background(), startRequest, tests.LocalNamespaceEntry.Name(), "SignalWithStartWorkflowExecution")
 	s.Error(err, "startRequest doesn't have request id, it should error out")
 
 	startRequest.RequestId = "request-id"
@@ -1091,7 +1091,7 @@ func (s *engineSuite) TestValidateSignalRequest() {
 		"data": payload.EncodeBytes(make([]byte, 4*1024*1024)),
 	}}
 	err = s.mockHistoryEngine.validateStartWorkflowExecutionRequest(
-		context.Background(), startRequest, tests.LocalNamespaceEntry.GetInfo().GetName(), "SignalWithStartWorkflowExecution")
+		context.Background(), startRequest, tests.LocalNamespaceEntry.Name(), "SignalWithStartWorkflowExecution")
 	s.Error(err, "memo should be too big")
 }
 
@@ -1542,8 +1542,8 @@ func (s *engineSuite) TestRespondWorkflowTaskCompletedBadBinary() {
 		namespace.WithID(uuid.New()),
 		namespace.WithBadBinary("test-bad-binary"),
 	)
-	s.mockNamespaceCache.EXPECT().GetNamespaceByID(ns.GetInfo().Id).Return(ns, nil).AnyTimes()
-	s.mockNamespaceCache.EXPECT().GetNamespace(ns.GetInfo().Id).Return(ns, nil).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(ns.ID()).Return(ns, nil).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespace(ns.ID()).Return(ns, nil).AnyTimes()
 	msBuilder := workflow.TestLocalMutableState(s.mockHistoryEngine.shard, s.eventsCache,
 		ns, log.NewTestLogger(), we.GetRunId())
 	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, payloads.EncodeString("input"), 100*time.Second, 50*time.Second, 200*time.Second, identity)
@@ -1565,7 +1565,7 @@ func (s *engineSuite) TestRespondWorkflowTaskCompletedBadBinary() {
 	})
 
 	_, err := s.mockHistoryEngine.RespondWorkflowTaskCompleted(context.Background(), &historyservice.RespondWorkflowTaskCompletedRequest{
-		NamespaceId: ns.GetInfo().Id,
+		NamespaceId: ns.ID(),
 		CompleteRequest: &workflowservice.RespondWorkflowTaskCompletedRequest{
 			TaskToken:      taskToken,
 			Commands:       commands,

--- a/service/history/nDCHistoryReplicator.go
+++ b/service/history/nDCHistoryReplicator.go
@@ -257,7 +257,7 @@ func (r *nDCHistoryReplicatorImpl) applyEvents(
 			return err
 		}
 
-		if r.shard.GetConfig().ReplicationEventsFromCurrentCluster(namespaceEntry.GetInfo().Name) {
+		if r.shard.GetConfig().ReplicationEventsFromCurrentCluster(namespaceEntry.Name()) {
 			// this branch is used when replicating events (generated from current cluster)from remote cluster to current cluster.
 			// this could happen when the events are lost in current cluster and plan to recover them from remote cluster.
 			mutableState, err = context.LoadWorkflowExecutionForReplication(task.getVersion())

--- a/service/history/nDCStandbyTaskUtil.go
+++ b/service/history/nDCStandbyTaskUtil.go
@@ -218,7 +218,7 @@ func refreshTasks(
 	defer cancel()
 
 	_, err = adminClient.RefreshWorkflowTasks(ctx, &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: namespaceEntry.GetInfo().Name,
+		Namespace: namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: workflowID,
 			RunId:      runID,

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -631,10 +631,10 @@ func (s *ContextImpl) AppendHistoryEvents(
 		// N.B. - Dual emit here makes sense so that we can see aggregate timer stats across all
 		// namespaces along with the individual namespaces stats
 		s.GetMetricsClient().RecordDistribution(metrics.SessionSizeStatsScope, metrics.HistorySize, size)
-		if entry, err := s.GetNamespaceCache().GetNamespaceByID(namespaceID); err == nil && entry != nil && entry.GetInfo() != nil {
+		if entry, err := s.GetNamespaceCache().GetNamespaceByID(namespaceID); err == nil && entry != nil {
 			s.GetMetricsClient().Scope(
 				metrics.SessionSizeStatsScope,
-				metrics.NamespaceTag(entry.GetInfo().Name),
+				metrics.NamespaceTag(entry.Name()),
 			).RecordDistribution(metrics.HistorySize, size)
 		}
 		if size >= historySizeLogThreshold {
@@ -927,7 +927,7 @@ func (s *ContextImpl) allocateTimerIDsLocked(
 			// This can happen if shard move and new host have a time SKU, or there is db write delay.
 			// We generate a new timer ID using timerMaxReadLevel.
 			s.logger.Debug("New timer generated is less than read level",
-				tag.WorkflowNamespaceID(namespaceEntry.GetInfo().Id),
+				tag.WorkflowNamespaceID(namespaceEntry.ID()),
 				tag.WorkflowID(workflowID),
 				tag.Timestamp(ts),
 				tag.CursorTimestamp(readCursorTS),

--- a/service/history/taskPriorityAssigner.go
+++ b/service/history/taskPriorityAssigner.go
@@ -129,9 +129,9 @@ func (a *taskPriorityAssignerImpl) getNamespaceInfo(
 	}
 
 	if namespaceEntry.IsGlobalNamespace() && a.currentClusterName != namespaceEntry.ActiveClusterName() {
-		return namespaceEntry.GetInfo().Name, false, nil
+		return namespaceEntry.Name(), false, nil
 	}
-	return namespaceEntry.GetInfo().Name, true, nil
+	return namespaceEntry.Name(), true, nil
 }
 
 func (a *taskPriorityAssignerImpl) getRateLimiter(

--- a/service/history/timerQueueActiveTaskExecutor.go
+++ b/service/history/timerQueueActiveTaskExecutor.go
@@ -648,7 +648,7 @@ func (t *timerQueueActiveTaskExecutor) emitTimeoutMetricScopeWithNamespaceTag(
 	if err != nil {
 		return
 	}
-	metricsScope := t.metricsClient.Scope(scope).Tagged(metrics.NamespaceTag(namespaceEntry.GetInfo().Name))
+	metricsScope := t.metricsClient.Scope(scope).Tagged(metrics.NamespaceTag(namespaceEntry.Name()))
 	switch timerType {
 	case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START:
 		metricsScope.IncCounter(metrics.ScheduleToStartTimeoutCounter)

--- a/service/history/timerQueueStandbyTaskExecutor_test.go
+++ b/service/history/timerQueueStandbyTaskExecutor_test.go
@@ -262,7 +262,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.fetchHistoryDuration))
 	s.mockAdminClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: s.namespaceEntry.GetInfo().Name,
+		Namespace: s.namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: timerTask.GetWorkflowId(),
 			RunId:      timerTask.GetRunId(),
@@ -487,7 +487,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending(
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.fetchHistoryDuration))
 	s.mockAdminClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: s.namespaceEntry.GetInfo().Name,
+		Namespace: s.namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: timerTask.GetWorkflowId(),
 			RunId:      timerTask.GetRunId(),
@@ -833,7 +833,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowTaskTimeout_Pend
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.fetchHistoryDuration))
 	s.mockAdminClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: s.namespaceEntry.GetInfo().Name,
+		Namespace: s.namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: timerTask.GetWorkflowId(),
 			RunId:      timerTask.GetRunId(),
@@ -990,7 +990,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pen
 
 	s.mockShard.SetCurrentTime(s.clusterName, time.Now().UTC().Add(s.fetchHistoryDuration))
 	s.mockAdminClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: s.namespaceEntry.GetInfo().Name,
+		Namespace: s.namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: timerTask.GetWorkflowId(),
 			RunId:      timerTask.GetRunId(),
@@ -1119,7 +1119,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending(
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.fetchHistoryDuration))
 	s.mockAdminClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: s.namespaceEntry.GetInfo().Name,
+		Namespace: s.namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: timerTask.GetWorkflowId(),
 			RunId:      timerTask.GetRunId(),

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -181,7 +181,7 @@ func (t *timerQueueTaskExecutorBase) archiveWorkflow(
 			NamespaceID:          task.GetNamespaceId(),
 			WorkflowID:           task.GetWorkflowId(),
 			RunID:                task.GetRunId(),
-			Namespace:            namespaceCacheEntry.GetInfo().Name,
+			Namespace:            namespaceCacheEntry.Name(),
 			ShardID:              t.shard.GetShardID(),
 			Targets:              []archiver.ArchivalTarget{archiver.ArchiveTargetHistory},
 			HistoryURI:           namespaceCacheEntry.HistoryArchivalState().URI,

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -302,7 +302,7 @@ func (t *transferQueueActiveTaskExecutor) processCloseExecution(
 	workflowExecutionTime := timestamp.TimeValue(mutableState.GetExecutionInfo().GetExecutionTime())
 	visibilityMemo := getWorkflowMemo(copyMemo(executionInfo.Memo))
 	searchAttr := getSearchAttributes(copySearchAttributes(executionInfo.SearchAttributes))
-	namespace := mutableState.GetNamespaceEntry().GetInfo().Name
+	namespace := mutableState.GetNamespaceEntry().Name()
 	children := copyChildWorkflowInfos(mutableState.GetPendingChildExecutionInfos())
 
 	// NOTE: do not access anything related mutable state after this lock release
@@ -399,7 +399,7 @@ func (t *transferQueueActiveTaskExecutor) processCancelExecution(
 	if err != nil {
 		return err
 	}
-	targetNamespace := targetNamespaceEntry.GetInfo().Name
+	targetNamespace := targetNamespaceEntry.Name()
 
 	// handle workflow cancel itself
 	if task.GetNamespaceId() == task.GetTargetNamespaceId() && task.GetWorkflowId() == task.GetTargetWorkflowId() {
@@ -493,7 +493,7 @@ func (t *transferQueueActiveTaskExecutor) processSignalExecution(
 	if err != nil {
 		return err
 	}
-	targetNamespace := targetNamespaceEntry.GetInfo().Name
+	targetNamespace := targetNamespaceEntry.Name()
 
 	// handle workflow signal itself
 	if task.GetNamespaceId() == task.GetTargetNamespaceId() && task.GetWorkflowId() == task.GetTargetWorkflowId() {
@@ -603,7 +603,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		// it is possible that the namespace got deleted. Use namespaceID instead as this is only needed for the history event
 		namespace = task.GetNamespaceId()
 	} else {
-		namespace = namespaceEntry.GetInfo().Name
+		namespace = namespaceEntry.Name()
 	}
 
 	// Get target namespace name
@@ -615,7 +615,7 @@ func (t *transferQueueActiveTaskExecutor) processStartChildExecution(
 		// it is possible that the namespace got deleted. Use namespaceID instead as this is only needed for the history event
 		targetNamespace = task.GetNamespaceId()
 	} else {
-		targetNamespace = namespaceEntry.GetInfo().Name
+		targetNamespace = namespaceEntry.Name()
 	}
 
 	initiatedEventID := task.GetScheduleId()
@@ -756,7 +756,7 @@ func (t *transferQueueActiveTaskExecutor) processResetWorkflow(
 	if err != nil {
 		return err
 	}
-	logger = log.With(logger, tag.WorkflowNamespace(namespaceEntry.GetInfo().Name))
+	logger = log.With(logger, tag.WorkflowNamespace(namespaceEntry.Name()))
 
 	reason, resetPoint := workflow.FindAutoResetPoint(t.shard.GetTimeSource(), namespaceEntry.VerifyBinaryChecksum, executionInfo.AutoResetPoints)
 	if resetPoint == nil {
@@ -805,7 +805,7 @@ func (t *transferQueueActiveTaskExecutor) processResetWorkflow(
 
 	if err := t.resetWorkflow(
 		task,
-		namespaceEntry.GetInfo().Name,
+		namespaceEntry.Name(),
 		reason,
 		resetPoint,
 		baseContext,

--- a/service/history/transferQueueStandbyTaskExecutor_test.go
+++ b/service/history/transferQueueStandbyTaskExecutor_test.go
@@ -695,7 +695,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCancelExecution_Pendi
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockAdminClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: s.namespaceEntry.GetInfo().Name,
+		Namespace: s.namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: transferTask.GetWorkflowId(),
 			RunId:      transferTask.GetRunId(),
@@ -850,7 +850,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessSignalExecution_Pendi
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockAdminClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: s.namespaceEntry.GetInfo().Name,
+		Namespace: s.namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: transferTask.GetWorkflowId(),
 			RunId:      transferTask.GetRunId(),
@@ -1005,7 +1005,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_P
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockAdminClient.EXPECT().RefreshWorkflowTasks(gomock.Any(), &adminservice.RefreshWorkflowTasksRequest{
-		Namespace: s.namespaceEntry.GetInfo().Name,
+		Namespace: s.namespaceEntry.Name(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: transferTask.GetWorkflowId(),
 			RunId:      transferTask.GetRunId(),

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -192,7 +192,7 @@ func (t *transferQueueTaskExecutorBase) recordWorkflowClosed(
 	_, err = t.historyService.archivalClient.Archive(ctx, &archiver.ClientRequest{
 		ArchiveRequest: &archiver.ArchiveRequest{
 			NamespaceID:      namespaceID,
-			Namespace:        namespaceEntry.GetInfo().Name,
+			Namespace:        namespaceEntry.Name(),
 			WorkflowID:       workflowID,
 			RunID:            runID,
 			WorkflowTypeName: workflowTypeName,

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -242,7 +242,7 @@ func (t *visibilityQueueTaskExecutor) recordStartExecution(
 	request := &manager.RecordWorkflowExecutionStartedRequest{
 		VisibilityRequestBase: &manager.VisibilityRequestBase{
 			NamespaceID: namespaceID,
-			Namespace:   namespaceEntry.GetInfo().Name,
+			Namespace:   namespaceEntry.Name(),
 			Execution: commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
 				RunId:      runID,
@@ -284,7 +284,7 @@ func (t *visibilityQueueTaskExecutor) upsertExecution(
 	request := &manager.UpsertWorkflowExecutionRequest{
 		VisibilityRequestBase: &manager.VisibilityRequestBase{
 			NamespaceID: namespaceID,
-			Namespace:   namespaceEntry.GetInfo().Name,
+			Namespace:   namespaceEntry.Name(),
 			Execution: commonpb.WorkflowExecution{
 				WorkflowId: workflowID,
 				RunId:      runID,
@@ -420,7 +420,7 @@ func (t *visibilityQueueTaskExecutor) recordCloseExecution(
 		return t.visibilityMgr.RecordWorkflowExecutionClosed(&manager.RecordWorkflowExecutionClosedRequest{
 			VisibilityRequestBase: &manager.VisibilityRequestBase{
 				NamespaceID: namespaceID,
-				Namespace:   namespaceEntry.GetInfo().Name,
+				Namespace:   namespaceEntry.Name(),
 				Execution: commonpb.WorkflowExecution{
 					WorkflowId: workflowID,
 					RunId:      runID,

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -230,7 +230,7 @@ func (c *ContextImpl) GetNamespace() string {
 	if err != nil {
 		return ""
 	}
-	return namespaceEntry.GetInfo().Name
+	return namespaceEntry.Name()
 }
 
 func (c *ContextImpl) GetHistorySize() int64 {
@@ -876,7 +876,7 @@ func (c *ContextImpl) ReapplyEvents(
 	_, err = sourceCluster.ReapplyEvents(
 		ctx2,
 		&adminservice.ReapplyEventsRequest{
-			Namespace:         namespaceEntry.GetInfo().Name,
+			Namespace:         namespaceEntry.Name(),
 			WorkflowExecution: execution,
 			Events:            reapplyEventsDataBlob,
 		},
@@ -953,6 +953,6 @@ func emitStateTransitionCount(
 
 	metricsClient.Scope(
 		metrics.WorkflowContextScope,
-		metrics.NamespaceTag(mutableState.GetNamespaceEntry().GetInfo().Name),
+		metrics.NamespaceTag(mutableState.GetNamespaceEntry().Name()),
 	).RecordDistribution(metrics.StateTransitionCount, int(mutableState.GetExecutionInfo().StateTransitionCount))
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1308,7 +1308,7 @@ func (e *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 
 	createRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                uuid.New(),
-		Namespace:                e.namespaceEntry.GetInfo().Name,
+		Namespace:                e.namespaceEntry.Name(),
 		WorkflowId:               execution.WorkflowId,
 		TaskQueue:                tq,
 		WorkflowType:             wType,
@@ -1326,7 +1326,7 @@ func (e *MutableStateImpl) addWorkflowExecutionStartedEventForContinueAsNew(
 	enums.SetDefaultContinueAsNewInitiator(&command.Initiator)
 
 	req := &historyservice.StartWorkflowExecutionRequest{
-		NamespaceId:              e.namespaceEntry.GetInfo().Id,
+		NamespaceId:              e.namespaceEntry.ID(),
 		StartRequest:             createRequest,
 		ParentExecutionInfo:      parentExecutionInfo,
 		LastCompletionResult:     command.LastCompletionResult,
@@ -1442,7 +1442,7 @@ func (e *MutableStateImpl) ReplicateWorkflowExecutionStartedEvent(
 	event := startEvent.GetWorkflowExecutionStartedEventAttributes()
 	e.executionState.CreateRequestId = requestID
 	e.executionState.RunId = execution.GetRunId()
-	e.executionInfo.NamespaceId = e.namespaceEntry.GetInfo().Id
+	e.executionInfo.NamespaceId = e.namespaceEntry.ID()
 	e.executionInfo.WorkflowId = execution.GetWorkflowId()
 	e.executionInfo.FirstExecutionRunId = event.GetFirstExecutionRunId()
 	e.executionInfo.TaskQueue = event.TaskQueue.GetName()
@@ -1818,7 +1818,7 @@ func (e *MutableStateImpl) ReplicateActivityTaskScheduledEvent(
 		if err != nil {
 			return nil, err
 		}
-		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
+		targetNamespaceID = targetNamespaceEntry.ID()
 	}
 
 	scheduleEventID := event.GetEventId()
@@ -4146,7 +4146,7 @@ func (e *MutableStateImpl) startTransactionHandleWorkflowTaskTTL() {
 		return
 	}
 
-	ttl := e.config.StickyTTL(e.GetNamespaceEntry().GetInfo().Name)
+	ttl := e.config.StickyTTL(e.GetNamespaceEntry().Name())
 	expired := e.timeSource.Now().After(timestamp.TimeValue(e.executionInfo.LastUpdateTime).Add(ttl))
 	if expired && !e.HasPendingWorkflowTask() {
 		e.ClearStickyness()
@@ -4328,7 +4328,7 @@ func (e *MutableStateImpl) closeTransactionHandleWorkflowReset(
 			return err
 		}
 		e.logInfo("Auto-Reset task is scheduled",
-			tag.WorkflowNamespace(namespaceEntry.GetInfo().Name),
+			tag.WorkflowNamespace(namespaceEntry.Name()),
 			tag.WorkflowID(e.executionInfo.WorkflowId),
 			tag.WorkflowRunID(e.executionState.RunId),
 			tag.WorkflowResetBaseRunID(pt.GetRunId()),
@@ -4393,14 +4393,14 @@ func (e *MutableStateImpl) shouldGenerateChecksum() bool {
 	if e.namespaceEntry == nil {
 		return false
 	}
-	return rand.Intn(100) < e.config.MutableStateChecksumGenProbability(e.namespaceEntry.GetInfo().Name)
+	return rand.Intn(100) < e.config.MutableStateChecksumGenProbability(e.namespaceEntry.Name())
 }
 
 func (e *MutableStateImpl) shouldVerifyChecksum() bool {
 	if e.namespaceEntry == nil {
 		return false
 	}
-	return rand.Intn(100) < e.config.MutableStateChecksumVerifyProbability(e.namespaceEntry.GetInfo().Name)
+	return rand.Intn(100) < e.config.MutableStateChecksumVerifyProbability(e.namespaceEntry.Name())
 }
 
 func (e *MutableStateImpl) shouldInvalidateCheckum() bool {

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -142,7 +142,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 				if err != nil {
 					return nil, err
 				}
-				parentNamespaceID = parentNamespaceEntry.GetInfo().Id
+				parentNamespaceID = parentNamespaceEntry.ID()
 			}
 
 			if err := b.mutableState.ReplicateWorkflowExecutionStartedEvent(

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -208,7 +208,7 @@ func SetupNewWorkflowForRetryOrCron(
 
 	createRequest := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:                uuid.New(),
-		Namespace:                newMutableState.GetNamespaceEntry().GetInfo().Name,
+		Namespace:                newMutableState.GetNamespaceEntry().Name(),
 		WorkflowId:               newExecution.WorkflowId,
 		TaskQueue:                tq,
 		WorkflowType:             wType,
@@ -229,7 +229,7 @@ func SetupNewWorkflowForRetryOrCron(
 	}
 
 	req := &historyservice.StartWorkflowExecutionRequest{
-		NamespaceId:              newMutableState.GetNamespaceEntry().GetInfo().Id,
+		NamespaceId:              newMutableState.GetNamespaceEntry().ID(),
 		StartRequest:             createRequest,
 		ParentExecutionInfo:      parentInfo,
 		LastCompletionResult:     lastCompletionResult,

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -527,7 +527,7 @@ func (r *TaskGeneratorImpl) getTargetNamespaceID(
 		if err != nil {
 			return "", err
 		}
-		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
+		targetNamespaceID = targetNamespaceEntry.ID()
 	}
 
 	return targetNamespaceID, nil

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -607,7 +607,7 @@ func emitMutationMetrics(
 	}
 
 	metricsClient := shard.GetMetricsClient()
-	namespaceName := namespaceEntry.GetInfo().Name
+	namespaceName := namespaceEntry.Name()
 	for _, stat := range stats {
 		emitMutableStateStatus(
 			metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.NamespaceTag(namespaceName)),
@@ -630,7 +630,7 @@ func emitGetMetrics(
 	}
 
 	metricsClient := shard.GetMetricsClient()
-	namespaceName := namespaceEntry.GetInfo().Name
+	namespaceName := namespaceEntry.Name()
 	for _, stat := range stats {
 		emitMutableStateStatus(
 			metricsClient.Scope(metrics.ExecutionSizeStatsScope, metrics.NamespaceTag(namespaceName)),

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -203,7 +203,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandScheduleActivity(
 		if err != nil {
 			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to schedule activity across namespace %v.", attr.GetNamespace()))
 		}
-		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
+		targetNamespaceID = targetNamespaceEntry.ID()
 	}
 
 	if err := handler.validateCommandAttr(
@@ -563,7 +563,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandRequestCancelExternalWorkfl
 		if err != nil {
 			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to cancel workflow across namespace: %v.", attr.GetNamespace()))
 		}
-		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
+		targetNamespaceID = targetNamespaceEntry.ID()
 	}
 
 	if err := handler.validateCommandAttr(
@@ -633,7 +633,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 		return handler.failCommand(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
 
-	namespace := handler.mutableState.GetNamespaceEntry().GetInfo().Name
+	namespace := handler.mutableState.GetNamespaceEntry().Name()
 
 	if err := handler.validateCommandAttr(
 		func() error {
@@ -706,7 +706,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 		if err != nil {
 			return err
 		}
-		parentNamespace = parentNamespaceEntry.GetInfo().Name
+		parentNamespace = parentNamespaceEntry.Name()
 	}
 
 	_, newStateBuilder, err := handler.mutableState.AddContinueAsNewEvent(
@@ -733,8 +733,8 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 	)
 
 	parentNamespaceEntry := handler.mutableState.GetNamespaceEntry()
-	parentNamespaceID := parentNamespaceEntry.GetInfo().Id
-	parentNamespace := parentNamespaceEntry.GetInfo().Name
+	parentNamespaceID := parentNamespaceEntry.ID()
+	parentNamespace := parentNamespaceEntry.Name()
 	targetNamespaceID := parentNamespaceID
 	targetNamespace := parentNamespace
 	if attr.GetNamespace() != "" {
@@ -742,8 +742,8 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 		if err != nil {
 			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to schedule child execution across namespace %v.", attr.GetNamespace()))
 		}
-		targetNamespace = targetNamespaceEntry.GetInfo().Name
-		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
+		targetNamespace = targetNamespaceEntry.Name()
+		targetNamespaceID = targetNamespaceEntry.ID()
 	} else {
 		attr.Namespace = parentNamespace
 	}
@@ -837,7 +837,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandSignalExternalWorkflow(
 		if err != nil {
 			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to signal workflow across namespace: %v.", attr.GetNamespace()))
 		}
-		targetNamespaceID = targetNamespaceEntry.GetInfo().Id
+		targetNamespaceID = targetNamespaceEntry.ID()
 	}
 
 	if err := handler.validateCommandAttr(
@@ -886,7 +886,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandUpsertWorkflowSearchAttribu
 	if err != nil {
 		return serviceerror.NewUnavailable(fmt.Sprintf("Unable to get namespace for namespaceID: %v.", namespaceID))
 	}
-	namespace := namespaceEntry.GetInfo().Name
+	namespace := namespaceEntry.Name()
 
 	// valid search attributes for upsert
 	if err := handler.validateCommandAttr(

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -120,7 +120,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskScheduled(
 	if err != nil {
 		return err
 	}
-	namespaceID := namespaceEntry.GetInfo().Id
+	namespaceID := namespaceEntry.ID()
 
 	execution := commonpb.WorkflowExecution{
 		WorkflowId: req.WorkflowExecution.WorkflowId,
@@ -165,7 +165,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 	if err != nil {
 		return nil, err
 	}
-	namespaceID := namespaceEntry.GetInfo().Id
+	namespaceID := namespaceEntry.ID()
 
 	execution := commonpb.WorkflowExecution{
 		WorkflowId: req.WorkflowExecution.WorkflowId,
@@ -235,7 +235,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 			}
 
 			workflowScheduleToStartLatency := workflowTask.StartedTime.Sub(*workflowTask.ScheduledTime)
-			namespaceName := namespaceEntry.GetInfo().GetName()
+			namespaceName := namespaceEntry.Name()
 			taskQueue := workflowTask.TaskQueue
 			metrics.GetPerTaskQueueScope(metricsScope, namespaceName, taskQueue.GetName(), taskQueue.GetKind()).
 				Tagged(metrics.TaskTypeTag("workflow")).
@@ -263,7 +263,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskFailed(
 	if err != nil {
 		return err
 	}
-	namespaceID := namespaceEntry.GetInfo().Id
+	namespaceID := namespaceEntry.ID()
 
 	request := req.FailedRequest
 	token, err := handler.tokenSerializer.Deserialize(request.TaskToken)
@@ -312,7 +312,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	if err != nil {
 		return nil, err
 	}
-	namespaceID := namespaceEntry.GetInfo().Id
+	namespaceID := namespaceEntry.ID()
 
 	request := req.CompleteRequest
 	token, err0 := handler.tokenSerializer.Deserialize(request.TaskToken)
@@ -370,7 +370,7 @@ Update_History_Loop:
 		}
 
 		startedID := currentWorkflowTask.StartedID
-		maxResetPoints := handler.config.MaxAutoResetPoints(namespaceEntry.GetInfo().Name)
+		maxResetPoints := handler.config.MaxAutoResetPoints(namespaceEntry.Name())
 		if msBuilder.GetExecutionInfo().AutoResetPoints != nil && maxResetPoints == len(msBuilder.GetExecutionInfo().AutoResetPoints.Points) {
 			handler.metricsClient.IncCounter(metrics.HistoryRespondWorkflowTaskCompletedScope, metrics.AutoResetPointsLimitExceededCounter)
 		}
@@ -379,7 +379,7 @@ Update_History_Loop:
 		var workflowTaskHeartbeatTimeout bool
 		var completedEvent *historypb.HistoryEvent
 		if workflowTaskHeartbeating {
-			namespace := namespaceEntry.GetInfo().Name
+			namespace := namespaceEntry.Name()
 			timeout := handler.config.WorkflowTaskHeartbeatTimeout(namespace)
 			origSchedTime := timestamp.TimeValue(currentWorkflowTask.OriginalScheduledTime)
 			if origSchedTime.UnixNano() > 0 && handler.timeSource.Now().After(origSchedTime.Add(timeout)) {
@@ -427,7 +427,7 @@ Update_History_Loop:
 		if err := namespaceEntry.VerifyBinaryChecksum(binChecksum); err != nil {
 			wtFailedCause = NewWorkflowTaskFailedCause(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_BINARY, serviceerror.NewInvalidArgument(fmt.Sprintf("binary %v is already marked as bad deployment", binChecksum)))
 		} else {
-			namespace := namespaceEntry.GetInfo().Name
+			namespace := namespaceEntry.Name()
 			workflowSizeChecker := newWorkflowSizeChecker(
 				handler.config.BlobSizeLimitWarn(namespace),
 				handler.config.BlobSizeLimitError(namespace),
@@ -678,14 +678,14 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(msBuilder
 		return
 	}
 
-	namespaceID := namespaceEntry.GetInfo().Id
-	namespace := namespaceEntry.GetInfo().Name
+	namespaceID := namespaceEntry.ID()
+	namespace := namespaceEntry.Name()
 	workflowID := msBuilder.GetExecutionInfo().WorkflowId
 	runID := msBuilder.GetExecutionState().GetRunId()
 
 	scope := handler.metricsClient.Scope(
 		metrics.HistoryRespondWorkflowTaskCompletedScope,
-		metrics.NamespaceTag(namespaceEntry.GetInfo().Name),
+		metrics.NamespaceTag(namespaceEntry.Name()),
 		metrics.CommandTypeTag("ConsistentQuery"))
 
 	// if its a heartbeat workflow task it means local activities may still be running on the worker

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -139,7 +139,7 @@ func newTaskQueueConfig(id *taskQueueID, config *Config, namespaceCache namespac
 		return nil, err
 	}
 
-	namespace := namespaceEntry.GetInfo().Name
+	namespace := namespaceEntry.Name()
 	taskQueueName := id.name
 	taskType := id.taskType
 

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -343,7 +343,7 @@ func (h *Handler) namespaceName(id string) string {
 	if err != nil {
 		return ""
 	}
-	return entry.GetInfo().Name
+	return entry.Name()
 }
 
 func (h *Handler) reportForwardedPerTaskQueueCounter(hCtx *handlerContext, namespaceId string) {

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -580,7 +580,7 @@ func (c *taskQueueManagerImpl) tryInitNamespaceAndScope() {
 		return
 	}
 
-	namespace = entry.GetInfo().Name
+	namespace = entry.Name()
 
 	scope := metrics.GetPerTaskQueueScope(c.metricsClient.Scope(metrics.MatchingTaskQueueMgrScope), namespace, c.taskQueueID.name, c.taskQueueKind)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove namespace.CacheEntry.GetInfo()

<!-- Tell your future self why have you made these changes -->
**Why?**
Part of a larger refactoring to make CacheEntry immutable by prohibiting
access to its internal NamespaceInfo, NamespaceConfig, and
NamespaceReplicationConfig

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no