### PR TITLE
Matching GetTasks call reduction

### DIFF
--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -303,7 +303,7 @@ func (c *taskQueueManagerImpl) AddTask(
 		c.signalIfFatal(err)
 		return resp, err
 	})
-	if err == nil {
+	if !syncMatch && err == nil {
 		c.taskReader.Signal()
 	}
 	return syncMatch, err

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -137,6 +137,13 @@ func (tr *taskReader) getTasksPump(ctx context.Context) error {
 
 Loop:
 	for {
+		// Prioritize exiting over other processing
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
 		select {
 		case <-ctx.Done():
 			return nil
@@ -158,9 +165,9 @@ Loop:
 				continue Loop
 			}
 
-			if err := tr.addTasksToBuffer(ctx, tasks); err != nil {
-				return err
-			}
+			// only error here is due to context cancelation which we also
+			// handle above
+			tr.addTasksToBuffer(ctx, tasks)
 			// There maybe more tasks. We yield now, but signal pump to check again later.
 			tr.Signal()
 


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**
- Don't signal the taskReader to fetch a batch after a sync-match
- Ensure taskReader gives priority to exiting over further signal
  processing
- Remove redundant error handling in taskReader

<!-- Tell your future self why have you made these changes -->
**Why?**
We reviewed the taskReader task pump loop and the sync-match path and found these opportunities to improve clarity and reduce GetTasks calls.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit tests for taskReader signaling from taskQueueManager. Other changes are non-functional.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Frequency of taskReader.Signal() calls after sync-match success could be masking other places where such a call should exist but is missing.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
