### PR TITLE
Remove tctl admin command to output cluster metadata

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -595,14 +595,6 @@ func newAdminClusterCommands() []cli.Command {
 				AdminDescribeCluster(c)
 			},
 		},
-		{
-			Name:    "metadata",
-			Aliases: []string{"m"},
-			Usage:   "Show cluster metadata",
-			Action: func(c *cli.Context) {
-				AdminClusterMetadata(c)
-			},
-		},
 	}
 }
 

--- a/tools/cli/adminClusterCommands.go
+++ b/tools/cli/adminClusterCommands.go
@@ -26,7 +26,6 @@ package cli
 
 import (
 	"github.com/urfave/cli"
-	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/server/api/adminservice/v1"
 )
@@ -43,17 +42,4 @@ func AdminDescribeCluster(c *cli.Context) {
 	}
 
 	prettyPrintJSONObject(response)
-}
-
-// AdminClusterMetadata is used to dump information about the cluster
-func AdminClusterMetadata(c *cli.Context) {
-	frontendClient := cFactory.FrontendClient(c)
-	ctx, cancel := newContext(c)
-	defer cancel()
-
-	info, err := frontendClient.GetClusterInfo(ctx, &workflowservice.GetClusterInfoRequest{})
-	if err != nil {
-		ErrorAndExit("Operation AdminClusterMetadata failed.", err)
-	}
-	prettyPrintJSONObject(info)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Removing command `tctl admin cluster metadata` in favor of `tctl admin cluster describe`

<!-- Tell your future self why have you made these changes -->
**Why?**

- Cluster metadata is now part of admin DescribeCluster API and `tctl admin cluster describe`. Simplifying tctl admin commands usage

- related https://github.com/temporalio/temporal/pull/2150

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- verified command is not available in `tctl admin cluster -h`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

- automated scripts that rely on `tctl admin cluster metadata` won't work

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
