### PR TITLE
Add worker manager to worker service

### DIFF
--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -125,6 +125,7 @@ var (
 	ComponentArchiver                 = component("archiver")
 	ComponentBatcher                  = component("batcher")
 	ComponentWorker                   = component("worker")
+	ComponentWorkerManager            = component("worker-manager")
 	ComponentServiceResolver          = component("service-resolver")
 	ComponentMetadataInitializer      = component("metadata-initializer")
 	ComponentAddSearchAttributes      = component("add-search-attributes")

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -72,6 +72,7 @@ var Module = fx.Options(
 	fx.Provide(HistoryServiceClientProvider),
 	fx.Provide(cluster.NewMetadataFromConfig),
 	fx.Provide(NewService),
+	fx.Provide(NewWorkerManager),
 	fx.Invoke(ServiceLifetimeHooks),
 )
 

--- a/service/worker/worker.go
+++ b/service/worker/worker.go
@@ -1,0 +1,124 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package worker
+
+import (
+	"sync/atomic"
+
+	sdkclient "go.temporal.io/sdk/client"
+	sdkworker "go.temporal.io/sdk/worker"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.uber.org/fx"
+)
+
+const DefaultWorkerTaskQueue = "default-worker-tq"
+
+type (
+	// WorkerComponent represent a type of work needed for worker role
+	WorkerComponent interface {
+		// Register registers Workflow and Activity types provided by this worker component
+		Register(sdkworker.Worker)
+		// DedicatedWorkerOptions returns a DedicatedWorkerOptions for this worker component. Return nil to use
+		// default worker instance.
+		DedicatedWorkerOptions() *DedicatedWorkerOptions
+	}
+
+	DedicatedWorkerOptions struct {
+		TaskQueue string
+		Options   sdkworker.Options
+	}
+
+	// workerManager maintains list of SDK workers.
+	workerManager struct {
+		status           int32
+		logger           log.Logger
+		sdkClient        sdkclient.Client
+		workers          []sdkworker.Worker
+		workerComponents []WorkerComponent
+	}
+
+	initParams struct {
+		fx.In
+		Logger           log.Logger
+		SdkClient        sdkclient.Client
+		WorkerComponents []WorkerComponent `group:"workerComponent"`
+	}
+)
+
+func NewWorkerManager(params initParams) *workerManager {
+	return &workerManager{
+		logger:           params.Logger,
+		sdkClient:        params.SdkClient,
+		workerComponents: params.WorkerComponents,
+	}
+}
+
+func (wm *workerManager) Start() {
+	if !atomic.CompareAndSwapInt32(
+		&wm.status,
+		common.DaemonStatusInitialized,
+		common.DaemonStatusStarted,
+	) {
+		return
+	}
+
+	defaultWorkerOptions := sdkworker.Options{
+		// TODO: add dynamic config for this
+	}
+	defaultWorker := sdkworker.New(wm.sdkClient, DefaultWorkerTaskQueue, defaultWorkerOptions)
+	wm.workers = []sdkworker.Worker{defaultWorker}
+
+	for _, wc := range wm.workerComponents {
+		workerOptions := wc.DedicatedWorkerOptions()
+		if workerOptions == nil {
+			// use default worker
+			wc.Register(defaultWorker)
+		} else {
+			// this worker component requires a dedicated worker
+			dedicatedWorker := sdkworker.New(wm.sdkClient, workerOptions.TaskQueue, workerOptions.Options)
+			wc.Register(dedicatedWorker)
+			wm.workers = append(wm.workers, dedicatedWorker)
+		}
+	}
+
+	wm.logger.Info("", tag.ComponentWorkerManager, tag.LifeCycleStarted)
+}
+
+func (wm *workerManager) Stop() {
+	if !atomic.CompareAndSwapInt32(
+		&wm.status,
+		common.DaemonStatusStarted,
+		common.DaemonStatusStopped,
+	) {
+		return
+	}
+
+	for _, w := range wm.workers {
+		w.Stop()
+	}
+	wm.logger.Info("", tag.ComponentWorkerManager, tag.LifeCycleStopped)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a new worker manager to manage all sdk workers for server worker role.

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, each component duplicate the logic to create separate sdk workers. We should have one place for all sdk workers and use DI to register workflow/activity from each component.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run server, see below logs in start and stop:
{"level":"info","ts":"2021-11-03T10:26:44.091-0700","msg":"none","component":"worker-manager","lifecycle":"Started","logging-call-at":"worker.go:108"}
{"level":"info","ts":"2021-11-03T10:26:55.496-0700","msg":"none","component":"worker-manager","lifecycle":"Stopped","logging-call-at":"worker.go:123"}

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No