### PR TITLE
Do not generate sync activity task for deleted activity

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1048,6 +1048,7 @@ func (e *MutableStateImpl) DeleteActivity(
 	}
 
 	delete(e.updateActivityInfos, scheduleEventID)
+	delete(e.syncActivityTasks, scheduleEventID)
 	e.deleteActivityInfos[scheduleEventID] = struct{}{}
 	return nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not generate sync activity task for deleted activity

<!-- Tell your future self why have you made these changes -->
**Why?**
- The generated sync activity will be a no-op as the activity has already closed

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no