### PR TITLE
Unload shard if loaded task ID is greater than max transfer ID

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -128,5 +128,7 @@ type (
 		GetSearchAttributesProvider() searchattribute.Provider
 		GetSearchAttributesMapper() searchattribute.Mapper
 		GetArchivalMetadata() archiver.ArchivalMetadata
+
+		Unload()
 	}
 )

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1269,6 +1269,10 @@ func (s *ContextImpl) start() {
 	s.transitionLocked(contextRequestAcquire{})
 }
 
+func (s *ContextImpl) Unload() {
+	s.stop()
+}
+
 // stop should only be called by the controller.
 func (s *ContextImpl) stop() {
 	s.wLock()

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1088,7 +1088,8 @@ func (s *ContextImpl) allocateTaskIDsLocked(
 	return s.allocateTimerIDsLocked(
 		namespaceEntry,
 		workflowID,
-		timerTasks)
+		timerTasks,
+		transferMaxReadLevel)
 }
 
 func (s *ContextImpl) allocateTransferIDsLocked(
@@ -1115,6 +1116,7 @@ func (s *ContextImpl) allocateTimerIDsLocked(
 	namespaceEntry *namespace.Namespace,
 	workflowID string,
 	timerTasks []tasks.Task,
+	transferMaxReadLevel *int64,
 ) error {
 
 	// assign IDs for the timer tasks. They need to be assigned under shard lock.
@@ -1145,6 +1147,7 @@ func (s *ContextImpl) allocateTimerIDsLocked(
 			return err
 		}
 		task.SetTaskID(seqNum)
+		*transferMaxReadLevel = seqNum
 		visibilityTs := task.GetVisibilityTime()
 		s.contextTaggedLogger.Debug("Assigning new timer",
 			tag.Timestamp(visibilityTs), tag.TaskID(task.GetTaskID()), tag.AckLevel(s.shardInfo.TimerAckLevelTime))

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -695,6 +695,18 @@ func (mr *MockContextMockRecorder) SetCurrentTime(cluster, currentTime interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentTime", reflect.TypeOf((*MockContext)(nil).SetCurrentTime), cluster, currentTime)
 }
 
+// Unload mocks base method.
+func (m *MockContext) Unload() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Unload")
+}
+
+// Unload indicates an expected call of Unload.
+func (mr *MockContextMockRecorder) Unload() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unload", reflect.TypeOf((*MockContext)(nil).Unload))
+}
+
 // UpdateClusterReplicationLevel mocks base method.
 func (m *MockContext) UpdateClusterReplicationLevel(cluster string, ackTaskID int64, ackTimestamp time.Time) error {
 	m.ctrl.T.Helper()

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -168,6 +168,12 @@ func (t *taskProcessor) taskWorker(
 			if !ok {
 				return
 			}
+			if task.GetTaskID() > t.shard.GetTransferMaxReadLevel() {
+				// this could happen if we lost ownership and was not aware of it.
+				// unload shard
+				t.shard.Unload()
+				return
+			}
 			t.processTaskAndAck(notificationChan, task)
 		}
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add sanity check to task processor to make sure task ID is not greater than max task ID known to this shard. 

<!-- Tell your future self why have you made these changes -->
**Why?**
This will guard against from shard reading timer tasks generated by other shard owner while current pod lost ownership.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eye_balls.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No