### PR TITLE
Rework health check

### DIFF
--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -30,6 +30,8 @@ import (
 	"fmt"
 	"testing"
 
+	"google.golang.org/grpc/health"
+
 	"go.temporal.io/server/api/adminservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
@@ -145,6 +147,7 @@ func (s *adminHandlerSuite) SetupTest() {
 		s.mockResource.GetSearchAttributesManager(),
 		s.mockMetadata,
 		s.mockResource.GetArchivalMetadata(),
+		health.NewServer(),
 	}
 	s.handler = NewAdminHandler(args)
 	s.handler.Start()

--- a/service/frontend/dcRedirectionHandler.go
+++ b/service/frontend/dcRedirectionHandler.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"go.temporal.io/api/workflowservice/v1"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
@@ -102,21 +101,6 @@ func (handler *DCRedirectionHandlerImpl) Stop() {
 // GetConfig return config
 func (handler *DCRedirectionHandlerImpl) GetConfig() *Config {
 	return handler.frontendHandler.GetConfig()
-}
-
-// UpdateHealthStatus sets the health status for this rpc handler.
-// This health status will be used within the rpc health check handler
-func (handler *DCRedirectionHandlerImpl) UpdateHealthStatus(status HealthStatus) {
-	handler.frontendHandler.UpdateHealthStatus(status)
-}
-
-// Check is for health check
-func (handler *DCRedirectionHandlerImpl) Check(ctx context.Context, request *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
-	return handler.frontendHandler.Check(ctx, request)
-}
-
-func (handler *DCRedirectionHandlerImpl) Watch(request *healthpb.HealthCheckRequest, server healthpb.Health_WatchServer) error {
-	return handler.frontendHandler.Watch(request, server)
 }
 
 // Namespace APIs, namespace APIs does not require redirection

--- a/service/frontend/dcRedirectionHandler_test.go
+++ b/service/frontend/dcRedirectionHandler_test.go
@@ -34,7 +34,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/api/workflowservicemock/v1"
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
+	"google.golang.org/grpc/health"
 
 	tokenspb "go.temporal.io/server/api/token/v1"
 	"go.temporal.io/server/common/cluster"
@@ -125,6 +125,7 @@ func (s *dcRedirectionHandlerSuite) SetupTest() {
 		s.mockResource.GetSearchAttributesProvider(),
 		s.mockResource.GetClusterMetadata(),
 		s.mockResource.GetArchivalMetadata(),
+		health.NewServer(),
 	)
 
 	s.mockFrontendHandler = workflowservicemock.NewMockWorkflowServiceServer(s.controller)
@@ -900,17 +901,6 @@ func (serverHandler *testServerHandler) Start() {
 }
 
 func (serverHandler *testServerHandler) Stop() {
-}
-
-func (serverHandler *testServerHandler) Check(context.Context, *healthpb.HealthCheckRequest) (*healthpb.HealthCheckResponse, error) {
-	return nil, nil
-}
-
-func (serverHandler *testServerHandler) Watch(*healthpb.HealthCheckRequest, healthpb.Health_WatchServer) error {
-	return nil
-}
-
-func (serverHandler *testServerHandler) UpdateHealthStatus(status HealthStatus) {
 }
 
 func (serverHandler *testServerHandler) GetConfig() *Config {

--- a/service/frontend/interface.go
+++ b/service/frontend/interface.go
@@ -30,9 +30,13 @@ import (
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 
-	healthpb "google.golang.org/grpc/health/grpc_health_v1"
-
 	"go.temporal.io/server/common"
+)
+
+const (
+	WorkflowServiceName = "temporal.api.workflowservice.v1.WorkflowService"
+	OperatorServiceName = "temporal.api.operatorservice.v1.OperatorService"
+	AdminServiceName    = "temporal.api.adminservice.v1.AdminService"
 )
 
 type (
@@ -40,12 +44,6 @@ type (
 	Handler interface {
 		workflowservice.WorkflowServiceServer
 		common.Daemon
-
-		// HealthServer is the health check method for the whole frontend server
-		healthpb.HealthServer
-		// UpdateHealthStatus sets the health status for this rpc handler.
-		// This health status will be used within the rpc health check handler
-		UpdateHealthStatus(status HealthStatus)
 
 		GetConfig() *Config
 	}

--- a/service/frontend/interface_mock.go
+++ b/service/frontend/interface_mock.go
@@ -35,7 +35,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "go.temporal.io/api/operatorservice/v1"
 	v10 "go.temporal.io/api/workflowservice/v1"
-	grpc_health_v1 "google.golang.org/grpc/health/grpc_health_v1"
 )
 
 // MockHandler is a mock of Handler interface.
@@ -59,21 +58,6 @@ func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
-}
-
-// Check mocks base method.
-func (m *MockHandler) Check(arg0 context.Context, arg1 *grpc_health_v1.HealthCheckRequest) (*grpc_health_v1.HealthCheckResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Check", arg0, arg1)
-	ret0, _ := ret[0].(*grpc_health_v1.HealthCheckResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Check indicates an expected call of Check.
-func (mr *MockHandlerMockRecorder) Check(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Check", reflect.TypeOf((*MockHandler)(nil).Check), arg0, arg1)
 }
 
 // CountWorkflowExecutions mocks base method.
@@ -699,18 +683,6 @@ func (mr *MockHandlerMockRecorder) TerminateWorkflowExecution(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TerminateWorkflowExecution", reflect.TypeOf((*MockHandler)(nil).TerminateWorkflowExecution), arg0, arg1)
 }
 
-// UpdateHealthStatus mocks base method.
-func (m *MockHandler) UpdateHealthStatus(status HealthStatus) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateHealthStatus", status)
-}
-
-// UpdateHealthStatus indicates an expected call of UpdateHealthStatus.
-func (mr *MockHandlerMockRecorder) UpdateHealthStatus(status interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHealthStatus", reflect.TypeOf((*MockHandler)(nil).UpdateHealthStatus), status)
-}
-
 // UpdateNamespace mocks base method.
 func (m *MockHandler) UpdateNamespace(arg0 context.Context, arg1 *v10.UpdateNamespaceRequest) (*v10.UpdateNamespaceResponse, error) {
 	m.ctrl.T.Helper()
@@ -724,20 +696,6 @@ func (m *MockHandler) UpdateNamespace(arg0 context.Context, arg1 *v10.UpdateName
 func (mr *MockHandlerMockRecorder) UpdateNamespace(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespace", reflect.TypeOf((*MockHandler)(nil).UpdateNamespace), arg0, arg1)
-}
-
-// Watch mocks base method.
-func (m *MockHandler) Watch(arg0 *grpc_health_v1.HealthCheckRequest, arg1 grpc_health_v1.Health_WatchServer) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Watch", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Watch indicates an expected call of Watch.
-func (mr *MockHandlerMockRecorder) Watch(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Watch", reflect.TypeOf((*MockHandler)(nil).Watch), arg0, arg1)
 }
 
 // MockOperatorHandler is a mock of OperatorHandler interface.

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -31,6 +31,7 @@ import (
 	"testing"
 
 	"go.temporal.io/api/operatorservice/v1"
+	"google.golang.org/grpc/health"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/mock"
@@ -81,6 +82,7 @@ func (s *operatorHandlerSuite) SetupTest() {
 		s.mockResource.GetMetricsClient(),
 		s.mockResource.GetSearchAttributesProvider(),
 		s.mockResource.GetSearchAttributesManager(),
+		health.NewServer(),
 	}
 	s.handler = NewOperatorHandlerImpl(args)
 	s.handler.Start()
@@ -152,7 +154,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 	}
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
-	handler.ESConfig = &client.Config{
+	handler.esConfig = &client.Config{
 		Indices: map[string]string{
 			"visibility": "random-index-name",
 		},
@@ -248,7 +250,7 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes() {
 	s.NotNil(resp)
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
-	handler.ESConfig = &client.Config{
+	handler.esConfig = &client.Config{
 		Indices: map[string]string{
 			"visibility": "random-index-name",
 		},
@@ -328,7 +330,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 	}
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
-	handler.ESConfig = &client.Config{
+	handler.esConfig = &client.Config{
 		Indices: map[string]string{
 			"visibility": "random-index-name",
 		},

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -45,6 +45,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/grpc/health"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
@@ -176,6 +177,7 @@ func (s *workflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 		s.mockResource.GetSearchAttributesProvider(),
 		s.mockResource.GetClusterMetadata(),
 		s.mockResource.GetArchivalMetadata(),
+		health.NewServer(),
 	)
 }
 


### PR DESCRIPTION
**What changed?**

The standard gRPC Health Check Service implementation is used instead of the custom implementation in Workflow Handler. This allows each separate service/handler to announce the state.

**Why?**

Less custom code, correct implementation of health check that doesn't fall back into a single handler.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests for health check cover this change

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
