### PR TITLE
Set git revision at build from env variable

### DIFF
--- a/develop/scripts/create_build_info_data.sh
+++ b/develop/scripts/create_build_info_data.sh
@@ -4,7 +4,7 @@ set -eu
 
 build_info_data_file="build/info/data.json"
 
-git_revision="${GITHUB_SHA_SHORT:-$(git rev-parse --short HEAD)}}" # "6cbfa2a3a"
+git_revision="${GITHUB_SHA_SHORT:-$(git rev-parse --short HEAD)}" # "6cbfa2a3a"
 
 build_time_unix=$(date '+%s')              # seconds since epoch
 

--- a/develop/scripts/create_build_info_data.sh
+++ b/develop/scripts/create_build_info_data.sh
@@ -4,7 +4,11 @@ set -eu
 
 build_info_data_file="build/info/data.json"
 
-git_revision=$(git rev-parse --short HEAD) # "6cbfa2a3a"
+git_revision=${GITHUB_SHA_SHORT-}
+if [ -z "${git_revision}" ]; then
+  git_revision=$(git rev-parse --short HEAD) # "6cbfa2a3a"
+fi
+
 build_time_unix=$(date '+%s')              # seconds since epoch
 
 echo '{"gitRevision":"'"${git_revision}"'","buildTimeUnix":'"${build_time_unix}"'}' > "${build_info_data_file}"

--- a/develop/scripts/create_build_info_data.sh
+++ b/develop/scripts/create_build_info_data.sh
@@ -4,10 +4,7 @@ set -eu
 
 build_info_data_file="build/info/data.json"
 
-git_revision=${GITHUB_SHA_SHORT-}
-if [ -z "${git_revision}" ]; then
-  git_revision=$(git rev-parse --short HEAD) # "6cbfa2a3a"
-fi
+git_revision="${GITHUB_SHA_SHORT:-$(git rev-parse --short HEAD)}}" # "6cbfa2a3a"
 
 build_time_unix=$(date '+%s')              # seconds since epoch
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Allows to set git revision at build from env variable

<!-- Tell your future self why have you made these changes -->
**Why?**

Github actions only fetch one commit of data for submodules and not git history, hence the build was throwing "not a git repository"
https://github.com/temporalio/docker-builds/runs/4975313307?check_suite_focus=true#step:7:321

There is an option to fetch git history but seems only for the root project and not the submodules, using `fetch_depth` param, see https://github.com/actions/checkout#checkout-v2

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

```
$ bash develop/scripts/create_build_info_data.sh

$ cat ./build/info/data.json 
{"gitRevision":"864150a00","buildTimeUnix":1643337842}

$ export GITHUB_SHA_SHORT=333

$ bash develop/scripts/create_build_info_data.sh

$ cat ./build/info/data.json 

{"gitRevision":"333","buildTimeUnix":1643337908}
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
