### PR TITLE
Check max taskID instead of max read level when process task

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -69,6 +69,8 @@ type (
 		GetTransferMaxReadLevel() int64
 		UpdateTimerMaxReadLevel(cluster string) time.Time
 
+		GetMaxTaskIDForCurrentRangeID() int64
+
 		SetCurrentTime(cluster string, currentTime time.Time)
 		GetCurrentTime(cluster string) time.Time
 		GetLastUpdatedTime() time.Time

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -185,6 +185,13 @@ func (s *ContextImpl) GetEngine() (Engine, error) {
 	return s.engine, nil
 }
 
+func (s *ContextImpl) GetMaxTaskIDForCurrentRangeID() int64 {
+	s.rLock()
+	defer s.rUnlock()
+	// maxTransferSequenceNumber is the exclusive upper bound of task ID for current range.
+	return s.maxTransferSequenceNumber - 1
+}
+
 func (s *ContextImpl) GenerateTransferTaskID() (int64, error) {
 	s.wLock()
 	defer s.wUnlock()

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -387,6 +387,20 @@ func (mr *MockContextMockRecorder) GetLogger() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockContext)(nil).GetLogger))
 }
 
+// GetMaxTaskIDForCurrentRangeID mocks base method.
+func (m *MockContext) GetMaxTaskIDForCurrentRangeID() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMaxTaskIDForCurrentRangeID")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetMaxTaskIDForCurrentRangeID indicates an expected call of GetMaxTaskIDForCurrentRangeID.
+func (mr *MockContextMockRecorder) GetMaxTaskIDForCurrentRangeID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMaxTaskIDForCurrentRangeID", reflect.TypeOf((*MockContext)(nil).GetMaxTaskIDForCurrentRangeID))
+}
+
 // GetMetricsClient mocks base method.
 func (m *MockContext) GetMetricsClient() metrics.Client {
 	m.ctrl.T.Helper()

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -168,8 +168,8 @@ func (t *taskProcessor) taskWorker(
 			if !ok {
 				return
 			}
-			if task.GetTaskID() > t.shard.GetTransferMaxReadLevel() {
-				// this could happen if we lost ownership and was not aware of it.
+			if task.GetTaskID() > t.shard.GetMaxTaskIDForCurrentRangeID() {
+				// this could happen if we lost ownership and were not aware of it.
 				// unload shard
 				t.shard.Unload()
 				return


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Check max taskID of current range instead of max read level when process task.

<!-- Tell your future self why have you made these changes -->
**Why?**
Update max read level might be delayed, which would cause unnecessary shard unload.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eye_ball

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No