### PR TITLE
Allow setting workflow run timeout in tctl

### DIFF
--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -280,17 +280,17 @@ func (s *cliAppSuite) TestShowHistory_PrintDateTime() {
 func (s *cliAppSuite) TestStartWorkflow() {
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	// start with wid
-	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-w", "wid", "-wrp", "AllowDuplicateFailedOnly"})
+	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-rt", "60", "-w", "wid", "-wrp", "AllowDuplicateFailedOnly"})
 	s.Nil(err)
 	// start without wid
-	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-wrp", "AllowDuplicateFailedOnly"})
+	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-rt", "60", "-wrp", "AllowDuplicateFailedOnly"})
 	s.Nil(err)
 }
 
 func (s *cliAppSuite) TestStartWorkflow_Failed() {
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), serviceerror.NewInvalidArgument("faked error"))
 	// start with wid
-	errorCode := s.RunErrorExitCode([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-w", "wid"})
+	errorCode := s.RunErrorExitCode([]string{"", "--ns", cliTestNamespace, "workflow", "start", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-rt", "60", "-w", "wid"})
 	s.Equal(1, errorCode)
 }
 
@@ -299,14 +299,14 @@ func (s *cliAppSuite) TestRunWorkflow() {
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, "wid", mock.Anything, mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
 
 	// start with wid
-	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "run", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-w", "wid", "wrp", "2"})
+	err := s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "run", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-rt", "60", "-w", "wid", "wrp", "2"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 
 	s.sdkClient.On("ExecuteWorkflow", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(workflowRun(), nil)
 	s.sdkClient.On("GetWorkflowHistory", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(historyEventIterator()).Once()
 	// start without wid
-	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "run", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "wrp", "2"})
+	err = s.app.Run([]string{"", "--ns", cliTestNamespace, "workflow", "run", "-tq", "testTaskQueue", "-wt", "testWorkflowType", "-et", "60", "-rt", "60", "wrp", "2"})
 	s.Nil(err)
 	s.sdkClient.AssertExpectations(s.T())
 }

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -69,8 +69,10 @@ const (
 	FlagWorkflowTypeWithAlias                 = FlagWorkflowType + ", wt"
 	FlagWorkflowStatus                        = "status"
 	FlagWorkflowStatusWithAlias               = FlagWorkflowStatus + ", s"
-	FlagExecutionTimeout                      = "execution_timeout"
-	FlagExecutionTimeoutWithAlias             = FlagExecutionTimeout + ", et"
+	FlagWorkflowExecutionTimeout              = "execution_timeout"
+	FlagWorkflowExecutionTimeoutWithAlias     = FlagWorkflowExecutionTimeout + ", et"
+	FlagWorkflowRunTimeout                    = "run-timeout"
+	FlagWorkflowRunTimeoutWithAlias           = FlagWorkflowRunTimeout + ", rt"
 	FlagWorkflowTaskTimeout                   = "workflow_task_timeout"
 	FlagWorkflowTaskTimeoutWithAlias          = FlagWorkflowTaskTimeout + ", wtt"
 	FlagContextTimeout                        = "context_timeout"
@@ -332,13 +334,17 @@ func getFlagsForStart() []cli.Flag {
 			Usage: "WorkflowTypeName",
 		},
 		cli.IntFlag{
-			Name:  FlagExecutionTimeoutWithAlias,
-			Usage: "Execution start to close timeout in seconds",
+			Name:  FlagWorkflowExecutionTimeoutWithAlias,
+			Usage: "Workflow execution timeout, including retries and continue-as-new (seconds)",
+		},
+		cli.IntFlag{
+			Name:  FlagWorkflowRunTimeoutWithAlias,
+			Usage: "Single workflow run timeout (seconds)",
 		},
 		cli.IntFlag{
 			Name:  FlagWorkflowTaskTimeoutWithAlias,
 			Value: defaultWorkflowTaskTimeoutInSeconds,
-			Usage: "Workflow task start to close timeout in seconds",
+			Usage: "Workflow task start to close timeout (seconds)",
 		},
 		cli.StringFlag{
 			Name: FlagCronSchedule,

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -188,7 +188,8 @@ func startWorkflowHelper(c *cli.Context, shouldPrintProgress bool) {
 	namespace := getRequiredGlobalOption(c, FlagNamespace)
 	taskQueue := getRequiredOption(c, FlagTaskQueue)
 	workflowType := getRequiredOption(c, FlagWorkflowType)
-	et := c.Int(FlagExecutionTimeout)
+	et := c.Int(FlagWorkflowExecutionTimeout)
+	rt := c.Int(FlagWorkflowRunTimeout)
 	dt := c.Int(FlagWorkflowTaskTimeout)
 	wid := c.String(FlagWorkflowID)
 	if len(wid) == 0 {
@@ -209,6 +210,7 @@ func startWorkflowHelper(c *cli.Context, shouldPrintProgress bool) {
 		TaskQueue:                taskQueue,
 		WorkflowExecutionTimeout: time.Duration(et) * time.Second,
 		WorkflowTaskTimeout:      time.Duration(dt) * time.Second,
+		WorkflowRunTimeout:       time.Duration(rt) * time.Second,
 		WorkflowIDReusePolicy:    reusePolicy,
 	}
 	if c.IsSet(FlagCronSchedule) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Allows to set Workflow Run Timeout when starting a workflow from tctl

<!-- Tell your future self why have you made these changes -->
**Why?**

Allows to limit workflow run timeout (in addition to execution and task timeouts)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Added the flag in unit tests
Verified the run timeout is set (through UI) 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
