### PR TITLE
Change shard persistence interface to get-or-create

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -147,10 +147,8 @@ const (
 
 	// -- Common Operation scopes --
 
-	// PersistenceCreateShardScope tracks CreateShard calls made by service to persistence layer
-	PersistenceCreateShardScope
-	// PersistenceGetShardScope tracks GetShard calls made by service to persistence layer
-	PersistenceGetShardScope
+	// PersistenceGetOrCreateShardScope tracks GetOrCreateShard calls made by service to persistence layer
+	PersistenceGetOrCreateShardScope
 	// PersistenceUpdateShardScope tracks UpdateShard calls made by service to persistence layer
 	PersistenceUpdateShardScope
 	// PersistenceCreateWorkflowExecutionScope tracks CreateWorkflowExecution calls made by service to persistence layer
@@ -1141,8 +1139,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 	// common scope Names
 	Common: {
 		UnknownScope:                                      {operation: "Unknown"},
-		PersistenceCreateShardScope:                       {operation: "CreateShard"},
-		PersistenceGetShardScope:                          {operation: "GetShard"},
+		PersistenceGetOrCreateShardScope:                  {operation: "GetOrCreateShard"},
 		PersistenceUpdateShardScope:                       {operation: "UpdateShard"},
 		PersistenceCreateWorkflowExecutionScope:           {operation: "CreateWorkflowExecution"},
 		PersistenceGetWorkflowExecutionScope:              {operation: "GetWorkflowExecution"},

--- a/common/metrics/defs_test.go
+++ b/common/metrics/defs_test.go
@@ -36,7 +36,7 @@ import (
 var IsMetric = regexp.MustCompile(`^[a-z][a-z_]*$`).MatchString
 
 func TestScopeDefsMapped(t *testing.T) {
-	for i := PersistenceCreateShardScope; i < NumCommonScopes; i++ {
+	for i := PersistenceGetOrCreateShardScope; i < NumCommonScopes; i++ {
 		key, ok := ScopeDefs[Common][i]
 		require.True(t, ok)
 		require.NotEmpty(t, key)

--- a/common/persistence/cassandra/shard_store.go
+++ b/common/persistence/cassandra/shard_store.go
@@ -128,7 +128,7 @@ func (d *ShardStore) GetOrCreateShard(
 	}
 	if !applied {
 		// conflict, try again
-		request.CreateShardInfo = nil
+		request.CreateShardInfo = nil // prevent loop
 		return d.GetOrCreateShard(request)
 	}
 	return &p.InternalGetOrCreateShardResponse{

--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -1001,21 +1001,14 @@ func (s *FaultInjectionShardStore) GetClusterName() string {
 	return s.baseShardStore.GetClusterName()
 }
 
-func (s *FaultInjectionShardStore) CreateShard(request *persistence.InternalCreateShardRequest) error {
-	if err := s.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return s.baseShardStore.CreateShard(request)
-}
-
-func (s *FaultInjectionShardStore) GetShard(request *persistence.InternalGetShardRequest) (
-	*persistence.InternalGetShardResponse,
+func (s *FaultInjectionShardStore) GetOrCreateShard(request *persistence.InternalGetOrCreateShardRequest) (
+	*persistence.InternalGetOrCreateShardResponse,
 	error,
 ) {
 	if err := s.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return s.baseShardStore.GetShard(request)
+	return s.baseShardStore.GetOrCreateShard(request)
 }
 
 func (s *FaultInjectionShardStore) UpdateShard(request *persistence.InternalUpdateShardRequest) error {

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -199,8 +199,8 @@ type (
 		InitialShardInfo *persistencespb.ShardInfo
 	}
 
-	// GetShardResponse is the response to GetOrCreateShard
-	GetShardResponse struct {
+	// GetOrCreateShardResponse is the response to GetOrCreateShard
+	GetOrCreateShardResponse struct {
 		ShardInfo *persistencespb.ShardInfo
 	}
 
@@ -1028,7 +1028,7 @@ type (
 	ShardManager interface {
 		Closeable
 		GetName() string
-		GetOrCreateShard(request *GetOrCreateShardRequest) (*GetShardResponse, error)
+		GetOrCreateShard(request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error)
 		UpdateShard(request *UpdateShardRequest) error
 	}
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -191,17 +191,15 @@ type (
 		TaskType    enumspb.TaskQueueType
 	}
 
-	// CreateShardRequest is used to create a shard in executions table
-	CreateShardRequest struct {
-		ShardInfo *persistencespb.ShardInfo
+	// GetOrCreateShardRequest is used to get shard information, or supply
+	// initial information to create a shard in executions table
+	GetOrCreateShardRequest struct {
+		ShardID          int32
+		CreateIfMissing  bool
+		InitialShardInfo *persistencespb.ShardInfo
 	}
 
-	// GetShardRequest is used to get shard information
-	GetShardRequest struct {
-		ShardID int32
-	}
-
-	// GetShardResponse is the response to GetShard
+	// GetShardResponse is the response to GetOrCreateShard
 	GetShardResponse struct {
 		ShardInfo *persistencespb.ShardInfo
 	}
@@ -1030,8 +1028,7 @@ type (
 	ShardManager interface {
 		Closeable
 		GetName() string
-		CreateShard(request *CreateShardRequest) error
-		GetShard(request *GetShardRequest) (*GetShardResponse, error)
+		GetOrCreateShard(request *GetOrCreateShardRequest) (*GetShardResponse, error)
 		UpdateShard(request *UpdateShardRequest) error
 	}
 

--- a/common/persistence/dataInterfaces_mock.go
+++ b/common/persistence/dataInterfaces_mock.go
@@ -104,20 +104,6 @@ func (mr *MockShardManagerMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockShardManager)(nil).Close))
 }
 
-// CreateShard mocks base method.
-func (m *MockShardManager) CreateShard(request *CreateShardRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateShard", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateShard indicates an expected call of CreateShard.
-func (mr *MockShardManagerMockRecorder) CreateShard(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateShard", reflect.TypeOf((*MockShardManager)(nil).CreateShard), request)
-}
-
 // GetName mocks base method.
 func (m *MockShardManager) GetName() string {
 	m.ctrl.T.Helper()
@@ -132,19 +118,19 @@ func (mr *MockShardManagerMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockShardManager)(nil).GetName))
 }
 
-// GetShard mocks base method.
-func (m *MockShardManager) GetShard(request *GetShardRequest) (*GetShardResponse, error) {
+// GetOrCreateShard mocks base method.
+func (m *MockShardManager) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetShardResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShard", request)
+	ret := m.ctrl.Call(m, "GetOrCreateShard", request)
 	ret0, _ := ret[0].(*GetShardResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetShard indicates an expected call of GetShard.
-func (mr *MockShardManagerMockRecorder) GetShard(request interface{}) *gomock.Call {
+// GetOrCreateShard indicates an expected call of GetOrCreateShard.
+func (mr *MockShardManagerMockRecorder) GetOrCreateShard(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShard", reflect.TypeOf((*MockShardManager)(nil).GetShard), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateShard", reflect.TypeOf((*MockShardManager)(nil).GetOrCreateShard), request)
 }
 
 // UpdateShard mocks base method.

--- a/common/persistence/dataInterfaces_mock.go
+++ b/common/persistence/dataInterfaces_mock.go
@@ -119,10 +119,10 @@ func (mr *MockShardManagerMockRecorder) GetName() *gomock.Call {
 }
 
 // GetOrCreateShard mocks base method.
-func (m *MockShardManager) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetShardResponse, error) {
+func (m *MockShardManager) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrCreateShard", request)
-	ret0, _ := ret[0].(*GetShardResponse)
+	ret0, _ := ret[0].(*GetOrCreateShardResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -114,10 +114,10 @@ func (mr *MockShardStoreMockRecorder) GetName() *gomock.Call {
 }
 
 // GetShard mocks base method.
-func (m *MockShardStore) GetShard(request *persistence.InternalGetShardRequest) (*persistence.InternalGetShardResponse, error) {
+func (m *MockShardStore) GetShard(request *persistence.InternalGetShardRequest) (*persistence.InternalGetOrCreateShardResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetShard", request)
-	ret0, _ := ret[0].(*persistence.InternalGetShardResponse)
+	ret0, _ := ret[0].(*persistence.InternalGetOrCreateShardResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -71,20 +71,6 @@ func (mr *MockShardStoreMockRecorder) Close() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockShardStore)(nil).Close))
 }
 
-// CreateShard mocks base method.
-func (m *MockShardStore) CreateShard(request *persistence.InternalCreateShardRequest) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateShard", request)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// CreateShard indicates an expected call of CreateShard.
-func (mr *MockShardStoreMockRecorder) CreateShard(request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateShard", reflect.TypeOf((*MockShardStore)(nil).CreateShard), request)
-}
-
 // GetClusterName mocks base method.
 func (m *MockShardStore) GetClusterName() string {
 	m.ctrl.T.Helper()
@@ -113,19 +99,19 @@ func (mr *MockShardStoreMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockShardStore)(nil).GetName))
 }
 
-// GetShard mocks base method.
-func (m *MockShardStore) GetShard(request *persistence.InternalGetShardRequest) (*persistence.InternalGetOrCreateShardResponse, error) {
+// GetOrCreateShard mocks base method.
+func (m *MockShardStore) GetOrCreateShard(request *persistence.InternalGetOrCreateShardRequest) (*persistence.InternalGetOrCreateShardResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShard", request)
+	ret := m.ctrl.Call(m, "GetOrCreateShard", request)
 	ret0, _ := ret[0].(*persistence.InternalGetOrCreateShardResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetShard indicates an expected call of GetShard.
-func (mr *MockShardStoreMockRecorder) GetShard(request interface{}) *gomock.Call {
+// GetOrCreateShard indicates an expected call of GetOrCreateShard.
+func (mr *MockShardStoreMockRecorder) GetOrCreateShard(request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShard", reflect.TypeOf((*MockShardStore)(nil).GetShard), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateShard", reflect.TypeOf((*MockShardStore)(nil).GetOrCreateShard), request)
 }
 
 // UpdateShard mocks base method.

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -3123,10 +3123,17 @@ func (s *ExecutionManagerSuite) TestCreateGetShardBackfill() {
 		ClusterReplicationLevel: map[string]int64{},
 		ReplicationDlqAckLevel:  map[string]int64{},
 	}
-	createRequest := &p.CreateShardRequest{
-		ShardInfo: shardInfo,
+	request := &p.GetOrCreateShardRequest{
+		ShardID:          shardID,
+		CreateIfMissing:  false,
+		InitialShardInfo: shardInfo,
 	}
-	s.Nil(s.ShardMgr.CreateShard(createRequest))
+	resp, err := s.ShardMgr.GetOrCreateShard(request)
+	s.Error(err) // initially missing
+
+	request.CreateIfMissing = true
+	resp, err = s.ShardMgr.GetOrCreateShard(request)
+	s.NoError(err) // now it's created
 
 	shardInfo.ClusterTransferAckLevel = map[string]int64{
 		s.ClusterMetadata.GetCurrentClusterName(): currentClusterTransferAck,
@@ -3134,7 +3141,7 @@ func (s *ExecutionManagerSuite) TestCreateGetShardBackfill() {
 	shardInfo.ClusterTimerAckLevel = map[string]*time.Time{
 		s.ClusterMetadata.GetCurrentClusterName(): currentClusterTimerAck,
 	}
-	resp, err := s.ShardMgr.GetShard(&p.GetShardRequest{ShardID: shardID})
+	resp, err = s.ShardMgr.GetOrCreateShard(&p.GetOrCreateShardRequest{ShardID: shardID})
 	s.NoError(err)
 	s.True(timeComparatorGoPtr(shardInfo.UpdateTime, resp.ShardInfo.UpdateTime, TimePrecision))
 	s.True(timeComparatorGoPtr(shardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], resp.ShardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], TimePrecision))
@@ -3179,11 +3186,12 @@ func (s *ExecutionManagerSuite) TestCreateGetUpdateGetShard() {
 		ClusterReplicationLevel:      map[string]int64{},
 		ReplicationDlqAckLevel:       map[string]int64{},
 	}
-	createRequest := &p.CreateShardRequest{
-		ShardInfo: shardInfo,
+	createRequest := &p.GetOrCreateShardRequest{
+		ShardID:          shardID,
+		InitialShardInfo: shardInfo,
+		CreateIfMissing:  true,
 	}
-	s.Nil(s.ShardMgr.CreateShard(createRequest))
-	resp, err := s.ShardMgr.GetShard(&p.GetShardRequest{ShardID: shardID})
+	resp, err := s.ShardMgr.GetOrCreateShard(createRequest)
 	s.NoError(err)
 	s.True(timeComparatorGoPtr(shardInfo.UpdateTime, resp.ShardInfo.UpdateTime, TimePrecision))
 	s.True(timeComparatorGoPtr(shardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], resp.ShardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], TimePrecision))
@@ -3228,7 +3236,7 @@ func (s *ExecutionManagerSuite) TestCreateGetUpdateGetShard() {
 	}
 	s.Nil(s.ShardMgr.UpdateShard(updateRequest))
 
-	resp, err = s.ShardMgr.GetShard(&p.GetShardRequest{ShardID: shardID})
+	resp, err = s.ShardMgr.GetOrCreateShard(&p.GetOrCreateShardRequest{ShardID: shardID})
 	s.NoError(err)
 	s.True(timeComparatorGoPtr(shardInfo.UpdateTime, resp.ShardInfo.UpdateTime, TimePrecision))
 	s.True(timeComparatorGoPtr(shardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], resp.ShardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], TimePrecision))

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -254,33 +254,22 @@ func (s *TestBase) fatalOnError(msg string, err error) {
 	}
 }
 
-// CreateShard is a utility method to create the shard using persistence layer
-func (s *TestBase) CreateShard(shardID int32, owner string, rangeID int64) error {
+// GetOrCreateShard is a utility method to get/create the shard using persistence layer
+func (s *TestBase) GetOrCreateShard(shardID int32, owner string, rangeID int64, createIfMissing bool) (*persistencespb.ShardInfo, error) {
 	info := &persistencespb.ShardInfo{
 		ShardId: shardID,
 		Owner:   owner,
 		RangeId: rangeID,
 	}
-
-	_, err := s.ShardMgr.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+	resp, err := s.ShardMgr.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
 		ShardID:          shardID,
+		CreateIfMissing:  createIfMissing,
 		InitialShardInfo: info,
-		CreateIfMissing:  true,
 	})
-	return err
-}
-
-// GetShard is a utility method to get the shard using persistence layer
-func (s *TestBase) GetShard(shardID int32) (*persistencespb.ShardInfo, error) {
-	response, err := s.ShardMgr.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
-		ShardID: shardID,
-	})
-
 	if err != nil {
 		return nil, err
 	}
-
-	return response.ShardInfo, nil
+	return resp.ShardInfo, nil
 }
 
 // UpdateShard is a utility method to update the shard using persistence layer

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -236,7 +236,11 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	}
 
 	s.TaskIDGenerator = &TestTransferTaskIDGenerator{}
-	err = s.ShardMgr.CreateShard(&persistence.CreateShardRequest{ShardInfo: s.ShardInfo})
+	_, err = s.ShardMgr.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+		ShardID:          shardID,
+		InitialShardInfo: s.ShardInfo,
+		CreateIfMissing:  true,
+	})
 	s.fatalOnError("CreateShard", err)
 
 	queue, err := factory.NewNamespaceReplicationQueue()
@@ -258,14 +262,17 @@ func (s *TestBase) CreateShard(shardID int32, owner string, rangeID int64) error
 		RangeId: rangeID,
 	}
 
-	return s.ShardMgr.CreateShard(&persistence.CreateShardRequest{
-		ShardInfo: info,
+	_, err := s.ShardMgr.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+		ShardID:          shardID,
+		InitialShardInfo: info,
+		CreateIfMissing:  true,
 	})
+	return err
 }
 
 // GetShard is a utility method to get the shard using persistence layer
 func (s *TestBase) GetShard(shardID int32) (*persistencespb.ShardInfo, error) {
-	response, err := s.ShardMgr.GetShard(&persistence.GetShardRequest{
+	response, err := s.ShardMgr.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
 		ShardID: shardID,
 	})
 

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -55,8 +55,7 @@ type (
 		Closeable
 		GetName() string
 		GetClusterName() string
-		CreateShard(request *InternalCreateShardRequest) error
-		GetShard(request *InternalGetShardRequest) (*InternalGetShardResponse, error)
+		GetOrCreateShard(request *InternalGetOrCreateShardRequest) (*InternalGetOrCreateShardResponse, error)
 		UpdateShard(request *InternalUpdateShardRequest) error
 	}
 
@@ -203,20 +202,16 @@ type (
 		Version int64
 	}
 
-	// InternalCreateShardRequest is used by ShardStore to create new shard
-	InternalCreateShardRequest struct {
-		ShardID   int32
-		RangeID   int64
-		ShardInfo *commonpb.DataBlob
+	// InternalGetOrCreateShardRequest is used by ShardStore to retrieve or create a shard.
+	// GetOrCreateShard should: if shard exists, return it. If not, and CreateShardInfo != nil,
+	// call it and create the shard with the initial shardInfo and rangeID. Otherwise return error.
+	InternalGetOrCreateShardRequest struct {
+		ShardID         int32
+		CreateShardInfo func() (rangeID int64, shardInfo *commonpb.DataBlob, err error)
 	}
 
-	// InternalGetShardRequest is used by ShardStore to retrieve a shard
-	InternalGetShardRequest struct {
-		ShardID int32
-	}
-
-	// InternalGetShardResponse is the response to GetShard
-	InternalGetShardResponse struct {
+	// InternalGetOrCreateShardResponse is the response to GetShard
+	InternalGetOrCreateShardResponse struct {
 		ShardInfo *commonpb.DataBlob
 	}
 

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -148,7 +148,7 @@ func (p *shardPersistenceClient) GetName() string {
 }
 
 func (p *shardPersistenceClient) GetOrCreateShard(
-	request *GetOrCreateShardRequest) (*GetShardResponse, error) {
+	request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetOrCreateShardScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetOrCreateShardScope, metrics.PersistenceLatency)

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -147,30 +147,16 @@ func (p *shardPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *shardPersistenceClient) CreateShard(request *CreateShardRequest) error {
-	p.metricClient.IncCounter(metrics.PersistenceCreateShardScope, metrics.PersistenceRequests)
+func (p *shardPersistenceClient) GetOrCreateShard(
+	request *GetOrCreateShardRequest) (*GetShardResponse, error) {
+	p.metricClient.IncCounter(metrics.PersistenceGetOrCreateShardScope, metrics.PersistenceRequests)
 
-	sw := p.metricClient.StartTimer(metrics.PersistenceCreateShardScope, metrics.PersistenceLatency)
-	err := p.persistence.CreateShard(request)
+	sw := p.metricClient.StartTimer(metrics.PersistenceGetOrCreateShardScope, metrics.PersistenceLatency)
+	response, err := p.persistence.GetOrCreateShard(request)
 	sw.Stop()
 
 	if err != nil {
-		p.updateErrorMetric(metrics.PersistenceCreateShardScope, err)
-	}
-
-	return err
-}
-
-func (p *shardPersistenceClient) GetShard(
-	request *GetShardRequest) (*GetShardResponse, error) {
-	p.metricClient.IncCounter(metrics.PersistenceGetShardScope, metrics.PersistenceRequests)
-
-	sw := p.metricClient.StartTimer(metrics.PersistenceGetShardScope, metrics.PersistenceLatency)
-	response, err := p.persistence.GetShard(request)
-	sw.Stop()
-
-	if err != nil {
-		p.updateErrorMetric(metrics.PersistenceGetShardScope, err)
+		p.updateErrorMetric(metrics.PersistenceGetOrCreateShardScope, err)
 	}
 
 	return response, err

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -140,7 +140,7 @@ func (p *shardRateLimitedPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *shardRateLimitedPersistenceClient) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetShardResponse, error) {
+func (p *shardRateLimitedPersistenceClient) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -140,21 +140,12 @@ func (p *shardRateLimitedPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *shardRateLimitedPersistenceClient) CreateShard(request *CreateShardRequest) error {
-	if ok := p.rateLimiter.Allow(); !ok {
-		return ErrPersistenceLimitExceeded
-	}
-
-	err := p.persistence.CreateShard(request)
-	return err
-}
-
-func (p *shardRateLimitedPersistenceClient) GetShard(request *GetShardRequest) (*GetShardResponse, error) {
+func (p *shardRateLimitedPersistenceClient) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetShardResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	response, err := p.persistence.GetShard(request)
+	response, err := p.persistence.GetOrCreateShard(request)
 	return response, err
 }
 

--- a/common/persistence/shard_manager.go
+++ b/common/persistence/shard_manager.go
@@ -55,7 +55,7 @@ func (m *shardManagerImpl) GetName() string {
 	return m.shardStore.GetName()
 }
 
-func (m *shardManagerImpl) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetShardResponse, error) {
+func (m *shardManagerImpl) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
 	var createShardInfo func() (int64, *commonpb.DataBlob, error)
 	if request.CreateIfMissing {
 		createShardInfo = func() (int64, *commonpb.DataBlob, error) {
@@ -83,7 +83,7 @@ func (m *shardManagerImpl) GetOrCreateShard(request *GetOrCreateShardRequest) (*
 	if err != nil {
 		return nil, err
 	}
-	return &GetShardResponse{
+	return &GetOrCreateShardResponse{
 		ShardInfo: shardInfo,
 	}, nil
 }

--- a/common/persistence/sql/shard.go
+++ b/common/persistence/sql/shard.go
@@ -94,7 +94,7 @@ func (m *sqlShardStore) GetOrCreateShard(
 		}, nil
 	} else if m.Db.IsDupEntryError(err) {
 		// conflict, try again
-		request.CreateShardInfo = nil
+		request.CreateShardInfo = nil // prevent loop
 		return m.GetOrCreateShard(request)
 	} else {
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetOrCreateShard: failed to insert into shards table. Error: %v", err))

--- a/common/persistence/sql/shard.go
+++ b/common/persistence/sql/shard.go
@@ -57,36 +57,9 @@ func (m *sqlShardStore) GetClusterName() string {
 	return m.currentClusterName
 }
 
-func (m *sqlShardStore) CreateShard(
-	request *persistence.InternalCreateShardRequest,
-) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
-	if _, err := m.GetShard(&persistence.InternalGetShardRequest{
-		ShardID: request.ShardID,
-	}); err == nil {
-		return &persistence.ShardAlreadyExistError{
-			Msg: fmt.Sprintf("CreateShard operaiton failed. Shard with ID %v already exists.", request.ShardID),
-		}
-	}
-
-	row := &sqlplugin.ShardsRow{
-		ShardID:      request.ShardID,
-		RangeID:      request.RangeID,
-		Data:         request.ShardInfo.Data,
-		DataEncoding: request.ShardInfo.EncodingType.String(),
-	}
-
-	if _, err := m.Db.InsertIntoShards(ctx, row); err != nil {
-		return serviceerror.NewUnavailable(fmt.Sprintf("CreateShard operation failed. Failed to insert into shards table. Error: %v", err))
-	}
-
-	return nil
-}
-
-func (m *sqlShardStore) GetShard(
-	request *persistence.InternalGetShardRequest,
-) (*persistence.InternalGetShardResponse, error) {
+func (m *sqlShardStore) GetOrCreateShard(
+	request *persistence.InternalGetOrCreateShardRequest,
+) (*persistence.InternalGetOrCreateShardResponse, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	row, err := m.Db.SelectFromShards(ctx, sqlplugin.ShardsFilter{
@@ -94,13 +67,35 @@ func (m *sqlShardStore) GetShard(
 	})
 	switch err {
 	case nil:
-		return &persistence.InternalGetShardResponse{
+		return &persistence.InternalGetOrCreateShardResponse{
 			ShardInfo: persistence.NewDataBlob(row.Data, row.DataEncoding),
 		}, nil
 	case sql.ErrNoRows:
-		return nil, serviceerror.NewNotFound(fmt.Sprintf("GetShard operation failed. Shard with ID %v not found. Error: %v", request.ShardID, err))
+		break
 	default:
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetShard operation failed. Failed to get record. ShardId: %v. Error: %v", request.ShardID, err))
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetOrCreateShard: failed to get ShardID %v. Error: %v", request.ShardID, err))
+	}
+
+	if request.CreateShardInfo == nil {
+		return nil, serviceerror.NewNotFound(fmt.Sprintf("GetOrCreateShard: ShardID %v not found. Error: %v", request.ShardID, err))
+	}
+
+	rangeID, shardInfo, err := request.CreateShardInfo()
+	row = &sqlplugin.ShardsRow{
+		ShardID:      request.ShardID,
+		RangeID:      rangeID,
+		Data:         shardInfo.Data,
+		DataEncoding: shardInfo.EncodingType.String(),
+	}
+	_, err = m.Db.InsertIntoShards(ctx, row)
+	switch err {
+	case nil:
+		return &persistence.InternalGetOrCreateShardResponse{
+			ShardInfo: shardInfo,
+		}, nil
+	// TODO: handle conflict
+	default:
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetOrCreateShard: failed to insert into shards table. Error: %v", err))
 	}
 }
 

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -145,7 +145,6 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 
 	testBase := persistencetests.NewTestBase(&options.Persistence)
 	testBase.Setup(clusterMetadataConfig)
-	setupShards(testBase, options.HistoryConfig.NumHistoryShards, logger)
 	archiverBase := newArchiverBase(options.EnableArchival, logger)
 
 	pConfig := testBase.DefaultTestCluster.Config()
@@ -222,15 +221,6 @@ func newPProfInitializerImpl(logger log.Logger, port int) *pprof.PProfInitialize
 			Port: port,
 		},
 		Logger: logger,
-	}
-}
-
-func setupShards(testBase persistencetests.TestBase, numHistoryShards int32, logger log.Logger) {
-	for shardID := int32(1); shardID <= numHistoryShards; shardID++ {
-		err := testBase.CreateShard(int32(shardID), "", 0)
-		if err != nil {
-			logger.Fatal("Failed to create shard", tag.Error(err))
-		}
 	}
 }
 

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -591,7 +591,7 @@ func (h *Handler) CloseShard(_ context.Context, request *historyservice.CloseSha
 // GetShard gets a shard hosted by this instance
 func (h *Handler) GetShard(_ context.Context, request *historyservice.GetShardRequest) (_ *historyservice.GetShardResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
-	resp, err := h.controller.GetShardManager().GetShard(&persistence.GetShardRequest{
+	resp, err := h.controller.GetShardManager().GetOrCreateShard(&persistence.GetOrCreateShardRequest{
 		ShardID: request.ShardId,
 	})
 	if err != nil {

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1348,32 +1348,6 @@ func (s *ContextImpl) transitionLocked(request contextRequest) {
 	)
 }
 
-func (s *ContextImpl) loadOrCreateShardMetadata() (*persistence.ShardInfoWithFailover, error) {
-	resp, err := s.GetShardManager().GetShard(&persistence.GetShardRequest{
-		ShardID: s.shardID,
-	})
-
-	if _, ok := err.(*serviceerror.NotFound); ok {
-		// EntityNotExistsError: doesn't exist in db yet, try to create it
-		req := &persistence.CreateShardRequest{
-			ShardInfo: &persistencespb.ShardInfo{
-				ShardId: s.shardID,
-			},
-		}
-		err = s.GetShardManager().CreateShard(req)
-		if err != nil {
-			return nil, err
-		}
-		return &persistence.ShardInfoWithFailover{ShardInfo: req.ShardInfo}, nil
-	}
-
-	if err != nil {
-		return nil, err
-	}
-
-	return &persistence.ShardInfoWithFailover{ShardInfo: resp.ShardInfo}, nil
-}
-
 func (s *ContextImpl) loadShardMetadata(ownershipChanged *bool) error {
 	// Only have to do this once, we can just re-acquire the rangeid lock after that
 	s.rLock()
@@ -1390,13 +1364,18 @@ func (s *ContextImpl) loadShardMetadata(ownershipChanged *bool) error {
 	s.rUnlock()
 
 	// We don't have any shardInfo yet, load it (outside of context rwlock)
-
-	shardInfo, err := s.loadOrCreateShardMetadata()
+	resp, err := s.GetShardManager().GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+		ShardID:         s.shardID,
+		CreateIfMissing: true,
+	})
 	if err != nil {
 		s.logger.Error("Failed to load shard", tag.Error(err))
 		return err
 	}
+	shardInfo := &persistence.ShardInfoWithFailover{ShardInfo: resp.ShardInfo}
 
+	// shardInfo is a fresh value, so we don't really need to copy, but
+	// copyShardInfo also ensures that all maps are non-nil
 	updatedShardInfo := copyShardInfo(shardInfo)
 	*ownershipChanged = shardInfo.Owner != s.GetHostInfo().Identity()
 	updatedShardInfo.Owner = s.GetHostInfo().Identity()

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -123,7 +123,10 @@ func (s *controllerSuite) TestAcquireShardSuccess() {
 			s.mockHistoryEngine.EXPECT().Start().Return()
 			s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 			s.mockEngineFactory.EXPECT().CreateEngine(gomock.Any()).Return(s.mockHistoryEngine)
-			s.mockShardManager.EXPECT().GetShard(&persistence.GetShardRequest{ShardID: shardID}).Return(
+			s.mockShardManager.EXPECT().GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+				ShardID:         shardID,
+				CreateIfMissing: true,
+			}).Return(
 				&persistence.GetShardResponse{
 					ShardInfo: &persistencespb.ShardInfo{
 						ShardId:             shardID,
@@ -205,7 +208,10 @@ func (s *controllerSuite) TestAcquireShardsConcurrently() {
 			s.mockHistoryEngine.EXPECT().Start().Return()
 			s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 			s.mockEngineFactory.EXPECT().CreateEngine(gomock.Any()).Return(s.mockHistoryEngine)
-			s.mockShardManager.EXPECT().GetShard(&persistence.GetShardRequest{ShardID: shardID}).Return(
+			s.mockShardManager.EXPECT().GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+				ShardID:         shardID,
+				CreateIfMissing: true,
+			}).Return(
 				&persistence.GetShardResponse{
 					ShardInfo: &persistencespb.ShardInfo{
 						ShardId:             shardID,
@@ -294,7 +300,10 @@ func (s *controllerSuite) TestAcquireShardRenewSuccess() {
 		s.mockHistoryEngine.EXPECT().Start().Return()
 		s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 		s.mockEngineFactory.EXPECT().CreateEngine(gomock.Any()).Return(s.mockHistoryEngine)
-		s.mockShardManager.EXPECT().GetShard(&persistence.GetShardRequest{ShardID: shardID}).Return(
+		s.mockShardManager.EXPECT().GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+			ShardID:         shardID,
+			CreateIfMissing: true,
+		}).Return(
 			&persistence.GetShardResponse{
 				ShardInfo: &persistencespb.ShardInfo{
 					ShardId:             shardID,
@@ -368,7 +377,10 @@ func (s *controllerSuite) TestAcquireShardRenewLookupFailed() {
 		s.mockHistoryEngine.EXPECT().Start().Return()
 		s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 		s.mockEngineFactory.EXPECT().CreateEngine(gomock.Any()).Return(s.mockHistoryEngine)
-		s.mockShardManager.EXPECT().GetShard(&persistence.GetShardRequest{ShardID: shardID}).Return(
+		s.mockShardManager.EXPECT().GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+			ShardID:         shardID,
+			CreateIfMissing: true,
+		}).Return(
 			&persistence.GetShardResponse{
 				ShardInfo: &persistencespb.ShardInfo{
 					ShardId:             shardID,
@@ -577,7 +589,10 @@ func (s *controllerSuite) setupMocksForAcquireShard(shardID int32, mockEngine *M
 	mockEngine.EXPECT().Start()
 	s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 	s.mockEngineFactory.EXPECT().CreateEngine(newContextMatcher(shardID)).Return(mockEngine)
-	s.mockShardManager.EXPECT().GetShard(&persistence.GetShardRequest{ShardID: shardID}).Return(
+	s.mockShardManager.EXPECT().GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+		ShardID:         shardID,
+		CreateIfMissing: true,
+	}).Return(
 		&persistence.GetShardResponse{
 			ShardInfo: &persistencespb.ShardInfo{
 				ShardId:             shardID,

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -127,7 +127,7 @@ func (s *controllerSuite) TestAcquireShardSuccess() {
 				ShardID:         shardID,
 				CreateIfMissing: true,
 			}).Return(
-				&persistence.GetShardResponse{
+				&persistence.GetOrCreateShardResponse{
 					ShardInfo: &persistencespb.ShardInfo{
 						ShardId:             shardID,
 						Owner:               s.hostInfo.Identity(),
@@ -212,7 +212,7 @@ func (s *controllerSuite) TestAcquireShardsConcurrently() {
 				ShardID:         shardID,
 				CreateIfMissing: true,
 			}).Return(
-				&persistence.GetShardResponse{
+				&persistence.GetOrCreateShardResponse{
 					ShardInfo: &persistencespb.ShardInfo{
 						ShardId:             shardID,
 						Owner:               s.hostInfo.Identity(),
@@ -304,7 +304,7 @@ func (s *controllerSuite) TestAcquireShardRenewSuccess() {
 			ShardID:         shardID,
 			CreateIfMissing: true,
 		}).Return(
-			&persistence.GetShardResponse{
+			&persistence.GetOrCreateShardResponse{
 				ShardInfo: &persistencespb.ShardInfo{
 					ShardId:             shardID,
 					Owner:               s.hostInfo.Identity(),
@@ -381,7 +381,7 @@ func (s *controllerSuite) TestAcquireShardRenewLookupFailed() {
 			ShardID:         shardID,
 			CreateIfMissing: true,
 		}).Return(
-			&persistence.GetShardResponse{
+			&persistence.GetOrCreateShardResponse{
 				ShardInfo: &persistencespb.ShardInfo{
 					ShardId:             shardID,
 					Owner:               s.hostInfo.Identity(),
@@ -593,7 +593,7 @@ func (s *controllerSuite) setupMocksForAcquireShard(shardID int32, mockEngine *M
 		ShardID:         shardID,
 		CreateIfMissing: true,
 	}).Return(
-		&persistence.GetShardResponse{
+		&persistence.GetOrCreateShardResponse{
 			ShardInfo: &persistencespb.ShardInfo{
 				ShardId:             shardID,
 				Owner:               s.hostInfo.Identity(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Persistence shard interface is almost always used with "get or create" semantics instead of separate get and create, so make that the official interface. There's an admin rpc to get without create, which is still supported.

<!-- Tell your future self why have you made these changes -->
**Why?**

Simpler code (net line count minus 89 lines!), allows for optimizations in persistence.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit tests, integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
