### PR TITLE
Create v2 index template for ES visibility 

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -58,6 +58,8 @@ const (
 	scrollKeepAliveInterval      = "1m"
 
 	readTimeout = 16 * time.Second
+
+	v2IndexPrefix = "temporal_visibility_v2"
 )
 
 type (
@@ -598,14 +600,22 @@ func (s *visibilityStore) buildSearchParameters(
 		params.SearchAfter = token.SearchAfter
 	}
 
-	if overStartTime {
-		params.Sorter = append(params.Sorter, elastic.NewFieldSort(searchattribute.StartTime).Desc())
+	if strings.HasPrefix(s.index, v2IndexPrefix) {
+		params.Sorter = []elastic.Sorter{
+			elastic.NewFieldSort(searchattribute.CloseTime).Desc(),
+			elastic.NewFieldSort(searchattribute.StartTime).Desc(),
+			elastic.NewFieldSort(searchattribute.RunID).Desc(),
+		}
 	} else {
-		params.Sorter = append(params.Sorter, elastic.NewFieldSort(searchattribute.CloseTime).Desc())
-	}
+		if overStartTime {
+			params.Sorter = append(params.Sorter, elastic.NewFieldSort(searchattribute.StartTime).Desc())
+		} else {
+			params.Sorter = append(params.Sorter, elastic.NewFieldSort(searchattribute.CloseTime).Desc())
+		}
 
-	// RunID is explicit tiebreaker.
-	params.Sorter = append(params.Sorter, elastic.NewFieldSort(searchattribute.RunID).Desc())
+		// RunID is explicit tiebreaker.
+		params.Sorter = append(params.Sorter, elastic.NewFieldSort(searchattribute.RunID).Desc())
+	}
 
 	return params, nil
 }
@@ -658,6 +668,15 @@ func (s *visibilityStore) convertQuery(namespace namespace.Name, namespaceID nam
 
 func (s *visibilityStore) setDefaultFieldSort(fieldSorts []*elastic.FieldSort) []elastic.Sorter {
 	if len(fieldSorts) == 0 {
+		if strings.HasPrefix(s.index, v2IndexPrefix) {
+			// Sort by the index sorting order defined in the index template.
+			return []elastic.Sorter{
+				elastic.NewFieldSort(searchattribute.CloseTime).Desc(),
+				elastic.NewFieldSort(searchattribute.StartTime).Desc(),
+				elastic.NewFieldSort(searchattribute.RunID).Desc(),
+			}
+		}
+
 		// Set default sorting by StartTime desc and RunID as tiebreaker.
 		return []elastic.Sorter{
 			elastic.NewFieldSort(searchattribute.StartTime).Desc(),

--- a/schema/elasticsearch/visibility/versioned/v2/index_template_v6.json
+++ b/schema/elasticsearch/visibility/versioned/v2/index_template_v6.json
@@ -1,0 +1,71 @@
+{
+  "order": 0,
+  "index_patterns": [
+    "temporal_visibility_v2*"
+  ],
+  "settings": {
+    "index": {
+      "number_of_shards": "1",
+      "number_of_replicas": "0",
+      "auto_expand_replicas": "0-2",
+      "sort.field": [ "CloseTime", "StartTime", "RunId" ],
+      "sort.order": [ "desc", "desc", "desc" ]
+    }
+  },
+  "mappings": {
+    "_doc": {
+      "dynamic": "false",
+      "properties": {
+        "NamespaceId": {
+          "type": "keyword"
+        },
+        "WorkflowId": {
+          "type": "keyword"
+        },
+        "RunId": {
+          "type": "keyword"
+        },
+        "WorkflowType": {
+          "type": "keyword"
+        },
+        "StartTime": {
+          "type": "date"
+        },
+        "ExecutionTime": {
+          "type": "date"
+        },
+        "CloseTime": {
+          "type": "date"
+        },
+        "ExecutionDuration": {
+          "type": "long"
+        },
+        "ExecutionStatus": {
+          "type": "keyword"
+        },
+        "TaskQueue": {
+          "type": "keyword"
+        },
+        "TemporalChangeVersion": {
+          "type": "keyword"
+        },
+        "BatcherNamespace": {
+          "type": "keyword"
+        },
+        "BatcherUser": {
+          "type": "keyword"
+        },
+        "BinaryChecksums": {
+          "type": "keyword"
+        },
+        "HistoryLength": {
+          "type": "long"
+        },
+        "StateTransitionCount": {
+          "type": "long"
+        }
+      }
+    }
+  },
+  "aliases": {}
+}

--- a/schema/elasticsearch/visibility/versioned/v2/index_template_v7.json
+++ b/schema/elasticsearch/visibility/versioned/v2/index_template_v7.json
@@ -1,0 +1,70 @@
+{
+  "order": 0,
+  "index_patterns": [
+    "temporal_visibility_v2*"
+  ],
+  "settings": {
+    "index": {
+      "number_of_shards": "1",
+      "number_of_replicas": "0",
+      "auto_expand_replicas": "0-2",
+      "search.idle.after": "365d",
+      "sort.field": [ "CloseTime", "StartTime", "RunId" ],
+      "sort.order": [ "desc", "desc", "desc" ]
+    }
+  },
+  "mappings": {
+    "dynamic": "false",
+    "properties": {
+      "NamespaceId": {
+        "type": "keyword"
+      },
+      "WorkflowId": {
+        "type": "keyword"
+      },
+      "RunId": {
+        "type": "keyword"
+      },
+      "WorkflowType": {
+        "type": "keyword"
+      },
+      "StartTime": {
+        "type": "date_nanos"
+      },
+      "ExecutionTime": {
+        "type": "date_nanos"
+      },
+      "CloseTime": {
+        "type": "date_nanos"
+      },
+      "ExecutionDuration": {
+        "type": "long"
+      },
+      "ExecutionStatus": {
+        "type": "keyword"
+      },
+      "TaskQueue": {
+        "type": "keyword"
+      },
+      "TemporalChangeVersion": {
+        "type": "keyword"
+      },
+      "BatcherNamespace": {
+        "type": "keyword"
+      },
+      "BatcherUser": {
+        "type": "keyword"
+      },
+      "BinaryChecksums": {
+        "type": "keyword"
+      },
+      "HistoryLength": {
+        "type": "long"
+      },
+      "StateTransitionCount": {
+        "type": "long"
+      }
+    }
+  },
+  "aliases": {}
+}


### PR DESCRIPTION
Create v2 index template for ES visibility and adjust order by clauses accordingly.

<!-- Describe what has changed in this PR -->
**What changed?**
Add elastic search index sorting for visibility.

<!-- Tell your future self why have you made these changes -->
**Why?**
Sorting is expensive during query and this allows us to get rid of it for the most common queries (including all the list open and list closed wf APIs).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Perf improvements have been verified in an existing customer dataset.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No. This is not enabled by default.  A follow up PR will address potential issues in the dual write path for upgrade.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No