### PR TITLE
 Reduce heartbeat timeout for flaky test

### DIFF
--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -525,7 +525,7 @@ func (s *clientIntegrationSuite) Test_ActivityTimeouts() {
 		ctx4 := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
 			ActivityID:          "Heartbeat",
 			StartToCloseTimeout: 10 * time.Second,
-			HeartbeatTimeout:    2 * time.Second,
+			HeartbeatTimeout:    1 * time.Second,
 			RetryPolicy:         noRetryPolicy,
 		})
 		f4 := workflow.ExecuteActivity(ctx4, activityFn)

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -481,7 +481,7 @@ func (s *clientIntegrationSuite) Test_ActivityTimeouts() {
 				// so here, we reduce the duration between two heartbeats, so that they are
 				// more likey be sent in the heartbeat batch at 1.6s
 				// (basically increasing the room for delay in heartbeat goroutine from 0.1s to 1s)
-				for i := 0; i < 4; i++ {
+				for i := 0; i < 3; i++ {
 					activity.RecordHeartbeat(ctx, i)
 					time.Sleep(200 * time.Millisecond)
 				}
@@ -594,7 +594,7 @@ func (s *clientIntegrationSuite) Test_ActivityTimeouts() {
 	s.True(timeoutErr.HasLastHeartbeatDetails())
 	var v int
 	s.NoError(timeoutErr.LastHeartbeatDetails(&v))
-	s.Equal(3, v)
+	s.Equal(2, v)
 
 	//s.printHistory(id, workflowRun.GetRunID())
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
 1. Reduce heartbeat timeout for flaky test.
 2. Reduce heartbeat count.

<!-- Tell your future self why have you made these changes -->
**Why?**
A detail is mentioned in the test. The client heartbeat do batches to send them to server. This change tries to reduce the heartbeat batch window and tries to send the heartbeats sooner if the test is slow.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The test could still be flaky if the box is slow.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
