### PR TITLE
Build docker image using Buildkite

### DIFF
--- a/develop/buildkite/Dockerfile
+++ b/develop/buildkite/Dockerfile
@@ -1,2 +1,2 @@
-FROM temporalio/base-ci-builder:1.1.0
+FROM temporalio/base-ci-builder:1.2.0
 WORKDIR /temporal

--- a/develop/buildkite/pipeline.yml
+++ b/develop/buildkite/pipeline.yml
@@ -11,11 +11,11 @@ steps:
 
   - wait
 
-  - label: ":golang: build docker image"
+  - label: ":docker: build docker images"
     agents:
       queue: "default"
       docker: "*"
-    command: "make docker-server"
+    command: "docker build ."
 
   - label: ":golang: unit test"
     agents:

--- a/develop/buildkite/pipeline.yml
+++ b/develop/buildkite/pipeline.yml
@@ -11,15 +11,11 @@ steps:
 
   - wait
 
-  - label: ":golang: build without cgo"
+  - label: ":golang: build docker image"
     agents:
       queue: "default"
       docker: "*"
-    command: "CGO_ENABLED=0 make bins"
-    plugins:
-      - docker-compose#v3.8.0:
-          run: build
-          config: ./develop/buildkite/docker-compose.yml
+    command: "make docker-server"
 
   - label: ":golang: unit test"
     agents:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Build docker image using Buildkite.

<!-- Tell your future self why have you made these changes -->
**Why?**
`ci-build` target builds project with `CGO_ENABLED=1` but docker images are getting build without cgo. Adding extra validation step which build docker image (without publishing) and validates that:
1. Project can be built without cgo,
2. `Dockerfile` is valid and all its dependencies exist.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
With Buildkite.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.