### PR TITLE
Revert "Added mockgen to base-ci-builder Docker image (#2574)"

### DIFF
--- a/docker/base-images/base-ci-builder.Dockerfile
+++ b/docker/base-images/base-ci-builder.Dockerfile
@@ -10,5 +10,3 @@ RUN apk add --update --no-cache \
     shellcheck
 
 RUN wget -O- https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | sh
-
-RUN go get github.com/golang/mock/mockgen


### PR DESCRIPTION
This reverts commit 9cb3f5a61da2d2aba2d6ade22054700411c77bbe.

After discussing with build pipeline owner, learned more idiomatic way to regenerate Mocks in CI