### PR TITLE
Refactor persistence task serializer

### DIFF
--- a/common/persistence/serialization/serializer.go
+++ b/common/persistence/serialization/serializer.go
@@ -102,8 +102,8 @@ type (
 		ReplicationTaskToBlob(replicationTask *replicationspb.ReplicationTask, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
 		ReplicationTaskFromBlob(data *commonpb.DataBlob) (*replicationspb.ReplicationTask, error)
 
-		SerializeTasks(taskSlice []tasks.Task) (map[tasks.Key]commonpb.DataBlob, error)
-		DeserializeTasks(category tasks.Category, blobSlice []commonpb.DataBlob) ([]tasks.Task, error)
+		SerializeTask(task tasks.Task) (commonpb.DataBlob, error)
+		DeserializeTask(category tasks.Category, blob commonpb.DataBlob) (tasks.Task, error)
 	}
 
 	// SerializationError is an error type for serialization

--- a/common/persistence/serialization/task_serializer.go
+++ b/common/persistence/serialization/task_serializer.go
@@ -48,283 +48,255 @@ func NewTaskSerializer() *TaskSerializer {
 	return &TaskSerializer{}
 }
 
-func (s *TaskSerializer) SerializeTasks(
-	taskSlice []tasks.Task,
-) (map[tasks.Key]commonpb.DataBlob, error) {
-	blobSlice := make(map[tasks.Key]commonpb.DataBlob, len(taskSlice))
-	var key tasks.Key
-	var blob commonpb.DataBlob
-	var err error
-	for _, task := range taskSlice {
-		category := task.GetCategory()
-		switch category.ID() {
-		case tasks.CategoryIDTransfer:
-			key, blob, err = s.SerializeTransferTask(task)
-		case tasks.CategoryIDTimer:
-			key, blob, err = s.SerializeTimerTask(task)
-		case tasks.CategoryIDVisibility:
-			key, blob, err = s.SerializeVisibilityTask(task)
-		case tasks.CategoryIDReplication:
-			key, blob, err = s.SerializeReplicationTask(task)
-		default:
-			err = serviceerror.NewInternal(fmt.Sprintf("Unknown task category: %v", category))
-		}
-
-		if err != nil {
-			return nil, err
-		}
-		blobSlice[key] = blob
-	}
-	return blobSlice, nil
-}
-
-func (s *TaskSerializer) DeserializeTasks(
-	category tasks.Category,
-	blobs []commonpb.DataBlob,
-) ([]tasks.Task, error) {
+func (s *TaskSerializer) SerializeTask(
+	task tasks.Task,
+) (commonpb.DataBlob, error) {
+	category := task.GetCategory()
 	switch category.ID() {
 	case tasks.CategoryIDTransfer:
-		return s.DeserializeTransferTasks(blobs)
+		return s.serializeTransferTask(task)
 	case tasks.CategoryIDTimer:
-		return s.DeserializeTimerTasks(blobs)
+		return s.serializeTimerTask(task)
 	case tasks.CategoryIDVisibility:
-		return s.DeserializeVisibilityTasks(blobs)
+		return s.serializeVisibilityTask(task)
 	case tasks.CategoryIDReplication:
-		return s.DeserializeReplicationTasks(blobs)
+		return s.serializeReplicationTask(task)
+	default:
+		return commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown task category: %v", category))
+	}
+}
+
+func (s *TaskSerializer) DeserializeTask(
+	category tasks.Category,
+	blob commonpb.DataBlob,
+) (tasks.Task, error) {
+	switch category.ID() {
+	case tasks.CategoryIDTransfer:
+		return s.deserializeTransferTasks(blob)
+	case tasks.CategoryIDTimer:
+		return s.deserializeTimerTasks(blob)
+	case tasks.CategoryIDVisibility:
+		return s.deserializeVisibilityTasks(blob)
+	case tasks.CategoryIDReplication:
+		return s.deserializeReplicationTasks(blob)
 	default:
 		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown task category: %v", category))
 	}
 }
 
-func (s *TaskSerializer) SerializeTransferTask(
+func (s *TaskSerializer) serializeTransferTask(
 	task tasks.Task,
-) (tasks.Key, commonpb.DataBlob, error) {
+) (commonpb.DataBlob, error) {
 	var transferTask *persistencespb.TransferTaskInfo
 	switch task := task.(type) {
 	case *tasks.WorkflowTask:
-		transferTask = s.TransferWorkflowTaskToProto(task)
+		transferTask = s.transferWorkflowTaskToProto(task)
 	case *tasks.ActivityTask:
-		transferTask = s.TransferActivityTaskToProto(task)
+		transferTask = s.transferActivityTaskToProto(task)
 	case *tasks.CancelExecutionTask:
-		transferTask = s.TransferRequestCancelTaskToProto(task)
+		transferTask = s.transferRequestCancelTaskToProto(task)
 	case *tasks.SignalExecutionTask:
-		transferTask = s.TransferSignalTaskToProto(task)
+		transferTask = s.transferSignalTaskToProto(task)
 	case *tasks.StartChildExecutionTask:
-		transferTask = s.TransferChildWorkflowTaskToProto(task)
+		transferTask = s.transferChildWorkflowTaskToProto(task)
 	case *tasks.CloseExecutionTask:
-		transferTask = s.TransferCloseTaskToProto(task)
+		transferTask = s.transferCloseTaskToProto(task)
 	case *tasks.ResetWorkflowTask:
-		transferTask = s.TransferResetTaskToProto(task)
+		transferTask = s.transferResetTaskToProto(task)
 	case *tasks.DeleteExecutionTask:
-		transferTask = s.TransferDeleteExecutionTaskToProto(task)
+		transferTask = s.transferDeleteExecutionTaskToProto(task)
 	default:
-		return tasks.Key{}, commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown transfer task type: %v", task))
+		return commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown transfer task type: %v", task))
 	}
 
 	blob, err := TransferTaskInfoToBlob(transferTask)
 	if err != nil {
-		return tasks.Key{}, commonpb.DataBlob{}, err
+		return commonpb.DataBlob{}, err
 	}
-	return task.GetKey(), blob, nil
+	return blob, nil
 }
 
-func (s *TaskSerializer) DeserializeTransferTasks(
-	blobSlice []commonpb.DataBlob,
-) ([]tasks.Task, error) {
-	taskSlice := make([]tasks.Task, len(blobSlice))
-	for index, blob := range blobSlice {
-		transferTask, err := TransferTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
-		if err != nil {
-			return nil, err
-		}
-		var task tasks.Task
-		switch transferTask.TaskType {
-		case enumsspb.TASK_TYPE_TRANSFER_WORKFLOW_TASK:
-			task = s.transferWorkflowTaskFromProto(transferTask)
-		case enumsspb.TASK_TYPE_TRANSFER_ACTIVITY_TASK:
-			task = s.transferActivityTaskFromProto(transferTask)
-		case enumsspb.TASK_TYPE_TRANSFER_CANCEL_EXECUTION:
-			task = s.transferRequestCancelTaskFromProto(transferTask)
-		case enumsspb.TASK_TYPE_TRANSFER_SIGNAL_EXECUTION:
-			task = s.transferSignalTaskFromProto(transferTask)
-		case enumsspb.TASK_TYPE_TRANSFER_START_CHILD_EXECUTION:
-			task = s.transferChildWorkflowTaskFromProto(transferTask)
-		case enumsspb.TASK_TYPE_TRANSFER_CLOSE_EXECUTION:
-			task = s.transferCloseTaskFromProto(transferTask)
-		case enumsspb.TASK_TYPE_TRANSFER_RESET_WORKFLOW:
-			task = s.transferResetTaskFromProto(transferTask)
-		case enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION:
-			task = s.transferDeleteExecutionTaskFromProto(transferTask)
-		default:
-			return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown transfer task type: %v", transferTask.TaskType))
-		}
-
-		taskSlice[index] = task
+func (s *TaskSerializer) deserializeTransferTasks(
+	blob commonpb.DataBlob,
+) (tasks.Task, error) {
+	transferTask, err := TransferTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	if err != nil {
+		return nil, err
 	}
-	return taskSlice, nil
+
+	var task tasks.Task
+	switch transferTask.TaskType {
+	case enumsspb.TASK_TYPE_TRANSFER_WORKFLOW_TASK:
+		task = s.transferWorkflowTaskFromProto(transferTask)
+	case enumsspb.TASK_TYPE_TRANSFER_ACTIVITY_TASK:
+		task = s.transferActivityTaskFromProto(transferTask)
+	case enumsspb.TASK_TYPE_TRANSFER_CANCEL_EXECUTION:
+		task = s.transferRequestCancelTaskFromProto(transferTask)
+	case enumsspb.TASK_TYPE_TRANSFER_SIGNAL_EXECUTION:
+		task = s.transferSignalTaskFromProto(transferTask)
+	case enumsspb.TASK_TYPE_TRANSFER_START_CHILD_EXECUTION:
+		task = s.transferChildWorkflowTaskFromProto(transferTask)
+	case enumsspb.TASK_TYPE_TRANSFER_CLOSE_EXECUTION:
+		task = s.transferCloseTaskFromProto(transferTask)
+	case enumsspb.TASK_TYPE_TRANSFER_RESET_WORKFLOW:
+		task = s.transferResetTaskFromProto(transferTask)
+	case enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION:
+		task = s.transferDeleteExecutionTaskFromProto(transferTask)
+	default:
+		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown transfer task type: %v", transferTask.TaskType))
+	}
+	return task, nil
 }
 
-func (s *TaskSerializer) SerializeTimerTask(
+func (s *TaskSerializer) serializeTimerTask(
 	task tasks.Task,
-) (tasks.Key, commonpb.DataBlob, error) {
+) (commonpb.DataBlob, error) {
 	var timerTask *persistencespb.TimerTaskInfo
 	switch task := task.(type) {
 	case *tasks.WorkflowTaskTimeoutTask:
-		timerTask = s.TimerWorkflowTaskToProto(task)
+		timerTask = s.timerWorkflowTaskToProto(task)
 	case *tasks.WorkflowBackoffTimerTask:
-		timerTask = s.TimerWorkflowDelayTaskToProto(task)
+		timerTask = s.timerWorkflowDelayTaskToProto(task)
 	case *tasks.ActivityTimeoutTask:
-		timerTask = s.TimerActivityTaskToProto(task)
+		timerTask = s.timerActivityTaskToProto(task)
 	case *tasks.ActivityRetryTimerTask:
-		timerTask = s.TimerActivityRetryTaskToProto(task)
+		timerTask = s.timerActivityRetryTaskToProto(task)
 	case *tasks.UserTimerTask:
-		timerTask = s.TimerUserTaskToProto(task)
+		timerTask = s.timerUserTaskToProto(task)
 	case *tasks.WorkflowTimeoutTask:
-		timerTask = s.TimerWorkflowRunToProto(task)
+		timerTask = s.timerWorkflowRunToProto(task)
 	case *tasks.DeleteHistoryEventTask:
-		timerTask = s.TimerWorkflowCleanupTaskToProto(task)
+		timerTask = s.timerWorkflowCleanupTaskToProto(task)
 	default:
-		return tasks.Key{}, commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown timer task type: %v", task))
+		return commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown timer task type: %v", task))
 	}
 
 	blob, err := TimerTaskInfoToBlob(timerTask)
 	if err != nil {
-		return tasks.Key{}, commonpb.DataBlob{}, err
+		return commonpb.DataBlob{}, err
 	}
-	return task.GetKey(), blob, nil
+	return blob, nil
 }
 
-func (s *TaskSerializer) DeserializeTimerTasks(
-	blobSlice []commonpb.DataBlob,
-) ([]tasks.Task, error) {
-	taskSlice := make([]tasks.Task, len(blobSlice))
-	for index, blob := range blobSlice {
-		timerTask, err := TimerTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
-		if err != nil {
-			return nil, err
-		}
-		var timer tasks.Task
-		switch timerTask.TaskType {
-		case enumsspb.TASK_TYPE_WORKFLOW_TASK_TIMEOUT:
-			timer = s.timerWorkflowTaskFromProto(timerTask)
-		case enumsspb.TASK_TYPE_WORKFLOW_BACKOFF_TIMER:
-			timer = s.timerWorkflowDelayTaskFromProto(timerTask)
-		case enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT:
-			timer = s.timerActivityTaskFromProto(timerTask)
-		case enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER:
-			timer = s.timerActivityRetryTaskFromProto(timerTask)
-		case enumsspb.TASK_TYPE_USER_TIMER:
-			timer = s.timerUserTaskFromProto(timerTask)
-		case enumsspb.TASK_TYPE_WORKFLOW_RUN_TIMEOUT:
-			timer = s.timerWorkflowRunFromProto(timerTask)
-		case enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT:
-			timer = s.timerWorkflowCleanupTaskFromProto(timerTask)
-		default:
-			return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown timer task type: %v", timerTask.TaskType))
-		}
-
-		taskSlice[index] = timer
+func (s *TaskSerializer) deserializeTimerTasks(
+	blob commonpb.DataBlob,
+) (tasks.Task, error) {
+	timerTask, err := TimerTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	if err != nil {
+		return nil, err
 	}
-	return taskSlice, nil
+
+	var timer tasks.Task
+	switch timerTask.TaskType {
+	case enumsspb.TASK_TYPE_WORKFLOW_TASK_TIMEOUT:
+		timer = s.timerWorkflowTaskFromProto(timerTask)
+	case enumsspb.TASK_TYPE_WORKFLOW_BACKOFF_TIMER:
+		timer = s.timerWorkflowDelayTaskFromProto(timerTask)
+	case enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT:
+		timer = s.timerActivityTaskFromProto(timerTask)
+	case enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER:
+		timer = s.timerActivityRetryTaskFromProto(timerTask)
+	case enumsspb.TASK_TYPE_USER_TIMER:
+		timer = s.timerUserTaskFromProto(timerTask)
+	case enumsspb.TASK_TYPE_WORKFLOW_RUN_TIMEOUT:
+		timer = s.timerWorkflowRunFromProto(timerTask)
+	case enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT:
+		timer = s.timerWorkflowCleanupTaskFromProto(timerTask)
+	default:
+		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown timer task type: %v", timerTask.TaskType))
+	}
+	return timer, nil
 }
 
-func (s *TaskSerializer) SerializeVisibilityTask(
+func (s *TaskSerializer) serializeVisibilityTask(
 	task tasks.Task,
-) (tasks.Key, commonpb.DataBlob, error) {
+) (commonpb.DataBlob, error) {
 	var visibilityTask *persistencespb.VisibilityTaskInfo
 	switch task := task.(type) {
 	case *tasks.StartExecutionVisibilityTask:
-		visibilityTask = s.VisibilityStartTaskToProto(task)
+		visibilityTask = s.visibilityStartTaskToProto(task)
 	case *tasks.UpsertExecutionVisibilityTask:
-		visibilityTask = s.VisibilityUpsertTaskToProto(task)
+		visibilityTask = s.visibilityUpsertTaskToProto(task)
 	case *tasks.CloseExecutionVisibilityTask:
-		visibilityTask = s.VisibilityCloseTaskToProto(task)
+		visibilityTask = s.visibilityCloseTaskToProto(task)
 	case *tasks.DeleteExecutionVisibilityTask:
-		visibilityTask = s.VisibilityDeleteTaskToProto(task)
+		visibilityTask = s.visibilityDeleteTaskToProto(task)
 	default:
-		return tasks.Key{}, commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown visibility task type: %v", task))
+		return commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown visibility task type: %v", task))
 	}
 
 	blob, err := VisibilityTaskInfoToBlob(visibilityTask)
 	if err != nil {
-		return tasks.Key{}, commonpb.DataBlob{}, err
+		return commonpb.DataBlob{}, err
 	}
-	return task.GetKey(), blob, nil
+	return blob, nil
 }
 
-func (s *TaskSerializer) DeserializeVisibilityTasks(
-	blobSlice []commonpb.DataBlob,
-) ([]tasks.Task, error) {
-	taskSlice := make([]tasks.Task, len(blobSlice))
-	for index, blob := range blobSlice {
-		visibilityTask, err := VisibilityTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
-		if err != nil {
-			return nil, err
-		}
-		var visibility tasks.Task
-		switch visibilityTask.TaskType {
-		case enumsspb.TASK_TYPE_VISIBILITY_START_EXECUTION:
-			visibility = s.visibilityStartTaskFromProto(visibilityTask)
-		case enumsspb.TASK_TYPE_VISIBILITY_UPSERT_EXECUTION:
-			visibility = s.visibilityUpsertTaskFromProto(visibilityTask)
-		case enumsspb.TASK_TYPE_VISIBILITY_CLOSE_EXECUTION:
-			visibility = s.visibilityCloseTaskFromProto(visibilityTask)
-		case enumsspb.TASK_TYPE_VISIBILITY_DELETE_EXECUTION:
-			visibility = s.visibilityDeleteTaskFromProto(visibilityTask)
-		default:
-			return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown visibility task type: %v", visibilityTask.TaskType))
-		}
-
-		taskSlice[index] = visibility
+func (s *TaskSerializer) deserializeVisibilityTasks(
+	blob commonpb.DataBlob,
+) (tasks.Task, error) {
+	visibilityTask, err := VisibilityTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	if err != nil {
+		return nil, err
 	}
-	return taskSlice, nil
+
+	var visibility tasks.Task
+	switch visibilityTask.TaskType {
+	case enumsspb.TASK_TYPE_VISIBILITY_START_EXECUTION:
+		visibility = s.visibilityStartTaskFromProto(visibilityTask)
+	case enumsspb.TASK_TYPE_VISIBILITY_UPSERT_EXECUTION:
+		visibility = s.visibilityUpsertTaskFromProto(visibilityTask)
+	case enumsspb.TASK_TYPE_VISIBILITY_CLOSE_EXECUTION:
+		visibility = s.visibilityCloseTaskFromProto(visibilityTask)
+	case enumsspb.TASK_TYPE_VISIBILITY_DELETE_EXECUTION:
+		visibility = s.visibilityDeleteTaskFromProto(visibilityTask)
+	default:
+		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown visibility task type: %v", visibilityTask.TaskType))
+	}
+	return visibility, nil
 }
 
-func (s *TaskSerializer) SerializeReplicationTask(
+func (s *TaskSerializer) serializeReplicationTask(
 	task tasks.Task,
-) (tasks.Key, commonpb.DataBlob, error) {
+) (commonpb.DataBlob, error) {
 	var replicationTask *persistencespb.ReplicationTaskInfo
 	switch task := task.(type) {
 	case *tasks.SyncActivityTask:
-		replicationTask = s.ReplicationActivityTaskToProto(task)
+		replicationTask = s.replicationActivityTaskToProto(task)
 	case *tasks.HistoryReplicationTask:
-		replicationTask = s.ReplicationHistoryTaskToProto(task)
+		replicationTask = s.replicationHistoryTaskToProto(task)
 	default:
-		return tasks.Key{}, commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown repication task type: %v", task))
+		return commonpb.DataBlob{}, serviceerror.NewInternal(fmt.Sprintf("Unknown repication task type: %v", task))
 	}
 
 	blob, err := ReplicationTaskInfoToBlob(replicationTask)
 	if err != nil {
-		return tasks.Key{}, commonpb.DataBlob{}, err
+		return commonpb.DataBlob{}, err
 	}
-	return task.GetKey(), blob, nil
+	return blob, nil
 }
 
-func (s *TaskSerializer) DeserializeReplicationTasks(
-	blobSlice []commonpb.DataBlob,
-) ([]tasks.Task, error) {
-	taskSlice := make([]tasks.Task, len(blobSlice))
-	for index, blob := range blobSlice {
-		replicationTask, err := ReplicationTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
-		if err != nil {
-			return nil, err
-		}
-		var replication tasks.Task
-		switch replicationTask.TaskType {
-		case enumsspb.TASK_TYPE_REPLICATION_SYNC_ACTIVITY:
-			replication = s.replicationActivityTaskFromProto(replicationTask)
-		case enumsspb.TASK_TYPE_REPLICATION_HISTORY:
-			replication = s.replicationHistoryTaskFromProto(replicationTask)
-		default:
-			return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown replication task type: %v", replicationTask.TaskType))
-		}
-
-		taskSlice[index] = replication
+func (s *TaskSerializer) deserializeReplicationTasks(
+	blob commonpb.DataBlob,
+) (tasks.Task, error) {
+	replicationTask, err := ReplicationTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	if err != nil {
+		return nil, err
 	}
-	return taskSlice, nil
+	var replication tasks.Task
+	switch replicationTask.TaskType {
+	case enumsspb.TASK_TYPE_REPLICATION_SYNC_ACTIVITY:
+		replication = s.replicationActivityTaskFromProto(replicationTask)
+	case enumsspb.TASK_TYPE_REPLICATION_HISTORY:
+		replication = s.replicationHistoryTaskFromProto(replicationTask)
+	default:
+		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown replication task type: %v", replicationTask.TaskType))
+	}
+
+	return replication, nil
 }
 
-func (s *TaskSerializer) TransferActivityTaskToProto(
+func (s *TaskSerializer) transferActivityTaskToProto(
 	activityTask *tasks.ActivityTask,
 ) *persistencespb.TransferTaskInfo {
 	return &persistencespb.TransferTaskInfo{
@@ -362,7 +334,7 @@ func (s *TaskSerializer) transferActivityTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TransferWorkflowTaskToProto(
+func (s *TaskSerializer) transferWorkflowTaskToProto(
 	workflowTask *tasks.WorkflowTask,
 ) *persistencespb.TransferTaskInfo {
 	return &persistencespb.TransferTaskInfo{
@@ -399,7 +371,7 @@ func (s *TaskSerializer) transferWorkflowTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TransferRequestCancelTaskToProto(
+func (s *TaskSerializer) transferRequestCancelTaskToProto(
 	requestCancelTask *tasks.CancelExecutionTask,
 ) *persistencespb.TransferTaskInfo {
 	return &persistencespb.TransferTaskInfo{
@@ -439,7 +411,7 @@ func (s *TaskSerializer) transferRequestCancelTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TransferSignalTaskToProto(
+func (s *TaskSerializer) transferSignalTaskToProto(
 	signalTask *tasks.SignalExecutionTask,
 ) *persistencespb.TransferTaskInfo {
 	return &persistencespb.TransferTaskInfo{
@@ -479,7 +451,7 @@ func (s *TaskSerializer) transferSignalTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TransferChildWorkflowTaskToProto(
+func (s *TaskSerializer) transferChildWorkflowTaskToProto(
 	childWorkflowTask *tasks.StartChildExecutionTask,
 ) *persistencespb.TransferTaskInfo {
 	return &persistencespb.TransferTaskInfo{
@@ -517,7 +489,7 @@ func (s *TaskSerializer) transferChildWorkflowTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TransferCloseTaskToProto(
+func (s *TaskSerializer) transferCloseTaskToProto(
 	closeTask *tasks.CloseExecutionTask,
 ) *persistencespb.TransferTaskInfo {
 	return &persistencespb.TransferTaskInfo{
@@ -552,7 +524,7 @@ func (s *TaskSerializer) transferCloseTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TransferResetTaskToProto(
+func (s *TaskSerializer) transferResetTaskToProto(
 	resetTask *tasks.ResetWorkflowTask,
 ) *persistencespb.TransferTaskInfo {
 	return &persistencespb.TransferTaskInfo{
@@ -587,7 +559,7 @@ func (s *TaskSerializer) transferResetTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TransferDeleteExecutionTaskToProto(
+func (s *TaskSerializer) transferDeleteExecutionTaskToProto(
 	deleteExecutionTask *tasks.DeleteExecutionTask,
 ) *persistencespb.TransferTaskInfo {
 	return &persistencespb.TransferTaskInfo{
@@ -616,7 +588,7 @@ func (s *TaskSerializer) transferDeleteExecutionTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TimerWorkflowTaskToProto(
+func (s *TaskSerializer) timerWorkflowTaskToProto(
 	workflowTimer *tasks.WorkflowTaskTimeoutTask,
 ) *persistencespb.TimerTaskInfo {
 	return &persistencespb.TimerTaskInfo{
@@ -652,7 +624,7 @@ func (s *TaskSerializer) timerWorkflowTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TimerWorkflowDelayTaskToProto(
+func (s *TaskSerializer) timerWorkflowDelayTaskToProto(
 	workflowDelayTimer *tasks.WorkflowBackoffTimerTask,
 ) *persistencespb.TimerTaskInfo {
 	return &persistencespb.TimerTaskInfo{
@@ -686,7 +658,7 @@ func (s *TaskSerializer) timerWorkflowDelayTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TimerActivityTaskToProto(
+func (s *TaskSerializer) timerActivityTaskToProto(
 	activityTimer *tasks.ActivityTimeoutTask,
 ) *persistencespb.TimerTaskInfo {
 	return &persistencespb.TimerTaskInfo{
@@ -703,6 +675,7 @@ func (s *TaskSerializer) TimerActivityTaskToProto(
 		VisibilityTime:      &activityTimer.VisibilityTimestamp,
 	}
 }
+
 func (s *TaskSerializer) timerActivityTaskFromProto(
 	activityTimer *persistencespb.TimerTaskInfo,
 ) *tasks.ActivityTimeoutTask {
@@ -721,7 +694,7 @@ func (s *TaskSerializer) timerActivityTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TimerActivityRetryTaskToProto(
+func (s *TaskSerializer) timerActivityRetryTaskToProto(
 	activityRetryTimer *tasks.ActivityRetryTimerTask,
 ) *persistencespb.TimerTaskInfo {
 	return &persistencespb.TimerTaskInfo{
@@ -756,7 +729,7 @@ func (s *TaskSerializer) timerActivityRetryTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TimerUserTaskToProto(
+func (s *TaskSerializer) timerUserTaskToProto(
 	userTimer *tasks.UserTimerTask,
 ) *persistencespb.TimerTaskInfo {
 	return &persistencespb.TimerTaskInfo{
@@ -790,7 +763,7 @@ func (s *TaskSerializer) timerUserTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) TimerWorkflowRunToProto(
+func (s *TaskSerializer) timerWorkflowRunToProto(
 	workflowTimer *tasks.WorkflowTimeoutTask,
 ) *persistencespb.TimerTaskInfo {
 	return &persistencespb.TimerTaskInfo{
@@ -823,7 +796,7 @@ func (s *TaskSerializer) timerWorkflowRunFromProto(
 	}
 }
 
-func (s *TaskSerializer) TimerWorkflowCleanupTaskToProto(
+func (s *TaskSerializer) timerWorkflowCleanupTaskToProto(
 	workflowCleanupTimer *tasks.DeleteHistoryEventTask,
 ) *persistencespb.TimerTaskInfo {
 	return &persistencespb.TimerTaskInfo{
@@ -856,7 +829,7 @@ func (s *TaskSerializer) timerWorkflowCleanupTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) VisibilityStartTaskToProto(
+func (s *TaskSerializer) visibilityStartTaskToProto(
 	startVisibilityTask *tasks.StartExecutionVisibilityTask,
 ) *persistencespb.VisibilityTaskInfo {
 	return &persistencespb.VisibilityTaskInfo{
@@ -885,7 +858,7 @@ func (s *TaskSerializer) visibilityStartTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) VisibilityUpsertTaskToProto(
+func (s *TaskSerializer) visibilityUpsertTaskToProto(
 	upsertVisibilityTask *tasks.UpsertExecutionVisibilityTask,
 ) *persistencespb.VisibilityTaskInfo {
 	return &persistencespb.VisibilityTaskInfo{
@@ -914,7 +887,7 @@ func (s *TaskSerializer) visibilityUpsertTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) VisibilityCloseTaskToProto(
+func (s *TaskSerializer) visibilityCloseTaskToProto(
 	closetVisibilityTask *tasks.CloseExecutionVisibilityTask,
 ) *persistencespb.VisibilityTaskInfo {
 	return &persistencespb.VisibilityTaskInfo{
@@ -943,7 +916,7 @@ func (s *TaskSerializer) visibilityCloseTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) VisibilityDeleteTaskToProto(
+func (s *TaskSerializer) visibilityDeleteTaskToProto(
 	deleteVisibilityTask *tasks.DeleteExecutionVisibilityTask,
 ) *persistencespb.VisibilityTaskInfo {
 	return &persistencespb.VisibilityTaskInfo{
@@ -974,7 +947,7 @@ func (s *TaskSerializer) visibilityDeleteTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) ReplicationActivityTaskToProto(
+func (s *TaskSerializer) replicationActivityTaskToProto(
 	activityTask *tasks.SyncActivityTask,
 ) *persistencespb.ReplicationTaskInfo {
 	return &persistencespb.ReplicationTaskInfo{
@@ -1013,7 +986,7 @@ func (s *TaskSerializer) replicationActivityTaskFromProto(
 	}
 }
 
-func (s *TaskSerializer) ReplicationHistoryTaskToProto(
+func (s *TaskSerializer) replicationHistoryTaskToProto(
 	historyTask *tasks.HistoryReplicationTask,
 ) *persistencespb.ReplicationTaskInfo {
 	return &persistencespb.ReplicationTaskInfo{

--- a/common/persistence/serialization/task_serializer_test.go
+++ b/common/persistence/serialization/task_serializer_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/definition"
@@ -333,10 +332,9 @@ func (s *taskSerializerSuite) TestReplicateHistoryTask() {
 func (s *taskSerializerSuite) assertEqualTasks(
 	task tasks.Task,
 ) {
-	blobMap, err := s.taskSerializer.SerializeTasks([]tasks.Task{task})
+	blob, err := s.taskSerializer.SerializeTask(task)
 	s.NoError(err)
-	blobSlice := []commonpb.DataBlob{blobMap[task.GetKey()]}
-	taskSlice, err := s.taskSerializer.DeserializeTasks(task.GetCategory(), blobSlice)
+	deserializedTask, err := s.taskSerializer.DeserializeTask(task.GetCategory(), blob)
 	s.NoError(err)
-	s.Equal([]tasks.Task{task}, taskSlice)
+	s.Equal(task, deserializedTask)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Refactor persistence task serializer to serialize/deserialize one task at a time

<!-- Tell your future self why have you made these changes -->
**Why?**
- Address a TODO in code to avoid unnecessary conversion between `map[tasks.Key]common.DataBlob` and `[]p.InternalHistoryTask`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no