### PR TITLE
Fix parent close policy processor for deleted namespace

### DIFF
--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -1396,15 +1396,17 @@ func (t *transferQueueActiveTaskExecutor) applyParentClosePolicy(
 		return nil
 
 	case enumspb.PARENT_CLOSE_POLICY_TERMINATE:
-		childNamespaceId, err := t.registry.GetNamespaceID(namespace.Name(childInfo.GetNamespace()))
+		childNamespaceID, err := t.registry.GetNamespaceID(namespace.Name(childInfo.GetNamespace()))
 		switch err.(type) {
-		case nil, *serviceerror.NotFound:
+		case nil:
+		case *serviceerror.NotFound:
 			// If child namespace is deleted there is nothing to close.
+			return nil
 		default:
 			return err
 		}
 		_, err = t.historyClient.TerminateWorkflowExecution(ctx, &historyservice.TerminateWorkflowExecutionRequest{
-			NamespaceId: childNamespaceId.String(),
+			NamespaceId: childNamespaceID.String(),
 			TerminateRequest: &workflowservice.TerminateWorkflowExecutionRequest{
 				Namespace: childInfo.GetNamespace(),
 				WorkflowExecution: &commonpb.WorkflowExecution{

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -1424,16 +1424,18 @@ func (t *transferQueueActiveTaskExecutor) applyParentClosePolicy(
 		return err
 
 	case enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL:
-		childNamespaceId, err := t.registry.GetNamespaceID(namespace.Name(childInfo.GetNamespace()))
+		childNamespaceID, err := t.registry.GetNamespaceID(namespace.Name(childInfo.GetNamespace()))
 		switch err.(type) {
-		case nil, *serviceerror.NotFound:
+		case nil:
+		case *serviceerror.NotFound:
 			// If child namespace is deleted there is nothing to close.
+			return nil
 		default:
 			return err
 		}
 
 		_, err = t.historyClient.RequestCancelWorkflowExecution(ctx, &historyservice.RequestCancelWorkflowExecutionRequest{
-			NamespaceId: childNamespaceId.String(),
+			NamespaceId: childNamespaceID.String(),
 			CancelRequest: &workflowservice.RequestCancelWorkflowExecutionRequest{
 				Namespace: childInfo.GetNamespace(),
 				WorkflowExecution: &commonpb.WorkflowExecution{

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -1123,6 +1123,93 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 	s.Nil(err)
 }
 
+func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParent_ChildInDeletedNamespace() {
+	execution := commonpb.WorkflowExecution{
+		WorkflowId: "some random workflow ID",
+		RunId:      uuid.New(),
+	}
+	workflowType := "some random workflow type"
+	taskQueueName := "some random task queue"
+
+	s.mockNamespaceCache.EXPECT().GetNamespace(namespace.Name("child namespace1")).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
+
+	mutableState := workflow.TestGlobalMutableState(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
+	_, err := mutableState.AddWorkflowExecutionStartedEvent(
+		execution,
+		&historyservice.StartWorkflowExecutionRequest{
+			Attempt:     1,
+			NamespaceId: s.namespaceID.String(),
+			StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+				WorkflowType:             &commonpb.WorkflowType{Name: workflowType},
+				TaskQueue:                &taskqueuepb.TaskQueue{Name: taskQueueName},
+				WorkflowExecutionTimeout: timestamp.DurationPtr(2 * time.Second),
+				WorkflowTaskTimeout:      timestamp.DurationPtr(1 * time.Second),
+			},
+		},
+	)
+	s.NoError(err)
+
+	wt := addWorkflowTaskScheduledEvent(mutableState)
+	event := addWorkflowTaskStartedEvent(mutableState, wt.ScheduleID, taskQueueName, uuid.New())
+	wt.StartedID = event.GetEventId()
+
+	event, _ = mutableState.AddWorkflowTaskCompletedEvent(wt.ScheduleID, wt.StartedID, &workflowservice.RespondWorkflowTaskCompletedRequest{
+		Identity: "some random identity",
+		Commands: []*commandpb.Command{
+			{
+				CommandType: enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
+					Namespace:  "child namespace1",
+					WorkflowId: "child workflow1",
+					WorkflowType: &commonpb.WorkflowType{
+						Name: "child workflow type",
+					},
+					TaskQueue:         &taskqueuepb.TaskQueue{Name: taskQueueName},
+					Input:             payloads.EncodeString("random input"),
+					ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+				}},
+			},
+		},
+	}, configs.DefaultHistoryMaxAutoResetPoints)
+
+	_, _, err = mutableState.AddStartChildWorkflowExecutionInitiatedEvent(event.GetEventId(), uuid.New(), &commandpb.StartChildWorkflowExecutionCommandAttributes{
+		Namespace:  "child namespace1",
+		WorkflowId: "child workflow1",
+		WorkflowType: &commonpb.WorkflowType{
+			Name: "child workflow type",
+		},
+		TaskQueue:         &taskqueuepb.TaskQueue{Name: taskQueueName},
+		Input:             payloads.EncodeString("random input"),
+		ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+	})
+	s.NoError(err)
+
+	mutableState.FlushBufferedEvents()
+
+	taskID := int64(22)
+	event = addCompleteWorkflowEvent(mutableState, event.GetEventId(), nil)
+
+	transferTask := &tasks.CloseExecutionTask{
+		WorkflowKey: definition.NewWorkflowKey(
+			s.namespaceID.String(),
+			execution.GetWorkflowId(),
+			execution.GetRunId(),
+		),
+		Version:             s.version,
+		TaskID:              taskID,
+		VisibilityTimestamp: time.Now().UTC(),
+	}
+
+	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
+	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewDisabledArchvialConfig())
+
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(namespace.Name("child namespace1")).Return(namespace.EmptyID, serviceerror.NewNotFound("namespace not found")).AnyTimes()
+
+	err = s.transferQueueActiveTaskExecutor.execute(context.Background(), transferTask, true)
+	s.NoError(err)
+}
+
 func (s *transferQueueActiveTaskExecutorSuite) TestProcessCancelExecution_Success() {
 
 	execution := commonpb.WorkflowExecution{

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -1169,6 +1169,19 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 					ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_TERMINATE,
 				}},
 			},
+			{
+				CommandType: enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
+					Namespace:  "child namespace1",
+					WorkflowId: "child workflow2",
+					WorkflowType: &commonpb.WorkflowType{
+						Name: "child workflow type",
+					},
+					TaskQueue:         &taskqueuepb.TaskQueue{Name: taskQueueName},
+					Input:             payloads.EncodeString("random input"),
+					ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
+				}},
+			},
 		},
 	}, configs.DefaultHistoryMaxAutoResetPoints)
 
@@ -1181,6 +1194,18 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 		TaskQueue:         &taskqueuepb.TaskQueue{Name: taskQueueName},
 		Input:             payloads.EncodeString("random input"),
 		ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_TERMINATE,
+	})
+	s.NoError(err)
+
+	_, _, err = mutableState.AddStartChildWorkflowExecutionInitiatedEvent(event.GetEventId(), uuid.New(), &commandpb.StartChildWorkflowExecutionCommandAttributes{
+		Namespace:  "child namespace1",
+		WorkflowId: "child workflow2",
+		WorkflowType: &commonpb.WorkflowType{
+			Name: "child workflow type",
+		},
+		TaskQueue:         &taskqueuepb.TaskQueue{Name: taskQueueName},
+		Input:             payloads.EncodeString("random input"),
+		ParentClosePolicy: enumspb.PARENT_CLOSE_POLICY_REQUEST_CANCEL,
 	})
 	s.NoError(err)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix parent close policy processor for deleted namespace.

<!-- Tell your future self why have you made these changes -->
**Why?**
Due to bug, `TerminateWorkflow` was still called even if namespace is deleted and not found in namespace registry.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.