### PR TITLE
Change operator service error codes if Search attributes are not found or already exist

### DIFF
--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -150,7 +150,7 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 			return nil, h.error(serviceerror.NewInvalidArgument(fmt.Sprintf(errSearchAttributeIsReservedMessage, saName)), scope, endpointName)
 		}
 		if currentSearchAttributes.IsDefined(saName) {
-			return nil, h.error(serviceerror.NewInvalidArgument(fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName)), scope, endpointName)
+			return nil, h.error(serviceerror.NewAlreadyExist(fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName)), scope, endpointName)
 		}
 		if _, ok := enumspb.IndexedValueType_name[int32(saType)]; !ok {
 			return nil, h.error(serviceerror.NewInvalidArgument(fmt.Sprintf(errUnknownSearchAttributeTypeMessage, saType)), scope, endpointName)
@@ -221,7 +221,7 @@ func (h *OperatorHandlerImpl) RemoveSearchAttributes(ctx context.Context, reques
 
 	for _, saName := range request.GetSearchAttributes() {
 		if !currentSearchAttributes.IsDefined(saName) {
-			return nil, h.error(serviceerror.NewInvalidArgument(fmt.Sprintf(errSearchAttributeDoesntExistMessage, saName)), scope, endpointName)
+			return nil, h.error(serviceerror.NewNotFound(fmt.Sprintf(errSearchAttributeDoesntExistMessage, saName)), scope, endpointName)
 		}
 		if _, ok := newCustomSearchAttributes[saName]; !ok {
 			return nil, h.error(serviceerror.NewInvalidArgument(fmt.Sprintf(errUnableToRemoveNonCustomSearchAttributesMessage, saName)), scope, endpointName)

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -138,7 +138,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 					"CustomTextField": enumspb.INDEXED_VALUE_TYPE_TEXT,
 				},
 			},
-			Expected: &serviceerror.InvalidArgument{Message: "Search attribute CustomTextField already exists."},
+			Expected: &serviceerror.AlreadyExists{Message: "Search attribute CustomTextField already exists."},
 		},
 	}
 	for _, testCase := range testCases3 {
@@ -174,7 +174,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 					"CustomTextField": enumspb.INDEXED_VALUE_TYPE_TEXT,
 				},
 			},
-			Expected: &serviceerror.InvalidArgument{Message: "Search attribute CustomTextField already exists."},
+			Expected: &serviceerror.AlreadyExists{Message: "Search attribute CustomTextField already exists."},
 		},
 	}
 	for _, testCase := range testCases2 {
@@ -315,7 +315,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 					"ProductId",
 				},
 			},
-			Expected: &serviceerror.InvalidArgument{Message: "Search attribute ProductId doesn't exist."},
+			Expected: &serviceerror.NotFound{Message: "Search attribute ProductId doesn't exist."},
 		},
 	}
 	for _, testCase := range testCases3 {
@@ -351,7 +351,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 					"ProductId",
 				},
 			},
-			Expected: &serviceerror.InvalidArgument{Message: "Search attribute ProductId doesn't exist."},
+			Expected: &serviceerror.NotFound{Message: "Search attribute ProductId doesn't exist."},
 		},
 	}
 	for _, testCase := range testCases2 {


### PR DESCRIPTION
Change operator service error codes if Search attributes are not found or already exist to NOT_FOUND and ALREADY_EXIST from INVALID_ARGUMENT, which will simplify the client-side handling of these failures.