### PR TITLE
Updated SetUpCassandraDatabase to take an actual logger instead of creating a NoopLogger

### DIFF
--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -60,7 +60,7 @@ func setUpCassandraTest(t *testing.T) (cassandraTestData, func()) {
 	var testData cassandraTestData
 	testData.cfg = newCassandraConfig()
 	testData.logger = log.NewZapLogger(zaptest.NewLogger(t))
-	SetUpCassandraDatabase(testData.cfg)
+	SetUpCassandraDatabase(testData.cfg, testData.logger)
 	SetUpCassandraSchema(testData.cfg, testData.logger)
 
 	testData.factory = cassandra.NewFactory(

--- a/common/persistence/tests/cassandra_test_util.go
+++ b/common/persistence/tests/cassandra_test_util.go
@@ -48,12 +48,12 @@ const (
 	testCassandraVisibilitySchema = "../../../schema/cassandra/visibility/schema.cql"
 )
 
-func SetUpCassandraDatabase(cfg *config.Cassandra) {
+func SetUpCassandraDatabase(cfg *config.Cassandra, logger log.Logger) {
 	adminCfg := *cfg
 	// NOTE need to connect with empty name to create new database
 	adminCfg.Keyspace = "system"
 
-	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver(), log.NewNoopLogger())
+	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver(), logger)
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}


### PR DESCRIPTION
This is useful for diagnosing persistence test failures.