### PR TITLE
export struct MetricDefinition + field metricName

### DIFF
--- a/common/metrics/common.go
+++ b/common/metrics/common.go
@@ -43,8 +43,8 @@ func mergeMapToRight(src map[string]string, dest map[string]string) {
 	}
 }
 
-func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {
-	defs := make(map[int]metricDefinition)
+func getMetricDefs(serviceIdx ServiceIdx) map[int]MetricDefinition {
+	defs := make(map[int]MetricDefinition)
 	for idx, def := range MetricDefs[Common] {
 		defs[idx] = def
 	}

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -219,13 +219,7 @@ var (
 func (c *Config) InitMetricReporters(logger log.Logger, customReporter interface{}) (Reporter, Reporter, error) {
 	// init from config only
 	if customReporter == nil {
-		if c.Prometheus != nil && len(c.Prometheus.Framework) > 0 {
-			return c.initReportersFromPrometheusConfig(logger, customReporter)
-		}
-
-		scope := c.NewScope(logger)
-		reporter := newTallyReporter(scope, &c.ClientConfig)
-		return reporter, reporter, nil
+		return c.HackOfTheCentury(logger, customReporter)
 	}
 
 	// handle custom reporter from ServerOptions
@@ -240,6 +234,16 @@ func (c *Config) InitMetricReporters(logger log.Logger, customReporter interface
 		return nil, nil, fmt.Errorf(
 			"specified customReporter does not implement tally.BaseStatsReporter or metrics.Reporter")
 	}
+}
+
+func (c *Config) HackOfTheCentury(logger log.Logger, customReporter interface{}) (Reporter, Reporter, error) {
+	if c.Prometheus != nil && len(c.Prometheus.Framework) > 0 {
+		return c.initReportersFromPrometheusConfig(logger, customReporter)
+	}
+
+	scope := c.NewScope(logger)
+	reporter := newTallyReporter(scope, &c.ClientConfig)
+	return reporter, reporter, nil
 }
 
 func (c *Config) initReportersFromPrometheusConfig(logger log.Logger, customReporter interface{}) (Reporter, Reporter, error) {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -38,11 +38,11 @@ type (
 
 	MetricUnit string
 
-	// metricDefinition contains the definition for a metric
-	metricDefinition struct {
+	// MetricDefinition contains the definition for a metric
+	MetricDefinition struct {
 		// nolint
 		metricType       MetricType    // metric type
-		metricName       MetricName    // metric name
+		MetricName       MetricName    // metric name
 		metricRollupName MetricName    // optional. if non-empty, this name must be used for rolled-up version of this metric
 		buckets          tally.Buckets // buckets if we are emitting histograms
 		unit             MetricUnit
@@ -2194,7 +2194,7 @@ const (
 )
 
 // MetricDefs record the metrics for all services
-var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
+var MetricDefs = map[ServiceIdx]map[int]MetricDefinition{
 	Common: {
 		ServiceRequests:                                     NewCounterDef("service_requests"),
 		ServicePendingRequests:                              NewGaugeDef("service_pending_requests"),
@@ -2655,31 +2655,31 @@ func (mn MetricName) String() string {
 	return string(mn)
 }
 
-func NewTimerDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Timer, unit: Milliseconds}
+func NewTimerDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Timer, unit: Milliseconds}
 }
 
-func NewRollupTimerDef(name string, rollupName string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricRollupName: MetricName(rollupName), metricType: Timer, unit: Milliseconds}
+func NewRollupTimerDef(name string, rollupName string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricRollupName: MetricName(rollupName), metricType: Timer, unit: Milliseconds}
 }
 
-func NewBytesHistogramDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Bytes}
+func NewBytesHistogramDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Histogram, unit: Bytes}
 }
 
-func NewDimensionlessHistogramDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Dimensionless}
+func NewDimensionlessHistogramDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Histogram, unit: Dimensionless}
 }
 
-func NewCounterDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Counter}
+func NewCounterDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Counter}
 }
 
 // Rollup counter name is used to report aggregated metric excluding namespace tag.
-func NewRollupCounterDef(name string, rollupName string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricRollupName: MetricName(rollupName), metricType: Counter}
+func NewRollupCounterDef(name string, rollupName string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricRollupName: MetricName(rollupName), metricType: Counter}
 }
 
-func NewGaugeDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Gauge}
+func NewGaugeDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Gauge}
 }

--- a/common/metrics/defs_test.go
+++ b/common/metrics/defs_test.go
@@ -104,8 +104,8 @@ func TestMetricDefsMapped(t *testing.T) {
 func TestMetricDefs(t *testing.T) {
 	for service, metrics := range MetricDefs {
 		for _, metricDef := range metrics {
-			matched := IsMetric(string(metricDef.metricName))
-			assert.True(t, matched, fmt.Sprintf("Service: %v, metric_name: %v", service, metricDef.metricName))
+			matched := IsMetric(string(metricDef.MetricName))
+			assert.True(t, matched, fmt.Sprintf("Service: %v, metric_name: %v", service, metricDef.MetricName))
 		}
 	}
 }

--- a/common/metrics/metric_client_tests.go
+++ b/common/metrics/metric_client_tests.go
@@ -73,7 +73,7 @@ func (s *MetricTestSuiteBase) TestClientReportCounter() {
 		TestScope1,
 		TestCounterMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestCounterMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsCounter(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsCounter(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
@@ -82,7 +82,7 @@ func (s *MetricTestSuiteBase) TestClientReportGauge() {
 		TestScope1,
 		TestGaugeMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestGaugeMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsGauge(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsGauge(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
@@ -92,7 +92,7 @@ func (s *MetricTestSuiteBase) TestClientReportTimer() {
 		TestScope1,
 		TestTimerMetric1, targetDuration)
 	testDef := MetricDefs[UnitTestService][TestTimerMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsTimer(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, targetDuration))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsTimer(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, targetDuration))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
@@ -101,21 +101,21 @@ func (s *MetricTestSuiteBase) TestClientReportHistogram() {
 		TestScope1,
 		TestDimensionlessHistogramMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestDimensionlessHistogramMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsHistogram(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsHistogram(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
 func (s *MetricTestSuiteBase) TestScopeReportCounter() {
 	s.testClient.Scope(TestScope1).AddCounter(TestCounterMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestCounterMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsCounter(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsCounter(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
 func (s *MetricTestSuiteBase) TestScopeReportGauge() {
 	s.testClient.Scope(TestScope1).UpdateGauge(TestGaugeMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestGaugeMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsGauge(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsGauge(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
@@ -123,6 +123,6 @@ func (s *MetricTestSuiteBase) TestScopeReportTimer() {
 	targetDuration := time.Second * 100
 	s.testClient.Scope(TestScope1).RecordTimer(TestTimerMetric1, targetDuration)
 	testDef := MetricDefs[UnitTestService][TestTimerMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsTimer(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, targetDuration))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsTimer(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation}, targetDuration))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }

--- a/common/metrics/opentelemetry_client.go
+++ b/common/metrics/opentelemetry_client.go
@@ -36,7 +36,7 @@ type (
 		// parentReporter is the parent scope for the metrics
 		rootScope    *opentelemetryScope
 		childScopes  map[int]Scope
-		metricDefs   map[int]metricDefinition
+		metricDefs   map[int]MetricDefinition
 		serviceIdx   ServiceIdx
 		scopeWrapper func(impl internalScope) internalScope
 		gaugeCache   OtelGaugeCache

--- a/common/metrics/opentelemetry_scope.go
+++ b/common/metrics/opentelemetry_scope.go
@@ -40,7 +40,7 @@ type (
 		labels            []attribute.KeyValue
 		tags              map[string]string
 		rootScope         *opentelemetryScope
-		defs              map[int]metricDefinition
+		defs              map[int]MetricDefinition
 		isNamespaceTagged bool
 
 		gaugeCache OtelGaugeCache
@@ -52,7 +52,7 @@ func newOpentelemetryScope(
 	reporter OpentelemetryReporter,
 	rootScope *opentelemetryScope,
 	tags map[string]string,
-	defs map[int]metricDefinition,
+	defs map[int]MetricDefinition,
 	isNamespace bool,
 	gaugeCache OtelGaugeCache,
 	selfAsRoot bool,
@@ -80,7 +80,7 @@ func (m *opentelemetryScope) IncCounter(id int) {
 func (m *opentelemetryScope) AddCounter(id int, delta int64) {
 	def := m.defs[id]
 	ctx := context.Background()
-	m.reporter.GetMeterMust().NewInt64Counter(def.metricName.String()).Add(ctx, delta, m.labels...)
+	m.reporter.GetMeterMust().NewInt64Counter(def.MetricName.String()).Add(ctx, delta, m.labels...)
 
 	if !def.metricRollupName.Empty() && (m.rootScope != nil) {
 		m.rootScope.reporter.GetMeterMust().NewInt64Counter(def.metricRollupName.String()).Add(
@@ -91,7 +91,7 @@ func (m *opentelemetryScope) AddCounter(id int, delta int64) {
 
 func (m *opentelemetryScope) UpdateGauge(id int, value float64) {
 	def := m.defs[id]
-	m.gaugeCache.Set(def.metricName.String(), m.tags, value)
+	m.gaugeCache.Set(def.MetricName.String(), m.tags, value)
 	if !def.metricRollupName.Empty() && (m.rootScope != nil) {
 		m.gaugeCache.Set(def.metricRollupName.String(), m.rootScope.tags, value)
 	}
@@ -105,18 +105,18 @@ func (m *opentelemetryScope) StartTimer(id int) Stopwatch {
 	}
 
 	timer := newOpenTelemetryStopwatchMetric(
-		m.reporter.GetMeterMust().NewInt64Histogram(def.metricName.String(), opt...),
+		m.reporter.GetMeterMust().NewInt64Histogram(def.MetricName.String(), opt...),
 		m.labels)
 	switch {
 	case !def.metricRollupName.Empty():
 		timerRollup := newOpenTelemetryStopwatchMetric(
-			m.rootScope.reporter.GetMeterMust().NewInt64Histogram(def.metricName.String(), opt...),
+			m.rootScope.reporter.GetMeterMust().NewInt64Histogram(def.MetricName.String(), opt...),
 			m.rootScope.labels)
 		return newOpenTelemetryStopwatch([]openTelemetryStopwatchMetric{timer, timerRollup})
 	case m.isNamespaceTagged:
 		allScope := m.taggedString(map[string]string{namespace: namespaceAllValue}, false)
 		timerAll := newOpenTelemetryStopwatchMetric(
-			allScope.reporter.GetMeterMust().NewInt64Histogram(def.metricName.String(), opt...),
+			allScope.reporter.GetMeterMust().NewInt64Histogram(def.MetricName.String(), opt...),
 			allScope.labels)
 		return newOpenTelemetryStopwatch([]openTelemetryStopwatchMetric{timer, timerAll})
 	default:
@@ -133,7 +133,7 @@ func (m *opentelemetryScope) RecordTimer(id int, d time.Duration) {
 		opt = append(opt, unitToOptions(def.unit))
 	}
 
-	m.reporter.GetMeterMust().NewInt64Histogram(def.metricName.String(), opt...).Record(ctx, d.Nanoseconds(), m.labels...)
+	m.reporter.GetMeterMust().NewInt64Histogram(def.MetricName.String(), opt...).Record(ctx, d.Nanoseconds(), m.labels...)
 
 	if !def.metricRollupName.Empty() && (m.rootScope != nil) {
 		m.rootScope.reporter.GetMeterMust().NewInt64Histogram(def.metricRollupName.String(), opt...).Record(
@@ -147,7 +147,7 @@ func (m *opentelemetryScope) RecordTimer(id int, d time.Duration) {
 			ctx, d.Nanoseconds(), m.rootScope.labels...,
 		)
 	case m.isNamespaceTagged:
-		m.reporter.GetMeterMust().NewInt64Histogram(def.metricName.String(), opt...).Record(
+		m.reporter.GetMeterMust().NewInt64Histogram(def.MetricName.String(), opt...).Record(
 			ctx,
 			d.Nanoseconds(),
 			m.taggedString(map[string]string{namespace: namespaceAllValue}, false).labels...,
@@ -164,7 +164,7 @@ func (m *opentelemetryScope) RecordDistribution(id int, d int) {
 	}
 
 	ctx := context.Background()
-	m.reporter.GetMeterMust().NewInt64Histogram(def.metricName.String(), opt...).Record(ctx, value, m.labels...)
+	m.reporter.GetMeterMust().NewInt64Histogram(def.MetricName.String(), opt...).Record(ctx, value, m.labels...)
 
 	if !def.metricRollupName.Empty() && (m.rootScope != nil) {
 		m.rootScope.reporter.GetMeterMust().NewInt64Histogram(def.metricRollupName.String(), opt...).Record(
@@ -178,7 +178,7 @@ func (m *opentelemetryScope) RecordDistribution(id int, d int) {
 			ctx, value, m.rootScope.labels...,
 		)
 	case m.isNamespaceTagged:
-		m.reporter.GetMeterMust().NewInt64Histogram(def.metricName.String(), opt...).Record(
+		m.reporter.GetMeterMust().NewInt64Histogram(def.MetricName.String(), opt...).Record(
 			ctx,
 			value,
 			m.taggedString(map[string]string{namespace: namespaceAllValue}, false).labels...,

--- a/common/metrics/tally_client.go
+++ b/common/metrics/tally_client.go
@@ -35,7 +35,7 @@ type TallyClient struct {
 	// This is the scope provided by user to the client. It contains no client-specific tags.
 	globalRootScope tally.Scope
 	childScopes     map[int]tally.Scope
-	metricDefs      map[int]metricDefinition
+	metricDefs      map[int]MetricDefinition
 	serviceIdx      ServiceIdx
 	scopeWrapper    func(impl internalScope) internalScope
 	perUnitBuckets  map[MetricUnit]tally.Buckets
@@ -91,21 +91,21 @@ func NewClient(clientConfig *ClientConfig, scope tally.Scope, serviceIdx Service
 // IncCounter increments one for a counter and emits
 // to metrics backend
 func (m *TallyClient) IncCounter(scopeIdx int, counterIdx int) {
-	name := string(m.metricDefs[counterIdx].metricName)
+	name := string(m.metricDefs[counterIdx].MetricName)
 	m.childScopes[scopeIdx].Counter(name).Inc(1)
 }
 
 // AddCounter adds delta to the counter and
 // emits to the metrics backend
 func (m *TallyClient) AddCounter(scopeIdx int, counterIdx int, delta int64) {
-	name := string(m.metricDefs[counterIdx].metricName)
+	name := string(m.metricDefs[counterIdx].MetricName)
 	m.childScopes[scopeIdx].Counter(name).Inc(delta)
 }
 
 // StartTimer starts a timer for the given
 // metric name
 func (m *TallyClient) StartTimer(scopeIdx int, timerIdx int) Stopwatch {
-	name := string(m.metricDefs[timerIdx].metricName)
+	name := string(m.metricDefs[timerIdx].MetricName)
 	timer := m.childScopes[scopeIdx].Timer(name)
 	return NewStopwatch(timer)
 }
@@ -113,7 +113,7 @@ func (m *TallyClient) StartTimer(scopeIdx int, timerIdx int) Stopwatch {
 // RecordTimer record and emit a timer for the given
 // metric name
 func (m *TallyClient) RecordTimer(scopeIdx int, timerIdx int, d time.Duration) {
-	name := string(m.metricDefs[timerIdx].metricName)
+	name := string(m.metricDefs[timerIdx].MetricName)
 	m.childScopes[scopeIdx].Timer(name).Record(d)
 }
 
@@ -121,14 +121,14 @@ func (m *TallyClient) RecordTimer(scopeIdx int, timerIdx int, d time.Duration) {
 // metric name
 func (m *TallyClient) RecordDistribution(scopeIdx int, timerIdx int, d int) {
 	def := m.metricDefs[timerIdx]
-	name := string(def.metricName)
+	name := string(def.MetricName)
 	buckets, _ := m.perUnitBuckets[def.unit]
 	m.childScopes[scopeIdx].Histogram(name, buckets).RecordValue(float64(d))
 }
 
 // UpdateGauge reports Gauge type metric
 func (m *TallyClient) UpdateGauge(scopeIdx int, gaugeIdx int, value float64) {
-	name := string(m.metricDefs[gaugeIdx].metricName)
+	name := string(m.metricDefs[gaugeIdx].MetricName)
 	m.childScopes[scopeIdx].Gauge(name).Update(value)
 }
 

--- a/common/metrics/tally_scope.go
+++ b/common/metrics/tally_scope.go
@@ -33,7 +33,7 @@ import (
 type tallyScope struct {
 	scope             tally.Scope
 	rootScope         internalScope
-	defs              map[int]metricDefinition
+	defs              map[int]MetricDefinition
 	isNamespaceTagged bool
 	perUnitBuckets    map[MetricUnit]tally.Buckets
 }
@@ -41,7 +41,7 @@ type tallyScope struct {
 func newTallyScopeInternal(
 	rootScope internalScope,
 	scope tally.Scope,
-	defs map[int]metricDefinition,
+	defs map[int]MetricDefinition,
 	isNamespace bool,
 	perUnitBuckets map[MetricUnit]tally.Buckets,
 ) internalScope {
@@ -63,7 +63,7 @@ func (m *tallyScope) IncCounter(id int) {
 
 func (m *tallyScope) AddCounter(id int, delta int64) {
 	def := m.defs[id]
-	m.scope.Counter(def.metricName.String()).Inc(delta)
+	m.scope.Counter(def.MetricName.String()).Inc(delta)
 	if !def.metricRollupName.Empty() {
 		m.rootScope.AddCounterInternal(def.metricRollupName.String(), delta)
 	}
@@ -75,7 +75,7 @@ func (m *tallyScope) AddCounterInternal(name string, delta int64) {
 
 func (m *tallyScope) UpdateGauge(id int, value float64) {
 	def := m.defs[id]
-	m.scope.Gauge(def.metricName.String()).Update(value)
+	m.scope.Gauge(def.MetricName.String()).Update(value)
 	if !def.metricRollupName.Empty() {
 		m.scope.Gauge(def.metricRollupName.String()).Update(value)
 	}
@@ -83,12 +83,12 @@ func (m *tallyScope) UpdateGauge(id int, value float64) {
 
 func (m *tallyScope) StartTimer(id int) Stopwatch {
 	def := m.defs[id]
-	timer := NewStopwatch(m.scope.Timer(def.metricName.String()))
+	timer := NewStopwatch(m.scope.Timer(def.MetricName.String()))
 	switch {
 	case !def.metricRollupName.Empty():
 		return NewCompositeStopwatch(timer, m.rootScope.StartTimerInternal(def.metricRollupName.String()))
 	case m.isNamespaceTagged:
-		timerAll := m.rootScope.StartTimerInternal(def.metricName.String() + totalMetricSuffix)
+		timerAll := m.rootScope.StartTimerInternal(def.MetricName.String() + totalMetricSuffix)
 		return NewCompositeStopwatch(timer, timerAll)
 	default:
 		return timer
@@ -101,12 +101,12 @@ func (m *tallyScope) StartTimerInternal(timer string) Stopwatch {
 
 func (m *tallyScope) RecordTimer(id int, d time.Duration) {
 	def := m.defs[id]
-	m.scope.Timer(def.metricName.String()).Record(d)
+	m.scope.Timer(def.MetricName.String()).Record(d)
 	switch {
 	case !def.metricRollupName.Empty():
 		m.rootScope.RecordTimerInternal(def.metricRollupName.String(), d)
 	case m.isNamespaceTagged:
-		m.rootScope.RecordTimerInternal(def.metricName.String()+totalMetricSuffix, d)
+		m.rootScope.RecordTimerInternal(def.MetricName.String()+totalMetricSuffix, d)
 	}
 }
 
@@ -116,13 +116,13 @@ func (m *tallyScope) RecordTimerInternal(name string, d time.Duration) {
 
 func (m *tallyScope) RecordDistribution(id int, d int) {
 	def := m.defs[id]
-	m.RecordDistributionInternal(def.metricName.String(), def.unit, d)
+	m.RecordDistributionInternal(def.MetricName.String(), def.unit, d)
 
 	switch {
 	case !def.metricRollupName.Empty():
 		m.rootScope.RecordDistributionInternal(def.metricRollupName.String(), def.unit, d)
 	case m.isNamespaceTagged:
-		m.rootScope.RecordDistributionInternal(def.metricName.String()+totalMetricSuffix, def.unit, d)
+		m.rootScope.RecordDistributionInternal(def.MetricName.String()+totalMetricSuffix, def.unit, d)
 	}
 }
 


### PR DESCRIPTION
**What changed?**

We are exporting the struct `MetricDefinition` and also making the field `metricName` in that struct a public field.

**Why?**

This is required to implement a custom statsd metric implementation, otherwise we can't correlate the metric
identifier with the metric name.

