### PR TITLE
Switch to admin API in tctl update namespace

### DIFF
--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -264,7 +264,7 @@ func (adh *AdminHandler) UpdateNamespace(ctx context.Context, request *adminserv
 	}
 
 	if request.GetNamespace() == "" {
-		return nil, adh.error(errNamespaceNotSet, scope)
+		return nil, adh.error(interceptor.ErrNamespaceNotSet, scope)
 	}
 
 	req := &workflowservice.UpdateNamespaceRequest{

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -369,9 +369,12 @@ func newAdminNamespaceCommands() []cli.Command {
 			Name:    "update",
 			Aliases: []string{"up", "u"},
 			Usage:   "Update existing workflow namespace",
-			Flags:   adminUpdateNamespaceFlags,
+			Flags:   updateNamespaceFlags,
 			Action: func(c *cli.Context) {
-				newNamespaceCLI(c, true).UpdateNamespace(c)
+				err := UpdateNamespace(c)
+				if err != nil {
+					ErrorAndExit("unable to register namespace", err)
+				}
 			},
 		},
 		{

--- a/tools/cli/namespaceUtils.go
+++ b/tools/cli/namespaceUtils.go
@@ -193,11 +193,6 @@ var (
 		adminNamespaceCommonFlags...,
 	)
 
-	adminUpdateNamespaceFlags = append(
-		updateNamespaceFlags,
-		adminNamespaceCommonFlags...,
-	)
-
 	adminDescribeNamespaceFlags = append(
 		updateNamespaceFlags,
 		adminNamespaceCommonFlags...,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Switches to Admin API when updating namespaces through `tctl admin namespace update`

<!-- Tell your future self why have you made these changes -->
**Why?**

Simplifies tctl usage by removing direct DB connection params

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

```
$ tctl --ns 1 admin namespace update --description 222
Namespace 1 successfully updated
$ ./tctl admin namespace list
... Name:1,Description:222222222222...
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
