### PR TITLE
Fix elasticsearch_bulk_processor_wait_add_latency metric

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -185,8 +185,8 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 		return nil
 	})
 	if !isDup {
-		ackCh.add(p.metricsClient)
 		p.bulkProcessor.Add(request)
+		ackCh.recordAdd(p.metricsClient)
 	}
 	return ackCh.ackChInternal
 }
@@ -207,7 +207,7 @@ func (p *processorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableReq
 			if !ok {
 				p.logger.Fatal(fmt.Sprintf("mapToAckChan has item of a wrong type %T (%T expected).", value, &ackChan{}), tag.Value(key))
 			}
-			ackCh.start(p.metricsClient)
+			ackCh.recordStart(p.metricsClient)
 			return nil
 		})
 	}
@@ -401,12 +401,12 @@ func newAckChan() *ackChan {
 	}
 }
 
-func (a *ackChan) add(metricsClient metrics.Client) {
+func (a *ackChan) recordAdd(metricsClient metrics.Client) {
 	a.addedAt = time.Now().UTC()
 	metricsClient.RecordTimer(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorWaitAddLatency, a.addedAt.Sub(a.createdAt))
 }
 
-func (a *ackChan) start(metricsClient metrics.Client) {
+func (a *ackChan) recordStart(metricsClient metrics.Client) {
 	a.startedAt = time.Now().UTC()
 	metricsClient.RecordTimer(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorWaitStartLatency, a.startedAt.Sub(a.addedAt))
 }

--- a/common/persistence/visibility/store/elasticsearch/processor_test.go
+++ b/common/persistence/visibility/store/elasticsearch/processor_test.go
@@ -354,13 +354,14 @@ func (s *processorSuite) TestBulkBeforeAction() {
 	s.mockMetricClient.EXPECT().AddCounter(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorRequests, int64(1))
 	s.mockMetricClient.EXPECT().RecordDistribution(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorBulkSize, 1)
 	s.mockMetricClient.EXPECT().RecordDistribution(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorQueuedRequests, 0)
+	s.mockMetricClient.EXPECT().RecordTimer(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorWaitAddLatency, gomock.Any())
 	s.mockMetricClient.EXPECT().RecordTimer(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorWaitStartLatency, gomock.Any())
 
 	mapVal := newAckChan()
+	mapVal.recordAdd(s.mockMetricClient)
 	s.esProcessor.mapToAckChan.Put(testKey, mapVal)
 	s.True(mapVal.startedAt.IsZero())
 	s.esProcessor.bulkBeforeAction(0, requests)
-
 	s.False(mapVal.startedAt.IsZero())
 }
 

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -199,6 +199,8 @@ func (s *visibilityStore) addBulkIndexRequestAndWait(
 func (s *visibilityStore) addBulkRequestAndWait(bulkRequest *client.BulkableRequest, visibilityTaskKey string) error {
 	s.checkProcessor()
 
+	// Add method is blocking. If bulk processor is busy flushing previous bulk, request will wait here.
+	// Therefore, ackTimeoutTimer in fact wait for request to be committed after it was added to bulk processor.
 	ackCh := s.processor.Add(bulkRequest, visibilityTaskKey)
 	ackTimeoutTimer := time.NewTimer(s.processorAckTimeout())
 	defer ackTimeoutTimer.Stop()

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
+
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/persistence/visibility"
@@ -447,7 +448,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		SearchAttributesTotalSizeLimit:    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.SearchAttributesTotalSizeLimit, 40*1024),
 		IndexerConcurrency:                dc.GetIntProperty(dynamicconfig.WorkerIndexerConcurrency, 100),
 		ESProcessorNumOfWorkers:           dc.GetIntProperty(dynamicconfig.WorkerESProcessorNumOfWorkers, 1),
-		// Should be not greater than NumberOfShards(512)/NumberOfHistoryNodes(4) * VisibilityTaskWorkerCount(10) divided by workflow distribution factor (2 at least).
+		// Should be not greater than NumberOfShards(512)/NumberOfHistoryNodes(4) * VisibilityTaskWorkerCount(10)/ESProcessorNumOfWorkers(1) divided by workflow distribution factor (2 at least).
 		// Otherwise, visibility queue processors won't be able to fill up bulk with documents (even under heavy load) and bulk will flush due to interval, not number of actions.
 		ESProcessorBulkActions: dc.GetIntProperty(dynamicconfig.WorkerESProcessorBulkActions, 500),
 		// 16MB - just a sanity check. With ES document size ~1Kb it should never be reached.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix `elasticsearch_bulk_processor_wait_add_latency` metric.

<!-- Tell your future self why have you made these changes -->
**Why?**
Bulk processor wait add time was incorrectly counted towards wait start time.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run test tool locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.