### PR TITLE
Use rpc context for shard acquisition timeout

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -233,7 +233,7 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *hist
 	}
 	workflowID := taskToken.GetWorkflowId()
 
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -258,7 +258,7 @@ func (h *Handler) RecordActivityTaskStarted(ctx context.Context, request *histor
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -287,7 +287,7 @@ func (h *Handler) RecordWorkflowTaskStarted(ctx context.Context, request *histor
 		return nil, h.convertError(errTaskQueueNotSet)
 	}
 
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		h.GetLogger().Error("RecordWorkflowTaskStarted failed.",
 			tag.Error(err1),
@@ -328,7 +328,7 @@ func (h *Handler) RespondActivityTaskCompleted(ctx context.Context, request *his
 	}
 	workflowID := taskToken.GetWorkflowId()
 
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -363,7 +363,7 @@ func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *histor
 	}
 	workflowID := taskToken.GetWorkflowId()
 
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -398,7 +398,7 @@ func (h *Handler) RespondActivityTaskCanceled(ctx context.Context, request *hist
 	}
 	workflowID := taskToken.GetWorkflowId()
 
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -439,7 +439,7 @@ func (h *Handler) RespondWorkflowTaskCompleted(ctx context.Context, request *his
 	}
 	workflowID := token.GetWorkflowId()
 
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -480,7 +480,7 @@ func (h *Handler) RespondWorkflowTaskFailed(ctx context.Context, request *histor
 	}
 	workflowID := token.GetWorkflowId()
 
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -505,7 +505,7 @@ func (h *Handler) StartWorkflowExecution(ctx context.Context, request *historyse
 
 	startRequest := request.StartRequest
 	workflowID := startRequest.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -612,7 +612,7 @@ func (h *Handler) DescribeMutableState(ctx context.Context, request *historyserv
 
 	workflowExecution := request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -636,7 +636,7 @@ func (h *Handler) GetMutableState(ctx context.Context, request *historyservice.G
 
 	workflowExecution := request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -660,7 +660,7 @@ func (h *Handler) PollMutableState(ctx context.Context, request *historyservice.
 
 	workflowExecution := request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -684,7 +684,7 @@ func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *histor
 
 	workflowExecution := request.Request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -718,7 +718,7 @@ func (h *Handler) RequestCancelWorkflowExecution(ctx context.Context, request *h
 		tag.WorkflowRunID(cancelRequest.WorkflowExecution.GetRunId()))
 
 	workflowID := cancelRequest.WorkflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -748,7 +748,7 @@ func (h *Handler) SignalWorkflowExecution(ctx context.Context, request *historys
 
 	workflowExecution := request.SignalRequest.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -781,7 +781,7 @@ func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context, request 
 
 	signalWithStartRequest := request.SignalWithStartRequest
 	workflowID := signalWithStartRequest.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -834,7 +834,7 @@ func (h *Handler) RemoveSignalMutableState(ctx context.Context, request *history
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -864,7 +864,7 @@ func (h *Handler) TerminateWorkflowExecution(ctx context.Context, request *histo
 
 	workflowExecution := request.TerminateRequest.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -894,7 +894,7 @@ func (h *Handler) ResetWorkflowExecution(ctx context.Context, request *historyse
 
 	workflowExecution := request.ResetRequest.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -922,7 +922,7 @@ func (h *Handler) QueryWorkflow(ctx context.Context, request *historyservice.Que
 	}
 
 	workflowID := request.GetRequest().GetExecution().GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -966,7 +966,7 @@ func (h *Handler) ScheduleWorkflowTask(ctx context.Context, request *historyserv
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -1000,7 +1000,7 @@ func (h *Handler) RecordChildExecutionCompleted(ctx context.Context, request *hi
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -1032,7 +1032,7 @@ func (h *Handler) ResetStickyTaskQueue(ctx context.Context, request *historyserv
 	}
 
 	workflowID := request.Execution.GetWorkflowId()
-	engine, err := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1061,7 +1061,7 @@ func (h *Handler) ReplicateEventsV2(ctx context.Context, request *historyservice
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	engine, err1 := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err1 := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err1 != nil {
 		return nil, h.convertError(err1)
 	}
@@ -1096,7 +1096,7 @@ func (h *Handler) SyncShardStatus(ctx context.Context, request *historyservice.S
 	}
 
 	// shard ID is already provided in the request
-	engine, err := h.controller.GetEngineForShard(request.GetShardId())
+	engine, err := h.controller.GetEngineForShard(ctx, request.GetShardId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1132,7 +1132,7 @@ func (h *Handler) SyncActivity(ctx context.Context, request *historyservice.Sync
 	}
 
 	workflowID := request.GetWorkflowId()
-	engine, err := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1162,7 +1162,7 @@ func (h *Handler) GetReplicationMessages(ctx context.Context, request *historyse
 		go func(token *replicationspb.ReplicationToken) {
 			defer wg.Done()
 
-			engine, err := h.controller.GetEngineForShard(token.GetShardId())
+			engine, err := h.controller.GetEngineForShard(ctx, token.GetShardId())
 			if err != nil {
 				h.GetLogger().Warn("History engine not found for shard", tag.Error(err))
 				return
@@ -1230,6 +1230,7 @@ func (h *Handler) GetDLQReplicationMessages(ctx context.Context, request *histor
 		}
 
 		engine, err := h.controller.GetEngine(
+			ctx,
 			namespace.ID(taskInfos[0].GetNamespaceId()),
 			taskInfos[0].GetWorkflowId(),
 		)
@@ -1278,7 +1279,7 @@ func (h *Handler) ReapplyEvents(ctx context.Context, request *historyservice.Rea
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	workflowID := request.GetRequest().GetWorkflowExecution().GetWorkflowId()
-	engine, err := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1312,7 +1313,7 @@ func (h *Handler) GetDLQMessages(ctx context.Context, request *historyservice.Ge
 		return nil, errShuttingDown
 	}
 
-	engine, err := h.controller.GetEngineForShard(request.GetShardId())
+	engine, err := h.controller.GetEngineForShard(ctx, request.GetShardId())
 	if err != nil {
 		err = h.convertError(err)
 		return nil, err
@@ -1335,7 +1336,7 @@ func (h *Handler) PurgeDLQMessages(ctx context.Context, request *historyservice.
 		return nil, errShuttingDown
 	}
 
-	engine, err := h.controller.GetEngineForShard(request.GetShardId())
+	engine, err := h.controller.GetEngineForShard(ctx, request.GetShardId())
 	if err != nil {
 		err = h.convertError(err)
 		return nil, err
@@ -1357,7 +1358,7 @@ func (h *Handler) MergeDLQMessages(ctx context.Context, request *historyservice.
 		return nil, errShuttingDown
 	}
 
-	engine, err := h.controller.GetEngineForShard(request.GetShardId())
+	engine, err := h.controller.GetEngineForShard(ctx, request.GetShardId())
 	if err != nil {
 		err = h.convertError(err)
 		return nil, err
@@ -1383,7 +1384,7 @@ func (h *Handler) RefreshWorkflowTasks(ctx context.Context, request *historyserv
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	execution := request.GetRequest().GetExecution()
 	workflowID := execution.GetWorkflowId()
-	engine, err := h.controller.GetEngine(namespaceID, workflowID)
+	engine, err := h.controller.GetEngine(ctx, namespaceID, workflowID)
 	if err != nil {
 		err = h.convertError(err)
 		return nil, err
@@ -1418,7 +1419,7 @@ func (h *Handler) GenerateLastHistoryReplicationTasks(
 	}
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
-	engine, err := h.controller.GetEngine(namespaceID, request.GetExecution().GetWorkflowId())
+	engine, err := h.controller.GetEngine(ctx, namespaceID, request.GetExecution().GetWorkflowId())
 	if err != nil {
 		err = h.convertError(err)
 		return nil, err
@@ -1447,7 +1448,7 @@ func (h *Handler) GetReplicationStatus(
 
 	resp := &historyservice.GetReplicationStatusResponse{}
 	for _, shardID := range h.controller.ShardIDs() {
-		engine, err := h.controller.GetEngineForShard(shardID)
+		engine, err := h.controller.GetEngineForShard(ctx, shardID)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When the shard rangeid lock status is unknown, rpcs that call into this history engine wait a short amount of time for the lock to be [re]acquired before returning an unavailable error (since #2102). This makes them wait using the full timeout of the rpc context instead.

<!-- Tell your future self why have you made these changes -->
**Why?**
The client would just retry anyway, this moves the retry into the server.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests + integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
