### PR TITLE
Specify the entrypoint absolutely

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir /etc/temporal/config
 RUN chown -R temporal:temporal /etc/temporal/config
 
 USER temporal
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["/etc/temporal/entrypoint.sh"]
 
 COPY config/dynamicconfig /etc/temporal/config/dynamicconfig
 COPY docker/config_template.yaml /etc/temporal/config/config_template.yaml


### PR DESCRIPTION
**What changed?**.
Specify the entrypoint in `Dockerfile` absolutely.

**Why?**
When used as a container in a K8s Pod in Jenkins with the K8s plugin, the working dir is overridden, causing the entrypoint script to not be found.

**How did you test it?**
Tested the concept by specifying the command absolutely in the jenkins pod config. Tested the change by building the image locally.

**Potential risks**
Low. Container wouldn't start if this change was incorrect.

**Is hotfix candidate?**
No.
