### PR TITLE
Fix remote sync match for standby namespaces

### DIFF
--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -286,15 +286,12 @@ func (c *taskQueueManagerImpl) AddTask(
 			return err
 		}
 
-		if !namespaceEntry.ActiveInCluster(c.clusterMeta.GetCurrentClusterName()) {
-			_, err := c.taskWriter.appendTask(params.execution, taskInfo)
-			syncMatch = false
-			return err
-		}
-
-		syncMatch, err = c.trySyncMatch(ctx, params)
-		if syncMatch {
-			return err
+		syncMatch = false
+		if namespaceEntry.ActiveInCluster(c.clusterMeta.GetCurrentClusterName()) {
+			syncMatch, err = c.trySyncMatch(ctx, params)
+			if syncMatch {
+				return err
+			}
 		}
 
 		if params.forwardedFrom != "" {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- do not persist forwarded tasks for standby namespaces

<!-- Tell your future self why have you made these changes -->
**Why?**
- Forwarded tasks should never be persisted
- Ideally child partition should not send remote sync request if namespace is passive, but child partition and parent partition may live in two different hosts and have different view of whether namespace is active or not (e.g. child think it's active while parent refreshes namespace cache first and found it's actually passive), so the check on the receiver side is still needed.
- forwarded tasks have no ttl and will live in db forever if namespace never does failover, causing large partition issue.
- more details here: https://github.com/uber/cadence/pull/4654

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes