### PR TITLE
New GetSystemInfo RPC

### DIFF
--- a/client/frontend/client.go
+++ b/client/frontend/client.go
@@ -582,6 +582,20 @@ func (c *clientImpl) GetClusterInfo(
 	return client.GetClusterInfo(ctx, request, opts...)
 }
 
+func (c *clientImpl) GetSystemInfo(
+	ctx context.Context,
+	request *workflowservice.GetSystemInfoRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetSystemInfoResponse, error) {
+	client, err := c.getRandomClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return client.GetSystemInfo(ctx, request, opts...)
+}
+
 func (c *clientImpl) ListTaskQueuePartitions(
 	ctx context.Context,
 	request *workflowservice.ListTaskQueuePartitionsRequest,

--- a/client/frontend/metricClient.go
+++ b/client/frontend/metricClient.go
@@ -713,6 +713,23 @@ func (c *metricClient) GetClusterInfo(
 	return resp, err
 }
 
+func (c *metricClient) GetSystemInfo(
+	ctx context.Context,
+	request *workflowservice.GetSystemInfoRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetSystemInfoResponse, error) {
+
+	c.metricsClient.IncCounter(metrics.FrontendClientGetSystemInfoScope, metrics.ClientRequests)
+	sw := c.metricsClient.StartTimer(metrics.FrontendClientGetSystemInfoScope, metrics.ClientLatency)
+	resp, err := c.client.GetSystemInfo(ctx, request, opts...)
+	sw.Stop()
+
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.FrontendClientGetSystemInfoScope, metrics.ClientFailures)
+	}
+	return resp, err
+}
+
 func (c *metricClient) ListTaskQueuePartitions(
 	ctx context.Context,
 	request *workflowservice.ListTaskQueuePartitionsRequest,

--- a/client/frontend/retryableClient.go
+++ b/client/frontend/retryableClient.go
@@ -605,6 +605,21 @@ func (c *retryableClient) GetClusterInfo(
 	return resp, err
 }
 
+func (c *retryableClient) GetSystemInfo(
+	ctx context.Context,
+	request *workflowservice.GetSystemInfoRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetSystemInfoResponse, error) {
+	var resp *workflowservice.GetSystemInfoResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.GetSystemInfo(ctx, request, opts...)
+		return err
+	}
+	err := backoff.Retry(op, c.policy, c.isRetryable)
+	return resp, err
+}
+
 func (c *retryableClient) ListTaskQueuePartitions(
 	ctx context.Context,
 	request *workflowservice.ListTaskQueuePartitionsRequest,

--- a/common/authorization/frontend_api.go
+++ b/common/authorization/frontend_api.go
@@ -36,6 +36,7 @@ var readOnlyNamespaceAPI = map[string]struct{}{
 	"QueryWorkflow":                  {},
 	"DescribeWorkflowExecution":      {},
 	"DescribeTaskQueue":              {},
+	"GetSystemInfo":                  {},
 	"ListTaskQueuePartitions":        {},
 }
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -513,6 +513,8 @@ const (
 	FrontendClientReapplyEventsScope
 	// FrontendClientGetClusterInfoScope tracks RPC calls to frontend
 	FrontendClientGetClusterInfoScope
+	// FrontendClientGetSystemInfoScope tracks RPC calls to frontend
+	FrontendClientGetSystemInfoScope
 	// FrontendClientListTaskQueuePartitionsScope tracks RPC calls to frontend service
 	FrontendClientListTaskQueuePartitionsScope
 	// AdminClientAddSearchAttributesScope tracks RPC calls to admin service
@@ -870,6 +872,8 @@ const (
 	FrontendGetSearchAttributesScope
 	// FrontendGetClusterInfoScope is the metric scope for frontend.GetClusterInfo
 	FrontendGetClusterInfoScope
+	// FrontendGetSystemInfoScope is the metric scope for frontend.GetSystemInfo
+	FrontendGetSystemInfoScope
 
 	// VersionCheckScope is scope used by version checker
 	VersionCheckScope
@@ -1380,6 +1384,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		FrontendClientGetDLQReplicationTasksScope:             {operation: "FrontendClientGetDLQReplicationTasksScope", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientReapplyEventsScope:                      {operation: "FrontendClientReapplyEventsScope", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientGetClusterInfoScope:                     {operation: "FrontendClientGetClusterInfoScope", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
+		FrontendClientGetSystemInfoScope:                      {operation: "FrontendClientGetSystemInfoScope", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientListTaskQueuePartitionsScope:            {operation: "FrontendClientListTaskQueuePartitions", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		AdminClientAddSearchAttributesScope:                   {operation: "AdminClientAddSearchAttributes", tags: map[string]string{ServiceRoleTagName: AdminRoleTagValue}},
 		AdminClientRemoveSearchAttributesScope:                {operation: "AdminClientRemoveSearchAttributes", tags: map[string]string{ServiceRoleTagName: AdminRoleTagValue}},
@@ -1547,6 +1552,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		FrontendResetStickyTaskQueueScope:               {operation: "ResetStickyTaskQueue"},
 		FrontendGetSearchAttributesScope:                {operation: "GetSearchAttributes"},
 		FrontendGetClusterInfoScope:                     {operation: "GetClusterInfo"},
+		FrontendGetSystemInfoScope:                      {operation: "GetSystemInfo"},
 		VersionCheckScope:                               {operation: "VersionCheck"},
 		AuthorizationScope:                              {operation: "Authorization"},
 	},

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.0.1
 	go.opentelemetry.io/otel/sdk/export/metric v0.24.0
 	go.opentelemetry.io/otel/sdk/metric v0.24.0
-	go.temporal.io/api v1.7.0
+	go.temporal.io/api v1.7.1-0.20211215222122-0be6c74f9c9a
 	go.temporal.io/sdk v1.12.0
 	go.temporal.io/version v0.0.0-20201015012359-4d3bb966d193
 	go.uber.org/atomic v1.9.0
@@ -55,7 +55,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211005180243-6b3c2da341f1
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	google.golang.org/api v0.59.0
-	google.golang.org/grpc v1.42.0
+	google.golang.org/grpc v1.43.0
 	google.golang.org/grpc/examples v0.0.0-20211021223902-4f21cde702d9
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/validator.v2 v2.0.0-20210331031555-b37d688a7fb0
@@ -107,8 +107,8 @@ require (
 	go.opentelemetry.io/otel/trace v1.1.0 // indirect
 	go.uber.org/dig v1.13.0 // indirect
 	golang.org/x/crypto v0.0.0-20210921155107-089bfa567519 // indirect
-	golang.org/x/net v0.0.0-20211209124913-491a49abca63 // indirect
-	golang.org/x/sys v0.0.0-20211209171907-798191bca915 // indirect
+	golang.org/x/net v0.0.0-20211215060638-4ddde0e984e9 // indirect
+	golang.org/x/sys v0.0.0-20211215211219-4abf325e0275 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -460,8 +460,8 @@ go.opentelemetry.io/otel/trace v1.1.0 h1:N25T9qCL0+7IpOT8RrRy0WYlL7y6U0WiUJzXcVd
 go.opentelemetry.io/otel/trace v1.1.0/go.mod h1:i47XtdcBQiktu5IsrPqOHe8w+sBmnLwwHt8wiUsWGTI=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.temporal.io/api v1.5.0/go.mod h1:BqKxEJJYdxb5dqf0ODfzfMxh8UEQ5L3zKS51FiIYYkA=
-go.temporal.io/api v1.7.0 h1:fMaxrk8u12zPPOKgN6HCHyJjQQX6HcCxtMQTjck1rGE=
-go.temporal.io/api v1.7.0/go.mod h1:Bjxr81kDTMY0IYxbosWleAVOFE+Pnp4SRk87oWchYv8=
+go.temporal.io/api v1.7.1-0.20211215222122-0be6c74f9c9a h1:FYS1fRCzAbcek09VA3wJbzLNaG57exFehU4MrP7edN0=
+go.temporal.io/api v1.7.1-0.20211215222122-0be6c74f9c9a/go.mod h1:EMC/8OQVvVUeTSfVQ/OpAaIHmVadlzaKwHVjUmgz3tk=
 go.temporal.io/sdk v1.12.0 h1:QkqOpmgXVnHHCFP9HbSbyrF3jYgLBKY/3NdZyR7e5nQ=
 go.temporal.io/sdk v1.12.0/go.mod h1:lSp3lH1lI0TyOsus0arnO3FYvjVXBZGi/G7DjnAnm6o=
 go.temporal.io/version v0.0.0-20201015012359-4d3bb966d193 h1:jhIqHkAE74DnEXipymFTzmTxyboMYmv6iVkkCFC1pas=
@@ -579,8 +579,8 @@ golang.org/x/net v0.0.0-20210503060351-7fd8e65b6420/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210913180222-943fd674d43e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
-golang.org/x/net v0.0.0-20211209124913-491a49abca63 h1:iocB37TsdFuN6IBRZ+ry36wrkoV51/tl5vOWqkcPGvY=
-golang.org/x/net v0.0.0-20211209124913-491a49abca63/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211215060638-4ddde0e984e9 h1:kmreh1vGI63l2FxOAYS3Yv6ATsi7lSTuwNSVbGfJV9I=
+golang.org/x/net v0.0.0-20211215060638-4ddde0e984e9/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -672,8 +672,8 @@ golang.org/x/sys v0.0.0-20210910150752-751e447fb3d0/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210917161153-d61c044b1678/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20211209171907-798191bca915 h1:P+8mCzuEpyszAT6T42q0sxU+eveBAF/cJ2Kp0x6/8+0=
-golang.org/x/sys v0.0.0-20211209171907-798191bca915/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211215211219-4abf325e0275 h1:QrMf/wK/gIZUuD4s06oYPfuSxBzj4mL/rjA7D++U14o=
+golang.org/x/sys v0.0.0-20211215211219-4abf325e0275/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -887,8 +887,8 @@ google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQ
 google.golang.org/grpc v1.39.0/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.39.1/go.mod h1:PImNr+rS9TWYb2O4/emRugxiyHZ5JyHW5F+RPnDzfrE=
 google.golang.org/grpc v1.40.0/go.mod h1:ogyxbiOoUXAkP+4+xa6PZSE9DZgIHtSpzjDTB9KAK34=
-google.golang.org/grpc v1.42.0 h1:XT2/MFpuPFsEX2fWh3YQtHkZ+WYZFQRfaUgLZYj/p6A=
-google.golang.org/grpc v1.42.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
+google.golang.org/grpc v1.43.0 h1:Eeu7bZtDZ2DpRCsLhUlcrLnvYaMK1Gz86a+hMVvELmM=
+google.golang.org/grpc v1.43.0/go.mod h1:k+4IHHFw41K8+bbowsex27ge2rCb65oeWqe4jJ590SU=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/examples v0.0.0-20211021223902-4f21cde702d9 h1:oCTatYoJk72TQY+qm6mv9RvZlo9dp3SJJYVK4/ypTQs=
 google.golang.org/grpc/examples v0.0.0-20211021223902-4f21cde702d9/go.mod h1:gID3PKrg7pWKntu9Ss6zTLJ0ttC0X9IHgREOCZwbCVU=

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -94,6 +94,7 @@ var (
 
 	OtherAPIToPriority = map[string]int{
 		"GetClusterInfo":      0,
+		"GetSystemInfo":       0,
 		"GetSearchAttributes": 0,
 
 		"RegisterNamespace":  0,

--- a/service/frontend/configs/quotas_test.go
+++ b/service/frontend/configs/quotas_test.go
@@ -151,6 +151,7 @@ func (s *quotasSuite) TestVisibilityAPIs() {
 func (s *quotasSuite) TestOtherAPIs() {
 	apis := map[string]struct{}{
 		"GetClusterInfo":      {},
+		"GetSystemInfo":       {},
 		"GetSearchAttributes": {},
 
 		"RegisterNamespace":  {},

--- a/service/frontend/dcRedirectionHandler.go
+++ b/service/frontend/dcRedirectionHandler.go
@@ -1189,6 +1189,14 @@ func (handler *DCRedirectionHandlerImpl) GetClusterInfo(
 	return handler.frontendHandler.GetClusterInfo(ctx, request)
 }
 
+// GetSystemInfo API call
+func (handler *DCRedirectionHandlerImpl) GetSystemInfo(
+	ctx context.Context,
+	request *workflowservice.GetSystemInfoRequest,
+) (*workflowservice.GetSystemInfoResponse, error) {
+	return handler.frontendHandler.GetSystemInfo(ctx, request)
+}
+
 func (handler *DCRedirectionHandlerImpl) beforeCall(
 	scope int,
 ) (metrics.Scope, time.Time) {

--- a/service/frontend/interface_mock.go
+++ b/service/frontend/interface_mock.go
@@ -194,6 +194,21 @@ func (mr *MockHandlerMockRecorder) GetSearchAttributes(arg0, arg1 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSearchAttributes", reflect.TypeOf((*MockHandler)(nil).GetSearchAttributes), arg0, arg1)
 }
 
+// GetSystemInfo mocks base method.
+func (m *MockHandler) GetSystemInfo(arg0 context.Context, arg1 *v1.GetSystemInfoRequest) (*v1.GetSystemInfoResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSystemInfo", arg0, arg1)
+	ret0, _ := ret[0].(*v1.GetSystemInfoResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetSystemInfo indicates an expected call of GetSystemInfo.
+func (mr *MockHandlerMockRecorder) GetSystemInfo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSystemInfo", reflect.TypeOf((*MockHandler)(nil).GetSystemInfo), arg0, arg1)
+}
+
 // GetWorkflowExecutionHistory mocks base method.
 func (m *MockHandler) GetWorkflowExecutionHistory(arg0 context.Context, arg1 *v1.GetWorkflowExecutionHistoryRequest) (*v1.GetWorkflowExecutionHistoryResponse, error) {
 	m.ctrl.T.Helper()

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2778,6 +2778,39 @@ func (wh *WorkflowHandler) GetClusterInfo(_ context.Context, _ *workflowservice.
 	}, nil
 }
 
+// GetSystemInfo returns information about the Temporal system.
+func (wh *WorkflowHandler) GetSystemInfo(ctx context.Context, request *workflowservice.GetSystemInfoRequest) (_ *workflowservice.GetSystemInfoResponse, retError error) {
+	defer log.CapturePanic(wh.logger, &retError)
+
+	if wh.isStopped() {
+		return nil, errShuttingDown
+	}
+
+	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
+		return nil, err
+	}
+
+	if request == nil {
+		return nil, errRequestNotSet
+	}
+
+	_, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
+	if err != nil {
+		return nil, err
+	}
+
+	return &workflowservice.GetSystemInfoResponse{
+		ServerVersion: headers.ServerVersion,
+		// Capabilities should be added as needed. In many cases, capabilities are
+		// hardcoded boolean true values since older servers will respond with a
+		// form of this message without the field which is implied false.
+		Capabilities: &workflowservice.GetSystemInfoResponse_Capabilities{
+			SignalAndQueryHeader:         true,
+			InternalErrorDifferentiation: true,
+		},
+	}, nil
+}
+
 // ListTaskQueuePartitions returns all the partition and host for a task queue.
 func (wh *WorkflowHandler) ListTaskQueuePartitions(ctx context.Context, request *workflowservice.ListTaskQueuePartitionsRequest) (_ *workflowservice.ListTaskQueuePartitionsResponse, retError error) {
 	defer log.CapturePanic(wh.logger, &retError)

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -1655,6 +1655,23 @@ func (s *workflowHandlerSuite) TestVerifyHistoryIsComplete() {
 	}
 }
 
+func (s *workflowHandlerSuite) TestGetSystemInfo() {
+	config := s.newConfig()
+	config.EnableReadVisibilityFromES = dc.GetBoolPropertyFnFilteredByNamespace(true)
+
+	wh := s.getWorkflowHandler(config)
+
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(s.testNamespaceID, nil).AnyTimes()
+
+	resp, err := wh.GetSystemInfo(context.Background(), &workflowservice.GetSystemInfoRequest{
+		Namespace: s.testNamespace.String(),
+	})
+	s.NoError(err)
+	s.Equal(headers.ServerVersion, resp.ServerVersion)
+	s.True(resp.Capabilities.SignalAndQueryHeader)
+	s.True(resp.Capabilities.InternalErrorDifferentiation)
+}
+
 func (s *workflowHandlerSuite) newConfig() *Config {
 	return NewConfig(dc.NewCollection(dc.NewNoopClient(), s.mockResource.GetLogger()), numHistoryShards, "", false)
 }


### PR DESCRIPTION
**What changed?**

`WorkflowService.GetSystemInfo` RPC call was added mimics some of `GetClusterInfo` but is namespace aware. Initial version uses a fixed response. This uses https://github.com/temporalio/api/pull/134.

This was previously done in #2297 but a new branch was required to get fresh master without having to rebase over submodule updates.

Closes #2190

**Why?**

Callers for cloud and open-source servers need a namespace-aware call they can make to determine server version and system capabilities. Future capabilities can be added as needed.

**How did you test it?**

Standard unit test.

**Potential risks**

None, but the proto should be reviewed for future compatibility.

**Is hotfix candidate?**

No