### PR TITLE
Handle namespaceNotActive error in parentClosePolicy workflow

### DIFF
--- a/service/worker/parentclosepolicy/processor.go
+++ b/service/worker/parentclosepolicy/processor.go
@@ -63,26 +63,30 @@ type (
 		Config Config
 		// ClientBean is an instance of client.Bean for a collection of clients
 		ClientBean client.Bean
+		// CurrentCluster is the name of current cluster
+		CurrentCluster string
 	}
 
 	// Processor is the background sub-system that execute workflow for ParentClosePolicy
 	Processor struct {
-		svcClient     sdkclient.Client
-		clientBean    client.Bean
-		metricsClient metrics.Client
-		cfg           Config
-		logger        log.Logger
+		svcClient      sdkclient.Client
+		clientBean     client.Bean
+		metricsClient  metrics.Client
+		cfg            Config
+		logger         log.Logger
+		currentCluster string
 	}
 )
 
 // New returns a new instance as daemon
 func New(params *BootstrapParams) *Processor {
 	return &Processor{
-		svcClient:     params.SdkSystemClient,
-		metricsClient: params.MetricsClient,
-		cfg:           params.Config,
-		logger:        log.With(params.Logger, tag.ComponentBatcher),
-		clientBean:    params.ClientBean,
+		svcClient:      params.SdkSystemClient,
+		metricsClient:  params.MetricsClient,
+		cfg:            params.Config,
+		logger:         log.With(params.Logger, tag.ComponentBatcher),
+		clientBean:     params.ClientBean,
+		currentCluster: params.CurrentCluster,
 	}
 }
 

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -184,6 +184,7 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 
 	if err := signalRemoteCluster(
 		ctx,
+		processor.currentCluster,
 		processor.clientBean,
 		request.ParentExecution,
 		remoteExecutions,
@@ -198,6 +199,7 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 
 func signalRemoteCluster(
 	ctx context.Context,
+	currentCluster string,
 	clientBean client.Bean,
 	parentExecution commonpb.WorkflowExecution,
 	remoteExecutions map[string][]RequestDetail,
@@ -230,7 +232,7 @@ func signalRemoteCluster(
 				},
 				Input:                 nil,
 				WorkflowTaskTimeout:   timestamp.DurationPtr(workflowTaskTimeout),
-				Identity:              common.WorkerServiceName + "-service",
+				Identity:              currentCluster + "-" + common.WorkerServiceName + "-service",
 				WorkflowIdReusePolicy: workflowIDReusePolicy,
 				SignalName:            processorChannelName,
 				SignalInput:           signalInput,

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -28,18 +28,24 @@ import (
 	"context"
 	"time"
 
+	"github.com/pborman/uuid"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/converter"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
 
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/client"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/primitives/timestamp"
 )
 
 const (
@@ -113,6 +119,8 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 	// will cause terminate or cancel request to return mismatch error
 	childWorkflowOnly := request.ParentExecution.GetWorkflowId() != "" &&
 		request.ParentExecution.GetRunId() != ""
+
+	remoteExecutions := make(map[string][]RequestDetail)
 	for _, execution := range request.Executions {
 		namespaceId := execution.NamespaceID
 		if len(execution.NamespaceID) == 0 {
@@ -160,19 +168,81 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 			})
 		}
 
-		if err != nil {
-			if _, ok := err.(*serviceerror.NotFound); ok {
-				err = nil
-			}
-		}
-
-		if err != nil {
+		switch typedErr := err.(type) {
+		case nil:
+			processor.metricsClient.IncCounter(metrics.ParentClosePolicyProcessorScope, metrics.ParentClosePolicyProcessorSuccess)
+		case *serviceerror.NotFound:
+			// no-op
+		case *serviceerror.NamespaceNotActive:
+			remoteExecutions[typedErr.ActiveCluster] = append(remoteExecutions[typedErr.ActiveCluster], execution)
+		default:
 			processor.metricsClient.IncCounter(metrics.ParentClosePolicyProcessorScope, metrics.ParentClosePolicyProcessorFailures)
 			getActivityLogger(ctx).Error("failed to process parent close policy", tag.Error(err))
 			return err
 		}
-		processor.metricsClient.IncCounter(metrics.ParentClosePolicyProcessorScope, metrics.ParentClosePolicyProcessorSuccess)
 	}
+
+	if err := signalRemoteCluster(
+		ctx,
+		processor.clientBean,
+		request.ParentExecution,
+		remoteExecutions,
+		processor.cfg.NumParentClosePolicySystemWorkflows(),
+	); err != nil {
+		getActivityLogger(ctx).Error("Failed to signal remote parent close policy workflow", tag.Error(err))
+		return err
+	}
+
+	return nil
+}
+
+func signalRemoteCluster(
+	ctx context.Context,
+	clientBean client.Bean,
+	parentExecution commonpb.WorkflowExecution,
+	remoteExecutions map[string][]RequestDetail,
+	numWorkflows int,
+) error {
+	for cluster, executions := range remoteExecutions {
+		remoteClient := clientBean.GetRemoteFrontendClient(cluster)
+
+		signalValue := Request{
+			ParentExecution: parentExecution,
+			Executions:      executions,
+		}
+		signalInput, err := converter.GetDefaultDataConverter().ToPayloads(signalValue)
+		if err != nil {
+			return err
+		}
+
+		signalCtx, cancel := context.WithTimeout(ctx, signalTimeout)
+		_, err = remoteClient.SignalWithStartWorkflowExecution(
+			signalCtx,
+			&workflowservice.SignalWithStartWorkflowExecutionRequest{
+				Namespace:  common.SystemLocalNamespace,
+				RequestId:  uuid.New(),
+				WorkflowId: getWorkflowID(numWorkflows),
+				WorkflowType: &commonpb.WorkflowType{
+					Name: processorWFTypeName,
+				},
+				TaskQueue: &taskqueue.TaskQueue{
+					Name: processorTaskQueueName,
+				},
+				Input:                 nil,
+				WorkflowTaskTimeout:   timestamp.DurationPtr(workflowTaskTimeout),
+				Identity:              common.WorkerServiceName + "-service",
+				WorkflowIdReusePolicy: workflowIDReusePolicy,
+				SignalName:            processorChannelName,
+				SignalInput:           signalInput,
+			},
+		)
+		cancel()
+
+		if err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/service/worker/parentclosepolicy/workflow_test.go
+++ b/service/worker/parentclosepolicy/workflow_test.go
@@ -1,0 +1,192 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package parentclosepolicy
+
+import (
+	"context"
+	"testing"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/api/workflowservicemock/v1"
+	"go.temporal.io/sdk/testsuite"
+
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	"go.temporal.io/server/client"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/service/history/tests"
+	"google.golang.org/grpc"
+)
+
+type parentClosePolicyWorkflowSuite struct {
+	*require.Assertions
+	suite.Suite
+	testsuite.WorkflowTestSuite
+
+	controller        *gomock.Controller
+	mockClientBean    *client.MockBean
+	mockHistoryClient *historyservicemock.MockHistoryServiceClient
+	mockRemoteClient  *workflowservicemock.MockWorkflowServiceClient
+
+	processor *Processor
+}
+
+func TestParentClosePolicyWorkflowSuite(t *testing.T) {
+	s := new(parentClosePolicyWorkflowSuite)
+	suite.Run(t, s)
+}
+
+func (s *parentClosePolicyWorkflowSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.controller = gomock.NewController(s.T())
+	s.mockClientBean = client.NewMockBean(s.controller)
+	s.mockHistoryClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
+	s.mockRemoteClient = workflowservicemock.NewMockWorkflowServiceClient(s.controller)
+
+	s.mockClientBean.EXPECT().GetHistoryClient().Return(s.mockHistoryClient).AnyTimes()
+	s.mockClientBean.EXPECT().GetRemoteFrontendClient(gomock.Any()).Return(s.mockRemoteClient).AnyTimes()
+
+	s.processor = &Processor{
+		metricsClient: metrics.NoopMetricsClient{},
+		logger:        log.NewNoopLogger(),
+		cfg: Config{
+			MaxConcurrentActivityExecutionSize:     dynamicconfig.GetIntPropertyFn(1000),
+			MaxConcurrentWorkflowTaskExecutionSize: dynamicconfig.GetIntPropertyFn(1000),
+			MaxConcurrentActivityTaskPollers:       dynamicconfig.GetIntPropertyFn(4),
+			MaxConcurrentWorkflowTaskPollers:       dynamicconfig.GetIntPropertyFn(4),
+			NumParentClosePolicySystemWorkflows:    dynamicconfig.GetIntPropertyFn(10),
+		},
+		clientBean: s.mockClientBean,
+	}
+}
+
+func (s *parentClosePolicyWorkflowSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_SameCluster() {
+	env := s.NewTestActivityEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterActivity(ProcessorActivity)
+
+	request := Request{
+		ParentExecution: commonpb.WorkflowExecution{
+			WorkflowId: "parent workflowID",
+			RunId:      "parent runID",
+		},
+		Executions: []RequestDetail{
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 1",
+				RunID:       "childworkflow runID 1",
+				Policy:      enums.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 2",
+				RunID:       "childworkflow runID 2",
+				Policy:      enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+			},
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 3",
+				RunID:       "childworkflow runID 3",
+				Policy:      enums.PARENT_CLOSE_POLICY_ABANDON,
+			},
+		},
+	}
+
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(&historyservice.TerminateWorkflowExecutionResponse{}, nil).Times(1)
+	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, &serviceerror.NotFound{}).Times(1)
+
+	_, err := env.ExecuteActivity(ProcessorActivity, request)
+	s.NoError(err)
+}
+
+func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_RemoteCluster() {
+	env := s.NewTestActivityEnvironment()
+	env.SetWorkerOptions(getWorkerOptions(s.processor))
+	env.RegisterActivity(ProcessorActivity)
+
+	request := Request{
+		ParentExecution: commonpb.WorkflowExecution{
+			WorkflowId: "parent workflowID",
+			RunId:      "parent runID",
+		},
+		Executions: []RequestDetail{
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 1",
+				RunID:       "childworkflow runID 1",
+				Policy:      enums.PARENT_CLOSE_POLICY_TERMINATE,
+			},
+			{
+				Namespace:   tests.ChildNamespace.String(),
+				NamespaceID: tests.ChildNamespaceID.String(),
+				WorkflowID:  "child workflowID 2",
+				RunID:       "childworkflow runID 2",
+				Policy:      enums.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+			},
+		},
+	}
+
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, &serviceerror.NamespaceNotActive{ActiveCluster: "remote cluster 1"}).Times(1)
+	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
+		Return(nil, &serviceerror.NamespaceNotActive{ActiveCluster: "remote cluster 2"}).Times(1)
+	s.mockRemoteClient.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			_ context.Context,
+			request *workflowservice.SignalWithStartWorkflowExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*workflowservice.SignalWithStartWorkflowExecutionResponse, error) {
+			s.Equal(common.SystemLocalNamespace, request.Namespace)
+			s.Equal(processorWFTypeName, request.WorkflowType.Name)
+			s.Equal(processorTaskQueueName, request.TaskQueue.Name)
+			s.Equal(workflowIDReusePolicy, request.WorkflowIdReusePolicy)
+			s.Equal(processorChannelName, request.SignalName)
+			return &workflowservice.SignalWithStartWorkflowExecutionResponse{}, nil
+		},
+	).Times(2)
+
+	_, err := env.ExecuteActivity(ProcessorActivity, request)
+	s.NoError(err)
+}

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -397,6 +397,7 @@ func (s *Service) startParentClosePolicyProcessor() {
 		MetricsClient:   s.metricsClient,
 		Logger:          s.logger,
 		ClientBean:      s.clientBean,
+		CurrentCluster:  s.clusterMetadata.GetCurrentClusterName(),
 	}
 	processor := parentclosepolicy.New(params)
 	if err := processor.Start(); err != nil {

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -239,6 +239,10 @@ func NewConfig(logger log.Logger, dcClient dynamicconfig.Client, params *resourc
 				dynamicconfig.WorkerParentCloseMaxConcurrentWorkflowTaskPollers,
 				4,
 			),
+			NumParentClosePolicySystemWorkflows: dc.GetIntProperty(
+				dynamicconfig.NumParentClosePolicySystemWorkflows,
+				10,
+			),
 		},
 		ScannerCfg: &scanner.Config{
 			MaxConcurrentActivityExecutionSize: dc.GetIntProperty(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Handle namespaceNotActive error in parentClosePolicy workflow
- If chlid domain active in a different cluster, signal the system workflow in the remote cluster to apply the parent close policy.
- We can't rely on frontend autoforwarding for Terminate/RequestCancel, because there're some request fields we need to use that only exist in history service interface.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Currently if child domain performs a failover after parent close policy receive the signal, the signal request can not be processed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- if remote cluster is down then, the workflow will keep retrying sending the signal, but this is the same as today because we will keep retrying on namespace not active error.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no
