### PR TITLE
Store namespaces in DELETED state in registry

### DIFF
--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -387,7 +387,10 @@ func (r *registry) refreshNamespaces(ctx context.Context) error {
 	}
 	namespaceNotificationVersion := metadata.NotificationVersion
 
-	request := &persistence.ListNamespacesRequest{PageSize: CacheRefreshPageSize}
+	request := &persistence.ListNamespacesRequest{
+		PageSize:       CacheRefreshPageSize,
+		IncludeDeleted: true,
+	}
 	var namespacesDb Namespaces
 	namespaceIDsDb := make(map[ID]struct{})
 

--- a/common/namespace/registry_test.go
+++ b/common/namespace/registry_test.go
@@ -268,8 +268,9 @@ func (s *registrySuite) TestRegisterCallback_CatchUp() {
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
 	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
-		PageSize:      namespace.CacheRefreshPageSize,
-		NextPageToken: nil,
+		PageSize:       namespace.CacheRefreshPageSize,
+		IncludeDeleted: true,
+		NextPageToken:  nil,
 	}).Return(&persistence.ListNamespacesResponse{
 		Namespaces: []*persistence.GetNamespaceResponse{
 			namespaceRecord1,
@@ -366,8 +367,9 @@ func (s *registrySuite) TestUpdateCache_TriggerCallBack() {
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
 	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
-		PageSize:      namespace.CacheRefreshPageSize,
-		NextPageToken: nil,
+		PageSize:       namespace.CacheRefreshPageSize,
+		IncludeDeleted: true,
+		NextPageToken:  nil,
 	}).Return(&persistence.ListNamespacesResponse{
 		Namespaces:    []*persistence.GetNamespaceResponse{namespaceRecord1Old, namespaceRecord2Old},
 		NextPageToken: nil,
@@ -445,8 +447,9 @@ func (s *registrySuite) TestUpdateCache_TriggerCallBack() {
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
 	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
-		PageSize:      namespace.CacheRefreshPageSize,
-		NextPageToken: nil,
+		PageSize:       namespace.CacheRefreshPageSize,
+		IncludeDeleted: true,
+		NextPageToken:  nil,
 	}).Return(&persistence.ListNamespacesResponse{
 		Namespaces: []*persistence.GetNamespaceResponse{
 			namespaceRecord1New,
@@ -494,8 +497,9 @@ func (s *registrySuite) TestGetTriggerListAndUpdateCache_ConcurrentAccess() {
 	entryOld := namespace.FromPersistentState(namespaceRecordOld)
 
 	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
-		PageSize:      namespace.CacheRefreshPageSize,
-		NextPageToken: nil,
+		PageSize:       namespace.CacheRefreshPageSize,
+		IncludeDeleted: true,
+		NextPageToken:  nil,
 	}).Return(&persistence.ListNamespacesResponse{
 		Namespaces:    []*persistence.GetNamespaceResponse{namespaceRecordOld},
 		NextPageToken: nil,
@@ -594,8 +598,9 @@ func (s *registrySuite) TestRemoveDeletedNamespace() {
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
 	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
-		PageSize:      namespace.CacheRefreshPageSize,
-		NextPageToken: nil,
+		PageSize:       namespace.CacheRefreshPageSize,
+		IncludeDeleted: true,
+		NextPageToken:  nil,
 	}).Return(&persistence.ListNamespacesResponse{
 		Namespaces: []*persistence.GetNamespaceResponse{
 			namespaceRecord1,
@@ -612,8 +617,9 @@ func (s *registrySuite) TestRemoveDeletedNamespace() {
 			NotificationVersion: namespaceNotificationVersion,
 		}, nil)
 	s.regPersistence.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
-		PageSize:      namespace.CacheRefreshPageSize,
-		NextPageToken: nil,
+		PageSize:       namespace.CacheRefreshPageSize,
+		IncludeDeleted: true,
+		NextPageToken:  nil,
 	}).Return(&persistence.ListNamespacesResponse{
 		Namespaces: []*persistence.GetNamespaceResponse{
 			// namespaceRecord1 is removed


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Store namespaces in `DELETED` state in registry.

<!-- Tell your future self why have you made these changes -->
**Why?**
Delete namespace workflow relies on namespace registry and it expects namespaces in `DELETED` state to be there.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.