### PR TITLE
Force metrics.Reporter as extension point

### DIFF
--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -37,10 +37,6 @@ import (
 )
 
 type nullStatsReporter struct{}
-type unsupportedNullStatsReporter struct{}
-
-var CachedNullStatsReporter tally.CachedStatsReporter = nullStatsReporter{}
-var UnsupportedNullStatsReporter tally.BaseStatsReporter = unsupportedNullStatsReporter{}
 
 func (r nullStatsReporter) Capabilities() tally.Capabilities {
 	panic("implement me")
@@ -63,14 +59,6 @@ func (r nullStatsReporter) AllocateTimer(name string, tags map[string]string) ta
 }
 
 func (r nullStatsReporter) AllocateHistogram(name string, tags map[string]string, buckets tally.Buckets) tally.CachedHistogram {
-	panic("implement me")
-}
-
-func (u unsupportedNullStatsReporter) Capabilities() tally.Capabilities {
-	panic("implement me")
-}
-
-func (u unsupportedNullStatsReporter) Flush() {
 	panic("implement me")
 }
 
@@ -129,39 +117,4 @@ func (s *MetricsSuite) TestNoop() {
 	config := &Config{}
 	scope := NewScope(log.NewNoopLogger(), config)
 	s.Equal(tally.NoopScope, scope)
-}
-
-func (s *MetricsSuite) TestCustomReporter() {
-	config := &Config{}
-	scope := NewCustomReporterScope(log.NewNoopLogger(), &config.ClientConfig, tally.NullStatsReporter)
-	s.NotNil(scope)
-	s.NotEqual(tally.NoopScope, scope)
-}
-
-func (s *MetricsSuite) TestCustomCachedReporter() {
-	config := &Config{}
-	scope := NewCustomReporterScope(log.NewNoopLogger(), &config.ClientConfig, CachedNullStatsReporter)
-	s.NotNil(scope)
-	s.NotEqual(tally.NoopScope, scope)
-}
-
-func (s *MetricsSuite) TestUnsupportedReporter() {
-	config := &Config{}
-	scope := NewCustomReporterScope(log.NewNoopLogger(), &config.ClientConfig, UnsupportedNullStatsReporter)
-	s.Equal(tally.NoopScope, scope)
-}
-
-func (s *MetricsSuite) TestOTCustomReporter() {
-	prom := &PrometheusConfig{
-		Framework:     "custom",
-		OnError:       "panic",
-		TimerType:     "histogram",
-		ListenAddress: "127.0.0.1:0",
-	}
-	config := &Config{}
-	config.Prometheus = prom
-	mockReporter := NewMockReporter(s.controller)
-	reporter, err := InitMetricsReporterInternal(log.NewNoopLogger(), config, mockReporter)
-	s.Equal(mockReporter, reporter)
-	s.Nil(err)
 }

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -699,10 +699,14 @@ func NamespaceLoggerProvider(so *serverOptions) NamespaceLogger {
 }
 
 func MetricReportersProvider(so *serverOptions, logger log.Logger) (ServerReporter, error) {
+	if so.metricsReporter != nil {
+		return so.metricsReporter, nil
+	}
+
 	var serverReporter ServerReporter
 	if so.config.Global.Metrics != nil {
 		var err error
-		serverReporter, err = metrics.InitMetricsReporterInternal(logger, so.config.Global.Metrics, so.metricsReporter)
+		serverReporter, err = metrics.InitMetricsReporter(logger, so.config.Global.Metrics)
 		if err != nil {
 			return nil, err
 		}

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -207,10 +207,9 @@ func newBootstrapParams(
 
 	params.ServerMetricsReporter = serverReporter
 
-	// todo: Replace this hack with actually using sdkReporter, Client or Scope.
 	if serverReporter == nil {
 		var err error
-		serverReporter, err = metrics.InitMetricsReporterInternal(logger, &svcCfg.Metrics, nil)
+		serverReporter, err = metrics.InitMetricsReporter(logger, &svcCfg.Metrics)
 		if err != nil {
 			return nil, fmt.Errorf(
 				"unable to initialize per-service metric client. "+

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -27,16 +27,18 @@ package temporal
 import (
 	"net/http"
 
+	"google.golang.org/grpc"
+
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	persistenceclient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/searchattribute"
-	"google.golang.org/grpc"
 )
 
 type (
@@ -124,7 +126,7 @@ func WithAudienceGetter(audienceGetter func(cfg *config.Config) authorization.JW
 // for Prometheus with framework metrics.FrameworkCustom it should be metrics.Reporter
 // not used otherwise
 // TODO: replace argument type with metrics.Reporter once tally is deprecated.
-func WithCustomMetricsReporter(reporter interface{}) ServerOption {
+func WithCustomMetricsReporter(reporter metrics.Reporter) ServerOption {
 	return newApplyFuncContainer(func(s *serverOptions) {
 		s.metricsReporter = reporter
 	})

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -121,11 +121,14 @@ func WithAudienceGetter(audienceGetter func(cfg *config.Config) authorization.JW
 	})
 }
 
-// Set custom metric reporter
-// for (deprecated) Tally it should be tally.BaseStatsReporter
-// for Prometheus with framework metrics.FrameworkCustom it should be metrics.Reporter
-// not used otherwise
-// TODO: replace argument type with metrics.Reporter once tally is deprecated.
+// WithCustomMetricsReporter sets custom metric reporter
+// Detailed examples can be found at https://github.com/temporalio/samples-server
+//
+// Sample usage:
+// logger := log.NewCLILogger()
+// mustProvider, err := NewCustomMustProviderImplementation(logger)
+// reporter, err2 := metrics.NewOpentelemeteryReporter(logger, &metrics.ClientConfig{}, mustProvider)
+// server := temporal.NewServer(temporal.WithCustomMetricsReporter(repoter))
 func WithCustomMetricsReporter(reporter metrics.Reporter) ServerOption {
 	return newApplyFuncContainer(func(s *serverOptions) {
 		s.metricsReporter = reporter

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -28,16 +28,18 @@ import (
 	"fmt"
 	"net/http"
 
+	"google.golang.org/grpc"
+
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/searchattribute"
-	"google.golang.org/grpc"
 )
 
 type (
@@ -58,7 +60,7 @@ type (
 		tlsConfigProvider          encryption.TLSConfigProvider
 		claimMapper                authorization.ClaimMapper
 		audienceGetter             authorization.JWTAudienceMapper
-		metricsReporter            interface{}
+		metricsReporter            metrics.Reporter
 		persistenceServiceResolver resolver.ServiceResolver
 		elasticsearchHttpClient    *http.Client
 		dynamicConfigClient        dynamicconfig.Client


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Require metrics.Reporter for custom metrics reporter.
Samples update https://github.com/temporalio/samples-server/pull/26

<!-- Tell your future self why have you made these changes -->
**Why?**
Deprecate old API.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manual/auto tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Custom metrics are not reported.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No