### PR TITLE
Use t.Setenv function to set env in unit tests

### DIFF
--- a/common/archiver/gcloud/connector/client_test.go
+++ b/common/archiver/gcloud/connector/client_test.go
@@ -222,7 +222,7 @@ func (s *clientSuite) TestGet() {
 
 func (s *clientSuite) TestWrongGoogleCredentialsPath() {
 	ctx := context.Background()
-	os.Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/Wrong/path")
+	s.T().Setenv("GOOGLE_APPLICATION_CREDENTIALS", "/Wrong/path")
 	_, err := connector.NewClient(ctx, &config.GstorageArchiver{})
 	s.Require().Error(err)
 }

--- a/tools/sql/clitest/mysql_cli_test.go
+++ b/tools/sql/clitest/mysql_cli_test.go
@@ -25,7 +25,6 @@
 package clitest
 
 import (
-	"os"
 	"strconv"
 	"testing"
 
@@ -93,10 +92,10 @@ func TestMySQLHandlerTestSuite(t *testing.T) {
 }
 
 func TestMySQLSetupSchemaTestSuite(t *testing.T) {
-	os.Setenv("SQL_HOST", environment.GetMySQLAddress())
-	os.Setenv("SQL_PORT", strconv.Itoa(environment.GetMySQLPort()))
-	os.Setenv("SQL_USER", testUser)
-	os.Setenv("SQL_PASSWORD", testPassword)
+	t.Setenv("SQL_HOST", environment.GetMySQLAddress())
+	t.Setenv("SQL_PORT", strconv.Itoa(environment.GetMySQLPort()))
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
 	suite.Run(t, NewSetupSchemaTestSuite(
 		environment.GetMySQLAddress(),
 		strconv.Itoa(environment.GetMySQLPort()),
@@ -106,10 +105,10 @@ func TestMySQLSetupSchemaTestSuite(t *testing.T) {
 }
 
 func TestMySQLUpdateSchemaTestSuite(t *testing.T) {
-	os.Setenv("SQL_HOST", environment.GetMySQLAddress())
-	os.Setenv("SQL_PORT", strconv.Itoa(environment.GetMySQLPort()))
-	os.Setenv("SQL_USER", testUser)
-	os.Setenv("SQL_PASSWORD", testPassword)
+	t.Setenv("SQL_HOST", environment.GetMySQLAddress())
+	t.Setenv("SQL_PORT", strconv.Itoa(environment.GetMySQLPort()))
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
 	suite.Run(t, NewUpdateSchemaTestSuite(
 		environment.GetMySQLAddress(),
 		strconv.Itoa(environment.GetMySQLPort()),
@@ -123,8 +122,8 @@ func TestMySQLUpdateSchemaTestSuite(t *testing.T) {
 }
 
 func TestMySQLVersionTestSuite(t *testing.T) {
-	os.Setenv("SQL_USER", testUser)
-	os.Setenv("SQL_PASSWORD", testPassword)
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
 	suite.Run(t, NewVersionTestSuite(
 		environment.GetMySQLAddress(),
 		strconv.Itoa(environment.GetMySQLPort()),

--- a/tools/sql/clitest/postgresql_cli_test.go
+++ b/tools/sql/clitest/postgresql_cli_test.go
@@ -25,7 +25,6 @@
 package clitest
 
 import (
-	"os"
 	"strconv"
 	"testing"
 
@@ -92,10 +91,10 @@ func TestPostgreSQLHandlerTestSuite(t *testing.T) {
 }
 
 func TestPostgreSQLSetupSchemaTestSuite(t *testing.T) {
-	os.Setenv("SQL_HOST", environment.GetPostgreSQLAddress())
-	os.Setenv("SQL_PORT", strconv.Itoa(environment.GetPostgreSQLPort()))
-	os.Setenv("SQL_USER", testUser)
-	os.Setenv("SQL_PASSWORD", testPassword)
+	t.Setenv("SQL_HOST", environment.GetPostgreSQLAddress())
+	t.Setenv("SQL_PORT", strconv.Itoa(environment.GetPostgreSQLPort()))
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
 	suite.Run(t, NewSetupSchemaTestSuite(
 		environment.GetPostgreSQLAddress(),
 		strconv.Itoa(environment.GetPostgreSQLPort()),
@@ -105,10 +104,10 @@ func TestPostgreSQLSetupSchemaTestSuite(t *testing.T) {
 }
 
 func TestPostgreSQLUpdateSchemaTestSuite(t *testing.T) {
-	os.Setenv("SQL_HOST", environment.GetPostgreSQLAddress())
-	os.Setenv("SQL_PORT", strconv.Itoa(environment.GetPostgreSQLPort()))
-	os.Setenv("SQL_USER", testUser)
-	os.Setenv("SQL_PASSWORD", testPassword)
+	t.Setenv("SQL_HOST", environment.GetPostgreSQLAddress())
+	t.Setenv("SQL_PORT", strconv.Itoa(environment.GetPostgreSQLPort()))
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
 	suite.Run(t, NewUpdateSchemaTestSuite(
 		environment.GetPostgreSQLAddress(),
 		strconv.Itoa(environment.GetPostgreSQLPort()),
@@ -122,8 +121,8 @@ func TestPostgreSQLUpdateSchemaTestSuite(t *testing.T) {
 }
 
 func TestPostgreSQLVersionTestSuite(t *testing.T) {
-	os.Setenv("SQL_USER", testUser)
-	os.Setenv("SQL_PASSWORD", testPassword)
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
 	suite.Run(t, NewVersionTestSuite(
 		environment.GetPostgreSQLAddress(),
 		strconv.Itoa(environment.GetPostgreSQLPort()),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Use t.Setenv() function instead of os.Setenv

<!-- Tell your future self why have you made these changes -->
**Why?**
- Leverage the *testing.T instance and isolate the unit testing scope (https://golang.org/doc/go1.17#testing)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No