### PR TITLE
Fix DeleteWorkflowExecution API when delete non current execution

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -158,6 +158,7 @@ func NewEngineWithShardContext(
 		historyCache,
 		config,
 		archivalClient,
+		shard.GetTimeSource(),
 	)
 
 	historyEngImpl := &historyEngineImpl{
@@ -2277,37 +2278,13 @@ func (e *historyEngineImpl) DeleteWorkflowExecution(
 	}
 	defer func() { wfCtx.getReleaseFn()(retError) }()
 
-	mutableState := wfCtx.getMutableState()
-
-	if mutableState.IsWorkflowExecutionRunning() {
-		// Running workflow cannot be deleted. Close or terminate it first.
-		return consts.ErrWorkflowNotCompleted
-	}
-
-	taskGenerator := workflow.NewTaskGenerator(
-		e.shard.GetNamespaceRegistry(),
-		e.logger,
-		mutableState,
-	)
-
-	deleteTask, err := taskGenerator.GenerateDeleteExecutionTask(e.timeSource.Now())
-	if err != nil {
-		return err
-	}
-
-	err = e.shard.AddTasks(&persistence.AddTasksRequest{
-		ShardID: e.shard.GetShardID(),
-		// RangeID is set by shard
-		NamespaceID:   nsID.String(),
-		WorkflowID:    request.GetWorkflowExecution().GetWorkflowId(),
-		RunID:         request.GetWorkflowExecution().GetRunId(),
-		TransferTasks: []tasks.Task{deleteTask},
-	})
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return e.workflowDeleteManager.AddDeleteWorkflowExecutionTask(
+		nsID,
+		commonpb.WorkflowExecution{
+			WorkflowId: request.GetWorkflowExecution().GetWorkflowId(),
+			RunId:      request.GetWorkflowExecution().GetRunId(),
+		},
+		wfCtx.getMutableState())
 }
 
 // RecordChildExecutionCompleted records the completion of child execution into parent execution history

--- a/service/history/nDCHistoryReplicator.go
+++ b/service/history/nDCHistoryReplicator.go
@@ -176,7 +176,7 @@ func newNDCHistoryReplicator(
 				logger,
 				state,
 				func(mutableState workflow.MutableState) workflow.TaskGenerator {
-					return workflow.NewTaskGenerator(shard.GetNamespaceRegistry(), logger, mutableState)
+					return workflow.NewTaskGenerator(shard.GetNamespaceRegistry(), mutableState)
 				},
 			)
 		},

--- a/service/history/nDCStateRebuilder.go
+++ b/service/history/nDCStateRebuilder.go
@@ -213,7 +213,7 @@ func (r *nDCStateRebuilderImpl) initializeBuilders(
 		r.logger,
 		resetMutableStateBuilder,
 		func(mutableState workflow.MutableState) workflow.TaskGenerator {
-			return workflow.NewTaskGenerator(r.shard.GetNamespaceRegistry(), r.logger, mutableState)
+			return workflow.NewTaskGenerator(r.shard.GetNamespaceRegistry(), mutableState)
 		},
 	)
 	return resetMutableStateBuilder, stateBuilder

--- a/service/history/workflow/delete_manager.go
+++ b/service/history/workflow/delete_manager.go
@@ -107,10 +107,12 @@ func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
 	err = m.shard.AddTasks(&persistence.AddTasksRequest{
 		ShardID: m.shard.GetShardID(),
 		// RangeID is set by shard
-		NamespaceID:   nsID.String(),
-		WorkflowID:    we.GetWorkflowId(),
-		RunID:         we.GetRunId(),
-		TransferTasks: []tasks.Task{deleteTask},
+		NamespaceID: nsID.String(),
+		WorkflowID:  we.GetWorkflowId(),
+		RunID:       we.GetRunId(),
+		Tasks: map[tasks.Category][]tasks.Task{
+			tasks.CategoryTransfer: {deleteTask},
+		},
 	})
 	if err != nil {
 		return err

--- a/service/history/workflow/delete_manager.go
+++ b/service/history/workflow/delete_manager.go
@@ -76,6 +76,12 @@ func NewDeleteManager(
 
 	return deleteManager
 }
+func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
+	namespaceID namespace.ID,
+	we commonpb.WorkflowExecution,
+) {
+
+}
 
 func (m *DeleteManagerImpl) DeleteWorkflowExecution(
 	namespaceID namespace.ID,

--- a/service/history/workflow/delete_manager_mock.go
+++ b/service/history/workflow/delete_manager_mock.go
@@ -59,30 +59,44 @@ func (m *MockDeleteManager) EXPECT() *MockDeleteManagerMockRecorder {
 	return m.recorder
 }
 
-// DeleteWorkflowExecution mocks base method.
-func (m *MockDeleteManager) DeleteWorkflowExecution(namespaceID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, sourceTaskVersion int64) error {
+// AddDeleteWorkflowExecutionTask mocks base method.
+func (m *MockDeleteManager) AddDeleteWorkflowExecutionTask(nsID namespace.ID, we v1.WorkflowExecution, ms MutableState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", namespaceID, we, weCtx, ms, sourceTaskVersion)
+	ret := m.ctrl.Call(m, "AddDeleteWorkflowExecutionTask", nsID, we, ms)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddDeleteWorkflowExecutionTask indicates an expected call of AddDeleteWorkflowExecutionTask.
+func (mr *MockDeleteManagerMockRecorder) AddDeleteWorkflowExecutionTask(nsID, we, ms interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddDeleteWorkflowExecutionTask", reflect.TypeOf((*MockDeleteManager)(nil).AddDeleteWorkflowExecutionTask), nsID, we, ms)
+}
+
+// DeleteWorkflowExecution mocks base method.
+func (m *MockDeleteManager) DeleteWorkflowExecution(nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, sourceTaskVersion int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", nsID, we, weCtx, ms, sourceTaskVersion)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecution(namespaceID, we, weCtx, ms, sourceTaskVersion interface{}) *gomock.Call {
+func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecution(nsID, we, weCtx, ms, sourceTaskVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecution), namespaceID, we, weCtx, ms, sourceTaskVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecution), nsID, we, weCtx, ms, sourceTaskVersion)
 }
 
 // DeleteWorkflowExecutionByRetention mocks base method.
-func (m *MockDeleteManager) DeleteWorkflowExecutionByRetention(namespaceID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, sourceTaskVersion int64) error {
+func (m *MockDeleteManager) DeleteWorkflowExecutionByRetention(nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, sourceTaskVersion int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecutionByRetention", namespaceID, we, weCtx, ms, sourceTaskVersion)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecutionByRetention", nsID, we, weCtx, ms, sourceTaskVersion)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecutionByRetention indicates an expected call of DeleteWorkflowExecutionByRetention.
-func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecutionByRetention(namespaceID, we, weCtx, ms, sourceTaskVersion interface{}) *gomock.Call {
+func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecutionByRetention(nsID, we, weCtx, ms, sourceTaskVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecutionByRetention", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecutionByRetention), namespaceID, we, weCtx, ms, sourceTaskVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecutionByRetention", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecutionByRetention), nsID, we, weCtx, ms, sourceTaskVersion)
 }

--- a/service/history/workflow/delete_manager_test.go
+++ b/service/history/workflow/delete_manager_test.go
@@ -41,6 +41,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	carchiver "go.temporal.io/server/common/archiver"
+	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -59,6 +60,7 @@ type (
 		mockCache          *MockCache
 		mockArchivalClient *archiver.MockClient
 		mockShardContext   *shard.MockContext
+		mockClock          *clock.EventTimeSource
 
 		deleteManager DeleteManager
 	}
@@ -83,6 +85,7 @@ func (s *deleteManagerWorkflowSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockCache = NewMockCache(s.controller)
 	s.mockArchivalClient = archiver.NewMockClient(s.controller)
+	s.mockClock = clock.NewEventTimeSource()
 
 	config := tests.NewDynamicConfig()
 	s.mockShardContext = shard.NewMockContext(s.controller)
@@ -93,6 +96,7 @@ func (s *deleteManagerWorkflowSuite) SetupTest() {
 		s.mockCache,
 		config,
 		s.mockArchivalClient,
+		s.mockClock,
 	)
 }
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -260,7 +260,7 @@ func NewMutableState(
 		common.FirstEventID,
 		s.bufferEventsInDB,
 	)
-	s.taskGenerator = NewTaskGenerator(shard.GetNamespaceRegistry(), s.logger, s)
+	s.taskGenerator = NewTaskGenerator(shard.GetNamespaceRegistry(), s)
 	s.workflowTaskManager = newWorkflowTaskStateMachine(s)
 
 	return s

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -36,7 +36,6 @@ import (
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/clock"
-	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -120,9 +119,7 @@ type (
 
 	TaskGeneratorImpl struct {
 		namespaceRegistry namespace.Registry
-		logger            log.Logger
-
-		mutableState MutableState
+		mutableState      MutableState
 	}
 )
 
@@ -132,15 +129,12 @@ var _ TaskGenerator = (*TaskGeneratorImpl)(nil)
 
 func NewTaskGenerator(
 	namespaceRegistry namespace.Registry,
-	logger log.Logger,
 	mutableState MutableState,
 ) *TaskGeneratorImpl {
 
 	mstg := &TaskGeneratorImpl{
 		namespaceRegistry: namespaceRegistry,
-		logger:            logger,
-
-		mutableState: mutableState,
+		mutableState:      mutableState,
 	}
 
 	return mstg

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -54,7 +54,7 @@ type (
 		) error
 		GenerateDeleteExecutionTask(
 			now time.Time,
-		) error
+		) (*tasks.DeleteExecutionTask, error)
 		GenerateRecordWorkflowStartedTasks(
 			now time.Time,
 			startEvent *historypb.HistoryEvent,
@@ -212,18 +212,16 @@ func (r *TaskGeneratorImpl) GenerateWorkflowCloseTasks(
 
 func (r *TaskGeneratorImpl) GenerateDeleteExecutionTask(
 	now time.Time,
-) error {
+) (*tasks.DeleteExecutionTask, error) {
 
 	currentVersion := r.mutableState.GetCurrentVersion()
 
-	r.mutableState.AddTasks(&tasks.DeleteExecutionTask{
+	return &tasks.DeleteExecutionTask{
 		// TaskID is set by shard
 		WorkflowKey:         r.mutableState.GetWorkflowKey(),
 		VisibilityTimestamp: now,
 		Version:             currentVersion,
-	})
-
-	return nil
+	}, nil
 }
 
 func (r *TaskGeneratorImpl) GenerateDelayedWorkflowTasks(

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -131,11 +131,12 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateDelayedWorkflowTasks(now, start
 }
 
 // GenerateDeleteExecutionTask mocks base method.
-func (m *MockTaskGenerator) GenerateDeleteExecutionTask(now time.Time) error {
+func (m *MockTaskGenerator) GenerateDeleteExecutionTask(now time.Time) (*tasks.DeleteExecutionTask, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateDeleteExecutionTask", now)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(*tasks.DeleteExecutionTask)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GenerateDeleteExecutionTask indicates an expected call of GenerateDeleteExecutionTask.

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -77,7 +77,6 @@ func (r *TaskRefresherImpl) RefreshTasks(
 
 	taskGenerator := NewTaskGenerator(
 		r.namespaceRegistry,
-		r.logger,
 		mutableState,
 	)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix `DeleteWorkflowExecution` API when delete non current execution. Instead of calling internal `updateWorkflow` funcion, adding transfer task using new `DeleteManager.AddDeleteWorkflowExecutionTask` function which essentially just calls `shard.AddTask`.

<!-- Tell your future self why have you made these changes -->
**Why?**
Previous implementation worked only for current workflows.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration test in another PR.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.