### PR TITLE
Add in flight poll activity / workflow task queue metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1588,6 +1588,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 // Common Metrics enum
 const (
 	ServiceRequests = iota
+	ServicePendingRequests
 	ServiceFailures
 	ServiceCriticalFailures
 	ServiceLatency
@@ -2031,6 +2032,7 @@ const (
 var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 	Common: {
 		ServiceRequests:                                     {metricName: "service_requests", metricType: Counter},
+		ServicePendingRequests:                              {metricName: "service_pending_requests", metricType: Gauge},
 		ServiceFailures:                                     {metricName: "service_errors", metricType: Counter},
 		ServiceCriticalFailures:                             {metricName: "service_errors_critical", metricType: Counter},
 		ServiceLatency:                                      {metricName: "service_latency", metricType: Timer},

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -28,7 +28,7 @@ import (
 	"context"
 
 	"go.uber.org/fx"
-	grpc "google.golang.org/grpc"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/keepalive"
 
 	"go.temporal.io/server/common"
@@ -203,6 +203,7 @@ func NamespaceCountLimitInterceptorProvider(
 ) *interceptor.NamespaceCountLimitInterceptor {
 	return interceptor.NewNamespaceCountLimitInterceptor(
 		serviceResource.GetNamespaceRegistry(),
+		serviceResource.GetLogger(),
 		serviceConfig.MaxNamespaceCountPerInstance,
 		configs.ExecutionAPICountLimitOverride,
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Add in flight poll activity / workflow task queue metrics

<!-- Tell your future self why have you made these changes -->
**Why?**

```
service_pending_requests{namespace="canary",operation="PollActivityTaskQueue"} 128
service_pending_requests{namespace="canary",operation="PollWorkflowTaskQueue"} 128
service_pending_requests{namespace="temporal_system",operation="PollActivityTaskQueue"} 44
service_pending_requests{namespace="temporal_system",operation="PollWorkflowTaskQueue"} 44
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No