### PR TITLE
Remove hacky force flush buffer check

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -303,7 +303,6 @@ var Keys = map[Key]string{
 	MutableStateChecksumGenProbability:                     "history.mutableStateChecksumGenProbability",
 	MutableStateChecksumVerifyProbability:                  "history.mutableStateChecksumVerifyProbability",
 	MutableStateChecksumInvalidateBefore:                   "history.mutableStateChecksumInvalidateBefore",
-	ReplicationEventsFromCurrentCluster:                    "history.ReplicationEventsFromCurrentCluster",
 	StandbyTaskReReplicationContextTimeout:                 "history.standbyTaskReReplicationContextTimeout",
 	EnableDropStuckTaskByNamespaceID:                       "history.DropStuckTaskByNamespace",
 	SkipReapplicationByNamespaceID:                         "history.SkipReapplicationByNamespaceID",
@@ -949,9 +948,6 @@ const (
 	MutableStateChecksumVerifyProbability
 	// MutableStateChecksumInvalidateBefore is the epoch timestamp before which all checksums are to be discarded
 	MutableStateChecksumInvalidateBefore
-
-	// ReplicationEventsFromCurrentCluster is a feature flag to allow cross DC replicate events that generated from the current cluster
-	ReplicationEventsFromCurrentCluster
 
 	// StandbyTaskReReplicationContextTimeout is the context timeout for standby task re-replication
 	StandbyTaskReReplicationContextTimeout

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -215,8 +215,7 @@ type Config struct {
 	MutableStateChecksumVerifyProbability dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MutableStateChecksumInvalidateBefore  dynamicconfig.FloatPropertyFn
 
-	// Crocess DC Replication configuration
-	ReplicationEventsFromCurrentCluster    dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	// NDC Replication configuration
 	StandbyTaskReReplicationContextTimeout dynamicconfig.DurationPropertyFnWithNamespaceIDFilter
 
 	SkipReapplicationByNamespaceID dynamicconfig.BoolPropertyFnWithNamespaceIDFilter
@@ -416,7 +415,6 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		MutableStateChecksumVerifyProbability: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateChecksumVerifyProbability, 0),
 		MutableStateChecksumInvalidateBefore:  dc.GetFloat64Property(dynamicconfig.MutableStateChecksumInvalidateBefore, 0),
 
-		ReplicationEventsFromCurrentCluster:    dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.ReplicationEventsFromCurrentCluster, false),
 		StandbyTaskReReplicationContextTimeout: dc.GetDurationPropertyFilteredByNamespaceID(dynamicconfig.StandbyTaskReReplicationContextTimeout, 3*time.Minute),
 
 		SkipReapplicationByNamespaceID: dc.GetBoolPropertyFnWithNamespaceIDFilter(dynamicconfig.SkipReapplicationByNamespaceID, false),

--- a/service/history/nDCHistoryReplicator.go
+++ b/service/history/nDCHistoryReplicator.go
@@ -250,20 +250,7 @@ func (r *nDCHistoryReplicatorImpl) applyEvents(
 	default:
 		// apply events, other than simple start workflow execution
 		// the continue as new + start workflow execution combination will also be processed here
-		var mutableState workflow.MutableState
-		var err error
-		namespaceEntry, err := r.namespaceRegistry.GetNamespaceByID(context.GetNamespaceID())
-		if err != nil {
-			return err
-		}
-
-		if r.shard.GetConfig().ReplicationEventsFromCurrentCluster(namespaceEntry.Name().String()) {
-			// this branch is used when replicating events (generated from current cluster)from remote cluster to current cluster.
-			// this could happen when the events are lost in current cluster and plan to recover them from remote cluster.
-			mutableState, err = context.LoadWorkflowExecutionForReplication(task.getVersion())
-		} else {
-			mutableState, err = context.LoadWorkflowExecution()
-		}
+		mutableState, err := context.LoadWorkflowExecution()
 		switch err.(type) {
 		case nil:
 			// Sanity check to make only 3DC mutable state here

--- a/service/history/workflow/context_mock.go
+++ b/service/history/workflow/context_mock.go
@@ -189,21 +189,6 @@ func (mr *MockContextMockRecorder) LoadWorkflowExecution() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadWorkflowExecution", reflect.TypeOf((*MockContext)(nil).LoadWorkflowExecution))
 }
 
-// LoadWorkflowExecutionForReplication mocks base method.
-func (m *MockContext) LoadWorkflowExecutionForReplication(incomingVersion int64) (MutableState, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "LoadWorkflowExecutionForReplication", incomingVersion)
-	ret0, _ := ret[0].(MutableState)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// LoadWorkflowExecutionForReplication indicates an expected call of LoadWorkflowExecutionForReplication.
-func (mr *MockContextMockRecorder) LoadWorkflowExecutionForReplication(incomingVersion interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadWorkflowExecutionForReplication", reflect.TypeOf((*MockContext)(nil).LoadWorkflowExecutionForReplication), incomingVersion)
-}
-
 // Lock mocks base method.
 func (m *MockContext) Lock(ctx context.Context, caller CallerType) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Remove hacky force flush buffer bypass for XDC if incoming version -> current cluster

<!-- Tell your future self why have you made these changes -->
**Why?**
NOTE: previously, this hacky bypass was added to allow workflow resend back to original
cluster due to local DB dataloss. Removing this hacky bypass due to breaking basic NDC
assumptions.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No