### PR TITLE
Allow customizing retry behavior for timeout failure

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -116,6 +116,6 @@ const (
 	// TimeoutFailureTypePrefix is the prefix for timeout failure types
 	// used in retry policy
 	// the actual failure type will be prefix + enums.TimeoutType.String()
-	// e.g. "Temporal Timeout: StartToClose" or "Temporal Timeout: Heartbeat"
-	TimeoutFailureTypePrefix = "Temporal Timeout: "
+	// e.g. "TemporalTimeout:StartToClose" or "TemporalTimeout:Heartbeat"
+	TimeoutFailureTypePrefix = "TemporalTimeout:"
 )

--- a/common/constants.go
+++ b/common/constants.go
@@ -111,3 +111,11 @@ const (
 	// DefaultTransactionSizeLimit is the largest allowed transaction size to persistence
 	DefaultTransactionSizeLimit = 4 * 1024 * 1024
 )
+
+const (
+	// TimeoutFailureTypePrefix is the prefix for timeout failure types
+	// used in retry policy
+	// the actual failure type will be prefix + enums.TimeoutType.String()
+	// e.g. "Temporal Timeout: StartToClose" or "Temporal Timeout: Heartbeat"
+	TimeoutFailureTypePrefix = "Temporal Timeout: "
+)

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/common/dynamicconfig"
@@ -104,6 +105,42 @@ func TestValidateRetryPolicy(t *testing.T) {
 			},
 			wantErr:       true,
 			wantErrString: "MaximumAttempts cannot be negative on retry policy.",
+		},
+		{
+			name: "timeout nonretryable error - valid type",
+			input: &commonpb.RetryPolicy{
+				BackoffCoefficient: 1,
+				NonRetryableErrorTypes: []string{
+					TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String(),
+					TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String(),
+					TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE.String(),
+					TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_HEARTBEAT.String(),
+				},
+			},
+			wantErr:       false,
+			wantErrString: "",
+		},
+		{
+			name: "timeout nonretryable error - unspecified type",
+			input: &commonpb.RetryPolicy{
+				BackoffCoefficient: 1,
+				NonRetryableErrorTypes: []string{
+					TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_UNSPECIFIED.String(),
+				},
+			},
+			wantErr:       true,
+			wantErrString: "Invalid timeout type value: Unspecified.",
+		},
+		{
+			name: "timeout nonretryable error - unknown type",
+			input: &commonpb.RetryPolicy{
+				BackoffCoefficient: 1,
+				NonRetryableErrorTypes: []string{
+					TimeoutFailureTypePrefix + "unknown",
+				},
+			},
+			wantErr:       true,
+			wantErrString: "Invalid timeout type value: unknown.",
 		},
 	}
 

--- a/service/history/timerQueueActiveTaskExecutor.go
+++ b/service/history/timerQueueActiveTaskExecutor.go
@@ -241,7 +241,8 @@ Loop:
 			break Loop
 		}
 
-		timeoutFailure := failure.NewTimeoutFailure("activity timeout", timerSequenceID.TimerType)
+		failureMsg := fmt.Sprintf("activity %v timeout", timerSequenceID.TimerType.String())
+		timeoutFailure := failure.NewTimeoutFailure(failureMsg, timerSequenceID.TimerType)
 		var retryState enumspb.RetryState
 		if retryState, err = mutableState.RetryActivity(
 			activityInfo,

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -40,16 +40,10 @@ import (
 
 	"go.temporal.io/server/api/historyservice/v1"
 	workflowspb "go.temporal.io/server/api/workflow/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
-)
-
-const (
-	// timeoutFailureTypePrefix is the prefix for timeout error types
-	// the actual failure type will be prefix + timeoutType.String
-	// e.g. "Temporal Timeout: StartToClose" or "Temporal Timeout: Heartbeat"
-	timeoutFailureTypePrefix = "Temporal Timeout: "
 )
 
 // TODO treat 0 as 0, not infinite
@@ -156,7 +150,7 @@ func matchTimeoutNonRetryableTypes(
 	timeoutType enumspb.TimeoutType,
 	nonRetryableTypes []string,
 ) bool {
-	timeoutFailureType := timeoutFailureTypePrefix + timeoutType.String()
+	timeoutFailureType := common.TimeoutFailureTypePrefix + timeoutType.String()
 	for _, nrt := range nonRetryableTypes {
 		if timeoutFailureType == nrt {
 			return true
@@ -171,7 +165,7 @@ func matchApplicationNonRetryableTypes(
 	nonRetryableTypes []string,
 ) bool {
 	for _, nrt := range nonRetryableTypes {
-		if strings.HasPrefix(nrt, timeoutFailureTypePrefix) {
+		if strings.HasPrefix(nrt, common.TimeoutFailureTypePrefix) {
 			continue
 		}
 

--- a/service/history/workflow/retry_test.go
+++ b/service/history/workflow/retry_test.go
@@ -71,7 +71,7 @@ func Test_IsRetryable(t *testing.T) {
 			TimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 		}},
 	}
-	a.False(isRetryable(f, []string{enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()})) // TODO
+	a.False(isRetryable(f, []string{timeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()}))
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
@@ -85,7 +85,7 @@ func Test_IsRetryable(t *testing.T) {
 			TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
 		}},
 	}
-	a.False(isRetryable(f, []string{enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String()})) // TODO
+	a.False(isRetryable(f, []string{timeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String()}))
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
@@ -106,14 +106,14 @@ func Test_IsRetryable(t *testing.T) {
 			TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
 		}},
 	}
-	a.False(isRetryable(f, []string{enumspb.TIMEOUT_TYPE_HEARTBEAT.String()})) // TODO
+	a.False(isRetryable(f, []string{timeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_HEARTBEAT.String()}))
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
 			TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
 		}},
 	}
-	a.True(isRetryable(f, []string{enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()})) // TODO
+	a.True(isRetryable(f, []string{timeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()}))
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{

--- a/service/history/workflow/retry_test.go
+++ b/service/history/workflow/retry_test.go
@@ -68,10 +68,24 @@ func Test_IsRetryable(t *testing.T) {
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+			TimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
+		}},
+	}
+	a.False(isRetryable(f, []string{enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()})) // TODO
+
+	f = &failurepb.Failure{
+		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
 			TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
 		}},
 	}
 	a.False(isRetryable(f, nil))
+
+	f = &failurepb.Failure{
+		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+			TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
+		}},
+	}
+	a.False(isRetryable(f, []string{enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String()})) // TODO
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
@@ -86,6 +100,20 @@ func Test_IsRetryable(t *testing.T) {
 		}},
 	}
 	a.True(isRetryable(f, nil))
+
+	f = &failurepb.Failure{
+		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+			TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
+		}},
+	}
+	a.False(isRetryable(f, []string{enumspb.TIMEOUT_TYPE_HEARTBEAT.String()})) // TODO
+
+	f = &failurepb.Failure{
+		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
+			TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
+		}},
+	}
+	a.True(isRetryable(f, []string{enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()})) // TODO
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{

--- a/service/history/workflow/retry_test.go
+++ b/service/history/workflow/retry_test.go
@@ -33,6 +33,7 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/failure"
@@ -65,13 +66,7 @@ func Test_IsRetryable(t *testing.T) {
 		}},
 	}
 	a.True(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
-		}},
-	}
-	a.False(isRetryable(f, []string{timeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()}))
+	a.False(isRetryable(f, []string{common.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()}))
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
@@ -79,13 +74,7 @@ func Test_IsRetryable(t *testing.T) {
 		}},
 	}
 	a.False(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START,
-		}},
-	}
-	a.False(isRetryable(f, []string{timeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String()}))
+	a.False(isRetryable(f, []string{common.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START.String()}))
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
@@ -93,6 +82,7 @@ func Test_IsRetryable(t *testing.T) {
 		}},
 	}
 	a.False(isRetryable(f, nil))
+	a.False(isRetryable(f, []string{common.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE.String()}))
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
@@ -100,20 +90,9 @@ func Test_IsRetryable(t *testing.T) {
 		}},
 	}
 	a.True(isRetryable(f, nil))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
-		}},
-	}
-	a.False(isRetryable(f, []string{timeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_HEARTBEAT.String()}))
-
-	f = &failurepb.Failure{
-		FailureInfo: &failurepb.Failure_TimeoutFailureInfo{TimeoutFailureInfo: &failurepb.TimeoutFailureInfo{
-			TimeoutType: enumspb.TIMEOUT_TYPE_HEARTBEAT,
-		}},
-	}
-	a.True(isRetryable(f, []string{timeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()}))
+	a.False(isRetryable(f, []string{common.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_HEARTBEAT.String()}))
+	a.True(isRetryable(f, []string{common.TimeoutFailureTypePrefix + enumspb.TIMEOUT_TYPE_START_TO_CLOSE.String()}))
+	a.True(isRetryable(f, []string{common.TimeoutFailureTypePrefix + "unknown timeout type string"}))
 
 	f = &failurepb.Failure{
 		FailureInfo: &failurepb.Failure_ServerFailureInfo{ServerFailureInfo: &failurepb.ServerFailureInfo{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allow customizing retry behavior for timeout errors
- NOTE: this changes the behavior for both activity and workflow retry policy

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/temporalio/temporal/issues/2496


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This change is technically breaking as the new format defined for timeout failure may matching user defined application error types. But the chance this will happen is very very low.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no