### PR TITLE
Allow global namespace update from all clusters

### DIFF
--- a/common/namespace/handler.go
+++ b/common/namespace/handler.go
@@ -549,10 +549,6 @@ func (d *HandlerImpl) UpdateNamespace(
 	if configurationChanged && activeClusterChanged && isGlobalNamespace {
 		return nil, errCannotDoNamespaceFailoverAndUpdate
 	} else if configurationChanged || activeClusterChanged || needsNamespacePromotion {
-		if configurationChanged && isGlobalNamespace && !d.clusterMetadata.IsMasterCluster() {
-			return nil, errNotMasterCluster
-		}
-
 		// set the versions
 		if configurationChanged {
 			configVersion++
@@ -581,10 +577,6 @@ func (d *HandlerImpl) UpdateNamespace(
 		if err != nil {
 			return nil, err
 		}
-	} else if isGlobalNamespace && !d.clusterMetadata.IsMasterCluster() {
-		// although there is no attr updated, just prevent customer to use the non master cluster
-		// for update namespace, ever (except if customer want to do a namespace failover)
-		return nil, errNotMasterCluster
 	}
 
 	if isGlobalNamespace {

--- a/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
@@ -519,12 +519,12 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 	})
 	s.NoError(err)
 
+	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil)
 	resp, err := s.handler.UpdateNamespace(context.Background(), &workflowservice.UpdateNamespaceRequest{
 		Namespace: namespace,
 	})
-	s.Error(err)
-	s.IsType(&serviceerror.InvalidArgument{}, err)
-	s.Nil(resp)
+	s.NoError(err)
+	s.NotNil(resp)
 }
 
 func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdateGetNamespace_GlobalNamespace_AllAttrSet() {
@@ -578,6 +578,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 	})
 	s.NoError(err)
 
+	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil)
 	updateResp, err := s.handler.UpdateNamespace(context.Background(), &workflowservice.UpdateNamespaceRequest{
 		Namespace: namespace,
 		UpdateInfo: &namespacepb.UpdateNamespaceInfo{
@@ -598,9 +599,8 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 			Clusters:          clusters,
 		},
 	})
-	s.Error(err)
-	s.IsType(&serviceerror.InvalidArgument{}, err)
-	s.Nil(updateResp)
+	s.NoError(err)
+	s.NotNil(updateResp)
 }
 
 func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdateGetNamespace_GlobalNamespace_Failover() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allow global namespace update from all clusters. Registration is still only allowed from master cluster.

<!-- Tell your future self why have you made these changes -->
**Why?**
During namespace handover, the coordinator is source cluster which does not necessary be master cluster. So we should allow global namespace update from any cluster. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manual test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No