### PR TITLE
buffer event as local namespace after promotion

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4198,8 +4198,10 @@ func (e *MutableStateImpl) startTransactionHandleNamespaceMigration(
 		return nil, err
 	}
 
-	// local namespace -> global namespace && with buffered events
-	if lastWriteVersion == common.EmptyVersion && namespaceEntry.FailoverVersion() > common.EmptyVersion && e.HasBufferedEvents() {
+	// local namespace -> global namespace && with buffered events or inflight workflow task
+	if lastWriteVersion == common.EmptyVersion &&
+		namespaceEntry.FailoverVersion() > common.EmptyVersion &&
+		(e.HasBufferedEvents() || e.HasInFlightWorkflowTask()) {
 		localNamespaceMutation := namespace.NewPretendAsLocalNamespace(
 			e.clusterMetadata.GetCurrentClusterName(),
 		)

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4198,10 +4198,8 @@ func (e *MutableStateImpl) startTransactionHandleNamespaceMigration(
 		return nil, err
 	}
 
-	// local namespace -> global namespace && with buffered events or inflight workflow task
-	if lastWriteVersion == common.EmptyVersion &&
-		namespaceEntry.FailoverVersion() > common.EmptyVersion &&
-		(e.HasBufferedEvents() || e.HasInFlightWorkflowTask()) {
+	// local namespace -> global namespace && with inflight workflow task
+	if lastWriteVersion == common.EmptyVersion && namespaceEntry.FailoverVersion() > common.EmptyVersion && e.HasInFlightWorkflowTask() {
 		localNamespaceMutation := namespace.NewPretendAsLocalNamespace(
 			e.clusterMetadata.GetCurrentClusterName(),
 		)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Pretend namespace is still local after it is promoted if there is inflight workflow task.


<!-- Tell your future self why have you made these changes -->
**Why?**
So event will be buffered as local event while there is inflight workflow task

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New integration test. Without this fix, the new case would fail on error "event version must be the same inside a batch"

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
