### PR TITLE
Replace Cyrillic c with c in rest of caCert variables

### DIFF
--- a/config/development_sqlite.yaml
+++ b/config/development_sqlite.yaml
@@ -19,7 +19,7 @@ persistence:
         maxConnLifetime: "1h"
         tls:
           enabled: false
-          сaFile: ""
+          caFile: ""
           certFile: ""
           keyFile: ""
           enableHostVerification: false
@@ -42,7 +42,7 @@ persistence:
         maxConnLifetime: "1h"
         tls:
           enabled: false
-          сaFile: ""
+          caFile: ""
           certFile: ""
           keyFile: ""
           enableHostVerification: false


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
## Summary
Following along https://github.com/temporalio/temporal/pull/2397, there were still a couple more Cyrillic letters checedk-in, likely from copy-pasting the config.

<!-- Tell your future self why have you made these changes -->
## Motivation
To ensure caCert is set from the config.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
## Testing
Verified presence of the letters with `rg "[^\x00-\x7F]"`, changed them to `c`, and then verified again with ripgrep that the letters were no longer present.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
## Risks
Should be low-risk, worst case perhaps someone will hit an error now that their caCert file is set correctly.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
## Hotfix?
Potentially not, as this is an sqlite development config which if I understand correctly is a feature still in development. Will defer to Temporal for this.