### PR TITLE
Favor local config value on enable global namespace

### DIFF
--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -938,7 +938,7 @@ func (adh *AdminHandler) DescribeCluster(
 		VersionInfo:              metadata.VersionInfo,
 		FailoverVersionIncrement: metadata.FailoverVersionIncrement,
 		InitialFailoverVersion:   metadata.InitialFailoverVersion,
-		IsGlobalNamespaceEnabled: metadata.IsGlobalNamespaceEnabled,
+		IsGlobalNamespaceEnabled: adh.clusterMetadata.IsGlobalNamespaceEnabled(),
 	}, nil
 }
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -607,9 +607,8 @@ func ApplyClusterMetadataConfigProvider(
 			logger.Warn(
 				mismatchLogMessage,
 				tag.Key("clusterMetadata.EnableGlobalNamespace"),
-				tag.IgnoredValue(clusterData.EnableGlobalNamespace),
-				tag.Value(resp.IsGlobalNamespaceEnabled))
-			config.ClusterMetadata.EnableGlobalNamespace = resp.IsGlobalNamespaceEnabled
+				tag.IgnoredValue(resp.IsGlobalNamespaceEnabled),
+				tag.Value(clusterData.EnableGlobalNamespace))
 		}
 		if resp.FailoverVersionIncrement != clusterData.FailoverVersionIncrement {
 			logger.Warn(

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -609,6 +609,7 @@ func ApplyClusterMetadataConfigProvider(
 				tag.Key("clusterMetadata.EnableGlobalNamespace"),
 				tag.IgnoredValue(resp.IsGlobalNamespaceEnabled),
 				tag.Value(clusterData.EnableGlobalNamespace))
+			// Favor local config value over storage.
 		}
 		if resp.FailoverVersionIncrement != clusterData.FailoverVersionIncrement {
 			logger.Warn(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Overwrite local config value on enable global namespace.

<!-- Tell your future self why have you made these changes -->
**Why?**
Local cluster config is defined in the application config and can be configurable.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes. This is to cover a case where a multi-cluster initialized with global namespace as false.