### PR TITLE
Treat enablement of TLS separately for server and client config

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -484,9 +484,12 @@ func (c *Config) String() string {
 	return maskedYaml
 }
 
-func (r *GroupTLS) IsEnabled() bool {
-	return r.Server.KeyFile != "" || r.Server.KeyData != "" ||
-		len(r.Client.RootCAFiles) > 0 || len(r.Client.RootCAData) > 0 ||
+func (r *GroupTLS) IsServerEnabled() bool {
+	return r.Server.KeyFile != "" || r.Server.KeyData != ""
+}
+
+func (r *GroupTLS) IsClientEnabled() bool {
+	return len(r.Client.RootCAFiles) > 0 || len(r.Client.RootCAData) > 0 ||
 		r.Client.ForceTLS
 }
 

--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -130,7 +130,7 @@ func (s *localStoreTlsProvider) GetInternodeClientConfig() (*tls.Config, error) 
 			return newClientTLSConfig(s.internodeClientCertProvider, client.ServerName,
 				s.settings.Internode.Server.RequireClientAuth, false, !client.DisableHostVerification)
 		},
-		s.settings.Internode.IsEnabled(),
+		s.settings.Internode.IsClientEnabled(),
 	)
 }
 
@@ -143,7 +143,7 @@ func (s *localStoreTlsProvider) GetFrontendClientConfig() (*tls.Config, error) {
 		useTLS = true
 	} else {
 		client = &s.settings.Frontend.Client
-		useTLS = s.settings.Frontend.IsEnabled()
+		useTLS = s.settings.Frontend.IsClientEnabled()
 	}
 	return s.getOrCreateConfig(
 		&s.cachedFrontendClientConfig,
@@ -161,7 +161,7 @@ func (s *localStoreTlsProvider) GetFrontendServerConfig() (*tls.Config, error) {
 		func() (*tls.Config, error) {
 			return newServerTLSConfig(s.frontendCertProvider, s.frontendPerHostCertProviderMap, &s.settings.Frontend, s.logger)
 		},
-		s.settings.Frontend.IsEnabled())
+		s.settings.Frontend.IsServerEnabled())
 }
 
 func (s *localStoreTlsProvider) GetInternodeServerConfig() (*tls.Config, error) {
@@ -170,7 +170,7 @@ func (s *localStoreTlsProvider) GetInternodeServerConfig() (*tls.Config, error) 
 		func() (*tls.Config, error) {
 			return newServerTLSConfig(s.internodeCertProvider, nil, &s.settings.Internode, s.logger)
 		},
-		s.settings.Internode.IsEnabled())
+		s.settings.Internode.IsServerEnabled())
 }
 
 func (s *localStoreTlsProvider) GetExpiringCerts(timeWindow time.Duration,

--- a/common/rpc/encryption/tls_config_test.go
+++ b/common/rpc/encryption/tls_config_test.go
@@ -51,19 +51,27 @@ func (s *tlsConfigTest) SetupTest() {
 func (s *tlsConfigTest) TestIsEnabled() {
 
 	emptyCfg := config.GroupTLS{}
-	s.False(emptyCfg.IsEnabled())
+	s.False(emptyCfg.IsServerEnabled())
+	s.False(emptyCfg.IsClientEnabled())
 	cfg := config.GroupTLS{Server: config.ServerTLS{KeyFile: "foo"}}
-	s.True(cfg.IsEnabled())
+	s.True(cfg.IsServerEnabled())
+	s.False(cfg.IsClientEnabled())
 	cfg = config.GroupTLS{Server: config.ServerTLS{KeyData: "foo"}}
-	s.True(cfg.IsEnabled())
+	s.True(cfg.IsServerEnabled())
+	s.False(cfg.IsClientEnabled())
 	cfg = config.GroupTLS{Client: config.ClientTLS{RootCAFiles: []string{"bar"}}}
-	s.True(cfg.IsEnabled())
+	s.False(cfg.IsServerEnabled())
+	s.True(cfg.IsClientEnabled())
 	cfg = config.GroupTLS{Client: config.ClientTLS{RootCAData: []string{"bar"}}}
-	s.True(cfg.IsEnabled())
+	s.False(cfg.IsServerEnabled())
+	s.True(cfg.IsClientEnabled())
 	cfg = config.GroupTLS{Client: config.ClientTLS{ForceTLS: true}}
-	s.True(cfg.IsEnabled())
+	s.False(cfg.IsServerEnabled())
+	s.True(cfg.IsClientEnabled())
 	cfg = config.GroupTLS{Client: config.ClientTLS{ForceTLS: false}}
-	s.False(cfg.IsEnabled())
+	s.False(cfg.IsServerEnabled())
+	s.False(cfg.IsClientEnabled())
+
 }
 
 func (s *tlsConfigTest) TestIsSystemWorker() {


### PR DESCRIPTION
**What changed?**
Replaced `GroupTLS.IsEnabled()` with `GroupTLS.IsServerEnabled()` and `GroupTLS.IsClientEnabled()`.

**Why?**
Fixes #2448 
Client may need to be enabled even when server TLS is disabled. The typical example is when client talks to a TLS-enabled load balancer. 

**How did you test it?**
Added a unit test that reproduced #2448.

**Potential risks**
In theory, this changes treatment of TLS configuration and may cause some unexpected change in behavior.
In reality, this restore the behavior that existed prior to the introduction of `ClientTLS.ForceTLS` flag.

**Is hotfix candidate?**
Potentially
