### PR TITLE
Slow down workflow task retry

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -478,6 +478,8 @@ const (
 	WorkflowTaskHeartbeatTimeout = "history.workflowTaskHeartbeatTimeout"
 	// WorkflowTaskCriticalAttempts is the number of attempts for a workflow task that's regarded as critical
 	WorkflowTaskCriticalAttempts = "history.workflowTaskCriticalAttempt"
+	// WorkflowTaskRetryMaxInterval is the maximum interval added to a workflow task's startToClose timeout for slowing down retry
+	WorkflowTaskRetryMaxInterval = "history.workflowTaskRetryMaxInterval"
 	// DefaultWorkflowTaskTimeout for a workflow task
 	DefaultWorkflowTaskTimeout = "history.defaultWorkflowTaskTimeout"
 	// SkipReapplicationByNamespaceID is whether skipping a event re-application for a namespace

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -193,6 +193,7 @@ type Config struct {
 	// So that workflow task will be scheduled to another worker(by clear stickyness)
 	WorkflowTaskHeartbeatTimeout dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	WorkflowTaskCriticalAttempts dynamicconfig.IntPropertyFn
+	WorkflowTaskRetryMaxInterval dynamicconfig.DurationPropertyFn
 
 	// The following is used by the new RPC replication stack
 	ReplicationTaskFetcherParallelism                    dynamicconfig.IntPropertyFn
@@ -385,6 +386,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		StickyTTL:                    dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.StickyTTL, time.Hour*24*365),
 		WorkflowTaskHeartbeatTimeout: dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.WorkflowTaskHeartbeatTimeout, time.Minute*30),
 		WorkflowTaskCriticalAttempts: dc.GetIntProperty(dynamicconfig.WorkflowTaskCriticalAttempts, 10),
+		WorkflowTaskRetryMaxInterval: dc.GetDurationProperty(dynamicconfig.WorkflowTaskRetryMaxInterval, time.Minute*10),
 
 		ReplicationTaskFetcherParallelism:            dc.GetIntProperty(dynamicconfig.ReplicationTaskFetcherParallelism, 4),
 		ReplicationTaskFetcherAggregationInterval:    dc.GetDurationProperty(dynamicconfig.ReplicationTaskFetcherAggregationInterval, 2*time.Second),

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -786,6 +786,13 @@ func (m *workflowTaskStateMachine) getStartToCloseTimeout(
 	defaultTimeout time.Duration,
 	attempt int32,
 ) time.Duration {
+	// This util function is only for calculating active workflow task timeout.
+	// Transient workflow task in passive cluster won't call this function and
+	// always use default timeout as it will either be completely overwritten by
+	// a replicated workflow schedule event from active cluster, or if used, it's
+	// attempt will be reset to 1.
+	// Check ReplicateTransientWorkflowTaskScheduled for details.
+
 	if attempt <= workflowTaskRetryBackoffMinAttempts {
 		return defaultTimeout
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Increase workflow task start to close timeout when workflow task is keep retrying

<!-- Tell your future self why have you made these changes -->
**Why?**
- Slow down workflow task retry.
- When workflow task is keep failing, workflow task response will be dropped and wait for the start to close timeout to happen

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests, tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- For sdk, since start to close timeout is increase, a workflow task may potentially executed for the entire start to close duration.

- The change only affects the timer duration for transient workflow task start to close timeout in active cluster. Since timer task processing logic is async, this can be viewed as a delayed fired timer.
- Doesn't affect xdc logic as transient workflow task scheduled is not a real event and won't be replicated. Instead standby will create a transient workflow schedule event when receiving a workflow task failed/timedout event using the default workflow task timeout (since if this transient scheduled event is used, the attempt will be reset to 1 when starting it). 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.