### PR TITLE
Pass exit signals to temporal-server

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -23,12 +23,4 @@ for arg in "$@" ; do [[ ${arg} == "develop" ]] && ./setup-develop.sh && break ; 
 # Run bash instead of Temporal Server if "bash" is passed as an argument (convenient to debug docker image).
 for arg in "$@" ; do [[ ${arg} == "bash" ]] && bash && exit 0 ; done
 
-trap 'kill -TERM $PID; wait $PID' TERM INT
-
-./start-temporal.sh &
-
-# Properly handle shutdown
-PID=$!
-wait $PID
-trap - TERM INT
-wait $PID
+exec ./start-temporal.sh

--- a/docker/start-temporal.sh
+++ b/docker/start-temporal.sh
@@ -12,12 +12,4 @@ if [ -z "${SERVICE_FLAGS}" ] && [ -n "${SERVICES}" ]; then
     for i in "${!SERVICE_FLAGS[@]}"; do SERVICE_FLAGS[$i]="--service=${SERVICE_FLAGS[$i]}"; done
 fi
 
-trap 'kill -TERM $PID; wait $PID' TERM INT
-
-exec temporal-server --env docker start "${SERVICE_FLAGS[@]}" &
-
-# Properly handle shutdown
-PID=$!
-wait $PID
-trap - TERM INT
-wait $PID
+exec temporal-server --env docker start "${SERVICE_FLAGS[@]}"


### PR DESCRIPTION
**What changed?**
This commit passes signals that entrypoint.sh receives from docker
through start-temporal.sh, to the temporal-server executable.

**Why?**
Currently, only entrypoint.sh receives signals from docker and doesn't
pass them onto the sub processes. Because of this, docker waits for the
container to shut down -- which it never does due to temporal-server
never receiving the signals -- and eventually all processes are killed
without any wait time.

**How did you test it?**
I tested this by overriding the scripts in my project and mounting those
over the images. I verified that upon firing a stop command, the
container shut down properly with "ShutdownHandler" among other entries
appearing in the log.

**Potential risks**
Nothing

**Is hotfix candidate?**
Yes, this change should be completely transparent to the end user.
