### PR TITLE
Do not wake up workflow in retry backoff upon signal

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2003,7 +2003,7 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 
 			executionInfo := mutableState.GetExecutionInfo()
 			createWorkflowTask := true
-			// Do not create workflow task when the workflow is still in first workflow task backoff period
+			// Do not create workflow task when the workflow has first workflow task backoff and execution is not started yet
 			workflowTaskBackoff := timestamp.TimeValue(executionInfo.GetExecutionTime()).After(timestamp.TimeValue(executionInfo.GetStartTime()))
 			if workflowTaskBackoff && !mutableState.HasProcessedOrPendingWorkflowTask() {
 				createWorkflowTask = false

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2003,8 +2003,9 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 
 			executionInfo := mutableState.GetExecutionInfo()
 			createWorkflowTask := true
-			// Do not create workflow task when the workflow is cron and the cron has not been started yet
-			if executionInfo.CronSchedule != "" && !mutableState.HasProcessedOrPendingWorkflowTask() {
+			// Do not create workflow task when the workflow is still in first workflow task backoff period
+			workflowTaskBackoff := timestamp.TimeValue(executionInfo.GetExecutionTime()).After(timestamp.TimeValue(executionInfo.GetStartTime()))
+			if workflowTaskBackoff && !mutableState.HasProcessedOrPendingWorkflowTask() {
 				createWorkflowTask = false
 			}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not wake up workflow in retry backoff upon signal

<!-- Tell your future self why have you made these changes -->
**Why?**
- Existing check only handles cron workflow not workflow retry.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- no