### PR TITLE
Adds flag to temporal-cassandra-tool to disable Initial Host Lookup

### DIFF
--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -50,16 +50,17 @@ type (
 	}
 	// CQLClientConfig contains the configuration for cql client
 	CQLClientConfig struct {
-		Hosts       string
-		Port        int
-		User        string
-		Password    string
-		Keyspace    string
-		Timeout     int
-		numReplicas int
-		Datacenter  string
-		Consistency string
-		TLS         *auth.TLS
+		Hosts                    string
+		Port                     int
+		User                     string
+		Password                 string
+		Keyspace                 string
+		Timeout                  int
+		numReplicas              int
+		Datacenter               string
+		Consistency              string
+		TLS                      *auth.TLS
+		DisableInitialHostLookup bool
 	}
 )
 
@@ -129,13 +130,14 @@ func newCQLClient(cfg *CQLClientConfig, logger log.Logger) (*cqlClient, error) {
 
 func (cfg *CQLClientConfig) toCassandraConfig() *config.Cassandra {
 	cassandraConfig := config.Cassandra{
-		Hosts:      cfg.Hosts,
-		Port:       cfg.Port,
-		User:       cfg.User,
-		Password:   cfg.Password,
-		Keyspace:   cfg.Keyspace,
-		TLS:        cfg.TLS,
-		Datacenter: cfg.Datacenter,
+		Hosts:                    cfg.Hosts,
+		Port:                     cfg.Port,
+		User:                     cfg.User,
+		Password:                 cfg.Password,
+		Keyspace:                 cfg.Keyspace,
+		TLS:                      cfg.TLS,
+		Datacenter:               cfg.Datacenter,
+		DisableInitialHostLookup: cfg.DisableInitialHostLookup,
 		Consistency: &config.CassandraStoreConsistency{
 			Default: &config.CassandraConsistencySettings{
 				Consistency: cfg.Consistency,

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -168,15 +168,16 @@ func doDropKeyspace(cfg *CQLClientConfig, name string, logger log.Logger) error 
 
 func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
 	config := &CQLClientConfig{
-		Hosts:       cli.GlobalString(schema.CLIOptEndpoint),
-		Port:        cli.GlobalInt(schema.CLIOptPort),
-		User:        cli.GlobalString(schema.CLIOptUser),
-		Password:    cli.GlobalString(schema.CLIOptPassword),
-		Timeout:     cli.GlobalInt(schema.CLIOptTimeout),
-		Keyspace:    cli.GlobalString(schema.CLIOptKeyspace),
-		numReplicas: cli.Int(schema.CLIOptReplicationFactor),
-		Datacenter:  cli.String(schema.CLIOptDatacenter),
-		Consistency: cli.String(schema.CLIOptConsistency),
+		Hosts:                    cli.GlobalString(schema.CLIOptEndpoint),
+		Port:                     cli.GlobalInt(schema.CLIOptPort),
+		User:                     cli.GlobalString(schema.CLIOptUser),
+		Password:                 cli.GlobalString(schema.CLIOptPassword),
+		Timeout:                  cli.GlobalInt(schema.CLIOptTimeout),
+		Keyspace:                 cli.GlobalString(schema.CLIOptKeyspace),
+		numReplicas:              cli.Int(schema.CLIOptReplicationFactor),
+		Datacenter:               cli.String(schema.CLIOptDatacenter),
+		Consistency:              cli.String(schema.CLIOptConsistency),
+		DisableInitialHostLookup: cli.GlobalBool(schema.CLIFlagDisableInitialHostLookup),
 	}
 
 	if cli.GlobalBool(schema.CLIFlagEnableTLS) {

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -105,7 +105,11 @@ func buildCLIOptions() *cli.App {
 			Name:  schema.CLIFlagQuiet,
 			Usage: "Don't set exit status to 1 on error",
 		},
-
+		cli.BoolFlag{
+			Name:   schema.CLIFlagDisableInitialHostLookup,
+			Usage:  "instructs gocql driver to only connect to the supplied hosts vs. attempting to lookup additional hosts via the system.peers table",
+			EnvVar: "CASSANDRA_DISABLE_INITIAL_HOST_LOOKUP",
+		},
 		cli.BoolFlag{
 			Name:   schema.CLIFlagEnableTLS,
 			Usage:  "enable TLS",

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -152,6 +152,8 @@ const (
 	CLIFlagQuiet = CLIOptQuiet + ", q"
 	// CLIFlagForce is the cli flag for force mode
 	CLIFlagForce = CLIOptForce + ", f"
+	// CLIFlagDisableInitialHostLookup is the cli flag for only using supplied hosts to connect to the database
+	CLIFlagDisableInitialHostLookup = "disable-initial-host-lookup"
 
 	// CLIFlagEnableTLS enables cassandra client TLS
 	CLIFlagEnableTLS = "tls"


### PR DESCRIPTION
Adds optional flag to disable initial host lookup when performing operations via the temporal-cassandra-tool. This is useful for some configurations of Cassandra where not having this flag enabled can significantly increase connection time or cause other issues. Validated that this worked against a test cluster.

Note that the server configuration also exposes this option, so we are just achieving parity between the server configuration and the tool configuration