### PR TITLE
Split goreleaser archive in two:cgo/nocgo

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -15,7 +15,7 @@ archives:
       - goos: windows
         format: zip
     files:
-      - config/*
+      - ./config/*
 
   - id: no-cgo
     builds:
@@ -28,7 +28,7 @@ archives:
       - goos: windows
         format: zip
     files:
-      - config/*
+      - ./config/*
 
 builds:
   - id: temporal-server
@@ -118,3 +118,6 @@ checksum:
 
 changelog:
   skip: true
+
+announce:
+  skip: "true"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -2,8 +2,36 @@ before:
   hooks:
     - go mod download
     - ./develop/scripts/create_build_info_data.sh
+
+archives:
+  - id: default
+    builds:
+      - temporal-server
+      - tctl
+      - temporal-cassandra-tool
+      - temporal-sql-tool
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - config/*
+
+  - id: no-cgo
+    builds:
+      - temporal-server-no-cgo
+      - tctl-no-cgo
+      - temporal-cassandra-tool-no-cgo
+      - temporal-sql-tool-no-cgo
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}_no_cgo"
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - config/*
+
 builds:
-  - id: "temporal-server"
+  - id: temporal-server
     dir: cmd/server
     binary: temporal-server
     goos:
@@ -13,7 +41,7 @@ builds:
     goarch:
       - amd64
       - arm64
-  - id: "temporal-server-no-cgo"
+  - id: temporal-server-no-cgo
     dir: cmd/server
     binary: temporal-server
     env:
@@ -23,7 +51,7 @@ builds:
     goarch:
       - amd64
       - arm64
-  - id: "tctl"
+  - id: tctl
     dir: cmd/tools/cli
     binary: tctl
     goos:
@@ -33,7 +61,17 @@ builds:
     goarch:
       - amd64
       - arm64
-  - id: "temporal-cassandra-tool"
+  - id: tctl-no-cgo
+    dir: cmd/tools/cli
+    binary: tctl
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: temporal-cassandra-tool
     dir: cmd/tools/cassandra
     binary: temporal-cassandra-tool
     goos:
@@ -43,7 +81,17 @@ builds:
     goarch:
       - amd64
       - arm64
-  - id: "temporal-sql-tool"
+  - id: temporal-cassandra-tool-no-cgo
+    dir: cmd/tools/cassandra
+    binary: temporal-cassandra-tool
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+  - id: temporal-sql-tool
     dir: cmd/tools/sql
     binary: temporal-sql-tool
     goos:
@@ -53,14 +101,20 @@ builds:
     goarch:
       - amd64
       - arm64
+  - id: temporal-sql-tool-no-cgo
+    dir: cmd/tools/sql
+    binary: temporal-sql-tool
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+    goarch:
+      - amd64
+      - arm64
+
 checksum:
   name_template: 'checksums.txt'
   algorithm: sha256
-snapshot:
-  name_template: "{{ .Tag }}-next"
+
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
+  skip: true


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Split goreleaser archive in two:cgo/nocgo.

<!-- Tell your future self why have you made these changes -->
**Why?**
Because Linux archives has also no-cgo binaries, number of binaries per archive is different, which violates release best practices.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run goreleaser locally. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Release binaries won't be built.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.