### PR TITLE
Separate queue processor and history engine implementation

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -43,8 +43,6 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 
-	"go.temporal.io/server/client"
-	"go.temporal.io/server/common/archiver/provider"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/tasks"
@@ -107,7 +105,6 @@ type (
 		logger                        log.Logger
 		throttledLogger               log.Logger
 		config                        *configs.Config
-		archivalClient                archiver.Client
 		workflowResetter              workflowResetter
 		replicationTaskFetchers       ReplicationTaskFetchers
 		replicationTaskProcessorsLock sync.Mutex
@@ -118,7 +115,6 @@ type (
 		rawMatchingClient             matchingservice.MatchingServiceClient
 		replicationDLQHandler         replicationDLQHandler
 		searchAttributesValidator     *searchattribute.Validator
-		workflowDeleteManager         workflow.DeleteManager
 	}
 )
 
@@ -134,31 +130,13 @@ func NewEngineWithShardContext(
 	replicationTaskFetchers ReplicationTaskFetchers,
 	rawMatchingClient matchingservice.MatchingServiceClient,
 	newCacheFn workflow.NewCacheFn,
-	clientBean client.Bean,
-	archiverProvider provider.ArchiverProvider,
-	registry namespace.Registry,
-) *historyEngineImpl {
+	archivalClient archiver.Client,
+) shard.Engine {
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 
 	logger := shard.GetLogger()
 	executionManager := shard.GetExecutionManager()
 	historyCache := newCacheFn(shard)
-
-	archivalClient := archiver.NewClient(
-		shard.GetMetricsClient(),
-		logger,
-		publicClient,
-		shard.GetConfig().NumArchiveSystemWorkflows,
-		shard.GetConfig().ArchiveRequestRPS,
-		archiverProvider,
-	)
-
-	workflowDeleteManager := workflow.NewDeleteManager(
-		shard,
-		historyCache,
-		config,
-		archivalClient,
-	)
 
 	historyEngImpl := &historyEngineImpl{
 		status:                    common.DaemonStatusInitialized,
@@ -174,21 +152,41 @@ func NewEngineWithShardContext(
 		metricsClient:             shard.GetMetricsClient(),
 		eventNotifier:             eventNotifier,
 		config:                    config,
-		archivalClient:            archivalClient,
 		publicClient:              publicClient,
 		matchingClient:            matchingClient,
 		rawMatchingClient:         rawMatchingClient,
 		replicationTaskProcessors: make(map[string]ReplicationTaskProcessor),
 		replicationTaskFetchers:   replicationTaskFetchers,
-		workflowDeleteManager:     workflowDeleteManager,
 	}
 
-	txProcessor := newTransferQueueProcessor(shard, historyEngImpl,
-		matchingClient, historyClient, logger, clientBean, registry)
-	timerProcessor := newTimerQueueProcessor(shard, historyEngImpl,
-		matchingClient, logger, clientBean)
-	visibilityProcessor := newVisibilityQueueProcessor(shard, historyEngImpl, visibilityMgr,
-		matchingClient, historyClient, logger)
+	// Please make sure all components needed for initializing a queue processor
+	// can either be provided via fx or can be retrieved from shard context or
+	// history engine interface. (history cache is a special case for now, and will
+	// be addressed once it's promoted to be a host level component)
+	// TODO: intialize queue via QueueProcessorFactory
+	txProcessor := newTransferQueueProcessor(
+		shard,
+		historyEngImpl,
+		historyCache,
+		archivalClient,
+		publicClient,
+		matchingClient,
+		historyClient,
+	)
+	timerProcessor := newTimerQueueProcessor(
+		shard,
+		historyEngImpl,
+		historyCache,
+		archivalClient,
+		matchingClient,
+	)
+	visibilityProcessor := newVisibilityQueueProcessor(
+		shard,
+		historyCache,
+		visibilityMgr,
+		matchingClient,
+		historyClient,
+	)
 	historyEngImpl.queueProcessors = map[tasks.Category]queues.Processor{
 		txProcessor.Category():         txProcessor,
 		timerProcessor.Category():      timerProcessor,

--- a/service/history/historyEngineFactory.go
+++ b/service/history/historyEngineFactory.go
@@ -28,14 +28,12 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
-	"go.temporal.io/server/client"
-	"go.temporal.io/server/common/archiver/provider"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/worker/archiver"
 )
 
 type (
@@ -49,9 +47,7 @@ type (
 		replicationTaskFetchers ReplicationTaskFetchers
 		rawMatchingClient       matchingservice.MatchingServiceClient
 		newCacheFn              workflow.NewCacheFn
-		clientBean              client.Bean
-		archiverProvider        provider.ArchiverProvider
-		registry                namespace.Registry
+		archivalClient          archiver.Client
 	}
 )
 
@@ -65,9 +61,7 @@ func NewEngineFactory(
 	replicationTaskFetchers ReplicationTaskFetchers,
 	rawMatchingClient matchingservice.MatchingServiceClient,
 	newCacheFn workflow.NewCacheFn,
-	clientBean client.Bean,
-	archiverProvider provider.ArchiverProvider,
-	registry namespace.Registry,
+	archivalClient archiver.Client,
 ) shard.EngineFactory {
 	return &historyEngineFactory{
 		visibilityMgr:           visibilityMgr,
@@ -79,9 +73,7 @@ func NewEngineFactory(
 		replicationTaskFetchers: replicationTaskFetchers,
 		rawMatchingClient:       rawMatchingClient,
 		newCacheFn:              newCacheFn,
-		clientBean:              clientBean,
-		archiverProvider:        archiverProvider,
-		registry:                registry,
+		archivalClient:          archivalClient,
 	}
 }
 
@@ -99,8 +91,6 @@ func (f *historyEngineFactory) CreateEngine(
 		f.replicationTaskFetchers,
 		f.rawMatchingClient,
 		f.newCacheFn,
-		f.clientBean,
-		f.archiverProvider,
-		f.registry,
+		f.archivalClient,
 	)
 }

--- a/service/history/queues/queue.go
+++ b/service/history/queues/queue.go
@@ -28,6 +28,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow"
 )
 
 //go:generate mockgen -copyright_file ../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination queue_mock.go
@@ -43,6 +44,10 @@ type (
 	}
 
 	ProcessorFactory interface {
-		CreateProcessor(shard shard.Context, engine shard.Engine) Processor
+		// TODO: remove the cache parameter after workflow cache become a host level component
+		// and it can be provided as a parameter when creating a ProcessorFactory instance.
+		// Currently, workflow cache is shard level, but we can't get it from shard or engine interface,
+		// as that will lead to a cycle dependency issue between shard and workflow package.
+		CreateProcessor(shard shard.Context, engine shard.Engine, cache workflow.Cache) Processor
 	}
 )

--- a/service/history/queues/queue_mock.go
+++ b/service/history/queues/queue_mock.go
@@ -34,6 +34,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	shard "go.temporal.io/server/service/history/shard"
 	tasks "go.temporal.io/server/service/history/tasks"
+	workflow "go.temporal.io/server/service/history/workflow"
 )
 
 // MockProcessor is a mock of Processor interface.
@@ -169,15 +170,15 @@ func (m *MockProcessorFactory) EXPECT() *MockProcessorFactoryMockRecorder {
 }
 
 // CreateProcessor mocks base method.
-func (m *MockProcessorFactory) CreateProcessor(shard shard.Context, engine shard.Engine) Processor {
+func (m *MockProcessorFactory) CreateProcessor(shard shard.Context, engine shard.Engine, cache workflow.Cache) Processor {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateProcessor", shard, engine)
+	ret := m.ctrl.Call(m, "CreateProcessor", shard, engine, cache)
 	ret0, _ := ret[0].(Processor)
 	return ret0
 }
 
 // CreateProcessor indicates an expected call of CreateProcessor.
-func (mr *MockProcessorFactoryMockRecorder) CreateProcessor(shard, engine interface{}) *gomock.Call {
+func (mr *MockProcessorFactoryMockRecorder) CreateProcessor(shard, engine, cache interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProcessor", reflect.TypeOf((*MockProcessorFactory)(nil).CreateProcessor), shard, engine)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProcessor", reflect.TypeOf((*MockProcessorFactory)(nil).CreateProcessor), shard, engine, cache)
 }

--- a/service/history/timerQueueAckMgr.go
+++ b/service/history/timerQueueAckMgr.go
@@ -141,7 +141,6 @@ func compareTimerIDLess(first *timerKey, second *timerKey) bool {
 func newTimerQueueAckMgr(
 	scope int,
 	shard shard.Context,
-	metricsClient metrics.Client,
 	minLevel time.Time,
 	timeNow timeNow,
 	updateTimerAckLevel updateTimerAckLevel,
@@ -155,7 +154,7 @@ func newTimerQueueAckMgr(
 		isFailover:          false,
 		shard:               shard,
 		executionMgr:        shard.GetExecutionManager(),
-		metricsClient:       metricsClient,
+		metricsClient:       shard.GetMetricsClient(),
 		logger:              logger,
 		config:              shard.GetConfig(),
 		timeNow:             timeNow,
@@ -177,7 +176,6 @@ func newTimerQueueAckMgr(
 
 func newTimerQueueFailoverAckMgr(
 	shard shard.Context,
-	metricsClient metrics.Client,
 	minLevel time.Time,
 	maxLevel time.Time,
 	timeNow timeNow,
@@ -193,7 +191,7 @@ func newTimerQueueFailoverAckMgr(
 		isFailover:          true,
 		shard:               shard,
 		executionMgr:        shard.GetExecutionManager(),
-		metricsClient:       metricsClient,
+		metricsClient:       shard.GetMetricsClient(),
 		logger:              logger,
 		config:              shard.GetConfig(),
 		timeNow:             timeNow,

--- a/service/history/timerQueueAckMgr_test.go
+++ b/service/history/timerQueueAckMgr_test.go
@@ -139,7 +139,6 @@ func (s *timerQueueAckMgrSuite) SetupTest() {
 	s.timerQueueAckMgr = newTimerQueueAckMgr(
 		0,
 		s.mockShard,
-		s.mockShard.GetMetricsClient(),
 		s.mockShard.GetTimerClusterAckLevel(s.clusterName),
 		func() time.Time {
 			return s.mockShard.GetCurrentTime(s.clusterName)
@@ -584,7 +583,6 @@ func (s *timerQueueFailoverAckMgrSuite) SetupTest() {
 	s.maxLevel = time.Now().UTC().Add(10 * time.Minute)
 	s.timerQueueFailoverAckMgr = newTimerQueueFailoverAckMgr(
 		s.mockShard,
-		s.mockShard.GetMetricsClient(),
 		s.minLevel,
 		s.maxLevel,
 		func() time.Time {

--- a/service/history/timerQueueActiveTaskExecutor.go
+++ b/service/history/timerQueueActiveTaskExecutor.go
@@ -62,21 +62,19 @@ type (
 
 func newTimerQueueActiveTaskExecutor(
 	shard shard.Context,
+	workflowCache workflow.Cache,
 	workflowDeleteManager workflow.DeleteManager,
-	cache workflow.Cache,
 	queueProcessor *timerQueueActiveProcessorImpl,
 	logger log.Logger,
-	metricsClient metrics.Client,
 	config *configs.Config,
 	matchingClient matchingservice.MatchingServiceClient,
 ) queueTaskExecutor {
 	return &timerQueueActiveTaskExecutor{
 		timerQueueTaskExecutorBase: newTimerQueueTaskExecutorBase(
 			shard,
+			workflowCache,
 			workflowDeleteManager,
-			cache,
 			logger,
-			metricsClient,
 			config,
 		),
 		queueProcessor: queueProcessor,

--- a/service/history/timerQueueActiveTaskExecutor_test.go
+++ b/service/history/timerQueueActiveTaskExecutor_test.go
@@ -171,24 +171,23 @@ func (s *timerQueueActiveTaskExecutorSuite) SetupTest() {
 			s.mockTimerProcessor.Category():      s.mockTimerProcessor,
 			s.mockVisibilityProcessor.Category(): s.mockVisibilityProcessor,
 		},
-		workflowDeleteManager: s.mockDeleteManager,
 	}
 	s.mockShard.SetEngineForTesting(h)
 	s.mockHistoryEngine = h
 
 	s.timerQueueActiveTaskExecutor = newTimerQueueActiveTaskExecutor(
 		s.mockShard,
+		h.historyCache,
 		s.mockDeleteManager,
-		historyCache,
 		newTimerQueueActiveProcessor(
 			s.mockShard,
-			h,
+			h.historyCache,
+			s.mockDeleteManager,
 			s.mockMatchingClient,
 			newTaskAllocator(s.mockShard),
 			s.logger,
 		),
 		s.logger,
-		s.mockShard.GetMetricsClient(),
 		config,
 		s.mockShard.Resource.GetMatchingClient(),
 	).(*timerQueueActiveTaskExecutor)

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -37,7 +37,6 @@ import (
 
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
-	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
@@ -49,6 +48,8 @@ import (
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/worker/archiver"
 )
 
 var (
@@ -64,10 +65,12 @@ type (
 		isGlobalNamespaceEnabled   bool
 		currentClusterName         string
 		shard                      shard.Context
+		historyEngine              shard.Engine
 		taskAllocator              taskAllocator
 		config                     *configs.Config
 		metricsClient              metrics.Client
-		historyService             *historyEngineImpl
+		workflowCache              workflow.Cache
+		workflowDeleteManager      workflow.DeleteManager
 		ackLevel                   timerKey
 		logger                     log.Logger
 		matchingClient             matchingservice.MatchingServiceClient
@@ -77,31 +80,38 @@ type (
 		activeTimerProcessor       *timerQueueActiveProcessorImpl
 		standbyTimerProcessorsLock sync.RWMutex
 		standbyTimerProcessors     map[string]*timerQueueStandbyProcessorImpl
-		clientBean                 client.Bean
 	}
 )
 
 func newTimerQueueProcessor(
 	shard shard.Context,
-	historyService *historyEngineImpl,
+	historyEngine shard.Engine,
+	workflowCache workflow.Cache,
+	archivalClient archiver.Client,
 	matchingClient matchingservice.MatchingServiceClient,
-	logger log.Logger,
-	clientBean client.Bean,
 ) queues.Processor {
 
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 	config := shard.GetConfig()
-	logger = log.With(logger, tag.ComponentTimerQueue)
+	logger := log.With(shard.GetLogger(), tag.ComponentTimerQueue)
 	taskAllocator := newTaskAllocator(shard)
+	workflowDeleteManager := workflow.NewDeleteManager(
+		shard,
+		workflowCache,
+		config,
+		archivalClient,
+	)
 
 	return &timerQueueProcessorImpl{
 		isGlobalNamespaceEnabled: shard.GetClusterMetadata().IsGlobalNamespaceEnabled(),
 		currentClusterName:       currentClusterName,
 		shard:                    shard,
+		historyEngine:            historyEngine,
 		taskAllocator:            taskAllocator,
 		config:                   config,
-		metricsClient:            historyService.metricsClient,
-		historyService:           historyService,
+		metricsClient:            shard.GetMetricsClient(),
+		workflowCache:            workflowCache,
+		workflowDeleteManager:    workflowDeleteManager,
 		ackLevel:                 timerKey{VisibilityTimestamp: shard.GetTimerAckLevel()},
 		logger:                   logger,
 		matchingClient:           matchingClient,
@@ -109,13 +119,13 @@ func newTimerQueueProcessor(
 		shutdownChan:             make(chan struct{}),
 		activeTimerProcessor: newTimerQueueActiveProcessor(
 			shard,
-			historyService,
+			workflowCache,
+			workflowDeleteManager,
 			matchingClient,
 			taskAllocator,
 			logger,
 		),
 		standbyTimerProcessors: make(map[string]*timerQueueStandbyProcessorImpl),
-		clientBean:             clientBean,
 	}
 }
 
@@ -205,7 +215,8 @@ func (t *timerQueueProcessorImpl) FailoverNamespace(
 	// we should consider make the failover idempotent
 	updateShardAckLevel, failoverTimerProcessor := newTimerQueueFailoverProcessor(
 		t.shard,
-		t.historyService,
+		t.workflowCache,
+		t.workflowDeleteManager,
 		namespaceIDs,
 		standbyClusterName,
 		minLevel,
@@ -351,7 +362,7 @@ func (t *timerQueueProcessorImpl) handleClusterMetadataUpdate(
 				t.shard.GetNamespaceRegistry(),
 				t.shard.GetRemoteAdminClient(clusterName),
 				func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
-					return t.historyService.ReplicateEventsV2(ctx, request)
+					return t.historyEngine.ReplicateEventsV2(ctx, request)
 				},
 				t.shard.GetPayloadSerializer(),
 				t.config.StandbyTaskReReplicationContextTimeout,
@@ -359,12 +370,12 @@ func (t *timerQueueProcessorImpl) handleClusterMetadataUpdate(
 			)
 			processor := newTimerQueueStandbyProcessor(
 				t.shard,
-				t.historyService,
+				t.workflowCache,
+				t.workflowDeleteManager,
 				clusterName,
 				t.taskAllocator,
 				nDCHistoryResender,
 				t.logger,
-				t.clientBean,
 			)
 			processor.Start()
 			t.standbyTimerProcessors[clusterName] = processor

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"time"
 
-	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -37,6 +36,7 @@ import (
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow"
 )
 
 const (
@@ -57,12 +57,12 @@ type (
 
 func newTimerQueueStandbyProcessor(
 	shard shard.Context,
-	historyService *historyEngineImpl,
+	workflowCache workflow.Cache,
+	workflowDeleteManager workflow.DeleteManager,
 	clusterName string,
 	taskAllocator taskAllocator,
 	nDCHistoryResender xdc.NDCHistoryResender,
 	logger log.Logger,
-	clientBean client.Bean,
 ) *timerQueueStandbyProcessorImpl {
 
 	timeNow := func() time.Time {
@@ -72,6 +72,7 @@ func newTimerQueueStandbyProcessor(
 		return shard.UpdateTimerClusterAckLevel(clusterName, ackLevel.VisibilityTimestamp)
 	}
 	logger = log.With(logger, tag.ClusterName(clusterName))
+	metricsClient := shard.GetMetricsClient()
 	timerTaskFilter := func(task tasks.Task) (bool, error) {
 		return taskAllocator.verifyStandbyTask(clusterName, namespace.ID(task.GetNamespaceID()), task)
 	}
@@ -81,7 +82,6 @@ func newTimerQueueStandbyProcessor(
 	timerQueueAckMgr := newTimerQueueAckMgr(
 		metrics.TimerStandbyQueueProcessorScope,
 		shard,
-		historyService.metricsClient,
 		shard.GetTimerClusterAckLevel(clusterName),
 		timeNow,
 		updateShardAckLevel,
@@ -93,25 +93,23 @@ func newTimerQueueStandbyProcessor(
 		shard:           shard,
 		timerTaskFilter: timerTaskFilter,
 		logger:          logger,
-		metricsClient:   historyService.metricsClient,
+		metricsClient:   metricsClient,
 		timerGate:       timerGate,
 		taskExecutor: newTimerQueueStandbyTaskExecutor(
 			shard,
-			historyService.workflowDeleteManager,
-			historyService.historyCache,
+			workflowCache,
+			workflowDeleteManager,
 			nDCHistoryResender,
 			logger,
-			historyService.metricsClient,
 			clusterName,
 			shard.GetConfig(),
-			clientBean,
 		),
 	}
 
 	processor.timerQueueProcessorBase = newTimerQueueProcessorBase(
 		metrics.TimerStandbyQueueProcessorScope,
 		shard,
-		historyService,
+		workflowCache,
 		processor,
 		timerQueueAckMgr,
 		timerGate,

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -33,7 +33,6 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/api/adminservice/v1"
-	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
@@ -60,26 +59,23 @@ type (
 
 func newTimerQueueStandbyTaskExecutor(
 	shard shard.Context,
-	deleteManager workflow.DeleteManager,
-	cache workflow.Cache,
+	workflowCache workflow.Cache,
+	workflowDeleteManager workflow.DeleteManager,
 	nDCHistoryResender xdc.NDCHistoryResender,
 	logger log.Logger,
-	metricsClient metrics.Client,
 	clusterName string,
 	config *configs.Config,
-	clientBean client.Bean,
 ) queueTaskExecutor {
 	return &timerQueueStandbyTaskExecutor{
 		timerQueueTaskExecutorBase: newTimerQueueTaskExecutorBase(
 			shard,
-			deleteManager,
-			cache,
+			workflowCache,
+			workflowDeleteManager,
 			logger,
-			metricsClient,
 			config,
 		),
 		clusterName:        clusterName,
-		adminClient:        clientBean.GetRemoteAdminClient(clusterName),
+		adminClient:        shard.GetRemoteAdminClient(clusterName),
 		nDCHistoryResender: nDCHistoryResender,
 	}
 }

--- a/service/history/timerQueueStandbyTaskExecutor_test.go
+++ b/service/history/timerQueueStandbyTaskExecutor_test.go
@@ -43,7 +43,6 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -91,7 +90,6 @@ type (
 		discardDuration      time.Duration
 
 		timerQueueStandbyTaskExecutor *timerQueueStandbyTaskExecutor
-		mockBean                      *client.MockBean
 	}
 )
 
@@ -178,24 +176,18 @@ func (s *timerQueueStandbyTaskExecutorSuite) SetupTest() {
 			s.mockTxProcessor.Category():    s.mockTxProcessor,
 			s.mockTimerProcessor.Category(): s.mockTimerProcessor,
 		},
-		workflowDeleteManager: s.mockDeleteManager,
 	}
 	s.mockShard.SetEngineForTesting(h)
-	s.mockBean = client.NewMockBean(s.controller)
-	s.mockBean.EXPECT().GetRemoteAdminClient("standby").Return(s.mockAdminClient)
 
 	s.timerQueueStandbyTaskExecutor = newTimerQueueStandbyTaskExecutor(
 		s.mockShard,
+		h.historyCache,
 		s.mockDeleteManager,
-		historyCache,
 		s.mockNDCHistoryResender,
 		s.logger,
-		s.mockShard.GetMetricsClient(),
 		s.clusterName,
 		config,
-		s.mockBean,
 	).(*timerQueueStandbyTaskExecutor)
-
 }
 
 func (s *timerQueueStandbyTaskExecutorSuite) TearDownTest() {

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -51,18 +51,17 @@ type (
 
 func newTimerQueueTaskExecutorBase(
 	shard shard.Context,
+	workflowCache workflow.Cache,
 	deleteManager workflow.DeleteManager,
-	cache workflow.Cache,
 	logger log.Logger,
-	metricsClient metrics.Client,
 	config *configs.Config,
 ) *timerQueueTaskExecutorBase {
 	return &timerQueueTaskExecutorBase{
 		shard:         shard,
+		cache:         workflowCache,
 		deleteManager: deleteManager,
-		cache:         cache,
 		logger:        logger,
-		metricsClient: metricsClient,
+		metricsClient: shard.GetMetricsClient(),
 		config:        config,
 	}
 }

--- a/service/history/timerQueueTaskExecutorBase_test.go
+++ b/service/history/timerQueueTaskExecutorBase_test.go
@@ -92,10 +92,9 @@ func (s *timerQueueTaskExecutorBaseSuite) SetupTest() {
 
 	s.timerQueueTaskExecutorBase = newTimerQueueTaskExecutorBase(
 		s.testShardContext,
-		s.mockDeleteManager,
 		s.mockCache,
+		s.mockDeleteManager,
 		s.testShardContext.GetLogger(),
-		s.testShardContext.GetMetricsClient(),
 		config,
 	)
 }

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/pborman/uuid"
 
+	sdkclient "go.temporal.io/sdk/client"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common/log"
@@ -38,6 +39,8 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/worker/archiver"
 )
 
 type (
@@ -57,12 +60,13 @@ type (
 
 func newTransferQueueActiveProcessor(
 	shard shard.Context,
-	historyEngine *historyEngineImpl,
+	workflowCache workflow.Cache,
+	archivalClient archiver.Client,
+	publicClient sdkclient.Client,
 	matchingClient matchingservice.MatchingServiceClient,
 	historyClient historyservice.HistoryServiceClient,
 	taskAllocator taskAllocator,
 	logger log.Logger,
-	registry namespace.Registry,
 ) *transferQueueActiveProcessorImpl {
 
 	config := shard.GetConfig()
@@ -101,16 +105,16 @@ func newTransferQueueActiveProcessor(
 		currentClusterName: currentClusterName,
 		shard:              shard,
 		logger:             logger,
-		metricsClient:      historyEngine.metricsClient,
+		metricsClient:      shard.GetMetricsClient(),
 		transferTaskFilter: transferTaskFilter,
 		taskExecutor: newTransferQueueActiveTaskExecutor(
 			shard,
-			historyEngine,
+			workflowCache,
+			archivalClient,
+			publicClient,
 			logger,
-			historyEngine.metricsClient,
 			config,
 			matchingClient,
-			registry,
 		),
 		transferQueueProcessorBase: newTransferQueueProcessorBase(
 			shard,
@@ -136,7 +140,7 @@ func newTransferQueueActiveProcessor(
 		options,
 		processor,
 		queueAckMgr,
-		historyEngine.historyCache,
+		workflowCache,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TransferActiveQueueProcessorScope),
 	)
@@ -148,7 +152,9 @@ func newTransferQueueActiveProcessor(
 
 func newTransferQueueFailoverProcessor(
 	shard shard.Context,
-	historyEngine *historyEngineImpl,
+	workflowCache workflow.Cache,
+	archivalClient archiver.Client,
+	publicClient sdkclient.Client,
 	matchingClient matchingservice.MatchingServiceClient,
 	historyClient historyservice.HistoryServiceClient,
 	namespaceIDs map[string]struct{},
@@ -157,7 +163,6 @@ func newTransferQueueFailoverProcessor(
 	maxLevel int64,
 	taskAllocator taskAllocator,
 	logger log.Logger,
-	registry namespace.Registry,
 ) (func(ackLevel int64) error, *transferQueueActiveProcessorImpl) {
 
 	config := shard.GetConfig()
@@ -212,16 +217,16 @@ func newTransferQueueFailoverProcessor(
 		currentClusterName: currentClusterName,
 		shard:              shard,
 		logger:             logger,
-		metricsClient:      historyEngine.metricsClient,
+		metricsClient:      shard.GetMetricsClient(),
 		transferTaskFilter: transferTaskFilter,
 		taskExecutor: newTransferQueueActiveTaskExecutor(
 			shard,
-			historyEngine,
+			workflowCache,
+			archivalClient,
+			publicClient,
 			logger,
-			historyEngine.metricsClient,
 			config,
 			matchingClient,
-			registry,
 		),
 		transferQueueProcessorBase: newTransferQueueProcessorBase(
 			shard,
@@ -247,7 +252,7 @@ func newTransferQueueFailoverProcessor(
 		options,
 		processor,
 		queueAckMgr,
-		historyEngine.historyCache,
+		workflowCache,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TransferActiveQueueProcessorScope),
 	)

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -219,18 +219,17 @@ func (s *transferQueueActiveTaskExecutorSuite) SetupTest() {
 			s.mockTxProcessor.Category():    s.mockTxProcessor,
 			s.mockTimerProcessor.Category(): s.mockTimerProcessor,
 		},
-		archivalClient: s.mockArchivalClient,
 	}
 	s.mockShard.SetEngineForTesting(h)
 
 	s.transferQueueActiveTaskExecutor = newTransferQueueActiveTaskExecutor(
 		s.mockShard,
-		h,
+		h.historyCache,
+		s.mockArchivalClient,
+		h.publicClient,
 		s.logger,
-		s.mockShard.GetMetricsClient(),
 		config,
 		s.mockShard.Resource.MatchingClient,
-		s.mockNamespaceCache,
 	).(*transferQueueActiveTaskExecutor)
 	s.transferQueueActiveTaskExecutor.parentClosePolicyClient = s.mockParentClosePolicyClient
 }

--- a/service/history/visibilityQueueProcessor.go
+++ b/service/history/visibilityQueueProcessor.go
@@ -41,6 +41,7 @@ import (
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow"
 )
 
 type (
@@ -74,15 +75,15 @@ type (
 
 func newVisibilityQueueProcessor(
 	shard shard.Context,
-	historyEngine *historyEngineImpl,
+	workflowCache workflow.Cache,
 	visibilityMgr manager.VisibilityManager,
 	matchingClient matchingservice.MatchingServiceClient,
 	historyClient historyservice.HistoryServiceClient,
-	logger log.Logger,
 ) queues.Processor {
 
 	config := shard.GetConfig()
-	logger = log.With(logger, tag.ComponentVisibilityQueue)
+	logger := log.With(shard.GetLogger(), tag.ComponentVisibilityQueue)
+	metricsClient := shard.GetMetricsClient()
 
 	options := &QueueProcessorOptions{
 		BatchSize:                           config.VisibilityTaskBatchSize,
@@ -121,15 +122,12 @@ func newVisibilityQueueProcessor(
 		visibilityQueueShutdown:  visibilityQueueShutdown,
 		visibilityTaskFilter:     visibilityTaskFilter,
 		logger:                   logger,
-		metricsClient:            historyEngine.metricsClient,
+		metricsClient:            metricsClient,
 		taskExecutor: newVisibilityQueueTaskExecutor(
 			shard,
-			historyEngine,
+			workflowCache,
 			visibilityMgr,
 			logger,
-			historyEngine.metricsClient,
-			config,
-			matchingClient,
 		),
 
 		config:       config,
@@ -155,7 +153,7 @@ func newVisibilityQueueProcessor(
 		options,
 		retProcessor,
 		queueAckMgr,
-		historyEngine.historyCache,
+		workflowCache,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.VisibilityQueueProcessorScope),
 	)

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -40,25 +40,20 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
-	"go.temporal.io/server/service/worker/parentclosepolicy"
 )
 
 type (
 	visibilityQueueTaskExecutor struct {
-		shard                   shard.Context
-		historyService          *historyEngineImpl
-		cache                   workflow.Cache
-		logger                  log.Logger
-		metricsClient           metrics.Client
-		matchingClient          matchingservice.MatchingServiceClient
-		visibilityMgr           manager.VisibilityManager
-		config                  *configs.Config
-		historyClient           historyservice.HistoryServiceClient
-		parentClosePolicyClient parentclosepolicy.Client
+		shard          shard.Context
+		cache          workflow.Cache
+		logger         log.Logger
+		metricsClient  metrics.Client
+		matchingClient matchingservice.MatchingServiceClient
+		visibilityMgr  manager.VisibilityManager
+		historyClient  historyservice.HistoryServiceClient
 	}
 )
 
@@ -68,29 +63,17 @@ var (
 
 func newVisibilityQueueTaskExecutor(
 	shard shard.Context,
-	historyService *historyEngineImpl,
+	workflowCache workflow.Cache,
 	visibilityMgr manager.VisibilityManager,
 	logger log.Logger,
-	metricsClient metrics.Client,
-	config *configs.Config,
-	matchingClient matchingservice.MatchingServiceClient,
 ) *visibilityQueueTaskExecutor {
 	return &visibilityQueueTaskExecutor{
-		shard:          shard,
-		historyService: historyService,
-		cache:          historyService.historyCache,
-		logger:         logger,
-		metricsClient:  metricsClient,
-		matchingClient: matchingClient,
-		visibilityMgr:  visibilityMgr,
-		config:         config,
-		historyClient:  shard.GetHistoryClient(),
-		parentClosePolicyClient: parentclosepolicy.NewClient(
-			shard.GetMetricsClient(),
-			shard.GetLogger(),
-			historyService.publicClient,
-			config.NumParentClosePolicySystemWorkflows(),
-		),
+		shard:         shard,
+		cache:         workflowCache,
+		logger:        logger,
+		metricsClient: shard.GetMetricsClient(),
+		visibilityMgr: visibilityMgr,
+		historyClient: shard.GetHistoryClient(),
 	}
 }
 

--- a/service/history/visibilityQueueTaskExecutor_test.go
+++ b/service/history/visibilityQueueTaskExecutor_test.go
@@ -165,12 +165,9 @@ func (s *visibilityQueueTaskExecutorSuite) SetupTest() {
 
 	s.visibilityQueueTaskExecutor = newVisibilityQueueTaskExecutor(
 		s.mockShard,
-		h,
+		h.historyCache,
 		s.mockVisibilityMgr,
 		s.logger,
-		s.mockShard.GetMetricsClient(),
-		config,
-		s.mockShard.Resource.GetMatchingClient(),
 	)
 }
 

--- a/service/history/workflow/delete_manager.go
+++ b/service/history/workflow/delete_manager.go
@@ -216,11 +216,11 @@ func (m *DeleteManagerImpl) archiveWorkflowIfEnabled(
 
 	req := &archiver.ClientRequest{
 		ArchiveRequest: &archiver.ArchiveRequest{
+			ShardID:              m.shard.GetShardID(),
 			NamespaceID:          namespaceID.String(),
 			WorkflowID:           workflowExecution.GetWorkflowId(),
 			RunID:                workflowExecution.GetRunId(),
 			Namespace:            namespaceRegistryEntry.Name().String(),
-			ShardID:              m.shard.GetShardID(),
 			Targets:              []archiver.ArchivalTarget{archiver.ArchiveTargetHistory},
 			HistoryURI:           namespaceRegistryEntry.HistoryArchivalState().URI,
 			NextEventID:          mutableState.GetNextEventID(),

--- a/service/worker/archiver/client.go
+++ b/service/worker/archiver/client.go
@@ -64,13 +64,13 @@ type (
 
 	// ArchiveRequest is the request signal sent to the archival workflow
 	ArchiveRequest struct {
+		ShardID     int32
 		NamespaceID string
 		Namespace   string
 		WorkflowID  string
 		RunID       string
 
 		// history archival
-		ShardID              int32
 		BranchToken          []byte
 		NextEventID          int64
 		CloseFailoverVersion int64
@@ -155,6 +155,7 @@ func (c *client) Archive(ctx context.Context, request *ClientRequest) (*ClientRe
 	}
 	logger := log.With(
 		c.logger,
+		tag.ShardID(request.ArchiveRequest.ShardID),
 		tag.ArchivalCallerServiceName(request.CallerService),
 		tag.ArchivalArchiveAttemptedInline(request.AttemptArchiveInline),
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Make queue processor depend on history engine interface

<!-- Tell your future self why have you made these changes -->
**Why?**
- Prepare for initializing queue processor via queue processor factory

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- In worst case some components may not be initialized correctly. should be caught be tests. 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no