### PR TITLE
Add pipeline to trigger Temporal docker images build

### DIFF
--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -1,0 +1,26 @@
+name: 'Trigger Docker image build'
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  trigger:
+    name: 'trigger Docker image build'
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Dispatch docker builds Github Action
+        env:
+          PAT: ${{ secrets.COMMANDER_DATA_TOKEN }}
+          PARENT_REPO: temporalio/docker-builds
+          PARENT_BRANCH: main
+          WORKFLOW_ID: update-submodules.yml
+        run: |
+          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ env.PAT }}" https://api.github.com/repos/${{ env.PARENT_REPO }}/actions/workflows/${{ env.WORKFLOW_ID }}/dispatches -d '{"ref":"${{ env.PARENT_BRANCH }}"}'


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Triggers update of Temporal submodule in https://github.com/temporalio/docker-builds
Results in docker images builds & publish for auto-setup, server and admin-tools images

<!-- Tell your future self why have you made these changes -->
**Why?**

automation and moving to Github Actions

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

commits history may start showing up as failed 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
