### PR TITLE
Revert persistence rate limit error type

### DIFF
--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -1333,12 +1333,7 @@ func (p *metricEmitter) updateErrorMetric(scope int, err error) {
 		p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
 
 	default:
-		if err == ErrPersistenceLimitExceeded {
-			p.metricClient.IncCounter(scope, metrics.PersistenceErrBusyCounter)
-			p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
-		} else {
-			p.logger.Error("Operation failed with internal error.", tag.Error(err), tag.MetricScope(scope))
-			p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
-		}
+		p.logger.Error("Operation failed with internal error.", tag.Error(err), tag.MetricScope(scope))
+		p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
 	}
 }

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -34,7 +34,7 @@ import (
 
 var (
 	// ErrPersistenceLimitExceeded is the error indicating QPS limit reached.
-	ErrPersistenceLimitExceeded = serviceerror.NewUnavailable("Persistence Max QPS Reached.")
+	ErrPersistenceLimitExceeded = serviceerror.NewResourceExhausted("Persistence Max QPS Reached.")
 )
 
 type (

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -193,13 +193,8 @@ func (m *visibilityManagerMetrics) updateErrorMetric(scope metrics.Scope, err er
 	case *serviceerror.NotFound:
 		scope.IncCounter(metrics.VisibilityPersistenceNotFound)
 	default:
-		if err == persistence.ErrPersistenceLimitExceeded {
-			scope.IncCounter(metrics.VisibilityPersistenceResourceExhausted)
-			scope.IncCounter(metrics.VisibilityPersistenceFailures)
-		} else {
-			m.logger.Error("Operation failed with an error.", tag.Error(err))
-			scope.IncCounter(metrics.VisibilityPersistenceFailures)
-		}
+		m.logger.Error("Operation failed with an error.", tag.Error(err))
+		scope.IncCounter(metrics.VisibilityPersistenceFailures)
 	}
 
 	return err

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1174,6 +1174,11 @@ func (s *ContextImpl) handleErrorLocked(err error) error {
 }
 
 func (s *ContextImpl) handleErrorAndUpdateMaxReadLevelLocked(err error, newMaxReadLevel int64) error {
+	if err == persistence.ErrPersistenceLimitExceeded {
+		s.updateMaxReadLevelLocked(newMaxReadLevel)
+		return nil
+	}
+
 	switch err.(type) {
 	case nil:
 		// Persistence success: update max read level

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1174,11 +1174,6 @@ func (s *ContextImpl) handleErrorLocked(err error) error {
 }
 
 func (s *ContextImpl) handleErrorAndUpdateMaxReadLevelLocked(err error, newMaxReadLevel int64) error {
-	if err == persistence.ErrPersistenceLimitExceeded {
-		s.updateMaxReadLevelLocked(newMaxReadLevel)
-		return nil
-	}
-
 	switch err.(type) {
 	case nil:
 		// Persistence success: update max read level


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Revert persistence rate limit error type.

<!-- Tell your future self why have you made these changes -->
**Why?**
Persistence rate limiting error type was changed from ResourceExahusted to Unavailable but the shard context's handleError was not updated. This cause shard to unload/reload on this error which increases persistence load and amplify the problem.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes