### PR TITLE
Add testhelper package to create temp file and dir

### DIFF
--- a/common/archiver/filestore/historyArchiver_test.go
+++ b/common/archiver/filestore/historyArchiver_test.go
@@ -27,11 +27,12 @@ package filestore
 import (
 	"context"
 	"errors"
-	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"path"
 	"testing"
 	"time"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"

--- a/common/archiver/filestore/historyArchiver_test.go
+++ b/common/archiver/filestore/historyArchiver_test.go
@@ -27,6 +27,7 @@ package filestore
 import (
 	"context"
 	"errors"
+	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"path"
 	"testing"
@@ -308,9 +309,7 @@ func (s *historyArchiverSuite) TestArchive_Success() {
 		historyIterator.EXPECT().HasNext().Return(false),
 	)
 
-	dir, err := os.MkdirTemp("", "TestArchiveSingleRead")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestArchiveSingleRead")
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
 	request := &archiver.ArchiveHistoryRequest{
@@ -493,9 +492,7 @@ func (s *historyArchiverSuite) TestArchiveAndGet() {
 		historyIterator.EXPECT().HasNext().Return(false),
 	)
 
-	dir, err := os.MkdirTemp("", "TestArchiveAndGet")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestArchiveAndGet")
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
 	archiveRequest := &archiver.ArchiveHistoryRequest{

--- a/common/archiver/filestore/util_test.go
+++ b/common/archiver/filestore/util_test.go
@@ -25,11 +25,12 @@
 package filestore
 
 import (
-	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/common/archiver/filestore/util_test.go
+++ b/common/archiver/filestore/util_test.go
@@ -25,6 +25,7 @@
 package filestore
 
 import (
+	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"path/filepath"
 	"testing"
@@ -59,9 +60,7 @@ func (s *UtilSuite) SetupTest() {
 }
 
 func (s *UtilSuite) TestFileExists() {
-	dir, err := os.MkdirTemp("", "TestFileExists")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestFileExists")
 	s.assertDirectoryExists(dir)
 
 	exists, err := fileExists(dir)
@@ -80,9 +79,7 @@ func (s *UtilSuite) TestFileExists() {
 }
 
 func (s *UtilSuite) TestDirectoryExists() {
-	dir, err := os.MkdirTemp("", "TestDirectoryExists")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestDirectoryExists")
 	s.assertDirectoryExists(dir)
 
 	subdir := "subdir"
@@ -99,9 +96,7 @@ func (s *UtilSuite) TestDirectoryExists() {
 }
 
 func (s *UtilSuite) TestMkdirAll() {
-	dir, err := os.MkdirTemp("", "TestMkdirAll")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestMkdirAll")
 	s.assertDirectoryExists(dir)
 
 	s.NoError(mkdirAll(dir, testDirMode))
@@ -120,9 +115,7 @@ func (s *UtilSuite) TestMkdirAll() {
 }
 
 func (s *UtilSuite) TestWriteFile() {
-	dir, err := os.MkdirTemp("", "TestWriteFile")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestWriteFile")
 	s.assertDirectoryExists(dir)
 
 	filename := "test-file-name"
@@ -140,9 +133,7 @@ func (s *UtilSuite) TestWriteFile() {
 }
 
 func (s *UtilSuite) TestReadFile() {
-	dir, err := os.MkdirTemp("", "TestReadFile")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestReadFile")
 	s.assertDirectoryExists(dir)
 
 	filename := "test-file-name"
@@ -159,9 +150,7 @@ func (s *UtilSuite) TestReadFile() {
 }
 
 func (s *UtilSuite) TestListFilesByPrefix() {
-	dir, err := os.MkdirTemp("", "TestListFiles")
-	s.NoError(err)
-	defer os.Remove(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestListFiles")
 	s.assertDirectoryExists(dir)
 
 	filename := "test-file-name"
@@ -224,9 +213,7 @@ func (s *UtilSuite) TestEncodeDecodeHistoryBatches() {
 }
 
 func (s *UtilSuite) TestValidateDirPath() {
-	dir, err := os.MkdirTemp("", "TestValidateDirPath")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestValidateDirPath")
 	s.assertDirectoryExists(dir)
 	filename := "test-file-name"
 	s.createFile(dir, filename)

--- a/common/archiver/filestore/visibilityArchiver_test.go
+++ b/common/archiver/filestore/visibilityArchiver_test.go
@@ -27,11 +27,12 @@ package filestore
 import (
 	"context"
 	"errors"
-	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"path"
 	"testing"
 	"time"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"

--- a/common/archiver/filestore/visibilityArchiver_test.go
+++ b/common/archiver/filestore/visibilityArchiver_test.go
@@ -27,6 +27,7 @@ package filestore
 import (
 	"context"
 	"errors"
+	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"path"
 	"testing"
@@ -161,9 +162,7 @@ func (s *visibilityArchiverSuite) TestArchive_Fail_NonRetryableErrorOption() {
 }
 
 func (s *visibilityArchiverSuite) TestArchive_Success() {
-	dir, err := os.MkdirTemp("", "TestVisibilityArchive")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestVisibilityArchive")
 
 	visibilityArchiver := s.newTestVisibilityArchiver()
 	closeTimestamp := timestamp.TimeNowPtrUtc()
@@ -469,9 +468,7 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 }
 
 func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
-	dir, err := os.MkdirTemp("", "TestArchiveAndQuery")
-	s.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "TestArchiveAndQuery")
 
 	visibilityArchiver := s.newTestVisibilityArchiver()
 	mockParser := NewMockQueryParser(s.controller)

--- a/common/config/loader_test.go
+++ b/common/config/loader_test.go
@@ -25,9 +25,10 @@
 package config
 
 import (
-	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"testing"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/common/config/loader_test.go
+++ b/common/config/loader_test.go
@@ -25,6 +25,7 @@
 package config
 
 import (
+	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"testing"
 
@@ -59,13 +60,10 @@ func (s *LoaderSuite) SetupTest() {
 }
 
 func (s *LoaderSuite) TestBaseYaml() {
-
-	dir, err := os.MkdirTemp("", "loader.testBaseYaml")
-	s.Nil(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "loader.testBaseYaml")
 
 	data := buildConfig("", "")
-	err = os.WriteFile(path(dir, "base.yaml"), []byte(data), fileMode)
+	err := os.WriteFile(path(dir, "base.yaml"), []byte(data), fileMode)
 	s.Nil(err)
 
 	envs := []string{"", "prod"}
@@ -83,10 +81,7 @@ func (s *LoaderSuite) TestBaseYaml() {
 }
 
 func (s *LoaderSuite) TestHierarchy() {
-
-	dir, err := os.MkdirTemp("", "loader.testHierarchy")
-	s.Nil(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "loader.testHierarchy")
 
 	s.createFile(dir, "base.yaml", "", "")
 	s.createFile(dir, "development.yaml", "development", "")
@@ -112,7 +107,7 @@ func (s *LoaderSuite) TestHierarchy() {
 
 	for _, tc := range testCases {
 		var cfg testConfig
-		err = Load(tc.env, dir, tc.zone, &cfg)
+		err := Load(tc.env, dir, tc.zone, &cfg)
 		s.Nil(err)
 		s.Equal(tc.item1, cfg.Items.Item1)
 		s.Equal(tc.item2, cfg.Items.Item2)

--- a/common/log/zap_logger_test.go
+++ b/common/log/zap_logger_test.go
@@ -27,12 +27,13 @@ package log
 import (
 	"bytes"
 	"fmt"
-	"go.temporal.io/server/tests/testhelper"
 	"io"
 	"os"
 	"strconv"
 	"strings"
 	"testing"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/common/log/zap_logger_test.go
+++ b/common/log/zap_logger_test.go
@@ -27,6 +27,7 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"go.temporal.io/server/tests/testhelper"
 	"io"
 	"os"
 	"strconv"
@@ -64,10 +65,7 @@ func (s *LogSuite) TestParseLogLevel() {
 }
 
 func (s *LogSuite) TestNewLogger() {
-
-	dir, err := os.MkdirTemp("", "config.testNewLogger")
-	s.Nil(err)
-	defer os.RemoveAll(dir)
+	dir := testhelper.MkdirTemp(s.T(), "", "config.testNewLogger")
 
 	cfg := Config{
 		Level:      "info",
@@ -76,9 +74,10 @@ func (s *LogSuite) TestNewLogger() {
 
 	log := BuildZapLogger(cfg)
 	s.NotNil(log)
-	_, err = os.Stat(dir + "/test.log")
+	_, err := os.Stat(dir + "/test.log")
 	s.Nil(err)
 }
+
 func TestDefaultLogger(t *testing.T) {
 	old := os.Stdout // keep backup of the real stdout
 	r, w, _ := os.Pipe()
@@ -165,5 +164,4 @@ func TestEmptyMsg(t *testing.T) {
 	lineNum := fmt.Sprintf("%v", par+1)
 	fmt.Println(out, lineNum)
 	assert.Equal(t, `{"level":"info","msg":"`+defaultMsgForEmpty+`","error":"test error","wf-action":"add-workflow-started-event","logging-call-at":"zap_logger_test.go:`+lineNum+`"}`+"\n", out)
-
 }

--- a/tests/testhelper/io.go
+++ b/tests/testhelper/io.go
@@ -25,9 +25,10 @@
 package testhelper
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // CreateTemp is a helper function which creates a temporary file,

--- a/tests/testhelper/io.go
+++ b/tests/testhelper/io.go
@@ -1,0 +1,57 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package testhelper
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+// CreateTemp is a helper function which creates a temporary file,
+// and it is automatically closed after test is completed
+func CreateTemp(t testing.TB, dir, pattern string) *os.File {
+	t.Helper()
+
+	tempFile, err := os.CreateTemp(dir, pattern)
+	require.NoError(t, err)
+	require.NotNil(t, tempFile)
+
+	t.Cleanup(func() { require.NoError(t, os.Remove(tempFile.Name())) })
+	return tempFile
+}
+
+// MkdirTemp is a helper function which creates a temporary directory,
+// and they are automatically removed after test is completed
+func MkdirTemp(t testing.TB, dir, pattern string) string {
+	t.Helper()
+
+	tempDir, err := os.MkdirTemp(dir, pattern)
+	require.NoError(t, err)
+	require.NotNil(t, tempDir)
+
+	t.Cleanup(func() { require.NoError(t, os.RemoveAll(tempDir)) })
+	return tempDir
+}

--- a/tools/common/schema/test/dbtest.go
+++ b/tools/common/schema/test/dbtest.go
@@ -26,8 +26,8 @@ package test
 
 import (
 	"fmt"
+	"go.temporal.io/server/tests/testhelper"
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -78,15 +78,10 @@ func (tb *DBTestBase) TearDownSuiteBase() {
 
 // RunParseFileTest runs a test against the ParseFile method
 func (tb *DBTestBase) RunParseFileTest(content string) {
-	rootDir, err := os.MkdirTemp("", "dbClientTestDir")
-	tb.Nil(err)
-	defer os.Remove(rootDir)
+	rootDir := testhelper.MkdirTemp(tb.T(), "", "dbClientTestDir")
+	cqlFile := testhelper.CreateTemp(tb.T(), rootDir, "parseCQLTest")
 
-	cqlFile, err := os.CreateTemp(rootDir, "parseCQLTest")
-	tb.Nil(err)
-	defer os.Remove(cqlFile.Name())
-
-	_, err = cqlFile.WriteString(content)
+	_, err := cqlFile.WriteString(content)
 	tb.NoError(err)
 	stmts, err := schema.ParseFile(cqlFile.Name())
 	tb.Nil(err)

--- a/tools/common/schema/test/dbtest.go
+++ b/tools/common/schema/test/dbtest.go
@@ -26,9 +26,10 @@ package test
 
 import (
 	"fmt"
-	"go.temporal.io/server/tests/testhelper"
 	"math/rand"
 	"time"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/tools/common/schema/test/setuptest.go
+++ b/tools/common/schema/test/setuptest.go
@@ -26,8 +26,8 @@ package test
 
 import (
 	"fmt"
+	"go.temporal.io/server/tests/testhelper"
 	"math/rand"
-	"os"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -85,13 +85,8 @@ func (tb *SetupSchemaTestBase) RunSetupTest(
 	tb.Nil(err)
 	tb.Equal(0, len(tables))
 
-	tmpDir, err := os.MkdirTemp("", "setupSchemaTestDir")
-	tb.Nil(err)
-	defer os.Remove(tmpDir)
-
-	sqlFile, err := os.CreateTemp(tmpDir, "setupSchema.cliOptionsTest")
-	tb.Nil(err)
-	defer os.Remove(sqlFile.Name())
+	tmpDir := testhelper.MkdirTemp(tb.T(), "", "setupSchemaTestDir")
+	sqlFile := testhelper.CreateTemp(tb.T(), tmpDir, "setupSchema.cliOptionsTest")
 
 	_, err = sqlFile.WriteString(sqlFileContent)
 	tb.NoError(err)

--- a/tools/common/schema/test/setuptest.go
+++ b/tools/common/schema/test/setuptest.go
@@ -26,9 +26,10 @@ package test
 
 import (
 	"fmt"
-	"go.temporal.io/server/tests/testhelper"
 	"math/rand"
 	"time"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/tools/common/schema/test/updatetest.go
+++ b/tools/common/schema/test/updatetest.go
@@ -26,6 +26,7 @@ package test
 
 import (
 	"fmt"
+	"go.temporal.io/server/tests/testhelper"
 	"math/rand"
 	"os"
 	"time"
@@ -97,9 +98,7 @@ func (tb *UpdateSchemaTestBase) RunDryrunTest(app *cli.App, db DB, dbNameFlag st
 
 // RunUpdateSchemaTest tests schema update
 func (tb *UpdateSchemaTestBase) RunUpdateSchemaTest(app *cli.App, db DB, dbNameFlag string, sqlFileContent string, expectedTables []string) {
-	tmpDir, err := os.MkdirTemp("", "update_schema_test")
-	tb.Nil(err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := testhelper.MkdirTemp(tb.T(), "", "update_schema_test")
 
 	tb.makeSchemaVersionDirs(tmpDir, sqlFileContent)
 

--- a/tools/common/schema/test/updatetest.go
+++ b/tools/common/schema/test/updatetest.go
@@ -26,10 +26,11 @@ package test
 
 import (
 	"fmt"
-	"go.temporal.io/server/tests/testhelper"
 	"math/rand"
 	"os"
 	"time"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -25,6 +25,7 @@
 package schema
 
 import (
+	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"testing"
 
@@ -46,21 +47,15 @@ func (s *UpdateTaskTestSuite) SetupSuite() {
 }
 
 func (s *UpdateTaskTestSuite) TestReadSchemaDir() {
-
-	emptyDir, err := os.MkdirTemp("", "update_schema_test_empty")
-	s.NoError(err)
-	defer os.RemoveAll(emptyDir)
-
-	tmpDir, err := os.MkdirTemp("", "update_schema_test")
-	s.NoError(err)
-	defer os.RemoveAll(tmpDir)
+	emptyDir := testhelper.MkdirTemp(s.T(), "", "update_schema_test_empty")
+	tmpDir := testhelper.MkdirTemp(s.T(), "", "update_schema_test")
 
 	subDirs := []string{"v0.5", "v1.5", "v2.5", "v3.5", "v10.2", "abc", "2.0", "3.0"}
 	for _, d := range subDirs {
 		s.NoError(os.Mkdir(tmpDir+"/"+d, os.FileMode(0444)))
 	}
 
-	_, err = readSchemaDir(tmpDir, "11.0", "11.2")
+	_, err := readSchemaDir(tmpDir, "11.0", "11.2")
 	s.Error(err)
 	_, err = readSchemaDir(tmpDir, "0.5", "10.3")
 	s.Error(err)
@@ -91,10 +86,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDir() {
 }
 
 func (s *UpdateTaskTestSuite) TestReadManifest() {
-
-	tmpDir, err := os.MkdirTemp("", "update_schema_test")
-	s.Nil(err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := testhelper.MkdirTemp(s.T(), "", "update_schema_test")
 
 	input := `{
 		"CurrVersion": "0.4",

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -25,9 +25,10 @@
 package schema
 
 import (
-	"go.temporal.io/server/tests/testhelper"
 	"os"
 	"testing"
+
+	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Introduce `testhelper` package to create temp file and dir, this receives testing.TB so both *testing.T and *testing.B are accepted.
- These functions use t.Cleanup function to cleanup the temporary files and dirs after tests are done.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Reduce redundant defer code (remove temp files / dirs) after tests are completed.
- Error is asserted in the test helper functions so we don't need to check err when executing the MkdirTemp / CreateTemp.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit/Integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No