### PR TITLE
Disable fx logs

### DIFF
--- a/host/onebox.go
+++ b/host/onebox.go
@@ -410,6 +410,7 @@ func (c *temporalImpl) startFrontend(hosts map[string][]string, startWG *sync.Wa
 		fx.Provide(func() esclient.Client { return c.esClient }),
 		frontend.Module,
 		fx.Populate(&frontendService),
+		fx.NopLogger,
 	)
 	err = feApp.Err()
 	if err != nil {
@@ -500,7 +501,8 @@ func (c *temporalImpl) startHistory(
 			fx.Provide(func() *esclient.Config { return c.esConfig }),
 			fx.Provide(func() esclient.Client { return c.esClient }),
 			history.Module,
-			fx.Populate(&historyService))
+			fx.Populate(&historyService),
+			fx.NopLogger)
 		err = app.Err()
 		if err != nil {
 			c.logger.Fatal("unable to construct history service", tag.Error(err))
@@ -569,6 +571,7 @@ func (c *temporalImpl) startMatching(hosts map[string][]string, startWG *sync.Wa
 		fx.Provide(func() log.Logger { return c.logger }),
 		matching.Module,
 		fx.Populate(&matchingService),
+		fx.NopLogger,
 	)
 	err = app.Err()
 	if err != nil {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -106,6 +106,7 @@ func NewServerFx(opts ...ServerOption) *ServerFx {
 		fx.Provide(WorkerServiceProvider),
 		fx.Provide(ApplyClusterMetadataConfigProvider),
 		fx.Invoke(ServerLifetimeHooks),
+		fx.NopLogger,
 	)
 	s := &ServerFx{
 		app,
@@ -186,7 +187,7 @@ func HistoryServiceProvider(
 		logger.Info("Service is not requested, skipping initialization.", tag.Service(serviceName))
 		return ServicesGroupOut{
 			Services: &ServicesMetadata{
-				App:           fx.New(),
+				App:           fx.New(fx.NopLogger),
 				ServiceName:   serviceName,
 				ServiceStopFn: func() {},
 			},
@@ -212,6 +213,7 @@ func HistoryServiceProvider(
 		fx.Provide(func() esclient.Client { return esClient }),
 		fx.Provide(newBootstrapParams),
 		history.Module,
+		fx.NopLogger,
 	)
 
 	stopFn := func() { stopService(logger, app, serviceName, stopChan) }
@@ -243,7 +245,7 @@ func MatchingServiceProvider(
 		logger.Info("Service is not requested, skipping initialization.", tag.Service(serviceName))
 		return ServicesGroupOut{
 			Services: &ServicesMetadata{
-				App:           fx.New(),
+				App:           fx.New(fx.NopLogger),
 				ServiceName:   serviceName,
 				ServiceStopFn: func() {},
 			},
@@ -269,6 +271,7 @@ func MatchingServiceProvider(
 		fx.Provide(func() esclient.Client { return esClient }),
 		fx.Provide(newBootstrapParams),
 		matching.Module,
+		fx.NopLogger,
 	)
 
 	stopFn := func() { stopService(logger, app, serviceName, stopChan) }
@@ -300,7 +303,7 @@ func FrontendServiceProvider(
 		logger.Info("Service is not requested, skipping initialization.", tag.Service(serviceName))
 		return ServicesGroupOut{
 			Services: &ServicesMetadata{
-				App:           fx.New(),
+				App:           fx.New(fx.NopLogger),
 				ServiceName:   serviceName,
 				ServiceStopFn: func() {},
 			},
@@ -326,6 +329,7 @@ func FrontendServiceProvider(
 		fx.Provide(func() esclient.Client { return esClient }),
 		fx.Provide(newBootstrapParams),
 		frontend.Module,
+		fx.NopLogger,
 	)
 
 	stopFn := func() { stopService(logger, app, serviceName, stopChan) }
@@ -357,7 +361,7 @@ func WorkerServiceProvider(
 		logger.Info("Service is not requested, skipping initialization.", tag.Service(serviceName))
 		return ServicesGroupOut{
 			Services: &ServicesMetadata{
-				App:           fx.New(),
+				App:           fx.New(fx.NopLogger),
 				ServiceName:   serviceName,
 				ServiceStopFn: func() {},
 			},
@@ -383,6 +387,7 @@ func WorkerServiceProvider(
 		fx.Provide(func() esclient.Client { return esClient }),
 		fx.Provide(newBootstrapParams),
 		worker.Module,
+		fx.NopLogger,
 	)
 
 	stopFn := func() { stopService(logger, app, serviceName, stopChan) }


### PR DESCRIPTION
**What changed?**
It disables fx's logging using `fx.NopLogger`.

**Why?**
My thinking is that fx logging is only useful when wiring dependencies during development but rather verbose and unneeded otherwise.

**How did you test it?**
I've confirmed that fx logs are not written to stderr anymore when running or embedding Temporal.


**Potential risks**

**Is hotfix candidate?**