### PR TITLE
Fix replication error handling

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -3089,7 +3089,7 @@ func (e *historyEngineImpl) ReapplyEvents(
 				// TODO when https://github.com/uber/cadence/issues/2420 is finished, remove this block,
 				//  since cannot reapply event to a finished workflow which had no workflow tasks started
 				if baseRebuildLastEventID == common.EmptyEventID {
-					e.logger.Warn("cannot reapply event to a finished workflow",
+					e.logger.Warn("cannot reapply event to a finished workflow with no workflow task",
 						tag.WorkflowNamespaceID(namespaceID.String()),
 						tag.WorkflowID(currentExecution.GetWorkflowId()),
 					)
@@ -3112,7 +3112,7 @@ func (e *historyEngineImpl) ReapplyEvents(
 				baseCurrentBranchToken := baseCurrentVersionHistory.GetBranchToken()
 				baseNextEventID := mutableState.GetNextEventID()
 
-				if err = e.workflowResetter.resetWorkflow(
+				err = e.workflowResetter.resetWorkflow(
 					ctx,
 					namespaceID,
 					workflowID,
@@ -3134,7 +3134,14 @@ func (e *historyEngineImpl) ReapplyEvents(
 					eventsReapplicationResetWorkflowReason,
 					toReapplyEvents,
 					enumspb.RESET_REAPPLY_TYPE_SIGNAL,
-				); err != nil {
+				)
+				switch err.(type) {
+				case *serviceerror.InvalidArgument:
+					// no-op. Usually this is due to reset workflow with pending child workflows
+					e.logger.Warn("Cannot reset workflow. Ignoring reapply events.", tag.Error(err))
+				case nil:
+					//no-op
+				default:
 					return nil, err
 				}
 				return &updateWorkflowAction{

--- a/service/history/nDCTransactionMgr.go
+++ b/service/history/nDCTransactionMgr.go
@@ -30,6 +30,8 @@ import (
 	"context"
 	"time"
 
+	"go.temporal.io/server/common"
+
 	"go.temporal.io/server/common/persistence/serialization"
 
 	"github.com/pborman/uuid"
@@ -37,7 +39,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -344,7 +345,7 @@ func (r *nDCTransactionMgrImpl) backfillWorkflowEventsReapply(
 		baseCurrentBranchToken := baseCurrentVersionHistory.GetBranchToken()
 		baseNextEventID := baseMutableState.GetNextEventID()
 
-		if err = r.workflowResetter.resetWorkflow(
+		err = r.workflowResetter.resetWorkflow(
 			ctx,
 			namespaceID,
 			workflowID,
@@ -359,7 +360,14 @@ func (r *nDCTransactionMgrImpl) backfillWorkflowEventsReapply(
 			eventsReapplicationResetWorkflowReason,
 			targetWorkflowEvents.Events,
 			enumspb.RESET_REAPPLY_TYPE_SIGNAL,
-		); err != nil {
+		)
+		switch err.(type) {
+		case *serviceerror.InvalidArgument:
+			// no-op. Usually this is due to reset workflow with pending child workflows
+			r.logger.Warn("Cannot reset workflow. Ignoring reapply events.", tag.Error(err))
+		case nil:
+			//no-op
+		default:
 			return 0, workflow.TransactionPolicyActive, err
 		}
 		// after the reset of target workflow (current workflow) with additional events to be reapplied


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix replication error handling

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Drop replication task if the workflow is not found in source cluster.
2. Return no error if workflow cannot be reset in reapply case.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Some no op tasks will be put into DLQ

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes