### PR TITLE
Disallow marking activity as cancelled without activity being request cancelled first

### DIFF
--- a/service/history/consts/const.go
+++ b/service/history/consts/const.go
@@ -50,6 +50,8 @@ var (
 	ErrStaleState = errors.New("cache mutable state could potentially be stale")
 	// ErrActivityTaskNotFound is the error to indicate activity task could be duplicate and activity already completed
 	ErrActivityTaskNotFound = serviceerror.NewNotFound("invalid activityID or activity already timed out or invoking workflow is completed")
+	// ErrActivityTaskNotCancelRequested is the error to indicate activity to be canceled is not cancel requested
+	ErrActivityTaskNotCancelRequested = serviceerror.NewInvalidArgument("unable to mark activity as canceled without activity being request canceled first")
 	// ErrWorkflowCompleted is the error to indicate workflow execution already completed
 	ErrWorkflowCompleted = serviceerror.NewNotFound("workflow execution already completed")
 	// ErrWorkflowExecutionNotFound is the error to indicate workflow execution does not exist

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1642,6 +1642,11 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(
 				return nil, consts.ErrActivityTaskNotFound
 			}
 
+			// sanity check if activity is requested to be cancelled
+			if !ai.CancelRequested {
+				return nil, consts.ErrActivityTaskNotCancelRequested
+			}
+
 			if _, err := mutableState.AddActivityTaskCanceledEvent(
 				scheduleID,
 				ai.StartedId,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Disallow marking activity as cancelled without activity being request cancelled first

<!-- Tell your future self why have you made these changes -->
**Why?**
SDK should not try to marking activity as cancelled without activity being request cancelled first

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No