### PR TITLE
Improve extensibility of optentelemetry metrics

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -267,7 +267,7 @@ func InitReporterFromPrometheusConfig(logger log.Logger, config *PrometheusConfi
 	case FrameworkTally:
 		return NewTallyReporterFromPrometheusConfig(logger, config, clientConfig), nil
 	case FrameworkOpentelemetry:
-		return NewOpentelemeteryReporter(logger, config, clientConfig)
+		return NewOpentelemeteryReporterWithMust(logger, config, clientConfig)
 	default:
 		err := fmt.Errorf("unsupported framework type specified in config: %q", config.Framework)
 		logger.Error(err.Error())

--- a/common/metrics/opentelemetry_client.go
+++ b/common/metrics/opentelemetry_client.go
@@ -46,7 +46,7 @@ type (
 
 // NewOpentelemeteryClientByReporter creates and returns a new instance of Client implementation
 // serviceIdx indicates the service type in (InputhostIndex, ... StorageIndex)
-func newOpentelemeteryClient(clientConfig *ClientConfig, serviceIdx ServiceIdx, reporter OpentelemetryReporter, logger log.Logger, gaugeCache OtelGaugeCache) (Client, error) {
+func NewOpentelemeteryClient(clientConfig *ClientConfig, serviceIdx ServiceIdx, reporter OpentelemetryReporter, logger log.Logger, gaugeCache OtelGaugeCache) (Client, error) {
 	tagsFilterConfig := NewTagFilteringScopeConfig(clientConfig.ExcludeTags)
 
 	scopeWrapper := func(impl internalScope) internalScope {

--- a/common/metrics/opentelemetry_must_provider.go
+++ b/common/metrics/opentelemetry_must_provider.go
@@ -1,0 +1,137 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"go.opentelemetry.io/otel/exporters/prometheus"
+	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/sdk/export/metric/aggregation"
+	controller "go.opentelemetry.io/otel/sdk/metric/controller/basic"
+	processor "go.opentelemetry.io/otel/sdk/metric/processor/basic"
+	"go.opentelemetry.io/otel/sdk/resource"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+)
+
+var _ OpentelemetryMustProvider = (*opentelemetryMustProviderImpl)(nil)
+
+type (
+	OpentelemetryMustProvider interface {
+		Stop(logger log.Logger)
+		GetMeterMust() metric.MeterMust
+	}
+
+	opentelemetryMustProviderImpl struct {
+		exporter  *prometheus.Exporter
+		meter     metric.Meter
+		meterMust metric.MeterMust
+		config    *PrometheusConfig
+		server    *http.Server
+	}
+)
+
+func NewOpentelemetryMustProvider(
+	logger log.Logger,
+	prometheusConfig *PrometheusConfig,
+	clientConfig *ClientConfig,
+) (*opentelemetryMustProviderImpl, error) {
+	histogramBoundaries := prometheusConfig.DefaultHistogramBoundaries
+	if len(histogramBoundaries) == 0 {
+		histogramBoundaries = defaultHistogramBoundaries
+	}
+
+	c := controller.New(
+		processor.NewFactory(
+			NewOtelAggregatorSelector(
+				histogramBoundaries,
+				clientConfig.PerUnitHistogramBoundaries,
+			),
+			aggregation.CumulativeTemporalitySelector(),
+			processor.WithMemory(true),
+		),
+		controller.WithResource(resource.Empty()),
+	)
+	exporter, err := prometheus.New(prometheus.Config{DefaultHistogramBoundaries: histogramBoundaries}, c)
+
+	if err != nil {
+		logger.Error("Failed to initialize prometheus exporter.", tag.Error(err))
+		return nil, err
+	}
+
+	metricServer := initPrometheusListener(prometheusConfig, logger, exporter)
+
+	meter := c.Meter("temporal")
+	meterMust := metric.Must(meter)
+	reporter := &opentelemetryMustProviderImpl{
+		exporter:  exporter,
+		meter:     meter,
+		meterMust: meterMust,
+		config:    prometheusConfig,
+		server:    metricServer,
+	}
+
+	return reporter, nil
+}
+
+func initPrometheusListener(config *PrometheusConfig, logger log.Logger, exporter *prometheus.Exporter) *http.Server {
+	handlerPath := config.HandlerPath
+	if handlerPath == "" {
+		handlerPath = "/metrics"
+	}
+
+	handler := http.NewServeMux()
+	handler.HandleFunc(handlerPath, exporter.ServeHTTP)
+
+	if config.ListenAddress == "" {
+		logger.Fatal("Listen address must be specified.", tag.Address(config.ListenAddress))
+	}
+	server := &http.Server{Addr: config.ListenAddress, Handler: handler}
+
+	go func() {
+		err := server.ListenAndServe()
+		if err != http.ErrServerClosed {
+			logger.Fatal("Failed to initialize prometheus listener.", tag.Address(config.ListenAddress))
+		}
+	}()
+
+	return server
+}
+
+func (r *opentelemetryMustProviderImpl) GetMeterMust() metric.MeterMust {
+	return r.meterMust
+}
+
+func (r *opentelemetryMustProviderImpl) Stop(logger log.Logger) {
+	ctx, closeCtx := context.WithTimeout(context.Background(), time.Second)
+	defer closeCtx()
+	if err := r.server.Shutdown(ctx); !(err == nil || err == http.ErrServerClosed) {
+		logger.Error("Prometheus metrics server shutdown failure.", tag.Address(r.config.ListenAddress), tag.Error(err))
+	}
+}

--- a/common/metrics/opentelemetry_user_scope.go
+++ b/common/metrics/opentelemetry_user_scope.go
@@ -40,7 +40,7 @@ type opentelemetryUserScope struct {
 	gaugeCache OtelGaugeCache
 }
 
-func newOpentelemetryUserScope(
+func NewOpentelemetryUserScope(
 	meterMust metric.MeterMust,
 	tags map[string]string,
 	gaugeCache OtelGaugeCache,
@@ -95,5 +95,5 @@ func (o opentelemetryUserScope) Tagged(tags map[string]string) UserScope {
 	for key, value := range tags {
 		tagMap[key] = value
 	}
-	return newOpentelemetryUserScope(o.meterMust, tagMap, o.gaugeCache)
+	return NewOpentelemetryUserScope(o.meterMust, tagMap, o.gaugeCache)
 }

--- a/common/metrics/otel_metric_test_utility.go
+++ b/common/metrics/otel_metric_test_utility.go
@@ -62,7 +62,7 @@ func NewOtelMetricTestUtility() *OtelMetricTestUtility {
 }
 
 func (t *OtelMetricTestUtility) GetClient(config *ClientConfig, idx ServiceIdx) Client {
-	result, err := newOpentelemeteryClient(config, idx, t.reporter, log.NewNoopLogger(), t.gaugeCache)
+	result, err := NewOpentelemeteryClient(config, idx, t.reporter, log.NewNoopLogger(), t.gaugeCache)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Extracted OtelMustProvider for easier user override.

See sample at https://github.com/temporalio/samples-server/pull/25

<!-- Tell your future self why have you made these changes -->
**Why?**
Ease of use.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual/auto tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Metrics are not reported correctly

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No