### PR TITLE
Switch to admin API in tctl register namespace

### DIFF
--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -264,7 +264,7 @@ func (adh *AdminHandler) UpdateNamespace(ctx context.Context, request *adminserv
 	}
 
 	if request.GetNamespace() == "" {
-		return nil, adh.error(errNamespaceNotSet, scope)
+		return nil, adh.error(interceptor.ErrNamespaceNotSet, scope)
 	}
 
 	req := &workflowservice.UpdateNamespaceRequest{

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -360,9 +360,12 @@ func newAdminNamespaceCommands() []cli.Command {
 			Name:    "register",
 			Aliases: []string{"re"},
 			Usage:   "Register workflow namespace",
-			Flags:   adminRegisterNamespaceFlags,
+			Flags:   registerNamespaceFlags,
 			Action: func(c *cli.Context) {
-				newNamespaceCLI(c, true).RegisterNamespace(c)
+				err := RegisterNamespace(c)
+				if err != nil {
+					ErrorAndExit("unable to register namespace", err)
+				}
 			},
 		},
 		{

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -37,6 +37,8 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
+	replicationpb "go.temporal.io/api/replication/v1"
+	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -181,6 +183,99 @@ func describeMutableState(c *cli.Context) *adminservice.DescribeMutableStateResp
 		ErrorAndExit("Get workflow mutableState failed", err)
 	}
 	return resp
+}
+
+// RegisterNamespace register a namespace
+func RegisterNamespace(c *cli.Context) error {
+	namespace := getRequiredGlobalOption(c, FlagNamespace)
+
+	description := c.String(FlagDescription)
+	ownerEmail := c.String(FlagOwnerEmail)
+
+	client := cFactory.AdminClient(c)
+
+	var err error
+	retention := defaultNamespaceRetention
+	if c.IsSet(FlagRetention) {
+		retention, err = timestamp.ParseDurationDefaultDays(c.String(FlagRetention))
+		if err != nil {
+			return fmt.Errorf("option %s format is invalid: %s", FlagRetention, err)
+		}
+	}
+
+	var isGlobalNamespace bool
+	if c.IsSet(FlagIsGlobalNamespace) {
+		isGlobalNamespace, err = strconv.ParseBool(c.String(FlagIsGlobalNamespace))
+		if err != nil {
+			return fmt.Errorf("option %s format is invalid: %w.", FlagIsGlobalNamespace, err)
+		}
+	}
+
+	namespaceData := map[string]string{}
+	if c.IsSet(FlagNamespaceData) {
+		namespaceDataStr := c.String(FlagNamespaceData)
+		namespaceData, err = parseNamespaceDataKVs(namespaceDataStr)
+		if err != nil {
+			return fmt.Errorf("option %s format is invalid: %s", FlagNamespaceData, err)
+		}
+	}
+	if len(requiredNamespaceDataKeys) > 0 {
+		err = checkRequiredNamespaceDataKVs(namespaceData)
+		if err != nil {
+			return fmt.Errorf("namespace data missed required data: %s", err)
+		}
+	}
+
+	var activeClusterName string
+	if c.IsSet(FlagActiveClusterName) {
+		activeClusterName = c.String(FlagActiveClusterName)
+	}
+
+	var clusters []*replicationpb.ClusterReplicationConfig
+	if c.IsSet(FlagClusters) {
+		clusterStr := c.String(FlagClusters)
+		clusters = append(clusters, &replicationpb.ClusterReplicationConfig{
+			ClusterName: clusterStr,
+		})
+		for _, clusterStr := range c.Args() {
+			clusters = append(clusters, &replicationpb.ClusterReplicationConfig{
+				ClusterName: clusterStr,
+			})
+		}
+	}
+
+	archState := archivalState(c, FlagHistoryArchivalState)
+	archVisState := archivalState(c, FlagVisibilityArchivalState)
+
+	req := &adminservice.RegisterNamespaceRequest{
+		Namespace:                        namespace,
+		Description:                      description,
+		OwnerEmail:                       ownerEmail,
+		Data:                             namespaceData,
+		WorkflowExecutionRetentionPeriod: &retention,
+		Clusters:                         clusters,
+		ActiveClusterName:                activeClusterName,
+		HistoryArchivalState:             archState,
+		HistoryArchivalUri:               c.String(FlagHistoryArchivalURI),
+		VisibilityArchivalState:          archVisState,
+		VisibilityArchivalUri:            c.String(FlagVisibilityArchivalURI),
+		IsGlobalNamespace:                isGlobalNamespace,
+	}
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+	_, err = client.RegisterNamespace(ctx, req)
+	if err != nil {
+		if _, ok := err.(*serviceerror.NamespaceAlreadyExists); !ok {
+			return fmt.Errorf("namespace registration failed: %s", err)
+		} else {
+			return fmt.Errorf("namespace %s is already registered: %s", namespace, err)
+		}
+	} else {
+		fmt.Printf("Namespace %s successfully registered.\n", namespace)
+	}
+
+	return nil
 }
 
 // AdminListNamespaces outputs a list of all namespaces

--- a/tools/cli/namespaceUtils.go
+++ b/tools/cli/namespaceUtils.go
@@ -188,11 +188,6 @@ var (
 		},
 	}
 
-	adminRegisterNamespaceFlags = append(
-		registerNamespaceFlags,
-		adminNamespaceCommonFlags...,
-	)
-
 	adminUpdateNamespaceFlags = append(
 		updateNamespaceFlags,
 		adminNamespaceCommonFlags...,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Switches to Admin API when registering namespaces through `tctl admin namespace register`

<!-- Tell your future self why have you made these changes -->
**Why?**

Simplifies tctl usage by removing direct DB connection params

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

tctl --namespace notdefault admin namespace register --description d1 --owner_email o@gmail.com --retention 24

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
