### PR TITLE
Fix timerMaxReadLevel map init and update

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -512,7 +512,10 @@ func (s *ContextImpl) UpdateTimerMaxReadLevel(cluster string) time.Time {
 		currentTime = s.getRemoteClusterInfoLocked(cluster).CurrentTime
 	}
 
-	s.timerMaxReadLevelMap[cluster] = currentTime.Add(s.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)
+	newClusterMaxReadLevel := currentTime.Add(s.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)
+	if newClusterMaxReadLevel.After(s.timerMaxReadLevelMap[cluster]) {
+		s.timerMaxReadLevelMap[cluster] = newClusterMaxReadLevel
+	}
 	return s.timerMaxReadLevelMap[cluster]
 }
 
@@ -1433,24 +1436,21 @@ func (s *ContextImpl) loadShardMetadata(ownershipChanged *bool) error {
 	// initialize the cluster current time to be the same as ack level
 	remoteClusterInfos := make(map[string]*remoteClusterInfo)
 	timerMaxReadLevelMap := make(map[string]time.Time)
+	currentClusterName := s.GetClusterMetadata().GetCurrentClusterName()
 	for clusterName, info := range s.GetClusterMetadata().GetAllClusterInfo() {
 		if !info.Enabled {
 			continue
 		}
 
 		currentReadTime := timestamp.TimeValue(shardInfo.TimerAckLevelTime)
-		if clusterName != s.GetClusterMetadata().GetCurrentClusterName() {
-			if currentTime, ok := shardInfo.ClusterTimerAckLevel[clusterName]; ok {
-				currentReadTime = timestamp.TimeValue(currentTime)
-			}
-
-			remoteClusterInfos[clusterName] = &remoteClusterInfo{CurrentTime: currentReadTime}
-			timerMaxReadLevelMap[clusterName] = currentReadTime
-		} else { // active cluster
-			timerMaxReadLevelMap[clusterName] = currentReadTime
+		if currentTime, ok := shardInfo.ClusterTimerAckLevel[clusterName]; ok {
+			currentReadTime = timestamp.TimeValue(currentTime)
 		}
+		timerMaxReadLevelMap[clusterName] = currentReadTime.Truncate(time.Millisecond)
 
-		timerMaxReadLevelMap[clusterName] = timerMaxReadLevelMap[clusterName].Truncate(time.Millisecond)
+		if clusterName != currentClusterName {
+			remoteClusterInfos[clusterName] = &remoteClusterInfo{CurrentTime: currentReadTime}
+		}
 	}
 
 	s.wLock()

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -512,9 +512,9 @@ func (s *ContextImpl) UpdateTimerMaxReadLevel(cluster string) time.Time {
 		currentTime = s.getRemoteClusterInfoLocked(cluster).CurrentTime
 	}
 
-	newClusterMaxReadLevel := currentTime.Add(s.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)
-	if newClusterMaxReadLevel.After(s.timerMaxReadLevelMap[cluster]) {
-		s.timerMaxReadLevelMap[cluster] = newClusterMaxReadLevel
+	newMaxReadLevel := currentTime.Add(s.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)
+	if newMaxReadLevel.After(s.timerMaxReadLevelMap[cluster]) {
+		s.timerMaxReadLevelMap[cluster] = newMaxReadLevel
 	}
 	return s.timerMaxReadLevelMap[cluster]
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- When init, make sure for each cluster timer max read level is not before its ack level
- For update, make sure the time max read level won't go backward (e.g due to time skew)

<!-- Tell your future self why have you made these changes -->
**Why?**
- Fix bug, which may lead to timer task loss

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
yes