### PR TITLE
Increase add-search-attributes tctl admin command timeout to 30s

### DIFF
--- a/tools/cli/admin_cluster_search_attributes_commands.go
+++ b/tools/cli/admin_cluster_search_attributes_commands.go
@@ -29,13 +29,19 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 	enumspb "go.temporal.io/api/enums/v1"
+
 	"go.temporal.io/server/api/adminservice/v1"
 	clispb "go.temporal.io/server/api/cli/v1"
+)
+
+const (
+	addSearchAttributesTimeout = 30 * time.Second
 )
 
 // AdminAddSearchAttributes to add search attributes
@@ -92,7 +98,7 @@ func AdminAddSearchAttributes(c *cli.Context) {
 		SkipSchemaUpdate: c.Bool(FlagSkipSchemaUpdate),
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel := newContextWithTimeout(c, addSearchAttributesTimeout)
 	defer cancel()
 	_, err = adminClient.AddSearchAttributes(ctx, request)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Increase `add-search-attributes` tctl admin command timeout to 30s.

<!-- Tell your future self why have you made these changes -->
**Why?**
Default 5s timeout sometimes is not enough to run and get results of underlying system workflow.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.