### PR TITLE
Persistence context part 6: visibility store interfaces

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -134,7 +134,10 @@ func (s *visibilityStore) GetName() string {
 	return persistenceName
 }
 
-func (s *visibilityStore) RecordWorkflowExecutionStarted(request *store.InternalRecordWorkflowExecutionStartedRequest) error {
+func (s *visibilityStore) RecordWorkflowExecutionStarted(
+	_ context.Context,
+	request *store.InternalRecordWorkflowExecutionStartedRequest,
+) error {
 	visibilityTaskKey := getVisibilityTaskKey(request.ShardID, request.TaskID)
 	doc, err := s.generateESDoc(request.InternalVisibilityRequestBase, visibilityTaskKey)
 	if err != nil {
@@ -144,7 +147,10 @@ func (s *visibilityStore) RecordWorkflowExecutionStarted(request *store.Internal
 	return s.addBulkIndexRequestAndWait(request.InternalVisibilityRequestBase, doc, visibilityTaskKey)
 }
 
-func (s *visibilityStore) RecordWorkflowExecutionClosed(request *store.InternalRecordWorkflowExecutionClosedRequest) error {
+func (s *visibilityStore) RecordWorkflowExecutionClosed(
+	_ context.Context,
+	request *store.InternalRecordWorkflowExecutionClosedRequest,
+) error {
 	visibilityTaskKey := getVisibilityTaskKey(request.ShardID, request.TaskID)
 	doc, err := s.generateESDoc(request.InternalVisibilityRequestBase, visibilityTaskKey)
 	if err != nil {
@@ -159,7 +165,10 @@ func (s *visibilityStore) RecordWorkflowExecutionClosed(request *store.InternalR
 	return s.addBulkIndexRequestAndWait(request.InternalVisibilityRequestBase, doc, visibilityTaskKey)
 }
 
-func (s *visibilityStore) UpsertWorkflowExecution(request *store.InternalUpsertWorkflowExecutionRequest) error {
+func (s *visibilityStore) UpsertWorkflowExecution(
+	_ context.Context,
+	request *store.InternalUpsertWorkflowExecutionRequest,
+) error {
 	visibilityTaskKey := getVisibilityTaskKey(request.ShardID, request.TaskID)
 	doc, err := s.generateESDoc(request.InternalVisibilityRequestBase, visibilityTaskKey)
 	if err != nil {
@@ -169,7 +178,10 @@ func (s *visibilityStore) UpsertWorkflowExecution(request *store.InternalUpsertW
 	return s.addBulkIndexRequestAndWait(request.InternalVisibilityRequestBase, doc, visibilityTaskKey)
 }
 
-func (s *visibilityStore) DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
+func (s *visibilityStore) DeleteWorkflowExecution(
+	_ context.Context,
+	request *manager.VisibilityDeleteWorkflowExecutionRequest,
+) error {
 	docID := getDocID(request.WorkflowID, request.RunID)
 
 	bulkDeleteRequest := &client.BulkableRequest{
@@ -253,7 +265,10 @@ func (s *visibilityStore) checkProcessor() {
 	}
 }
 
-func (s *visibilityStore) ListOpenWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ListOpenWorkflowExecutions(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 
 	boolQuery := elastic.NewBoolQuery().
 		Filter(elastic.NewTermQuery(searchattribute.ExecutionStatus, enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String()))
@@ -277,7 +292,10 @@ func (s *visibilityStore) ListOpenWorkflowExecutions(request *manager.ListWorkfl
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
-func (s *visibilityStore) ListClosedWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ListClosedWorkflowExecutions(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 
 	boolQuery := elastic.NewBoolQuery().
 		MustNot(elastic.NewTermQuery(searchattribute.ExecutionStatus, enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING.String()))
@@ -301,7 +319,10 @@ func (s *visibilityStore) ListClosedWorkflowExecutions(request *manager.ListWork
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
-func (s *visibilityStore) ListOpenWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ListOpenWorkflowExecutionsByType(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 
 	boolQuery := elastic.NewBoolQuery().
 		Filter(
@@ -327,7 +348,10 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByType(request *manager.List
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
-func (s *visibilityStore) ListClosedWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ListClosedWorkflowExecutionsByType(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 
 	boolQuery := elastic.NewBoolQuery().
 		Filter(elastic.NewTermQuery(searchattribute.WorkflowType, request.WorkflowTypeName)).
@@ -352,7 +376,10 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByType(request *manager.Li
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
-func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 
 	boolQuery := elastic.NewBoolQuery().
 		Filter(
@@ -378,7 +405,10 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(request *manage
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
-func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 
 	boolQuery := elastic.NewBoolQuery().
 		Filter(elastic.NewTermQuery(searchattribute.WorkflowID, request.WorkflowID)).
@@ -403,7 +433,10 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(request *mana
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
-func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(
+	_ context.Context,
+	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 
 	boolQuery := elastic.NewBoolQuery().
 		Filter(elastic.NewTermQuery(searchattribute.ExecutionStatus, request.Status.String()))
@@ -427,7 +460,10 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(request *manager.
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, isRecordValid)
 }
 
-func (s *visibilityStore) ListWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ListWorkflowExecutions(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	p, err := s.buildSearchParametersV2(request)
 	if err != nil {
 		return nil, err
@@ -452,7 +488,10 @@ func (s *visibilityStore) ListWorkflowExecutions(request *manager.ListWorkflowEx
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
 }
 
-func (s *visibilityStore) ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) ScanWorkflowExecutions(
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	ctx, cancel := newReadContext()
 	defer cancel()
 
@@ -549,7 +588,10 @@ func (s *visibilityStore) scanWorkflowExecutionsWithScroll(ctx context.Context, 
 	return s.getListWorkflowExecutionsResponse(searchResult, request.Namespace, request.PageSize, nil)
 }
 
-func (s *visibilityStore) CountWorkflowExecutions(request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
+func (s *visibilityStore) CountWorkflowExecutions(
+	_ context.Context,
+	request *manager.CountWorkflowExecutionsRequest,
+) (*manager.CountWorkflowExecutionsResponse, error) {
 	boolQuery, _, err := s.convertQuery(request.Namespace, request.NamespaceID, request.Query)
 	if err != nil {
 		return nil, err

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -128,11 +128,11 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutions() {
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterOpen))
 			return testSearchResult, nil
 		})
-	_, err := s.visibilityStore.ListOpenWorkflowExecutions(createTestRequest())
+	_, err := s.visibilityStore.ListOpenWorkflowExecutions(context.Background(), createTestRequest())
 	s.NoError(err)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ListOpenWorkflowExecutions(createTestRequest())
+	_, err = s.visibilityStore.ListOpenWorkflowExecutions(context.Background(), createTestRequest())
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -146,11 +146,11 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutions() {
 			s.True(strings.Contains(fmt.Sprintf("%v", source), filterClose))
 			return testSearchResult, nil
 		})
-	_, err := s.visibilityStore.ListClosedWorkflowExecutions(createTestRequest())
+	_, err := s.visibilityStore.ListClosedWorkflowExecutions(context.Background(), createTestRequest())
 	s.NoError(err)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ListClosedWorkflowExecutions(createTestRequest())
+	_, err = s.visibilityStore.ListClosedWorkflowExecutions(context.Background(), createTestRequest())
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -171,11 +171,11 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
 		ListWorkflowExecutionsRequest: testRequest,
 		WorkflowTypeName:              testWorkflowType,
 	}
-	_, err := s.visibilityStore.ListOpenWorkflowExecutionsByType(request)
+	_, err := s.visibilityStore.ListOpenWorkflowExecutionsByType(context.Background(), request)
 	s.NoError(err)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByType(request)
+	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByType(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -196,11 +196,11 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
 		ListWorkflowExecutionsRequest: testRequest,
 		WorkflowTypeName:              testWorkflowType,
 	}
-	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByType(request)
+	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByType(context.Background(), request)
 	s.NoError(err)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByType(request)
+	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByType(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -221,11 +221,11 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 		ListWorkflowExecutionsRequest: testRequest,
 		WorkflowID:                    testWorkflowID,
 	}
-	_, err := s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(request)
+	_, err := s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.NoError(err)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(request)
+	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -246,11 +246,11 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
 		ListWorkflowExecutionsRequest: testRequest,
 		WorkflowID:                    testWorkflowID,
 	}
-	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(request)
+	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.NoError(err)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(request)
+	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -270,11 +270,11 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByStatus() {
 		ListWorkflowExecutionsRequest: testRequest,
 		Status:                        testStatus,
 	}
-	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByStatus(request)
+	_, err := s.visibilityStore.ListClosedWorkflowExecutionsByStatus(context.Background(), request)
 	s.NoError(err)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByStatus(request)
+	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByStatus(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -937,18 +937,18 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 		PageSize:    10,
 		Query:       `ExecutionStatus = "Terminated"`,
 	}
-	_, err := s.visibilityStore.ListWorkflowExecutions(request)
+	_, err := s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ListWorkflowExecutions(request)
+	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
 	s.True(strings.Contains(err.Error(), "ListWorkflowExecutions failed"))
 
 	request.Query = `invalid query`
-	_, err = s.visibilityStore.ListWorkflowExecutions(request)
+	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok = err.(*serviceerror.InvalidArgument)
 	s.True(ok)
@@ -972,7 +972,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions_Error() {
 		PageSize:    10,
 		Query:       `ExecutionStatus = "Terminated"`,
 	}
-	_, err := s.visibilityStore.ListWorkflowExecutions(request)
+	_, err := s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	var internalErr *serviceerror.Internal
 	s.ErrorAs(err, &internalErr)
@@ -987,7 +987,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions_Error() {
 				},
 			}
 		})
-	_, err = s.visibilityStore.ListWorkflowExecutions(request)
+	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	var unavailableErr *serviceerror.Unavailable
 	s.ErrorAs(err, &unavailableErr)
 	s.Equal("ListWorkflowExecutions failed: elastic: Error 500 (Internal Server Error): error reason [type=]", unavailableErr.Message)
@@ -1018,12 +1018,12 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 		PageSize:    10,
 		Query:       `ExecutionStatus = "Terminated"`,
 	}
-	_, err := s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err := s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// test bad request
 	request.Query = `invalid query`
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.InvalidArgument)
 	s.True(ok)
@@ -1039,18 +1039,18 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV6() {
 	tokenBytes, err := s.visibilityStore.serializePageToken(token)
 	s.NoError(err)
 	request.NextPageToken = tokenBytes
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// test io.EOF error
 	mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(testSearchResult, io.EOF)
 	mockESClientV6.EXPECT().CloseScroll(gomock.Any(), gomock.Any()).Return(nil)
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// test unavailable error
 	mockESClientV6.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok = err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -1083,12 +1083,12 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_Scroll() {
 		PageSize:    10,
 		Query:       `ExecutionStatus = "Terminated"`,
 	}
-	_, err := s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err := s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// test bad request
 	request.Query = `invalid query`
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.InvalidArgument)
 	s.True(ok)
@@ -1104,18 +1104,18 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_Scroll() {
 	tokenBytes, err := s.visibilityStore.serializePageToken(token)
 	s.NoError(err)
 	request.NextPageToken = tokenBytes
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// test io.EOF error
 	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(testSearchResult, io.EOF)
 	s.mockESClient.EXPECT().CloseScroll(gomock.Any(), gomock.Any()).Return(nil)
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// test unavailable error
 	s.mockESClient.EXPECT().Scroll(gomock.Any(), scrollID, "1m").Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok = err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -1158,12 +1158,12 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_PIT() {
 	s.mockESClient.EXPECT().IsPointInTimeSupported(gomock.Any()).Return(true).AnyTimes()
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(searchResult, nil)
 	s.mockESClient.EXPECT().OpenPointInTime(gomock.Any(), testIndex, gomock.Any()).Return(pitID, nil)
-	_, err := s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err := s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// test bad request
 	request.Query = `invalid query`
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.InvalidArgument)
 	s.True(ok)
@@ -1178,7 +1178,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_PIT() {
 	tokenBytes, err := s.visibilityStore.serializePageToken(token)
 	s.NoError(err)
 	request.NextPageToken = tokenBytes
-	result, err := s.visibilityStore.ScanWorkflowExecutions(request)
+	result, err := s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 	responseToken, err := s.visibilityStore.deserializePageToken(result.NextPageToken)
 	s.NoError(err)
@@ -1195,12 +1195,12 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutionsV7_PIT() {
 	}
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(searchResult, nil)
 	s.mockESClient.EXPECT().ClosePointInTime(gomock.Any(), pitID).Return(true, nil)
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 
 	// test unavailable error
 	s.mockESClient.EXPECT().Search(gomock.Any(), gomock.Any()).Return(nil, errTestESSearch)
-	_, err = s.visibilityStore.ScanWorkflowExecutions(request)
+	_, err = s.visibilityStore.ScanWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok = err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -1224,7 +1224,7 @@ func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 		Namespace:   testNamespace,
 		Query:       `ExecutionStatus = "Terminated"`,
 	}
-	resp, err := s.visibilityStore.CountWorkflowExecutions(request)
+	resp, err := s.visibilityStore.CountWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
 	s.Equal(int64(1), resp.Count)
 
@@ -1240,7 +1240,7 @@ func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 			return int64(0), errTestESSearch
 		})
 
-	_, err = s.visibilityStore.CountWorkflowExecutions(request)
+	_, err = s.visibilityStore.CountWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok := err.(*serviceerror.Unavailable)
 	s.True(ok)
@@ -1248,7 +1248,7 @@ func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 
 	// test bad request
 	request.Query = `invalid query`
-	_, err = s.visibilityStore.CountWorkflowExecutions(request)
+	_, err = s.visibilityStore.CountWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	_, ok = err.(*serviceerror.InvalidArgument)
 	s.True(ok)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_write_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_write_test.go
@@ -25,6 +25,7 @@
 package elasticsearch
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -96,7 +97,7 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionStarted() {
 			return ackCh
 		})
 
-	err := s.visibilityStore.RecordWorkflowExecutionStarted(request)
+	err := s.visibilityStore.RecordWorkflowExecutionStarted(context.Background(), request)
 	s.NoError(err)
 }
 
@@ -129,7 +130,7 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionStarted_EmptyRequest() {
 			return ackCh
 		})
 
-	err := s.visibilityStore.RecordWorkflowExecutionStarted(request)
+	err := s.visibilityStore.RecordWorkflowExecutionStarted(context.Background(), request)
 	s.NoError(err)
 }
 
@@ -186,7 +187,7 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionClosed() {
 			return ackCh
 		})
 
-	err := s.visibilityStore.RecordWorkflowExecutionClosed(request)
+	err := s.visibilityStore.RecordWorkflowExecutionClosed(context.Background(), request)
 	s.NoError(err)
 }
 
@@ -219,7 +220,7 @@ func (s *ESVisibilitySuite) TestRecordWorkflowExecutionClosed_EmptyRequest() {
 			return ackCh
 		})
 
-	err := s.visibilityStore.RecordWorkflowExecutionClosed(request)
+	err := s.visibilityStore.RecordWorkflowExecutionClosed(context.Background(), request)
 	s.NoError(err)
 }
 
@@ -246,7 +247,7 @@ func (s *ESVisibilitySuite) TestDeleteExecution() {
 			return ackCh
 		})
 
-	err := s.visibilityStore.DeleteWorkflowExecution(request)
+	err := s.visibilityStore.DeleteWorkflowExecution(context.Background(), request)
 	s.NoError(err)
 }
 
@@ -267,7 +268,7 @@ func (s *ESVisibilitySuite) TestDeleteExecution_EmptyRequest() {
 			return ackCh
 		})
 
-	err := s.visibilityStore.DeleteWorkflowExecution(request)
+	err := s.visibilityStore.DeleteWorkflowExecution(context.Background(), request)
 	s.NoError(err)
 }
 

--- a/common/persistence/visibility/store/standard/cassandra/visibility_store.go
+++ b/common/persistence/visibility/store/standard/cassandra/visibility_store.go
@@ -25,6 +25,7 @@
 package cassandra
 
 import (
+	"context"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -156,7 +157,9 @@ func (v *visibilityStore) Close() {
 }
 
 func (v *visibilityStore) RecordWorkflowExecutionStarted(
-	request *store.InternalRecordWorkflowExecutionStartedRequest) error {
+	_ context.Context,
+	request *store.InternalRecordWorkflowExecutionStartedRequest,
+) error {
 
 	query := v.session.Query(templateCreateWorkflowExecutionStarted,
 		request.NamespaceID,
@@ -178,7 +181,10 @@ func (v *visibilityStore) RecordWorkflowExecutionStarted(
 	return gocql.ConvertError("RecordWorkflowExecutionStarted", err)
 }
 
-func (v *visibilityStore) RecordWorkflowExecutionClosed(request *store.InternalRecordWorkflowExecutionClosedRequest) error {
+func (v *visibilityStore) RecordWorkflowExecutionClosed(
+	_ context.Context,
+	request *store.InternalRecordWorkflowExecutionClosedRequest,
+) error {
 	batch := v.session.NewBatch(gocql.LoggedBatch)
 
 	// First, remove execution from the open table
@@ -225,12 +231,16 @@ func (v *visibilityStore) RecordWorkflowExecutionClosed(request *store.InternalR
 	return gocql.ConvertError("RecordWorkflowExecutionClosed", err)
 }
 
-func (v *visibilityStore) UpsertWorkflowExecution(_ *store.InternalUpsertWorkflowExecutionRequest) error {
+func (v *visibilityStore) UpsertWorkflowExecution(
+	_ context.Context,
+	_ *store.InternalUpsertWorkflowExecutionRequest,
+) error {
 	// Not OperationNotSupportedErr!
 	return nil
 }
 
 func (v *visibilityStore) ListOpenWorkflowExecutions(
+	_ context.Context,
 	request *manager.ListWorkflowExecutionsRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	query := v.session.
@@ -260,7 +270,9 @@ func (v *visibilityStore) ListOpenWorkflowExecutions(
 }
 
 func (v *visibilityStore) ListOpenWorkflowExecutionsByType(
-	request *manager.ListWorkflowExecutionsByTypeRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	query := v.session.
 		Query(templateGetOpenWorkflowExecutionsByType,
 			request.NamespaceID.String(),
@@ -289,7 +301,9 @@ func (v *visibilityStore) ListOpenWorkflowExecutionsByType(
 }
 
 func (v *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
-	request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	query := v.session.
 		Query(templateGetOpenWorkflowExecutionsByID,
 			request.NamespaceID.String(),
@@ -318,7 +332,9 @@ func (v *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
 }
 
 func (v *visibilityStore) ListClosedWorkflowExecutions(
-	request *manager.ListWorkflowExecutionsRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	query := v.session.
 		Query(templateGetClosedWorkflowExecutions,
 			request.NamespaceID.String(),
@@ -346,7 +362,9 @@ func (v *visibilityStore) ListClosedWorkflowExecutions(
 }
 
 func (v *visibilityStore) ListClosedWorkflowExecutionsByType(
-	request *manager.ListWorkflowExecutionsByTypeRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	query := v.session.
 		Query(templateGetClosedWorkflowExecutionsByType,
 			request.NamespaceID.String(),
@@ -375,7 +393,9 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByType(
 }
 
 func (v *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
-	request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+	_ context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	query := v.session.
 		Query(templateGetClosedWorkflowExecutionsByID,
 			request.NamespaceID.String(),
@@ -404,7 +424,9 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
 }
 
 func (v *visibilityStore) ListClosedWorkflowExecutionsByStatus(
-	request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+	_ context.Context,
+	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	query := v.session.
 		Query(templateGetClosedWorkflowExecutionsByStatus,
 			request.NamespaceID.String(),
@@ -432,7 +454,10 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByStatus(
 	return response, nil
 }
 
-func (v *visibilityStore) DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
+func (v *visibilityStore) DeleteWorkflowExecution(
+	_ context.Context,
+	request *manager.VisibilityDeleteWorkflowExecutionRequest,
+) error {
 	var query gocql.Query
 	if request.StartTime != nil {
 		query = v.session.Query(templateDeleteWorkflowExecutionStarted,
@@ -456,15 +481,24 @@ func (v *visibilityStore) DeleteWorkflowExecution(request *manager.VisibilityDel
 	return nil
 }
 
-func (v *visibilityStore) ListWorkflowExecutions(_ *manager.ListWorkflowExecutionsRequestV2) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (v *visibilityStore) ListWorkflowExecutions(
+	_ context.Context,
+	_ *manager.ListWorkflowExecutionsRequestV2,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	return nil, store.OperationNotSupportedErr
 }
 
-func (v *visibilityStore) ScanWorkflowExecutions(_ *manager.ListWorkflowExecutionsRequestV2) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (v *visibilityStore) ScanWorkflowExecutions(
+	_ context.Context,
+	_ *manager.ListWorkflowExecutionsRequestV2,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	return nil, store.OperationNotSupportedErr
 }
 
-func (v *visibilityStore) CountWorkflowExecutions(_ *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
+func (v *visibilityStore) CountWorkflowExecutions(
+	_ context.Context,
+	_ *manager.CountWorkflowExecutionsRequest,
+) (*manager.CountWorkflowExecutionsResponse, error) {
 	return nil, store.OperationNotSupportedErr
 }
 

--- a/common/persistence/visibility/store/standard/sql/visibility_store.go
+++ b/common/persistence/visibility/store/standard/sql/visibility_store.go
@@ -91,6 +91,7 @@ func (s *visibilityStore) GetName() string {
 }
 
 func (s *visibilityStore) RecordWorkflowExecutionStarted(
+	_ context.Context,
 	request *store.InternalRecordWorkflowExecutionStartedRequest,
 ) error {
 	ctx, cancel := newVisibilityContext()
@@ -111,7 +112,10 @@ func (s *visibilityStore) RecordWorkflowExecutionStarted(
 	return err
 }
 
-func (s *visibilityStore) RecordWorkflowExecutionClosed(request *store.InternalRecordWorkflowExecutionClosedRequest) error {
+func (s *visibilityStore) RecordWorkflowExecutionClosed(
+	_ context.Context,
+	request *store.InternalRecordWorkflowExecutionClosedRequest,
+) error {
 	ctx, cancel := newVisibilityContext()
 	defer cancel()
 	result, err := s.sqlStore.Db.ReplaceIntoVisibility(ctx, &sqlplugin.VisibilityRow{
@@ -142,6 +146,7 @@ func (s *visibilityStore) RecordWorkflowExecutionClosed(request *store.InternalR
 }
 
 func (s *visibilityStore) UpsertWorkflowExecution(
+	_ context.Context,
 	_ *store.InternalUpsertWorkflowExecutionRequest,
 ) error {
 	// Not OperationNotSupportedErr!
@@ -149,6 +154,7 @@ func (s *visibilityStore) UpsertWorkflowExecution(
 }
 
 func (s *visibilityStore) ListOpenWorkflowExecutions(
+	_ context.Context,
 	request *manager.ListWorkflowExecutionsRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	ctx, cancel := newVisibilityContext()
@@ -172,6 +178,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutions(
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutions(
+	_ context.Context,
 	request *manager.ListWorkflowExecutionsRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	ctx, cancel := newVisibilityContext()
@@ -193,6 +200,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutions(
 }
 
 func (s *visibilityStore) ListOpenWorkflowExecutionsByType(
+	_ context.Context,
 	request *manager.ListWorkflowExecutionsByTypeRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	ctx, cancel := newVisibilityContext()
@@ -216,6 +224,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByType(
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByType(
+	_ context.Context,
 	request *manager.ListWorkflowExecutionsByTypeRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	ctx, cancel := newVisibilityContext()
@@ -238,6 +247,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByType(
 }
 
 func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
+	_ context.Context,
 	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	ctx, cancel := newVisibilityContext()
@@ -261,6 +271,7 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
+	_ context.Context,
 	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	ctx, cancel := newVisibilityContext()
@@ -283,6 +294,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(
+	_ context.Context,
 	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	ctx, cancel := newVisibilityContext()
@@ -305,6 +317,7 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(
 }
 
 func (s *visibilityStore) DeleteWorkflowExecution(
+	_ context.Context,
 	request *manager.VisibilityDeleteWorkflowExecutionRequest,
 ) error {
 	ctx, cancel := newVisibilityContext()
@@ -320,18 +333,21 @@ func (s *visibilityStore) DeleteWorkflowExecution(
 }
 
 func (s *visibilityStore) ListWorkflowExecutions(
+	_ context.Context,
 	_ *manager.ListWorkflowExecutionsRequestV2,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	return nil, store.OperationNotSupportedErr
 }
 
 func (s *visibilityStore) ScanWorkflowExecutions(
+	_ context.Context,
 	_ *manager.ListWorkflowExecutionsRequestV2,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 	return nil, store.OperationNotSupportedErr
 }
 
 func (s *visibilityStore) CountWorkflowExecutions(
+	_ context.Context,
 	_ *manager.CountWorkflowExecutionsRequest,
 ) (*manager.CountWorkflowExecutionsResponse, error) {
 	return nil, store.OperationNotSupportedErr

--- a/common/persistence/visibility/store/standard/visibility_store.go
+++ b/common/persistence/visibility/store/standard/visibility_store.go
@@ -25,6 +25,7 @@
 package standard
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"reflect"
@@ -71,59 +72,101 @@ func (s *standardStore) GetName() string {
 	return s.store.GetName()
 }
 
-func (s *standardStore) RecordWorkflowExecutionStarted(request *store.InternalRecordWorkflowExecutionStartedRequest) error {
-	return s.store.RecordWorkflowExecutionStarted(request)
+func (s *standardStore) RecordWorkflowExecutionStarted(
+	ctx context.Context,
+	request *store.InternalRecordWorkflowExecutionStartedRequest,
+) error {
+	return s.store.RecordWorkflowExecutionStarted(ctx, request)
 }
 
-func (s *standardStore) RecordWorkflowExecutionClosed(request *store.InternalRecordWorkflowExecutionClosedRequest) error {
-	return s.store.RecordWorkflowExecutionClosed(request)
+func (s *standardStore) RecordWorkflowExecutionClosed(
+	ctx context.Context,
+	request *store.InternalRecordWorkflowExecutionClosedRequest,
+) error {
+	return s.store.RecordWorkflowExecutionClosed(ctx, request)
 }
 
-func (s *standardStore) UpsertWorkflowExecution(request *store.InternalUpsertWorkflowExecutionRequest) error {
-	return s.store.UpsertWorkflowExecution(request)
+func (s *standardStore) UpsertWorkflowExecution(
+	ctx context.Context,
+	request *store.InternalUpsertWorkflowExecutionRequest,
+) error {
+	return s.store.UpsertWorkflowExecution(ctx, request)
 }
 
-func (s *standardStore) DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
-	return s.store.DeleteWorkflowExecution(request)
+func (s *standardStore) DeleteWorkflowExecution(
+	ctx context.Context,
+	request *manager.VisibilityDeleteWorkflowExecutionRequest,
+) error {
+	return s.store.DeleteWorkflowExecution(ctx, request)
 }
 
-func (s *standardStore) ListOpenWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.store.ListOpenWorkflowExecutions(request)
+func (s *standardStore) ListOpenWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
+	return s.store.ListOpenWorkflowExecutions(ctx, request)
 }
 
-func (s *standardStore) ListClosedWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.store.ListClosedWorkflowExecutions(request)
+func (s *standardStore) ListClosedWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
+	return s.store.ListClosedWorkflowExecutions(ctx, request)
 }
 
-func (s *standardStore) ListOpenWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.store.ListOpenWorkflowExecutionsByType(request)
+func (s *standardStore) ListOpenWorkflowExecutionsByType(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
+	return s.store.ListOpenWorkflowExecutionsByType(ctx, request)
 }
 
-func (s *standardStore) ListClosedWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.store.ListClosedWorkflowExecutionsByType(request)
+func (s *standardStore) ListClosedWorkflowExecutionsByType(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByTypeRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
+	return s.store.ListClosedWorkflowExecutionsByType(ctx, request)
 }
 
-func (s *standardStore) ListOpenWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.store.ListOpenWorkflowExecutionsByWorkflowID(request)
+func (s *standardStore) ListOpenWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
+	return s.store.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 }
 
-func (s *standardStore) ListClosedWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.store.ListClosedWorkflowExecutionsByWorkflowID(request)
+func (s *standardStore) ListClosedWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
+	return s.store.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 }
 
-func (s *standardStore) ListClosedWorkflowExecutionsByStatus(request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.store.ListClosedWorkflowExecutionsByStatus(request)
+func (s *standardStore) ListClosedWorkflowExecutionsByStatus(
+	ctx context.Context,
+	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
+	return s.store.ListClosedWorkflowExecutionsByStatus(ctx, request)
 }
 
-func (s *standardStore) ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return s.store.ScanWorkflowExecutions(request)
+func (s *standardStore) ScanWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
+	return s.store.ScanWorkflowExecutions(ctx, request)
 }
 
-func (s *standardStore) CountWorkflowExecutions(request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
-	return s.store.CountWorkflowExecutions(request)
+func (s *standardStore) CountWorkflowExecutions(
+	ctx context.Context,
+	request *manager.CountWorkflowExecutionsRequest,
+) (*manager.CountWorkflowExecutionsResponse, error) {
+	return s.store.CountWorkflowExecutions(ctx, request)
 }
 
-func (s *standardStore) ListWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *standardStore) ListWorkflowExecutions(
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	converter := newQueryConverter()
 	filter, err := converter.GetFilter(request.Query)
 	if err != nil {
@@ -148,6 +191,7 @@ func (s *standardStore) ListWorkflowExecutions(request *manager.ListWorkflowExec
 			WorkflowID:                    *filter.WorkflowID,
 		}
 		return s.listWorkflowExecutionsHelper(
+			ctx,
 			request,
 			s.listOpenWorkflowExecutionsByWorkflowID,
 			s.listClosedWorkflowExecutionsByWorkflowID)
@@ -157,21 +201,23 @@ func (s *standardStore) ListWorkflowExecutions(request *manager.ListWorkflowExec
 			WorkflowTypeName:              *filter.WorkflowTypeName,
 		}
 		return s.listWorkflowExecutionsHelper(
+			ctx,
 			request,
 			s.listOpenWorkflowExecutionsByType,
 			s.listClosedWorkflowExecutionsByType)
 	} else if filter.Status != int32(enumspb.WORKFLOW_EXECUTION_STATUS_UNSPECIFIED) {
 		if filter.Status == int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING) {
-			return s.ListOpenWorkflowExecutions(baseReq)
+			return s.ListOpenWorkflowExecutions(ctx, baseReq)
 		} else {
 			request := &manager.ListClosedWorkflowExecutionsByStatusRequest{
 				ListWorkflowExecutionsRequest: baseReq,
 				Status:                        enumspb.WorkflowExecutionStatus(filter.Status),
 			}
-			return s.ListClosedWorkflowExecutionsByStatus(request)
+			return s.ListClosedWorkflowExecutionsByStatus(ctx, request)
 		}
 	} else {
 		return s.listWorkflowExecutionsHelper(
+			ctx,
 			baseReq,
 			s.listOpenWorkflowExecutions,
 			s.listClosedWorkflowExecutions)
@@ -179,9 +225,10 @@ func (s *standardStore) ListWorkflowExecutions(request *manager.ListWorkflowExec
 }
 
 func (s *standardStore) listWorkflowExecutionsHelper(
+	ctx context.Context,
 	request listRequest,
-	listOpenFunc func(request listRequest) (*store.InternalListWorkflowExecutionsResponse, error),
-	listCloseFunc func(request listRequest) (*store.InternalListWorkflowExecutionsResponse, error),
+	listOpenFunc func(ctx context.Context, request listRequest) (*store.InternalListWorkflowExecutionsResponse, error),
+	listCloseFunc func(ctx context.Context, request listRequest) (*store.InternalListWorkflowExecutionsResponse, error),
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
 
 	var token nextPageToken
@@ -200,7 +247,7 @@ func (s *standardStore) listWorkflowExecutionsHelper(
 	resp := &store.InternalListWorkflowExecutionsResponse{}
 
 	if token.ForOpenWorkflows {
-		listOpenResp, err := listOpenFunc(request)
+		listOpenResp, err := listOpenFunc(ctx, request)
 		if err != nil {
 			return nil, err
 		}
@@ -226,7 +273,7 @@ func (s *standardStore) listWorkflowExecutionsHelper(
 		}
 	}
 
-	listCloseResp, err := listCloseFunc(request)
+	listCloseResp, err := listCloseFunc(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -247,56 +294,74 @@ func (s *standardStore) listWorkflowExecutionsHelper(
 	return resp, nil
 }
 
-func (s *standardStore) listOpenWorkflowExecutionsByWorkflowID(request listRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *standardStore) listOpenWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request listRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	actualRequest, ok := request.(*manager.ListWorkflowExecutionsByWorkflowIDRequest)
 	if !ok {
 		panic(fmt.Errorf("wrong request type %v for listOpenWorkflowExecutionsByWorkflowID", reflect.TypeOf(request)))
 	}
 
-	return s.ListOpenWorkflowExecutionsByWorkflowID(actualRequest)
+	return s.ListOpenWorkflowExecutionsByWorkflowID(ctx, actualRequest)
 }
 
-func (s *standardStore) listOpenWorkflowExecutionsByType(request listRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *standardStore) listOpenWorkflowExecutionsByType(
+	ctx context.Context,
+	request listRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	actualRequest, ok := request.(*manager.ListWorkflowExecutionsByTypeRequest)
 	if !ok {
 		panic(fmt.Errorf("wrong request type %v for listOpenWorkflowExecutionsByType", reflect.TypeOf(request)))
 	}
 
-	return s.ListOpenWorkflowExecutionsByType(actualRequest)
+	return s.ListOpenWorkflowExecutionsByType(ctx, actualRequest)
 }
 
-func (s *standardStore) listOpenWorkflowExecutions(request listRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *standardStore) listOpenWorkflowExecutions(
+	ctx context.Context,
+	request listRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	actualRequest, ok := request.(*manager.ListWorkflowExecutionsRequest)
 	if !ok {
 		panic(fmt.Errorf("wrong request type %v for listOpenWorkflowExecutions", reflect.TypeOf(request)))
 	}
 
-	return s.ListOpenWorkflowExecutions(actualRequest)
+	return s.ListOpenWorkflowExecutions(ctx, actualRequest)
 }
 
-func (s *standardStore) listClosedWorkflowExecutionsByWorkflowID(request listRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *standardStore) listClosedWorkflowExecutionsByWorkflowID(
+	ctx context.Context,
+	request listRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	actualRequest, ok := request.(*manager.ListWorkflowExecutionsByWorkflowIDRequest)
 	if !ok {
 		panic(fmt.Errorf("wrong request type %v for listClosedWorkflowExecutionsByWorkflowID", reflect.TypeOf(request)))
 	}
 
-	return s.ListClosedWorkflowExecutionsByWorkflowID(actualRequest)
+	return s.ListClosedWorkflowExecutionsByWorkflowID(ctx, actualRequest)
 }
 
-func (s *standardStore) listClosedWorkflowExecutionsByType(request listRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *standardStore) listClosedWorkflowExecutionsByType(
+	ctx context.Context,
+	request listRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	actualRequest, ok := request.(*manager.ListWorkflowExecutionsByTypeRequest)
 	if !ok {
 		panic(fmt.Errorf("wrong request type %v for listClosedWorkflowExecutionsByType", reflect.TypeOf(request)))
 	}
 
-	return s.ListClosedWorkflowExecutionsByType(actualRequest)
+	return s.ListClosedWorkflowExecutionsByType(ctx, actualRequest)
 }
 
-func (s *standardStore) listClosedWorkflowExecutions(request listRequest) (*store.InternalListWorkflowExecutionsResponse, error) {
+func (s *standardStore) listClosedWorkflowExecutions(
+	ctx context.Context,
+	request listRequest,
+) (*store.InternalListWorkflowExecutionsResponse, error) {
 	actualRequest, ok := request.(*manager.ListWorkflowExecutionsRequest)
 	if !ok {
 		panic(fmt.Errorf("wrong request type %v for listClosedWorkflowExecutions", reflect.TypeOf(request)))
 	}
 
-	return s.ListClosedWorkflowExecutions(actualRequest)
+	return s.ListClosedWorkflowExecutions(ctx, actualRequest)
 }

--- a/common/persistence/visibility/store/visibility_store.go
+++ b/common/persistence/visibility/store/visibility_store.go
@@ -28,6 +28,7 @@ package store
 //go:generate mockgen -copyright_file ../../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination visibility_store_mock.go -aux_files go.temporal.io/server/common/persistence=../../dataInterfaces.go
 
 import (
+	"context"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -44,22 +45,22 @@ type (
 		GetName() string
 
 		// Write APIs.
-		RecordWorkflowExecutionStarted(request *InternalRecordWorkflowExecutionStartedRequest) error
-		RecordWorkflowExecutionClosed(request *InternalRecordWorkflowExecutionClosedRequest) error
-		UpsertWorkflowExecution(request *InternalUpsertWorkflowExecutionRequest) error
-		DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error
+		RecordWorkflowExecutionStarted(ctx context.Context, request *InternalRecordWorkflowExecutionStartedRequest) error
+		RecordWorkflowExecutionClosed(ctx context.Context, request *InternalRecordWorkflowExecutionClosedRequest) error
+		UpsertWorkflowExecution(ctx context.Context, request *InternalUpsertWorkflowExecutionRequest) error
+		DeleteWorkflowExecution(ctx context.Context, request *manager.VisibilityDeleteWorkflowExecutionRequest) error
 
 		// Read APIs.
-		ListOpenWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error)
-		ListClosedWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error)
-		ListOpenWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error)
-		ListClosedWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error)
-		ListOpenWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*InternalListWorkflowExecutionsResponse, error)
-		ListClosedWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*InternalListWorkflowExecutionsResponse, error)
-		ListClosedWorkflowExecutionsByStatus(request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*InternalListWorkflowExecutionsResponse, error)
-		ListWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error)
-		ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error)
-		CountWorkflowExecutions(request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error)
+		ListOpenWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error)
+		ListClosedWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error)
+		ListOpenWorkflowExecutionsByType(ctx context.Context, request *manager.ListWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error)
+		ListClosedWorkflowExecutionsByType(ctx context.Context, request *manager.ListWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error)
+		ListOpenWorkflowExecutionsByWorkflowID(ctx context.Context, request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*InternalListWorkflowExecutionsResponse, error)
+		ListClosedWorkflowExecutionsByWorkflowID(ctx context.Context, request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*InternalListWorkflowExecutionsResponse, error)
+		ListClosedWorkflowExecutionsByStatus(ctx context.Context, request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*InternalListWorkflowExecutionsResponse, error)
+		ListWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error)
+		ScanWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error)
+		CountWorkflowExecutions(ctx context.Context, request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error)
 	}
 
 	// InternalWorkflowExecutionInfo is visibility info for internal response

--- a/common/persistence/visibility/store/visibility_store_mock.go
+++ b/common/persistence/visibility/store/visibility_store_mock.go
@@ -29,6 +29,7 @@
 package store
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -71,32 +72,32 @@ func (mr *MockVisibilityStoreMockRecorder) Close() *gomock.Call {
 }
 
 // CountWorkflowExecutions mocks base method.
-func (m *MockVisibilityStore) CountWorkflowExecutions(request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) CountWorkflowExecutions(ctx context.Context, request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CountWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "CountWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*manager.CountWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CountWorkflowExecutions indicates an expected call of CountWorkflowExecutions.
-func (mr *MockVisibilityStoreMockRecorder) CountWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) CountWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).CountWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CountWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).CountWorkflowExecutions), ctx, request)
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockVisibilityStore) DeleteWorkflowExecution(request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
+func (m *MockVisibilityStore) DeleteWorkflowExecution(ctx context.Context, request *manager.VisibilityDeleteWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockVisibilityStoreMockRecorder) DeleteWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) DeleteWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockVisibilityStore)(nil).DeleteWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockVisibilityStore)(nil).DeleteWorkflowExecution), ctx, request)
 }
 
 // GetName mocks base method.
@@ -114,178 +115,178 @@ func (mr *MockVisibilityStoreMockRecorder) GetName() *gomock.Call {
 }
 
 // ListClosedWorkflowExecutions mocks base method.
-func (m *MockVisibilityStore) ListClosedWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ListClosedWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClosedWorkflowExecutions indicates an expected call of ListClosedWorkflowExecutions.
-func (mr *MockVisibilityStoreMockRecorder) ListClosedWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ListClosedWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ListClosedWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ListClosedWorkflowExecutions), ctx, request)
 }
 
 // ListClosedWorkflowExecutionsByStatus mocks base method.
-func (m *MockVisibilityStore) ListClosedWorkflowExecutionsByStatus(request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ListClosedWorkflowExecutionsByStatus(ctx context.Context, request *manager.ListClosedWorkflowExecutionsByStatusRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByStatus", request)
+	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByStatus", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClosedWorkflowExecutionsByStatus indicates an expected call of ListClosedWorkflowExecutionsByStatus.
-func (mr *MockVisibilityStoreMockRecorder) ListClosedWorkflowExecutionsByStatus(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ListClosedWorkflowExecutionsByStatus(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByStatus", reflect.TypeOf((*MockVisibilityStore)(nil).ListClosedWorkflowExecutionsByStatus), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByStatus", reflect.TypeOf((*MockVisibilityStore)(nil).ListClosedWorkflowExecutionsByStatus), ctx, request)
 }
 
 // ListClosedWorkflowExecutionsByType mocks base method.
-func (m *MockVisibilityStore) ListClosedWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ListClosedWorkflowExecutionsByType(ctx context.Context, request *manager.ListWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByType", request)
+	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByType", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClosedWorkflowExecutionsByType indicates an expected call of ListClosedWorkflowExecutionsByType.
-func (mr *MockVisibilityStoreMockRecorder) ListClosedWorkflowExecutionsByType(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ListClosedWorkflowExecutionsByType(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByType", reflect.TypeOf((*MockVisibilityStore)(nil).ListClosedWorkflowExecutionsByType), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByType", reflect.TypeOf((*MockVisibilityStore)(nil).ListClosedWorkflowExecutionsByType), ctx, request)
 }
 
 // ListClosedWorkflowExecutionsByWorkflowID mocks base method.
-func (m *MockVisibilityStore) ListClosedWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ListClosedWorkflowExecutionsByWorkflowID(ctx context.Context, request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByWorkflowID", request)
+	ret := m.ctrl.Call(m, "ListClosedWorkflowExecutionsByWorkflowID", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListClosedWorkflowExecutionsByWorkflowID indicates an expected call of ListClosedWorkflowExecutionsByWorkflowID.
-func (mr *MockVisibilityStoreMockRecorder) ListClosedWorkflowExecutionsByWorkflowID(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ListClosedWorkflowExecutionsByWorkflowID(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByWorkflowID", reflect.TypeOf((*MockVisibilityStore)(nil).ListClosedWorkflowExecutionsByWorkflowID), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListClosedWorkflowExecutionsByWorkflowID", reflect.TypeOf((*MockVisibilityStore)(nil).ListClosedWorkflowExecutionsByWorkflowID), ctx, request)
 }
 
 // ListOpenWorkflowExecutions mocks base method.
-func (m *MockVisibilityStore) ListOpenWorkflowExecutions(request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ListOpenWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOpenWorkflowExecutions indicates an expected call of ListOpenWorkflowExecutions.
-func (mr *MockVisibilityStoreMockRecorder) ListOpenWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ListOpenWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ListOpenWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ListOpenWorkflowExecutions), ctx, request)
 }
 
 // ListOpenWorkflowExecutionsByType mocks base method.
-func (m *MockVisibilityStore) ListOpenWorkflowExecutionsByType(request *manager.ListWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ListOpenWorkflowExecutionsByType(ctx context.Context, request *manager.ListWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutionsByType", request)
+	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutionsByType", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOpenWorkflowExecutionsByType indicates an expected call of ListOpenWorkflowExecutionsByType.
-func (mr *MockVisibilityStoreMockRecorder) ListOpenWorkflowExecutionsByType(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ListOpenWorkflowExecutionsByType(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutionsByType", reflect.TypeOf((*MockVisibilityStore)(nil).ListOpenWorkflowExecutionsByType), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutionsByType", reflect.TypeOf((*MockVisibilityStore)(nil).ListOpenWorkflowExecutionsByType), ctx, request)
 }
 
 // ListOpenWorkflowExecutionsByWorkflowID mocks base method.
-func (m *MockVisibilityStore) ListOpenWorkflowExecutionsByWorkflowID(request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ListOpenWorkflowExecutionsByWorkflowID(ctx context.Context, request *manager.ListWorkflowExecutionsByWorkflowIDRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutionsByWorkflowID", request)
+	ret := m.ctrl.Call(m, "ListOpenWorkflowExecutionsByWorkflowID", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListOpenWorkflowExecutionsByWorkflowID indicates an expected call of ListOpenWorkflowExecutionsByWorkflowID.
-func (mr *MockVisibilityStoreMockRecorder) ListOpenWorkflowExecutionsByWorkflowID(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ListOpenWorkflowExecutionsByWorkflowID(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutionsByWorkflowID", reflect.TypeOf((*MockVisibilityStore)(nil).ListOpenWorkflowExecutionsByWorkflowID), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenWorkflowExecutionsByWorkflowID", reflect.TypeOf((*MockVisibilityStore)(nil).ListOpenWorkflowExecutionsByWorkflowID), ctx, request)
 }
 
 // ListWorkflowExecutions mocks base method.
-func (m *MockVisibilityStore) ListWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ListWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "ListWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListWorkflowExecutions indicates an expected call of ListWorkflowExecutions.
-func (mr *MockVisibilityStoreMockRecorder) ListWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ListWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ListWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ListWorkflowExecutions), ctx, request)
 }
 
 // RecordWorkflowExecutionClosed mocks base method.
-func (m *MockVisibilityStore) RecordWorkflowExecutionClosed(request *InternalRecordWorkflowExecutionClosedRequest) error {
+func (m *MockVisibilityStore) RecordWorkflowExecutionClosed(ctx context.Context, request *InternalRecordWorkflowExecutionClosedRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordWorkflowExecutionClosed", request)
+	ret := m.ctrl.Call(m, "RecordWorkflowExecutionClosed", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecordWorkflowExecutionClosed indicates an expected call of RecordWorkflowExecutionClosed.
-func (mr *MockVisibilityStoreMockRecorder) RecordWorkflowExecutionClosed(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) RecordWorkflowExecutionClosed(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionClosed", reflect.TypeOf((*MockVisibilityStore)(nil).RecordWorkflowExecutionClosed), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionClosed", reflect.TypeOf((*MockVisibilityStore)(nil).RecordWorkflowExecutionClosed), ctx, request)
 }
 
 // RecordWorkflowExecutionStarted mocks base method.
-func (m *MockVisibilityStore) RecordWorkflowExecutionStarted(request *InternalRecordWorkflowExecutionStartedRequest) error {
+func (m *MockVisibilityStore) RecordWorkflowExecutionStarted(ctx context.Context, request *InternalRecordWorkflowExecutionStartedRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RecordWorkflowExecutionStarted", request)
+	ret := m.ctrl.Call(m, "RecordWorkflowExecutionStarted", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RecordWorkflowExecutionStarted indicates an expected call of RecordWorkflowExecutionStarted.
-func (mr *MockVisibilityStoreMockRecorder) RecordWorkflowExecutionStarted(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) RecordWorkflowExecutionStarted(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionStarted", reflect.TypeOf((*MockVisibilityStore)(nil).RecordWorkflowExecutionStarted), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecordWorkflowExecutionStarted", reflect.TypeOf((*MockVisibilityStore)(nil).RecordWorkflowExecutionStarted), ctx, request)
 }
 
 // ScanWorkflowExecutions mocks base method.
-func (m *MockVisibilityStore) ScanWorkflowExecutions(request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error) {
+func (m *MockVisibilityStore) ScanWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ScanWorkflowExecutions", request)
+	ret := m.ctrl.Call(m, "ScanWorkflowExecutions", ctx, request)
 	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ScanWorkflowExecutions indicates an expected call of ScanWorkflowExecutions.
-func (mr *MockVisibilityStoreMockRecorder) ScanWorkflowExecutions(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) ScanWorkflowExecutions(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ScanWorkflowExecutions), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ScanWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ScanWorkflowExecutions), ctx, request)
 }
 
 // UpsertWorkflowExecution mocks base method.
-func (m *MockVisibilityStore) UpsertWorkflowExecution(request *InternalUpsertWorkflowExecutionRequest) error {
+func (m *MockVisibilityStore) UpsertWorkflowExecution(ctx context.Context, request *InternalUpsertWorkflowExecutionRequest) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpsertWorkflowExecution", request)
+	ret := m.ctrl.Call(m, "UpsertWorkflowExecution", ctx, request)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpsertWorkflowExecution indicates an expected call of UpsertWorkflowExecution.
-func (mr *MockVisibilityStoreMockRecorder) UpsertWorkflowExecution(request interface{}) *gomock.Call {
+func (mr *MockVisibilityStoreMockRecorder) UpsertWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertWorkflowExecution", reflect.TypeOf((*MockVisibilityStore)(nil).UpsertWorkflowExecution), request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertWorkflowExecution", reflect.TypeOf((*MockVisibilityStore)(nil).UpsertWorkflowExecution), ctx, request)
 }

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -77,7 +77,7 @@ func (p *visibilityManagerImpl) GetName() string {
 }
 
 func (p *visibilityManagerImpl) RecordWorkflowExecutionStarted(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.RecordWorkflowExecutionStartedRequest,
 ) error {
 	requestBase, err := p.newInternalVisibilityRequestBase(request.VisibilityRequestBase)
@@ -87,11 +87,11 @@ func (p *visibilityManagerImpl) RecordWorkflowExecutionStarted(
 	req := &store.InternalRecordWorkflowExecutionStartedRequest{
 		InternalVisibilityRequestBase: requestBase,
 	}
-	return p.store.RecordWorkflowExecutionStarted(req)
+	return p.store.RecordWorkflowExecutionStarted(ctx, req)
 }
 
 func (p *visibilityManagerImpl) RecordWorkflowExecutionClosed(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.RecordWorkflowExecutionClosedRequest,
 ) error {
 	requestBase, err := p.newInternalVisibilityRequestBase(request.VisibilityRequestBase)
@@ -103,11 +103,11 @@ func (p *visibilityManagerImpl) RecordWorkflowExecutionClosed(
 		CloseTime:                     request.CloseTime,
 		HistoryLength:                 request.HistoryLength,
 	}
-	return p.store.RecordWorkflowExecutionClosed(req)
+	return p.store.RecordWorkflowExecutionClosed(ctx, req)
 }
 
 func (p *visibilityManagerImpl) UpsertWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.UpsertWorkflowExecutionRequest,
 ) error {
 	requestBase, err := p.newInternalVisibilityRequestBase(request.VisibilityRequestBase)
@@ -117,21 +117,21 @@ func (p *visibilityManagerImpl) UpsertWorkflowExecution(
 	req := &store.InternalUpsertWorkflowExecutionRequest{
 		InternalVisibilityRequestBase: requestBase,
 	}
-	return p.store.UpsertWorkflowExecution(req)
+	return p.store.UpsertWorkflowExecution(ctx, req)
 }
 
 func (p *visibilityManagerImpl) DeleteWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.VisibilityDeleteWorkflowExecutionRequest,
 ) error {
-	return p.store.DeleteWorkflowExecution(request)
+	return p.store.DeleteWorkflowExecution(ctx, request)
 }
 
 func (p *visibilityManagerImpl) ListOpenWorkflowExecutions(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsRequest,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ListOpenWorkflowExecutions(request)
+	response, err := p.store.ListOpenWorkflowExecutions(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -139,10 +139,10 @@ func (p *visibilityManagerImpl) ListOpenWorkflowExecutions(
 }
 
 func (p *visibilityManagerImpl) ListClosedWorkflowExecutions(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsRequest,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ListClosedWorkflowExecutions(request)
+	response, err := p.store.ListClosedWorkflowExecutions(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -151,10 +151,10 @@ func (p *visibilityManagerImpl) ListClosedWorkflowExecutions(
 }
 
 func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByType(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsByTypeRequest,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ListOpenWorkflowExecutionsByType(request)
+	response, err := p.store.ListOpenWorkflowExecutionsByType(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -163,10 +163,10 @@ func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByType(
 }
 
 func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByType(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsByTypeRequest,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ListClosedWorkflowExecutionsByType(request)
+	response, err := p.store.ListClosedWorkflowExecutionsByType(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -175,10 +175,10 @@ func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByType(
 }
 
 func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByWorkflowID(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ListOpenWorkflowExecutionsByWorkflowID(request)
+	response, err := p.store.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -187,10 +187,10 @@ func (p *visibilityManagerImpl) ListOpenWorkflowExecutionsByWorkflowID(
 }
 
 func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByWorkflowID(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ListClosedWorkflowExecutionsByWorkflowID(request)
+	response, err := p.store.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -199,10 +199,10 @@ func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByWorkflowID(
 }
 
 func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByStatus(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ListClosedWorkflowExecutionsByStatus(request)
+	response, err := p.store.ListClosedWorkflowExecutionsByStatus(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -211,10 +211,10 @@ func (p *visibilityManagerImpl) ListClosedWorkflowExecutionsByStatus(
 }
 
 func (p *visibilityManagerImpl) ListWorkflowExecutions(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsRequestV2,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ListWorkflowExecutions(request)
+	response, err := p.store.ListWorkflowExecutions(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -223,10 +223,10 @@ func (p *visibilityManagerImpl) ListWorkflowExecutions(
 }
 
 func (p *visibilityManagerImpl) ScanWorkflowExecutions(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsRequestV2,
 ) (*manager.ListWorkflowExecutionsResponse, error) {
-	response, err := p.store.ScanWorkflowExecutions(request)
+	response, err := p.store.ScanWorkflowExecutions(ctx, request)
 	if err != nil {
 		return nil, err
 	}
@@ -235,10 +235,10 @@ func (p *visibilityManagerImpl) ScanWorkflowExecutions(
 }
 
 func (p *visibilityManagerImpl) CountWorkflowExecutions(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.CountWorkflowExecutionsRequest,
 ) (*manager.CountWorkflowExecutionsResponse, error) {
-	response, err := p.store.CountWorkflowExecutions(request)
+	response, err := p.store.CountWorkflowExecutions(ctx, request)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/visibility/visibility_manager_test.go
+++ b/common/persistence/visibility/visibility_manager_test.go
@@ -100,7 +100,7 @@ func (s *VisibilityManagerSuite) TestRecordWorkflowExecutionStarted() {
 			StartTime:        time.Now().UTC(),
 		},
 	}
-	s.visibilityStore.EXPECT().RecordWorkflowExecutionStarted(gomock.Any()).Return(nil)
+	s.visibilityStore.EXPECT().RecordWorkflowExecutionStarted(gomock.Any(), gomock.Any()).Return(nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceRecordWorkflowExecutionStartedScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	s.NoError(s.visibilityManager.RecordWorkflowExecutionStarted(context.Background(), request))
 
@@ -121,7 +121,7 @@ func (s *VisibilityManagerSuite) TestRecordWorkflowExecutionClosed() {
 		},
 	}
 
-	s.visibilityStore.EXPECT().RecordWorkflowExecutionClosed(gomock.Any()).Return(nil)
+	s.visibilityStore.EXPECT().RecordWorkflowExecutionClosed(gomock.Any(), gomock.Any()).Return(nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceRecordWorkflowExecutionClosedScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	s.NoError(s.visibilityManager.RecordWorkflowExecutionClosed(context.Background(), request))
 
@@ -135,7 +135,7 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutions() {
 		NamespaceID: testNamespaceUUID,
 		Namespace:   testNamespace,
 	}
-	s.visibilityStore.EXPECT().ListOpenWorkflowExecutions(gomock.Any()).Return(nil, nil)
+	s.visibilityStore.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	_, err := s.visibilityManager.ListOpenWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
@@ -151,7 +151,7 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutions() {
 		NamespaceID: testNamespaceUUID,
 		Namespace:   testNamespace,
 	}
-	s.visibilityStore.EXPECT().ListClosedWorkflowExecutions(gomock.Any()).Return(nil, nil)
+	s.visibilityStore.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	_, err := s.visibilityManager.ListClosedWorkflowExecutions(context.Background(), request)
 	s.NoError(err)
@@ -170,7 +170,7 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutionsByType() {
 		ListWorkflowExecutionsRequest: req,
 		WorkflowTypeName:              testWorkflowTypeName,
 	}
-	s.visibilityStore.EXPECT().ListOpenWorkflowExecutionsByType(gomock.Any()).Return(nil, nil)
+	s.visibilityStore.EXPECT().ListOpenWorkflowExecutionsByType(gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsByTypeScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	_, err := s.visibilityManager.ListOpenWorkflowExecutionsByType(context.Background(), request)
 	s.NoError(err)
@@ -189,7 +189,7 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByType() {
 		ListWorkflowExecutionsRequest: req,
 		WorkflowTypeName:              testWorkflowTypeName,
 	}
-	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByType(gomock.Any()).Return(nil, nil)
+	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByType(gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByTypeScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByType(context.Background(), request)
 	s.NoError(err)
@@ -208,7 +208,7 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 		ListWorkflowExecutionsRequest: req,
 		WorkflowID:                    testWorkflowExecution.GetWorkflowId(),
 	}
-	s.visibilityStore.EXPECT().ListOpenWorkflowExecutionsByWorkflowID(gomock.Any()).Return(nil, nil)
+	s.visibilityStore.EXPECT().ListOpenWorkflowExecutionsByWorkflowID(gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsByWorkflowIDScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	_, err := s.visibilityManager.ListOpenWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.NoError(err)
@@ -227,7 +227,7 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByWorkflowID() 
 		ListWorkflowExecutionsRequest: req,
 		WorkflowID:                    testWorkflowExecution.GetWorkflowId(),
 	}
-	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByWorkflowID(gomock.Any()).Return(nil, nil)
+	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByWorkflowID(gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByWorkflowIDScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByWorkflowID(context.Background(), request)
 	s.NoError(err)
@@ -246,7 +246,7 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByStatus() {
 		ListWorkflowExecutionsRequest: req,
 		Status:                        enumspb.WORKFLOW_EXECUTION_STATUS_FAILED,
 	}
-	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByStatus(gomock.Any()).Return(nil, nil)
+	s.visibilityStore.EXPECT().ListClosedWorkflowExecutionsByStatus(gomock.Any(), gomock.Any()).Return(nil, nil)
 	s.metricClient.EXPECT().Scope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByStatusScope, metrics.StandardVisibilityTypeTag()).Return(metrics.NoopScope).Times(2)
 	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByStatus(context.Background(), request)
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add context parameter to visibility store interfaces.
- NOTE: there's no behavior change in this PR. SQL, Cassandra and ElasticSearch store implementation still ignores the context passed it. Those will be changed in a follow up PR.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enforce persistence timeout, instead of always timeout after 10s
- Required for host level task worker pool

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
-  Very low, context is currently ignored by persistence store implementation

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.