### PR TITLE
Fix fail workflow task and generate new workflow task

### DIFF
--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -662,8 +662,10 @@ func (s *clientIntegrationSuite) Test_UnhandledCommandAndNewTask() {
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                  id,
 		TaskQueue:           s.taskQueue,
-		WorkflowRunTimeout:  10 * time.Second,
+		// Intentionally use same timeout for WorkflowTaskTimeout and WorkflowRunTimeout so if workflow task is not
+		// correctly dispatched, it would time out which would fail the workflow and cause test to fail.
 		WorkflowTaskTimeout: 10 * time.Second,
+		WorkflowRunTimeout:  10 * time.Second,
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -660,8 +660,8 @@ func (s *clientIntegrationSuite) Test_UnhandledCommandAndNewTask() {
 
 	id := "integration-test-unhandled-command-new-task"
 	workflowOptions := sdkclient.StartWorkflowOptions{
-		ID:                  id,
-		TaskQueue:           s.taskQueue,
+		ID:        id,
+		TaskQueue: s.taskQueue,
 		// Intentionally use same timeout for WorkflowTaskTimeout and WorkflowRunTimeout so if workflow task is not
 		// correctly dispatched, it would time out which would fail the workflow and cause test to fail.
 		WorkflowTaskTimeout: 10 * time.Second,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Correctly handle new workflow task in case RespondWorkflowTaskCompleted failed.

<!-- Tell your future self why have you made these changes -->
**Why?**
In case of RespondWorkflowTaskCompleted failed, server would return error and won't be able to piggyback a new workflow task. The new workflow task needs to go through normal transfer queue -> matching -> poller route to be delivered to worker.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No