### PR TITLE
Dedup SignalWithStart based on RequestId

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1955,6 +1955,13 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(
 				return nil, consts.ErrSignalsLimitExceeded
 			}
 
+			if sRequest.GetRequestId() != "" && mutableState.IsSignalRequested(sRequest.GetRequestId()) {
+				// duplicate signal
+				return &historyservice.SignalWithStartWorkflowExecutionResponse{RunId: context.GetExecution().RunId}, nil
+			}
+			if sRequest.GetRequestId() != "" {
+				mutableState.AddSignalRequested(sRequest.GetRequestId())
+			}
 			if _, err := mutableState.AddWorkflowExecutionSignaled(
 				sRequest.GetSignalName(),
 				sRequest.GetSignalInput(),
@@ -2071,6 +2078,9 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(
 	}
 
 	// Add signal event
+	if sRequest.GetRequestId() != "" {
+		mutableState.AddSignalRequested(sRequest.GetRequestId())
+	}
 	if _, err := mutableState.AddWorkflowExecutionSignaled(
 		sRequest.GetSignalName(),
 		sRequest.GetSignalInput(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Dedup signals received by SignalWithStartWorkflowExecution

<!-- Tell your future self why have you made these changes -->
**Why?**
Signals sent with same RequestId are not deduped.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test, call SignalWithStartWorkflowExecution and/or SignalWorkflowExecution with same RequestId, verify signal are deduped.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No