### PR TITLE
[Docker build] add separate visibility env vars for different db instance

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -33,15 +33,15 @@ persistence:
                     serverName: {{ default .Env.CASSANDRA_HOST_NAME "" }}
         visibility:
             cassandra:
-                {{- $vis_seeds := default .Env.VISIBILITY_CASSANDRA_SEEDS .Env.CASSANDRA_SEEDS -}}
-                {{- $vis_port := default .Env.VISIBILITY_CASSANDRA_PORT .Env.CASSANDRA_PORT -}}
-                {{- $vis_user := default .Env.VISIBILITY_CASSANDRA_USER .Env.CASSANDRA_USER -}}
-                {{- $vis_pwd := default .Env.VISIBILITY_CASSANDRA_PASSWORD .Env.CASSANDRA_PASSWORD -}}
-                hosts: "{{ default $vis_seeds "" }}"
+                {{- $visibility_seeds := default .Env.VISIBILITY_CASSANDRA_SEEDS .Env.CASSANDRA_SEEDS -}}
+                {{- $visibility_port := default .Env.VISIBILITY_CASSANDRA_PORT .Env.CASSANDRA_PORT -}}
+                {{- $visibility_user := default .Env.VISIBILITY_CASSANDRA_USER .Env.CASSANDRA_USER -}}
+                {{- $visibility_pwd := default .Env.VISIBILITY_CASSANDRA_PASSWORD .Env.CASSANDRA_PASSWORD -}}
+                hosts: "{{ default $visibility_seeds "" }}"
                 keyspace: "{{ default .Env.VISIBILITY_KEYSPACE "temporal_visibility" }}"
-                user: "{{ default $vis_user "" }}"
-                password: "{{ default $vis_pwd "" }}"
-                port: {{ default $vis_port "9042" }}
+                user: "{{ default $visibility_user "" }}"
+                password: "{{ default $visibility_pwd "" }}"
+                port: {{ default $visibility_port "9042" }}
                 maxConns: {{ default .Env.CASSANDRA_MAX_CONNS "10" }}
                 tls:
                     enabled: {{ default .Env.CASSANDRA_TLS_ENABLED "false" }}
@@ -80,14 +80,14 @@ persistence:
             sql:
                 pluginName: "mysql"
                 databaseName: "{{ default .Env.VISIBILITY_DBNAME "temporal_visibility" }}"
-                {{- $vis_seeds := default .Env.VISIBILITY_MYSQL_SEEDS .Env.MYSQL_SEEDS -}}
-                {{- $vis_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT -}}
-                connectAddr: "{{ default $vis_seeds "" }}:{{ default $vis_port "3306" }}"
+                {{- $visibility_seeds := default .Env.VISIBILITY_MYSQL_SEEDS .Env.MYSQL_SEEDS -}}
+                {{- $visibility_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT -}}
+                {{- $visibility_user := default .Env.VISIBILITY_MYSQL_USER .Env.MYSQL_USER -}}
+                {{- $visibility_pwd := default .Env.VISIBILITY_MYSQL_PWD .Env.MYSQL_PWD -}}
+                connectAddr: "{{ default $visibility_seeds "" }}:{{ default $visibility_port "3306" }}"
                 connectProtocol: "tcp"
-                {{- $vis_user := default .Env.VISIBILITY_MYSQL_USER .Env.MYSQL_USER -}}
-                {{- $vis_pwd := default .Env.VISIBILITY_MYSQL_PWD .Env.MYSQL_PWD -}}
-                user: "{{ default $vis_user "" }}"
-                password: "{{ default $vis_pwd "" }}"
+                user: "{{ default $visibility_user "" }}"
+                password: "{{ default $visibility_pwd "" }}"
                 {{- if .Env.MYSQL_TX_ISOLATION_COMPAT }}
                 connectAttributes:
                     tx_isolation: "'READ-COMMITTED'"
@@ -125,14 +125,14 @@ persistence:
             sql:
                 pluginName: "postgres"
                 databaseName: "{{ default .Env.VISIBILITY_DBNAME "temporal_visibility" }}"
-                {{- $vis_seeds := default .Env.VISIBILITY_POSTGRES_SEEDS .Env.POSTGRES_SEEDS -}}
-                {{- $vis_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT -}}
-                connectAddr: "{{ default $vis_seeds "" }}:{{ default $vis_port "5432" }}"
+                {{- $visibility_seeds := default .Env.VISIBILITY_POSTGRES_SEEDS .Env.POSTGRES_SEEDS -}}
+                {{- $visibility_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT -}}
+                {{- $visibility_user := default .Env.VISIBILITY_POSTGRES_USER .Env.POSTGRES_USER -}}
+                {{- $visibility_pwd := default .Env.VISIBILITY_POSTGRES_PWD .Env.POSTGRES_PWD -}}
+                connectAddr: "{{ default $visibility_seeds "" }}:{{ default $visibility_port "5432" }}"
                 connectProtocol: "tcp"
-                {{- $vis_user := default .Env.VISIBILITY_POSTGRES_USER .Env.POSTGRES_USER -}}
-                {{- $vis_pwd := default .Env.VISIBILITY_POSTGRES_PWD .Env.POSTGRES_PWD -}}
-                user: "{{ default $vis_user "" }}"
-                password: "{{ default $vis_pwd "" }}"
+                user: "{{ default $visibility_user "" }}"
+                password: "{{ default $visibility_pwd "" }}"
                 maxConns: {{ default .Env.SQL_VIS_MAX_CONNS "10" }}
                 maxIdleConns: {{ default .Env.SQL_VIS_MAX_IDLE_CONNS "10" }}
                 maxConnLifetime: {{ default .Env.SQL_VIS_MAX_CONN_TIME "1h" }}

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -33,10 +33,10 @@ persistence:
                     serverName: {{ default .Env.CASSANDRA_HOST_NAME "" }}
         visibility:
             cassandra:
-                {{- $visibility_seeds := default .Env.VISIBILITY_CASSANDRA_SEEDS .Env.CASSANDRA_SEEDS -}}
-                {{- $visibility_port := default .Env.VISIBILITY_CASSANDRA_PORT .Env.CASSANDRA_PORT -}}
-                {{- $visibility_user := default .Env.VISIBILITY_CASSANDRA_USER .Env.CASSANDRA_USER -}}
-                {{- $visibility_pwd := default .Env.VISIBILITY_CASSANDRA_PASSWORD .Env.CASSANDRA_PASSWORD -}}
+                {{ $visibility_seeds := default .Env.VISIBILITY_CASSANDRA_SEEDS .Env.CASSANDRA_SEEDS }}
+                {{ $visibility_port := default .Env.VISIBILITY_CASSANDRA_PORT .Env.CASSANDRA_PORT }}
+                {{ $visibility_user := default .Env.VISIBILITY_CASSANDRA_USER .Env.CASSANDRA_USER }}
+                {{ $visibility_pwd := default .Env.VISIBILITY_CASSANDRA_PASSWORD .Env.CASSANDRA_PASSWORD }}
                 hosts: "{{ default $visibility_seeds "" }}"
                 keyspace: "{{ default .Env.VISIBILITY_KEYSPACE "temporal_visibility" }}"
                 user: "{{ default $visibility_user "" }}"
@@ -78,12 +78,12 @@ persistence:
                     serverName: {{ default .Env.SQL_HOST_NAME "" }}
         visibility:
             sql:
+                {{ $visibility_seeds := default .Env.VISIBILITY_MYSQL_SEEDS .Env.MYSQL_SEEDS }}
+                {{ $visibility_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT }}
+                {{ $visibility_user := default .Env.VISIBILITY_MYSQL_USER .Env.MYSQL_USER }}
+                {{ $visibility_pwd := default .Env.VISIBILITY_MYSQL_PWD .Env.MYSQL_PWD }}
                 pluginName: "mysql"
                 databaseName: "{{ default .Env.VISIBILITY_DBNAME "temporal_visibility" }}"
-                {{- $visibility_seeds := default .Env.VISIBILITY_MYSQL_SEEDS .Env.MYSQL_SEEDS -}}
-                {{- $visibility_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT -}}
-                {{- $visibility_user := default .Env.VISIBILITY_MYSQL_USER .Env.MYSQL_USER -}}
-                {{- $visibility_pwd := default .Env.VISIBILITY_MYSQL_PWD .Env.MYSQL_PWD -}}
                 connectAddr: "{{ default $visibility_seeds "" }}:{{ default $visibility_port "3306" }}"
                 connectProtocol: "tcp"
                 user: "{{ default $visibility_user "" }}"
@@ -123,12 +123,12 @@ persistence:
                     serverName: {{ default .Env.SQL_HOST_NAME "" }}
         visibility:
             sql:
+                {{ $visibility_seeds := default .Env.VISIBILITY_POSTGRES_SEEDS .Env.POSTGRES_SEEDS }}
+                {{ $visibility_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT }}
+                {{ $visibility_user := default .Env.VISIBILITY_POSTGRES_USER .Env.POSTGRES_USER }}
+                {{ $visibility_pwd := default .Env.VISIBILITY_POSTGRES_PWD .Env.POSTGRES_PWD }}
                 pluginName: "postgres"
                 databaseName: "{{ default .Env.VISIBILITY_DBNAME "temporal_visibility" }}"
-                {{- $visibility_seeds := default .Env.VISIBILITY_POSTGRES_SEEDS .Env.POSTGRES_SEEDS -}}
-                {{- $visibility_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT -}}
-                {{- $visibility_user := default .Env.VISIBILITY_POSTGRES_USER .Env.POSTGRES_USER -}}
-                {{- $visibility_pwd := default .Env.VISIBILITY_POSTGRES_PWD .Env.POSTGRES_PWD -}}
                 connectAddr: "{{ default $visibility_seeds "" }}:{{ default $visibility_port "5432" }}"
                 connectProtocol: "tcp"
                 user: "{{ default $visibility_user "" }}"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -33,11 +33,15 @@ persistence:
                     serverName: {{ default .Env.CASSANDRA_HOST_NAME "" }}
         visibility:
             cassandra:
-                hosts: "{{ default .Env.CASSANDRA_SEEDS "" }}"
+                {{- $vis_seeds := default .Env.VISIBILITY_CASSANDRA_SEEDS .Env.CASSANDRA_SEEDS -}}
+                {{- $vis_port := default .Env.VISIBILITY_CASSANDRA_PORT .Env.CASSANDRA_PORT -}}
+                {{- $vis_user := default .Env.VISIBILITY_CASSANDRA_USER .Env.CASSANDRA_USER -}}
+                {{- $vis_pwd := default .Env.VISIBILITY_CASSANDRA_PASSWORD .Env.CASSANDRA_PASSWORD -}}
+                hosts: "{{ default $vis_seeds "" }}"
                 keyspace: "{{ default .Env.VISIBILITY_KEYSPACE "temporal_visibility" }}"
-                user: "{{ default .Env.CASSANDRA_USER "" }}"
-                password: "{{ default .Env.CASSANDRA_PASSWORD "" }}"
-                port: {{ default .Env.CASSANDRA_PORT "9042" }}
+                user: "{{ default $vis_user "" }}"
+                password: "{{ default $vis_pwd "" }}"
+                port: {{ default $vis_port "9042" }}
                 maxConns: {{ default .Env.CASSANDRA_MAX_CONNS "10" }}
                 tls:
                     enabled: {{ default .Env.CASSANDRA_TLS_ENABLED "false" }}
@@ -76,10 +80,14 @@ persistence:
             sql:
                 pluginName: "mysql"
                 databaseName: "{{ default .Env.VISIBILITY_DBNAME "temporal_visibility" }}"
-                connectAddr: "{{ default .Env.MYSQL_SEEDS "" }}:{{ default .Env.DB_PORT "3306" }}"
+                {{- $vis_seeds := default .Env.VISIBILITY_MYSQL_SEEDS .Env.MYSQL_SEEDS -}}
+                {{- $vis_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT -}}
+                connectAddr: "{{ default $vis_seeds "" }}:{{ default $vis_port "3306" }}"
                 connectProtocol: "tcp"
-                user: "{{ default .Env.MYSQL_USER "" }}"
-                password: "{{ default .Env.MYSQL_PWD "" }}"
+                {{- $vis_user := default .Env.VISIBILITY_MYSQL_USER .Env.MYSQL_USER -}}
+                {{- $vis_pwd := default .Env.VISIBILITY_MYSQL_PWD .Env.MYSQL_PWD -}}
+                user: "{{ default $vis_user "" }}"
+                password: "{{ default $vis_pwd "" }}"
                 {{- if .Env.MYSQL_TX_ISOLATION_COMPAT }}
                 connectAttributes:
                     tx_isolation: "'READ-COMMITTED'"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -117,10 +117,14 @@ persistence:
             sql:
                 pluginName: "postgres"
                 databaseName: "{{ default .Env.VISIBILITY_DBNAME "temporal_visibility" }}"
-                connectAddr: "{{ default .Env.POSTGRES_SEEDS "" }}:{{ default .Env.DB_PORT "5432" }}"
+                {{- $vis_seeds := default .Env.VISIBILITY_POSTGRES_SEEDS .Env.POSTGRES_SEEDS -}}
+                {{- $vis_port := default .Env.VISIBILITY_DB_PORT .Env.DB_PORT -}}
+                connectAddr: "{{ default $vis_seeds "" }}:{{ default $vis_port "5432" }}"
                 connectProtocol: "tcp"
-                user: "{{ default .Env.POSTGRES_USER "" }}"
-                password: "{{ default .Env.POSTGRES_PWD "" }}"
+                {{- $vis_user := default .Env.VISIBILITY_POSTGRES_USER .Env.POSTGRES_USER -}}
+                {{- $vis_pwd := default .Env.VISIBILITY_POSTGRES_PWD .Env.POSTGRES_PWD -}}
+                user: "{{ default $vis_user "" }}"
+                password: "{{ default $vis_pwd "" }}"
                 maxConns: {{ default .Env.SQL_VIS_MAX_CONNS "10" }}
                 maxIdleConns: {{ default .Env.SQL_VIS_MAX_IDLE_CONNS "10" }}
                 maxConnLifetime: {{ default .Env.SQL_VIS_MAX_CONN_TIME "1h" }}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

add separate visibility env vars for different db instance - some deployment environments, like Render, do not allow for creating another db on the same db instance. There is no hard requirement inside of Temporal, but this assumption is baked into the docker image - so we need to offer separate env vars that people can override.

closes https://github.com/temporalio/temporal/issues/1388

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

not yet tested

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

n/a


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no