### PR TITLE
Add tzdata to server base image and binary

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -31,6 +31,7 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	_ "time/tzdata" // embed tzdata as a fallback
 
 	"github.com/urfave/cli/v2"
 

--- a/docker/base-images/README.md
+++ b/docker/base-images/README.md
@@ -5,7 +5,7 @@ To build a new version of base docker image run:
 make <base_image_name> DOCKER_IMAGE_TAG=<new_base_image_version>
 ```
 
-Check [MakeFile](Makefile) for all possible `base_image_name` options.
+Check [Makefile](Makefile) for all possible `base_image_name` options.
 
 For example:
 ```bash

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -19,6 +19,7 @@ FROM alpine:3.13 AS base-server
 
 RUN apk add --update --no-cache \
     ca-certificates \
+    tzdata \
     bash \
     curl \
     vim


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This adds `tzdata` to the server base image (as an Alpine package), so it will end up in the built server images. It also adds embedded `tzdata` to the server binary as a fallback (using Go's time/tzdata package), in case the binary is run in another context. In general we expect the Alpine package to be more up-to-date than Go's embedded `tzdata` (currently 2021e vs 2021a).

<!-- Tell your future self why have you made these changes -->
**Why?**
So the server can do time zone calculations.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Built images + binaries.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.