### PR TITLE
Add support for GetWorkflowHistory in reverse order

### DIFF
--- a/client/frontend/client.go
+++ b/client/frontend/client.go
@@ -133,6 +133,20 @@ func (c *clientImpl) GetWorkflowExecutionHistory(
 	return client.GetWorkflowExecutionHistory(ctx, request, opts...)
 }
 
+func (c *clientImpl) GetWorkflowExecutionHistoryReverse(
+	ctx context.Context,
+	request *workflowservice.GetWorkflowExecutionHistoryReverseRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetWorkflowExecutionHistoryReverseResponse, error) {
+	client, err := c.getRandomClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return client.GetWorkflowExecutionHistoryReverse(ctx, request, opts...)
+}
+
 func (c *clientImpl) ListArchivedWorkflowExecutions(
 	ctx context.Context,
 	request *workflowservice.ListArchivedWorkflowExecutionsRequest,

--- a/client/frontend/metricClient.go
+++ b/client/frontend/metricClient.go
@@ -138,6 +138,23 @@ func (c *metricClient) GetWorkflowExecutionHistory(
 	return resp, err
 }
 
+func (c *metricClient) GetWorkflowExecutionHistoryReverse(
+	ctx context.Context,
+	request *workflowservice.GetWorkflowExecutionHistoryReverseRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetWorkflowExecutionHistoryReverseResponse, error) {
+	c.metricsClient.IncCounter(metrics.FrontendClientGetWorkflowExecutionHistoryReverseScope, metrics.ClientRequests)
+
+	sw := c.metricsClient.StartTimer(metrics.FrontendClientGetWorkflowExecutionHistoryReverseScope, metrics.ClientLatency)
+	resp, err := c.client.GetWorkflowExecutionHistoryReverse(ctx, request, opts...)
+	sw.Stop()
+
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.FrontendClientGetWorkflowExecutionHistoryReverseScope, metrics.ClientFailures)
+	}
+	return resp, err
+}
+
 func (c *metricClient) ListArchivedWorkflowExecutions(
 	ctx context.Context,
 	request *workflowservice.ListArchivedWorkflowExecutionsRequest,

--- a/client/frontend/retryableClient.go
+++ b/client/frontend/retryableClient.go
@@ -125,6 +125,21 @@ func (c *retryableClient) GetWorkflowExecutionHistory(
 	return resp, err
 }
 
+func (c *retryableClient) GetWorkflowExecutionHistoryReverse(
+	ctx context.Context,
+	request *workflowservice.GetWorkflowExecutionHistoryReverseRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.GetWorkflowExecutionHistoryReverseResponse, error) {
+	var resp *workflowservice.GetWorkflowExecutionHistoryReverseResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.GetWorkflowExecutionHistoryReverse(ctx, request, opts...)
+		return err
+	}
+	err := backoff.Retry(op, c.policy, c.isRetryable)
+	return resp, err
+}
+
 func (c *retryableClient) ListArchivedWorkflowExecutions(
 	ctx context.Context,
 	request *workflowservice.ListArchivedWorkflowExecutionsRequest,

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1274,7 +1274,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		PersistenceAppendHistoryNodesScope:         {operation: "AppendHistoryNodes"},
 		PersistenceDeleteHistoryNodesScope:         {operation: "DeleteHistoryNodes"},
 		PersistenceReadHistoryBranchScope:          {operation: "ReadHistoryBranch"},
-		PersistenceReadHistoryBranchReverseScope:          {operation: "ReadHistoryBranchReverse"},
+		PersistenceReadHistoryBranchReverseScope:   {operation: "ReadHistoryBranchReverse"},
 		PersistenceForkHistoryBranchScope:          {operation: "ForkHistoryBranch"},
 		PersistenceDeleteHistoryBranchScope:        {operation: "DeleteHistoryBranch"},
 		PersistenceTrimHistoryBranchScope:          {operation: "TrimHistoryBranch"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -667,7 +667,7 @@ const (
 	PersistenceDeleteHistoryNodesScope
 	// PersistenceReadHistoryBranchScope tracks ReadHistoryBranch calls made by service to persistence layer
 	PersistenceReadHistoryBranchScope
-	// PersistenceReadHistoryBranchScope tracks ReadHistoryBranch calls made by service to persistence layer
+	// PersistenceReadHistoryBranchReverseScope tracks ReadHistoryBranchReverse calls made by service to persistence layer
 	PersistenceReadHistoryBranchReverseScope
 	// PersistenceForkHistoryBranchScope tracks ForkHistoryBranch calls made by service to persistence layer
 	PersistenceForkHistoryBranchScope
@@ -822,7 +822,7 @@ const (
 	FrontendRespondActivityTaskCanceledByIdScope
 	// FrontendGetWorkflowExecutionHistoryScope is the metric scope for non-long-poll frontend.GetWorkflowExecutionHistory
 	FrontendGetWorkflowExecutionHistoryScope
-	// FrontendGetWorkflowExecutionHistoryScope is the metric scope for non-long-poll frontend.GetWorkflowExecutionHistory
+	// FrontendGetWorkflowExecutionHistoryReverseScope is the metric for frontend.GetWorkflowExecutionHistoryReverse
 	FrontendGetWorkflowExecutionHistoryReverseScope
 	// FrontendPollWorkflowExecutionHistoryScope is the metric scope for long poll case of frontend.GetWorkflowExecutionHistory
 	FrontendPollWorkflowExecutionHistoryScope

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -667,6 +667,8 @@ const (
 	PersistenceDeleteHistoryNodesScope
 	// PersistenceReadHistoryBranchScope tracks ReadHistoryBranch calls made by service to persistence layer
 	PersistenceReadHistoryBranchScope
+	// PersistenceReadHistoryBranchScope tracks ReadHistoryBranch calls made by service to persistence layer
+	PersistenceReadHistoryBranchReverseScope
 	// PersistenceForkHistoryBranchScope tracks ForkHistoryBranch calls made by service to persistence layer
 	PersistenceForkHistoryBranchScope
 	// PersistenceDeleteHistoryBranchScope tracks DeleteHistoryBranch calls made by service to persistence layer
@@ -820,6 +822,8 @@ const (
 	FrontendRespondActivityTaskCanceledByIdScope
 	// FrontendGetWorkflowExecutionHistoryScope is the metric scope for non-long-poll frontend.GetWorkflowExecutionHistory
 	FrontendGetWorkflowExecutionHistoryScope
+	// FrontendGetWorkflowExecutionHistoryScope is the metric scope for non-long-poll frontend.GetWorkflowExecutionHistory
+	FrontendGetWorkflowExecutionHistoryReverseScope
 	// FrontendPollWorkflowExecutionHistoryScope is the metric scope for long poll case of frontend.GetWorkflowExecutionHistory
 	FrontendPollWorkflowExecutionHistoryScope
 	// FrontendGetWorkflowExecutionRawHistoryScope is the metric scope for frontend.GetWorkflowExecutionRawHistory
@@ -1270,6 +1274,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		PersistenceAppendHistoryNodesScope:         {operation: "AppendHistoryNodes"},
 		PersistenceDeleteHistoryNodesScope:         {operation: "DeleteHistoryNodes"},
 		PersistenceReadHistoryBranchScope:          {operation: "ReadHistoryBranch"},
+		PersistenceReadHistoryBranchReverseScope:          {operation: "ReadHistoryBranchReverse"},
 		PersistenceForkHistoryBranchScope:          {operation: "ForkHistoryBranch"},
 		PersistenceDeleteHistoryBranchScope:        {operation: "DeleteHistoryBranch"},
 		PersistenceTrimHistoryBranchScope:          {operation: "TrimHistoryBranch"},
@@ -1530,6 +1535,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		FrontendRespondActivityTaskFailedByIdScope:      {operation: "RespondActivityTaskFailedById"},
 		FrontendRespondActivityTaskCanceledByIdScope:    {operation: "RespondActivityTaskCanceledById"},
 		FrontendGetWorkflowExecutionHistoryScope:        {operation: "GetWorkflowExecutionHistory"},
+		FrontendGetWorkflowExecutionHistoryReverseScope: {operation: "GetWorkflowExecutionHistoryReverse"},
 		FrontendPollWorkflowExecutionHistoryScope:       {operation: "PollWorkflowExecutionHistory"},
 		FrontendGetWorkflowExecutionRawHistoryScope:     {operation: "GetWorkflowExecutionRawHistory"},
 		FrontendPollForWorkflowExecutionRawHistoryScope: {operation: "PollForWorkflowExecutionRawHistory"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -432,6 +432,8 @@ const (
 	FrontendClientDescribeWorkflowExecutionScope
 	// FrontendClientGetWorkflowExecutionHistoryScope tracks RPC calls to frontend service
 	FrontendClientGetWorkflowExecutionHistoryScope
+	// FrontendClientGetWorkflowExecutionHistoryReverseScope tracks RPC calls to frontend service
+	FrontendClientGetWorkflowExecutionHistoryReverseScope
 	// FrontendClientGetWorkflowExecutionRawHistoryScope tracks RPC calls to frontend service
 	FrontendClientGetWorkflowExecutionRawHistoryScope
 	// FrontendClientPollForWorkflowExecutionRawHistoryScope tracks RPC calls to frontend service
@@ -570,6 +572,8 @@ const (
 	DCRedirectionDescribeWorkflowExecutionScope
 	// DCRedirectionGetWorkflowExecutionHistoryScope tracks RPC calls for dc redirection
 	DCRedirectionGetWorkflowExecutionHistoryScope
+	// DCRedirectionGetWorkflowExecutionHistoryReverseScope tracks RPC calls for dc redirection
+	DCRedirectionGetWorkflowExecutionHistoryReverseScope
 	// DCRedirectionGetWorkflowExecutionRawHistoryScope tracks RPC calls for dc redirection
 	DCRedirectionGetWorkflowExecutionRawHistoryScope
 	// DCRedirectionPollForWorkflowExecutionRawHistoryScope tracks RPC calls for dc redirection
@@ -1343,6 +1347,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		FrontendClientDescribeTaskQueueScope:                  {operation: "FrontendClientDescribeTaskQueue", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientDescribeWorkflowExecutionScope:          {operation: "FrontendClientDescribeWorkflowExecution", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientGetWorkflowExecutionHistoryScope:        {operation: "FrontendClientGetWorkflowExecutionHistory", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
+		FrontendClientGetWorkflowExecutionHistoryReverseScope: {operation: "FrontendClientGetWorkflowExecutionHistoryReverse", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientGetWorkflowExecutionRawHistoryScope:     {operation: "FrontendClientGetWorkflowExecutionRawHistory", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientPollForWorkflowExecutionRawHistoryScope: {operation: "FrontendClientPollForWorkflowExecutionRawHistoryScope", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientListArchivedWorkflowExecutionsScope:     {operation: "FrontendClientListArchivedWorkflowExecutions", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
@@ -1412,6 +1417,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		DCRedirectionDescribeTaskQueueScope:                   {operation: "DCRedirectionDescribeTaskQueue", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDescribeWorkflowExecutionScope:           {operation: "DCRedirectionDescribeWorkflowExecution", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionGetWorkflowExecutionHistoryScope:         {operation: "DCRedirectionGetWorkflowExecutionHistory", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
+		DCRedirectionGetWorkflowExecutionHistoryReverseScope:  {operation: "DCRedirectionGetWorkflowExecutionHistoryReverse", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionGetWorkflowExecutionRawHistoryScope:      {operation: "DCRedirectionGetWorkflowExecutionRawHistoryScope", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionPollForWorkflowExecutionRawHistoryScope:  {operation: "DCRedirectionPollForWorkflowExecutionRawHistoryScope", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionListArchivedWorkflowExecutionsScope:      {operation: "DCRedirectionListArchivedWorkflowExecutions", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -44,10 +44,11 @@ const (
 		`tree_id, branch_id, node_id, prev_txn_id, txn_id, data, data_encoding) ` +
 		`VALUES (?, ?, ?, ?, ?, ?, ?) `
 
-	v2templateReadHistoryNodeReverseSuffix = `ORDER BY branch_id DESC, node_id DESC `
-
 	v2templateReadHistoryNode = `SELECT node_id, prev_txn_id, txn_id, data, data_encoding FROM history_node ` +
 		`WHERE tree_id = ? AND branch_id = ? AND node_id >= ? AND node_id < ? `
+
+	v2templateReadHistoryNodeReverse = `SELECT node_id, prev_txn_id, txn_id, data, data_encoding FROM history_node ` +
+		`WHERE tree_id = ? AND branch_id = ? AND node_id >= ? AND node_id < ? ORDER BY branch_id DESC, node_id DESC `
 
 	v2templateReadHistoryNodeMetadata = `SELECT node_id, prev_txn_id, txn_id FROM history_node ` +
 		`WHERE tree_id = ? AND branch_id = ? AND node_id >= ? AND node_id < ? `
@@ -165,7 +166,6 @@ func (h *HistoryStore) DeleteHistoryNodes(
 func (h *HistoryStore) ReadHistoryBranch(
 	request *p.InternalReadHistoryBranchRequest,
 ) (*p.InternalReadHistoryBranchResponse, error) {
-
 	treeID, err := primitives.ValidateUUID(request.TreeID)
 	if err != nil {
 		return nil, serviceerror.NewInternal(fmt.Sprintf("ReadHistoryBranch - Gocql TreeId UUID cast failed. Error: %v", err))
@@ -179,16 +179,13 @@ func (h *HistoryStore) ReadHistoryBranch(
 	var queryString string
 	if request.MetadataOnly {
 		queryString = v2templateReadHistoryNodeMetadata
+	} else if request.ReverseOrder {
+		queryString = v2templateReadHistoryNodeReverse
 	} else {
 		queryString = v2templateReadHistoryNode
 	}
 
-	var orderSuffix string
-	if request.ReverseOrder {
-		orderSuffix = v2templateReadHistoryNodeReverseSuffix
-	}
-
-	query := h.Session.Query(queryString+orderSuffix, treeID, branchID, request.MinNodeID, request.MaxNodeID)
+	query := h.Session.Query(queryString, treeID, branchID, request.MinNodeID, request.MaxNodeID)
 
 	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
 	var pagingToken []byte

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -839,6 +839,37 @@ type (
 		Size int
 	}
 
+	// ReadHistoryBranchRequest is used to read a history branch
+	ReadHistoryBranchReverseRequest struct {
+		// The shard to get history branch data
+		ShardID int32
+		// The branch to be read
+		BranchToken []byte
+		// Get the history nodes upto MaxEventID.  Exclusive.
+		MaxEventID int64
+		// Maximum number of batches of events per page. Not that number of events in a batch >=1, it is not number of events per page.
+		// However for a single page, it is also possible that the returned events is less than PageSize (event zero events) due to stale events.
+		PageSize int
+		// LastFirstTransactionID specified in mutable state. Only used for reading in reverse order.
+		LastFirstTransactionID int64
+		// Whether we want to return events in reverse order.
+		ReverseOrder bool
+		// Token to continue reading next page of history append transactions.  Pass in empty slice for first page
+		NextPageToken []byte
+	}
+
+	// ReadHistoryBranchResponse is the response to ReadHistoryBranchRequest
+	ReadHistoryBranchReverseResponse struct {
+		// History events
+		HistoryEvents []*historypb.HistoryEvent
+		// Token to read next page if there are more events beyond page size.
+		// Use this to set NextPageToken on ReadHistoryBranchRequest to read the next page.
+		// Empty means we have reached the last page, not need to continue
+		NextPageToken []byte
+		// Size of history read from store
+		Size int
+	}
+
 	// ReadHistoryBranchByBatchResponse is the response to ReadHistoryBranchRequest
 	ReadHistoryBranchByBatchResponse struct {
 		// History events by batch
@@ -1112,6 +1143,8 @@ type (
 		ReadHistoryBranch(request *ReadHistoryBranchRequest) (*ReadHistoryBranchResponse, error)
 		// ReadHistoryBranchByBatch returns history node data for a branch ByBatch
 		ReadHistoryBranchByBatch(request *ReadHistoryBranchRequest) (*ReadHistoryBranchByBatchResponse, error)
+		// ReadHistoryBranch returns history node data for a branch
+		ReadHistoryBranchReverse(request *ReadHistoryBranchReverseRequest) (*ReadHistoryBranchReverseResponse, error)
 		// ReadRawHistoryBranch returns history node raw data for a branch ByBatch
 		// NOTE: this API should only be used by 3+DC
 		ReadRawHistoryBranch(request *ReadHistoryBranchRequest) (*ReadRawHistoryBranchResponse, error)

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -852,8 +852,6 @@ type (
 		PageSize int
 		// LastFirstTransactionID specified in mutable state. Only used for reading in reverse order.
 		LastFirstTransactionID int64
-		// Whether we want to return events in reverse order.
-		ReverseOrder bool
 		// Token to continue reading next page of history append transactions.  Pass in empty slice for first page
 		NextPageToken []byte
 	}

--- a/common/persistence/dataInterfaces_mock.go
+++ b/common/persistence/dataInterfaces_mock.go
@@ -706,6 +706,21 @@ func (mr *MockExecutionManagerMockRecorder) ReadHistoryBranchByBatch(request int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadHistoryBranchByBatch", reflect.TypeOf((*MockExecutionManager)(nil).ReadHistoryBranchByBatch), request)
 }
 
+// ReadHistoryBranchReverse mocks base method.
+func (m *MockExecutionManager) ReadHistoryBranchReverse(request *ReadHistoryBranchReverseRequest) (*ReadHistoryBranchReverseResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadHistoryBranchReverse", request)
+	ret0, _ := ret[0].(*ReadHistoryBranchReverseResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadHistoryBranchReverse indicates an expected call of ReadHistoryBranchReverse.
+func (mr *MockExecutionManagerMockRecorder) ReadHistoryBranchReverse(request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadHistoryBranchReverse", reflect.TypeOf((*MockExecutionManager)(nil).ReadHistoryBranchReverse), request)
+}
+
 // ReadRawHistoryBranch mocks base method.
 func (m *MockExecutionManager) ReadRawHistoryBranch(request *ReadHistoryBranchRequest) (*ReadRawHistoryBranchResponse, error) {
 	m.ctrl.T.Helper()

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -1057,24 +1057,6 @@ func (m *executionManagerImpl) toWorkflowMutableState(internState *InternalWorkf
 	return state, nil
 }
 
-func getLastWriteVersion(
-	versionHistories *historyspb.VersionHistories,
-) (int64, error) {
-	// TODO remove this if check once legacy execution tests are removed
-	if versionHistories == nil {
-		return common.EmptyVersion, nil
-	}
-	versionHistory, err := versionhistory.GetCurrentVersionHistory(versionHistories)
-	if err != nil {
-		return 0, err
-	}
-	versionHistoryItem, err := versionhistory.GetLastVersionHistoryItem(versionHistory)
-	if err != nil {
-		return 0, err
-	}
-	return versionHistoryItem.GetVersion(), nil
-}
-
 func getCurrentBranchToken(
 	versionHistories *historyspb.VersionHistories,
 ) ([]byte, error) {

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -1089,9 +1089,3 @@ func getCurrentBranchLastWriteVersion(
 	return versionHistoryItem.GetVersion(), nil
 }
 
-func (m *executionManagerImpl) reverseSlice(events []*historypb.HistoryEvent) []*historypb.HistoryEvent {
-	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
-		events[i], events[j] = events[j], events[i]
-	}
-	return events
-}

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -1088,4 +1088,3 @@ func getCurrentBranchLastWriteVersion(
 	}
 	return versionHistoryItem.GetVersion(), nil
 }
-

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -1113,4 +1113,3 @@ func (m *executionManagerImpl) reverseSlice(events []*historypb.HistoryEvent) []
 	}
 	return events
 }
-

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -1057,6 +1057,24 @@ func (m *executionManagerImpl) toWorkflowMutableState(internState *InternalWorkf
 	return state, nil
 }
 
+func getLastWriteVersion(
+	versionHistories *historyspb.VersionHistories,
+) (int64, error) {
+	// TODO remove this if check once legacy execution tests are removed
+	if versionHistories == nil {
+		return common.EmptyVersion, nil
+	}
+	versionHistory, err := versionhistory.GetCurrentVersionHistory(versionHistories)
+	if err != nil {
+		return 0, err
+	}
+	versionHistoryItem, err := versionhistory.GetLastVersionHistoryItem(versionHistory)
+	if err != nil {
+		return 0, err
+	}
+	return versionHistoryItem.GetVersion(), nil
+}
+
 func getCurrentBranchToken(
 	versionHistories *historyspb.VersionHistories,
 ) ([]byte, error) {
@@ -1088,3 +1106,11 @@ func getCurrentBranchLastWriteVersion(
 	}
 	return versionHistoryItem.GetVersion(), nil
 }
+
+func (m *executionManagerImpl) reverseSlice(events []*historypb.HistoryEvent) []*historypb.HistoryEvent {
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
+	return events
+}
+

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -924,6 +924,13 @@ func (m *executionManagerImpl) readHistoryBranchReverse(
 	return historyEvents, transactionIDs, nextPageToken, dataSize, nil
 }
 
+func (m *executionManagerImpl) reverseSlice(events []*historypb.HistoryEvent) []*historypb.HistoryEvent {
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
+	return events
+}
+
 func (m *executionManagerImpl) filterHistoryNodes(
 	lastNodeID int64,
 	lastTransactionID int64,

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -244,7 +244,7 @@ func (m *executionManagerImpl) TrimHistoryBranch(
 	var pageToken []byte
 	transactionIDToNode := map[int64]historyNodeMetadata{}
 	for doContinue := true; doContinue; doContinue = len(pageToken) > 0 {
-		token, err := m.deserializeToken(pageToken, minNodeID-1)
+		token, err := m.deserializeToken(pageToken, minNodeID-1, defaultLastTransactionID)
 		if err != nil {
 			return nil, err
 		}
@@ -277,7 +277,7 @@ func (m *executionManagerImpl) TrimHistoryBranch(
 			}
 		}
 
-		pageToken, err = m.serializeToken(token)
+		pageToken, err = m.serializeToken(token, false)
 		if err != nil {
 			return nil, err
 		}
@@ -474,7 +474,7 @@ func (m *executionManagerImpl) ReadRawHistoryBranch(
 		return nil, err
 	}
 
-	nextPageToken, err := m.serializeToken(token)
+	nextPageToken, err := m.serializeToken(token, false)
 	if err != nil {
 		return nil, err
 	}
@@ -484,6 +484,17 @@ func (m *executionManagerImpl) ReadRawHistoryBranch(
 		NextPageToken:     nextPageToken,
 		Size:              dataSize,
 	}, nil
+}
+
+// ReadHistoryBranchReverse returns history node data for a branch
+// Pagination is implemented here, the actual minNodeID passing to persistence layer is calculated along with token's LastNodeID
+func (m *executionManagerImpl) ReadHistoryBranchReverse(
+	request *ReadHistoryBranchReverseRequest,
+) (*ReadHistoryBranchReverseResponse, error) {
+	resp := &ReadHistoryBranchReverseResponse{}
+	var err error
+	resp.HistoryEvents, _, resp.NextPageToken, resp.Size, err = m.readHistoryBranchReverse(request)
+	return resp, err
 }
 
 func (m *executionManagerImpl) GetAllHistoryTreeBranches(
@@ -573,6 +584,65 @@ func (m *executionManagerImpl) readRawHistoryBranch(
 	return resp.Nodes, token, nil
 }
 
+func (m *executionManagerImpl) readRawHistoryBranchReverse(
+	shardID int32,
+	treeID string,
+	branchAncestors []*persistencespb.HistoryBranchRange,
+	minNodeID int64,
+	maxNodeID int64,
+	token *historyPagingToken,
+	pageSize int,
+	metadataOnly bool,
+) ([]InternalHistoryNode, *historyPagingToken, error) {
+	if token.CurrentRangeIndex == notStartedIndex {
+		for i := range branchAncestors {
+			idx := len(branchAncestors) - 1 - i
+			br := branchAncestors[idx]
+			// Skip branches that don't have relevant nodes
+			if maxNodeID <= br.GetBeginNodeId() {
+				continue
+			}
+			if minNodeID >= br.GetEndNodeId() {
+				break
+			}
+
+			if token.CurrentRangeIndex == notStartedIndex {
+				token.CurrentRangeIndex = idx
+			}
+			token.FinalRangeIndex = idx
+		}
+
+		if token.CurrentRangeIndex == notStartedIndex {
+			return nil, nil, serviceerror.NewDataLoss("branchRange is corrupted")
+		}
+	}
+
+	currentBranch := branchAncestors[token.CurrentRangeIndex]
+	// minNodeID remains the same, since caller can read from the middle
+	// maxNodeID need to be shortened since this branch can contain additional history nodes
+	if currentBranch.GetEndNodeId() < maxNodeID {
+		maxNodeID = currentBranch.GetEndNodeId()
+	}
+	branchID := currentBranch.GetBranchId()
+
+	resp, err := m.persistence.ReadHistoryBranch(&InternalReadHistoryBranchRequest{
+		ShardID:       shardID,
+		TreeID:        treeID,
+		BranchID:      branchID,
+		MinNodeID:     minNodeID,
+		MaxNodeID:     maxNodeID,
+		NextPageToken: token.StoreToken,
+		PageSize:      pageSize,
+		MetadataOnly:  metadataOnly,
+		ReverseOrder:  true,
+	})
+	if err != nil {
+		return nil, nil, err
+	}
+	token.StoreToken = resp.NextPageToken
+	return resp.Nodes, token, nil
+}
+
 func (m *executionManagerImpl) readRawHistoryBranchAndFilter(
 	request *ReadHistoryBranchRequest,
 ) ([]*commonpb.DataBlob, []int64, *historyPagingToken, int, error) {
@@ -604,6 +674,7 @@ func (m *executionManagerImpl) readRawHistoryBranchAndFilter(
 	token, err := m.deserializeToken(
 		request.NextPageToken,
 		request.MinEventID-1,
+		defaultLastTransactionID,
 	)
 	if err != nil {
 		return nil, nil, nil, 0, err
@@ -648,6 +719,92 @@ func (m *executionManagerImpl) readRawHistoryBranchAndFilter(
 		lastNode := nodes[len(nodes)-1]
 		token.LastNodeID = lastNode.NodeID
 		token.LastTransactionID = lastNode.TransactionID
+	}
+
+	return dataBlobs, transactionIDs, token, dataSize, nil
+}
+
+func (m *executionManagerImpl) readRawHistoryBranchReverseAndFilter(
+	request *ReadHistoryBranchReverseRequest,
+) ([]*commonpb.DataBlob, []int64, *historyPagingToken, int, error) {
+
+	shardID := request.ShardID
+	branchToken := request.BranchToken
+	minNodeID := common.FirstEventID
+	maxNodeID := request.MaxEventID
+	if maxNodeID == common.EmptyEventID {
+		maxNodeID = common.EndEventID
+	} else {
+		maxNodeID++ // downstream code is exclusive on maxNodeID
+	}
+
+	branch, err := serialization.HistoryBranchFromBlob(branchToken, enumspb.ENCODING_TYPE_PROTO3.String())
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+	treeID := branch.TreeId
+	branchID := branch.BranchId
+	branchAncestors := branch.Ancestors
+
+	// merge tree ID & branch ID into branch ancestors so the processing logic is simple
+	beginNodeID := common.FirstEventID
+	if len(branch.Ancestors) > 0 {
+		beginNodeID = branch.Ancestors[len(branch.Ancestors)-1].GetEndNodeId()
+	}
+	branchAncestors = append(branchAncestors, &persistencespb.HistoryBranchRange{
+		BranchId:    branchID,
+		BeginNodeId: beginNodeID,
+		EndNodeId:   maxNodeID,
+	})
+
+	token, err := m.deserializeToken(
+		request.NextPageToken,
+		request.MaxEventID,
+		request.LastFirstTransactionID,
+	)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	nodes, token, err := m.readRawHistoryBranchReverse(
+		shardID,
+		treeID,
+		branchAncestors,
+		minNodeID,
+		maxNodeID,
+		token,
+		request.PageSize,
+		false,
+	)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+	if len(nodes) == 0 && len(request.NextPageToken) == 0 {
+		return nil, nil, nil, 0, serviceerror.NewNotFound("Workflow execution history not found.")
+	}
+
+	nodes, err = m.filterHistoryNodesReverse(
+		token.LastNodeID,
+		token.LastTransactionID,
+		nodes,
+	)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	var dataBlobs []*commonpb.DataBlob
+	transactionIDs := make([]int64, 0, len(nodes))
+	dataSize := 0
+	if len(nodes) > 0 {
+		dataBlobs = make([]*commonpb.DataBlob, len(nodes))
+		for index, node := range nodes {
+			dataBlobs[index] = node.Events
+			dataSize += len(node.Events.Data)
+			transactionIDs = append(transactionIDs, node.TransactionID)
+		}
+		lastNode := nodes[len(nodes)-1]
+		token.LastNodeID = lastNode.NodeID
+		token.LastTransactionID = lastNode.PrevTransactionID
 	}
 
 	return dataBlobs, transactionIDs, token, dataSize, nil
@@ -705,11 +862,66 @@ func (m *executionManagerImpl) readHistoryBranch(
 		token.LastEventID = lastEvent.GetEventId()
 	}
 
-	nextPageToken, err := m.serializeToken(token)
+	nextPageToken, err := m.serializeToken(token, false)
 	if err != nil {
 		return nil, nil, nil, nil, 0, err
 	}
 	return historyEvents, historyEventBatches, transactionIDs, nextPageToken, dataSize, nil
+}
+
+func (m *executionManagerImpl) readHistoryBranchReverse(
+	request *ReadHistoryBranchReverseRequest,
+) ([]*historypb.HistoryEvent, []int64, []byte, int, error) {
+
+	dataBlobs, transactionIDs, token, dataSize, err := m.readRawHistoryBranchReverseAndFilter(request)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+
+	historyEvents := make([]*historypb.HistoryEvent, 0, request.PageSize)
+
+	for _, batch := range dataBlobs {
+		events, err := m.serializer.DeserializeEvents(batch)
+		if err != nil {
+			return nil, nil, nil, dataSize, err
+		}
+		if len(events) == 0 {
+			m.logger.Error("Empty events in a batch")
+			return nil, nil, nil, dataSize, serviceerror.NewDataLoss(fmt.Sprintf("corrupted history event batch, empty events"))
+		}
+
+		firstEvent := events[0]           // first
+		eventCount := len(events)         // length
+		lastEvent := events[eventCount-1] // last
+
+		if firstEvent.GetVersion() != lastEvent.GetVersion() || firstEvent.GetEventId()+int64(eventCount-1) != lastEvent.GetEventId() {
+			// in a single batch, version should be the same, and ID should be contiguous
+			m.logger.Error("Corrupted event batch",
+				tag.FirstEventVersion(firstEvent.GetVersion()), tag.WorkflowFirstEventID(firstEvent.GetEventId()),
+				tag.LastEventVersion(lastEvent.GetVersion()), tag.WorkflowNextEventID(lastEvent.GetEventId()),
+				tag.Counter(eventCount))
+			return historyEvents, transactionIDs, nil, dataSize, serviceerror.NewDataLoss("corrupted history event batch, wrong version and IDs")
+		}
+		if (token.LastEventID != common.EmptyEventID) && (lastEvent.GetEventId() != token.LastEventID-1) {
+			m.logger.Error("Corrupted non-contiguous event batch",
+				tag.WorkflowFirstEventID(firstEvent.GetEventId()),
+				tag.WorkflowNextEventID(lastEvent.GetEventId()),
+				tag.TokenLastEventID(token.LastEventID),
+				tag.Counter(eventCount))
+			return historyEvents, transactionIDs, nil, dataSize, serviceerror.NewDataLoss("corrupted history event batch, eventID is not contiguous")
+		}
+
+		events = m.reverseSlice(events)
+
+		historyEvents = append(historyEvents, events...)
+		token.LastEventID = firstEvent.GetEventId()
+	}
+
+	nextPageToken, err := m.serializeToken(token, true)
+	if err != nil {
+		return nil, nil, nil, 0, err
+	}
+	return historyEvents, transactionIDs, nextPageToken, dataSize, nil
 }
 
 func (m *executionManagerImpl) filterHistoryNodes(
@@ -748,21 +960,49 @@ func (m *executionManagerImpl) filterHistoryNodes(
 	return result, nil
 }
 
+func (m *executionManagerImpl) filterHistoryNodesReverse(
+	lastNodeID int64,
+	lastTransactionID int64,
+	nodes []InternalHistoryNode,
+) ([]InternalHistoryNode, error) {
+	var result []InternalHistoryNode
+	for _, node := range nodes {
+		if lastNodeID == defaultLastNodeID {
+			lastNodeID = node.NodeID
+		}
+		if node.TransactionID != lastTransactionID {
+			continue
+		}
+
+		switch {
+		case node.NodeID > lastNodeID:
+			return nil, serviceerror.NewUnavailable(fmt.Sprintf("corrupted data, nodeID cannot decrease"))
+		default:
+			lastTransactionID = node.PrevTransactionID
+			lastNodeID = node.NodeID
+			result = append(result, node)
+		}
+	}
+	return result, nil
+}
+
 func (m *executionManagerImpl) deserializeToken(
 	token []byte,
 	defaultLastEventID int64,
+	lastTransactionId int64,
 ) (*historyPagingToken, error) {
 
 	return m.pagingTokenSerializer.Deserialize(
 		token,
 		defaultLastEventID,
 		defaultLastNodeID,
-		defaultLastTransactionID,
+		lastTransactionId,
 	)
 }
 
 func (m *executionManagerImpl) serializeToken(
 	pagingToken *historyPagingToken,
+	reverseOrder bool,
 ) ([]byte, error) {
 
 	if len(pagingToken.StoreToken) == 0 {
@@ -771,7 +1011,12 @@ func (m *executionManagerImpl) serializeToken(
 			return nil, nil
 		}
 
-		pagingToken.CurrentRangeIndex++
+		if reverseOrder {
+			pagingToken.CurrentRangeIndex--
+
+		} else {
+			pagingToken.CurrentRangeIndex++
+		}
 		return m.pagingTokenSerializer.Serialize(pagingToken)
 	}
 

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -597,6 +597,8 @@ type (
 		ShardID int32
 		// whether to only return metadata, excluding node content
 		MetadataOnly bool
+		// whether we iterate in reverse order
+		ReverseOrder bool
 	}
 
 	// InternalCompleteForkBranchRequest is used to update some tree/branch meta data for forking

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -858,12 +858,12 @@ func (p *executionPersistenceClient) ReadHistoryBranchReverse(request *ReadHisto
 	*ReadHistoryBranchReverseResponse,
 	error,
 ) {
-	p.metricClient.IncCounter(metrics.PersistenceReadHistoryBranchScope, metrics.PersistenceRequests)
-	sw := p.metricClient.StartTimer(metrics.PersistenceReadHistoryBranchScope, metrics.PersistenceLatency)
+	p.metricClient.IncCounter(metrics.PersistenceReadHistoryBranchReverseScope, metrics.PersistenceRequests)
+	sw := p.metricClient.StartTimer(metrics.PersistenceReadHistoryBranchReverseScope, metrics.PersistenceLatency)
 	response, err := p.persistence.ReadHistoryBranchReverse(request)
 	sw.Stop()
 	if err != nil {
-		p.updateErrorMetric(metrics.PersistenceReadHistoryBranchScope, err)
+		p.updateErrorMetric(metrics.PersistenceReadHistoryBranchReverseScope, err)
 	}
 	return response, err
 }

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -854,6 +854,20 @@ func (p *executionPersistenceClient) ReadHistoryBranch(request *ReadHistoryBranc
 	return response, err
 }
 
+func (p *executionPersistenceClient) ReadHistoryBranchReverse(request *ReadHistoryBranchReverseRequest) (
+	*ReadHistoryBranchReverseResponse,
+	error,
+) {
+	p.metricClient.IncCounter(metrics.PersistenceReadHistoryBranchScope, metrics.PersistenceRequests)
+	sw := p.metricClient.StartTimer(metrics.PersistenceReadHistoryBranchScope, metrics.PersistenceLatency)
+	response, err := p.persistence.ReadHistoryBranchReverse(request)
+	sw.Stop()
+	if err != nil {
+		p.updateErrorMetric(metrics.PersistenceReadHistoryBranchScope, err)
+	}
+	return response, err
+}
+
 // ReadHistoryBranchByBatch returns history node data for a branch ByBatch
 func (p *executionPersistenceClient) ReadHistoryBranchByBatch(request *ReadHistoryBranchRequest) (*ReadHistoryBranchByBatchResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceReadHistoryBranchScope, metrics.PersistenceRequests)

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -601,6 +601,15 @@ func (p *executionRateLimitedPersistenceClient) ReadHistoryBranch(request *ReadH
 	return response, err
 }
 
+// ReadHistoryBranch returns history node data for a branch
+func (p *executionRateLimitedPersistenceClient) ReadHistoryBranchReverse(request *ReadHistoryBranchReverseRequest) (*ReadHistoryBranchReverseResponse, error) {
+	if ok := p.rateLimiter.Allow(); !ok {
+		return nil, ErrPersistenceLimitExceeded
+	}
+	response, err := p.persistence.ReadHistoryBranchReverse(request)
+	return response, err
+}
+
 // ReadHistoryBranchByBatch returns history node data for a branch
 func (p *executionRateLimitedPersistenceClient) ReadHistoryBranchByBatch(request *ReadHistoryBranchRequest) (*ReadHistoryBranchByBatchResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {

--- a/common/persistence/sql/sqlplugin/history_node.go
+++ b/common/persistence/sql/sqlplugin/history_node.go
@@ -53,8 +53,10 @@ type (
 		MinNodeID    int64
 		MinTxnID     int64
 		MaxNodeID    int64
+		MaxTxnID     int64
 		PageSize     int
 		MetadataOnly bool
+		ReverseOrder bool
 	}
 
 	// HistoryNodeDeleteFilter contains the column names within history_node table that

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -43,7 +43,7 @@ const (
 		`ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT ? `
 
 	getHistoryNodesReverseQuery = `SELECT node_id, prev_txn_id, txn_id, data, data_encoding FROM history_node ` +
-		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id = ? AND ((node_id = ? AND txn_id < ?) OR node_id < ?) ` +
+		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ? AND ((node_id = ? AND txn_id < ?) OR node_id < ?) ` +
 		`ORDER BY shard_id, tree_id, branch_id DESC, node_id DESC, txn_id DESC LIMIT ? `
 
 	getHistoryNodeMetadataQuery = `SELECT node_id, prev_txn_id, txn_id FROM history_node ` +

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -105,27 +105,35 @@ func (mdb *db) RangeSelectFromHistoryNode(
 	var query string
 	if filter.MetadataOnly {
 		query = getHistoryNodeMetadataQuery
+	} else if filter.ReverseOrder {
+		query = getHistoryNodesReverseQuery
 	} else {
-		if filter.ReverseOrder {
-			query = getHistoryNodesReverseQuery
-		} else {
-			query = getHistoryNodesQuery
-		}
+		query = getHistoryNodesQuery
 	}
 
-	args := []interface{}{
-		filter.ShardID,
-		filter.TreeID,
-		filter.BranchID,
-		filter.MinNodeID,
-		-filter.MinTxnID, // NOTE: transaction ID is *= -1 when stored
-		filter.MinNodeID,
-		filter.MaxNodeID,
-		filter.PageSize,
-	}
+	var args []interface{}
 	if filter.ReverseOrder {
-		args[4] = filter.MaxTxnID
-		args[5] = -filter.MaxTxnID
+		args = []interface{}{
+			filter.ShardID,
+			filter.TreeID,
+			filter.BranchID,
+			filter.MinNodeID,
+			filter.MaxTxnID,
+			-filter.MaxTxnID,
+			filter.MaxNodeID,
+			filter.PageSize,
+		}
+	} else {
+		args = []interface{}{
+			filter.ShardID,
+			filter.TreeID,
+			filter.BranchID,
+			filter.MinNodeID,
+			-filter.MinTxnID, // NOTE: transaction ID is *= -1 when stored
+			filter.MinNodeID,
+			filter.MaxNodeID,
+			filter.PageSize,
+		}
 	}
 
 	var rows []sqlplugin.HistoryNodeRow

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -42,6 +42,10 @@ const (
 		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND ((node_id = ? AND txn_id > ?) OR node_id > ?) AND node_id < ? ` +
 		`ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT ? `
 
+	getHistoryNodesReverseQuery = `SELECT node_id, prev_txn_id, txn_id, data, data_encoding FROM history_node ` +
+		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id = ? AND ((node_id = ? AND txn_id < ?) OR node_id < ?) ` +
+		`ORDER BY shard_id, tree_id, branch_id DESC, node_id DESC, txn_id DESC LIMIT ? `
+
 	getHistoryNodeMetadataQuery = `SELECT node_id, prev_txn_id, txn_id FROM history_node ` +
 		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND ((node_id = ? AND txn_id > ?) OR node_id > ?) AND node_id < ? ` +
 		`ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT ? `
@@ -102,13 +106,14 @@ func (mdb *db) RangeSelectFromHistoryNode(
 	if filter.MetadataOnly {
 		query = getHistoryNodeMetadataQuery
 	} else {
-		query = getHistoryNodesQuery
+		if filter.ReverseOrder {
+			query = getHistoryNodesReverseQuery
+		} else {
+			query = getHistoryNodesQuery
+		}
 	}
 
-	var rows []sqlplugin.HistoryNodeRow
-	if err := mdb.conn.SelectContext(ctx,
-		&rows,
-		query,
+	args := []interface{}{
 		filter.ShardID,
 		filter.TreeID,
 		filter.BranchID,
@@ -117,9 +122,17 @@ func (mdb *db) RangeSelectFromHistoryNode(
 		filter.MinNodeID,
 		filter.MaxNodeID,
 		filter.PageSize,
-	); err != nil {
+	}
+	if filter.ReverseOrder {
+		args[4] = filter.MaxTxnID
+		args[5] = -filter.MaxTxnID
+	}
+
+	var rows []sqlplugin.HistoryNodeRow
+	if err := mdb.conn.SelectContext(ctx, &rows, query, args...); err != nil {
 		return nil, err
 	}
+
 	// NOTE: since we let txn_id multiple by -1 when inserting, we have to revert it back here
 	for index := range rows {
 		rows[index].TxnID = -rows[index].TxnID

--- a/common/persistence/sql/sqlplugin/postgresql/events.go
+++ b/common/persistence/sql/sqlplugin/postgresql/events.go
@@ -107,27 +107,35 @@ func (pdb *db) RangeSelectFromHistoryNode(
 	var query string
 	if filter.MetadataOnly {
 		query = getHistoryNodeMetadataQuery
+	} else if filter.ReverseOrder {
+		query = getHistoryNodesReverseQuery
 	} else {
-		if filter.ReverseOrder {
-			query = getHistoryNodesReverseQuery
-		} else {
-			query = getHistoryNodesQuery
-		}
+		query = getHistoryNodesQuery
 	}
 
-	args := []interface{}{
-		filter.ShardID,
-		filter.TreeID,
-		filter.BranchID,
-		filter.MinNodeID,
-		-filter.MinTxnID, // NOTE: transaction ID is *= -1 when stored
-		filter.MinNodeID,
-		filter.MaxNodeID,
-		filter.PageSize,
-	}
+	var args []interface{}
 	if filter.ReverseOrder {
-		args[4] = filter.MaxTxnID
-		args[5] = -filter.MaxTxnID
+		args = []interface{}{
+			filter.ShardID,
+			filter.TreeID,
+			filter.BranchID,
+			filter.MinNodeID,
+			filter.MaxTxnID,
+			-filter.MaxTxnID,
+			filter.MaxNodeID,
+			filter.PageSize,
+		}
+	} else {
+		args = []interface{}{
+			filter.ShardID,
+			filter.TreeID,
+			filter.BranchID,
+			filter.MinNodeID,
+			-filter.MinTxnID, // NOTE: transaction ID is *= -1 when stored
+			filter.MinNodeID,
+			filter.MaxNodeID,
+			filter.PageSize,
+		}
 	}
 
 	var rows []sqlplugin.HistoryNodeRow

--- a/common/persistence/sql/sqlplugin/postgresql/events.go
+++ b/common/persistence/sql/sqlplugin/postgresql/events.go
@@ -44,7 +44,7 @@ const (
 		`ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT $8 `
 
 	getHistoryNodesReverseQuery = `SELECT node_id, prev_txn_id, txn_id, data, data_encoding FROM history_node ` +
-		`WHERE shard_id = $1 AND tree_id = $2 AND branch_id = $3 AND node_id > $4 AND ((node_id = $5 AND txn_id < $6) OR node_id < $7) ` +
+		`WHERE shard_id = $1 AND tree_id = $2 AND branch_id = $3 AND node_id >= $4 AND ((node_id = $5 AND txn_id < $6) OR node_id < $7) ` +
 		`ORDER BY shard_id, tree_id, branch_id DESC, node_id DESC, txn_id DESC LIMIT $8 `
 
 	getHistoryNodeMetadataQuery = `SELECT node_id, prev_txn_id, txn_id FROM history_node ` +

--- a/common/persistence/sql/sqlplugin/sqlite/events.go
+++ b/common/persistence/sql/sqlplugin/sqlite/events.go
@@ -107,27 +107,35 @@ func (mdb *db) RangeSelectFromHistoryNode(
 	var query string
 	if filter.MetadataOnly {
 		query = getHistoryNodeMetadataQuery
+	} else if filter.ReverseOrder {
+		query = getHistoryNodesReverseQuery
 	} else {
-		if filter.ReverseOrder {
-			query = getHistoryNodesReverseQuery
-		} else {
-			query = getHistoryNodesQuery
-		}
+		query = getHistoryNodesQuery
 	}
 
-	args := []interface{}{
-		filter.ShardID,
-		filter.TreeID,
-		filter.BranchID,
-		filter.MinNodeID,
-		-filter.MinTxnID, // NOTE: transaction ID is *= -1 when stored
-		filter.MinNodeID,
-		filter.MaxNodeID,
-		filter.PageSize,
-	}
+	var args []interface{}
 	if filter.ReverseOrder {
-		args[4] = filter.MaxTxnID
-		args[5] = -filter.MaxTxnID
+		args = []interface{}{
+			filter.ShardID,
+			filter.TreeID,
+			filter.BranchID,
+			filter.MinNodeID,
+			filter.MaxTxnID,
+			-filter.MaxTxnID,
+			filter.MaxNodeID,
+			filter.PageSize,
+		}
+	} else {
+		args = []interface{}{
+			filter.ShardID,
+			filter.TreeID,
+			filter.BranchID,
+			filter.MinNodeID,
+			-filter.MinTxnID, // NOTE: transaction ID is *= -1 when stored
+			filter.MinNodeID,
+			filter.MaxNodeID,
+			filter.PageSize,
+		}
 	}
 
 	var rows []sqlplugin.HistoryNodeRow

--- a/common/persistence/sql/sqlplugin/sqlite/events.go
+++ b/common/persistence/sql/sqlplugin/sqlite/events.go
@@ -46,7 +46,7 @@ const (
 		`ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT ? `
 
 	getHistoryNodesReverseQuery = `SELECT node_id, prev_txn_id, txn_id, data, data_encoding FROM history_node ` +
-		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND  node_id > ? AND ((node_id = ? AND txn_id < ?) OR node_id < ?) ` +
+		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ? AND ((node_id = ? AND txn_id < ?) OR node_id < ?) ` +
 		`ORDER BY shard_id, tree_id, branch_id DESC, node_id DESC, txn_id DESC LIMIT ? `
 
 	getHistoryNodeMetadataQuery = `SELECT node_id, prev_txn_id, txn_id FROM history_node ` +

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -78,7 +78,7 @@ func NewTelemetryInterceptor(
 func (ti *TelemetryInterceptor) overrideScope(scope int, req interface{}) int {
 	// GetWorkflowExecutionHistory method handles both long poll and regular calls.
 	// Current plan is to eventually split GetWorkflowExecutionHistory into two APIs,
-	// remove this if case when that is done.
+	// remove this "if" case when that is done.
 	if scope == metrics.FrontendGetWorkflowExecutionHistoryScope {
 		request := req.(*workflowservice.GetWorkflowExecutionHistoryRequest)
 		if request.GetWaitNewEvent() {

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.4.0
 	go.opentelemetry.io/otel/sdk/export/metric v0.27.0
 	go.opentelemetry.io/otel/sdk/metric v0.27.0
-	go.temporal.io/api v1.7.1-0.20220131203817-08fe71b1361d
+	go.temporal.io/api v1.7.1-0.20220204183313-62ccc454aff1
 	go.temporal.io/sdk v1.13.0
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -477,8 +477,8 @@ go.opentelemetry.io/otel/trace v1.4.0 h1:4OOUrPZdVFQkbzl/JSdvGCWIdw5ONXXxzHlaLlW
 go.opentelemetry.io/otel/trace v1.4.0/go.mod h1:uc3eRsqDfWs9R7b92xbQbU42/eTNz4N+gLP8qJCi4aE=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.temporal.io/api v1.6.1-0.20211110205628-60c98e9cbfe2/go.mod h1:IlUgOTGfmJuOkGrCZdptNxyXKE9CQz6oOx7/aH9bFY4=
-go.temporal.io/api v1.7.1-0.20220131203817-08fe71b1361d h1:vEjuA6VQaTr+lnt3sQMjiFsCYTjvrL3xcUuRj2Ef/ac=
-go.temporal.io/api v1.7.1-0.20220131203817-08fe71b1361d/go.mod h1:RJ6blV8Zh4cdZvR48DzFuMHUCP8fV4lIIBLDPkLkMBk=
+go.temporal.io/api v1.7.1-0.20220204183313-62ccc454aff1 h1:humtSJEW366psQ45wTPzAu6h0OOx8fEA/e9tTRUOpt0=
+go.temporal.io/api v1.7.1-0.20220204183313-62ccc454aff1/go.mod h1:NrEuqajUZkSELldM2X+3qCMC7cHfGNlXqagwJDRQdk8=
 go.temporal.io/sdk v1.13.0 h1:8PW27o/uYAf1C1u8WUd6LNa6He2nYkBhdUX3c5gif5o=
 go.temporal.io/sdk v1.13.0/go.mod h1:TCof7U/xas2FyDnx/UUEv4c/O/S41Lnhva+6JVer+Jo=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
@@ -693,7 +693,6 @@ golang.org/x/sys v0.0.0-20211124211545-fe61309f8881/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20211210111614-af8b64212486/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158 h1:rm+CHSpPEEW2IsXUib1ThaHIjuBVZjxNgSKmBLFfD4c=
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -890,7 +889,6 @@ google.golang.org/genproto v0.0.0-20211221195035-429b39de9b1c/go.mod h1:5CzLGKJ6
 google.golang.org/genproto v0.0.0-20211223182754-3ac035c7e7cb/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220111164026-67b88f271998/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220114231437-d2e6a121cae0/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
-google.golang.org/genproto v0.0.0-20220126215142-9970aeb2e350/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220201184016-50beb8ab5c44/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220204002441-d6cc3cc0770e/go.mod h1:5CzLGKJ67TSI2B9POpiiyGha0AjJvZIUgRMt1dSmuhc=
 google.golang.org/genproto v0.0.0-20220211171837-173942840c17 h1:2X+CNIheCutWRyKRte8szGxrE5ggtV4U+NKAbh/oLhg=

--- a/host/gethistory_test.go
+++ b/host/gethistory_test.go
@@ -26,8 +26,13 @@ package host
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"time"
+
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/workflow"
 
 	"go.temporal.io/server/common/persistence/serialization"
 
@@ -570,4 +575,202 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 		}
 	}
 	s.Equal(11, len(allEvents))
+}
+
+func (s *clientIntegrationSuite) TestGetHistoryReverse() {
+	activityFn := func(ctx context.Context) error {
+		return nil
+	}
+
+	var err1 error
+
+	activityId := "heartbeat_retry"
+	workflowFn := func(ctx workflow.Context) error {
+		activityRetryPolicy := &temporal.RetryPolicy{
+			InitialInterval:    time.Second * 2,
+			BackoffCoefficient: 1,
+			MaximumInterval:    time.Second * 2,
+			MaximumAttempts:    3,
+		}
+
+		ctx1 := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			ActivityID:             activityId,
+			ScheduleToStartTimeout: 2 * time.Second,
+			StartToCloseTimeout:    2 * time.Second,
+			RetryPolicy:            activityRetryPolicy,
+		})
+		f1 := workflow.ExecuteActivity(ctx1, activityFn)
+		err1 = f1.Get(ctx1, nil)
+		s.NoError(err1)
+
+		return nil
+	}
+
+	s.worker.RegisterActivity(activityFn)
+	s.worker.RegisterWorkflow(workflowFn)
+
+	wfId := "integration-test-gethistoryreverse"
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:                 wfId,
+		TaskQueue:          s.taskQueue,
+		WorkflowRunTimeout: 20 * time.Second,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	workflowRun, err := s.sdkClient.ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	if err != nil {
+		s.Logger.Fatal("Start workflow failed with err", tag.Error(err))
+	}
+
+	s.NotNil(workflowRun)
+	s.True(workflowRun.GetRunID() != "")
+
+	err = workflowRun.Get(ctx, nil)
+	s.NoError(err)
+
+	wfeResponse, err := s.sdkClient.DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+	s.Nil(err)
+
+	eventDefaultOrder := s.getHistory(s.namespace, wfeResponse.WorkflowExecutionInfo.Execution)
+	eventDefaultOrder = reverseSlice(eventDefaultOrder)
+
+	events := s.getHistoryReverse(s.namespace, wfeResponse.WorkflowExecutionInfo.Execution, 100)
+	s.Equal(len(eventDefaultOrder), len(events))
+	s.Equal(eventDefaultOrder, events)
+
+	events = s.getHistoryReverse(s.namespace, wfeResponse.WorkflowExecutionInfo.Execution, 3)
+	s.Equal(len(eventDefaultOrder), len(events))
+	s.Equal(eventDefaultOrder, events)
+
+	events = s.getHistoryReverse(s.namespace, wfeResponse.WorkflowExecutionInfo.Execution, 1)
+	s.Equal(len(eventDefaultOrder), len(events))
+	s.Equal(eventDefaultOrder, events)
+}
+
+func (s *clientIntegrationSuite) TestGetHistoryReverse_MultipleBranches() {
+	activityFn := func(ctx context.Context) error {
+		return nil
+	}
+
+	var err1, err2 error
+
+	activityId := "activity-gethistory-reverse-multiple-branches"
+	workflowFn := func(ctx workflow.Context) error {
+		activityRetryPolicy := &temporal.RetryPolicy{
+			InitialInterval:    time.Second * 2,
+			BackoffCoefficient: 1,
+			MaximumInterval:    time.Second * 2,
+			MaximumAttempts:    3,
+		}
+
+		ctx1 := workflow.WithActivityOptions(ctx, workflow.ActivityOptions{
+			ActivityID:             activityId,
+			ScheduleToStartTimeout: 2 * time.Second,
+			StartToCloseTimeout:    2 * time.Second,
+			RetryPolicy:            activityRetryPolicy,
+		})
+
+		f1 := workflow.ExecuteActivity(ctx1, activityFn)
+		err1 = f1.Get(ctx1, nil)
+		s.NoError(err1)
+
+		workflow.Sleep(ctx, time.Second*2)
+
+		f2 := workflow.ExecuteActivity(ctx1, activityFn)
+		err2 = f2.Get(ctx1, nil)
+		s.NoError(err2)
+
+		return nil
+	}
+
+	s.worker.RegisterActivity(activityFn)
+	s.worker.RegisterWorkflow(workflowFn)
+
+	wfId := "integration-test-gethistory-reverse-branch"
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:                 wfId,
+		TaskQueue:          s.taskQueue,
+		WorkflowRunTimeout: 20 * time.Second,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	workflowRun, err := s.sdkClient.ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	if err != nil {
+		s.Logger.Fatal("Start workflow failed with err", tag.Error(err))
+	}
+
+	s.NotNil(workflowRun)
+	s.True(workflowRun.GetRunID() != "")
+
+	// we want to reset workflow in the middle of execution
+	time.Sleep(time.Second)
+
+	s.NoError(err1)
+	s.NoError(err2)
+
+	wfeResponse, err := s.sdkClient.DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
+	s.NoError(err)
+
+	rweResponse, err := s.sdkClient.ResetWorkflowExecution(ctx, &workflowservice.ResetWorkflowExecutionRequest{
+		Namespace:                 s.namespace,
+		WorkflowExecution:         wfeResponse.WorkflowExecutionInfo.Execution,
+		Reason:                    "TestGetHistoryReverseBranch",
+		WorkflowTaskFinishEventId: 10,
+		RequestId:                 "test_id",
+	})
+	s.NoError(err)
+
+	resetRunId := rweResponse.GetRunId()
+	resetWorkflowRun := s.sdkClient.GetWorkflow(ctx, wfId, resetRunId)
+	err = resetWorkflowRun.Get(ctx, nil)
+	s.NoError(err)
+
+	resetWfeResponse, err := s.sdkClient.DescribeWorkflowExecution(ctx, resetWorkflowRun.GetID(), resetWorkflowRun.GetRunID())
+	s.NoError(err)
+
+	eventsDefaultOrder := s.getHistory(s.namespace, resetWfeResponse.WorkflowExecutionInfo.Execution)
+	eventsDefaultOrder = reverseSlice(eventsDefaultOrder)
+
+	events := s.getHistoryReverse(s.namespace, resetWfeResponse.WorkflowExecutionInfo.Execution, 100)
+	s.Equal(len(eventsDefaultOrder), len(events))
+	s.Equal(eventsDefaultOrder, events)
+
+	events = s.getHistoryReverse(s.namespace, resetWfeResponse.WorkflowExecutionInfo.Execution, 3)
+	s.Equal(len(eventsDefaultOrder), len(events))
+	s.Equal(eventsDefaultOrder, events)
+
+	events = s.getHistoryReverse(s.namespace, resetWfeResponse.WorkflowExecutionInfo.Execution, 1)
+	s.Equal(len(eventsDefaultOrder), len(events))
+	s.Equal(eventsDefaultOrder, events)
+}
+
+func reverseSlice(events []*historypb.HistoryEvent) []*historypb.HistoryEvent {
+	for i, j := 0, len(events)-1; i < j; i, j = i+1, j-1 {
+		events[i], events[j] = events[j], events[i]
+	}
+	return events
+}
+
+func (s *IntegrationBase) getHistoryReverse(namespace string, execution *commonpb.WorkflowExecution, pageSize int32) []*historypb.HistoryEvent {
+	historyResponse, err := s.engine.GetWorkflowExecutionHistoryReverse(NewContext(), &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+		Namespace:       namespace,
+		Execution:       execution,
+		NextPageToken:   nil,
+		MaximumPageSize: pageSize,
+	})
+	s.Require().NoError(err)
+
+	events := historyResponse.History.Events
+	for historyResponse.NextPageToken != nil {
+		historyResponse, err = s.engine.GetWorkflowExecutionHistoryReverse(NewContext(), &workflowservice.GetWorkflowExecutionHistoryReverseRequest{
+			Namespace:       namespace,
+			Execution:       execution,
+			NextPageToken:   historyResponse.NextPageToken,
+			MaximumPageSize: pageSize,
+		})
+		s.Require().NoError(err)
+		events = append(events, historyResponse.History.Events...)
+	}
+
+	return events
 }

--- a/host/gethistory_test.go
+++ b/host/gethistory_test.go
@@ -650,7 +650,7 @@ func (s *clientIntegrationSuite) TestGetHistoryReverse_MultipleBranches() {
 		return nil
 	}
 
-	activityId := "activity-gethistory-reverse-multiple-branches"
+	activityId := "integration-test-activity-gethistory-reverse-multiple-branches"
 	workflowFn := func(ctx workflow.Context) error {
 		activityRetryPolicy := &temporal.RetryPolicy{
 			InitialInterval:    time.Second * 2,
@@ -684,7 +684,7 @@ func (s *clientIntegrationSuite) TestGetHistoryReverse_MultipleBranches() {
 	s.worker.RegisterActivity(activityFn)
 	s.worker.RegisterWorkflow(workflowFn)
 
-	wfId := "integration-test-gethistory-reverse-branch"
+	wfId := "integration-test-wf-gethistory-reverse-multiple-branches"
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                 wfId,
 		TaskQueue:          s.taskQueue,

--- a/host/gethistory_test.go
+++ b/host/gethistory_test.go
@@ -582,8 +582,6 @@ func (s *clientIntegrationSuite) TestGetHistoryReverse() {
 		return nil
 	}
 
-	var err1 error
-
 	activityId := "heartbeat_retry"
 	workflowFn := func(ctx workflow.Context) error {
 		activityRetryPolicy := &temporal.RetryPolicy{
@@ -600,7 +598,7 @@ func (s *clientIntegrationSuite) TestGetHistoryReverse() {
 			RetryPolicy:            activityRetryPolicy,
 		})
 		f1 := workflow.ExecuteActivity(ctx1, activityFn)
-		err1 = f1.Get(ctx1, nil)
+		err1 := f1.Get(ctx1, nil)
 		s.NoError(err1)
 
 		return nil
@@ -652,8 +650,6 @@ func (s *clientIntegrationSuite) TestGetHistoryReverse_MultipleBranches() {
 		return nil
 	}
 
-	var err1, err2 error
-
 	activityId := "activity-gethistory-reverse-multiple-branches"
 	workflowFn := func(ctx workflow.Context) error {
 		activityRetryPolicy := &temporal.RetryPolicy{
@@ -669,6 +665,8 @@ func (s *clientIntegrationSuite) TestGetHistoryReverse_MultipleBranches() {
 			StartToCloseTimeout:    2 * time.Second,
 			RetryPolicy:            activityRetryPolicy,
 		})
+
+		var err1, err2 error
 
 		f1 := workflow.ExecuteActivity(ctx1, activityFn)
 		err1 = f1.Get(ctx1, nil)
@@ -704,9 +702,6 @@ func (s *clientIntegrationSuite) TestGetHistoryReverse_MultipleBranches() {
 
 	// we want to reset workflow in the middle of execution
 	time.Sleep(time.Second)
-
-	s.NoError(err1)
-	s.NoError(err2)
 
 	wfeResponse, err := s.sdkClient.DescribeWorkflowExecution(ctx, workflowRun.GetID(), workflowRun.GetRunID())
 	s.NoError(err)

--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -54,13 +54,13 @@ CREATE TABLE executions (
   };
 
 CREATE TABLE history_node (
-  tree_id           uuid,
-  branch_id         uuid,
-  node_id           bigint, -- node_id: first eventID in a batch of events
-  txn_id            bigint, -- for override the same node_id: bigger txn_id wins
-  prev_txn_id       bigint, -- pointing to the previous node: event chaining
-  data                blob, -- Batch of workflow execution history events as a blob
-  data_encoding       text, -- Protocol used for history serialization
+  tree_id           uuid, -- run_id if no reset, otherwise run_id of first run
+  branch_id         uuid, -- changes in case of reset workflow. Conflict resolution can also change branch id.
+  node_id           bigint, -- == first eventID in a batch of events
+  txn_id            bigint, -- in case of multiple transactions on same node, we utilize highest transaction ID. Unique.
+  prev_txn_id       bigint, -- point to the previous node: event chaining
+  data                blob, -- batch of workflow execution history events as a blob
+  data_encoding       text, -- protocol used for history serialization
   PRIMARY KEY ((tree_id), branch_id, node_id, txn_id )
 ) WITH CLUSTERING ORDER BY (branch_id ASC, node_id ASC, txn_id DESC)
   AND COMPACTION = {

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -58,13 +58,14 @@ var (
 		"RespondWorkflowTaskCompleted":     1,
 
 		// priority 2
-		"ResetWorkflowExecution":    2,
-		"DescribeWorkflowExecution": 2,
-		"RespondWorkflowTaskFailed": 2,
-		"QueryWorkflow":             2,
-		"RespondQueryTaskCompleted": 2,
-		"PollWorkflowTaskQueue":     2,
-		"PollActivityTaskQueue":     2,
+		"ResetWorkflowExecution":             2,
+		"DescribeWorkflowExecution":          2,
+		"RespondWorkflowTaskFailed":          2,
+		"QueryWorkflow":                      2,
+		"RespondQueryTaskCompleted":          2,
+		"PollWorkflowTaskQueue":              2,
+		"PollActivityTaskQueue":              2,
+		"GetWorkflowExecutionHistoryReverse": 2,
 
 		// priority 3
 		"ResetStickyTaskQueue":    3,

--- a/service/frontend/configs/quotas_test.go
+++ b/service/frontend/configs/quotas_test.go
@@ -84,12 +84,13 @@ func (s *quotasSuite) TestOtherAPIToPriorityMapping() {
 
 func (s *quotasSuite) TestExecutionAPIs() {
 	apis := map[string]struct{}{
-		"StartWorkflowExecution":           {},
-		"SignalWithStartWorkflowExecution": {},
-		"SignalWorkflowExecution":          {},
-		"RequestCancelWorkflowExecution":   {},
-		"TerminateWorkflowExecution":       {},
-		"GetWorkflowExecutionHistory":      {},
+		"StartWorkflowExecution":             {},
+		"SignalWithStartWorkflowExecution":   {},
+		"SignalWorkflowExecution":            {},
+		"RequestCancelWorkflowExecution":     {},
+		"TerminateWorkflowExecution":         {},
+		"GetWorkflowExecutionHistory":        {},
+		"GetWorkflowExecutionHistoryReverse": {},
 
 		"RecordActivityTaskHeartbeat":      {},
 		"RecordActivityTaskHeartbeatById":  {},

--- a/service/frontend/interface_mock.go
+++ b/service/frontend/interface_mock.go
@@ -224,6 +224,21 @@ func (mr *MockHandlerMockRecorder) GetWorkflowExecutionHistory(arg0, arg1 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecutionHistory", reflect.TypeOf((*MockHandler)(nil).GetWorkflowExecutionHistory), arg0, arg1)
 }
 
+// GetWorkflowExecutionHistoryReverse mocks base method.
+func (m *MockHandler) GetWorkflowExecutionHistoryReverse(arg0 context.Context, arg1 *v1.GetWorkflowExecutionHistoryReverseRequest) (*v1.GetWorkflowExecutionHistoryReverseResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowExecutionHistoryReverse", arg0, arg1)
+	ret0, _ := ret[0].(*v1.GetWorkflowExecutionHistoryReverseResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkflowExecutionHistoryReverse indicates an expected call of GetWorkflowExecutionHistoryReverse.
+func (mr *MockHandlerMockRecorder) GetWorkflowExecutionHistoryReverse(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecutionHistoryReverse", reflect.TypeOf((*MockHandler)(nil).GetWorkflowExecutionHistoryReverse), arg0, arg1)
+}
+
 // ListArchivedWorkflowExecutions mocks base method.
 func (m *MockHandler) ListArchivedWorkflowExecutions(arg0 context.Context, arg1 *v1.ListArchivedWorkflowExecutionsRequest) (*v1.ListArchivedWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -742,6 +742,148 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(ctx context.Context, requ
 	}, nil
 }
 
+// GetWorkflowExecutionHistory returns the history of specified workflow execution.  It fails with 'EntityNotExistError' if specified workflow
+// execution in unknown to the service.
+func (wh *WorkflowHandler) GetWorkflowExecutionHistoryReverse(ctx context.Context, request *workflowservice.GetWorkflowExecutionHistoryReverseRequest) (_ *workflowservice.GetWorkflowExecutionHistoryReverseResponse, retError error) {
+	defer log.CapturePanic(wh.logger, &retError)
+
+	if wh.isStopped() {
+		return nil, errShuttingDown
+	}
+
+	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
+		return nil, err
+	}
+
+	if request == nil {
+		return nil, errRequestNotSet
+	}
+
+	if err := wh.validateExecution(request.Execution); err != nil {
+		return nil, err
+	}
+
+	if request.GetMaximumPageSize() <= 0 {
+		request.MaximumPageSize = int32(wh.config.HistoryMaxPageSize(request.GetNamespace()))
+	}
+
+	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
+	if err != nil {
+		return nil, err
+	}
+
+	// force limit page size if exceed
+	if request.GetMaximumPageSize() > common.GetHistoryMaxPageSize {
+		wh.throttledLogger.Warn("GetHistory page size is larger than threshold",
+			tag.WorkflowID(request.Execution.GetWorkflowId()),
+			tag.WorkflowRunID(request.Execution.GetRunId()),
+			tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowSize(int64(request.GetMaximumPageSize())))
+		request.MaximumPageSize = common.GetHistoryMaxPageSize
+	}
+
+	queryMutableState := func(
+		namespaceUUID namespace.ID,
+		execution *commonpb.WorkflowExecution,
+		expectedNextEventID int64,
+		currentBranchToken []byte,
+	) ([]byte, string, int64, int64, int64, bool, error) {
+		response, err := wh.historyClient.PollMutableState(ctx, &historyservice.PollMutableStateRequest{
+			NamespaceId:         namespaceUUID.String(),
+			Execution:           execution,
+			ExpectedNextEventId: expectedNextEventID,
+			CurrentBranchToken:  currentBranchToken,
+		})
+
+		if err != nil {
+			return nil, "", 0, 0, 0, false, err
+		}
+		isWorkflowRunning := response.GetWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
+
+		return response.CurrentBranchToken,
+			response.Execution.GetRunId(),
+			response.GetLastFirstEventId(),
+			response.GetNextEventId(),
+			response.GetLastFirstEventTxnId(),
+			isWorkflowRunning,
+			nil
+	}
+
+	execution := request.Execution
+	var continuationToken *tokenspb.HistoryContinuation
+
+	var runID string
+	var lastFirstTxnID int64
+
+	if request.NextPageToken == nil {
+		continuationToken = &tokenspb.HistoryContinuation{}
+		continuationToken.BranchToken, runID, _, _, lastFirstTxnID, _, err =
+			queryMutableState(namespaceID, execution, common.FirstEventID, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		execution.RunId = runID
+		continuationToken.RunId = runID
+		continuationToken.FirstEventId = common.FirstEventID
+		continuationToken.NextEventId = common.EmptyEventID
+		continuationToken.PersistenceToken = nil
+	} else {
+		continuationToken, err = deserializeHistoryToken(request.NextPageToken)
+		if err != nil {
+			return nil, errInvalidNextPageToken
+		}
+		if execution.GetRunId() != "" && execution.GetRunId() != continuationToken.GetRunId() {
+			return nil, errNextPageTokenRunIDMismatch
+		}
+
+		execution.RunId = continuationToken.GetRunId()
+	}
+
+	// TODO below is a temporal solution to guard against invalid event batch
+	//  when data inconsistency occurs
+	//  long term solution should check event batch pointing backwards within history store
+	defer func() {
+		if _, ok := retError.(*serviceerror.DataLoss); ok {
+			wh.trimHistoryNode(ctx, namespaceID.String(), execution.GetWorkflowId(), execution.GetRunId())
+		}
+	}()
+
+	history := &historypb.History{}
+	history.Events = []*historypb.HistoryEvent{}
+	// return all events
+	history, continuationToken.PersistenceToken, continuationToken.NextEventId, err = wh.getHistoryReverse(
+		wh.metricsScope(ctx),
+		namespaceID,
+		namespace.Name(request.GetNamespace()),
+		*execution,
+		continuationToken.FirstEventId,
+		continuationToken.NextEventId,
+		lastFirstTxnID,
+		request.GetMaximumPageSize(),
+		continuationToken.PersistenceToken,
+		continuationToken.BranchToken,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if continuationToken.NextEventId < continuationToken.FirstEventId {
+		continuationToken = nil
+	}
+
+	nextToken, err := serializeHistoryToken(continuationToken)
+	if err != nil {
+		return nil, err
+	}
+
+	return &workflowservice.GetWorkflowExecutionHistoryReverseResponse{
+		History:       history,
+		NextPageToken: nextToken,
+		Archived:      false,
+	}, nil
+}
+
 // PollWorkflowTaskQueue is called by application worker to process WorkflowTask from a specific task queue.  A
 // WorkflowTask is dispatched to callers for active workflow executions, with pending workflow tasks.
 // Application is then expected to call 'RespondWorkflowTaskCompleted' API when it is done processing the WorkflowTask.
@@ -2998,6 +3140,64 @@ func (wh *WorkflowHandler) getHistory(
 		Events: historyEvents,
 	}
 	return executionHistory, nextPageToken, nil
+}
+
+func (wh *WorkflowHandler) getHistoryReverse(
+	scope metrics.Scope,
+	namespaceID namespace.ID,
+	namespace namespace.Name,
+	execution commonpb.WorkflowExecution,
+	firstEventID int64,
+	nextEventID int64,
+	lastFirstTxnID int64,
+	pageSize int32,
+	nextPageToken []byte,
+	branchToken []byte,
+) (*historypb.History, []byte, int64, error) {
+	var size int
+	// isFirstPage := len(nextPageToken) == 0
+	shardID := common.WorkflowIDToHistoryShard(namespaceID.String(), execution.GetWorkflowId(), wh.config.NumHistoryShards)
+	var err error
+	var historyEvents []*historypb.HistoryEvent
+
+	historyEvents, size, nextPageToken, err = persistence.ReadFullPageEventsReverse(wh.persistenceExecutionManager, &persistence.ReadHistoryBranchReverseRequest{
+		BranchToken:            branchToken,
+		MaxEventID:             nextEventID,
+		LastFirstTransactionID: lastFirstTxnID,
+		PageSize:               int(pageSize),
+		NextPageToken:          nextPageToken,
+		ShardID:                shardID,
+	})
+
+	switch err.(type) {
+	case nil:
+		// noop
+	case *serviceerror.DataLoss:
+		// log event
+		wh.logger.Error("encountered data loss event", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.GetWorkflowId()), tag.WorkflowRunID(execution.GetRunId()))
+		return nil, nil, 0, err
+	default:
+		return nil, nil, 0, err
+	}
+
+	scope.Tagged(metrics.StatsTypeTag(metrics.SizeStatsTypeTagValue)).RecordDistribution(metrics.HistorySize, size)
+
+	if err := wh.processSearchAttributes(historyEvents, namespace); err != nil {
+		return nil, nil, 0, err
+	}
+
+	executionHistory := &historypb.History{
+		Events: historyEvents,
+	}
+
+	var newNextEventID int64
+	if len(historyEvents) > 0 {
+		newNextEventID = historyEvents[len(historyEvents)-1].EventId - 1
+	} else {
+		newNextEventID = nextEventID
+	}
+
+	return executionHistory, nextPageToken, newNextEventID, nil
 }
 
 func (wh *WorkflowHandler) processOutgoingSearchAttributes(events []*historypb.HistoryEvent, namespace namespace.Name) error {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -786,7 +786,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistoryReverse(ctx context.Contex
 		execution *commonpb.WorkflowExecution,
 		expectedNextEventID int64,
 		currentBranchToken []byte,
-	) ([]byte, string, int64, int64, int64, bool, error) {
+	) ([]byte, string, int64, bool, error) {
 		response, err := wh.historyClient.PollMutableState(ctx, &historyservice.PollMutableStateRequest{
 			NamespaceId:         namespaceUUID.String(),
 			Execution:           execution,
@@ -795,14 +795,12 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistoryReverse(ctx context.Contex
 		})
 
 		if err != nil {
-			return nil, "", 0, 0, 0, false, err
+			return nil, "", 0, false, err
 		}
 		isWorkflowRunning := response.GetWorkflowStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING
 
 		return response.CurrentBranchToken,
 			response.Execution.GetRunId(),
-			response.GetLastFirstEventId(),
-			response.GetNextEventId(),
 			response.GetLastFirstEventTxnId(),
 			isWorkflowRunning,
 			nil
@@ -816,7 +814,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistoryReverse(ctx context.Contex
 
 	if request.NextPageToken == nil {
 		continuationToken = &tokenspb.HistoryContinuation{}
-		continuationToken.BranchToken, runID, _, _, lastFirstTxnID, _, err =
+		continuationToken.BranchToken, runID, lastFirstTxnID, _, err =
 			queryMutableState(namespaceID, execution, common.FirstEventID, nil)
 		if err != nil {
 			return nil, err

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -3174,7 +3174,7 @@ func (wh *WorkflowHandler) getHistoryReverse(
 
 	scope.Tagged(metrics.StatsTypeTag(metrics.SizeStatsTypeTagValue)).RecordDistribution(metrics.HistorySize, size)
 
-	if err := wh.processSearchAttributes(historyEvents, namespace); err != nil {
+	if err := wh.processOutgoingSearchAttributes(historyEvents, namespace); err != nil {
 		return nil, nil, 0, err
 	}
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -878,7 +878,6 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistoryReverse(ctx context.Contex
 	return &workflowservice.GetWorkflowExecutionHistoryReverseResponse{
 		History:       history,
 		NextPageToken: nextToken,
-		Archived:      false,
 	}, nil
 }
 


### PR DESCRIPTION
**This PR requires changes to API repo first**
https://github.com/temporalio/api/pull/147
and fix to LastFirstTransactionID (changes included into this PR due to how github reviews work with branching) https://github.com/temporalio/temporal/pull/2438
I'll cleanup/rebase changes once above PRs are merged.

<!-- Describe what has changed in this PR -->
**What changed?**
Add support to retrieve workflow history in reverse order.

<!-- Tell your future self why have you made these changes -->
**Why?**
More convenient query for long histories in some cases.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Automated tests, manual tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
History is not queried correctly.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No