### PR TITLE
Avoid acquiring shared lock recursively

### DIFF
--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -473,7 +473,7 @@ func (r *registry) getNamespace(name string) (*Namespace, error) {
 	r.cacheLock.RLock()
 	defer r.cacheLock.RUnlock()
 	if id, ok := r.cacheNameToID.Get(name).(string); ok {
-		return r.getNamespaceByID(id)
+		return r.getNamespaceByIDLocked(id)
 	}
 	return nil, serviceerror.NewNotFound(
 		fmt.Sprintf("Namespace name %q not found", name))
@@ -483,6 +483,10 @@ func (r *registry) getNamespace(name string) (*Namespace, error) {
 func (r *registry) getNamespaceByID(id string) (*Namespace, error) {
 	r.cacheLock.RLock()
 	defer r.cacheLock.RUnlock()
+	return r.getNamespaceByIDLocked(id)
+}
+
+func (r *registry) getNamespaceByIDLocked(id string) (*Namespace, error) {
 	if ns, ok := r.cacheByID.Get(id).(*Namespace); ok {
 		return ns, nil
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Avoid acquiring namespace.Registry shared lock recursively

<!-- Tell your future self why have you made these changes -->
**Why?**
Per the Go docs for sync.RWMutex, pending calls to RWMutex.Lock() block
calls to RWMutex.RLock(). With this understood we can see that the call
from getNamespace to getNamespaceByID acquires the read side of the
RWMutex twice - any interleaved call to RWMutex.Lock() between those two
RLock() calls will cause a deadlock - the Lock() call cannot continue
and the second RLock() call also will not continue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added a unit test but this being a deadlock requiring extremely precise timing the unit test does not capture the error  condition.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No