### PR TITLE
Remove cache.Cache from workflow.Cache

### DIFF
--- a/service/history/nDCActivityReplicator_test.go
+++ b/service/history/nDCActivityReplicator_test.go
@@ -74,7 +74,7 @@ type (
 		mockExecutionMgr *persistence.MockExecutionManager
 
 		logger       log.Logger
-		historyCache workflow.Cache
+		historyCache *workflow.CacheImpl
 
 		nDCActivityReplicator *nDCActivityReplicatorImpl
 	}
@@ -123,7 +123,7 @@ func (s *activityReplicatorSuite) SetupTest() {
 
 	s.logger = s.mockShard.GetLogger()
 
-	s.historyCache = workflow.NewCache(s.mockShard)
+	s.historyCache = workflow.NewCache(s.mockShard).(*workflow.CacheImpl)
 	engine := &historyEngineImpl{
 		currentClusterName: s.mockClusterMetadata.GetCurrentClusterName(),
 		shard:              s.mockShard,

--- a/service/history/timerQueueActiveTaskExecutor_test.go
+++ b/service/history/timerQueueActiveTaskExecutor_test.go
@@ -1497,8 +1497,7 @@ func (s *timerQueueActiveTaskExecutorSuite) getMutableStateFromCache(
 	workflowID string,
 	runID string,
 ) workflow.MutableState {
-
-	return s.mockHistoryEngine.historyCache.Get(
+	return s.mockHistoryEngine.historyCache.(*workflow.CacheImpl).Get(
 		definition.NewWorkflowIdentifier(namespaceID, workflowID, runID),
 	).(*workflow.ContextImpl).MutableState
 }

--- a/service/history/workflow/cache.go
+++ b/service/history/workflow/cache.go
@@ -49,8 +49,6 @@ type (
 	ReleaseCacheFunc func(err error)
 
 	Cache interface {
-		cache.Cache
-
 		GetOrCreateCurrentWorkflowExecution(
 			ctx context.Context,
 			namespaceID string,

--- a/service/history/workflowResetter_test.go
+++ b/service/history/workflowResetter_test.go
@@ -684,7 +684,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents_WithConti
 	resetMutableState.EXPECT().GetNextEventID().Return(newNextEventID).AnyTimes()
 	resetMutableState.EXPECT().GetCurrentBranchToken().Return(newBranchToken, nil).AnyTimes()
 	resetContextCacheKey := definition.NewWorkflowIdentifier(s.namespaceID, s.workflowID, newRunID)
-	_, _ = s.workflowResetter.historyCache.PutIfNotExist(resetContextCacheKey, resetContext)
+	_, _ = s.workflowResetter.historyCache.(*workflow.CacheImpl).PutIfNotExist(resetContextCacheKey, resetContext)
 
 	mutableState := workflow.NewMockMutableState(s.controller)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Simplify workflow.Cache interface

<!-- Tell your future self why have you made these changes -->
**Why?**
There is no need to expose the underline cache.Cache interface. They are only used by tests.
Simplify workflow.Cache interface to include only necessary methods so it is easier for different implementation.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No