### PR TITLE
Use StartedIdentity as LastWorkerIdentity if no retry

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1192,6 +1192,7 @@ func (e *historyEngineImpl) DescribeWorkflowExecution(
 			} else {
 				p.LastStartedTime = ai.StartedTime
 			}
+			p.LastWorkerIdentity = ai.StartedIdentity
 			if ai.HasRetryPolicy {
 				p.Attempt = ai.Attempt
 				p.ExpirationTime = ai.RetryExpirationTime


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use StartedIdentity as LastWorkerIdentity for PendingActivity if no retry.

<!-- Tell your future self why have you made these changes -->
**Why?**
DescribeWorkflow reports pending activity info which includes LastWorkerIdentity. The LastWorkerIdentity is only set when retry is happening. This PR change that so it would return StartedIdentity before any retry. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eye_balls

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No