### PR TITLE
removing vim from docker images due to CVE

### DIFF
--- a/docker/base-images/base-admin-tools.Dockerfile
+++ b/docker/base-images/base-admin-tools.Dockerfile
@@ -6,7 +6,6 @@ RUN apk add --update --no-cache \
     tzdata \
     bash \
     curl \
-    vim \
     jq \
     mysql-client \
     postgresql-client \

--- a/docker/base-images/base-server.Dockerfile
+++ b/docker/base-images/base-server.Dockerfile
@@ -19,8 +19,7 @@ RUN apk add --update --no-cache \
     ca-certificates \
     tzdata \
     bash \
-    curl \
-    vim
+    curl
 
 COPY --from=dockerize-builder /usr/local/bin/dockerize /usr/local/bin/dockerize
 # set up nsswitch.conf for Go's "netgo" implementation


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Mirror of a commit
https://github.com/temporalio/docker-builds/pull/31

<!-- Tell your future self why have you made these changes -->
**Why?**
Resolve CVE, prevent future for same target tool

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Same as mirrored PR

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Users shouldn't depend on vim being available in the containers

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Maybe?