### PR TITLE
Trigger Docker builds on release branches

### DIFF
--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - release/*
-  workflow_dispatch:
 
 jobs:
   trigger:

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-      - release/v[0-9]+.[0-9]+.[0-9]+ # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags
+      - release/*
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release/v[0-9]+.[0-9]+.[0-9]+ # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#patterns-to-match-branches-and-tags
   workflow_dispatch:
 
 jobs:
@@ -16,11 +17,18 @@ jobs:
         shell: bash
 
     steps:
+      - name: Get git branch name
+        id: get_branch
+        run: |
+          echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
+
       - name: Dispatch docker builds Github Action
         env:
           PAT: ${{ secrets.COMMANDER_DATA_TOKEN }}
           PARENT_REPO: temporalio/docker-builds
-          PARENT_BRANCH: main
+          PARENT_BRANCH: ${{ toJSON('main') }}
           WORKFLOW_ID: update-submodules.yml
+          REPO: ${{ toJSON('temporal') }}
+          BRANCH: ${{ toJSON(steps.get_branch.outputs.branch) }}
         run: |
-          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token ${{ env.PAT }}" https://api.github.com/repos/${{ env.PARENT_REPO }}/actions/workflows/${{ env.WORKFLOW_ID }}/dispatches -d '{"ref":"${{ env.PARENT_BRANCH }}"}'
+          curl -fL -X POST -H "Accept: application/vnd.github.v3+json" -H "Authorization: token $PAT" "https://api.github.com/repos/$PARENT_REPO/actions/workflows/$WORKFLOW_ID/dispatches" -d '{"ref":'"$PARENT_BRANCH"', "inputs": { "repo":'"$REPO"', "branch":'"$BRANCH"' }}'


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Starts Triggering Docker builds on commits into Release branches

Related PR:
https://github.com/temporalio/docker-builds/pull/23

<!-- Tell your future self why have you made these changes -->
**Why?**

Automating releases

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Tested the code with personal repos and simulating the changes:
https://github.com/feedmeapples/gha-parent
https://github.com/feedmeapples/gha-child


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
