### PR TITLE
Pass useTLS in GetFrontendClientConfig's callback

### DIFF
--- a/common/rpc/encryption/localStoreTlsProvider.go
+++ b/common/rpc/encryption/localStoreTlsProvider.go
@@ -157,7 +157,7 @@ func (s *localStoreTlsProvider) GetFrontendClientConfig() (*tls.Config, error) {
 		&s.cachedFrontendClientConfig,
 		func() (*tls.Config, error) {
 			return newClientTLSConfig(s.workerCertProvider, client.ServerName,
-				s.settings.Frontend.Server.RequireClientAuth, true, !client.DisableHostVerification)
+				useTLS, true, !client.DisableHostVerification)
 		},
 		useTLS,
 	)


### PR DESCRIPTION
**What changed?**
Use `useTLS` in the GetFrontendClientConfig's callback instead of `Frontend.Server.RequireClientAuth`

**Why?**
https://community.temporal.io/t/temporal-service-1-14-4-upgraded-frontend-worker-pods-are-crashing/3882/17

**How did you test it?**
Unit tests

**Potential risks**
Should be low

**Is hotfix candidate?**
Yes