### PR TITLE
Refactor task filter function and interface

### DIFF
--- a/service/history/queueProcessorFactory.go
+++ b/service/history/queueProcessorFactory.go
@@ -153,6 +153,5 @@ func (f *visibilityQueueProcessorFactory) CreateProcessor(
 		shard,
 		workflowCache,
 		f.VisibilityMgr,
-		newTaskAllocator(shard),
 	)
 }

--- a/service/history/queueProcessorFactory.go
+++ b/service/history/queueProcessorFactory.go
@@ -26,6 +26,8 @@ package history
 
 import (
 	sdkclient "go.temporal.io/sdk/client"
+	"go.uber.org/fx"
+
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/resource"
@@ -33,7 +35,6 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/worker/archiver"
-	"go.uber.org/fx"
 )
 
 var QueueProcessorModule = fx.Options(
@@ -152,5 +153,6 @@ func (f *visibilityQueueProcessorFactory) CreateProcessor(
 		shard,
 		workflowCache,
 		f.VisibilityMgr,
+		newTaskAllocator(shard),
 	)
 }

--- a/service/history/taskAllocator.go
+++ b/service/history/taskAllocator.go
@@ -38,6 +38,7 @@ type (
 		verifyActiveTask(taskNamespaceID namespace.ID, task interface{}) bool
 		verifyFailoverActiveTask(targetNamespaceIDs map[string]struct{}, taskNamespaceID namespace.ID, task interface{}) bool
 		verifyStandbyTask(standbyCluster string, taskNamespaceID namespace.ID, task interface{}) bool
+		verifyTaskNamespaceExists(taskNamespaceID namespace.ID) bool
 		lock()
 		unlock()
 	}
@@ -60,6 +61,17 @@ func newTaskAllocator(shard shard.Context) taskAllocator {
 		namespaceRegistry:  shard.GetNamespaceRegistry(),
 		logger:             shard.GetLogger(),
 	}
+}
+func (t *taskAllocatorImpl) verifyTaskNamespaceExists(taskNamespaceID namespace.ID) bool {
+	t.locker.RLock()
+	defer t.locker.RUnlock()
+
+	_, err := t.namespaceRegistry.GetNamespaceByID(taskNamespaceID)
+	if err != nil {
+		return false
+	}
+
+	return true
 }
 
 // verifyActiveTask, will return true if task activeness check is successful

--- a/service/history/taskAllocator.go
+++ b/service/history/taskAllocator.go
@@ -38,7 +38,6 @@ type (
 		verifyActiveTask(taskNamespaceID namespace.ID, task interface{}) bool
 		verifyFailoverActiveTask(targetNamespaceIDs map[string]struct{}, taskNamespaceID namespace.ID, task interface{}) bool
 		verifyStandbyTask(standbyCluster string, taskNamespaceID namespace.ID, task interface{}) bool
-		verifyTaskNamespaceExists(taskNamespaceID namespace.ID, task interface{}) bool
 		lock()
 		unlock()
 	}
@@ -62,18 +61,6 @@ func newTaskAllocator(shard shard.Context) taskAllocator {
 		logger:             shard.GetLogger(),
 	}
 }
-func (t *taskAllocatorImpl) verifyTaskNamespaceExists(taskNamespaceID namespace.ID, task interface{}) bool {
-	t.locker.RLock()
-	defer t.locker.RUnlock()
-
-	_, err := t.namespaceRegistry.GetNamespaceByID(taskNamespaceID)
-	if err != nil {
-		t.logger.Debug("Unable to find namespace, skip task.", tag.WorkflowNamespaceID(taskNamespaceID.String()), tag.Value(task))
-		return false
-	}
-
-	return true
-}
 
 // verifyActiveTask, will return true if task activeness check is successful
 func (t *taskAllocatorImpl) verifyActiveTask(taskNamespaceID namespace.ID, task interface{}) bool {
@@ -82,8 +69,8 @@ func (t *taskAllocatorImpl) verifyActiveTask(taskNamespaceID namespace.ID, task 
 
 	namespaceEntry, err := t.namespaceRegistry.GetNamespaceByID(taskNamespaceID)
 	if err != nil {
-		t.logger.Debug("Unable to find namespace, skip task.", tag.WorkflowNamespaceID(taskNamespaceID.String()), tag.Value(task))
-		return false
+		t.logger.Debug("Unable to find namespace, process task.", tag.WorkflowNamespaceID(taskNamespaceID.String()), tag.Value(task))
+		return true
 	}
 	if namespaceEntry.IsGlobalNamespace() && t.currentClusterName != namespaceEntry.ActiveClusterName() {
 		// timer task does not belong to cluster name

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -352,6 +352,7 @@ func (t *taskProcessor) ackTaskOnce(
 func (t *taskProcessor) getNamespaceTagByID(namespaceID namespace.ID) metrics.Tag {
 	namespaceName, err := t.shard.GetNamespaceRegistry().GetNamespaceName(namespaceID)
 	if err != nil {
+		t.logger.Debug("Unable to get namespace", tag.Error(err))
 		return metrics.NamespaceUnknownTag()
 	}
 	return metrics.NamespaceTag(namespaceName.String())

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -208,19 +208,12 @@ func (t *taskProcessor) processTaskAndAck(
 	var scope metrics.Scope
 	var err error
 
-FilterLoop:
-	for {
-		select {
-		case <-t.shutdownCh:
-			// this must return without ack
-			return
-		default:
-			task.shouldProcessTask, err = task.processor.getTaskFilter()(task.Task)
-			if err == nil {
-				break FilterLoop
-			}
-			time.Sleep(loadNamespaceEntryForTimerTaskRetryDelay)
-		}
+	select {
+	case <-t.shutdownCh:
+		// this must return without ack
+		return
+	default:
+		task.shouldProcessTask = task.processor.getTaskFilter()(task.Task)
 	}
 
 	op := func() error {

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -352,7 +352,6 @@ func (t *taskProcessor) ackTaskOnce(
 func (t *taskProcessor) getNamespaceTagByID(namespaceID namespace.ID) metrics.Tag {
 	namespaceName, err := t.shard.GetNamespaceRegistry().GetNamespaceName(namespaceID)
 	if err != nil {
-		t.logger.Error("Unable to get namespace", tag.Error(err))
 		return metrics.NamespaceUnknownTag()
 	}
 	return metrics.NamespaceTag(namespaceName.String())

--- a/service/history/taskProcessor_test.go
+++ b/service/history/taskProcessor_test.go
@@ -139,14 +139,10 @@ func (s *taskProcessorSuite) TestProcessTaskAndAck_ShutDown() {
 
 func (s *taskProcessorSuite) TestProcessTaskAndAck_NamespaceErrRetry_ProcessNoErr() {
 	task := NewTaskInfo(s.mockProcessor, &taskForTest{Key: tasks.Key{TaskID: 12345, FireTime: time.Now().UTC()}}, s.logger)
-	var taskFilterErr taskFilter = func(task tasks.Task) (bool, error) {
-		return false, errors.New("some random error")
-	}
-	var taskFilter taskFilter = func(task tasks.Task) (bool, error) {
-		return true, nil
+	var taskFilterErr taskFilter = func(task tasks.Task) bool {
+		return false
 	}
 	s.mockProcessor.EXPECT().getTaskFilter().Return(taskFilterErr)
-	s.mockProcessor.EXPECT().getTaskFilter().Return(taskFilter)
 	s.mockProcessor.EXPECT().process(typeOfCtx, task).Return(s.scopeIdx, nil)
 	s.mockProcessor.EXPECT().complete(task)
 	s.mockShard.Resource.NamespaceCache.EXPECT().GetNamespaceName(gomock.Any()).Return(tests.Namespace, nil)
@@ -159,8 +155,8 @@ func (s *taskProcessorSuite) TestProcessTaskAndAck_NamespaceErrRetry_ProcessNoEr
 func (s *taskProcessorSuite) TestProcessTaskAndAck_NamespaceFalse_ProcessNoErr() {
 	task := NewTaskInfo(s.mockProcessor, &taskForTest{Key: tasks.Key{TaskID: 12345, FireTime: time.Now().UTC()}}, s.logger)
 	task.shouldProcessTask = false
-	var taskFilter taskFilter = func(task tasks.Task) (bool, error) {
-		return false, nil
+	var taskFilter taskFilter = func(task tasks.Task) bool {
+		return false
 	}
 	s.mockProcessor.EXPECT().getTaskFilter().Return(taskFilter)
 	s.mockProcessor.EXPECT().process(typeOfCtx, task).Return(s.scopeIdx, nil)
@@ -174,8 +170,8 @@ func (s *taskProcessorSuite) TestProcessTaskAndAck_NamespaceFalse_ProcessNoErr()
 
 func (s *taskProcessorSuite) TestProcessTaskAndAck_NamespaceTrue_ProcessNoErr() {
 	task := NewTaskInfo(s.mockProcessor, &taskForTest{Key: tasks.Key{TaskID: 12345, FireTime: time.Now().UTC()}}, s.logger)
-	var taskFilter taskFilter = func(task tasks.Task) (bool, error) {
-		return true, nil
+	var taskFilter taskFilter = func(task tasks.Task) bool {
+		return true
 	}
 
 	s.mockProcessor.EXPECT().getTaskFilter().Return(taskFilter)
@@ -191,8 +187,8 @@ func (s *taskProcessorSuite) TestProcessTaskAndAck_NamespaceTrue_ProcessNoErr() 
 func (s *taskProcessorSuite) TestProcessTaskAndAck_NamespaceTrue_ProcessErrNoErr() {
 	err := errors.New("some random err")
 	task := NewTaskInfo(s.mockProcessor, &taskForTest{Key: tasks.Key{TaskID: 12345, FireTime: time.Now().UTC()}}, s.logger)
-	var taskFilter taskFilter = func(task tasks.Task) (bool, error) {
-		return true, nil
+	var taskFilter taskFilter = func(task tasks.Task) bool {
+		return true
 	}
 	s.mockProcessor.EXPECT().getTaskFilter().Return(taskFilter)
 	s.mockProcessor.EXPECT().process(typeOfCtx, task).Return(s.scopeIdx, err)
@@ -263,8 +259,8 @@ func (s *taskProcessorSuite) TestHandleTaskError_RandomErr() {
 func (s *taskProcessorSuite) TestProcessTaskAndAck_SetsUserLatencyCorrectly() {
 	task := NewTaskInfo(s.mockProcessor, &taskForTest{Key: tasks.Key{TaskID: 12345, FireTime: time.Now().UTC()}}, s.logger)
 	task.shouldProcessTask = false
-	var taskFilter taskFilter = func(task tasks.Task) (bool, error) {
-		return false, nil
+	var taskFilter taskFilter = func(task tasks.Task) bool {
+		return false
 	}
 	expectedUserLatency := int64(133)
 	updateContext := func(ctx context.Context, taskInfo interface{}) {

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -77,7 +77,7 @@ func newTimerQueueActiveProcessor(
 	}
 	logger = log.With(logger, tag.ClusterName(currentClusterName))
 	metricsClient := shard.GetMetricsClient()
-	timerTaskFilter := func(task tasks.Task) (bool, error) {
+	timerTaskFilter := func(task tasks.Task) bool {
 		return taskAllocator.verifyActiveTask(namespace.ID(task.GetNamespaceID()), task)
 	}
 
@@ -170,7 +170,7 @@ func newTimerQueueFailoverProcessor(
 		tag.WorkflowNamespaceIDs(namespaceIDs),
 		tag.FailoverMsg("from: "+standbyClusterName),
 	)
-	timerTaskFilter := func(task tasks.Task) (bool, error) {
+	timerTaskFilter := func(task tasks.Task) bool {
 		return taskAllocator.verifyFailoverActiveTask(namespaceIDs, namespace.ID(task.GetNamespaceID()), task)
 	}
 

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -50,8 +50,7 @@ import (
 var (
 	emptyTime = time.Time{}
 
-	loadNamespaceEntryForTimerTaskRetryDelay = 100 * time.Millisecond
-	loadTimerTaskThrottleRetryDelay          = 5 * time.Second
+	loadTimerTaskThrottleRetryDelay = 5 * time.Second
 )
 
 type (

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -77,7 +77,7 @@ func newTimerQueueStandbyProcessor(
 	}
 	logger = log.With(logger, tag.ClusterName(clusterName))
 	metricsClient := shard.GetMetricsClient()
-	timerTaskFilter := func(task tasks.Task) (bool, error) {
+	timerTaskFilter := func(task tasks.Task) bool {
 		return taskAllocator.verifyStandbyTask(clusterName, namespace.ID(task.GetNamespaceID()), task)
 	}
 

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/pborman/uuid"
 
 	sdkclient "go.temporal.io/sdk/client"
+
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common/log"
@@ -87,7 +88,7 @@ func newTransferQueueActiveProcessor(
 	}
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 	logger = log.With(logger, tag.ClusterName(currentClusterName))
-	transferTaskFilter := func(task tasks.Task) (bool, error) {
+	transferTaskFilter := func(task tasks.Task) bool {
 		return taskAllocator.verifyActiveTask(namespace.ID(task.GetNamespaceID()), task)
 	}
 	maxReadAckLevel := func() int64 {
@@ -194,7 +195,7 @@ func newTransferQueueFailoverProcessor(
 		tag.FailoverMsg("from: "+standbyClusterName),
 	)
 
-	transferTaskFilter := func(task tasks.Task) (bool, error) {
+	transferTaskFilter := func(task tasks.Task) bool {
 		return taskAllocator.verifyFailoverActiveTask(namespaceIDs, namespace.ID(task.GetNamespaceID()), task)
 	}
 	maxReadAckLevel := func() int64 {

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -28,7 +28,6 @@ import (
 	"context"
 
 	"github.com/pborman/uuid"
-
 	sdkclient "go.temporal.io/sdk/client"
 
 	"go.temporal.io/server/api/historyservice/v1"

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -59,7 +59,7 @@ var (
 )
 
 type (
-	taskFilter func(task tasks.Task) (bool, error)
+	taskFilter func(task tasks.Task) bool
 
 	transferQueueProcessorImpl struct {
 		isGlobalNamespaceEnabled  bool

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -85,7 +85,7 @@ func newTransferQueueStandbyProcessor(
 	}
 	logger = log.With(logger, tag.ClusterName(clusterName))
 
-	transferTaskFilter := func(task tasks.Task) (bool, error) {
+	transferTaskFilter := func(task tasks.Task) bool {
 		return taskAllocator.verifyStandbyTask(clusterName, namespace.ID(task.GetNamespaceID()), task)
 	}
 	maxReadAckLevel := func() int64 {

--- a/service/history/visibilityQueueProcessor.go
+++ b/service/history/visibilityQueueProcessor.go
@@ -33,7 +33,6 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/service/history/configs"
@@ -76,7 +75,6 @@ func newVisibilityQueueProcessor(
 	shard shard.Context,
 	workflowCache workflow.Cache,
 	visibilityMgr manager.VisibilityManager,
-	taskAllocator taskAllocator,
 ) queues.Processor {
 
 	config := shard.GetConfig()
@@ -98,8 +96,8 @@ func newVisibilityQueueProcessor(
 		EnablePriorityTaskProcessor:         config.VisibilityProcessorEnablePriorityTaskProcessor,
 		MetricScope:                         metrics.VisibilityQueueProcessorScope,
 	}
-	visibilityTaskFilter := func(task tasks.Task) bool {
-		return taskAllocator.verifyTaskNamespaceExists(namespace.ID(task.GetNamespaceID()), task)
+	visibilityTaskFilter := func(taskInfo tasks.Task) bool {
+		return true
 	}
 	maxReadAckLevel := func() int64 {
 		return shard.GetQueueMaxReadLevel(

--- a/service/history/visibilityQueueProcessor.go
+++ b/service/history/visibilityQueueProcessor.go
@@ -99,7 +99,7 @@ func newVisibilityQueueProcessor(
 		MetricScope:                         metrics.VisibilityQueueProcessorScope,
 	}
 	visibilityTaskFilter := func(task tasks.Task) bool {
-		return taskAllocator.verifyActiveTask(namespace.ID(task.GetNamespaceID()), task)
+		return taskAllocator.verifyTaskNamespaceExists(namespace.ID(task.GetNamespaceID()))
 	}
 	maxReadAckLevel := func() int64 {
 		return shard.GetQueueMaxReadLevel(

--- a/service/history/visibilityQueueProcessor.go
+++ b/service/history/visibilityQueueProcessor.go
@@ -99,7 +99,7 @@ func newVisibilityQueueProcessor(
 		MetricScope:                         metrics.VisibilityQueueProcessorScope,
 	}
 	visibilityTaskFilter := func(task tasks.Task) bool {
-		return taskAllocator.verifyTaskNamespaceExists(namespace.ID(task.GetNamespaceID()))
+		return taskAllocator.verifyTaskNamespaceExists(namespace.ID(task.GetNamespaceID()), task)
 	}
 	maxReadAckLevel := func() int64 {
 		return shard.GetQueueMaxReadLevel(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor task filter function and interface.

<!-- Tell your future self why have you made these changes -->
**Why?**
I believe it is some leftover after namespace registry refactoring because the only error which can be returned from `GetNamespaceByID` is `serviceerror.NotFound` in fact.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.