### PR TITLE
Use admin API for tctl list cluster members

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -272,8 +272,7 @@ func newAdminMembershipCommands() []cli.Command {
 		{
 			Name:  "list_db",
 			Usage: "List cluster membership items",
-			Flags: append(
-				getDBFlags(),
+			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagHeartbeatedWithin,
 					Value: "15m",
@@ -286,9 +285,9 @@ func newAdminMembershipCommands() []cli.Command {
 					Value: "all",
 					Usage: "Membership role filter: all (default), frontend, history, matching, worker",
 				},
-			),
+			},
 			Action: func(c *cli.Context) {
-				AdminListClusterMembership(c)
+				AdminListClusterMembers(c)
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

updated `tctl admin membership list_db` command to retrieve data from admin API instead of directly connecting to DB

<!-- Tell your future self why have you made these changes -->
**Why?**

Simplifies usage as users don't have to pass the DB connection options

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

`tctl admin membership list_db`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
