### PR TITLE
Add validation for invalid starttime filter for standard visibility

### DIFF
--- a/common/persistence/visibility/store/standard/converter_test.go
+++ b/common/persistence/visibility/store/standard/converter_test.go
@@ -61,6 +61,7 @@ var unsupportedQuery = []string{
 	`ExecutionStatus = "Running" AND WorkflowType = "xyz"`,
 	`WorkflowID = "abc" OR WorkflowType = "xyz"`,
 	`WorkflowID != "abc"`,
+	`StartTime < "2022-01-15T05:43:12.74127Z"`,
 }
 
 func TestSupportedQueryFilters(t *testing.T) {

--- a/common/persistence/visibility/store/standard/query_interceptors.go
+++ b/common/persistence/visibility/store/standard/query_interceptors.go
@@ -98,6 +98,10 @@ func (vi *valuesInterceptor) Values(name string, values ...interface{}) ([]inter
 		}
 		return values, err
 	case searchattribute.StartTime:
+		if len(values) != 2 {
+			return nil, query.NewConverterError("StartTime only supports BETWEEN ... AND ... filter")
+		}
+
 		values, err := vi.nextInterceptor.Values(name, values...)
 		if err == nil {
 			minTime, err := time.Parse(time.RFC3339Nano, values[0].(string))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Return errors when user specifies comparison filter for `StartTime` for standard visibility.

<!-- Tell your future self why have you made these changes -->
**Why?**
Right now it will panic due to `nil` pointer exception. Technically it is possible to process comparison filter for `StartTime`, but we decided to only support equals comparison for all the standard queries. Open this up just for `StartTime` adds unnecessary complexity with minimum benefit. User can easily translate a comparison expression to a `BETWEEN ... AND ...` expression for `StartTime` which is currently supported.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.