### PR TITLE
Stop server start up on malformed dynamic config

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -144,10 +144,7 @@ func buildCLI() *cli.App {
 				if cfg.DynamicConfigClient != nil {
 					dynamicConfigClient, err = dynamicconfig.NewFileBasedClient(cfg.DynamicConfigClient, logger, temporal.InterruptCh())
 					if err != nil {
-						// TODO: uncomment the next line and remove next 3 lines in 1.14.
-						// return cli.Exit(fmt.Sprintf("Unable to create dynamic config client. Error: %v", err), 1)
-						logger.Error("Unable to read dynamic config file. Continue with default settings but the ERROR MUST BE FIXED before the next upgrade", tag.Error(err))
-						dynamicConfigClient = dynamicconfig.NewNoopClient()
+						return cli.Exit(fmt.Sprintf("Unable to create dynamic config client. Error: %v", err), 1)
 					}
 				} else {
 					dynamicConfigClient = dynamicconfig.NewNoopClient()

--- a/common/dynamicconfig/noop_client.go
+++ b/common/dynamicconfig/noop_client.go
@@ -80,7 +80,3 @@ func (mc *noopClient) GetMapValue(name Key, filters map[Filter]interface{}, defa
 func (mc *noopClient) GetDurationValue(name Key, filters map[Filter]interface{}, defaultValue time.Duration) (time.Duration, error) {
 	return defaultValue, errors.New("unable to find key")
 }
-
-// TODO: remove in 1.14
-func (mc *noopClient) IsNoopClient() {
-}

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -482,26 +482,23 @@ func SoExpander(so *serverOptions) (
 	return &so.config.Global.PProf, so.config, so.persistenceServiceResolver
 }
 
-func DynamicConfigClientProvider(so *serverOptions, logger log.Logger, stoppedCh chan interface{}) dynamicconfig.Client {
+func DynamicConfigClientProvider(so *serverOptions, logger log.Logger, stoppedCh chan interface{}) (dynamicconfig.Client, error) {
 	var result dynamicconfig.Client
 	var err error
 	if so.dynamicConfigClient != nil {
-		return so.dynamicConfigClient
+		return so.dynamicConfigClient, nil
 	}
 
 	if so.config.DynamicConfigClient != nil {
 		result, err = dynamicconfig.NewFileBasedClient(so.config.DynamicConfigClient, logger, stoppedCh)
 		if err != nil {
-			// TODO: uncomment the next line and remove next 3 lines in 1.14.
-			// return fmt.Errorf("unable to create dynamic config client: %w", err)
-			logger.Error("Unable to read dynamic config file. Continue with default settings but the ERROR MUST BE FIXED before the next upgrade", tag.Error(err))
-			result = dynamicconfig.NewNoopClient()
+			return nil, fmt.Errorf("unable to create dynamic config client: %w", err)
 		}
-		return result
+		return result, nil
 	}
 
 	logger.Info("Dynamic config client is not configured. Using default values.")
-	return dynamicconfig.NewNoopClient()
+	return dynamicconfig.NewNoopClient(), nil
 }
 
 func DcCollectionProvider(dynamicConfigClient dynamicconfig.Client, logger log.Logger) *dynamicconfig.Collection {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Stop server start up on malformed dynamic config.

<!-- Tell your future self why have you made these changes -->
**Why?**
If dynamic config has syntax error server shouldn't hide error and use default noop dynamic config but exit right away.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Running locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Server will not start if dynamic config has errors.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.