### PR TITLE
Fix set default per unit histogram boundaries

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -435,7 +435,3 @@ func histogramBoundariesToHistogramObjectives(boundaries []float64) []prometheus
 	}
 	return result
 }
-
-func histogramBoundariesToValueBuckets(buckets []float64) tally.ValueBuckets {
-	return tally.ValueBuckets(buckets)
-}

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -345,10 +345,14 @@ func convertPrometheusConfigToTally(
 }
 
 func setDefaultPerUnitHistogramBoundaries(clientConfig *ClientConfig) {
-	if clientConfig.PerUnitHistogramBoundaries != nil && len(clientConfig.PerUnitHistogramBoundaries) == len(defaultPerUnitHistogramBoundaries) {
-		return
+	if clientConfig.PerUnitHistogramBoundaries == nil {
+		clientConfig.PerUnitHistogramBoundaries = make(map[string][]float64)
 	}
-	clientConfig.PerUnitHistogramBoundaries = defaultPerUnitHistogramBoundaries
+	for unit, bucket := range defaultPerUnitHistogramBoundaries {
+		if _, ok := clientConfig.PerUnitHistogramBoundaries[unit]; !ok {
+			clientConfig.PerUnitHistogramBoundaries[unit] = bucket
+		}
+	}
 }
 
 // newM3Scope returns a new m3 scope with

--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -248,6 +248,7 @@ var (
 // extension := MyExtensions(reporter.UserScope())
 // serverOptions.WithReporter(reporter)
 func InitMetricsReporter(logger log.Logger, c *Config) (Reporter, error) {
+	setDefaultPerUnitHistogramBoundaries(&c.ClientConfig)
 	if c.Prometheus != nil && len(c.Prometheus.Framework) > 0 {
 		return InitReporterFromPrometheusConfig(logger, c.Prometheus, &c.ClientConfig)
 	}
@@ -305,7 +306,6 @@ func NewTallyReporterFromPrometheusConfig(
 ) Reporter {
 	tallyConfig := convertPrometheusConfigToTally(config)
 	tallyScope := newPrometheusScope(logger, tallyConfig, clientConfig)
-	setDefaultPerUnitHistogramBoundaries(clientConfig)
 	return NewTallyReporter(tallyScope, clientConfig)
 }
 
@@ -345,7 +345,7 @@ func convertPrometheusConfigToTally(
 }
 
 func setDefaultPerUnitHistogramBoundaries(clientConfig *ClientConfig) {
-	if clientConfig.PerUnitHistogramBoundaries != nil && len(clientConfig.PerUnitHistogramBoundaries) > 0 {
+	if clientConfig.PerUnitHistogramBoundaries != nil && len(clientConfig.PerUnitHistogramBoundaries) == len(defaultPerUnitHistogramBoundaries) {
 		return
 	}
 	clientConfig.PerUnitHistogramBoundaries = defaultPerUnitHistogramBoundaries

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -118,3 +118,36 @@ func (s *MetricsSuite) TestNoop() {
 	scope := NewScope(log.NewNoopLogger(), config)
 	s.Equal(tally.NoopScope, scope)
 }
+
+func (s *MetricsSuite) TestSetDefaultPerUnitHistogramBoundaries() {
+	type histogramTest struct {
+		input        map[string][]float64
+		expectResult map[string][]float64
+	}
+
+	customizedBoundaries := map[string][]float64{
+		Dimensionless: {1},
+		"notDefine":   {1},
+		Milliseconds:  defaultPerUnitHistogramBoundaries[Milliseconds],
+		Bytes:         defaultPerUnitHistogramBoundaries[Bytes],
+	}
+	testCases := []histogramTest{
+		{
+			nil,
+			defaultPerUnitHistogramBoundaries,
+		},
+		{
+			map[string][]float64{
+				Dimensionless: {1},
+				"notDefine":   {1},
+			},
+			customizedBoundaries,
+		},
+	}
+
+	for _, test := range testCases {
+		config := &ClientConfig{PerUnitHistogramBoundaries: test.input}
+		setDefaultPerUnitHistogramBoundaries(config)
+		s.Equal(test.expectResult, config.PerUnitHistogramBoundaries)
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix set default per unit histogram boundaries

<!-- Tell your future self why have you made these changes -->
**Why?**
Current default histogram boundaries only get set when framework is define. If framework is not define, we fallback to tally with a different init code path. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
