### PR TITLE
Persistence context part 5: persistence store interfaces

### DIFF
--- a/common/persistence/cassandra/cluster_metadata_store.go
+++ b/common/persistence/cassandra/cluster_metadata_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"net"
 	"strings"
 	"time"
@@ -86,6 +87,7 @@ func NewClusterMetadataStore(
 }
 
 func (m *ClusterMetadataStore) ListClusterMetadata(
+	_ context.Context,
 	request *p.InternalListClusterMetadataRequest,
 ) (*p.InternalListClusterMetadataResponse, error) {
 	query := m.session.Query(templateListClusterMetadata, constMetadataPartition)
@@ -122,6 +124,7 @@ func (m *ClusterMetadataStore) ListClusterMetadata(
 }
 
 func (m *ClusterMetadataStore) GetClusterMetadata(
+	_ context.Context,
 	request *p.InternalGetClusterMetadataRequest,
 ) (*p.InternalGetClusterMetadataResponse, error) {
 
@@ -141,7 +144,10 @@ func (m *ClusterMetadataStore) GetClusterMetadata(
 	}, nil
 }
 
-func (m *ClusterMetadataStore) SaveClusterMetadata(request *p.InternalSaveClusterMetadataRequest) (bool, error) {
+func (m *ClusterMetadataStore) SaveClusterMetadata(
+	_ context.Context,
+	request *p.InternalSaveClusterMetadataRequest,
+) (bool, error) {
 	var query gocql.Query
 	if request.Version == 0 {
 		query = m.session.Query(
@@ -175,7 +181,10 @@ func (m *ClusterMetadataStore) SaveClusterMetadata(request *p.InternalSaveCluste
 	return true, nil
 }
 
-func (m *ClusterMetadataStore) DeleteClusterMetadata(request *p.InternalDeleteClusterMetadataRequest) error {
+func (m *ClusterMetadataStore) DeleteClusterMetadata(
+	_ context.Context,
+	request *p.InternalDeleteClusterMetadataRequest,
+) error {
 	query := m.session.Query(templateDeleteClusterMetadata, constMetadataPartition, request.ClusterName)
 	if err := query.Exec(); err != nil {
 		return gocql.ConvertError("DeleteClusterMetadata", err)
@@ -183,7 +192,10 @@ func (m *ClusterMetadataStore) DeleteClusterMetadata(request *p.InternalDeleteCl
 	return nil
 }
 
-func (m *ClusterMetadataStore) GetClusterMembers(request *p.GetClusterMembersRequest) (*p.GetClusterMembersResponse, error) {
+func (m *ClusterMetadataStore) GetClusterMembers(
+	_ context.Context,
+	request *p.GetClusterMembersRequest,
+) (*p.GetClusterMembersResponse, error) {
 	var queryString strings.Builder
 	var operands []interface{}
 	queryString.WriteString(templateGetClusterMembership)
@@ -257,7 +269,10 @@ func (m *ClusterMetadataStore) GetClusterMembers(request *p.GetClusterMembersReq
 	return &p.GetClusterMembersResponse{ActiveMembers: clusterMembers, NextPageToken: pagingToken}, nil
 }
 
-func (m *ClusterMetadataStore) UpsertClusterMembership(request *p.UpsertClusterMembershipRequest) error {
+func (m *ClusterMetadataStore) UpsertClusterMembership(
+	_ context.Context,
+	request *p.UpsertClusterMembershipRequest,
+) error {
 	query := m.session.Query(templateUpsertActiveClusterMembership, constMembershipPartition, []byte(request.HostID),
 		request.RPCAddress, request.RPCPort, request.Role, request.SessionStart, time.Now().UTC(), int64(request.RecordExpiry.Seconds()))
 	err := query.Exec()
@@ -269,7 +284,10 @@ func (m *ClusterMetadataStore) UpsertClusterMembership(request *p.UpsertClusterM
 	return nil
 }
 
-func (m *ClusterMetadataStore) PruneClusterMembership(request *p.PruneClusterMembershipRequest) error {
+func (m *ClusterMetadataStore) PruneClusterMembership(
+	_ context.Context,
+	request *p.PruneClusterMembershipRequest,
+) error {
 	return nil
 }
 

--- a/common/persistence/cassandra/execution_store.go
+++ b/common/persistence/cassandra/execution_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"time"
 
 	"go.temporal.io/server/common/log"
@@ -130,54 +131,57 @@ func NewExecutionStore(
 }
 
 func (d *ExecutionStore) CreateWorkflowExecution(
+	ctx context.Context,
 	request *p.InternalCreateWorkflowExecutionRequest,
 ) (*p.InternalCreateWorkflowExecutionResponse, error) {
 	for _, req := range request.NewWorkflowNewEvents {
-		if err := d.AppendHistoryNodes(req); err != nil {
+		if err := d.AppendHistoryNodes(ctx, req); err != nil {
 			return nil, err
 		}
 	}
 
-	return d.MutableStateStore.CreateWorkflowExecution(request)
+	return d.MutableStateStore.CreateWorkflowExecution(ctx, request)
 }
 
 func (d *ExecutionStore) UpdateWorkflowExecution(
+	ctx context.Context,
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
 	for _, req := range request.UpdateWorkflowNewEvents {
-		if err := d.AppendHistoryNodes(req); err != nil {
+		if err := d.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 	for _, req := range request.NewWorkflowNewEvents {
-		if err := d.AppendHistoryNodes(req); err != nil {
+		if err := d.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 
-	return d.MutableStateStore.UpdateWorkflowExecution(request)
+	return d.MutableStateStore.UpdateWorkflowExecution(ctx, request)
 }
 
 func (d *ExecutionStore) ConflictResolveWorkflowExecution(
+	ctx context.Context,
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
 	for _, req := range request.CurrentWorkflowEventsNewEvents {
-		if err := d.AppendHistoryNodes(req); err != nil {
+		if err := d.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 	for _, req := range request.ResetWorkflowEventsNewEvents {
-		if err := d.AppendHistoryNodes(req); err != nil {
+		if err := d.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 	for _, req := range request.NewWorkflowEventsNewEvents {
-		if err := d.AppendHistoryNodes(req); err != nil {
+		if err := d.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 
-	return d.MutableStateStore.ConflictResolveWorkflowExecution(request)
+	return d.MutableStateStore.ConflictResolveWorkflowExecution(ctx, request)
 }
 
 func (d *ExecutionStore) GetName() string {

--- a/common/persistence/cassandra/history_store.go
+++ b/common/persistence/cassandra/history_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 	"sort"
 
@@ -89,6 +90,7 @@ func NewHistoryStore(
 // AppendHistoryNodes upsert a batch of events as a single node to a history branch
 // Note that it's not allowed to append above the branch's ancestors' nodes, which means nodeID >= ForkNodeID
 func (h *HistoryStore) AppendHistoryNodes(
+	_ context.Context,
 	request *p.InternalAppendHistoryNodesRequest,
 ) error {
 	branchInfo := request.BranchInfo
@@ -135,6 +137,7 @@ func (h *HistoryStore) AppendHistoryNodes(
 
 // DeleteHistoryNodes delete a history node
 func (h *HistoryStore) DeleteHistoryNodes(
+	_ context.Context,
 	request *p.InternalDeleteHistoryNodesRequest,
 ) error {
 	branchInfo := request.BranchInfo
@@ -164,6 +167,7 @@ func (h *HistoryStore) DeleteHistoryNodes(
 // ReadHistoryBranch returns history node data for a branch
 // NOTE: For branch that has ancestors, we need to query Cassandra multiple times, because it doesn't support OR/UNION operator
 func (h *HistoryStore) ReadHistoryBranch(
+	_ context.Context,
 	request *p.InternalReadHistoryBranchRequest,
 ) (*p.InternalReadHistoryBranchResponse, error) {
 	treeID, err := primitives.ValidateUUID(request.TreeID)
@@ -255,6 +259,7 @@ func (h *HistoryStore) ReadHistoryBranch(
 //       8[8,9]
 //
 func (h *HistoryStore) ForkHistoryBranch(
+	_ context.Context,
 	request *p.InternalForkHistoryBranchRequest,
 ) error {
 
@@ -281,6 +286,7 @@ func (h *HistoryStore) ForkHistoryBranch(
 
 // DeleteHistoryBranch removes a branch
 func (h *HistoryStore) DeleteHistoryBranch(
+	_ context.Context,
 	request *p.InternalDeleteHistoryBranchRequest,
 ) error {
 	batch := h.Session.NewBatch(gocql.LoggedBatch)
@@ -312,6 +318,7 @@ func (h *HistoryStore) deleteBranchRangeNodes(
 }
 
 func (h *HistoryStore) GetAllHistoryTreeBranches(
+	_ context.Context,
 	request *p.GetAllHistoryTreeBranchesRequest,
 ) (*p.InternalGetAllHistoryTreeBranchesResponse, error) {
 
@@ -359,6 +366,7 @@ func (h *HistoryStore) GetAllHistoryTreeBranches(
 
 // GetHistoryTree returns all branch information of a tree
 func (h *HistoryStore) GetHistoryTree(
+	_ context.Context,
 	request *p.GetHistoryTreeRequest,
 ) (*p.InternalGetHistoryTreeResponse, error) {
 

--- a/common/persistence/cassandra/matching_task_store.go
+++ b/common/persistence/cassandra/matching_task_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -150,6 +151,7 @@ func NewMatchingTaskStore(
 }
 
 func (d *MatchingTaskStore) CreateTaskQueue(
+	_ context.Context,
 	request *p.InternalCreateTaskQueueRequest,
 ) error {
 	query := d.Session.Query(templateInsertTaskQueueQuery,
@@ -181,6 +183,7 @@ func (d *MatchingTaskStore) CreateTaskQueue(
 }
 
 func (d *MatchingTaskStore) GetTaskQueue(
+	_ context.Context,
 	request *p.InternalGetTaskQueueRequest,
 ) (*p.InternalGetTaskQueueResponse, error) {
 	query := d.Session.Query(templateGetTaskQueueQuery,
@@ -206,6 +209,7 @@ func (d *MatchingTaskStore) GetTaskQueue(
 
 // UpdateTaskQueue update task queue
 func (d *MatchingTaskStore) UpdateTaskQueue(
+	_ context.Context,
 	request *p.InternalUpdateTaskQueueRequest,
 ) (*p.UpdateTaskQueueResponse, error) {
 	var err error
@@ -276,12 +280,14 @@ func (d *MatchingTaskStore) UpdateTaskQueue(
 }
 
 func (d *MatchingTaskStore) ListTaskQueue(
+	_ context.Context,
 	_ *p.ListTaskQueueRequest,
 ) (*p.InternalListTaskQueueResponse, error) {
 	return nil, serviceerror.NewUnavailable(fmt.Sprintf("unsupported operation"))
 }
 
 func (d *MatchingTaskStore) DeleteTaskQueue(
+	_ context.Context,
 	request *p.DeleteTaskQueueRequest,
 ) error {
 	query := d.Session.Query(templateDeleteTaskQueueQuery,
@@ -301,6 +307,7 @@ func (d *MatchingTaskStore) DeleteTaskQueue(
 
 // CreateTasks add tasks
 func (d *MatchingTaskStore) CreateTasks(
+	_ context.Context,
 	request *p.InternalCreateTasksRequest,
 ) (*p.CreateTasksResponse, error) {
 	batch := d.Session.NewBatch(gocql.LoggedBatch)
@@ -380,6 +387,7 @@ func GetTaskTTL(expireTime *time.Time) int64 {
 
 // GetTasks get a task
 func (d *MatchingTaskStore) GetTasks(
+	_ context.Context,
 	request *p.GetTasksRequest,
 ) (*p.InternalGetTasksResponse, error) {
 	// Reading taskqueue tasks need to be quorum level consistent, otherwise we could lose tasks
@@ -437,6 +445,7 @@ func (d *MatchingTaskStore) GetTasks(
 
 // CompleteTask delete a task
 func (d *MatchingTaskStore) CompleteTask(
+	_ context.Context,
 	request *p.CompleteTaskRequest,
 ) error {
 	tli := request.TaskQueue
@@ -459,6 +468,7 @@ func (d *MatchingTaskStore) CompleteTask(
 // Limit request parameter i.e. either all tasks leq the task_id will be deleted or an error will
 // be returned to the caller
 func (d *MatchingTaskStore) CompleteTasksLessThan(
+	_ context.Context,
 	request *p.CompleteTasksLessThanRequest,
 ) (int, error) {
 	query := d.Session.Query(templateCompleteTasksLessThanQuery,

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -372,6 +373,7 @@ func NewMutableStateStore(
 }
 
 func (d *MutableStateStore) CreateWorkflowExecution(
+	_ context.Context,
 	request *p.InternalCreateWorkflowExecutionRequest,
 ) (*p.InternalCreateWorkflowExecutionResponse, error) {
 	batch := d.Session.NewBatch(gocql.LoggedBatch)
@@ -481,6 +483,7 @@ func (d *MutableStateStore) CreateWorkflowExecution(
 }
 
 func (d *MutableStateStore) GetWorkflowExecution(
+	_ context.Context,
 	request *p.GetWorkflowExecutionRequest,
 ) (*p.InternalGetWorkflowExecutionResponse, error) {
 	query := d.Session.Query(templateGetWorkflowExecutionQuery,
@@ -567,6 +570,7 @@ func (d *MutableStateStore) GetWorkflowExecution(
 }
 
 func (d *MutableStateStore) UpdateWorkflowExecution(
+	_ context.Context,
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
 	batch := d.Session.NewBatch(gocql.LoggedBatch)
@@ -699,6 +703,7 @@ func (d *MutableStateStore) UpdateWorkflowExecution(
 }
 
 func (d *MutableStateStore) ConflictResolveWorkflowExecution(
+	_ context.Context,
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
 	batch := d.Session.NewBatch(gocql.LoggedBatch)
@@ -864,7 +869,7 @@ func (d *MutableStateStore) assertNotCurrentExecution(
 	runID string,
 ) error {
 
-	if resp, err := d.GetCurrentExecution(&p.GetCurrentExecutionRequest{
+	if resp, err := d.GetCurrentExecution(context.TODO(), &p.GetCurrentExecutionRequest{
 		ShardID:     shardID,
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
@@ -889,6 +894,7 @@ func (d *MutableStateStore) assertNotCurrentExecution(
 }
 
 func (d *MutableStateStore) DeleteWorkflowExecution(
+	_ context.Context,
 	request *p.DeleteWorkflowExecutionRequest,
 ) error {
 	query := d.Session.Query(templateDeleteWorkflowExecutionMutableStateQuery,
@@ -905,6 +911,7 @@ func (d *MutableStateStore) DeleteWorkflowExecution(
 }
 
 func (d *MutableStateStore) DeleteCurrentWorkflowExecution(
+	_ context.Context,
 	request *p.DeleteCurrentWorkflowExecutionRequest,
 ) error {
 	query := d.Session.Query(templateDeleteWorkflowExecutionCurrentRowQuery,
@@ -922,6 +929,7 @@ func (d *MutableStateStore) DeleteCurrentWorkflowExecution(
 }
 
 func (d *MutableStateStore) GetCurrentExecution(
+	_ context.Context,
 	request *p.GetCurrentExecutionRequest,
 ) (*p.InternalGetCurrentExecutionResponse, error) {
 	query := d.Session.Query(templateGetCurrentExecutionQuery,
@@ -957,6 +965,7 @@ func (d *MutableStateStore) GetCurrentExecution(
 }
 
 func (d *MutableStateStore) SetWorkflowExecution(
+	_ context.Context,
 	request *p.InternalSetWorkflowExecutionRequest,
 ) error {
 	batch := d.Session.NewBatch(gocql.LoggedBatch)
@@ -1011,6 +1020,7 @@ func (d *MutableStateStore) SetWorkflowExecution(
 }
 
 func (d *MutableStateStore) ListConcreteExecutions(
+	_ context.Context,
 	request *p.ListConcreteExecutionsRequest,
 ) (*p.InternalListConcreteExecutionsResponse, error) {
 	query := d.Session.Query(

--- a/common/persistence/cassandra/mutable_state_task_store.go
+++ b/common/persistence/cassandra/mutable_state_task_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 
 	"go.temporal.io/api/serviceerror"
@@ -241,6 +242,7 @@ func NewMutableStateTaskStore(
 }
 
 func (d *MutableStateTaskStore) AddHistoryTasks(
+	_ context.Context,
 	request *p.InternalAddHistoryTasksRequest,
 ) error {
 	batch := d.Session.NewBatch(gocql.LoggedBatch)
@@ -289,6 +291,7 @@ func (d *MutableStateTaskStore) AddHistoryTasks(
 }
 
 func (d *MutableStateTaskStore) GetHistoryTask(
+	_ context.Context,
 	request *p.GetHistoryTaskRequest,
 ) (*p.InternalGetHistoryTaskResponse, error) {
 	switch request.TaskCategory.ID() {
@@ -306,6 +309,7 @@ func (d *MutableStateTaskStore) GetHistoryTask(
 }
 
 func (d *MutableStateTaskStore) GetHistoryTasks(
+	_ context.Context,
 	request *p.GetHistoryTasksRequest,
 ) (*p.InternalGetHistoryTasksResponse, error) {
 	switch request.TaskCategory.ID() {
@@ -323,6 +327,7 @@ func (d *MutableStateTaskStore) GetHistoryTasks(
 }
 
 func (d *MutableStateTaskStore) CompleteHistoryTask(
+	_ context.Context,
 	request *p.CompleteHistoryTaskRequest,
 ) error {
 	switch request.TaskCategory.ID() {
@@ -340,6 +345,7 @@ func (d *MutableStateTaskStore) CompleteHistoryTask(
 }
 
 func (d *MutableStateTaskStore) RangeCompleteHistoryTasks(
+	_ context.Context,
 	request *p.RangeCompleteHistoryTasksRequest,
 ) error {
 	switch request.TaskCategory.ID() {
@@ -628,6 +634,7 @@ func (d *MutableStateTaskStore) rangeCompleteReplicationTasks(
 }
 
 func (d *MutableStateTaskStore) PutReplicationTaskToDLQ(
+	_ context.Context,
 	request *p.PutReplicationTaskToDLQRequest,
 ) error {
 	task := request.TaskInfo
@@ -657,6 +664,7 @@ func (d *MutableStateTaskStore) PutReplicationTaskToDLQ(
 }
 
 func (d *MutableStateTaskStore) GetReplicationTasksFromDLQ(
+	_ context.Context,
 	request *p.GetReplicationTasksFromDLQRequest,
 ) (*p.InternalGetHistoryTasksResponse, error) {
 	// Reading replication tasks need to be quorum level consistent, otherwise we could lose tasks
@@ -675,6 +683,7 @@ func (d *MutableStateTaskStore) GetReplicationTasksFromDLQ(
 }
 
 func (d *MutableStateTaskStore) DeleteReplicationTaskFromDLQ(
+	_ context.Context,
 	request *p.DeleteReplicationTaskFromDLQRequest,
 ) error {
 
@@ -693,6 +702,7 @@ func (d *MutableStateTaskStore) DeleteReplicationTaskFromDLQ(
 }
 
 func (d *MutableStateTaskStore) RangeDeleteReplicationTaskFromDLQ(
+	_ context.Context,
 	request *p.RangeDeleteReplicationTaskFromDLQRequest,
 ) error {
 

--- a/common/persistence/cassandra/queue_store.go
+++ b/common/persistence/cassandra/queue_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -72,7 +73,10 @@ func NewQueueStore(
 	}, nil
 }
 
-func (q *QueueStore) Init(blob *commonpb.DataBlob) error {
+func (q *QueueStore) Init(
+	_ context.Context,
+	blob *commonpb.DataBlob,
+) error {
 	if err := q.initializeQueueMetadata(blob); err != nil {
 		return err
 	}
@@ -84,6 +88,7 @@ func (q *QueueStore) Init(blob *commonpb.DataBlob) error {
 }
 
 func (q *QueueStore) EnqueueMessage(
+	_ context.Context,
 	blob commonpb.DataBlob,
 ) error {
 	lastMessageID, err := q.getLastMessageID(q.queueType)
@@ -96,6 +101,7 @@ func (q *QueueStore) EnqueueMessage(
 }
 
 func (q *QueueStore) EnqueueMessageToDLQ(
+	_ context.Context,
 	blob commonpb.DataBlob,
 ) (int64, error) {
 	// Use negative queue type as the dlq type
@@ -144,6 +150,7 @@ func (q *QueueStore) getLastMessageID(
 }
 
 func (q *QueueStore) ReadMessages(
+	_ context.Context,
 	lastMessageID int64,
 	maxCount int,
 ) ([]*persistence.QueueMessage, error) {
@@ -172,6 +179,7 @@ func (q *QueueStore) ReadMessages(
 }
 
 func (q *QueueStore) ReadMessagesFromDLQ(
+	_ context.Context,
 	firstMessageID int64,
 	lastMessageID int64,
 	pageSize int,
@@ -206,6 +214,7 @@ func (q *QueueStore) ReadMessagesFromDLQ(
 }
 
 func (q *QueueStore) DeleteMessagesBefore(
+	_ context.Context,
 	messageID int64,
 ) error {
 
@@ -217,6 +226,7 @@ func (q *QueueStore) DeleteMessagesBefore(
 }
 
 func (q *QueueStore) DeleteMessageFromDLQ(
+	_ context.Context,
 	messageID int64,
 ) error {
 
@@ -230,6 +240,7 @@ func (q *QueueStore) DeleteMessageFromDLQ(
 }
 
 func (q *QueueStore) RangeDeleteMessagesFromDLQ(
+	_ context.Context,
 	firstMessageID int64,
 	lastMessageID int64,
 ) error {
@@ -243,11 +254,16 @@ func (q *QueueStore) RangeDeleteMessagesFromDLQ(
 	return nil
 }
 
-func (q *QueueStore) UpdateAckLevel(metadata *persistence.InternalQueueMetadata) error {
+func (q *QueueStore) UpdateAckLevel(
+	_ context.Context,
+	metadata *persistence.InternalQueueMetadata,
+) error {
 	return q.updateAckLevel(metadata, q.queueType)
 }
 
-func (q *QueueStore) GetAckLevels() (*persistence.InternalQueueMetadata, error) {
+func (q *QueueStore) GetAckLevels(
+	_ context.Context,
+) (*persistence.InternalQueueMetadata, error) {
 	queueMetadata, err := q.getQueueMetadata(q.queueType)
 	if err != nil {
 		return nil, gocql.ConvertError("GetAckLevels", err)
@@ -256,11 +272,16 @@ func (q *QueueStore) GetAckLevels() (*persistence.InternalQueueMetadata, error) 
 	return queueMetadata, nil
 }
 
-func (q *QueueStore) UpdateDLQAckLevel(metadata *persistence.InternalQueueMetadata) error {
+func (q *QueueStore) UpdateDLQAckLevel(
+	_ context.Context,
+	metadata *persistence.InternalQueueMetadata,
+) error {
 	return q.updateAckLevel(metadata, q.getDLQTypeFromQueueType())
 }
 
-func (q *QueueStore) GetDLQAckLevels() (*persistence.InternalQueueMetadata, error) {
+func (q *QueueStore) GetDLQAckLevels(
+	_ context.Context,
+) (*persistence.InternalQueueMetadata, error) {
 	// Use negative queue type as the dlq type
 	queueMetadata, err := q.getQueueMetadata(q.getDLQTypeFromQueueType())
 	if err != nil {

--- a/common/persistence/cassandra/shard_store.go
+++ b/common/persistence/cassandra/shard_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -81,6 +82,7 @@ func NewShardStore(
 }
 
 func (d *ShardStore) GetOrCreateShard(
+	_ context.Context,
 	request *p.InternalGetOrCreateShardRequest,
 ) (*p.InternalGetOrCreateShardResponse, error) {
 	query := d.Session.Query(templateGetShardQuery,
@@ -129,7 +131,7 @@ func (d *ShardStore) GetOrCreateShard(
 	if !applied {
 		// conflict, try again
 		request.CreateShardInfo = nil // prevent loop
-		return d.GetOrCreateShard(request)
+		return d.GetOrCreateShard(context.TODO(), request)
 	}
 	return &p.InternalGetOrCreateShardResponse{
 		ShardInfo: shardInfo,
@@ -137,6 +139,7 @@ func (d *ShardStore) GetOrCreateShard(
 }
 
 func (d *ShardStore) UpdateShard(
+	_ context.Context,
 	request *p.InternalUpdateShardRequest,
 ) error {
 	query := d.Session.Query(templateUpdateShardQuery,

--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -25,6 +25,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -253,57 +254,79 @@ func (q *FaultInjectionQueue) Close() {
 	q.baseQueue.Close()
 }
 
-func (q *FaultInjectionQueue) Init(blob *commonpb.DataBlob) error {
+func (q *FaultInjectionQueue) Init(
+	ctx context.Context,
+	blob *commonpb.DataBlob,
+) error {
 	// potentially Init can return golang errors from blob.go encode/decode.
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return q.baseQueue.Init(blob)
+	return q.baseQueue.Init(ctx, blob)
 }
 
-func (q *FaultInjectionQueue) EnqueueMessage(blob commonpb.DataBlob) error {
+func (q *FaultInjectionQueue) EnqueueMessage(
+	ctx context.Context,
+	blob commonpb.DataBlob,
+) error {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return q.baseQueue.EnqueueMessage(blob)
+	return q.baseQueue.EnqueueMessage(ctx, blob)
 }
 
-func (q *FaultInjectionQueue) ReadMessages(lastMessageID int64, maxCount int) ([]*persistence.QueueMessage, error) {
+func (q *FaultInjectionQueue) ReadMessages(
+	ctx context.Context,
+	lastMessageID int64,
+	maxCount int,
+) ([]*persistence.QueueMessage, error) {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return q.baseQueue.ReadMessages(lastMessageID, maxCount)
+	return q.baseQueue.ReadMessages(ctx, lastMessageID, maxCount)
 }
 
-func (q *FaultInjectionQueue) DeleteMessagesBefore(messageID int64) error {
+func (q *FaultInjectionQueue) DeleteMessagesBefore(
+	ctx context.Context,
+	messageID int64,
+) error {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return q.baseQueue.DeleteMessagesBefore(messageID)
+	return q.baseQueue.DeleteMessagesBefore(ctx, messageID)
 }
 
-func (q *FaultInjectionQueue) UpdateAckLevel(metadata *persistence.InternalQueueMetadata) error {
+func (q *FaultInjectionQueue) UpdateAckLevel(
+	ctx context.Context,
+	metadata *persistence.InternalQueueMetadata,
+) error {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return q.baseQueue.UpdateAckLevel(metadata)
+	return q.baseQueue.UpdateAckLevel(ctx, metadata)
 }
 
-func (q *FaultInjectionQueue) GetAckLevels() (*persistence.InternalQueueMetadata, error) {
+func (q *FaultInjectionQueue) GetAckLevels(
+	ctx context.Context,
+) (*persistence.InternalQueueMetadata, error) {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return q.baseQueue.GetAckLevels()
+	return q.baseQueue.GetAckLevels(ctx)
 }
 
-func (q *FaultInjectionQueue) EnqueueMessageToDLQ(blob commonpb.DataBlob) (int64, error) {
+func (q *FaultInjectionQueue) EnqueueMessageToDLQ(
+	ctx context.Context,
+	blob commonpb.DataBlob,
+) (int64, error) {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return 0, err
 	}
-	return q.baseQueue.EnqueueMessageToDLQ(blob)
+	return q.baseQueue.EnqueueMessageToDLQ(ctx, blob)
 }
 
 func (q *FaultInjectionQueue) ReadMessagesFromDLQ(
+	ctx context.Context,
 	firstMessageID int64,
 	lastMessageID int64,
 	pageSize int,
@@ -312,45 +335,57 @@ func (q *FaultInjectionQueue) ReadMessagesFromDLQ(
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return nil, nil, err
 	}
-	return q.baseQueue.ReadMessagesFromDLQ(firstMessageID, lastMessageID, pageSize, pageToken)
+	return q.baseQueue.ReadMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 }
 
-func (q *FaultInjectionQueue) DeleteMessageFromDLQ(messageID int64) error {
+func (q *FaultInjectionQueue) DeleteMessageFromDLQ(
+	ctx context.Context,
+	messageID int64,
+) error {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return q.baseQueue.DeleteMessageFromDLQ(messageID)
+	return q.baseQueue.DeleteMessageFromDLQ(ctx, messageID)
 }
 
-func (q *FaultInjectionQueue) RangeDeleteMessagesFromDLQ(firstMessageID int64, lastMessageID int64) error {
+func (q *FaultInjectionQueue) RangeDeleteMessagesFromDLQ(
+	ctx context.Context,
+	firstMessageID int64,
+	lastMessageID int64,
+) error {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return q.baseQueue.RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID)
+	return q.baseQueue.RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID)
 }
 
-func (q *FaultInjectionQueue) UpdateDLQAckLevel(metadata *persistence.InternalQueueMetadata) error {
+func (q *FaultInjectionQueue) UpdateDLQAckLevel(
+	ctx context.Context,
+	metadata *persistence.InternalQueueMetadata,
+) error {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return q.baseQueue.UpdateDLQAckLevel(metadata)
+	return q.baseQueue.UpdateDLQAckLevel(ctx, metadata)
 }
 
-func (q *FaultInjectionQueue) GetDLQAckLevels() (*persistence.InternalQueueMetadata, error) {
+func (q *FaultInjectionQueue) GetDLQAckLevels(
+	ctx context.Context,
+) (*persistence.InternalQueueMetadata, error) {
 	if err := q.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return q.baseQueue.GetDLQAckLevels()
+	return q.baseQueue.GetDLQAckLevels(ctx)
 }
 
 func (q *FaultInjectionQueue) UpdateRate(rate float64) {
 	q.ErrorGenerator.UpdateRate(rate)
 }
 
-func NewFaultInjectionExecutionStore(rate float64, executionStore persistence.ExecutionStore) (
-	*FaultInjectionExecutionStore,
-	error,
-) {
+func NewFaultInjectionExecutionStore(
+	rate float64,
+	executionStore persistence.ExecutionStore,
+) (*FaultInjectionExecutionStore, error) {
 	errorGenerator := newErrorGenerator(
 		rate,
 		append(
@@ -380,219 +415,267 @@ func (e *FaultInjectionExecutionStore) GetName() string {
 	return e.baseExecutionStore.GetName()
 }
 
-func (e *FaultInjectionExecutionStore) GetWorkflowExecution(request *persistence.GetWorkflowExecutionRequest) (
-	*persistence.InternalGetWorkflowExecutionResponse,
-	error,
-) {
+func (e *FaultInjectionExecutionStore) GetWorkflowExecution(
+	ctx context.Context,
+	request *persistence.GetWorkflowExecutionRequest,
+) (*persistence.InternalGetWorkflowExecutionResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.GetWorkflowExecution(request)
+	return e.baseExecutionStore.GetWorkflowExecution(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) SetWorkflowExecution(request *persistence.InternalSetWorkflowExecutionRequest) error {
+func (e *FaultInjectionExecutionStore) SetWorkflowExecution(
+	ctx context.Context,
+	request *persistence.InternalSetWorkflowExecutionRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.SetWorkflowExecution(request)
+	return e.baseExecutionStore.SetWorkflowExecution(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) UpdateWorkflowExecution(request *persistence.InternalUpdateWorkflowExecutionRequest) error {
+func (e *FaultInjectionExecutionStore) UpdateWorkflowExecution(
+	ctx context.Context,
+	request *persistence.InternalUpdateWorkflowExecutionRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.UpdateWorkflowExecution(request)
+	return e.baseExecutionStore.UpdateWorkflowExecution(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) ConflictResolveWorkflowExecution(request *persistence.InternalConflictResolveWorkflowExecutionRequest) error {
+func (e *FaultInjectionExecutionStore) ConflictResolveWorkflowExecution(
+	ctx context.Context,
+	request *persistence.InternalConflictResolveWorkflowExecutionRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.ConflictResolveWorkflowExecution(request)
+	return e.baseExecutionStore.ConflictResolveWorkflowExecution(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) CreateWorkflowExecution(request *persistence.InternalCreateWorkflowExecutionRequest) (
-	*persistence.InternalCreateWorkflowExecutionResponse,
-	error,
-) {
+func (e *FaultInjectionExecutionStore) CreateWorkflowExecution(
+	ctx context.Context,
+	request *persistence.InternalCreateWorkflowExecutionRequest,
+) (*persistence.InternalCreateWorkflowExecutionResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.CreateWorkflowExecution(request)
+	return e.baseExecutionStore.CreateWorkflowExecution(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) DeleteWorkflowExecution(request *persistence.DeleteWorkflowExecutionRequest) error {
+func (e *FaultInjectionExecutionStore) DeleteWorkflowExecution(
+	ctx context.Context,
+	request *persistence.DeleteWorkflowExecutionRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.DeleteWorkflowExecution(request)
+	return e.baseExecutionStore.DeleteWorkflowExecution(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) DeleteCurrentWorkflowExecution(request *persistence.DeleteCurrentWorkflowExecutionRequest) error {
+func (e *FaultInjectionExecutionStore) DeleteCurrentWorkflowExecution(
+	ctx context.Context,
+	request *persistence.DeleteCurrentWorkflowExecutionRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.DeleteCurrentWorkflowExecution(request)
+	return e.baseExecutionStore.DeleteCurrentWorkflowExecution(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) GetCurrentExecution(request *persistence.GetCurrentExecutionRequest) (
-	*persistence.InternalGetCurrentExecutionResponse,
-	error,
-) {
+func (e *FaultInjectionExecutionStore) GetCurrentExecution(
+	ctx context.Context,
+	request *persistence.GetCurrentExecutionRequest,
+) (*persistence.InternalGetCurrentExecutionResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.GetCurrentExecution(request)
+	return e.baseExecutionStore.GetCurrentExecution(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) ListConcreteExecutions(request *persistence.ListConcreteExecutionsRequest) (
-	*persistence.InternalListConcreteExecutionsResponse,
-	error,
-) {
+func (e *FaultInjectionExecutionStore) ListConcreteExecutions(
+	ctx context.Context,
+	request *persistence.ListConcreteExecutionsRequest,
+) (*persistence.InternalListConcreteExecutionsResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.ListConcreteExecutions(request)
+	return e.baseExecutionStore.ListConcreteExecutions(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) AddHistoryTasks(request *persistence.InternalAddHistoryTasksRequest) error {
+func (e *FaultInjectionExecutionStore) AddHistoryTasks(
+	ctx context.Context,
+	request *persistence.InternalAddHistoryTasksRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.AddHistoryTasks(request)
+	return e.baseExecutionStore.AddHistoryTasks(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) GetHistoryTask(request *persistence.GetHistoryTaskRequest) (
-	*persistence.InternalGetHistoryTaskResponse,
-	error,
-) {
+func (e *FaultInjectionExecutionStore) GetHistoryTask(
+	ctx context.Context,
+	request *persistence.GetHistoryTaskRequest,
+) (*persistence.InternalGetHistoryTaskResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.GetHistoryTask(request)
+	return e.baseExecutionStore.GetHistoryTask(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) GetHistoryTasks(request *persistence.GetHistoryTasksRequest) (
+func (e *FaultInjectionExecutionStore) GetHistoryTasks(
+	ctx context.Context,
+	request *persistence.GetHistoryTasksRequest,
+) (*persistence.InternalGetHistoryTasksResponse, error) {
+	if err := e.ErrorGenerator.Generate(); err != nil {
+		return nil, err
+	}
+	return e.baseExecutionStore.GetHistoryTasks(ctx, request)
+}
+
+func (e *FaultInjectionExecutionStore) CompleteHistoryTask(
+	ctx context.Context,
+	request *persistence.CompleteHistoryTaskRequest,
+) error {
+	if err := e.ErrorGenerator.Generate(); err != nil {
+		return err
+	}
+	return e.baseExecutionStore.CompleteHistoryTask(ctx, request)
+}
+
+func (e *FaultInjectionExecutionStore) RangeCompleteHistoryTasks(
+	ctx context.Context,
+	request *persistence.RangeCompleteHistoryTasksRequest,
+) error {
+	if err := e.ErrorGenerator.Generate(); err != nil {
+		return err
+	}
+	return e.baseExecutionStore.RangeCompleteHistoryTasks(ctx, request)
+}
+
+func (e *FaultInjectionExecutionStore) PutReplicationTaskToDLQ(
+	ctx context.Context,
+	request *persistence.PutReplicationTaskToDLQRequest,
+) error {
+	if err := e.ErrorGenerator.Generate(); err != nil {
+		return err
+	}
+	return e.baseExecutionStore.PutReplicationTaskToDLQ(ctx, request)
+}
+
+func (e *FaultInjectionExecutionStore) GetReplicationTasksFromDLQ(
+	ctx context.Context,
+	request *persistence.GetReplicationTasksFromDLQRequest,
+) (
 	*persistence.InternalGetHistoryTasksResponse,
 	error,
 ) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.GetHistoryTasks(request)
+	return e.baseExecutionStore.GetReplicationTasksFromDLQ(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) CompleteHistoryTask(request *persistence.CompleteHistoryTaskRequest) error {
+func (e *FaultInjectionExecutionStore) DeleteReplicationTaskFromDLQ(
+	ctx context.Context,
+	request *persistence.DeleteReplicationTaskFromDLQRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.CompleteHistoryTask(request)
+	return e.baseExecutionStore.DeleteReplicationTaskFromDLQ(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) RangeCompleteHistoryTasks(request *persistence.RangeCompleteHistoryTasksRequest) error {
+func (e *FaultInjectionExecutionStore) RangeDeleteReplicationTaskFromDLQ(
+	ctx context.Context,
+	request *persistence.RangeDeleteReplicationTaskFromDLQRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.RangeCompleteHistoryTasks(request)
+	return e.baseExecutionStore.RangeDeleteReplicationTaskFromDLQ(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) PutReplicationTaskToDLQ(request *persistence.PutReplicationTaskToDLQRequest) error {
+func (e *FaultInjectionExecutionStore) AppendHistoryNodes(
+	ctx context.Context,
+	request *persistence.InternalAppendHistoryNodesRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.PutReplicationTaskToDLQ(request)
+	return e.baseExecutionStore.AppendHistoryNodes(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) GetReplicationTasksFromDLQ(request *persistence.GetReplicationTasksFromDLQRequest) (
-	*persistence.InternalGetHistoryTasksResponse,
-	error,
-) {
+func (e *FaultInjectionExecutionStore) DeleteHistoryNodes(
+	ctx context.Context,
+	request *persistence.InternalDeleteHistoryNodesRequest,
+) error {
+	if err := e.ErrorGenerator.Generate(); err != nil {
+		return err
+	}
+	return e.baseExecutionStore.DeleteHistoryNodes(ctx, request)
+}
+
+func (e *FaultInjectionExecutionStore) ReadHistoryBranch(
+	ctx context.Context,
+	request *persistence.InternalReadHistoryBranchRequest,
+) (*persistence.InternalReadHistoryBranchResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.GetReplicationTasksFromDLQ(request)
+	return e.baseExecutionStore.ReadHistoryBranch(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) DeleteReplicationTaskFromDLQ(request *persistence.DeleteReplicationTaskFromDLQRequest) error {
+func (e *FaultInjectionExecutionStore) ForkHistoryBranch(
+	ctx context.Context,
+	request *persistence.InternalForkHistoryBranchRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.DeleteReplicationTaskFromDLQ(request)
+	return e.baseExecutionStore.ForkHistoryBranch(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) RangeDeleteReplicationTaskFromDLQ(request *persistence.RangeDeleteReplicationTaskFromDLQRequest) error {
+func (e *FaultInjectionExecutionStore) DeleteHistoryBranch(
+	ctx context.Context,
+	request *persistence.InternalDeleteHistoryBranchRequest,
+) error {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return e.baseExecutionStore.RangeDeleteReplicationTaskFromDLQ(request)
+	return e.baseExecutionStore.DeleteHistoryBranch(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) AppendHistoryNodes(request *persistence.InternalAppendHistoryNodesRequest) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.AppendHistoryNodes(request)
-}
-
-func (e *FaultInjectionExecutionStore) DeleteHistoryNodes(request *persistence.InternalDeleteHistoryNodesRequest) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.DeleteHistoryNodes(request)
-}
-
-func (e *FaultInjectionExecutionStore) ReadHistoryBranch(request *persistence.InternalReadHistoryBranchRequest) (
-	*persistence.InternalReadHistoryBranchResponse,
-	error,
-) {
+func (e *FaultInjectionExecutionStore) GetHistoryTree(
+	ctx context.Context,
+	request *persistence.GetHistoryTreeRequest,
+) (*persistence.InternalGetHistoryTreeResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.ReadHistoryBranch(request)
+	return e.baseExecutionStore.GetHistoryTree(ctx, request)
 }
 
-func (e *FaultInjectionExecutionStore) ForkHistoryBranch(request *persistence.InternalForkHistoryBranchRequest) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.ForkHistoryBranch(request)
-}
-
-func (e *FaultInjectionExecutionStore) DeleteHistoryBranch(request *persistence.InternalDeleteHistoryBranchRequest) error {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return err
-	}
-	return e.baseExecutionStore.DeleteHistoryBranch(request)
-}
-
-func (e *FaultInjectionExecutionStore) GetHistoryTree(request *persistence.GetHistoryTreeRequest) (
-	*persistence.InternalGetHistoryTreeResponse,
-	error,
-) {
+func (e *FaultInjectionExecutionStore) GetAllHistoryTreeBranches(
+	ctx context.Context,
+	request *persistence.GetAllHistoryTreeBranchesRequest,
+) (*persistence.InternalGetAllHistoryTreeBranchesResponse, error) {
 	if err := e.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return e.baseExecutionStore.GetHistoryTree(request)
-}
-
-func (e *FaultInjectionExecutionStore) GetAllHistoryTreeBranches(request *persistence.GetAllHistoryTreeBranchesRequest) (
-	*persistence.InternalGetAllHistoryTreeBranchesResponse,
-	error,
-) {
-	if err := e.ErrorGenerator.Generate(); err != nil {
-		return nil, err
-	}
-	return e.baseExecutionStore.GetAllHistoryTreeBranches(request)
+	return e.baseExecutionStore.GetAllHistoryTreeBranches(ctx, request)
 }
 
 func (e *FaultInjectionExecutionStore) UpdateRate(rate float64) {
 	e.ErrorGenerator.UpdateRate(rate)
 }
 
-func NewFaultInjectionClusterMetadataStore(rate float64, baseStore persistence.ClusterMetadataStore) (
-	*FaultInjectionClusterMetadataStore,
-	error,
-) {
+func NewFaultInjectionClusterMetadataStore(
+	rate float64,
+	baseStore persistence.ClusterMetadataStore,
+) (*FaultInjectionClusterMetadataStore, error) {
 	errorGenerator := newErrorGenerator(rate, defaultErrors)
 	return &FaultInjectionClusterMetadataStore{
 		baseCMStore:    baseStore,
@@ -608,66 +691,74 @@ func (c *FaultInjectionClusterMetadataStore) GetName() string {
 	return c.baseCMStore.GetName()
 }
 
-func (c *FaultInjectionClusterMetadataStore) ListClusterMetadata(request *persistence.InternalListClusterMetadataRequest) (
-	*persistence.InternalListClusterMetadataResponse,
-	error,
-) {
+func (c *FaultInjectionClusterMetadataStore) ListClusterMetadata(
+	ctx context.Context,
+	request *persistence.InternalListClusterMetadataRequest,
+) (*persistence.InternalListClusterMetadataResponse, error) {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return c.baseCMStore.ListClusterMetadata(request)
+	return c.baseCMStore.ListClusterMetadata(ctx, request)
 }
 
-func (c *FaultInjectionClusterMetadataStore) GetClusterMetadata(request *persistence.InternalGetClusterMetadataRequest) (
-	*persistence.InternalGetClusterMetadataResponse,
-	error,
-) {
+func (c *FaultInjectionClusterMetadataStore) GetClusterMetadata(
+	ctx context.Context,
+	request *persistence.InternalGetClusterMetadataRequest,
+) (*persistence.InternalGetClusterMetadataResponse, error) {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return c.baseCMStore.GetClusterMetadata(request)
+	return c.baseCMStore.GetClusterMetadata(ctx, request)
 }
 
 func (c *FaultInjectionClusterMetadataStore) SaveClusterMetadata(
+	ctx context.Context,
 	request *persistence.InternalSaveClusterMetadataRequest,
 ) (bool, error) {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return false, err
 	}
-	return c.baseCMStore.SaveClusterMetadata(request)
+	return c.baseCMStore.SaveClusterMetadata(ctx, request)
 }
 
 func (c *FaultInjectionClusterMetadataStore) DeleteClusterMetadata(
+	ctx context.Context,
 	request *persistence.InternalDeleteClusterMetadataRequest,
 ) error {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return c.baseCMStore.DeleteClusterMetadata(request)
+	return c.baseCMStore.DeleteClusterMetadata(ctx, request)
 }
 
-func (c *FaultInjectionClusterMetadataStore) GetClusterMembers(request *persistence.GetClusterMembersRequest) (
-	*persistence.GetClusterMembersResponse,
-	error,
-) {
+func (c *FaultInjectionClusterMetadataStore) GetClusterMembers(
+	ctx context.Context,
+	request *persistence.GetClusterMembersRequest,
+) (*persistence.GetClusterMembersResponse, error) {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return c.baseCMStore.GetClusterMembers(request)
+	return c.baseCMStore.GetClusterMembers(ctx, request)
 }
 
-func (c *FaultInjectionClusterMetadataStore) UpsertClusterMembership(request *persistence.UpsertClusterMembershipRequest) error {
+func (c *FaultInjectionClusterMetadataStore) UpsertClusterMembership(
+	ctx context.Context,
+	request *persistence.UpsertClusterMembershipRequest,
+) error {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return c.baseCMStore.UpsertClusterMembership(request)
+	return c.baseCMStore.UpsertClusterMembership(ctx, request)
 }
 
-func (c *FaultInjectionClusterMetadataStore) PruneClusterMembership(request *persistence.PruneClusterMembershipRequest) error {
+func (c *FaultInjectionClusterMetadataStore) PruneClusterMembership(
+	ctx context.Context,
+	request *persistence.PruneClusterMembershipRequest,
+) error {
 	if err := c.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return c.baseCMStore.PruneClusterMembership(request)
+	return c.baseCMStore.PruneClusterMembership(ctx, request)
 }
 
 func (c *FaultInjectionClusterMetadataStore) UpdateRate(rate float64) {
@@ -693,69 +784,83 @@ func (m *FaultInjectionMetadataStore) GetName() string {
 	return m.baseMetadataStore.GetName()
 }
 
-func (m *FaultInjectionMetadataStore) CreateNamespace(request *persistence.InternalCreateNamespaceRequest) (
-	*persistence.CreateNamespaceResponse,
-	error,
-) {
+func (m *FaultInjectionMetadataStore) CreateNamespace(
+	ctx context.Context,
+	request *persistence.InternalCreateNamespaceRequest,
+) (*persistence.CreateNamespaceResponse, error) {
 	if err := m.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return m.baseMetadataStore.CreateNamespace(request)
+	return m.baseMetadataStore.CreateNamespace(ctx, request)
 }
 
-func (m *FaultInjectionMetadataStore) GetNamespace(request *persistence.GetNamespaceRequest) (
-	*persistence.InternalGetNamespaceResponse,
-	error,
-) {
+func (m *FaultInjectionMetadataStore) GetNamespace(
+	ctx context.Context,
+	request *persistence.GetNamespaceRequest,
+) (*persistence.InternalGetNamespaceResponse, error) {
 	if err := m.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return m.baseMetadataStore.GetNamespace(request)
+	return m.baseMetadataStore.GetNamespace(ctx, request)
 }
 
-func (m *FaultInjectionMetadataStore) UpdateNamespace(request *persistence.InternalUpdateNamespaceRequest) error {
+func (m *FaultInjectionMetadataStore) UpdateNamespace(
+	ctx context.Context,
+	request *persistence.InternalUpdateNamespaceRequest,
+) error {
 	if err := m.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return m.baseMetadataStore.UpdateNamespace(request)
+	return m.baseMetadataStore.UpdateNamespace(ctx, request)
 }
 
-func (m *FaultInjectionMetadataStore) RenameNamespace(request *persistence.InternalRenameNamespaceRequest) error {
+func (m *FaultInjectionMetadataStore) RenameNamespace(
+	ctx context.Context,
+	request *persistence.InternalRenameNamespaceRequest,
+) error {
 	if err := m.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return m.baseMetadataStore.RenameNamespace(request)
+	return m.baseMetadataStore.RenameNamespace(ctx, request)
 }
 
-func (m *FaultInjectionMetadataStore) DeleteNamespace(request *persistence.DeleteNamespaceRequest) error {
+func (m *FaultInjectionMetadataStore) DeleteNamespace(
+	ctx context.Context,
+	request *persistence.DeleteNamespaceRequest,
+) error {
 	if err := m.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return m.baseMetadataStore.DeleteNamespace(request)
+	return m.baseMetadataStore.DeleteNamespace(ctx, request)
 }
 
-func (m *FaultInjectionMetadataStore) DeleteNamespaceByName(request *persistence.DeleteNamespaceByNameRequest) error {
+func (m *FaultInjectionMetadataStore) DeleteNamespaceByName(
+	ctx context.Context,
+	request *persistence.DeleteNamespaceByNameRequest,
+) error {
 	if err := m.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return m.baseMetadataStore.DeleteNamespaceByName(request)
+	return m.baseMetadataStore.DeleteNamespaceByName(ctx, request)
 }
 
-func (m *FaultInjectionMetadataStore) ListNamespaces(request *persistence.InternalListNamespacesRequest) (
-	*persistence.InternalListNamespacesResponse,
-	error,
-) {
+func (m *FaultInjectionMetadataStore) ListNamespaces(
+	ctx context.Context,
+	request *persistence.InternalListNamespacesRequest,
+) (*persistence.InternalListNamespacesResponse, error) {
 	if err := m.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return m.baseMetadataStore.ListNamespaces(request)
+	return m.baseMetadataStore.ListNamespaces(ctx, request)
 }
 
-func (m *FaultInjectionMetadataStore) GetMetadata() (*persistence.GetMetadataResponse, error) {
+func (m *FaultInjectionMetadataStore) GetMetadata(
+	ctx context.Context,
+) (*persistence.GetMetadataResponse, error) {
 	if err := m.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return m.baseMetadataStore.GetMetadata()
+	return m.baseMetadataStore.GetMetadata(ctx)
 }
 
 func (m *FaultInjectionMetadataStore) UpdateRate(rate float64) {
@@ -782,85 +887,94 @@ func (t *FaultInjectionTaskStore) GetName() string {
 	return t.baseTaskStore.GetName()
 }
 
-func (t *FaultInjectionTaskStore) CreateTaskQueue(request *persistence.InternalCreateTaskQueueRequest) error {
+func (t *FaultInjectionTaskStore) CreateTaskQueue(
+	ctx context.Context,
+	request *persistence.InternalCreateTaskQueueRequest,
+) error {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return t.baseTaskStore.CreateTaskQueue(request)
+	return t.baseTaskStore.CreateTaskQueue(ctx, request)
 }
 
-func (t *FaultInjectionTaskStore) GetTaskQueue(request *persistence.InternalGetTaskQueueRequest) (
-	*persistence.InternalGetTaskQueueResponse,
-	error,
-) {
+func (t *FaultInjectionTaskStore) GetTaskQueue(
+	ctx context.Context,
+	request *persistence.InternalGetTaskQueueRequest,
+) (*persistence.InternalGetTaskQueueResponse, error) {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return t.baseTaskStore.GetTaskQueue(request)
+	return t.baseTaskStore.GetTaskQueue(ctx, request)
 }
 
-func (t *FaultInjectionTaskStore) UpdateTaskQueue(request *persistence.InternalUpdateTaskQueueRequest) (
-	*persistence.UpdateTaskQueueResponse,
-	error,
-) {
+func (t *FaultInjectionTaskStore) UpdateTaskQueue(
+	ctx context.Context,
+	request *persistence.InternalUpdateTaskQueueRequest,
+) (*persistence.UpdateTaskQueueResponse, error) {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return t.baseTaskStore.UpdateTaskQueue(request)
+	return t.baseTaskStore.UpdateTaskQueue(ctx, request)
 }
 
-func (t *FaultInjectionTaskStore) ListTaskQueue(request *persistence.ListTaskQueueRequest) (
-	*persistence.InternalListTaskQueueResponse,
-	error,
-) {
+func (t *FaultInjectionTaskStore) ListTaskQueue(
+	ctx context.Context,
+	request *persistence.ListTaskQueueRequest,
+) (*persistence.InternalListTaskQueueResponse, error) {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return t.baseTaskStore.ListTaskQueue(request)
+	return t.baseTaskStore.ListTaskQueue(ctx, request)
 }
 
-func (t *FaultInjectionTaskStore) DeleteTaskQueue(request *persistence.DeleteTaskQueueRequest) error {
+func (t *FaultInjectionTaskStore) DeleteTaskQueue(
+	ctx context.Context,
+	request *persistence.DeleteTaskQueueRequest,
+) error {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return t.baseTaskStore.DeleteTaskQueue(request)
+	return t.baseTaskStore.DeleteTaskQueue(ctx, request)
 }
 
-func (t *FaultInjectionTaskStore) CreateTasks(request *persistence.InternalCreateTasksRequest) (
-	*persistence.CreateTasksResponse,
-	error,
-) {
+func (t *FaultInjectionTaskStore) CreateTasks(
+	ctx context.Context,
+	request *persistence.InternalCreateTasksRequest,
+) (*persistence.CreateTasksResponse, error) {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return t.baseTaskStore.CreateTasks(request)
+	return t.baseTaskStore.CreateTasks(ctx, request)
 }
 
-func (t *FaultInjectionTaskStore) GetTasks(request *persistence.GetTasksRequest) (
-	*persistence.InternalGetTasksResponse,
-	error,
-) {
+func (t *FaultInjectionTaskStore) GetTasks(
+	ctx context.Context,
+	request *persistence.GetTasksRequest,
+) (*persistence.InternalGetTasksResponse, error) {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return t.baseTaskStore.GetTasks(request)
+	return t.baseTaskStore.GetTasks(ctx, request)
 }
 
-func (t *FaultInjectionTaskStore) CompleteTask(request *persistence.CompleteTaskRequest) error {
+func (t *FaultInjectionTaskStore) CompleteTask(
+	ctx context.Context,
+	request *persistence.CompleteTaskRequest,
+) error {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return t.baseTaskStore.CompleteTask(request)
+	return t.baseTaskStore.CompleteTask(ctx, request)
 }
 
-func (t *FaultInjectionTaskStore) CompleteTasksLessThan(request *persistence.CompleteTasksLessThanRequest) (
-	int,
-	error,
-) {
+func (t *FaultInjectionTaskStore) CompleteTasksLessThan(
+	ctx context.Context,
+	request *persistence.CompleteTasksLessThanRequest,
+) (int, error) {
 	if err := t.ErrorGenerator.Generate(); err != nil {
 		return 0, err
 	}
-	return t.baseTaskStore.CompleteTasksLessThan(request)
+	return t.baseTaskStore.CompleteTasksLessThan(ctx, request)
 }
 
 func (t *FaultInjectionTaskStore) UpdateRate(rate float64) {
@@ -902,21 +1016,24 @@ func (s *FaultInjectionShardStore) GetClusterName() string {
 	return s.baseShardStore.GetClusterName()
 }
 
-func (s *FaultInjectionShardStore) GetOrCreateShard(request *persistence.InternalGetOrCreateShardRequest) (
-	*persistence.InternalGetOrCreateShardResponse,
-	error,
-) {
+func (s *FaultInjectionShardStore) GetOrCreateShard(
+	ctx context.Context,
+	request *persistence.InternalGetOrCreateShardRequest,
+) (*persistence.InternalGetOrCreateShardResponse, error) {
 	if err := s.ErrorGenerator.Generate(); err != nil {
 		return nil, err
 	}
-	return s.baseShardStore.GetOrCreateShard(request)
+	return s.baseShardStore.GetOrCreateShard(ctx, request)
 }
 
-func (s *FaultInjectionShardStore) UpdateShard(request *persistence.InternalUpdateShardRequest) error {
+func (s *FaultInjectionShardStore) UpdateShard(
+	ctx context.Context,
+	request *persistence.InternalUpdateShardRequest,
+) error {
 	if err := s.ErrorGenerator.Generate(); err != nil {
 		return err
 	}
-	return s.baseShardStore.UpdateShard(request)
+	return s.baseShardStore.UpdateShard(ctx, request)
 }
 
 func (s *FaultInjectionShardStore) UpdateRate(rate float64) {

--- a/common/persistence/clusterMetadataStore.go
+++ b/common/persistence/clusterMetadataStore.go
@@ -83,14 +83,14 @@ func (m *clusterMetadataManagerImpl) Close() {
 }
 
 func (m *clusterMetadataManagerImpl) GetClusterMembers(
-	_ context.Context,
+	ctx context.Context,
 	request *GetClusterMembersRequest,
 ) (*GetClusterMembersResponse, error) {
-	return m.persistence.GetClusterMembers(request)
+	return m.persistence.GetClusterMembers(ctx, request)
 }
 
 func (m *clusterMetadataManagerImpl) UpsertClusterMembership(
-	_ context.Context,
+	ctx context.Context,
 	request *UpsertClusterMembershipRequest,
 ) error {
 	if request.RecordExpiry.Seconds() < 1 {
@@ -109,21 +109,21 @@ func (m *clusterMetadataManagerImpl) UpsertClusterMembership(
 		return ErrIncompleteMembershipUpsert
 	}
 
-	return m.persistence.UpsertClusterMembership(request)
+	return m.persistence.UpsertClusterMembership(ctx, request)
 }
 
 func (m *clusterMetadataManagerImpl) PruneClusterMembership(
-	_ context.Context,
+	ctx context.Context,
 	request *PruneClusterMembershipRequest,
 ) error {
-	return m.persistence.PruneClusterMembership(request)
+	return m.persistence.PruneClusterMembership(ctx, request)
 }
 
 func (m *clusterMetadataManagerImpl) ListClusterMetadata(
-	_ context.Context,
+	ctx context.Context,
 	request *ListClusterMetadataRequest,
 ) (*ListClusterMetadataResponse, error) {
-	resp, err := m.persistence.ListClusterMetadata(&InternalListClusterMetadataRequest{
+	resp, err := m.persistence.ListClusterMetadata(ctx, &InternalListClusterMetadataRequest{
 		PageSize:      request.PageSize,
 		NextPageToken: request.NextPageToken,
 	})
@@ -143,9 +143,9 @@ func (m *clusterMetadataManagerImpl) ListClusterMetadata(
 }
 
 func (m *clusterMetadataManagerImpl) GetCurrentClusterMetadata(
-	_ context.Context,
+	ctx context.Context,
 ) (*GetClusterMetadataResponse, error) {
-	resp, err := m.persistence.GetClusterMetadata(&InternalGetClusterMetadataRequest{ClusterName: m.currentClusterName})
+	resp, err := m.persistence.GetClusterMetadata(ctx, &InternalGetClusterMetadataRequest{ClusterName: m.currentClusterName})
 	if err != nil {
 		return nil, err
 	}
@@ -158,10 +158,10 @@ func (m *clusterMetadataManagerImpl) GetCurrentClusterMetadata(
 }
 
 func (m *clusterMetadataManagerImpl) GetClusterMetadata(
-	_ context.Context,
+	ctx context.Context,
 	request *GetClusterMetadataRequest,
 ) (*GetClusterMetadataResponse, error) {
-	resp, err := m.persistence.GetClusterMetadata(&InternalGetClusterMetadataRequest{ClusterName: request.ClusterName})
+	resp, err := m.persistence.GetClusterMetadata(ctx, &InternalGetClusterMetadataRequest{ClusterName: request.ClusterName})
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(
 
 	oldClusterMetadata, err := m.GetClusterMetadata(ctx, &GetClusterMetadataRequest{ClusterName: request.GetClusterName()})
 	if _, notFound := err.(*serviceerror.NotFound); notFound {
-		return m.persistence.SaveClusterMetadata(&InternalSaveClusterMetadataRequest{
+		return m.persistence.SaveClusterMetadata(ctx, &InternalSaveClusterMetadataRequest{
 			ClusterName:     request.ClusterName,
 			ClusterMetadata: mcm,
 			Version:         request.Version,
@@ -197,7 +197,7 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(
 		return false, nil
 	}
 
-	return m.persistence.SaveClusterMetadata(&InternalSaveClusterMetadataRequest{
+	return m.persistence.SaveClusterMetadata(ctx, &InternalSaveClusterMetadataRequest{
 		ClusterName:     request.ClusterName,
 		ClusterMetadata: mcm,
 		Version:         request.Version,
@@ -205,14 +205,14 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(
 }
 
 func (m *clusterMetadataManagerImpl) DeleteClusterMetadata(
-	_ context.Context,
+	ctx context.Context,
 	request *DeleteClusterMetadataRequest,
 ) error {
 	if request.ClusterName == m.currentClusterName {
 		return serviceerror.NewInvalidArgument("Cannot delete current cluster metadata")
 	}
 
-	return m.persistence.DeleteClusterMetadata(&InternalDeleteClusterMetadataRequest{ClusterName: request.ClusterName})
+	return m.persistence.DeleteClusterMetadata(ctx, &InternalDeleteClusterMetadataRequest{ClusterName: request.ClusterName})
 }
 
 func (m *clusterMetadataManagerImpl) convertInternalGetClusterMetadataResponse(

--- a/common/persistence/metadata_manager.go
+++ b/common/persistence/metadata_manager.go
@@ -71,7 +71,7 @@ func (m *metadataManagerImpl) GetName() string {
 }
 
 func (m *metadataManagerImpl) CreateNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *CreateNamespaceRequest,
 ) (*CreateNamespaceResponse, error) {
 	datablob, err := m.serializer.NamespaceDetailToBlob(request.Namespace, enumspb.ENCODING_TYPE_PROTO3)
@@ -79,7 +79,7 @@ func (m *metadataManagerImpl) CreateNamespace(
 		return nil, err
 	}
 
-	return m.persistence.CreateNamespace(&InternalCreateNamespaceRequest{
+	return m.persistence.CreateNamespace(ctx, &InternalCreateNamespaceRequest{
 		ID:        request.Namespace.Info.Id,
 		Name:      request.Namespace.Info.Name,
 		IsGlobal:  request.IsGlobalNamespace,
@@ -88,10 +88,10 @@ func (m *metadataManagerImpl) CreateNamespace(
 }
 
 func (m *metadataManagerImpl) GetNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *GetNamespaceRequest,
 ) (*GetNamespaceResponse, error) {
-	resp, err := m.persistence.GetNamespace(request)
+	resp, err := m.persistence.GetNamespace(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -99,7 +99,7 @@ func (m *metadataManagerImpl) GetNamespace(
 }
 
 func (m *metadataManagerImpl) UpdateNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *UpdateNamespaceRequest,
 ) error {
 	datablob, err := m.serializer.NamespaceDetailToBlob(request.Namespace, enumspb.ENCODING_TYPE_PROTO3)
@@ -107,7 +107,7 @@ func (m *metadataManagerImpl) UpdateNamespace(
 		return err
 	}
 
-	return m.persistence.UpdateNamespace(&InternalUpdateNamespaceRequest{
+	return m.persistence.UpdateNamespace(ctx, &InternalUpdateNamespaceRequest{
 		Id:                  request.Namespace.Info.Id,
 		Name:                request.Namespace.Info.Name,
 		Namespace:           datablob,
@@ -151,21 +151,21 @@ func (m *metadataManagerImpl) RenameNamespace(
 		PreviousName: previousName,
 	}
 
-	return m.persistence.RenameNamespace(renameRequest)
+	return m.persistence.RenameNamespace(ctx, renameRequest)
 }
 
 func (m *metadataManagerImpl) DeleteNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *DeleteNamespaceRequest,
 ) error {
-	return m.persistence.DeleteNamespace(request)
+	return m.persistence.DeleteNamespace(ctx, request)
 }
 
 func (m *metadataManagerImpl) DeleteNamespaceByName(
-	_ context.Context,
+	ctx context.Context,
 	request *DeleteNamespaceByNameRequest,
 ) error {
-	return m.persistence.DeleteNamespaceByName(request)
+	return m.persistence.DeleteNamespaceByName(ctx, request)
 }
 
 func (m *metadataManagerImpl) ConvertInternalGetResponse(d *InternalGetNamespaceResponse) (*GetNamespaceResponse, error) {
@@ -192,7 +192,7 @@ func (m *metadataManagerImpl) ConvertInternalGetResponse(d *InternalGetNamespace
 }
 
 func (m *metadataManagerImpl) ListNamespaces(
-	_ context.Context,
+	ctx context.Context,
 	request *ListNamespacesRequest,
 ) (*ListNamespacesResponse, error) {
 	var namespaces []*GetNamespaceResponse
@@ -200,7 +200,7 @@ func (m *metadataManagerImpl) ListNamespaces(
 	pageSize := request.PageSize
 
 	for {
-		resp, err := m.persistence.ListNamespaces(&InternalListNamespacesRequest{
+		resp, err := m.persistence.ListNamespaces(ctx, &InternalListNamespacesRequest{
 			PageSize:      pageSize,
 			NextPageToken: nextPageToken,
 		})
@@ -274,9 +274,9 @@ func (m *metadataManagerImpl) InitializeSystemNamespaces(
 }
 
 func (m *metadataManagerImpl) GetMetadata(
-	_ context.Context,
+	ctx context.Context,
 ) (*GetMetadataResponse, error) {
-	return m.persistence.GetMetadata()
+	return m.persistence.GetMetadata(ctx)
 }
 
 func (m *metadataManagerImpl) Close() {

--- a/common/persistence/mock/store_mock.go
+++ b/common/persistence/mock/store_mock.go
@@ -29,6 +29,7 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -100,32 +101,32 @@ func (mr *MockShardStoreMockRecorder) GetName() *gomock.Call {
 }
 
 // GetOrCreateShard mocks base method.
-func (m *MockShardStore) GetOrCreateShard(request *persistence.InternalGetOrCreateShardRequest) (*persistence.InternalGetOrCreateShardResponse, error) {
+func (m *MockShardStore) GetOrCreateShard(ctx context.Context, request *persistence.InternalGetOrCreateShardRequest) (*persistence.InternalGetOrCreateShardResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrCreateShard", request)
+	ret := m.ctrl.Call(m, "GetOrCreateShard", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetOrCreateShardResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetOrCreateShard indicates an expected call of GetOrCreateShard.
-func (mr *MockShardStoreMockRecorder) GetOrCreateShard(request interface{}) *gomock.Call {
+func (mr *MockShardStoreMockRecorder) GetOrCreateShard(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateShard", reflect.TypeOf((*MockShardStore)(nil).GetOrCreateShard), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateShard", reflect.TypeOf((*MockShardStore)(nil).GetOrCreateShard), ctx, request)
 }
 
 // UpdateShard mocks base method.
-func (m *MockShardStore) UpdateShard(request *persistence.InternalUpdateShardRequest) error {
+func (m *MockShardStore) UpdateShard(ctx context.Context, request *persistence.InternalUpdateShardRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateShard", request)
+	ret := m.ctrl.Call(m, "UpdateShard", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateShard indicates an expected call of UpdateShard.
-func (mr *MockShardStoreMockRecorder) UpdateShard(request interface{}) *gomock.Call {
+func (mr *MockShardStoreMockRecorder) UpdateShard(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShard", reflect.TypeOf((*MockShardStore)(nil).UpdateShard), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateShard", reflect.TypeOf((*MockShardStore)(nil).UpdateShard), ctx, request)
 }
 
 // MockTaskStore is a mock of TaskStore interface.
@@ -164,75 +165,75 @@ func (mr *MockTaskStoreMockRecorder) Close() *gomock.Call {
 }
 
 // CompleteTask mocks base method.
-func (m *MockTaskStore) CompleteTask(request *persistence.CompleteTaskRequest) error {
+func (m *MockTaskStore) CompleteTask(ctx context.Context, request *persistence.CompleteTaskRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteTask", request)
+	ret := m.ctrl.Call(m, "CompleteTask", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CompleteTask indicates an expected call of CompleteTask.
-func (mr *MockTaskStoreMockRecorder) CompleteTask(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) CompleteTask(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTask", reflect.TypeOf((*MockTaskStore)(nil).CompleteTask), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTask", reflect.TypeOf((*MockTaskStore)(nil).CompleteTask), ctx, request)
 }
 
 // CompleteTasksLessThan mocks base method.
-func (m *MockTaskStore) CompleteTasksLessThan(request *persistence.CompleteTasksLessThanRequest) (int, error) {
+func (m *MockTaskStore) CompleteTasksLessThan(ctx context.Context, request *persistence.CompleteTasksLessThanRequest) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteTasksLessThan", request)
+	ret := m.ctrl.Call(m, "CompleteTasksLessThan", ctx, request)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CompleteTasksLessThan indicates an expected call of CompleteTasksLessThan.
-func (mr *MockTaskStoreMockRecorder) CompleteTasksLessThan(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) CompleteTasksLessThan(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTasksLessThan", reflect.TypeOf((*MockTaskStore)(nil).CompleteTasksLessThan), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteTasksLessThan", reflect.TypeOf((*MockTaskStore)(nil).CompleteTasksLessThan), ctx, request)
 }
 
 // CreateTaskQueue mocks base method.
-func (m *MockTaskStore) CreateTaskQueue(request *persistence.InternalCreateTaskQueueRequest) error {
+func (m *MockTaskStore) CreateTaskQueue(ctx context.Context, request *persistence.InternalCreateTaskQueueRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTaskQueue", request)
+	ret := m.ctrl.Call(m, "CreateTaskQueue", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateTaskQueue indicates an expected call of CreateTaskQueue.
-func (mr *MockTaskStoreMockRecorder) CreateTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) CreateTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).CreateTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).CreateTaskQueue), ctx, request)
 }
 
 // CreateTasks mocks base method.
-func (m *MockTaskStore) CreateTasks(request *persistence.InternalCreateTasksRequest) (*persistence.CreateTasksResponse, error) {
+func (m *MockTaskStore) CreateTasks(ctx context.Context, request *persistence.InternalCreateTasksRequest) (*persistence.CreateTasksResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateTasks", request)
+	ret := m.ctrl.Call(m, "CreateTasks", ctx, request)
 	ret0, _ := ret[0].(*persistence.CreateTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateTasks indicates an expected call of CreateTasks.
-func (mr *MockTaskStoreMockRecorder) CreateTasks(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) CreateTasks(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTasks", reflect.TypeOf((*MockTaskStore)(nil).CreateTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTasks", reflect.TypeOf((*MockTaskStore)(nil).CreateTasks), ctx, request)
 }
 
 // DeleteTaskQueue mocks base method.
-func (m *MockTaskStore) DeleteTaskQueue(request *persistence.DeleteTaskQueueRequest) error {
+func (m *MockTaskStore) DeleteTaskQueue(ctx context.Context, request *persistence.DeleteTaskQueueRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteTaskQueue", request)
+	ret := m.ctrl.Call(m, "DeleteTaskQueue", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteTaskQueue indicates an expected call of DeleteTaskQueue.
-func (mr *MockTaskStoreMockRecorder) DeleteTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) DeleteTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).DeleteTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).DeleteTaskQueue), ctx, request)
 }
 
 // GetName mocks base method.
@@ -250,63 +251,63 @@ func (mr *MockTaskStoreMockRecorder) GetName() *gomock.Call {
 }
 
 // GetTaskQueue mocks base method.
-func (m *MockTaskStore) GetTaskQueue(request *persistence.InternalGetTaskQueueRequest) (*persistence.InternalGetTaskQueueResponse, error) {
+func (m *MockTaskStore) GetTaskQueue(ctx context.Context, request *persistence.InternalGetTaskQueueRequest) (*persistence.InternalGetTaskQueueResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTaskQueue", request)
+	ret := m.ctrl.Call(m, "GetTaskQueue", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetTaskQueueResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTaskQueue indicates an expected call of GetTaskQueue.
-func (mr *MockTaskStoreMockRecorder) GetTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) GetTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).GetTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).GetTaskQueue), ctx, request)
 }
 
 // GetTasks mocks base method.
-func (m *MockTaskStore) GetTasks(request *persistence.GetTasksRequest) (*persistence.InternalGetTasksResponse, error) {
+func (m *MockTaskStore) GetTasks(ctx context.Context, request *persistence.GetTasksRequest) (*persistence.InternalGetTasksResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTasks", request)
+	ret := m.ctrl.Call(m, "GetTasks", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetTasks indicates an expected call of GetTasks.
-func (mr *MockTaskStoreMockRecorder) GetTasks(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) GetTasks(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasks", reflect.TypeOf((*MockTaskStore)(nil).GetTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTasks", reflect.TypeOf((*MockTaskStore)(nil).GetTasks), ctx, request)
 }
 
 // ListTaskQueue mocks base method.
-func (m *MockTaskStore) ListTaskQueue(request *persistence.ListTaskQueueRequest) (*persistence.InternalListTaskQueueResponse, error) {
+func (m *MockTaskStore) ListTaskQueue(ctx context.Context, request *persistence.ListTaskQueueRequest) (*persistence.InternalListTaskQueueResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListTaskQueue", request)
+	ret := m.ctrl.Call(m, "ListTaskQueue", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalListTaskQueueResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListTaskQueue indicates an expected call of ListTaskQueue.
-func (mr *MockTaskStoreMockRecorder) ListTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) ListTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).ListTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).ListTaskQueue), ctx, request)
 }
 
 // UpdateTaskQueue mocks base method.
-func (m *MockTaskStore) UpdateTaskQueue(request *persistence.InternalUpdateTaskQueueRequest) (*persistence.UpdateTaskQueueResponse, error) {
+func (m *MockTaskStore) UpdateTaskQueue(ctx context.Context, request *persistence.InternalUpdateTaskQueueRequest) (*persistence.UpdateTaskQueueResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateTaskQueue", request)
+	ret := m.ctrl.Call(m, "UpdateTaskQueue", ctx, request)
 	ret0, _ := ret[0].(*persistence.UpdateTaskQueueResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdateTaskQueue indicates an expected call of UpdateTaskQueue.
-func (mr *MockTaskStoreMockRecorder) UpdateTaskQueue(request interface{}) *gomock.Call {
+func (mr *MockTaskStoreMockRecorder) UpdateTaskQueue(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).UpdateTaskQueue), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateTaskQueue", reflect.TypeOf((*MockTaskStore)(nil).UpdateTaskQueue), ctx, request)
 }
 
 // MockMetadataStore is a mock of MetadataStore interface.
@@ -345,61 +346,61 @@ func (mr *MockMetadataStoreMockRecorder) Close() *gomock.Call {
 }
 
 // CreateNamespace mocks base method.
-func (m *MockMetadataStore) CreateNamespace(request *persistence.InternalCreateNamespaceRequest) (*persistence.CreateNamespaceResponse, error) {
+func (m *MockMetadataStore) CreateNamespace(ctx context.Context, request *persistence.InternalCreateNamespaceRequest) (*persistence.CreateNamespaceResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateNamespace", request)
+	ret := m.ctrl.Call(m, "CreateNamespace", ctx, request)
 	ret0, _ := ret[0].(*persistence.CreateNamespaceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateNamespace indicates an expected call of CreateNamespace.
-func (mr *MockMetadataStoreMockRecorder) CreateNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataStoreMockRecorder) CreateNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockMetadataStore)(nil).CreateNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNamespace", reflect.TypeOf((*MockMetadataStore)(nil).CreateNamespace), ctx, request)
 }
 
 // DeleteNamespace mocks base method.
-func (m *MockMetadataStore) DeleteNamespace(request *persistence.DeleteNamespaceRequest) error {
+func (m *MockMetadataStore) DeleteNamespace(ctx context.Context, request *persistence.DeleteNamespaceRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNamespace", request)
+	ret := m.ctrl.Call(m, "DeleteNamespace", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNamespace indicates an expected call of DeleteNamespace.
-func (mr *MockMetadataStoreMockRecorder) DeleteNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataStoreMockRecorder) DeleteNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockMetadataStore)(nil).DeleteNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockMetadataStore)(nil).DeleteNamespace), ctx, request)
 }
 
 // DeleteNamespaceByName mocks base method.
-func (m *MockMetadataStore) DeleteNamespaceByName(request *persistence.DeleteNamespaceByNameRequest) error {
+func (m *MockMetadataStore) DeleteNamespaceByName(ctx context.Context, request *persistence.DeleteNamespaceByNameRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteNamespaceByName", request)
+	ret := m.ctrl.Call(m, "DeleteNamespaceByName", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteNamespaceByName indicates an expected call of DeleteNamespaceByName.
-func (mr *MockMetadataStoreMockRecorder) DeleteNamespaceByName(request interface{}) *gomock.Call {
+func (mr *MockMetadataStoreMockRecorder) DeleteNamespaceByName(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespaceByName", reflect.TypeOf((*MockMetadataStore)(nil).DeleteNamespaceByName), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespaceByName", reflect.TypeOf((*MockMetadataStore)(nil).DeleteNamespaceByName), ctx, request)
 }
 
 // GetMetadata mocks base method.
-func (m *MockMetadataStore) GetMetadata() (*persistence.GetMetadataResponse, error) {
+func (m *MockMetadataStore) GetMetadata(ctx context.Context) (*persistence.GetMetadataResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetadata")
+	ret := m.ctrl.Call(m, "GetMetadata", ctx)
 	ret0, _ := ret[0].(*persistence.GetMetadataResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMetadata indicates an expected call of GetMetadata.
-func (mr *MockMetadataStoreMockRecorder) GetMetadata() *gomock.Call {
+func (mr *MockMetadataStoreMockRecorder) GetMetadata(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockMetadataStore)(nil).GetMetadata))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockMetadataStore)(nil).GetMetadata), ctx)
 }
 
 // GetName mocks base method.
@@ -417,61 +418,61 @@ func (mr *MockMetadataStoreMockRecorder) GetName() *gomock.Call {
 }
 
 // GetNamespace mocks base method.
-func (m *MockMetadataStore) GetNamespace(request *persistence.GetNamespaceRequest) (*persistence.InternalGetNamespaceResponse, error) {
+func (m *MockMetadataStore) GetNamespace(ctx context.Context, request *persistence.GetNamespaceRequest) (*persistence.InternalGetNamespaceResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetNamespace", request)
+	ret := m.ctrl.Call(m, "GetNamespace", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetNamespaceResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetNamespace indicates an expected call of GetNamespace.
-func (mr *MockMetadataStoreMockRecorder) GetNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataStoreMockRecorder) GetNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockMetadataStore)(nil).GetNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockMetadataStore)(nil).GetNamespace), ctx, request)
 }
 
 // ListNamespaces mocks base method.
-func (m *MockMetadataStore) ListNamespaces(request *persistence.InternalListNamespacesRequest) (*persistence.InternalListNamespacesResponse, error) {
+func (m *MockMetadataStore) ListNamespaces(ctx context.Context, request *persistence.InternalListNamespacesRequest) (*persistence.InternalListNamespacesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListNamespaces", request)
+	ret := m.ctrl.Call(m, "ListNamespaces", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalListNamespacesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListNamespaces indicates an expected call of ListNamespaces.
-func (mr *MockMetadataStoreMockRecorder) ListNamespaces(request interface{}) *gomock.Call {
+func (mr *MockMetadataStoreMockRecorder) ListNamespaces(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockMetadataStore)(nil).ListNamespaces), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListNamespaces", reflect.TypeOf((*MockMetadataStore)(nil).ListNamespaces), ctx, request)
 }
 
 // RenameNamespace mocks base method.
-func (m *MockMetadataStore) RenameNamespace(request *persistence.InternalRenameNamespaceRequest) error {
+func (m *MockMetadataStore) RenameNamespace(ctx context.Context, request *persistence.InternalRenameNamespaceRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RenameNamespace", request)
+	ret := m.ctrl.Call(m, "RenameNamespace", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RenameNamespace indicates an expected call of RenameNamespace.
-func (mr *MockMetadataStoreMockRecorder) RenameNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataStoreMockRecorder) RenameNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameNamespace", reflect.TypeOf((*MockMetadataStore)(nil).RenameNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RenameNamespace", reflect.TypeOf((*MockMetadataStore)(nil).RenameNamespace), ctx, request)
 }
 
 // UpdateNamespace mocks base method.
-func (m *MockMetadataStore) UpdateNamespace(request *persistence.InternalUpdateNamespaceRequest) error {
+func (m *MockMetadataStore) UpdateNamespace(ctx context.Context, request *persistence.InternalUpdateNamespaceRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateNamespace", request)
+	ret := m.ctrl.Call(m, "UpdateNamespace", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateNamespace indicates an expected call of UpdateNamespace.
-func (mr *MockMetadataStoreMockRecorder) UpdateNamespace(request interface{}) *gomock.Call {
+func (mr *MockMetadataStoreMockRecorder) UpdateNamespace(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespace", reflect.TypeOf((*MockMetadataStore)(nil).UpdateNamespace), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespace", reflect.TypeOf((*MockMetadataStore)(nil).UpdateNamespace), ctx, request)
 }
 
 // MockClusterMetadataStore is a mock of ClusterMetadataStore interface.
@@ -510,47 +511,47 @@ func (mr *MockClusterMetadataStoreMockRecorder) Close() *gomock.Call {
 }
 
 // DeleteClusterMetadata mocks base method.
-func (m *MockClusterMetadataStore) DeleteClusterMetadata(request *persistence.InternalDeleteClusterMetadataRequest) error {
+func (m *MockClusterMetadataStore) DeleteClusterMetadata(ctx context.Context, request *persistence.InternalDeleteClusterMetadataRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteClusterMetadata", request)
+	ret := m.ctrl.Call(m, "DeleteClusterMetadata", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteClusterMetadata indicates an expected call of DeleteClusterMetadata.
-func (mr *MockClusterMetadataStoreMockRecorder) DeleteClusterMetadata(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataStoreMockRecorder) DeleteClusterMetadata(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).DeleteClusterMetadata), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).DeleteClusterMetadata), ctx, request)
 }
 
 // GetClusterMembers mocks base method.
-func (m *MockClusterMetadataStore) GetClusterMembers(request *persistence.GetClusterMembersRequest) (*persistence.GetClusterMembersResponse, error) {
+func (m *MockClusterMetadataStore) GetClusterMembers(ctx context.Context, request *persistence.GetClusterMembersRequest) (*persistence.GetClusterMembersResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMembers", request)
+	ret := m.ctrl.Call(m, "GetClusterMembers", ctx, request)
 	ret0, _ := ret[0].(*persistence.GetClusterMembersResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetClusterMembers indicates an expected call of GetClusterMembers.
-func (mr *MockClusterMetadataStoreMockRecorder) GetClusterMembers(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataStoreMockRecorder) GetClusterMembers(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMembers", reflect.TypeOf((*MockClusterMetadataStore)(nil).GetClusterMembers), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMembers", reflect.TypeOf((*MockClusterMetadataStore)(nil).GetClusterMembers), ctx, request)
 }
 
 // GetClusterMetadata mocks base method.
-func (m *MockClusterMetadataStore) GetClusterMetadata(request *persistence.InternalGetClusterMetadataRequest) (*persistence.InternalGetClusterMetadataResponse, error) {
+func (m *MockClusterMetadataStore) GetClusterMetadata(ctx context.Context, request *persistence.InternalGetClusterMetadataRequest) (*persistence.InternalGetClusterMetadataResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetClusterMetadata", request)
+	ret := m.ctrl.Call(m, "GetClusterMetadata", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetClusterMetadataResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetClusterMetadata indicates an expected call of GetClusterMetadata.
-func (mr *MockClusterMetadataStoreMockRecorder) GetClusterMetadata(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataStoreMockRecorder) GetClusterMetadata(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).GetClusterMetadata), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).GetClusterMetadata), ctx, request)
 }
 
 // GetName mocks base method.
@@ -568,61 +569,61 @@ func (mr *MockClusterMetadataStoreMockRecorder) GetName() *gomock.Call {
 }
 
 // ListClusterMetadata mocks base method.
-func (m *MockClusterMetadataStore) ListClusterMetadata(request *persistence.InternalListClusterMetadataRequest) (*persistence.InternalListClusterMetadataResponse, error) {
+func (m *MockClusterMetadataStore) ListClusterMetadata(ctx context.Context, request *persistence.InternalListClusterMetadataRequest) (*persistence.InternalListClusterMetadataResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClusterMetadata", request)
+	ret := m.ctrl.Call(m, "ListClusterMetadata", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalListClusterMetadataResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClusterMetadata indicates an expected call of ListClusterMetadata.
-func (mr *MockClusterMetadataStoreMockRecorder) ListClusterMetadata(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataStoreMockRecorder) ListClusterMetadata(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).ListClusterMetadata), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).ListClusterMetadata), ctx, request)
 }
 
 // PruneClusterMembership mocks base method.
-func (m *MockClusterMetadataStore) PruneClusterMembership(request *persistence.PruneClusterMembershipRequest) error {
+func (m *MockClusterMetadataStore) PruneClusterMembership(ctx context.Context, request *persistence.PruneClusterMembershipRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PruneClusterMembership", request)
+	ret := m.ctrl.Call(m, "PruneClusterMembership", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PruneClusterMembership indicates an expected call of PruneClusterMembership.
-func (mr *MockClusterMetadataStoreMockRecorder) PruneClusterMembership(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataStoreMockRecorder) PruneClusterMembership(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneClusterMembership", reflect.TypeOf((*MockClusterMetadataStore)(nil).PruneClusterMembership), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PruneClusterMembership", reflect.TypeOf((*MockClusterMetadataStore)(nil).PruneClusterMembership), ctx, request)
 }
 
 // SaveClusterMetadata mocks base method.
-func (m *MockClusterMetadataStore) SaveClusterMetadata(request *persistence.InternalSaveClusterMetadataRequest) (bool, error) {
+func (m *MockClusterMetadataStore) SaveClusterMetadata(ctx context.Context, request *persistence.InternalSaveClusterMetadataRequest) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveClusterMetadata", request)
+	ret := m.ctrl.Call(m, "SaveClusterMetadata", ctx, request)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // SaveClusterMetadata indicates an expected call of SaveClusterMetadata.
-func (mr *MockClusterMetadataStoreMockRecorder) SaveClusterMetadata(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataStoreMockRecorder) SaveClusterMetadata(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).SaveClusterMetadata), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveClusterMetadata", reflect.TypeOf((*MockClusterMetadataStore)(nil).SaveClusterMetadata), ctx, request)
 }
 
 // UpsertClusterMembership mocks base method.
-func (m *MockClusterMetadataStore) UpsertClusterMembership(request *persistence.UpsertClusterMembershipRequest) error {
+func (m *MockClusterMetadataStore) UpsertClusterMembership(ctx context.Context, request *persistence.UpsertClusterMembershipRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertClusterMembership", request)
+	ret := m.ctrl.Call(m, "UpsertClusterMembership", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertClusterMembership indicates an expected call of UpsertClusterMembership.
-func (mr *MockClusterMetadataStoreMockRecorder) UpsertClusterMembership(request interface{}) *gomock.Call {
+func (mr *MockClusterMetadataStoreMockRecorder) UpsertClusterMembership(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertClusterMembership", reflect.TypeOf((*MockClusterMetadataStore)(nil).UpsertClusterMembership), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertClusterMembership", reflect.TypeOf((*MockClusterMetadataStore)(nil).UpsertClusterMembership), ctx, request)
 }
 
 // MockExecutionStore is a mock of ExecutionStore interface.
@@ -649,31 +650,31 @@ func (m *MockExecutionStore) EXPECT() *MockExecutionStoreMockRecorder {
 }
 
 // AddHistoryTasks mocks base method.
-func (m *MockExecutionStore) AddHistoryTasks(request *persistence.InternalAddHistoryTasksRequest) error {
+func (m *MockExecutionStore) AddHistoryTasks(ctx context.Context, request *persistence.InternalAddHistoryTasksRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddHistoryTasks", request)
+	ret := m.ctrl.Call(m, "AddHistoryTasks", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AddHistoryTasks indicates an expected call of AddHistoryTasks.
-func (mr *MockExecutionStoreMockRecorder) AddHistoryTasks(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) AddHistoryTasks(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddHistoryTasks", reflect.TypeOf((*MockExecutionStore)(nil).AddHistoryTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddHistoryTasks", reflect.TypeOf((*MockExecutionStore)(nil).AddHistoryTasks), ctx, request)
 }
 
 // AppendHistoryNodes mocks base method.
-func (m *MockExecutionStore) AppendHistoryNodes(request *persistence.InternalAppendHistoryNodesRequest) error {
+func (m *MockExecutionStore) AppendHistoryNodes(ctx context.Context, request *persistence.InternalAppendHistoryNodesRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AppendHistoryNodes", request)
+	ret := m.ctrl.Call(m, "AppendHistoryNodes", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // AppendHistoryNodes indicates an expected call of AppendHistoryNodes.
-func (mr *MockExecutionStoreMockRecorder) AppendHistoryNodes(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) AppendHistoryNodes(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendHistoryNodes", reflect.TypeOf((*MockExecutionStore)(nil).AppendHistoryNodes), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendHistoryNodes", reflect.TypeOf((*MockExecutionStore)(nil).AppendHistoryNodes), ctx, request)
 }
 
 // Close mocks base method.
@@ -689,205 +690,205 @@ func (mr *MockExecutionStoreMockRecorder) Close() *gomock.Call {
 }
 
 // CompleteHistoryTask mocks base method.
-func (m *MockExecutionStore) CompleteHistoryTask(request *persistence.CompleteHistoryTaskRequest) error {
+func (m *MockExecutionStore) CompleteHistoryTask(ctx context.Context, request *persistence.CompleteHistoryTaskRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CompleteHistoryTask", request)
+	ret := m.ctrl.Call(m, "CompleteHistoryTask", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CompleteHistoryTask indicates an expected call of CompleteHistoryTask.
-func (mr *MockExecutionStoreMockRecorder) CompleteHistoryTask(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) CompleteHistoryTask(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteHistoryTask", reflect.TypeOf((*MockExecutionStore)(nil).CompleteHistoryTask), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CompleteHistoryTask", reflect.TypeOf((*MockExecutionStore)(nil).CompleteHistoryTask), ctx, request)
 }
 
 // ConflictResolveWorkflowExecution mocks base method.
-func (m *MockExecutionStore) ConflictResolveWorkflowExecution(request *persistence.InternalConflictResolveWorkflowExecutionRequest) error {
+func (m *MockExecutionStore) ConflictResolveWorkflowExecution(ctx context.Context, request *persistence.InternalConflictResolveWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ConflictResolveWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "ConflictResolveWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ConflictResolveWorkflowExecution indicates an expected call of ConflictResolveWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) ConflictResolveWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) ConflictResolveWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConflictResolveWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).ConflictResolveWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConflictResolveWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).ConflictResolveWorkflowExecution), ctx, request)
 }
 
 // CreateWorkflowExecution mocks base method.
-func (m *MockExecutionStore) CreateWorkflowExecution(request *persistence.InternalCreateWorkflowExecutionRequest) (*persistence.InternalCreateWorkflowExecutionResponse, error) {
+func (m *MockExecutionStore) CreateWorkflowExecution(ctx context.Context, request *persistence.InternalCreateWorkflowExecutionRequest) (*persistence.InternalCreateWorkflowExecutionResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "CreateWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalCreateWorkflowExecutionResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreateWorkflowExecution indicates an expected call of CreateWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) CreateWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) CreateWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).CreateWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).CreateWorkflowExecution), ctx, request)
 }
 
 // DeleteCurrentWorkflowExecution mocks base method.
-func (m *MockExecutionStore) DeleteCurrentWorkflowExecution(request *persistence.DeleteCurrentWorkflowExecutionRequest) error {
+func (m *MockExecutionStore) DeleteCurrentWorkflowExecution(ctx context.Context, request *persistence.DeleteCurrentWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteCurrentWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "DeleteCurrentWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteCurrentWorkflowExecution indicates an expected call of DeleteCurrentWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) DeleteCurrentWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) DeleteCurrentWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCurrentWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).DeleteCurrentWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCurrentWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).DeleteCurrentWorkflowExecution), ctx, request)
 }
 
 // DeleteHistoryBranch mocks base method.
-func (m *MockExecutionStore) DeleteHistoryBranch(request *persistence.InternalDeleteHistoryBranchRequest) error {
+func (m *MockExecutionStore) DeleteHistoryBranch(ctx context.Context, request *persistence.InternalDeleteHistoryBranchRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteHistoryBranch", request)
+	ret := m.ctrl.Call(m, "DeleteHistoryBranch", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteHistoryBranch indicates an expected call of DeleteHistoryBranch.
-func (mr *MockExecutionStoreMockRecorder) DeleteHistoryBranch(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) DeleteHistoryBranch(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHistoryBranch", reflect.TypeOf((*MockExecutionStore)(nil).DeleteHistoryBranch), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHistoryBranch", reflect.TypeOf((*MockExecutionStore)(nil).DeleteHistoryBranch), ctx, request)
 }
 
 // DeleteHistoryNodes mocks base method.
-func (m *MockExecutionStore) DeleteHistoryNodes(request *persistence.InternalDeleteHistoryNodesRequest) error {
+func (m *MockExecutionStore) DeleteHistoryNodes(ctx context.Context, request *persistence.InternalDeleteHistoryNodesRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteHistoryNodes", request)
+	ret := m.ctrl.Call(m, "DeleteHistoryNodes", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteHistoryNodes indicates an expected call of DeleteHistoryNodes.
-func (mr *MockExecutionStoreMockRecorder) DeleteHistoryNodes(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) DeleteHistoryNodes(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHistoryNodes", reflect.TypeOf((*MockExecutionStore)(nil).DeleteHistoryNodes), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteHistoryNodes", reflect.TypeOf((*MockExecutionStore)(nil).DeleteHistoryNodes), ctx, request)
 }
 
 // DeleteReplicationTaskFromDLQ mocks base method.
-func (m *MockExecutionStore) DeleteReplicationTaskFromDLQ(request *persistence.DeleteReplicationTaskFromDLQRequest) error {
+func (m *MockExecutionStore) DeleteReplicationTaskFromDLQ(ctx context.Context, request *persistence.DeleteReplicationTaskFromDLQRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteReplicationTaskFromDLQ", request)
+	ret := m.ctrl.Call(m, "DeleteReplicationTaskFromDLQ", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteReplicationTaskFromDLQ indicates an expected call of DeleteReplicationTaskFromDLQ.
-func (mr *MockExecutionStoreMockRecorder) DeleteReplicationTaskFromDLQ(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) DeleteReplicationTaskFromDLQ(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteReplicationTaskFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).DeleteReplicationTaskFromDLQ), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteReplicationTaskFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).DeleteReplicationTaskFromDLQ), ctx, request)
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockExecutionStore) DeleteWorkflowExecution(request *persistence.DeleteWorkflowExecutionRequest) error {
+func (m *MockExecutionStore) DeleteWorkflowExecution(ctx context.Context, request *persistence.DeleteWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) DeleteWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) DeleteWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).DeleteWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).DeleteWorkflowExecution), ctx, request)
 }
 
 // ForkHistoryBranch mocks base method.
-func (m *MockExecutionStore) ForkHistoryBranch(request *persistence.InternalForkHistoryBranchRequest) error {
+func (m *MockExecutionStore) ForkHistoryBranch(ctx context.Context, request *persistence.InternalForkHistoryBranchRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ForkHistoryBranch", request)
+	ret := m.ctrl.Call(m, "ForkHistoryBranch", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ForkHistoryBranch indicates an expected call of ForkHistoryBranch.
-func (mr *MockExecutionStoreMockRecorder) ForkHistoryBranch(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) ForkHistoryBranch(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForkHistoryBranch", reflect.TypeOf((*MockExecutionStore)(nil).ForkHistoryBranch), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForkHistoryBranch", reflect.TypeOf((*MockExecutionStore)(nil).ForkHistoryBranch), ctx, request)
 }
 
 // GetAllHistoryTreeBranches mocks base method.
-func (m *MockExecutionStore) GetAllHistoryTreeBranches(request *persistence.GetAllHistoryTreeBranchesRequest) (*persistence.InternalGetAllHistoryTreeBranchesResponse, error) {
+func (m *MockExecutionStore) GetAllHistoryTreeBranches(ctx context.Context, request *persistence.GetAllHistoryTreeBranchesRequest) (*persistence.InternalGetAllHistoryTreeBranchesResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllHistoryTreeBranches", request)
+	ret := m.ctrl.Call(m, "GetAllHistoryTreeBranches", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetAllHistoryTreeBranchesResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAllHistoryTreeBranches indicates an expected call of GetAllHistoryTreeBranches.
-func (mr *MockExecutionStoreMockRecorder) GetAllHistoryTreeBranches(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) GetAllHistoryTreeBranches(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllHistoryTreeBranches", reflect.TypeOf((*MockExecutionStore)(nil).GetAllHistoryTreeBranches), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllHistoryTreeBranches", reflect.TypeOf((*MockExecutionStore)(nil).GetAllHistoryTreeBranches), ctx, request)
 }
 
 // GetCurrentExecution mocks base method.
-func (m *MockExecutionStore) GetCurrentExecution(request *persistence.GetCurrentExecutionRequest) (*persistence.InternalGetCurrentExecutionResponse, error) {
+func (m *MockExecutionStore) GetCurrentExecution(ctx context.Context, request *persistence.GetCurrentExecutionRequest) (*persistence.InternalGetCurrentExecutionResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCurrentExecution", request)
+	ret := m.ctrl.Call(m, "GetCurrentExecution", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetCurrentExecutionResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCurrentExecution indicates an expected call of GetCurrentExecution.
-func (mr *MockExecutionStoreMockRecorder) GetCurrentExecution(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) GetCurrentExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentExecution", reflect.TypeOf((*MockExecutionStore)(nil).GetCurrentExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentExecution", reflect.TypeOf((*MockExecutionStore)(nil).GetCurrentExecution), ctx, request)
 }
 
 // GetHistoryTask mocks base method.
-func (m *MockExecutionStore) GetHistoryTask(request *persistence.GetHistoryTaskRequest) (*persistence.InternalGetHistoryTaskResponse, error) {
+func (m *MockExecutionStore) GetHistoryTask(ctx context.Context, request *persistence.GetHistoryTaskRequest) (*persistence.InternalGetHistoryTaskResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistoryTask", request)
+	ret := m.ctrl.Call(m, "GetHistoryTask", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetHistoryTaskResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetHistoryTask indicates an expected call of GetHistoryTask.
-func (mr *MockExecutionStoreMockRecorder) GetHistoryTask(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) GetHistoryTask(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTask", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTask), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTask", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTask), ctx, request)
 }
 
 // GetHistoryTasks mocks base method.
-func (m *MockExecutionStore) GetHistoryTasks(request *persistence.GetHistoryTasksRequest) (*persistence.InternalGetHistoryTasksResponse, error) {
+func (m *MockExecutionStore) GetHistoryTasks(ctx context.Context, request *persistence.GetHistoryTasksRequest) (*persistence.InternalGetHistoryTasksResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistoryTasks", request)
+	ret := m.ctrl.Call(m, "GetHistoryTasks", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetHistoryTasksResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetHistoryTasks indicates an expected call of GetHistoryTasks.
-func (mr *MockExecutionStoreMockRecorder) GetHistoryTasks(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) GetHistoryTasks(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTasks", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTasks", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTasks), ctx, request)
 }
 
 // GetHistoryTree mocks base method.
-func (m *MockExecutionStore) GetHistoryTree(request *persistence.GetHistoryTreeRequest) (*persistence.InternalGetHistoryTreeResponse, error) {
+func (m *MockExecutionStore) GetHistoryTree(ctx context.Context, request *persistence.GetHistoryTreeRequest) (*persistence.InternalGetHistoryTreeResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistoryTree", request)
+	ret := m.ctrl.Call(m, "GetHistoryTree", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetHistoryTreeResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetHistoryTree indicates an expected call of GetHistoryTree.
-func (mr *MockExecutionStoreMockRecorder) GetHistoryTree(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) GetHistoryTree(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTree", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTree), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryTree", reflect.TypeOf((*MockExecutionStore)(nil).GetHistoryTree), ctx, request)
 }
 
 // GetName mocks base method.
@@ -905,133 +906,133 @@ func (mr *MockExecutionStoreMockRecorder) GetName() *gomock.Call {
 }
 
 // GetReplicationTasksFromDLQ mocks base method.
-func (m *MockExecutionStore) GetReplicationTasksFromDLQ(request *persistence.GetReplicationTasksFromDLQRequest) (*persistence.InternalGetReplicationTasksFromDLQResponse, error) {
+func (m *MockExecutionStore) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (*persistence.InternalGetReplicationTasksFromDLQResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetReplicationTasksFromDLQ", request)
+	ret := m.ctrl.Call(m, "GetReplicationTasksFromDLQ", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetReplicationTasksFromDLQResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetReplicationTasksFromDLQ indicates an expected call of GetReplicationTasksFromDLQ.
-func (mr *MockExecutionStoreMockRecorder) GetReplicationTasksFromDLQ(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) GetReplicationTasksFromDLQ(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTasksFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).GetReplicationTasksFromDLQ), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationTasksFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).GetReplicationTasksFromDLQ), ctx, request)
 }
 
 // GetWorkflowExecution mocks base method.
-func (m *MockExecutionStore) GetWorkflowExecution(request *persistence.GetWorkflowExecutionRequest) (*persistence.InternalGetWorkflowExecutionResponse, error) {
+func (m *MockExecutionStore) GetWorkflowExecution(ctx context.Context, request *persistence.GetWorkflowExecutionRequest) (*persistence.InternalGetWorkflowExecutionResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "GetWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalGetWorkflowExecutionResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWorkflowExecution indicates an expected call of GetWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) GetWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) GetWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).GetWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).GetWorkflowExecution), ctx, request)
 }
 
 // ListConcreteExecutions mocks base method.
-func (m *MockExecutionStore) ListConcreteExecutions(request *persistence.ListConcreteExecutionsRequest) (*persistence.InternalListConcreteExecutionsResponse, error) {
+func (m *MockExecutionStore) ListConcreteExecutions(ctx context.Context, request *persistence.ListConcreteExecutionsRequest) (*persistence.InternalListConcreteExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListConcreteExecutions", request)
+	ret := m.ctrl.Call(m, "ListConcreteExecutions", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalListConcreteExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListConcreteExecutions indicates an expected call of ListConcreteExecutions.
-func (mr *MockExecutionStoreMockRecorder) ListConcreteExecutions(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) ListConcreteExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConcreteExecutions", reflect.TypeOf((*MockExecutionStore)(nil).ListConcreteExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListConcreteExecutions", reflect.TypeOf((*MockExecutionStore)(nil).ListConcreteExecutions), ctx, request)
 }
 
 // PutReplicationTaskToDLQ mocks base method.
-func (m *MockExecutionStore) PutReplicationTaskToDLQ(request *persistence.PutReplicationTaskToDLQRequest) error {
+func (m *MockExecutionStore) PutReplicationTaskToDLQ(ctx context.Context, request *persistence.PutReplicationTaskToDLQRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutReplicationTaskToDLQ", request)
+	ret := m.ctrl.Call(m, "PutReplicationTaskToDLQ", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // PutReplicationTaskToDLQ indicates an expected call of PutReplicationTaskToDLQ.
-func (mr *MockExecutionStoreMockRecorder) PutReplicationTaskToDLQ(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) PutReplicationTaskToDLQ(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutReplicationTaskToDLQ", reflect.TypeOf((*MockExecutionStore)(nil).PutReplicationTaskToDLQ), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutReplicationTaskToDLQ", reflect.TypeOf((*MockExecutionStore)(nil).PutReplicationTaskToDLQ), ctx, request)
 }
 
 // RangeCompleteHistoryTasks mocks base method.
-func (m *MockExecutionStore) RangeCompleteHistoryTasks(request *persistence.RangeCompleteHistoryTasksRequest) error {
+func (m *MockExecutionStore) RangeCompleteHistoryTasks(ctx context.Context, request *persistence.RangeCompleteHistoryTasksRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeCompleteHistoryTasks", request)
+	ret := m.ctrl.Call(m, "RangeCompleteHistoryTasks", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RangeCompleteHistoryTasks indicates an expected call of RangeCompleteHistoryTasks.
-func (mr *MockExecutionStoreMockRecorder) RangeCompleteHistoryTasks(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) RangeCompleteHistoryTasks(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteHistoryTasks", reflect.TypeOf((*MockExecutionStore)(nil).RangeCompleteHistoryTasks), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeCompleteHistoryTasks", reflect.TypeOf((*MockExecutionStore)(nil).RangeCompleteHistoryTasks), ctx, request)
 }
 
 // RangeDeleteReplicationTaskFromDLQ mocks base method.
-func (m *MockExecutionStore) RangeDeleteReplicationTaskFromDLQ(request *persistence.RangeDeleteReplicationTaskFromDLQRequest) error {
+func (m *MockExecutionStore) RangeDeleteReplicationTaskFromDLQ(ctx context.Context, request *persistence.RangeDeleteReplicationTaskFromDLQRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeDeleteReplicationTaskFromDLQ", request)
+	ret := m.ctrl.Call(m, "RangeDeleteReplicationTaskFromDLQ", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RangeDeleteReplicationTaskFromDLQ indicates an expected call of RangeDeleteReplicationTaskFromDLQ.
-func (mr *MockExecutionStoreMockRecorder) RangeDeleteReplicationTaskFromDLQ(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) RangeDeleteReplicationTaskFromDLQ(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeDeleteReplicationTaskFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).RangeDeleteReplicationTaskFromDLQ), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeDeleteReplicationTaskFromDLQ", reflect.TypeOf((*MockExecutionStore)(nil).RangeDeleteReplicationTaskFromDLQ), ctx, request)
 }
 
 // ReadHistoryBranch mocks base method.
-func (m *MockExecutionStore) ReadHistoryBranch(request *persistence.InternalReadHistoryBranchRequest) (*persistence.InternalReadHistoryBranchResponse, error) {
+func (m *MockExecutionStore) ReadHistoryBranch(ctx context.Context, request *persistence.InternalReadHistoryBranchRequest) (*persistence.InternalReadHistoryBranchResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadHistoryBranch", request)
+	ret := m.ctrl.Call(m, "ReadHistoryBranch", ctx, request)
 	ret0, _ := ret[0].(*persistence.InternalReadHistoryBranchResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadHistoryBranch indicates an expected call of ReadHistoryBranch.
-func (mr *MockExecutionStoreMockRecorder) ReadHistoryBranch(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) ReadHistoryBranch(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadHistoryBranch", reflect.TypeOf((*MockExecutionStore)(nil).ReadHistoryBranch), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadHistoryBranch", reflect.TypeOf((*MockExecutionStore)(nil).ReadHistoryBranch), ctx, request)
 }
 
 // SetWorkflowExecution mocks base method.
-func (m *MockExecutionStore) SetWorkflowExecution(request *persistence.InternalSetWorkflowExecutionRequest) error {
+func (m *MockExecutionStore) SetWorkflowExecution(ctx context.Context, request *persistence.InternalSetWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "SetWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetWorkflowExecution indicates an expected call of SetWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) SetWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) SetWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).SetWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).SetWorkflowExecution), ctx, request)
 }
 
 // UpdateWorkflowExecution mocks base method.
-func (m *MockExecutionStore) UpdateWorkflowExecution(request *persistence.InternalUpdateWorkflowExecutionRequest) error {
+func (m *MockExecutionStore) UpdateWorkflowExecution(ctx context.Context, request *persistence.InternalUpdateWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "UpdateWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateWorkflowExecution indicates an expected call of UpdateWorkflowExecution.
-func (mr *MockExecutionStoreMockRecorder) UpdateWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockExecutionStoreMockRecorder) UpdateWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).UpdateWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecution", reflect.TypeOf((*MockExecutionStore)(nil).UpdateWorkflowExecution), ctx, request)
 }
 
 // MockQueue is a mock of Queue interface.
@@ -1070,139 +1071,139 @@ func (mr *MockQueueMockRecorder) Close() *gomock.Call {
 }
 
 // DeleteMessageFromDLQ mocks base method.
-func (m *MockQueue) DeleteMessageFromDLQ(messageID int64) error {
+func (m *MockQueue) DeleteMessageFromDLQ(ctx context.Context, messageID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMessageFromDLQ", messageID)
+	ret := m.ctrl.Call(m, "DeleteMessageFromDLQ", ctx, messageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteMessageFromDLQ indicates an expected call of DeleteMessageFromDLQ.
-func (mr *MockQueueMockRecorder) DeleteMessageFromDLQ(messageID interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) DeleteMessageFromDLQ(ctx, messageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMessageFromDLQ", reflect.TypeOf((*MockQueue)(nil).DeleteMessageFromDLQ), messageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMessageFromDLQ", reflect.TypeOf((*MockQueue)(nil).DeleteMessageFromDLQ), ctx, messageID)
 }
 
 // DeleteMessagesBefore mocks base method.
-func (m *MockQueue) DeleteMessagesBefore(messageID int64) error {
+func (m *MockQueue) DeleteMessagesBefore(ctx context.Context, messageID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteMessagesBefore", messageID)
+	ret := m.ctrl.Call(m, "DeleteMessagesBefore", ctx, messageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteMessagesBefore indicates an expected call of DeleteMessagesBefore.
-func (mr *MockQueueMockRecorder) DeleteMessagesBefore(messageID interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) DeleteMessagesBefore(ctx, messageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMessagesBefore", reflect.TypeOf((*MockQueue)(nil).DeleteMessagesBefore), messageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteMessagesBefore", reflect.TypeOf((*MockQueue)(nil).DeleteMessagesBefore), ctx, messageID)
 }
 
 // EnqueueMessage mocks base method.
-func (m *MockQueue) EnqueueMessage(blob common.DataBlob) error {
+func (m *MockQueue) EnqueueMessage(ctx context.Context, blob common.DataBlob) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnqueueMessage", blob)
+	ret := m.ctrl.Call(m, "EnqueueMessage", ctx, blob)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // EnqueueMessage indicates an expected call of EnqueueMessage.
-func (mr *MockQueueMockRecorder) EnqueueMessage(blob interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) EnqueueMessage(ctx, blob interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueMessage", reflect.TypeOf((*MockQueue)(nil).EnqueueMessage), blob)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueMessage", reflect.TypeOf((*MockQueue)(nil).EnqueueMessage), ctx, blob)
 }
 
 // EnqueueMessageToDLQ mocks base method.
-func (m *MockQueue) EnqueueMessageToDLQ(blob common.DataBlob) (int64, error) {
+func (m *MockQueue) EnqueueMessageToDLQ(ctx context.Context, blob common.DataBlob) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "EnqueueMessageToDLQ", blob)
+	ret := m.ctrl.Call(m, "EnqueueMessageToDLQ", ctx, blob)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // EnqueueMessageToDLQ indicates an expected call of EnqueueMessageToDLQ.
-func (mr *MockQueueMockRecorder) EnqueueMessageToDLQ(blob interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) EnqueueMessageToDLQ(ctx, blob interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueMessageToDLQ", reflect.TypeOf((*MockQueue)(nil).EnqueueMessageToDLQ), blob)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EnqueueMessageToDLQ", reflect.TypeOf((*MockQueue)(nil).EnqueueMessageToDLQ), ctx, blob)
 }
 
 // GetAckLevels mocks base method.
-func (m *MockQueue) GetAckLevels() (*persistence.InternalQueueMetadata, error) {
+func (m *MockQueue) GetAckLevels(ctx context.Context) (*persistence.InternalQueueMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAckLevels")
+	ret := m.ctrl.Call(m, "GetAckLevels", ctx)
 	ret0, _ := ret[0].(*persistence.InternalQueueMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAckLevels indicates an expected call of GetAckLevels.
-func (mr *MockQueueMockRecorder) GetAckLevels() *gomock.Call {
+func (mr *MockQueueMockRecorder) GetAckLevels(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAckLevels", reflect.TypeOf((*MockQueue)(nil).GetAckLevels))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAckLevels", reflect.TypeOf((*MockQueue)(nil).GetAckLevels), ctx)
 }
 
 // GetDLQAckLevels mocks base method.
-func (m *MockQueue) GetDLQAckLevels() (*persistence.InternalQueueMetadata, error) {
+func (m *MockQueue) GetDLQAckLevels(ctx context.Context) (*persistence.InternalQueueMetadata, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetDLQAckLevels")
+	ret := m.ctrl.Call(m, "GetDLQAckLevels", ctx)
 	ret0, _ := ret[0].(*persistence.InternalQueueMetadata)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetDLQAckLevels indicates an expected call of GetDLQAckLevels.
-func (mr *MockQueueMockRecorder) GetDLQAckLevels() *gomock.Call {
+func (mr *MockQueueMockRecorder) GetDLQAckLevels(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDLQAckLevels", reflect.TypeOf((*MockQueue)(nil).GetDLQAckLevels))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDLQAckLevels", reflect.TypeOf((*MockQueue)(nil).GetDLQAckLevels), ctx)
 }
 
 // Init mocks base method.
-func (m *MockQueue) Init(blob *common.DataBlob) error {
+func (m *MockQueue) Init(ctx context.Context, blob *common.DataBlob) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Init", blob)
+	ret := m.ctrl.Call(m, "Init", ctx, blob)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Init indicates an expected call of Init.
-func (mr *MockQueueMockRecorder) Init(blob interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) Init(ctx, blob interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockQueue)(nil).Init), blob)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Init", reflect.TypeOf((*MockQueue)(nil).Init), ctx, blob)
 }
 
 // RangeDeleteMessagesFromDLQ mocks base method.
-func (m *MockQueue) RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID int64) error {
+func (m *MockQueue) RangeDeleteMessagesFromDLQ(ctx context.Context, firstMessageID, lastMessageID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RangeDeleteMessagesFromDLQ", firstMessageID, lastMessageID)
+	ret := m.ctrl.Call(m, "RangeDeleteMessagesFromDLQ", ctx, firstMessageID, lastMessageID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RangeDeleteMessagesFromDLQ indicates an expected call of RangeDeleteMessagesFromDLQ.
-func (mr *MockQueueMockRecorder) RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeDeleteMessagesFromDLQ", reflect.TypeOf((*MockQueue)(nil).RangeDeleteMessagesFromDLQ), firstMessageID, lastMessageID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RangeDeleteMessagesFromDLQ", reflect.TypeOf((*MockQueue)(nil).RangeDeleteMessagesFromDLQ), ctx, firstMessageID, lastMessageID)
 }
 
 // ReadMessages mocks base method.
-func (m *MockQueue) ReadMessages(lastMessageID int64, maxCount int) ([]*persistence.QueueMessage, error) {
+func (m *MockQueue) ReadMessages(ctx context.Context, lastMessageID int64, maxCount int) ([]*persistence.QueueMessage, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadMessages", lastMessageID, maxCount)
+	ret := m.ctrl.Call(m, "ReadMessages", ctx, lastMessageID, maxCount)
 	ret0, _ := ret[0].([]*persistence.QueueMessage)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ReadMessages indicates an expected call of ReadMessages.
-func (mr *MockQueueMockRecorder) ReadMessages(lastMessageID, maxCount interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) ReadMessages(ctx, lastMessageID, maxCount interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadMessages", reflect.TypeOf((*MockQueue)(nil).ReadMessages), lastMessageID, maxCount)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadMessages", reflect.TypeOf((*MockQueue)(nil).ReadMessages), ctx, lastMessageID, maxCount)
 }
 
 // ReadMessagesFromDLQ mocks base method.
-func (m *MockQueue) ReadMessagesFromDLQ(firstMessageID, lastMessageID int64, pageSize int, pageToken []byte) ([]*persistence.QueueMessage, []byte, error) {
+func (m *MockQueue) ReadMessagesFromDLQ(ctx context.Context, firstMessageID, lastMessageID int64, pageSize int, pageToken []byte) ([]*persistence.QueueMessage, []byte, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReadMessagesFromDLQ", firstMessageID, lastMessageID, pageSize, pageToken)
+	ret := m.ctrl.Call(m, "ReadMessagesFromDLQ", ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 	ret0, _ := ret[0].([]*persistence.QueueMessage)
 	ret1, _ := ret[1].([]byte)
 	ret2, _ := ret[2].(error)
@@ -1210,35 +1211,35 @@ func (m *MockQueue) ReadMessagesFromDLQ(firstMessageID, lastMessageID int64, pag
 }
 
 // ReadMessagesFromDLQ indicates an expected call of ReadMessagesFromDLQ.
-func (mr *MockQueueMockRecorder) ReadMessagesFromDLQ(firstMessageID, lastMessageID, pageSize, pageToken interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) ReadMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadMessagesFromDLQ", reflect.TypeOf((*MockQueue)(nil).ReadMessagesFromDLQ), firstMessageID, lastMessageID, pageSize, pageToken)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadMessagesFromDLQ", reflect.TypeOf((*MockQueue)(nil).ReadMessagesFromDLQ), ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 }
 
 // UpdateAckLevel mocks base method.
-func (m *MockQueue) UpdateAckLevel(metadata *persistence.InternalQueueMetadata) error {
+func (m *MockQueue) UpdateAckLevel(ctx context.Context, metadata *persistence.InternalQueueMetadata) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateAckLevel", metadata)
+	ret := m.ctrl.Call(m, "UpdateAckLevel", ctx, metadata)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateAckLevel indicates an expected call of UpdateAckLevel.
-func (mr *MockQueueMockRecorder) UpdateAckLevel(metadata interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) UpdateAckLevel(ctx, metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAckLevel", reflect.TypeOf((*MockQueue)(nil).UpdateAckLevel), metadata)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAckLevel", reflect.TypeOf((*MockQueue)(nil).UpdateAckLevel), ctx, metadata)
 }
 
 // UpdateDLQAckLevel mocks base method.
-func (m *MockQueue) UpdateDLQAckLevel(metadata *persistence.InternalQueueMetadata) error {
+func (m *MockQueue) UpdateDLQAckLevel(ctx context.Context, metadata *persistence.InternalQueueMetadata) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDLQAckLevel", metadata)
+	ret := m.ctrl.Call(m, "UpdateDLQAckLevel", ctx, metadata)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateDLQAckLevel indicates an expected call of UpdateDLQAckLevel.
-func (mr *MockQueueMockRecorder) UpdateDLQAckLevel(metadata interface{}) *gomock.Call {
+func (mr *MockQueueMockRecorder) UpdateDLQAckLevel(ctx, metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDLQAckLevel", reflect.TypeOf((*MockQueue)(nil).UpdateDLQAckLevel), metadata)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDLQAckLevel", reflect.TypeOf((*MockQueue)(nil).UpdateDLQAckLevel), ctx, metadata)
 }

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -56,36 +56,36 @@ type (
 		Closeable
 		GetName() string
 		GetClusterName() string
-		GetOrCreateShard(request *InternalGetOrCreateShardRequest) (*InternalGetOrCreateShardResponse, error)
-		UpdateShard(request *InternalUpdateShardRequest) error
+		GetOrCreateShard(ctx context.Context, request *InternalGetOrCreateShardRequest) (*InternalGetOrCreateShardResponse, error)
+		UpdateShard(ctx context.Context, request *InternalUpdateShardRequest) error
 	}
 
 	// TaskStore is a lower level of TaskManager
 	TaskStore interface {
 		Closeable
 		GetName() string
-		CreateTaskQueue(request *InternalCreateTaskQueueRequest) error
-		GetTaskQueue(request *InternalGetTaskQueueRequest) (*InternalGetTaskQueueResponse, error)
-		UpdateTaskQueue(request *InternalUpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error)
-		ListTaskQueue(request *ListTaskQueueRequest) (*InternalListTaskQueueResponse, error)
-		DeleteTaskQueue(request *DeleteTaskQueueRequest) error
-		CreateTasks(request *InternalCreateTasksRequest) (*CreateTasksResponse, error)
-		GetTasks(request *GetTasksRequest) (*InternalGetTasksResponse, error)
-		CompleteTask(request *CompleteTaskRequest) error
-		CompleteTasksLessThan(request *CompleteTasksLessThanRequest) (int, error)
+		CreateTaskQueue(ctx context.Context, request *InternalCreateTaskQueueRequest) error
+		GetTaskQueue(ctx context.Context, request *InternalGetTaskQueueRequest) (*InternalGetTaskQueueResponse, error)
+		UpdateTaskQueue(ctx context.Context, request *InternalUpdateTaskQueueRequest) (*UpdateTaskQueueResponse, error)
+		ListTaskQueue(ctx context.Context, request *ListTaskQueueRequest) (*InternalListTaskQueueResponse, error)
+		DeleteTaskQueue(ctx context.Context, request *DeleteTaskQueueRequest) error
+		CreateTasks(ctx context.Context, request *InternalCreateTasksRequest) (*CreateTasksResponse, error)
+		GetTasks(ctx context.Context, request *GetTasksRequest) (*InternalGetTasksResponse, error)
+		CompleteTask(ctx context.Context, request *CompleteTaskRequest) error
+		CompleteTasksLessThan(ctx context.Context, request *CompleteTasksLessThanRequest) (int, error)
 	}
 	// MetadataStore is a lower level of MetadataManager
 	MetadataStore interface {
 		Closeable
 		GetName() string
-		CreateNamespace(request *InternalCreateNamespaceRequest) (*CreateNamespaceResponse, error)
-		GetNamespace(request *GetNamespaceRequest) (*InternalGetNamespaceResponse, error)
-		UpdateNamespace(request *InternalUpdateNamespaceRequest) error
-		RenameNamespace(request *InternalRenameNamespaceRequest) error
-		DeleteNamespace(request *DeleteNamespaceRequest) error
-		DeleteNamespaceByName(request *DeleteNamespaceByNameRequest) error
-		ListNamespaces(request *InternalListNamespacesRequest) (*InternalListNamespacesResponse, error)
-		GetMetadata() (*GetMetadataResponse, error)
+		CreateNamespace(ctx context.Context, request *InternalCreateNamespaceRequest) (*CreateNamespaceResponse, error)
+		GetNamespace(ctx context.Context, request *GetNamespaceRequest) (*InternalGetNamespaceResponse, error)
+		UpdateNamespace(ctx context.Context, request *InternalUpdateNamespaceRequest) error
+		RenameNamespace(ctx context.Context, request *InternalRenameNamespaceRequest) error
+		DeleteNamespace(ctx context.Context, request *DeleteNamespaceRequest) error
+		DeleteNamespaceByName(ctx context.Context, request *DeleteNamespaceByNameRequest) error
+		ListNamespaces(ctx context.Context, request *InternalListNamespacesRequest) (*InternalListNamespacesResponse, error)
+		GetMetadata(ctx context.Context) (*GetMetadataResponse, error)
 	}
 
 	// ClusterMetadataStore is a lower level of ClusterMetadataManager.
@@ -94,14 +94,14 @@ type (
 	ClusterMetadataStore interface {
 		Closeable
 		GetName() string
-		ListClusterMetadata(request *InternalListClusterMetadataRequest) (*InternalListClusterMetadataResponse, error)
-		GetClusterMetadata(request *InternalGetClusterMetadataRequest) (*InternalGetClusterMetadataResponse, error)
-		SaveClusterMetadata(request *InternalSaveClusterMetadataRequest) (bool, error)
-		DeleteClusterMetadata(request *InternalDeleteClusterMetadataRequest) error
+		ListClusterMetadata(ctx context.Context, request *InternalListClusterMetadataRequest) (*InternalListClusterMetadataResponse, error)
+		GetClusterMetadata(ctx context.Context, request *InternalGetClusterMetadataRequest) (*InternalGetClusterMetadataResponse, error)
+		SaveClusterMetadata(ctx context.Context, request *InternalSaveClusterMetadataRequest) (bool, error)
+		DeleteClusterMetadata(ctx context.Context, request *InternalDeleteClusterMetadataRequest) error
 		// Membership APIs
-		GetClusterMembers(request *GetClusterMembersRequest) (*GetClusterMembersResponse, error)
-		UpsertClusterMembership(request *UpsertClusterMembershipRequest) error
-		PruneClusterMembership(request *PruneClusterMembershipRequest) error
+		GetClusterMembers(ctx context.Context, request *GetClusterMembersRequest) (*GetClusterMembersResponse, error)
+		UpsertClusterMembership(ctx context.Context, request *UpsertClusterMembershipRequest) error
+		PruneClusterMembership(ctx context.Context, request *PruneClusterMembershipRequest) error
 	}
 
 	// ExecutionStore is used to manage workflow execution including mutable states / history / tasks.
@@ -109,66 +109,66 @@ type (
 		Closeable
 		GetName() string
 		// The below three APIs are related to serialization/deserialization
-		CreateWorkflowExecution(request *InternalCreateWorkflowExecutionRequest) (*InternalCreateWorkflowExecutionResponse, error)
-		UpdateWorkflowExecution(request *InternalUpdateWorkflowExecutionRequest) error
-		ConflictResolveWorkflowExecution(request *InternalConflictResolveWorkflowExecutionRequest) error
+		CreateWorkflowExecution(ctx context.Context, request *InternalCreateWorkflowExecutionRequest) (*InternalCreateWorkflowExecutionResponse, error)
+		UpdateWorkflowExecution(ctx context.Context, request *InternalUpdateWorkflowExecutionRequest) error
+		ConflictResolveWorkflowExecution(ctx context.Context, request *InternalConflictResolveWorkflowExecutionRequest) error
 
-		DeleteWorkflowExecution(request *DeleteWorkflowExecutionRequest) error
-		DeleteCurrentWorkflowExecution(request *DeleteCurrentWorkflowExecutionRequest) error
-		GetCurrentExecution(request *GetCurrentExecutionRequest) (*InternalGetCurrentExecutionResponse, error)
-		GetWorkflowExecution(request *GetWorkflowExecutionRequest) (*InternalGetWorkflowExecutionResponse, error)
-		SetWorkflowExecution(request *InternalSetWorkflowExecutionRequest) error
+		DeleteWorkflowExecution(ctx context.Context, request *DeleteWorkflowExecutionRequest) error
+		DeleteCurrentWorkflowExecution(ctx context.Context, request *DeleteCurrentWorkflowExecutionRequest) error
+		GetCurrentExecution(ctx context.Context, request *GetCurrentExecutionRequest) (*InternalGetCurrentExecutionResponse, error)
+		GetWorkflowExecution(ctx context.Context, request *GetWorkflowExecutionRequest) (*InternalGetWorkflowExecutionResponse, error)
+		SetWorkflowExecution(ctx context.Context, request *InternalSetWorkflowExecutionRequest) error
 
 		// Scan related methods
-		ListConcreteExecutions(request *ListConcreteExecutionsRequest) (*InternalListConcreteExecutionsResponse, error)
+		ListConcreteExecutions(ctx context.Context, request *ListConcreteExecutionsRequest) (*InternalListConcreteExecutionsResponse, error)
 
 		// Tasks related APIs
-		AddHistoryTasks(request *InternalAddHistoryTasksRequest) error
-		GetHistoryTask(request *GetHistoryTaskRequest) (*InternalGetHistoryTaskResponse, error)
-		GetHistoryTasks(request *GetHistoryTasksRequest) (*InternalGetHistoryTasksResponse, error)
-		CompleteHistoryTask(request *CompleteHistoryTaskRequest) error
-		RangeCompleteHistoryTasks(request *RangeCompleteHistoryTasksRequest) error
+		AddHistoryTasks(ctx context.Context, request *InternalAddHistoryTasksRequest) error
+		GetHistoryTask(ctx context.Context, request *GetHistoryTaskRequest) (*InternalGetHistoryTaskResponse, error)
+		GetHistoryTasks(ctx context.Context, request *GetHistoryTasksRequest) (*InternalGetHistoryTasksResponse, error)
+		CompleteHistoryTask(ctx context.Context, request *CompleteHistoryTaskRequest) error
+		RangeCompleteHistoryTasks(ctx context.Context, request *RangeCompleteHistoryTasksRequest) error
 
-		PutReplicationTaskToDLQ(request *PutReplicationTaskToDLQRequest) error
-		GetReplicationTasksFromDLQ(request *GetReplicationTasksFromDLQRequest) (*InternalGetReplicationTasksFromDLQResponse, error)
-		DeleteReplicationTaskFromDLQ(request *DeleteReplicationTaskFromDLQRequest) error
-		RangeDeleteReplicationTaskFromDLQ(request *RangeDeleteReplicationTaskFromDLQRequest) error
+		PutReplicationTaskToDLQ(ctx context.Context, request *PutReplicationTaskToDLQRequest) error
+		GetReplicationTasksFromDLQ(ctx context.Context, request *GetReplicationTasksFromDLQRequest) (*InternalGetReplicationTasksFromDLQResponse, error)
+		DeleteReplicationTaskFromDLQ(ctx context.Context, request *DeleteReplicationTaskFromDLQRequest) error
+		RangeDeleteReplicationTaskFromDLQ(ctx context.Context, request *RangeDeleteReplicationTaskFromDLQRequest) error
 
 		// The below are history V2 APIs
 		// V2 regards history events growing as a tree, decoupled from workflow concepts
 
 		// AppendHistoryNodes add a node to history node table
-		AppendHistoryNodes(request *InternalAppendHistoryNodesRequest) error
+		AppendHistoryNodes(ctx context.Context, request *InternalAppendHistoryNodesRequest) error
 		// DeleteHistoryNodes delete a node from history node table
-		DeleteHistoryNodes(request *InternalDeleteHistoryNodesRequest) error
+		DeleteHistoryNodes(ctx context.Context, request *InternalDeleteHistoryNodesRequest) error
 		// ReadHistoryBranch returns history node data for a branch
-		ReadHistoryBranch(request *InternalReadHistoryBranchRequest) (*InternalReadHistoryBranchResponse, error)
+		ReadHistoryBranch(ctx context.Context, request *InternalReadHistoryBranchRequest) (*InternalReadHistoryBranchResponse, error)
 		// ForkHistoryBranch forks a new branch from a old branch
-		ForkHistoryBranch(request *InternalForkHistoryBranchRequest) error
+		ForkHistoryBranch(ctx context.Context, request *InternalForkHistoryBranchRequest) error
 		// DeleteHistoryBranch removes a branch
-		DeleteHistoryBranch(request *InternalDeleteHistoryBranchRequest) error
+		DeleteHistoryBranch(ctx context.Context, request *InternalDeleteHistoryBranchRequest) error
 		// GetHistoryTree returns all branch information of a tree
-		GetHistoryTree(request *GetHistoryTreeRequest) (*InternalGetHistoryTreeResponse, error)
+		GetHistoryTree(ctx context.Context, request *GetHistoryTreeRequest) (*InternalGetHistoryTreeResponse, error)
 		// GetAllHistoryTreeBranches returns all branches of all trees
-		GetAllHistoryTreeBranches(request *GetAllHistoryTreeBranchesRequest) (*InternalGetAllHistoryTreeBranchesResponse, error)
+		GetAllHistoryTreeBranches(ctx context.Context, request *GetAllHistoryTreeBranchesRequest) (*InternalGetAllHistoryTreeBranchesResponse, error)
 	}
 
 	// Queue is a store to enqueue and get messages
 	Queue interface {
 		Closeable
-		Init(blob *commonpb.DataBlob) error
-		EnqueueMessage(blob commonpb.DataBlob) error
-		ReadMessages(lastMessageID int64, maxCount int) ([]*QueueMessage, error)
-		DeleteMessagesBefore(messageID int64) error
-		UpdateAckLevel(metadata *InternalQueueMetadata) error
-		GetAckLevels() (*InternalQueueMetadata, error)
+		Init(ctx context.Context, blob *commonpb.DataBlob) error
+		EnqueueMessage(ctx context.Context, blob commonpb.DataBlob) error
+		ReadMessages(ctx context.Context, lastMessageID int64, maxCount int) ([]*QueueMessage, error)
+		DeleteMessagesBefore(ctx context.Context, messageID int64) error
+		UpdateAckLevel(ctx context.Context, metadata *InternalQueueMetadata) error
+		GetAckLevels(ctx context.Context) (*InternalQueueMetadata, error)
 
-		EnqueueMessageToDLQ(blob commonpb.DataBlob) (int64, error)
-		ReadMessagesFromDLQ(firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error)
-		DeleteMessageFromDLQ(messageID int64) error
-		RangeDeleteMessagesFromDLQ(firstMessageID int64, lastMessageID int64) error
-		UpdateDLQAckLevel(metadata *InternalQueueMetadata) error
-		GetDLQAckLevels() (*InternalQueueMetadata, error)
+		EnqueueMessageToDLQ(ctx context.Context, blob commonpb.DataBlob) (int64, error)
+		ReadMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error)
+		DeleteMessageFromDLQ(ctx context.Context, messageID int64) error
+		RangeDeleteMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64) error
+		UpdateDLQAckLevel(ctx context.Context, metadata *InternalQueueMetadata) error
+		GetDLQAckLevels(ctx context.Context) (*InternalQueueMetadata, error)
 	}
 
 	// QueueMessage is the message that stores in the queue

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -999,15 +999,21 @@ func (p *executionPersistenceClient) GetHistoryTree(
 	return response, err
 }
 
-func (p *queuePersistenceClient) Init(blob *commonpb.DataBlob) error {
-	return p.persistence.Init(blob)
+func (p *queuePersistenceClient) Init(
+	ctx context.Context,
+	blob *commonpb.DataBlob,
+) error {
+	return p.persistence.Init(ctx, blob)
 }
 
-func (p *queuePersistenceClient) EnqueueMessage(blob commonpb.DataBlob) error {
+func (p *queuePersistenceClient) EnqueueMessage(
+	ctx context.Context,
+	blob commonpb.DataBlob,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceEnqueueMessageScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceEnqueueMessageScope, metrics.PersistenceLatency)
-	err := p.persistence.EnqueueMessage(blob)
+	err := p.persistence.EnqueueMessage(ctx, blob)
 	sw.Stop()
 
 	if err != nil {
@@ -1017,11 +1023,15 @@ func (p *queuePersistenceClient) EnqueueMessage(blob commonpb.DataBlob) error {
 	return err
 }
 
-func (p *queuePersistenceClient) ReadMessages(lastMessageID int64, maxCount int) ([]*QueueMessage, error) {
+func (p *queuePersistenceClient) ReadMessages(
+	ctx context.Context,
+	lastMessageID int64,
+	maxCount int,
+) ([]*QueueMessage, error) {
 	p.metricClient.IncCounter(metrics.PersistenceReadQueueMessagesScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceReadQueueMessagesScope, metrics.PersistenceLatency)
-	result, err := p.persistence.ReadMessages(lastMessageID, maxCount)
+	result, err := p.persistence.ReadMessages(ctx, lastMessageID, maxCount)
 	sw.Stop()
 
 	if err != nil {
@@ -1031,11 +1041,14 @@ func (p *queuePersistenceClient) ReadMessages(lastMessageID int64, maxCount int)
 	return result, err
 }
 
-func (p *queuePersistenceClient) UpdateAckLevel(metadata *InternalQueueMetadata) error {
+func (p *queuePersistenceClient) UpdateAckLevel(
+	ctx context.Context,
+	metadata *InternalQueueMetadata,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceUpdateAckLevelScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceUpdateAckLevelScope, metrics.PersistenceLatency)
-	err := p.persistence.UpdateAckLevel(metadata)
+	err := p.persistence.UpdateAckLevel(ctx, metadata)
 	sw.Stop()
 
 	if err != nil {
@@ -1045,11 +1058,13 @@ func (p *queuePersistenceClient) UpdateAckLevel(metadata *InternalQueueMetadata)
 	return err
 }
 
-func (p *queuePersistenceClient) GetAckLevels() (*InternalQueueMetadata, error) {
+func (p *queuePersistenceClient) GetAckLevels(
+	ctx context.Context,
+) (*InternalQueueMetadata, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetAckLevelScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetAckLevelScope, metrics.PersistenceLatency)
-	result, err := p.persistence.GetAckLevels()
+	result, err := p.persistence.GetAckLevels(ctx)
 	sw.Stop()
 
 	if err != nil {
@@ -1059,11 +1074,14 @@ func (p *queuePersistenceClient) GetAckLevels() (*InternalQueueMetadata, error) 
 	return result, err
 }
 
-func (p *queuePersistenceClient) DeleteMessagesBefore(messageID int64) error {
+func (p *queuePersistenceClient) DeleteMessagesBefore(
+	ctx context.Context,
+	messageID int64,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceDeleteQueueMessagesScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceDeleteQueueMessagesScope, metrics.PersistenceLatency)
-	err := p.persistence.DeleteMessagesBefore(messageID)
+	err := p.persistence.DeleteMessagesBefore(ctx, messageID)
 	sw.Stop()
 
 	if err != nil {
@@ -1073,11 +1091,14 @@ func (p *queuePersistenceClient) DeleteMessagesBefore(messageID int64) error {
 	return err
 }
 
-func (p *queuePersistenceClient) EnqueueMessageToDLQ(blob commonpb.DataBlob) (int64, error) {
+func (p *queuePersistenceClient) EnqueueMessageToDLQ(
+	ctx context.Context,
+	blob commonpb.DataBlob,
+) (int64, error) {
 	p.metricClient.IncCounter(metrics.PersistenceEnqueueMessageToDLQScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceEnqueueMessageToDLQScope, metrics.PersistenceLatency)
-	messageID, err := p.persistence.EnqueueMessageToDLQ(blob)
+	messageID, err := p.persistence.EnqueueMessageToDLQ(ctx, blob)
 	sw.Stop()
 
 	if err != nil {
@@ -1087,11 +1108,17 @@ func (p *queuePersistenceClient) EnqueueMessageToDLQ(blob commonpb.DataBlob) (in
 	return messageID, err
 }
 
-func (p *queuePersistenceClient) ReadMessagesFromDLQ(firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error) {
+func (p *queuePersistenceClient) ReadMessagesFromDLQ(
+	ctx context.Context,
+	firstMessageID int64,
+	lastMessageID int64,
+	pageSize int,
+	pageToken []byte,
+) ([]*QueueMessage, []byte, error) {
 	p.metricClient.IncCounter(metrics.PersistenceReadQueueMessagesFromDLQScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceReadQueueMessagesFromDLQScope, metrics.PersistenceLatency)
-	result, token, err := p.persistence.ReadMessagesFromDLQ(firstMessageID, lastMessageID, pageSize, pageToken)
+	result, token, err := p.persistence.ReadMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 	sw.Stop()
 
 	if err != nil {
@@ -1101,11 +1128,14 @@ func (p *queuePersistenceClient) ReadMessagesFromDLQ(firstMessageID int64, lastM
 	return result, token, err
 }
 
-func (p *queuePersistenceClient) DeleteMessageFromDLQ(messageID int64) error {
+func (p *queuePersistenceClient) DeleteMessageFromDLQ(
+	ctx context.Context,
+	messageID int64,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceDeleteQueueMessageFromDLQScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceDeleteQueueMessageFromDLQScope, metrics.PersistenceLatency)
-	err := p.persistence.DeleteMessageFromDLQ(messageID)
+	err := p.persistence.DeleteMessageFromDLQ(ctx, messageID)
 	sw.Stop()
 
 	if err != nil {
@@ -1115,11 +1145,15 @@ func (p *queuePersistenceClient) DeleteMessageFromDLQ(messageID int64) error {
 	return err
 }
 
-func (p *queuePersistenceClient) RangeDeleteMessagesFromDLQ(firstMessageID int64, lastMessageID int64) error {
+func (p *queuePersistenceClient) RangeDeleteMessagesFromDLQ(
+	ctx context.Context,
+	firstMessageID int64,
+	lastMessageID int64,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceRangeDeleteMessagesFromDLQScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceRangeDeleteMessagesFromDLQScope, metrics.PersistenceLatency)
-	err := p.persistence.RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID)
+	err := p.persistence.RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID)
 	sw.Stop()
 
 	if err != nil {
@@ -1129,11 +1163,14 @@ func (p *queuePersistenceClient) RangeDeleteMessagesFromDLQ(firstMessageID int64
 	return err
 }
 
-func (p *queuePersistenceClient) UpdateDLQAckLevel(metadata *InternalQueueMetadata) error {
+func (p *queuePersistenceClient) UpdateDLQAckLevel(
+	ctx context.Context,
+	metadata *InternalQueueMetadata,
+) error {
 	p.metricClient.IncCounter(metrics.PersistenceUpdateDLQAckLevelScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceUpdateDLQAckLevelScope, metrics.PersistenceLatency)
-	err := p.persistence.UpdateDLQAckLevel(metadata)
+	err := p.persistence.UpdateDLQAckLevel(ctx, metadata)
 	sw.Stop()
 
 	if err != nil {
@@ -1143,11 +1180,13 @@ func (p *queuePersistenceClient) UpdateDLQAckLevel(metadata *InternalQueueMetada
 	return err
 }
 
-func (p *queuePersistenceClient) GetDLQAckLevels() (*InternalQueueMetadata, error) {
+func (p *queuePersistenceClient) GetDLQAckLevels(
+	ctx context.Context,
+) (*InternalQueueMetadata, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetDLQAckLevelScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetDLQAckLevelScope, metrics.PersistenceLatency)
-	result, err := p.persistence.GetDLQAckLevels()
+	result, err := p.persistence.GetDLQAckLevels(ctx)
 	sw.Stop()
 
 	if err != nil {

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -716,99 +716,138 @@ func (p *executionRateLimitedPersistenceClient) GetAllHistoryTreeBranches(
 	return response, err
 }
 
-func (p *queueRateLimitedPersistenceClient) EnqueueMessage(blob commonpb.DataBlob) error {
+func (p *queueRateLimitedPersistenceClient) EnqueueMessage(
+	ctx context.Context,
+	blob commonpb.DataBlob,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.EnqueueMessage(blob)
+	return p.persistence.EnqueueMessage(ctx, blob)
 }
 
-func (p *queueRateLimitedPersistenceClient) ReadMessages(lastMessageID int64, maxCount int) ([]*QueueMessage, error) {
+func (p *queueRateLimitedPersistenceClient) ReadMessages(
+	ctx context.Context,
+	lastMessageID int64,
+	maxCount int,
+) ([]*QueueMessage, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.ReadMessages(lastMessageID, maxCount)
+	return p.persistence.ReadMessages(ctx, lastMessageID, maxCount)
 }
 
-func (p *queueRateLimitedPersistenceClient) UpdateAckLevel(metadata *InternalQueueMetadata) error {
+func (p *queueRateLimitedPersistenceClient) UpdateAckLevel(
+	ctx context.Context,
+	metadata *InternalQueueMetadata,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.UpdateAckLevel(metadata)
+	return p.persistence.UpdateAckLevel(ctx, metadata)
 }
 
-func (p *queueRateLimitedPersistenceClient) GetAckLevels() (*InternalQueueMetadata, error) {
+func (p *queueRateLimitedPersistenceClient) GetAckLevels(
+	ctx context.Context,
+) (*InternalQueueMetadata, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.GetAckLevels()
+	return p.persistence.GetAckLevels(ctx)
 }
 
-func (p *queueRateLimitedPersistenceClient) DeleteMessagesBefore(messageID int64) error {
+func (p *queueRateLimitedPersistenceClient) DeleteMessagesBefore(
+	ctx context.Context,
+	messageID int64,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.DeleteMessagesBefore(messageID)
+	return p.persistence.DeleteMessagesBefore(ctx, messageID)
 }
 
-func (p *queueRateLimitedPersistenceClient) EnqueueMessageToDLQ(blob commonpb.DataBlob) (int64, error) {
+func (p *queueRateLimitedPersistenceClient) EnqueueMessageToDLQ(
+	ctx context.Context,
+	blob commonpb.DataBlob,
+) (int64, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return EmptyQueueMessageID, ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.EnqueueMessageToDLQ(blob)
+	return p.persistence.EnqueueMessageToDLQ(ctx, blob)
 }
 
-func (p *queueRateLimitedPersistenceClient) ReadMessagesFromDLQ(firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error) {
+func (p *queueRateLimitedPersistenceClient) ReadMessagesFromDLQ(
+	ctx context.Context,
+	firstMessageID int64,
+	lastMessageID int64,
+	pageSize int,
+	pageToken []byte,
+) ([]*QueueMessage, []byte, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, nil, ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.ReadMessagesFromDLQ(firstMessageID, lastMessageID, pageSize, pageToken)
+	return p.persistence.ReadMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 }
 
-func (p *queueRateLimitedPersistenceClient) RangeDeleteMessagesFromDLQ(firstMessageID int64, lastMessageID int64) error {
+func (p *queueRateLimitedPersistenceClient) RangeDeleteMessagesFromDLQ(
+	ctx context.Context,
+	firstMessageID int64,
+	lastMessageID int64,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID)
+	return p.persistence.RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID)
 }
-func (p *queueRateLimitedPersistenceClient) UpdateDLQAckLevel(metadata *InternalQueueMetadata) error {
+func (p *queueRateLimitedPersistenceClient) UpdateDLQAckLevel(
+	ctx context.Context,
+	metadata *InternalQueueMetadata,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.UpdateDLQAckLevel(metadata)
+	return p.persistence.UpdateDLQAckLevel(ctx, metadata)
 }
 
-func (p *queueRateLimitedPersistenceClient) GetDLQAckLevels() (*InternalQueueMetadata, error) {
+func (p *queueRateLimitedPersistenceClient) GetDLQAckLevels(
+	ctx context.Context,
+) (*InternalQueueMetadata, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.GetDLQAckLevels()
+	return p.persistence.GetDLQAckLevels(ctx)
 }
 
-func (p *queueRateLimitedPersistenceClient) DeleteMessageFromDLQ(messageID int64) error {
+func (p *queueRateLimitedPersistenceClient) DeleteMessageFromDLQ(
+	ctx context.Context,
+	messageID int64,
+) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.DeleteMessageFromDLQ(messageID)
+	return p.persistence.DeleteMessageFromDLQ(ctx, messageID)
 }
 
 func (p *queueRateLimitedPersistenceClient) Close() {
 	p.persistence.Close()
 }
 
-func (p *queueRateLimitedPersistenceClient) Init(blob *commonpb.DataBlob) error {
-	return p.persistence.Init(blob)
+func (p *queueRateLimitedPersistenceClient) Init(
+	ctx context.Context,
+	blob *commonpb.DataBlob,
+) error {
+	return p.persistence.Init(ctx, blob)
 }
 
 func (c *clusterMetadataRateLimitedPersistenceClient) Close() {

--- a/common/persistence/shard_manager.go
+++ b/common/persistence/shard_manager.go
@@ -59,7 +59,7 @@ func (m *shardManagerImpl) GetName() string {
 }
 
 func (m *shardManagerImpl) GetOrCreateShard(
-	_ context.Context,
+	ctx context.Context,
 	request *GetOrCreateShardRequest,
 ) (*GetOrCreateShardResponse, error) {
 	var createShardInfo func() (int64, *commonpb.DataBlob, error)
@@ -76,7 +76,7 @@ func (m *shardManagerImpl) GetOrCreateShard(
 		}
 		return shardInfo.GetRangeId(), data, nil
 	}
-	internalResp, err := m.shardStore.GetOrCreateShard(&InternalGetOrCreateShardRequest{
+	internalResp, err := m.shardStore.GetOrCreateShard(ctx, &InternalGetOrCreateShardRequest{
 		ShardID:          request.ShardID,
 		CreateShardInfo:  createShardInfo,
 		LifecycleContext: request.LifecycleContext,
@@ -94,7 +94,7 @@ func (m *shardManagerImpl) GetOrCreateShard(
 }
 
 func (m *shardManagerImpl) UpdateShard(
-	_ context.Context,
+	ctx context.Context,
 	request *UpdateShardRequest,
 ) error {
 	shardInfo := request.ShardInfo
@@ -110,5 +110,5 @@ func (m *shardManagerImpl) UpdateShard(
 		ShardInfo:       shardInfoBlob,
 		PreviousRangeID: request.PreviousRangeID,
 	}
-	return m.shardStore.UpdateShard(internalRequest)
+	return m.shardStore.UpdateShard(ctx, internalRequest)
 }

--- a/common/persistence/sql/cluster_metadata.go
+++ b/common/persistence/sql/cluster_metadata.go
@@ -25,6 +25,7 @@
 package sql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"net"
@@ -44,6 +45,7 @@ type sqlClusterMetadataManager struct {
 var _ p.ClusterMetadataStore = (*sqlClusterMetadataManager)(nil)
 
 func (s *sqlClusterMetadataManager) ListClusterMetadata(
+	_ context.Context,
 	request *p.InternalListClusterMetadataRequest,
 ) (*p.InternalListClusterMetadataResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -88,6 +90,7 @@ func (s *sqlClusterMetadataManager) ListClusterMetadata(
 }
 
 func (s *sqlClusterMetadataManager) GetClusterMetadata(
+	_ context.Context,
 	request *p.InternalGetClusterMetadataRequest,
 ) (*p.InternalGetClusterMetadataResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -104,7 +107,10 @@ func (s *sqlClusterMetadataManager) GetClusterMetadata(
 	}, nil
 }
 
-func (s *sqlClusterMetadataManager) SaveClusterMetadata(request *p.InternalSaveClusterMetadataRequest) (bool, error) {
+func (s *sqlClusterMetadataManager) SaveClusterMetadata(
+	_ context.Context,
+	request *p.InternalSaveClusterMetadataRequest,
+) (bool, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	err := s.txExecute(ctx, "SaveClusterMetadata", func(tx sqlplugin.Tx) error {
@@ -142,6 +148,7 @@ func (s *sqlClusterMetadataManager) SaveClusterMetadata(request *p.InternalSaveC
 }
 
 func (s *sqlClusterMetadataManager) DeleteClusterMetadata(
+	_ context.Context,
 	request *p.InternalDeleteClusterMetadataRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -154,7 +161,10 @@ func (s *sqlClusterMetadataManager) DeleteClusterMetadata(
 	return nil
 }
 
-func (s *sqlClusterMetadataManager) GetClusterMembers(request *p.GetClusterMembersRequest) (*p.GetClusterMembersResponse, error) {
+func (s *sqlClusterMetadataManager) GetClusterMembers(
+	_ context.Context,
+	request *p.GetClusterMembersRequest,
+) (*p.GetClusterMembersResponse, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	var lastSeenHostId []byte
@@ -213,7 +223,10 @@ func (s *sqlClusterMetadataManager) GetClusterMembers(request *p.GetClusterMembe
 	return &p.GetClusterMembersResponse{ActiveMembers: convertedRows, NextPageToken: nextPageToken}, nil
 }
 
-func (s *sqlClusterMetadataManager) UpsertClusterMembership(request *p.UpsertClusterMembershipRequest) error {
+func (s *sqlClusterMetadataManager) UpsertClusterMembership(
+	_ context.Context,
+	request *p.UpsertClusterMembershipRequest,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	now := time.Now().UTC()
@@ -234,7 +247,10 @@ func (s *sqlClusterMetadataManager) UpsertClusterMembership(request *p.UpsertClu
 	return nil
 }
 
-func (s *sqlClusterMetadataManager) PruneClusterMembership(request *p.PruneClusterMembershipRequest) error {
+func (s *sqlClusterMetadataManager) PruneClusterMembership(
+	_ context.Context,
+	request *p.PruneClusterMembershipRequest,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	_, err := s.Db.PruneClusterMembership(ctx, &sqlplugin.PruneClusterMembershipFilter{

--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -79,16 +79,18 @@ func (m *sqlExecutionStore) txExecuteShardLocked(
 }
 
 func (m *sqlExecutionStore) CreateWorkflowExecution(
+	_ context.Context,
 	request *p.InternalCreateWorkflowExecutionRequest,
 ) (response *p.InternalCreateWorkflowExecutionResponse, err error) {
+	ctx, cancel := newExecutionContext()
+	defer cancel()
+
 	for _, req := range request.NewWorkflowNewEvents {
-		if err := m.AppendHistoryNodes(req); err != nil {
+		if err := m.AppendHistoryNodes(ctx, req); err != nil {
 			return nil, err
 		}
 	}
 
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	err = m.txExecuteShardLocked(ctx,
 		"CreateWorkflowExecution",
 		request.ShardID,
@@ -224,6 +226,7 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 }
 
 func (m *sqlExecutionStore) GetWorkflowExecution(
+	_ context.Context,
 	request *p.GetWorkflowExecutionRequest,
 ) (*p.InternalGetWorkflowExecutionResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -338,23 +341,25 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 }
 
 func (m *sqlExecutionStore) UpdateWorkflowExecution(
+	_ context.Context,
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
+	ctx, cancel := newExecutionContext()
+	defer cancel()
+
 	// first append history
 	for _, req := range request.UpdateWorkflowNewEvents {
-		if err := m.AppendHistoryNodes(req); err != nil {
+		if err := m.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 	for _, req := range request.NewWorkflowNewEvents {
-		if err := m.AppendHistoryNodes(req); err != nil {
+		if err := m.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 
 	// then update mutable state
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	return m.txExecuteShardLocked(ctx,
 		"UpdateWorkflowExecution",
 		request.ShardID,
@@ -458,27 +463,29 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 }
 
 func (m *sqlExecutionStore) ConflictResolveWorkflowExecution(
+	_ context.Context,
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
+	ctx, cancel := newExecutionContext()
+	defer cancel()
+
 	// first append history
 	for _, req := range request.CurrentWorkflowEventsNewEvents {
-		if err := m.AppendHistoryNodes(req); err != nil {
+		if err := m.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 	for _, req := range request.ResetWorkflowEventsNewEvents {
-		if err := m.AppendHistoryNodes(req); err != nil {
+		if err := m.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 	for _, req := range request.NewWorkflowEventsNewEvents {
-		if err := m.AppendHistoryNodes(req); err != nil {
+		if err := m.AppendHistoryNodes(ctx, req); err != nil {
 			return err
 		}
 	}
 
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	return m.txExecuteShardLocked(ctx,
 		"ConflictResolveWorkflowExecution",
 		request.ShardID,
@@ -599,6 +606,7 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 }
 
 func (m *sqlExecutionStore) DeleteWorkflowExecution(
+	_ context.Context,
 	request *p.DeleteWorkflowExecutionRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -619,6 +627,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 // runID. The following code will delete the row from current_executions if and only if the runID is
 // same as the one we are trying to delete here
 func (m *sqlExecutionStore) DeleteCurrentWorkflowExecution(
+	_ context.Context,
 	request *p.DeleteCurrentWorkflowExecutionRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -635,6 +644,7 @@ func (m *sqlExecutionStore) DeleteCurrentWorkflowExecution(
 }
 
 func (m *sqlExecutionStore) GetCurrentExecution(
+	_ context.Context,
 	request *p.GetCurrentExecutionRequest,
 ) (*p.InternalGetCurrentExecutionResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -662,6 +672,7 @@ func (m *sqlExecutionStore) GetCurrentExecution(
 }
 
 func (m *sqlExecutionStore) SetWorkflowExecution(
+	_ context.Context,
 	request *p.InternalSetWorkflowExecutionRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -694,6 +705,7 @@ func (m *sqlExecutionStore) setWorkflowExecutionTx(
 }
 
 func (m *sqlExecutionStore) ListConcreteExecutions(
+	_ context.Context,
 	_ *p.ListConcreteExecutionsRequest,
 ) (*p.InternalListConcreteExecutionsResponse, error) {
 	return nil, serviceerror.NewUnimplemented("ListConcreteExecutions is not implemented")

--- a/common/persistence/sql/execution_tasks.go
+++ b/common/persistence/sql/execution_tasks.go
@@ -25,6 +25,7 @@
 package sql
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -41,6 +42,7 @@ import (
 )
 
 func (m *sqlExecutionStore) AddHistoryTasks(
+	_ context.Context,
 	request *p.InternalAddHistoryTasksRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -59,6 +61,7 @@ func (m *sqlExecutionStore) AddHistoryTasks(
 }
 
 func (m *sqlExecutionStore) GetHistoryTask(
+	_ context.Context,
 	request *p.GetHistoryTaskRequest,
 ) (*p.InternalGetHistoryTaskResponse, error) {
 	switch request.TaskCategory.ID() {
@@ -76,6 +79,7 @@ func (m *sqlExecutionStore) GetHistoryTask(
 }
 
 func (m *sqlExecutionStore) GetHistoryTasks(
+	_ context.Context,
 	request *p.GetHistoryTasksRequest,
 ) (*p.InternalGetHistoryTasksResponse, error) {
 	switch request.TaskCategory.ID() {
@@ -93,6 +97,7 @@ func (m *sqlExecutionStore) GetHistoryTasks(
 }
 
 func (m *sqlExecutionStore) CompleteHistoryTask(
+	_ context.Context,
 	request *p.CompleteHistoryTaskRequest,
 ) error {
 	switch request.TaskCategory.ID() {
@@ -110,6 +115,7 @@ func (m *sqlExecutionStore) CompleteHistoryTask(
 }
 
 func (m *sqlExecutionStore) RangeCompleteHistoryTasks(
+	_ context.Context,
 	request *p.RangeCompleteHistoryTasksRequest,
 ) error {
 	switch request.TaskCategory.ID() {
@@ -486,6 +492,7 @@ func (m *sqlExecutionStore) rangeCompleteReplicationTasks(
 }
 
 func (m *sqlExecutionStore) PutReplicationTaskToDLQ(
+	_ context.Context,
 	request *p.PutReplicationTaskToDLQRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -515,6 +522,7 @@ func (m *sqlExecutionStore) PutReplicationTaskToDLQ(
 }
 
 func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
+	_ context.Context,
 	request *p.GetReplicationTasksFromDLQRequest,
 ) (*p.InternalGetHistoryTasksResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -543,6 +551,7 @@ func (m *sqlExecutionStore) GetReplicationTasksFromDLQ(
 }
 
 func (m *sqlExecutionStore) DeleteReplicationTaskFromDLQ(
+	_ context.Context,
 	request *p.DeleteReplicationTaskFromDLQRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -558,6 +567,7 @@ func (m *sqlExecutionStore) DeleteReplicationTaskFromDLQ(
 }
 
 func (m *sqlExecutionStore) RangeDeleteReplicationTaskFromDLQ(
+	_ context.Context,
 	request *p.RangeDeleteReplicationTaskFromDLQRequest,
 ) error {
 	ctx, cancel := newExecutionContext()

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -25,6 +25,7 @@
 package sql
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"math"
@@ -45,6 +46,7 @@ const (
 
 // AppendHistoryNodes add(or override) a node to a history branch
 func (m *sqlExecutionStore) AppendHistoryNodes(
+	_ context.Context,
 	request *p.InternalAppendHistoryNodesRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -121,6 +123,7 @@ func (m *sqlExecutionStore) AppendHistoryNodes(
 }
 
 func (m *sqlExecutionStore) DeleteHistoryNodes(
+	_ context.Context,
 	request *p.InternalDeleteHistoryNodesRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -162,6 +165,7 @@ func (m *sqlExecutionStore) DeleteHistoryNodes(
 
 // ReadHistoryBranch returns history node data for a branch
 func (m *sqlExecutionStore) ReadHistoryBranch(
+	_ context.Context,
 	request *p.InternalReadHistoryBranchRequest,
 ) (*p.InternalReadHistoryBranchResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -294,6 +298,7 @@ func (m *sqlExecutionStore) ReadHistoryBranch(
 //       8[8,9]
 //
 func (m *sqlExecutionStore) ForkHistoryBranch(
+	_ context.Context,
 	request *p.InternalForkHistoryBranchRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -334,6 +339,7 @@ func (m *sqlExecutionStore) ForkHistoryBranch(
 
 // DeleteHistoryBranch removes a branch
 func (m *sqlExecutionStore) DeleteHistoryBranch(
+	_ context.Context,
 	request *p.InternalDeleteHistoryBranchRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -381,6 +387,7 @@ func (m *sqlExecutionStore) DeleteHistoryBranch(
 }
 
 func (m *sqlExecutionStore) GetAllHistoryTreeBranches(
+	_ context.Context,
 	request *p.GetAllHistoryTreeBranchesRequest,
 ) (*p.InternalGetAllHistoryTreeBranchesResponse, error) {
 
@@ -391,6 +398,7 @@ func (m *sqlExecutionStore) GetAllHistoryTreeBranches(
 
 // GetHistoryTree returns all branch information of a tree
 func (m *sqlExecutionStore) GetHistoryTree(
+	_ context.Context,
 	request *p.GetHistoryTreeRequest,
 ) (*p.InternalGetHistoryTreeResponse, error) {
 	ctx, cancel := newExecutionContext()

--- a/common/persistence/sql/metadata.go
+++ b/common/persistence/sql/metadata.go
@@ -55,6 +55,7 @@ func newMetadataPersistenceV2(
 }
 
 func (m *sqlMetadataManagerV2) CreateNamespace(
+	_ context.Context,
 	request *persistence.InternalCreateNamespaceRequest,
 ) (*persistence.CreateNamespaceResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -96,6 +97,7 @@ func (m *sqlMetadataManagerV2) CreateNamespace(
 }
 
 func (m *sqlMetadataManagerV2) GetNamespace(
+	_ context.Context,
 	request *persistence.GetNamespaceRequest,
 ) (*persistence.InternalGetNamespaceResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -148,15 +150,24 @@ func (m *sqlMetadataManagerV2) namespaceRowToGetNamespaceResponse(row *sqlplugin
 	}, nil
 }
 
-func (m *sqlMetadataManagerV2) UpdateNamespace(request *persistence.InternalUpdateNamespaceRequest) error {
+func (m *sqlMetadataManagerV2) UpdateNamespace(
+	_ context.Context,
+	request *persistence.InternalUpdateNamespaceRequest,
+) error {
 	return m.updateNamespace(request, "UpdateNamespace")
 }
 
-func (m *sqlMetadataManagerV2) RenameNamespace(request *persistence.InternalRenameNamespaceRequest) error {
+func (m *sqlMetadataManagerV2) RenameNamespace(
+	_ context.Context,
+	request *persistence.InternalRenameNamespaceRequest,
+) error {
 	return m.updateNamespace(request.InternalUpdateNamespaceRequest, "RenameNamespace")
 }
 
-func (m *sqlMetadataManagerV2) updateNamespace(request *persistence.InternalUpdateNamespaceRequest, operationName string) error {
+func (m *sqlMetadataManagerV2) updateNamespace(
+	request *persistence.InternalUpdateNamespaceRequest,
+	operationName string,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	idBytes, err := primitives.ParseUUID(request.Id)
@@ -198,7 +209,10 @@ func (m *sqlMetadataManagerV2) updateNamespace(request *persistence.InternalUpda
 	})
 }
 
-func (m *sqlMetadataManagerV2) DeleteNamespace(request *persistence.DeleteNamespaceRequest) error {
+func (m *sqlMetadataManagerV2) DeleteNamespace(
+	_ context.Context,
+	request *persistence.DeleteNamespaceRequest,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	idBytes, err := primitives.ParseUUID(request.ID)
@@ -214,7 +228,10 @@ func (m *sqlMetadataManagerV2) DeleteNamespace(request *persistence.DeleteNamesp
 	})
 }
 
-func (m *sqlMetadataManagerV2) DeleteNamespaceByName(request *persistence.DeleteNamespaceByNameRequest) error {
+func (m *sqlMetadataManagerV2) DeleteNamespaceByName(
+	_ context.Context,
+	request *persistence.DeleteNamespaceByNameRequest,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	return m.txExecute(ctx, "DeleteNamespaceByName", func(tx sqlplugin.Tx) error {
@@ -225,7 +242,9 @@ func (m *sqlMetadataManagerV2) DeleteNamespaceByName(request *persistence.Delete
 	})
 }
 
-func (m *sqlMetadataManagerV2) GetMetadata() (*persistence.GetMetadataResponse, error) {
+func (m *sqlMetadataManagerV2) GetMetadata(
+	_ context.Context,
+) (*persistence.GetMetadataResponse, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	row, err := m.Db.SelectFromNamespaceMetadata(ctx)
@@ -235,7 +254,10 @@ func (m *sqlMetadataManagerV2) GetMetadata() (*persistence.GetMetadataResponse, 
 	return &persistence.GetMetadataResponse{NotificationVersion: row.NotificationVersion}, nil
 }
 
-func (m *sqlMetadataManagerV2) ListNamespaces(request *persistence.InternalListNamespacesRequest) (*persistence.InternalListNamespacesResponse, error) {
+func (m *sqlMetadataManagerV2) ListNamespaces(
+	_ context.Context,
+	request *persistence.InternalListNamespacesRequest,
+) (*persistence.InternalListNamespacesResponse, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	var pageToken *primitives.UUID

--- a/common/persistence/sql/queue.go
+++ b/common/persistence/sql/queue.go
@@ -58,7 +58,10 @@ func newQueue(
 	return queue, nil
 }
 
-func (q *sqlQueue) Init(blob *commonpb.DataBlob) error {
+func (q *sqlQueue) Init(
+	_ context.Context,
+	blob *commonpb.DataBlob,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	if err := q.initializeQueueMetadata(ctx, blob); err != nil {
@@ -71,6 +74,7 @@ func (q *sqlQueue) Init(blob *commonpb.DataBlob) error {
 }
 
 func (q *sqlQueue) EnqueueMessage(
+	_ context.Context,
 	blob commonpb.DataBlob,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -99,6 +103,7 @@ func (q *sqlQueue) EnqueueMessage(
 }
 
 func (q *sqlQueue) ReadMessages(
+	_ context.Context,
 	lastMessageID int64,
 	pageSize int,
 ) ([]*persistence.QueueMessage, error) {
@@ -127,6 +132,7 @@ func (q *sqlQueue) ReadMessages(
 }
 
 func (q *sqlQueue) DeleteMessagesBefore(
+	_ context.Context,
 	messageID int64,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -142,7 +148,10 @@ func (q *sqlQueue) DeleteMessagesBefore(
 	return nil
 }
 
-func (q *sqlQueue) UpdateAckLevel(metadata *persistence.InternalQueueMetadata) error {
+func (q *sqlQueue) UpdateAckLevel(
+	_ context.Context,
+	metadata *persistence.InternalQueueMetadata,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	err := q.txExecute(ctx, "UpdateAckLevel", func(tx sqlplugin.Tx) error {
@@ -171,7 +180,9 @@ func (q *sqlQueue) UpdateAckLevel(metadata *persistence.InternalQueueMetadata) e
 	return nil
 }
 
-func (q *sqlQueue) GetAckLevels() (*persistence.InternalQueueMetadata, error) {
+func (q *sqlQueue) GetAckLevels(
+	_ context.Context,
+) (*persistence.InternalQueueMetadata, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	row, err := q.Db.SelectFromQueueMetadata(ctx, sqlplugin.QueueMetadataFilter{
@@ -188,6 +199,7 @@ func (q *sqlQueue) GetAckLevels() (*persistence.InternalQueueMetadata, error) {
 }
 
 func (q *sqlQueue) EnqueueMessageToDLQ(
+	_ context.Context,
 	blob commonpb.DataBlob,
 ) (int64, error) {
 	ctx, cancel := newExecutionContext()
@@ -218,6 +230,7 @@ func (q *sqlQueue) EnqueueMessageToDLQ(
 }
 
 func (q *sqlQueue) ReadMessagesFromDLQ(
+	_ context.Context,
 	firstMessageID int64,
 	lastMessageID int64,
 	pageSize int,
@@ -262,6 +275,7 @@ func (q *sqlQueue) ReadMessagesFromDLQ(
 }
 
 func (q *sqlQueue) DeleteMessageFromDLQ(
+	_ context.Context,
 	messageID int64,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -277,6 +291,7 @@ func (q *sqlQueue) DeleteMessageFromDLQ(
 }
 
 func (q *sqlQueue) RangeDeleteMessagesFromDLQ(
+	_ context.Context,
 	firstMessageID int64,
 	lastMessageID int64,
 ) error {
@@ -293,7 +308,10 @@ func (q *sqlQueue) RangeDeleteMessagesFromDLQ(
 	return nil
 }
 
-func (q *sqlQueue) UpdateDLQAckLevel(metadata *persistence.InternalQueueMetadata) error {
+func (q *sqlQueue) UpdateDLQAckLevel(
+	_ context.Context,
+	metadata *persistence.InternalQueueMetadata,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	err := q.txExecute(ctx, "UpdateDLQAckLevel", func(tx sqlplugin.Tx) error {
@@ -322,7 +340,9 @@ func (q *sqlQueue) UpdateDLQAckLevel(metadata *persistence.InternalQueueMetadata
 	return nil
 }
 
-func (q *sqlQueue) GetDLQAckLevels() (*persistence.InternalQueueMetadata, error) {
+func (q *sqlQueue) GetDLQAckLevels(
+	_ context.Context,
+) (*persistence.InternalQueueMetadata, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	row, err := q.Db.SelectFromQueueMetadata(ctx, sqlplugin.QueueMetadataFilter{

--- a/common/persistence/sql/shard.go
+++ b/common/persistence/sql/shard.go
@@ -58,6 +58,7 @@ func (m *sqlShardStore) GetClusterName() string {
 }
 
 func (m *sqlShardStore) GetOrCreateShard(
+	_ context.Context,
 	request *persistence.InternalGetOrCreateShardRequest,
 ) (*persistence.InternalGetOrCreateShardResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -95,13 +96,14 @@ func (m *sqlShardStore) GetOrCreateShard(
 	} else if m.Db.IsDupEntryError(err) {
 		// conflict, try again
 		request.CreateShardInfo = nil // prevent loop
-		return m.GetOrCreateShard(request)
+		return m.GetOrCreateShard(ctx, request)
 	} else {
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetOrCreateShard: failed to insert into shards table. Error: %v", err))
 	}
 }
 
 func (m *sqlShardStore) UpdateShard(
+	_ context.Context,
 	request *persistence.InternalUpdateShardRequest,
 ) error {
 	ctx, cancel := newExecutionContext()

--- a/common/persistence/sql/task.go
+++ b/common/persistence/sql/task.go
@@ -72,7 +72,10 @@ func newTaskPersistence(
 	}, nil
 }
 
-func (m *sqlTaskManager) CreateTaskQueue(request *persistence.InternalCreateTaskQueueRequest) error {
+func (m *sqlTaskManager) CreateTaskQueue(
+	_ context.Context,
+	request *persistence.InternalCreateTaskQueueRequest,
+) error {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
@@ -98,7 +101,10 @@ func (m *sqlTaskManager) CreateTaskQueue(request *persistence.InternalCreateTask
 	return nil
 }
 
-func (m *sqlTaskManager) GetTaskQueue(request *persistence.InternalGetTaskQueueRequest) (*persistence.InternalGetTaskQueueResponse, error) {
+func (m *sqlTaskManager) GetTaskQueue(
+	_ context.Context,
+	request *persistence.InternalGetTaskQueueRequest,
+) (*persistence.InternalGetTaskQueueResponse, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
@@ -135,6 +141,7 @@ func (m *sqlTaskManager) GetTaskQueue(request *persistence.InternalGetTaskQueueR
 }
 
 func (m *sqlTaskManager) UpdateTaskQueue(
+	_ context.Context,
 	request *persistence.InternalUpdateTaskQueueRequest,
 ) (*persistence.UpdateTaskQueueResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -178,7 +185,10 @@ func (m *sqlTaskManager) UpdateTaskQueue(
 	return resp, err
 }
 
-func (m *sqlTaskManager) ListTaskQueue(request *persistence.ListTaskQueueRequest) (*persistence.InternalListTaskQueueResponse, error) {
+func (m *sqlTaskManager) ListTaskQueue(
+	_ context.Context,
+	request *persistence.ListTaskQueueRequest,
+) (*persistence.InternalListTaskQueueResponse, error) {
 	ctx, cancel := newExecutionContext()
 	defer cancel()
 	pageToken := taskQueuePageToken{MinTaskQueueId: minTaskQueueId}
@@ -309,6 +319,7 @@ func getBoundariesForPartition(partition uint32, totalPartitions uint32) (uint32
 }
 
 func (m *sqlTaskManager) DeleteTaskQueue(
+	_ context.Context,
 	request *persistence.DeleteTaskQueueRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -338,6 +349,7 @@ func (m *sqlTaskManager) DeleteTaskQueue(
 	return nil
 }
 func (m *sqlTaskManager) CreateTasks(
+	_ context.Context,
 	request *persistence.InternalCreateTasksRequest,
 ) (*persistence.CreateTasksResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -380,6 +392,7 @@ func (m *sqlTaskManager) CreateTasks(
 }
 
 func (m *sqlTaskManager) GetTasks(
+	_ context.Context,
 	request *persistence.GetTasksRequest,
 ) (*persistence.InternalGetTasksResponse, error) {
 	ctx, cancel := newExecutionContext()
@@ -434,6 +447,7 @@ func (m *sqlTaskManager) GetTasks(
 }
 
 func (m *sqlTaskManager) CompleteTask(
+	_ context.Context,
 	request *persistence.CompleteTaskRequest,
 ) error {
 	ctx, cancel := newExecutionContext()
@@ -456,6 +470,7 @@ func (m *sqlTaskManager) CompleteTask(
 }
 
 func (m *sqlTaskManager) CompleteTasksLessThan(
+	_ context.Context,
 	request *persistence.CompleteTasksLessThanRequest,
 ) (int, error) {
 	ctx, cancel := newExecutionContext()

--- a/common/persistence/task_manager.go
+++ b/common/persistence/task_manager.go
@@ -61,7 +61,7 @@ func (m *taskManagerImpl) GetName() string {
 }
 
 func (m *taskManagerImpl) CreateTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *CreateTaskQueueRequest,
 ) (*CreateTaskQueueResponse, error) {
 	taskQueueInfo := request.TaskQueueInfo
@@ -85,14 +85,14 @@ func (m *taskManagerImpl) CreateTaskQueue(
 		ExpiryTime:    taskQueueInfo.ExpiryTime,
 		TaskQueueInfo: taskQueueInfoBlob,
 	}
-	if err := m.taskStore.CreateTaskQueue(internalRequest); err != nil {
+	if err := m.taskStore.CreateTaskQueue(ctx, internalRequest); err != nil {
 		return nil, err
 	}
 	return &CreateTaskQueueResponse{}, nil
 }
 
 func (m *taskManagerImpl) UpdateTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *UpdateTaskQueueRequest,
 ) (*UpdateTaskQueueResponse, error) {
 	taskQueueInfo := request.TaskQueueInfo
@@ -119,14 +119,14 @@ func (m *taskManagerImpl) UpdateTaskQueue(
 
 		PrevRangeID: request.PrevRangeID,
 	}
-	return m.taskStore.UpdateTaskQueue(internalRequest)
+	return m.taskStore.UpdateTaskQueue(ctx, internalRequest)
 }
 
 func (m *taskManagerImpl) GetTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *GetTaskQueueRequest,
 ) (*GetTaskQueueResponse, error) {
-	response, err := m.taskStore.GetTaskQueue(&InternalGetTaskQueueRequest{
+	response, err := m.taskStore.GetTaskQueue(ctx, &InternalGetTaskQueueRequest{
 		NamespaceID: request.NamespaceID,
 		TaskQueue:   request.TaskQueue,
 		TaskType:    request.TaskType,
@@ -146,10 +146,10 @@ func (m *taskManagerImpl) GetTaskQueue(
 }
 
 func (m *taskManagerImpl) ListTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *ListTaskQueueRequest,
 ) (*ListTaskQueueResponse, error) {
-	internalResp, err := m.taskStore.ListTaskQueue(request)
+	internalResp, err := m.taskStore.ListTaskQueue(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -172,14 +172,14 @@ func (m *taskManagerImpl) ListTaskQueue(
 }
 
 func (m *taskManagerImpl) DeleteTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *DeleteTaskQueueRequest,
 ) error {
-	return m.taskStore.DeleteTaskQueue(request)
+	return m.taskStore.DeleteTaskQueue(ctx, request)
 }
 
 func (m *taskManagerImpl) CreateTasks(
-	_ context.Context,
+	ctx context.Context,
 	request *CreateTasksRequest,
 ) (*CreateTasksResponse, error) {
 	taskQueueInfo := request.TaskQueueInfo.Data
@@ -209,18 +209,18 @@ func (m *taskManagerImpl) CreateTasks(
 		TaskQueueInfo: taskQueueInfoBlob,
 		Tasks:         tasks,
 	}
-	return m.taskStore.CreateTasks(internalRequest)
+	return m.taskStore.CreateTasks(ctx, internalRequest)
 }
 
 func (m *taskManagerImpl) GetTasks(
-	_ context.Context,
+	ctx context.Context,
 	request *GetTasksRequest,
 ) (*GetTasksResponse, error) {
 	if request.InclusiveMinTaskID >= request.ExclusiveMaxTaskID {
 		return &GetTasksResponse{}, nil
 	}
 
-	internalResp, err := m.taskStore.GetTasks(request)
+	internalResp, err := m.taskStore.GetTasks(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -236,15 +236,15 @@ func (m *taskManagerImpl) GetTasks(
 }
 
 func (m *taskManagerImpl) CompleteTask(
-	_ context.Context,
+	ctx context.Context,
 	request *CompleteTaskRequest,
 ) error {
-	return m.taskStore.CompleteTask(request)
+	return m.taskStore.CompleteTask(ctx, request)
 }
 
 func (m *taskManagerImpl) CompleteTasksLessThan(
-	_ context.Context,
+	ctx context.Context,
 	request *CompleteTasksLessThanRequest,
 ) (int, error) {
-	return m.taskStore.CompleteTasksLessThan(request)
+	return m.taskStore.CompleteTasksLessThan(ctx, request)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add context parameter to persistence store interfaces.
- NOTE: there's no behavior change in this PR. SQL and Cassandra store implementation still ignores the context passed it. Those will be changed in a follow up PR.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enforce persistence timeout, instead of always timeout after 10s
- Required for host level task worker pool

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
-  Very low, context is currently ignored by persistence store implementation

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.