### PR TITLE
Change Invalid search attribute value message

### DIFF
--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -111,7 +111,7 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 			if err = payload.Decode(saPayload, &invalidValue); err != nil {
 				invalidValue = fmt.Sprintf("value from <%s>", saPayload.String())
 			}
-			return serviceerror.NewInvalidArgument(fmt.Sprintf("%v is not a valid value for search attribute %s of type %s", invalidValue, saName, saType))
+			return serviceerror.NewInvalidArgument(fmt.Sprintf("invalid value for search attribute %s of type %s: %v", saName, saType, invalidValue))
 		}
 	}
 	return nil

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -97,7 +97,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	attr.IndexedFields = fields
 	err = saValidator.Validate(attr, namespace, "")
 	s.Error(err)
-	s.Equal("123 is not a valid value for search attribute CustomBoolField of type Bool", err.Error())
+	s.Equal("invalid value for search attribute CustomBoolField of type Bool: 123", err.Error())
 
 	intArrayPayload, err := payload.Encode([]int{1, 2})
 	s.NoError(err)
@@ -174,7 +174,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	attr.IndexedFields = fields
 	err = saValidator.Validate(attr, namespace, "")
 	s.Error(err)
-	s.Equal("123 is not a valid value for search attribute alias_of_CustomBoolField of type Bool", err.Error())
+	s.Equal("invalid value for search attribute alias_of_CustomBoolField of type Bool: 123", err.Error())
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {


### PR DESCRIPTION
**Why?**

Currently, if an invalid string search attribute is sent in the upsert or start, a message like 
"this is a string and not an int is not a valid value for search attribute CustomIntField of type Int" is produced. 
This makes it hard for the reader to consume because the search attributes boundaries are not defined.

The string value of the search attribute in this message should be escaped with " or the message should be reworked to the most common validation errors pattern in Temporal: <validation error>: <invalid value> 

**What changed?**

Reworked the error message about invalid search attribute to the same pattern as our validation errors to remove the need to escape the original value in the final message.

**How did you test it?**
The unit tests cover the validation errors

**Potential risks**
None

**Is hotfix candidate?**
No