### PR TITLE
Notify new tasks when workflow is potentially updated

### DIFF
--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -88,7 +88,7 @@ func (t *TransactionImpl) CreateWorkflowExecution(
 		NewWorkflowSnapshot: *newWorkflowSnapshot,
 		NewWorkflowEvents:   newWorkflowEventsSeq,
 	})
-	if operationMayApplied(err) {
+	if operationPossiblySucceeded(err) {
 		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
 	}
 	if err != nil {
@@ -132,7 +132,7 @@ func (t *TransactionImpl) ConflictResolveWorkflowExecution(
 		CurrentWorkflowMutation: currentWorkflowMutation,
 		CurrentWorkflowEvents:   currentWorkflowEventsSeq,
 	})
-	if operationMayApplied(err) {
+	if operationPossiblySucceeded(err) {
 		NotifyWorkflowSnapshotTasks(engine, resetWorkflowSnapshot, nsEntry.IsGlobalNamespace())
 		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
 		NotifyWorkflowMutationTasks(engine, currentWorkflowMutation, nsEntry.IsGlobalNamespace())
@@ -188,7 +188,7 @@ func (t *TransactionImpl) UpdateWorkflowExecution(
 		NewWorkflowSnapshot:    newWorkflowSnapshot,
 		NewWorkflowEvents:      newWorkflowEventsSeq,
 	})
-	if operationMayApplied(err) {
+	if operationPossiblySucceeded(err) {
 		NotifyWorkflowMutationTasks(engine, currentWorkflowMutation, nsEntry.IsGlobalNamespace())
 		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
 	}
@@ -736,7 +736,7 @@ func emitCompletionMetrics(
 	}
 }
 
-func operationMayApplied(err error) bool {
+func operationPossiblySucceeded(err error) bool {
 	switch err.(type) {
 	case *persistence.CurrentWorkflowConditionFailedError,
 		*persistence.WorkflowConditionFailedError,

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -72,17 +72,6 @@ func (t *TransactionImpl) CreateWorkflowExecution(
 	newWorkflowEventsSeq []*persistence.WorkflowEvents,
 ) (int64, error) {
 
-	resp, err := createWorkflowExecutionWithRetry(t.shard, &persistence.CreateWorkflowExecutionRequest{
-		ShardID: t.shard.GetShardID(),
-		// RangeID , this is set by shard context
-		Mode:                createMode,
-		NewWorkflowSnapshot: *newWorkflowSnapshot,
-		NewWorkflowEvents:   newWorkflowEventsSeq,
-	})
-	if err != nil {
-		return 0, err
-	}
-
 	engine, err := t.shard.GetEngine()
 	if err != nil {
 		return 0, err
@@ -91,7 +80,21 @@ func (t *TransactionImpl) CreateWorkflowExecution(
 	if err != nil {
 		return 0, err
 	}
-	NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
+
+	resp, err := createWorkflowExecutionWithRetry(t.shard, &persistence.CreateWorkflowExecutionRequest{
+		ShardID: t.shard.GetShardID(),
+		// RangeID , this is set by shard context
+		Mode:                createMode,
+		NewWorkflowSnapshot: *newWorkflowSnapshot,
+		NewWorkflowEvents:   newWorkflowEventsSeq,
+	})
+	if operationMayApplied(err) {
+		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
+	}
+	if err != nil {
+		return 0, err
+	}
+
 	if err := NotifyNewHistorySnapshotEvent(engine, newWorkflowSnapshot); err != nil {
 		t.logger.Error("unable to notify workflow creation", tag.Error(err))
 	}
@@ -109,6 +112,15 @@ func (t *TransactionImpl) ConflictResolveWorkflowExecution(
 	currentWorkflowEventsSeq []*persistence.WorkflowEvents,
 ) (int64, int64, int64, error) {
 
+	engine, err := t.shard.GetEngine()
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	nsEntry, err := t.shard.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(resetWorkflowSnapshot.ExecutionInfo.NamespaceId))
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
 	resp, err := conflictResolveWorkflowExecutionWithRetry(t.shard, &persistence.ConflictResolveWorkflowExecutionRequest{
 		ShardID: t.shard.GetShardID(),
 		// RangeID , this is set by shard context
@@ -120,21 +132,15 @@ func (t *TransactionImpl) ConflictResolveWorkflowExecution(
 		CurrentWorkflowMutation: currentWorkflowMutation,
 		CurrentWorkflowEvents:   currentWorkflowEventsSeq,
 	})
+	if operationMayApplied(err) {
+		NotifyWorkflowSnapshotTasks(engine, resetWorkflowSnapshot, nsEntry.IsGlobalNamespace())
+		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
+		NotifyWorkflowMutationTasks(engine, currentWorkflowMutation, nsEntry.IsGlobalNamespace())
+	}
 	if err != nil {
 		return 0, 0, 0, err
 	}
 
-	engine, err := t.shard.GetEngine()
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	nsEntry, err := t.shard.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(resetWorkflowSnapshot.ExecutionInfo.NamespaceId))
-	if err != nil {
-		return 0, 0, 0, err
-	}
-	NotifyWorkflowSnapshotTasks(engine, resetWorkflowSnapshot, nsEntry.IsGlobalNamespace())
-	NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
-	NotifyWorkflowMutationTasks(engine, currentWorkflowMutation, nsEntry.IsGlobalNamespace())
 	if err := NotifyNewHistorySnapshotEvent(engine, resetWorkflowSnapshot); err != nil {
 		t.logger.Error("unable to notify workflow reset", tag.Error(err))
 	}
@@ -164,6 +170,15 @@ func (t *TransactionImpl) UpdateWorkflowExecution(
 	newWorkflowEventsSeq []*persistence.WorkflowEvents,
 ) (int64, int64, error) {
 
+	engine, err := t.shard.GetEngine()
+	if err != nil {
+		return 0, 0, err
+	}
+	nsEntry, err := t.shard.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(currentWorkflowMutation.ExecutionInfo.NamespaceId))
+	if err != nil {
+		return 0, 0, err
+	}
+
 	resp, err := updateWorkflowExecutionWithRetry(t.shard, &persistence.UpdateWorkflowExecutionRequest{
 		ShardID: t.shard.GetShardID(),
 		// RangeID , this is set by shard context
@@ -173,20 +188,14 @@ func (t *TransactionImpl) UpdateWorkflowExecution(
 		NewWorkflowSnapshot:    newWorkflowSnapshot,
 		NewWorkflowEvents:      newWorkflowEventsSeq,
 	})
+	if operationMayApplied(err) {
+		NotifyWorkflowMutationTasks(engine, currentWorkflowMutation, nsEntry.IsGlobalNamespace())
+		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
+	}
 	if err != nil {
 		return 0, 0, err
 	}
 
-	engine, err := t.shard.GetEngine()
-	if err != nil {
-		return 0, 0, err
-	}
-	nsEntry, err := t.shard.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(currentWorkflowMutation.ExecutionInfo.NamespaceId))
-	if err != nil {
-		return 0, 0, err
-	}
-	NotifyWorkflowMutationTasks(engine, currentWorkflowMutation, nsEntry.IsGlobalNamespace())
-	NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, nsEntry.IsGlobalNamespace())
 	if err := NotifyNewHistoryMutationEvent(engine, currentWorkflowMutation); err != nil {
 		t.logger.Error("unable to notify workflow mutation", tag.Error(err))
 	}
@@ -725,4 +734,22 @@ func emitCompletionMetrics(
 			completionMetric.status,
 		)
 	}
+}
+
+func operationMayApplied(err error) bool {
+	switch err.(type) {
+	case *persistence.CurrentWorkflowConditionFailedError,
+		*persistence.WorkflowConditionFailedError,
+		*persistence.ConditionFailedError,
+		*persistence.ShardOwnershipLostError,
+		*persistence.InvalidPersistenceRequestError,
+		*persistence.TransactionSizeLimitError,
+		*serviceerror.ResourceExhausted,
+		*serviceerror.NotFound:
+		// Persistence failure that means the write was definitely not committed:
+		return false
+	default:
+		return true
+	}
+
 }

--- a/service/history/workflow/transaction_test.go
+++ b/service/history/workflow/transaction_test.go
@@ -104,13 +104,13 @@ func (s *transactionSuite) TestOperationMayApplied() {
 	}
 
 	for _, tc := range testCases {
-		s.Equal(tc.mayApplied, operationMayApplied(tc.err))
+		s.Equal(tc.mayApplied, operationPossiblySucceeded(tc.err))
 	}
 }
 
 func (s *transactionSuite) TestCreateWorkflowExecution_NotifyTaskWhenFailed() {
 	timeoutErr := &persistence.TimeoutError{}
-	s.True(operationMayApplied(timeoutErr))
+	s.True(operationPossiblySucceeded(timeoutErr))
 
 	s.mockShard.EXPECT().CreateWorkflowExecution(gomock.Any()).Return(nil, timeoutErr)
 	s.setupMockForTaskNotification()
@@ -133,7 +133,7 @@ func (s *transactionSuite) TestCreateWorkflowExecution_NotifyTaskWhenFailed() {
 
 func (s *transactionSuite) TestUpdateWorkflowExecution_NotifyTaskWhenFailed() {
 	timeoutErr := &persistence.TimeoutError{}
-	s.True(operationMayApplied(timeoutErr))
+	s.True(operationPossiblySucceeded(timeoutErr))
 
 	s.mockShard.EXPECT().UpdateWorkflowExecution(gomock.Any()).Return(nil, timeoutErr)
 	s.setupMockForTaskNotification() // for current workflow mutation
@@ -159,7 +159,7 @@ func (s *transactionSuite) TestUpdateWorkflowExecution_NotifyTaskWhenFailed() {
 
 func (s *transactionSuite) TestConflictResolveWorkflowExecution_NotifyTaskWhenFailed() {
 	timeoutErr := &persistence.TimeoutError{}
-	s.True(operationMayApplied(timeoutErr))
+	s.True(operationPossiblySucceeded(timeoutErr))
 
 	s.mockShard.EXPECT().ConflictResolveWorkflowExecution(gomock.Any()).Return(nil, timeoutErr)
 	s.setupMockForTaskNotification() // for reset workflow snapshot

--- a/service/history/workflow/transaction_test.go
+++ b/service/history/workflow/transaction_test.go
@@ -1,0 +1,194 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package workflow
+
+import (
+	"errors"
+
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/api/serviceerror"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tests"
+)
+
+type (
+	transactionSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		controller         *gomock.Controller
+		mockShard          *shard.MockContext
+		mockEngine         *shard.MockEngine
+		mockNamespaceCache *namespace.MockRegistry
+
+		logger log.Logger
+
+		transaction *TransactionImpl
+	}
+)
+
+func TestTransactionSuite(t *testing.T) {
+	s := new(transactionSuite)
+	suite.Run(t, s)
+}
+
+func (s *transactionSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.controller = gomock.NewController(s.T())
+	s.mockShard = shard.NewMockContext(s.controller)
+	s.mockEngine = shard.NewMockEngine(s.controller)
+	s.mockNamespaceCache = namespace.NewMockRegistry(s.controller)
+	s.logger = log.NewTestLogger()
+
+	s.mockShard.EXPECT().GetShardID().Return(int32(1)).AnyTimes()
+	s.mockShard.EXPECT().GetEngine().Return(s.mockEngine, nil).AnyTimes()
+	s.mockShard.EXPECT().GetNamespaceRegistry().Return(s.mockNamespaceCache).AnyTimes()
+	s.mockShard.EXPECT().GetLogger().Return(s.logger).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
+
+	s.transaction = NewTransaction(s.mockShard)
+}
+
+func (s *transactionSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *transactionSuite) TestOperationMayApplied() {
+	testCases := []struct {
+		err        error
+		mayApplied bool
+	}{
+		{err: &persistence.CurrentWorkflowConditionFailedError{}, mayApplied: false},
+		{err: &persistence.WorkflowConditionFailedError{}, mayApplied: false},
+		{err: &persistence.ConditionFailedError{}, mayApplied: false},
+		{err: &persistence.ShardOwnershipLostError{}, mayApplied: false},
+		{err: &persistence.InvalidPersistenceRequestError{}, mayApplied: false},
+		{err: &persistence.TransactionSizeLimitError{}, mayApplied: false},
+		{err: &serviceerror.ResourceExhausted{}, mayApplied: false},
+		{err: &serviceerror.NotFound{}, mayApplied: false},
+		{err: nil, mayApplied: true},
+		{err: &persistence.TimeoutError{}, mayApplied: true},
+		{err: &serviceerror.Unavailable{}, mayApplied: true},
+		{err: errors.New("some unknown error"), mayApplied: true},
+	}
+
+	for _, tc := range testCases {
+		s.Equal(tc.mayApplied, operationMayApplied(tc.err))
+	}
+}
+
+func (s *transactionSuite) TestCreateWorkflowExecution_NotifyTaskWhenFailed() {
+	timeoutErr := &persistence.TimeoutError{}
+	s.True(operationMayApplied(timeoutErr))
+
+	s.mockShard.EXPECT().CreateWorkflowExecution(gomock.Any()).Return(nil, timeoutErr)
+	s.setupMockForTaskNotification()
+
+	_, err := s.transaction.CreateWorkflowExecution(
+		persistence.CreateWorkflowModeBrandNew,
+		&persistence.WorkflowSnapshot{
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				NamespaceId: tests.NamespaceID.String(),
+				WorkflowId:  tests.WorkflowID,
+			},
+			ExecutionState: &persistencespb.WorkflowExecutionState{
+				RunId: tests.RunID,
+			},
+		},
+		[]*persistence.WorkflowEvents{},
+	)
+	s.Equal(timeoutErr, err)
+}
+
+func (s *transactionSuite) TestUpdateWorkflowExecution_NotifyTaskWhenFailed() {
+	timeoutErr := &persistence.TimeoutError{}
+	s.True(operationMayApplied(timeoutErr))
+
+	s.mockShard.EXPECT().UpdateWorkflowExecution(gomock.Any()).Return(nil, timeoutErr)
+	s.setupMockForTaskNotification() // for current workflow mutation
+	s.setupMockForTaskNotification() // for new workflow snapshot
+
+	_, _, err := s.transaction.UpdateWorkflowExecution(
+		persistence.UpdateWorkflowModeUpdateCurrent,
+		&persistence.WorkflowMutation{
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				NamespaceId: tests.NamespaceID.String(),
+				WorkflowId:  tests.WorkflowID,
+			},
+			ExecutionState: &persistencespb.WorkflowExecutionState{
+				RunId: tests.RunID,
+			},
+		},
+		[]*persistence.WorkflowEvents{},
+		&persistence.WorkflowSnapshot{},
+		[]*persistence.WorkflowEvents{},
+	)
+	s.Equal(timeoutErr, err)
+}
+
+func (s *transactionSuite) TestConflictResolveWorkflowExecution_NotifyTaskWhenFailed() {
+	timeoutErr := &persistence.TimeoutError{}
+	s.True(operationMayApplied(timeoutErr))
+
+	s.mockShard.EXPECT().ConflictResolveWorkflowExecution(gomock.Any()).Return(nil, timeoutErr)
+	s.setupMockForTaskNotification() // for reset workflow snapshot
+	s.setupMockForTaskNotification() // for new workflow snapshot
+	s.setupMockForTaskNotification() // for current workflow mutation
+
+	_, _, _, err := s.transaction.ConflictResolveWorkflowExecution(
+		persistence.ConflictResolveWorkflowModeUpdateCurrent,
+		&persistence.WorkflowSnapshot{
+			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
+				NamespaceId: tests.NamespaceID.String(),
+				WorkflowId:  tests.WorkflowID,
+			},
+			ExecutionState: &persistencespb.WorkflowExecutionState{
+				RunId: tests.RunID,
+			},
+		},
+		[]*persistence.WorkflowEvents{},
+		&persistence.WorkflowSnapshot{},
+		[]*persistence.WorkflowEvents{},
+		&persistence.WorkflowMutation{},
+		[]*persistence.WorkflowEvents{},
+	)
+	s.Equal(timeoutErr, err)
+}
+
+func (s *transactionSuite) setupMockForTaskNotification() {
+	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any(), gomock.Any()).Times(1)
+	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any(), gomock.Any()).Times(1)
+	s.mockEngine.EXPECT().NotifyNewVisibilityTasks(gomock.Any()).Times(1)
+	s.mockEngine.EXPECT().NotifyNewReplicationTasks(gomock.Any()).Times(1)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Notify new tasks if persistence operation may succeed (applied)

<!-- Tell your future self why have you made these changes -->
**Why?**
- Please check https://github.com/uber/cadence/pull/3678
- Note: even if we don't notify, those tasks won't be lost since queue processor will load tasks every 30s or so. Workflow will just experience delay.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit test


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
We may have more task loading persistence requests


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
