### PR TITLE
Handle history not found error when archiving history

### DIFF
--- a/common/archiver/README.md
+++ b/common/archiver/README.md
@@ -23,11 +23,11 @@ Create a new directory in the `archiver` folder. The structure should look like 
 
 ```go
 type HistoryArchiver interface {
-	  // Archive is used to archive a workflow history. When the context expires the method should stop trying to archive.
-	  // Implementors are free to archive however they want, including implementing retries of sub-operations. The URI defines
-	  // the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
-	  // The Archive method may or may not be automatically retried by the caller. The ArchiveOptions are used
-	  // to interact with these retries including giving the implementor the ability to cancel retries and record progress
+    // Archive is used to archive a workflow history. When the context expires the method should stop trying to archive.
+    // Implementors are free to archive however they want, including implementing retries of sub-operations. The URI defines
+    // the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
+    // The Archive method may or may not be automatically retried by the caller. The ArchiveOptions are used
+    // to interact with these retries including giving the implementor the ability to cancel retries and record progress
     // between retry attempts. 
     // This method will be invoked after a workflow passes its retention period.
     // It's possible that this method will be invoked for one workflow multiple times and potentially concurrently,

--- a/common/archiver/README.md
+++ b/common/archiver/README.md
@@ -23,13 +23,15 @@ Create a new directory in the `archiver` folder. The structure should look like 
 
 ```go
 type HistoryArchiver interface {
-	// Archive is used to archive a workflow history. When the context expires the method should stop trying to archive.
-	// Implementors are free to archive however they want, including implementing retries of sub-operations. The URI defines
-	// the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
-	// The Archive method may or may not be automatically retried by the caller. The ArchiveOptions are used
-	// to interact with these retries including giving the implementor the ability to cancel retries and record progress
-  // between retry attempts. 
-  // This method will be invoked after a workflow passes its retention period.
+	  // Archive is used to archive a workflow history. When the context expires the method should stop trying to archive.
+	  // Implementors are free to archive however they want, including implementing retries of sub-operations. The URI defines
+	  // the resource that histories should be archived into. The implementor gets to determine how to interpret the URI.
+	  // The Archive method may or may not be automatically retried by the caller. The ArchiveOptions are used
+	  // to interact with these retries including giving the implementor the ability to cancel retries and record progress
+    // between retry attempts. 
+    // This method will be invoked after a workflow passes its retention period.
+    // It's possible that this method will be invoked for one workflow multiple times and potentially concurrently,
+    // implementation should correctly handle the workflow not exist case and return nil error.
     Archive(context.Context, URI, *ArchiveHistoryRequest, ...ArchiveOption) error
     
     // Get is used to access an archived history. When context expires method should stop trying to fetch history.

--- a/common/archiver/constants.go
+++ b/common/archiver/constants.go
@@ -33,6 +33,8 @@ const (
 	ArchiveNonRetryableErrorMsg = "Archive method encountered an non-retryable error."
 	// ArchiveTransientErrorMsg is the log message when the Archive() method encounters a transient error
 	ArchiveTransientErrorMsg = "Archive method encountered a transient error."
+	// ArchiveSkippedInfoMsg is the log messsage when the Archive() method encounter an not found error
+	ArchiveSkippedInfoMsg = "Archive method encountered not found error and skipped the archival"
 
 	// ErrReasonInvalidURI is the error reason for invalid URI
 	ErrReasonInvalidURI = "URI is invalid"

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/codec"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
@@ -165,10 +166,20 @@ func (h *historyArchiver) Archive(
 	for historyIterator.HasNext() {
 		historyBlob, err := getNextHistoryBlob(ctx, historyIterator)
 		if err != nil {
+			if common.IsNotFoundError(err) {
+				// workflow history no longer exists, may due to duplicated archival signal
+				// this may happen even in the middle of iterating history as two archival signals
+				// can be processed concurrently.
+				logger.Info(archiver.ArchiveSkippedInfoMsg)
+				scope.IncCounter(metrics.HistoryArchiverDuplicateArchivalsCount)
+				return nil
+			}
+
+			logger := log.With(logger, tag.ArchivalArchiveFailReason(archiver.ErrReasonReadHistory), tag.Error(err))
 			if common.IsPersistenceTransientError(err) {
-				logger.Error(archiver.ArchiveTransientErrorMsg, tag.ArchivalArchiveFailReason(archiver.ErrReasonReadHistory), tag.Error(err))
+				logger.Error(archiver.ArchiveTransientErrorMsg)
 			} else {
-				logger.Error(archiver.ArchiveNonRetryableErrorMsg, tag.ArchivalArchiveFailReason(archiver.ErrReasonReadHistory), tag.Error(err))
+				logger.Error(archiver.ArchiveNonRetryableErrorMsg)
 			}
 			return err
 		}

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1831,6 +1831,7 @@ const (
 	HistoryArchiverHistoryMutatedCount
 	HistoryArchiverTotalUploadSize
 	HistoryArchiverHistorySize
+	HistoryArchiverDuplicateArchivalsCount
 
 	// The following metrics are only used by internal history archiver implemention.
 	// TODO: move them to internal repo once temporal plugin model is in place.
@@ -1841,7 +1842,6 @@ const (
 	HistoryArchiverDeterministicConstructionCheckFailedCount
 	HistoryArchiverRunningBlobIntegrityCheckCount
 	HistoryArchiverBlobIntegrityCheckFailedCount
-	HistoryArchiverDuplicateArchivalsCount
 
 	VisibilityArchiverArchiveNonRetryableErrorCount
 	VisibilityArchiverArchiveTransientErrorCount
@@ -2298,13 +2298,13 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		HistoryArchiverHistoryMutatedCount:                        NewCounterDef("history_archiver_history_mutated"),
 		HistoryArchiverTotalUploadSize:                            NewBytesHistogramDef("history_archiver_total_upload_size"),
 		HistoryArchiverHistorySize:                                NewBytesHistogramDef("history_archiver_history_size"),
+		HistoryArchiverDuplicateArchivalsCount:                    NewCounterDef("history_archiver_duplicate_archivals"),
 		HistoryArchiverBlobExistsCount:                            NewCounterDef("history_archiver_blob_exists"),
 		HistoryArchiverBlobSize:                                   NewBytesHistogramDef("history_archiver_blob_size"),
 		HistoryArchiverRunningDeterministicConstructionCheckCount: NewCounterDef("history_archiver_running_deterministic_construction_check"),
 		HistoryArchiverDeterministicConstructionCheckFailedCount:  NewCounterDef("history_archiver_deterministic_construction_check_failed"),
 		HistoryArchiverRunningBlobIntegrityCheckCount:             NewCounterDef("history_archiver_running_blob_integrity_check"),
 		HistoryArchiverBlobIntegrityCheckFailedCount:              NewCounterDef("history_archiver_blob_integrity_check_failed"),
-		HistoryArchiverDuplicateArchivalsCount:                    NewCounterDef("history_archiver_duplicate_archivals"),
 		VisibilityArchiverArchiveNonRetryableErrorCount:           NewCounterDef("visibility_archiver_archive_non_retryable_error"),
 		VisibilityArchiverArchiveTransientErrorCount:              NewCounterDef("visibility_archiver_archive_transient_error"),
 		VisibilityArchiveSuccessCount:                             NewCounterDef("visibility_archiver_archive_success"),

--- a/common/util.go
+++ b/common/util.go
@@ -269,6 +269,11 @@ func IsResourceExhausted(err error) bool {
 	return false
 }
 
+func IsNotFoundError(err error) bool {
+	var notFoundError *serviceerror.NotFound
+	return errors.As(err, &notFoundError)
+}
+
 // WorkflowIDToHistoryShard is used to map namespaceID-workflowID pair to a shardID
 func WorkflowIDToHistoryShard(
 	namespaceID string,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Skip archival if workflow history not found.

<!-- Tell your future self why have you made these changes -->
**Why?**
It's possible that history archiver get multiple requests for archiving the same workflow (e.g. when signal system workflow times out and retry). 

Skip archival if workflow history not found. If workflow history not found, we currently return an non-retryable error immediately. It's the same as just return from the Archive method with nil error in terms of behavior since workflow won't retry the non-retryable error. As not found is an expected error, we should not emit non-retryable log/metric.

https://github.com/temporalio/temporal/issues/2464

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
