### PR TITLE
Make matching service executeWithRetry function stateless

### DIFF
--- a/service/matching/db_task_queue_ownership.go
+++ b/service/matching/db_task_queue_ownership.go
@@ -154,7 +154,7 @@ func (m *dbTaskQueueOwnershipImpl) takeTaskQueueOwnership() error {
 
 	case *serviceerror.NotFound:
 		if _, err := m.store.CreateTaskQueue(&persistence.CreateTaskQueueRequest{
-			RangeID: initialRangeID,
+			RangeID: dbTaskInitialRangeID,
 			TaskQueueInfo: &persistencespb.TaskQueueInfo{
 				NamespaceId:    m.taskQueueKey.NamespaceID,
 				Name:           m.taskQueueKey.TaskQueueName,
@@ -169,7 +169,7 @@ func (m *dbTaskQueueOwnershipImpl) takeTaskQueueOwnership() error {
 			return err
 		}
 		m.stateLastUpdateTime = timestamp.TimePtr(m.timeSource.Now())
-		m.updateStateLocked(initialRangeID, 0)
+		m.updateStateLocked(dbTaskInitialRangeID, 0)
 		m.status = dbTaskQueueOwnershipStatusOwned
 		return nil
 
@@ -275,7 +275,7 @@ func (m *dbTaskQueueOwnershipImpl) expiryTime() *time.Time {
 	case enumspb.TASK_QUEUE_KIND_NORMAL:
 		return nil
 	case enumspb.TASK_QUEUE_KIND_STICKY:
-		return timestamp.TimePtr(m.timeSource.Now().Add(stickyTaskQueueTTL))
+		return timestamp.TimePtr(m.timeSource.Now().Add(dbTaskStickyTaskQueueTTL))
 	default:
 		panic(fmt.Sprintf("taskQueueDB encountered unknown task kind: %v", m.taskQueueKind))
 	}

--- a/service/matching/db_task_queue_ownership_test.go
+++ b/service/matching/db_task_queue_ownership_test.go
@@ -118,7 +118,7 @@ func (s *dbTaskOwnershipSuite) TestTaskOwnership_Create_Success() {
 		TaskType:    s.taskQueueType,
 	}).Return(nil, serviceerror.NewNotFound("random error message"))
 	s.taskStore.EXPECT().CreateTaskQueue(&persistence.CreateTaskQueueRequest{
-		RangeID: initialRangeID,
+		RangeID: dbTaskInitialRangeID,
 		TaskQueueInfo: &persistencespb.TaskQueueInfo{
 			NamespaceId:    s.namespaceID,
 			Name:           s.taskQueueName,
@@ -130,12 +130,12 @@ func (s *dbTaskOwnershipSuite) TestTaskOwnership_Create_Success() {
 		},
 	}).Return(&persistence.CreateTaskQueueResponse{}, nil)
 
-	minTaskID, maxTaskID := rangeIDToTaskIDRange(initialRangeID, s.taskIDRangeSize)
+	minTaskID, maxTaskID := rangeIDToTaskIDRange(dbTaskInitialRangeID, s.taskIDRangeSize)
 	err := s.taskOwnership.takeTaskQueueOwnership()
 	s.NoError(err)
 	s.Equal(s.now, *s.taskOwnership.stateLastUpdateTime)
 	s.Equal(dbTaskQueueOwnershipState{
-		rangeID:             initialRangeID,
+		rangeID:             dbTaskInitialRangeID,
 		ackedTaskID:         0,
 		lastAllocatedTaskID: 0,
 		minTaskIDExclusive:  minTaskID,
@@ -156,7 +156,7 @@ func (s *dbTaskOwnershipSuite) TestTaskOwnership_Create_Failed() {
 		TaskType:    s.taskQueueType,
 	}).Return(nil, serviceerror.NewNotFound("random error message"))
 	s.taskStore.EXPECT().CreateTaskQueue(&persistence.CreateTaskQueueRequest{
-		RangeID: initialRangeID,
+		RangeID: dbTaskInitialRangeID,
 		TaskQueueInfo: &persistencespb.TaskQueueInfo{
 			NamespaceId:    s.namespaceID,
 			Name:           s.taskQueueName,

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -196,13 +196,16 @@ Loop:
 }
 
 func (tr *taskReader) getTaskBatchWithRange(readLevel int64, maxReadLevel int64) ([]*persistencespb.AllocatedTaskInfo, error) {
-	response, err := tr.tlMgr.executeWithRetry(func() (interface{}, error) {
-		return tr.tlMgr.db.GetTasks(readLevel, maxReadLevel, tr.tlMgr.config.GetTasksBatchSize())
+	var response *persistence.GetTasksResponse
+	var err error
+	err = executeWithRetry(func() error {
+		response, err = tr.tlMgr.db.GetTasks(readLevel, maxReadLevel, tr.tlMgr.config.GetTasksBatchSize())
+		return err
 	})
 	if err != nil {
 		return nil, err
 	}
-	return response.(*persistence.GetTasksResponse).Tasks, err
+	return response.Tasks, err
 }
 
 // Returns a batch of tasks from persistence starting form current read level.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Make matching service executeWithRetry function stateless
* Polish new db task logic for later integration

<!-- Tell your future self why have you made these changes -->
**Why?**
Cleanup logic for later integration

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No