### PR TITLE
Fix timer queue cluster ack level update

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -384,7 +384,7 @@ func (s *ContextImpl) UpdateQueueClusterAckLevel(
 	case tasks.CategoryTransfer:
 		s.shardInfo.ClusterTransferAckLevel[cluster] = ackLevel.TaskID
 	case tasks.CategoryTimer:
-		s.shardInfo.TimerAckLevelTime = timestamp.TimePtr(ackLevel.FireTime)
+		s.shardInfo.ClusterTimerAckLevel[cluster] = timestamp.TimePtr(ackLevel.FireTime)
 	case tasks.CategoryReplication:
 		s.shardInfo.ClusterReplicationLevel[cluster] = ackLevel.TaskID
 	case tasks.CategoryVisibility:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix timer queue cluster ack level update
- Need to be part of 1.16

<!-- Tell your future self why have you made these changes -->
**Why?**
- Update the right field in shard info for backward compatibility

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
-  Tested/Verified locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- No, won't cause big issue. Even if that field is not updated and we perform a rollback, since the underlying tasks in DB is already deleted, we don't re-processing them, and ack level will fix itself on next update.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- no, not released yet