### PR TITLE
Move namespace name validation to RegisterNamespace

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -369,12 +369,6 @@ func (wh *WorkflowHandler) StartWorkflowExecution(ctx context.Context, request *
 		return nil, errNamespaceNotSet
 	}
 
-	wh.GetLogger().Debug("Start workflow execution request namespace.", tag.WorkflowNamespace(namespaceName.String()))
-	namespaceID, err := wh.GetNamespaceRegistry().GetNamespaceID(namespaceName)
-	if err != nil {
-		return nil, err
-	}
-
 	if request.GetWorkflowId() == "" {
 		return nil, errWorkflowIDNotSet
 	}
@@ -420,6 +414,12 @@ func (wh *WorkflowHandler) StartWorkflowExecution(ctx context.Context, request *
 	}
 
 	enums.SetDefaultWorkflowIdReusePolicy(&request.WorkflowIdReusePolicy)
+
+	wh.GetLogger().Debug("Start workflow execution request namespace", tag.WorkflowNamespace(namespaceName.String()))
+	namespaceID, err := wh.GetNamespaceRegistry().GetNamespaceID(namespaceName)
+	if err != nil {
+		return nil, err
+	}
 
 	wh.GetLogger().Debug("Start workflow execution request namespaceID", tag.WorkflowNamespaceID(namespaceID.String()))
 	resp, err := wh.GetHistoryClient().StartWorkflowExecution(ctx, common.CreateHistoryStartWorkflowRequest(namespaceID.String(), request, nil, time.Now().UTC()))

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -227,6 +227,10 @@ func (wh *WorkflowHandler) RegisterNamespace(ctx context.Context, request *workf
 		return nil, errNamespaceNotSet
 	}
 
+	if len(request.GetNamespace()) > wh.config.MaxIDLengthLimit() {
+		return nil, errNamespaceTooLong
+	}
+
 	resp, err := wh.namespaceHandler.RegisterNamespace(ctx, request)
 	if err != nil {
 		return nil, err
@@ -365,8 +369,10 @@ func (wh *WorkflowHandler) StartWorkflowExecution(ctx context.Context, request *
 		return nil, errNamespaceNotSet
 	}
 
-	if len(namespaceName) > wh.config.MaxIDLengthLimit() {
-		return nil, errNamespaceTooLong
+	wh.GetLogger().Debug("Start workflow execution request namespace.", tag.WorkflowNamespace(namespaceName.String()))
+	namespaceID, err := wh.GetNamespaceRegistry().GetNamespaceID(namespaceName)
+	if err != nil {
+		return nil, err
 	}
 
 	if request.GetWorkflowId() == "" {
@@ -377,7 +383,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(ctx context.Context, request *
 		return nil, errWorkflowIDTooLong
 	}
 
-	if err := wh.validateRetryPolicy(request.GetNamespace(), request.RetryPolicy); err != nil {
+	if err := wh.validateRetryPolicy(namespaceName, request.RetryPolicy); err != nil {
 		return nil, err
 	}
 
@@ -414,12 +420,6 @@ func (wh *WorkflowHandler) StartWorkflowExecution(ctx context.Context, request *
 	}
 
 	enums.SetDefaultWorkflowIdReusePolicy(&request.WorkflowIdReusePolicy)
-
-	wh.GetLogger().Debug("Start workflow execution request namespace", tag.WorkflowNamespace(namespaceName.String()))
-	namespaceID, err := wh.GetNamespaceRegistry().GetNamespaceID(namespaceName)
-	if err != nil {
-		return nil, err
-	}
 
 	wh.GetLogger().Debug("Start workflow execution request namespaceID", tag.WorkflowNamespaceID(namespaceID.String()))
 	resp, err := wh.GetHistoryClient().StartWorkflowExecution(ctx, common.CreateHistoryStartWorkflowRequest(namespaceID.String(), request, nil, time.Now().UTC()))
@@ -760,9 +760,6 @@ func (wh *WorkflowHandler) PollWorkflowTaskQueue(ctx context.Context, request *w
 	if request.GetNamespace() == "" {
 		return nil, errNamespaceNotSet
 	}
-	if len(request.GetNamespace()) > wh.config.MaxIDLengthLimit() {
-		return nil, errNamespaceTooLong
-	}
 
 	if len(request.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return nil, errIdentityTooLong
@@ -1030,10 +1027,6 @@ func (wh *WorkflowHandler) PollActivityTaskQueue(ctx context.Context, request *w
 
 	if request.GetNamespace() == "" {
 		return nil, errNamespaceNotSet
-	}
-
-	if len(request.GetNamespace()) > wh.config.MaxIDLengthLimit() {
-		return nil, errNamespaceTooLong
 	}
 
 	if err := wh.validateTaskQueue(request.TaskQueue); err != nil {
@@ -1916,10 +1909,6 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context, request 
 		return nil, errNamespaceNotSet
 	}
 
-	if len(request.GetNamespace()) > wh.config.MaxIDLengthLimit() {
-		return nil, errNamespaceTooLong
-	}
-
 	if err := wh.validateExecution(request.WorkflowExecution); err != nil {
 		return nil, err
 	}
@@ -1993,10 +1982,6 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, errNamespaceNotSet
 	}
 
-	if len(namespaceName) > wh.config.MaxIDLengthLimit() {
-		return nil, errNamespaceTooLong
-	}
-
 	if request.GetWorkflowId() == "" {
 		return nil, errWorkflowIDNotSet
 	}
@@ -2033,7 +2018,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, err
 	}
 
-	if err := wh.validateRetryPolicy(request.GetNamespace(), request.RetryPolicy); err != nil {
+	if err := wh.validateRetryPolicy(namespaceName, request.RetryPolicy); err != nil {
 		return nil, err
 	}
 
@@ -3473,13 +3458,13 @@ func (hs HealthStatus) String() string {
 	}
 }
 
-func (wh *WorkflowHandler) validateRetryPolicy(namespace string, retryPolicy *commonpb.RetryPolicy) error {
+func (wh *WorkflowHandler) validateRetryPolicy(namespaceName namespace.Name, retryPolicy *commonpb.RetryPolicy) error {
 	if retryPolicy == nil {
 		// By default, if the user does not explicitly set a retry policy for a Workflow, do not perform any retries.
 		return nil
 	}
 
-	defaultWorkflowRetrySettings := common.FromConfigToDefaultRetrySettings(wh.getDefaultWorkflowRetrySettings(namespace))
+	defaultWorkflowRetrySettings := common.FromConfigToDefaultRetrySettings(wh.getDefaultWorkflowRetrySettings(namespaceName.String()))
 	common.EnsureRetryPolicyDefaults(retryPolicy, defaultWorkflowRetrySettings)
 	return common.ValidateRetryPolicy(retryPolicy)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move namespace name validation to `RegisterNamespace`.

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously namespace name was validated when it was used (i.e. `StartWorkflowExecution`) but not when registered (`RegisterNamespace`).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.