### PR TITLE
Added GetVersionedSchemaFilesInOrder helper function to cassandra_test_util.go

### DIFF
--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -56,25 +56,25 @@ type cassandraTestData struct {
 }
 
 func setUpCassandraTest(t *testing.T) (cassandraTestData, func()) {
-	var td cassandraTestData
-	td.cfg = newCassandraConfig()
-	td.logger = log.NewZapLogger(zaptest.NewLogger(t))
-	SetUpCassandraDatabase(td.cfg)
-	SetUpCassandraSchema(td.cfg, td.logger)
+	var testData cassandraTestData
+	testData.cfg = newCassandraConfig()
+	testData.logger = log.NewZapLogger(zaptest.NewLogger(t))
+	SetUpCassandraDatabase(testData.cfg)
+	SetUpCassandraSchema(testData.cfg, testData.logger)
 
-	td.factory = cassandra.NewFactory(
-		*td.cfg,
+	testData.factory = cassandra.NewFactory(
+		*testData.cfg,
 		resolver.NewNoopResolver(),
 		testCassandraClusterName,
-		td.logger,
+		testData.logger,
 	)
 
 	tearDown := func() {
-		td.factory.Close()
-		TearDownCassandraKeyspace(td.cfg)
+		testData.factory.Close()
+		TearDownCassandraKeyspace(testData.cfg)
 	}
 
-	return td, tearDown
+	return testData, tearDown
 }
 
 func TestCassandraExecutionMutableStateStoreSuite(t *testing.T) {

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -25,8 +25,9 @@
 package tests
 
 import (
-	"go.uber.org/zap/zaptest"
 	"testing"
+
+	"go.uber.org/zap/zaptest"
 
 	"github.com/stretchr/testify/suite"
 
@@ -50,9 +51,9 @@ const (
 )
 
 type cassandraTestData struct {
-	cfg *config.Cassandra
+	cfg     *config.Cassandra
 	factory *cassandra.Factory
-	logger log.Logger
+	logger  log.Logger
 }
 
 func setUpCassandraTest(t *testing.T) (cassandraTestData, func()) {

--- a/common/persistence/tests/cassandra_test_util.go
+++ b/common/persistence/tests/cassandra_test_util.go
@@ -26,6 +26,12 @@ package tests
 
 import (
 	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
 	"github.com/blang/semver/v4"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
@@ -33,11 +39,6 @@ import (
 	"go.temporal.io/server/common/persistence/cassandra"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
-	"os"
-	"path"
-	"path/filepath"
-	"sort"
-	"strings"
 )
 
 const (

--- a/common/persistence/tests/cassandra_test_util.go
+++ b/common/persistence/tests/cassandra_test_util.go
@@ -119,7 +119,11 @@ func TearDownCassandraKeyspace(cfg *config.Cassandra) {
 	}
 }
 
-func GetVersionedSchemaFilesInOrder(schemaDir string, logger log.Logger) []string {
+// GetSchemaFiles takes a root directory which contains subdirectories whose names are semantic versions and returns
+// the .cql files within. E.g.: //schema/cassandra/temporal/versioned
+// Subdirectories are ordered by semantic version, but files within the same subdirectory are in arbitrary order.
+// All .cql files are returned regardless of whether they are named in manifest.json.
+func GetSchemaFiles(schemaDir string, logger log.Logger) []string {
 	var retVal []string
 
 	versionDirPath := path.Join(schemaDir, "versioned")

--- a/common/persistence/tests/cassandra_test_util.go
+++ b/common/persistence/tests/cassandra_test_util.go
@@ -26,14 +26,13 @@ package tests
 
 import (
 	"fmt"
-	"path/filepath"
-
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/cassandra"
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
+	"path/filepath"
 )
 
 const (
@@ -65,35 +64,24 @@ func SetUpCassandraDatabase(cfg *config.Cassandra) {
 	}
 }
 
-func SetUpCassandraSchema(cfg *config.Cassandra) {
-	session, err := gocql.NewSession(*cfg, resolver.NewNoopResolver(), log.NewNoopLogger())
+func SetUpCassandraSchema(cfg *config.Cassandra, logger log.Logger) {
+	ApplySchemaUpdate(cfg, testCassandraExecutionSchema, logger)
+	ApplySchemaUpdate(cfg, testCassandraVisibilitySchema, logger)
+}
+
+func ApplySchemaUpdate(cfg *config.Cassandra, schemaFile string, logger log.Logger) {
+	session, err := gocql.NewSession(*cfg, resolver.NewNoopResolver(), logger)
 	if err != nil {
-		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
+		panic(err)
 	}
 	defer session.Close()
 
-	schemaPath, err := filepath.Abs(testCassandraExecutionSchema)
+	schemaPath, err := filepath.Abs(schemaFile)
 	if err != nil {
 		panic(err)
 	}
 
 	statements, err := p.LoadAndSplitQuery([]string{schemaPath})
-	if err != nil {
-		panic(err)
-	}
-
-	for _, stmt := range statements {
-		if err = session.Query(stmt).Exec(); err != nil {
-			panic(err)
-		}
-	}
-
-	schemaPath, err = filepath.Abs(testCassandraVisibilitySchema)
-	if err != nil {
-		panic(err)
-	}
-
-	statements, err = p.LoadAndSplitQuery([]string{schemaPath})
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Also, minor cleanups:

- Deduplicated setUp/tearDown code
- Replaced no-op logger with test logger  