### PR TITLE
Added mockgen to base-ci-builder Docker image

### DIFF
--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -10,3 +10,5 @@ RUN apk add --update --no-cache \
     shellcheck
 
 RUN wget -O- https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh
+
+RUN go get github.com/golang/mock/mockgen


### PR DESCRIPTION
This is useful for all consuming packages that generate and test mocks during CI