### PR TITLE
Always report service error as additional metric with error-type tag

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1754,6 +1754,7 @@ const (
 	ServiceRequests = iota
 	ServicePendingRequests
 	ServiceFailures
+	ServiceFailuresWithType
 	ServiceCriticalFailures
 	ServiceLatency
 	ServiceLatencyNoUserLatency
@@ -2253,6 +2254,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ServiceRequests:                                     NewCounterDef("service_requests"),
 		ServicePendingRequests:                              NewGaugeDef("service_pending_requests"),
 		ServiceFailures:                                     NewCounterDef("service_errors"),
+		ServiceFailuresWithType:                             NewCounterDef("service_errors_with_type"),
 		ServiceCriticalFailures:                             NewCounterDef("service_errors_critical"),
 		ServiceLatency:                                      NewTimerDef("service_latency"),
 		ServiceLatencyNoUserLatency:                         NewTimerDef("service_latency_nouserlatency"),

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -147,6 +147,8 @@ func (ti *TelemetryInterceptor) handleError(
 	err error,
 ) {
 
+	scope.Tagged(metrics.ServiceErrorTypeTag(err)).IncCounter(metrics.ServiceFailuresWithType)
+
 	if common.IsContextDeadlineExceededErr(err) {
 		scope.IncCounter(metrics.ServiceErrContextTimeoutCounter)
 		return

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -1628,6 +1628,8 @@ func (adh *AdminHandler) startRequestProfile(scope int) (metrics.Scope, metrics.
 }
 
 func (adh *AdminHandler) error(err error, scope metrics.Scope) error {
+	scope.Tagged(metrics.ServiceErrorTypeTag(err)).IncCounter(metrics.ServiceFailuresWithType)
+
 	switch err := err.(type) {
 	case *serviceerror.Unavailable:
 		adh.logger.Error("unavailable error", tag.Error(err))

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -346,6 +346,8 @@ func (h *OperatorHandlerImpl) startRequestProfile(scope int) (metrics.Scope, met
 }
 
 func (h *OperatorHandlerImpl) error(err error, scope metrics.Scope, endpointName string) error {
+	scope.Tagged(metrics.ServiceErrorTypeTag(err)).IncCounter(metrics.ServiceFailuresWithType)
+
 	switch err := err.(type) {
 	case *serviceerror.Unavailable:
 		h.logger.Error("Unavailable error.", tag.Error(err), tag.Endpoint(endpointName))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding additional generic service_errors metric with error_type tag for all service errors.
Additional metric for service errors with error type as tag

<!-- Tell your future self why have you made these changes -->
**Why?**
Simplify consumption error dashboards.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Locally, I am good at failures

```
# HELP service_errors_entity_not_found service_errors_entity_not_found counter
# TYPE service_errors_entity_not_found counter
service_errors_entity_not_found{namespace="temporal_system",operation="DescribeWorkflowExecution",service_name="frontend"} 1
service_errors_entity_not_found{namespace="temporal_system",operation="DescribeWorkflowExecution",service_name="history"} 1
# HELP service_errors_namespace_already_exists service_errors_namespace_already_exists counter
# TYPE service_errors_namespace_already_exists counter
service_errors_namespace_already_exists{namespace="canary",operation="RegisterNamespace",service_name="frontend"} 4
service_errors_namespace_already_exists{namespace="default",operation="RegisterNamespace",service_name="frontend"} 4
# HELP service_errors_with_type service_errors_with_type counter
# TYPE service_errors_with_type counter
service_errors_with_type{error_type="serviceerror_NamespaceAlreadyExists",namespace="canary",operation="RegisterNamespace",service_name="frontend"} 4
service_errors_with_type{error_type="serviceerror_NamespaceAlreadyExists",namespace="default",operation="RegisterNamespace",service_name="frontend"} 4
service_errors_with_type{error_type="serviceerror_NotFound",namespace="temporal_system",operation="DescribeWorkflowExecution",service_name="frontend"} 1
service_errors_with_type{error_type="serviceerror_NotFound",namespace="temporal_system",operation="DescribeWorkflowExecution",service_name="history"} 1
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None, cardinality

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No