### PR TITLE
Handle activity retry timer in passive

### DIFF
--- a/service/history/nDCActivityReplicator.go
+++ b/service/history/nDCActivityReplicator.go
@@ -92,10 +92,10 @@ func (r *nDCActivityReplicatorImpl) SyncActivity(
 ) (retError error) {
 
 	// sync activity info will only be sent from active side, when
-	// 1. activity has retry policy and activity got started
-	// 2. activity heart beat
+	// 1. activity retry
+	// 2. activity start
+	// 3. activity heart beat
 	// no sync activity task will be sent when active side fail / timeout activity,
-	// since standby side does not have activity retry timer
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	execution := commonpb.WorkflowExecution{
 		WorkflowId: request.WorkflowId,

--- a/service/history/nDCActivityReplicator.go
+++ b/service/history/nDCActivityReplicator.go
@@ -30,19 +30,17 @@ import (
 	"context"
 	"time"
 
-	"go.temporal.io/server/common/definition"
-	"go.temporal.io/server/service/history/tasks"
-
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
-
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/namespace"
@@ -51,6 +49,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
 )
 
@@ -195,7 +194,7 @@ func (r *nDCActivityReplicatorImpl) SyncActivity(
 				WorkflowID:  request.GetWorkflowId(),
 				RunID:       request.GetRunId(),
 			},
-			VisibilityTimestamp: *request.GetScheduledTime(),
+			VisibilityTimestamp: eventTime,
 			EventID:             request.GetScheduledId(),
 			Version:             request.GetVersion(),
 			Attempt:             request.GetAttempt(),

--- a/service/history/nDCActivityReplicator.go
+++ b/service/history/nDCActivityReplicator.go
@@ -28,9 +28,10 @@ package history
 
 import (
 	"context"
+	"time"
+
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/service/history/tasks"
-	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"

--- a/service/history/nDCActivityReplicator.go
+++ b/service/history/nDCActivityReplicator.go
@@ -187,7 +187,7 @@ func (r *nDCActivityReplicatorImpl) SyncActivity(
 	}
 
 	// sync activity with empty started ID means activity retry
-	if request.StartedId == common.EmptyEventID {
+	if request.StartedId == common.EmptyEventID && request.Attempt > activityInfo.GetAttempt() {
 		mutableState.AddTasks(&tasks.ActivityRetryTimerTask{
 			WorkflowKey: definition.WorkflowKey{
 				NamespaceID: request.GetNamespaceId(),

--- a/service/history/nDCActivityReplicator_test.go
+++ b/service/history/nDCActivityReplicator_test.go
@@ -846,16 +846,6 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityFound_Zombie() {
 	}, true)
 	s.mockMutableState.EXPECT().ReplicateActivityInfo(request, false).Return(nil)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
-	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityRetryTimerTask{
-		WorkflowKey: definition.WorkflowKey{
-			NamespaceID: request.NamespaceId,
-			WorkflowID:  request.WorkflowId,
-			RunID:       request.RunId,
-		},
-		VisibilityTimestamp: now,
-		EventID:             request.GetScheduledId(),
-		Version:             request.GetVersion(),
-	})
 	s.mockClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
 
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
@@ -948,16 +938,6 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityFound_NonZombie() {
 	}, true)
 	s.mockMutableState.EXPECT().ReplicateActivityInfo(request, false).Return(nil)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
-	s.mockMutableState.EXPECT().AddTasks(&tasks.ActivityRetryTimerTask{
-		WorkflowKey: definition.WorkflowKey{
-			NamespaceID: request.NamespaceId,
-			WorkflowID:  request.WorkflowId,
-			RunID:       request.RunId,
-		},
-		VisibilityTimestamp: now,
-		EventID:             request.GetScheduledId(),
-		Version:             request.GetVersion(),
-	})
 
 	s.mockClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
 

--- a/service/history/nDCStandbyTaskUtil.go
+++ b/service/history/nDCStandbyTaskUtil.go
@@ -100,6 +100,7 @@ type (
 
 	pushActivityTaskToMatchingInfo struct {
 		taskQueue                          string
+		namespaceID                        string
 		activityTaskScheduleToStartTimeout time.Duration
 	}
 
@@ -120,12 +121,23 @@ func newHistoryResendInfo(
 }
 
 func newPushActivityToMatchingInfo(
+	activityScheduleToStartTimeout time.Duration,
+) *pushActivityTaskToMatchingInfo {
+
+	return &pushActivityTaskToMatchingInfo{
+		activityTaskScheduleToStartTimeout: activityScheduleToStartTimeout,
+	}
+}
+
+func newActivityRetryTimerToMatchingInfo(
 	taskQueue string,
+	namespaceID string,
 	activityScheduleToStartTimeout time.Duration,
 ) *pushActivityTaskToMatchingInfo {
 
 	return &pushActivityTaskToMatchingInfo{
 		taskQueue:                          taskQueue,
+		namespaceID:                        namespaceID,
 		activityTaskScheduleToStartTimeout: activityScheduleToStartTimeout,
 	}
 }

--- a/service/history/nDCStandbyTaskUtil.go
+++ b/service/history/nDCStandbyTaskUtil.go
@@ -99,6 +99,7 @@ type (
 	}
 
 	pushActivityTaskToMatchingInfo struct {
+		taskQueue                          string
 		activityTaskScheduleToStartTimeout time.Duration
 	}
 
@@ -119,10 +120,12 @@ func newHistoryResendInfo(
 }
 
 func newPushActivityToMatchingInfo(
+	taskQueue string,
 	activityScheduleToStartTimeout time.Duration,
 ) *pushActivityTaskToMatchingInfo {
 
 	return &pushActivityTaskToMatchingInfo{
+		taskQueue:                          taskQueue,
 		activityTaskScheduleToStartTimeout: activityScheduleToStartTimeout,
 	}
 }

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -378,6 +378,7 @@ func (t *timerQueueProcessorImpl) handleClusterMetadataUpdate(
 				t.shard,
 				t.workflowCache,
 				t.workflowDeleteManager,
+				t.matchingClient,
 				clusterName,
 				t.taskAllocator,
 				nDCHistoryResender,

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -28,6 +28,8 @@ import (
 	"context"
 	"time"
 
+	"go.temporal.io/server/api/matchingservice/v1"
+
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -59,6 +61,7 @@ func newTimerQueueStandbyProcessor(
 	shard shard.Context,
 	workflowCache workflow.Cache,
 	workflowDeleteManager workflow.DeleteManager,
+	matchingClient matchingservice.MatchingServiceClient,
 	clusterName string,
 	taskAllocator taskAllocator,
 	nDCHistoryResender xdc.NDCHistoryResender,
@@ -104,6 +107,7 @@ func newTimerQueueStandbyProcessor(
 			workflowCache,
 			workflowDeleteManager,
 			nDCHistoryResender,
+			matchingClient,
 			logger,
 			clusterName,
 			shard.GetConfig(),

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -303,7 +303,7 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityRetryTimerTask(
 			return nil, nil
 		}
 
-		return newPushActivityToMatchingInfo(activityInfo.TaskQueue, *activityInfo.ScheduleToStartTimeout), nil
+		return newActivityRetryTimerToMatchingInfo(activityInfo.TaskQueue, activityInfo.NamespaceId, *activityInfo.ScheduleToStartTimeout), nil
 	}
 
 	return t.processTimer(
@@ -584,7 +584,7 @@ func (t *timerQueueStandbyTaskExecutor) pushActivity(
 	defer cancel()
 
 	_, err := t.matchingClient.AddActivityTask(ctx, &matchingservice.AddActivityTaskRequest{
-		NamespaceId:       activityTask.NamespaceID,
+		NamespaceId:       pushActivityInfo.namespaceID,
 		SourceNamespaceId: activityTask.NamespaceID,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: activityTask.WorkflowID,

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -29,10 +29,12 @@ import (
 	"fmt"
 	"time"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
-
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
@@ -53,6 +55,7 @@ type (
 
 		clusterName        string
 		adminClient        adminservice.AdminServiceClient
+		matchingClient     matchingservice.MatchingServiceClient
 		nDCHistoryResender xdc.NDCHistoryResender
 	}
 )
@@ -62,6 +65,7 @@ func newTimerQueueStandbyTaskExecutor(
 	workflowCache workflow.Cache,
 	workflowDeleteManager workflow.DeleteManager,
 	nDCHistoryResender xdc.NDCHistoryResender,
+	matchingClient matchingservice.MatchingServiceClient,
 	logger log.Logger,
 	clusterName string,
 	config *configs.Config,
@@ -77,6 +81,7 @@ func newTimerQueueStandbyTaskExecutor(
 		clusterName:        clusterName,
 		adminClient:        shard.GetRemoteAdminClient(clusterName),
 		nDCHistoryResender: nDCHistoryResender,
+		matchingClient:     matchingClient,
 	}
 }
 
@@ -108,9 +113,10 @@ func (t *timerQueueStandbyTaskExecutor) execute(
 		}
 		return t.executeWorkflowBackoffTimerTask(ctx, task)
 	case *tasks.ActivityRetryTimerTask:
-		// retry backoff timer should not get created on passive cluster
-		// TODO: add error logs
-		return nil
+		if !shouldProcessTask {
+			return nil
+		}
+		return t.executeActivityRetryTimerTask(ctx, task)
 	case *tasks.WorkflowTimeoutTask:
 		return t.executeWorkflowTimeoutTask(ctx, task)
 	case *tasks.DeleteHistoryEventTask:
@@ -205,7 +211,7 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 				return getHistoryResendInfo(mutableState)
 			}
 			// since the activity timer are already sorted, so if there is one timer which will not expired
-			// all activity timer after this timer will not expired
+			// all activity timer after this timer will not expire
 			break Loop //nolint:staticcheck
 		}
 
@@ -268,6 +274,49 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 			t.config.StandbyTaskMissingEventsDiscardDelay(),
 			t.fetchHistoryFromRemote,
 			standbyTimerTaskPostActionTaskDiscarded,
+		),
+	)
+}
+
+func (t *timerQueueStandbyTaskExecutor) executeActivityRetryTimerTask(
+	ctx context.Context,
+	task *tasks.ActivityRetryTimerTask,
+) (retError error) {
+
+	actionFn := func(context workflow.Context, mutableState workflow.MutableState) (interface{}, error) {
+
+		activityInfo, ok := mutableState.GetActivityInfo(task.EventID) //activity schedule ID
+		if !ok {
+			return nil, nil
+		}
+
+		ok = VerifyTaskVersion(t.shard, t.logger, mutableState.GetNamespaceEntry(), activityInfo.Version, task.Version, task)
+		if !ok {
+			return nil, nil
+		}
+
+		if activityInfo.Attempt > task.Attempt {
+			return nil, nil
+		}
+
+		if activityInfo.StartedId != common.EmptyEventID {
+			return nil, nil
+		}
+
+		return newPushActivityToMatchingInfo(activityInfo.TaskQueue, *activityInfo.ScheduleToStartTimeout), nil
+	}
+
+	return t.processTimer(
+		ctx,
+		task,
+		actionFn,
+		getStandbyPostActionFn(
+			task,
+			t.getCurrentTime,
+			t.config.StandbyTaskMissingEventsResendDelay(),
+			t.config.StandbyTaskMissingEventsDiscardDelay(),
+			t.pushActivity,
+			t.pushActivity,
 		),
 	)
 }
@@ -516,6 +565,39 @@ func (t *timerQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 
 	// return error so task processing logic will retry
 	return consts.ErrTaskRetry
+}
+
+func (t *timerQueueStandbyTaskExecutor) pushActivity(
+	task tasks.Task,
+	postActionInfo interface{},
+	logger log.Logger,
+) error {
+
+	if postActionInfo == nil {
+		return nil
+	}
+
+	pushActivityInfo := postActionInfo.(*pushActivityTaskToMatchingInfo)
+	activityScheduleToStartTimeout := &pushActivityInfo.activityTaskScheduleToStartTimeout
+	activityTask := task.(*tasks.ActivityRetryTimerTask)
+	ctx, cancel := context.WithTimeout(context.Background(), transferActiveTaskDefaultTimeout)
+	defer cancel()
+
+	_, err := t.matchingClient.AddActivityTask(ctx, &matchingservice.AddActivityTaskRequest{
+		NamespaceId:       activityTask.NamespaceID,
+		SourceNamespaceId: activityTask.NamespaceID,
+		Execution: &commonpb.WorkflowExecution{
+			WorkflowId: activityTask.WorkflowID,
+			RunId:      activityTask.RunID,
+		},
+		TaskQueue: &taskqueuepb.TaskQueue{
+			Name: pushActivityInfo.taskQueue,
+			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
+		},
+		ScheduleId:             activityTask.EventID,
+		ScheduleToStartTimeout: activityScheduleToStartTimeout,
+	})
+	return err
 }
 
 func (t *timerQueueStandbyTaskExecutor) getCurrentTime() time.Time {

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -144,7 +144,7 @@ func (t *transferQueueStandbyTaskExecutor) processActivityTask(
 		}
 
 		if activityInfo.StartedId == common.EmptyEventID {
-			return newPushActivityToMatchingInfo(activityInfo.TaskQueue, *activityInfo.ScheduleToStartTimeout), nil
+			return newPushActivityToMatchingInfo(*activityInfo.ScheduleToStartTimeout), nil
 		}
 
 		return nil, nil

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -144,7 +144,7 @@ func (t *transferQueueStandbyTaskExecutor) processActivityTask(
 		}
 
 		if activityInfo.StartedId == common.EmptyEventID {
-			return newPushActivityToMatchingInfo(*activityInfo.ScheduleToStartTimeout), nil
+			return newPushActivityToMatchingInfo(activityInfo.TaskQueue, *activityInfo.ScheduleToStartTimeout), nil
 		}
 
 		return nil, nil

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -33,7 +33,6 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 
 	"go.temporal.io/server/api/matchingservice/v1"
-	m "go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -108,7 +107,7 @@ func (t *transferQueueTaskExecutorBase) pushActivity(
 	ctx, cancel := context.WithTimeout(context.Background(), transferActiveTaskDefaultTimeout)
 	defer cancel()
 
-	_, err := t.matchingClient.AddActivityTask(ctx, &m.AddActivityTaskRequest{
+	_, err := t.matchingClient.AddActivityTask(ctx, &matchingservice.AddActivityTaskRequest{
 		NamespaceId:       task.TargetNamespaceID,
 		SourceNamespaceId: task.NamespaceID,
 		Execution: &commonpb.WorkflowExecution{
@@ -135,7 +134,7 @@ func (t *transferQueueTaskExecutorBase) pushWorkflowTask(
 	ctx, cancel := context.WithTimeout(context.Background(), transferActiveTaskDefaultTimeout)
 	defer cancel()
 
-	_, err := t.matchingClient.AddWorkflowTask(ctx, &m.AddWorkflowTaskRequest{
+	_, err := t.matchingClient.AddWorkflowTask(ctx, &matchingservice.AddWorkflowTaskRequest{
 		NamespaceId: task.NamespaceID,
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: task.WorkflowID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Handle activity retry timer in passive

<!-- Tell your future self why have you made these changes -->
**Why?**
Case: activity is retrying in source cluster and then failover to target cluster. We should persist the retry timer and handle the timer correctly.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
