### PR TITLE
Fix queue diff metrics for disabled clusters

### DIFF
--- a/service/history/replicationDLQHandler_test.go
+++ b/service/history/replicationDLQHandler_test.go
@@ -109,6 +109,7 @@ func (s *replicationDLQHandlerSuite) SetupTest() {
 	s.shardManager = s.mockResource.ShardMgr
 	s.config = tests.NewDynamicConfig()
 	s.clusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.clusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.taskExecutors = make(map[string]replicationTaskExecutor)
 	s.taskExecutor = NewMockreplicationTaskExecutor(s.controller)
 	s.sourceCluster = cluster.TestAlternativeClusterName

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -992,10 +992,15 @@ func (s *ContextImpl) updateShardInfoLocked() error {
 
 func (s *ContextImpl) emitShardInfoMetricsLogsLocked() {
 	currentCluster := s.GetClusterMetadata().GetCurrentClusterName()
+	clusterInfo := s.GetClusterMetadata().GetAllClusterInfo()
 
 	minTransferLevel := s.shardInfo.ClusterTransferAckLevel[currentCluster]
 	maxTransferLevel := s.shardInfo.ClusterTransferAckLevel[currentCluster]
-	for _, v := range s.shardInfo.ClusterTransferAckLevel {
+	for clusterName, v := range s.shardInfo.ClusterTransferAckLevel {
+		if !clusterInfo[clusterName].Enabled {
+			continue
+		}
+
 		if v < minTransferLevel {
 			minTransferLevel = v
 		}
@@ -1007,7 +1012,11 @@ func (s *ContextImpl) emitShardInfoMetricsLogsLocked() {
 
 	minTimerLevel := timestamp.TimeValue(s.shardInfo.ClusterTimerAckLevel[currentCluster])
 	maxTimerLevel := timestamp.TimeValue(s.shardInfo.ClusterTimerAckLevel[currentCluster])
-	for _, v := range s.shardInfo.ClusterTimerAckLevel {
+	for clusterName, v := range s.shardInfo.ClusterTimerAckLevel {
+		if !clusterInfo[clusterName].Enabled {
+			continue
+		}
+
 		t := timestamp.TimeValue(v)
 		if t.Before(minTimerLevel) {
 			minTimerLevel = t

--- a/service/history/timerQueueAckMgr_test.go
+++ b/service/history/timerQueueAckMgr_test.go
@@ -476,6 +476,7 @@ func (s *timerQueueAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 		NextPageToken: nil,
 	}
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockExecutionMgr.EXPECT().GetTimerTasks(gomock.Any()).Return(response, nil)
 	s.mockExecutionMgr.EXPECT().GetTimerTasks(gomock.Any()).Return(&persistence.GetTimerTasksResponse{}, nil)
 	filteredTasks, lookAheadTask, moreTasks, err := s.timerQueueAckMgr.readTimerTasks()
@@ -784,6 +785,7 @@ func (s *timerQueueFailoverAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 		NextPageToken: nil,
 	}
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockExecutionMgr.EXPECT().GetTimerTasks(gomock.Any()).Return(response, nil)
 	filteredTasks, lookAheadTask, moreTasks, err := s.timerQueueFailoverAckMgr.readTimerTasks()
 	s.Nil(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Ignore disabled cluster when calculating queue diff metrics

<!-- Tell your future self why have you made these changes -->
**Why?**
- Disabled clusters' ack level won't advance and they also won't prevent overall task queue ack level from advancing. If they are included in the calculation, the queue diff metrics will only keeping increasing, while there's actually no lag at all.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, just changing metrics

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.