### PR TITLE
Limit task processing time

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1927,6 +1927,7 @@ const (
 	TaskSkipped
 	TaskAttemptTimer
 	TaskStandbyRetryCounter
+	TaskWorkflowBusyCounter
 	TaskNotActiveCounter
 	TaskLimitExceededCounter
 	TaskBatchCompleteCounter
@@ -2408,6 +2409,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskDiscarded:            NewCounterDef("task_errors_discarded"),
 		TaskSkipped:              NewCounterDef("task_skipped"),
 		TaskStandbyRetryCounter:  NewCounterDef("task_errors_standby_retry_counter"),
+		TaskWorkflowBusyCounter:  NewCounterDef("task_errors_workflow_busy"),
 		TaskNotActiveCounter:     NewCounterDef("task_errors_not_active_counter"),
 		TaskLimitExceededCounter: NewCounterDef("task_errors_limit_exceeded_counter"),
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -419,7 +419,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		MutableStateChecksumVerifyProbability: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateChecksumVerifyProbability, 0),
 		MutableStateChecksumInvalidateBefore:  dc.GetFloat64Property(dynamicconfig.MutableStateChecksumInvalidateBefore, 0),
 
-		StandbyTaskReReplicationContextTimeout: dc.GetDurationPropertyFilteredByNamespaceID(dynamicconfig.StandbyTaskReReplicationContextTimeout, 3*time.Minute),
+		StandbyTaskReReplicationContextTimeout: dc.GetDurationPropertyFilteredByNamespaceID(dynamicconfig.StandbyTaskReReplicationContextTimeout, 30*time.Second),
 
 		SkipReapplicationByNamespaceID: dc.GetBoolPropertyFnWithNamespaceIDFilter(dynamicconfig.SkipReapplicationByNamespaceID, false),
 

--- a/service/history/consts/const.go
+++ b/service/history/consts/const.go
@@ -78,6 +78,8 @@ var (
 	ErrUnknownCluster = serviceerror.NewInvalidArgument("unknown cluster")
 	// ErrBufferedQueryCleared is error indicating mutable state is cleared while buffered query is pending
 	ErrBufferedQueryCleared = serviceerror.NewUnavailable("buffered query cleared, please retry")
+	// ErrWorkflowBusy is error indicating workflow is currently busy and workflow context can't be locked within specified timeout
+	ErrWorkflowBusy = serviceerror.NewUnavailable("timeout locking workflow execution")
 
 	// FailedWorkflowStatuses is a set of failed workflow close states, used for start workflow policy
 	// for start workflow execution API

--- a/service/history/nDCStandbyTaskUtil.go
+++ b/service/history/nDCStandbyTaskUtil.go
@@ -42,13 +42,14 @@ import (
 )
 
 type (
-	standbyActionFn     func(workflow.Context, workflow.MutableState) (interface{}, error)
-	standbyPostActionFn func(tasks.Task, interface{}, log.Logger) error
+	standbyActionFn     func(context.Context, workflow.Context, workflow.MutableState) (interface{}, error)
+	standbyPostActionFn func(context.Context, tasks.Task, interface{}, log.Logger) error
 
 	standbyCurrentTimeFn func() time.Time
 )
 
 func standbyTaskPostActionNoOp(
+	_ context.Context,
 	_ tasks.Task,
 	postActionInfo interface{},
 	_ log.Logger,
@@ -63,6 +64,7 @@ func standbyTaskPostActionNoOp(
 }
 
 func standbyTransferTaskPostActionTaskDiscarded(
+	_ context.Context,
 	taskInfo tasks.Task,
 	postActionInfo interface{},
 	logger log.Logger,
@@ -77,6 +79,7 @@ func standbyTransferTaskPostActionTaskDiscarded(
 }
 
 func standbyTimerTaskPostActionTaskDiscarded(
+	_ context.Context,
 	taskInfo tasks.Task,
 	postActionInfo interface{},
 	logger log.Logger,
@@ -195,6 +198,7 @@ func getStandbyPostActionFn(
 }
 
 func refreshTasks(
+	ctx context.Context,
 	adminClient adminservice.AdminServiceClient,
 	namespaceRegistry namespace.Registry,
 	namespaceID namespace.ID,
@@ -205,9 +209,6 @@ func refreshTasks(
 	if err != nil {
 		return err
 	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), refreshTaskTimeout)
-	defer cancel()
 
 	_, err = adminClient.RefreshWorkflowTasks(ctx, &adminservice.RefreshWorkflowTasksRequest{
 		Namespace: namespaceEntry.Name().String(),

--- a/service/history/nDCTaskUtil.go
+++ b/service/history/nDCTaskUtil.go
@@ -26,7 +26,6 @@ package history
 
 import (
 	"context"
-	"time"
 
 	"go.temporal.io/api/serviceerror"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -37,10 +36,6 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
-)
-
-const (
-	refreshTaskTimeout = 30 * time.Second
 )
 
 // VerifyTaskVersion, will return true if failover version check is successful

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -30,12 +30,14 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
@@ -135,7 +137,42 @@ func (t *timerQueueTaskExecutorBase) executeDeleteHistoryEventTask(
 	)
 }
 
-func (t *timerQueueTaskExecutorBase) getNamespaceIDAndWorkflowExecution(
+func getWorkflowExecutionContextForTask(
+	ctx context.Context,
+	workflowCache workflow.Cache,
+	task tasks.Task,
+) (workflow.Context, workflow.ReleaseCacheFunc, error) {
+	namespaceID, execution := getTaskNamespaceIDAndWorkflowExecution(task)
+	return getWorkflowExecutionContext(
+		ctx,
+		workflowCache,
+		namespaceID,
+		execution,
+	)
+}
+
+func getWorkflowExecutionContext(
+	ctx context.Context,
+	workflowCache workflow.Cache,
+	namespaceID namespace.ID,
+	execution commonpb.WorkflowExecution,
+) (workflow.Context, workflow.ReleaseCacheFunc, error) {
+	ctx, cancel := context.WithTimeout(ctx, taskGetExecutionTimeout)
+	defer cancel()
+
+	weContext, release, err := workflowCache.GetOrCreateWorkflowExecution(
+		ctx,
+		namespaceID,
+		execution,
+		workflow.CallerTypeTask,
+	)
+	if common.IsContextDeadlineExceededErr(err) {
+		err = consts.ErrWorkflowBusy
+	}
+	return weContext, release, err
+}
+
+func getTaskNamespaceIDAndWorkflowExecution(
 	task tasks.Task,
 ) (namespace.ID, commonpb.WorkflowExecution) {
 

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -1025,7 +1025,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 	persistenceMutableState := s.createPersistenceMutableState(mutableState, event.GetEventId(), event.GetVersion())
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewDisabledArchvialConfig())
-	s.mockParentClosePolicyClient.EXPECT().SendParentClosePolicyRequest(gomock.Any()).DoAndReturn(
+	s.mockParentClosePolicyClient.EXPECT().SendParentClosePolicyRequest(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(request parentclosepolicy.Request) error {
 			s.Equal(execution, request.ParentExecution)
 			return nil

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -1026,7 +1026,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewDisabledArchvialConfig())
 	s.mockParentClosePolicyClient.EXPECT().SendParentClosePolicyRequest(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(request parentclosepolicy.Request) error {
+		func(_ context.Context, request parentclosepolicy.Request) error {
 			s.Equal(execution, request.ParentExecution)
 			return nil
 		},

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -92,19 +92,10 @@ func (t *visibilityQueueTaskExecutor) processStartExecution(
 	ctx context.Context,
 	task *tasks.StartExecutionVisibilityTask,
 ) (retError error) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, taskTimeout)
-
+	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
-	weContext, release, err := t.cache.GetOrCreateWorkflowExecution(
-		ctx,
-		namespace.ID(task.NamespaceID),
-		commonpb.WorkflowExecution{
-			WorkflowId: task.WorkflowID,
-			RunId:      task.RunID,
-		},
-		workflow.CallerTypeTask,
-	)
+
+	weContext, release, err := getWorkflowExecutionContextForTask(ctx, t.cache, task)
 	if err != nil {
 		return err
 	}
@@ -167,19 +158,10 @@ func (t *visibilityQueueTaskExecutor) processUpsertExecution(
 	ctx context.Context,
 	task *tasks.UpsertExecutionVisibilityTask,
 ) (retError error) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, taskTimeout)
-
+	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
-	weContext, release, err := t.cache.GetOrCreateWorkflowExecution(
-		ctx,
-		namespace.ID(task.NamespaceID),
-		commonpb.WorkflowExecution{
-			WorkflowId: task.WorkflowID,
-			RunId:      task.RunID,
-		},
-		workflow.CallerTypeTask,
-	)
+
+	weContext, release, err := getWorkflowExecutionContextForTask(ctx, t.cache, task)
 	if err != nil {
 		return err
 	}
@@ -318,19 +300,10 @@ func (t *visibilityQueueTaskExecutor) processCloseExecution(
 	ctx context.Context,
 	task *tasks.CloseExecutionVisibilityTask,
 ) (retError error) {
-	var cancel context.CancelFunc
-	ctx, cancel = context.WithTimeout(ctx, taskTimeout)
-
+	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
-	weContext, release, err := t.cache.GetOrCreateWorkflowExecution(
-		ctx,
-		namespace.ID(task.NamespaceID),
-		commonpb.WorkflowExecution{
-			WorkflowId: task.WorkflowID,
-			RunId:      task.RunID,
-		},
-		workflow.CallerTypeTask,
-	)
+
+	weContext, release, err := getWorkflowExecutionContextForTask(ctx, t.cache, task)
 	if err != nil {
 		return err
 	}
@@ -446,6 +419,9 @@ func (t *visibilityQueueTaskExecutor) processDeleteExecution(
 	ctx context.Context,
 	task *tasks.DeleteExecutionVisibilityTask,
 ) (retError error) {
+	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
+	defer cancel()
+
 	if task.CloseTime == nil {
 		// CloseTime is not set for workflow executions with TTL (old version).
 		// They will be deleted using Cassandra TTL and this task should be ignored.

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -271,7 +271,7 @@ func (c *ContextImpl) LoadWorkflowExecution(ctx context.Context) (MutableState, 
 	}
 
 	if c.MutableState == nil {
-		response, err := getWorkflowExecutionWithRetry(c.shard, &persistence.GetWorkflowExecutionRequest{
+		response, err := getWorkflowExecutionWithRetry(ctx, c.shard, &persistence.GetWorkflowExecutionRequest{
 			ShardID:     c.shard.GetShardID(),
 			NamespaceID: c.workflowKey.NamespaceID,
 			WorkflowID:  c.workflowKey.WorkflowID,

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -326,13 +326,14 @@ func appendHistoryV2EventsWithRetry(
 ) (int64, error) {
 
 	resp := 0
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = shard.AppendHistoryEvents(ctx, request, namespaceID, execution)
 		return err
 	}
 
-	err := backoff.Retry(
+	err := backoff.RetryContext(
+		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
 		common.IsPersistenceTransientError,
@@ -347,13 +348,14 @@ func createWorkflowExecutionWithRetry(
 ) (*persistence.CreateWorkflowExecutionResponse, error) {
 
 	var resp *persistence.CreateWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = shard.CreateWorkflowExecution(ctx, request)
 		return err
 	}
 
-	err := backoff.Retry(
+	err := backoff.RetryContext(
+		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
 		common.IsPersistenceTransientError,
@@ -396,13 +398,14 @@ func conflictResolveWorkflowExecutionWithRetry(
 ) (*persistence.ConflictResolveWorkflowExecutionResponse, error) {
 
 	var resp *persistence.ConflictResolveWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = shard.ConflictResolveWorkflowExecution(ctx, request)
 		return err
 	}
 
-	err := backoff.Retry(
+	err := backoff.RetryContext(
+		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
 		common.IsPersistenceTransientError,
@@ -448,19 +451,21 @@ func conflictResolveWorkflowExecutionWithRetry(
 }
 
 func getWorkflowExecutionWithRetry(
+	ctx context.Context,
 	shard shard.Context,
 	request *persistence.GetWorkflowExecutionRequest,
 ) (*persistence.GetWorkflowExecutionResponse, error) {
 
 	var resp *persistence.GetWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
-		resp, err = shard.GetWorkflowExecution(context.TODO(), request)
+		resp, err = shard.GetWorkflowExecution(ctx, request)
 
 		return err
 	}
 
-	err := backoff.Retry(
+	err := backoff.RetryContext(
+		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
 		common.IsPersistenceTransientError,
@@ -501,13 +506,15 @@ func updateWorkflowExecutionWithRetry(
 
 	var resp *persistence.UpdateWorkflowExecutionResponse
 	var err error
-	op := func() error {
+	op := func(ctx context.Context) error {
 		resp, err = shard.UpdateWorkflowExecution(ctx, request)
 		return err
 	}
 
-	err = backoff.Retry(
-		op, PersistenceOperationRetryPolicy,
+	err = backoff.RetryContext(
+		ctx,
+		op,
+		PersistenceOperationRetryPolicy,
 		common.IsPersistenceTransientError,
 	)
 	if err != nil {
@@ -558,13 +565,15 @@ func setWorkflowExecutionWithRetry(
 
 	var resp *persistence.SetWorkflowExecutionResponse
 	var err error
-	op := func() error {
+	op := func(ctx context.Context) error {
 		resp, err = shard.SetWorkflowExecution(ctx, request)
 		return err
 	}
 
-	err = backoff.Retry(
-		op, PersistenceOperationRetryPolicy,
+	err = backoff.RetryContext(
+		ctx,
+		op,
+		PersistenceOperationRetryPolicy,
 		common.IsPersistenceTransientError,
 	)
 	if err != nil {

--- a/service/worker/parentclosepolicy/client.go
+++ b/service/worker/parentclosepolicy/client.go
@@ -44,7 +44,7 @@ type (
 
 	// Client is used to send request to processor workflow
 	Client interface {
-		SendParentClosePolicyRequest(Request) error
+		SendParentClosePolicyRequest(context.Context, Request) error
 	}
 
 	clientImpl struct {
@@ -79,7 +79,7 @@ func NewClient(
 	}
 }
 
-func (c *clientImpl) SendParentClosePolicyRequest(request Request) error {
+func (c *clientImpl) SendParentClosePolicyRequest(ctx context.Context, request Request) error {
 	workflowID := getWorkflowID(c.numWorkflows)
 	workflowOptions := sdkclient.StartWorkflowOptions{
 		ID:                    workflowID,
@@ -87,7 +87,7 @@ func (c *clientImpl) SendParentClosePolicyRequest(request Request) error {
 		WorkflowTaskTimeout:   workflowTaskTimeout,
 		WorkflowIDReusePolicy: workflowIDReusePolicy,
 	}
-	signalCtx, cancel := context.WithTimeout(context.Background(), signalTimeout)
+	signalCtx, cancel := context.WithTimeout(ctx, signalTimeout)
 	defer cancel()
 
 	sdkClient := c.sdkClientFactory.GetSystemClient(c.logger)

--- a/service/worker/parentclosepolicy/client_mock.go
+++ b/service/worker/parentclosepolicy/client_mock.go
@@ -29,6 +29,7 @@
 package parentclosepolicy
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -58,15 +59,15 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // SendParentClosePolicyRequest mocks base method.
-func (m *MockClient) SendParentClosePolicyRequest(arg0 Request) error {
+func (m *MockClient) SendParentClosePolicyRequest(arg0 context.Context, arg1 Request) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendParentClosePolicyRequest", arg0)
+	ret := m.ctrl.Call(m, "SendParentClosePolicyRequest", arg0, arg1)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendParentClosePolicyRequest indicates an expected call of SendParentClosePolicyRequest.
-func (mr *MockClientMockRecorder) SendParentClosePolicyRequest(arg0 interface{}) *gomock.Call {
+func (mr *MockClientMockRecorder) SendParentClosePolicyRequest(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendParentClosePolicyRequest", reflect.TypeOf((*MockClient)(nil).SendParentClosePolicyRequest), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendParentClosePolicyRequest", reflect.TypeOf((*MockClient)(nil).SendParentClosePolicyRequest), arg0, arg1)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Limit task processing time to 3s
- 500ms for getting workflow execution lock
- For workflow reset task and standby history resend the timeout is 20s and 30s (default) respectively. The timeout for resend is controlled by a dynamicconfig.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Host level pool require the processing for each task to be fast

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Integration tests & canary

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- In terms of short context time + retry adding more load to downstream, this should not be a problem as the new retry policy is much less aggressive compared to the previous one. If worker pool sees timeout errors, the task will skip in-place retry and be send back to the rescheduler and the exponential backoff policy will kick in. 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.