### PR TITLE
Fix c symbol in caCert variable name

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -75,7 +75,7 @@ persistence:
                 maxConnLifetime: {{ default .Env.SQL_MAX_CONN_TIME "1h" }}
                 tls:
                     enabled: {{ default .Env.SQL_TLS_ENABLED "false" }}
-                    сaFile: {{ default .Env.SQL_CA "" }}
+                    caFile: {{ default .Env.SQL_CA "" }}
                     certFile: {{ default .Env.SQL_CERT "" }}
                     keyFile: {{ default .Env.SQL_CERT_KEY "" }}
                     enableHostVerification: {{ default .Env.SQL_HOST_VERIFICATION "false" }}
@@ -105,7 +105,7 @@ persistence:
                 maxConnLifetime: {{ default .Env.SQL_VIS_MAX_CONN_TIME "1h" }}
                 tls:
                     enabled: {{ default .Env.SQL_TLS_ENABLED "false" }}
-                    сaFile: {{ default .Env.SQL_CA "" }}
+                    caFile: {{ default .Env.SQL_CA "" }}
                     certFile: {{ default .Env.SQL_CERT "" }}
                     keyFile: {{ default .Env.SQL_CERT_KEY "" }}
                     enableHostVerification: {{ default .Env.SQL_HOST_VERIFICATION "false" }}
@@ -124,7 +124,7 @@ persistence:
                 maxConnLifetime: {{ default .Env.SQL_MAX_CONN_TIME "1h" }}
                 tls:
                     enabled: {{ default .Env.SQL_TLS_ENABLED "false" }}
-                    сaFile: {{ default .Env.SQL_CA "" }}
+                    caFile: {{ default .Env.SQL_CA "" }}
                     certFile: {{ default .Env.SQL_CERT "" }}
                     keyFile: {{ default .Env.SQL_CERT_KEY "" }}
                     enableHostVerification: {{ default .Env.SQL_HOST_VERIFICATION "false" }}
@@ -150,7 +150,7 @@ persistence:
                 maxConnLifetime: {{ default .Env.SQL_VIS_MAX_CONN_TIME "1h" }}
                 tls:
                     enabled: {{ default .Env.SQL_TLS_ENABLED "false" }}
-                    сaFile: {{ default .Env.SQL_CA "" }}
+                    caFile: {{ default .Env.SQL_CA "" }}
                     certFile: {{ default .Env.SQL_CERT "" }}
                     keyFile: {{ default .Env.SQL_CERT_KEY "" }}
                     enableHostVerification: {{ default .Env.SQL_HOST_VERIFICATION "false" }}
@@ -183,7 +183,7 @@ global:
             checkInterval: {{ default .Env.TEMPORAL_TLS_EXPIRATION_CHECKS_CHECK_INTERVAL "0s" }}
         internode:
             # This server section configures the TLS certificate that internal temporal
-            # cluster nodes (history or matching) present to other clients within the Temporal Cluster. 
+            # cluster nodes (history or matching) present to other clients within the Temporal Cluster.
             server:
                 requireClientAuth: {{ default .Env.TEMPORAL_TLS_REQUIRE_CLIENT_AUTH "false" }}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Unicode symbol 'с' (U+0441) was replaced with 'c' (U+0063).

<!-- Tell your future self why have you made these changes -->
**Why?**
While testing access to RDS(Postgres) I found the issue with the variable `caCert` which uses Russian Unicode symbol 'с' (U+0441) instead of the English 'c' (U+0063).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Checked that setting up `SQL_CA` env variable sets the `caCert` fields in temporal service config.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
