### PR TITLE
Remove `go mod init` from dockerize build in base-server.Dockerfile

### DIFF
--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -8,7 +8,6 @@ RUN apk add --update --no-cache \
 RUN mkdir -p /xsrc && \
     git clone https://github.com/jwilder/dockerize.git && \
     cd dockerize && \
-    go mod init github.com/jwilder/dockerize && \
     go mod tidy && \
     go build -o /usr/local/bin/dockerize . && \
     rm -rf /xsrc


### PR DESCRIPTION
Dockerize moved from using Glock to Go modules and introduced go.mod and go.sum files into the repository.
Therefore, the Go module initialization command has to be removed from the `base-server` Dockerfile as it breaks the build.

See: https://github.com/jwilder/dockerize/commit/6f92b85658d6d66bbad3771289a94c1a5c8c8172

**What changed?**
The `go mod init` command was removed from the build of the `dockerize` tool in the `base-server` image.

**Why?**
A clean build of the `base-server` image fails.

**How did you test it?**
I've run the build and checked the server locally.

**Potential risks**
The build of Docker images based on the `base-server` image will fail: `temporal-server` and  `temporal-tctl`.

**Is hotfix candidate?**
No
