### PR TITLE
Use base-server:1.5.0 after recent update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_BUILDER_IMAGE=temporalio/base-builder:1.5.0
-ARG BASE_SERVER_IMAGE=temporalio/base-server:1.4.0
+ARG BASE_SERVER_IMAGE=temporalio/base-server:1.5.0
 ARG BASE_ADMIN_TOOLS_IMAGE=temporalio/base-admin-tools:1.3.0
 ARG GOPROXY
 

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -8,7 +8,6 @@ RUN apk add --update --no-cache \
 RUN mkdir -p /xsrc && \
     git clone https://github.com/jwilder/dockerize.git && \
     cd dockerize && \
-    go mod tidy && \
     go build -o /usr/local/bin/dockerize . && \
     rm -rf /xsrc
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use `base-server:1.5.0` after recent update.

<!-- Tell your future self why have you made these changes -->
**Why?**
Follow up for #2393.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
With Buildkite.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
New version of `dockerize` is used now. Should be 100% backwards compatible though.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.