### PR TITLE
Persistence Context Part 3: Namespace Replication Queue

### DIFF
--- a/common/namespace/dlqMessageHandler_test.go
+++ b/common/namespace/dlqMessageHandler_test.go
@@ -95,8 +95,8 @@ func (s *dlqMessageHandlerSuite) TestReadMessages() {
 			SourceTaskId: 1,
 		},
 	}
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(ackLevel, lastMessageID, pageSize, pageToken).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID, pageSize, pageToken).
 		Return(tasks, nil, nil)
 
 	resp, token, err := s.dlqMessageHandler.Read(context.Background(), lastMessageID, pageSize, pageToken)
@@ -118,8 +118,8 @@ func (s *dlqMessageHandlerSuite) TestReadMessages_ThrowErrorOnGetDLQAckLevel() {
 		},
 	}
 	testError := fmt.Errorf("test")
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(int64(-1), testError)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(int64(-1), testError)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(tasks, nil, nil).Times(0)
 
 	_, _, err := s.dlqMessageHandler.Read(context.Background(), lastMessageID, pageSize, pageToken)
@@ -134,8 +134,8 @@ func (s *dlqMessageHandlerSuite) TestReadMessages_ThrowErrorOnReadMessages() {
 	pageToken := []byte{}
 
 	testError := fmt.Errorf("test")
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(ackLevel, lastMessageID, pageSize, pageToken).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID, pageSize, pageToken).
 		Return(nil, nil, testError)
 
 	_, _, err := s.dlqMessageHandler.Read(context.Background(), lastMessageID, pageSize, pageToken)
@@ -147,9 +147,9 @@ func (s *dlqMessageHandlerSuite) TestPurgeMessages() {
 	ackLevel := int64(10)
 	lastMessageID := int64(20)
 
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(ackLevel, lastMessageID).Return(nil)
-	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(lastMessageID).Return(nil)
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID).Return(nil)
+	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any(), lastMessageID).Return(nil)
 	err := s.dlqMessageHandler.Purge(context.Background(), lastMessageID)
 
 	s.NoError(err)
@@ -159,9 +159,9 @@ func (s *dlqMessageHandlerSuite) TestPurgeMessages_ThrowErrorOnGetDLQAckLevel() 
 	lastMessageID := int64(20)
 	testError := fmt.Errorf("test")
 
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(int64(-1), testError)
-	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(gomock.Any(), gomock.Any()).Return(nil).Times(0)
-	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any()).Times(0)
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(int64(-1), testError)
+	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).Times(0)
+	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any(), gomock.Any()).Times(0)
 	err := s.dlqMessageHandler.Purge(context.Background(), lastMessageID)
 
 	s.Equal(testError, err)
@@ -172,9 +172,9 @@ func (s *dlqMessageHandlerSuite) TestPurgeMessages_ThrowErrorOnPurgeMessages() {
 	lastMessageID := int64(20)
 	testError := fmt.Errorf("test")
 
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(ackLevel, lastMessageID).Return(testError)
-	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any()).Times(0)
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID).Return(testError)
+	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any(), gomock.Any()).Times(0)
 	err := s.dlqMessageHandler.Purge(context.Background(), lastMessageID)
 
 	s.Equal(testError, err)
@@ -200,12 +200,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages() {
 			},
 		},
 	}
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(ackLevel, lastMessageID, pageSize, pageToken).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID, pageSize, pageToken).
 		Return(tasks, nil, nil)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any(), namespaceAttribute).Return(nil)
-	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(messageID).Return(nil)
-	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(ackLevel, messageID).Return(nil)
+	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any(), messageID).Return(nil)
+	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(gomock.Any(), ackLevel, messageID).Return(nil)
 
 	token, err := s.dlqMessageHandler.Merge(context.Background(), lastMessageID, pageSize, pageToken)
 	s.NoError(err)
@@ -231,12 +231,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnGetDLQAckLevel() 
 			},
 		},
 	}
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(int64(-1), testError)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(int64(-1), testError)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(tasks, nil, nil).Times(0)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any(), gomock.Any()).Times(0)
-	s.mockReplicationQueue.EXPECT().DeleteMessageFromDLQ(gomock.Any()).Times(0)
-	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any()).Times(0)
+	s.mockReplicationQueue.EXPECT().DeleteMessageFromDLQ(gomock.Any(), gomock.Any()).Times(0)
+	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any(), gomock.Any()).Times(0)
 
 	token, err := s.dlqMessageHandler.Merge(context.Background(), lastMessageID, pageSize, pageToken)
 	s.Equal(testError, err)
@@ -250,12 +250,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnGetDLQMessages() 
 	pageToken := []byte{}
 	testError := fmt.Errorf("test")
 
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(ackLevel, lastMessageID, pageSize, pageToken).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID, pageSize, pageToken).
 		Return(nil, nil, testError)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any(), gomock.Any()).Times(0)
-	s.mockReplicationQueue.EXPECT().DeleteMessageFromDLQ(gomock.Any()).Times(0)
-	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any()).Times(0)
+	s.mockReplicationQueue.EXPECT().DeleteMessageFromDLQ(gomock.Any(), gomock.Any()).Times(0)
+	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any(), gomock.Any()).Times(0)
 
 	token, err := s.dlqMessageHandler.Merge(context.Background(), lastMessageID, pageSize, pageToken)
 	s.Equal(testError, err)
@@ -292,8 +292,8 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnHandleReceivingTa
 			},
 		},
 	}
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(ackLevel, lastMessageID, pageSize, pageToken).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID, pageSize, pageToken).
 		Return(tasks, nil, nil)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any(), namespaceAttribute1).Return(nil)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any(), namespaceAttribute2).Return(testError)
@@ -333,12 +333,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnDeleteMessages() 
 			},
 		},
 	}
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(ackLevel, lastMessageID, pageSize, pageToken).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID, pageSize, pageToken).
 		Return(tasks, nil, nil)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any(), namespaceAttribute1).Return(nil)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any(), namespaceAttribute2).Return(nil)
-	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(ackLevel, messageID2).Return(testError)
+	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(gomock.Any(), ackLevel, messageID2).Return(testError)
 
 	token, err := s.dlqMessageHandler.Merge(context.Background(), lastMessageID, pageSize, pageToken)
 	s.Error(err)
@@ -365,12 +365,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_IgnoreErrorOnUpdateDLQAckLeve
 			},
 		},
 	}
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil)
-	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(ackLevel, lastMessageID, pageSize, pageToken).
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel(gomock.Any()).Return(ackLevel, nil)
+	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), ackLevel, lastMessageID, pageSize, pageToken).
 		Return(tasks, nil, nil)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any(), namespaceAttribute).Return(nil)
-	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(ackLevel, messageID).Return(nil)
-	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(messageID).Return(testError)
+	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(gomock.Any(), ackLevel, messageID).Return(nil)
+	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any(), messageID).Return(testError)
 
 	token, err := s.dlqMessageHandler.Merge(context.Background(), lastMessageID, pageSize, pageToken)
 	s.NoError(err)

--- a/common/namespace/handler.go
+++ b/common/namespace/handler.go
@@ -268,6 +268,7 @@ func (d *HandlerImpl) RegisterNamespace(
 	}
 
 	err = d.namespaceReplicator.HandleTransmissionTask(
+		ctx,
 		enumsspb.NAMESPACE_OPERATION_CREATE,
 		namespaceRequest.Namespace.Info,
 		namespaceRequest.Namespace.Config,
@@ -570,8 +571,16 @@ func (d *HandlerImpl) UpdateNamespace(
 		}
 	}
 
-	err = d.namespaceReplicator.HandleTransmissionTask(enumsspb.NAMESPACE_OPERATION_UPDATE,
-		info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
+	err = d.namespaceReplicator.HandleTransmissionTask(
+		ctx,
+		enumsspb.NAMESPACE_OPERATION_UPDATE,
+		info,
+		config,
+		replicationConfig,
+		configVersion,
+		failoverVersion,
+		isGlobalNamespace,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/common/namespace/handler_GlobalNamespaceEnabled_MasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_MasterCluster_test.go
@@ -441,7 +441,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestRegisterG
 		})
 	}
 
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil).Times(0)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).Times(0)
 
 	retention := 1 * time.Hour * 24
 	registerResp, err := s.handler.RegisterNamespace(context.Background(), &workflowservice.RegisterNamespaceRequest{
@@ -503,7 +503,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestRegisterG
 	data := map[string]string{"some random key": "some random value"}
 	isGlobalNamespace := true
 
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 
 	registerResp, err := s.handler.RegisterNamespace(context.Background(), &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        namespace,
@@ -569,7 +569,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestUpdateGet
 	s.True(len(clusters) > 1)
 	isGlobalNamespace := true
 
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil).Times(2)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	registerResp, err := s.handler.RegisterNamespace(context.Background(), &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        namespace,
@@ -653,7 +653,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestUpdateGet
 	s.True(len(clusters) > 1)
 	isGlobalNamespace := true
 
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil).Times(2)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	registerResp, err := s.handler.RegisterNamespace(context.Background(), &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        namespace,
@@ -761,7 +761,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) TestUpdateGet
 	s.True(len(clusters) > 1)
 	isGlobalNamespace := true
 
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil).Times(2)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
 	registerResp, err := s.handler.RegisterNamespace(context.Background(), &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        namespace,

--- a/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
@@ -519,7 +519,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 	})
 	s.NoError(err)
 
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 	resp, err := s.handler.UpdateNamespace(context.Background(), &workflowservice.UpdateNamespaceRequest{
 		Namespace: namespace,
 	})
@@ -578,7 +578,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 	})
 	s.NoError(err)
 
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 	updateResp, err := s.handler.UpdateNamespace(context.Background(), &workflowservice.UpdateNamespaceRequest{
 		Namespace: namespace,
 		UpdateInfo: &namespacepb.UpdateNamespaceInfo{
@@ -686,7 +686,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestUpdate
 		s.Equal(isGlobalNamespace, isGlobalNamespace)
 	}
 
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 
 	updateResp, err := s.handler.UpdateNamespace(context.Background(), &workflowservice.UpdateNamespaceRequest{
 		Namespace: namespace,

--- a/common/namespace/handler_test.go
+++ b/common/namespace/handler_test.go
@@ -295,7 +295,7 @@ func (s *namespaceHandlerCommonSuite) TestListNamespace() {
 			ClusterName: clusterName,
 		})
 	}
-	s.mockProducer.EXPECT().Publish(gomock.Any()).Return(nil)
+	s.mockProducer.EXPECT().Publish(gomock.Any(), gomock.Any()).Return(nil)
 	registerResp, err = s.handler.RegisterNamespace(context.Background(), &workflowservice.RegisterNamespaceRequest{
 		Namespace:                        namespace2,
 		Description:                      description2,

--- a/common/namespace/transmissionTaskHandler.go
+++ b/common/namespace/transmissionTaskHandler.go
@@ -25,6 +25,8 @@
 package namespace
 
 import (
+	"context"
+
 	namespacepb "go.temporal.io/api/namespace/v1"
 	replicationpb "go.temporal.io/api/replication/v1"
 
@@ -41,6 +43,7 @@ type (
 	// Replicator is the interface which can replicate the namespace
 	Replicator interface {
 		HandleTransmissionTask(
+			ctx context.Context,
 			namespaceOperation enumsspb.NamespaceOperation,
 			info *persistencespb.NamespaceInfo,
 			config *persistencespb.NamespaceConfig,
@@ -70,6 +73,7 @@ func NewNamespaceReplicator(
 
 // HandleTransmissionTask handle transmission of the namespace replication task
 func (namespaceReplicator *namespaceReplicatorImpl) HandleTransmissionTask(
+	ctx context.Context,
 	namespaceOperation enumsspb.NamespaceOperation,
 	info *persistencespb.NamespaceInfo,
 	config *persistencespb.NamespaceConfig,
@@ -116,6 +120,7 @@ func (namespaceReplicator *namespaceReplicatorImpl) HandleTransmissionTask(
 	}
 
 	return namespaceReplicator.namespaceReplicationQueue.Publish(
+		ctx,
 		&replicationspb.ReplicationTask{
 			TaskType:   taskType,
 			Attributes: task,

--- a/common/namespace/transmissionTaskHandler_test.go
+++ b/common/namespace/transmissionTaskHandler_test.go
@@ -25,6 +25,7 @@
 package namespace
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -120,7 +121,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask
 	}
 	isGlobalNamespace := true
 
-	s.namespaceReplicationQueue.EXPECT().Publish(&replicationspb.ReplicationTask{
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), &replicationspb.ReplicationTask{
 		TaskType: taskType,
 		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
 			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
@@ -151,7 +152,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask
 		},
 	}).Return(nil)
 
-	err := s.namespaceReplicator.HandleTransmissionTask(namespaceOperation, info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
+	err := s.namespaceReplicator.HandleTransmissionTask(context.Background(), namespaceOperation, info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
 	s.Nil(err)
 }
 
@@ -195,7 +196,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_RegisterNamespaceTask
 	}
 	isGlobalNamespace := false
 
-	err := s.namespaceReplicator.HandleTransmissionTask(namespaceOperation, info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
+	err := s.namespaceReplicator.HandleTransmissionTask(context.Background(), namespaceOperation, info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
 	s.Nil(err)
 }
 
@@ -241,7 +242,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_I
 	}
 	isGlobalNamespace := true
 
-	s.namespaceReplicationQueue.EXPECT().Publish(&replicationspb.ReplicationTask{
+	s.namespaceReplicationQueue.EXPECT().Publish(gomock.Any(), &replicationspb.ReplicationTask{
 		TaskType: taskType,
 		Attributes: &replicationspb.ReplicationTask_NamespaceTaskAttributes{
 			NamespaceTaskAttributes: &replicationspb.NamespaceTaskAttributes{
@@ -271,7 +272,7 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_I
 		},
 	}).Return(nil)
 
-	err := s.namespaceReplicator.HandleTransmissionTask(namespaceOperation, info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
+	err := s.namespaceReplicator.HandleTransmissionTask(context.Background(), namespaceOperation, info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
 	s.Nil(err)
 }
 
@@ -314,6 +315,6 @@ func (s *transmissionTaskSuite) TestHandleTransmissionTask_UpdateNamespaceTask_N
 	}
 	isGlobalNamespace := false
 
-	err := s.namespaceReplicator.HandleTransmissionTask(namespaceOperation, info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
+	err := s.namespaceReplicator.HandleTransmissionTask(context.Background(), namespaceOperation, info, config, replicationConfig, configVersion, failoverVersion, isGlobalNamespace)
 	s.Nil(err)
 }

--- a/common/persistence/namespaceReplicationQueue_mock.go
+++ b/common/persistence/namespaceReplicationQueue_mock.go
@@ -29,6 +29,7 @@
 package persistence
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -59,53 +60,53 @@ func (m *MockNamespaceReplicationQueue) EXPECT() *MockNamespaceReplicationQueueM
 }
 
 // DeleteMessageFromDLQ mocks base method.
-func (m *MockNamespaceReplicationQueue) DeleteMessageFromDLQ(messageID int64) error {
+func (m *MockNamespaceReplicationQueue) DeleteMessageFromDLQ(ctx context.Context, messageID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMessageFromDLQ", messageID)
+	ret := m.ctrl.Call(m, "DeleteMessageFromDLQ", ctx, messageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteMessageFromDLQ indicates an expected call of DeleteMessageFromDLQ.
-func (mr *MockNamespaceReplicationQueueMockRecorder) DeleteMessageFromDLQ(messageID interface{}) *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) DeleteMessageFromDLQ(ctx, messageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMessageFromDLQ", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).DeleteMessageFromDLQ), messageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMessageFromDLQ", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).DeleteMessageFromDLQ), ctx, messageID)
 }
 
 // GetAckLevels mocks base method.
-func (m *MockNamespaceReplicationQueue) GetAckLevels() (map[string]int64, error) {
+func (m *MockNamespaceReplicationQueue) GetAckLevels(ctx context.Context) (map[string]int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAckLevels")
+	ret := m.ctrl.Call(m, "GetAckLevels", ctx)
 	ret0, _ := ret[0].(map[string]int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAckLevels indicates an expected call of GetAckLevels.
-func (mr *MockNamespaceReplicationQueueMockRecorder) GetAckLevels() *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) GetAckLevels(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAckLevels", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).GetAckLevels))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAckLevels", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).GetAckLevels), ctx)
 }
 
 // GetDLQAckLevel mocks base method.
-func (m *MockNamespaceReplicationQueue) GetDLQAckLevel() (int64, error) {
+func (m *MockNamespaceReplicationQueue) GetDLQAckLevel(ctx context.Context) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDLQAckLevel")
+	ret := m.ctrl.Call(m, "GetDLQAckLevel", ctx)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDLQAckLevel indicates an expected call of GetDLQAckLevel.
-func (mr *MockNamespaceReplicationQueueMockRecorder) GetDLQAckLevel() *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) GetDLQAckLevel(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDLQAckLevel", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).GetDLQAckLevel))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDLQAckLevel", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).GetDLQAckLevel), ctx)
 }
 
 // GetMessagesFromDLQ mocks base method.
-func (m *MockNamespaceReplicationQueue) GetMessagesFromDLQ(firstMessageID, lastMessageID int64, pageSize int, pageToken []byte) ([]*repication.ReplicationTask, []byte, error) {
+func (m *MockNamespaceReplicationQueue) GetMessagesFromDLQ(ctx context.Context, firstMessageID, lastMessageID int64, pageSize int, pageToken []byte) ([]*repication.ReplicationTask, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMessagesFromDLQ", firstMessageID, lastMessageID, pageSize, pageToken)
+	ret := m.ctrl.Call(m, "GetMessagesFromDLQ", ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 	ret0, _ := ret[0].([]*repication.ReplicationTask)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -113,15 +114,15 @@ func (m *MockNamespaceReplicationQueue) GetMessagesFromDLQ(firstMessageID, lastM
 }
 
 // GetMessagesFromDLQ indicates an expected call of GetMessagesFromDLQ.
-func (mr *MockNamespaceReplicationQueueMockRecorder) GetMessagesFromDLQ(firstMessageID, lastMessageID, pageSize, pageToken interface{}) *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) GetMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessagesFromDLQ", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).GetMessagesFromDLQ), firstMessageID, lastMessageID, pageSize, pageToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMessagesFromDLQ", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).GetMessagesFromDLQ), ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 }
 
 // GetReplicationMessages mocks base method.
-func (m *MockNamespaceReplicationQueue) GetReplicationMessages(lastMessageID int64, maxCount int) ([]*repication.ReplicationTask, int64, error) {
+func (m *MockNamespaceReplicationQueue) GetReplicationMessages(ctx context.Context, lastMessageID int64, maxCount int) ([]*repication.ReplicationTask, int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReplicationMessages", lastMessageID, maxCount)
+	ret := m.ctrl.Call(m, "GetReplicationMessages", ctx, lastMessageID, maxCount)
 	ret0, _ := ret[0].([]*repication.ReplicationTask)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
@@ -129,51 +130,51 @@ func (m *MockNamespaceReplicationQueue) GetReplicationMessages(lastMessageID int
 }
 
 // GetReplicationMessages indicates an expected call of GetReplicationMessages.
-func (mr *MockNamespaceReplicationQueueMockRecorder) GetReplicationMessages(lastMessageID, maxCount interface{}) *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) GetReplicationMessages(ctx, lastMessageID, maxCount interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationMessages", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).GetReplicationMessages), lastMessageID, maxCount)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationMessages", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).GetReplicationMessages), ctx, lastMessageID, maxCount)
 }
 
 // Publish mocks base method.
-func (m *MockNamespaceReplicationQueue) Publish(message interface{}) error {
+func (m *MockNamespaceReplicationQueue) Publish(ctx context.Context, message interface{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Publish", message)
+	ret := m.ctrl.Call(m, "Publish", ctx, message)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Publish indicates an expected call of Publish.
-func (mr *MockNamespaceReplicationQueueMockRecorder) Publish(message interface{}) *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) Publish(ctx, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).Publish), message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Publish", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).Publish), ctx, message)
 }
 
 // PublishToDLQ mocks base method.
-func (m *MockNamespaceReplicationQueue) PublishToDLQ(message interface{}) error {
+func (m *MockNamespaceReplicationQueue) PublishToDLQ(ctx context.Context, message interface{}) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PublishToDLQ", message)
+	ret := m.ctrl.Call(m, "PublishToDLQ", ctx, message)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PublishToDLQ indicates an expected call of PublishToDLQ.
-func (mr *MockNamespaceReplicationQueueMockRecorder) PublishToDLQ(message interface{}) *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) PublishToDLQ(ctx, message interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishToDLQ", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).PublishToDLQ), message)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PublishToDLQ", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).PublishToDLQ), ctx, message)
 }
 
 // RangeDeleteMessagesFromDLQ mocks base method.
-func (m *MockNamespaceReplicationQueue) RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID int64) error {
+func (m *MockNamespaceReplicationQueue) RangeDeleteMessagesFromDLQ(ctx context.Context, firstMessageID, lastMessageID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeDeleteMessagesFromDLQ", firstMessageID, lastMessageID)
+	ret := m.ctrl.Call(m, "RangeDeleteMessagesFromDLQ", ctx, firstMessageID, lastMessageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RangeDeleteMessagesFromDLQ indicates an expected call of RangeDeleteMessagesFromDLQ.
-func (mr *MockNamespaceReplicationQueueMockRecorder) RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID interface{}) *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeDeleteMessagesFromDLQ", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).RangeDeleteMessagesFromDLQ), firstMessageID, lastMessageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeDeleteMessagesFromDLQ", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).RangeDeleteMessagesFromDLQ), ctx, firstMessageID, lastMessageID)
 }
 
 // Start mocks base method.
@@ -201,29 +202,29 @@ func (mr *MockNamespaceReplicationQueueMockRecorder) Stop() *gomock.Call {
 }
 
 // UpdateAckLevel mocks base method.
-func (m *MockNamespaceReplicationQueue) UpdateAckLevel(lastProcessedMessageID int64, clusterName string) error {
+func (m *MockNamespaceReplicationQueue) UpdateAckLevel(ctx context.Context, lastProcessedMessageID int64, clusterName string) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAckLevel", lastProcessedMessageID, clusterName)
+	ret := m.ctrl.Call(m, "UpdateAckLevel", ctx, lastProcessedMessageID, clusterName)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateAckLevel indicates an expected call of UpdateAckLevel.
-func (mr *MockNamespaceReplicationQueueMockRecorder) UpdateAckLevel(lastProcessedMessageID, clusterName interface{}) *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) UpdateAckLevel(ctx, lastProcessedMessageID, clusterName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAckLevel", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).UpdateAckLevel), lastProcessedMessageID, clusterName)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAckLevel", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).UpdateAckLevel), ctx, lastProcessedMessageID, clusterName)
 }
 
 // UpdateDLQAckLevel mocks base method.
-func (m *MockNamespaceReplicationQueue) UpdateDLQAckLevel(lastProcessedMessageID int64) error {
+func (m *MockNamespaceReplicationQueue) UpdateDLQAckLevel(ctx context.Context, lastProcessedMessageID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDLQAckLevel", lastProcessedMessageID)
+	ret := m.ctrl.Call(m, "UpdateDLQAckLevel", ctx, lastProcessedMessageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateDLQAckLevel indicates an expected call of UpdateDLQAckLevel.
-func (mr *MockNamespaceReplicationQueueMockRecorder) UpdateDLQAckLevel(lastProcessedMessageID interface{}) *gomock.Call {
+func (mr *MockNamespaceReplicationQueueMockRecorder) UpdateDLQAckLevel(ctx, lastProcessedMessageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDLQAckLevel", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).UpdateDLQAckLevel), lastProcessedMessageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDLQAckLevel", reflect.TypeOf((*MockNamespaceReplicationQueue)(nil).UpdateDLQAckLevel), ctx, lastProcessedMessageID)
 }

--- a/service/worker/replicator/namespace_replication_message_processor.go
+++ b/service/worker/replicator/namespace_replication_message_processor.go
@@ -200,7 +200,7 @@ func (p *namespaceReplicationMessageProcessor) putNamespaceReplicationTaskToDLQ(
 		metrics.NamespaceReplicationTaskScope,
 		metrics.NamespaceTag(namespaceAttribute.GetInfo().GetName()),
 	).IncCounter(metrics.NamespaceReplicationEnqueueDLQCount)
-	return p.namespaceReplicationQueue.PublishToDLQ(task)
+	return p.namespaceReplicationQueue.PublishToDLQ(context.TODO(), task)
 }
 
 func (p *namespaceReplicationMessageProcessor) handleNamespaceReplicationTask(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add context parameter to Namespace Replication Queue interface
- Passed in context is not used right now
- Wire up most logic in application layer to pass context parameter to persistence
- Some application logic still use context.TODO() as placeholder and will be replace later.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enforce persistence timeout, instead of always timeout after 10s
- Require for host level task worker pool

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Very low risk as passed in context not used

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no