### PR TITLE
#2551 Fixing syntax in first migration to the Cassandra schema

### DIFF
--- a/schema/cassandra/temporal/schema.cql
+++ b/schema/cassandra/temporal/schema.cql
@@ -1,7 +1,7 @@
 CREATE TYPE serialized_event_batch (
   encoding_type text,
   version       int,
-  data          blob,
+  data          blob
 );
 
 CREATE TABLE executions (

--- a/schema/cassandra/temporal/versioned/v1.0/schema.cql
+++ b/schema/cassandra/temporal/versioned/v1.0/schema.cql
@@ -1,7 +1,7 @@
 CREATE TYPE serialized_event_batch (
   encoding_type text,
   version       int,
-  data          blob,
+  data          blob
 );
 
 CREATE TABLE executions (


### PR DESCRIPTION
See #2551

Just bad syntax, nothing to add. Maybe a question: how is that possible that there are newer migrations if this one does not get through.