### PR TITLE
add link to explain docker builds and auto setup

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,5 +1,7 @@
 # Build docker image
 
+Temporal builds 4 Docker images with [every release](https://github.com/temporalio/temporal/releases): Server, Server [with Auto Setup](https://docs.temporal.io/blog/auto-setup), tctl CLI, and Admin-Tools. There are [other builds e.g. for CI](https://hub.docker.com/u/temporalio) as well.
+
 ## Prerequisites
 
 To build docker image:


### PR DESCRIPTION
**What changed?**

this is my attempt to introduce documentation for future employees and users to discover more about the docker/auto-setup situation we have.

are there any other locations where adding links/info makes sense?