### PR TITLE
Add custom grpc inspectors

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -32,7 +32,6 @@ import (
 	"strings"
 
 	"github.com/urfave/cli/v2"
-
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"

--- a/common/resource/bootstrapParams.go
+++ b/common/resource/bootstrapParams.go
@@ -27,6 +27,7 @@ package resource
 import (
 	"github.com/uber-go/tally/v4"
 	sdkclient "go.temporal.io/sdk/client"
+	"google.golang.org/grpc"
 
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
@@ -72,6 +73,7 @@ type (
 		PersistenceServiceResolver   resolver.ServiceResolver
 		AudienceGetter               authorization.JWTAudienceMapper
 		SearchAttributesMapper       searchattribute.Mapper
+		CustomInterceptors           []grpc.UnaryServerInterceptor
 	}
 
 	// MembershipMonitorFactory provides a bootstrapped membership monitor

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -184,13 +184,17 @@ func newBootstrapParams(
 ) (*resource.BootstrapParams, error) {
 	svcName := string(serviceName)
 	params := &resource.BootstrapParams{
-		Name:                     svcName,
-		NamespaceLogger:          namespaceLogger,
-		PersistenceConfig:        persistenceConfig,
-		ClusterMetadataConfig:    clusterMetadata,
-		DCRedirectionPolicy:      so.config.DCRedirectionPolicy,
-		AbstractDatastoreFactory: so.customDataStoreFactory,
-		ClientFactoryProvider:    so.clientFactoryProvider,
+		Name:                       svcName,
+		NamespaceLogger:            namespaceLogger,
+		PersistenceConfig:          persistenceConfig,
+		ClusterMetadataConfig:      clusterMetadata,
+		DCRedirectionPolicy:        so.config.DCRedirectionPolicy,
+		AbstractDatastoreFactory:   so.customDataStoreFactory,
+		ClientFactoryProvider:      so.clientFactoryProvider,
+		AudienceGetter:             so.audienceGetter,
+		PersistenceServiceResolver: so.persistenceServiceResolver,
+		SearchAttributesMapper:     so.searchAttributesMapper,
+		CustomInterceptors:         so.customInterceptors,
 	}
 
 	svcCfg := so.config.Services[svcName]
@@ -284,10 +288,6 @@ func newBootstrapParams(
 	} else {
 		params.ClaimMapper = authorization.NewNoopClaimMapper()
 	}
-	params.AudienceGetter = so.audienceGetter
-
-	params.PersistenceServiceResolver = so.persistenceServiceResolver
-	params.SearchAttributesMapper = so.searchAttributesMapper
 
 	return params, nil
 }

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/searchattribute"
+	"google.golang.org/grpc"
 )
 
 type (
@@ -166,5 +167,17 @@ func WithClientFactoryProvider(clientFactoryProvider client.FactoryProvider) Ser
 func WithSearchAttributesMapper(m searchattribute.Mapper) ServerOption {
 	return newApplyFuncContainer(func(s *serverOptions) {
 		s.searchAttributesMapper = m
+	})
+}
+
+// WithChainedFrontendGrpcInterceptors sets a chain of ordered custom grpc interceptors that will be invoked for all
+// Frontend gRPC API calls. The list of custom interceptors will be appended to the end of the internal
+// ServerInterceptors. The custom interceptors will be invoked in the order as they appear in the supplied list, after
+// the internal ServerInterceptors.
+func WithChainedFrontendGrpcInterceptors(
+	interceptors ...grpc.UnaryServerInterceptor,
+) ServerOption {
+	return newApplyFuncContainer(func(s *serverOptions) {
+		s.customInterceptors = interceptors
 	})
 }

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/searchattribute"
+	"google.golang.org/grpc"
 )
 
 type (
@@ -64,6 +65,7 @@ type (
 		customDataStoreFactory     persistenceClient.AbstractDataStoreFactory
 		clientFactoryProvider      client.FactoryProvider
 		searchAttributesMapper     searchattribute.Mapper
+		customInterceptors         []grpc.UnaryServerInterceptor
 	}
 )
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add server options for custom interceptors

<!-- Tell your future self why have you made these changes -->
**Why?**
This open up a new categories of integrations with server by using custom interceptors.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test with 2 interceptors with code like:
```
temporal.WithChainedFrontendGrpcInterceptors(
	func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
		fmt.Printf("intercept1: %v\n", info.FullMethod)
		return handler(ctx, req)
	},
	func(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (resp interface{}, err error) {
		fmt.Printf("intercept2: %v\n", info.FullMethod)
		return handler(ctx, req)
	},
),
```
And verify output like:
```
intercept1: /temporal.api.workflowservice.v1.WorkflowService/DescribeNamespace
intercept2: /temporal.api.workflowservice.v1.WorkflowService/DescribeNamespace
intercept1: /temporal.api.workflowservice.v1.WorkflowService/PollActivityTaskQueue
intercept2: /temporal.api.workflowservice.v1.WorkflowService/PollActivityTaskQueue
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No