### PR TITLE
Use the custom data converter for query responses.

### DIFF
--- a/tools/cli/data_converter_commands.go
+++ b/tools/cli/data_converter_commands.go
@@ -35,7 +35,6 @@ import (
 	"github.com/urfave/cli"
 
 	commonpb "go.temporal.io/api/common/v1"
-	"go.temporal.io/server/tools/cli/dataconverter"
 )
 
 const dataConverterURL = "%s/data-converter/%d"
@@ -70,7 +69,7 @@ func processMessage(c *websocket.Conn) error {
 
 	payloadResponse := PayloadResponse{
 		RequestID: payloadRequest.RequestID,
-		Content:   dataconverter.GetCurrent().ToString(&payload),
+		Content:   customDataConverter().ToString(&payload),
 	}
 
 	var response []byte

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -45,6 +45,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
 
 	"go.temporal.io/server/common/codec"
 	"go.temporal.io/server/common/collection"
@@ -75,7 +76,7 @@ func GetHistory(ctx context.Context, workflowClient sdkclient.Client, workflowID
 // HistoryEventToString convert HistoryEvent to string
 func HistoryEventToString(e *historypb.HistoryEvent, printFully bool, maxFieldLength int) string {
 	data := getEventAttributes(e)
-	return stringify.AnyToString(data, printFully, maxFieldLength, dataconverter.GetCurrent())
+	return stringify.AnyToString(data, printFully, maxFieldLength, customDataConverter())
 }
 
 // ColorEvent takes an event and return string with color
@@ -811,4 +812,12 @@ func prompt(msg string, autoConfirm bool) {
 	if textLower != "y" && textLower != "yes" {
 		os.Exit(1)
 	}
+}
+
+func defaultDataConverter() converter.DataConverter {
+	return converter.GetDefaultDataConverter()
+}
+
+func customDataConverter() converter.DataConverter {
+	return dataconverter.GetCurrent()
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

tctl will now use the custom data converter for printing query results.

<!-- Tell your future self why have you made these changes -->
**Why?**

This lines up with the SDK behaviour on the worker side which uses the custom data converter to encode the query response.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Tested `tctl workflow stack` on a Temporal application using an encrypting data converter. Without this fix I see "[encoding binary/encrypted: payload encoding is not supported]". With this fix I see the query response as I'd expect.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

None.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No.
