### PR TITLE
Use correct absolute paths to scripts in dockerfile

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -12,15 +12,15 @@ else
     export TEMPORAL_CLI_ADDRESS="${BIND_ON_IP}:7233"
 fi
 
-dockerize -template ./config/config_template.yaml:./config/docker.yaml
+dockerize -template /etc/temporal/config/config_template.yaml:/etc/temporal/config/docker.yaml
 
 # Automatically setup Temporal Server (databases, Elasticsearch, default namespace) if "autosetup" is passed as an argument.
-for arg in "$@" ; do [[ ${arg} == "autosetup" ]] && ./auto-setup.sh && break ; done
+for arg in "$@" ; do [[ ${arg} == "autosetup" ]] && /etc/temporal/auto-setup.sh && break ; done
 
 # Setup Temporal Server in development mode if "develop" is passed as an argument.
-for arg in "$@" ; do [[ ${arg} == "develop" ]] && ./setup-develop.sh && break ; done
+for arg in "$@" ; do [[ ${arg} == "develop" ]] && /etc/temporal/setup-develop.sh && break ; done
 
 # Run bash instead of Temporal Server if "bash" is passed as an argument (convenient to debug docker image).
 for arg in "$@" ; do [[ ${arg} == "bash" ]] && bash && exit 0 ; done
 
-exec ./start-temporal.sh
+exec /etc/temporal/start-temporal.sh


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Use absolute paths to scripts and config in docker image


<!-- Tell your future self why have you made these changes -->
When used in a pod in Jenkins with the K8s plugin, the working directory is overridden, meaning none of these scripts can be located without manually specifying the command:

```
command: [ "/bin/bash", "-c", "cd /etc/temporal && ./entrypoint.sh autosetup" ]
```


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Test in Jenkins to ensure correctness, and built the docker image locally.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Worst case: Container would fail to start


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
Hotfix: No
