### PR TITLE
Return NOT_FOUND for invalid workflow ID

### DIFF
--- a/service/history/workflow/cache.go
+++ b/service/history/workflow/cache.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"sync/atomic"
 	"time"
+	"unicode/utf8"
 
 	"github.com/pborman/uuid"
 	commonpb "go.temporal.io/api/common/v1"
@@ -232,6 +233,11 @@ func (c *CacheImpl) validateWorkflowExecutionInfo(
 
 	if execution.GetWorkflowId() == "" {
 		return serviceerror.NewInvalidArgument("Can't load workflow execution.  WorkflowId not set.")
+	}
+
+	if !utf8.ValidString(execution.GetWorkflowId()) {
+		// We know workflow cannot exist with invalid utf8 string as WorkflowID.
+		return serviceerror.NewNotFound("Workflow not exists.")
 	}
 
 	// RunID is not provided, lets try to retrieve the RunID for current active execution


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Check WorkflowID and return NOT_FOUND error for WorkflowID using invalid UTF8 string. 

<!-- Tell your future self why have you made these changes -->
**Why?**
PR #2276 prevent workflow with invalid UTF8 string as WorkflowID from being created. But for the ones already created, the GetWorkflowExecution (to load mutable state) will fail on persistence on "String didn't validate" error and the system would keep retrying. We need to skip those tasks that try to load workflow with invalid utf8 string as workflowID. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eye_balls

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes