### PR TITLE
Matching sync match task should not have completion function

### DIFF
--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -522,7 +522,7 @@ func (c *taskQueueManagerImpl) trySyncMatch(ctx context.Context, params addTaskP
 		TaskId: syncMatchTaskId,
 	}
 
-	task := newInternalTask(fakeTaskIdWrapper, c.completeTask, params.source, params.forwardedFrom, true)
+	task := newInternalTask(fakeTaskIdWrapper, nil, params.source, params.forwardedFrom, true)
 	matched, err := c.matcher.Offer(childCtx, task)
 	cancel()
 	return matched, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Remove completion function reference when doing sync matching

<!-- Tell your future self why have you made these changes -->
**Why?**
Existing logic will provide both resp channel & completion function when doing sync matching: https://github.com/temporalio/temporal/blob/v1.14.0/service/matching/taskQueueManager.go#L529
https://github.com/temporalio/temporal/blob/v1.14.0/service/matching/task.go#L83

However only resp channel will be used: https://github.com/temporalio/temporal/blob/v1.14.0/service/matching/task.go#L158

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests & CICD

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No