### PR TITLE
Bundle shard controller deps into struct

### DIFF
--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -244,6 +244,17 @@ func (s *Test) GetHostInfo() *membership.HostInfo {
 	return testHostInfo
 }
 
+// GetHostInfoProvider for testing
+func (s *Test) GetHostInfoProvider() HostInfoProvider {
+	return testResourceHostInfoProvider{s}
+}
+
+type testResourceHostInfoProvider struct {
+	*Test
+}
+func (t testResourceHostInfoProvider) Start() error { return nil }
+func (t testResourceHostInfoProvider) HostInfo() *membership.HostInfo { return t.GetHostInfo() }
+
 // GetClusterMetadata for testing
 func (s *Test) GetClusterMetadata() cluster.Metadata {
 	return s.ClusterMetadata

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -252,7 +252,8 @@ func (s *Test) GetHostInfoProvider() HostInfoProvider {
 type testResourceHostInfoProvider struct {
 	*Test
 }
-func (t testResourceHostInfoProvider) Start() error { return nil }
+
+func (t testResourceHostInfoProvider) Start() error                   { return nil }
 func (t testResourceHostInfoProvider) HostInfo() *membership.HostInfo { return t.GetHostInfo() }
 
 // GetClusterMetadata for testing

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -79,7 +79,7 @@ type (
 
 	ContextImpl struct {
 		// These fields are constant:
-		ShardControllerDeps
+		shardControllerDeps
 		shardID             int32
 		eventsCache         events.Cache
 		closeCallback       func(*ContextImpl)
@@ -1630,7 +1630,7 @@ func (s *ContextImpl) acquireShard(newMaxReadLevel int64) {
 
 func newContext(
 	shardID int32,
-	deps ShardControllerDeps,
+	deps shardControllerDeps,
 	factory EngineFactory,
 	closeCallback func(*ContextImpl),
 ) (*ContextImpl, error) {
@@ -1640,7 +1640,7 @@ func newContext(
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 
 	shardContext := &ContextImpl{
-		ShardControllerDeps: deps,
+		shardControllerDeps: deps,
 		state:               contextStateInitialized,
 		shardID:             shardID,
 		closeCallback:       closeCallback,

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -89,10 +89,10 @@ func (s *contextSuite) SetupTest() {
 	s.namespaceID = "namespace-Id"
 	s.namespaceEntry = namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{Id: s.namespaceID.String()}, &persistencespb.NamespaceConfig{}, "")
 	s.mockNamespaceCache = s.mockResource.NamespaceCache
-	shardContext.namespaceRegistry = s.mockResource.NamespaceCache
+	shardContext.d.NamespaceRegistry = s.mockResource.NamespaceCache
 
 	s.mockClusterMetadata = s.mockResource.ClusterMetadata
-	shardContext.clusterMetadata = s.mockClusterMetadata
+	shardContext.d.ClusterMetadata = s.mockClusterMetadata
 
 	s.mockExecutionManager = s.mockResource.ExecutionMgr
 	s.mockHistoryEngine = NewMockEngine(s.controller)

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -89,10 +89,10 @@ func (s *contextSuite) SetupTest() {
 	s.namespaceID = "namespace-Id"
 	s.namespaceEntry = namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{Id: s.namespaceID.String()}, &persistencespb.NamespaceConfig{}, "")
 	s.mockNamespaceCache = s.mockResource.NamespaceCache
-	shardContext.d.NamespaceRegistry = s.mockResource.NamespaceCache
+	shardContext.NamespaceRegistry = s.mockResource.NamespaceCache
 
 	s.mockClusterMetadata = s.mockResource.ClusterMetadata
-	shardContext.d.ClusterMetadata = s.mockClusterMetadata
+	shardContext.ClusterMetadata = s.mockClusterMetadata
 
 	s.mockExecutionManager = s.mockResource.ExecutionMgr
 	s.mockHistoryEngine = NewMockEngine(s.controller)

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -72,7 +72,7 @@ func NewTestContext(
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	hostIdentity := resource.GetHostInfo().Identity()
 	shard := &ContextImpl{
-		ShardControllerDeps: ShardControllerDeps{
+		shardControllerDeps: shardControllerDeps{
 			Config:                      config,
 			Logger:                      resource.GetLogger(),
 			ThrottledLogger:             resource.GetThrottledLogger(),

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -57,7 +57,7 @@ func NewTestContextWithTimeSource(
 	timeSource clock.TimeSource,
 ) *ContextTest {
 	result := NewTestContext(ctrl, shardInfo, config)
-	result.d.TimeSource = timeSource
+	result.TimeSource = timeSource
 	result.Resource.TimeSource = timeSource
 	return result
 }
@@ -72,7 +72,7 @@ func NewTestContext(
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	hostIdentity := resource.GetHostInfo().Identity()
 	shard := &ContextImpl{
-		d: ShardControllerDeps{
+		ShardControllerDeps: ShardControllerDeps{
 			Config:                      config,
 			Logger:                      resource.GetLogger(),
 			ThrottledLogger:             resource.GetThrottledLogger(),

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -49,7 +49,7 @@ const (
 
 type (
 	ControllerImpl struct {
-		d ShardControllerDeps
+		d shardControllerDeps
 
 		status              int32
 		membershipUpdateCh  chan *membership.ChangedEvent

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -89,7 +89,7 @@ func NewTestController(
 ) *ControllerImpl {
 	hostIdentity := resource.GetHostInfo().Identity()
 	return &ControllerImpl{
-		d: ShardControllerDeps{
+		d: shardControllerDeps{
 			Config:                      config,
 			Logger:                      resource.GetLogger(),
 			ThrottledLogger:             resource.GetThrottledLogger(),

--- a/service/history/shard/fx.go
+++ b/service/history/shard/fx.go
@@ -48,48 +48,35 @@ var Module = fx.Options(
 	fx.Provide(ShardControllerProvider),
 )
 
-func ShardControllerProvider(
-	config *configs.Config,
-	logger log.Logger,
-	throttledLogger resource.ThrottledLogger,
-	persistenceExecutionManager persistence.ExecutionManager,
-	persistenceShardManager persistence.ShardManager,
-	clientBean client.Bean,
-	historyClient historyservice.HistoryServiceClient,
-	historyServiceResolver membership.ServiceResolver,
-	metricsClient metrics.Client,
-	payloadSerializer serialization.Serializer,
-	timeSource clock.TimeSource,
-	namespaceRegistry namespace.Registry,
-	saProvider searchattribute.Provider,
-	saMapper searchattribute.Mapper,
-	clusterMetadata cluster.Metadata,
-	archivalMetadata archiver.ArchivalMetadata,
-	hostInfoProvider resource.HostInfoProvider,
-) *ControllerImpl {
+type ShardControllerDeps struct {
+	fx.In
+
+	Config                      *configs.Config
+	Logger                      log.Logger
+	ThrottledLogger             resource.ThrottledLogger
+	PersistenceExecutionManager persistence.ExecutionManager
+	PersistenceShardManager     persistence.ShardManager
+	ClientBean                  client.Bean
+	HistoryClient               historyservice.HistoryServiceClient
+	HistoryServiceResolver      membership.ServiceResolver
+	MetricsClient               metrics.Client
+	PayloadSerializer           serialization.Serializer
+	TimeSource                  clock.TimeSource
+	NamespaceRegistry           namespace.Registry
+	SaProvider                  searchattribute.Provider
+	SaMapper                    searchattribute.Mapper
+	ClusterMetadata             cluster.Metadata
+	ArchivalMetadata            archiver.ArchivalMetadata
+	HostInfoProvider            resource.HostInfoProvider
+}
+
+func ShardControllerProvider(d ShardControllerDeps) *ControllerImpl {
 	return &ControllerImpl{
-		status:                      common.DaemonStatusInitialized,
-		membershipUpdateCh:          make(chan *membership.ChangedEvent, 10),
-		historyShards:               make(map[int32]*ContextImpl),
-		shutdownCh:                  make(chan struct{}),
-		logger:                      logger,
-		contextTaggedLogger:         logger,          // will add tags in Start
-		throttledLogger:             throttledLogger, // will add tags in Start
-		config:                      config,
-		metricsScope:                metricsClient.Scope(metrics.HistoryShardControllerScope),
-		persistenceExecutionManager: persistenceExecutionManager,
-		persistenceShardManager:     persistenceShardManager,
-		clientBean:                  clientBean,
-		historyClient:               historyClient,
-		historyServiceResolver:      historyServiceResolver,
-		metricsClient:               metricsClient,
-		payloadSerializer:           payloadSerializer,
-		timeSource:                  timeSource,
-		namespaceRegistry:           namespaceRegistry,
-		saProvider:                  saProvider,
-		saMapper:                    saMapper,
-		clusterMetadata:             clusterMetadata,
-		archivalMetadata:            archivalMetadata,
-		hostInfoProvider:            hostInfoProvider,
+		d:                  d,
+		status:             common.DaemonStatusInitialized,
+		membershipUpdateCh: make(chan *membership.ChangedEvent, 10),
+		shutdownCh:         make(chan struct{}),
+		metricsScope:       d.MetricsClient.Scope(metrics.HistoryShardControllerScope),
+		historyShards:      make(map[int32]*ContextImpl),
 	}
 }

--- a/service/history/shard/fx.go
+++ b/service/history/shard/fx.go
@@ -48,7 +48,7 @@ var Module = fx.Options(
 	fx.Provide(ShardControllerProvider),
 )
 
-type ShardControllerDeps struct {
+type shardControllerDeps struct {
 	fx.In
 
 	Config                      *configs.Config
@@ -70,7 +70,7 @@ type ShardControllerDeps struct {
 	HostInfoProvider            resource.HostInfoProvider
 }
 
-func ShardControllerProvider(d ShardControllerDeps) *ControllerImpl {
+func ShardControllerProvider(d shardControllerDeps) *ControllerImpl {
 	return &ControllerImpl{
 		d:                  d,
 		status:             common.DaemonStatusInitialized,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use `fx.In` to reduce boilerplate of long lists of dependencies.

Since the deps struct can't be embedded directly (without a field name), this pattern required changing a lot of references to go through the new field. This is kind of annoying but seems to be required for now.

<!-- Tell your future self why have you made these changes -->
**Why?**
Maintainability

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests + integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
