### PR TITLE
Fix GenerateLastHistoryReplicationTask to use shard.AddTasks()

### DIFF
--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -248,6 +248,6 @@ type (
 		StartTransactionSkipWorkflowTaskFail(entry *namespace.Namespace) error
 		CloseTransactionAsMutation(now time.Time, transactionPolicy TransactionPolicy) (*persistence.WorkflowMutation, []*persistence.WorkflowEvents, error)
 		CloseTransactionAsSnapshot(now time.Time, transactionPolicy TransactionPolicy) (*persistence.WorkflowSnapshot, []*persistence.WorkflowEvents, error)
-		GenerateLastHistoryReplicationTasks(now time.Time) error
+		GenerateLastHistoryReplicationTasks(now time.Time) (*tasks.HistoryReplicationTask, error)
 	}
 )

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -3847,9 +3847,8 @@ func (e *MutableStateImpl) UpdateDuplicatedResource(
 	e.appliedEvents[id] = struct{}{}
 }
 
-func (e *MutableStateImpl) GenerateLastHistoryReplicationTasks(now time.Time) error {
-	e.taskGenerator.GenerateLastHistoryReplicationTasks(now)
-	return nil
+func (e *MutableStateImpl) GenerateLastHistoryReplicationTasks(now time.Time) (*tasks.HistoryReplicationTask, error) {
+	return e.taskGenerator.GenerateLastHistoryReplicationTasks(now)
 }
 
 func (e *MutableStateImpl) prepareCloseTransaction(

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -940,11 +940,12 @@ func (mr *MockMutableStateMockRecorder) FlushBufferedEvents() *gomock.Call {
 }
 
 // GenerateLastHistoryReplicationTasks mocks base method.
-func (m *MockMutableState) GenerateLastHistoryReplicationTasks(now time.Time) error {
+func (m *MockMutableState) GenerateLastHistoryReplicationTasks(now time.Time) (*tasks.HistoryReplicationTask, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateLastHistoryReplicationTasks", now)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*tasks.HistoryReplicationTask)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GenerateLastHistoryReplicationTasks indicates an expected call of GenerateLastHistoryReplicationTasks.

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -34,6 +34,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	history "go.temporal.io/api/history/v1"
+	tasks "go.temporal.io/server/service/history/tasks"
 )
 
 // MockTaskGenerator is a mock of TaskGenerator interface.
@@ -144,11 +145,12 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateHistoryReplicationTasks(now, br
 }
 
 // GenerateLastHistoryReplicationTasks mocks base method.
-func (m *MockTaskGenerator) GenerateLastHistoryReplicationTasks(now time.Time) error {
+func (m *MockTaskGenerator) GenerateLastHistoryReplicationTasks(now time.Time) (*tasks.HistoryReplicationTask, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateLastHistoryReplicationTasks", now)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*tasks.HistoryReplicationTask)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GenerateLastHistoryReplicationTasks indicates an expected call of GenerateLastHistoryReplicationTasks.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix GenerateLastHistoryReplicationTask

<!-- Tell your future self why have you made these changes -->
**Why?**
Closed workflow are immutable, need to call shard.AddTasks directly for the generated replication task.
