### PR TITLE
Pin MySQL version to 8.0.19

### DIFF
--- a/common/persistence/sql/sqlplugin/tests/visibility_test.go
+++ b/common/persistence/sql/sqlplugin/tests/visibility_test.go
@@ -524,6 +524,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 			break
 		}
 	}
+	s.Len(rows, len(visibilities))
 	s.sortByStartTimeDescRunIDAsc(visibilities)
 	for index := range rows {
 		rows[index].NamespaceID = namespaceID.String()
@@ -647,7 +648,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 			break
 		}
 	}
-
+	s.Len(rows, len(visibilities))
 	s.sortByCloseTimeDescRunIDAsc(visibilities)
 	for index := range rows {
 		rows[index].NamespaceID = namespaceID.String()
@@ -772,6 +773,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 			break
 		}
 	}
+	s.Len(rows, len(visibilities))
 	s.sortByStartTimeDescRunIDAsc(visibilities)
 	for index := range rows {
 		rows[index].NamespaceID = namespaceID.String()
@@ -895,7 +897,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 			break
 		}
 	}
-
+	s.Len(rows, len(visibilities))
 	s.sortByCloseTimeDescRunIDAsc(visibilities)
 	for index := range rows {
 		rows[index].NamespaceID = namespaceID.String()
@@ -1020,6 +1022,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusOpen_Multip
 			break
 		}
 	}
+	s.Len(rows, len(visibilities))
 	s.sortByStartTimeDescRunIDAsc(visibilities)
 	for index := range rows {
 		rows[index].NamespaceID = namespaceID.String()
@@ -1151,7 +1154,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusClose_Multi
 			break
 		}
 	}
-
+	s.Len(rows, len(visibilities))
 	s.sortByCloseTimeDescRunIDAsc(visibilities)
 	for index := range rows {
 		rows[index].NamespaceID = namespaceID.String()
@@ -1290,6 +1293,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeMul
 		}
 	}
 
+	s.Len(rows, len(visibilities))
 	s.sortByCloseTimeDescRunIDAsc(visibilities)
 	for index := range rows {
 		rows[index].NamespaceID = namespaceID.String()

--- a/develop/buildkite/docker-compose.yml
+++ b/develop/buildkite/docker-compose.yml
@@ -9,7 +9,7 @@ services:
           - cassandra
 
   mysql:
-    image: mysql:8.0.11
+    image: mysql:8.0.19
     environment:
       MYSQL_ROOT_PASSWORD: root
     volumes:

--- a/develop/buildkite/docker-compose.yml
+++ b/develop/buildkite/docker-compose.yml
@@ -9,7 +9,7 @@ services:
           - cassandra
 
   mysql:
-    image: mysql:8.0
+    image: mysql:8.0.11
     environment:
       MYSQL_ROOT_PASSWORD: root
     volumes:

--- a/develop/docker-compose/docker-compose.yml
+++ b/develop/docker-compose/docker-compose.yml
@@ -6,7 +6,7 @@ version: "3.5"
 
 services:
   mysql:
-    image: mysql:8.0.11
+    image: mysql:8.0.19
     container_name: temporal-dev-mysql
     ports:
       - "3306:3306"

--- a/develop/docker-compose/docker-compose.yml
+++ b/develop/docker-compose/docker-compose.yml
@@ -6,7 +6,7 @@ version: "3.5"
 
 services:
   mysql:
-    image: mysql:8.0
+    image: mysql:8.0.11
     container_name: temporal-dev-mysql
     ports:
       - "3306:3306"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Pin MySQL version to 8.0.19.

<!-- Tell your future self why have you made these changes -->
**Why?**
8.0.19 is the first GA version of MySQL 8 which works fine and pass all tests. Previous versions don't work (visibility unit test fail while pagination). Using it for development environment as minimus MySQL 8 supported version.

I think previous versions don't work because of:
> The removal of a subquery because the condition in which it occurred was always false was expected to be performed during resolution, but when the subquery did not involve any tables, the server executed it while resolving it. This resulted in the failure of a subsequent check to confirm that the subquery was only being resolved and not yet optimized. Now in such cases, the server also checks to see whether the subquery was already executed. (Bug #30273827)

which was fix in [8.0.19](https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-19.html).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests locally and on buildkite.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.