### PR TITLE
Don't fail ContinueAsNew command if parent namespace doesn't exist

### DIFF
--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -779,10 +779,9 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 	if handler.mutableState.HasParentExecution() {
 		parentNamespaceID := namespace.ID(handler.mutableState.GetExecutionInfo().ParentNamespaceId)
 		parentNamespaceEntry, err := handler.namespaceRegistry.GetNamespaceByID(parentNamespaceID)
-		if err != nil {
-			return err
+		if err == nil {
+			parentNamespace = parentNamespaceEntry.Name()
 		}
-		parentNamespace = parentNamespaceEntry.Name()
 	}
 
 	_, newStateBuilder, err := handler.mutableState.AddContinueAsNewEvent(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Don't fail `ContinueAsNew` command if parent namespace doesn't exist.

<!-- Tell your future self why have you made these changes -->
**Why?**
`ContinueAsNew` can be called for the same namespace only, but internally mutable state supports different parent namespace. In case if this feature will ever be used, with this PR, subsequient calls to `ContinueAsNew` won't fail and won't store parent namespace name (only Id).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.