### PR TITLE
Detecting stale cache when RecordChildExecutionCompleted

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2257,6 +2257,9 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(
 
 			// Check mutable state to make sure child execution is in pending child executions
 			ci, isRunning := mutableState.GetChildExecutionInfo(initiatedID)
+			if !isRunning && initiatedID >= mutableState.GetNextEventID() {
+				return nil, consts.ErrStaleState
+			}
 			if !isRunning || ci.StartedId == common.EmptyEventID {
 				return nil, serviceerror.NewNotFound("Pending child execution not found.")
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
detect stale cache when RecordChildExecutionCompleted

<!-- Tell your future self why have you made these changes -->
**Why?**
Below sequence could cause missing child completed event in parent:
t1: history pod h1 is owner of the shard, mutable state cache contains workflow p1, at this time child c1 is not started yet.
t2: h2 is new owner of the shard,
t3: on h2, p1 starts child c1
t4: h2 is killed, and h1 become the new owner, but previous engine from t1 for shard is still alive, with staled cache.
t5: child c1 completed, and calls RecordChildExecutionCompleted which is sent to h1 with staled cache that does not have c1 as pending child, it would respond Not_found error.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eye_ball

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes