### PR TITLE
Add RequestID validation for ResetWorkflow

### DIFF
--- a/client/history/client.go
+++ b/client/history/client.go
@@ -26,6 +26,7 @@ package history
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -1057,6 +1058,9 @@ func (c *clientImpl) getClientForWorkflowID(namespaceID, workflowID string) (his
 }
 
 func (c *clientImpl) getClientForShardID(shardID int32) (historyservice.HistoryServiceClient, error) {
+	if shardID <= 0 {
+		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Invalid ShardID: %d", shardID))
+	}
 	client, err := c.clients.GetClientForKey(convert.Int32ToString(shardID))
 	if err != nil {
 		return nil, err

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2086,9 +2086,14 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context, request *
 	if request == nil {
 		return nil, errRequestNotSet
 	}
-
 	if request.GetNamespace() == "" {
 		return nil, errNamespaceNotSet
+	}
+	if request.GetRequestId() == "" {
+		return nil, errRequestIDNotSet
+	}
+	if len(request.GetRequestId()) > wh.config.MaxIDLengthLimit() {
+		return nil, errRequestIDTooLong
 	}
 
 	if err := wh.validateExecution(request.WorkflowExecution); err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add RequestID validation for ResetWorkflow

<!-- Tell your future self why have you made these changes -->
**Why?**
If this value is not set by user, the request will get deduped and causing lots of confusion. 
