### PR TITLE
Enable cgo by default and disable it explicitly for docker image build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,8 +6,6 @@ builds:
   - id: "temporal-server"
     dir: cmd/server
     binary: temporal-server
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -15,11 +13,19 @@ builds:
     goarch:
       - amd64
       - arm64
+  - id: "temporal-server-no-cgo"
+    dir: cmd/server
+    binary: temporal-server
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
   - id: "tctl"
     dir: cmd/tools/cli
     binary: tctl
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -30,8 +36,6 @@ builds:
   - id: "temporal-cassandra-tool"
     dir: cmd/tools/cassandra
     binary: temporal-cassandra-tool
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - darwin
@@ -42,8 +46,6 @@ builds:
   - id: "temporal-sql-tool"
     dir: cmd/tools/sql
     binary: temporal-sql-tool
-    env:
-      - CGO_ENABLED=0
     goos:
       - linux
       - darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /temporal
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN make bins
+RUN CGO_ENABLED=0 make bins
 
 ##### Temporal server #####
 FROM ${BASE_SERVER_IMAGE} AS temporal-server

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Install all tools and builds binaries.
 install: update-tools bins
 
-# Rebuild binaries (used by Dockerfile and Buildkite).
+# Rebuild binaries (used by Dockerfile).
 bins: clean-bins temporal-server tctl plugins temporal-cassandra-tool temporal-sql-tool
 
 # Install all tools, recompile proto files, run all possible checks and tests (long but comprehensive).

--- a/cmd/server/main_cgo.go
+++ b/cmd/server/main_cgo.go
@@ -1,7 +1,5 @@
 // The MIT License
 //
-// Copyright (c) 2021 Datadog, Inc.
-//
 // Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
 //
 // Copyright (c) 2020 Uber Technologies, Inc.
@@ -26,17 +24,8 @@
 
 //go:build cgo
 
-package sqlite
+package main
 
 import (
-	"github.com/mattn/go-sqlite3"
+	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite" // needed to load sqlite plugin
 )
-
-const (
-	goSqlDriverName = "sqlite3"
-)
-
-func (mdb *db) IsDupEntryError(err error) bool {
-	sqlErr, ok := err.(sqlite3.Error)
-	return ok && sqlErr.Code == sqlite3.ErrConstraint
-}

--- a/cmd/tools/sql/main_cgo.go
+++ b/cmd/tools/sql/main_cgo.go
@@ -1,7 +1,5 @@
 // The MIT License
 //
-// Copyright (c) 2021 Datadog, Inc.
-//
 // Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
 //
 // Copyright (c) 2020 Uber Technologies, Inc.
@@ -26,17 +24,8 @@
 
 //go:build cgo
 
-package sqlite
+package main
 
 import (
-	"github.com/mattn/go-sqlite3"
+	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite" // needed to load sqlite plugin
 )
-
-const (
-	goSqlDriverName = "sqlite3"
-)
-
-func (mdb *db) IsDupEntryError(err error) bool {
-	sqlErr, ok := err.(sqlite3.Error)
-	return ok && sqlErr.Code == sqlite3.ErrConstraint
-}

--- a/common/persistence/sql/sqlplugin/sqlite/admin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/admin.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/sqlite/cluster_metadata.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/db.go
+++ b/common/persistence/sql/sqlplugin/sqlite/db.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/events.go
+++ b/common/persistence/sql/sqlplugin/sqlite/events.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/execution.go
+++ b/common/persistence/sql/sqlplugin/sqlite/execution.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/sqlite/execution_maps.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/namespace.go
+++ b/common/persistence/sql/sqlplugin/sqlite/namespace.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (
@@ -32,6 +34,7 @@ import (
 	"errors"
 
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 )
 

--- a/common/persistence/sql/sqlplugin/sqlite/plugin.go
+++ b/common/persistence/sql/sqlplugin/sqlite/plugin.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/queue.go
+++ b/common/persistence/sql/sqlplugin/sqlite/queue.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/shard.go
+++ b/common/persistence/sql/sqlplugin/sqlite/shard.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/task.go
+++ b/common/persistence/sql/sqlplugin/sqlite/task.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/sqlite/typeconv.go
+++ b/common/persistence/sql/sqlplugin/sqlite/typeconv.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import "time"

--- a/common/persistence/sql/sqlplugin/sqlite/visibility.go
+++ b/common/persistence/sql/sqlplugin/sqlite/visibility.go
@@ -24,6 +24,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package sqlite
 
 import (

--- a/common/persistence/sql/sqlplugin/tests/sqlite_test.go
+++ b/common/persistence/sql/sqlplugin/tests/sqlite_test.go
@@ -22,6 +22,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//go:build cgo
+
 package tests
 
 import (
@@ -29,6 +31,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/persistence/sql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"

--- a/develop/buildkite/pipeline.yml
+++ b/develop/buildkite/pipeline.yml
@@ -3,7 +3,7 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "make ci-build"
+    command: "CGO_ENABLED=0 make bins; CGO_ENABLED=1 make ci-build"
     plugins:
       - docker-compose#v3.8.0:
           run: build

--- a/develop/buildkite/pipeline.yml
+++ b/develop/buildkite/pipeline.yml
@@ -3,13 +3,23 @@ steps:
     agents:
       queue: "default"
       docker: "*"
-    command: "CGO_ENABLED=0 make bins; CGO_ENABLED=1 make ci-build"
+    command: "make ci-build"
     plugins:
       - docker-compose#v3.8.0:
           run: build
           config: ./develop/buildkite/docker-compose.yml
 
   - wait
+
+  - label: ":golang: build without cgo"
+    agents:
+      queue: "default"
+      docker: "*"
+    command: "CGO_ENABLED=0 make bins"
+    plugins:
+      - docker-compose#v3.8.0:
+          run: build
+          config: ./develop/buildkite/docker-compose.yml
 
   - label: ":golang: unit test"
     agents:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Enable `cgo` by default and disable it explicitly for docker image build.

<!-- Tell your future self why have you made these changes -->
**Why?**
SQLite requires `cgo` to be enabled. Production image would never use SQLite and still can be built without `cgo` i.e. `CGO_ENABLED=0`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Build locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.