### PR TITLE
Support concurrency flag in the tctl batch command

### DIFF
--- a/tools/cli/batch.go
+++ b/tools/cli/batch.go
@@ -114,6 +114,11 @@ func newBatchCommands() []cli.Command {
 					Name:  FlagYes,
 					Usage: "Optional flag to disable confirmation prompt",
 				},
+				cli.IntFlag{
+					Name:  FlagConcurrency,
+					Value: batcher.DefaultConcurrency,
+					Usage: "Number of goroutines running in parallel to process",
+				},
 			},
 			Action: func(c *cli.Context) {
 				StartBatchJob(c)

--- a/tools/cli/workflowBatchCommands.go
+++ b/tools/cli/workflowBatchCommands.go
@@ -158,6 +158,7 @@ func StartBatchJob(c *cli.Context) {
 		sigVal = getRequiredOption(c, FlagInput)
 	}
 	rps := c.Int(FlagRPS)
+	concurrency := c.Int(FlagConcurrency)
 
 	client := cFactory.SDKClient(c, common.SystemLocalNamespace)
 	tcCtx, cancel := newContext(c)
@@ -169,7 +170,8 @@ func StartBatchJob(c *cli.Context) {
 	if err != nil {
 		ErrorAndExit("Failed to count impacting workflows for starting a batch job", err)
 	}
-	fmt.Printf("This batch job will be operating on %v workflows.\n", resp.GetCount())
+	fmt.Printf("This batch job will be operating on %v workflows, with max RPS of %v and concurrency of %v.\n",
+		resp.GetCount(), rps, concurrency)
 	if !c.Bool(FlagYes) {
 		reader := bufio.NewReader(os.Stdin)
 		for {
@@ -214,7 +216,8 @@ func StartBatchJob(c *cli.Context) {
 			SignalName: sigName,
 			Input:      sigInput,
 		},
-		RPS: rps,
+		RPS:         rps,
+		Concurrency: concurrency,
 	}
 	wf, err := client.ExecuteWorkflow(tcCtx, options, batcher.BatchWFTypeName, params)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
A concurrency flag is added in the tctl cli tool for the `batch create` command

<!-- Tell your future self why have you made these changes -->
**Why?**
The concurrency parameter is supported by the batch API but not exposed in the tctl tool. We need to increase throughput of the batch execution by adjusting the concurrency parameter.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
There are no unit test for batch command, so I did a local build and verified that the concurrency flag I added works with the batch jobs we created

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No