### PR TITLE
Use type from type map before type from Metadata

### DIFF
--- a/common/searchattribute/encode.go
+++ b/common/searchattribute/encode.go
@@ -27,6 +27,7 @@ package searchattribute
 import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+
 	"go.temporal.io/server/common/payload"
 )
 
@@ -63,8 +64,8 @@ func Encode(searchAttributes map[string]interface{}, typeMap *NameTypeMap) (*com
 }
 
 // Decode decodes search attributes to the map of search attribute values using (in order):
-// 1. type from MetadataType field,
-// 2. type from typeMap (can be nil).
+// 1. type from typeMap,
+// 2. if typeMap is nil, type from MetadataType field is used.
 // In case of error, it will continue to next search attribute and return last error.
 func Decode(searchAttributes *commonpb.SearchAttributes, typeMap *NameTypeMap) (map[string]interface{}, error) {
 	if len(searchAttributes.GetIndexedFields()) == 0 {

--- a/common/searchattribute/encode_value.go
+++ b/common/searchattribute/encode_value.go
@@ -46,14 +46,15 @@ func EncodeValue(val interface{}, t enumspb.IndexedValueType) (*commonpb.Payload
 }
 
 // DecodeValue decodes search attribute value from Payload using (in order):
-// 1. type from MetadataType field,
-// 2. passed type t.
+// 1. passed type t.
+// 2. type from MetadataType field, if t is not specified.
 func DecodeValue(value *commonpb.Payload, t enumspb.IndexedValueType) (interface{}, error) {
-	valueTypeMetadata, metadataHasValueType := value.Metadata[MetadataType]
-	if metadataHasValueType {
-		if ivt, ok := enumspb.IndexedValueType_value[string(valueTypeMetadata)]; ok {
-			// MetadataType field has priority over passed type.
-			t = enumspb.IndexedValueType(ivt)
+	if t == enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED {
+		if valueTypeMetadata, metadataHasValueType := value.Metadata[MetadataType]; metadataHasValueType {
+			if ivt, ok := enumspb.IndexedValueType_value[string(valueTypeMetadata)]; ok {
+				// MetadataType field has priority over passed type.
+				t = enumspb.IndexedValueType(ivt)
+			}
 		}
 	}
 

--- a/common/searchattribute/encode_value.go
+++ b/common/searchattribute/encode_value.go
@@ -50,12 +50,7 @@ func EncodeValue(val interface{}, t enumspb.IndexedValueType) (*commonpb.Payload
 // 2. type from MetadataType field, if t is not specified.
 func DecodeValue(value *commonpb.Payload, t enumspb.IndexedValueType) (interface{}, error) {
 	if t == enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED {
-		if valueTypeMetadata, metadataHasValueType := value.Metadata[MetadataType]; metadataHasValueType {
-			if ivt, ok := enumspb.IndexedValueType_value[string(valueTypeMetadata)]; ok {
-				// MetadataType field has priority over passed type.
-				t = enumspb.IndexedValueType(ivt)
-			}
-		}
+		t = enumspb.IndexedValueType(enumspb.IndexedValueType_value[string(value.Metadata[MetadataType])])
 	}
 
 	switch t {

--- a/common/searchattribute/encode_value_test.go
+++ b/common/searchattribute/encode_value_test.go
@@ -25,7 +25,6 @@
 package searchattribute
 
 import (
-	"errors"
 	"testing"
 	"time"
 
@@ -94,7 +93,7 @@ func Test_DecodeValue_Error(t *testing.T) {
 	payloadStr := payload.EncodeString("qwe")
 	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
 	assert.Error(err)
-	assert.True(errors.Is(err, ErrInvalidType))
+	assert.ErrorIs(err, ErrInvalidType)
 	assert.Nil(decodedStr)
 
 	payloadInt, err := payload.Encode(123)
@@ -102,7 +101,7 @@ func Test_DecodeValue_Error(t *testing.T) {
 	payloadInt.Metadata["type"] = []byte("UnknownType")
 	decodedInt, err := DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
 	assert.Error(err)
-	assert.True(errors.Is(err, ErrInvalidType))
+	assert.ErrorIs(err, ErrInvalidType)
 	assert.Nil(decodedInt)
 
 	payloadInt, err = payload.Encode(123)
@@ -110,7 +109,7 @@ func Test_DecodeValue_Error(t *testing.T) {
 	payloadInt.Metadata["type"] = []byte("Text")
 	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
 	assert.Error(err)
-	assert.True(errors.Is(err, converter.ErrUnableToDecode), err.Error())
+	assert.ErrorIs(err, converter.ErrUnableToDecode, err.Error())
 	assert.Nil(decodedInt)
 }
 

--- a/common/searchattribute/encode_value_test.go
+++ b/common/searchattribute/encode_value_test.go
@@ -41,21 +41,14 @@ func Test_DecodeValue_FromMetadata_Success(t *testing.T) {
 
 	payloadStr := payload.EncodeString("qwe")
 	payloadStr.Metadata["type"] = []byte("Text")
-	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
+	decodedStr, err := DecodeValue(payloadStr, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED) // MetadataType is used.
 	assert.NoError(err)
 	assert.Equal("qwe", decodedStr)
-
-	payloadInt, err := payload.Encode(123)
-	assert.NoError(err)
-	payloadInt.Metadata["type"] = []byte("Int")
-	decodedInt, err := DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_TEXT) // MetadataType should be used anyway
-	assert.NoError(err)
-	assert.Equal(int64(123), decodedInt)
 
 	payloadBool, err := payload.Encode(true)
 	assert.NoError(err)
 	payloadBool.Metadata["type"] = []byte("Bool")
-	decodedBool, err := DecodeValue(payloadBool, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
+	decodedBool, err := DecodeValue(payloadBool, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED) // MetadataType is used.
 	assert.NoError(err)
 	assert.Equal(true, decodedBool)
 }
@@ -76,7 +69,14 @@ func Test_DecodeValue_FromParameter_Success(t *testing.T) {
 
 	payloadInt, err = payload.Encode(123)
 	assert.NoError(err)
-	payloadInt.Metadata["type"] = []byte("UnknownType") // should not be used because incorrect
+	payloadInt.Metadata["type"] = []byte("String") // MetadataType is not used.
+	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT)
+	assert.NoError(err)
+	assert.Equal(int64(123), decodedInt)
+
+	payloadInt, err = payload.Encode(123)
+	assert.NoError(err)
+	payloadInt.Metadata["type"] = []byte("UnknownType") // MetadataType is not used.
 	decodedInt, err = DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT)
 	assert.NoError(err)
 	assert.Equal(int64(123), decodedInt)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use type from type map before type from Metadata.

<!-- Tell your future self why have you made these changes -->
**Why?**
Before if wrong type was passed in metadata together with value of that type, it passes validation but fails on write to Elasticsearch. Closes #2693.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.