### PR TITLE
Persistence Context Part 2: Shard, Task, Metadata, ClusterMetadata Manager

### DIFF
--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -381,8 +381,8 @@ func (m *metadataImpl) refreshLoop(ctx context.Context) error {
 	}
 }
 
-func (m *metadataImpl) refreshClusterMetadata(_ context.Context) error {
-	clusterMetadataMap, err := m.listAllClusterMetadataFromDB()
+func (m *metadataImpl) refreshClusterMetadata(ctx context.Context) error {
+	clusterMetadataMap, err := m.listAllClusterMetadataFromDB(ctx)
 	if err != nil {
 		return err
 	}
@@ -486,7 +486,9 @@ func updateVersionToClusterName(clusterInfo map[string]ClusterInformation, failo
 	return versionToClusterName
 }
 
-func (m *metadataImpl) listAllClusterMetadataFromDB() (map[string]*ClusterInformation, error) {
+func (m *metadataImpl) listAllClusterMetadataFromDB(
+	ctx context.Context,
+) (map[string]*ClusterInformation, error) {
 	result := make(map[string]*ClusterInformation)
 	if m.clusterMetadataStore == nil {
 		return result, nil
@@ -494,6 +496,7 @@ func (m *metadataImpl) listAllClusterMetadataFromDB() (map[string]*ClusterInform
 
 	paginationFn := func(paginationToken []byte) ([]interface{}, []byte, error) {
 		resp, err := m.clusterMetadataStore.ListClusterMetadata(
+			ctx,
 			&persistence.ListClusterMetadataRequest{
 				PageSize:      defaultClusterMetadataPageSize,
 				NextPageToken: paginationToken,

--- a/common/cluster/metadata_test.go
+++ b/common/cluster/metadata_test.go
@@ -160,7 +160,7 @@ func (s *metadataSuite) Test_RefreshClusterMetadata_Success() {
 		s.Nil(newMetadata)
 	}
 
-	s.mockClusterMetadataStore.EXPECT().ListClusterMetadata(gomock.Any()).Return(
+	s.mockClusterMetadataStore.EXPECT().ListClusterMetadata(gomock.Any(), gomock.Any()).Return(
 		&persistence.ListClusterMetadataResponse{
 			ClusterMetadata: []*persistence.GetClusterMetadataResponse{
 				{
@@ -190,7 +190,7 @@ func (s *metadataSuite) Test_RefreshClusterMetadata_Success() {
 func (s *metadataSuite) Test_ListAllClusterMetadataFromDB_Success() {
 	nextPageSizeToken := []byte{1}
 	newClusterName := uuid.New()
-	s.mockClusterMetadataStore.EXPECT().ListClusterMetadata(&persistence.ListClusterMetadataRequest{
+	s.mockClusterMetadataStore.EXPECT().ListClusterMetadata(gomock.Any(), &persistence.ListClusterMetadataRequest{
 		PageSize:      defaultClusterMetadataPageSize,
 		NextPageToken: nil,
 	}).Return(
@@ -208,7 +208,7 @@ func (s *metadataSuite) Test_ListAllClusterMetadataFromDB_Success() {
 			},
 			NextPageToken: nextPageSizeToken,
 		}, nil).Times(1)
-	s.mockClusterMetadataStore.EXPECT().ListClusterMetadata(&persistence.ListClusterMetadataRequest{
+	s.mockClusterMetadataStore.EXPECT().ListClusterMetadata(gomock.Any(), &persistence.ListClusterMetadataRequest{
 		PageSize:      defaultClusterMetadataPageSize,
 		NextPageToken: nextPageSizeToken,
 	}).Return(
@@ -226,7 +226,7 @@ func (s *metadataSuite) Test_ListAllClusterMetadataFromDB_Success() {
 			},
 		}, nil).Times(1)
 
-	resp, err := s.metadata.listAllClusterMetadataFromDB()
+	resp, err := s.metadata.listAllClusterMetadataFromDB(context.Background())
 	s.NoError(err)
 	s.Equal(2, len(resp))
 }

--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -245,7 +245,7 @@ func fetchCurrentBootstrapHostports(manager persistence.ClusterMetadataManager, 
 
 	for {
 		resp, err := manager.GetClusterMembers(
-			context.Background(),
+			context.TODO(),
 			&persistence.GetClusterMembersRequest{
 				LastHeartbeatWithin: healthyHostLastHeartbeatCutoff,
 				PageSize:            pageSize,

--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -25,6 +25,7 @@
 package membership
 
 import (
+	"context"
 	"fmt"
 	"math"
 	"math/rand"
@@ -156,8 +157,11 @@ func ServiceNameToServiceTypeEnum(name string) (persistence.ServiceType, error) 
 	}
 }
 
-func (rpo *ringpopMonitor) upsertMyMembership(request *persistence.UpsertClusterMembershipRequest) error {
-	err := rpo.metadataManager.UpsertClusterMembership(request)
+func (rpo *ringpopMonitor) upsertMyMembership(
+	ctx context.Context,
+	request *persistence.UpsertClusterMembershipRequest,
+) error {
+	err := rpo.metadataManager.UpsertClusterMembership(ctx, request)
 
 	if err == nil {
 		rpo.logger.Debug("Membership heartbeat upserted successfully",
@@ -187,7 +191,10 @@ func SplitHostPortTyped(hostPort string) (net.IP, uint16, error) {
 
 func (rpo *ringpopMonitor) startHeartbeat(broadcastHostport string) error {
 	// Start by cleaning up expired records to avoid growth
-	err := rpo.metadataManager.PruneClusterMembership(&persistence.PruneClusterMembershipRequest{MaxRecordsPruned: 10})
+	err := rpo.metadataManager.PruneClusterMembership(context.TODO(), &persistence.PruneClusterMembershipRequest{MaxRecordsPruned: 10})
+	if err != nil {
+		return err
+	}
 
 	sessionStarted := time.Now().UTC()
 
@@ -217,7 +224,7 @@ func (rpo *ringpopMonitor) startHeartbeat(broadcastHostport string) error {
 	// Expire in 48 hours to allow for inspection of table by humans for debug scenarios.
 	// For bootstrapping, we filter to a much shorter duration on the
 	// read side by filtering on the last time a heartbeat was seen.
-	err = rpo.upsertMyMembership(req)
+	err = rpo.upsertMyMembership(context.TODO(), req)
 	if err == nil {
 		rpo.logger.Info("Membership heartbeat upserted successfully",
 			tag.Address(broadcastAddress.String()),
@@ -238,6 +245,7 @@ func fetchCurrentBootstrapHostports(manager persistence.ClusterMetadataManager, 
 
 	for {
 		resp, err := manager.GetClusterMembers(
+			context.Background(),
 			&persistence.GetClusterMembersRequest{
 				LastHeartbeatWithin: healthyHostLastHeartbeatCutoff,
 				PageSize:            pageSize,
@@ -270,7 +278,7 @@ func fetchCurrentBootstrapHostports(manager persistence.ClusterMetadataManager, 
 func (rpo *ringpopMonitor) startHeartbeatUpsertLoop(request *persistence.UpsertClusterMembershipRequest) {
 	loopUpsertMembership := func() {
 		for {
-			err := rpo.upsertMyMembership(request)
+			err := rpo.upsertMyMembership(context.TODO(), request)
 
 			if err != nil {
 				rpo.logger.Error("Membership upsert failed.", tag.Error(err))

--- a/common/membership/rp_cluster_test.go
+++ b/common/membership/rp_cluster_test.go
@@ -25,6 +25,7 @@
 package membership
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -120,7 +121,7 @@ func NewTestRingpopCluster(
 
 	firstGetClusterMemberCall := true
 	mockMgr.EXPECT().GetClusterMembers(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ *persistence.GetClusterMembersRequest) (*persistence.GetClusterMembersResponse, error) {
+		func(_ context.Context, _ *persistence.GetClusterMembersRequest) (*persistence.GetClusterMembersResponse, error) {
 			res := &persistence.GetClusterMembersResponse{ActiveMembers: []*persistence.ClusterMember{seedMember}}
 
 			if firstGetClusterMemberCall {

--- a/common/membership/rp_cluster_test.go
+++ b/common/membership/rp_cluster_test.go
@@ -65,8 +65,8 @@ func NewTestRingpopCluster(
 	defer ctrl.Finish()
 
 	mockMgr := persistence.NewMockClusterMetadataManager(ctrl)
-	mockMgr.EXPECT().PruneClusterMembership(gomock.Any()).Return(nil).AnyTimes()
-	mockMgr.EXPECT().UpsertClusterMembership(gomock.Any()).Return(nil).AnyTimes()
+	mockMgr.EXPECT().PruneClusterMembership(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	mockMgr.EXPECT().UpsertClusterMembership(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	cluster := &TestRingpopCluster{
 		hostUUIDs:    make([]string, size),
@@ -119,7 +119,7 @@ func NewTestRingpopCluster(
 	}
 
 	firstGetClusterMemberCall := true
-	mockMgr.EXPECT().GetClusterMembers(gomock.Any()).DoAndReturn(
+	mockMgr.EXPECT().GetClusterMembers(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ *persistence.GetClusterMembersRequest) (*persistence.GetClusterMembersResponse, error) {
 			res := &persistence.GetClusterMembersResponse{ActiveMembers: []*persistence.ClusterMember{seedMember}}
 

--- a/common/namespace/dlqMessageHandler.go
+++ b/common/namespace/dlqMessageHandler.go
@@ -27,6 +27,8 @@
 package namespace
 
 import (
+	"context"
+
 	"go.temporal.io/api/serviceerror"
 
 	replicationspb "go.temporal.io/server/api/replication/v1"
@@ -38,9 +40,9 @@ import (
 type (
 	// DLQMessageHandler is the interface handles namespace DLQ messages
 	DLQMessageHandler interface {
-		Read(lastMessageID int64, pageSize int, pageToken []byte) ([]*replicationspb.ReplicationTask, []byte, error)
-		Purge(lastMessageID int64) error
-		Merge(lastMessageID int64, pageSize int, pageToken []byte) ([]byte, error)
+		Read(ctx context.Context, lastMessageID int64, pageSize int, pageToken []byte) ([]*replicationspb.ReplicationTask, []byte, error)
+		Purge(ctx context.Context, lastMessageID int64) error
+		Merge(ctx context.Context, lastMessageID int64, pageSize int, pageToken []byte) ([]byte, error)
 	}
 
 	dlqMessageHandlerImpl struct {
@@ -65,6 +67,7 @@ func NewDLQMessageHandler(
 
 // ReadMessages reads namespace replication DLQ messages
 func (d *dlqMessageHandlerImpl) Read(
+	ctx context.Context,
 	lastMessageID int64,
 	pageSize int,
 	pageToken []byte,
@@ -85,6 +88,7 @@ func (d *dlqMessageHandlerImpl) Read(
 
 // PurgeMessages purges namespace replication DLQ messages
 func (d *dlqMessageHandlerImpl) Purge(
+	ctx context.Context,
 	lastMessageID int64,
 ) error {
 
@@ -111,6 +115,7 @@ func (d *dlqMessageHandlerImpl) Purge(
 
 // MergeMessages merges namespace replication DLQ messages
 func (d *dlqMessageHandlerImpl) Merge(
+	ctx context.Context,
 	lastMessageID int64,
 	pageSize int,
 	pageToken []byte,
@@ -139,6 +144,7 @@ func (d *dlqMessageHandlerImpl) Merge(
 		}
 
 		if err := d.replicationHandler.Execute(
+			ctx,
 			namespaceTask,
 		); err != nil {
 			return nil, err

--- a/common/namespace/dlqMessageHandler_mock.go
+++ b/common/namespace/dlqMessageHandler_mock.go
@@ -29,6 +29,7 @@
 package namespace
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -59,38 +60,38 @@ func (m *MockDLQMessageHandler) EXPECT() *MockDLQMessageHandlerMockRecorder {
 }
 
 // Merge mocks base method.
-func (m *MockDLQMessageHandler) Merge(lastMessageID int64, pageSize int, pageToken []byte) ([]byte, error) {
+func (m *MockDLQMessageHandler) Merge(ctx context.Context, lastMessageID int64, pageSize int, pageToken []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Merge", lastMessageID, pageSize, pageToken)
+	ret := m.ctrl.Call(m, "Merge", ctx, lastMessageID, pageSize, pageToken)
 	ret0, _ := ret[0].([]byte)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Merge indicates an expected call of Merge.
-func (mr *MockDLQMessageHandlerMockRecorder) Merge(lastMessageID, pageSize, pageToken interface{}) *gomock.Call {
+func (mr *MockDLQMessageHandlerMockRecorder) Merge(ctx, lastMessageID, pageSize, pageToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Merge", reflect.TypeOf((*MockDLQMessageHandler)(nil).Merge), lastMessageID, pageSize, pageToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Merge", reflect.TypeOf((*MockDLQMessageHandler)(nil).Merge), ctx, lastMessageID, pageSize, pageToken)
 }
 
 // Purge mocks base method.
-func (m *MockDLQMessageHandler) Purge(lastMessageID int64) error {
+func (m *MockDLQMessageHandler) Purge(ctx context.Context, lastMessageID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Purge", lastMessageID)
+	ret := m.ctrl.Call(m, "Purge", ctx, lastMessageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Purge indicates an expected call of Purge.
-func (mr *MockDLQMessageHandlerMockRecorder) Purge(lastMessageID interface{}) *gomock.Call {
+func (mr *MockDLQMessageHandlerMockRecorder) Purge(ctx, lastMessageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Purge", reflect.TypeOf((*MockDLQMessageHandler)(nil).Purge), lastMessageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Purge", reflect.TypeOf((*MockDLQMessageHandler)(nil).Purge), ctx, lastMessageID)
 }
 
 // Read mocks base method.
-func (m *MockDLQMessageHandler) Read(lastMessageID int64, pageSize int, pageToken []byte) ([]*repication.ReplicationTask, []byte, error) {
+func (m *MockDLQMessageHandler) Read(ctx context.Context, lastMessageID int64, pageSize int, pageToken []byte) ([]*repication.ReplicationTask, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Read", lastMessageID, pageSize, pageToken)
+	ret := m.ctrl.Call(m, "Read", ctx, lastMessageID, pageSize, pageToken)
 	ret0, _ := ret[0].([]*repication.ReplicationTask)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -98,7 +99,7 @@ func (m *MockDLQMessageHandler) Read(lastMessageID int64, pageSize int, pageToke
 }
 
 // Read indicates an expected call of Read.
-func (mr *MockDLQMessageHandlerMockRecorder) Read(lastMessageID, pageSize, pageToken interface{}) *gomock.Call {
+func (mr *MockDLQMessageHandlerMockRecorder) Read(ctx, lastMessageID, pageSize, pageToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockDLQMessageHandler)(nil).Read), lastMessageID, pageSize, pageToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockDLQMessageHandler)(nil).Read), ctx, lastMessageID, pageSize, pageToken)
 }

--- a/common/namespace/handler.go
+++ b/common/namespace/handler.go
@@ -117,7 +117,7 @@ func NewHandler(
 
 // RegisterNamespace register a new namespace
 func (d *HandlerImpl) RegisterNamespace(
-	_ context.Context,
+	ctx context.Context,
 	registerRequest *workflowservice.RegisterNamespaceRequest,
 ) (*workflowservice.RegisterNamespaceResponse, error) {
 
@@ -141,7 +141,7 @@ func (d *HandlerImpl) RegisterNamespace(
 	}
 
 	// first check if the name is already registered as the local namespace
-	_, err := d.metadataMgr.GetNamespace(&persistence.GetNamespaceRequest{Name: registerRequest.GetNamespace()})
+	_, err := d.metadataMgr.GetNamespace(ctx, &persistence.GetNamespaceRequest{Name: registerRequest.GetNamespace()})
 	switch err.(type) {
 	case nil:
 		// namespace already exists, cannot proceed
@@ -262,7 +262,7 @@ func (d *HandlerImpl) RegisterNamespace(
 		IsGlobalNamespace: isGlobalNamespace,
 	}
 
-	namespaceResponse, err := d.metadataMgr.CreateNamespace(namespaceRequest)
+	namespaceResponse, err := d.metadataMgr.CreateNamespace(ctx, namespaceRequest)
 	if err != nil {
 		return nil, err
 	}
@@ -299,7 +299,7 @@ func (d *HandlerImpl) ListNamespaces(
 		pageSize = int(listRequest.GetPageSize())
 	}
 
-	resp, err := d.metadataMgr.ListNamespaces(&persistence.ListNamespacesRequest{
+	resp, err := d.metadataMgr.ListNamespaces(ctx, &persistence.ListNamespacesRequest{
 		PageSize:      pageSize,
 		NextPageToken: listRequest.NextPageToken,
 	})
@@ -341,7 +341,7 @@ func (d *HandlerImpl) DescribeNamespace(
 		Name: describeRequest.GetNamespace(),
 		ID:   describeRequest.GetId(),
 	}
-	resp, err := d.metadataMgr.GetNamespace(req)
+	resp, err := d.metadataMgr.GetNamespace(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -365,12 +365,12 @@ func (d *HandlerImpl) UpdateNamespace(
 	// this version can be regarded as the lock on the v2 namespace table
 	// and since we do not know which table will return the namespace afterwards
 	// this call has to be made
-	metadata, err := d.metadataMgr.GetMetadata()
+	metadata, err := d.metadataMgr.GetMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}
 	notificationVersion := metadata.NotificationVersion
-	getResponse, err := d.metadataMgr.GetNamespace(&persistence.GetNamespaceRequest{Name: updateRequest.GetNamespace()})
+	getResponse, err := d.metadataMgr.GetNamespace(ctx, &persistence.GetNamespaceRequest{Name: updateRequest.GetNamespace()})
 	if err != nil {
 		return nil, err
 	}
@@ -564,7 +564,7 @@ func (d *HandlerImpl) UpdateNamespace(
 			IsGlobalNamespace:   isGlobalNamespace,
 			NotificationVersion: notificationVersion,
 		}
-		err = d.metadataMgr.UpdateNamespace(updateReq)
+		err = d.metadataMgr.UpdateNamespace(ctx, updateReq)
 		if err != nil {
 			return nil, err
 		}
@@ -606,12 +606,12 @@ func (d *HandlerImpl) DeprecateNamespace(
 	// this version can be regarded as the lock on the v2 namespace table
 	// and since we do not know which table will return the namespace afterwards
 	// this call has to be made
-	metadata, err := d.metadataMgr.GetMetadata()
+	metadata, err := d.metadataMgr.GetMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}
 	notificationVersion := metadata.NotificationVersion
-	getResponse, err := d.metadataMgr.GetNamespace(&persistence.GetNamespaceRequest{Name: deprecateRequest.GetNamespace()})
+	getResponse, err := d.metadataMgr.GetNamespace(ctx, &persistence.GetNamespaceRequest{Name: deprecateRequest.GetNamespace()})
 	if err != nil {
 		return nil, err
 	}
@@ -630,7 +630,7 @@ func (d *HandlerImpl) DeprecateNamespace(
 		NotificationVersion: notificationVersion,
 		IsGlobalNamespace:   getResponse.IsGlobalNamespace,
 	}
-	err = d.metadataMgr.UpdateNamespace(updateReq)
+	err = d.metadataMgr.UpdateNamespace(ctx, updateReq)
 	if err != nil {
 		return nil, err
 	}

--- a/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
@@ -491,7 +491,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 	data := map[string]string{"some random key": "some random value"}
 	isGlobalNamespace := true
 
-	_, err := s.MetadataManager.CreateNamespace(&persistence.CreateNamespaceRequest{
+	_, err := s.MetadataManager.CreateNamespace(context.Background(), &persistence.CreateNamespaceRequest{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
 				Id:          uuid.New(),
@@ -550,7 +550,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 	data := map[string]string{"some random key": "some random value"}
 	isGlobalNamespace := true
 
-	_, err := s.MetadataManager.CreateNamespace(&persistence.CreateNamespaceRequest{
+	_, err := s.MetadataManager.CreateNamespace(context.Background(), &persistence.CreateNamespaceRequest{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
 				Id:          uuid.New(),
@@ -627,7 +627,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 	data := map[string]string{"some random key": "some random value"}
 	isGlobalNamespace := true
 
-	_, err := s.MetadataManager.CreateNamespace(&persistence.CreateNamespaceRequest{
+	_, err := s.MetadataManager.CreateNamespace(context.Background(), &persistence.CreateNamespaceRequest{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
 				Id:          uuid.New(),

--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -103,17 +103,19 @@ type (
 		// from persistent storage, returning an instance of
 		// serviceerror.NotFound if there is no matching Namespace.
 		GetNamespace(
-			request *persistence.GetNamespaceRequest,
+			context.Context,
+			*persistence.GetNamespaceRequest,
 		) (*persistence.GetNamespaceResponse, error)
 
 		// ListNamespaces fetches a paged set of namespace persistent state
 		// instances.
 		ListNamespaces(
+			context.Context,
 			*persistence.ListNamespacesRequest,
 		) (*persistence.ListNamespacesResponse, error)
 
 		// GetMetadata fetches the notification version for Temporal namespaces.
-		GetMetadata() (*persistence.GetMetadataResponse, error)
+		GetMetadata(context.Context) (*persistence.GetMetadataResponse, error)
 	}
 
 	// PrepareCallbackFn is function to be called before CallbackFn is called,
@@ -379,7 +381,7 @@ func (r *registry) refreshLoop(ctx context.Context) error {
 func (r *registry) refreshNamespaces(ctx context.Context) error {
 	// first load the metadata record, then load namespaces
 	// this can guarantee that namespaces in the cache are not updated more than metadata record
-	metadata, err := r.persistence.GetMetadata()
+	metadata, err := r.persistence.GetMetadata(ctx)
 	if err != nil {
 		return err
 	}
@@ -390,7 +392,7 @@ func (r *registry) refreshNamespaces(ctx context.Context) error {
 	namespaceIDsDb := make(map[ID]struct{})
 
 	for {
-		response, err := r.persistence.ListNamespaces(request)
+		response, err := r.persistence.ListNamespaces(ctx, request)
 		if err != nil {
 			return err
 		}

--- a/common/namespace/registry_mock.go
+++ b/common/namespace/registry_mock.go
@@ -29,6 +29,7 @@
 package namespace
 
 import (
+	context "context"
 	reflect "reflect"
 	time "time"
 
@@ -97,48 +98,48 @@ func (m *MockPersistence) EXPECT() *MockPersistenceMockRecorder {
 }
 
 // GetMetadata mocks base method.
-func (m *MockPersistence) GetMetadata() (*persistence.GetMetadataResponse, error) {
+func (m *MockPersistence) GetMetadata(arg0 context.Context) (*persistence.GetMetadataResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetadata")
+	ret := m.ctrl.Call(m, "GetMetadata", arg0)
 	ret0, _ := ret[0].(*persistence.GetMetadataResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMetadata indicates an expected call of GetMetadata.
-func (mr *MockPersistenceMockRecorder) GetMetadata() *gomock.Call {
+func (mr *MockPersistenceMockRecorder) GetMetadata(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockPersistence)(nil).GetMetadata))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockPersistence)(nil).GetMetadata), arg0)
 }
 
 // GetNamespace mocks base method.
-func (m *MockPersistence) GetNamespace(request *persistence.GetNamespaceRequest) (*persistence.GetNamespaceResponse, error) {
+func (m *MockPersistence) GetNamespace(arg0 context.Context, arg1 *persistence.GetNamespaceRequest) (*persistence.GetNamespaceResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNamespace", request)
+	ret := m.ctrl.Call(m, "GetNamespace", arg0, arg1)
 	ret0, _ := ret[0].(*persistence.GetNamespaceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNamespace indicates an expected call of GetNamespace.
-func (mr *MockPersistenceMockRecorder) GetNamespace(request interface{}) *gomock.Call {
+func (mr *MockPersistenceMockRecorder) GetNamespace(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockPersistence)(nil).GetNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockPersistence)(nil).GetNamespace), arg0, arg1)
 }
 
 // ListNamespaces mocks base method.
-func (m *MockPersistence) ListNamespaces(arg0 *persistence.ListNamespacesRequest) (*persistence.ListNamespacesResponse, error) {
+func (m *MockPersistence) ListNamespaces(arg0 context.Context, arg1 *persistence.ListNamespacesRequest) (*persistence.ListNamespacesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNamespaces", arg0)
+	ret := m.ctrl.Call(m, "ListNamespaces", arg0, arg1)
 	ret0, _ := ret[0].(*persistence.ListNamespacesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListNamespaces indicates an expected call of ListNamespaces.
-func (mr *MockPersistenceMockRecorder) ListNamespaces(arg0 interface{}) *gomock.Call {
+func (mr *MockPersistenceMockRecorder) ListNamespaces(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockPersistence)(nil).ListNamespaces), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockPersistence)(nil).ListNamespaces), arg0, arg1)
 }
 
 // MockRegistry is a mock of Registry interface.

--- a/common/namespace/registry_test.go
+++ b/common/namespace/registry_test.go
@@ -160,11 +160,11 @@ func (s *registrySuite) TestListNamespace() {
 
 	pageToken := []byte("some random page token")
 
-	s.regPersistence.EXPECT().GetMetadata().Return(
+	s.regPersistence.EXPECT().GetMetadata(gomock.Any()).Return(
 		&persistence.GetMetadataResponse{
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
-	s.regPersistence.EXPECT().ListNamespaces(&persistence.ListNamespacesRequest{
+	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
 		PageSize:      namespace.CacheRefreshPageSize,
 		NextPageToken: nil,
 	}).Return(&persistence.ListNamespacesResponse{
@@ -172,7 +172,7 @@ func (s *registrySuite) TestListNamespace() {
 		NextPageToken: pageToken,
 	}, nil)
 
-	s.regPersistence.EXPECT().ListNamespaces(&persistence.ListNamespacesRequest{
+	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
 		PageSize:      namespace.CacheRefreshPageSize,
 		NextPageToken: pageToken,
 	}).Return(&persistence.ListNamespacesResponse{
@@ -257,11 +257,11 @@ func (s *registrySuite) TestRegisterCallback_CatchUp() {
 	entry2 := namespace.FromPersistentState(namespaceRecord2)
 	namespaceNotificationVersion++
 
-	s.regPersistence.EXPECT().GetMetadata().Return(
+	s.regPersistence.EXPECT().GetMetadata(gomock.Any()).Return(
 		&persistence.GetMetadataResponse{
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
-	s.regPersistence.EXPECT().ListNamespaces(&persistence.ListNamespacesRequest{
+	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
 		PageSize:      namespace.CacheRefreshPageSize,
 		NextPageToken: nil,
 	}).Return(&persistence.ListNamespacesResponse{
@@ -355,11 +355,11 @@ func (s *registrySuite) TestUpdateCache_TriggerCallBack() {
 	entry2Old := namespace.FromPersistentState(namespaceRecord2Old)
 	namespaceNotificationVersion++
 
-	s.regPersistence.EXPECT().GetMetadata().Return(
+	s.regPersistence.EXPECT().GetMetadata(gomock.Any()).Return(
 		&persistence.GetMetadataResponse{
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
-	s.regPersistence.EXPECT().ListNamespaces(&persistence.ListNamespacesRequest{
+	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
 		PageSize:      namespace.CacheRefreshPageSize,
 		NextPageToken: nil,
 	}).Return(&persistence.ListNamespacesResponse{
@@ -434,11 +434,11 @@ func (s *registrySuite) TestUpdateCache_TriggerCallBack() {
 	s.Empty(entriesOld)
 	s.Empty(entriesNew)
 
-	s.regPersistence.EXPECT().GetMetadata().Return(
+	s.regPersistence.EXPECT().GetMetadata(gomock.Any()).Return(
 		&persistence.GetMetadataResponse{
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
-	s.regPersistence.EXPECT().ListNamespaces(&persistence.ListNamespacesRequest{
+	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
 		PageSize:      namespace.CacheRefreshPageSize,
 		NextPageToken: nil,
 	}).Return(&persistence.ListNamespacesResponse{
@@ -461,7 +461,7 @@ func (s *registrySuite) TestUpdateCache_TriggerCallBack() {
 
 func (s *registrySuite) TestGetTriggerListAndUpdateCache_ConcurrentAccess() {
 	namespaceNotificationVersion := int64(999999) // make this notification version really large for test
-	s.regPersistence.EXPECT().GetMetadata().Return(
+	s.regPersistence.EXPECT().GetMetadata(gomock.Any()).Return(
 		&persistence.GetMetadataResponse{
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
@@ -487,7 +487,7 @@ func (s *registrySuite) TestGetTriggerListAndUpdateCache_ConcurrentAccess() {
 	}
 	entryOld := namespace.FromPersistentState(namespaceRecordOld)
 
-	s.regPersistence.EXPECT().ListNamespaces(&persistence.ListNamespacesRequest{
+	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
 		PageSize:      namespace.CacheRefreshPageSize,
 		NextPageToken: nil,
 	}).Return(&persistence.ListNamespacesResponse{
@@ -583,11 +583,11 @@ func (s *registrySuite) TestRemoveDeletedNamespace() {
 	}
 	namespaceNotificationVersion++
 
-	s.regPersistence.EXPECT().GetMetadata().Return(
+	s.regPersistence.EXPECT().GetMetadata(gomock.Any()).Return(
 		&persistence.GetMetadataResponse{
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
-	s.regPersistence.EXPECT().ListNamespaces(&persistence.ListNamespacesRequest{
+	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
 		PageSize:      namespace.CacheRefreshPageSize,
 		NextPageToken: nil,
 	}).Return(&persistence.ListNamespacesResponse{
@@ -601,11 +601,11 @@ func (s *registrySuite) TestRemoveDeletedNamespace() {
 	s.registry.Start()
 	defer s.registry.Stop()
 
-	s.regPersistence.EXPECT().GetMetadata().Return(
+	s.regPersistence.EXPECT().GetMetadata(gomock.Any()).Return(
 		&persistence.GetMetadataResponse{
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
-	s.regPersistence.EXPECT().ListNamespaces(&persistence.ListNamespacesRequest{
+	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
 		PageSize:      namespace.CacheRefreshPageSize,
 		NextPageToken: nil,
 	}).Return(&persistence.ListNamespacesResponse{
@@ -640,9 +640,9 @@ func TestCacheByName(t *testing.T) {
 		},
 	}
 	regPersist := persistence.NewMockMetadataManager(gomock.NewController(t))
-	regPersist.EXPECT().GetMetadata().Return(
+	regPersist.EXPECT().GetMetadata(gomock.Any()).Return(
 		&persistence.GetMetadataResponse{NotificationVersion: nsrec.NotificationVersion + 1}, nil)
-	regPersist.EXPECT().ListNamespaces(gomock.Any()).Return(&persistence.ListNamespacesResponse{
+	regPersist.EXPECT().ListNamespaces(gomock.Any(), gomock.Any()).Return(&persistence.ListNamespacesResponse{
 		Namespaces: []*persistence.GetNamespaceResponse{&nsrec},
 	}, nil)
 	reg := namespace.NewRegistry(

--- a/common/namespace/replicationTaskExecutor_test.go
+++ b/common/namespace/replicationTaskExecutor_test.go
@@ -25,6 +25,7 @@
 package namespace
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -127,18 +128,18 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 		FailoverVersion: failoverVersion,
 	}
 
-	err := s.namespaceReplicator.Execute(task)
+	err := s.namespaceReplicator.Execute(context.Background(), task)
 	s.Nil(err)
 
 	task.Id = uuid.New()
 	task.Info.Name = name
-	err = s.namespaceReplicator.Execute(task)
+	err = s.namespaceReplicator.Execute(context.Background(), task)
 	s.NotNil(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 
 	task.Id = id
 	task.Info.Name = "other random namespace test name"
-	err = s.namespaceReplicator.Execute(task)
+	err = s.namespaceReplicator.Execute(context.Background(), task)
 	s.NotNil(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 }
@@ -194,13 +195,13 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 		FailoverVersion: failoverVersion,
 	}
 
-	metadata, err := s.MetadataManager.GetMetadata()
+	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
-	err = s.namespaceReplicator.Execute(task)
+	err = s.namespaceReplicator.Execute(context.Background(), task)
 	s.Nil(err)
 
-	resp, err := s.MetadataManager.GetNamespace(&persistence.GetNamespaceRequest{ID: id})
+	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{ID: id})
 	s.Nil(err)
 	s.NotNil(resp)
 	s.EqualValues(id, resp.Namespace.Info.Id)
@@ -222,7 +223,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 	s.Equal(notificationVersion, resp.NotificationVersion)
 
 	// handle duplicated task
-	err = s.namespaceReplicator.Execute(task)
+	err = s.namespaceReplicator.Execute(context.Background(), task)
 	s.Nil(err)
 }
 
@@ -277,13 +278,13 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		FailoverVersion: failoverVersion,
 	}
 
-	metadata, err := s.MetadataManager.GetMetadata()
+	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
-	err = s.namespaceReplicator.Execute(updateTask)
+	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
 
-	resp, err := s.MetadataManager.GetNamespace(&persistence.GetNamespaceRequest{Name: name})
+	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})
 	s.Nil(err)
 	s.NotNil(resp)
 	s.EqualValues(id, resp.Namespace.Info.Id)
@@ -356,7 +357,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		FailoverVersion: failoverVersion,
 	}
 
-	err := s.namespaceReplicator.Execute(createTask)
+	err := s.namespaceReplicator.Execute(context.Background(), createTask)
 	s.Nil(err)
 
 	// success update case
@@ -406,12 +407,12 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		ConfigVersion:   updateConfigVersion,
 		FailoverVersion: updateFailoverVersion,
 	}
-	metadata, err := s.MetadataManager.GetMetadata()
+	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
-	err = s.namespaceReplicator.Execute(updateTask)
+	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
-	resp, err := s.MetadataManager.GetNamespace(&persistence.GetNamespaceRequest{Name: name})
+	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})
 	s.Nil(err)
 	s.NotNil(resp)
 	s.EqualValues(id, resp.Namespace.Info.Id)
@@ -484,7 +485,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		FailoverVersion: failoverVersion,
 	}
 
-	err := s.namespaceReplicator.Execute(createTask)
+	err := s.namespaceReplicator.Execute(context.Background(), createTask)
 	s.Nil(err)
 
 	// success update case
@@ -534,12 +535,12 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		ConfigVersion:   updateConfigVersion,
 		FailoverVersion: updateFailoverVersion,
 	}
-	metadata, err := s.MetadataManager.GetMetadata()
+	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
-	err = s.namespaceReplicator.Execute(updateTask)
+	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
-	resp, err := s.MetadataManager.GetNamespace(&persistence.GetNamespaceRequest{Name: name})
+	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})
 	s.Nil(err)
 	s.NotNil(resp)
 	s.EqualValues(id, resp.Namespace.Info.Id)
@@ -612,7 +613,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		FailoverVersion: failoverVersion,
 	}
 
-	err := s.namespaceReplicator.Execute(createTask)
+	err := s.namespaceReplicator.Execute(context.Background(), createTask)
 	s.Nil(err)
 
 	// success update case
@@ -658,12 +659,12 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		ConfigVersion:   updateConfigVersion,
 		FailoverVersion: updateFailoverVersion,
 	}
-	metadata, err := s.MetadataManager.GetMetadata()
+	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
-	err = s.namespaceReplicator.Execute(updateTask)
+	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
-	resp, err := s.MetadataManager.GetNamespace(&persistence.GetNamespaceRequest{Name: name})
+	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})
 	s.Nil(err)
 	s.NotNil(resp)
 	s.EqualValues(id, resp.Namespace.Info.Id)
@@ -735,10 +736,10 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		ConfigVersion:   configVersion,
 		FailoverVersion: failoverVersion,
 	}
-	metadata, err := s.MetadataManager.GetMetadata()
+	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
-	err = s.namespaceReplicator.Execute(createTask)
+	err = s.namespaceReplicator.Execute(context.Background(), createTask)
 	s.Nil(err)
 
 	// success update case
@@ -784,9 +785,9 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		ConfigVersion:   updateConfigVersion,
 		FailoverVersion: updateFailoverVersion,
 	}
-	err = s.namespaceReplicator.Execute(updateTask)
+	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
-	resp, err := s.MetadataManager.GetNamespace(&persistence.GetNamespaceRequest{Name: name})
+	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})
 	s.Nil(err)
 	s.NotNil(resp)
 	s.EqualValues(id, resp.Namespace.Info.Id)

--- a/common/namespace/replicationTaskHandler_mock.go
+++ b/common/namespace/replicationTaskHandler_mock.go
@@ -29,6 +29,7 @@
 package namespace
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -59,15 +60,15 @@ func (m *MockReplicationTaskExecutor) EXPECT() *MockReplicationTaskExecutorMockR
 }
 
 // Execute mocks base method.
-func (m *MockReplicationTaskExecutor) Execute(task *repication.NamespaceTaskAttributes) error {
+func (m *MockReplicationTaskExecutor) Execute(ctx context.Context, task *repication.NamespaceTaskAttributes) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Execute", task)
+	ret := m.ctrl.Call(m, "Execute", ctx, task)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Execute indicates an expected call of Execute.
-func (mr *MockReplicationTaskExecutorMockRecorder) Execute(task interface{}) *gomock.Call {
+func (mr *MockReplicationTaskExecutorMockRecorder) Execute(ctx, task interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockReplicationTaskExecutor)(nil).Execute), task)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockReplicationTaskExecutor)(nil).Execute), ctx, task)
 }

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -976,8 +976,8 @@ type (
 	ShardManager interface {
 		Closeable
 		GetName() string
-		GetOrCreateShard(request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error)
-		UpdateShard(request *UpdateShardRequest) error
+		GetOrCreateShard(ctx context.Context, request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error)
+		UpdateShard(ctx context.Context, request *UpdateShardRequest) error
 	}
 
 	// ExecutionManager is used to manage workflow executions
@@ -1043,14 +1043,14 @@ type (
 	TaskManager interface {
 		Closeable
 		GetName() string
-		CreateTaskQueue(request *CreateTaskQueueRequest) (*CreateTaskQueueResponse, error)
-		UpdateTaskQueue(request *UpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error)
-		GetTaskQueue(request *GetTaskQueueRequest) (*GetTaskQueueResponse, error)
-		ListTaskQueue(request *ListTaskQueueRequest) (*ListTaskQueueResponse, error)
-		DeleteTaskQueue(request *DeleteTaskQueueRequest) error
-		CreateTasks(request *CreateTasksRequest) (*CreateTasksResponse, error)
-		GetTasks(request *GetTasksRequest) (*GetTasksResponse, error)
-		CompleteTask(request *CompleteTaskRequest) error
+		CreateTaskQueue(ctx context.Context, request *CreateTaskQueueRequest) (*CreateTaskQueueResponse, error)
+		UpdateTaskQueue(ctx context.Context, request *UpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error)
+		GetTaskQueue(ctx context.Context, request *GetTaskQueueRequest) (*GetTaskQueueResponse, error)
+		ListTaskQueue(ctx context.Context, request *ListTaskQueueRequest) (*ListTaskQueueResponse, error)
+		DeleteTaskQueue(ctx context.Context, request *DeleteTaskQueueRequest) error
+		CreateTasks(ctx context.Context, request *CreateTasksRequest) (*CreateTasksResponse, error)
+		GetTasks(ctx context.Context, request *GetTasksRequest) (*GetTasksResponse, error)
+		CompleteTask(ctx context.Context, request *CompleteTaskRequest) error
 		// CompleteTasksLessThan completes tasks less than or equal to the given task id
 		// This API takes a limit parameter which specifies the count of maxRows that
 		// can be deleted. This parameter may be ignored by the underlying storage, but
@@ -1060,36 +1060,36 @@ type (
 		// On success, this method returns:
 		//  - number of rows actually deleted, if limit is honored
 		//  - UnknownNumRowsDeleted, when all rows below value are deleted
-		CompleteTasksLessThan(request *CompleteTasksLessThanRequest) (int, error)
+		CompleteTasksLessThan(ctx context.Context, request *CompleteTasksLessThanRequest) (int, error)
 	}
 
 	// MetadataManager is used to manage metadata CRUD for namespace entities
 	MetadataManager interface {
 		Closeable
 		GetName() string
-		CreateNamespace(request *CreateNamespaceRequest) (*CreateNamespaceResponse, error)
-		GetNamespace(request *GetNamespaceRequest) (*GetNamespaceResponse, error)
-		UpdateNamespace(request *UpdateNamespaceRequest) error
-		RenameNamespace(request *RenameNamespaceRequest) error
-		DeleteNamespace(request *DeleteNamespaceRequest) error
-		DeleteNamespaceByName(request *DeleteNamespaceByNameRequest) error
-		ListNamespaces(request *ListNamespacesRequest) (*ListNamespacesResponse, error)
-		GetMetadata() (*GetMetadataResponse, error)
-		InitializeSystemNamespaces(currentClusterName string) error
+		CreateNamespace(ctx context.Context, request *CreateNamespaceRequest) (*CreateNamespaceResponse, error)
+		GetNamespace(ctx context.Context, request *GetNamespaceRequest) (*GetNamespaceResponse, error)
+		UpdateNamespace(ctx context.Context, request *UpdateNamespaceRequest) error
+		RenameNamespace(ctx context.Context, request *RenameNamespaceRequest) error
+		DeleteNamespace(ctx context.Context, request *DeleteNamespaceRequest) error
+		DeleteNamespaceByName(ctx context.Context, request *DeleteNamespaceByNameRequest) error
+		ListNamespaces(ctx context.Context, request *ListNamespacesRequest) (*ListNamespacesResponse, error)
+		GetMetadata(ctx context.Context) (*GetMetadataResponse, error)
+		InitializeSystemNamespaces(ctx context.Context, currentClusterName string) error
 	}
 
 	// ClusterMetadataManager is used to manage cluster-wide metadata and configuration
 	ClusterMetadataManager interface {
 		Closeable
 		GetName() string
-		GetClusterMembers(request *GetClusterMembersRequest) (*GetClusterMembersResponse, error)
-		UpsertClusterMembership(request *UpsertClusterMembershipRequest) error
-		PruneClusterMembership(request *PruneClusterMembershipRequest) error
-		ListClusterMetadata(request *ListClusterMetadataRequest) (*ListClusterMetadataResponse, error)
-		GetCurrentClusterMetadata() (*GetClusterMetadataResponse, error)
-		GetClusterMetadata(request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error)
-		SaveClusterMetadata(request *SaveClusterMetadataRequest) (bool, error)
-		DeleteClusterMetadata(request *DeleteClusterMetadataRequest) error
+		GetClusterMembers(ctx context.Context, request *GetClusterMembersRequest) (*GetClusterMembersResponse, error)
+		UpsertClusterMembership(ctx context.Context, request *UpsertClusterMembershipRequest) error
+		PruneClusterMembership(ctx context.Context, request *PruneClusterMembershipRequest) error
+		ListClusterMetadata(ctx context.Context, request *ListClusterMetadataRequest) (*ListClusterMetadataResponse, error)
+		GetCurrentClusterMetadata(ctx context.Context) (*GetClusterMetadataResponse, error)
+		GetClusterMetadata(ctx context.Context, request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error)
+		SaveClusterMetadata(ctx context.Context, request *SaveClusterMetadataRequest) (bool, error)
+		DeleteClusterMetadata(ctx context.Context, request *DeleteClusterMetadataRequest) error
 	}
 )
 

--- a/common/persistence/dataInterfaces_mock.go
+++ b/common/persistence/dataInterfaces_mock.go
@@ -120,32 +120,32 @@ func (mr *MockShardManagerMockRecorder) GetName() *gomock.Call {
 }
 
 // GetOrCreateShard mocks base method.
-func (m *MockShardManager) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
+func (m *MockShardManager) GetOrCreateShard(ctx context.Context, request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrCreateShard", request)
+	ret := m.ctrl.Call(m, "GetOrCreateShard", ctx, request)
 	ret0, _ := ret[0].(*GetOrCreateShardResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOrCreateShard indicates an expected call of GetOrCreateShard.
-func (mr *MockShardManagerMockRecorder) GetOrCreateShard(request interface{}) *gomock.Call {
+func (mr *MockShardManagerMockRecorder) GetOrCreateShard(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateShard", reflect.TypeOf((*MockShardManager)(nil).GetOrCreateShard), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateShard", reflect.TypeOf((*MockShardManager)(nil).GetOrCreateShard), ctx, request)
 }
 
 // UpdateShard mocks base method.
-func (m *MockShardManager) UpdateShard(request *UpdateShardRequest) error {
+func (m *MockShardManager) UpdateShard(ctx context.Context, request *UpdateShardRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateShard", request)
+	ret := m.ctrl.Call(m, "UpdateShard", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateShard indicates an expected call of UpdateShard.
-func (mr *MockShardManagerMockRecorder) UpdateShard(request interface{}) *gomock.Call {
+func (mr *MockShardManagerMockRecorder) UpdateShard(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShard", reflect.TypeOf((*MockShardManager)(nil).UpdateShard), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShard", reflect.TypeOf((*MockShardManager)(nil).UpdateShard), ctx, request)
 }
 
 // MockExecutionManager is a mock of ExecutionManager interface.
@@ -644,76 +644,76 @@ func (mr *MockTaskManagerMockRecorder) Close() *gomock.Call {
 }
 
 // CompleteTask mocks base method.
-func (m *MockTaskManager) CompleteTask(request *CompleteTaskRequest) error {
+func (m *MockTaskManager) CompleteTask(ctx context.Context, request *CompleteTaskRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteTask", request)
+	ret := m.ctrl.Call(m, "CompleteTask", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CompleteTask indicates an expected call of CompleteTask.
-func (mr *MockTaskManagerMockRecorder) CompleteTask(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) CompleteTask(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTask", reflect.TypeOf((*MockTaskManager)(nil).CompleteTask), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTask", reflect.TypeOf((*MockTaskManager)(nil).CompleteTask), ctx, request)
 }
 
 // CompleteTasksLessThan mocks base method.
-func (m *MockTaskManager) CompleteTasksLessThan(request *CompleteTasksLessThanRequest) (int, error) {
+func (m *MockTaskManager) CompleteTasksLessThan(ctx context.Context, request *CompleteTasksLessThanRequest) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteTasksLessThan", request)
+	ret := m.ctrl.Call(m, "CompleteTasksLessThan", ctx, request)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CompleteTasksLessThan indicates an expected call of CompleteTasksLessThan.
-func (mr *MockTaskManagerMockRecorder) CompleteTasksLessThan(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) CompleteTasksLessThan(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTasksLessThan", reflect.TypeOf((*MockTaskManager)(nil).CompleteTasksLessThan), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTasksLessThan", reflect.TypeOf((*MockTaskManager)(nil).CompleteTasksLessThan), ctx, request)
 }
 
 // CreateTaskQueue mocks base method.
-func (m *MockTaskManager) CreateTaskQueue(request *CreateTaskQueueRequest) (*CreateTaskQueueResponse, error) {
+func (m *MockTaskManager) CreateTaskQueue(ctx context.Context, request *CreateTaskQueueRequest) (*CreateTaskQueueResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTaskQueue", request)
+	ret := m.ctrl.Call(m, "CreateTaskQueue", ctx, request)
 	ret0, _ := ret[0].(*CreateTaskQueueResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateTaskQueue indicates an expected call of CreateTaskQueue.
-func (mr *MockTaskManagerMockRecorder) CreateTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) CreateTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).CreateTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).CreateTaskQueue), ctx, request)
 }
 
 // CreateTasks mocks base method.
-func (m *MockTaskManager) CreateTasks(request *CreateTasksRequest) (*CreateTasksResponse, error) {
+func (m *MockTaskManager) CreateTasks(ctx context.Context, request *CreateTasksRequest) (*CreateTasksResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTasks", request)
+	ret := m.ctrl.Call(m, "CreateTasks", ctx, request)
 	ret0, _ := ret[0].(*CreateTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateTasks indicates an expected call of CreateTasks.
-func (mr *MockTaskManagerMockRecorder) CreateTasks(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) CreateTasks(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTasks", reflect.TypeOf((*MockTaskManager)(nil).CreateTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTasks", reflect.TypeOf((*MockTaskManager)(nil).CreateTasks), ctx, request)
 }
 
 // DeleteTaskQueue mocks base method.
-func (m *MockTaskManager) DeleteTaskQueue(request *DeleteTaskQueueRequest) error {
+func (m *MockTaskManager) DeleteTaskQueue(ctx context.Context, request *DeleteTaskQueueRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTaskQueue", request)
+	ret := m.ctrl.Call(m, "DeleteTaskQueue", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteTaskQueue indicates an expected call of DeleteTaskQueue.
-func (mr *MockTaskManagerMockRecorder) DeleteTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) DeleteTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).DeleteTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).DeleteTaskQueue), ctx, request)
 }
 
 // GetName mocks base method.
@@ -731,63 +731,63 @@ func (mr *MockTaskManagerMockRecorder) GetName() *gomock.Call {
 }
 
 // GetTaskQueue mocks base method.
-func (m *MockTaskManager) GetTaskQueue(request *GetTaskQueueRequest) (*GetTaskQueueResponse, error) {
+func (m *MockTaskManager) GetTaskQueue(ctx context.Context, request *GetTaskQueueRequest) (*GetTaskQueueResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTaskQueue", request)
+	ret := m.ctrl.Call(m, "GetTaskQueue", ctx, request)
 	ret0, _ := ret[0].(*GetTaskQueueResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTaskQueue indicates an expected call of GetTaskQueue.
-func (mr *MockTaskManagerMockRecorder) GetTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) GetTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).GetTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).GetTaskQueue), ctx, request)
 }
 
 // GetTasks mocks base method.
-func (m *MockTaskManager) GetTasks(request *GetTasksRequest) (*GetTasksResponse, error) {
+func (m *MockTaskManager) GetTasks(ctx context.Context, request *GetTasksRequest) (*GetTasksResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTasks", request)
+	ret := m.ctrl.Call(m, "GetTasks", ctx, request)
 	ret0, _ := ret[0].(*GetTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTasks indicates an expected call of GetTasks.
-func (mr *MockTaskManagerMockRecorder) GetTasks(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) GetTasks(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasks", reflect.TypeOf((*MockTaskManager)(nil).GetTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasks", reflect.TypeOf((*MockTaskManager)(nil).GetTasks), ctx, request)
 }
 
 // ListTaskQueue mocks base method.
-func (m *MockTaskManager) ListTaskQueue(request *ListTaskQueueRequest) (*ListTaskQueueResponse, error) {
+func (m *MockTaskManager) ListTaskQueue(ctx context.Context, request *ListTaskQueueRequest) (*ListTaskQueueResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTaskQueue", request)
+	ret := m.ctrl.Call(m, "ListTaskQueue", ctx, request)
 	ret0, _ := ret[0].(*ListTaskQueueResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListTaskQueue indicates an expected call of ListTaskQueue.
-func (mr *MockTaskManagerMockRecorder) ListTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) ListTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).ListTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).ListTaskQueue), ctx, request)
 }
 
 // UpdateTaskQueue mocks base method.
-func (m *MockTaskManager) UpdateTaskQueue(request *UpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error) {
+func (m *MockTaskManager) UpdateTaskQueue(ctx context.Context, request *UpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTaskQueue", request)
+	ret := m.ctrl.Call(m, "UpdateTaskQueue", ctx, request)
 	ret0, _ := ret[0].(*UpdateTaskQueueResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateTaskQueue indicates an expected call of UpdateTaskQueue.
-func (mr *MockTaskManagerMockRecorder) UpdateTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskManagerMockRecorder) UpdateTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).UpdateTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskQueue", reflect.TypeOf((*MockTaskManager)(nil).UpdateTaskQueue), ctx, request)
 }
 
 // MockMetadataManager is a mock of MetadataManager interface.
@@ -826,61 +826,61 @@ func (mr *MockMetadataManagerMockRecorder) Close() *gomock.Call {
 }
 
 // CreateNamespace mocks base method.
-func (m *MockMetadataManager) CreateNamespace(request *CreateNamespaceRequest) (*CreateNamespaceResponse, error) {
+func (m *MockMetadataManager) CreateNamespace(ctx context.Context, request *CreateNamespaceRequest) (*CreateNamespaceResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNamespace", request)
+	ret := m.ctrl.Call(m, "CreateNamespace", ctx, request)
 	ret0, _ := ret[0].(*CreateNamespaceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateNamespace indicates an expected call of CreateNamespace.
-func (mr *MockMetadataManagerMockRecorder) CreateNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) CreateNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockMetadataManager)(nil).CreateNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockMetadataManager)(nil).CreateNamespace), ctx, request)
 }
 
 // DeleteNamespace mocks base method.
-func (m *MockMetadataManager) DeleteNamespace(request *DeleteNamespaceRequest) error {
+func (m *MockMetadataManager) DeleteNamespace(ctx context.Context, request *DeleteNamespaceRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNamespace", request)
+	ret := m.ctrl.Call(m, "DeleteNamespace", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNamespace indicates an expected call of DeleteNamespace.
-func (mr *MockMetadataManagerMockRecorder) DeleteNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) DeleteNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockMetadataManager)(nil).DeleteNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockMetadataManager)(nil).DeleteNamespace), ctx, request)
 }
 
 // DeleteNamespaceByName mocks base method.
-func (m *MockMetadataManager) DeleteNamespaceByName(request *DeleteNamespaceByNameRequest) error {
+func (m *MockMetadataManager) DeleteNamespaceByName(ctx context.Context, request *DeleteNamespaceByNameRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNamespaceByName", request)
+	ret := m.ctrl.Call(m, "DeleteNamespaceByName", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNamespaceByName indicates an expected call of DeleteNamespaceByName.
-func (mr *MockMetadataManagerMockRecorder) DeleteNamespaceByName(request interface{}) *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) DeleteNamespaceByName(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespaceByName", reflect.TypeOf((*MockMetadataManager)(nil).DeleteNamespaceByName), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespaceByName", reflect.TypeOf((*MockMetadataManager)(nil).DeleteNamespaceByName), ctx, request)
 }
 
 // GetMetadata mocks base method.
-func (m *MockMetadataManager) GetMetadata() (*GetMetadataResponse, error) {
+func (m *MockMetadataManager) GetMetadata(ctx context.Context) (*GetMetadataResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetadata")
+	ret := m.ctrl.Call(m, "GetMetadata", ctx)
 	ret0, _ := ret[0].(*GetMetadataResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMetadata indicates an expected call of GetMetadata.
-func (mr *MockMetadataManagerMockRecorder) GetMetadata() *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) GetMetadata(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockMetadataManager)(nil).GetMetadata))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockMetadataManager)(nil).GetMetadata), ctx)
 }
 
 // GetName mocks base method.
@@ -898,75 +898,75 @@ func (mr *MockMetadataManagerMockRecorder) GetName() *gomock.Call {
 }
 
 // GetNamespace mocks base method.
-func (m *MockMetadataManager) GetNamespace(request *GetNamespaceRequest) (*GetNamespaceResponse, error) {
+func (m *MockMetadataManager) GetNamespace(ctx context.Context, request *GetNamespaceRequest) (*GetNamespaceResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNamespace", request)
+	ret := m.ctrl.Call(m, "GetNamespace", ctx, request)
 	ret0, _ := ret[0].(*GetNamespaceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNamespace indicates an expected call of GetNamespace.
-func (mr *MockMetadataManagerMockRecorder) GetNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) GetNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockMetadataManager)(nil).GetNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockMetadataManager)(nil).GetNamespace), ctx, request)
 }
 
 // InitializeSystemNamespaces mocks base method.
-func (m *MockMetadataManager) InitializeSystemNamespaces(currentClusterName string) error {
+func (m *MockMetadataManager) InitializeSystemNamespaces(ctx context.Context, currentClusterName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InitializeSystemNamespaces", currentClusterName)
+	ret := m.ctrl.Call(m, "InitializeSystemNamespaces", ctx, currentClusterName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InitializeSystemNamespaces indicates an expected call of InitializeSystemNamespaces.
-func (mr *MockMetadataManagerMockRecorder) InitializeSystemNamespaces(currentClusterName interface{}) *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) InitializeSystemNamespaces(ctx, currentClusterName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeSystemNamespaces", reflect.TypeOf((*MockMetadataManager)(nil).InitializeSystemNamespaces), currentClusterName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InitializeSystemNamespaces", reflect.TypeOf((*MockMetadataManager)(nil).InitializeSystemNamespaces), ctx, currentClusterName)
 }
 
 // ListNamespaces mocks base method.
-func (m *MockMetadataManager) ListNamespaces(request *ListNamespacesRequest) (*ListNamespacesResponse, error) {
+func (m *MockMetadataManager) ListNamespaces(ctx context.Context, request *ListNamespacesRequest) (*ListNamespacesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNamespaces", request)
+	ret := m.ctrl.Call(m, "ListNamespaces", ctx, request)
 	ret0, _ := ret[0].(*ListNamespacesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListNamespaces indicates an expected call of ListNamespaces.
-func (mr *MockMetadataManagerMockRecorder) ListNamespaces(request interface{}) *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) ListNamespaces(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockMetadataManager)(nil).ListNamespaces), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockMetadataManager)(nil).ListNamespaces), ctx, request)
 }
 
 // RenameNamespace mocks base method.
-func (m *MockMetadataManager) RenameNamespace(request *RenameNamespaceRequest) error {
+func (m *MockMetadataManager) RenameNamespace(ctx context.Context, request *RenameNamespaceRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RenameNamespace", request)
+	ret := m.ctrl.Call(m, "RenameNamespace", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RenameNamespace indicates an expected call of RenameNamespace.
-func (mr *MockMetadataManagerMockRecorder) RenameNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) RenameNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameNamespace", reflect.TypeOf((*MockMetadataManager)(nil).RenameNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameNamespace", reflect.TypeOf((*MockMetadataManager)(nil).RenameNamespace), ctx, request)
 }
 
 // UpdateNamespace mocks base method.
-func (m *MockMetadataManager) UpdateNamespace(request *UpdateNamespaceRequest) error {
+func (m *MockMetadataManager) UpdateNamespace(ctx context.Context, request *UpdateNamespaceRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNamespace", request)
+	ret := m.ctrl.Call(m, "UpdateNamespace", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateNamespace indicates an expected call of UpdateNamespace.
-func (mr *MockMetadataManagerMockRecorder) UpdateNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataManagerMockRecorder) UpdateNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespace", reflect.TypeOf((*MockMetadataManager)(nil).UpdateNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespace", reflect.TypeOf((*MockMetadataManager)(nil).UpdateNamespace), ctx, request)
 }
 
 // MockClusterMetadataManager is a mock of ClusterMetadataManager interface.
@@ -1005,62 +1005,62 @@ func (mr *MockClusterMetadataManagerMockRecorder) Close() *gomock.Call {
 }
 
 // DeleteClusterMetadata mocks base method.
-func (m *MockClusterMetadataManager) DeleteClusterMetadata(request *DeleteClusterMetadataRequest) error {
+func (m *MockClusterMetadataManager) DeleteClusterMetadata(ctx context.Context, request *DeleteClusterMetadataRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteClusterMetadata", request)
+	ret := m.ctrl.Call(m, "DeleteClusterMetadata", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteClusterMetadata indicates an expected call of DeleteClusterMetadata.
-func (mr *MockClusterMetadataManagerMockRecorder) DeleteClusterMetadata(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataManagerMockRecorder) DeleteClusterMetadata(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).DeleteClusterMetadata), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).DeleteClusterMetadata), ctx, request)
 }
 
 // GetClusterMembers mocks base method.
-func (m *MockClusterMetadataManager) GetClusterMembers(request *GetClusterMembersRequest) (*GetClusterMembersResponse, error) {
+func (m *MockClusterMetadataManager) GetClusterMembers(ctx context.Context, request *GetClusterMembersRequest) (*GetClusterMembersResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMembers", request)
+	ret := m.ctrl.Call(m, "GetClusterMembers", ctx, request)
 	ret0, _ := ret[0].(*GetClusterMembersResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetClusterMembers indicates an expected call of GetClusterMembers.
-func (mr *MockClusterMetadataManagerMockRecorder) GetClusterMembers(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataManagerMockRecorder) GetClusterMembers(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMembers", reflect.TypeOf((*MockClusterMetadataManager)(nil).GetClusterMembers), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMembers", reflect.TypeOf((*MockClusterMetadataManager)(nil).GetClusterMembers), ctx, request)
 }
 
 // GetClusterMetadata mocks base method.
-func (m *MockClusterMetadataManager) GetClusterMetadata(request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error) {
+func (m *MockClusterMetadataManager) GetClusterMetadata(ctx context.Context, request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMetadata", request)
+	ret := m.ctrl.Call(m, "GetClusterMetadata", ctx, request)
 	ret0, _ := ret[0].(*GetClusterMetadataResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetClusterMetadata indicates an expected call of GetClusterMetadata.
-func (mr *MockClusterMetadataManagerMockRecorder) GetClusterMetadata(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataManagerMockRecorder) GetClusterMetadata(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).GetClusterMetadata), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).GetClusterMetadata), ctx, request)
 }
 
 // GetCurrentClusterMetadata mocks base method.
-func (m *MockClusterMetadataManager) GetCurrentClusterMetadata() (*GetClusterMetadataResponse, error) {
+func (m *MockClusterMetadataManager) GetCurrentClusterMetadata(ctx context.Context) (*GetClusterMetadataResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentClusterMetadata")
+	ret := m.ctrl.Call(m, "GetCurrentClusterMetadata", ctx)
 	ret0, _ := ret[0].(*GetClusterMetadataResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCurrentClusterMetadata indicates an expected call of GetCurrentClusterMetadata.
-func (mr *MockClusterMetadataManagerMockRecorder) GetCurrentClusterMetadata() *gomock.Call {
+func (mr *MockClusterMetadataManagerMockRecorder) GetCurrentClusterMetadata(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).GetCurrentClusterMetadata))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).GetCurrentClusterMetadata), ctx)
 }
 
 // GetName mocks base method.
@@ -1078,59 +1078,59 @@ func (mr *MockClusterMetadataManagerMockRecorder) GetName() *gomock.Call {
 }
 
 // ListClusterMetadata mocks base method.
-func (m *MockClusterMetadataManager) ListClusterMetadata(request *ListClusterMetadataRequest) (*ListClusterMetadataResponse, error) {
+func (m *MockClusterMetadataManager) ListClusterMetadata(ctx context.Context, request *ListClusterMetadataRequest) (*ListClusterMetadataResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusterMetadata", request)
+	ret := m.ctrl.Call(m, "ListClusterMetadata", ctx, request)
 	ret0, _ := ret[0].(*ListClusterMetadataResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClusterMetadata indicates an expected call of ListClusterMetadata.
-func (mr *MockClusterMetadataManagerMockRecorder) ListClusterMetadata(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataManagerMockRecorder) ListClusterMetadata(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).ListClusterMetadata), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).ListClusterMetadata), ctx, request)
 }
 
 // PruneClusterMembership mocks base method.
-func (m *MockClusterMetadataManager) PruneClusterMembership(request *PruneClusterMembershipRequest) error {
+func (m *MockClusterMetadataManager) PruneClusterMembership(ctx context.Context, request *PruneClusterMembershipRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PruneClusterMembership", request)
+	ret := m.ctrl.Call(m, "PruneClusterMembership", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PruneClusterMembership indicates an expected call of PruneClusterMembership.
-func (mr *MockClusterMetadataManagerMockRecorder) PruneClusterMembership(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataManagerMockRecorder) PruneClusterMembership(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneClusterMembership", reflect.TypeOf((*MockClusterMetadataManager)(nil).PruneClusterMembership), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneClusterMembership", reflect.TypeOf((*MockClusterMetadataManager)(nil).PruneClusterMembership), ctx, request)
 }
 
 // SaveClusterMetadata mocks base method.
-func (m *MockClusterMetadataManager) SaveClusterMetadata(request *SaveClusterMetadataRequest) (bool, error) {
+func (m *MockClusterMetadataManager) SaveClusterMetadata(ctx context.Context, request *SaveClusterMetadataRequest) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveClusterMetadata", request)
+	ret := m.ctrl.Call(m, "SaveClusterMetadata", ctx, request)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SaveClusterMetadata indicates an expected call of SaveClusterMetadata.
-func (mr *MockClusterMetadataManagerMockRecorder) SaveClusterMetadata(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataManagerMockRecorder) SaveClusterMetadata(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).SaveClusterMetadata), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveClusterMetadata", reflect.TypeOf((*MockClusterMetadataManager)(nil).SaveClusterMetadata), ctx, request)
 }
 
 // UpsertClusterMembership mocks base method.
-func (m *MockClusterMetadataManager) UpsertClusterMembership(request *UpsertClusterMembershipRequest) error {
+func (m *MockClusterMetadataManager) UpsertClusterMembership(ctx context.Context, request *UpsertClusterMembershipRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertClusterMembership", request)
+	ret := m.ctrl.Call(m, "UpsertClusterMembership", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertClusterMembership indicates an expected call of UpsertClusterMembership.
-func (mr *MockClusterMetadataManagerMockRecorder) UpsertClusterMembership(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataManagerMockRecorder) UpsertClusterMembership(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertClusterMembership", reflect.TypeOf((*MockClusterMetadataManager)(nil).UpsertClusterMembership), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertClusterMembership", reflect.TypeOf((*MockClusterMetadataManager)(nil).UpsertClusterMembership), ctx, request)
 }

--- a/common/persistence/metadata_manager.go
+++ b/common/persistence/metadata_manager.go
@@ -25,6 +25,8 @@
 package persistence
 
 import (
+	"context"
+
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/serviceerror"
@@ -68,7 +70,10 @@ func (m *metadataManagerImpl) GetName() string {
 	return m.persistence.GetName()
 }
 
-func (m *metadataManagerImpl) CreateNamespace(request *CreateNamespaceRequest) (*CreateNamespaceResponse, error) {
+func (m *metadataManagerImpl) CreateNamespace(
+	_ context.Context,
+	request *CreateNamespaceRequest,
+) (*CreateNamespaceResponse, error) {
 	datablob, err := m.serializer.NamespaceDetailToBlob(request.Namespace, enumspb.ENCODING_TYPE_PROTO3)
 	if err != nil {
 		return nil, err
@@ -82,7 +87,10 @@ func (m *metadataManagerImpl) CreateNamespace(request *CreateNamespaceRequest) (
 	})
 }
 
-func (m *metadataManagerImpl) GetNamespace(request *GetNamespaceRequest) (*GetNamespaceResponse, error) {
+func (m *metadataManagerImpl) GetNamespace(
+	_ context.Context,
+	request *GetNamespaceRequest,
+) (*GetNamespaceResponse, error) {
 	resp, err := m.persistence.GetNamespace(request)
 	if err != nil {
 		return nil, err
@@ -90,7 +98,10 @@ func (m *metadataManagerImpl) GetNamespace(request *GetNamespaceRequest) (*GetNa
 	return m.ConvertInternalGetResponse(resp)
 }
 
-func (m *metadataManagerImpl) UpdateNamespace(request *UpdateNamespaceRequest) error {
+func (m *metadataManagerImpl) UpdateNamespace(
+	_ context.Context,
+	request *UpdateNamespaceRequest,
+) error {
 	datablob, err := m.serializer.NamespaceDetailToBlob(request.Namespace, enumspb.ENCODING_TYPE_PROTO3)
 	if err != nil {
 		return err
@@ -105,15 +116,18 @@ func (m *metadataManagerImpl) UpdateNamespace(request *UpdateNamespaceRequest) e
 	})
 }
 
-func (m *metadataManagerImpl) RenameNamespace(request *RenameNamespaceRequest) error {
-	ns, err := m.GetNamespace(&GetNamespaceRequest{
+func (m *metadataManagerImpl) RenameNamespace(
+	ctx context.Context,
+	request *RenameNamespaceRequest,
+) error {
+	ns, err := m.GetNamespace(ctx, &GetNamespaceRequest{
 		Name: request.PreviousName,
 	})
 	if err != nil {
 		return err
 	}
 
-	metadata, err := m.GetMetadata()
+	metadata, err := m.GetMetadata(ctx)
 	if err != nil {
 		return err
 	}
@@ -140,11 +154,17 @@ func (m *metadataManagerImpl) RenameNamespace(request *RenameNamespaceRequest) e
 	return m.persistence.RenameNamespace(renameRequest)
 }
 
-func (m *metadataManagerImpl) DeleteNamespace(request *DeleteNamespaceRequest) error {
+func (m *metadataManagerImpl) DeleteNamespace(
+	_ context.Context,
+	request *DeleteNamespaceRequest,
+) error {
 	return m.persistence.DeleteNamespace(request)
 }
 
-func (m *metadataManagerImpl) DeleteNamespaceByName(request *DeleteNamespaceByNameRequest) error {
+func (m *metadataManagerImpl) DeleteNamespaceByName(
+	_ context.Context,
+	request *DeleteNamespaceByNameRequest,
+) error {
 	return m.persistence.DeleteNamespaceByName(request)
 }
 
@@ -171,7 +191,10 @@ func (m *metadataManagerImpl) ConvertInternalGetResponse(d *InternalGetNamespace
 	}, nil
 }
 
-func (m *metadataManagerImpl) ListNamespaces(request *ListNamespacesRequest) (*ListNamespacesResponse, error) {
+func (m *metadataManagerImpl) ListNamespaces(
+	_ context.Context,
+	request *ListNamespacesRequest,
+) (*ListNamespacesResponse, error) {
 	resp, err := m.persistence.ListNamespaces(request)
 	if err != nil {
 		return nil, err
@@ -190,8 +213,11 @@ func (m *metadataManagerImpl) ListNamespaces(request *ListNamespacesRequest) (*L
 	}, nil
 }
 
-func (m *metadataManagerImpl) InitializeSystemNamespaces(currentClusterName string) error {
-	_, err := m.CreateNamespace(&CreateNamespaceRequest{
+func (m *metadataManagerImpl) InitializeSystemNamespaces(
+	ctx context.Context,
+	currentClusterName string,
+) error {
+	_, err := m.CreateNamespace(ctx, &CreateNamespaceRequest{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
 				Id:          common.SystemNamespaceID,
@@ -223,7 +249,9 @@ func (m *metadataManagerImpl) InitializeSystemNamespaces(currentClusterName stri
 	return nil
 }
 
-func (m *metadataManagerImpl) GetMetadata() (*GetMetadataResponse, error) {
+func (m *metadataManagerImpl) GetMetadata(
+	_ context.Context,
+) (*GetMetadataResponse, error) {
 	return m.persistence.GetMetadata()
 }
 

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -3167,7 +3167,7 @@ func (s *ExecutionManagerSuite) TestCreateGetShardBackfill() {
 		ShardID:          shardID,
 		InitialShardInfo: shardInfo,
 	}
-	resp, err := s.ShardMgr.GetOrCreateShard(request)
+	resp, err := s.ShardMgr.GetOrCreateShard(s.ctx, request)
 	s.NoError(err)
 
 	shardInfo.ClusterTransferAckLevel = map[string]int64{
@@ -3176,7 +3176,7 @@ func (s *ExecutionManagerSuite) TestCreateGetShardBackfill() {
 	shardInfo.ClusterTimerAckLevel = map[string]*time.Time{
 		s.ClusterMetadata.GetCurrentClusterName(): currentClusterTimerAck,
 	}
-	resp, err = s.ShardMgr.GetOrCreateShard(&p.GetOrCreateShardRequest{ShardID: shardID})
+	resp, err = s.ShardMgr.GetOrCreateShard(s.ctx, &p.GetOrCreateShardRequest{ShardID: shardID})
 	s.NoError(err)
 	s.True(timeComparatorGoPtr(shardInfo.UpdateTime, resp.ShardInfo.UpdateTime, TimePrecision))
 	s.True(timeComparatorGoPtr(shardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], resp.ShardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], TimePrecision))
@@ -3241,7 +3241,7 @@ func (s *ExecutionManagerSuite) TestCreateGetUpdateGetShard() {
 		ShardID:          shardID,
 		InitialShardInfo: shardInfo,
 	}
-	resp, err := s.ShardMgr.GetOrCreateShard(createRequest)
+	resp, err := s.ShardMgr.GetOrCreateShard(s.ctx, createRequest)
 	s.NoError(err)
 	s.True(timeComparatorGoPtr(shardInfo.UpdateTime, resp.ShardInfo.UpdateTime, TimePrecision))
 	s.True(timeComparatorGoPtr(shardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], resp.ShardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], TimePrecision))
@@ -3300,9 +3300,9 @@ func (s *ExecutionManagerSuite) TestCreateGetUpdateGetShard() {
 		ShardInfo:       shardInfo,
 		PreviousRangeID: rangeID,
 	}
-	s.Nil(s.ShardMgr.UpdateShard(updateRequest))
+	s.Nil(s.ShardMgr.UpdateShard(s.ctx, updateRequest))
 
-	resp, err = s.ShardMgr.GetOrCreateShard(&p.GetOrCreateShardRequest{ShardID: shardID})
+	resp, err = s.ShardMgr.GetOrCreateShard(s.ctx, &p.GetOrCreateShardRequest{ShardID: shardID})
 	s.NoError(err)
 	s.True(timeComparatorGoPtr(shardInfo.UpdateTime, resp.ShardInfo.UpdateTime, TimePrecision))
 	s.True(timeComparatorGoPtr(shardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], resp.ShardInfo.ClusterTimerAckLevel[cluster.TestCurrentClusterName], TimePrecision))

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -259,7 +259,7 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	}
 
 	s.TaskIDGenerator = &TestTransferTaskIDGenerator{}
-	_, err = s.ShardMgr.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+	_, err = s.ShardMgr.GetOrCreateShard(context.Background(), &persistence.GetOrCreateShardRequest{
 		ShardID:          shardID,
 		InitialShardInfo: s.ShardInfo,
 	})
@@ -277,13 +277,13 @@ func (s *TestBase) fatalOnError(msg string, err error) {
 }
 
 // GetOrCreateShard is a utility method to get/create the shard using persistence layer
-func (s *TestBase) GetOrCreateShard(shardID int32, owner string, rangeID int64) (*persistencespb.ShardInfo, error) {
+func (s *TestBase) GetOrCreateShard(ctx context.Context, shardID int32, owner string, rangeID int64) (*persistencespb.ShardInfo, error) {
 	info := &persistencespb.ShardInfo{
 		ShardId: shardID,
 		Owner:   owner,
 		RangeId: rangeID,
 	}
-	resp, err := s.ShardMgr.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+	resp, err := s.ShardMgr.GetOrCreateShard(ctx, &persistence.GetOrCreateShardRequest{
 		ShardID:          shardID,
 		InitialShardInfo: info,
 	})
@@ -294,8 +294,8 @@ func (s *TestBase) GetOrCreateShard(shardID int32, owner string, rangeID int64) 
 }
 
 // UpdateShard is a utility method to update the shard using persistence layer
-func (s *TestBase) UpdateShard(updatedInfo *persistencespb.ShardInfo, previousRangeID int64) error {
-	return s.ShardMgr.UpdateShard(&persistence.UpdateShardRequest{
+func (s *TestBase) UpdateShard(ctx context.Context, updatedInfo *persistencespb.ShardInfo, previousRangeID int64) error {
+	return s.ShardMgr.UpdateShard(ctx, &persistence.UpdateShardRequest{
 		ShardInfo:       updatedInfo,
 		PreviousRangeID: previousRangeID,
 	})

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -152,11 +152,13 @@ func (p *shardPersistenceClient) GetName() string {
 }
 
 func (p *shardPersistenceClient) GetOrCreateShard(
-	request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
+	ctx context.Context,
+	request *GetOrCreateShardRequest,
+) (*GetOrCreateShardResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetOrCreateShardScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetOrCreateShardScope, metrics.PersistenceLatency)
-	response, err := p.persistence.GetOrCreateShard(request)
+	response, err := p.persistence.GetOrCreateShard(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -166,11 +168,14 @@ func (p *shardPersistenceClient) GetOrCreateShard(
 	return response, err
 }
 
-func (p *shardPersistenceClient) UpdateShard(request *UpdateShardRequest) error {
+func (p *shardPersistenceClient) UpdateShard(
+	ctx context.Context,
+	request *UpdateShardRequest,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceUpdateShardScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceUpdateShardScope, metrics.PersistenceLatency)
-	err := p.persistence.UpdateShard(request)
+	err := p.persistence.UpdateShard(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -558,11 +563,14 @@ func (p *taskPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *taskPersistenceClient) CreateTasks(request *CreateTasksRequest) (*CreateTasksResponse, error) {
+func (p *taskPersistenceClient) CreateTasks(
+	ctx context.Context,
+	request *CreateTasksRequest,
+) (*CreateTasksResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceCreateTaskScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceCreateTaskScope, metrics.PersistenceLatency)
-	response, err := p.persistence.CreateTasks(request)
+	response, err := p.persistence.CreateTasks(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -572,11 +580,14 @@ func (p *taskPersistenceClient) CreateTasks(request *CreateTasksRequest) (*Creat
 	return response, err
 }
 
-func (p *taskPersistenceClient) GetTasks(request *GetTasksRequest) (*GetTasksResponse, error) {
+func (p *taskPersistenceClient) GetTasks(
+	ctx context.Context,
+	request *GetTasksRequest,
+) (*GetTasksResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetTasksScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetTasksScope, metrics.PersistenceLatency)
-	response, err := p.persistence.GetTasks(request)
+	response, err := p.persistence.GetTasks(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -586,11 +597,14 @@ func (p *taskPersistenceClient) GetTasks(request *GetTasksRequest) (*GetTasksRes
 	return response, err
 }
 
-func (p *taskPersistenceClient) CompleteTask(request *CompleteTaskRequest) error {
+func (p *taskPersistenceClient) CompleteTask(
+	ctx context.Context,
+	request *CompleteTaskRequest,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceCompleteTaskScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceCompleteTaskScope, metrics.PersistenceLatency)
-	err := p.persistence.CompleteTask(request)
+	err := p.persistence.CompleteTask(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -600,10 +614,13 @@ func (p *taskPersistenceClient) CompleteTask(request *CompleteTaskRequest) error
 	return err
 }
 
-func (p *taskPersistenceClient) CompleteTasksLessThan(request *CompleteTasksLessThanRequest) (int, error) {
+func (p *taskPersistenceClient) CompleteTasksLessThan(
+	ctx context.Context,
+	request *CompleteTasksLessThanRequest,
+) (int, error) {
 	p.metricClient.IncCounter(metrics.PersistenceCompleteTasksLessThanScope, metrics.PersistenceRequests)
 	sw := p.metricClient.StartTimer(metrics.PersistenceCompleteTasksLessThanScope, metrics.PersistenceLatency)
-	result, err := p.persistence.CompleteTasksLessThan(request)
+	result, err := p.persistence.CompleteTasksLessThan(ctx, request)
 	sw.Stop()
 	if err != nil {
 		p.updateErrorMetric(metrics.PersistenceCompleteTasksLessThanScope, err)
@@ -611,11 +628,14 @@ func (p *taskPersistenceClient) CompleteTasksLessThan(request *CompleteTasksLess
 	return result, err
 }
 
-func (p *taskPersistenceClient) CreateTaskQueue(request *CreateTaskQueueRequest) (*CreateTaskQueueResponse, error) {
+func (p *taskPersistenceClient) CreateTaskQueue(
+	ctx context.Context,
+	request *CreateTaskQueueRequest,
+) (*CreateTaskQueueResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceCreateTaskQueueScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceCreateTaskQueueScope, metrics.PersistenceLatency)
-	response, err := p.persistence.CreateTaskQueue(request)
+	response, err := p.persistence.CreateTaskQueue(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -625,11 +645,14 @@ func (p *taskPersistenceClient) CreateTaskQueue(request *CreateTaskQueueRequest)
 	return response, err
 }
 
-func (p *taskPersistenceClient) UpdateTaskQueue(request *UpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error) {
+func (p *taskPersistenceClient) UpdateTaskQueue(
+	ctx context.Context,
+	request *UpdateTaskQueueRequest,
+) (*UpdateTaskQueueResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceUpdateTaskQueueScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceUpdateTaskQueueScope, metrics.PersistenceLatency)
-	response, err := p.persistence.UpdateTaskQueue(request)
+	response, err := p.persistence.UpdateTaskQueue(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -639,10 +662,13 @@ func (p *taskPersistenceClient) UpdateTaskQueue(request *UpdateTaskQueueRequest)
 	return response, err
 }
 
-func (p *taskPersistenceClient) GetTaskQueue(request *GetTaskQueueRequest) (*GetTaskQueueResponse, error) {
+func (p *taskPersistenceClient) GetTaskQueue(
+	ctx context.Context,
+	request *GetTaskQueueRequest,
+) (*GetTaskQueueResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetTaskQueueScope, metrics.PersistenceRequests)
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetTaskQueueScope, metrics.PersistenceLatency)
-	response, err := p.persistence.GetTaskQueue(request)
+	response, err := p.persistence.GetTaskQueue(ctx, request)
 	sw.Stop()
 	if err != nil {
 		p.updateErrorMetric(metrics.PersistenceGetTaskQueueScope, err)
@@ -650,10 +676,13 @@ func (p *taskPersistenceClient) GetTaskQueue(request *GetTaskQueueRequest) (*Get
 	return response, err
 }
 
-func (p *taskPersistenceClient) ListTaskQueue(request *ListTaskQueueRequest) (*ListTaskQueueResponse, error) {
+func (p *taskPersistenceClient) ListTaskQueue(
+	ctx context.Context,
+	request *ListTaskQueueRequest,
+) (*ListTaskQueueResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceListTaskQueueScope, metrics.PersistenceRequests)
 	sw := p.metricClient.StartTimer(metrics.PersistenceListTaskQueueScope, metrics.PersistenceLatency)
-	response, err := p.persistence.ListTaskQueue(request)
+	response, err := p.persistence.ListTaskQueue(ctx, request)
 	sw.Stop()
 	if err != nil {
 		p.updateErrorMetric(metrics.PersistenceListTaskQueueScope, err)
@@ -661,10 +690,13 @@ func (p *taskPersistenceClient) ListTaskQueue(request *ListTaskQueueRequest) (*L
 	return response, err
 }
 
-func (p *taskPersistenceClient) DeleteTaskQueue(request *DeleteTaskQueueRequest) error {
+func (p *taskPersistenceClient) DeleteTaskQueue(
+	ctx context.Context,
+	request *DeleteTaskQueueRequest,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceDeleteTaskQueueScope, metrics.PersistenceRequests)
 	sw := p.metricClient.StartTimer(metrics.PersistenceDeleteTaskQueueScope, metrics.PersistenceLatency)
-	err := p.persistence.DeleteTaskQueue(request)
+	err := p.persistence.DeleteTaskQueue(ctx, request)
 	sw.Stop()
 	if err != nil {
 		p.updateErrorMetric(metrics.PersistenceDeleteTaskQueueScope, err)
@@ -680,11 +712,14 @@ func (p *metadataPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *metadataPersistenceClient) CreateNamespace(request *CreateNamespaceRequest) (*CreateNamespaceResponse, error) {
+func (p *metadataPersistenceClient) CreateNamespace(
+	ctx context.Context,
+	request *CreateNamespaceRequest,
+) (*CreateNamespaceResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceCreateNamespaceScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceCreateNamespaceScope, metrics.PersistenceLatency)
-	response, err := p.persistence.CreateNamespace(request)
+	response, err := p.persistence.CreateNamespace(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -694,11 +729,14 @@ func (p *metadataPersistenceClient) CreateNamespace(request *CreateNamespaceRequ
 	return response, err
 }
 
-func (p *metadataPersistenceClient) GetNamespace(request *GetNamespaceRequest) (*GetNamespaceResponse, error) {
+func (p *metadataPersistenceClient) GetNamespace(
+	ctx context.Context,
+	request *GetNamespaceRequest,
+) (*GetNamespaceResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetNamespaceScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetNamespaceScope, metrics.PersistenceLatency)
-	response, err := p.persistence.GetNamespace(request)
+	response, err := p.persistence.GetNamespace(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -708,11 +746,14 @@ func (p *metadataPersistenceClient) GetNamespace(request *GetNamespaceRequest) (
 	return response, err
 }
 
-func (p *metadataPersistenceClient) UpdateNamespace(request *UpdateNamespaceRequest) error {
+func (p *metadataPersistenceClient) UpdateNamespace(
+	ctx context.Context,
+	request *UpdateNamespaceRequest,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceUpdateNamespaceScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceUpdateNamespaceScope, metrics.PersistenceLatency)
-	err := p.persistence.UpdateNamespace(request)
+	err := p.persistence.UpdateNamespace(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -722,11 +763,14 @@ func (p *metadataPersistenceClient) UpdateNamespace(request *UpdateNamespaceRequ
 	return err
 }
 
-func (p *metadataPersistenceClient) RenameNamespace(request *RenameNamespaceRequest) error {
+func (p *metadataPersistenceClient) RenameNamespace(
+	ctx context.Context,
+	request *RenameNamespaceRequest,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceRenameNamespaceScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceRenameNamespaceScope, metrics.PersistenceLatency)
-	err := p.persistence.RenameNamespace(request)
+	err := p.persistence.RenameNamespace(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -736,11 +780,14 @@ func (p *metadataPersistenceClient) RenameNamespace(request *RenameNamespaceRequ
 	return err
 }
 
-func (p *metadataPersistenceClient) DeleteNamespace(request *DeleteNamespaceRequest) error {
+func (p *metadataPersistenceClient) DeleteNamespace(
+	ctx context.Context,
+	request *DeleteNamespaceRequest,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceDeleteNamespaceScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceDeleteNamespaceScope, metrics.PersistenceLatency)
-	err := p.persistence.DeleteNamespace(request)
+	err := p.persistence.DeleteNamespace(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -750,11 +797,14 @@ func (p *metadataPersistenceClient) DeleteNamespace(request *DeleteNamespaceRequ
 	return err
 }
 
-func (p *metadataPersistenceClient) DeleteNamespaceByName(request *DeleteNamespaceByNameRequest) error {
+func (p *metadataPersistenceClient) DeleteNamespaceByName(
+	ctx context.Context,
+	request *DeleteNamespaceByNameRequest,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceDeleteNamespaceByNameScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceDeleteNamespaceByNameScope, metrics.PersistenceLatency)
-	err := p.persistence.DeleteNamespaceByName(request)
+	err := p.persistence.DeleteNamespaceByName(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -764,11 +814,14 @@ func (p *metadataPersistenceClient) DeleteNamespaceByName(request *DeleteNamespa
 	return err
 }
 
-func (p *metadataPersistenceClient) ListNamespaces(request *ListNamespacesRequest) (*ListNamespacesResponse, error) {
+func (p *metadataPersistenceClient) ListNamespaces(
+	ctx context.Context,
+	request *ListNamespacesRequest,
+) (*ListNamespacesResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceListNamespaceScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceListNamespaceScope, metrics.PersistenceLatency)
-	response, err := p.persistence.ListNamespaces(request)
+	response, err := p.persistence.ListNamespaces(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -778,11 +831,13 @@ func (p *metadataPersistenceClient) ListNamespaces(request *ListNamespacesReques
 	return response, err
 }
 
-func (p *metadataPersistenceClient) GetMetadata() (*GetMetadataResponse, error) {
+func (p *metadataPersistenceClient) GetMetadata(
+	ctx context.Context,
+) (*GetMetadataResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetMetadataScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetMetadataScope, metrics.PersistenceLatency)
-	response, err := p.persistence.GetMetadata()
+	response, err := p.persistence.GetMetadata(ctx)
 	sw.Stop()
 
 	if err != nil {
@@ -1110,12 +1165,15 @@ func (c *clusterMetadataPersistenceClient) Close() {
 	c.persistence.Close()
 }
 
-func (c *clusterMetadataPersistenceClient) ListClusterMetadata(request *ListClusterMetadataRequest) (*ListClusterMetadataResponse, error) {
+func (c *clusterMetadataPersistenceClient) ListClusterMetadata(
+	ctx context.Context,
+	request *ListClusterMetadataRequest,
+) (*ListClusterMetadataResponse, error) {
 	// This is a wrapper of GetClusterMetadata API, use the same scope here
 	c.metricClient.IncCounter(metrics.PersistenceListClusterMetadataScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistenceListClusterMetadataScope, metrics.PersistenceLatency)
-	result, err := c.persistence.ListClusterMetadata(request)
+	result, err := c.persistence.ListClusterMetadata(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -1125,12 +1183,14 @@ func (c *clusterMetadataPersistenceClient) ListClusterMetadata(request *ListClus
 	return result, err
 }
 
-func (c *clusterMetadataPersistenceClient) GetCurrentClusterMetadata() (*GetClusterMetadataResponse, error) {
+func (c *clusterMetadataPersistenceClient) GetCurrentClusterMetadata(
+	ctx context.Context,
+) (*GetClusterMetadataResponse, error) {
 	// This is a wrapper of GetClusterMetadata API, use the same scope here
 	c.metricClient.IncCounter(metrics.PersistenceGetClusterMetadataScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistenceGetClusterMetadataScope, metrics.PersistenceLatency)
-	result, err := c.persistence.GetCurrentClusterMetadata()
+	result, err := c.persistence.GetCurrentClusterMetadata(ctx)
 	sw.Stop()
 
 	if err != nil {
@@ -1140,11 +1200,14 @@ func (c *clusterMetadataPersistenceClient) GetCurrentClusterMetadata() (*GetClus
 	return result, err
 }
 
-func (c *clusterMetadataPersistenceClient) GetClusterMetadata(request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error) {
+func (c *clusterMetadataPersistenceClient) GetClusterMetadata(
+	ctx context.Context,
+	request *GetClusterMetadataRequest,
+) (*GetClusterMetadataResponse, error) {
 	c.metricClient.IncCounter(metrics.PersistenceGetClusterMetadataScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistenceGetClusterMetadataScope, metrics.PersistenceLatency)
-	result, err := c.persistence.GetClusterMetadata(request)
+	result, err := c.persistence.GetClusterMetadata(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -1154,11 +1217,14 @@ func (c *clusterMetadataPersistenceClient) GetClusterMetadata(request *GetCluste
 	return result, err
 }
 
-func (c *clusterMetadataPersistenceClient) SaveClusterMetadata(request *SaveClusterMetadataRequest) (bool, error) {
+func (c *clusterMetadataPersistenceClient) SaveClusterMetadata(
+	ctx context.Context,
+	request *SaveClusterMetadataRequest,
+) (bool, error) {
 	c.metricClient.IncCounter(metrics.PersistenceSaveClusterMetadataScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistenceSaveClusterMetadataScope, metrics.PersistenceLatency)
-	applied, err := c.persistence.SaveClusterMetadata(request)
+	applied, err := c.persistence.SaveClusterMetadata(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -1168,11 +1234,14 @@ func (c *clusterMetadataPersistenceClient) SaveClusterMetadata(request *SaveClus
 	return applied, err
 }
 
-func (c *clusterMetadataPersistenceClient) DeleteClusterMetadata(request *DeleteClusterMetadataRequest) error {
+func (c *clusterMetadataPersistenceClient) DeleteClusterMetadata(
+	ctx context.Context,
+	request *DeleteClusterMetadataRequest,
+) error {
 	c.metricClient.IncCounter(metrics.PersistenceDeleteClusterMetadataScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistenceDeleteClusterMetadataScope, metrics.PersistenceLatency)
-	err := c.persistence.DeleteClusterMetadata(request)
+	err := c.persistence.DeleteClusterMetadata(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -1186,11 +1255,14 @@ func (c *clusterMetadataPersistenceClient) GetName() string {
 	return c.persistence.GetName()
 }
 
-func (c *clusterMetadataPersistenceClient) GetClusterMembers(request *GetClusterMembersRequest) (*GetClusterMembersResponse, error) {
+func (c *clusterMetadataPersistenceClient) GetClusterMembers(
+	ctx context.Context,
+	request *GetClusterMembersRequest,
+) (*GetClusterMembersResponse, error) {
 	c.metricClient.IncCounter(metrics.PersistenceGetClusterMembersScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistenceGetClusterMembersScope, metrics.PersistenceLatency)
-	res, err := c.persistence.GetClusterMembers(request)
+	res, err := c.persistence.GetClusterMembers(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -1200,11 +1272,14 @@ func (c *clusterMetadataPersistenceClient) GetClusterMembers(request *GetCluster
 	return res, err
 }
 
-func (c *clusterMetadataPersistenceClient) UpsertClusterMembership(request *UpsertClusterMembershipRequest) error {
+func (c *clusterMetadataPersistenceClient) UpsertClusterMembership(
+	ctx context.Context,
+	request *UpsertClusterMembershipRequest,
+) error {
 	c.metricClient.IncCounter(metrics.PersistenceUpsertClusterMembershipScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistenceUpsertClusterMembershipScope, metrics.PersistenceLatency)
-	err := c.persistence.UpsertClusterMembership(request)
+	err := c.persistence.UpsertClusterMembership(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -1214,11 +1289,14 @@ func (c *clusterMetadataPersistenceClient) UpsertClusterMembership(request *Upse
 	return err
 }
 
-func (c *clusterMetadataPersistenceClient) PruneClusterMembership(request *PruneClusterMembershipRequest) error {
+func (c *clusterMetadataPersistenceClient) PruneClusterMembership(
+	ctx context.Context,
+	request *PruneClusterMembershipRequest,
+) error {
 	c.metricClient.IncCounter(metrics.PersistencePruneClusterMembershipScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistencePruneClusterMembershipScope, metrics.PersistenceLatency)
-	err := c.persistence.PruneClusterMembership(request)
+	err := c.persistence.PruneClusterMembership(ctx, request)
 	sw.Stop()
 
 	if err != nil {
@@ -1228,11 +1306,14 @@ func (c *clusterMetadataPersistenceClient) PruneClusterMembership(request *Prune
 	return err
 }
 
-func (c *metadataPersistenceClient) InitializeSystemNamespaces(currentClusterName string) error {
+func (c *metadataPersistenceClient) InitializeSystemNamespaces(
+	ctx context.Context,
+	currentClusterName string,
+) error {
 	c.metricClient.IncCounter(metrics.PersistenceInitializeSystemNamespaceScope, metrics.PersistenceRequests)
 
 	sw := c.metricClient.StartTimer(metrics.PersistenceInitializeSystemNamespaceScope, metrics.PersistenceLatency)
-	err := c.persistence.InitializeSystemNamespaces(currentClusterName)
+	err := c.persistence.InitializeSystemNamespaces(ctx, currentClusterName)
 	sw.Stop()
 
 	if err != nil {

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -143,21 +143,27 @@ func (p *shardRateLimitedPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *shardRateLimitedPersistenceClient) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
+func (p *shardRateLimitedPersistenceClient) GetOrCreateShard(
+	ctx context.Context,
+	request *GetOrCreateShardRequest,
+) (*GetOrCreateShardResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	response, err := p.persistence.GetOrCreateShard(request)
+	response, err := p.persistence.GetOrCreateShard(ctx, request)
 	return response, err
 }
 
-func (p *shardRateLimitedPersistenceClient) UpdateShard(request *UpdateShardRequest) error {
+func (p *shardRateLimitedPersistenceClient) UpdateShard(
+	ctx context.Context,
+	request *UpdateShardRequest,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	err := p.persistence.UpdateShard(request)
+	err := p.persistence.UpdateShard(ctx, request)
 	return err
 }
 
@@ -389,73 +395,100 @@ func (p *taskRateLimitedPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *taskRateLimitedPersistenceClient) CreateTasks(request *CreateTasksRequest) (*CreateTasksResponse, error) {
+func (p *taskRateLimitedPersistenceClient) CreateTasks(
+	ctx context.Context,
+	request *CreateTasksRequest,
+) (*CreateTasksResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	response, err := p.persistence.CreateTasks(request)
+	response, err := p.persistence.CreateTasks(ctx, request)
 	return response, err
 }
 
-func (p *taskRateLimitedPersistenceClient) GetTasks(request *GetTasksRequest) (*GetTasksResponse, error) {
+func (p *taskRateLimitedPersistenceClient) GetTasks(
+	ctx context.Context,
+	request *GetTasksRequest,
+) (*GetTasksResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	response, err := p.persistence.GetTasks(request)
+	response, err := p.persistence.GetTasks(ctx, request)
 	return response, err
 }
 
-func (p *taskRateLimitedPersistenceClient) CompleteTask(request *CompleteTaskRequest) error {
+func (p *taskRateLimitedPersistenceClient) CompleteTask(
+	ctx context.Context,
+	request *CompleteTaskRequest,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	err := p.persistence.CompleteTask(request)
+	err := p.persistence.CompleteTask(ctx, request)
 	return err
 }
 
-func (p *taskRateLimitedPersistenceClient) CompleteTasksLessThan(request *CompleteTasksLessThanRequest) (int, error) {
+func (p *taskRateLimitedPersistenceClient) CompleteTasksLessThan(
+	ctx context.Context,
+	request *CompleteTasksLessThanRequest,
+) (int, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return 0, ErrPersistenceLimitExceeded
 	}
-	return p.persistence.CompleteTasksLessThan(request)
+	return p.persistence.CompleteTasksLessThan(ctx, request)
 }
 
-func (p *taskRateLimitedPersistenceClient) CreateTaskQueue(request *CreateTaskQueueRequest) (*CreateTaskQueueResponse, error) {
+func (p *taskRateLimitedPersistenceClient) CreateTaskQueue(
+	ctx context.Context,
+	request *CreateTaskQueueRequest,
+) (*CreateTaskQueueResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return p.persistence.CreateTaskQueue(request)
+	return p.persistence.CreateTaskQueue(ctx, request)
 }
 
-func (p *taskRateLimitedPersistenceClient) UpdateTaskQueue(request *UpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error) {
+func (p *taskRateLimitedPersistenceClient) UpdateTaskQueue(
+	ctx context.Context,
+	request *UpdateTaskQueueRequest,
+) (*UpdateTaskQueueResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return p.persistence.UpdateTaskQueue(request)
+	return p.persistence.UpdateTaskQueue(ctx, request)
 }
 
-func (p *taskRateLimitedPersistenceClient) GetTaskQueue(request *GetTaskQueueRequest) (*GetTaskQueueResponse, error) {
+func (p *taskRateLimitedPersistenceClient) GetTaskQueue(
+	ctx context.Context,
+	request *GetTaskQueueRequest,
+) (*GetTaskQueueResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return p.persistence.GetTaskQueue(request)
+	return p.persistence.GetTaskQueue(ctx, request)
 }
 
-func (p *taskRateLimitedPersistenceClient) ListTaskQueue(request *ListTaskQueueRequest) (*ListTaskQueueResponse, error) {
+func (p *taskRateLimitedPersistenceClient) ListTaskQueue(
+	ctx context.Context,
+	request *ListTaskQueueRequest,
+) (*ListTaskQueueResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return p.persistence.ListTaskQueue(request)
+	return p.persistence.ListTaskQueue(ctx, request)
 }
 
-func (p *taskRateLimitedPersistenceClient) DeleteTaskQueue(request *DeleteTaskQueueRequest) error {
+func (p *taskRateLimitedPersistenceClient) DeleteTaskQueue(
+	ctx context.Context,
+	request *DeleteTaskQueueRequest,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
-	return p.persistence.DeleteTaskQueue(request)
+	return p.persistence.DeleteTaskQueue(ctx, request)
 }
 
 func (p *taskRateLimitedPersistenceClient) Close() {
@@ -466,75 +499,98 @@ func (p *metadataRateLimitedPersistenceClient) GetName() string {
 	return p.persistence.GetName()
 }
 
-func (p *metadataRateLimitedPersistenceClient) CreateNamespace(request *CreateNamespaceRequest) (*CreateNamespaceResponse, error) {
+func (p *metadataRateLimitedPersistenceClient) CreateNamespace(
+	ctx context.Context,
+	request *CreateNamespaceRequest,
+) (*CreateNamespaceResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	response, err := p.persistence.CreateNamespace(request)
+	response, err := p.persistence.CreateNamespace(ctx, request)
 	return response, err
 }
 
-func (p *metadataRateLimitedPersistenceClient) GetNamespace(request *GetNamespaceRequest) (*GetNamespaceResponse, error) {
+func (p *metadataRateLimitedPersistenceClient) GetNamespace(
+	ctx context.Context,
+	request *GetNamespaceRequest,
+) (*GetNamespaceResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	response, err := p.persistence.GetNamespace(request)
+	response, err := p.persistence.GetNamespace(ctx, request)
 	return response, err
 }
 
-func (p *metadataRateLimitedPersistenceClient) UpdateNamespace(request *UpdateNamespaceRequest) error {
+func (p *metadataRateLimitedPersistenceClient) UpdateNamespace(
+	ctx context.Context,
+	request *UpdateNamespaceRequest,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	err := p.persistence.UpdateNamespace(request)
+	err := p.persistence.UpdateNamespace(ctx, request)
 	return err
 }
 
-func (p *metadataRateLimitedPersistenceClient) RenameNamespace(request *RenameNamespaceRequest) error {
+func (p *metadataRateLimitedPersistenceClient) RenameNamespace(
+	ctx context.Context,
+	request *RenameNamespaceRequest,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	err := p.persistence.RenameNamespace(request)
+	err := p.persistence.RenameNamespace(ctx, request)
 	return err
 }
 
-func (p *metadataRateLimitedPersistenceClient) DeleteNamespace(request *DeleteNamespaceRequest) error {
+func (p *metadataRateLimitedPersistenceClient) DeleteNamespace(
+	ctx context.Context,
+	request *DeleteNamespaceRequest,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	err := p.persistence.DeleteNamespace(request)
+	err := p.persistence.DeleteNamespace(ctx, request)
 	return err
 }
 
-func (p *metadataRateLimitedPersistenceClient) DeleteNamespaceByName(request *DeleteNamespaceByNameRequest) error {
+func (p *metadataRateLimitedPersistenceClient) DeleteNamespaceByName(
+	ctx context.Context,
+	request *DeleteNamespaceByNameRequest,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	err := p.persistence.DeleteNamespaceByName(request)
+	err := p.persistence.DeleteNamespaceByName(ctx, request)
 	return err
 }
 
-func (p *metadataRateLimitedPersistenceClient) ListNamespaces(request *ListNamespacesRequest) (*ListNamespacesResponse, error) {
+func (p *metadataRateLimitedPersistenceClient) ListNamespaces(
+	ctx context.Context,
+	request *ListNamespacesRequest,
+) (*ListNamespacesResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	response, err := p.persistence.ListNamespaces(request)
+	response, err := p.persistence.ListNamespaces(ctx, request)
 	return response, err
 }
 
-func (p *metadataRateLimitedPersistenceClient) GetMetadata() (*GetMetadataResponse, error) {
+func (p *metadataRateLimitedPersistenceClient) GetMetadata(
+	ctx context.Context,
+) (*GetMetadataResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	response, err := p.persistence.GetMetadata()
+	response, err := p.persistence.GetMetadata(ctx)
 	return response, err
 }
 
@@ -763,65 +819,91 @@ func (c *clusterMetadataRateLimitedPersistenceClient) GetName() string {
 	return c.persistence.GetName()
 }
 
-func (c *clusterMetadataRateLimitedPersistenceClient) GetClusterMembers(request *GetClusterMembersRequest) (*GetClusterMembersResponse, error) {
+func (c *clusterMetadataRateLimitedPersistenceClient) GetClusterMembers(
+	ctx context.Context,
+	request *GetClusterMembersRequest,
+) (*GetClusterMembersResponse, error) {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return c.persistence.GetClusterMembers(request)
+	return c.persistence.GetClusterMembers(ctx, request)
 }
 
-func (c *clusterMetadataRateLimitedPersistenceClient) UpsertClusterMembership(request *UpsertClusterMembershipRequest) error {
+func (c *clusterMetadataRateLimitedPersistenceClient) UpsertClusterMembership(
+	ctx context.Context,
+	request *UpsertClusterMembershipRequest,
+) error {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
-	return c.persistence.UpsertClusterMembership(request)
+	return c.persistence.UpsertClusterMembership(ctx, request)
 }
 
-func (c *clusterMetadataRateLimitedPersistenceClient) PruneClusterMembership(request *PruneClusterMembershipRequest) error {
+func (c *clusterMetadataRateLimitedPersistenceClient) PruneClusterMembership(
+	ctx context.Context,
+	request *PruneClusterMembershipRequest,
+) error {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
-	return c.persistence.PruneClusterMembership(request)
+	return c.persistence.PruneClusterMembership(ctx, request)
 }
 
-func (c *clusterMetadataRateLimitedPersistenceClient) ListClusterMetadata(request *ListClusterMetadataRequest) (*ListClusterMetadataResponse, error) {
+func (c *clusterMetadataRateLimitedPersistenceClient) ListClusterMetadata(
+	ctx context.Context,
+	request *ListClusterMetadataRequest,
+) (*ListClusterMetadataResponse, error) {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return c.persistence.ListClusterMetadata(request)
+	return c.persistence.ListClusterMetadata(ctx, request)
 }
 
-func (c *clusterMetadataRateLimitedPersistenceClient) GetCurrentClusterMetadata() (*GetClusterMetadataResponse, error) {
+func (c *clusterMetadataRateLimitedPersistenceClient) GetCurrentClusterMetadata(
+	ctx context.Context,
+) (*GetClusterMetadataResponse, error) {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return c.persistence.GetCurrentClusterMetadata()
+	return c.persistence.GetCurrentClusterMetadata(ctx)
 }
 
-func (c *clusterMetadataRateLimitedPersistenceClient) GetClusterMetadata(request *GetClusterMetadataRequest) (*GetClusterMetadataResponse, error) {
+func (c *clusterMetadataRateLimitedPersistenceClient) GetClusterMetadata(
+	ctx context.Context,
+	request *GetClusterMetadataRequest,
+) (*GetClusterMetadataResponse, error) {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
-	return c.persistence.GetClusterMetadata(request)
+	return c.persistence.GetClusterMetadata(ctx, request)
 }
 
-func (c *clusterMetadataRateLimitedPersistenceClient) SaveClusterMetadata(request *SaveClusterMetadataRequest) (bool, error) {
+func (c *clusterMetadataRateLimitedPersistenceClient) SaveClusterMetadata(
+	ctx context.Context,
+	request *SaveClusterMetadataRequest,
+) (bool, error) {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return false, ErrPersistenceLimitExceeded
 	}
-	return c.persistence.SaveClusterMetadata(request)
+	return c.persistence.SaveClusterMetadata(ctx, request)
 }
 
-func (c *clusterMetadataRateLimitedPersistenceClient) DeleteClusterMetadata(request *DeleteClusterMetadataRequest) error {
+func (c *clusterMetadataRateLimitedPersistenceClient) DeleteClusterMetadata(
+	ctx context.Context,
+	request *DeleteClusterMetadataRequest,
+) error {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
-	return c.persistence.DeleteClusterMetadata(request)
+	return c.persistence.DeleteClusterMetadata(ctx, request)
 }
 
-func (c *metadataRateLimitedPersistenceClient) InitializeSystemNamespaces(currentClusterName string) error {
+func (c *metadataRateLimitedPersistenceClient) InitializeSystemNamespaces(
+	ctx context.Context,
+	currentClusterName string,
+) error {
 	if ok := c.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
-	return c.persistence.InitializeSystemNamespaces(currentClusterName)
+	return c.persistence.InitializeSystemNamespaces(ctx, currentClusterName)
 }

--- a/common/persistence/shard_manager.go
+++ b/common/persistence/shard_manager.go
@@ -25,6 +25,8 @@
 package persistence
 
 import (
+	"context"
+
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -56,7 +58,10 @@ func (m *shardManagerImpl) GetName() string {
 	return m.shardStore.GetName()
 }
 
-func (m *shardManagerImpl) GetOrCreateShard(request *GetOrCreateShardRequest) (*GetOrCreateShardResponse, error) {
+func (m *shardManagerImpl) GetOrCreateShard(
+	_ context.Context,
+	request *GetOrCreateShardRequest,
+) (*GetOrCreateShardResponse, error) {
 	var createShardInfo func() (int64, *commonpb.DataBlob, error)
 	createShardInfo = func() (int64, *commonpb.DataBlob, error) {
 		shardInfo := request.InitialShardInfo
@@ -88,7 +93,10 @@ func (m *shardManagerImpl) GetOrCreateShard(request *GetOrCreateShardRequest) (*
 	}, nil
 }
 
-func (m *shardManagerImpl) UpdateShard(request *UpdateShardRequest) error {
+func (m *shardManagerImpl) UpdateShard(
+	_ context.Context,
+	request *UpdateShardRequest,
+) error {
 	shardInfo := request.ShardInfo
 	shardInfo.UpdateTime = timestamp.TimeNowPtrUtc()
 

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -25,6 +25,7 @@
 package persistence
 
 import (
+	"context"
 	"fmt"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -59,7 +60,10 @@ func (m *taskManagerImpl) GetName() string {
 	return m.taskStore.GetName()
 }
 
-func (m *taskManagerImpl) CreateTaskQueue(request *CreateTaskQueueRequest) (*CreateTaskQueueResponse, error) {
+func (m *taskManagerImpl) CreateTaskQueue(
+	_ context.Context,
+	request *CreateTaskQueueRequest,
+) (*CreateTaskQueueResponse, error) {
 	taskQueueInfo := request.TaskQueueInfo
 	if taskQueueInfo.LastUpdateTime == nil {
 		panic("CreateTaskQueue encountered LastUpdateTime not set")
@@ -87,7 +91,10 @@ func (m *taskManagerImpl) CreateTaskQueue(request *CreateTaskQueueRequest) (*Cre
 	return &CreateTaskQueueResponse{}, nil
 }
 
-func (m *taskManagerImpl) UpdateTaskQueue(request *UpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error) {
+func (m *taskManagerImpl) UpdateTaskQueue(
+	_ context.Context,
+	request *UpdateTaskQueueRequest,
+) (*UpdateTaskQueueResponse, error) {
 	taskQueueInfo := request.TaskQueueInfo
 	if taskQueueInfo.LastUpdateTime == nil {
 		panic("UpdateTaskQueue encountered LastUpdateTime not set")
@@ -115,7 +122,10 @@ func (m *taskManagerImpl) UpdateTaskQueue(request *UpdateTaskQueueRequest) (*Upd
 	return m.taskStore.UpdateTaskQueue(internalRequest)
 }
 
-func (m *taskManagerImpl) GetTaskQueue(request *GetTaskQueueRequest) (*GetTaskQueueResponse, error) {
+func (m *taskManagerImpl) GetTaskQueue(
+	_ context.Context,
+	request *GetTaskQueueRequest,
+) (*GetTaskQueueResponse, error) {
 	response, err := m.taskStore.GetTaskQueue(&InternalGetTaskQueueRequest{
 		NamespaceID: request.NamespaceID,
 		TaskQueue:   request.TaskQueue,
@@ -135,7 +145,10 @@ func (m *taskManagerImpl) GetTaskQueue(request *GetTaskQueueRequest) (*GetTaskQu
 	}, nil
 }
 
-func (m *taskManagerImpl) ListTaskQueue(request *ListTaskQueueRequest) (*ListTaskQueueResponse, error) {
+func (m *taskManagerImpl) ListTaskQueue(
+	_ context.Context,
+	request *ListTaskQueueRequest,
+) (*ListTaskQueueResponse, error) {
 	internalResp, err := m.taskStore.ListTaskQueue(request)
 	if err != nil {
 		return nil, err
@@ -158,11 +171,17 @@ func (m *taskManagerImpl) ListTaskQueue(request *ListTaskQueueRequest) (*ListTas
 	}, nil
 }
 
-func (m *taskManagerImpl) DeleteTaskQueue(request *DeleteTaskQueueRequest) error {
+func (m *taskManagerImpl) DeleteTaskQueue(
+	_ context.Context,
+	request *DeleteTaskQueueRequest,
+) error {
 	return m.taskStore.DeleteTaskQueue(request)
 }
 
-func (m *taskManagerImpl) CreateTasks(request *CreateTasksRequest) (*CreateTasksResponse, error) {
+func (m *taskManagerImpl) CreateTasks(
+	_ context.Context,
+	request *CreateTasksRequest,
+) (*CreateTasksResponse, error) {
 	taskQueueInfo := request.TaskQueueInfo.Data
 	taskQueueInfo.LastUpdateTime = timestamp.TimeNowPtrUtc()
 	taskQueueInfoBlob, err := m.serializer.TaskQueueInfoToBlob(taskQueueInfo, enumspb.ENCODING_TYPE_PROTO3)
@@ -193,7 +212,10 @@ func (m *taskManagerImpl) CreateTasks(request *CreateTasksRequest) (*CreateTasks
 	return m.taskStore.CreateTasks(internalRequest)
 }
 
-func (m *taskManagerImpl) GetTasks(request *GetTasksRequest) (*GetTasksResponse, error) {
+func (m *taskManagerImpl) GetTasks(
+	_ context.Context,
+	request *GetTasksRequest,
+) (*GetTasksResponse, error) {
 	if request.InclusiveMinTaskID >= request.ExclusiveMaxTaskID {
 		return &GetTasksResponse{}, nil
 	}
@@ -213,10 +235,16 @@ func (m *taskManagerImpl) GetTasks(request *GetTasksRequest) (*GetTasksResponse,
 	return &GetTasksResponse{Tasks: tasks, NextPageToken: internalResp.NextPageToken}, nil
 }
 
-func (m *taskManagerImpl) CompleteTask(request *CompleteTaskRequest) error {
+func (m *taskManagerImpl) CompleteTask(
+	_ context.Context,
+	request *CompleteTaskRequest,
+) error {
 	return m.taskStore.CompleteTask(request)
 }
 
-func (m *taskManagerImpl) CompleteTasksLessThan(request *CompleteTasksLessThanRequest) (int, error) {
+func (m *taskManagerImpl) CompleteTasksLessThan(
+	_ context.Context,
+	request *CompleteTasksLessThanRequest,
+) (int, error) {
 	return m.taskStore.CompleteTasksLessThan(request)
 }

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -103,7 +103,7 @@ func (s *ExecutionMutableStateSuite) SetupTest() {
 	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), time.Second*30)
 
 	s.ShardID = 1 + rand.Int31n(16)
-	resp, err := s.ShardManager.GetOrCreateShard(&p.GetOrCreateShardRequest{
+	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
 		ShardID: s.ShardID,
 		InitialShardInfo: &persistencespb.ShardInfo{
 			ShardId: s.ShardID,
@@ -113,7 +113,7 @@ func (s *ExecutionMutableStateSuite) SetupTest() {
 	s.NoError(err)
 	previousRangeID := resp.ShardInfo.RangeId
 	resp.ShardInfo.RangeId += 1
-	err = s.ShardManager.UpdateShard(&p.UpdateShardRequest{
+	err = s.ShardManager.UpdateShard(s.Ctx, &p.UpdateShardRequest{
 		ShardInfo:       resp.ShardInfo,
 		PreviousRangeID: previousRangeID,
 	})

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -90,7 +90,7 @@ func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), time.Second*30)
 
 	s.ShardID = 1 + rand.Int31n(16)
-	resp, err := s.ShardManager.GetOrCreateShard(&p.GetOrCreateShardRequest{
+	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
 		ShardID: s.ShardID,
 		InitialShardInfo: &persistencespb.ShardInfo{
 			ShardId: s.ShardID,
@@ -100,7 +100,7 @@ func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 	s.NoError(err)
 	previousRangeID := resp.ShardInfo.RangeId
 	resp.ShardInfo.RangeId += 1
-	err = s.ShardManager.UpdateShard(&p.UpdateShardRequest{
+	err = s.ShardManager.UpdateShard(s.Ctx, &p.UpdateShardRequest{
 		ShardInfo:       resp.ShardInfo,
 		PreviousRangeID: previousRangeID,
 	})

--- a/common/persistence/tests/task_queue_task.go
+++ b/common/persistence/tests/task_queue_task.go
@@ -25,6 +25,7 @@
 package tests
 
 import (
+	"context"
 	"math/rand"
 	"testing"
 	"time"
@@ -54,6 +55,9 @@ type (
 
 		taskManager p.TaskManager
 		logger      log.Logger
+
+		ctx    context.Context
+		cancel context.CancelFunc
 	}
 )
 
@@ -82,6 +86,7 @@ func (s *TaskQueueTaskSuite) TearDownSuite() {
 
 func (s *TaskQueueTaskSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), time.Second*30)
 
 	s.stickyTTL = time.Second * 10
 	s.taskTTL = time.Second * 16
@@ -93,7 +98,7 @@ func (s *TaskQueueTaskSuite) SetupTest() {
 }
 
 func (s *TaskQueueTaskSuite) TearDownTest() {
-
+	s.cancel()
 }
 
 func (s *TaskQueueTaskSuite) TestCreateGet_Conflict() {
@@ -102,7 +107,7 @@ func (s *TaskQueueTaskSuite) TestCreateGet_Conflict() {
 
 	taskID := rand.Int63()
 	task := s.randomTask(taskID)
-	_, err := s.taskManager.CreateTasks(&p.CreateTasksRequest{
+	_, err := s.taskManager.CreateTasks(s.ctx, &p.CreateTasksRequest{
 		TaskQueueInfo: &p.PersistedTaskQueueInfo{
 			RangeID: rand.Int63(),
 			Data:    taskQueue,
@@ -111,7 +116,7 @@ func (s *TaskQueueTaskSuite) TestCreateGet_Conflict() {
 	})
 	s.IsType(&p.ConditionFailedError{}, err)
 
-	resp, err := s.taskManager.GetTasks(&p.GetTasksRequest{
+	resp, err := s.taskManager.GetTasks(s.ctx, &p.GetTasksRequest{
 		NamespaceID:        s.namespaceID,
 		TaskQueue:          s.taskQueueName,
 		TaskType:           s.taskQueueType,
@@ -131,7 +136,7 @@ func (s *TaskQueueTaskSuite) TestCreateGet_One() {
 
 	taskID := rand.Int63()
 	task := s.randomTask(taskID)
-	_, err := s.taskManager.CreateTasks(&p.CreateTasksRequest{
+	_, err := s.taskManager.CreateTasks(s.ctx, &p.CreateTasksRequest{
 		TaskQueueInfo: &p.PersistedTaskQueueInfo{
 			RangeID: rangeID,
 			Data:    taskQueue,
@@ -140,7 +145,7 @@ func (s *TaskQueueTaskSuite) TestCreateGet_One() {
 	})
 	s.NoError(err)
 
-	resp, err := s.taskManager.GetTasks(&p.GetTasksRequest{
+	resp, err := s.taskManager.GetTasks(s.ctx, &p.GetTasksRequest{
 		NamespaceID:        s.namespaceID,
 		TaskQueue:          s.taskQueueName,
 		TaskType:           s.taskQueueType,
@@ -173,7 +178,7 @@ func (s *TaskQueueTaskSuite) TestCreateGet_Multiple() {
 			tasks = append(tasks, task)
 			expectedTasks = append(expectedTasks, task)
 		}
-		_, err := s.taskManager.CreateTasks(&p.CreateTasksRequest{
+		_, err := s.taskManager.CreateTasks(s.ctx, &p.CreateTasksRequest{
 			TaskQueueInfo: &p.PersistedTaskQueueInfo{
 				RangeID: rangeID,
 				Data:    taskQueue,
@@ -186,7 +191,7 @@ func (s *TaskQueueTaskSuite) TestCreateGet_Multiple() {
 	var token []byte
 	var actualTasks []*persistencespb.AllocatedTaskInfo
 	for doContinue := true; doContinue; doContinue = len(token) > 0 {
-		resp, err := s.taskManager.GetTasks(&p.GetTasksRequest{
+		resp, err := s.taskManager.GetTasks(s.ctx, &p.GetTasksRequest{
 			NamespaceID:        s.namespaceID,
 			TaskQueue:          s.taskQueueName,
 			TaskType:           s.taskQueueType,
@@ -208,7 +213,7 @@ func (s *TaskQueueTaskSuite) TestCreateDelete_One() {
 
 	taskID := rand.Int63()
 	task := s.randomTask(taskID)
-	_, err := s.taskManager.CreateTasks(&p.CreateTasksRequest{
+	_, err := s.taskManager.CreateTasks(s.ctx, &p.CreateTasksRequest{
 		TaskQueueInfo: &p.PersistedTaskQueueInfo{
 			RangeID: rangeID,
 			Data:    taskQueue,
@@ -217,7 +222,7 @@ func (s *TaskQueueTaskSuite) TestCreateDelete_One() {
 	})
 	s.NoError(err)
 
-	err = s.taskManager.CompleteTask(&p.CompleteTaskRequest{
+	err = s.taskManager.CompleteTask(s.ctx, &p.CompleteTaskRequest{
 		TaskQueue: &p.TaskQueueKey{
 			NamespaceID:   s.namespaceID,
 			TaskQueueName: s.taskQueueName,
@@ -227,7 +232,7 @@ func (s *TaskQueueTaskSuite) TestCreateDelete_One() {
 	})
 	s.NoError(err)
 
-	resp, err := s.taskManager.GetTasks(&p.GetTasksRequest{
+	resp, err := s.taskManager.GetTasks(s.ctx, &p.GetTasksRequest{
 		NamespaceID:        s.namespaceID,
 		TaskQueue:          s.taskQueueName,
 		TaskType:           s.taskQueueType,
@@ -258,7 +263,7 @@ func (s *TaskQueueTaskSuite) TestCreateDelete_Multiple() {
 			task := s.randomTask(taskID)
 			tasks = append(tasks, task)
 		}
-		_, err := s.taskManager.CreateTasks(&p.CreateTasksRequest{
+		_, err := s.taskManager.CreateTasks(s.ctx, &p.CreateTasksRequest{
 			TaskQueueInfo: &p.PersistedTaskQueueInfo{
 				RangeID: rangeID,
 				Data:    taskQueue,
@@ -268,7 +273,7 @@ func (s *TaskQueueTaskSuite) TestCreateDelete_Multiple() {
 		s.NoError(err)
 	}
 
-	_, err := s.taskManager.CompleteTasksLessThan(&p.CompleteTasksLessThanRequest{
+	_, err := s.taskManager.CompleteTasksLessThan(s.ctx, &p.CompleteTasksLessThanRequest{
 		NamespaceID:        s.namespaceID,
 		TaskQueueName:      s.taskQueueName,
 		TaskType:           s.taskQueueType,
@@ -277,7 +282,7 @@ func (s *TaskQueueTaskSuite) TestCreateDelete_Multiple() {
 	})
 	s.NoError(err)
 
-	resp, err := s.taskManager.GetTasks(&p.GetTasksRequest{
+	resp, err := s.taskManager.GetTasks(s.ctx, &p.GetTasksRequest{
 		NamespaceID:        s.namespaceID,
 		TaskQueue:          s.taskQueueName,
 		TaskType:           s.taskQueueType,
@@ -298,7 +303,7 @@ func (s *TaskQueueTaskSuite) createTaskQueue(
 		int32(len(enumspb.TaskQueueKind_name)) + 1),
 	)
 	taskQueue := s.randomTaskQueueInfo(taskQueueKind)
-	_, err := s.taskManager.CreateTaskQueue(&p.CreateTaskQueueRequest{
+	_, err := s.taskManager.CreateTaskQueue(s.ctx, &p.CreateTaskQueueRequest{
 		RangeID:       rangeID,
 		TaskQueueInfo: taskQueue,
 	})

--- a/common/searchattribute/manager.go
+++ b/common/searchattribute/manager.go
@@ -121,7 +121,7 @@ func (m *managerImpl) needRefreshCache(saCache cache, forceRefreshCache bool, no
 }
 
 func (m *managerImpl) refreshCache(saCache cache, now time.Time) (cache, error) {
-	clusterMetadata, err := m.clusterMetadataManager.GetCurrentClusterMetadata(context.Background())
+	clusterMetadata, err := m.clusterMetadataManager.GetCurrentClusterMetadata(context.TODO())
 	if err != nil {
 		switch err.(type) {
 		case *serviceerror.NotFound:

--- a/common/searchattribute/manager.go
+++ b/common/searchattribute/manager.go
@@ -25,6 +25,7 @@
 package searchattribute
 
 import (
+	"context"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -120,7 +121,7 @@ func (m *managerImpl) needRefreshCache(saCache cache, forceRefreshCache bool, no
 }
 
 func (m *managerImpl) refreshCache(saCache cache, now time.Time) (cache, error) {
-	clusterMetadata, err := m.clusterMetadataManager.GetCurrentClusterMetadata()
+	clusterMetadata, err := m.clusterMetadataManager.GetCurrentClusterMetadata(context.Background())
 	if err != nil {
 		switch err.(type) {
 		case *serviceerror.NotFound:
@@ -156,11 +157,12 @@ func (m *managerImpl) refreshCache(saCache cache, now time.Time) (cache, error) 
 // SaveSearchAttributes saves search attributes to cluster metadata.
 // indexName can be an empty string when Elasticsearch is not configured.
 func (m *managerImpl) SaveSearchAttributes(
+	ctx context.Context,
 	indexName string,
 	newCustomSearchAttributes map[string]enumspb.IndexedValueType,
 ) error {
 
-	clusterMetadataResponse, err := m.clusterMetadataManager.GetCurrentClusterMetadata()
+	clusterMetadataResponse, err := m.clusterMetadataManager.GetCurrentClusterMetadata(ctx)
 	if err != nil {
 		return err
 	}
@@ -170,7 +172,7 @@ func (m *managerImpl) SaveSearchAttributes(
 		clusterMetadata.IndexSearchAttributes = map[string]*persistencespb.IndexSearchAttributes{indexName: nil}
 	}
 	clusterMetadata.IndexSearchAttributes[indexName] = &persistencespb.IndexSearchAttributes{CustomSearchAttributes: newCustomSearchAttributes}
-	_, err = m.clusterMetadataManager.SaveClusterMetadata(&persistence.SaveClusterMetadataRequest{
+	_, err = m.clusterMetadataManager.SaveClusterMetadata(ctx, &persistence.SaveClusterMetadataRequest{
 		ClusterMetadata: clusterMetadata,
 		Version:         clusterMetadataResponse.Version,
 	})

--- a/common/searchattribute/search_attirbute.go
+++ b/common/searchattribute/search_attirbute.go
@@ -27,6 +27,7 @@
 package searchattribute
 
 import (
+	"context"
 	"errors"
 	"fmt"
 
@@ -45,7 +46,7 @@ type (
 
 	Manager interface {
 		Provider
-		SaveSearchAttributes(indexName string, newCustomSearchAttributes map[string]enumspb.IndexedValueType) error
+		SaveSearchAttributes(ctx context.Context, indexName string, newCustomSearchAttributes map[string]enumspb.IndexedValueType) error
 	}
 )
 

--- a/common/searchattribute/search_attribute_mock.go
+++ b/common/searchattribute/search_attribute_mock.go
@@ -29,6 +29,7 @@
 package searchattribute
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -112,15 +113,15 @@ func (mr *MockManagerMockRecorder) GetSearchAttributes(indexName, forceRefreshCa
 }
 
 // SaveSearchAttributes mocks base method.
-func (m *MockManager) SaveSearchAttributes(indexName string, newCustomSearchAttributes map[string]v1.IndexedValueType) error {
+func (m *MockManager) SaveSearchAttributes(ctx context.Context, indexName string, newCustomSearchAttributes map[string]v1.IndexedValueType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveSearchAttributes", indexName, newCustomSearchAttributes)
+	ret := m.ctrl.Call(m, "SaveSearchAttributes", ctx, indexName, newCustomSearchAttributes)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveSearchAttributes indicates an expected call of SaveSearchAttributes.
-func (mr *MockManagerMockRecorder) SaveSearchAttributes(indexName, newCustomSearchAttributes interface{}) *gomock.Call {
+func (mr *MockManagerMockRecorder) SaveSearchAttributes(ctx, indexName, newCustomSearchAttributes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSearchAttributes", reflect.TypeOf((*MockManager)(nil).SaveSearchAttributes), indexName, newCustomSearchAttributes)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSearchAttributes", reflect.TypeOf((*MockManager)(nil).SaveSearchAttributes), ctx, indexName, newCustomSearchAttributes)
 }

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -26,6 +26,7 @@ package host
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"fmt"
 	"os"
@@ -304,7 +305,7 @@ func (s *IntegrationBase) registerArchivalNamespace(archivalNamespace string) er
 		},
 		IsGlobalNamespace: false,
 	}
-	response, err := s.testCluster.testBase.MetadataManager.CreateNamespace(namespaceRequest)
+	response, err := s.testCluster.testBase.MetadataManager.CreateNamespace(context.Background(), namespaceRequest)
 
 	s.Logger.Info("Register namespace succeeded",
 		tag.WorkflowNamespace(archivalNamespace),

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -729,7 +729,7 @@ func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.Wait
 }
 
 func (c *temporalImpl) createSystemNamespace() error {
-	err := c.metadataMgr.InitializeSystemNamespaces(c.clusterMetadataConfig.CurrentClusterName)
+	err := c.metadataMgr.InitializeSystemNamespaces(context.Background(), c.clusterMetadataConfig.CurrentClusterName)
 	if err != nil {
 		return fmt.Errorf("failed to create temporal-system namespace: %v", err)
 	}

--- a/host/test_cluster.go
+++ b/host/test_cluster.go
@@ -25,6 +25,7 @@
 package host
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -166,7 +167,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	}
 
 	for clusterName, clusterInfo := range clusterMetadataConfig.ClusterInformation {
-		_, err := testBase.ClusterMetadataManager.SaveClusterMetadata(&persistence.SaveClusterMetadataRequest{
+		_, err := testBase.ClusterMetadataManager.SaveClusterMetadata(context.Background(), &persistence.SaveClusterMetadataRequest{
 			ClusterMetadata: persistencespb.ClusterMetadata{
 				HistoryShardCount:        options.HistoryConfig.NumHistoryShards,
 				ClusterName:              clusterName,
@@ -185,6 +186,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	// This will save custom test search attributes to cluster metadata.
 	// Actual Elasticsearch fields are created from index template (testdata/es_v7_index_template.json).
 	err := testBase.SearchAttributesManager.SaveSearchAttributes(
+		context.Background(),
 		options.ESConfig.GetVisibilityIndex(),
 		searchattribute.TestNameTypeMap.Custom(),
 	)

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -727,7 +727,7 @@ func (s *adminHandlerSuite) Test_RemoveSearchAttributes() {
 	}
 
 	// Success case.
-	s.mockResource.SearchAttributesManager.EXPECT().SaveSearchAttributes("random-index-name", gomock.Any()).Return(nil)
+	s.mockResource.SearchAttributesManager.EXPECT().SaveSearchAttributes(gomock.Any(), "random-index-name", gomock.Any()).Return(nil)
 
 	resp, err := handler.RemoveSearchAttributes(ctx, &adminservice.RemoveSearchAttributesRequest{
 		SearchAttributes: []string{
@@ -741,6 +741,7 @@ func (s *adminHandlerSuite) Test_RemoveSearchAttributes() {
 func (s *adminHandlerSuite) Test_RemoveRemoteCluster_Success() {
 	var clusterName = "cluster"
 	s.mockClusterMetadataManager.EXPECT().DeleteClusterMetadata(
+		gomock.Any(),
 		&persistence.DeleteClusterMetadataRequest{ClusterName: clusterName},
 	).Return(nil)
 
@@ -751,6 +752,7 @@ func (s *adminHandlerSuite) Test_RemoveRemoteCluster_Success() {
 func (s *adminHandlerSuite) Test_RemoveRemoteCluster_Error() {
 	var clusterName = "cluster"
 	s.mockClusterMetadataManager.EXPECT().DeleteClusterMetadata(
+		gomock.Any(),
 		&persistence.DeleteClusterMetadataRequest{ClusterName: clusterName},
 	).Return(fmt.Errorf("test error"))
 
@@ -779,11 +781,11 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordFound_Success() 
 			InitialFailoverVersion:   0,
 			IsGlobalNamespaceEnabled: true,
 		}, nil)
-	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(&persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
+	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(gomock.Any(), &persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
 		&persistence.GetClusterMetadataResponse{
 			Version: recordVersion,
 		}, nil)
-	s.mockClusterMetadataManager.EXPECT().SaveClusterMetadata(&persistence.SaveClusterMetadataRequest{
+	s.mockClusterMetadataManager.EXPECT().SaveClusterMetadata(gomock.Any(), &persistence.SaveClusterMetadataRequest{
 		ClusterMetadata: persistencespb.ClusterMetadata{
 			ClusterName:              clusterName,
 			HistoryShardCount:        0,
@@ -819,11 +821,11 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordNotFound_Success
 			InitialFailoverVersion:   0,
 			IsGlobalNamespaceEnabled: true,
 		}, nil)
-	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(&persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
+	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(gomock.Any(), &persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
 		nil,
 		serviceerror.NewNotFound("expected empty result"),
 	)
-	s.mockClusterMetadataManager.EXPECT().SaveClusterMetadata(&persistence.SaveClusterMetadataRequest{
+	s.mockClusterMetadataManager.EXPECT().SaveClusterMetadata(gomock.Any(), &persistence.SaveClusterMetadataRequest{
 		ClusterMetadata: persistencespb.ClusterMetadata{
 			ClusterName:              clusterName,
 			HistoryShardCount:        0,
@@ -995,7 +997,7 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_GetClusterMetadata_Err
 			InitialFailoverVersion:   0,
 			IsGlobalNamespaceEnabled: true,
 		}, nil)
-	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(&persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
+	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(gomock.Any(), &persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
 		nil,
 		fmt.Errorf("test error"),
 	)
@@ -1023,11 +1025,11 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata_Er
 			InitialFailoverVersion:   0,
 			IsGlobalNamespaceEnabled: true,
 		}, nil)
-	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(&persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
+	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(gomock.Any(), &persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
 		nil,
 		serviceerror.NewNotFound("expected empty result"),
 	)
-	s.mockClusterMetadataManager.EXPECT().SaveClusterMetadata(&persistence.SaveClusterMetadataRequest{
+	s.mockClusterMetadataManager.EXPECT().SaveClusterMetadata(gomock.Any(), &persistence.SaveClusterMetadataRequest{
 		ClusterMetadata: persistencespb.ClusterMetadata{
 			ClusterName:              clusterName,
 			HistoryShardCount:        0,
@@ -1063,11 +1065,11 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata_No
 			InitialFailoverVersion:   0,
 			IsGlobalNamespaceEnabled: true,
 		}, nil)
-	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(&persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
+	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(gomock.Any(), &persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
 		nil,
 		serviceerror.NewNotFound("expected empty result"),
 	)
-	s.mockClusterMetadataManager.EXPECT().SaveClusterMetadata(&persistence.SaveClusterMetadataRequest{
+	s.mockClusterMetadataManager.EXPECT().SaveClusterMetadata(gomock.Any(), &persistence.SaveClusterMetadataRequest{
 		ClusterMetadata: persistencespb.ClusterMetadata{
 			ClusterName:              clusterName,
 			HistoryShardCount:        0,
@@ -1101,7 +1103,7 @@ func (s *adminHandlerSuite) Test_DescribeCluster_CurrentCluster_Success() {
 	s.mockResource.WorkerServiceResolver.EXPECT().MemberCount().Return(0)
 	s.mockResource.ExecutionMgr.EXPECT().GetName().Return("")
 	s.mockVisibilityMgr.EXPECT().GetName().Return("")
-	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(&persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
+	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(gomock.Any(), &persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
 		&persistence.GetClusterMetadataResponse{
 			ClusterMetadata: persistencespb.ClusterMetadata{
 				ClusterName:              clusterName,
@@ -1140,7 +1142,7 @@ func (s *adminHandlerSuite) Test_DescribeCluster_NonCurrentCluster_Success() {
 	s.mockResource.WorkerServiceResolver.EXPECT().MemberCount().Return(0)
 	s.mockResource.ExecutionMgr.EXPECT().GetName().Return("")
 	s.mockVisibilityMgr.EXPECT().GetName().Return("")
-	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(&persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
+	s.mockClusterMetadataManager.EXPECT().GetClusterMetadata(gomock.Any(), &persistence.GetClusterMetadataRequest{ClusterName: clusterName}).Return(
 		&persistence.GetClusterMetadataResponse{
 			ClusterMetadata: persistencespb.ClusterMetadata{
 				ClusterName:              clusterName,
@@ -1166,7 +1168,7 @@ func (s *adminHandlerSuite) Test_DescribeCluster_NonCurrentCluster_Success() {
 func (s *adminHandlerSuite) Test_ListClusters_Success() {
 	var pageSize int32 = 1
 
-	s.mockClusterMetadataManager.EXPECT().ListClusterMetadata(&persistence.ListClusterMetadataRequest{
+	s.mockClusterMetadataManager.EXPECT().ListClusterMetadata(gomock.Any(), &persistence.ListClusterMetadataRequest{
 		PageSize: int(pageSize),
 	}).Return(
 		&persistence.ListClusterMetadataResponse{

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -229,7 +229,7 @@ func (h *OperatorHandlerImpl) RemoveSearchAttributes(ctx context.Context, reques
 		delete(newCustomSearchAttributes, saName)
 	}
 
-	err = h.saManager.SaveSearchAttributes(indexName, newCustomSearchAttributes)
+	err = h.saManager.SaveSearchAttributes(ctx, indexName, newCustomSearchAttributes)
 	if err != nil {
 		return nil, h.error(serviceerror.NewUnavailable(fmt.Sprintf(errUnableToSaveSearchAttributesMessage, err)), scope, endpointName)
 	}

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -363,7 +363,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 	}
 
 	// Success case.
-	s.mockResource.SearchAttributesManager.EXPECT().SaveSearchAttributes("random-index-name", gomock.Any()).Return(nil)
+	s.mockResource.SearchAttributesManager.EXPECT().SaveSearchAttributes(gomock.Any(), "random-index-name", gomock.Any()).Return(nil)
 
 	resp, err := handler.RemoveSearchAttributes(ctx, &operatorservice.RemoveSearchAttributesRequest{
 		SearchAttributes: []string{

--- a/service/frontend/versionChecker.go
+++ b/service/frontend/versionChecker.go
@@ -72,7 +72,7 @@ func NewVersionChecker(
 func (vc *VersionChecker) Start() {
 	if vc.config.EnableServerVersionCheck() {
 		vc.startOnce.Do(func() {
-			go vc.versionCheckLoop()
+			go vc.versionCheckLoop(context.TODO())
 		})
 	}
 }
@@ -85,16 +85,18 @@ func (vc *VersionChecker) Stop() {
 	}
 }
 
-func (vc *VersionChecker) versionCheckLoop() {
+func (vc *VersionChecker) versionCheckLoop(
+	ctx context.Context,
+) {
 	timer := time.NewTicker(VersionCheckInterval)
 	defer timer.Stop()
-	vc.performVersionCheck(context.Background())
+	vc.performVersionCheck(ctx)
 	for {
 		select {
 		case <-vc.shutdownChan:
 			return
 		case <-timer.C:
-			vc.performVersionCheck(context.Background())
+			vc.performVersionCheck(ctx)
 		}
 	}
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2922,10 +2922,10 @@ func (wh *WorkflowHandler) DescribeTaskQueue(ctx context.Context, request *workf
 }
 
 // GetClusterInfo return information about Temporal deployment.
-func (wh *WorkflowHandler) GetClusterInfo(_ context.Context, _ *workflowservice.GetClusterInfoRequest) (_ *workflowservice.GetClusterInfoResponse, retError error) {
+func (wh *WorkflowHandler) GetClusterInfo(ctx context.Context, _ *workflowservice.GetClusterInfoRequest) (_ *workflowservice.GetClusterInfoResponse, retError error) {
 	defer log.CapturePanic(wh.logger, &retError)
 
-	metadata, err := wh.clusterMetadataManager.GetCurrentClusterMetadata()
+	metadata, err := wh.clusterMetadataManager.GetCurrentClusterMetadata(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -567,7 +567,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Failure_InvalidArchivalURI(
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI"))
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(errors.New("invalid URI"))
 	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
@@ -591,8 +591,8 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithNoArchiv
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", testHistoryArchivalURI))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", testVisibilityArchivalURI))
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
-	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any()).Return(&persistence.CreateNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
@@ -613,8 +613,8 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithArchival
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "invalidURI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "invalidURI"))
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
-	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any()).Return(&persistence.CreateNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
@@ -640,8 +640,8 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_ClusterNotConfigure
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewDisabledArchvialConfig())
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewDisabledArchvialConfig())
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
-	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any()).Return(&persistence.CreateNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
 
@@ -663,8 +663,8 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_NotEnabled() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
-	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any()).Return(&persistence.CreateNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
 
@@ -681,13 +681,13 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Success() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
-	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any()).Return(&persistence.CreateNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
 
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{}, nil)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(&persistence.GetNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{}, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(&persistence.GetNamespaceResponse{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
 				State: enumspb.NAMESPACE_STATE_REGISTERED,
@@ -699,7 +699,7 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Success() {
 			},
 		},
 	}, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
 		s.Equal(enumspb.NAMESPACE_STATE_DEPRECATED, request.Namespace.Info.State)
 		return nil
 	})
@@ -727,13 +727,13 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Error() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
-	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any()).Return(&persistence.CreateNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
 
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{}, nil)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(&persistence.GetNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{}, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(&persistence.GetNamespaceResponse{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
 				State: enumspb.NAMESPACE_STATE_REGISTERED,
@@ -745,7 +745,7 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Error() {
 			},
 		},
 	}, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
 		s.Equal(enumspb.NAMESPACE_STATE_DEPRECATED, request.Namespace.Info.State)
 		return serviceerror.NewInternal("db is down")
 	})
@@ -773,13 +773,13 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Success() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
-	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any()).Return(&persistence.CreateNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
 
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{}, nil)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(&persistence.GetNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{}, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(&persistence.GetNamespaceResponse{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
 				State: enumspb.NAMESPACE_STATE_REGISTERED,
@@ -791,7 +791,7 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Success() {
 			},
 		},
 	}, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
 		s.Equal(enumspb.NAMESPACE_STATE_DELETED, request.Namespace.Info.State)
 		return nil
 	})
@@ -819,13 +819,13 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Error() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
-	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any()).Return(&persistence.CreateNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
 
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{}, nil)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(&persistence.GetNamespaceResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{}, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(&persistence.GetNamespaceResponse{
 		Namespace: &persistencespb.NamespaceDetail{
 			Info: &persistencespb.NamespaceInfo{
 				State: enumspb.NAMESPACE_STATE_REGISTERED,
@@ -837,7 +837,7 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Error() {
 			},
 		},
 	}, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
 		s.Equal(enumspb.NAMESPACE_STATE_DELETED, request.Namespace.Info.State)
 		return serviceerror.NewInternal("db is down")
 	})
@@ -864,7 +864,7 @@ func (s *workflowHandlerSuite) TestDescribeNamespace_Success_ArchivalDisabled() 
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_DISABLED, URI: ""},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_DISABLED, URI: ""},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -887,7 +887,7 @@ func (s *workflowHandlerSuite) TestDescribeNamespace_Success_ArchivalEnabled() {
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testHistoryArchivalURI},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testVisibilityArchivalURI},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -906,14 +906,14 @@ func (s *workflowHandlerSuite) TestDescribeNamespace_Success_ArchivalEnabled() {
 }
 
 func (s *workflowHandlerSuite) TestUpdateNamespace_Failure_UpdateExistingArchivalURI() {
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testHistoryArchivalURI},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testVisibilityArchivalURI},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
@@ -932,14 +932,14 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Failure_UpdateExistingArchiva
 }
 
 func (s *workflowHandlerSuite) TestUpdateNamespace_Failure_InvalidArchivalURI() {
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_DISABLED, URI: ""},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_DISABLED, URI: ""},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(errors.New("invalid URI"))
 	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
@@ -957,15 +957,15 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Failure_InvalidArchivalURI() 
 }
 
 func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArchivalDisabledWithoutSettingURI() {
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testHistoryArchivalURI},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testVisibilityArchivalURI},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any()).Return(nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
@@ -994,14 +994,14 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArch
 }
 
 func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ClusterNotConfiguredForArchival() {
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: "some random history URI"},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: "some random visibility URI"},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewDisabledArchvialConfig())
@@ -1021,15 +1021,15 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ClusterNotConfiguredF
 }
 
 func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArchivalDisabledWithSettingBucket() {
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testHistoryArchivalURI},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testVisibilityArchivalURI},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any()).Return(nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
@@ -1058,14 +1058,14 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToArch
 }
 
 func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToEnabled() {
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testHistoryArchivalURI},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_ENABLED, URI: testVisibilityArchivalURI},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
@@ -1094,15 +1094,15 @@ func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalEnabledToEnab
 }
 
 func (s *workflowHandlerSuite) TestUpdateNamespace_Success_ArchivalNeverEnabledToEnabled() {
-	s.mockMetadataMgr.EXPECT().GetMetadata().Return(&persistence.GetMetadataResponse{
+	s.mockMetadataMgr.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)
 	getNamespaceResp := persistenceGetNamespaceResponse(
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_DISABLED, URI: ""},
 		&namespace.ArchivalState{State: enumspb.ARCHIVAL_STATE_DISABLED, URI: ""},
 	)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any()).Return(getNamespaceResp, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any()).Return(nil)
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(getNamespaceResp, nil)
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).Return(nil)
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -699,10 +699,12 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Success() {
 			},
 		},
 	}, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
-		s.Equal(enumspb.NAMESPACE_STATE_DEPRECATED, request.Namespace.Info.State)
-		return nil
-	})
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.UpdateNamespaceRequest) error {
+			s.Equal(enumspb.NAMESPACE_STATE_DEPRECATED, request.Namespace.Info.State)
+			return nil
+		},
+	)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -745,10 +747,12 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Error() {
 			},
 		},
 	}, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
-		s.Equal(enumspb.NAMESPACE_STATE_DEPRECATED, request.Namespace.Info.State)
-		return serviceerror.NewInternal("db is down")
-	})
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.UpdateNamespaceRequest) error {
+			s.Equal(enumspb.NAMESPACE_STATE_DEPRECATED, request.Namespace.Info.State)
+			return serviceerror.NewInternal("db is down")
+		},
+	)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -791,10 +795,12 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Success() {
 			},
 		},
 	}, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
-		s.Equal(enumspb.NAMESPACE_STATE_DELETED, request.Namespace.Info.State)
-		return nil
-	})
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.UpdateNamespaceRequest) error {
+			s.Equal(enumspb.NAMESPACE_STATE_DELETED, request.Namespace.Info.State)
+			return nil
+		},
+	)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -837,10 +843,12 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Error() {
 			},
 		},
 	}, nil)
-	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(func(request *persistence.UpdateNamespaceRequest) error {
-		s.Equal(enumspb.NAMESPACE_STATE_DELETED, request.Namespace.Info.State)
-		return serviceerror.NewInternal("db is down")
-	})
+	s.mockMetadataMgr.EXPECT().UpdateNamespace(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, request *persistence.UpdateNamespaceRequest) error {
+			s.Equal(enumspb.NAMESPACE_STATE_DELETED, request.Namespace.Info.State)
+			return serviceerror.NewInternal("db is down")
+		},
+	)
 
 	wh := s.getWorkflowHandler(s.newConfig())
 

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -603,9 +603,9 @@ func (h *Handler) CloseShard(_ context.Context, request *historyservice.CloseSha
 }
 
 // GetShard gets a shard hosted by this instance
-func (h *Handler) GetShard(_ context.Context, request *historyservice.GetShardRequest) (_ *historyservice.GetShardResponse, retError error) {
+func (h *Handler) GetShard(ctx context.Context, request *historyservice.GetShardRequest) (_ *historyservice.GetShardResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
-	resp, err := h.persistenceShardManager.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+	resp, err := h.persistenceShardManager.GetOrCreateShard(ctx, &persistence.GetOrCreateShardRequest{
 		ShardID: request.ShardId,
 	})
 	if err != nil {

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -887,7 +887,7 @@ func (s *engineSuite) TestRespondWorkflowTaskCompletedUpdateExecutionFailed() {
 
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, errors.New("FAILED"))
-	s.mockShardManager.EXPECT().UpdateShard(gomock.Any()).Return(nil).AnyTimes() // might be called in background goroutine
+	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil).AnyTimes() // might be called in background goroutine
 
 	_, err := s.mockHistoryEngine.RespondWorkflowTaskCompleted(context.Background(), &historyservice.RespondWorkflowTaskCompletedRequest{
 		NamespaceId: tests.NamespaceID.String(),
@@ -2354,7 +2354,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedUpdateExecutionFailed() {
 
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, errors.New("FAILED"))
-	s.mockShardManager.EXPECT().UpdateShard(gomock.Any()).Return(nil).AnyTimes() // might be called in background goroutine
+	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil).AnyTimes() // might be called in background goroutine
 
 	err := s.mockHistoryEngine.RespondActivityTaskCompleted(context.Background(), &historyservice.RespondActivityTaskCompletedRequest{
 		NamespaceId: tests.NamespaceID.String(),
@@ -2890,7 +2890,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedUpdateExecutionFailed() {
 
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(gwmsResponse, nil)
 	s.mockExecutionMgr.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(tests.UpdateWorkflowExecutionResponse, errors.New("FAILED"))
-	s.mockShardManager.EXPECT().UpdateShard(gomock.Any()).Return(nil).AnyTimes() // might be called in background goroutine
+	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil).AnyTimes() // might be called in background goroutine
 
 	err := s.mockHistoryEngine.RespondActivityTaskFailed(context.Background(), &historyservice.RespondActivityTaskFailedRequest{
 		NamespaceId: tests.NamespaceID.String(),

--- a/service/history/replicationDLQHandler_test.go
+++ b/service/history/replicationDLQHandler_test.go
@@ -210,7 +210,7 @@ func (s *replicationDLQHandlerSuite) TestPurgeMessages() {
 			SourceClusterName: s.sourceCluster,
 		}).Return(nil)
 
-	s.shardManager.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.shardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	err := s.replicationMessageHandler.purgeMessages(context.Background(), s.sourceCluster, lastMessageID)
 	s.NoError(err)
 }
@@ -289,7 +289,7 @@ func (s *replicationDLQHandlerSuite) TestMergeMessages() {
 		SourceClusterName: s.sourceCluster,
 	}).Return(nil)
 
-	s.shardManager.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.shardManager.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 
 	token, err := s.replicationMessageHandler.mergeMessages(ctx, s.sourceCluster, lastMessageID, pageSize, pageToken)
 	s.NoError(err)

--- a/service/history/replicationTaskProcessor_test.go
+++ b/service/history/replicationTaskProcessor_test.go
@@ -367,7 +367,7 @@ func (s *replicationTaskProcessorSuite) TestConvertTaskToDLQTask_History() {
 
 func (s *replicationTaskProcessorSuite) TestCleanupReplicationTask_Noop() {
 	ackedTaskID := int64(12345)
-	s.mockResource.ShardMgr.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.mockResource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	err := s.mockShard.UpdateQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName, tasks.Key{TaskID: ackedTaskID})
 	s.NoError(err)
 
@@ -378,7 +378,7 @@ func (s *replicationTaskProcessorSuite) TestCleanupReplicationTask_Noop() {
 
 func (s *replicationTaskProcessorSuite) TestCleanupReplicationTask_Cleanup() {
 	ackedTaskID := int64(12345)
-	s.mockResource.ShardMgr.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.mockResource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	err := s.mockShard.UpdateQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName, tasks.Key{TaskID: ackedTaskID})
 	s.NoError(err)
 

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -993,7 +993,7 @@ func (s *ContextImpl) renewRangeLocked(isStealing bool) error {
 		updatedShardInfo.StolenSinceRenew++
 	}
 
-	err := s.persistenceShardManager.UpdateShard(&persistence.UpdateShardRequest{
+	err := s.persistenceShardManager.UpdateShard(context.TODO(), &persistence.UpdateShardRequest{
 		ShardInfo:       updatedShardInfo.ShardInfo,
 		PreviousRangeID: s.shardInfo.GetRangeId()})
 	if err != nil {
@@ -1043,7 +1043,7 @@ func (s *ContextImpl) updateShardInfoLocked() error {
 	updatedShardInfo := copyShardInfo(s.shardInfo)
 	s.emitShardInfoMetricsLogsLocked()
 
-	err = s.persistenceShardManager.UpdateShard(&persistence.UpdateShardRequest{
+	err = s.persistenceShardManager.UpdateShard(context.TODO(), &persistence.UpdateShardRequest{
 		ShardInfo:       updatedShardInfo.ShardInfo,
 		PreviousRangeID: s.shardInfo.GetRangeId(),
 	})
@@ -1502,7 +1502,7 @@ func (s *ContextImpl) loadShardMetadata(ownershipChanged *bool) error {
 	s.rUnlock()
 
 	// We don't have any shardInfo yet, load it (outside of context rwlock)
-	resp, err := s.persistenceShardManager.GetOrCreateShard(&persistence.GetOrCreateShardRequest{
+	resp, err := s.persistenceShardManager.GetOrCreateShard(context.TODO(), &persistence.GetOrCreateShardRequest{
 		ShardID:          s.shardID,
 		LifecycleContext: s.lifecycleCtx,
 	})

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -159,7 +159,7 @@ func (s *contextSuite) TestTimerMaxReadLevelInitialization() {
 			cluster.TestCurrentClusterName: timestamp.TimePtr(now),
 		},
 	}
-	s.mockResource.ShardMgr.EXPECT().GetOrCreateShard(gomock.Any()).Return(
+	s.mockResource.ShardMgr.EXPECT().GetOrCreateShard(gomock.Any(), gomock.Any()).Return(
 		&persistence.GetOrCreateShardResponse{
 			ShardInfo: persistenceShardInfo,
 		},

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -180,7 +180,7 @@ func (s *controllerSuite) TestAcquireShardSuccess() {
 			s.mockHistoryEngine.EXPECT().Start().Return()
 			s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 			s.mockEngineFactory.EXPECT().CreateEngine(gomock.Any()).Return(s.mockHistoryEngine)
-			s.mockShardManager.EXPECT().GetOrCreateShard(getOrCreateShardRequestMatcher(shardID)).Return(
+			s.mockShardManager.EXPECT().GetOrCreateShard(gomock.Any(), getOrCreateShardRequestMatcher(shardID)).Return(
 				&persistence.GetOrCreateShardResponse{
 					ShardInfo: &persistencespb.ShardInfo{
 						ShardId:             shardID,
@@ -202,7 +202,7 @@ func (s *controllerSuite) TestAcquireShardSuccess() {
 						QueueAckLevels:          map[int32]*persistencespb.QueueAckLevel{},
 					},
 				}, nil)
-			s.mockShardManager.EXPECT().UpdateShard(&persistence.UpdateShardRequest{
+			s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), &persistence.UpdateShardRequest{
 				ShardInfo: &persistencespb.ShardInfo{
 					ShardId:             shardID,
 					Owner:               s.hostInfo.Identity(),
@@ -266,7 +266,7 @@ func (s *controllerSuite) TestAcquireShardsConcurrently() {
 			s.mockHistoryEngine.EXPECT().Start().Return()
 			s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 			s.mockEngineFactory.EXPECT().CreateEngine(gomock.Any()).Return(s.mockHistoryEngine)
-			s.mockShardManager.EXPECT().GetOrCreateShard(getOrCreateShardRequestMatcher(shardID)).Return(
+			s.mockShardManager.EXPECT().GetOrCreateShard(gomock.Any(), getOrCreateShardRequestMatcher(shardID)).Return(
 				&persistence.GetOrCreateShardResponse{
 					ShardInfo: &persistencespb.ShardInfo{
 						ShardId:             shardID,
@@ -288,7 +288,7 @@ func (s *controllerSuite) TestAcquireShardsConcurrently() {
 						QueueAckLevels:          map[int32]*persistencespb.QueueAckLevel{},
 					},
 				}, nil)
-			s.mockShardManager.EXPECT().UpdateShard(&persistence.UpdateShardRequest{
+			s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), &persistence.UpdateShardRequest{
 				ShardInfo: &persistencespb.ShardInfo{
 					ShardId:             shardID,
 					Owner:               s.hostInfo.Identity(),
@@ -361,7 +361,7 @@ func (s *controllerSuite) TestAcquireShardRenewSuccess() {
 		s.mockHistoryEngine.EXPECT().Start().Return()
 		s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 		s.mockEngineFactory.EXPECT().CreateEngine(gomock.Any()).Return(s.mockHistoryEngine)
-		s.mockShardManager.EXPECT().GetOrCreateShard(getOrCreateShardRequestMatcher(shardID)).Return(
+		s.mockShardManager.EXPECT().GetOrCreateShard(gomock.Any(), getOrCreateShardRequestMatcher(shardID)).Return(
 			&persistence.GetOrCreateShardResponse{
 				ShardInfo: &persistencespb.ShardInfo{
 					ShardId:             shardID,
@@ -383,7 +383,7 @@ func (s *controllerSuite) TestAcquireShardRenewSuccess() {
 					QueueAckLevels:          map[int32]*persistencespb.QueueAckLevel{},
 				},
 			}, nil)
-		s.mockShardManager.EXPECT().UpdateShard(&persistence.UpdateShardRequest{
+		s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), &persistence.UpdateShardRequest{
 			ShardInfo: &persistencespb.ShardInfo{
 				ShardId:             shardID,
 				Owner:               s.hostInfo.Identity(),
@@ -439,7 +439,7 @@ func (s *controllerSuite) TestAcquireShardRenewLookupFailed() {
 		s.mockHistoryEngine.EXPECT().Start().Return()
 		s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2)
 		s.mockEngineFactory.EXPECT().CreateEngine(gomock.Any()).Return(s.mockHistoryEngine)
-		s.mockShardManager.EXPECT().GetOrCreateShard(getOrCreateShardRequestMatcher(shardID)).Return(
+		s.mockShardManager.EXPECT().GetOrCreateShard(gomock.Any(), getOrCreateShardRequestMatcher(shardID)).Return(
 			&persistence.GetOrCreateShardResponse{
 				ShardInfo: &persistencespb.ShardInfo{
 					ShardId:             shardID,
@@ -461,7 +461,7 @@ func (s *controllerSuite) TestAcquireShardRenewLookupFailed() {
 					QueueAckLevels:          map[int32]*persistencespb.QueueAckLevel{},
 				},
 			}, nil)
-		s.mockShardManager.EXPECT().UpdateShard(&persistence.UpdateShardRequest{
+		s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), &persistence.UpdateShardRequest{
 			ShardInfo: &persistencespb.ShardInfo{
 				ShardId:             shardID,
 				Owner:               s.hostInfo.Identity(),
@@ -697,7 +697,7 @@ func (s *controllerSuite) setupMocksForAcquireShard(shardID int32, mockEngine *M
 	mockEngine.EXPECT().Start().MinTimes(minTimes)
 	s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).Times(2).MinTimes(minTimes)
 	s.mockEngineFactory.EXPECT().CreateEngine(newContextMatcher(shardID)).Return(mockEngine).MinTimes(minTimes)
-	s.mockShardManager.EXPECT().GetOrCreateShard(getOrCreateShardRequestMatcher(shardID)).Return(
+	s.mockShardManager.EXPECT().GetOrCreateShard(gomock.Any(), getOrCreateShardRequestMatcher(shardID)).Return(
 		&persistence.GetOrCreateShardResponse{
 			ShardInfo: &persistencespb.ShardInfo{
 				ShardId:             shardID,
@@ -719,7 +719,7 @@ func (s *controllerSuite) setupMocksForAcquireShard(shardID int32, mockEngine *M
 				QueueAckLevels:          map[int32]*persistencespb.QueueAckLevel{},
 			},
 		}, nil).MinTimes(minTimes)
-	s.mockShardManager.EXPECT().UpdateShard(&persistence.UpdateShardRequest{
+	s.mockShardManager.EXPECT().UpdateShard(gomock.Any(), &persistence.UpdateShardRequest{
 		ShardInfo: &persistencespb.ShardInfo{
 			ShardId:             shardID,
 			Owner:               s.hostInfo.Identity(),

--- a/service/history/timerQueueAckMgr_test.go
+++ b/service/history/timerQueueAckMgr_test.go
@@ -505,7 +505,7 @@ func (s *timerQueueAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 	s.False(moreTasks)
 
 	// we are not testing shard context
-	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	timerSequenceID1 := tasks.Key{
 		FireTime: timer1.VisibilityTimestamp,
 		TaskID:   timer1.TaskID,
@@ -515,7 +515,7 @@ func (s *timerQueueAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 	_ = s.timerQueueAckMgr.updateAckLevel()
 	s.Equal(timer1.VisibilityTimestamp.UnixNano(), s.mockShard.GetQueueClusterAckLevel(tasks.CategoryTimer, s.clusterName).FireTime.UnixNano())
 
-	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	timerSequenceID3 := tasks.Key{
 		FireTime: timer3.VisibilityTimestamp,
 		TaskID:   timer3.TaskID,
@@ -527,7 +527,7 @@ func (s *timerQueueAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 	s.Equal(timer1.VisibilityTimestamp.UnixNano(), s.mockShard.GetQueueClusterAckLevel(tasks.CategoryTimer, s.clusterName).FireTime.UnixNano())
 
 	// we are not testing shard context
-	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	timerSequenceID2 := tasks.Key{
 		FireTime: timer2.VisibilityTimestamp,
 		TaskID:   timer2.TaskID,
@@ -827,7 +827,7 @@ func (s *timerQueueFailoverAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 	}
 	s.timerQueueFailoverAckMgr.completeTimerTask(timer2.VisibilityTimestamp, timer2.TaskID)
 	s.True(s.timerQueueFailoverAckMgr.outstandingTasks[timerSequenceID2])
-	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	_ = s.timerQueueFailoverAckMgr.updateAckLevel()
 	select {
 	case <-s.timerQueueFailoverAckMgr.getFinishedChan():
@@ -841,7 +841,7 @@ func (s *timerQueueFailoverAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 	}
 	s.timerQueueFailoverAckMgr.completeTimerTask(timer3.VisibilityTimestamp, timer3.TaskID)
 	s.True(s.timerQueueFailoverAckMgr.outstandingTasks[timerSequenceID3])
-	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	_ = s.timerQueueFailoverAckMgr.updateAckLevel()
 	select {
 	case <-s.timerQueueFailoverAckMgr.getFinishedChan():
@@ -855,7 +855,7 @@ func (s *timerQueueFailoverAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
 	}
 	s.timerQueueFailoverAckMgr.completeTimerTask(timer1.VisibilityTimestamp, timer1.TaskID)
 	s.True(s.timerQueueFailoverAckMgr.outstandingTasks[timerSequenceID1])
-	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any()).Return(nil)
+	s.mockShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
 	_ = s.timerQueueFailoverAckMgr.updateAckLevel()
 	select {
 	case <-s.timerQueueFailoverAckMgr.getFinishedChan():

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -25,6 +25,7 @@
 package matching
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -93,24 +94,28 @@ func (db *taskQueueDB) RangeID() int64 {
 
 // RenewLease renews the lease on a taskqueue. If there is no previous lease,
 // this method will attempt to steal taskqueue from current owner
-func (db *taskQueueDB) RenewLease() (taskQueueState, error) {
+func (db *taskQueueDB) RenewLease(
+	ctx context.Context,
+) (taskQueueState, error) {
 	db.Lock()
 	defer db.Unlock()
 
 	if db.rangeID == 0 {
-		if err := db.takeOverTaskQueueLocked(); err != nil {
+		if err := db.takeOverTaskQueueLocked(ctx); err != nil {
 			return taskQueueState{}, err
 		}
 	} else {
-		if err := db.renewTaskQueueLocked(db.rangeID + 1); err != nil {
+		if err := db.renewTaskQueueLocked(ctx, db.rangeID+1); err != nil {
 			return taskQueueState{}, err
 		}
 	}
 	return taskQueueState{rangeID: db.rangeID, ackLevel: db.ackLevel}, nil
 }
 
-func (db *taskQueueDB) takeOverTaskQueueLocked() error {
-	response, err := db.store.GetTaskQueue(&persistence.GetTaskQueueRequest{
+func (db *taskQueueDB) takeOverTaskQueueLocked(
+	ctx context.Context,
+) error {
+	response, err := db.store.GetTaskQueue(ctx, &persistence.GetTaskQueueRequest{
 		NamespaceID: db.namespaceID.String(),
 		TaskQueue:   db.taskQueueName,
 		TaskType:    db.taskType,
@@ -120,7 +125,7 @@ func (db *taskQueueDB) takeOverTaskQueueLocked() error {
 		response.TaskQueueInfo.Kind = db.taskQueueKind
 		response.TaskQueueInfo.ExpiryTime = db.expiryTime()
 		response.TaskQueueInfo.LastUpdateTime = timestamp.TimeNowPtrUtc()
-		_, err := db.store.UpdateTaskQueue(&persistence.UpdateTaskQueueRequest{
+		_, err := db.store.UpdateTaskQueue(ctx, &persistence.UpdateTaskQueueRequest{
 			RangeID:       response.RangeID + 1,
 			TaskQueueInfo: response.TaskQueueInfo,
 			PrevRangeID:   response.RangeID,
@@ -133,7 +138,7 @@ func (db *taskQueueDB) takeOverTaskQueueLocked() error {
 		return nil
 
 	case *serviceerror.NotFound:
-		if _, err := db.store.CreateTaskQueue(&persistence.CreateTaskQueueRequest{
+		if _, err := db.store.CreateTaskQueue(ctx, &persistence.CreateTaskQueueRequest{
 			RangeID: initialRangeID,
 			TaskQueueInfo: &persistencespb.TaskQueueInfo{
 				NamespaceId:    db.namespaceID.String(),
@@ -156,9 +161,10 @@ func (db *taskQueueDB) takeOverTaskQueueLocked() error {
 }
 
 func (db *taskQueueDB) renewTaskQueueLocked(
+	ctx context.Context,
 	rangeID int64,
 ) error {
-	if _, err := db.store.UpdateTaskQueue(&persistence.UpdateTaskQueueRequest{
+	if _, err := db.store.UpdateTaskQueue(ctx, &persistence.UpdateTaskQueueRequest{
 		RangeID: rangeID,
 		TaskQueueInfo: &persistencespb.TaskQueueInfo{
 			NamespaceId:    db.namespaceID.String(),
@@ -179,10 +185,13 @@ func (db *taskQueueDB) renewTaskQueueLocked(
 }
 
 // UpdateState updates the taskQueue state with the given value
-func (db *taskQueueDB) UpdateState(ackLevel int64) error {
+func (db *taskQueueDB) UpdateState(
+	ctx context.Context,
+	ackLevel int64,
+) error {
 	db.Lock()
 	defer db.Unlock()
-	_, err := db.store.UpdateTaskQueue(&persistence.UpdateTaskQueueRequest{
+	_, err := db.store.UpdateTaskQueue(ctx, &persistence.UpdateTaskQueueRequest{
 		RangeID: db.rangeID,
 		TaskQueueInfo: &persistencespb.TaskQueueInfo{
 			NamespaceId:    db.namespaceID.String(),
@@ -202,10 +211,14 @@ func (db *taskQueueDB) UpdateState(ackLevel int64) error {
 }
 
 // CreateTasks creates a batch of given tasks for this task queue
-func (db *taskQueueDB) CreateTasks(tasks []*persistencespb.AllocatedTaskInfo) (*persistence.CreateTasksResponse, error) {
+func (db *taskQueueDB) CreateTasks(
+	ctx context.Context,
+	tasks []*persistencespb.AllocatedTaskInfo,
+) (*persistence.CreateTasksResponse, error) {
 	db.Lock()
 	defer db.Unlock()
 	return db.store.CreateTasks(
+		ctx,
 		&persistence.CreateTasksRequest{
 			TaskQueueInfo: &persistence.PersistedTaskQueueInfo{
 				Data: &persistencespb.TaskQueueInfo{
@@ -223,11 +236,12 @@ func (db *taskQueueDB) CreateTasks(tasks []*persistencespb.AllocatedTaskInfo) (*
 
 // GetTasks returns a batch of tasks between the given range
 func (db *taskQueueDB) GetTasks(
+	ctx context.Context,
 	inclusiveMinTaskID int64,
 	exclusiveMaxTaskID int64,
 	batchSize int,
 ) (*persistence.GetTasksResponse, error) {
-	return db.store.GetTasks(&persistence.GetTasksRequest{
+	return db.store.GetTasks(ctx, &persistence.GetTasksRequest{
 		NamespaceID:        db.namespaceID.String(),
 		TaskQueue:          db.taskQueueName,
 		TaskType:           db.taskType,
@@ -238,8 +252,11 @@ func (db *taskQueueDB) GetTasks(
 }
 
 // CompleteTask deletes a single task from this task queue
-func (db *taskQueueDB) CompleteTask(taskID int64) error {
-	err := db.store.CompleteTask(&persistence.CompleteTaskRequest{
+func (db *taskQueueDB) CompleteTask(
+	ctx context.Context,
+	taskID int64,
+) error {
+	err := db.store.CompleteTask(ctx, &persistence.CompleteTaskRequest{
 		TaskQueue: &persistence.TaskQueueKey{
 			NamespaceID:   db.namespaceID.String(),
 			TaskQueueName: db.taskQueueName,
@@ -261,8 +278,12 @@ func (db *taskQueueDB) CompleteTask(taskID int64) error {
 // CompleteTasksLessThan deletes of tasks less than the given taskID. Limit is
 // the upper bound of number of tasks that can be deleted by this method. It may
 // or may not be honored
-func (db *taskQueueDB) CompleteTasksLessThan(exclusiveMaxTaskID int64, limit int) (int, error) {
-	n, err := db.store.CompleteTasksLessThan(&persistence.CompleteTasksLessThanRequest{
+func (db *taskQueueDB) CompleteTasksLessThan(
+	ctx context.Context,
+	exclusiveMaxTaskID int64,
+	limit int,
+) (int, error) {
+	n, err := db.store.CompleteTasksLessThan(ctx, &persistence.CompleteTasksLessThanRequest{
 		NamespaceID:        db.namespaceID.String(),
 		TaskQueueName:      db.taskQueueName,
 		TaskType:           db.taskType,

--- a/service/matching/db_task_manager_test.go
+++ b/service/matching/db_task_manager_test.go
@@ -132,10 +132,10 @@ func (s *dbTaskManagerSuite) TearDownTest() {
 }
 
 func (s *dbTaskManagerSuite) TestAcquireOwnership_Success() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID).AnyTimes()
 
-	err := s.dbTaskManager.acquireOwnership()
+	err := s.dbTaskManager.acquireOwnership(context.Background())
 	s.NoError(err)
 	s.NotNil(s.dbTaskManager.taskWriter)
 	s.NotNil(s.dbTaskManager.taskReader)
@@ -143,9 +143,9 @@ func (s *dbTaskManagerSuite) TestAcquireOwnership_Success() {
 }
 
 func (s *dbTaskManagerSuite) TestAcquireOwnership_Failed() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(serviceerror.NewUnavailable("some random error"))
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(serviceerror.NewUnavailable("some random error"))
 
-	err := s.dbTaskManager.acquireOwnership()
+	err := s.dbTaskManager.acquireOwnership(context.Background())
 	s.Error(err)
 	s.Nil(s.dbTaskManager.taskWriter)
 	s.Nil(s.dbTaskManager.taskReader)
@@ -153,11 +153,11 @@ func (s *dbTaskManagerSuite) TestAcquireOwnership_Failed() {
 }
 
 func (s *dbTaskManagerSuite) TestStart_Success() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID).AnyTimes()
 	s.taskQueueOwnership.EXPECT().getLastAllocatedTaskID().Return(s.lastAllocatedTaskID).AnyTimes()
 	s.taskQueueOwnership.EXPECT().getShutdownChan().Return(nil).AnyTimes()
-	s.taskReader.EXPECT().taskIterator(s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
+	s.taskReader.EXPECT().taskIterator(gomock.Any(), s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
 		func(paginationToken []byte) ([]interface{}, []byte, error) {
 			return nil, nil, nil
 		},
@@ -171,13 +171,13 @@ func (s *dbTaskManagerSuite) TestStart_Success() {
 
 func (s *dbTaskManagerSuite) TestStart_ErrorThenSuccess() {
 	gomock.InOrder(
-		s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(serviceerror.NewUnavailable("some random error")),
-		s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil),
+		s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(serviceerror.NewUnavailable("some random error")),
+		s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil),
 	)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID).AnyTimes()
 	s.taskQueueOwnership.EXPECT().getLastAllocatedTaskID().Return(s.lastAllocatedTaskID).AnyTimes()
 	s.taskQueueOwnership.EXPECT().getShutdownChan().Return(nil).AnyTimes()
-	s.taskReader.EXPECT().taskIterator(s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
+	s.taskReader.EXPECT().taskIterator(gomock.Any(), s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
 		func(paginationToken []byte) ([]interface{}, []byte, error) {
 			return nil, nil, nil
 		},
@@ -190,7 +190,7 @@ func (s *dbTaskManagerSuite) TestStart_ErrorThenSuccess() {
 }
 
 func (s *dbTaskManagerSuite) TestStart_Error() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(&persistence.ConditionFailedError{})
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(&persistence.ConditionFailedError{})
 
 	s.dbTaskManager.Start()
 	<-s.dbTaskManager.startupChan
@@ -198,7 +198,7 @@ func (s *dbTaskManagerSuite) TestStart_Error() {
 }
 
 func (s *dbTaskManagerSuite) TestBufferAndWriteTask_NotReady() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(serviceerror.NewUnavailable("some random error")).AnyTimes()
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(serviceerror.NewUnavailable("some random error")).AnyTimes()
 	s.dbTaskManager.Start()
 
 	taskInfo := &persistencespb.TaskInfo{}
@@ -208,11 +208,11 @@ func (s *dbTaskManagerSuite) TestBufferAndWriteTask_NotReady() {
 }
 
 func (s *dbTaskManagerSuite) TestBufferAndWriteTask_Ready() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID).AnyTimes()
 	s.taskQueueOwnership.EXPECT().getLastAllocatedTaskID().Return(s.lastAllocatedTaskID).AnyTimes()
 	s.taskQueueOwnership.EXPECT().getShutdownChan().Return(nil).AnyTimes()
-	s.taskReader.EXPECT().taskIterator(s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
+	s.taskReader.EXPECT().taskIterator(gomock.Any(), s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
 		func(paginationToken []byte) ([]interface{}, []byte, error) {
 			return nil, nil, nil
 		},
@@ -232,9 +232,9 @@ func (s *dbTaskManagerSuite) TestBufferAndWriteTask_Ready() {
 }
 
 func (s *dbTaskManagerSuite) TestReadAndDispatchTasks_ReadSuccess_Expired() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID)
-	err := s.dbTaskManager.acquireOwnership()
+	err := s.dbTaskManager.acquireOwnership(context.Background())
 	s.NoError(err)
 
 	// make sure no signal exists in dispatch chan
@@ -255,14 +255,14 @@ func (s *dbTaskManagerSuite) TestReadAndDispatchTasks_ReadSuccess_Expired() {
 		},
 	}
 	s.taskQueueOwnership.EXPECT().getLastAllocatedTaskID().Return(s.lastAllocatedTaskID)
-	s.taskReader.EXPECT().taskIterator(s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
+	s.taskReader.EXPECT().taskIterator(gomock.Any(), s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
 		func(paginationToken []byte) ([]interface{}, []byte, error) {
 			return []interface{}{allocatedTaskInfo}, nil, nil
 		},
 	))
 	s.taskReader.EXPECT().ackTask(allocatedTaskInfo.TaskId)
 
-	s.dbTaskManager.readAndDispatchTasks()
+	s.dbTaskManager.readAndDispatchTasks(context.Background())
 }
 
 func (s *dbTaskManagerSuite) TestReadAndDispatchTasks_ReadSuccess_Dispatch() {
@@ -271,9 +271,9 @@ func (s *dbTaskManagerSuite) TestReadAndDispatchTasks_ReadSuccess_Dispatch() {
 		dispatchedTasks = append(dispatchedTasks, task.event.AllocatedTaskInfo)
 		return nil
 	}
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID)
-	err := s.dbTaskManager.acquireOwnership()
+	err := s.dbTaskManager.acquireOwnership(context.Background())
 	s.NoError(err)
 
 	// make sure no signal exists in dispatch chan
@@ -294,20 +294,20 @@ func (s *dbTaskManagerSuite) TestReadAndDispatchTasks_ReadSuccess_Dispatch() {
 		},
 	}
 	s.taskQueueOwnership.EXPECT().getLastAllocatedTaskID().Return(s.lastAllocatedTaskID)
-	s.taskReader.EXPECT().taskIterator(s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
+	s.taskReader.EXPECT().taskIterator(gomock.Any(), s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
 		func(paginationToken []byte) ([]interface{}, []byte, error) {
 			return []interface{}{allocatedTaskInfo}, nil, nil
 		},
 	))
 
-	s.dbTaskManager.readAndDispatchTasks()
+	s.dbTaskManager.readAndDispatchTasks(context.Background())
 	s.Equal([]*persistencespb.AllocatedTaskInfo{allocatedTaskInfo}, dispatchedTasks)
 }
 
 func (s *dbTaskManagerSuite) TestReadAndDispatchTasks_ReadFailure() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID)
-	err := s.dbTaskManager.acquireOwnership()
+	err := s.dbTaskManager.acquireOwnership(context.Background())
 	s.NoError(err)
 
 	// make sure no signal exists in dispatch chan
@@ -317,13 +317,13 @@ func (s *dbTaskManagerSuite) TestReadAndDispatchTasks_ReadFailure() {
 	}
 
 	s.taskQueueOwnership.EXPECT().getLastAllocatedTaskID().Return(s.lastAllocatedTaskID)
-	s.taskReader.EXPECT().taskIterator(s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
+	s.taskReader.EXPECT().taskIterator(gomock.Any(), s.lastAllocatedTaskID).Return(collection.NewPagingIterator(
 		func(paginationToken []byte) ([]interface{}, []byte, error) {
 			return nil, nil, serviceerror.NewUnavailable("random error")
 		},
 	))
 
-	s.dbTaskManager.readAndDispatchTasks()
+	s.dbTaskManager.readAndDispatchTasks(context.Background())
 	select {
 	case <-s.dbTaskManager.dispatchChan:
 		// noop
@@ -333,9 +333,9 @@ func (s *dbTaskManagerSuite) TestReadAndDispatchTasks_ReadFailure() {
 }
 
 func (s *dbTaskManagerSuite) TestUpdateAckTaskID() {
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID)
-	err := s.dbTaskManager.acquireOwnership()
+	err := s.dbTaskManager.acquireOwnership(context.Background())
 	s.NoError(err)
 
 	ackedTaskID := rand.Int63()
@@ -347,13 +347,13 @@ func (s *dbTaskManagerSuite) TestUpdateAckTaskID() {
 
 func (s *dbTaskManagerSuite) TestDeleteAckedTasks_Success() {
 	maxDeletedTaskIDInclusive := s.ackedTaskID - 100
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID).AnyTimes()
-	err := s.dbTaskManager.acquireOwnership()
+	err := s.dbTaskManager.acquireOwnership(context.Background())
 	s.NoError(err)
 	s.dbTaskManager.maxDeletedTaskIDInclusive = maxDeletedTaskIDInclusive
 
-	s.store.EXPECT().CompleteTasksLessThan(&persistence.CompleteTasksLessThanRequest{
+	s.store.EXPECT().CompleteTasksLessThan(gomock.Any(), &persistence.CompleteTasksLessThanRequest{
 		NamespaceID:        s.namespaceID,
 		TaskQueueName:      s.taskQueueName,
 		TaskType:           s.taskQueueType,
@@ -361,19 +361,19 @@ func (s *dbTaskManagerSuite) TestDeleteAckedTasks_Success() {
 		Limit:              100000,
 	}).Return(0, nil)
 
-	s.dbTaskManager.deleteAckedTasks()
+	s.dbTaskManager.deleteAckedTasks(context.Background())
 	s.Equal(s.ackedTaskID, s.dbTaskManager.maxDeletedTaskIDInclusive)
 }
 
 func (s *dbTaskManagerSuite) TestDeleteAckedTasks_Failed() {
 	maxDeletedTaskIDInclusive := s.ackedTaskID - 100
-	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership().Return(nil)
+	s.taskQueueOwnership.EXPECT().takeTaskQueueOwnership(gomock.Any()).Return(nil)
 	s.taskQueueOwnership.EXPECT().getAckedTaskID().Return(s.ackedTaskID).AnyTimes()
-	err := s.dbTaskManager.acquireOwnership()
+	err := s.dbTaskManager.acquireOwnership(context.Background())
 	s.NoError(err)
 	s.dbTaskManager.maxDeletedTaskIDInclusive = maxDeletedTaskIDInclusive
 
-	s.store.EXPECT().CompleteTasksLessThan(&persistence.CompleteTasksLessThanRequest{
+	s.store.EXPECT().CompleteTasksLessThan(gomock.Any(), &persistence.CompleteTasksLessThanRequest{
 		NamespaceID:        s.namespaceID,
 		TaskQueueName:      s.taskQueueName,
 		TaskType:           s.taskQueueType,
@@ -381,7 +381,7 @@ func (s *dbTaskManagerSuite) TestDeleteAckedTasks_Failed() {
 		Limit:              100000,
 	}).Return(0, serviceerror.NewUnavailable("random error"))
 
-	s.dbTaskManager.deleteAckedTasks()
+	s.dbTaskManager.deleteAckedTasks(context.Background())
 	s.Equal(maxDeletedTaskIDInclusive, s.dbTaskManager.maxDeletedTaskIDInclusive)
 }
 

--- a/service/matching/db_task_queue_ownership_mock.go
+++ b/service/matching/db_task_queue_ownership_mock.go
@@ -29,6 +29,7 @@
 package matching
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -59,9 +60,9 @@ func (m *MockdbTaskQueueOwnership) EXPECT() *MockdbTaskQueueOwnershipMockRecorde
 }
 
 // flushTasks mocks base method.
-func (m *MockdbTaskQueueOwnership) flushTasks(taskInfos ...*persistence.TaskInfo) error {
+func (m *MockdbTaskQueueOwnership) flushTasks(ctx context.Context, taskInfos ...*persistence.TaskInfo) error {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{}
+	varargs := []interface{}{ctx}
 	for _, a := range taskInfos {
 		varargs = append(varargs, a)
 	}
@@ -71,9 +72,10 @@ func (m *MockdbTaskQueueOwnership) flushTasks(taskInfos ...*persistence.TaskInfo
 }
 
 // flushTasks indicates an expected call of flushTasks.
-func (mr *MockdbTaskQueueOwnershipMockRecorder) flushTasks(taskInfos ...interface{}) *gomock.Call {
+func (mr *MockdbTaskQueueOwnershipMockRecorder) flushTasks(ctx interface{}, taskInfos ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "flushTasks", reflect.TypeOf((*MockdbTaskQueueOwnership)(nil).flushTasks), taskInfos...)
+	varargs := append([]interface{}{ctx}, taskInfos...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "flushTasks", reflect.TypeOf((*MockdbTaskQueueOwnership)(nil).flushTasks), varargs...)
 }
 
 // getAckedTaskID mocks base method.
@@ -119,31 +121,31 @@ func (mr *MockdbTaskQueueOwnershipMockRecorder) getShutdownChan() *gomock.Call {
 }
 
 // persistTaskQueue mocks base method.
-func (m *MockdbTaskQueueOwnership) persistTaskQueue() error {
+func (m *MockdbTaskQueueOwnership) persistTaskQueue(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "persistTaskQueue")
+	ret := m.ctrl.Call(m, "persistTaskQueue", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // persistTaskQueue indicates an expected call of persistTaskQueue.
-func (mr *MockdbTaskQueueOwnershipMockRecorder) persistTaskQueue() *gomock.Call {
+func (mr *MockdbTaskQueueOwnershipMockRecorder) persistTaskQueue(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "persistTaskQueue", reflect.TypeOf((*MockdbTaskQueueOwnership)(nil).persistTaskQueue))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "persistTaskQueue", reflect.TypeOf((*MockdbTaskQueueOwnership)(nil).persistTaskQueue), ctx)
 }
 
 // takeTaskQueueOwnership mocks base method.
-func (m *MockdbTaskQueueOwnership) takeTaskQueueOwnership() error {
+func (m *MockdbTaskQueueOwnership) takeTaskQueueOwnership(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "takeTaskQueueOwnership")
+	ret := m.ctrl.Call(m, "takeTaskQueueOwnership", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // takeTaskQueueOwnership indicates an expected call of takeTaskQueueOwnership.
-func (mr *MockdbTaskQueueOwnershipMockRecorder) takeTaskQueueOwnership() *gomock.Call {
+func (mr *MockdbTaskQueueOwnershipMockRecorder) takeTaskQueueOwnership(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "takeTaskQueueOwnership", reflect.TypeOf((*MockdbTaskQueueOwnership)(nil).takeTaskQueueOwnership))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "takeTaskQueueOwnership", reflect.TypeOf((*MockdbTaskQueueOwnership)(nil).takeTaskQueueOwnership), ctx)
 }
 
 // updateAckedTaskID mocks base method.

--- a/service/matching/db_task_reader_mock.go
+++ b/service/matching/db_task_reader_mock.go
@@ -29,6 +29,7 @@
 package matching
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -85,15 +86,15 @@ func (mr *MockdbTaskReaderMockRecorder) moveAckedTaskID() *gomock.Call {
 }
 
 // taskIterator mocks base method.
-func (m *MockdbTaskReader) taskIterator(maxTaskID int64) collection.Iterator {
+func (m *MockdbTaskReader) taskIterator(ctx context.Context, maxTaskID int64) collection.Iterator {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "taskIterator", maxTaskID)
+	ret := m.ctrl.Call(m, "taskIterator", ctx, maxTaskID)
 	ret0, _ := ret[0].(collection.Iterator)
 	return ret0
 }
 
 // taskIterator indicates an expected call of taskIterator.
-func (mr *MockdbTaskReaderMockRecorder) taskIterator(maxTaskID interface{}) *gomock.Call {
+func (mr *MockdbTaskReaderMockRecorder) taskIterator(ctx, maxTaskID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "taskIterator", reflect.TypeOf((*MockdbTaskReader)(nil).taskIterator), maxTaskID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "taskIterator", reflect.TypeOf((*MockdbTaskReader)(nil).taskIterator), ctx, maxTaskID)
 }

--- a/service/matching/db_task_writer_mock.go
+++ b/service/matching/db_task_writer_mock.go
@@ -29,6 +29,7 @@
 package matching
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -74,15 +75,15 @@ func (mr *MockdbTaskWriterMockRecorder) appendTask(task interface{}) *gomock.Cal
 }
 
 // flushTasks mocks base method.
-func (m *MockdbTaskWriter) flushTasks() {
+func (m *MockdbTaskWriter) flushTasks(ctx context.Context) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "flushTasks")
+	m.ctrl.Call(m, "flushTasks", ctx)
 }
 
 // flushTasks indicates an expected call of flushTasks.
-func (mr *MockdbTaskWriterMockRecorder) flushTasks() *gomock.Call {
+func (mr *MockdbTaskWriterMockRecorder) flushTasks(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "flushTasks", reflect.TypeOf((*MockdbTaskWriter)(nil).flushTasks))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "flushTasks", reflect.TypeOf((*MockdbTaskWriter)(nil).flushTasks), ctx)
 }
 
 // notifyFlushChan mocks base method.

--- a/service/matching/db_task_writer_test.go
+++ b/service/matching/db_task_writer_test.go
@@ -102,7 +102,7 @@ func (s *dbTaskWriterSuite) TestAppendFlushTask_Once_Success() {
 	ctx := context.Background()
 	task := s.randomTask()
 
-	s.taskOwnership.EXPECT().flushTasks(task).Return(nil)
+	s.taskOwnership.EXPECT().flushTasks(gomock.Any(), task).Return(nil)
 
 	fut := s.taskFlusher.appendTask(task)
 	s.taskFlusher.flushTasks(context.Background())
@@ -122,7 +122,7 @@ func (s *dbTaskWriterSuite) TestAppendFlushTask_Once_Failed() {
 	task := s.randomTask()
 	randomErr := serviceerror.NewUnavailable("random error")
 
-	s.taskOwnership.EXPECT().flushTasks(task).Return(randomErr)
+	s.taskOwnership.EXPECT().flushTasks(gomock.Any(), task).Return(randomErr)
 
 	fut := s.taskFlusher.appendTask(task)
 	s.taskFlusher.flushTasks(context.Background())

--- a/service/matching/db_task_writer_test.go
+++ b/service/matching/db_task_writer_test.go
@@ -105,7 +105,7 @@ func (s *dbTaskWriterSuite) TestAppendFlushTask_Once_Success() {
 	s.taskOwnership.EXPECT().flushTasks(task).Return(nil)
 
 	fut := s.taskFlusher.appendTask(task)
-	s.taskFlusher.flushTasks()
+	s.taskFlusher.flushTasks(context.Background())
 
 	_, err := fut.Get(ctx)
 	s.NoError(err)
@@ -125,7 +125,7 @@ func (s *dbTaskWriterSuite) TestAppendFlushTask_Once_Failed() {
 	s.taskOwnership.EXPECT().flushTasks(task).Return(randomErr)
 
 	fut := s.taskFlusher.appendTask(task)
-	s.taskFlusher.flushTasks()
+	s.taskFlusher.flushTasks(context.Background())
 
 	_, err := fut.Get(ctx)
 	s.Equal(randomErr, err)
@@ -150,9 +150,9 @@ func (s *dbTaskWriterSuite) TestAppendFlushTask_Multiple_OnePage_Success() {
 		futures = append(futures, fut)
 	}
 
-	s.taskOwnership.EXPECT().flushTasks(tasks...).Return(nil)
+	s.taskOwnership.EXPECT().flushTasks(gomock.Any(), tasks...).Return(nil)
 
-	s.taskFlusher.flushTasks()
+	s.taskFlusher.flushTasks(context.Background())
 
 	for _, fut := range futures {
 		_, err := fut.Get(ctx)
@@ -180,9 +180,9 @@ func (s *dbTaskWriterSuite) TestAppendFlushTask_Multiple_OnePage_Failed() {
 		futures = append(futures, fut)
 	}
 
-	s.taskOwnership.EXPECT().flushTasks(tasks...).Return(randomErr)
+	s.taskOwnership.EXPECT().flushTasks(gomock.Any(), tasks...).Return(randomErr)
 
-	s.taskFlusher.flushTasks()
+	s.taskFlusher.flushTasks(context.Background())
 
 	for _, fut := range futures {
 		_, err := fut.Get(ctx)
@@ -218,10 +218,10 @@ func (s *dbTaskWriterSuite) TestAppendFlushTask_Multiple_MultiPage_Success() {
 	}
 
 	for _, tasks := range taskBatch {
-		s.taskOwnership.EXPECT().flushTasks(tasks...).Return(nil)
+		s.taskOwnership.EXPECT().flushTasks(gomock.Any(), tasks...).Return(nil)
 	}
 
-	s.taskFlusher.flushTasks()
+	s.taskFlusher.flushTasks(context.Background())
 
 	for _, fut := range futures {
 		_, err := fut.Get(ctx)
@@ -253,10 +253,10 @@ func (s *dbTaskWriterSuite) TestAppendFlushTask_Multiple_MultiPage_Failed() {
 	}
 
 	for _, tasks := range taskBatch {
-		s.taskOwnership.EXPECT().flushTasks(tasks...).Return(randomErr)
+		s.taskOwnership.EXPECT().flushTasks(gomock.Any(), tasks...).Return(randomErr)
 	}
 
-	s.taskFlusher.flushTasks()
+	s.taskFlusher.flushTasks(context.Background())
 
 	for _, fut := range futures {
 		_, err := fut.Get(ctx)

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1951,7 +1951,10 @@ func newTestTaskQueueID(namespaceID namespace.ID, name string, taskType enumspb.
 	return result
 }
 
-func (m *testTaskManager) CreateTaskQueue(request *persistence.CreateTaskQueueRequest) (*persistence.CreateTaskQueueResponse, error) {
+func (m *testTaskManager) CreateTaskQueue(
+	_ context.Context,
+	request *persistence.CreateTaskQueueRequest,
+) (*persistence.CreateTaskQueueResponse, error) {
 	tli := request.TaskQueueInfo
 	tlm := m.getTaskQueueManager(newTestTaskQueueID(namespace.ID(tli.GetNamespaceId()), tli.Name, tli.TaskType))
 	tlm.Lock()
@@ -1969,7 +1972,10 @@ func (m *testTaskManager) CreateTaskQueue(request *persistence.CreateTaskQueueRe
 }
 
 // UpdateTaskQueue provides a mock function with given fields: request
-func (m *testTaskManager) UpdateTaskQueue(request *persistence.UpdateTaskQueueRequest) (*persistence.UpdateTaskQueueResponse, error) {
+func (m *testTaskManager) UpdateTaskQueue(
+	_ context.Context,
+	request *persistence.UpdateTaskQueueRequest,
+) (*persistence.UpdateTaskQueueResponse, error) {
 	tli := request.TaskQueueInfo
 	tlm := m.getTaskQueueManager(newTestTaskQueueID(namespace.ID(tli.GetNamespaceId()), tli.Name, tli.TaskType))
 	tlm.Lock()
@@ -1985,7 +1991,10 @@ func (m *testTaskManager) UpdateTaskQueue(request *persistence.UpdateTaskQueueRe
 	return &persistence.UpdateTaskQueueResponse{}, nil
 }
 
-func (m *testTaskManager) GetTaskQueue(request *persistence.GetTaskQueueRequest) (*persistence.GetTaskQueueResponse, error) {
+func (m *testTaskManager) GetTaskQueue(
+	_ context.Context,
+	request *persistence.GetTaskQueueRequest,
+) (*persistence.GetTaskQueueResponse, error) {
 	tlm := m.getTaskQueueManager(newTestTaskQueueID(namespace.ID(request.NamespaceID), request.TaskQueue, request.TaskType))
 	tlm.Lock()
 	defer tlm.Unlock()
@@ -2008,7 +2017,10 @@ func (m *testTaskManager) GetTaskQueue(request *persistence.GetTaskQueueRequest)
 }
 
 // CompleteTask provides a mock function with given fields: request
-func (m *testTaskManager) CompleteTask(request *persistence.CompleteTaskRequest) error {
+func (m *testTaskManager) CompleteTask(
+	_ context.Context,
+	request *persistence.CompleteTaskRequest,
+) error {
 	m.logger.Debug("CompleteTask", tag.TaskID(request.TaskID), tag.Name(request.TaskQueue.TaskQueueName), tag.WorkflowTaskQueueType(request.TaskQueue.TaskQueueType))
 	if request.TaskID <= 0 {
 		panic(fmt.Errorf("invalid taskID=%v", request.TaskID))
@@ -2024,7 +2036,10 @@ func (m *testTaskManager) CompleteTask(request *persistence.CompleteTaskRequest)
 	return nil
 }
 
-func (m *testTaskManager) CompleteTasksLessThan(request *persistence.CompleteTasksLessThanRequest) (int, error) {
+func (m *testTaskManager) CompleteTasksLessThan(
+	_ context.Context,
+	request *persistence.CompleteTasksLessThanRequest,
+) (int, error) {
 	tlm := m.getTaskQueueManager(newTestTaskQueueID(namespace.ID(request.NamespaceID), request.TaskQueueName, request.TaskType))
 	tlm.Lock()
 	defer tlm.Unlock()
@@ -2038,11 +2053,17 @@ func (m *testTaskManager) CompleteTasksLessThan(request *persistence.CompleteTas
 	return persistence.UnknownNumRowsAffected, nil
 }
 
-func (m *testTaskManager) ListTaskQueue(_ *persistence.ListTaskQueueRequest) (*persistence.ListTaskQueueResponse, error) {
+func (m *testTaskManager) ListTaskQueue(
+	_ context.Context,
+	_ *persistence.ListTaskQueueRequest,
+) (*persistence.ListTaskQueueResponse, error) {
 	return nil, fmt.Errorf("unsupported operation")
 }
 
-func (m *testTaskManager) DeleteTaskQueue(request *persistence.DeleteTaskQueueRequest) error {
+func (m *testTaskManager) DeleteTaskQueue(
+	_ context.Context,
+	request *persistence.DeleteTaskQueueRequest,
+) error {
 	m.Lock()
 	defer m.Unlock()
 	key := newTestTaskQueueID(namespace.ID(request.TaskQueue.NamespaceID), request.TaskQueue.TaskQueueName, request.TaskQueue.TaskQueueType)
@@ -2051,7 +2072,10 @@ func (m *testTaskManager) DeleteTaskQueue(request *persistence.DeleteTaskQueueRe
 }
 
 // CreateTask provides a mock function with given fields: request
-func (m *testTaskManager) CreateTasks(request *persistence.CreateTasksRequest) (*persistence.CreateTasksResponse, error) {
+func (m *testTaskManager) CreateTasks(
+	_ context.Context,
+	request *persistence.CreateTasksRequest,
+) (*persistence.CreateTasksResponse, error) {
 	namespaceID := namespace.ID(request.TaskQueueInfo.Data.GetNamespaceId())
 	taskQueue := request.TaskQueueInfo.Data.Name
 	taskType := request.TaskQueueInfo.Data.TaskType
@@ -2096,7 +2120,10 @@ func (m *testTaskManager) CreateTasks(request *persistence.CreateTasksRequest) (
 }
 
 // GetTasks provides a mock function with given fields: request
-func (m *testTaskManager) GetTasks(request *persistence.GetTasksRequest) (*persistence.GetTasksResponse, error) {
+func (m *testTaskManager) GetTasks(
+	_ context.Context,
+	request *persistence.GetTasksRequest,
+) (*persistence.GetTasksResponse, error) {
 	m.logger.Debug("testTaskManager.GetTasks", tag.MinLevel(request.InclusiveMinTaskID), tag.MaxLevel(request.ExclusiveMaxTaskID))
 
 	tlm := m.getTaskQueueManager(newTestTaskQueueID(namespace.ID(request.NamespaceID), request.TaskQueue, request.TaskType))

--- a/service/matching/taskGC.go
+++ b/service/matching/taskGC.go
@@ -25,6 +25,7 @@
 package matching
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 )
@@ -56,17 +57,17 @@ func newTaskGC(db *taskQueueDB, config *taskQueueConfig) *taskGC {
 
 // Run deletes a batch of completed tasks, if its possible to do so
 // Only attempts deletion if size or time thresholds are met
-func (tgc *taskGC) Run(ackLevel int64) {
-	tgc.tryDeleteNextBatch(ackLevel, false)
+func (tgc *taskGC) Run(ctx context.Context, ackLevel int64) {
+	tgc.tryDeleteNextBatch(ctx, ackLevel, false)
 }
 
 // RunNow deletes a batch of completed tasks if its possible to do so
 // This method attempts deletions without waiting for size/time threshold to be met
-func (tgc *taskGC) RunNow(ackLevel int64) {
-	tgc.tryDeleteNextBatch(ackLevel, true)
+func (tgc *taskGC) RunNow(ctx context.Context, ackLevel int64) {
+	tgc.tryDeleteNextBatch(ctx, ackLevel, true)
 }
 
-func (tgc *taskGC) tryDeleteNextBatch(ackLevel int64, ignoreTimeCond bool) {
+func (tgc *taskGC) tryDeleteNextBatch(ctx context.Context, ackLevel int64, ignoreTimeCond bool) {
 	if !tgc.tryLock() {
 		return
 	}
@@ -76,7 +77,7 @@ func (tgc *taskGC) tryDeleteNextBatch(ackLevel int64, ignoreTimeCond bool) {
 		return
 	}
 	tgc.lastDeleteTime = time.Now().UTC()
-	n, err := tgc.db.CompleteTasksLessThan(ackLevel+1, batchSize)
+	n, err := tgc.db.CompleteTasksLessThan(ctx, ackLevel+1, batchSize)
 	switch {
 	case err != nil:
 		return

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -66,7 +66,7 @@ type (
 	taskQueueManagerOpt func(*taskQueueManagerImpl)
 
 	idBlockAllocator interface {
-		RenewLease() (taskQueueState, error)
+		RenewLease(context.Context) (taskQueueState, error)
 		RangeID() int64
 	}
 
@@ -256,8 +256,8 @@ func (c *taskQueueManagerImpl) Stop() {
 	) {
 		return
 	}
-	_ = c.db.UpdateState(c.taskAckManager.getAckLevel())
-	c.taskGC.RunNow(c.taskAckManager.getAckLevel())
+	_ = c.db.UpdateState(context.TODO(), c.taskAckManager.getAckLevel())
+	c.taskGC.RunNow(context.TODO(), c.taskAckManager.getAckLevel())
 	c.liveness.Stop()
 	c.taskWriter.Stop()
 	c.taskReader.Stop()
@@ -484,7 +484,7 @@ func (c *taskQueueManagerImpl) completeTask(task *persistencespb.AllocatedTaskIn
 	}
 
 	ackLevel := c.taskAckManager.completeTask(task.GetTaskId())
-	c.taskGC.Run(ackLevel)
+	c.taskGC.Run(context.TODO(), ackLevel) // TODO: completeTaskFunc and task.finish() should take in a context
 }
 
 func rangeIDToTaskIDBlock(rangeID int64, rangeSize int64) taskIDBlock {

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -153,7 +153,7 @@ func (a *testIDBlockAlloc) RangeID() int64 {
 	return a.rid
 }
 
-func (a *testIDBlockAlloc) RenewLease() (taskQueueState, error) {
+func (a *testIDBlockAlloc) RenewLease(_ context.Context) (taskQueueState, error) {
 	s, err := a.alloc()
 	if err == nil {
 		a.rid = s.rangeID

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -199,7 +199,7 @@ func (tr *taskReader) getTaskBatchWithRange(readLevel int64, maxReadLevel int64)
 	var response *persistence.GetTasksResponse
 	var err error
 	err = executeWithRetry(func() error {
-		response, err = tr.tlMgr.db.GetTasks(readLevel+1, maxReadLevel+1, tr.tlMgr.config.GetTasksBatchSize())
+		response, err = tr.tlMgr.db.GetTasks(context.TODO(), readLevel+1, maxReadLevel+1, tr.tlMgr.config.GetTasksBatchSize())
 		return err
 	})
 	if err != nil {
@@ -270,7 +270,7 @@ func (tr *taskReader) addSingleTaskToBuffer(
 func (tr *taskReader) persistAckLevel() error {
 	ackLevel := tr.tlMgr.taskAckManager.getAckLevel()
 	tr.emitTaskLagMetric(ackLevel)
-	return tr.tlMgr.db.UpdateState(ackLevel)
+	return tr.tlMgr.db.UpdateState(context.TODO(), ackLevel)
 }
 
 func (tr *taskReader) isTaskAddedRecently(lastAddTime time.Time) bool {

--- a/service/worker/addsearchattributes/workflow.go
+++ b/service/worker/addsearchattributes/workflow.go
@@ -166,7 +166,7 @@ func (a *activities) WaitForYellowStatusActivity(ctx context.Context, indexName 
 	return nil
 }
 
-func (a *activities) UpdateClusterMetadataActivity(_ context.Context, params WorkflowParams) error {
+func (a *activities) UpdateClusterMetadataActivity(ctx context.Context, params WorkflowParams) error {
 	oldSearchAttributes, err := a.saManager.GetSearchAttributes(params.IndexName, true)
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrUnableToGetSearchAttributes, err)
@@ -179,7 +179,7 @@ func (a *activities) UpdateClusterMetadataActivity(_ context.Context, params Wor
 	for saName, saType := range params.CustomAttributesToAdd {
 		newCustomSearchAttributes[saName] = saType
 	}
-	err = a.saManager.SaveSearchAttributes(params.IndexName, newCustomSearchAttributes)
+	err = a.saManager.SaveSearchAttributes(ctx, params.IndexName, newCustomSearchAttributes)
 	if err != nil {
 		a.logger.Info("Unable to save search attributes to cluster metadata.", tag.ESIndex(params.IndexName), tag.Error(err))
 		a.metricsClient.IncCounter(metrics.AddSearchAttributesWorkflowScope, metrics.AddSearchAttributesFailuresCount)

--- a/service/worker/replicator/namespace_replication_message_processor.go
+++ b/service/worker/replicator/namespace_replication_message_processor.go
@@ -25,6 +25,7 @@
 package replicator
 
 import (
+	"context"
 	"sync/atomic"
 	"time"
 
@@ -209,7 +210,7 @@ func (p *namespaceReplicationMessageProcessor) handleNamespaceReplicationTask(
 	sw := p.metricsClient.StartTimer(metrics.NamespaceReplicationTaskScope, metrics.ReplicatorLatency)
 	defer sw.Stop()
 
-	return p.taskExecutor.Execute(task.GetNamespaceTaskAttributes())
+	return p.taskExecutor.Execute(context.TODO(), task.GetNamespaceTaskAttributes())
 }
 
 func (p *namespaceReplicationMessageProcessor) Stop() {

--- a/service/worker/scanner/taskqueue/db.go
+++ b/service/worker/scanner/taskqueue/db.go
@@ -25,6 +25,7 @@
 package taskqueue
 
 import (
+	"context"
 	"math"
 	"time"
 
@@ -40,7 +41,7 @@ func (s *Scavenger) completeTasks(key *p.TaskQueueKey, exclusiveMaxTaskID int64,
 	var n int
 	var err error
 	err = s.retryForever(func() error {
-		n, err = s.db.CompleteTasksLessThan(&p.CompleteTasksLessThanRequest{
+		n, err = s.db.CompleteTasksLessThan(context.TODO(), &p.CompleteTasksLessThanRequest{
 			NamespaceID:        key.NamespaceID,
 			TaskQueueName:      key.TaskQueueName,
 			TaskType:           key.TaskQueueType,
@@ -56,7 +57,7 @@ func (s *Scavenger) getTasks(key *p.TaskQueueKey, batchSize int) (*p.GetTasksRes
 	var err error
 	var resp *p.GetTasksResponse
 	err = s.retryForever(func() error {
-		resp, err = s.db.GetTasks(&p.GetTasksRequest{
+		resp, err = s.db.GetTasks(context.TODO(), &p.GetTasksRequest{
 			NamespaceID:        key.NamespaceID,
 			TaskQueue:          key.TaskQueueName,
 			TaskType:           key.TaskQueueType,
@@ -73,7 +74,7 @@ func (s *Scavenger) listTaskQueue(pageSize int, pageToken []byte) (*p.ListTaskQu
 	var err error
 	var resp *p.ListTaskQueueResponse
 	err = s.retryForever(func() error {
-		resp, err = s.db.ListTaskQueue(&p.ListTaskQueueRequest{
+		resp, err = s.db.ListTaskQueue(context.TODO(), &p.ListTaskQueueRequest{
 			PageSize:  pageSize,
 			PageToken: pageToken,
 		})
@@ -85,7 +86,7 @@ func (s *Scavenger) listTaskQueue(pageSize int, pageToken []byte) (*p.ListTaskQu
 func (s *Scavenger) deleteTaskQueue(key *p.TaskQueueKey, rangeID int64) error {
 	// retry only on service busy errors
 	return backoff.Retry(func() error {
-		return s.db.DeleteTaskQueue(&p.DeleteTaskQueueRequest{
+		return s.db.DeleteTaskQueue(context.TODO(), &p.DeleteTaskQueueRequest{
 			TaskQueue: &p.TaskQueueKey{
 				NamespaceID:   key.NamespaceID,
 				TaskQueueName: key.TaskQueueName,

--- a/service/worker/scanner/taskqueue/scavenger_test.go
+++ b/service/worker/scanner/taskqueue/scavenger_test.go
@@ -184,31 +184,31 @@ func (s *ScavengerTestSuite) runScavenger() {
 }
 
 func (s *ScavengerTestSuite) setupTaskMgrMocks() {
-	s.taskMgr.EXPECT().ListTaskQueue(gomock.Any()).DoAndReturn(
+	s.taskMgr.EXPECT().ListTaskQueue(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(req *p.ListTaskQueueRequest) (*p.ListTaskQueueResponse, error) {
 			items, next := s.taskQueueTable.list(req.PageToken, req.PageSize)
 			return &p.ListTaskQueueResponse{Items: items, NextPageToken: next}, nil
 		}).AnyTimes()
-	s.taskMgr.EXPECT().DeleteTaskQueue(gomock.Any()).DoAndReturn(
+	s.taskMgr.EXPECT().DeleteTaskQueue(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(req *p.DeleteTaskQueueRequest) error {
 			s.taskQueueTable.delete(req.TaskQueue.TaskQueueName)
 			return nil
 		}).AnyTimes()
-	s.taskMgr.EXPECT().GetTasks(gomock.Any()).DoAndReturn(
+	s.taskMgr.EXPECT().GetTasks(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(req *p.GetTasksRequest) (*p.GetTasksResponse, error) {
 			result := s.taskTables[req.TaskQueue].get(req.PageSize)
 			return &p.GetTasksResponse{Tasks: result}, nil
 		}).AnyTimes()
-	s.taskMgr.EXPECT().CompleteTasksLessThan(gomock.Any()).DoAndReturn(
+	s.taskMgr.EXPECT().CompleteTasksLessThan(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(req *p.CompleteTasksLessThanRequest) (int, error) {
 			return s.taskTables[req.TaskQueueName].deleteLessThan(req.ExclusiveMaxTaskID, req.Limit), nil
 		}).AnyTimes()
 }
 
 func (s *ScavengerTestSuite) setupTaskMgrMocksWithErrors() {
-	s.taskMgr.EXPECT().ListTaskQueue(gomock.Any()).Return(nil, errTest)
-	s.taskMgr.EXPECT().GetTasks(gomock.Any()).Return(nil, errTest)
-	s.taskMgr.EXPECT().CompleteTasksLessThan(gomock.Any()).Return(0, errTest)
-	s.taskMgr.EXPECT().DeleteTaskQueue(gomock.Any()).Return(errTest)
+	s.taskMgr.EXPECT().ListTaskQueue(gomock.Any(), gomock.Any()).Return(nil, errTest)
+	s.taskMgr.EXPECT().GetTasks(gomock.Any(), gomock.Any()).Return(nil, errTest)
+	s.taskMgr.EXPECT().CompleteTasksLessThan(gomock.Any(), gomock.Any()).Return(0, errTest)
+	s.taskMgr.EXPECT().DeleteTaskQueue(gomock.Any(), gomock.Any()).Return(errTest)
 	s.setupTaskMgrMocks()
 }

--- a/service/worker/scanner/taskqueue/scavenger_test.go
+++ b/service/worker/scanner/taskqueue/scavenger_test.go
@@ -25,6 +25,7 @@
 package taskqueue
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -185,22 +186,22 @@ func (s *ScavengerTestSuite) runScavenger() {
 
 func (s *ScavengerTestSuite) setupTaskMgrMocks() {
 	s.taskMgr.EXPECT().ListTaskQueue(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(req *p.ListTaskQueueRequest) (*p.ListTaskQueueResponse, error) {
+		func(_ context.Context, req *p.ListTaskQueueRequest) (*p.ListTaskQueueResponse, error) {
 			items, next := s.taskQueueTable.list(req.PageToken, req.PageSize)
 			return &p.ListTaskQueueResponse{Items: items, NextPageToken: next}, nil
 		}).AnyTimes()
 	s.taskMgr.EXPECT().DeleteTaskQueue(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(req *p.DeleteTaskQueueRequest) error {
+		func(_ context.Context, req *p.DeleteTaskQueueRequest) error {
 			s.taskQueueTable.delete(req.TaskQueue.TaskQueueName)
 			return nil
 		}).AnyTimes()
 	s.taskMgr.EXPECT().GetTasks(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(req *p.GetTasksRequest) (*p.GetTasksResponse, error) {
+		func(_ context.Context, req *p.GetTasksRequest) (*p.GetTasksResponse, error) {
 			result := s.taskTables[req.TaskQueue].get(req.PageSize)
 			return &p.GetTasksResponse{Tasks: result}, nil
 		}).AnyTimes()
 	s.taskMgr.EXPECT().CompleteTasksLessThan(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(req *p.CompleteTasksLessThanRequest) (int, error) {
+		func(_ context.Context, req *p.CompleteTasksLessThanRequest) (int, error) {
 			return s.taskTables[req.TaskQueueName].deleteLessThan(req.ExclusiveMaxTaskID, req.Limit), nil
 		}).AnyTimes()
 }

--- a/service/worker/scanner/workflow_test.go
+++ b/service/worker/scanner/workflow_test.go
@@ -80,7 +80,7 @@ func (s *scannerWorkflowTestSuite) TestScavengerActivity() {
 	defer controller.Finish()
 	mockResource := resource.NewTest(controller, metrics.Worker)
 
-	mockResource.TaskMgr.EXPECT().ListTaskQueue(gomock.Any()).Return(&p.ListTaskQueueResponse{}, nil)
+	mockResource.TaskMgr.EXPECT().ListTaskQueue(gomock.Any(), gomock.Any()).Return(&p.ListTaskQueueResponse{}, nil)
 
 	ctx := scannerContext{
 		logger:           mockResource.GetLogger(),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -25,6 +25,7 @@
 package worker
 
 import (
+	"context"
 	"math/rand"
 	"sync/atomic"
 	"time"
@@ -331,7 +332,7 @@ func (s *Service) Start() {
 	// seed the random generator once for this service
 	rand.Seed(time.Now().UnixNano())
 
-	s.ensureSystemNamespaceExists()
+	s.ensureSystemNamespaceExists(context.TODO())
 	s.startScanner()
 
 	if s.clusterMetadata.IsGlobalNamespaceEnabled() {
@@ -469,8 +470,10 @@ func (s *Service) startArchiver() {
 	}
 }
 
-func (s *Service) ensureSystemNamespaceExists() {
-	_, err := s.metadataManager.GetNamespace(&persistence.GetNamespaceRequest{Name: common.SystemLocalNamespace})
+func (s *Service) ensureSystemNamespaceExists(
+	ctx context.Context,
+) {
+	_, err := s.metadataManager.GetNamespace(ctx, &persistence.GetNamespaceRequest{Name: common.SystemLocalNamespace})
 	switch err.(type) {
 	case nil:
 		// noop

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -112,12 +112,14 @@ func (s *ServerImpl) Start() error {
 	s.logger.Debug(s.so.config.String())
 
 	if err := initSystemNamespaces(
+		context.TODO(),
 		&s.persistenceConfig,
 		s.clusterMetadata.CurrentClusterName,
 		s.so.persistenceServiceResolver,
 		s.persistenceFactoryProvider,
 		s.logger,
-		s.so.customDataStoreFactory); err != nil {
+		s.so.customDataStoreFactory,
+	); err != nil {
 		return fmt.Errorf("unable to initialize system namespace: %w", err)
 	}
 
@@ -241,6 +243,7 @@ func NewBootstrapParams(
 }
 
 func initSystemNamespaces(
+	ctx context.Context,
 	cfg *config.Persistence,
 	currentClusterName string,
 	persistenceServiceResolver resolver.ServiceResolver,
@@ -272,7 +275,7 @@ func initSystemNamespaces(
 		return fmt.Errorf("unable to initialize metadata manager: %w", err)
 	}
 	defer metadataManager.Close()
-	if err = metadataManager.InitializeSystemNamespaces(currentClusterName); err != nil {
+	if err = metadataManager.InitializeSystemNamespaces(ctx, currentClusterName); err != nil {
 		return fmt.Errorf("unable to register system namespace: %w", err)
 	}
 	return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add context parameter to Shard, Task, Metadata, ClusterMetadata manager interface
- Passed in context is not used right now
- Wire up most logic in application layer to pass context parameter to persistence
- Some application logic still use context.TODO() as placeholder and will be replace later.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enforce persistence timeout, instead of always timeout after 10s
- Require for host level task worker pool

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Very low risk as passed in context not used

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no