### PR TITLE
[docs] improve documentation for building images

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ make docker-auto-setup
 
 This will build a local `temporalio/auto-setup` docker image with the label "test".
 
-To *run* the docker image with dependencies (e.g. PostgreSQL and Elasticsearch), you can use `docker-compose`. See our [docker-compose repo](https://github.com/temporalio/docker-compose) for reference configurations - and update the image accordingly to `image: temporalio/auto-setup:1.15.0`.
+To *run* the docker image with dependencies (e.g. PostgreSQL and Elasticsearch), you can use `docker-compose`. See our [docker-compose repo](https://github.com/temporalio/docker-compose) for reference configurations - and update the image accordingly to `image: temporalio/auto-setup:test`.
 
 ## Build docker image for any commit
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,11 +4,18 @@ Temporal builds 4 Docker images with [every release](https://github.com/temporal
 
 ## Prerequisites
 
-To build docker image:
-  * [docker](https://docs.docker.com/engine/installation/)
+To build docker image, you will need [Docker](https://docs.docker.com/engine/installation/).
 
-To run docker image with dependencies:
-  * [docker-compose](https://docs.docker.com/compose/install/)
+To *run* the docker image with dependencies (e.g. PostgreSQL and Elasticsearch), you can use `docker-compose`. See our [docker-compose repo](https://github.com/temporalio/docker-compose) for reference configurations.
+
+## Build docker image for master
+
+You can build the image by running `make`:
+
+```bash
+# at project root
+make docker-auto-setup
+```
 
 ## Build docker image for any commit
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -15,7 +15,7 @@ You can build the image by running `make`:
 make docker-auto-setup
 ```
 
-This will build a local `temporalio/auto-setup` docker image with the label "test".
+This will build a local `temporalio/auto-setup` docker image with the tag "test".
 
 To *run* the docker image with dependencies (e.g. PostgreSQL and Elasticsearch), you can use `docker-compose`. See our [docker-compose repo](https://github.com/temporalio/docker-compose) for reference configurations - and update the image accordingly to `image: temporalio/auto-setup:test`.
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -4,11 +4,9 @@ Temporal builds 4 Docker images with [every release](https://github.com/temporal
 
 ## Prerequisites
 
-To build docker image, you will need [Docker](https://docs.docker.com/engine/installation/).
+To build our docker image, you will need [Docker](https://docs.docker.com/engine/installation/).
 
-To *run* the docker image with dependencies (e.g. PostgreSQL and Elasticsearch), you can use `docker-compose`. See our [docker-compose repo](https://github.com/temporalio/docker-compose) for reference configurations.
-
-## Build docker image for master
+## Build docker image from master
 
 You can build the image by running `make`:
 
@@ -16,6 +14,10 @@ You can build the image by running `make`:
 # at project root
 make docker-auto-setup
 ```
+
+This will build a local `temporalio/auto-setup` docker image with the label "test".
+
+To *run* the docker image with dependencies (e.g. PostgreSQL and Elasticsearch), you can use `docker-compose`. See our [docker-compose repo](https://github.com/temporalio/docker-compose) for reference configurations - and update the image accordingly to `image: temporalio/auto-setup:1.15.0`.
 
 ## Build docker image for any commit
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

improve documentation for building images

<!-- Tell your future self why have you made these changes -->
**Why?**

when i was working on auto-setup, it was not obvious from the readme that the main way to build the image was to run `make` at the project root, until Alex told me.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
