### PR TITLE
Track max replication task ID for Namespace Handover

### DIFF
--- a/common/namespace/replicationTaskExecutor.go
+++ b/common/namespace/replicationTaskExecutor.go
@@ -289,7 +289,7 @@ func (h *namespaceReplicationTaskExecutorImpl) convertClusterReplicationConfigFr
 
 func (h *namespaceReplicationTaskExecutorImpl) validateNamespaceStatus(input enumspb.NamespaceState) error {
 	switch input {
-	case enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED:
+	case enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_HANDOVER:
 		return nil
 	default:
 		return ErrInvalidNamespaceState

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -65,6 +65,9 @@ var (
 		"SignalWithStartWorkflowExecution": {enumspb.NAMESPACE_STATE_REGISTERED},
 		"DescribeNamespace":                {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_DELETED, enumspb.NAMESPACE_STATE_HANDOVER},
 		"UpdateNamespace":                  {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_HANDOVER},
+		"GetReplicationMessages":           {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_HANDOVER},
+		"ReplicateEventsV2":                {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_HANDOVER},
+		"GetWorkflowExecutionRawHistoryV2": {enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED, enumspb.NAMESPACE_STATE_HANDOVER},
 	}
 	// If API name is not in the map above, these are allowed states for all APIs that have `namespace` or `task_token` field in the request object.
 	defaultAllowedNamespaceStates = []enumspb.NamespaceState{enumspb.NAMESPACE_STATE_REGISTERED, enumspb.NAMESPACE_STATE_DEPRECATED}

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -108,6 +108,7 @@ type (
 
 		GetNamespaceNotificationVersion() int64
 		UpdateNamespaceNotificationVersion(namespaceNotificationVersion int64) error
+		UpdateHandoverNamespaces(newNamespaces []*namespace.Namespace, maxRepTaskID int64)
 
 		CreateWorkflowExecution(request *persistence.CreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error)
 		UpdateWorkflowExecution(request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error)

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -635,6 +635,18 @@ func (mr *MockContextMockRecorder) UpdateClusterReplicationLevel(cluster, ackTas
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateClusterReplicationLevel", reflect.TypeOf((*MockContext)(nil).UpdateClusterReplicationLevel), cluster, ackTaskID, ackTimestamp)
 }
 
+// UpdateHandoverNamespaces mocks base method.
+func (m *MockContext) UpdateHandoverNamespaces(newNamespaces []*namespace.Namespace, maxRepTaskID int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateHandoverNamespaces", newNamespaces, maxRepTaskID)
+}
+
+// UpdateHandoverNamespaces indicates an expected call of UpdateHandoverNamespaces.
+func (mr *MockContextMockRecorder) UpdateHandoverNamespaces(newNamespaces, maxRepTaskID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHandoverNamespaces", reflect.TypeOf((*MockContext)(nil).UpdateHandoverNamespaces), newNamespaces, maxRepTaskID)
+}
+
 // UpdateNamespaceNotificationVersion mocks base method.
 func (m *MockContext) UpdateNamespaceNotificationVersion(namespaceNotificationVersion int64) error {
 	m.ctrl.T.Helper()

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -69,6 +69,7 @@ func NewTestContext(
 		maxTransferSequenceNumber: 100000,
 		timerMaxReadLevelMap:      make(map[string]time.Time),
 		remoteClusterInfos:        make(map[string]*remoteClusterInfo),
+		handoverNamespaces:        make(map[string]*namespaceHandOverInfo),
 	}
 	return &ContextTest{
 		ContextImpl:     shard,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Track max replication task ID when Namespace in Handover state

<!-- Tell your future self why have you made these changes -->
**Why?**
So it is possible to monitor if remote cluster is ready to take over the namespace in handover state.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test with print statement to verify the max replication task id is valid when namespace transition into handover state. Also test when shard reload, the max replication task is still valid. Server restart case is also tested.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No