### PR TITLE
Add dynamic config to force refresh search attributes cache

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -74,19 +74,20 @@ var Keys = map[Key]string{
 	EnableReadVisibilityFromES:                "system.enableReadVisibilityFromES",
 	EnableReadFromSecondaryAdvancedVisibility: "system.enableReadFromSecondaryAdvancedVisibility",
 
-	HistoryArchivalState:                   "system.historyArchivalState",
-	EnableReadFromHistoryArchival:          "system.enableReadFromHistoryArchival",
-	VisibilityArchivalState:                "system.visibilityArchivalState",
-	EnableReadFromVisibilityArchival:       "system.enableReadFromVisibilityArchival",
-	EnableNamespaceNotActiveAutoForwarding: "system.enableNamespaceNotActiveAutoForwarding",
-	TransactionSizeLimit:                   "system.transactionSizeLimit",
-	DisallowQuery:                          "system.disallowQuery",
-	EnableBatcher:                          "worker.enableBatcher",
-	EnableParentClosePolicyWorker:          "system.enableParentClosePolicyWorker",
-	EnableStickyQuery:                      "system.enableStickyQuery",
-	EnablePriorityTaskProcessor:            "system.enablePriorityTaskProcessor",
-	EnableAuthorization:                    "system.enableAuthorization",
-	EnableCrossNamespaceCommands:           "system.enableCrossNamespaceCommands",
+	HistoryArchivalState:                    "system.historyArchivalState",
+	EnableReadFromHistoryArchival:           "system.enableReadFromHistoryArchival",
+	VisibilityArchivalState:                 "system.visibilityArchivalState",
+	EnableReadFromVisibilityArchival:        "system.enableReadFromVisibilityArchival",
+	EnableNamespaceNotActiveAutoForwarding:  "system.enableNamespaceNotActiveAutoForwarding",
+	TransactionSizeLimit:                    "system.transactionSizeLimit",
+	DisallowQuery:                           "system.disallowQuery",
+	EnableBatcher:                           "worker.enableBatcher",
+	EnableParentClosePolicyWorker:           "system.enableParentClosePolicyWorker",
+	EnableStickyQuery:                       "system.enableStickyQuery",
+	EnablePriorityTaskProcessor:             "system.enablePriorityTaskProcessor",
+	EnableAuthorization:                     "system.enableAuthorization",
+	EnableCrossNamespaceCommands:            "system.enableCrossNamespaceCommands",
+	ForceSearchAttributesCacheRefreshOnRead: "system.forceSearchAttributesCacheRefreshOnRead",
 
 	// size limit
 	BlobSizeLimitError:     "limit.blobSize.error",
@@ -437,6 +438,11 @@ const (
 	// MaxIDLengthLimit is the length limit for various IDs, including: Namespace, TaskQueue, WorkflowID, ActivityID, TimerID,
 	// WorkflowType, ActivityType, SignalName, MarkerName, ErrorReason/FailureReason/CancelCause, Identity, RequestID
 	MaxIDLengthLimit
+
+	// ForceSearchAttributesCacheRefreshOnRead forces refreshing search attributes cache on a read operation, so we always
+	// get the latest data from DB. This effectively bypasses cache value and is used to facilitate testing of changes in
+	// search attributes. This should not be turned on in production.
+	ForceSearchAttributesCacheRefreshOnRead
 
 	// key for frontend
 

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -40,7 +40,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
-
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
@@ -51,6 +50,7 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -213,7 +213,7 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	s.fatalOnError("NewClusterMetadataManager", err)
 
 	s.ClusterMetadata = cluster.NewMetadataFromConfig(clusterMetadataConfig, s.ClusterMetadataManager, s.Logger)
-	s.SearchAttributesManager = searchattribute.NewManager(clock.NewRealTimeSource(), s.ClusterMetadataManager)
+	s.SearchAttributesManager = searchattribute.NewManager(clock.NewRealTimeSource(), s.ClusterMetadataManager, dynamicconfig.GetBoolPropertyFn(true))
 
 	s.MetadataManager, err = factory.NewMetadataManager()
 	s.fatalOnError("NewMetadataManager", err)

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -159,15 +159,23 @@ func TimeSourceProvider() clock.TimeSource {
 func SearchAttributeProviderProvider(
 	timeSource clock.TimeSource,
 	cmMgr persistence.ClusterMetadataManager,
+	dynamicCollection *dynamicconfig.Collection,
 ) searchattribute.Provider {
-	return searchattribute.NewManager(timeSource, cmMgr)
+	return searchattribute.NewManager(
+		timeSource,
+		cmMgr,
+		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false))
 }
 
 func SearchAttributeManagerProvider(
 	timeSource clock.TimeSource,
 	cmMgr persistence.ClusterMetadataManager,
+	dynamicCollection *dynamicconfig.Collection,
 ) searchattribute.Manager {
-	return searchattribute.NewManager(timeSource, cmMgr)
+	return searchattribute.NewManager(
+		timeSource,
+		cmMgr,
+		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false))
 }
 
 func NamespaceRegistryProvider(

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -252,8 +252,14 @@ func New(
 		return nil, err
 	}
 
-	saProvider := searchattribute.NewManager(clock.NewRealTimeSource(), persistenceBean.GetClusterMetadataManager())
-	saManager := searchattribute.NewManager(clock.NewRealTimeSource(), persistenceBean.GetClusterMetadataManager())
+	saProvider := searchattribute.NewManager(
+		clock.NewRealTimeSource(),
+		persistenceBean.GetClusterMetadataManager(),
+		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false))
+	saManager := searchattribute.NewManager(
+		clock.NewRealTimeSource(),
+		persistenceBean.GetClusterMetadataManager(),
+		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false))
 
 	namespaceRegistry := namespace.NewRegistry(
 		persistenceBean.GetMetadataManager(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a dynamic config to force refresh search attributes cache on each read.
This helps local testing scenarios so we get a consistent view of the latest info.

<!-- Tell your future self why have you made these changes -->
**Why?**
See above.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local testing.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No. This flag should never be turned on in production.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.