### PR TITLE
Persistence context Part 7: SQL store implementation

### DIFF
--- a/common/persistence/sql/execution.go
+++ b/common/persistence/sql/execution.go
@@ -79,12 +79,9 @@ func (m *sqlExecutionStore) txExecuteShardLocked(
 }
 
 func (m *sqlExecutionStore) CreateWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalCreateWorkflowExecutionRequest,
 ) (response *p.InternalCreateWorkflowExecutionResponse, err error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
-
 	for _, req := range request.NewWorkflowNewEvents {
 		if err := m.AppendHistoryNodes(ctx, req); err != nil {
 			return nil, err
@@ -226,11 +223,9 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 }
 
 func (m *sqlExecutionStore) GetWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *p.GetWorkflowExecutionRequest,
 ) (*p.InternalGetWorkflowExecutionResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	namespaceID := primitives.MustParseUUID(request.NamespaceID)
 	workflowID := request.WorkflowID
 	runID := primitives.MustParseUUID(request.RunID)
@@ -341,12 +336,9 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 }
 
 func (m *sqlExecutionStore) UpdateWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
-
 	// first append history
 	for _, req := range request.UpdateWorkflowNewEvents {
 		if err := m.AppendHistoryNodes(ctx, req); err != nil {
@@ -463,12 +455,9 @@ func (m *sqlExecutionStore) updateWorkflowExecutionTx(
 }
 
 func (m *sqlExecutionStore) ConflictResolveWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
-
 	// first append history
 	for _, req := range request.CurrentWorkflowEventsNewEvents {
 		if err := m.AppendHistoryNodes(ctx, req); err != nil {
@@ -606,11 +595,9 @@ func (m *sqlExecutionStore) conflictResolveWorkflowExecutionTx(
 }
 
 func (m *sqlExecutionStore) DeleteWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *p.DeleteWorkflowExecutionRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	namespaceID := primitives.MustParseUUID(request.NamespaceID)
 	runID := primitives.MustParseUUID(request.RunID)
 	_, err := m.Db.DeleteFromExecutions(ctx, sqlplugin.ExecutionsFilter{
@@ -627,11 +614,9 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 // runID. The following code will delete the row from current_executions if and only if the runID is
 // same as the one we are trying to delete here
 func (m *sqlExecutionStore) DeleteCurrentWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *p.DeleteCurrentWorkflowExecutionRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	namespaceID := primitives.MustParseUUID(request.NamespaceID)
 	runID := primitives.MustParseUUID(request.RunID)
 	_, err := m.Db.DeleteFromCurrentExecutions(ctx, sqlplugin.CurrentExecutionsFilter{
@@ -644,11 +629,9 @@ func (m *sqlExecutionStore) DeleteCurrentWorkflowExecution(
 }
 
 func (m *sqlExecutionStore) GetCurrentExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *p.GetCurrentExecutionRequest,
 ) (*p.InternalGetCurrentExecutionResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	row, err := m.Db.SelectFromCurrentExecutions(ctx, sqlplugin.CurrentExecutionsFilter{
 		ShardID:     request.ShardID,
 		NamespaceID: primitives.MustParseUUID(request.NamespaceID),
@@ -672,11 +655,9 @@ func (m *sqlExecutionStore) GetCurrentExecution(
 }
 
 func (m *sqlExecutionStore) SetWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalSetWorkflowExecutionRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	return m.txExecuteShardLocked(ctx,
 		"SetWorkflowExecution",
 		request.ShardID,

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -25,7 +25,6 @@
 package sql
 
 import (
-	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -198,10 +197,4 @@ func (c *DbConn) Close() error {
 		return err
 	}
 	return nil
-}
-
-// TODO remove this function when NoSQL & SQL layer all support context timeout
-func newExecutionContext() (context.Context, context.CancelFunc) {
-	ctx := context.Background()
-	return context.WithTimeout(ctx, executionTimeout)
 }

--- a/common/persistence/sql/history_store.go
+++ b/common/persistence/sql/history_store.go
@@ -46,11 +46,9 @@ const (
 
 // AppendHistoryNodes add(or override) a node to a history branch
 func (m *sqlExecutionStore) AppendHistoryNodes(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalAppendHistoryNodesRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	branchInfo := request.BranchInfo
 	node := request.Node
 
@@ -123,11 +121,9 @@ func (m *sqlExecutionStore) AppendHistoryNodes(
 }
 
 func (m *sqlExecutionStore) DeleteHistoryNodes(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalDeleteHistoryNodesRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	branchInfo := request.BranchInfo
 	nodeID := request.NodeID
 	txnID := request.TransactionID
@@ -165,11 +161,9 @@ func (m *sqlExecutionStore) DeleteHistoryNodes(
 
 // ReadHistoryBranch returns history node data for a branch
 func (m *sqlExecutionStore) ReadHistoryBranch(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalReadHistoryBranchRequest,
 ) (*p.InternalReadHistoryBranchResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	branchIDBytes, err := primitives.ParseUUID(request.BranchID)
 	if err != nil {
 		return nil, err
@@ -298,11 +292,9 @@ func (m *sqlExecutionStore) ReadHistoryBranch(
 //       8[8,9]
 //
 func (m *sqlExecutionStore) ForkHistoryBranch(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalForkHistoryBranchRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	forkB := request.ForkBranchInfo
 	treeInfoBlob := request.TreeInfo
 	newBranchIdBytes, err := primitives.ParseUUID(request.NewBranchID)
@@ -339,12 +331,9 @@ func (m *sqlExecutionStore) ForkHistoryBranch(
 
 // DeleteHistoryBranch removes a branch
 func (m *sqlExecutionStore) DeleteHistoryBranch(
-	_ context.Context,
+	ctx context.Context,
 	request *p.InternalDeleteHistoryBranchRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
-
 	branchIDBytes, err := primitives.ParseUUID(request.BranchId)
 	if err != nil {
 		return err
@@ -398,11 +387,9 @@ func (m *sqlExecutionStore) GetAllHistoryTreeBranches(
 
 // GetHistoryTree returns all branch information of a tree
 func (m *sqlExecutionStore) GetHistoryTree(
-	_ context.Context,
+	ctx context.Context,
 	request *p.GetHistoryTreeRequest,
 ) (*p.InternalGetHistoryTreeResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	treeID, err := primitives.ParseUUID(request.TreeID)
 	if err != nil {
 		return nil, err

--- a/common/persistence/sql/metadata.go
+++ b/common/persistence/sql/metadata.go
@@ -55,11 +55,9 @@ func newMetadataPersistenceV2(
 }
 
 func (m *sqlMetadataManagerV2) CreateNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalCreateNamespaceRequest,
 ) (*persistence.CreateNamespaceResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	idBytes, err := primitives.ParseUUID(request.ID)
 	if err != nil {
 		return nil, err
@@ -97,11 +95,9 @@ func (m *sqlMetadataManagerV2) CreateNamespace(
 }
 
 func (m *sqlMetadataManagerV2) GetNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.GetNamespaceRequest,
 ) (*persistence.InternalGetNamespaceResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	idBytes, err := primitives.ParseUUID(request.ID)
 	if err != nil {
 		return nil, err
@@ -151,25 +147,24 @@ func (m *sqlMetadataManagerV2) namespaceRowToGetNamespaceResponse(row *sqlplugin
 }
 
 func (m *sqlMetadataManagerV2) UpdateNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalUpdateNamespaceRequest,
 ) error {
-	return m.updateNamespace(request, "UpdateNamespace")
+	return m.updateNamespace(ctx, request, "UpdateNamespace")
 }
 
 func (m *sqlMetadataManagerV2) RenameNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalRenameNamespaceRequest,
 ) error {
-	return m.updateNamespace(request.InternalUpdateNamespaceRequest, "RenameNamespace")
+	return m.updateNamespace(ctx, request.InternalUpdateNamespaceRequest, "RenameNamespace")
 }
 
 func (m *sqlMetadataManagerV2) updateNamespace(
+	ctx context.Context,
 	request *persistence.InternalUpdateNamespaceRequest,
 	operationName string,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	idBytes, err := primitives.ParseUUID(request.Id)
 	if err != nil {
 		return err
@@ -210,11 +205,9 @@ func (m *sqlMetadataManagerV2) updateNamespace(
 }
 
 func (m *sqlMetadataManagerV2) DeleteNamespace(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.DeleteNamespaceRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	idBytes, err := primitives.ParseUUID(request.ID)
 	if err != nil {
 		return err
@@ -229,11 +222,9 @@ func (m *sqlMetadataManagerV2) DeleteNamespace(
 }
 
 func (m *sqlMetadataManagerV2) DeleteNamespaceByName(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.DeleteNamespaceByNameRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	return m.txExecute(ctx, "DeleteNamespaceByName", func(tx sqlplugin.Tx) error {
 		_, err := tx.DeleteFromNamespace(ctx, sqlplugin.NamespaceFilter{
 			Name: &request.Name,
@@ -243,10 +234,8 @@ func (m *sqlMetadataManagerV2) DeleteNamespaceByName(
 }
 
 func (m *sqlMetadataManagerV2) GetMetadata(
-	_ context.Context,
+	ctx context.Context,
 ) (*persistence.GetMetadataResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	row, err := m.Db.SelectFromNamespaceMetadata(ctx)
 	if err != nil {
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetMetadata operation failed. Error: %v", err))
@@ -255,11 +244,9 @@ func (m *sqlMetadataManagerV2) GetMetadata(
 }
 
 func (m *sqlMetadataManagerV2) ListNamespaces(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalListNamespacesRequest,
 ) (*persistence.InternalListNamespacesResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	var pageToken *primitives.UUID
 	if request.NextPageToken != nil {
 		token := primitives.UUID(request.NextPageToken)

--- a/common/persistence/sql/shard.go
+++ b/common/persistence/sql/shard.go
@@ -58,11 +58,9 @@ func (m *sqlShardStore) GetClusterName() string {
 }
 
 func (m *sqlShardStore) GetOrCreateShard(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalGetOrCreateShardRequest,
 ) (*persistence.InternalGetOrCreateShardResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	row, err := m.Db.SelectFromShards(ctx, sqlplugin.ShardsFilter{
 		ShardID: request.ShardID,
 	})
@@ -103,11 +101,9 @@ func (m *sqlShardStore) GetOrCreateShard(
 }
 
 func (m *sqlShardStore) UpdateShard(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalUpdateShardRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	return m.txExecute(ctx, "UpdateShard", func(tx sqlplugin.Tx) error {
 		if err := lockShard(ctx,
 			tx,

--- a/common/persistence/sql/task.go
+++ b/common/persistence/sql/task.go
@@ -73,11 +73,9 @@ func newTaskPersistence(
 }
 
 func (m *sqlTaskManager) CreateTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalCreateTaskQueueRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
 		return serviceerror.NewInternal(err.Error())
@@ -102,11 +100,9 @@ func (m *sqlTaskManager) CreateTaskQueue(
 }
 
 func (m *sqlTaskManager) GetTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalGetTaskQueueRequest,
 ) (*persistence.InternalGetTaskQueueResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
 		return nil, serviceerror.NewInternal(err.Error())
@@ -141,11 +137,9 @@ func (m *sqlTaskManager) GetTaskQueue(
 }
 
 func (m *sqlTaskManager) UpdateTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalUpdateTaskQueueRequest,
 ) (*persistence.UpdateTaskQueueResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
 		return nil, serviceerror.NewInternal(err.Error())
@@ -186,11 +180,9 @@ func (m *sqlTaskManager) UpdateTaskQueue(
 }
 
 func (m *sqlTaskManager) ListTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.ListTaskQueueRequest,
 ) (*persistence.InternalListTaskQueueResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	pageToken := taskQueuePageToken{MinTaskQueueId: minTaskQueueId}
 	if request.PageToken != nil {
 		if err := gobDeserialize(request.PageToken, &pageToken); err != nil {
@@ -319,11 +311,9 @@ func getBoundariesForPartition(partition uint32, totalPartitions uint32) (uint32
 }
 
 func (m *sqlTaskManager) DeleteTaskQueue(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.DeleteTaskQueueRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.TaskQueue.NamespaceID)
 	if err != nil {
 		return serviceerror.NewUnavailable(err.Error())
@@ -349,12 +339,9 @@ func (m *sqlTaskManager) DeleteTaskQueue(
 	return nil
 }
 func (m *sqlTaskManager) CreateTasks(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.InternalCreateTasksRequest,
 ) (*persistence.CreateTasksResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
-
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
 		return nil, serviceerror.NewUnavailable(err.Error())
@@ -392,11 +379,9 @@ func (m *sqlTaskManager) CreateTasks(
 }
 
 func (m *sqlTaskManager) GetTasks(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.GetTasksRequest,
 ) (*persistence.InternalGetTasksResponse, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
 		return nil, serviceerror.NewUnavailable(err.Error())
@@ -447,11 +432,9 @@ func (m *sqlTaskManager) GetTasks(
 }
 
 func (m *sqlTaskManager) CompleteTask(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.CompleteTaskRequest,
 ) error {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.TaskQueue.NamespaceID)
 	if err != nil {
 		return serviceerror.NewUnavailable(err.Error())
@@ -470,11 +453,9 @@ func (m *sqlTaskManager) CompleteTask(
 }
 
 func (m *sqlTaskManager) CompleteTasksLessThan(
-	_ context.Context,
+	ctx context.Context,
 	request *persistence.CompleteTasksLessThanRequest,
 ) (int, error) {
-	ctx, cancel := newExecutionContext()
-	defer cancel()
 	nidBytes, err := primitives.ParseUUID(request.NamespaceID)
 	if err != nil {
 		return 0, serviceerror.NewUnavailable(err.Error())

--- a/common/persistence/visibility/store/standard/sql/visibility_store.go
+++ b/common/persistence/visibility/store/standard/sql/visibility_store.go
@@ -60,12 +60,6 @@ type (
 
 var _ store.VisibilityStore = (*visibilityStore)(nil)
 
-// TODO remove this function when NoSQL & SQL layer all support context timeout
-func newVisibilityContext() (context.Context, context.CancelFunc) {
-	ctx := context.Background()
-	return context.WithTimeout(ctx, visibilityTimeout)
-}
-
 // NewSQLVisibilityStore creates an instance of VisibilityStore
 func NewSQLVisibilityStore(
 	cfg config.SQL,
@@ -91,11 +85,9 @@ func (s *visibilityStore) GetName() string {
 }
 
 func (s *visibilityStore) RecordWorkflowExecutionStarted(
-	_ context.Context,
+	ctx context.Context,
 	request *store.InternalRecordWorkflowExecutionStartedRequest,
 ) error {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	_, err := s.sqlStore.Db.InsertIntoVisibility(ctx, &sqlplugin.VisibilityRow{
 		NamespaceID:      request.NamespaceID,
 		WorkflowID:       request.WorkflowID,
@@ -113,11 +105,9 @@ func (s *visibilityStore) RecordWorkflowExecutionStarted(
 }
 
 func (s *visibilityStore) RecordWorkflowExecutionClosed(
-	_ context.Context,
+	ctx context.Context,
 	request *store.InternalRecordWorkflowExecutionClosedRequest,
 ) error {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	result, err := s.sqlStore.Db.ReplaceIntoVisibility(ctx, &sqlplugin.VisibilityRow{
 		NamespaceID:      request.NamespaceID,
 		WorkflowID:       request.WorkflowID,
@@ -154,11 +144,9 @@ func (s *visibilityStore) UpsertWorkflowExecution(
 }
 
 func (s *visibilityStore) ListOpenWorkflowExecutions(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	return s.listWorkflowExecutions(
 		"ListOpenWorkflowExecutions",
 		request.NextPageToken,
@@ -178,11 +166,9 @@ func (s *visibilityStore) ListOpenWorkflowExecutions(
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutions(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	return s.listWorkflowExecutions("ListClosedWorkflowExecutions",
 		request.NextPageToken,
 		request.PageSize,
@@ -200,11 +186,9 @@ func (s *visibilityStore) ListClosedWorkflowExecutions(
 }
 
 func (s *visibilityStore) ListOpenWorkflowExecutionsByType(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsByTypeRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	return s.listWorkflowExecutions("ListOpenWorkflowExecutionsByType",
 		request.NextPageToken,
 		request.PageSize,
@@ -224,11 +208,9 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByType(
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByType(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsByTypeRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	return s.listWorkflowExecutions("ListClosedWorkflowExecutionsByType",
 		request.NextPageToken,
 		request.PageSize,
@@ -247,11 +229,9 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByType(
 }
 
 func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	return s.listWorkflowExecutions("ListOpenWorkflowExecutionsByWorkflowID",
 		request.NextPageToken,
 		request.PageSize,
@@ -271,11 +251,9 @@ func (s *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListWorkflowExecutionsByWorkflowIDRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	return s.listWorkflowExecutions("ListClosedWorkflowExecutionsByWorkflowID",
 		request.NextPageToken,
 		request.PageSize,
@@ -294,11 +272,9 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
 }
 
 func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.ListClosedWorkflowExecutionsByStatusRequest,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	return s.listWorkflowExecutions("ListClosedWorkflowExecutionsByStatus",
 		request.NextPageToken,
 		request.PageSize,
@@ -317,11 +293,9 @@ func (s *visibilityStore) ListClosedWorkflowExecutionsByStatus(
 }
 
 func (s *visibilityStore) DeleteWorkflowExecution(
-	_ context.Context,
+	ctx context.Context,
 	request *manager.VisibilityDeleteWorkflowExecutionRequest,
 ) error {
-	ctx, cancel := newVisibilityContext()
-	defer cancel()
 	_, err := s.sqlStore.Db.DeleteFromVisibility(ctx, sqlplugin.VisibilityDeleteFilter{
 		NamespaceID: request.NamespaceID.String(),
 		RunID:       request.RunID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Use passed in context for sql persistence store impl

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enforce persistence timeout, instead of always timeout after 8s
- Required for host level task worker pool

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
-  We may see an increased number of persistence context timeout error as now a lower context timeout will be used.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.