### PR TITLE
Correctly set shard ID when range complete replication tasks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -408,16 +408,6 @@ install-schema-cdc: temporal-cassandra-tool
 	./temporal-cassandra-tool -k temporal_visibility_standby setup-schema -v 0.0
 	./temporal-cassandra-tool -k temporal_visibility_standby update-schema -d ./schema/cassandra/visibility/versioned
 
-	@printf $(COLOR) "Set up temporal_other key space..."
-	./temporal-cassandra-tool drop -k temporal_other -f
-	./temporal-cassandra-tool create -k temporal_other --rf 1
-	./temporal-cassandra-tool -k temporal_other setup-schema -v 0.0
-	./temporal-cassandra-tool -k temporal_other update-schema -d ./schema/cassandra/temporal/versioned
-	./temporal-cassandra-tool drop -k temporal_visibility_other -f
-	./temporal-cassandra-tool create -k temporal_visibility_other --rf 1
-	./temporal-cassandra-tool -k temporal_visibility_other setup-schema -v 0.0
-	./temporal-cassandra-tool -k temporal_visibility_other update-schema -d ./schema/cassandra/visibility/versioned
-
 ##### Run server #####
 start-dependencies:
 	docker-compose -f ./develop/docker-compose/docker-compose.yml -f ./develop/docker-compose/docker-compose.$(GOOS).yml up

--- a/common/persistence/cassandra/mutable_state_task_store.go
+++ b/common/persistence/cassandra/mutable_state_task_store.go
@@ -641,7 +641,6 @@ func (d *MutableStateTaskStore) CompleteReplicationTask(
 func (d *MutableStateTaskStore) RangeCompleteReplicationTask(
 	request *p.RangeCompleteReplicationTaskRequest,
 ) error {
-
 	query := d.Session.Query(templateCompleteReplicationTaskBeforeQuery,
 		request.ShardID,
 		rowTypeReplicationTask,

--- a/service/history/replicationTaskProcessor.go
+++ b/service/history/replicationTaskProcessor.go
@@ -493,6 +493,7 @@ func (p *ReplicationTaskProcessorImpl) cleanupReplicationTasks() error {
 	)
 	err := p.shard.GetExecutionManager().RangeCompleteReplicationTask(
 		&persistence.RangeCompleteReplicationTaskRequest{
+			ShardID:            p.shard.GetShardID(),
 			InclusiveEndTaskID: *minAckedTaskID,
 		},
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Correctly set shard ID when range complete replication tasks

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously, shard ID is provided by storage layer, new logic now require shard ID as part of input request

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Update tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
