### PR TITLE
Exit retry for long poll if context is near deadline

### DIFF
--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
@@ -1851,4 +1852,14 @@ func listArchivedWorkflowExecutionsTestRequest() *workflowservice.ListArchivedWo
 		PageSize:  10,
 		Query:     "some random query string",
 	}
+}
+
+func TestContextNearDeadline(t *testing.T) {
+	assert.False(t, contextNearDeadline(context.Background(), longPollTailRoom))
+
+	ctx, _ := context.WithTimeout(context.Background(), time.Millisecond*500)
+	assert.True(t, contextNearDeadline(ctx, longPollTailRoom))
+	assert.False(t, contextNearDeadline(ctx, time.Millisecond))
+
+	assert.False(t, common.IsServiceTransientError(errContextNearDeadline))
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Stop retrying long polls if user's context is near deadline.

<!-- Tell your future self why have you made these changes -->
**Why?**
To avoid many context cancelled error from long polls while in retrying.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
