### PR TITLE
Backoff failed workflow task

### DIFF
--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -696,11 +696,11 @@ func (s *clientIntegrationSuite) Test_UnhandledCommandAndNewTask() {
 
 func (s *clientIntegrationSuite) Test_InvalidCommandAttribute() {
 	/*
-	This test simulates workflow generate command with invalid attributes.
-	Server is expected to fail the workflow task and schedule a retry immediately for first attempt,
-	but if workflow task keeps failing, server will drop the task and wait for timeout to schedule additional retries.
-	This is the same behavior as the SDK used to do, but now we would do on server.
-	 */
+		This test simulates workflow generate command with invalid attributes.
+		Server is expected to fail the workflow task and schedule a retry immediately for first attempt,
+		but if workflow task keeps failing, server will drop the task and wait for timeout to schedule additional retries.
+		This is the same behavior as the SDK used to do, but now we would do on server.
+	*/
 
 	activityFn := func(ctx context.Context) error {
 		return nil
@@ -757,8 +757,8 @@ func (s *clientIntegrationSuite) Test_InvalidCommandAttribute() {
 	// assert workflow task retried 3 times
 	s.Equal(3, len(calledTime))
 
-	s.True(calledTime[1].Sub(calledTime[0]) < time.Second) // retry immediately
-	s.True(calledTime[2].Sub(calledTime[1]) > time.Second * 3) // retry after WorkflowTaskTimeout
+	s.True(calledTime[1].Sub(calledTime[0]) < time.Second)   // retry immediately
+	s.True(calledTime[2].Sub(calledTime[1]) > time.Second*3) // retry after WorkflowTaskTimeout
 }
 
 func (s *clientIntegrationSuite) Test_BufferedQuery() {

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -490,6 +490,10 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			tag.WorkflowID(token.GetWorkflowId()),
 			tag.WorkflowRunID(token.GetRunId()),
 			tag.WorkflowNamespaceID(namespaceID.String()))
+		if currentWorkflowTask.Attempt > 1 {
+			// drop this workflow task if it keeps failing. This will cause the workflow task to timeout and get retried after timeout.
+			return nil, serviceerror.NewInvalidArgument(wtFailedCause.Message())
+		}
 		msBuilder, err = handler.historyEngine.failWorkflowTask(weContext, scheduleID, startedID, wtFailedCause, request)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This fixed a regression introduced in 1.15 by PR #2335

<!-- Tell your future self why have you made these changes -->
**Why?**
PR #2335 fixed an unnecessary delay after a failed workflow task, but it introduce a serious regression that when workflow task keeps failing, it would fall into a tight loop of retrying. 
The fix to the regression is simple, to drop workflow task if it is continuously failing  and let it timeout.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added integration test to cover invalid command attributes case. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.