### PR TITLE
Add NamespaceValidator interceptor

### DIFF
--- a/common/namespace/namespace.go
+++ b/common/namespace/namespace.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -151,6 +152,10 @@ func (ns *Namespace) ID() ID {
 // Name observes this namespace's configured name.
 func (ns *Namespace) Name() Name {
 	return Name(ns.info.Name)
+}
+
+func (ns *Namespace) State() enumspb.NamespaceState {
+	return ns.info.State
 }
 
 // ActiveClusterName observes the name of the cluster that is currently active

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -1,0 +1,142 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package interceptor
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+
+	"go.temporal.io/server/common/namespace"
+)
+
+type (
+	// NamespaceValidatorInterceptor validates:
+	// 1. Namespace is specified in request if there is a `namespace` field.
+	// 2. Namespace exists.
+	// 3. Namespace is in correct state.
+	NamespaceValidatorInterceptor struct {
+		namespaceRegistry namespace.Registry
+	}
+)
+
+var (
+	ErrNamespaceNotSet              = serviceerror.NewInvalidArgument("Namespace not set on request.")
+	errInvalidNamespaceStateMessage = "Namespace has invalid state: %s. Must be %s."
+
+	// By default, enumspb.NAMESPACE_STATE_REGISTERED and enumspb.NAMESPACE_STATE_DEPRECATED are allowed states for all APIs that have `namespace` field in the request object.
+	allowedNamespaceStates = map[string][]enumspb.NamespaceState{
+		"StartWorkflowExecution":           {enumspb.NAMESPACE_STATE_REGISTERED},
+		"SignalWithStartWorkflowExecution": {enumspb.NAMESPACE_STATE_REGISTERED},
+		"DescribeNamespace":                {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_DELETED},
+	}
+)
+
+var _ grpc.UnaryServerInterceptor = (*NamespaceValidatorInterceptor)(nil).Intercept
+
+func NewNamespaceValidatorInterceptor(
+	namespaceRegistry namespace.Registry,
+) *NamespaceValidatorInterceptor {
+	return &NamespaceValidatorInterceptor{
+		namespaceRegistry: namespaceRegistry,
+	}
+}
+
+func (ni *NamespaceValidatorInterceptor) Intercept(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
+	namespaceEntry, err := ni.extractNamespace(req)
+	if err != nil {
+		return nil, err
+	}
+	if namespaceEntry != nil {
+		_, methodName := splitMethodName(info.FullMethod)
+		allowedStates, allowedStatesDefined := allowedNamespaceStates[methodName]
+		if !allowedStatesDefined {
+			// If not explicitly defined, only enumspb.NAMESPACE_STATE_REGISTERED and enumspb.NAMESPACE_STATE_DEPRECATED are allowed.
+			if namespaceEntry.State() != enumspb.NAMESPACE_STATE_REGISTERED && namespaceEntry.State() != enumspb.NAMESPACE_STATE_DEPRECATED {
+				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errInvalidNamespaceStateMessage, namespaceEntry.State(), fmt.Sprintf("%s or %s", enumspb.NAMESPACE_STATE_REGISTERED.String(), enumspb.NAMESPACE_STATE_DEPRECATED.String())))
+			}
+		} else {
+			isStateAllowed := false
+			for _, allowedState := range allowedStates {
+				if allowedState == namespaceEntry.State() {
+					isStateAllowed = true
+					break
+				}
+			}
+			if !isStateAllowed {
+				var allowedStatesStr []string
+				for _, allowedState := range allowedStates {
+					allowedStatesStr = append(allowedStatesStr, allowedState.String())
+				}
+				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errInvalidNamespaceStateMessage, namespaceEntry.State(), strings.Join(allowedStatesStr, " or ")))
+			}
+		}
+	}
+
+	return handler(ctx, req)
+}
+
+func (ni *NamespaceValidatorInterceptor) extractNamespace(req interface{}) (*namespace.Namespace, error) {
+	if reqWithNamespace, ok := req.(NamespaceNameGetter); ok {
+		namespaceName := namespace.Name(reqWithNamespace.GetNamespace())
+
+		if !namespaceName.IsEmpty() {
+			// Special case for "RegisterNamespace" API. `namespaceName` is name of namespace that about to be registered. There is no namespace entry for it.
+			if _, isRegisterNamespace := req.(*workflowservice.RegisterNamespaceRequest); isRegisterNamespace {
+				return nil, nil
+			}
+
+			namespaceEntry, err := ni.namespaceRegistry.GetNamespace(namespaceName)
+			if err != nil {
+				return nil, err
+			}
+			return namespaceEntry, nil
+		}
+
+		// Special case for "DescribeNamespace" API which can get namespace by Id.
+		dnr, isDescribeNamespace := req.(*workflowservice.DescribeNamespaceRequest)
+		if !isDescribeNamespace || dnr.GetId() == "" {
+			return nil, ErrNamespaceNotSet
+		}
+
+		namespaceEntry, err := ni.namespaceRegistry.GetNamespaceByID(namespace.ID(dnr.GetId()))
+		if err != nil {
+			return nil, err
+		}
+		return namespaceEntry, nil
+	}
+
+	return nil, nil
+}

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -44,7 +44,7 @@ type (
 	// 1. Namespace is specified in task token if there is a `task_token` field.
 	// 2. Namespace is specified in request if there is a `namespace` field and no `task_token` field.
 	// 3. Namespace exists.
-	// 4. Namespace from request match namespace from task token , if check is enabled with dynamic config.
+	// 4. Namespace from request match namespace from task token, if check is enabled with dynamic config.
 	// 5. Namespace is in correct state.
 	NamespaceValidatorInterceptor struct {
 		namespaceRegistry               namespace.Registry

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -108,8 +108,8 @@ func (ni *NamespaceValidatorInterceptor) extractNamespace(req interface{}) (*nam
 	}
 
 	requestNamespaceEntry, requestErr := ni.extractNamespaceFromRequest(req)
+	// If namespace was extracted from token then it will be used.
 	if requestErr != nil && tokenNamespaceEntry == nil {
-		//
 		return nil, requestErr
 	}
 

--- a/common/rpc/interceptor/namespace_validator_test.go
+++ b/common/rpc/interceptor/namespace_validator_test.go
@@ -1,0 +1,248 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package interceptor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+)
+
+func TestNamespaceValidator_Intercept_NotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	registry := namespace.NewMockRegistry(ctrl)
+	registry.EXPECT().GetNamespace(namespace.Name("not-found-namespace")).Return(nil, serviceerror.NewNotFound("not-found"))
+
+	nvi := NewNamespaceValidatorInterceptor(registry)
+	serverInfo := &grpc.UnaryServerInfo{
+		FullMethod: "/temporal/StartWorkflowExecution",
+	}
+
+	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "not-found-namespace"}
+	handlerCalled := false
+	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return &workflowservice.StartWorkflowExecutionResponse{}, nil
+	})
+
+	assert.IsType(t, &serviceerror.NotFound{}, err)
+	assert.False(t, handlerCalled)
+}
+
+func TestNamespaceValidator_Intercept_Status(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	registry := namespace.NewMockRegistry(ctrl)
+	testCases := []struct {
+		state       enumspb.NamespaceState
+		expectedErr error
+		method      string
+		req         interface{}
+	}{
+		// StartWorkflowExecution
+		{
+			state:       enumspb.NAMESPACE_STATE_REGISTERED,
+			expectedErr: nil,
+			method:      "/temporal/StartWorkflowExecution",
+			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
+			expectedErr: &serviceerror.InvalidArgument{},
+			method:      "/temporal/StartWorkflowExecution",
+			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_DELETED,
+			expectedErr: &serviceerror.InvalidArgument{},
+			method:      "/temporal/StartWorkflowExecution",
+			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
+		},
+		// PollWorkflowTaskQueue
+		{
+			state:       enumspb.NAMESPACE_STATE_REGISTERED,
+			expectedErr: nil,
+			method:      "/temporal/PollWorkflowTaskQueue",
+			req:         &workflowservice.PollWorkflowTaskQueueRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
+			expectedErr: nil,
+			method:      "/temporal/PollWorkflowTaskQueue",
+			req:         &workflowservice.PollWorkflowTaskQueueRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_DELETED,
+			expectedErr: &serviceerror.InvalidArgument{},
+			method:      "/temporal/PollWorkflowTaskQueue",
+			req:         &workflowservice.PollWorkflowTaskQueueRequest{Namespace: "test-namespace"},
+		},
+		// DescribeNamespace
+		{
+			state:       enumspb.NAMESPACE_STATE_REGISTERED,
+			expectedErr: nil,
+			method:      "/temporal/DescribeNamespace",
+			req:         &workflowservice.DescribeNamespaceRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
+			expectedErr: nil,
+			method:      "/temporal/DescribeNamespace",
+			req:         &workflowservice.DescribeNamespaceRequest{Namespace: "test-namespace"},
+		},
+		{
+			state:       enumspb.NAMESPACE_STATE_DELETED,
+			expectedErr: nil,
+			method:      "/temporal/DescribeNamespace",
+			req:         &workflowservice.DescribeNamespaceRequest{Namespace: "test-namespace"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		registry.EXPECT().GetNamespace(namespace.Name("test-namespace")).Return(namespace.FromPersistentState(
+			&persistence.GetNamespaceResponse{
+				Namespace: &persistencespb.NamespaceDetail{
+					Config:            &persistencespb.NamespaceConfig{},
+					ReplicationConfig: &persistencespb.NamespaceReplicationConfig{},
+					Info: &persistencespb.NamespaceInfo{
+						State: testCase.state,
+					},
+				},
+			}), nil)
+
+		nvi := NewNamespaceValidatorInterceptor(registry)
+		serverInfo := &grpc.UnaryServerInfo{
+			FullMethod: testCase.method,
+		}
+
+		handlerCalled := false
+		_, err := nvi.Intercept(context.Background(), testCase.req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+			handlerCalled = true
+			return &workflowservice.StartWorkflowExecutionResponse{}, nil
+		})
+
+		if testCase.expectedErr != nil {
+			assert.IsType(t, testCase.expectedErr, err)
+			assert.False(t, handlerCalled)
+		} else {
+			assert.NoError(t, err)
+			assert.True(t, handlerCalled)
+		}
+	}
+}
+
+func TestNamespaceValidator_Intercept_DescribeNamespace_Id(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	registry := namespace.NewMockRegistry(ctrl)
+	registry.EXPECT().GetNamespaceByID(namespace.ID("test-namespace")).Return(namespace.FromPersistentState(
+		&persistence.GetNamespaceResponse{
+			Namespace: &persistencespb.NamespaceDetail{
+				Config:            &persistencespb.NamespaceConfig{},
+				ReplicationConfig: &persistencespb.NamespaceReplicationConfig{},
+				Info: &persistencespb.NamespaceInfo{
+					State: enumspb.NAMESPACE_STATE_REGISTERED,
+				},
+			},
+		}), nil)
+
+	nvi := NewNamespaceValidatorInterceptor(registry)
+	serverInfo := &grpc.UnaryServerInfo{
+		FullMethod: "/temporal/StartWorkflowExecution",
+	}
+
+	req := &workflowservice.DescribeNamespaceRequest{Id: "test-namespace"}
+	handlerCalled := false
+	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return &workflowservice.DescribeNamespaceResponse{}, nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled)
+}
+
+func TestNamespaceValidator_Intercept_GetClusterInfo(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	registry := namespace.NewMockRegistry(ctrl)
+
+	nvi := NewNamespaceValidatorInterceptor(registry)
+	serverInfo := &grpc.UnaryServerInfo{
+		FullMethod: "/temporal/GetClusterInfo",
+	}
+
+	req := &workflowservice.GetClusterInfoRequest{}
+	handlerCalled := false
+	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return &workflowservice.GetClusterInfoResponse{}, nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled)
+}
+
+func TestNamespaceValidator_Intercept_RegisterNamespace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	registry := namespace.NewMockRegistry(ctrl)
+
+	nvi := NewNamespaceValidatorInterceptor(registry)
+	serverInfo := &grpc.UnaryServerInfo{
+		FullMethod: "/temporal/RegisterNamespace",
+	}
+
+	req := &workflowservice.RegisterNamespaceRequest{Namespace: "new-namespace"}
+	handlerCalled := false
+	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return &workflowservice.RegisterNamespaceResponse{}, nil
+	})
+
+	assert.NoError(t, err)
+	assert.True(t, handlerCalled)
+
+	req = &workflowservice.RegisterNamespaceRequest{}
+	handlerCalled = false
+	_, err = nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return &workflowservice.RegisterNamespaceResponse{}, nil
+	})
+
+	assert.IsType(t, &serviceerror.InvalidArgument{}, err)
+	assert.False(t, handlerCalled)
+}

--- a/host/ndc/ndc_integration_test.go
+++ b/host/ndc/ndc_integration_test.go
@@ -1626,6 +1626,8 @@ func (s *nDCIntegrationTestSuite) registerNamespace() {
 		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(1 * time.Hour * 24),
 	})
 	s.Require().NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(2 * namespace.CacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: s.namespace,
@@ -1634,8 +1636,6 @@ func (s *nDCIntegrationTestSuite) registerNamespace() {
 	s.Require().NoError(err)
 	s.Require().NotNil(resp)
 	s.namespaceID = resp.GetNamespaceInfo().GetId()
-	// Wait for namespace cache to pick the change
-	time.Sleep(2 * namespace.CacheRefreshInterval)
 
 	s.logger.Info("Registered namespace", tag.WorkflowNamespace(s.namespace), tag.WorkflowNamespaceID(s.namespaceID))
 }

--- a/host/xdc/elasticsearch_test.go
+++ b/host/xdc/elasticsearch_test.go
@@ -158,14 +158,14 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
 
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
 	}
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 	resp2, err := client2.DescribeNamespace(host.NewContext(), descReq)

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -56,6 +56,8 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"gopkg.in/yaml.v2"
+
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/failure"
@@ -66,7 +68,6 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/environment"
 	"go.temporal.io/server/host"
-	"gopkg.in/yaml.v2"
 )
 
 type (
@@ -154,6 +155,8 @@ func (s *integrationClustersTestSuite) TestNamespaceFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -161,8 +164,6 @@ func (s *integrationClustersTestSuite) TestNamespaceFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 	resp2, err := client2.DescribeNamespace(host.NewContext(), descReq)
@@ -229,6 +230,8 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespaceName,
@@ -236,8 +239,6 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(namespace.CacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 	resp2, err := client2.DescribeNamespace(host.NewContext(), descReq)
@@ -510,6 +511,8 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -517,8 +520,6 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -660,6 +661,8 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(namespace.CacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespaceName,
@@ -667,8 +670,6 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(namespace.CacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 	resp2, err := client2.DescribeNamespace(host.NewContext(), descReq)
@@ -783,6 +784,8 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -790,8 +793,6 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -954,6 +955,8 @@ func (s *integrationClustersTestSuite) TestResetWorkflowFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -961,8 +964,6 @@ func (s *integrationClustersTestSuite) TestResetWorkflowFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -1111,6 +1112,8 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -1118,8 +1121,6 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -1235,6 +1236,8 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -1242,8 +1245,6 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -1402,6 +1403,8 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -1409,8 +1412,6 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -1560,6 +1561,8 @@ func (s *integrationClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -1567,8 +1570,6 @@ func (s *integrationClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -1667,6 +1668,8 @@ func (s *integrationClustersTestSuite) TestCronWorkflowFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -1674,8 +1677,6 @@ func (s *integrationClustersTestSuite) TestCronWorkflowFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -1752,6 +1753,8 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryFailover() {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,
@@ -1759,8 +1762,6 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryFailover() {
 	resp, err := client1.DescribeNamespace(host.NewContext(), descReq)
 	s.NoError(err)
 	s.NotNil(resp)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	client2 := s.cluster2.GetFrontendClient() // standby
 
@@ -1843,8 +1844,6 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryFailover() {
 func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 	namespace := "test-activity-heartbeat-workflow-failover-" + common.GenerateRandomString(5)
 	s.registerNamespace(namespace)
-	// Wait for namespace cache to pick the change
-	time.Sleep(cacheRefreshInterval)
 
 	taskqueue := "integration-activity-heartbeat-workflow-failover-test-taskqueue"
 	client1, worker1 := s.newClientAndWorker(s.cluster1.GetHost().FrontendGRPCAddress(), namespace, taskqueue, "worker1")
@@ -1989,6 +1988,8 @@ func (s *integrationClustersTestSuite) registerNamespace(namespace string) {
 	}
 	_, err := client1.RegisterNamespace(host.NewContext(), regReq)
 	s.NoError(err)
+	// Wait for namespace cache to pick the change
+	time.Sleep(cacheRefreshInterval)
 
 	descReq := &workflowservice.DescribeNamespaceRequest{
 		Namespace: namespace,

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -42,6 +42,7 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
+
 	"go.temporal.io/server/api/adminservice/v1"
 	clusterspb "go.temporal.io/server/api/cluster/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -63,6 +64,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/resource"
+	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/worker"
@@ -1028,7 +1030,7 @@ func (adh *AdminHandler) ReapplyEvents(ctx context.Context, request *adminservic
 		return nil, adh.error(errRequestNotSet, scope)
 	}
 	if request.GetNamespace() == "" {
-		return nil, adh.error(errNamespaceNotSet, scope)
+		return nil, adh.error(interceptor.ErrNamespaceNotSet, scope)
 	}
 	if request.WorkflowExecution == nil {
 		return nil, adh.error(errExecutionNotSet, scope)

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -221,7 +221,7 @@ func (adh *AdminHandler) RegisterNamespace(ctx context.Context, request *adminse
 	}
 
 	if request.GetNamespace() == "" {
-		return nil, adh.error(errNamespaceNotSet, scope)
+		return nil, adh.error(interceptor.ErrNamespaceNotSet, scope)
 	}
 
 	if len(request.GetNamespace()) > adh.config.MaxIDLengthLimit() {

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -27,8 +27,6 @@ package frontend
 import "go.temporal.io/api/serviceerror"
 
 var (
-	errTaskTokenNamespaceIDNotSet                         = serviceerror.NewInvalidArgument("NamespaceId is not set in the task token.")
-	errTaskTokenNotSet                                    = serviceerror.NewInvalidArgument("Task token not set on request.")
 	errInvalidTaskToken                                   = serviceerror.NewInvalidArgument("Invalid TaskToken.")
 	errTaskQueueNotSet                                    = serviceerror.NewInvalidArgument("TaskQueue is not set on request.")
 	errExecutionNotSet                                    = serviceerror.NewInvalidArgument("Execution is not set on request.")
@@ -72,7 +70,6 @@ var (
 	errDLQTypeIsNotSupported                              = serviceerror.NewInvalidArgument("The DLQ type is not supported.")
 	errFailureMustHaveApplicationFailureInfo              = serviceerror.NewInvalidArgument("Failure must have ApplicationFailureInfo.")
 	errStatusFilterMustBeNotRunning                       = serviceerror.NewInvalidArgument("StatusFilter must be specified and must be not Running.")
-	errTokenNamespaceMismatch                             = serviceerror.NewInvalidArgument("Operation requested with a token from a different namespace.")
 	errShuttingDown                                       = serviceerror.NewUnavailable("Shutting down")
 
 	errPageSizeTooBigMessage = "PageSize is larger than allowed %d."

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -27,7 +27,7 @@ package frontend
 import "go.temporal.io/api/serviceerror"
 
 var (
-	errNamespaceNotSet                                    = serviceerror.NewInvalidArgument("Namespace not set on request.")
+	errTaskTokenNamespaceIDNotSet                         = serviceerror.NewInvalidArgument("NamespaceId is not set in the task token.")
 	errTaskTokenNotSet                                    = serviceerror.NewInvalidArgument("Task token not set on request.")
 	errInvalidTaskToken                                   = serviceerror.NewInvalidArgument("Invalid TaskToken.")
 	errTaskQueueNotSet                                    = serviceerror.NewInvalidArgument("TaskQueue is not set on request.")

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -112,6 +112,7 @@ func GrpcServerOptionsProvider(
 		rpc.ServiceErrorInterceptor,
 		metrics.NewServerMetricsContextInjectorInterceptor(),
 		telemetryInterceptor.Intercept,
+		namespaceValidatorInterceptor.Intercept,
 		rateLimitInterceptor.Intercept,
 		namespaceRateLimiterInterceptor.Intercept,
 		namespaceCountLimiterInterceptor.Intercept,
@@ -122,7 +123,6 @@ func GrpcServerOptionsProvider(
 			logger,
 			params.AudienceGetter,
 		),
-		namespaceValidatorInterceptor.Intercept,
 	}
 	if len(params.CustomInterceptors) > 0 {
 		interceptors = append(interceptors, params.CustomInterceptors...)
@@ -226,10 +226,12 @@ func NamespaceCountLimitInterceptorProvider(
 }
 
 func NamespaceValidatorInterceptorProvider(
+	serviceConfig *Config,
 	serviceResource resource.Resource,
 ) *interceptor.NamespaceValidatorInterceptor {
 	return interceptor.NewNamespaceValidatorInterceptor(
 		serviceResource.GetNamespaceRegistry(),
+		serviceConfig.EnableTokenNamespaceEnforcement,
 	)
 }
 

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -55,7 +55,6 @@ import (
 	"go.temporal.io/server/api/historyservicemock/v1"
 	"go.temporal.io/server/api/matchingservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/provider"
@@ -1454,143 +1453,8 @@ func (s *workflowHandlerSuite) TestVerifyHistoryIsComplete() {
 	}
 }
 
-func (s *workflowHandlerSuite) TestTokenNamespaceEnforcementDisabled() {
-	s.executeTokenTestCases("wrong-namespace", false, false, false)
-}
-
-func (s *workflowHandlerSuite) TestTokenNamespaceEnforcementEnabledMismatch() {
-	s.executeTokenTestCases("wrong-namespace", true, true, true)
-}
-
-func (s *workflowHandlerSuite) TestTokenNamespaceEnforcementEnabledMatch() {
-	s.executeTokenTestCases(s.testNamespace, true, false, false)
-}
-
-func (s *workflowHandlerSuite) executeTokenTestCases(tokenNamespace namespace.Name, enforceNamespaceMatch bool,
-	isErrorExpected bool, isNilExpected bool) {
-	ctx := context.Background()
-	wh := s.setupTokenNamespaceTest(tokenNamespace, enforceNamespaceMatch)
-
-	req1 := s.newRespondActivityTaskCompletedRequest(uuid.New())
-	resp1, err := wh.RespondActivityTaskCompleted(ctx, req1)
-	s.checkResponse(err, resp1, isErrorExpected, isNilExpected)
-
-	req2 := s.newRespondActivityTaskFailedRequest(uuid.New())
-	resp2, err := wh.RespondActivityTaskFailed(ctx, req2)
-	s.checkResponse(err, resp2, isErrorExpected, isNilExpected)
-
-	req3 := s.newRespondActivityTaskCanceledRequest(uuid.New())
-	resp3, err := wh.RespondActivityTaskCanceled(ctx, req3)
-	s.checkResponse(err, resp3, isErrorExpected, isNilExpected)
-
-	req4 := s.newRespondWorkflowTaskCompletedRequest(uuid.New())
-	resp4, err := wh.RespondWorkflowTaskCompleted(ctx, req4)
-	s.checkResponse(err, resp4, isErrorExpected, isNilExpected)
-
-	req5 := s.newRespondWorkflowTaskFailedRequest(uuid.New())
-	resp5, err := wh.RespondWorkflowTaskFailed(ctx, req5)
-	s.checkResponse(err, resp5, isErrorExpected, isNilExpected)
-
-	req6 := s.newRespondQueryTaskCompletedRequest(uuid.New())
-	resp6, err := wh.RespondQueryTaskCompleted(ctx, req6)
-	s.checkResponse(err, resp6, isErrorExpected, isNilExpected)
-}
-
-func (s *workflowHandlerSuite) checkResponse(err error, response interface{},
-	isErrorExpected bool, isNilExpected bool) {
-	if isErrorExpected {
-		s.Error(err)
-	} else {
-		s.NoError(err)
-	}
-	if isNilExpected {
-		s.Nil(response)
-	} else {
-		s.NotNil(response)
-	}
-}
-
 func (s *workflowHandlerSuite) newConfig() *Config {
 	return NewConfig(dc.NewCollection(dc.NewNoopClient(), s.mockResource.GetLogger()), numHistoryShards, "", false)
-}
-
-func (s *workflowHandlerSuite) newRespondActivityTaskCompletedRequest(tokenNamespaceId string) *workflowservice.RespondActivityTaskCompletedRequest {
-	return &workflowservice.RespondActivityTaskCompletedRequest{
-		Namespace: s.testNamespace.String(),
-		TaskToken: s.newSerializedToken(tokenNamespaceId),
-	}
-}
-
-func (s *workflowHandlerSuite) newRespondActivityTaskFailedRequest(tokenNamespaceId string) *workflowservice.RespondActivityTaskFailedRequest {
-	return &workflowservice.RespondActivityTaskFailedRequest{
-		Namespace: s.testNamespace.String(),
-		TaskToken: s.newSerializedToken(tokenNamespaceId),
-	}
-}
-
-func (s *workflowHandlerSuite) newRespondActivityTaskCanceledRequest(tokenNamespaceId string) *workflowservice.RespondActivityTaskCanceledRequest {
-	return &workflowservice.RespondActivityTaskCanceledRequest{
-		Namespace: s.testNamespace.String(),
-		TaskToken: s.newSerializedToken(tokenNamespaceId),
-	}
-}
-
-func (s *workflowHandlerSuite) newRespondWorkflowTaskCompletedRequest(tokenNamespaceId string) *workflowservice.RespondWorkflowTaskCompletedRequest {
-	return &workflowservice.RespondWorkflowTaskCompletedRequest{
-		Namespace: s.testNamespace.String(),
-		TaskToken: s.newSerializedToken(tokenNamespaceId),
-	}
-}
-
-func (s *workflowHandlerSuite) newRespondWorkflowTaskFailedRequest(tokenNamespaceId string) *workflowservice.RespondWorkflowTaskFailedRequest {
-	return &workflowservice.RespondWorkflowTaskFailedRequest{
-		Namespace: s.testNamespace.String(),
-		TaskToken: s.newSerializedToken(tokenNamespaceId),
-	}
-}
-
-func (s *workflowHandlerSuite) newRespondQueryTaskCompletedRequest(tokenNamespaceId string) *workflowservice.RespondQueryTaskCompletedRequest {
-	return &workflowservice.RespondQueryTaskCompletedRequest{
-		Namespace: s.testNamespace.String(),
-		TaskToken: s.newSerializedQueryTaskToken(tokenNamespaceId),
-	}
-}
-
-func (s *workflowHandlerSuite) newSerializedToken(namespaceId string) []byte {
-	token, _ := s.tokenSerializer.Serialize(&tokenspb.Task{
-		NamespaceId: namespaceId,
-	})
-	return token
-}
-
-func (s *workflowHandlerSuite) newSerializedQueryTaskToken(namespaceId string) []byte {
-	token, _ := s.tokenSerializer.SerializeQueryTaskToken(&tokenspb.QueryTask{
-		NamespaceId: namespaceId,
-		TaskQueue:   "some-task-queue",
-		TaskId:      "some-task-id",
-	})
-	return token
-}
-
-func newNamespaceCacheEntry(namespaceName namespace.Name) *namespace.Namespace {
-	info := &persistencespb.NamespaceInfo{
-		Name: namespaceName.String(),
-	}
-	return namespace.NewLocalNamespaceForTest(info, nil, "")
-}
-
-func (s *workflowHandlerSuite) setupTokenNamespaceTest(tokenNamespace namespace.Name, enforce bool) *WorkflowHandler {
-	s.mockNamespaceCache.EXPECT().GetNamespaceByID(gomock.Any()).Return(newNamespaceCacheEntry(tokenNamespace), nil).AnyTimes()
-	ctx := context.Background()
-	s.mockHistoryClient.EXPECT().RespondActivityTaskCompleted(ctx, gomock.Any()).Return(nil, nil).AnyTimes()
-	s.mockHistoryClient.EXPECT().RespondActivityTaskFailed(ctx, gomock.Any()).Return(nil, nil).AnyTimes()
-	s.mockHistoryClient.EXPECT().RespondActivityTaskCanceled(ctx, gomock.Any()).Return(nil, nil).AnyTimes()
-	s.mockHistoryClient.EXPECT().RespondWorkflowTaskCompleted(ctx, gomock.Any()).Return(nil, nil).AnyTimes()
-	s.mockHistoryClient.EXPECT().RespondWorkflowTaskFailed(ctx, gomock.Any()).Return(nil, nil).AnyTimes()
-	s.mockMatchingClient.EXPECT().RespondQueryTaskCompleted(ctx, gomock.Any()).Return(nil, nil).AnyTimes()
-	cfg := s.newConfig()
-	cfg.EnableTokenNamespaceEnforcement = dc.GetBoolPropertyFn(enforce)
-	return s.getWorkflowHandler(cfg)
 }
 
 func updateRequest(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `NamespaceValidator` interceptor.

<!-- Tell your future self why have you made these changes -->
**Why?**
Centralize namespace validation on one place. `NamespaceValidatorInterceptor` validates:
1. Namespace is specified in request if there is a `namespace` field.
2. Namespace exists.
3. Namespace is in correct state.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
For some reason `RecordActivityTaskHeartbeat` (unlike all other similar APIs) didn't compare namespace Id from task token with namespace in request itself (`checkNamespaceMatch` call). I believe it was just a missing check which I added.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.