### PR TITLE
Trigger history node validation & trimming logic within write path

### DIFF
--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -990,6 +990,12 @@ func (m *executionManagerImpl) trimHistoryNode(
 		RunID:       runID,
 	})
 	if err != nil {
+		m.logger.Error("ExecutionManager unable to get mutable state for trimming history branch",
+			tag.WorkflowNamespaceID(namespaceID),
+			tag.WorkflowID(workflowID),
+			tag.WorkflowRunID(runID),
+			tag.Error(err),
+		)
 		return // best effort trim
 	}
 
@@ -1007,7 +1013,13 @@ func (m *executionManagerImpl) trimHistoryNode(
 		TransactionID: mutableStateLastNodeTransactionID,
 	}); err != nil {
 		// best effort trim
-		m.logger.Error("ExecutionManager unable to trim history branch", tag.Error(err))
+		m.logger.Error("ExecutionManager unable to trim history branch",
+			tag.WorkflowNamespaceID(namespaceID),
+			tag.WorkflowID(workflowID),
+			tag.WorkflowRunID(runID),
+			tag.Error(err),
+		)
+		return
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Trigger history node validation & trimming logic for the following APIs (write path)
  * CreateWorkflowExecution: no auto fix since this API is creating a brand new workflow
  * ConflictResolveWorkflowExecution: auto fix for reset workflow & current workflow
  * UpdateWorkflowExecution: auto fix for update workflow
  
<!-- Tell your future self why have you made these changes -->
**Why?**
Add additional protection, similar to #2366 (read path)
For details see #1449

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No