### PR TITLE
Use time.Unix(0, 0) instead of time.Time

### DIFF
--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -2931,7 +2931,7 @@ func (s *ExecutionManagerSuite) TestReplicationTransferTaskTasks() {
 	s.Equal(int64(3), task1.GetNextEventId())
 	s.Equal(int64(9), task1.Version)
 
-	err = s.CompleteTransferTask(task1.GetTaskId())
+	err = s.CompleteReplicationTask(task1.GetTaskId())
 	s.NoError(err)
 	tasks2, err := s.GetReplicationTasks(1, false)
 	s.NoError(err)

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -230,7 +230,7 @@ func (s *TestBase) Setup(clusterMetadataConfig *config.ClusterMetadata) {
 		RangeId:                 0,
 		TransferAckLevel:        0,
 		ReplicationAckLevel:     0,
-		TimerAckLevelTime:       &time.Time{},
+		TimerAckLevelTime:       timestamp.TimePtr(time.Unix(0, 0).UTC()),
 		ClusterTimerAckLevel:    map[string]*time.Time{},
 		ClusterTransferAckLevel: map[string]int64{clusterName: 0},
 	}
@@ -1103,7 +1103,7 @@ Loop:
 	for {
 		response, err := s.ExecutionManager.GetTimerIndexTasks(&persistence.GetTimerIndexTasksRequest{
 			ShardID:       s.ShardInfo.GetShardId(),
-			MinTimestamp:  time.Time{},
+			MinTimestamp:  time.Unix(0, 0).UTC(),
 			MaxTimestamp:  time.Unix(0, math.MaxInt64).UTC(),
 			BatchSize:     batchSize,
 			NextPageToken: token,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Use time.Unix(0, 0) instead of time.Time in persistence tests
* Fix persistence test bug

<!-- Tell your future self why have you made these changes -->
**Why?**
Bugfix of tests

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No