### PR TITLE
Expose metrics reporters constructors to end-user

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -207,7 +207,7 @@ var (
 	}
 )
 
-// InitMetricReporters is a root function for initalizing metrics clients.
+// InitMetricReporters is a root function for initializing metrics clients.
 //
 // Usage pattern
 // serverReporter, sdkReporter, err := c.InitMetricReporters(logger, customReporter)
@@ -216,23 +216,26 @@ var (
 // customReporter Provide this argument if you want to report metrics to a custom metric platform, otherwise use nil.
 //
 // returns SeverReporter, SDKReporter, error
-func (c *Config) InitMetricReporters(logger log.Logger, customReporter interface{}) (Reporter, Reporter, error) {
-	// init from config only
-	if customReporter == nil {
-		if c.Prometheus != nil && len(c.Prometheus.Framework) > 0 {
-			return c.initReportersFromPrometheusConfig(logger, customReporter)
-		}
-
-		scope := c.NewScope(logger)
-		reporter := newTallyReporter(scope, &c.ClientConfig)
-		return reporter, reporter, nil
+func InitMetricReporters(logger log.Logger, c *Config, customReporter interface{}) (Reporter, Reporter, error) {
+	if customReporter != nil {
+		return initMetricsReportersFromCustomReporter(logger, c, customReporter)
 	}
 
-	// handle custom reporter from ServerOptions
+	// TODO deprecated path support, remove once we deprecate custom SDK reporter (target version 1.17)
+	if c.PrometheusSDK != nil {
+		return initReportersFromPrometheusConfig(logger, c)
+	}
+
+	reporter, err := InitMetricsReporter(logger, c)
+	return reporter, reporter, err
+}
+
+// initMetricsReportersFromCustomReporter handles custom reporter from ServerOptions
+func initMetricsReportersFromCustomReporter(logger log.Logger, c *Config, customReporter interface{}) (Reporter, Reporter, error) {
 	switch cReporter := customReporter.(type) {
 	case tally.BaseStatsReporter:
-		scope := c.NewCustomReporterScope(logger, cReporter)
-		reporter := newTallyReporter(scope, &c.ClientConfig)
+		scope := NewCustomReporterScope(logger, &c.ClientConfig, cReporter)
+		reporter := NewTallyReporter(scope, &c.ClientConfig)
 		return reporter, reporter, nil
 	case Reporter:
 		return cReporter, cReporter, nil
@@ -242,14 +245,39 @@ func (c *Config) InitMetricReporters(logger log.Logger, customReporter interface
 	}
 }
 
-func (c *Config) initReportersFromPrometheusConfig(logger log.Logger, customReporter interface{}) (Reporter, Reporter, error) {
-	serverReporter, err := c.initReporterFromPrometheusConfig(logger, c.Prometheus, &c.ClientConfig)
+// InitMetricsReporter is a method that initializes reporter to be used inside server.
+//
+// Reporter is a base for reporting metrics and is used to initialize MetricsClient or UserScope.
+// MetricsClient is utilized internally in server to report metrics.
+// UserScope is utilized by user to report metrics.
+//
+// Recommended to use for current support for reporting metrics in extensions.
+//
+// reporter := InitMetricsReporter()
+// extension := MyExtensions(reporter.UserScope())
+// serverOptions.WithReporter(reporter)
+func InitMetricsReporter(logger log.Logger, c *Config) (Reporter, error) {
+	if c.Prometheus != nil && len(c.Prometheus.Framework) > 0 {
+		return InitReporterFromPrometheusConfig(logger, c.Prometheus, &c.ClientConfig)
+	}
+	return NewTallyReporterFromConfig(logger, c)
+}
+
+func NewTallyReporterFromConfig(logger log.Logger, c *Config) (*TallyReporter, error) {
+	scope := NewScope(logger, c)
+	reporter := NewTallyReporter(scope, &c.ClientConfig)
+	return reporter, nil
+}
+
+// TODO: this method should be removed once we deprecate Config.PrometheusSDK
+func initReportersFromPrometheusConfig(logger log.Logger, c *Config) (Reporter, Reporter, error) {
+	serverReporter, err := InitReporterFromPrometheusConfig(logger, c.Prometheus, &c.ClientConfig)
 	if err != nil {
 		return nil, nil, err
 	}
 	sdkReporter := serverReporter
 	if c.PrometheusSDK != nil {
-		sdkReporter, err = c.initReporterFromPrometheusConfig(logger, c.PrometheusSDK, &c.ClientConfig)
+		sdkReporter, err = InitReporterFromPrometheusConfig(logger, c.PrometheusSDK, &c.ClientConfig)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -257,23 +285,22 @@ func (c *Config) initReportersFromPrometheusConfig(logger log.Logger, customRepo
 	return serverReporter, sdkReporter, nil
 }
 
-func (c *Config) initReporterFromPrometheusConfig(logger log.Logger, config *PrometheusConfig, clientConfig *ClientConfig) (Reporter, error) {
+// InitReporterFromPrometheusConfig initializes reporter from PrometheusConfig
+//
+// This is a custom case of initializing temporal metrics reporter.
+func InitReporterFromPrometheusConfig(logger log.Logger, config *PrometheusConfig, clientConfig *ClientConfig) (Reporter, error) {
+	// TODO: We should switch to this being the only metrics reporter constructor once we decide to deprecate tally and
+	// custom tally configs Config.Statsd and Config.M3.
 	switch config.Framework {
 	case FrameworkTally:
-		return c.newTallyReporterByPrometheusConfig(logger, config), nil
+		return NewTallyReporterFromPrometheusConfig(logger, config, clientConfig), nil
 	case FrameworkOpentelemetry:
-		return newOpentelemeteryReporter(logger, config, clientConfig)
+		return NewOpentelemeteryReporter(logger, config, clientConfig)
 	default:
 		err := fmt.Errorf("unsupported framework type specified in config: %q", config.Framework)
 		logger.Error(err.Error())
 		return nil, err
 	}
-}
-
-func (c *Config) newTallyReporterByPrometheusConfig(logger log.Logger, config *PrometheusConfig) Reporter {
-	tallyConfig := c.convertPrometheusConfigToTally(config)
-	tallyScope := c.newPrometheusScope(logger, tallyConfig)
-	return newTallyReporter(tallyScope, &c.ClientConfig)
 }
 
 // NewScope builds a new tally scope for this metrics configuration
@@ -283,20 +310,32 @@ func (c *Config) newTallyReporterByPrometheusConfig(logger log.Logger, config *P
 //
 // Current priority order is:
 // m3 > statsd > prometheus
-func (c *Config) NewScope(logger log.Logger) tally.Scope {
+func NewScope(logger log.Logger, c *Config) tally.Scope {
 	if c.M3 != nil {
-		return c.newM3Scope(logger)
+		return newM3Scope(logger, c)
 	}
 	if c.Statsd != nil {
-		return c.newStatsdScope(logger)
+		return newStatsdScope(logger, c)
 	}
 	if c.Prometheus != nil {
-		return c.newPrometheusScope(logger, c.convertPrometheusConfigToTally(c.Prometheus))
+		return newPrometheusScope(logger, convertPrometheusConfigToTally(c.Prometheus), &c.ClientConfig)
 	}
 	return tally.NoopScope
 }
 
-func (c *Config) buildHistogramBuckets(config *PrometheusConfig) []prometheus.HistogramObjective {
+func NewTallyReporterFromPrometheusConfig(
+	logger log.Logger,
+	config *PrometheusConfig,
+	clientConfig *ClientConfig,
+) Reporter {
+	tallyConfig := convertPrometheusConfigToTally(config)
+	tallyScope := newPrometheusScope(logger, tallyConfig, clientConfig)
+	return NewTallyReporter(tallyScope, clientConfig)
+}
+
+func buildHistogramBuckets(
+	config *PrometheusConfig,
+) []prometheus.HistogramObjective {
 	var result []prometheus.HistogramObjective
 	if len(config.DefaultHistogramBuckets) > 0 {
 		result = make([]prometheus.HistogramObjective, len(config.DefaultHistogramBuckets))
@@ -309,7 +348,9 @@ func (c *Config) buildHistogramBuckets(config *PrometheusConfig) []prometheus.Hi
 	return result
 }
 
-func (c *Config) convertPrometheusConfigToTally(config *PrometheusConfig) *prometheus.Configuration {
+func convertPrometheusConfigToTally(
+	config *PrometheusConfig,
+) *prometheus.Configuration {
 	defaultObjectives := make([]prometheus.SummaryObjective, len(config.DefaultSummaryObjectives))
 	for i, item := range config.DefaultSummaryObjectives {
 		defaultObjectives[i].AllowedError = item.AllowedError
@@ -321,13 +362,13 @@ func (c *Config) convertPrometheusConfigToTally(config *PrometheusConfig) *prome
 		ListenNetwork:            config.ListenNetwork,
 		ListenAddress:            config.ListenAddress,
 		TimerType:                "histogram",
-		DefaultHistogramBuckets:  c.buildHistogramBuckets(config),
+		DefaultHistogramBuckets:  buildHistogramBuckets(config),
 		DefaultSummaryObjectives: defaultObjectives,
 		OnError:                  config.OnError,
 	}
 }
 
-func (c *Config) NewCustomReporterScope(logger log.Logger, customReporter tally.BaseStatsReporter) tally.Scope {
+func NewCustomReporterScope(logger log.Logger, c *ClientConfig, customReporter tally.BaseStatsReporter) tally.Scope {
 	options := tally.ScopeOptions{
 		DefaultBuckets: histogramBoundariesToValueBuckets(defaultHistogramBoundaries),
 	}
@@ -351,7 +392,7 @@ func (c *Config) NewCustomReporterScope(logger log.Logger, customReporter tally.
 
 // newM3Scope returns a new m3 scope with
 // a default reporting interval of a second
-func (c *Config) newM3Scope(logger log.Logger) tally.Scope {
+func newM3Scope(logger log.Logger, c *Config) tally.Scope {
 	reporter, err := c.M3.NewReporter()
 	if err != nil {
 		logger.Fatal("error creating m3 reporter", tag.Error(err))
@@ -368,7 +409,7 @@ func (c *Config) newM3Scope(logger log.Logger) tally.Scope {
 
 // newM3Scope returns a new statsd scope with
 // a default reporting interval of a second
-func (c *Config) newStatsdScope(logger log.Logger) tally.Scope {
+func newStatsdScope(logger log.Logger, c *Config) tally.Scope {
 	config := c.Statsd
 	if len(config.HostPort) == 0 {
 		return tally.NoopScope
@@ -392,7 +433,11 @@ func (c *Config) newStatsdScope(logger log.Logger) tally.Scope {
 
 // newPrometheusScope returns a new prometheus scope with
 // a default reporting interval of a second
-func (c *Config) newPrometheusScope(logger log.Logger, config *prometheus.Configuration) tally.Scope {
+func newPrometheusScope(
+	logger log.Logger,
+	config *prometheus.Configuration,
+	clientConfig *ClientConfig,
+) tally.Scope {
 	if len(config.DefaultHistogramBuckets) == 0 {
 		config.DefaultHistogramBuckets = histogramBoundariesToHistogramObjectives(defaultHistogramBoundaries)
 	}
@@ -408,11 +453,11 @@ func (c *Config) newPrometheusScope(logger log.Logger, config *prometheus.Config
 		logger.Fatal("error creating prometheus reporter", tag.Error(err))
 	}
 	scopeOpts := tally.ScopeOptions{
-		Tags:            c.Tags,
+		Tags:            clientConfig.Tags,
 		CachedReporter:  reporter,
 		Separator:       prometheus.DefaultSeparator,
 		SanitizeOptions: &sanitizeOptions,
-		Prefix:          c.Prefix,
+		Prefix:          clientConfig.Prefix,
 		DefaultBuckets:  histogramBoundariesToValueBuckets(defaultHistogramBoundaries),
 	}
 	scope, _ := tally.NewRootScope(scopeOpts, time.Second)

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -97,7 +97,7 @@ func (s *MetricsSuite) TestStatsd() {
 
 	config := new(Config)
 	config.Statsd = statsd
-	scope := config.NewScope(log.NewNoopLogger())
+	scope := NewScope(log.NewNoopLogger(), config)
 	s.NotNil(scope)
 }
 
@@ -109,7 +109,7 @@ func (s *MetricsSuite) TestM3() {
 	}
 	config := new(Config)
 	config.M3 = m3
-	scope := config.NewScope(log.NewNoopLogger())
+	scope := NewScope(log.NewNoopLogger(), config)
 	s.NotNil(scope)
 }
 
@@ -121,33 +121,33 @@ func (s *MetricsSuite) TestPrometheus() {
 	}
 	config := new(Config)
 	config.Prometheus = prom
-	scope := config.NewScope(log.NewNoopLogger())
+	scope := NewScope(log.NewNoopLogger(), config)
 	s.NotNil(scope)
 }
 
 func (s *MetricsSuite) TestNoop() {
 	config := &Config{}
-	scope := config.NewScope(log.NewNoopLogger())
+	scope := NewScope(log.NewNoopLogger(), config)
 	s.Equal(tally.NoopScope, scope)
 }
 
 func (s *MetricsSuite) TestCustomReporter() {
 	config := &Config{}
-	scope := config.NewCustomReporterScope(log.NewNoopLogger(), tally.NullStatsReporter)
+	scope := NewCustomReporterScope(log.NewNoopLogger(), &config.ClientConfig, tally.NullStatsReporter)
 	s.NotNil(scope)
 	s.NotEqual(tally.NoopScope, scope)
 }
 
 func (s *MetricsSuite) TestCustomCachedReporter() {
 	config := &Config{}
-	scope := config.NewCustomReporterScope(log.NewNoopLogger(), CachedNullStatsReporter)
+	scope := NewCustomReporterScope(log.NewNoopLogger(), &config.ClientConfig, CachedNullStatsReporter)
 	s.NotNil(scope)
 	s.NotEqual(tally.NoopScope, scope)
 }
 
 func (s *MetricsSuite) TestUnsupportedReporter() {
 	config := &Config{}
-	scope := config.NewCustomReporterScope(log.NewNoopLogger(), UnsupportedNullStatsReporter)
+	scope := NewCustomReporterScope(log.NewNoopLogger(), &config.ClientConfig, UnsupportedNullStatsReporter)
 	s.Equal(tally.NoopScope, scope)
 }
 
@@ -161,7 +161,7 @@ func (s *MetricsSuite) TestOTCustomReporter() {
 	config := &Config{}
 	config.Prometheus = prom
 	mockReporter := NewMockReporter(s.controller)
-	reporter, sdkReporter, err := config.InitMetricReporters(log.NewNoopLogger(), mockReporter)
+	reporter, sdkReporter, err := InitMetricReporters(log.NewNoopLogger(), config, mockReporter)
 	s.Equal(mockReporter, reporter)
 	s.Equal(mockReporter, sdkReporter)
 	s.Nil(err)

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -161,8 +161,7 @@ func (s *MetricsSuite) TestOTCustomReporter() {
 	config := &Config{}
 	config.Prometheus = prom
 	mockReporter := NewMockReporter(s.controller)
-	reporter, sdkReporter, err := InitMetricReporters(log.NewNoopLogger(), config, mockReporter)
+	reporter, err := InitMetricsReporterInternal(log.NewNoopLogger(), config, mockReporter)
 	s.Equal(mockReporter, reporter)
-	s.Equal(mockReporter, sdkReporter)
 	s.Nil(err)
 }

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -116,6 +116,7 @@ type (
 	Reporter interface {
 		NewClient(logger log.Logger, serviceIdx ServiceIdx) (Client, error)
 		Stop(logger log.Logger)
+		UserScope() UserScope
 	}
 )
 

--- a/common/metrics/interfaces_mock.go
+++ b/common/metrics/interfaces_mock.go
@@ -488,3 +488,17 @@ func (mr *MockReporterMockRecorder) Stop(logger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockReporter)(nil).Stop), logger)
 }
+
+// UserScope mocks base method.
+func (m *MockReporter) UserScope() UserScope {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UserScope")
+	ret0, _ := ret[0].(UserScope)
+	return ret0
+}
+
+// UserScope indicates an expected call of UserScope.
+func (mr *MockReporterMockRecorder) UserScope() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UserScope", reflect.TypeOf((*MockReporter)(nil).UserScope))
+}

--- a/common/metrics/opentelemetry_client.go
+++ b/common/metrics/opentelemetry_client.go
@@ -40,7 +40,7 @@ type (
 		serviceIdx   ServiceIdx
 		scopeWrapper func(impl internalScope) internalScope
 		gaugeCache   OtelGaugeCache
-		userScope    *opentelemetryUserScope
+		userScope    UserScope
 	}
 )
 
@@ -53,9 +53,7 @@ func newOpentelemeteryClient(clientConfig *ClientConfig, serviceIdx ServiceIdx, 
 		return NewTagFilteringScope(tagsFilterConfig, impl)
 	}
 
-	userScope := newOpentelemetryUserScope(reporter, clientConfig.Tags, gaugeCache)
-
-	globalRootScope := newOpentelemetryScope(serviceIdx, reporter, nil, clientConfig.Tags, getMetricDefs(serviceIdx), false, gaugeCache, false)
+	globalRootScope := newOpentelemetryScope(serviceIdx, reporter.GetMeterMust(), nil, clientConfig.Tags, getMetricDefs(serviceIdx), false, gaugeCache, false)
 
 	totalScopes := len(ScopeDefs[Common]) + len(ScopeDefs[serviceIdx])
 	metricsClient := &opentelemetryClient{
@@ -65,7 +63,7 @@ func newOpentelemeteryClient(clientConfig *ClientConfig, serviceIdx ServiceIdx, 
 		serviceIdx:   serviceIdx,
 		scopeWrapper: scopeWrapper,
 		gaugeCache:   gaugeCache,
-		userScope:    userScope,
+		userScope:    reporter.UserScope(),
 	}
 
 	for idx, def := range ScopeDefs[Common] {

--- a/common/metrics/opentelemetry_reporter.go
+++ b/common/metrics/opentelemetry_reporter.go
@@ -65,7 +65,7 @@ type (
 	}
 )
 
-func newOpentelemeteryReporter(
+func NewOpentelemeteryReporter(
 	logger log.Logger,
 	prometheusConfig *PrometheusConfig,
 	clientConfig *ClientConfig,

--- a/common/metrics/opentelemetry_reporter.go
+++ b/common/metrics/opentelemetry_reporter.go
@@ -158,5 +158,5 @@ func (r *opentelemetryReporterImpl) Stop(logger log.Logger) {
 }
 
 func (r *opentelemetryReporterImpl) UserScope() UserScope {
-	return r.UserScope()
+	return r.userScope
 }

--- a/common/metrics/opentelemetry_user_scope.go
+++ b/common/metrics/opentelemetry_user_scope.go
@@ -29,23 +29,24 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 )
 
 type opentelemetryUserScope struct {
-	reporter OpentelemetryReporter
-	labels   []attribute.KeyValue
-	tags     map[string]string
+	meterMust metric.MeterMust
+	labels    []attribute.KeyValue
+	tags      map[string]string
 
 	gaugeCache OtelGaugeCache
 }
 
 func newOpentelemetryUserScope(
-	reporter OpentelemetryReporter,
+	meterMust metric.MeterMust,
 	tags map[string]string,
 	gaugeCache OtelGaugeCache,
 ) *opentelemetryUserScope {
 	result := &opentelemetryUserScope{
-		reporter:   reporter,
+		meterMust:  meterMust,
 		tags:       tags,
 		gaugeCache: gaugeCache,
 	}
@@ -59,25 +60,25 @@ func (o opentelemetryUserScope) IncCounter(counter string) {
 
 func (o opentelemetryUserScope) AddCounter(counter string, delta int64) {
 	ctx := context.Background()
-	o.reporter.GetMeterMust().NewInt64Counter(counter).Add(ctx, delta, o.labels...)
+	o.meterMust.NewInt64Counter(counter).Add(ctx, delta, o.labels...)
 }
 
 func (o opentelemetryUserScope) StartTimer(timer string) Stopwatch {
 	metric := newOpenTelemetryStopwatchMetric(
-		o.reporter.GetMeterMust().NewInt64Histogram(timer),
+		o.meterMust.NewInt64Histogram(timer),
 		o.labels)
 	return newOpenTelemetryStopwatch([]openTelemetryStopwatchMetric{metric})
 }
 
 func (o opentelemetryUserScope) RecordTimer(timer string, d time.Duration) {
 	ctx := context.Background()
-	o.reporter.GetMeterMust().NewInt64Histogram(timer).Record(ctx, d.Nanoseconds(), o.labels...)
+	o.meterMust.NewInt64Histogram(timer).Record(ctx, d.Nanoseconds(), o.labels...)
 }
 
 func (o opentelemetryUserScope) RecordDistribution(id string, d int) {
 	value := int64(d)
 	ctx := context.Background()
-	o.reporter.GetMeterMust().NewInt64Histogram(id).Record(ctx, value, o.labels...)
+	o.meterMust.NewInt64Histogram(id).Record(ctx, value, o.labels...)
 }
 
 func (o opentelemetryUserScope) UpdateGauge(gauge string, value float64) {
@@ -94,5 +95,5 @@ func (o opentelemetryUserScope) Tagged(tags map[string]string) UserScope {
 	for key, value := range tags {
 		tagMap[key] = value
 	}
-	return newOpentelemetryUserScope(o.reporter, tagMap, o.gaugeCache)
+	return newOpentelemetryUserScope(o.meterMust, tagMap, o.gaugeCache)
 }

--- a/common/metrics/otel_metric_test_utility.go
+++ b/common/metrics/otel_metric_test_utility.go
@@ -207,5 +207,5 @@ func (t TestOtelReporter) NewClient(logger log.Logger, serviceIdx ServiceIdx) (C
 func (t TestOtelReporter) Stop(logger log.Logger) {}
 
 func (t TestOtelReporter) UserScope() UserScope {
-	panic("should not be used in current tests setup")
+	return NewNoopMetricsUserScope()
 }

--- a/common/metrics/otel_metric_test_utility.go
+++ b/common/metrics/otel_metric_test_utility.go
@@ -57,7 +57,7 @@ func NewOtelMetricTestUtility() *OtelMetricTestUtility {
 	reporter := NewTestOtelReporter()
 	return &OtelMetricTestUtility{
 		reporter:   reporter,
-		gaugeCache: NewOtelGaugeCache(reporter),
+		gaugeCache: NewOtelGaugeCache(reporter.GetMeterMust()),
 	}
 }
 
@@ -205,3 +205,7 @@ func (t TestOtelReporter) NewClient(logger log.Logger, serviceIdx ServiceIdx) (C
 }
 
 func (t TestOtelReporter) Stop(logger log.Logger) {}
+
+func (t TestOtelReporter) UserScope() UserScope {
+	panic("should not be used in current tests setup")
+}

--- a/common/metrics/runtime.go
+++ b/common/metrics/runtime.go
@@ -124,6 +124,7 @@ func (r *RuntimeMetricsReporter) Start() {
 	if !atomic.CompareAndSwapInt32(&r.started, 0, 1) {
 		return
 	}
+	r.report()
 	go func() {
 		ticker := time.NewTicker(r.reportInterval)
 		for {

--- a/common/metrics/tally_client.go
+++ b/common/metrics/tally_client.go
@@ -39,6 +39,7 @@ type TallyClient struct {
 	serviceIdx      ServiceIdx
 	scopeWrapper    func(impl internalScope) internalScope
 	perUnitBuckets  map[MetricUnit]tally.Buckets
+	userScope       UserScope
 }
 
 // NewClient creates and returns a new instance of
@@ -65,6 +66,7 @@ func NewClient(clientConfig *ClientConfig, scope tally.Scope, serviceIdx Service
 		serviceIdx:      serviceIdx,
 		scopeWrapper:    scopeWrapper,
 		perUnitBuckets:  perUnitBuckets,
+		userScope:       newTallyUserScope(scope),
 	}
 
 	for idx, def := range ScopeDefs[Common] {
@@ -156,5 +158,5 @@ func (m *TallyClient) Scope(scopeIdx int, tags ...Tag) Scope {
 // UserScope returns a new metrics scope that can be used to add additional
 // information to the metrics emitted by user code
 func (m *TallyClient) UserScope() UserScope {
-	return newTallyUserScope(m.globalRootScope)
+	return m.userScope
 }

--- a/common/metrics/tally_reporter.go
+++ b/common/metrics/tally_reporter.go
@@ -30,10 +30,13 @@ import (
 	"go.temporal.io/server/common/log"
 )
 
+var _ Reporter = (*TallyReporter)(nil)
+
 // TallyReporter is a base class for reporting metrics to Tally.
 type TallyReporter struct {
 	scope        tally.Scope
 	clientConfig *ClientConfig
+	userScope    UserScope
 }
 
 func NewTallyReporter(
@@ -43,6 +46,7 @@ func NewTallyReporter(
 	return &TallyReporter{
 		scope:        scope,
 		clientConfig: clientConfig,
+		userScope:    newTallyUserScope(scope),
 	}
 }
 
@@ -56,4 +60,8 @@ func (tr *TallyReporter) GetScope() tally.Scope {
 
 func (tr *TallyReporter) Stop(logger log.Logger) {
 	// noop
+}
+
+func (tr *TallyReporter) UserScope() UserScope {
+	return tr.userScope
 }

--- a/common/metrics/tally_reporter.go
+++ b/common/metrics/tally_reporter.go
@@ -36,7 +36,7 @@ type TallyReporter struct {
 	clientConfig *ClientConfig
 }
 
-func newTallyReporter(
+func NewTallyReporter(
 	scope tally.Scope,
 	clientConfig *ClientConfig,
 ) *TallyReporter {

--- a/common/resource/bootstrapParams.go
+++ b/common/resource/bootstrapParams.go
@@ -54,7 +54,6 @@ type (
 		ClusterMetadataConfig        *cluster.Config
 		ReplicatorConfig             config.Replicator
 		ServerMetricsReporter        metrics.Reporter
-		SDKMetricsReporter           metrics.Reporter
 		MetricsClient                metrics.Client
 		DCRedirectionPolicy          config.DCRedirectionPolicy
 		SdkClientFactory             sdk.ClientFactory

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -193,7 +193,6 @@ type Service struct {
 	server            *grpc.Server
 
 	serverMetricsReporter          metrics.Reporter
-	sdkMetricsReporter             metrics.Reporter
 	logger                         log.Logger
 	grpcListener                   net.Listener
 	userMetricsScope               metrics.UserScope
@@ -293,10 +292,6 @@ func (s *Service) Stop() {
 
 	if s.serverMetricsReporter != nil {
 		s.serverMetricsReporter.Stop(logger)
-	}
-
-	if s.sdkMetricsReporter != nil {
-		s.sdkMetricsReporter.Stop(logger)
 	}
 
 	logger.Info("frontend stopped")

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -709,7 +709,7 @@ func MetricReportersProvider(so *serverOptions, logger log.Logger) (ServerReport
 	var sdkReporter SdkReporter
 	if so.config.Global.Metrics != nil {
 		var err error
-		serverReporter, sdkReporter, err = so.config.Global.Metrics.InitMetricReporters(logger, so.metricsReporter)
+		serverReporter, sdkReporter, err = metrics.InitMetricReporters(logger, so.config.Global.Metrics, so.metricsReporter)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -65,7 +65,6 @@ import (
 
 type (
 	ServerReporter metrics.Reporter
-	SdkReporter    metrics.Reporter
 
 	ServiceStopFn func()
 
@@ -229,7 +228,6 @@ type (
 		NamespaceLogger            NamespaceLogger
 		DynamicConfigClient        dynamicconfig.Client
 		ServerReporter             ServerReporter
-		SdkReporter                SdkReporter
 		EsConfig                   *esclient.Config
 		EsClient                   esclient.Client
 		TlsConfigProvider          encryption.TLSConfigProvider
@@ -284,7 +282,6 @@ func HistoryServiceProvider(
 		fx.Provide(func() ServiceName { return ServiceName(serviceName) }),
 		fx.Provide(func() log.Logger { return params.Logger }),
 		fx.Provide(func() ServerReporter { return params.ServerReporter }),
-		fx.Provide(func() SdkReporter { return params.SdkReporter }),
 		fx.Provide(func() NamespaceLogger { return params.NamespaceLogger }), // resolves untyped nil error
 		fx.Provide(func() esclient.Client { return params.EsClient }),
 		fx.Provide(newBootstrapParams),
@@ -340,7 +337,6 @@ func MatchingServiceProvider(
 		fx.Provide(func() ServiceName { return ServiceName(serviceName) }),
 		fx.Provide(func() log.Logger { return params.Logger }),
 		fx.Provide(func() ServerReporter { return params.ServerReporter }),
-		fx.Provide(func() SdkReporter { return params.SdkReporter }),
 		fx.Provide(func() NamespaceLogger { return params.NamespaceLogger }), // resolves untyped nil error
 		fx.Provide(func() esclient.Client { return params.EsClient }),
 		fx.Provide(newBootstrapParams),
@@ -396,7 +392,6 @@ func FrontendServiceProvider(
 		fx.Provide(func() ServiceName { return ServiceName(serviceName) }),
 		fx.Provide(func() log.Logger { return params.Logger }),
 		fx.Provide(func() ServerReporter { return params.ServerReporter }),
-		fx.Provide(func() SdkReporter { return params.SdkReporter }),
 		fx.Provide(func() NamespaceLogger { return params.NamespaceLogger }), // resolves untyped nil error
 		fx.Provide(func() esclient.Client { return params.EsClient }),
 		fx.Provide(newBootstrapParams),
@@ -452,7 +447,6 @@ func WorkerServiceProvider(
 		fx.Provide(func() ServiceName { return ServiceName(serviceName) }),
 		fx.Provide(func() log.Logger { return params.Logger }),
 		fx.Provide(func() ServerReporter { return params.ServerReporter }),
-		fx.Provide(func() SdkReporter { return params.SdkReporter }),
 		fx.Provide(func() NamespaceLogger { return params.NamespaceLogger }), // resolves untyped nil error
 		fx.Provide(func() esclient.Client { return params.EsClient }),
 		fx.Provide(newBootstrapParams),
@@ -704,17 +698,16 @@ func NamespaceLoggerProvider(so *serverOptions) NamespaceLogger {
 	return so.namespaceLogger
 }
 
-func MetricReportersProvider(so *serverOptions, logger log.Logger) (ServerReporter, SdkReporter, error) {
+func MetricReportersProvider(so *serverOptions, logger log.Logger) (ServerReporter, error) {
 	var serverReporter ServerReporter
-	var sdkReporter SdkReporter
 	if so.config.Global.Metrics != nil {
 		var err error
-		serverReporter, sdkReporter, err = metrics.InitMetricReporters(logger, so.config.Global.Metrics, so.metricsReporter)
+		serverReporter, err = metrics.InitMetricsReporterInternal(logger, so.config.Global.Metrics, so.metricsReporter)
 		if err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
-	return serverReporter, sdkReporter, nil
+	return serverReporter, nil
 }
 
 func MetricsClientProvider(logger log.Logger, serverReporter ServerReporter) (metrics.Client, error) {

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -219,7 +219,7 @@ func newBootstrapParams(
 	// todo: Replace this hack with actually using sdkReporter, Client or Scope.
 	if serverReporter == nil {
 		var err error
-		serverReporter, sdkReporter, err = svcCfg.Metrics.InitMetricReporters(logger, nil)
+		serverReporter, sdkReporter, err = metrics.InitMetricReporters(logger, &svcCfg.Metrics, nil)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"unable to initialize per-service metric client. "+


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Cleaned up and exposed metric reporters constructors to the user.

<!-- Tell your future self why have you made these changes -->
**Why?**
Simplify reporter construction for the user.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manual/auto tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Metrics reporters are not initialized correctly.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No