### PR TITLE
Remove sampled retention

### DIFF
--- a/common/namespace/namespace_test.go
+++ b/common/namespace/namespace_test.go
@@ -109,23 +109,14 @@ func Test_GetRetentionDays(t *testing.T) {
 	for _, tt := range [...]struct {
 		name       string
 		retention  string
-		rate       string
 		workflowID string
 		want       time.Duration
 	}{
 		{
 			name:       "30x0",
 			retention:  "30",
-			rate:       "0",
 			workflowID: uuid.NewString(),
 			want:       defaultRetention,
-		},
-		{
-			name:       "30x1",
-			retention:  "30",
-			rate:       "1",
-			workflowID: uuid.NewString(),
-			want:       30 * 24 * time.Hour,
 		},
 		{
 			name:       "invalid retention",
@@ -133,43 +124,10 @@ func Test_GetRetentionDays(t *testing.T) {
 			workflowID: uuid.NewString(),
 			want:       defaultRetention,
 		},
-		{
-			name:       "invalid rate",
-			retention:  "30",
-			rate:       "invalid-value",
-			workflowID: uuid.NewString(),
-			want:       defaultRetention,
-		},
-		{
-			name:       "hash outside of sample rate",
-			retention:  "30",
-			rate:       "0.8",
-			workflowID: "3aef42a8-db0a-4a3b-b8b7-9829d74b4ebf",
-			want:       defaultRetention,
-		},
-		{
-			name:       "hash inside sample rate",
-			retention:  "30",
-			rate:       "0.9",
-			workflowID: "3aef42a8-db0a-4a3b-b8b7-9829d74b4ebf",
-			want:       30 * 24 * time.Hour,
-		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			ns := base.Clone(
-				namespace.WithData(namespace.SampleRetentionKey, tt.retention),
-				namespace.WithData(namespace.SampleRateKey, tt.rate))
-			require.Equal(t, tt.want, ns.Retention(tt.workflowID))
+			ns := base.Clone()
+			require.Equal(t, tt.want, ns.Retention())
 		})
 	}
-}
-
-func TestIsSampledForLongerRetentionEnabled(t *testing.T) {
-	ns := base(t)
-	wid := uuid.NewString()
-	require.False(t, ns.IsSampledForLongerRetentionEnabled(wid))
-	ns = ns.Clone(
-		namespace.WithData(namespace.SampleRetentionKey, "30"),
-		namespace.WithData(namespace.SampleRateKey, "0"))
-	require.True(t, ns.IsSampledForLongerRetentionEnabled(wid))
 }

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -274,11 +274,6 @@ func (t *visibilityQueueTaskExecutor) recordStartExecution(
 		return err
 	}
 
-	// if sampled for longer retention is enabled, only record those sampled events
-	if namespaceEntry.IsSampledForLongerRetentionEnabled(workflowID) && !namespaceEntry.IsSampledForLongerRetention(workflowID) {
-		return nil
-	}
-
 	request := &manager.RecordWorkflowExecutionStartedRequest{
 		VisibilityRequestBase: &manager.VisibilityRequestBase{
 			NamespaceID: namespaceID,
@@ -449,12 +444,7 @@ func (t *visibilityQueueTaskExecutor) recordCloseExecution(
 
 	recordWorkflowClose := true
 
-	retention := namespaceEntry.Retention(workflowID)
-	// if sampled for longer retention is enabled, only record those sampled events
-	if namespaceEntry.IsSampledForLongerRetentionEnabled(workflowID) &&
-		!namespaceEntry.IsSampledForLongerRetention(workflowID) {
-		recordWorkflowClose = false
-	}
+	retention := namespaceEntry.Retention()
 
 	if recordWorkflowClose {
 		return t.visibilityMgr.RecordWorkflowExecutionClosed(&manager.RecordWorkflowExecutionClosedRequest{

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1518,7 +1518,7 @@ func (e *MutableStateImpl) ReplicateWorkflowExecutionStartedEvent(
 		event.GetPrevAutoResetPoints(),
 		event.GetContinuedExecutionRunId(),
 		timestamp.TimeValue(startEvent.GetEventTime()),
-		e.namespaceEntry.Retention(e.executionInfo.WorkflowId),
+		e.namespaceEntry.Retention(),
 	)
 
 	if event.Memo != nil {

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -190,7 +190,7 @@ func (r *TaskGeneratorImpl) GenerateWorkflowCloseTasks(
 	namespaceEntry, err := r.namespaceRegistry.GetNamespaceByID(namespace.ID(executionInfo.NamespaceId))
 	switch err.(type) {
 	case nil:
-		retention = namespaceEntry.Retention(executionInfo.WorkflowId)
+		retention = namespaceEntry.Retention()
 	case *serviceerror.NotFound:
 		// namespace is not accessible, use default value above
 	default:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove sampled retention

<!-- Tell your future self why have you made these changes -->
**Why?**
This was added as a temporary hack more than 3 years ago that should have been removed long ago. It was never mentioned anywhere in the doc that this exists. No one should have used this hack. In fact, it seems the visibility queue executor is wrong when sampled retention is enabled, it only writes for those sampled workflows.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eye_balls

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No