### PR TITLE
Persistence Context Part 4: Visibility Manager

### DIFF
--- a/common/persistence/visibility/manager/visibility_manager.go
+++ b/common/persistence/visibility/manager/visibility_manager.go
@@ -28,6 +28,7 @@ package manager
 //go:generate mockgen -copyright_file ../../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination visibility_manager_mock.go -aux_files go.temporal.io/server/common/persistence=../../dataInterfaces.go
 
 import (
+	"context"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -45,22 +46,22 @@ type (
 		GetName() string
 
 		// Write APIs.
-		RecordWorkflowExecutionStarted(request *RecordWorkflowExecutionStartedRequest) error
-		RecordWorkflowExecutionClosed(request *RecordWorkflowExecutionClosedRequest) error
-		UpsertWorkflowExecution(request *UpsertWorkflowExecutionRequest) error
-		DeleteWorkflowExecution(request *VisibilityDeleteWorkflowExecutionRequest) error
+		RecordWorkflowExecutionStarted(ctx context.Context, request *RecordWorkflowExecutionStartedRequest) error
+		RecordWorkflowExecutionClosed(ctx context.Context, request *RecordWorkflowExecutionClosedRequest) error
+		UpsertWorkflowExecution(ctx context.Context, request *UpsertWorkflowExecutionRequest) error
+		DeleteWorkflowExecution(ctx context.Context, request *VisibilityDeleteWorkflowExecutionRequest) error
 
 		// Read APIs.
-		ListOpenWorkflowExecutions(request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error)
-		ListClosedWorkflowExecutions(request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error)
-		ListOpenWorkflowExecutionsByType(request *ListWorkflowExecutionsByTypeRequest) (*ListWorkflowExecutionsResponse, error)
-		ListClosedWorkflowExecutionsByType(request *ListWorkflowExecutionsByTypeRequest) (*ListWorkflowExecutionsResponse, error)
-		ListOpenWorkflowExecutionsByWorkflowID(request *ListWorkflowExecutionsByWorkflowIDRequest) (*ListWorkflowExecutionsResponse, error)
-		ListClosedWorkflowExecutionsByWorkflowID(request *ListWorkflowExecutionsByWorkflowIDRequest) (*ListWorkflowExecutionsResponse, error)
-		ListClosedWorkflowExecutionsByStatus(request *ListClosedWorkflowExecutionsByStatusRequest) (*ListWorkflowExecutionsResponse, error)
-		ListWorkflowExecutions(request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error)
-		ScanWorkflowExecutions(request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error)
-		CountWorkflowExecutions(request *CountWorkflowExecutionsRequest) (*CountWorkflowExecutionsResponse, error)
+		ListOpenWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error)
+		ListClosedWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error)
+		ListOpenWorkflowExecutionsByType(ctx context.Context, request *ListWorkflowExecutionsByTypeRequest) (*ListWorkflowExecutionsResponse, error)
+		ListClosedWorkflowExecutionsByType(ctx context.Context, request *ListWorkflowExecutionsByTypeRequest) (*ListWorkflowExecutionsResponse, error)
+		ListOpenWorkflowExecutionsByWorkflowID(ctx context.Context, request *ListWorkflowExecutionsByWorkflowIDRequest) (*ListWorkflowExecutionsResponse, error)
+		ListClosedWorkflowExecutionsByWorkflowID(ctx context.Context, request *ListWorkflowExecutionsByWorkflowIDRequest) (*ListWorkflowExecutionsResponse, error)
+		ListClosedWorkflowExecutionsByStatus(ctx context.Context, request *ListClosedWorkflowExecutionsByStatusRequest) (*ListWorkflowExecutionsResponse, error)
+		ListWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error)
+		ScanWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error)
+		CountWorkflowExecutions(ctx context.Context, request *CountWorkflowExecutionsRequest) (*CountWorkflowExecutionsResponse, error)
 	}
 
 	VisibilityRequestBase struct {

--- a/common/persistence/visibility/manager/visibility_manager_mock.go
+++ b/common/persistence/visibility/manager/visibility_manager_mock.go
@@ -29,6 +29,7 @@
 package manager
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -70,32 +71,32 @@ func (mr *MockVisibilityManagerMockRecorder) Close() *gomock.Call {
 }
 
 // CountWorkflowExecutions mocks base method.
-func (m *MockVisibilityManager) CountWorkflowExecutions(request *CountWorkflowExecutionsRequest) (*CountWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) CountWorkflowExecutions(ctx context.Context, request *CountWorkflowExecutionsRequest) (*CountWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "CountWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*CountWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CountWorkflowExecutions indicates an expected call of CountWorkflowExecutions.
-func (mr *MockVisibilityManagerMockRecorder) CountWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) CountWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).CountWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).CountWorkflowExecutions), ctx, request)
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockVisibilityManager) DeleteWorkflowExecution(request *VisibilityDeleteWorkflowExecutionRequest) error {
+func (m *MockVisibilityManager) DeleteWorkflowExecution(ctx context.Context, request *VisibilityDeleteWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockVisibilityManagerMockRecorder) DeleteWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) DeleteWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockVisibilityManager)(nil).DeleteWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockVisibilityManager)(nil).DeleteWorkflowExecution), ctx, request)
 }
 
 // GetName mocks base method.
@@ -113,178 +114,178 @@ func (mr *MockVisibilityManagerMockRecorder) GetName() *gomock.Call {
 }
 
 // ListClosedWorkflowExecutions mocks base method.
-func (m *MockVisibilityManager) ListClosedWorkflowExecutions(request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ListClosedWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClosedWorkflowExecutions indicates an expected call of ListClosedWorkflowExecutions.
-func (mr *MockVisibilityManagerMockRecorder) ListClosedWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ListClosedWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ListClosedWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ListClosedWorkflowExecutions), ctx, request)
 }
 
 // ListClosedWorkflowExecutionsByStatus mocks base method.
-func (m *MockVisibilityManager) ListClosedWorkflowExecutionsByStatus(request *ListClosedWorkflowExecutionsByStatusRequest) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ListClosedWorkflowExecutionsByStatus(ctx context.Context, request *ListClosedWorkflowExecutionsByStatusRequest) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByStatus", request)
+	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByStatus", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClosedWorkflowExecutionsByStatus indicates an expected call of ListClosedWorkflowExecutionsByStatus.
-func (mr *MockVisibilityManagerMockRecorder) ListClosedWorkflowExecutionsByStatus(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ListClosedWorkflowExecutionsByStatus(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByStatus", reflect.TypeOf((*MockVisibilityManager)(nil).ListClosedWorkflowExecutionsByStatus), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByStatus", reflect.TypeOf((*MockVisibilityManager)(nil).ListClosedWorkflowExecutionsByStatus), ctx, request)
 }
 
 // ListClosedWorkflowExecutionsByType mocks base method.
-func (m *MockVisibilityManager) ListClosedWorkflowExecutionsByType(request *ListWorkflowExecutionsByTypeRequest) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ListClosedWorkflowExecutionsByType(ctx context.Context, request *ListWorkflowExecutionsByTypeRequest) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByType", request)
+	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByType", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClosedWorkflowExecutionsByType indicates an expected call of ListClosedWorkflowExecutionsByType.
-func (mr *MockVisibilityManagerMockRecorder) ListClosedWorkflowExecutionsByType(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ListClosedWorkflowExecutionsByType(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByType", reflect.TypeOf((*MockVisibilityManager)(nil).ListClosedWorkflowExecutionsByType), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByType", reflect.TypeOf((*MockVisibilityManager)(nil).ListClosedWorkflowExecutionsByType), ctx, request)
 }
 
 // ListClosedWorkflowExecutionsByWorkflowID mocks base method.
-func (m *MockVisibilityManager) ListClosedWorkflowExecutionsByWorkflowID(request *ListWorkflowExecutionsByWorkflowIDRequest) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ListClosedWorkflowExecutionsByWorkflowID(ctx context.Context, request *ListWorkflowExecutionsByWorkflowIDRequest) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByWorkflowID", request)
+	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByWorkflowID", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClosedWorkflowExecutionsByWorkflowID indicates an expected call of ListClosedWorkflowExecutionsByWorkflowID.
-func (mr *MockVisibilityManagerMockRecorder) ListClosedWorkflowExecutionsByWorkflowID(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ListClosedWorkflowExecutionsByWorkflowID(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByWorkflowID", reflect.TypeOf((*MockVisibilityManager)(nil).ListClosedWorkflowExecutionsByWorkflowID), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByWorkflowID", reflect.TypeOf((*MockVisibilityManager)(nil).ListClosedWorkflowExecutionsByWorkflowID), ctx, request)
 }
 
 // ListOpenWorkflowExecutions mocks base method.
-func (m *MockVisibilityManager) ListOpenWorkflowExecutions(request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ListOpenWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOpenWorkflowExecutions indicates an expected call of ListOpenWorkflowExecutions.
-func (mr *MockVisibilityManagerMockRecorder) ListOpenWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ListOpenWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ListOpenWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ListOpenWorkflowExecutions), ctx, request)
 }
 
 // ListOpenWorkflowExecutionsByType mocks base method.
-func (m *MockVisibilityManager) ListOpenWorkflowExecutionsByType(request *ListWorkflowExecutionsByTypeRequest) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ListOpenWorkflowExecutionsByType(ctx context.Context, request *ListWorkflowExecutionsByTypeRequest) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutionsByType", request)
+	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutionsByType", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOpenWorkflowExecutionsByType indicates an expected call of ListOpenWorkflowExecutionsByType.
-func (mr *MockVisibilityManagerMockRecorder) ListOpenWorkflowExecutionsByType(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ListOpenWorkflowExecutionsByType(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutionsByType", reflect.TypeOf((*MockVisibilityManager)(nil).ListOpenWorkflowExecutionsByType), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutionsByType", reflect.TypeOf((*MockVisibilityManager)(nil).ListOpenWorkflowExecutionsByType), ctx, request)
 }
 
 // ListOpenWorkflowExecutionsByWorkflowID mocks base method.
-func (m *MockVisibilityManager) ListOpenWorkflowExecutionsByWorkflowID(request *ListWorkflowExecutionsByWorkflowIDRequest) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ListOpenWorkflowExecutionsByWorkflowID(ctx context.Context, request *ListWorkflowExecutionsByWorkflowIDRequest) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutionsByWorkflowID", request)
+	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutionsByWorkflowID", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOpenWorkflowExecutionsByWorkflowID indicates an expected call of ListOpenWorkflowExecutionsByWorkflowID.
-func (mr *MockVisibilityManagerMockRecorder) ListOpenWorkflowExecutionsByWorkflowID(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ListOpenWorkflowExecutionsByWorkflowID(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutionsByWorkflowID", reflect.TypeOf((*MockVisibilityManager)(nil).ListOpenWorkflowExecutionsByWorkflowID), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutionsByWorkflowID", reflect.TypeOf((*MockVisibilityManager)(nil).ListOpenWorkflowExecutionsByWorkflowID), ctx, request)
 }
 
 // ListWorkflowExecutions mocks base method.
-func (m *MockVisibilityManager) ListWorkflowExecutions(request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ListWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "ListWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListWorkflowExecutions indicates an expected call of ListWorkflowExecutions.
-func (mr *MockVisibilityManagerMockRecorder) ListWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ListWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ListWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ListWorkflowExecutions), ctx, request)
 }
 
 // RecordWorkflowExecutionClosed mocks base method.
-func (m *MockVisibilityManager) RecordWorkflowExecutionClosed(request *RecordWorkflowExecutionClosedRequest) error {
+func (m *MockVisibilityManager) RecordWorkflowExecutionClosed(ctx context.Context, request *RecordWorkflowExecutionClosedRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordWorkflowExecutionClosed", request)
+	ret := m.ctrl.Call(m, "RecordWorkflowExecutionClosed", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecordWorkflowExecutionClosed indicates an expected call of RecordWorkflowExecutionClosed.
-func (mr *MockVisibilityManagerMockRecorder) RecordWorkflowExecutionClosed(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) RecordWorkflowExecutionClosed(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionClosed", reflect.TypeOf((*MockVisibilityManager)(nil).RecordWorkflowExecutionClosed), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionClosed", reflect.TypeOf((*MockVisibilityManager)(nil).RecordWorkflowExecutionClosed), ctx, request)
 }
 
 // RecordWorkflowExecutionStarted mocks base method.
-func (m *MockVisibilityManager) RecordWorkflowExecutionStarted(request *RecordWorkflowExecutionStartedRequest) error {
+func (m *MockVisibilityManager) RecordWorkflowExecutionStarted(ctx context.Context, request *RecordWorkflowExecutionStartedRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordWorkflowExecutionStarted", request)
+	ret := m.ctrl.Call(m, "RecordWorkflowExecutionStarted", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecordWorkflowExecutionStarted indicates an expected call of RecordWorkflowExecutionStarted.
-func (mr *MockVisibilityManagerMockRecorder) RecordWorkflowExecutionStarted(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) RecordWorkflowExecutionStarted(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionStarted", reflect.TypeOf((*MockVisibilityManager)(nil).RecordWorkflowExecutionStarted), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionStarted", reflect.TypeOf((*MockVisibilityManager)(nil).RecordWorkflowExecutionStarted), ctx, request)
 }
 
 // ScanWorkflowExecutions mocks base method.
-func (m *MockVisibilityManager) ScanWorkflowExecutions(request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityManager) ScanWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScanWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "ScanWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*ListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ScanWorkflowExecutions indicates an expected call of ScanWorkflowExecutions.
-func (mr *MockVisibilityManagerMockRecorder) ScanWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) ScanWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ScanWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanWorkflowExecutions", reflect.TypeOf((*MockVisibilityManager)(nil).ScanWorkflowExecutions), ctx, request)
 }
 
 // UpsertWorkflowExecution mocks base method.
-func (m *MockVisibilityManager) UpsertWorkflowExecution(request *UpsertWorkflowExecutionRequest) error {
+func (m *MockVisibilityManager) UpsertWorkflowExecution(ctx context.Context, request *UpsertWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "UpsertWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertWorkflowExecution indicates an expected call of UpsertWorkflowExecution.
-func (mr *MockVisibilityManagerMockRecorder) UpsertWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockVisibilityManagerMockRecorder) UpsertWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertWorkflowExecution", reflect.TypeOf((*MockVisibilityManager)(nil).UpsertWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertWorkflowExecution", reflect.TypeOf((*MockVisibilityManager)(nil).UpsertWorkflowExecution), ctx, request)
 }

--- a/common/persistence/visibility/persistence-tests/visibility_persistence_suite_test.go
+++ b/common/persistence/visibility/persistence-tests/visibility_persistence_suite_test.go
@@ -25,6 +25,7 @@
 package persistencetests
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -57,6 +58,9 @@ type (
 
 		persistencetests.TestBase
 		VisibilityMgr manager.VisibilityManager
+
+		ctx    context.Context
+		cancel context.CancelFunc
 	}
 )
 
@@ -84,6 +88,11 @@ func (s *VisibilityPersistenceSuite) SetupSuite() {
 func (s *VisibilityPersistenceSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
+	s.ctx, s.cancel = context.WithTimeout(context.Background(), time.Second*30)
+}
+
+func (s *VisibilityPersistenceSuite) TearDownTest() {
+	s.cancel()
 }
 
 // TearDownSuite implementation
@@ -98,7 +107,7 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibility() {
 	startTime := time.Now().UTC().Add(time.Second * -5)
 	startReq := s.createOpenWorkflowRecord(testNamespaceUUID, "visibility-workflow-test", "visibility-workflow", startTime, "test-queue")
 
-	resp, err1 := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err1 := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime,
@@ -110,7 +119,7 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibility() {
 
 	closeReq := s.createClosedWorkflowRecord(startReq, time.Now())
 
-	resp, err3 := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err3 := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime,
@@ -119,7 +128,7 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibility() {
 	s.Nil(err3)
 	s.Equal(0, len(resp.Executions))
 
-	resp, err4 := s.VisibilityMgr.ListClosedWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err4 := s.VisibilityMgr.ListClosedWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime,
@@ -137,7 +146,7 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityTimeSkew() {
 	startTime := time.Now()
 	openRecord := s.createOpenWorkflowRecord(testNamespaceUUID, "visibility-workflow-test-time-skew", "visibility-workflow", startTime, "test-queue")
 
-	resp, err1 := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err1 := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime,
@@ -149,7 +158,7 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityTimeSkew() {
 
 	closedRecord := s.createClosedWorkflowRecord(openRecord, startTime.Add(-10*time.Millisecond))
 
-	resp, err3 := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err3 := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime,
@@ -158,7 +167,7 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityTimeSkew() {
 	s.NoError(err3)
 	s.Equal(0, len(resp.Executions))
 
-	resp, err4 := s.VisibilityMgr.ListClosedWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err4 := s.VisibilityMgr.ListClosedWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime.Add(-10 * time.Millisecond), // This is actually close_time
@@ -176,7 +185,7 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityShortWorkflow() {
 	openRecord := s.createOpenWorkflowRecord(testNamespaceUUID, "visibility-workflow-test-short-workflow", "visibility-workflow", startTime, "test-queue")
 	closedRecord := s.createClosedWorkflowRecord(openRecord, startTime.Add(10*time.Millisecond))
 
-	resp, err3 := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err3 := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime,
@@ -185,7 +194,7 @@ func (s *VisibilityPersistenceSuite) TestBasicVisibilityShortWorkflow() {
 	s.NoError(err3)
 	s.Equal(0, len(resp.Executions))
 
-	resp, err4 := s.VisibilityMgr.ListClosedWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err4 := s.VisibilityMgr.ListClosedWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime.Add(10 * time.Millisecond), // This is actually close_time
@@ -208,7 +217,7 @@ func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 	openRecord2 := s.createOpenWorkflowRecord(testNamespaceUUID, "visibility-pagination-test2", "visibility-workflow", startTime2, "test-queue")
 
 	// Get the first one
-	resp, err2 := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err2 := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime1,
@@ -219,7 +228,7 @@ func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
 
 	// Use token to get the second one
-	resp, err3 := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err3 := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          1,
 		EarliestStartTime: startTime1,
@@ -233,7 +242,7 @@ func (s *VisibilityPersistenceSuite) TestVisibilityPagination() {
 	// It is possible to not return non empty token which is going to return empty result
 	if len(resp.NextPageToken) != 0 {
 		// Now should get empty result by using token
-		resp, err4 := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+		resp, err4 := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 			NamespaceID:       testNamespaceUUID,
 			PageSize:          1,
 			EarliestStartTime: startTime1,
@@ -255,7 +264,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 	openRecord2 := s.createOpenWorkflowRecord(testNamespaceUUID, "visibility-filtering-test2", "visibility-workflow-2", startTime, "test-queue")
 
 	// List open workflows with start time filter
-	resp, err := s.VisibilityMgr.ListOpenWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err := s.VisibilityMgr.ListOpenWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		PageSize:          2,
 		EarliestStartTime: time.Now().Add(-time.Hour),
@@ -267,7 +276,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 
 	// List with WorkflowType filter in query string
 	queryStr := fmt.Sprintf(`StartTime BETWEEN "%v" AND "%v"`, time.Now().Add(-time.Hour).Format(time.RFC3339Nano), time.Now().Format(time.RFC3339Nano))
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: testNamespaceUUID,
 		PageSize:    2,
 		Query:       queryStr,
@@ -277,7 +286,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 	s.assertOpenExecutionEquals(openRecord2, resp.Executions[0])
 
 	queryStr = fmt.Sprintf(`StartTime BETWEEN "%v" AND "%v"`, time.Now().Add(-3*time.Hour).Format(time.RFC3339Nano), time.Now().Format(time.RFC3339Nano))
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: testNamespaceUUID,
 		PageSize:    2,
 		Query:       queryStr,
@@ -285,7 +294,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStartTime() {
 	s.Nil(err)
 	s.Equal(2, len(resp.Executions))
 
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: testNamespaceUUID,
 		PageSize:    2,
 		Query:       queryStr + ` AND WorkflowType = "visibility-workflow-1"`,
@@ -305,7 +314,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 	openRecord2 := s.createOpenWorkflowRecord(testNamespaceUUID, "visibility-filtering-test2", "visibility-workflow-2", startTime, "test-queue")
 
 	// List open with filtering
-	resp, err2 := s.VisibilityMgr.ListOpenWorkflowExecutionsByType(&manager.ListWorkflowExecutionsByTypeRequest{
+	resp, err2 := s.VisibilityMgr.ListOpenWorkflowExecutionsByType(s.ctx, &manager.ListWorkflowExecutionsByTypeRequest{
 		ListWorkflowExecutionsRequest: &manager.ListWorkflowExecutionsRequest{
 			NamespaceID:       testNamespaceUUID,
 			PageSize:          2,
@@ -319,7 +328,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
 
 	// List with WorkflowType filter in query string
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: testNamespaceUUID,
 		PageSize:    2,
 		Query:       fmt.Sprintf(`WorkflowType = "visibility-workflow-1"`),
@@ -333,7 +342,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 	closedRecord2 := s.createClosedWorkflowRecord(openRecord2, time.Now())
 
 	// List closed with filtering
-	resp, err5 := s.VisibilityMgr.ListClosedWorkflowExecutionsByType(&manager.ListWorkflowExecutionsByTypeRequest{
+	resp, err5 := s.VisibilityMgr.ListClosedWorkflowExecutionsByType(s.ctx, &manager.ListWorkflowExecutionsByTypeRequest{
 		ListWorkflowExecutionsRequest: &manager.ListWorkflowExecutionsRequest{
 			NamespaceID:       testNamespaceUUID,
 			PageSize:          2,
@@ -347,7 +356,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByType() {
 	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
 
 	// List with WorkflowType filter in query string
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: testNamespaceUUID,
 		PageSize:    2,
 		Query:       fmt.Sprintf(`WorkflowType = "visibility-workflow-2"`),
@@ -367,7 +376,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	openRecord2 := s.createOpenWorkflowRecord(testNamespaceUUID, "visibility-filtering-test2", "visibility-workflow", startTime, "test-queue")
 
 	// List open with filtering
-	resp, err2 := s.VisibilityMgr.ListOpenWorkflowExecutionsByWorkflowID(&manager.ListWorkflowExecutionsByWorkflowIDRequest{
+	resp, err2 := s.VisibilityMgr.ListOpenWorkflowExecutionsByWorkflowID(s.ctx, &manager.ListWorkflowExecutionsByWorkflowIDRequest{
 		ListWorkflowExecutionsRequest: &manager.ListWorkflowExecutionsRequest{
 			NamespaceID:       testNamespaceUUID,
 			PageSize:          2,
@@ -381,7 +390,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	s.assertOpenExecutionEquals(openRecord1, resp.Executions[0])
 
 	// List workflow with workflowID filter in query string
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: testNamespaceUUID,
 		PageSize:    2,
 		Query:       fmt.Sprintf(`WorkflowId = "visibility-filtering-test1"`),
@@ -395,7 +404,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	closedRecord2 := s.createClosedWorkflowRecord(openRecord2, time.Now())
 
 	// List closed with filtering
-	resp, err5 := s.VisibilityMgr.ListClosedWorkflowExecutionsByWorkflowID(&manager.ListWorkflowExecutionsByWorkflowIDRequest{
+	resp, err5 := s.VisibilityMgr.ListClosedWorkflowExecutionsByWorkflowID(s.ctx, &manager.ListWorkflowExecutionsByWorkflowIDRequest{
 		ListWorkflowExecutionsRequest: &manager.ListWorkflowExecutionsRequest{
 			NamespaceID:       testNamespaceUUID,
 			PageSize:          2,
@@ -409,7 +418,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByWorkflowID() {
 	s.assertClosedExecutionEquals(closedRecord2, resp.Executions[0])
 
 	// List workflow with workflowID filter in query string
-	resp, err = s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: testNamespaceUUID,
 		PageSize:    2,
 		Query:       fmt.Sprintf(`WorkflowId = "visibility-filtering-test2"`),
@@ -429,7 +438,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 		WorkflowId: "visibility-filtering-test1",
 		RunId:      "fb15e4b5-356f-466d-8c6d-a29223e5c536",
 	}
-	err0 := s.VisibilityMgr.RecordWorkflowExecutionStarted(&manager.RecordWorkflowExecutionStartedRequest{
+	err0 := s.VisibilityMgr.RecordWorkflowExecutionStarted(s.ctx, &manager.RecordWorkflowExecutionStartedRequest{
 		VisibilityRequestBase: &manager.VisibilityRequestBase{
 			NamespaceID:      testNamespaceUUID,
 			Execution:        workflowExecution1,
@@ -443,7 +452,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 		WorkflowId: "visibility-filtering-test2",
 		RunId:      "843f6fc7-102a-4c63-a2d4-7c653b01bf52",
 	}
-	err1 := s.VisibilityMgr.RecordWorkflowExecutionStarted(&manager.RecordWorkflowExecutionStartedRequest{
+	err1 := s.VisibilityMgr.RecordWorkflowExecutionStarted(s.ctx, &manager.RecordWorkflowExecutionStartedRequest{
 		VisibilityRequestBase: &manager.VisibilityRequestBase{
 			NamespaceID:      testNamespaceUUID,
 			Execution:        workflowExecution2,
@@ -454,7 +463,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 	s.Nil(err1)
 
 	// Close both executions with different status
-	err2 := s.VisibilityMgr.RecordWorkflowExecutionClosed(&manager.RecordWorkflowExecutionClosedRequest{
+	err2 := s.VisibilityMgr.RecordWorkflowExecutionClosed(s.ctx, &manager.RecordWorkflowExecutionClosedRequest{
 		VisibilityRequestBase: &manager.VisibilityRequestBase{
 			NamespaceID:      testNamespaceUUID,
 			Execution:        workflowExecution1,
@@ -477,11 +486,11 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 		CloseTime:     time.Now(),
 		HistoryLength: 3,
 	}
-	err3 := s.VisibilityMgr.RecordWorkflowExecutionClosed(closeReq)
+	err3 := s.VisibilityMgr.RecordWorkflowExecutionClosed(s.ctx, closeReq)
 	s.Nil(err3)
 
 	// List closed with filtering
-	resp, err4 := s.VisibilityMgr.ListClosedWorkflowExecutionsByStatus(&manager.ListClosedWorkflowExecutionsByStatusRequest{
+	resp, err4 := s.VisibilityMgr.ListClosedWorkflowExecutionsByStatus(s.ctx, &manager.ListClosedWorkflowExecutionsByStatusRequest{
 		ListWorkflowExecutionsRequest: &manager.ListWorkflowExecutionsRequest{
 			NamespaceID:       testNamespaceUUID,
 			PageSize:          2,
@@ -494,7 +503,7 @@ func (s *VisibilityPersistenceSuite) TestFilteringByStatus() {
 	s.Equal(1, len(resp.Executions))
 	s.assertClosedExecutionEquals(closeReq, resp.Executions[0])
 
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: testNamespaceUUID,
 		PageSize:    5,
 		Query:       `ExecutionStatus = "Failed"`,
@@ -515,7 +524,7 @@ func (s *VisibilityPersistenceSuite) TestDelete() {
 			WorkflowId: uuid.New(),
 			RunId:      uuid.New(),
 		}
-		err0 := s.VisibilityMgr.RecordWorkflowExecutionStarted(&manager.RecordWorkflowExecutionStartedRequest{
+		err0 := s.VisibilityMgr.RecordWorkflowExecutionStarted(s.ctx, &manager.RecordWorkflowExecutionStartedRequest{
 			VisibilityRequestBase: &manager.VisibilityRequestBase{
 				NamespaceID:      testNamespaceUUID,
 				Execution:        workflowExecution,
@@ -535,11 +544,11 @@ func (s *VisibilityPersistenceSuite) TestDelete() {
 			CloseTime:     closeTime,
 			HistoryLength: 3,
 		}
-		err1 := s.VisibilityMgr.RecordWorkflowExecutionClosed(closeReq)
+		err1 := s.VisibilityMgr.RecordWorkflowExecutionClosed(s.ctx, closeReq)
 		s.Nil(err1)
 	}
 
-	resp, err3 := s.VisibilityMgr.ListClosedWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+	resp, err3 := s.VisibilityMgr.ListClosedWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 		NamespaceID:       testNamespaceUUID,
 		EarliestStartTime: startTime,
 		LatestStartTime:   closeTime,
@@ -550,7 +559,7 @@ func (s *VisibilityPersistenceSuite) TestDelete() {
 
 	remaining := nRows
 	for _, row := range resp.Executions {
-		err4 := s.VisibilityMgr.DeleteWorkflowExecution(&manager.VisibilityDeleteWorkflowExecutionRequest{
+		err4 := s.VisibilityMgr.DeleteWorkflowExecution(s.ctx, &manager.VisibilityDeleteWorkflowExecutionRequest{
 			NamespaceID: testNamespaceUUID,
 			WorkflowID:  row.GetExecution().GetWorkflowId(),
 			RunID:       row.GetExecution().GetRunId(),
@@ -558,7 +567,7 @@ func (s *VisibilityPersistenceSuite) TestDelete() {
 		})
 		s.Nil(err4)
 		remaining--
-		resp, err5 := s.VisibilityMgr.ListClosedWorkflowExecutions(&manager.ListWorkflowExecutionsRequest{
+		resp, err5 := s.VisibilityMgr.ListClosedWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequest{
 			NamespaceID:       testNamespaceUUID,
 			EarliestStartTime: startTime,
 			LatestStartTime:   closeTime,
@@ -619,7 +628,7 @@ func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
 	}
 
 	for _, test := range tests {
-		s.Equal(test.expected, s.VisibilityMgr.UpsertWorkflowExecution(test.request))
+		s.Equal(test.expected, s.VisibilityMgr.UpsertWorkflowExecution(s.ctx, test.request))
 	}
 }
 
@@ -655,7 +664,7 @@ func (s *VisibilityPersistenceSuite) TestAdvancedVisibilityPagination() {
 
 func (s *VisibilityPersistenceSuite) listWithPagination(namespaceID namespace.ID, pageSize int) []*workflowpb.WorkflowExecutionInfo {
 	var executions []*workflowpb.WorkflowExecutionInfo
-	resp, err := s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+	resp, err := s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: namespaceID,
 		PageSize:    pageSize,
 		Query:       "",
@@ -664,7 +673,7 @@ func (s *VisibilityPersistenceSuite) listWithPagination(namespaceID namespace.ID
 	executions = append(executions, resp.Executions...)
 
 	for len(resp.NextPageToken) > 0 {
-		resp, err = s.VisibilityMgr.ListWorkflowExecutions(&manager.ListWorkflowExecutionsRequestV2{
+		resp, err = s.VisibilityMgr.ListWorkflowExecutions(s.ctx, &manager.ListWorkflowExecutionsRequestV2{
 			NamespaceID:   namespaceID,
 			PageSize:      pageSize,
 			Query:         "",
@@ -691,7 +700,7 @@ func (s *VisibilityPersistenceSuite) createClosedWorkflowRecord(
 		CloseTime:     closeTime,
 		HistoryLength: 5,
 	}
-	err := s.VisibilityMgr.RecordWorkflowExecutionClosed(closeReq)
+	err := s.VisibilityMgr.RecordWorkflowExecutionClosed(s.ctx, closeReq)
 	s.Nil(err)
 	return closeReq
 }
@@ -716,7 +725,7 @@ func (s *VisibilityPersistenceSuite) createOpenWorkflowRecord(
 			TaskQueue:        taskQueue,
 		},
 	}
-	err := s.VisibilityMgr.RecordWorkflowExecutionStarted(startReq)
+	err := s.VisibilityMgr.RecordWorkflowExecutionStarted(s.ctx, startReq)
 	s.Nil(err)
 	return startReq
 }

--- a/common/persistence/visibility/visibility_manager_dual.go
+++ b/common/persistence/visibility/visibility_manager_dual.go
@@ -25,6 +25,8 @@
 package visibility
 
 import (
+	"context"
+
 	"go.temporal.io/server/common/persistence/visibility/manager"
 )
 
@@ -61,13 +63,16 @@ func (v *visibilityManagerDual) GetName() string {
 	return "VisibilityManagerDual"
 }
 
-func (v *visibilityManagerDual) RecordWorkflowExecutionStarted(request *manager.RecordWorkflowExecutionStartedRequest) error {
+func (v *visibilityManagerDual) RecordWorkflowExecutionStarted(
+	ctx context.Context,
+	request *manager.RecordWorkflowExecutionStartedRequest,
+) error {
 	ms, err := v.managerSelector.writeManagers()
 	if err != nil {
 		return err
 	}
 	for _, m := range ms {
-		err = m.RecordWorkflowExecutionStarted(request)
+		err = m.RecordWorkflowExecutionStarted(ctx, request)
 		if err != nil {
 			return err
 		}
@@ -75,13 +80,16 @@ func (v *visibilityManagerDual) RecordWorkflowExecutionStarted(request *manager.
 	return nil
 }
 
-func (v *visibilityManagerDual) RecordWorkflowExecutionClosed(request *manager.RecordWorkflowExecutionClosedRequest) error {
+func (v *visibilityManagerDual) RecordWorkflowExecutionClosed(
+	ctx context.Context,
+	request *manager.RecordWorkflowExecutionClosedRequest,
+) error {
 	ms, err := v.managerSelector.writeManagers()
 	if err != nil {
 		return err
 	}
 	for _, m := range ms {
-		err = m.RecordWorkflowExecutionClosed(request)
+		err = m.RecordWorkflowExecutionClosed(ctx, request)
 		if err != nil {
 			return err
 		}
@@ -89,13 +97,16 @@ func (v *visibilityManagerDual) RecordWorkflowExecutionClosed(request *manager.R
 	return nil
 }
 
-func (v *visibilityManagerDual) UpsertWorkflowExecution(request *manager.UpsertWorkflowExecutionRequest) error {
+func (v *visibilityManagerDual) UpsertWorkflowExecution(
+	ctx context.Context,
+	request *manager.UpsertWorkflowExecutionRequest,
+) error {
 	ms, err := v.managerSelector.writeManagers()
 	if err != nil {
 		return err
 	}
 	for _, m := range ms {
-		err = m.UpsertWorkflowExecution(request)
+		err = m.UpsertWorkflowExecution(ctx, request)
 		if err != nil {
 			return err
 		}
@@ -103,13 +114,16 @@ func (v *visibilityManagerDual) UpsertWorkflowExecution(request *manager.UpsertW
 	return nil
 }
 
-func (v *visibilityManagerDual) DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
+func (v *visibilityManagerDual) DeleteWorkflowExecution(
+	ctx context.Context,
+	request *manager.VisibilityDeleteWorkflowExecutionRequest,
+) error {
 	ms, err := v.managerSelector.writeManagers()
 	if err != nil {
 		return err
 	}
 	for _, m := range ms {
-		err = m.DeleteWorkflowExecution(request)
+		err = m.DeleteWorkflowExecution(ctx, request)
 		if err != nil {
 			return err
 		}
@@ -117,42 +131,72 @@ func (v *visibilityManagerDual) DeleteWorkflowExecution(request *manager.Visibil
 	return nil
 }
 
-func (v *visibilityManagerDual) ListOpenWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ListOpenWorkflowExecutions(request)
+func (v *visibilityManagerDual) ListOpenWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ListOpenWorkflowExecutions(ctx, request)
 }
 
-func (v *visibilityManagerDual) ListClosedWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ListClosedWorkflowExecutions(request)
+func (v *visibilityManagerDual) ListClosedWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ListClosedWorkflowExecutions(ctx, request)
 }
 
-func (v *visibilityManagerDual) ListOpenWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ListOpenWorkflowExecutionsByType(request)
+func (v *visibilityManagerDual) ListOpenWorkflowExecutionsByType(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ListOpenWorkflowExecutionsByType(ctx, request)
 }
 
-func (v *visibilityManagerDual) ListClosedWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ListClosedWorkflowExecutionsByType(request)
+func (v *visibilityManagerDual) ListClosedWorkflowExecutionsByType(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ListClosedWorkflowExecutionsByType(ctx, request)
 }
 
-func (v *visibilityManagerDual) ListOpenWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ListOpenWorkflowExecutionsByWorkflowID(request)
+func (v *visibilityManagerDual) ListOpenWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 }
 
-func (v *visibilityManagerDual) ListClosedWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ListClosedWorkflowExecutionsByWorkflowID(request)
+func (v *visibilityManagerDual) ListClosedWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 }
 
-func (v *visibilityManagerDual) ListClosedWorkflowExecutionsByStatus(request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ListClosedWorkflowExecutionsByStatus(request)
+func (v *visibilityManagerDual) ListClosedWorkflowExecutionsByStatus(
+	ctx context.Context,
+	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ListClosedWorkflowExecutionsByStatus(ctx, request)
 }
 
-func (v *visibilityManagerDual) ListWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ListWorkflowExecutions(request)
+func (v *visibilityManagerDual) ListWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ListWorkflowExecutions(ctx, request)
 }
 
-func (v *visibilityManagerDual) ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*manager.ListWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).ScanWorkflowExecutions(request)
+func (v *visibilityManagerDual) ScanWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*manager.ListWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).ScanWorkflowExecutions(ctx, request)
 }
 
-func (v *visibilityManagerDual) CountWorkflowExecutions(request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
-	return v.managerSelector.readManager(request.Namespace).CountWorkflowExecutions(request)
+func (v *visibilityManagerDual) CountWorkflowExecutions(
+	ctx context.Context,
+	request *manager.CountWorkflowExecutionsRequest,
+) (*manager.CountWorkflowExecutionsResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).CountWorkflowExecutions(ctx, request)
 }

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -25,6 +25,7 @@
 package visibility
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -75,7 +76,10 @@ func (p *visibilityManagerImpl) GetName() string {
 	return p.store.GetName()
 }
 
-func (p *visibilityManagerImpl) RecordWorkflowExecutionStarted(request *manager.RecordWorkflowExecutionStartedRequest) error {
+func (p *visibilityManagerImpl) RecordWorkflowExecutionStarted(
+	_ context.Context,
+	request *manager.RecordWorkflowExecutionStartedRequest,
+) error {
 	requestBase, err := p.newInternalVisibilityRequestBase(request.VisibilityRequestBase)
 	if err != nil {
 		return err
@@ -86,7 +90,10 @@ func (p *visibilityManagerImpl) RecordWorkflowExecutionStarted(request *manager.
 	return p.store.RecordWorkflowExecutionStarted(req)
 }
 
-func (p *visibilityManagerImpl) RecordWorkflowExecutionClosed(request *manager.RecordWorkflowExecutionClosedRequest) error {
+func (p *visibilityManagerImpl) RecordWorkflowExecutionClosed(
+	_ context.Context,
+	request *manager.RecordWorkflowExecutionClosedRequest,
+) error {
 	requestBase, err := p.newInternalVisibilityRequestBase(request.VisibilityRequestBase)
 	if err != nil {
 		return err
@@ -99,7 +106,10 @@ func (p *visibilityManagerImpl) RecordWorkflowExecutionClosed(request *manager.R
 	return p.store.RecordWorkflowExecutionClosed(req)
 }
 
-func (p *visibilityManagerImpl) UpsertWorkflowExecution(request *manager.UpsertWorkflowExecutionRequest) error {
+func (p *visibilityManagerImpl) UpsertWorkflowExecution(
+	_ context.Context,
+	request *manager.UpsertWorkflowExecutionRequest,
+) error {
 	requestBase, err := p.newInternalVisibilityRequestBase(request.VisibilityRequestBase)
 	if err != nil {
 		return err
@@ -110,11 +120,17 @@ func (p *visibilityManagerImpl) UpsertWorkflowExecution(request *manager.UpsertW
 	return p.store.UpsertWorkflowExecution(req)
 }
 
-func (p *visibilityManagerImpl) DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
+func (p *visibilityManagerImpl) DeleteWorkflowExecution(
+	_ context.Context,
+	request *manager.VisibilityDeleteWorkflowExecutionRequest,
+) error {
 	return p.store.DeleteWorkflowExecution(request)
 }
 
-func (p *visibilityManagerImpl) ListOpenWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ListOpenWorkflowExecutions(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ListOpenWorkflowExecutions(request)
 	if err != nil {
 		return nil, err
@@ -122,7 +138,10 @@ func (p *visibilityManagerImpl) ListOpenWorkflowExecutions(request *manager.List
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ListClosedWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ListClosedWorkflowExecutions(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ListClosedWorkflowExecutions(request)
 	if err != nil {
 		return nil, err
@@ -131,7 +150,10 @@ func (p *visibilityManagerImpl) ListClosedWorkflowExecutions(request *manager.Li
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByType(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ListOpenWorkflowExecutionsByType(request)
 	if err != nil {
 		return nil, err
@@ -140,7 +162,10 @@ func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByType(request *manage
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByType(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ListClosedWorkflowExecutionsByType(request)
 	if err != nil {
 		return nil, err
@@ -149,7 +174,10 @@ func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByType(request *mana
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByWorkflowID(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ListOpenWorkflowExecutionsByWorkflowID(request)
 	if err != nil {
 		return nil, err
@@ -158,7 +186,10 @@ func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByWorkflowID(request *
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByWorkflowID(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ListClosedWorkflowExecutionsByWorkflowID(request)
 	if err != nil {
 		return nil, err
@@ -167,7 +198,10 @@ func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByWorkflowID(request
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByStatus(request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByStatus(
+	_ context.Context,
+	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ListClosedWorkflowExecutionsByStatus(request)
 	if err != nil {
 		return nil, err
@@ -176,7 +210,10 @@ func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByStatus(request *ma
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ListWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ListWorkflowExecutions(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ListWorkflowExecutions(request)
 	if err != nil {
 		return nil, err
@@ -185,7 +222,10 @@ func (p *visibilityManagerImpl) ListWorkflowExecutions(request *manager.ListWork
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*manager.ListWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) ScanWorkflowExecutions(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	response, err := p.store.ScanWorkflowExecutions(request)
 	if err != nil {
 		return nil, err
@@ -194,7 +234,10 @@ func (p *visibilityManagerImpl) ScanWorkflowExecutions(request *manager.ListWork
 	return p.convertInternalListResponse(response)
 }
 
-func (p *visibilityManagerImpl) CountWorkflowExecutions(request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
+func (p *visibilityManagerImpl) CountWorkflowExecutions(
+	_ context.Context,
+	request *manager.CountWorkflowExecutionsRequest,
+) (*manager.CountWorkflowExecutionsResponse, error) {
 	response, err := p.store.CountWorkflowExecutions(request)
 	if err != nil {
 		return nil, err

--- a/common/persistence/visibility/visibility_manager_rate_limited.go
+++ b/common/persistence/visibility/visibility_manager_rate_limited.go
@@ -25,6 +25,8 @@
 package visibility
 
 import (
+	"context"
+
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility/manager"
@@ -67,91 +69,144 @@ func (m *visibilityManagerRateLimited) GetName() string {
 
 // Below are write APIs.
 
-func (m *visibilityManagerRateLimited) RecordWorkflowExecutionStarted(request *manager.RecordWorkflowExecutionStartedRequest) error {
+func (m *visibilityManagerRateLimited) RecordWorkflowExecutionStarted(
+	ctx context.Context,
+	request *manager.RecordWorkflowExecutionStartedRequest,
+) error {
 	if ok := m.writeRateLimiter.Allow(); !ok {
 		return persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.RecordWorkflowExecutionStarted(request)
+	return m.delegate.RecordWorkflowExecutionStarted(ctx, request)
 }
 
-func (m *visibilityManagerRateLimited) RecordWorkflowExecutionClosed(request *manager.RecordWorkflowExecutionClosedRequest) error {
+func (m *visibilityManagerRateLimited) RecordWorkflowExecutionClosed(
+	ctx context.Context,
+	request *manager.RecordWorkflowExecutionClosedRequest,
+) error {
 	if ok := m.writeRateLimiter.Allow(); !ok {
 		return persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.RecordWorkflowExecutionClosed(request)
+	return m.delegate.RecordWorkflowExecutionClosed(ctx, request)
 }
-func (m *visibilityManagerRateLimited) UpsertWorkflowExecution(request *manager.UpsertWorkflowExecutionRequest) error {
+
+func (m *visibilityManagerRateLimited) UpsertWorkflowExecution(
+	ctx context.Context,
+	request *manager.UpsertWorkflowExecutionRequest,
+) error {
 	if ok := m.writeRateLimiter.Allow(); !ok {
 		return persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.UpsertWorkflowExecution(request)
+	return m.delegate.UpsertWorkflowExecution(ctx, request)
 }
-func (m *visibilityManagerRateLimited) DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
+
+func (m *visibilityManagerRateLimited) DeleteWorkflowExecution(
+	ctx context.Context,
+	request *manager.VisibilityDeleteWorkflowExecutionRequest,
+) error {
 	if ok := m.writeRateLimiter.Allow(); !ok {
 		return persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.DeleteWorkflowExecution(request)
+	return m.delegate.DeleteWorkflowExecution(ctx, request)
 }
 
 // Below are read APIs.
 
-func (m *visibilityManagerRateLimited) ListOpenWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerRateLimited) ListOpenWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ListOpenWorkflowExecutions(request)
+	return m.delegate.ListOpenWorkflowExecutions(ctx, request)
 }
-func (m *visibilityManagerRateLimited) ListClosedWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) ListClosedWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ListClosedWorkflowExecutions(request)
+	return m.delegate.ListClosedWorkflowExecutions(ctx, request)
 }
-func (m *visibilityManagerRateLimited) ListOpenWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) ListOpenWorkflowExecutionsByType(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ListOpenWorkflowExecutionsByType(request)
+	return m.delegate.ListOpenWorkflowExecutionsByType(ctx, request)
 }
-func (m *visibilityManagerRateLimited) ListClosedWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) ListClosedWorkflowExecutionsByType(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ListClosedWorkflowExecutionsByType(request)
+	return m.delegate.ListClosedWorkflowExecutionsByType(ctx, request)
 }
-func (m *visibilityManagerRateLimited) ListOpenWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) ListOpenWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ListOpenWorkflowExecutionsByWorkflowID(request)
+	return m.delegate.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 }
-func (m *visibilityManagerRateLimited) ListClosedWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) ListClosedWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ListClosedWorkflowExecutionsByWorkflowID(request)
+	return m.delegate.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 }
-func (m *visibilityManagerRateLimited) ListClosedWorkflowExecutionsByStatus(request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) ListClosedWorkflowExecutionsByStatus(
+	ctx context.Context,
+	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ListClosedWorkflowExecutionsByStatus(request)
+	return m.delegate.ListClosedWorkflowExecutionsByStatus(ctx, request)
 }
-func (m *visibilityManagerRateLimited) ListWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*manager.ListWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) ListWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ListWorkflowExecutions(request)
+	return m.delegate.ListWorkflowExecutions(ctx, request)
 }
-func (m *visibilityManagerRateLimited) ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*manager.ListWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) ScanWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.ScanWorkflowExecutions(request)
+	return m.delegate.ScanWorkflowExecutions(ctx, request)
 }
-func (m *visibilityManagerRateLimited) CountWorkflowExecutions(request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
+
+func (m *visibilityManagerRateLimited) CountWorkflowExecutions(
+	ctx context.Context,
+	request *manager.CountWorkflowExecutionsRequest,
+) (*manager.CountWorkflowExecutionsResponse, error) {
 	if ok := m.readRateLimiter.Allow(); !ok {
 		return nil, persistence.ErrPersistenceLimitExceeded
 	}
-	return m.delegate.CountWorkflowExecutions(request)
+	return m.delegate.CountWorkflowExecutions(ctx, request)
 }

--- a/common/persistence/visibility/visibility_manager_test.go
+++ b/common/persistence/visibility/visibility_manager_test.go
@@ -25,6 +25,7 @@
 package visibility
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -101,10 +102,10 @@ func (s *VisibilityManagerSuite) TestRecordWorkflowExecutionStarted() {
 	}
 	s.visibilityStore.EXPECT().RecordWorkflowExecutionStarted(gomock.Any()).Return(nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceRecordWorkflowExecutionStartedScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	s.NoError(s.visibilityManager.RecordWorkflowExecutionStarted(request))
+	s.NoError(s.visibilityManager.RecordWorkflowExecutionStarted(context.Background(), request))
 
 	// no remaining tokens
-	err := s.visibilityManager.RecordWorkflowExecutionStarted(request)
+	err := s.visibilityManager.RecordWorkflowExecutionStarted(context.Background(), request)
 	s.Error(err)
 	s.ErrorIs(err, persistence.ErrPersistenceLimitExceeded)
 }
@@ -122,9 +123,9 @@ func (s *VisibilityManagerSuite) TestRecordWorkflowExecutionClosed() {
 
 	s.visibilityStore.EXPECT().RecordWorkflowExecutionClosed(gomock.Any()).Return(nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceRecordWorkflowExecutionClosedScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	s.NoError(s.visibilityManager.RecordWorkflowExecutionClosed(request))
+	s.NoError(s.visibilityManager.RecordWorkflowExecutionClosed(context.Background(), request))
 
-	err := s.visibilityManager.RecordWorkflowExecutionClosed(request)
+	err := s.visibilityManager.RecordWorkflowExecutionClosed(context.Background(), request)
 	s.Error(err)
 	s.ErrorIs(err, persistence.ErrPersistenceLimitExceeded)
 }
@@ -136,11 +137,11 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutions() {
 	}
 	s.visibilityStore.EXPECT().ListOpenWorkflowExecutions(gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	_, err := s.visibilityManager.ListOpenWorkflowExecutions(request)
+	_, err := s.visibilityManager.ListOpenWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// no remaining tokens
-	_, err = s.visibilityManager.ListOpenWorkflowExecutions(request)
+	_, err = s.visibilityManager.ListOpenWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	s.Equal(persistence.ErrPersistenceLimitExceeded, err)
 }
@@ -152,11 +153,11 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutions() {
 	}
 	s.visibilityStore.EXPECT().ListClosedWorkflowExecutions(gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	_, err := s.visibilityManager.ListClosedWorkflowExecutions(request)
+	_, err := s.visibilityManager.ListClosedWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// no remaining tokens
-	_, err = s.visibilityManager.ListClosedWorkflowExecutions(request)
+	_, err = s.visibilityManager.ListClosedWorkflowExecutions(context.Background(), request)
 	s.Equal(persistence.ErrPersistenceLimitExceeded, err)
 }
 
@@ -171,11 +172,11 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutionsByType() {
 	}
 	s.visibilityStore.EXPECT().ListOpenWorkflowExecutionsByType(gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsByTypeScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	_, err := s.visibilityManager.ListOpenWorkflowExecutionsByType(request)
+	_, err := s.visibilityManager.ListOpenWorkflowExecutionsByType(context.Background(), request)
 	s.NoError(err)
 
 	// no remaining tokens
-	_, err = s.visibilityManager.ListOpenWorkflowExecutionsByType(request)
+	_, err = s.visibilityManager.ListOpenWorkflowExecutionsByType(context.Background(), request)
 	s.Equal(persistence.ErrPersistenceLimitExceeded, err)
 }
 
@@ -190,11 +191,11 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByType() {
 	}
 	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByType(gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByTypeScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByType(request)
+	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByType(context.Background(), request)
 	s.NoError(err)
 
 	// no remaining tokens
-	_, err = s.visibilityManager.ListClosedWorkflowExecutionsByType(request)
+	_, err = s.visibilityManager.ListClosedWorkflowExecutionsByType(context.Background(), request)
 	s.Equal(persistence.ErrPersistenceLimitExceeded, err)
 }
 
@@ -209,11 +210,11 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 	}
 	s.visibilityStore.EXPECT().ListOpenWorkflowExecutionsByWorkflowID(gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsByWorkflowIDScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	_, err := s.visibilityManager.ListOpenWorkflowExecutionsByWorkflowID(request)
+	_, err := s.visibilityManager.ListOpenWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.NoError(err)
 
 	// no remaining tokens
-	_, err = s.visibilityManager.ListOpenWorkflowExecutionsByWorkflowID(request)
+	_, err = s.visibilityManager.ListOpenWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.Equal(persistence.ErrPersistenceLimitExceeded, err)
 }
 
@@ -228,11 +229,11 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByWorkflowID() 
 	}
 	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByWorkflowID(gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByWorkflowIDScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByWorkflowID(request)
+	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.NoError(err)
 
 	// no remaining tokens
-	_, err = s.visibilityManager.ListClosedWorkflowExecutionsByWorkflowID(request)
+	_, err = s.visibilityManager.ListClosedWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.Equal(persistence.ErrPersistenceLimitExceeded, err)
 }
 
@@ -247,10 +248,10 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByStatus() {
 	}
 	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByStatus(gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByStatusScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
-	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByStatus(request)
+	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByStatus(context.Background(), request)
 	s.NoError(err)
 
 	// no remaining tokens
-	_, err = s.visibilityManager.ListClosedWorkflowExecutionsByStatus(request)
+	_, err = s.visibilityManager.ListClosedWorkflowExecutionsByStatus(context.Background(), request)
 	s.Equal(persistence.ErrPersistenceLimitExceeded, err)
 }

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -25,6 +25,8 @@
 package visibility
 
 import (
+	"context"
+
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/common/log"
@@ -66,100 +68,142 @@ func (m *visibilityManagerMetrics) GetName() string {
 	return m.delegate.GetName()
 }
 
-func (m *visibilityManagerMetrics) RecordWorkflowExecutionStarted(request *manager.RecordWorkflowExecutionStartedRequest) error {
+func (m *visibilityManagerMetrics) RecordWorkflowExecutionStarted(
+	ctx context.Context,
+	request *manager.RecordWorkflowExecutionStartedRequest,
+) error {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceRecordWorkflowExecutionStartedScope)
-	err := m.delegate.RecordWorkflowExecutionStarted(request)
+	err := m.delegate.RecordWorkflowExecutionStarted(ctx, request)
 	sw.Stop()
 	return m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) RecordWorkflowExecutionClosed(request *manager.RecordWorkflowExecutionClosedRequest) error {
+func (m *visibilityManagerMetrics) RecordWorkflowExecutionClosed(
+	ctx context.Context,
+	request *manager.RecordWorkflowExecutionClosedRequest,
+) error {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceRecordWorkflowExecutionClosedScope)
-	err := m.delegate.RecordWorkflowExecutionClosed(request)
+	err := m.delegate.RecordWorkflowExecutionClosed(ctx, request)
 	sw.Stop()
 	return m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) UpsertWorkflowExecution(request *manager.UpsertWorkflowExecutionRequest) error {
+func (m *visibilityManagerMetrics) UpsertWorkflowExecution(
+	ctx context.Context,
+	request *manager.UpsertWorkflowExecutionRequest,
+) error {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceUpsertWorkflowExecutionScope)
-	err := m.delegate.UpsertWorkflowExecution(request)
+	err := m.delegate.UpsertWorkflowExecution(ctx, request)
 	sw.Stop()
 	return m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
+func (m *visibilityManagerMetrics) DeleteWorkflowExecution(
+	ctx context.Context,
+	request *manager.VisibilityDeleteWorkflowExecutionRequest,
+) error {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceDeleteWorkflowExecutionScope)
-	err := m.delegate.DeleteWorkflowExecution(request)
+	err := m.delegate.DeleteWorkflowExecution(ctx, request)
 	sw.Stop()
 	return m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ListOpenWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ListOpenWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsScope)
-	response, err := m.delegate.ListOpenWorkflowExecutions(request)
+	response, err := m.delegate.ListOpenWorkflowExecutions(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ListClosedWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ListClosedWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsScope)
-	response, err := m.delegate.ListClosedWorkflowExecutions(request)
+	response, err := m.delegate.ListClosedWorkflowExecutions(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ListOpenWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ListOpenWorkflowExecutionsByType(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsByTypeScope)
-	response, err := m.delegate.ListOpenWorkflowExecutionsByType(request)
+	response, err := m.delegate.ListOpenWorkflowExecutionsByType(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByType(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByTypeScope)
-	response, err := m.delegate.ListClosedWorkflowExecutionsByType(request)
+	response, err := m.delegate.ListClosedWorkflowExecutionsByType(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ListOpenWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ListOpenWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsByWorkflowIDScope)
-	response, err := m.delegate.ListOpenWorkflowExecutionsByWorkflowID(request)
+	response, err := m.delegate.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByWorkflowIDScope)
-	response, err := m.delegate.ListClosedWorkflowExecutionsByWorkflowID(request)
+	response, err := m.delegate.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByStatus(request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByStatus(
+	ctx context.Context,
+	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByStatusScope)
-	response, err := m.delegate.ListClosedWorkflowExecutionsByStatus(request)
+	response, err := m.delegate.ListClosedWorkflowExecutionsByStatus(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ListWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ListWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceListWorkflowExecutionsScope)
-	response, err := m.delegate.ListWorkflowExecutions(request)
+	response, err := m.delegate.ListWorkflowExecutions(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*manager.ListWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) ScanWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*manager.ListWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceScanWorkflowExecutionsScope)
-	response, err := m.delegate.ScanWorkflowExecutions(request)
+	response, err := m.delegate.ScanWorkflowExecutions(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }
 
-func (m *visibilityManagerMetrics) CountWorkflowExecutions(request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
+func (m *visibilityManagerMetrics) CountWorkflowExecutions(
+	ctx context.Context,
+	request *manager.CountWorkflowExecutionsRequest,
+) (*manager.CountWorkflowExecutionsResponse, error) {
 	scope, sw := m.tagScope(metrics.VisibilityPersistenceCountWorkflowExecutionsScope)
-	response, err := m.delegate.CountWorkflowExecutions(request)
+	response, err := m.delegate.CountWorkflowExecutions(ctx, request)
 	sw.Stop()
 	return response, m.updateErrorMetric(scope, err)
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2270,6 +2270,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context, reque
 			err = errNoPermission
 		} else {
 			persistenceResp, err = wh.visibilityMrg.ListOpenWorkflowExecutionsByWorkflowID(
+				ctx,
 				&manager.ListWorkflowExecutionsByWorkflowIDRequest{
 					ListWorkflowExecutionsRequest: baseReq,
 					WorkflowID:                    request.GetExecutionFilter().GetWorkflowId(),
@@ -2281,7 +2282,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context, reque
 		if wh.config.DisableListVisibilityByFilter(namespaceName.String()) {
 			err = errNoPermission
 		} else {
-			persistenceResp, err = wh.visibilityMrg.ListOpenWorkflowExecutionsByType(&manager.ListWorkflowExecutionsByTypeRequest{
+			persistenceResp, err = wh.visibilityMrg.ListOpenWorkflowExecutionsByType(ctx, &manager.ListWorkflowExecutionsByTypeRequest{
 				ListWorkflowExecutionsRequest: baseReq,
 				WorkflowTypeName:              request.GetTypeFilter().GetName(),
 			})
@@ -2289,7 +2290,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context, reque
 		wh.logger.Debug("List open workflow with filter",
 			tag.WorkflowNamespace(request.GetNamespace()), tag.WorkflowListWorkflowFilterByType)
 	} else {
-		persistenceResp, err = wh.visibilityMrg.ListOpenWorkflowExecutions(baseReq)
+		persistenceResp, err = wh.visibilityMrg.ListOpenWorkflowExecutions(ctx, baseReq)
 	}
 
 	if err != nil {
@@ -2363,6 +2364,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context, req
 			err = errNoPermission
 		} else {
 			persistenceResp, err = wh.visibilityMrg.ListClosedWorkflowExecutionsByWorkflowID(
+				ctx,
 				&manager.ListWorkflowExecutionsByWorkflowIDRequest{
 					ListWorkflowExecutionsRequest: baseReq,
 					WorkflowID:                    request.GetExecutionFilter().GetWorkflowId(),
@@ -2374,7 +2376,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context, req
 		if wh.config.DisableListVisibilityByFilter(namespaceName.String()) {
 			err = errNoPermission
 		} else {
-			persistenceResp, err = wh.visibilityMrg.ListClosedWorkflowExecutionsByType(&manager.ListWorkflowExecutionsByTypeRequest{
+			persistenceResp, err = wh.visibilityMrg.ListClosedWorkflowExecutionsByType(ctx, &manager.ListWorkflowExecutionsByTypeRequest{
 				ListWorkflowExecutionsRequest: baseReq,
 				WorkflowTypeName:              request.GetTypeFilter().GetName(),
 			})
@@ -2388,7 +2390,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context, req
 			if request.GetStatusFilter().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED || request.GetStatusFilter().GetStatus() == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
 				err = errStatusFilterMustBeNotRunning
 			} else {
-				persistenceResp, err = wh.visibilityMrg.ListClosedWorkflowExecutionsByStatus(&manager.ListClosedWorkflowExecutionsByStatusRequest{
+				persistenceResp, err = wh.visibilityMrg.ListClosedWorkflowExecutionsByStatus(ctx, &manager.ListClosedWorkflowExecutionsByStatusRequest{
 					ListWorkflowExecutionsRequest: baseReq,
 					Status:                        request.GetStatusFilter().GetStatus(),
 				})
@@ -2397,7 +2399,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context, req
 		wh.logger.Debug("List closed workflow with filter",
 			tag.WorkflowNamespace(request.GetNamespace()), tag.WorkflowListWorkflowFilterByStatus)
 	} else {
-		persistenceResp, err = wh.visibilityMrg.ListClosedWorkflowExecutions(baseReq)
+		persistenceResp, err = wh.visibilityMrg.ListClosedWorkflowExecutions(ctx, baseReq)
 	}
 
 	if err != nil {
@@ -2447,7 +2449,7 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(ctx context.Context, request *
 		NextPageToken: request.NextPageToken,
 		Query:         request.GetQuery(),
 	}
-	persistenceResp, err := wh.visibilityMrg.ListWorkflowExecutions(req)
+	persistenceResp, err := wh.visibilityMrg.ListWorkflowExecutions(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -2581,7 +2583,7 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(ctx context.Context, request *
 		NextPageToken: request.NextPageToken,
 		Query:         request.GetQuery(),
 	}
-	persistenceResp, err := wh.visibilityMrg.ScanWorkflowExecutions(req)
+	persistenceResp, err := wh.visibilityMrg.ScanWorkflowExecutions(ctx, req)
 	if err != nil {
 		return nil, err
 	}
@@ -2620,7 +2622,7 @@ func (wh *WorkflowHandler) CountWorkflowExecutions(ctx context.Context, request 
 		Namespace:   namespaceName,
 		Query:       request.GetQuery(),
 	}
-	persistenceResp, err := wh.visibilityMrg.CountWorkflowExecutions(req)
+	persistenceResp, err := wh.visibilityMrg.CountWorkflowExecutions(ctx, req)
 	if err != nil {
 		return nil, err
 	}

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -1631,7 +1631,7 @@ func (s *workflowHandlerSuite) TestListWorkflowExecutions() {
 	wh := s.getWorkflowHandler(config)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(s.testNamespaceID, nil).AnyTimes()
-	s.mockVisibilityMgr.EXPECT().ListWorkflowExecutions(gomock.Any()).Return(&manager.ListWorkflowExecutionsResponse{}, nil)
+	s.mockVisibilityMgr.EXPECT().ListWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.ListWorkflowExecutionsResponse{}, nil)
 
 	listRequest := &workflowservice.ListWorkflowExecutionsRequest{
 		Namespace: s.testNamespace.String(),
@@ -1656,7 +1656,7 @@ func (s *workflowHandlerSuite) TestScanWorkflowExecutions() {
 	wh := s.getWorkflowHandler(config)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(s.testNamespaceID, nil).AnyTimes()
-	s.mockVisibilityMgr.EXPECT().ScanWorkflowExecutions(gomock.Any()).Return(&manager.ListWorkflowExecutionsResponse{}, nil)
+	s.mockVisibilityMgr.EXPECT().ScanWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.ListWorkflowExecutionsResponse{}, nil)
 
 	scanRequest := &workflowservice.ScanWorkflowExecutionsRequest{
 		Namespace: s.testNamespace.String(),
@@ -1685,7 +1685,7 @@ func (s *workflowHandlerSuite) TestCountWorkflowExecutions() {
 	wh := s.getWorkflowHandler(config)
 
 	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(s.testNamespaceID, nil).AnyTimes()
-	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 5}, nil)
+	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 5}, nil)
 
 	countRequest := &workflowservice.CountWorkflowExecutionsRequest{
 		Namespace: s.testNamespace.String(),

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -87,7 +87,7 @@ func (t *visibilityQueueTaskExecutor) execute(
 	case *tasks.CloseExecutionVisibilityTask:
 		return t.processCloseExecution(ctx, task)
 	case *tasks.DeleteExecutionVisibilityTask:
-		return t.processDeleteExecution(task)
+		return t.processDeleteExecution(ctx, task)
 	default:
 		return errUnknownVisibilityTask
 	}
@@ -152,6 +152,7 @@ func (t *visibilityQueueTaskExecutor) processStartExecution(
 	release(nil)
 
 	return t.recordStartExecution(
+		ctx,
 		namespace.ID(task.GetNamespaceID()),
 		task.GetWorkflowID(),
 		task.GetRunID(),
@@ -215,6 +216,7 @@ func (t *visibilityQueueTaskExecutor) processUpsertExecution(
 	release(nil)
 
 	return t.upsertExecution(
+		ctx,
 		namespace.ID(task.GetNamespaceID()),
 		task.GetWorkflowID(),
 		task.GetRunID(),
@@ -231,6 +233,7 @@ func (t *visibilityQueueTaskExecutor) processUpsertExecution(
 }
 
 func (t *visibilityQueueTaskExecutor) recordStartExecution(
+	ctx context.Context,
 	namespaceID namespace.ID,
 	workflowID string,
 	runID string,
@@ -269,10 +272,11 @@ func (t *visibilityQueueTaskExecutor) recordStartExecution(
 			SearchAttributes: searchAttributes,
 		},
 	}
-	return t.visibilityMgr.RecordWorkflowExecutionStarted(request)
+	return t.visibilityMgr.RecordWorkflowExecutionStarted(ctx, request)
 }
 
 func (t *visibilityQueueTaskExecutor) upsertExecution(
+	ctx context.Context,
 	namespaceID namespace.ID,
 	workflowID string,
 	runID string,
@@ -312,7 +316,7 @@ func (t *visibilityQueueTaskExecutor) upsertExecution(
 		},
 	}
 
-	return t.visibilityMgr.UpsertWorkflowExecution(request)
+	return t.visibilityMgr.UpsertWorkflowExecution(ctx, request)
 }
 
 func (t *visibilityQueueTaskExecutor) processCloseExecution(
@@ -379,6 +383,7 @@ func (t *visibilityQueueTaskExecutor) processCloseExecution(
 	// the rest of logic is making RPC call, which takes time.
 	release(nil)
 	return t.recordCloseExecution(
+		ctx,
 		namespace.ID(task.GetNamespaceID()),
 		task.GetWorkflowID(),
 		task.GetRunID(),
@@ -397,6 +402,7 @@ func (t *visibilityQueueTaskExecutor) processCloseExecution(
 }
 
 func (t *visibilityQueueTaskExecutor) recordCloseExecution(
+	ctx context.Context,
 	namespaceID namespace.ID,
 	workflowID string,
 	runID string,
@@ -418,7 +424,7 @@ func (t *visibilityQueueTaskExecutor) recordCloseExecution(
 		return err
 	}
 
-	return t.visibilityMgr.RecordWorkflowExecutionClosed(&manager.RecordWorkflowExecutionClosedRequest{
+	return t.visibilityMgr.RecordWorkflowExecutionClosed(ctx, &manager.RecordWorkflowExecutionClosedRequest{
 		VisibilityRequestBase: &manager.VisibilityRequestBase{
 			NamespaceID: namespaceID,
 			Namespace:   namespaceEntry.Name(),
@@ -442,6 +448,7 @@ func (t *visibilityQueueTaskExecutor) recordCloseExecution(
 }
 
 func (t *visibilityQueueTaskExecutor) processDeleteExecution(
+	ctx context.Context,
 	task *tasks.DeleteExecutionVisibilityTask,
 ) (retError error) {
 	if task.CloseTime == nil {
@@ -457,7 +464,7 @@ func (t *visibilityQueueTaskExecutor) processDeleteExecution(
 		TaskID:      task.TaskID,
 		CloseTime:   *task.CloseTime,
 	}
-	return t.visibilityMgr.DeleteWorkflowExecution(request)
+	return t.visibilityMgr.DeleteWorkflowExecution(ctx, request)
 }
 
 func getWorkflowMemo(

--- a/service/history/visibilityQueueTaskExecutor_test.go
+++ b/service/history/visibilityQueueTaskExecutor_test.go
@@ -236,7 +236,7 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessCloseExecution() {
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-	s.mockVisibilityMgr.EXPECT().RecordWorkflowExecutionClosed(gomock.Any()).Return(nil)
+	s.mockVisibilityMgr.EXPECT().RecordWorkflowExecutionClosed(gomock.Any(), gomock.Any()).Return(nil)
 
 	err = s.visibilityQueueTaskExecutor.execute(context.Background(), visibilityTask, true)
 	s.Nil(err)
@@ -288,7 +288,10 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessRecordWorkflowStartedTask(
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, di.ScheduleID, di.Version)
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-	s.mockVisibilityMgr.EXPECT().RecordWorkflowExecutionStarted(s.createRecordWorkflowExecutionStartedRequest(s.namespace, event, visibilityTask, mutableState, backoff, taskQueueName)).Return(nil)
+	s.mockVisibilityMgr.EXPECT().RecordWorkflowExecutionStarted(
+		gomock.Any(),
+		s.createRecordWorkflowExecutionStartedRequest(s.namespace, event, visibilityTask, mutableState, backoff, taskQueueName),
+	).Return(nil)
 
 	err = s.visibilityQueueTaskExecutor.execute(context.Background(), visibilityTask, true)
 	s.Nil(err)
@@ -335,7 +338,10 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, di.ScheduleID, di.Version)
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-	s.mockVisibilityMgr.EXPECT().UpsertWorkflowExecution(s.createUpsertWorkflowSearchAttributesRequest(s.namespace, visibilityTask, mutableState, taskQueueName)).Return(nil)
+	s.mockVisibilityMgr.EXPECT().UpsertWorkflowExecution(
+		gomock.Any(),
+		s.createUpsertWorkflowSearchAttributesRequest(s.namespace, visibilityTask, mutableState, taskQueueName),
+	).Return(nil)
 
 	err = s.visibilityQueueTaskExecutor.execute(context.Background(), visibilityTask, true)
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add context parameter to Namespace Replication Queue interface
- Passed in context is not used right now
- Wire up most logic in application layer to pass context parameter to persistence

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enforce persistence timeout, instead of always timeout after 10s
- Required for host level task worker pool

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Very low risk as passed in context not used

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- no