### PR TITLE
Use --target for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-ARG TARGET=server
 ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.5.0
 ARG BASE_SERVER_IMAGE=temporalio/base-server:1.4.0
 ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.3.0
@@ -80,6 +79,3 @@ COPY --from=temporal-builder /temporal/temporal-cassandra-tool /usr/local/bin
 COPY --from=temporal-builder /temporal/temporal-sql-tool /usr/local/bin
 COPY --from=temporal-builder /temporal/tctl /usr/local/bin
 COPY --from=temporal-builder /temporal/tctl-authorization-plugin /usr/local/bin
-
-##### Build requested image #####
-FROM temporal-${TARGET}

--- a/Makefile
+++ b/Makefile
@@ -469,38 +469,38 @@ build-fossa: bins fossa-analyze fossa-delay fossa-test
 ##### Docker #####
 docker-server:
 	@printf $(COLOR) "Building docker image temporalio/server:$(DOCKER_IMAGE_TAG)..."
-	docker build . -t temporalio/server:$(DOCKER_IMAGE_TAG) --build-arg TARGET=server
+	docker build . -t temporalio/server:$(DOCKER_IMAGE_TAG) --target temporal-server
 
 docker-auto-setup:
 	@printf $(COLOR) "Build docker image temporalio/auto-setup:$(DOCKER_IMAGE_TAG)..."
-	docker build . -t temporalio/auto-setup:$(DOCKER_IMAGE_TAG) --build-arg TARGET=auto-setup
+	docker build . -t temporalio/auto-setup:$(DOCKER_IMAGE_TAG) --target temporal-auto-setup
 
 docker-tctl:
 	@printf $(COLOR) "Build docker image temporalio/tctl:$(DOCKER_IMAGE_TAG)..."
-	docker build . -t temporalio/tctl:$(DOCKER_IMAGE_TAG) --build-arg TARGET=tctl
+	docker build . -t temporalio/tctl:$(DOCKER_IMAGE_TAG) --target temporal-tctl
 
 docker-admin-tools:
 	@printf $(COLOR) "Build docker image temporalio/admin-tools:$(DOCKER_IMAGE_TAG)..."
-	docker build . -t temporalio/admin-tools:$(DOCKER_IMAGE_TAG) --build-arg TARGET=admin-tools
+	docker build . -t temporalio/admin-tools:$(DOCKER_IMAGE_TAG) --target temporal-admin-tools
 
 docker-buildx-container:
 	docker buildx create --name builder-x --driver docker-container --use
 
 docker-server-x:
 	@printf $(COLOR) "Building cross-platform docker image temporalio/server:$(DOCKER_IMAGE_TAG)..."
-	docker buildx build . -t temporalio/server:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) --build-arg TARGET=server
+	docker buildx build . -t temporalio/server:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) --target temporal-server
 
 docker-auto-setup-x:
 	@printf $(COLOR) "Build cross-platform docker image temporalio/auto-setup:$(DOCKER_IMAGE_TAG)..."
-	docker buildx build . -t temporalio/auto-setup:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) --build-arg TARGET=auto-setup
+	docker buildx build . -t temporalio/auto-setup:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) --target temporal-auto-setup
 
 docker-tctl-x:
 	@printf $(COLOR) "Build cross-platform docker image temporalio/tctl:$(DOCKER_IMAGE_TAG)..."
-	docker buildx build . -t temporalio/tctl:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) --build-arg TARGET=tctl
+	docker buildx build . -t temporalio/tctl:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) --target temporal-tctl
 
 docker-admin-tools-x:
 	@printf $(COLOR) "Build cross-platform docker image temporalio/admin-tools:$(DOCKER_IMAGE_TAG)..."
-	docker buildx build . -t temporalio/admin-tools:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) --build-arg TARGET=admin-tools
+	docker buildx build . -t temporalio/admin-tools:$(DOCKER_IMAGE_TAG) --platform linux/amd64,linux/arm64 --output type=$(DOCKER_BUILDX_OUTPUT) --target temporal-admin-tools
 
 ##### Grafana #####
 update-dashboards:

--- a/docker/README.md
+++ b/docker/README.md
@@ -13,7 +13,7 @@ To run docker image with dependencies:
 Replace **YOUR_TAG** and **YOUR_CHECKOUT_COMMIT** in the below command to build:
 ```bash
 git checkout YOUR_CHECKOUT_COMMIT
-docker build . -t temporalio/auto-setup:YOUR_TAG --build-arg TARGET=auto-setup
+docker build . -t temporalio/auto-setup:YOUR_TAG --target temporal-auto-setup
 ```
 
 ## Run Temporal with custom docker image


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use docker's built-in `--target` instead of a `TARGET` build arg.

<!-- Tell your future self why have you made these changes -->
**Why?**
Simpler, use built-in feature.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If anyone else has scripts that use the build arg, they'd have to be changed.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.