### PR TITLE
Make cluster metadata schema backward compatible

### DIFF
--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -701,6 +701,13 @@ func (c *FaultInjectionClusterMetadataStore) GetName() string {
 	return c.baseCMStore.GetName()
 }
 
+func (c *FaultInjectionClusterMetadataStore) GetClusterMetadataV1() (*persistence.InternalGetClusterMetadataResponse, error) {
+	if err := c.ErrorGenerator.Generate(); err != nil {
+		return nil, err
+	}
+	return c.baseCMStore.GetClusterMetadataV1()
+}
+
 func (c *FaultInjectionClusterMetadataStore) GetClusterMetadata(request *persistence.InternalGetClusterMetadataRequest) (
 	*persistence.InternalGetClusterMetadataResponse,
 	error,
@@ -711,10 +718,18 @@ func (c *FaultInjectionClusterMetadataStore) GetClusterMetadata(request *persist
 	return c.baseCMStore.GetClusterMetadata(request)
 }
 
-func (c *FaultInjectionClusterMetadataStore) SaveClusterMetadata(request *persistence.InternalSaveClusterMetadataRequest) (
-	bool,
-	error,
-) {
+func (c *FaultInjectionClusterMetadataStore) SaveClusterMetadataV1(
+	request *persistence.InternalSaveClusterMetadataRequest,
+) (bool, error) {
+	if err := c.ErrorGenerator.Generate(); err != nil {
+		return false, err
+	}
+	return c.baseCMStore.SaveClusterMetadataV1(request)
+}
+
+func (c *FaultInjectionClusterMetadataStore) SaveClusterMetadata(
+	request *persistence.InternalSaveClusterMetadataRequest,
+	) (bool, error) {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return false, err
 	}

--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -729,7 +729,7 @@ func (c *FaultInjectionClusterMetadataStore) SaveClusterMetadataV1(
 
 func (c *FaultInjectionClusterMetadataStore) SaveClusterMetadata(
 	request *persistence.InternalSaveClusterMetadataRequest,
-	) (bool, error) {
+) (bool, error) {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return false, err
 	}

--- a/common/persistence/clusterMetadataStore.go
+++ b/common/persistence/clusterMetadataStore.go
@@ -121,6 +121,19 @@ func (m *clusterMetadataManagerImpl) GetCurrentClusterMetadata() (*GetClusterMet
 	return &GetClusterMetadataResponse{ClusterMetadata: *mcm, Version: resp.Version}, nil
 }
 
+func (m *clusterMetadataManagerImpl) GetClusterMetadataV1() (*GetClusterMetadataResponse, error) {
+	resp, err := m.persistence.GetClusterMetadataV1()
+	if err != nil {
+		return nil, err
+	}
+
+	mcm, err := m.serializer.DeserializeClusterMetadata(resp.ClusterMetadata)
+	if err != nil {
+		return nil, err
+	}
+	return &GetClusterMetadataResponse{ClusterMetadata: *mcm, Version: resp.Version}, nil
+}
+
 func (m *clusterMetadataManagerImpl) GetClusterMetadata(request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error) {
 	resp, err := m.persistence.GetClusterMetadata(&InternalGetClusterMetadataRequest{ClusterName: request.ClusterName})
 	if err != nil {
@@ -139,6 +152,35 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(request *SaveClusterMet
 	if err != nil {
 		return false, err
 	}
+	// 1. Write current cluster metadata to cluster metadata table
+	if request.ClusterName == m.currentClusterName {
+		oldClusterMetadata, err := m.GetClusterMetadataV1()
+		switch err.(type) {
+		case nil:
+			if immutableFieldsChanged(oldClusterMetadata.ClusterMetadata, request.ClusterMetadata) {
+				return false, nil
+			}
+			applied, err := m.persistence.SaveClusterMetadataV1(&InternalSaveClusterMetadataRequest{
+				ClusterMetadata: mcm,
+				Version:         oldClusterMetadata.Version,
+			})
+			if err != nil || !applied {
+				return false, err
+			}
+		case *serviceerror.NotFound:
+			applied, err := m.persistence.SaveClusterMetadataV1(&InternalSaveClusterMetadataRequest{
+				ClusterMetadata: mcm,
+				Version:         0,
+			})
+			if err != nil || !applied {
+				return false, err
+			}
+		default:
+			return false, err
+		}
+	}
+
+	// 2. Write to cluster metadata info table
 	oldClusterMetadata, err := m.GetClusterMetadata(&GetClusterMetadataRequest{ClusterName: request.GetClusterName()})
 	if _, notFound := err.(*serviceerror.NotFound); notFound {
 		return m.persistence.SaveClusterMetadata(&InternalSaveClusterMetadataRequest{
@@ -175,5 +217,5 @@ func immutableFieldsChanged(old persistencespb.ClusterMetadata, cur persistences
 		(old.ClusterId != "" && old.ClusterId != cur.ClusterId) ||
 		(old.HistoryShardCount != 0 && old.HistoryShardCount != cur.HistoryShardCount) ||
 		(old.FailoverVersionIncrement != 0 && old.FailoverVersionIncrement != cur.FailoverVersionIncrement) ||
-		(old.InitialFailoverVersion != cur.InitialFailoverVersion)
+		(old.InitialFailoverVersion != 0 && old.InitialFailoverVersion != cur.InitialFailoverVersion)
 }

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -1159,6 +1159,7 @@ type (
 		UpsertClusterMembership(request *UpsertClusterMembershipRequest) error
 		PruneClusterMembership(request *PruneClusterMembershipRequest) error
 		GetCurrentClusterMetadata() (*GetClusterMetadataResponse, error)
+		GetClusterMetadataV1() (*GetClusterMetadataResponse, error) //TODO: deprecate this after 1.15+
 		GetClusterMetadata(request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error)
 		SaveClusterMetadata(request *SaveClusterMetadataRequest) (bool, error)
 		DeleteClusterMetadata(request *DeleteClusterMetadataRequest) error

--- a/common/persistence/dataInterfaces_mock.go
+++ b/common/persistence/dataInterfaces_mock.go
@@ -1176,6 +1176,21 @@ func (mr *MockClusterMetadataManagerMockRecorder) GetClusterMetadata(request int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).GetClusterMetadata), request)
 }
 
+// GetClusterMetadataV1 mocks base method.
+func (m *MockClusterMetadataManager) GetClusterMetadataV1() (*GetClusterMetadataResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMetadataV1")
+	ret0, _ := ret[0].(*GetClusterMetadataResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterMetadataV1 indicates an expected call of GetClusterMetadataV1.
+func (mr *MockClusterMetadataManagerMockRecorder) GetClusterMetadataV1() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadataV1", reflect.TypeOf((*MockClusterMetadataManager)(nil).GetClusterMetadataV1))
+}
+
 // GetCurrentClusterMetadata mocks base method.
 func (m *MockClusterMetadataManager) GetCurrentClusterMetadata() (*GetClusterMetadataResponse, error) {
 	m.ctrl.T.Helper()

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -567,6 +567,21 @@ func (mr *MockClusterMetadataStoreMockRecorder) GetClusterMetadata(request inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).GetClusterMetadata), request)
 }
 
+// GetClusterMetadataV1 mocks base method.
+func (m *MockClusterMetadataStore) GetClusterMetadataV1() (*persistence.InternalGetClusterMetadataResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMetadataV1")
+	ret0, _ := ret[0].(*persistence.InternalGetClusterMetadataResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetClusterMetadataV1 indicates an expected call of GetClusterMetadataV1.
+func (mr *MockClusterMetadataStoreMockRecorder) GetClusterMetadataV1() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadataV1", reflect.TypeOf((*MockClusterMetadataStore)(nil).GetClusterMetadataV1))
+}
+
 // GetName mocks base method.
 func (m *MockClusterMetadataStore) GetName() string {
 	m.ctrl.T.Helper()
@@ -608,6 +623,21 @@ func (m *MockClusterMetadataStore) SaveClusterMetadata(request *persistence.Inte
 func (mr *MockClusterMetadataStoreMockRecorder) SaveClusterMetadata(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).SaveClusterMetadata), request)
+}
+
+// SaveClusterMetadataV1 mocks base method.
+func (m *MockClusterMetadataStore) SaveClusterMetadataV1(request *persistence.InternalSaveClusterMetadataRequest) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SaveClusterMetadataV1", request)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SaveClusterMetadataV1 indicates an expected call of SaveClusterMetadataV1.
+func (mr *MockClusterMetadataStoreMockRecorder) SaveClusterMetadataV1(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveClusterMetadataV1", reflect.TypeOf((*MockClusterMetadataStore)(nil).SaveClusterMetadataV1), request)
 }
 
 // UpsertClusterMembership mocks base method.

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -94,7 +94,9 @@ type (
 	ClusterMetadataStore interface {
 		Closeable
 		GetName() string
+		GetClusterMetadataV1() (*InternalGetClusterMetadataResponse, error) //TODO: deprecate this after 1.15+
 		GetClusterMetadata(request *InternalGetClusterMetadataRequest) (*InternalGetClusterMetadataResponse, error)
+		SaveClusterMetadataV1(request *InternalSaveClusterMetadataRequest) (bool, error) //TODO: deprecate this after 1.15+
 		SaveClusterMetadata(request *InternalSaveClusterMetadataRequest) (bool, error)
 		DeleteClusterMetadata(request *InternalDeleteClusterMetadataRequest) error
 		// Membership APIs

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -1121,6 +1121,20 @@ func (c *clusterMetadataPersistenceClient) GetCurrentClusterMetadata() (*GetClus
 	return result, err
 }
 
+func (c *clusterMetadataPersistenceClient) GetClusterMetadataV1() (*GetClusterMetadataResponse, error) {
+	c.metricClient.IncCounter(metrics.PersistenceGetClusterMetadataScope, metrics.PersistenceRequests)
+
+	sw := c.metricClient.StartTimer(metrics.PersistenceGetClusterMetadataScope, metrics.PersistenceLatency)
+	result, err := c.persistence.GetClusterMetadataV1()
+	sw.Stop()
+
+	if err != nil {
+		c.metricClient.IncCounter(metrics.PersistenceGetClusterMetadataScope, metrics.PersistenceFailures)
+	}
+
+	return result, err
+}
+
 func (c *clusterMetadataPersistenceClient) GetClusterMetadata(request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error) {
 	c.metricClient.IncCounter(metrics.PersistenceGetClusterMetadataScope, metrics.PersistenceRequests)
 

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -799,6 +799,13 @@ func (c *clusterMetadataRateLimitedPersistenceClient) GetCurrentClusterMetadata(
 	return c.persistence.GetCurrentClusterMetadata()
 }
 
+func (c *clusterMetadataRateLimitedPersistenceClient) GetClusterMetadataV1() (*GetClusterMetadataResponse, error) {
+	if ok := c.rateLimiter.Allow(); !ok {
+		return nil, ErrPersistenceLimitExceeded
+	}
+	return c.persistence.GetClusterMetadataV1()
+}
+
 func (c *clusterMetadataRateLimitedPersistenceClient) GetClusterMetadata(request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error) {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded

--- a/common/persistence/sql/cluster_metadata.go
+++ b/common/persistence/sql/cluster_metadata.go
@@ -43,6 +43,20 @@ type sqlClusterMetadataManager struct {
 
 var _ p.ClusterMetadataStore = (*sqlClusterMetadataManager)(nil)
 
+func (s *sqlClusterMetadataManager) GetClusterMetadataV1() (*p.InternalGetClusterMetadataResponse, error) {
+	ctx, cancel := newExecutionContext()
+	defer cancel()
+	row, err := s.Db.GetClusterMetadataV1(ctx)
+
+	if err != nil {
+		return nil, convertCommonErrors("GetClusterMetadataV1", err)
+	}
+	return &p.InternalGetClusterMetadataResponse{
+		ClusterMetadata: p.NewDataBlob(row.Data, row.DataEncoding),
+		Version:         row.Version,
+	}, nil
+}
+
 func (s *sqlClusterMetadataManager) GetClusterMetadata(
 	request *p.InternalGetClusterMetadataRequest,
 ) (*p.InternalGetClusterMetadataResponse, error) {
@@ -58,6 +72,40 @@ func (s *sqlClusterMetadataManager) GetClusterMetadata(
 		ClusterMetadata: p.NewDataBlob(row.Data, row.DataEncoding),
 		Version:         row.Version,
 	}, nil
+}
+
+func (s *sqlClusterMetadataManager) SaveClusterMetadataV1(request *p.InternalSaveClusterMetadataRequest) (bool, error) {
+	ctx, cancel := newExecutionContext()
+	defer cancel()
+	err := s.txExecute(ctx, "SaveClusterMetadataV1", func(tx sqlplugin.Tx) error {
+		oldClusterMetadata, err := tx.WriteLockGetClusterMetadataV1(ctx)
+		var lastVersion int64
+		if err != nil {
+			if err != sql.ErrNoRows {
+				return serviceerror.NewUnavailable(fmt.Sprintf("SaveClusterMetadataV1 operation failed. Error %v", err))
+			}
+		} else {
+			lastVersion = oldClusterMetadata.Version
+		}
+		if request.Version != lastVersion {
+			return serviceerror.NewUnavailable(fmt.Sprintf("SaveClusterMetadataV1 encountered version mismatch, expected %v but got %v.",
+				request.Version, oldClusterMetadata.Version))
+		}
+		_, err = tx.SaveClusterMetadataV1(ctx, &sqlplugin.ClusterMetadataRow{
+			Data:         request.ClusterMetadata.Data,
+			DataEncoding: request.ClusterMetadata.EncodingType.String(),
+			Version:      request.Version,
+		})
+		if err != nil {
+			return convertCommonErrors("SaveClusterMetadataV1", err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		return false, serviceerror.NewUnavailable(err.Error())
+	}
+	return true, nil
 }
 
 func (s *sqlClusterMetadataManager) SaveClusterMetadata(request *p.InternalSaveClusterMetadataRequest) (bool, error) {

--- a/common/persistence/sql/sqlplugin/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/cluster_metadata.go
@@ -77,9 +77,12 @@ type (
 
 	// ClusterMetadata is the SQL persistence interface for cluster metadata
 	ClusterMetadata interface {
+		SaveClusterMetadataV1(ctx context.Context, row *ClusterMetadataRow) (sql.Result, error) // TODO: deprecate this after 1.15+
 		SaveClusterMetadata(ctx context.Context, row *ClusterMetadataRow) (sql.Result, error)
+		GetClusterMetadataV1(ctx context.Context) (*ClusterMetadataRow, error) // TODO: deprecate this after 1.15+
 		GetClusterMetadata(ctx context.Context, filter *ClusterMetadataFilter) (*ClusterMetadataRow, error)
 		DeleteClusterMetadata(ctx context.Context, filter *ClusterMetadataFilter) (sql.Result, error)
+		WriteLockGetClusterMetadataV1(ctx context.Context) (*ClusterMetadataRow, error) // TODO: deprecate this after 1.15+
 		WriteLockGetClusterMetadata(ctx context.Context, filter *ClusterMetadataFilter) (*ClusterMetadataRow, error)
 		GetClusterMembers(ctx context.Context, filter *ClusterMembershipFilter) ([]ClusterMembershipRow, error)
 		UpsertClusterMembership(ctx context.Context, row *ClusterMembershipRow) (sql.Result, error)

--- a/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
@@ -38,6 +38,14 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
+	insertClusterMetadataQryV1 = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, version) VALUES(?, ?, ?, ?)`
+
+	updateClusterMetadataQryV1 = `UPDATE cluster_metadata SET data = ?, data_encoding = ?, version = ? WHERE metadata_partition = ?`
+
+	getClusterMetadataQryV1          = `SELECT data, data_encoding, version FROM cluster_metadata WHERE metadata_partition = ?`
+	writeLockGetClusterMetadataQryV1 = getClusterMetadataQryV1 + ` FOR UPDATE`
+
+	// ****** CLUSTER_METADATA_INFO TABLE ******
 	insertClusterMetadataQry = `INSERT INTO cluster_metadata_info (metadata_partition, cluster_name, data, data_encoding, version) VALUES(?, ?, ?, ?, ?)`
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata_info SET data = ?, data_encoding = ?, version = ? WHERE metadata_partition = ? AND cluster_name = ?`
@@ -75,6 +83,28 @@ cluster_membership WHERE membership_partition = ?`
 	templateWithOrderBySessionStartSuffix = ` ORDER BY membership_partition ASC, host_id ASC`
 )
 
+func (mdb *db) SaveClusterMetadataV1(
+	ctx context.Context,
+	row *sqlplugin.ClusterMetadataRow,
+) (sql.Result, error) {
+	if row.Version == 0 {
+		return mdb.conn.ExecContext(ctx,
+			insertClusterMetadataQryV1,
+			constMetadataPartition,
+			row.Data,
+			row.DataEncoding,
+			1,
+		)
+	}
+	return mdb.conn.ExecContext(ctx,
+		updateClusterMetadataQryV1,
+		row.Data,
+		row.DataEncoding,
+		row.Version+1,
+		constMetadataPartition,
+	)
+}
+
 func (mdb *db) SaveClusterMetadata(
 	ctx context.Context,
 	row *sqlplugin.ClusterMetadataRow,
@@ -97,6 +127,19 @@ func (mdb *db) SaveClusterMetadata(
 		constMetadataPartition,
 		row.ClusterName,
 	)
+}
+
+func (mdb *db) GetClusterMetadataV1(ctx context.Context) (*sqlplugin.ClusterMetadataRow, error) {
+	var row sqlplugin.ClusterMetadataRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		getClusterMetadataQryV1,
+		constMetadataPartition,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, err
 }
 
 func (mdb *db) GetClusterMetadata(
@@ -126,6 +169,21 @@ func (mdb *db) DeleteClusterMetadata(
 		constMetadataPartition,
 		filter.ClusterName,
 	)
+}
+
+func (mdb *db) WriteLockGetClusterMetadataV1(
+	ctx context.Context,
+) (*sqlplugin.ClusterMetadataRow, error) {
+	var row sqlplugin.ClusterMetadataRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		writeLockGetClusterMetadataQryV1,
+		constMetadataPartition,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, err
 }
 
 func (mdb *db) WriteLockGetClusterMetadata(

--- a/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
@@ -39,7 +39,7 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
-	insertClusterMetadataQryV1= `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, version) VALUES($1, $2, $3, $4)`
+	insertClusterMetadataQryV1 = `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, version) VALUES($1, $2, $3, $4)`
 
 	updateClusterMetadataQryV1 = `UPDATE cluster_metadata SET data = $1, data_encoding = $2, version = $3 WHERE metadata_partition = $4`
 

--- a/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
@@ -39,6 +39,15 @@ const constMetadataPartition = 0
 const constMembershipPartition = 0
 const (
 	// ****** CLUSTER_METADATA TABLE ******
+	insertClusterMetadataQryV1= `INSERT INTO cluster_metadata (metadata_partition, data, data_encoding, version) VALUES($1, $2, $3, $4)`
+
+	updateClusterMetadataQryV1 = `UPDATE cluster_metadata SET data = $1, data_encoding = $2, version = $3 WHERE metadata_partition = $4`
+
+	getClusterMetadataQryV1 = `SELECT data, data_encoding, version FROM cluster_metadata WHERE metadata_partition = $1`
+
+	writeLockGetClusterMetadataQryV1 = getClusterMetadataQryV1 + ` FOR UPDATE`
+
+	// ****** CLUSTER_METADATA_INFO TABLE ******
 	insertClusterMetadataQry = `INSERT INTO cluster_metadata_info (metadata_partition, cluster_name, data, data_encoding, version) VALUES($1, $2, $3, $4, $5)`
 
 	updateClusterMetadataQry = `UPDATE cluster_metadata_info SET data = $1, data_encoding = $2, version = $3 WHERE metadata_partition = $4 AND cluster_name = $5`
@@ -79,6 +88,28 @@ cluster_membership WHERE membership_partition = $`
 	templateWithOrderBySessionStartSuffix = ` ORDER BY membership_partition ASC, host_id ASC`
 )
 
+func (pdb *db) SaveClusterMetadataV1(
+	ctx context.Context,
+	row *sqlplugin.ClusterMetadataRow,
+) (sql.Result, error) {
+	if row.Version == 0 {
+		return pdb.conn.ExecContext(ctx,
+			insertClusterMetadataQryV1,
+			constMetadataPartition,
+			row.Data,
+			row.DataEncoding,
+			1,
+		)
+	}
+	return pdb.conn.ExecContext(ctx,
+		updateClusterMetadataQryV1,
+		row.Data,
+		row.DataEncoding,
+		row.Version+1,
+		constMetadataPartition,
+	)
+}
+
 func (pdb *db) SaveClusterMetadata(
 	ctx context.Context,
 	row *sqlplugin.ClusterMetadataRow,
@@ -103,6 +134,19 @@ func (pdb *db) SaveClusterMetadata(
 	)
 }
 
+func (pdb *db) GetClusterMetadataV1(ctx context.Context) (*sqlplugin.ClusterMetadataRow, error) {
+	var row sqlplugin.ClusterMetadataRow
+	err := pdb.conn.GetContext(ctx,
+		&row,
+		getClusterMetadataQryV1,
+		constMetadataPartition,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, err
+}
+
 func (pdb *db) GetClusterMetadata(
 	ctx context.Context,
 	filter *sqlplugin.ClusterMetadataFilter,
@@ -118,6 +162,21 @@ func (pdb *db) GetClusterMetadata(
 		return nil, err
 	}
 	return &row, err
+}
+
+func (pdb *db) WriteLockGetClusterMetadataV1(
+	ctx context.Context,
+) (*sqlplugin.ClusterMetadataRow, error) {
+	var row sqlplugin.ClusterMetadataRow
+	err := pdb.conn.GetContext(ctx,
+		&row,
+		writeLockGetClusterMetadataQryV1,
+		constMetadataPartition,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
 }
 
 func (pdb *db) WriteLockGetClusterMetadata(

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -27,8 +27,9 @@ package temporal
 import (
 	"context"
 	"fmt"
-	"go.temporal.io/api/serviceerror"
 	"time"
+
+	"go.temporal.io/api/serviceerror"
 
 	"github.com/uber-go/tally/v4"
 	"go.uber.org/fx"

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -27,7 +27,7 @@ package temporal
 import (
 	"context"
 	"fmt"
-	"strconv"
+	"go.temporal.io/api/serviceerror"
 	"time"
 
 	"github.com/uber-go/tally/v4"
@@ -482,6 +482,11 @@ func ApplyClusterMetadataConfigProvider(
 	}
 	defer clusterMetadataManager.Close()
 
+	/**
+	 * 1. Create cluster metadata info in both cluster_metadata and cluster_metadata_info tables.
+	 * 2. For non current clusters, the initialization will be succeeded in the first time but fails in the following due to version conditional update.
+	 * 3. For current cluster, 1) initialize in both tables (applied == true), 2) migrate data from cluster_metadata to cluster_metadata_info (applied == false)
+	 */
 	clusterData := config.ClusterMetadata
 	for clusterName, clusterInfo := range clusterData.ClusterInformation {
 		var clusterId = ""
@@ -489,6 +494,7 @@ func ApplyClusterMetadataConfigProvider(
 			// Only set current cluster Id as we don't know the remote cluster Id.
 			clusterId = uuid.New()
 		}
+		//Case 1: initialize cluster metadata config
 		// We assume the existing remote cluster info is correct.
 		applied, err := clusterMetadataManager.SaveClusterMetadata(
 			&persistence.SaveClusterMetadataRequest{
@@ -505,7 +511,6 @@ func ApplyClusterMetadataConfigProvider(
 		if err != nil {
 			logger.Warn("Failed to save cluster metadata.", tag.Error(err), tag.ClusterName(clusterName))
 		}
-
 		if applied {
 			logger.Info("Successfully saved cluster metadata.", tag.ClusterName(clusterName))
 			continue
@@ -514,54 +519,53 @@ func ApplyClusterMetadataConfigProvider(
 		resp, err := clusterMetadataManager.GetClusterMetadata(&persistence.GetClusterMetadataRequest{
 			ClusterName: clusterName,
 		})
-		if err != nil {
+		switch err.(type) {
+		case nil:
+			// Verify current cluster metadata
+			if clusterName == clusterData.CurrentClusterName {
+				var persistedShardCount = resp.HistoryShardCount
+				if config.Persistence.NumHistoryShards != persistedShardCount {
+					logger.Error(
+						mismatchLogMessage,
+						tag.Key("persistence.numHistoryShards"),
+						tag.IgnoredValue(config.Persistence.NumHistoryShards),
+						tag.Value(persistedShardCount))
+					config.Persistence.NumHistoryShards = persistedShardCount
+				}
+			}
+		case *serviceerror.NotFound:
+			if clusterName == clusterData.CurrentClusterName {
+				// Case 3: data exists in cluster metadata but not in cluster metadata info. Back fill data.
+				oldClusterMetadata, err := clusterMetadataManager.GetClusterMetadataV1()
+				if err != nil {
+					return config.ClusterMetadata, config.Persistence, fmt.Errorf("error while getting old cluster metadata: %w", err)
+				}
+				applied, err = clusterMetadataManager.SaveClusterMetadata(&persistence.SaveClusterMetadataRequest{
+					ClusterMetadata: persistencespb.ClusterMetadata{
+						HistoryShardCount:        oldClusterMetadata.HistoryShardCount,
+						ClusterName:              oldClusterMetadata.ClusterName,
+						ClusterId:                oldClusterMetadata.ClusterId,
+						VersionInfo:              oldClusterMetadata.VersionInfo,
+						IndexSearchAttributes:    oldClusterMetadata.IndexSearchAttributes,
+						ClusterAddress:           clusterInfo.RPCAddress,
+						FailoverVersionIncrement: clusterData.FailoverVersionIncrement,
+						InitialFailoverVersion:   clusterInfo.InitialFailoverVersion,
+						IsGlobalNamespaceEnabled: clusterData.EnableGlobalNamespace,
+						IsConnectionEnabled:      clusterInfo.Enabled,
+					}})
+				if err != nil || !applied {
+					return config.ClusterMetadata, config.Persistence, fmt.Errorf("error while backfiling cluster metadata: %w", err)
+				}
+			} else {
+				return config.ClusterMetadata,
+					config.Persistence,
+					fmt.Errorf("error while fetching metadata from cluster %s: %w", clusterName, err)
+			}
+		default:
 			return config.ClusterMetadata,
 				config.Persistence,
 				fmt.Errorf("error while fetching metadata from cluster %s: %w", clusterName, err)
 		}
-
-		if clusterName == resp.GetClusterName() {
-			var persistedShardCount = resp.HistoryShardCount
-			if config.Persistence.NumHistoryShards != persistedShardCount {
-				logger.Error(
-					mismatchLogMessage,
-					tag.Key("persistence.numHistoryShards"),
-					tag.IgnoredValue(config.Persistence.NumHistoryShards),
-					tag.Value(persistedShardCount))
-				config.Persistence.NumHistoryShards = persistedShardCount
-			}
-		}
-
-		// Overwrite cluster information from DB
-		if clusterInfo.Enabled != resp.IsConnectionEnabled {
-			logger.Error(
-				mismatchLogMessage,
-				tag.Key("clusterInfo.enabled"),
-				tag.IgnoredValue(clusterInfo.Enabled),
-				tag.Value(resp.IsConnectionEnabled))
-
-			clusterInfo.Enabled = resp.IsConnectionEnabled
-		}
-		if clusterInfo.Enabled && clusterInfo.RPCAddress != resp.ClusterAddress {
-			logger.Error(
-				mismatchLogMessage,
-				tag.Key("clusterInfo.rpcAddress"),
-				tag.IgnoredValue(clusterInfo.RPCAddress),
-				tag.Value(resp.ClusterAddress))
-
-			clusterInfo.RPCAddress = resp.ClusterAddress
-		}
-		if clusterInfo.Enabled && clusterInfo.InitialFailoverVersion != resp.InitialFailoverVersion {
-			logger.Error(
-				mismatchLogMessage,
-				tag.Key("clusterInfo.initialFailoverVersion"),
-				tag.IgnoredValue(clusterInfo.InitialFailoverVersion),
-				tag.Value(resp.InitialFailoverVersion))
-
-			clusterInfo.InitialFailoverVersion = resp.InitialFailoverVersion
-		}
-		fmt.Println("cluster : version" + clusterName + ":" + strconv.Itoa(int(clusterInfo.InitialFailoverVersion)))
-		config.ClusterMetadata.ClusterInformation[clusterName] = clusterInfo
 	}
 	return config.ClusterMetadata, config.Persistence, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. SaveClusterMetadata write to both cluster_metadata and cluster_metadata_info
2. Fx initializes cluster metadata if it doesn't exist in both cluster_metadata and cluster_metadata_info or migrate date from cluster_metadata to cluster_metadata_info

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Make service backward compatible. The indexed search attributes stores in cluster metadata so that if it only write to the new table. It will fail if the server is rolled back.
2. Make cluster metadata forward compatible. For existing search attribute, we should migration(backfill) them to the new table.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local inter-cluster tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In the worst case, the customized search attributes fail to be migrated and workflows could be blocked.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A