### PR TITLE
Fix transient workflow task check in getRawHistory

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2875,7 +2875,7 @@ func (wh *WorkflowHandler) getRawHistory(
 		})
 	}
 
-	if len(nextPageToken) == 0 && transientWorkflowTaskInfo != nil {
+	if len(resp.NextPageToken) == 0 && transientWorkflowTaskInfo != nil {
 		if err := wh.validateTransientWorkflowTaskEvents(nextEventID, transientWorkflowTaskInfo); err != nil {
 			scope.IncCounter(metrics.ServiceErrIncompleteHistoryCounter)
 			wh.logger.Error("getHistory error",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix transient workflow task check in getRawHistory

<!-- Tell your future self why have you made these changes -->
**Why?**
- Existing check checks the wrong nextPageToken, and transient workflow task won't be returned if input nextPageToken is not empty.
- This will cause raw transient workflow task not being sent to worker if workflow history is long (larger than one page, which will cause worker to all GetWorkflowExecutionHistory). On the worker side, we will see the `premature end of stream` error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added unit test. Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes