### PR TITLE
Fix unloading shard after task id sanity check

### DIFF
--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -124,8 +124,9 @@ func (s *ContextTest) SetEventsCacheForTesting(c events.Cache) {
 	s.eventsCache = c
 }
 
-// StopForTest calls private method stop(). In general only the controller should call stop, but integration
-// tests need to do it also to clean up any background acquireShard goroutines that may exist.
+// StopForTest calls private method finishStop(). In general only the controller
+// should call that, but integration tests need to do it also to clean up any
+// background acquireShard goroutines that may exist.
 func (s *ContextTest) StopForTest() {
-	s.stop()
+	s.finishStop()
 }

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -170,7 +170,7 @@ func (c *ControllerImpl) CloseShardByID(shardID int32) {
 	// Stop the current shard, if it exists.
 	if shard != nil {
 		shard.contextTaggedLogger.Info("", tag.LifeCycleStopping, tag.ComponentShardContext, tag.ShardID(shardID))
-		shard.stop()
+		shard.finishStop()
 		c.metricsScope.IncCounter(metrics.ShardContextRemovedCounter)
 		shard.contextTaggedLogger.Info("", tag.LifeCycleStopped, tag.ComponentShardContext, tag.Number(newNumShards))
 	}
@@ -186,7 +186,7 @@ func (c *ControllerImpl) shardClosedCallback(shard *ContextImpl) {
 
 	// Whether shard was in the shards map or not, in both cases we should stop it.
 	shard.contextTaggedLogger.Info("", tag.LifeCycleStopping, tag.ComponentShardContext, tag.ShardID(shard.shardID))
-	shard.stop()
+	shard.finishStop()
 	c.metricsScope.IncCounter(metrics.ShardContextRemovedCounter)
 	shard.contextTaggedLogger.Info("", tag.LifeCycleStopped, tag.ComponentShardContext, tag.Number(newNumShards))
 }
@@ -374,7 +374,7 @@ func (c *ControllerImpl) doShutdown() {
 	c.Lock()
 	defer c.Unlock()
 	for _, shard := range c.historyShards {
-		shard.stop()
+		shard.finishStop()
 	}
 	c.historyShards = nil
 }

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -516,7 +516,7 @@ func (s *controllerSuite) TestHistoryEngineClosed() {
 	for shardID := int32(1); shardID <= numShards; shardID++ {
 		mockEngine := NewMockEngine(s.controller)
 		historyEngines[shardID] = mockEngine
-		s.setupMocksForAcquireShard(shardID, mockEngine, 5, 6)
+		s.setupMocksForAcquireShard(shardID, mockEngine, 5, 6, true)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -613,7 +613,7 @@ func (s *controllerSuite) TestShardControllerClosed() {
 	for shardID := int32(1); shardID <= numShards; shardID++ {
 		mockEngine := NewMockEngine(s.controller)
 		historyEngines[shardID] = mockEngine
-		s.setupMocksForAcquireShard(shardID, mockEngine, 5, 6)
+		s.setupMocksForAcquireShard(shardID, mockEngine, 5, 6, true)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -658,7 +658,13 @@ func (s *controllerSuite) TestShardControllerClosed() {
 
 func (s *controllerSuite) TestShardExplicitUnload() {
 	s.config.NumberOfShards = 1
-	s.mockServiceResolver.EXPECT().Lookup(gomock.Any()).Return(s.hostInfo, nil)
+
+	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestSingleDCClusterInfo).AnyTimes()
+	mockEngine := NewMockEngine(s.controller)
+	mockEngine.EXPECT().Stop().AnyTimes()
+	s.setupMocksForAcquireShard(0, mockEngine, 5, 6, false)
+
 	shard, err := s.shardController.getOrCreateShardContext(0)
 	s.NoError(err)
 	s.Equal(1, s.shardController.NumShards())
@@ -670,11 +676,11 @@ func (s *controllerSuite) TestShardExplicitUnload() {
 		time.Sleep(1 * time.Millisecond)
 	}
 	s.Equal(0, s.shardController.NumShards())
-	s.Equal(contextStateStopped, shard.state)
+	s.False(shard.isValid())
 }
 
 func (s *controllerSuite) setupMocksForAcquireShard(shardID int32, mockEngine *MockEngine, currentRangeID,
-	newRangeID int64) {
+	newRangeID int64, required bool) {
 
 	replicationAck := int64(201)
 	currentClusterTransferAck := int64(210)
@@ -682,10 +688,15 @@ func (s *controllerSuite) setupMocksForAcquireShard(shardID int32, mockEngine *M
 	currentClusterTimerAck := timestamp.TimeNowPtrUtcAddSeconds(-100)
 	alternativeClusterTimerAck := timestamp.TimeNowPtrUtcAddSeconds(-200)
 
+	minTimes := 0
+	if required {
+		minTimes = 1
+	}
+
 	// s.mockResource.ExecutionMgr.On("Close").Return()
-	mockEngine.EXPECT().Start()
-	s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
-	s.mockEngineFactory.EXPECT().CreateEngine(newContextMatcher(shardID)).Return(mockEngine)
+	mockEngine.EXPECT().Start().MinTimes(minTimes)
+	s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2).MinTimes(minTimes)
+	s.mockEngineFactory.EXPECT().CreateEngine(newContextMatcher(shardID)).Return(mockEngine).MinTimes(minTimes)
 	s.mockShardManager.EXPECT().GetOrCreateShard(getOrCreateShardRequestMatcher(shardID)).Return(
 		&persistence.GetOrCreateShardResponse{
 			ShardInfo: &persistencespb.ShardInfo{
@@ -707,7 +718,7 @@ func (s *controllerSuite) setupMocksForAcquireShard(shardID int32, mockEngine *M
 				ReplicationDlqAckLevel:  map[string]int64{},
 				QueueAckLevels:          map[int32]*persistencespb.QueueAckLevel{},
 			},
-		}, nil)
+		}, nil).MinTimes(minTimes)
 	s.mockShardManager.EXPECT().UpdateShard(&persistence.UpdateShardRequest{
 		ShardInfo: &persistencespb.ShardInfo{
 			ShardId:             shardID,
@@ -730,7 +741,7 @@ func (s *controllerSuite) setupMocksForAcquireShard(shardID int32, mockEngine *M
 			QueueAckLevels:          map[int32]*persistencespb.QueueAckLevel{},
 		},
 		PreviousRangeID: currentRangeID,
-	}).Return(nil)
+	}).Return(nil).MinTimes(minTimes)
 }
 
 func newContextMatcher(shardID int32) *contextMatcher {


### PR DESCRIPTION
**What changed?**
In #2361, the shard would get unloaded without going through the controller, which would leave it in the controller's map in a stopped state. This makes it go through the controller. Also renamed the stop method to make it less confusing.

**Why?**
The consequences are pretty benign for now (wrong metrics on number of shards loaded/unloaded), but could be worse if the interaction between controller and context gets more complex.

**How did you test it?**
new unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
