### PR TITLE
Fix history client NPE for invalid shardID

### DIFF
--- a/client/history/client.go
+++ b/client/history/client.go
@@ -186,15 +186,13 @@ func (c *clientImpl) DescribeHistoryHost(
 func (c *clientImpl) RemoveTask(
 	ctx context.Context,
 	request *historyservice.RemoveTaskRequest,
-	opts ...grpc.CallOption) (*historyservice.RemoveTaskResponse, error) {
-	var err error
-	var client historyservice.HistoryServiceClient
-	if request.GetShardId() != 0 {
-		client, err = c.getClientForShardID(request.GetShardId())
-		if err != nil {
-			return nil, err
-		}
+	opts ...grpc.CallOption,
+) (*historyservice.RemoveTaskResponse, error) {
+	client, err := c.getClientForShardID(request.GetShardId())
+	if err != nil {
+		return nil, err
 	}
+
 	var response *historyservice.RemoveTaskResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -214,16 +212,13 @@ func (c *clientImpl) RemoveTask(
 func (c *clientImpl) CloseShard(
 	ctx context.Context,
 	request *historyservice.CloseShardRequest,
-	opts ...grpc.CallOption) (*historyservice.CloseShardResponse, error) {
-
-	var err error
-	var client historyservice.HistoryServiceClient
-	if request.ShardId != 0 {
-		client, err = c.getClientForShardID(request.GetShardId())
-		if err != nil {
-			return nil, err
-		}
+	opts ...grpc.CallOption,
+) (*historyservice.CloseShardResponse, error) {
+	client, err := c.getClientForShardID(request.GetShardId())
+	if err != nil {
+		return nil, err
 	}
+
 	var response *historyservice.CloseShardResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -243,16 +238,13 @@ func (c *clientImpl) CloseShard(
 func (c *clientImpl) GetShard(
 	ctx context.Context,
 	request *historyservice.GetShardRequest,
-	opts ...grpc.CallOption) (*historyservice.GetShardResponse, error) {
-
-	var err error
-	var client historyservice.HistoryServiceClient
-	if request.ShardId != 0 {
-		client, err = c.getClientForShardID(request.GetShardId())
-		if err != nil {
-			return nil, err
-		}
+	opts ...grpc.CallOption,
+) (*historyservice.GetShardResponse, error) {
+	client, err := c.getClientForShardID(request.GetShardId())
+	if err != nil {
+		return nil, err
 	}
+
 	var response *historyservice.GetShardResponse
 	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
 		var err error
@@ -830,7 +822,7 @@ func (c *clientImpl) SyncShardStatus(
 	opts ...grpc.CallOption) (*historyservice.SyncShardStatusResponse, error) {
 
 	// we do not have a workflow ID here, instead, we have something even better
-	client, err := c.getClientForShardID(int32(request.GetShardId()))
+	client, err := c.getClientForShardID(request.GetShardId())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix history client NPE for invalid shardID

<!-- Tell your future self why have you made these changes -->
**Why?**
- Current if shardID is 0, `client` will not be initialized but still be used to make the rpc call, result in an NPE error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
-  Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
