### PR TITLE
Use ListWorkflow instead of ScanWorkflow for batch operation

### DIFF
--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -266,10 +266,7 @@ func BatchActivity(ctx context.Context, batchParams BatchParams) (HeartBeatDetai
 	}
 
 	for {
-		// TODO https://github.com/uber/cadence/issues/2154
-		//  Need to improve scan concurrency because it will hold an ES resource until the workflow finishes.
-		//  And we can't use list API because terminate / reset will mutate the result.
-		resp, err := sdkClient.ScanWorkflow(ctx, &workflowservice.ScanWorkflowExecutionsRequest{
+		resp, err := sdkClient.ListWorkflow(ctx, &workflowservice.ListWorkflowExecutionsRequest{
 			PageSize:      int32(pageSize),
 			NextPageToken: hbd.PageToken,
 			Query:         batchParams.Query,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use `ListWorkflow` instead of `ScanWorkflow` for batch operation.

<!-- Tell your future self why have you made these changes -->
**Why?**
`ScanWorkflow` holds Elasticsearch resource and become a concern of system stability.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.