### PR TITLE
Remove --state from namespace update command

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -129,7 +129,6 @@ const (
 	FlagDescriptionWithAlias                  = FlagDescription + ", desc"
 	FlagOwnerEmail                            = "owner_email"
 	FlagOwnerEmailWithAlias                   = FlagOwnerEmail + ", oe"
-	FlagState                                 = "state"
 	FlagRetention                             = "retention"
 	FlagRetentionWithAlias                    = FlagRetention + ", rd"
 	FlagHistoryArchivalState                  = "history_archival_state"

--- a/tools/cli/namespaceCommands.go
+++ b/tools/cli/namespaceCommands.go
@@ -200,7 +200,6 @@ func (d *namespaceCLIImpl) UpdateNamespace(c *cli.Context) {
 		description := resp.NamespaceInfo.GetDescription()
 		ownerEmail := resp.NamespaceInfo.GetOwnerEmail()
 		retention := timestamp.DurationValue(resp.Config.GetWorkflowExecutionRetentionTtl())
-		state := enumspb.NAMESPACE_STATE_UNSPECIFIED
 		var clusters []*replicationpb.ClusterReplicationConfig
 
 		if c.IsSet(FlagDescription) {
@@ -208,14 +207,6 @@ func (d *namespaceCLIImpl) UpdateNamespace(c *cli.Context) {
 		}
 		if c.IsSet(FlagOwnerEmail) {
 			ownerEmail = c.String(FlagOwnerEmail)
-		}
-		if c.IsSet(FlagState) {
-			stateStr := c.String(FlagState)
-			if stateInt, ok := enumspb.NamespaceState_value[stateStr]; !ok {
-				ErrorAndExit(fmt.Sprintf("Unknown namespace state: %s. Supported states: [Registered, Deprecated, Deleted, Handover].", stateStr), nil)
-			} else {
-				state = enumspb.NamespaceState(stateInt)
-			}
 		}
 		namespaceData := map[string]string{}
 		if c.IsSet(FlagNamespaceData) {
@@ -270,7 +261,6 @@ func (d *namespaceCLIImpl) UpdateNamespace(c *cli.Context) {
 			Description: description,
 			OwnerEmail:  ownerEmail,
 			Data:        namespaceData,
-			State:       state,
 		}
 		updateConfig := &namespacepb.NamespaceConfig{
 			WorkflowExecutionRetentionTtl: &retention,

--- a/tools/cli/namespaceUtils.go
+++ b/tools/cli/namespaceUtils.go
@@ -112,10 +112,6 @@ var (
 			Usage: "Owner email",
 		},
 		cli.StringFlag{
-			Name:  FlagState,
-			Usage: "Namespace state",
-		},
-		cli.StringFlag{
 			Name:  FlagRetentionWithAlias,
 			Usage: "Workflow execution retention",
 		},


### PR DESCRIPTION
Namespace state update needs more steps and should be handled by a workflow.
Update the state metadata should be just one step of the workflow.
We should create other command for tctl to trigger operations like DeleteNamespace.