### PR TITLE
Cherry-picks change to 1.15.x branch: Adds ExecutionInfo reference to InternalWorkflowMutation #2530

### DIFF
--- a/common/persistence/cassandra/util.go
+++ b/common/persistence/cassandra/util.go
@@ -54,7 +54,7 @@ func applyWorkflowMutationBatch(
 		namespaceID,
 		workflowID,
 		runID,
-		workflowMutation.ExecutionInfo,
+		workflowMutation.ExecutionInfoBlob,
 		workflowMutation.ExecutionState,
 		workflowMutation.ExecutionStateBlob,
 		workflowMutation.NextEventID,

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -454,6 +454,7 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 		UpsertRequestCancelInfos:  make(map[int64]*commonpb.DataBlob),
 		UpsertSignalInfos:         make(map[int64]*commonpb.DataBlob),
 
+		ExecutionInfo:  input.ExecutionInfo,
 		ExecutionState: input.ExecutionState,
 
 		DeleteActivityInfos:       input.DeleteActivityInfos,
@@ -476,7 +477,7 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 		NextEventID:     input.NextEventID,
 	}
 
-	result.ExecutionInfo, err = m.serializer.WorkflowExecutionInfoToBlob(input.ExecutionInfo, enumspb.ENCODING_TYPE_PROTO3)
+	result.ExecutionInfoBlob, err = m.serializer.WorkflowExecutionInfoToBlob(input.ExecutionInfo, enumspb.ENCODING_TYPE_PROTO3)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -380,7 +380,8 @@ type (
 		WorkflowID  string
 		RunID       string
 
-		ExecutionInfo      *commonpb.DataBlob
+		ExecutionInfo      *persistencespb.WorkflowExecutionInfo
+		ExecutionInfoBlob  *commonpb.DataBlob
 		ExecutionState     *persistencespb.WorkflowExecutionState
 		ExecutionStateBlob *commonpb.DataBlob
 		NextEventID        int64

--- a/common/persistence/size.go
+++ b/common/persistence/size.go
@@ -104,7 +104,7 @@ func statusOfInternalWorkflowMutation(
 		return nil
 	}
 
-	executionInfoSize := sizeOfBlob(mutation.ExecutionInfo)
+	executionInfoSize := sizeOfBlob(mutation.ExecutionInfoBlob)
 	executionStateSize := sizeOfBlob(mutation.ExecutionStateBlob)
 
 	activityInfoCount := len(mutation.UpsertActivityInfos)

--- a/common/persistence/sql/execution_util.go
+++ b/common/persistence/sql/execution_util.go
@@ -86,7 +86,7 @@ func applyWorkflowMutationTx(
 		tx,
 		namespaceID,
 		workflowID,
-		workflowMutation.ExecutionInfo,
+		workflowMutation.ExecutionInfoBlob,
 		workflowMutation.ExecutionState,
 		workflowMutation.NextEventID,
 		lastWriteVersion,


### PR DESCRIPTION
This enables the underlying store to have access to the ExecutionInfo on the Mutation object without having to do deserialization