### PR TITLE
Do not drop workflow task if it failed due to unhandled events

### DIFF
--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -499,7 +499,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			tag.WorkflowID(token.GetWorkflowId()),
 			tag.WorkflowRunID(token.GetRunId()),
 			tag.WorkflowNamespaceID(namespaceID.String()))
-		if currentWorkflowTask.Attempt > 1 {
+		if currentWorkflowTask.Attempt > 1 && wtFailedCause.failedCause != enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND {
 			// drop this workflow task if it keeps failing. This will cause the workflow task to timeout and get retried after timeout.
 			return nil, serviceerror.NewInvalidArgument(wtFailedCause.Message())
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Do not drop workflow task if it failed due to unhandled events.

<!-- Tell your future self why have you made these changes -->
**Why?**
When there are unhandled events, server would fail workflow task. In that case, we don't want to have this extra delay.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
