### PR TITLE
Move ackLevel past gaps in task ids

### DIFF
--- a/service/matching/ackManager.go
+++ b/service/matching/ackManager.go
@@ -82,6 +82,8 @@ func (m *ackManager) setReadLevelAfterGap(newReadLevel int64) {
 	defer m.Unlock()
 	if m.ackLevel == m.readLevel {
 		// This is called after we read a range and find no tasks. The range we read was m.readLevel to newReadLevel.
+		// (We know this because nothing should change m.readLevel except the getTasksPump loop itself, after initialization.
+		// And getTasksPump doesn't start until it gets a signal from taskWriter that it's initialized the levels.)
 		// If we've acked all tasks up to m.readLevel, and there are no tasks between that and newReadLevel, then we've
 		// acked all tasks up to newReadLevel too. This lets us advance the ack level on a task queue with no activity
 		// but where the rangeid has moved higher, to prevent excessive reads on the next load.
@@ -97,7 +99,7 @@ func (m *ackManager) getAckLevel() int64 {
 }
 
 // Moves ack level to the new level if it is higher than the current one.
-// Also updates the read level it is lower than the ackLevel.
+// Also updates the read level if it is lower than the ackLevel.
 func (m *ackManager) setAckLevel(ackLevel int64) {
 	m.Lock()
 	defer m.Unlock()

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -160,6 +160,7 @@ func (s *matchingEngineSuite) TestAckManager() {
 	const t3 = 320
 	const t4 = 340
 	const t5 = 360
+	const t6 = 380
 
 	m.addTask(t1)
 	s.EqualValues(100, m.getAckLevel())
@@ -199,6 +200,11 @@ func (s *matchingEngineSuite) TestAckManager() {
 
 	m.setReadLevel(t5)
 	s.EqualValues(t5, m.getReadLevel())
+
+	m.setAckLevel(t5)
+	m.setReadLevelAfterGap(t6)
+	s.EqualValues(t6, m.getReadLevel())
+	s.EqualValues(t6, m.getAckLevel())
 }
 
 func (s *matchingEngineSuite) TestAckManager_Sort() {
@@ -1647,6 +1653,29 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch_ReadBatchDone() {
 	s.NoError(err)
 }
 
+func (s *matchingEngineSuite) TestTaskQueueManager_CyclingBehavior() {
+	namespaceID := namespace.ID(uuid.New())
+	tl := "makeToast"
+	tlID := newTestTaskQueueID(namespaceID, tl, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
+	tlNormal := enumspb.TASK_QUEUE_KIND_NORMAL
+	config := defaultTestConfig()
+
+	for i := 0; i < 4; i++ {
+		prevGetTasksCount := s.taskManager.getGetTasksCount(tlID)
+
+		tlMgr, err := newTaskQueueManager(s.matchingEngine, tlID, tlNormal, config, s.matchingEngine.clusterMeta)
+		s.NoError(err)
+
+		tlMgr.Start()
+		// tlMgr.taskWriter startup is async so give it time to complete
+		time.Sleep(100 * time.Millisecond)
+		tlMgr.Stop()
+
+		getTasksCount := s.taskManager.getGetTasksCount(tlID) - prevGetTasksCount
+		s.LessOrEqual(getTasksCount, 1)
+	}
+}
+
 func (s *matchingEngineSuite) TestTaskExpiryAndCompletion() {
 	runID := uuid.NewRandom().String()
 	workflowID := uuid.New()
@@ -1827,6 +1856,7 @@ type testTaskQueueManager struct {
 	rangeID         int64
 	ackLevel        int64
 	createTaskCount int
+	getTasksCount   int
 	tasks           *treemap.Map
 }
 
@@ -2012,6 +2042,7 @@ func (m *testTaskManager) GetTasks(request *persistence.GetTasksRequest) (*persi
 		}
 		tasks = append(tasks, it.Value().(*persistencespb.AllocatedTaskInfo))
 	}
+	tlm.getTasksCount++
 	return &persistence.GetTasksResponse{
 		Tasks: tasks,
 	}, nil
@@ -2031,6 +2062,14 @@ func (m *testTaskManager) getCreateTaskCount(taskQueue *taskQueueID) int {
 	tlm.Lock()
 	defer tlm.Unlock()
 	return tlm.createTaskCount
+}
+
+// getGetTasksCount returns how many times GetTasks was called
+func (m *testTaskManager) getGetTasksCount(taskQueue *taskQueueID) int {
+	tlm := m.getTaskQueueManager(taskQueue)
+	tlm.Lock()
+	defer tlm.Unlock()
+	return tlm.getTasksCount
 }
 
 func (m *testTaskManager) String() string {

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -74,10 +74,11 @@ func (tr *taskReader) Start() {
 		return
 	}
 
-	tr.Signal()
-
 	tr.gorogrp.Go(tr.dispatchBufferedTasks)
 	tr.gorogrp.Go(tr.getTasksPump)
+
+	// Do not signal getTasksPump to start here, let it wait until taskWriter
+	// acquires the lease and initializes the read level and max read level.
 }
 
 func (tr *taskReader) Stop() {
@@ -132,6 +133,14 @@ dispatchLoop:
 }
 
 func (tr *taskReader) getTasksPump(ctx context.Context) error {
+	// Wait for one notification from taskWriter
+	select {
+	case <-ctx.Done():
+		return nil
+	case <-tr.notifyC:
+		tr.Signal()
+	}
+
 	updateAckTimer := time.NewTimer(tr.tlMgr.config.UpdateAckInterval())
 	defer updateAckTimer.Stop()
 

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -158,7 +158,7 @@ Loop:
 			}
 
 			if len(tasks) == 0 {
-				tr.tlMgr.taskAckManager.setReadLevel(readLevel)
+				tr.tlMgr.taskAckManager.setReadLevelAfterGap(readLevel)
 				if !isReadBatchDone {
 					tr.Signal()
 				}


### PR DESCRIPTION
**What changed?**
If we read a gap in tasks immediately after the current ack level, advance the ack level to the end of the gap.

Also, don't let taskReader start reading before taskWriter has acquired the lease (and thus initialized our rangeid and ack level).

<!-- Tell your future self why have you made these changes -->
**Why?**
If task queues are continuously reloaded (increasing rangeid with each lease), without any db activity to increase the ack level (either no load or low sync-match-only load), then the range that we try to read when loading a task queue (from the ack level to the end of the previous rangeid block) will increase over time, unless we advance the ack level past the gaps.

This also gets rid of the useless read of the range [-1, 0) that taskReader would do immediately on starting, before taskWriter acquires the lease and initializes the right values. That confused the test in particular.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Lots of manual testing and a unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It's confusing code

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
