### PR TITLE
Upgrade golang to 1.17.3

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.17.3
       - name: Get build date
         id: date
         run: echo "::set-output name=date::$(date '+%F-%T')"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ This doc is for contributors to Temporal Server (hopefully that's you!)
 ## Prerequisites
 
 ### Build prerequisites 
-* [Go Lang](https://golang.org/) (minimum version required is 1.17):
+* [Go Lang](https://golang.org/) (minimum version required is 1.17.3):
   - Install on macOS with `brew install go`.
   - Install on Ubuntu with `sudo apt install golang`.
 * [Protocol buffers compiler](https://github.com/protocolbuffers/protobuf/) (only if you are going to change `proto` files):

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG TARGET=server
-ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.4.0
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.3.0
-ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.2.0
+ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.5.0
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.4.0
+ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.3.0
 ARG GOPROXY
 
 ##### Temporal builder #####

--- a/docker/base-images/base-builder.Dockerfile
+++ b/docker/base-images/base-builder.Dockerfile
@@ -1,5 +1,5 @@
 # alpine3.14 requires docker 20.10: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
-FROM golang:1.17-alpine3.13 AS base-builder
+FROM golang:1.17.3-alpine3.13 AS base-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -1,6 +1,6 @@
 # alpine3.14 requires docker 20.10: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
 # Buildkite elastic stack needs to be upgraded to the version which has docker 20.10.0 (at least).
-FROM golang:1.17-alpine3.13 AS base-ci-builder
+FROM golang:1.17.3-alpine3.13 AS base-ci-builder
 
 RUN apk add --update --no-cache \
     make \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -1,6 +1,6 @@
 ##### dockerize builder: built from source to support arm & x86 #####
 # alpine3.14 requires docker 20.10: https://gitlab.alpinelinux.org/alpine/aports/-/issues/12396
-FROM golang:1.17-alpine3.13 AS dockerize-builder
+FROM golang:1.17.3-alpine3.13 AS dockerize-builder
 
 RUN apk add --update --no-cache \
     git


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Upgrade to go 1.17.3

<!-- Tell your future self why have you made these changes -->
**Why?**
Golang Vulnerability CVE-2021-39293
https://github.com/temporalio/temporal/issues/2184
