### PR TITLE
Refactor worker for addsearchattributes using fx

### DIFF
--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -36,7 +36,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/sdk/client"
-
 	"go.temporal.io/server/api/adminservice/v1"
 	clusterspb "go.temporal.io/server/api/cluster/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -59,6 +58,7 @@ import (
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/xdc"
+	"go.temporal.io/server/service/worker"
 	"go.temporal.io/server/service/worker/addsearchattributes"
 )
 
@@ -195,7 +195,7 @@ func (adh *AdminHandler) AddSearchAttributes(ctx context.Context, request *admin
 	run, err := adh.GetSDKClient().ExecuteWorkflow(
 		ctx,
 		client.StartWorkflowOptions{
-			TaskQueue: addsearchattributes.TaskQueueName,
+			TaskQueue: worker.DefaultWorkerTaskQueue,
 			ID:        addsearchattributes.WorkflowName,
 		},
 		addsearchattributes.WorkflowName,

--- a/service/worker/addsearchattributes/workflow.go
+++ b/service/worker/addsearchattributes/workflow.go
@@ -42,8 +42,6 @@ import (
 )
 
 const (
-	// TaskQueueName is the task queue name.
-	TaskQueueName = "temporal-sys-add-search-attributes-task-queue"
 	// WorkflowName is the workflow name.
 	WorkflowName = "temporal-sys-add-search-attributes-workflow"
 )
@@ -97,20 +95,6 @@ var (
 	ErrUnableToGetSearchAttributes  = errors.New("unable to get search attributes from cluster metadata")
 	ErrUnableToSaveSearchAttributes = errors.New("unable to save search attributes to cluster metadata")
 )
-
-func newActivities(
-	esClient esclient.Client,
-	saManager searchattribute.Manager,
-	metricsClient metrics.Client,
-	logger log.Logger,
-) *activities {
-	return &activities{
-		esClient:      esClient,
-		saManager:     saManager,
-		metricsClient: metricsClient,
-		logger:        logger,
-	}
-}
 
 // AddSearchAttributesWorkflow is the workflow that adds search attributes to the cluster for specific index.
 func AddSearchAttributesWorkflow(ctx workflow.Context, params WorkflowParams) error {

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -27,52 +27,32 @@ package worker
 import (
 	"context"
 
-	"go.temporal.io/server/service/worker/scanner/replication"
-	"go.uber.org/fx"
-
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/client/history"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/archiver"
-	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/persistence"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/service"
+	"go.temporal.io/server/service/worker/addsearchattributes"
+	"go.temporal.io/server/service/worker/scanner/replication"
+	"go.uber.org/fx"
 )
 
 var Module = fx.Options(
-	persistenceClient.Module,
 	replication.Module,
+	addsearchattributes.Module,
+	resource.Module,
 	fx.Provide(ParamsExpandProvider),
-	fx.Provide(resource.PersistenceConfigProvider),
 	fx.Provide(dynamicconfig.NewCollection),
 	fx.Provide(ThrottledLoggerRpsFnProvider),
 	fx.Provide(NewConfig),
 	fx.Provide(PersistenceMaxQpsProvider),
-	fx.Provide(ArchivalMetadataProvider),
 	fx.Provide(NamespaceReplicationQueueProvider),
-	fx.Provide(resource.ClusterMetadataManagerProvider),
-	fx.Provide(resource.MetricsClientProvider),
-	fx.Provide(resource.ClientBeanProvider),
-	fx.Provide(resource.NamespaceCacheProvider),
-	fx.Provide(resource.ArchiverProviderProvider),
-	fx.Provide(resource.MetricsScopeProvider),
-	fx.Provide(resource.MembershipMonitorProvider),
-	fx.Provide(resource.PersistenceExecutionManagerProvider),
-	fx.Provide(resource.AbstractDatastoreFactoryProvider),
-	fx.Provide(resource.PersistenceServiceResolverProvider),
-	fx.Provide(resource.SdkClientProvider),
-	fx.Provide(resource.ClientFactoryProvider),
-	fx.Provide(resource.SnTaggedLoggerProvider),
-	fx.Provide(resource.MembershipFactoryProvider),
-	fx.Provide(resource.ServiceNameProvider),
-	fx.Provide(resource.MetadataManagerProvider),
 	fx.Provide(PersistenceTaskManagerProvider),
 	fx.Provide(HistoryServiceClientProvider),
-	fx.Provide(cluster.NewMetadataFromConfig),
 	fx.Provide(NewService),
 	fx.Provide(NewWorkerManager),
 	fx.Invoke(ServiceLifetimeHooks),
@@ -90,10 +70,6 @@ func PersistenceMaxQpsProvider(
 	serviceConfig *Config,
 ) persistenceClient.PersistenceMaxQps {
 	return service.PersistenceMaxQpsFn(serviceConfig.PersistenceMaxQPS, serviceConfig.PersistenceGlobalMaxQPS)
-}
-
-func ArchivalMetadataProvider(params *resource.BootstrapParams) archiver.ArchivalMetadata {
-	return params.ArchivalMetadata
 }
 
 func NamespaceReplicationQueueProvider(bean persistenceClient.Bean) persistence.NamespaceReplicationQueue {

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -37,7 +37,6 @@ import (
 	"go.temporal.io/server/common"
 	carchiver "go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/provider"
-	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -49,8 +48,6 @@ import (
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/resource"
-	"go.temporal.io/server/common/searchattribute"
-	"go.temporal.io/server/service/worker/addsearchattributes"
 	"go.temporal.io/server/service/worker/archiver"
 	"go.temporal.io/server/service/worker/batcher"
 	"go.temporal.io/server/service/worker/parentclosepolicy"
@@ -350,8 +347,6 @@ func (s *Service) Start() {
 		s.startParentClosePolicyProcessor()
 	}
 
-	s.startAddSearchAttributes()
-
 	s.manager.Start()
 
 	s.logger.Info(
@@ -414,25 +409,6 @@ func (s *Service) startBatcher() {
 	if err := batcher.New(params).Start(); err != nil {
 		s.logger.Fatal(
 			"error starting batcher",
-			tag.Error(err),
-		)
-	}
-}
-
-func (s *Service) startAddSearchAttributes() {
-	addSearchAttributesService := addsearchattributes.New(
-		s.sdkClient,
-		s.esClient,
-		searchattribute.NewManager(
-			clock.NewRealTimeSource(),
-			s.clusterMetadataManager,
-		),
-		s.metricsClient,
-		s.logger,
-	)
-	if err := addSearchAttributesService.Start(); err != nil {
-		s.logger.Fatal(
-			"error starting add search attributes service",
 			tag.Error(err),
 		)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor worker part for addsearchattributes using fx

<!-- Tell your future self why have you made these changes -->
**Why?**
Remove duplicate code of initiating sdk workers for different background work types.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test. 
1) tctl admin cl add-search-attributes --name FxWorkerKeywordField --type Keyword
2) tctl --ns temporal-system wf show -w temporal-sys-add-search-attributes-workflow
verify the workflow completed successfully and is run on taskqueue: default-worker-tq.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No