### PR TITLE
Use better retry logic in reclaimresources workflow

### DIFF
--- a/common/persistence/visibility/visibility_manager_dual.go
+++ b/common/persistence/visibility/visibility_manager_dual.go
@@ -26,6 +26,7 @@ package visibility
 
 import (
 	"context"
+	"strings"
 
 	"go.temporal.io/server/common/persistence/visibility/manager"
 )
@@ -60,7 +61,7 @@ func (v *visibilityManagerDual) Close() {
 }
 
 func (v *visibilityManagerDual) GetName() string {
-	return "VisibilityManagerDual"
+	return strings.Join([]string{v.visibilityManager.GetName(), v.secondaryVisibilityManager.GetName()}, ",")
 }
 
 func (v *visibilityManagerDual) RecordWorkflowExecutionStarted(

--- a/service/worker/deletenamespace/errors/errors.go
+++ b/service/worker/deletenamespace/errors/errors.go
@@ -32,10 +32,12 @@ import (
 
 const (
 	ExecutionsStillExistErrType = "ExecutionsStillExist"
+	NoProgressErrType           = "NoProgress"
 )
 
 var (
 	ErrUnableToExecuteActivity      = errors.New("unable to execute activity")
 	ErrUnableToExecuteChildWorkflow = errors.New("unable to execute child workflow")
 	ErrExecutionsStillExist         = temporal.NewApplicationError("executions are still exist", ExecutionsStillExistErrType)
+	ErrNoProgress                   = temporal.NewNonRetryableApplicationError("no progress were made", NoProgressErrType, nil)
 )

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -62,7 +62,6 @@ func NewActivities(
 	}
 }
 func (a *Activities) IsAdvancedVisibilityActivity(_ context.Context) (bool, error) {
-	// TODO: remove this check after CountWorkflowExecutions is implemented in standard visibility.
 	return strings.Contains(a.visibilityManager.GetName(), "elasticsearch"), nil
 }
 
@@ -105,6 +104,11 @@ func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context
 }
 
 func (a *Activities) EnsureNoExecutionsStdVisibilityActivity(ctx context.Context, nsID namespace.ID, nsName namespace.Name) error {
+	// Standard visibility does not support CountWorkflowExecutions but only supports ListWorkflowExecutions.
+	// To prevent read of many records from DB, set PageSize to 1 and use this single record as indicator of workflow executions existence.
+	// Unfortunately, this doesn't allow to report progress and retry is limited only by timeout.
+	// TODO: remove this activity after CountWorkflowExecutions is implemented in standard visibility.
+
 	req := &manager.ListWorkflowExecutionsRequestV2{
 		NamespaceID: nsID,
 		Namespace:   nsName,

--- a/service/worker/deletenamespace/reclaimresources/activities_test.go
+++ b/service/worker/deletenamespace/reclaimresources/activities_test.go
@@ -42,7 +42,6 @@ import (
 func Test_EnsureNoExecutionsActivity_NoExecutions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	visibilityManager := manager.NewMockVisibilityManager(ctrl)
-	visibilityManager.EXPECT().GetName().Return("elasticsearch")
 
 	visibilityManager.EXPECT().CountWorkflowExecutions(gomock.Any(), &manager.CountWorkflowExecutionsRequest{
 		NamespaceID: "namespace-id",
@@ -58,7 +57,7 @@ func Test_EnsureNoExecutionsActivity_NoExecutions(t *testing.T) {
 		logger:            log.NewNoopLogger(),
 	}
 
-	err := a.EnsureNoExecutionsActivity(context.Background(), "namespace-id", "namespace")
+	err := a.EnsureNoExecutionsAdvVisibilityActivity(context.Background(), "namespace-id", "namespace")
 	require.NoError(t, err)
 
 	ctrl.Finish()
@@ -70,7 +69,6 @@ func Test_EnsureNoExecutionsActivity_ExecutionsExist(t *testing.T) {
 
 	ctrl := gomock.NewController(t)
 	visibilityManager := manager.NewMockVisibilityManager(ctrl)
-	visibilityManager.EXPECT().GetName().Return("elasticsearch")
 
 	visibilityManager.EXPECT().CountWorkflowExecutions(gomock.Any(), &manager.CountWorkflowExecutionsRequest{
 		NamespaceID: "namespace-id",
@@ -85,9 +83,9 @@ func Test_EnsureNoExecutionsActivity_ExecutionsExist(t *testing.T) {
 		metricsClient:     metrics.NoopClient,
 		logger:            log.NewNoopLogger(),
 	}
-	env.RegisterActivity(a.EnsureNoExecutionsActivity)
+	env.RegisterActivity(a.EnsureNoExecutionsAdvVisibilityActivity)
 
-	_, err := env.ExecuteActivity(a.EnsureNoExecutionsActivity, namespace.ID("namespace-id"), namespace.Name("namespace"))
+	_, err := env.ExecuteActivity(a.EnsureNoExecutionsAdvVisibilityActivity, namespace.ID("namespace-id"), namespace.Name("namespace"))
 	require.Error(t, err)
 	var appErr *temporal.ApplicationError
 	require.ErrorAs(t, err, &appErr)

--- a/service/worker/deletenamespace/reclaimresources/activities_test.go
+++ b/service/worker/deletenamespace/reclaimresources/activities_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 
@@ -39,7 +40,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 )
 
-func Test_EnsureNoExecutionsActivity_NoExecutions(t *testing.T) {
+func Test_EnsureNoExecutionsAdvVisibilityActivity_NoExecutions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	visibilityManager := manager.NewMockVisibilityManager(ctrl)
 
@@ -63,7 +64,7 @@ func Test_EnsureNoExecutionsActivity_NoExecutions(t *testing.T) {
 	ctrl.Finish()
 }
 
-func Test_EnsureNoExecutionsActivity_ExecutionsExist(t *testing.T) {
+func Test_EnsureNoExecutionsAdvVisibilityActivity_ExecutionsExist(t *testing.T) {
 	testSuite := &testsuite.WorkflowTestSuite{}
 	env := testSuite.NewTestActivityEnvironment()
 
@@ -86,6 +87,59 @@ func Test_EnsureNoExecutionsActivity_ExecutionsExist(t *testing.T) {
 	env.RegisterActivity(a.EnsureNoExecutionsAdvVisibilityActivity)
 
 	_, err := env.ExecuteActivity(a.EnsureNoExecutionsAdvVisibilityActivity, namespace.ID("namespace-id"), namespace.Name("namespace"))
+	require.Error(t, err)
+	var appErr *temporal.ApplicationError
+	require.ErrorAs(t, err, &appErr)
+	require.Equal(t, "ExecutionsStillExist", appErr.Type())
+	ctrl.Finish()
+}
+
+func Test_EnsureNoExecutionsStdVisibilityActivity_NoExecutions(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	visibilityManager := manager.NewMockVisibilityManager(ctrl)
+
+	visibilityManager.EXPECT().ListWorkflowExecutions(gomock.Any(), &manager.ListWorkflowExecutionsRequestV2{
+		NamespaceID: "namespace-id",
+		Namespace:   "namespace",
+		PageSize:    1,
+	}).Return(&manager.ListWorkflowExecutionsResponse{
+		Executions: []*workflowpb.WorkflowExecutionInfo{},
+	}, nil)
+
+	a := &Activities{
+		visibilityManager: visibilityManager,
+		metadataManager:   nil,
+		metricsClient:     metrics.NoopClient,
+		logger:            log.NewNoopLogger(),
+	}
+
+	err := a.EnsureNoExecutionsStdVisibilityActivity(context.Background(), "namespace-id", "namespace")
+	require.NoError(t, err)
+
+	ctrl.Finish()
+}
+
+func Test_EnsureNoExecutionsStdVisibilityActivity_ExecutionsExist(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	visibilityManager := manager.NewMockVisibilityManager(ctrl)
+
+	visibilityManager.EXPECT().ListWorkflowExecutions(gomock.Any(), &manager.ListWorkflowExecutionsRequestV2{
+		NamespaceID: "namespace-id",
+		Namespace:   "namespace",
+		PageSize:    1,
+	}).Return(&manager.ListWorkflowExecutionsResponse{
+		Executions: []*workflowpb.WorkflowExecutionInfo{{}},
+	}, nil)
+
+	a := &Activities{
+		visibilityManager: visibilityManager,
+		metadataManager:   nil,
+		metricsClient:     metrics.NoopClient,
+		logger:            log.NewNoopLogger(),
+	}
+
+	err := a.EnsureNoExecutionsStdVisibilityActivity(context.Background(), "namespace-id", "namespace")
+
 	require.Error(t, err)
 	var appErr *temporal.ApplicationError
 	require.ErrorAs(t, err, &appErr)

--- a/service/worker/deletenamespace/workflow_test.go
+++ b/service/worker/deletenamespace/workflow_test.go
@@ -47,10 +47,10 @@ func Test_DeleteNamespaceWorkflow_ByName(t *testing.T) {
 		getNamespaceInfoResult{
 			NamespaceID: "namespace-id",
 			Namespace:   "namespace",
-		}, nil)
-	env.OnActivity(a.MarkNamespaceDeletedActivity, mock.Anything, namespace.Name("namespace")).Return(nil)
-	env.OnActivity(a.GenerateDeletedNamespaceNameActivity, mock.Anything, namespace.Name("namespace")).Return(namespace.Name("namespace-delete-220878"), nil)
-	env.OnActivity(a.RenameNamespaceActivity, mock.Anything, namespace.Name("namespace"), namespace.Name("namespace-delete-220878")).Return(nil)
+		}, nil).Once()
+	env.OnActivity(a.MarkNamespaceDeletedActivity, mock.Anything, namespace.Name("namespace")).Return(nil).Once()
+	env.OnActivity(a.GenerateDeletedNamespaceNameActivity, mock.Anything, namespace.Name("namespace")).Return(namespace.Name("namespace-delete-220878"), nil).Once()
+	env.OnActivity(a.RenameNamespaceActivity, mock.Anything, namespace.Name("namespace"), namespace.Name("namespace-delete-220878")).Return(nil).Once()
 
 	env.RegisterWorkflow(reclaimresources.ReclaimResourcesWorkflow)
 	env.OnWorkflow(reclaimresources.ReclaimResourcesWorkflow, mock.Anything, reclaimresources.ReclaimResourcesParams{DeleteExecutionsParams: deleteexecutions.DeleteExecutionsParams{
@@ -67,7 +67,7 @@ func Test_DeleteNamespaceWorkflow_ByName(t *testing.T) {
 	}}).Return(reclaimresources.ReclaimResourcesResult{
 		SuccessCount: 10,
 		ErrorCount:   0,
-	}, nil)
+	}, nil).Once()
 
 	// Delete by name.
 	env.ExecuteWorkflow(DeleteNamespaceWorkflow, DeleteNamespaceWorkflowParams{
@@ -93,10 +93,10 @@ func Test_DeleteNamespaceWorkflow_ByID(t *testing.T) {
 		getNamespaceInfoResult{
 			NamespaceID: "namespace-id",
 			Namespace:   "namespace",
-		}, nil)
-	env.OnActivity(a.MarkNamespaceDeletedActivity, mock.Anything, namespace.Name("namespace")).Return(nil)
-	env.OnActivity(a.GenerateDeletedNamespaceNameActivity, mock.Anything, namespace.Name("namespace")).Return(namespace.Name("namespace-delete-220878"), nil)
-	env.OnActivity(a.RenameNamespaceActivity, mock.Anything, namespace.Name("namespace"), namespace.Name("namespace-delete-220878")).Return(nil)
+		}, nil).Once()
+	env.OnActivity(a.MarkNamespaceDeletedActivity, mock.Anything, namespace.Name("namespace")).Return(nil).Once()
+	env.OnActivity(a.GenerateDeletedNamespaceNameActivity, mock.Anything, namespace.Name("namespace")).Return(namespace.Name("namespace-delete-220878"), nil).Once()
+	env.OnActivity(a.RenameNamespaceActivity, mock.Anything, namespace.Name("namespace"), namespace.Name("namespace-delete-220878")).Return(nil).Once()
 
 	env.RegisterWorkflow(reclaimresources.ReclaimResourcesWorkflow)
 	env.OnWorkflow(reclaimresources.ReclaimResourcesWorkflow, mock.Anything, reclaimresources.ReclaimResourcesParams{DeleteExecutionsParams: deleteexecutions.DeleteExecutionsParams{
@@ -113,7 +113,7 @@ func Test_DeleteNamespaceWorkflow_ByID(t *testing.T) {
 	}}).Return(reclaimresources.ReclaimResourcesResult{
 		SuccessCount: 10,
 		ErrorCount:   0,
-	}, nil)
+	}, nil).Once()
 
 	// Delete by name.
 	env.ExecuteWorkflow(DeleteNamespaceWorkflow, DeleteNamespaceWorkflowParams{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use better retry logic in `reclaimresources` workflow.

<!-- Tell your future self why have you made these changes -->
**Why?**
When advanced visibility is enabled, `EnsureNoExecutionActivity` uses better retry logic now. Instead of just retrying for some period of time, it monitors progress of task processing. If progress is made then it keeps waiting. In case if no progress is made activity returns non-retryable error and workflow tries to delete executions again.

Standard visibility just retries for 30 minutes making approximately 20 attempts.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified unit tests and local run.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.