### PR TITLE
Move namespace cache delay to reclaim resources workflow

### DIFF
--- a/service/worker/deletenamespace/workflow.go
+++ b/service/worker/deletenamespace/workflow.go
@@ -42,8 +42,6 @@ import (
 const (
 	// WorkflowName is the workflow name.
 	WorkflowName = "temporal-sys-delete-namespace-workflow"
-
-	namespaceCacheRefreshDelay = 11 * time.Second
 )
 
 type (
@@ -136,11 +134,6 @@ func DeleteNamespaceWorkflow(ctx workflow.Context, params DeleteNamespaceWorkflo
 	err = workflow.ExecuteLocalActivity(ctx31, a.RenameNamespaceActivity, params.Namespace, result.DeletedNamespace).Get(ctx, nil)
 	if err != nil {
 		return result, fmt.Errorf("%w: RenameNamespaceActivity: %v", errors.ErrUnableToExecuteActivity, err)
-	}
-
-	err = workflow.Sleep(ctx, namespaceCacheRefreshDelay)
-	if err != nil {
-		return result, err
 	}
 
 	// Step 4. Reclaim workflow resources asynchronously.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move namespace cache delay to reclaim resources workflow.

<!-- Tell your future self why have you made these changes -->
**Why?**
Other namespace APIs don't want for cache to be updated and returns right away. To keep parity with them `DeleteNamespace` shouldn't wait for cache to be refreshed and return right away. This will also make API call almost instant and mitigate possible timeout errors on caller side.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.