### PR TITLE
export MetricDefinition struct and some of its fields

### DIFF
--- a/common/metrics/common.go
+++ b/common/metrics/common.go
@@ -43,8 +43,8 @@ func mergeMapToRight(src map[string]string, dest map[string]string) {
 	}
 }
 
-func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {
-	defs := make(map[int]metricDefinition)
+func getMetricDefs(serviceIdx ServiceIdx) map[int]MetricDefinition {
+	defs := make(map[int]MetricDefinition)
 	for idx, def := range MetricDefs[Common] {
 		defs[idx] = def
 	}

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -38,12 +38,12 @@ type (
 
 	MetricUnit string
 
-	// metricDefinition contains the definition for a metric
-	metricDefinition struct {
+	// MetricDefinition contains the definition for a metric
+	MetricDefinition struct {
 		// nolint
 		metricType       MetricType    // metric type
-		metricName       MetricName    // metric name
-		metricRollupName MetricName    // optional. if non-empty, this name must be used for rolled-up version of this metric
+		MetricName       MetricName    // metric name
+		MetricRollupName MetricName    // optional. if non-empty, this name must be used for rolled-up version of this metric
 		buckets          tally.Buckets // buckets if we are emitting histograms
 		unit             MetricUnit
 	}
@@ -2248,7 +2248,7 @@ const (
 )
 
 // MetricDefs record the metrics for all services
-var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
+var MetricDefs = map[ServiceIdx]map[int]MetricDefinition{
 	Common: {
 		ServiceRequests:                                     NewCounterDef("service_requests"),
 		ServicePendingRequests:                              NewGaugeDef("service_pending_requests"),
@@ -2731,31 +2731,31 @@ func (mn MetricName) String() string {
 	return string(mn)
 }
 
-func NewTimerDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Timer, unit: Milliseconds}
+func NewTimerDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Timer, unit: Milliseconds}
 }
 
-func NewRollupTimerDef(name string, rollupName string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricRollupName: MetricName(rollupName), metricType: Timer, unit: Milliseconds}
+func NewRollupTimerDef(name string, rollupName string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), MetricRollupName: MetricName(rollupName), metricType: Timer, unit: Milliseconds}
 }
 
-func NewBytesHistogramDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Bytes}
+func NewBytesHistogramDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Histogram, unit: Bytes}
 }
 
-func NewDimensionlessHistogramDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Dimensionless}
+func NewDimensionlessHistogramDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Histogram, unit: Dimensionless}
 }
 
-func NewCounterDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Counter}
+func NewCounterDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Counter}
 }
 
 // Rollup counter name is used to report aggregated metric excluding namespace tag.
-func NewRollupCounterDef(name string, rollupName string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricRollupName: MetricName(rollupName), metricType: Counter}
+func NewRollupCounterDef(name string, rollupName string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), MetricRollupName: MetricName(rollupName), metricType: Counter}
 }
 
-func NewGaugeDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Gauge}
+func NewGaugeDef(name string) MetricDefinition {
+	return MetricDefinition{MetricName: MetricName(name), metricType: Gauge}
 }

--- a/common/metrics/defs_test.go
+++ b/common/metrics/defs_test.go
@@ -104,8 +104,8 @@ func TestMetricDefsMapped(t *testing.T) {
 func TestMetricDefs(t *testing.T) {
 	for service, metrics := range MetricDefs {
 		for _, metricDef := range metrics {
-			matched := IsMetric(string(metricDef.metricName))
-			assert.True(t, matched, fmt.Sprintf("Service: %v, metric_name: %v", service, metricDef.metricName))
+			matched := IsMetric(string(metricDef.MetricName))
+			assert.True(t, matched, fmt.Sprintf("Service: %v, metric_name: %v", service, metricDef.MetricName))
 		}
 	}
 }

--- a/common/metrics/metric_client_tests.go
+++ b/common/metrics/metric_client_tests.go
@@ -75,7 +75,7 @@ func (s *MetricTestSuiteBase) TestClientReportCounter() {
 		TestScope1,
 		TestCounterMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestCounterMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsCounter(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsCounter(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
@@ -84,7 +84,7 @@ func (s *MetricTestSuiteBase) TestClientReportGauge() {
 		TestScope1,
 		TestGaugeMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestGaugeMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsGauge(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsGauge(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
@@ -94,7 +94,7 @@ func (s *MetricTestSuiteBase) TestClientReportTimer() {
 		TestScope1,
 		TestTimerMetric1, targetDuration)
 	testDef := MetricDefs[UnitTestService][TestTimerMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsTimer(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, targetDuration))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsTimer(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, targetDuration))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
@@ -103,21 +103,21 @@ func (s *MetricTestSuiteBase) TestClientReportHistogram() {
 		TestScope1,
 		TestDimensionlessHistogramMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestDimensionlessHistogramMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsHistogram(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsHistogram(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
 func (s *MetricTestSuiteBase) TestScopeReportCounter() {
 	s.testClient.Scope(TestScope1).AddCounter(TestCounterMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestCounterMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsCounter(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsCounter(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
 func (s *MetricTestSuiteBase) TestScopeReportGauge() {
 	s.testClient.Scope(TestScope1).UpdateGauge(TestGaugeMetric1, 66)
 	testDef := MetricDefs[UnitTestService][TestGaugeMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsGauge(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsGauge(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, 66))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }
 
@@ -125,6 +125,6 @@ func (s *MetricTestSuiteBase) TestScopeReportTimer() {
 	targetDuration := time.Second * 100
 	s.testClient.Scope(TestScope1).RecordTimer(TestTimerMetric1, targetDuration)
 	testDef := MetricDefs[UnitTestService][TestTimerMetric1]
-	assert.NoError(s.T(), s.metricTestUtility.ContainsTimer(testDef.metricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, targetDuration))
+	assert.NoError(s.T(), s.metricTestUtility.ContainsTimer(testDef.MetricName, map[string]string{namespace: namespaceAllValue, OperationTagName: ScopeDefs[UnitTestService][TestScope1].operation, serviceName: primitives.UnitTestService}, targetDuration))
 	assert.Equal(s.T(), 1, s.metricTestUtility.CollectionSize())
 }

--- a/common/metrics/opentelemetry_client.go
+++ b/common/metrics/opentelemetry_client.go
@@ -37,7 +37,7 @@ type (
 		// parentReporter is the parent scope for the metrics
 		rootScope    *opentelemetryScope
 		childScopes  map[int]Scope
-		metricDefs   map[int]metricDefinition
+		metricDefs   map[int]MetricDefinition
 		serviceIdx   ServiceIdx
 		scopeWrapper func(impl internalScope) internalScope
 		gaugeCache   OtelGaugeCache

--- a/common/metrics/tally_client.go
+++ b/common/metrics/tally_client.go
@@ -38,7 +38,7 @@ type TallyClient struct {
 	// This is the scope provided by user to the client. It contains no client-specific tags.
 	globalRootScope tally.Scope
 	childScopes     map[int]tally.Scope
-	metricDefs      map[int]metricDefinition
+	metricDefs      map[int]MetricDefinition
 	serviceIdx      ServiceIdx
 	scopeWrapper    func(impl internalScope) internalScope
 	perUnitBuckets  map[MetricUnit]tally.Buckets
@@ -103,21 +103,21 @@ func NewClient(clientConfig *ClientConfig, scope tally.Scope, serviceIdx Service
 // IncCounter increments one for a counter and emits
 // to metrics backend
 func (m *TallyClient) IncCounter(scopeIdx int, counterIdx int) {
-	name := string(m.metricDefs[counterIdx].metricName)
+	name := string(m.metricDefs[counterIdx].MetricName)
 	m.childScopes[scopeIdx].Counter(name).Inc(1)
 }
 
 // AddCounter adds delta to the counter and
 // emits to the metrics backend
 func (m *TallyClient) AddCounter(scopeIdx int, counterIdx int, delta int64) {
-	name := string(m.metricDefs[counterIdx].metricName)
+	name := string(m.metricDefs[counterIdx].MetricName)
 	m.childScopes[scopeIdx].Counter(name).Inc(delta)
 }
 
 // StartTimer starts a timer for the given
 // metric name
 func (m *TallyClient) StartTimer(scopeIdx int, timerIdx int) Stopwatch {
-	name := string(m.metricDefs[timerIdx].metricName)
+	name := string(m.metricDefs[timerIdx].MetricName)
 	timer := m.childScopes[scopeIdx].Timer(name)
 	return NewStopwatch(timer)
 }
@@ -125,7 +125,7 @@ func (m *TallyClient) StartTimer(scopeIdx int, timerIdx int) Stopwatch {
 // RecordTimer record and emit a timer for the given
 // metric name
 func (m *TallyClient) RecordTimer(scopeIdx int, timerIdx int, d time.Duration) {
-	name := string(m.metricDefs[timerIdx].metricName)
+	name := string(m.metricDefs[timerIdx].MetricName)
 	m.childScopes[scopeIdx].Timer(name).Record(d)
 }
 
@@ -133,14 +133,14 @@ func (m *TallyClient) RecordTimer(scopeIdx int, timerIdx int, d time.Duration) {
 // metric name
 func (m *TallyClient) RecordDistribution(scopeIdx int, timerIdx int, d int) {
 	def := m.metricDefs[timerIdx]
-	name := string(def.metricName)
+	name := string(def.MetricName)
 	buckets, _ := m.perUnitBuckets[def.unit]
 	m.childScopes[scopeIdx].Histogram(name, buckets).RecordValue(float64(d))
 }
 
 // UpdateGauge reports Gauge type metric
 func (m *TallyClient) UpdateGauge(scopeIdx int, gaugeIdx int, value float64) {
-	name := string(m.metricDefs[gaugeIdx].metricName)
+	name := string(m.metricDefs[gaugeIdx].MetricName)
 	m.childScopes[scopeIdx].Gauge(name).Update(value)
 }
 

--- a/common/metrics/tally_scope.go
+++ b/common/metrics/tally_scope.go
@@ -33,7 +33,7 @@ import (
 type tallyScope struct {
 	scope             tally.Scope
 	rootScope         internalScope
-	defs              map[int]metricDefinition
+	defs              map[int]MetricDefinition
 	isNamespaceTagged bool
 	perUnitBuckets    map[MetricUnit]tally.Buckets
 }
@@ -41,7 +41,7 @@ type tallyScope struct {
 func newTallyScopeInternal(
 	rootScope internalScope,
 	scope tally.Scope,
-	defs map[int]metricDefinition,
+	defs map[int]MetricDefinition,
 	isNamespace bool,
 	perUnitBuckets map[MetricUnit]tally.Buckets,
 ) internalScope {
@@ -63,9 +63,9 @@ func (m *tallyScope) IncCounter(id int) {
 
 func (m *tallyScope) AddCounter(id int, delta int64) {
 	def := m.defs[id]
-	m.scope.Counter(def.metricName.String()).Inc(delta)
-	if !def.metricRollupName.Empty() {
-		m.rootScope.AddCounterInternal(def.metricRollupName.String(), delta)
+	m.scope.Counter(def.MetricName.String()).Inc(delta)
+	if !def.MetricRollupName.Empty() {
+		m.rootScope.AddCounterInternal(def.MetricRollupName.String(), delta)
 	}
 }
 
@@ -75,20 +75,20 @@ func (m *tallyScope) AddCounterInternal(name string, delta int64) {
 
 func (m *tallyScope) UpdateGauge(id int, value float64) {
 	def := m.defs[id]
-	m.scope.Gauge(def.metricName.String()).Update(value)
-	if !def.metricRollupName.Empty() {
-		m.scope.Gauge(def.metricRollupName.String()).Update(value)
+	m.scope.Gauge(def.MetricName.String()).Update(value)
+	if !def.MetricRollupName.Empty() {
+		m.scope.Gauge(def.MetricRollupName.String()).Update(value)
 	}
 }
 
 func (m *tallyScope) StartTimer(id int) Stopwatch {
 	def := m.defs[id]
-	timer := NewStopwatch(m.scope.Timer(def.metricName.String()))
+	timer := NewStopwatch(m.scope.Timer(def.MetricName.String()))
 	switch {
-	case !def.metricRollupName.Empty():
-		return NewCompositeStopwatch(timer, m.rootScope.StartTimerInternal(def.metricRollupName.String()))
+	case !def.MetricRollupName.Empty():
+		return NewCompositeStopwatch(timer, m.rootScope.StartTimerInternal(def.MetricRollupName.String()))
 	case m.isNamespaceTagged:
-		timerAll := m.rootScope.StartTimerInternal(def.metricName.String() + totalMetricSuffix)
+		timerAll := m.rootScope.StartTimerInternal(def.MetricName.String() + totalMetricSuffix)
 		return NewCompositeStopwatch(timer, timerAll)
 	default:
 		return timer
@@ -101,12 +101,12 @@ func (m *tallyScope) StartTimerInternal(timer string) Stopwatch {
 
 func (m *tallyScope) RecordTimer(id int, d time.Duration) {
 	def := m.defs[id]
-	m.scope.Timer(def.metricName.String()).Record(d)
+	m.scope.Timer(def.MetricName.String()).Record(d)
 	switch {
-	case !def.metricRollupName.Empty():
-		m.rootScope.RecordTimerInternal(def.metricRollupName.String(), d)
+	case !def.MetricRollupName.Empty():
+		m.rootScope.RecordTimerInternal(def.MetricRollupName.String(), d)
 	case m.isNamespaceTagged:
-		m.rootScope.RecordTimerInternal(def.metricName.String()+totalMetricSuffix, d)
+		m.rootScope.RecordTimerInternal(def.MetricName.String()+totalMetricSuffix, d)
 	}
 }
 
@@ -116,13 +116,13 @@ func (m *tallyScope) RecordTimerInternal(name string, d time.Duration) {
 
 func (m *tallyScope) RecordDistribution(id int, d int) {
 	def := m.defs[id]
-	m.RecordDistributionInternal(def.metricName.String(), def.unit, d)
+	m.RecordDistributionInternal(def.MetricName.String(), def.unit, d)
 
 	switch {
-	case !def.metricRollupName.Empty():
-		m.rootScope.RecordDistributionInternal(def.metricRollupName.String(), def.unit, d)
+	case !def.MetricRollupName.Empty():
+		m.rootScope.RecordDistributionInternal(def.MetricRollupName.String(), def.unit, d)
 	case m.isNamespaceTagged:
-		m.rootScope.RecordDistributionInternal(def.metricName.String()+totalMetricSuffix, def.unit, d)
+		m.rootScope.RecordDistributionInternal(def.MetricName.String()+totalMetricSuffix, def.unit, d)
 	}
 }
 


### PR DESCRIPTION
**What changed?**

This PR exports the struct `metricDefinition` and its fields `metricName` and `metricRollupName`


**Why?**

These changes are required in order to be able to write a custom implementation of the Scope interface:

https://github.com/temporalio/temporal/blob/c1d63b713724a1a9b78c8d4674511610d1ac6608/common/metrics/interfaces.go#L74-L92

Do note that these are the bare-minimum fields that we need to expose, but we might also want to include all other fields as exported.


We really need this because the scope implementation receives a metric ID, and to transform the metric ID into a metric name we are required to store a map that correlates a given metricID with its metricDefinition. We can see examples of this pattern on the already-implemented interface:

https://github.com/temporalio/temporal/blob/c1d63b713724a1a9b78c8d4674511610d1ac6608/common/metrics/tally_scope.go#L102-L104


Without this change, there is no way to implement the whole `Scope` interface, and thus a custom external metric exporter is not possible (when you don't want to use the tally interface).