### PR TITLE
SDK update with dependency abstraction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/robfig/cron v1.2.0
 	github.com/stretchr/testify v1.7.0
 	github.com/temporalio/ringpop-go v0.0.0-20211012191444-6f91b5915e95
-	github.com/uber-go/tally/v4 v4.0.1
+	github.com/uber-go/tally/v4 v4.1.1
 	github.com/uber/tchannel-go v1.22.0
 	github.com/urfave/cli v1.22.5
 	github.com/urfave/cli/v2 v2.3.0
@@ -45,7 +45,8 @@ require (
 	go.opentelemetry.io/otel/sdk/export/metric v0.24.0
 	go.opentelemetry.io/otel/sdk/metric v0.24.0
 	go.temporal.io/api v1.6.1-0.20211123053254-cae1d6470032
-	go.temporal.io/sdk v1.11.0
+	go.temporal.io/sdk v1.11.2
+	go.temporal.io/sdk/contrib/tally v0.1.0
 	go.temporal.io/version v0.0.0-20201015012359-4d3bb966d193
 	go.uber.org/atomic v1.9.0
 	go.uber.org/fx v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -418,8 +418,9 @@ github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq
 github.com/uber-common/bark v1.0.0/go.mod h1:g0ZuPcD7XiExKHynr93Q742G/sbrdVQkghrqLGOoFuY=
 github.com/uber-common/bark v1.3.0 h1:DkuZCBaQS9LWuNAPrCO6yQVANckIX3QI0QwLemUnzCo=
 github.com/uber-common/bark v1.3.0/go.mod h1:5fDe/YcIVP55XhFF9hUihX2lDsDcpFrTZEAwAVwtPDw=
-github.com/uber-go/tally/v4 v4.0.1 h1:Gb78H57b/dEn9zkGmSfSaIR1SjLMB4z38N0quvJ5ERo=
 github.com/uber-go/tally/v4 v4.0.1/go.mod h1:mcbhHhuBx59QTSR77pXGWYyB0XgxO6OI9JKAgWDOiNY=
+github.com/uber-go/tally/v4 v4.1.1 h1:jhy6WOZp4nHyCqeV43x3Wz370LXUGBhgW2JmzOIHCWI=
+github.com/uber-go/tally/v4 v4.1.1/go.mod h1:aXeSTDMl4tNosyf6rdU8jlgScHyjEGGtfJ/uwCIf/vM=
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-client-go v2.29.1+incompatible h1:R9ec3zO3sGpzs0abd43Y+fBZRJ9uiH6lXyR/+u6brW4=
 github.com/uber/jaeger-client-go v2.29.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
@@ -471,8 +472,11 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.temporal.io/api v1.5.0/go.mod h1:BqKxEJJYdxb5dqf0ODfzfMxh8UEQ5L3zKS51FiIYYkA=
 go.temporal.io/api v1.6.1-0.20211123053254-cae1d6470032 h1:NWqyrKZjNtZMWaisvqswD+wZ+cjACm42Z12c1Ns0978=
 go.temporal.io/api v1.6.1-0.20211123053254-cae1d6470032/go.mod h1:Ip5fOBxBedzcDrqxa2RBbMVcUFkKUgUIhrrhokF8ocg=
-go.temporal.io/sdk v1.11.0 h1:KMulQdR67ZL8M30m60LQVfGL0bUNd2TgjHplM/RUk5M=
-go.temporal.io/sdk v1.11.0/go.mod h1:YPiw910FVnuF0/j4qHgqxGEB3kNCOD7ZQY3fOmZltnw=
+go.temporal.io/sdk v1.11.1/go.mod h1:YPiw910FVnuF0/j4qHgqxGEB3kNCOD7ZQY3fOmZltnw=
+go.temporal.io/sdk v1.11.2 h1:5uaN3Q8RI3wmA8KfUM1kLqUlTyeJPzwyPJfDqALat5k=
+go.temporal.io/sdk v1.11.2/go.mod h1:lSp3lH1lI0TyOsus0arnO3FYvjVXBZGi/G7DjnAnm6o=
+go.temporal.io/sdk/contrib/tally v0.1.0 h1:s8q9NU4sqKA4z15Bc61dDPQlf9oPT+QuiKO7KhYoeOA=
+go.temporal.io/sdk/contrib/tally v0.1.0/go.mod h1:UQecTexayWPXL59/yaqRHBicBx2NJ/DQNhzzdZIFQfE=
 go.temporal.io/version v0.0.0-20201015012359-4d3bb966d193 h1:jhIqHkAE74DnEXipymFTzmTxyboMYmv6iVkkCFC1pas=
 go.temporal.io/version v0.0.0-20201015012359-4d3bb966d193/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/uber-go/tally/v4"
 	sdkclient "go.temporal.io/sdk/client"
+	sdktally "go.temporal.io/sdk/contrib/tally"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/client"
@@ -250,10 +251,10 @@ func newBootstrapParams(
 	}
 
 	params.SdkClient, err = sdkclient.NewClient(sdkclient.Options{
-		HostPort:     cfg.PublicClient.HostPort,
-		Namespace:    common.SystemLocalNamespace,
-		MetricsScope: globalTallyScope,
-		Logger:       log.NewSdkLogger(logger),
+		HostPort:       cfg.PublicClient.HostPort,
+		Namespace:      common.SystemLocalNamespace,
+		MetricsHandler: sdktally.NewMetricsHandler(globalTallyScope),
+		Logger:         log.NewSdkLogger(logger),
 		ConnectionOptions: sdkclient.ConnectionOptions{
 			TLS:                options,
 			DisableHealthCheck: true,


### PR DESCRIPTION
**What changed?**

Incorporating dependency abstraction into separate modules from https://github.com/temporalio/sdk-go/pull/653

**Why?**

Demonstrate how the SDK module abstraction affects this repo.

**How did you test it?**

Instead of a `replace` in `go.mod`, I instead setup my own vanity import HTTP server on `127.0.0.1:80`, set `go.temporal.io` to use `127.0.0.1` in my `/etc/hosts`, set `GOPRIVATE=go.temporal.io`, set `GOINSECURE=go.temporal.io`, pointed the repos at https://github.com/cretz/temporal-sdk-go, and made two tags only in that fork: `v1.11.2` for the root (it'll be `v1.12.0` when we actually release), and `contrib/tally/v0.1.0` for just the Tally nested module.