### PR TITLE
Move shard locking into persistence

### DIFF
--- a/common/locks/id_mutex_test.go
+++ b/common/locks/id_mutex_test.go
@@ -37,7 +37,7 @@ type (
 		suite.Suite
 
 		cleanupLocks bool
-		numShard     uint32
+		numShards    uint32
 		idMutex      IDMutex
 	}
 
@@ -152,8 +152,8 @@ func (s *idMutexSuite) TearDownSuite() {
 }
 
 func (s *idMutexSuite) SetupTest() {
-	s.numShard = 32
-	s.idMutex = NewIDMutex(s.numShard, func(key interface{}) uint32 {
+	s.numShards = 32
+	s.idMutex = NewIDMutex(s.numShards, func(key interface{}) uint32 {
 		id, ok := key.(string)
 		if !ok {
 			return 0
@@ -236,7 +236,7 @@ func (s *idMutexSuite) TestConcurrentAccess() {
 
 	if s.cleanupLocks {
 		impl := s.idMutex.(*idMutexImpl)
-		for i := uint32(0); i < s.numShard; i++ {
+		for i := uint32(0); i < s.numShards; i++ {
 			impl.shards[i].Lock()
 			s.Equal(0, len(impl.shards[i].mutexInfos))
 			impl.shards[i].Unlock()

--- a/common/persistence/cassandra/execution_store.go
+++ b/common/persistence/cassandra/execution_store.go
@@ -27,6 +27,7 @@ package cassandra
 import (
 	"time"
 
+	"go.temporal.io/server/common/locks"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
@@ -121,11 +122,12 @@ var _ p.ExecutionStore = (*ExecutionStore)(nil)
 func NewExecutionStore(
 	session gocql.Session,
 	logger log.Logger,
+	shardLock locks.IDMutex,
 ) *ExecutionStore {
 	return &ExecutionStore{
 		HistoryStore:          NewHistoryStore(session, logger),
-		MutableStateStore:     NewMutableStateStore(session, logger),
-		MutableStateTaskStore: NewMutableStateTaskStore(session, logger),
+		MutableStateStore:     NewMutableStateStore(session, logger, shardLock),
+		MutableStateTaskStore: NewMutableStateTaskStore(session, logger, shardLock),
 	}
 }
 

--- a/common/persistence/cassandra/factory.go
+++ b/common/persistence/cassandra/factory.go
@@ -48,12 +48,6 @@ type (
 	}
 )
 
-const (
-	// shardLockIDMutexShards is the number of internal shards to use for
-	// IDMutex (which history shards are hashed down to).
-	shardLockIDMutexShards = 4
-)
-
 // NewFactory returns an instance of a factory object which can be used to create
 // data stores that are backed by cassandra
 func NewFactory(
@@ -83,7 +77,7 @@ func NewFactoryFromSession(
 		session:     session,
 		// Serialize all LWTs on executions table ourselves to avoid Cassandra timeouts due to CAS contention.
 		// Key is shardID (partition key of table).
-		shardLock: locks.NewIDMutex(shardLockIDMutexShards, shardIDToLockShard, false),
+		shardLock: locks.NewIDMutex(),
 	}
 }
 
@@ -122,12 +116,4 @@ func (f *Factory) Close() {
 	f.Lock()
 	defer f.Unlock()
 	f.session.Close()
-}
-
-func shardIDToLockShard(i interface{}) uint32 {
-	shardID, ok := i.(int32)
-	if !ok {
-		panic("shardID is not int32")
-	}
-	return uint32(shardID)
 }

--- a/tools/cli/adminDBCleanCommand.go
+++ b/tools/cli/adminDBCleanCommand.go
@@ -176,7 +176,8 @@ func cleanShard(
 		return report
 	}
 	defer shardCorruptedFile.Close()
-	execStore := cassp.NewExecutionStore(session, log.NewNoopLogger())
+	shardLock := makeShardLock()
+	execStore := cassp.NewExecutionStore(session, log.NewNoopLogger(), shardLock)
 
 	scanner := bufio.NewScanner(shardCorruptedFile)
 	for scanner.Scan() {

--- a/tools/cli/adminDBScanCommand.go
+++ b/tools/cli/adminDBScanCommand.go
@@ -291,7 +291,8 @@ func scanShard(
 		deleteEmptyFiles(outputFiles.CorruptedExecutionFile, outputFiles.ExecutionCheckFailureFile, outputFiles.ShardScanReportFile)
 		closeFn()
 	}()
-	workflowStore := cassp.NewExecutionStore(session, log.NewNoopLogger())
+	shardLock := makeShardLock()
+	workflowStore := cassp.NewExecutionStore(session, log.NewNoopLogger(), shardLock)
 	execMan := persistence.NewExecutionManager(workflowStore, log.NewNoopLogger(), dynamicconfig.GetIntPropertyFn(common.DefaultTransactionSizeLimit))
 
 	var token []byte


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Serialize persistence operations on execution table in cassandra persistence layer, instead of in the shard context.

Refactor the (unused) IDMutex to work a little better for this application.

<!-- Tell your future self why have you made these changes -->
**Why?**
Allow higher concurrency for non-cassandra implementations.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit/integration tests. Will need to do more load testing.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It's possible that this could break some invariant or contract between shard context and history engine code.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
