### PR TITLE
Remove namespace/ dependence on cluster metadata

### DIFF
--- a/common/namespace/cache_mock.go
+++ b/common/namespace/cache_mock.go
@@ -70,57 +70,6 @@ func (mr *MockEntryMutationMockRecorder) apply(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "apply", reflect.TypeOf((*MockEntryMutation)(nil).apply), arg0)
 }
 
-// MockClusterInfo is a mock of ClusterInfo interface.
-type MockClusterInfo struct {
-	ctrl     *gomock.Controller
-	recorder *MockClusterInfoMockRecorder
-}
-
-// MockClusterInfoMockRecorder is the mock recorder for MockClusterInfo.
-type MockClusterInfoMockRecorder struct {
-	mock *MockClusterInfo
-}
-
-// NewMockClusterInfo creates a new mock instance.
-func NewMockClusterInfo(ctrl *gomock.Controller) *MockClusterInfo {
-	mock := &MockClusterInfo{ctrl: ctrl}
-	mock.recorder = &MockClusterInfoMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockClusterInfo) EXPECT() *MockClusterInfoMockRecorder {
-	return m.recorder
-}
-
-// GetCurrentClusterName mocks base method.
-func (m *MockClusterInfo) GetCurrentClusterName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentClusterName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetCurrentClusterName indicates an expected call of GetCurrentClusterName.
-func (mr *MockClusterInfoMockRecorder) GetCurrentClusterName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentClusterName", reflect.TypeOf((*MockClusterInfo)(nil).GetCurrentClusterName))
-}
-
-// IsGlobalNamespaceEnabled mocks base method.
-func (m *MockClusterInfo) IsGlobalNamespaceEnabled() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsGlobalNamespaceEnabled")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsGlobalNamespaceEnabled indicates an expected call of IsGlobalNamespaceEnabled.
-func (mr *MockClusterInfoMockRecorder) IsGlobalNamespaceEnabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsGlobalNamespaceEnabled", reflect.TypeOf((*MockClusterInfo)(nil).IsGlobalNamespaceEnabled))
-}
-
 // MockPersistence is a mock of Persistence interface.
 type MockPersistence struct {
 	ctrl     *gomock.Controller

--- a/common/namespace/mutate.go
+++ b/common/namespace/mutate.go
@@ -36,7 +36,7 @@ func (f entryMutationFunc) apply(ns *persistence.GetNamespaceResponse) {
 }
 
 // WithActiveCluster assigns the active cluster to a CacheEntry during a Clone
-// operation
+// operation.
 func WithActiveCluster(name string) EntryMutation {
 	return entryMutationFunc(
 		func(ns *persistence.GetNamespaceResponse) {
@@ -45,7 +45,7 @@ func WithActiveCluster(name string) EntryMutation {
 }
 
 // WithBadBinary adds a bad binary checksum to a CacheEntry during a Clone
-// operation
+// operation.
 func WithBadBinary(chksum string) EntryMutation {
 	return entryMutationFunc(
 		func(ns *persistence.GetNamespaceResponse) {
@@ -54,10 +54,18 @@ func WithBadBinary(chksum string) EntryMutation {
 		})
 }
 
-// WithID assigns the ID to a CacheEntry during a Clone operation
+// WithID assigns the ID to a CacheEntry during a Clone operation.
 func WithID(id string) EntryMutation {
 	return entryMutationFunc(
 		func(ns *persistence.GetNamespaceResponse) {
 			ns.Namespace.Info.Id = id
+		})
+}
+
+// WithGlobalFlag sets wether or not this CacheEntry is global.
+func WithGlobalFlag(b bool) EntryMutation {
+	return entryMutationFunc(
+		func(ns *persistence.GetNamespaceResponse) {
+			ns.IsGlobalNamespace = b
 		})
 }

--- a/common/namespace/testconstructors.go
+++ b/common/namespace/testconstructors.go
@@ -36,9 +36,7 @@ func NewLocalCacheEntryForTest(
 	info *persistencespb.NamespaceInfo,
 	config *persistencespb.NamespaceConfig,
 	targetCluster string,
-	thisCluster ClusterInfo,
 ) *CacheEntry {
-
 	return &CacheEntry{
 		info:              derefInfo(info),
 		config:            derefConfig(config),
@@ -48,7 +46,6 @@ func NewLocalCacheEntryForTest(
 			Clusters:          []string{targetCluster},
 		},
 		failoverVersion: common.EmptyVersion,
-		thisCluster:     thisCluster,
 	}
 }
 
@@ -59,16 +56,13 @@ func NewNamespaceCacheEntryForTest(
 	isGlobalNamespace bool,
 	repConfig *persistencespb.NamespaceReplicationConfig,
 	failoverVersion int64,
-	thisCluster ClusterInfo,
 ) *CacheEntry {
-
 	return &CacheEntry{
 		info:              derefInfo(info),
 		config:            derefConfig(config),
 		isGlobalNamespace: isGlobalNamespace,
 		replicationConfig: derefRepConfig(repConfig),
 		failoverVersion:   failoverVersion,
-		thisCluster:       thisCluster,
 	}
 }
 
@@ -78,16 +72,13 @@ func NewGlobalCacheEntryForTest(
 	config *persistencespb.NamespaceConfig,
 	repConfig *persistencespb.NamespaceReplicationConfig,
 	failoverVersion int64,
-	thisCluster ClusterInfo,
 ) *CacheEntry {
-
 	return &CacheEntry{
 		info:              derefInfo(info),
 		config:            derefConfig(config),
 		isGlobalNamespace: true,
 		replicationConfig: derefRepConfig(repConfig),
 		failoverVersion:   failoverVersion,
-		thisCluster:       thisCluster,
 	}
 }
 

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -210,7 +210,7 @@ func NamespaceCacheProvider(
 ) namespace.Cache {
 	return namespace.NewNamespaceCache(
 		metadataManager,
-		clusterMetadata,
+		clusterMetadata.IsGlobalNamespaceEnabled(),
 		metricsClient,
 		logger,
 	)

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -253,7 +253,7 @@ func New(
 
 	namespaceCache := namespace.NewNamespaceCache(
 		persistenceBean.GetMetadataManager(),
-		clusterMetadata,
+		clusterMetadata.IsGlobalNamespaceEnabled(),
 		params.MetricsClient,
 		logger,
 	)

--- a/common/xdc/nDCHistoryResender_test.go
+++ b/common/xdc/nDCHistoryResender_test.go
@@ -111,7 +111,6 @@ func (s *nDCHistoryResenderSuite) SetupTest() {
 			},
 		},
 		1234,
-		nil,
 	)
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.namespaceID).Return(namespaceEntry, nil).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespace(s.namespace).Return(namespaceEntry, nil).AnyTimes()

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -616,7 +616,7 @@ func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.Wait
 	var replicatorNamespaceCache namespace.Cache
 	if c.workerConfig.EnableReplicator {
 		metadataManager := persistence.NewMetadataPersistenceMetricsClient(c.metadataMgr, service.GetMetricsClient(), c.logger)
-		replicatorNamespaceCache = namespace.NewNamespaceCache(metadataManager, clusterMetadata, service.GetMetricsClient(), service.GetLogger())
+		replicatorNamespaceCache = namespace.NewNamespaceCache(metadataManager, clusterMetadata.IsGlobalNamespaceEnabled(), service.GetMetricsClient(), service.GetLogger())
 		replicatorNamespaceCache.Start()
 		c.startWorkerReplicator(service, clusterMetadata)
 	}
@@ -624,7 +624,7 @@ func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.Wait
 	var clientWorkerNamespaceCache namespace.Cache
 	if c.workerConfig.EnableArchiver {
 		metadataProxyManager := persistence.NewMetadataPersistenceMetricsClient(c.metadataMgr, service.GetMetricsClient(), c.logger)
-		clientWorkerNamespaceCache = namespace.NewNamespaceCache(metadataProxyManager, clusterMetadata, service.GetMetricsClient(), service.GetLogger())
+		clientWorkerNamespaceCache = namespace.NewNamespaceCache(metadataProxyManager, clusterMetadata.IsGlobalNamespaceEnabled(), service.GetMetricsClient(), service.GetLogger())
 		clientWorkerNamespaceCache.Start()
 		c.startWorkerClientWorker(params, service, clientWorkerNamespaceCache)
 	}

--- a/service/frontend/dcRedirectionPolicy_test.go
+++ b/service/frontend/dcRedirectionPolicy_test.go
@@ -339,7 +339,6 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) setupLocalNamespace() {
 		&persistencespb.NamespaceInfo{Id: s.namespaceID, Name: s.namespace},
 		&persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)},
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.namespaceID).Return(namespaceEntry, nil).AnyTimes()
@@ -358,7 +357,6 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) setupGlobalNamespaceWithO
 			},
 		},
 		1234, // not used
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.namespaceID).Return(namespaceEntry, nil).AnyTimes()
@@ -381,7 +379,6 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) setupGlobalNamespaceWithT
 			},
 		},
 		1234, // not used
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.namespaceID).Return(namespaceEntry, nil).AnyTimes()

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -977,8 +977,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_ArchivalURIEmpty()
 			VisibilityArchivalState: enumspb.ARCHIVAL_STATE_DISABLED,
 			VisibilityArchivalUri:   "",
 		},
-		"",
-		nil)
+		"")
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespaceEntry, nil).AnyTimes()
 
 	wh := s.getWorkflowHandler(s.newConfig())
@@ -997,8 +996,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_InvalidURI() {
 			VisibilityArchivalState: enumspb.ARCHIVAL_STATE_DISABLED,
 			VisibilityArchivalUri:   "",
 		},
-		"",
-		nil)
+		"")
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespaceEntry, nil).AnyTimes()
 
 	wh := s.getWorkflowHandler(s.newConfig())
@@ -1017,8 +1015,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
 			VisibilityArchivalState: enumspb.ARCHIVAL_STATE_DISABLED,
 			VisibilityArchivalUri:   "",
 		},
-		"",
-		nil)
+		"")
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespaceEntry, nil).AnyTimes()
 
 	nextPageToken := []byte{'1', '2', '3'}
@@ -1261,7 +1258,6 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_NamespaceNotCo
 			VisibilityArchivalState: enumspb.ARCHIVAL_STATE_DISABLED,
 		},
 		"",
-		nil,
 	), nil)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI")).Times(2)
 
@@ -1280,7 +1276,6 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Failure_InvalidURI() {
 			VisibilityArchivalUri:   "uri without scheme",
 		},
 		"",
-		nil,
 	), nil)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI")).Times(2)
 
@@ -1299,7 +1294,6 @@ func (s *workflowHandlerSuite) TestListArchivedVisibility_Success() {
 			VisibilityArchivalUri:   testVisibilityArchivalURI,
 		},
 		"",
-		nil,
 	), nil).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI")).Times(2)
 	s.mockVisibilityArchiver.EXPECT().Query(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&archiver.QueryVisibilityResponse{}, nil)
@@ -1575,7 +1569,7 @@ func newNamespaceCacheEntry(namespaceName string) *namespace.CacheEntry {
 	info := &persistencespb.NamespaceInfo{
 		Name: namespaceName,
 	}
-	return namespace.NewLocalCacheEntryForTest(info, nil, "", nil)
+	return namespace.NewLocalCacheEntryForTest(info, nil, "")
 }
 
 func (s *workflowHandlerSuite) setupTokenNamespaceTest(tokenNamespace string, enforce bool) *WorkflowHandler {

--- a/service/history/commandChecker_test.go
+++ b/service/history/commandChecker_test.go
@@ -135,13 +135,11 @@ func (s *commandAttrValidatorSuite) TestValidateSignalExternalWorkflowExecutionA
 		&persistencespb.NamespaceInfo{Name: s.testNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewLocalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil).AnyTimes()
@@ -204,13 +202,11 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToLocal(
 		&persistencespb.NamespaceInfo{Name: s.testNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewLocalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -225,7 +221,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToEffect
 		&persistencespb.NamespaceInfo{Name: s.testNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewGlobalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
@@ -235,7 +230,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToEffect
 			Clusters:          []string{cluster.TestCurrentClusterName},
 		},
 		1234,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -250,7 +244,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToEffect
 		&persistencespb.NamespaceInfo{Name: s.testNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewGlobalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
@@ -260,7 +253,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToEffect
 			Clusters:          []string{cluster.TestAlternativeClusterName},
 		},
 		1234,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -275,7 +267,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToGlobal
 		&persistencespb.NamespaceInfo{Name: s.testNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewGlobalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
@@ -288,7 +279,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_LocalToGlobal
 			},
 		},
 		1234,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -307,13 +297,11 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 			Clusters:          []string{cluster.TestCurrentClusterName},
 		},
 		1234,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewLocalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -332,13 +320,11 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 			Clusters:          []string{cluster.TestAlternativeClusterName},
 		},
 		1234,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewLocalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -357,7 +343,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 			Clusters:          []string{cluster.TestCurrentClusterName},
 		},
 		1234,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewGlobalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
@@ -367,7 +352,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 			Clusters:          []string{cluster.TestCurrentClusterName},
 		},
 		5678,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -386,7 +370,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 			Clusters:          []string{cluster.TestCurrentClusterName},
 		},
 		1234,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewGlobalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
@@ -396,7 +379,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 			Clusters:          []string{cluster.TestAlternativeClusterName},
 		},
 		5678,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -417,7 +399,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 			},
 		},
 		5678,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewGlobalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
@@ -430,7 +411,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_EffectiveLoca
 			},
 		},
 		1234,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -452,13 +432,11 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_GlobalToLocal
 			},
 		},
 		1234,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewLocalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
 		nil,
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -480,7 +458,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_GlobalToEffec
 			},
 		},
 		5678,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewGlobalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
@@ -492,7 +469,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_GlobalToEffec
 			},
 		},
 		1234,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)
@@ -514,7 +490,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_GlobalToGloba
 			},
 		},
 		1234,
-		nil,
 	)
 	targetNamespaceEntry := namespace.NewGlobalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: s.testTargetNamespaceID},
@@ -527,7 +502,6 @@ func (s *commandAttrValidatorSuite) TestValidateCrossNamespaceCall_GlobalToGloba
 			},
 		},
 		1234,
-		nil,
 	)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.testNamespaceID).Return(namespaceEntry, nil)

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -132,7 +132,7 @@ func (s *engine2Suite) SetupTest() {
 	s.mockClusterMetadata = s.mockShard.Resource.ClusterMetadata
 	s.mockEventsCache = s.mockShard.MockEventsCache
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespace.NewLocalCacheEntryForTest(
-		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{}, "", nil,
+		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{}, "",
 	), nil).AnyTimes()
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
 

--- a/service/history/historyEngine3_eventsv2_test.go
+++ b/service/history/historyEngine3_eventsv2_test.go
@@ -153,7 +153,7 @@ func (s *engine3Suite) TearDownTest() {
 
 func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 	testNamespaceEntry := namespace.NewLocalCacheEntryForTest(
-		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "", nil,
+		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "",
 	)
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
@@ -226,7 +226,7 @@ func (s *engine3Suite) TestRecordWorkflowTaskStartedSuccessStickyEnabled() {
 
 func (s *engine3Suite) TestStartWorkflowExecution_BrandNew() {
 	testNamespaceEntry := namespace.NewLocalCacheEntryForTest(
-		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "", nil,
+		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "",
 	)
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
@@ -260,7 +260,7 @@ func (s *engine3Suite) TestStartWorkflowExecution_BrandNew() {
 
 func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 	testNamespaceEntry := namespace.NewLocalCacheEntryForTest(
-		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "", nil,
+		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "",
 	)
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
@@ -303,7 +303,7 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 
 func (s *engine3Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 	testNamespaceEntry := namespace.NewLocalCacheEntryForTest(
-		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "", nil,
+		&persistencespb.NamespaceInfo{Id: tests.NamespaceID}, &persistencespb.NamespaceConfig{Retention: timestamp.DurationFromDays(1)}, "",
 	)
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespace(gomock.Any()).Return(testNamespaceEntry, nil).AnyTimes()

--- a/service/history/nDCActivityReplicator_test.go
+++ b/service/history/nDCActivityReplicator_test.go
@@ -625,7 +625,6 @@ func (s *activityReplicatorSuite) TestSyncActivity_WorkflowNotFound() {
 				},
 			},
 			version,
-			nil,
 		), nil,
 	).AnyTimes()
 
@@ -700,7 +699,6 @@ func (s *activityReplicatorSuite) TestSyncActivity_WorkflowClosed() {
 				},
 			},
 			lastWriteVersion,
-			nil,
 		), nil,
 	).AnyTimes()
 
@@ -776,7 +774,6 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityNotFound() {
 				},
 			},
 			lastWriteVersion,
-			nil,
 		), nil,
 	).AnyTimes()
 
@@ -867,7 +864,6 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityFound_Zombie() {
 				},
 			},
 			lastWriteVersion,
-			nil,
 		), nil,
 	).AnyTimes()
 
@@ -958,7 +954,6 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityFound_NonZombie() {
 				},
 			},
 			lastWriteVersion,
-			nil,
 		), nil,
 	).AnyTimes()
 

--- a/service/history/nDCStateRebuilder_test.go
+++ b/service/history/nDCStateRebuilder_test.go
@@ -320,7 +320,6 @@ func (s *nDCStateRebuilderSuite) TestRebuild() {
 			},
 		},
 		1234,
-		s.mockClusterMetadata,
 	), nil).AnyTimes()
 	s.mockTaskRefresher.EXPECT().RefreshTasks(s.now, gomock.Any()).Return(nil)
 

--- a/service/history/replicationTaskExecutor_test.go
+++ b/service/history/replicationTaskExecutor_test.go
@@ -148,7 +148,6 @@ func (s *replicationTaskExecutorSuite) TestFilterTask_Apply() {
 				cluster.TestAlternativeClusterName,
 			}},
 			0,
-			s.clusterMetadata,
 		), nil)
 	ok, err := s.replicationTaskHandler.filterTask(namespaceID, false)
 	s.NoError(err)
@@ -164,7 +163,6 @@ func (s *replicationTaskExecutorSuite) TestFilterTask_NotApply() {
 			nil,
 			&persistencespb.NamespaceReplicationConfig{Clusters: []string{cluster.TestAlternativeClusterName}},
 			0,
-			s.clusterMetadata,
 		), nil)
 	ok, err := s.replicationTaskHandler.filterTask(namespaceID, false)
 	s.NoError(err)

--- a/service/history/replicatorQueueProcessor_test.go
+++ b/service/history/replicatorQueueProcessor_test.go
@@ -240,7 +240,6 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowMissing() {
 			},
 		},
 		1234,
-		nil,
 	), nil).AnyTimes()
 
 	result, err := s.replicatorQueueProcessor.generateSyncActivityTask(ctx, task)
@@ -290,7 +289,6 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowCompleted() {
 			},
 		},
 		version,
-		nil,
 	), nil).AnyTimes()
 
 	result, err := s.replicatorQueueProcessor.generateSyncActivityTask(ctx, task)
@@ -342,7 +340,6 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityCompleted() {
 			},
 		},
 		version,
-		nil,
 	), nil).AnyTimes()
 
 	result, err := s.replicatorQueueProcessor.generateSyncActivityTask(ctx, task)
@@ -430,7 +427,6 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRetry() {
 			},
 		},
 		version,
-		nil,
 	), nil).AnyTimes()
 
 	result, err := s.replicatorQueueProcessor.generateSyncActivityTask(ctx, task)
@@ -541,7 +537,6 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRunning() {
 			},
 		},
 		version,
-		nil,
 	), nil).AnyTimes()
 
 	result, err := s.replicatorQueueProcessor.generateSyncActivityTask(ctx, task)

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -87,7 +87,7 @@ func (s *contextSuite) SetupTest() {
 	s.mockResource = shardContext.Resource
 
 	s.namespaceID = "namespace-Id"
-	s.namespaceEntry = namespace.NewLocalCacheEntryForTest(&persistencespb.NamespaceInfo{Id: s.namespaceID}, &persistencespb.NamespaceConfig{}, "", nil)
+	s.namespaceEntry = namespace.NewLocalCacheEntryForTest(&persistencespb.NamespaceInfo{Id: s.namespaceID}, &persistencespb.NamespaceConfig{}, "")
 	s.mockNamespaceCache = s.mockResource.NamespaceCache
 
 	s.mockClusterMetadata = s.mockResource.ClusterMetadata

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -62,7 +62,6 @@ var (
 			},
 		},
 		cluster.TestCurrentClusterName,
-		nil,
 	)
 
 	GlobalNamespaceEntry = namespace.NewGlobalCacheEntryForTest(
@@ -80,7 +79,6 @@ var (
 			},
 		},
 		Version,
-		nil,
 	)
 
 	GlobalParentNamespaceEntry = namespace.NewGlobalCacheEntryForTest(
@@ -94,7 +92,6 @@ var (
 			},
 		},
 		Version,
-		nil,
 	)
 
 	GlobalTargetNamespaceEntry = namespace.NewGlobalCacheEntryForTest(
@@ -108,7 +105,6 @@ var (
 			},
 		},
 		Version,
-		nil,
 	)
 
 	GlobalChildNamespaceEntry = namespace.NewGlobalCacheEntryForTest(
@@ -122,7 +118,6 @@ var (
 			},
 		},
 		Version,
-		nil,
 	)
 
 	CreateWorkflowExecutionResponse = &persistence.CreateWorkflowExecutionResponse{

--- a/service/history/timerQueueTaskExecutorBase_test.go
+++ b/service/history/timerQueueTaskExecutorBase_test.go
@@ -182,7 +182,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_NoErr_InlineArchiva
 
 	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false)
 
-	namespaceCacheEntry := namespace.NewNamespaceCacheEntryForTest(&persistencespb.NamespaceInfo{}, &persistencespb.NamespaceConfig{}, false, nil, 0, nil)
+	namespaceCacheEntry := namespace.NewNamespaceCacheEntryForTest(&persistencespb.NamespaceInfo{}, &persistencespb.NamespaceConfig{}, false, nil, 0)
 	err := s.timerQueueTaskExecutorBase.archiveWorkflow(&persistencespb.TimerTaskInfo{
 		ScheduleAttempt: 1}, s.mockWorkflowExecutionContext, s.mockMutableState, namespaceCacheEntry)
 	s.NoError(err)
@@ -201,7 +201,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_SendSignalErr() {
 		Return(nil, errors.New("failed to send signal"))
 	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false)
 
-	namespaceCacheEntry := namespace.NewNamespaceCacheEntryForTest(&persistencespb.NamespaceInfo{}, &persistencespb.NamespaceConfig{}, false, nil, 0, nil)
+	namespaceCacheEntry := namespace.NewNamespaceCacheEntryForTest(&persistencespb.NamespaceInfo{}, &persistencespb.NamespaceConfig{}, false, nil, 0)
 	err := s.timerQueueTaskExecutorBase.archiveWorkflow(&persistencespb.TimerTaskInfo{
 		ScheduleAttempt: 1}, s.mockWorkflowExecutionContext, s.mockMutableState, namespaceCacheEntry)
 	s.Error(err)

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -599,7 +599,6 @@ func (s *mutableStateSuite) newNamespaceCacheEntry() *namespace.CacheEntry {
 		true,
 		&persistencespb.NamespaceReplicationConfig{},
 		1,
-		nil,
 	)
 }
 

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -82,6 +82,7 @@ func NewHandler(
 			resource.GetMetricsClient(),
 			resource.GetNamespaceCache(),
 			resource.GetMatchingServiceResolver(),
+			resource.GetClusterMetadata(),
 		),
 	}
 

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -478,8 +478,7 @@ func (t *MatcherTestSuite) newNamespaceCache() namespace.Cache {
 	entry := namespace.NewLocalCacheEntryForTest(
 		&persistencespb.NamespaceInfo{Name: "test-namespace"},
 		&persistencespb.NamespaceConfig{},
-		"",
-		nil)
+		"")
 	dc := namespace.NewMockCache(t.controller)
 	dc.EXPECT().GetNamespaceByID(gomock.Any()).Return(entry, nil).AnyTimes()
 	return dc

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -41,6 +41,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
@@ -258,14 +259,13 @@ func createTestTaskQueueManagerWithConfig(
 	tm := newTestTaskManager(logger)
 	mockNamespaceCache := namespace.NewMockCache(controller)
 	mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(&namespace.CacheEntry{}, nil).AnyTimes()
-	me := newMatchingEngine(
-		cfg, tm, nil, logger, mockNamespaceCache,
-	)
+	cmeta := cluster.NewTestClusterMetadata(cluster.NewTestClusterMetadataConfig(false, true))
+	me := newMatchingEngine(cfg, tm, nil, logger, mockNamespaceCache)
 	tl := "tq"
 	dID := "deadbeef-0000-4567-890a-bcdef0123456"
 	tlID := newTestTaskQueueID(dID, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	tlKind := enumspb.TASK_QUEUE_KIND_NORMAL
-	tlMgr, err := newTaskQueueManager(me, tlID, tlKind, cfg, opts...)
+	tlMgr, err := newTaskQueueManager(me, tlID, tlKind, cfg, cmeta, opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removes the ClusterInfo interface for a bool parameter to the
cache constructor defining whether or not global namespaces are enabled
on the current cluster. Also refactored CacheEntry functions that relied
on a priori knowledge of the name of the cluster on which they are
currently being executed to taking that information as a parameter from
callers.

<!-- Tell your future self why have you made these changes -->
**Why?**
Decouples namespace.Cache from cluster metadata and makes it more flexible to use at the same time

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Old & new unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No