### PR TITLE
Use PPROF_PORT env to configure pprof port in config_template.yaml

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -149,6 +149,8 @@ global:
     membership:
         maxJoinDuration: 30s
         broadcastAddress: "{{ default .Env.TEMPORAL_BROADCAST_ADDRESS "" }}"
+    pprof:
+        port: {{ default .Env.PPROF_PORT "0" }}
     tls:
         refreshInterval: {{ default .Env.TEMPORAL_TLS_REFRESH_INTERVAL "0s" }}
         expirationChecks:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use `PPROF_PORT` env to configure pprof port in `config_template.yaml`.

<!-- Tell your future self why have you made these changes -->
**Why?**
To be able to configure `pprof` in production

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run docker-compose locally with and without `PPROF_PORT` env set.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.