### PR TITLE
Add NamespaceInvalidState and NamespaceNotFound errors

### DIFF
--- a/client/history/metricClient.go
+++ b/client/history/metricClient.go
@@ -632,6 +632,7 @@ func (c *metricClient) finishMetricsRecording(
 		case *serviceerror.Canceled,
 			*serviceerror.DeadlineExceeded,
 			*serviceerror.NotFound,
+			*serviceerror.NamespaceNotFound,
 			*serviceerror.WorkflowExecutionAlreadyStarted:
 			// noop - not interest and too many logs
 		default:

--- a/client/matching/metricClient.go
+++ b/client/matching/metricClient.go
@@ -261,6 +261,7 @@ func (c *metricClient) finishMetricsRecording(
 		case *serviceerror.Canceled,
 			*serviceerror.DeadlineExceeded,
 			*serviceerror.NotFound,
+			*serviceerror.NamespaceNotFound,
 			*serviceerror.WorkflowExecutionAlreadyStarted:
 			// noop - not interest and too many logs
 		default:

--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -153,7 +153,7 @@ func (h *historyArchiver) Archive(
 	for historyIterator.HasNext() {
 		historyBlob, err := getNextHistoryBlob(ctx, historyIterator)
 		if err != nil {
-			if common.IsNotFoundError(err) {
+			if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 				// workflow history no longer exists, may due to duplicated archival signal
 				// this may happen even in the middle of iterating history as two archival signals
 				// can be processed concurrently.

--- a/common/archiver/filestore/historyArchiver_test.go
+++ b/common/archiver/filestore/historyArchiver_test.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
+
 	"go.temporal.io/server/tests/testhelper"
 
 	"github.com/golang/mock/gomock"
@@ -294,7 +295,7 @@ func (s *historyArchiverSuite) TestArchive_Skip() {
 		historyIterator.EXPECT().HasNext().Return(true),
 		historyIterator.EXPECT().Next().Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, &serviceerror.NotFound{Message: "workflow not found"}),
+		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewNotFound("workflow not found")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)

--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -153,7 +153,7 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 		part := progress.CurrentPageNumber
 		historyBlob, err := getNextHistoryBlob(ctx, historyIterator)
 		if err != nil {
-			if common.IsNotFoundError(err) {
+			if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 				// workflow history no longer exists, may due to duplicated archival signal
 				// this may happen even in the middle of iterating history as two archival signals
 				// can be processed concurrently.

--- a/common/archiver/gcloud/historyArchiver_test.go
+++ b/common/archiver/gcloud/historyArchiver_test.go
@@ -332,7 +332,7 @@ func (h *historyArchiverSuite) TestArchive_Skip() {
 		historyIterator.EXPECT().HasNext().Return(true),
 		historyIterator.EXPECT().Next().Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, &serviceerror.NotFound{Message: "workflow not found"}),
+		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewNotFound("workflow not found")),
 	)
 
 	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)

--- a/common/archiver/historyIterator.go
+++ b/common/archiver/historyIterator.go
@@ -172,7 +172,7 @@ func (i *historyIterator) readHistoryBatches(firstEventID int64) ([]*historypb.H
 	newIterState := historyIteratorState{}
 	for size < targetSize {
 		currHistoryBatches, err := i.readHistory(firstEventID)
-		if _, ok := err.(*serviceerror.NotFound); ok && firstEventID != common.FirstEventID {
+		if _, isNotFound := err.(*serviceerror.NotFound); isNotFound && firstEventID != common.FirstEventID {
 			newIterState.FinishedIteration = true
 			return historyBatches, newIterState, nil
 		}
@@ -201,7 +201,7 @@ func (i *historyIterator) readHistoryBatches(firstEventID int64) ([]*historypb.H
 	// If you are here, it means the target size is met after adding the last batch of read history.
 	// We need to check if there's more history batches.
 	_, err := i.readHistory(firstEventID)
-	if _, ok := err.(*serviceerror.NotFound); ok && firstEventID != common.FirstEventID {
+	if _, isNotFound := err.(*serviceerror.NotFound); isNotFound && firstEventID != common.FirstEventID {
 		newIterState.FinishedIteration = true
 		return historyBatches, newIterState, nil
 	}

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -166,7 +166,7 @@ func (h *historyArchiver) Archive(
 	for historyIterator.HasNext() {
 		historyBlob, err := getNextHistoryBlob(ctx, historyIterator)
 		if err != nil {
-			if common.IsNotFoundError(err) {
+			if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 				// workflow history no longer exists, may due to duplicated archival signal
 				// this may happen even in the middle of iterating history as two archival signals
 				// can be processed concurrently.

--- a/common/archiver/s3store/historyArchiver_test.go
+++ b/common/archiver/s3store/historyArchiver_test.go
@@ -425,7 +425,7 @@ func (s *historyArchiverSuite) TestArchive_Skip() {
 		historyIterator.EXPECT().HasNext().Return(true),
 		historyIterator.EXPECT().Next().Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, &serviceerror.NotFound{Message: "workflow not found"}),
+		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewNotFound("workflow not found")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)

--- a/common/namespace/handler.go
+++ b/common/namespace/handler.go
@@ -146,7 +146,7 @@ func (d *HandlerImpl) RegisterNamespace(
 	case nil:
 		// namespace already exists, cannot proceed
 		return nil, serviceerror.NewNamespaceAlreadyExists("Namespace already exists.")
-	case *serviceerror.NotFound:
+	case *serviceerror.NamespaceNotFound:
 		// namespace does not exists, proceeds
 	default:
 		// other err

--- a/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
@@ -427,7 +427,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestRegist
 		Namespace: namespace,
 	})
 	s.Error(err)
-	s.IsType(&serviceerror.NotFound{}, err)
+	s.IsType(&serviceerror.NamespaceNotFound{}, err)
 	s.Nil(resp)
 }
 
@@ -469,7 +469,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) TestRegist
 		Namespace: namespace,
 	})
 	s.Error(err)
-	s.IsType(&serviceerror.NotFound{}, err)
+	s.IsType(&serviceerror.NamespaceNotFound{}, err)
 	s.Nil(resp)
 }
 

--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -28,13 +28,13 @@ package namespace
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cache"
 	"go.temporal.io/server/common/clock"
@@ -95,7 +95,7 @@ type (
 
 		// GetNamespace reads the state for a single namespace by name or ID
 		// from persistent storage, returning an instance of
-		// serviceerror.NotFound if there is no matching Namespace.
+		// serviceerror.NamespaceNotFound if there is no matching Namespace.
 		GetNamespace(
 			context.Context,
 			*persistence.GetNamespaceRequest,
@@ -484,8 +484,7 @@ func (r *registry) getNamespace(name Name) (*Namespace, error) {
 	if id, ok := r.cacheNameToID.Get(name).(ID); ok {
 		return r.getNamespaceByIDLocked(id)
 	}
-	return nil, serviceerror.NewNotFound(
-		fmt.Sprintf("Namespace name %q not found", name))
+	return nil, serviceerror.NewNamespaceNotFound(name.String())
 }
 
 // getNamespaceByID retrieves the information from the cache if it exists.
@@ -499,8 +498,7 @@ func (r *registry) getNamespaceByIDLocked(id ID) (*Namespace, error) {
 	if ns, ok := r.cacheByID.Get(id).(*Namespace); ok {
 		return ns, nil
 	}
-	return nil, serviceerror.NewNotFound(
-		fmt.Sprintf("Namespace id %q not found", id))
+	return nil, serviceerror.NewNamespaceNotFound(id.String())
 }
 
 func (r *registry) publishCacheUpdate(

--- a/common/namespace/registry_test.go
+++ b/common/namespace/registry_test.go
@@ -35,6 +35,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/serviceerror"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -520,7 +521,7 @@ func (s *registrySuite) TestGetTriggerListAndUpdateCache_ConcurrentAccess() {
 		case nil:
 			s.Equal(entryOld, entryNew)
 			waitGroup.Done()
-		case *serviceerror.NotFound:
+		case *serviceerror.NamespaceNotFound:
 			time.Sleep(4 * time.Second)
 			entryNew, err := s.registry.GetNamespaceByID(id)
 			s.NoError(err)
@@ -637,7 +638,7 @@ func (s *registrySuite) TestRemoveDeletedNamespace() {
 	ns1FromRegistry, err := s.registry.GetNamespace(namespace.Name(namespaceRecord1.Namespace.Info.Name))
 	s.Nil(ns1FromRegistry)
 	s.Error(err)
-	var notFound *serviceerror.NotFound
+	var notFound *serviceerror.NamespaceNotFound
 	s.ErrorAs(err, &notFound)
 }
 

--- a/common/namespace/replicationTaskExecutor.go
+++ b/common/namespace/replicationTaskExecutor.go
@@ -161,7 +161,7 @@ func (h *namespaceReplicationTaskExecutorImpl) handleNamespaceCreationReplicatio
 			if resp.Namespace.Info.Id != task.GetId() {
 				return ErrNameUUIDCollision
 			}
-		case *serviceerror.NotFound:
+		case *serviceerror.NamespaceNotFound:
 			// no check is necessary
 			recordExists = false
 		default:
@@ -177,7 +177,7 @@ func (h *namespaceReplicationTaskExecutorImpl) handleNamespaceCreationReplicatio
 			if resp.Namespace.Info.Name != task.Info.GetName() {
 				return ErrNameUUIDCollision
 			}
-		case *serviceerror.NotFound:
+		case *serviceerror.NamespaceNotFound:
 			// no check is necessary
 			recordExists = false
 		default:
@@ -219,7 +219,7 @@ func (h *namespaceReplicationTaskExecutorImpl) handleNamespaceUpdateReplicationT
 		Name: task.Info.GetName(),
 	})
 	if err != nil {
-		if _, ok := err.(*serviceerror.NotFound); ok {
+		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
 			// this can happen if the create namespace replication task is to processed.
 			// e.g. new cluster which does not have anything
 			return h.handleNamespaceCreationReplicationTask(ctx, task)

--- a/common/persistence/cassandra/metadata_store.go
+++ b/common/persistence/cassandra/metadata_store.go
@@ -288,7 +288,7 @@ func (m *MetadataStore) GetNamespace(
 			if len(ID) > 0 {
 				identity = ID
 			}
-			return serviceerror.NewNotFound(fmt.Sprintf("Namespace %s does not exist.", identity))
+			return serviceerror.NewNamespaceNotFound(identity)
 		}
 		return serviceerror.NewUnavailable(fmt.Sprintf("GetNamespace operation failed. Error %v", err))
 	}

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -879,7 +879,7 @@ func (d *MutableStateStore) assertNotCurrentExecution(
 		NamespaceID: namespaceID,
 		WorkflowID:  workflowID,
 	}); err != nil {
-		if _, ok := err.(*serviceerror.NotFound); ok {
+		if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 			// allow bypassing no current record
 			return nil
 		}

--- a/common/persistence/clusterMetadataStore.go
+++ b/common/persistence/clusterMetadataStore.go
@@ -30,6 +30,7 @@ import (
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/serialization"
@@ -59,7 +60,7 @@ type (
 
 var _ ClusterMetadataManager = (*clusterMetadataManagerImpl)(nil)
 
-//NewClusterMetadataManagerImpl returns new ClusterMetadataManager
+// NewClusterMetadataManagerImpl returns new ClusterMetadataManager
 func NewClusterMetadataManagerImpl(
 	persistence ClusterMetadataStore,
 	serializer serialization.Serializer,
@@ -183,7 +184,7 @@ func (m *clusterMetadataManagerImpl) SaveClusterMetadata(
 	}
 
 	oldClusterMetadata, err := m.GetClusterMetadata(ctx, &GetClusterMetadataRequest{ClusterName: request.GetClusterName()})
-	if _, notFound := err.(*serviceerror.NotFound); notFound {
+	if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 		return m.persistence.SaveClusterMetadata(ctx, &InternalSaveClusterMetadataRequest{
 			ClusterName:     request.ClusterName,
 			ClusterMetadata: mcm,

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1574,8 +1574,7 @@ func (s *ExecutionManagerSuite) TestDeleteCurrentWorkflow() {
 	runID0, err1 = s.GetCurrentWorkflowRunID(s.ctx, namespaceID, workflowExecution.GetWorkflowId())
 	s.Error(err1)
 	s.Empty(runID0)
-	_, ok := err1.(*serviceerror.NotFound)
-	s.True(ok)
+	s.IsType(&serviceerror.NotFound{}, err1)
 
 	// execution record should still be there
 	_, err2 = s.GetWorkflowMutableState(s.ctx, namespaceID, workflowExecution)
@@ -1623,12 +1622,11 @@ func (s *ExecutionManagerSuite) TestUpdateDeleteWorkflow() {
 	runID0, err1 = s.GetCurrentWorkflowRunID(s.ctx, namespaceID, workflowExecution.GetWorkflowId())
 	s.Error(err1)
 	s.Empty(runID0)
-	_, ok := err1.(*serviceerror.NotFound)
+	s.IsType(&serviceerror.NotFound{}, err1)
 	// execution record should still be there
 	_, err2 = s.GetWorkflowMutableState(s.ctx, namespaceID, workflowExecution)
 	s.Error(err2)
-	_, ok = err2.(*serviceerror.NotFound)
-	s.True(ok)
+	s.IsType(&serviceerror.NotFound{}, err2)
 }
 
 // TestCleanupCorruptedWorkflow test
@@ -1656,8 +1654,7 @@ func (s *ExecutionManagerSuite) TestCleanupCorruptedWorkflow() {
 	runID0, err4 := s.GetCurrentWorkflowRunID(s.ctx, namespaceID, workflowExecution.GetWorkflowId())
 	s.Error(err4)
 	s.Empty(runID0)
-	_, ok := err4.(*serviceerror.NotFound)
-	s.True(ok)
+	s.IsType(&serviceerror.NotFound{}, err4)
 
 	// we should still be able to load with runID
 	info1, err5 := s.GetWorkflowMutableState(s.ctx, namespaceID, workflowExecution)
@@ -1697,8 +1694,7 @@ func (s *ExecutionManagerSuite) TestCleanupCorruptedWorkflow() {
 	// execution record should be gone
 	_, err9 := s.GetWorkflowMutableState(s.ctx, namespaceID, workflowExecution)
 	s.Error(err9)
-	_, ok = err9.(*serviceerror.NotFound)
-	s.True(ok)
+	s.IsType(&serviceerror.NotFound{}, err9)
 }
 
 // TestGetCurrentWorkflow test

--- a/common/persistence/persistence-tests/metadataPersistenceV2Test.go
+++ b/common/persistence/persistence-tests/metadataPersistenceV2Test.go
@@ -215,7 +215,7 @@ func (m *MetadataPersistenceSuiteV2) TestGetNamespace() {
 	resp0, err0 := m.GetNamespace("", "does-not-exist")
 	m.Nil(resp0)
 	m.Error(err0)
-	m.IsType(&serviceerror.NotFound{}, err0)
+	m.IsType(&serviceerror.NamespaceNotFound{}, err0)
 	testBinaries := &namespacepb.BadBinaries{
 		Binaries: map[string]*namespacepb.BadBinaryInfo{
 			"abc": {
@@ -935,12 +935,12 @@ func (m *MetadataPersistenceSuiteV2) TestDeleteNamespace() {
 		time.Sleep(time.Second * time.Duration(i))
 	}
 	m.Error(err4)
-	m.IsType(&serviceerror.NotFound{}, err4)
+	m.IsType(&serviceerror.NamespaceNotFound{}, err4)
 	m.Nil(resp4)
 
 	resp5, err5 := m.GetNamespace(id, "")
 	m.Error(err5)
-	m.IsType(&serviceerror.NotFound{}, err5)
+	m.IsType(&serviceerror.NamespaceNotFound{}, err5)
 	m.Nil(resp5)
 
 	id = uuid.New()
@@ -976,12 +976,12 @@ func (m *MetadataPersistenceSuiteV2) TestDeleteNamespace() {
 
 	resp8, err8 := m.GetNamespace("", name)
 	m.Error(err8)
-	m.IsType(&serviceerror.NotFound{}, err8)
+	m.IsType(&serviceerror.NamespaceNotFound{}, err8)
 	m.Nil(resp8)
 
 	resp9, err9 := m.GetNamespace(id, "")
 	m.Error(err9)
-	m.IsType(&serviceerror.NotFound{}, err9)
+	m.IsType(&serviceerror.NamespaceNotFound{}, err9)
 	m.Nil(resp9)
 }
 

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -1399,7 +1399,7 @@ func (p *metricEmitter) updateErrorMetric(scope int, err error) {
 		p.metricClient.IncCounter(scope, metrics.PersistenceErrBadRequestCounter)
 	case *serviceerror.NamespaceAlreadyExists:
 		p.metricClient.IncCounter(scope, metrics.PersistenceErrNamespaceAlreadyExistsCounter)
-	case *serviceerror.NotFound:
+	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		p.metricClient.IncCounter(scope, metrics.PersistenceErrEntityNotExistsCounter)
 	case *serviceerror.ResourceExhausted:
 		p.metricClient.IncCounter(scope, metrics.PersistenceErrBusyCounter)

--- a/common/persistence/sql/metadata.go
+++ b/common/persistence/sql/metadata.go
@@ -124,7 +124,7 @@ func (m *sqlMetadataManagerV2) GetNamespace(
 				identity = request.ID
 			}
 
-			return nil, serviceerror.NewNotFound(fmt.Sprintf("Namespace %s does not exist.", identity))
+			return nil, serviceerror.NewNamespaceNotFound(identity)
 		default:
 			return nil, serviceerror.NewUnavailable(fmt.Sprintf("GetNamespace operation failed. Error %v", err))
 		}

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -229,7 +229,7 @@ func (ni *NamespaceValidatorInterceptor) checkNamespaceState(namespaceEntry *nam
 		}
 	}
 
-	return ni.invalidStateError(namespaceEntry, allowedStates)
+	return serviceerror.NewNamespaceInvalidState(namespaceEntry.Name().String(), namespaceEntry.State(), allowedStates)
 }
 
 func (ni *NamespaceValidatorInterceptor) checkReplicationState(namespaceEntry *namespace.Namespace, fullMethod string) error {
@@ -247,12 +247,4 @@ func (ni *NamespaceValidatorInterceptor) checkReplicationState(namespaceEntry *n
 	}
 
 	return errNamespaceHandover
-}
-
-func (ni *NamespaceValidatorInterceptor) invalidStateError(ns *namespace.Namespace, allowedStates []enumspb.NamespaceState) error {
-	var allowedStatesStr []string
-	for _, allowedState := range allowedStates {
-		allowedStatesStr = append(allowedStatesStr, allowedState.String())
-	}
-	return serviceerror.NewNamespaceInvalidState(ns.Name().String(), ns.State().String(), allowedStatesStr)
 }

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -27,7 +27,6 @@ package interceptor
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -54,11 +53,10 @@ type (
 )
 
 var (
-	ErrNamespaceNotSet              = serviceerror.NewInvalidArgument("Namespace not set on request.")
-	errNamespaceHandover            = serviceerror.NewUnavailable(fmt.Sprintf("Namespace replication in %s state.", enumspb.REPLICATION_STATE_HANDOVER.String()))
-	errTaskTokenNotSet              = serviceerror.NewInvalidArgument("Task token not set on request.")
-	errTaskTokenNamespaceMismatch   = serviceerror.NewInvalidArgument("Operation requested with a token from a different namespace.")
-	errInvalidNamespaceStateMessage = "Namespace has invalid state: %s. Must be %s."
+	ErrNamespaceNotSet            = serviceerror.NewInvalidArgument("Namespace not set on request.")
+	errNamespaceHandover          = serviceerror.NewUnavailable(fmt.Sprintf("Namespace replication in %s state.", enumspb.REPLICATION_STATE_HANDOVER.String()))
+	errTaskTokenNotSet            = serviceerror.NewInvalidArgument("Task token not set on request.")
+	errTaskTokenNamespaceMismatch = serviceerror.NewInvalidArgument("Operation requested with a token from a different namespace.")
 
 	allowedNamespaceStates = map[string][]enumspb.NamespaceState{
 		"StartWorkflowExecution":           {enumspb.NAMESPACE_STATE_REGISTERED},
@@ -231,7 +229,7 @@ func (ni *NamespaceValidatorInterceptor) checkNamespaceState(namespaceEntry *nam
 		}
 	}
 
-	return ni.stateNotAllowedError(namespaceEntry.State(), allowedStates)
+	return ni.invalidStateError(namespaceEntry, allowedStates)
 }
 
 func (ni *NamespaceValidatorInterceptor) checkReplicationState(namespaceEntry *namespace.Namespace, fullMethod string) error {
@@ -251,10 +249,10 @@ func (ni *NamespaceValidatorInterceptor) checkReplicationState(namespaceEntry *n
 	return errNamespaceHandover
 }
 
-func (ni *NamespaceValidatorInterceptor) stateNotAllowedError(currentState enumspb.NamespaceState, allowedStates []enumspb.NamespaceState) error {
+func (ni *NamespaceValidatorInterceptor) invalidStateError(ns *namespace.Namespace, allowedStates []enumspb.NamespaceState) error {
 	var allowedStatesStr []string
 	for _, allowedState := range allowedStates {
 		allowedStatesStr = append(allowedStatesStr, allowedState.String())
 	}
-	return serviceerror.NewInvalidArgument(fmt.Sprintf(errInvalidNamespaceStateMessage, currentState, strings.Join(allowedStatesStr, " or ")))
+	return serviceerror.NewNamespaceInvalidState(ns.Name().String(), ns.State().String(), allowedStatesStr)
 }

--- a/common/rpc/interceptor/namespace_validator_test.go
+++ b/common/rpc/interceptor/namespace_validator_test.go
@@ -135,7 +135,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotFound() {
 		FullMethod: "/temporal/random",
 	}
 
-	s.mockRegistry.EXPECT().GetNamespace(namespace.Name("not-found-namespace")).Return(nil, serviceerror.NewNotFound("not-found"))
+	s.mockRegistry.EXPECT().GetNamespace(namespace.Name("not-found-namespace")).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "not-found-namespace"}
 	handlerCalled := false
 	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
@@ -143,10 +143,10 @@ func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotFound() {
 		return &workflowservice.StartWorkflowExecutionResponse{}, nil
 	})
 
-	s.IsType(&serviceerror.NotFound{}, err)
+	s.IsType(&serviceerror.NamespaceNotFound{}, err)
 	s.False(handlerCalled)
 
-	s.mockRegistry.EXPECT().GetNamespaceByID(namespace.ID("not-found-namespace-id")).Return(nil, serviceerror.NewNotFound("not-found"))
+	s.mockRegistry.EXPECT().GetNamespaceByID(namespace.ID("not-found-namespace-id")).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	taskToken, _ := common.NewProtoTaskTokenSerializer().Serialize(&tokenspb.Task{
 		NamespaceId: "not-found-namespace-id",
 	})
@@ -160,7 +160,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotFound() {
 		return &workflowservice.RespondWorkflowTaskCompletedResponse{}, nil
 	})
 
-	s.IsType(&serviceerror.NotFound{}, err)
+	s.IsType(&serviceerror.NamespaceNotFound{}, err)
 	s.False(handlerCalled)
 }
 
@@ -181,13 +181,13 @@ func (s *namespaceValidatorSuite) Test_Intercept_StatusFromNamespace() {
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
-			expectedErr: &serviceerror.InvalidArgument{},
+			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      "/temporal/StartWorkflowExecution",
 			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
-			expectedErr: &serviceerror.InvalidArgument{},
+			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      "/temporal/StartWorkflowExecution",
 			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
@@ -239,7 +239,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_StatusFromNamespace() {
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
-			expectedErr: &serviceerror.InvalidArgument{},
+			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      "/temporal/PollWorkflowTaskQueue",
 			req:         &workflowservice.PollWorkflowTaskQueueRequest{Namespace: "test-namespace"},
 		},
@@ -265,7 +265,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_StatusFromNamespace() {
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
-			expectedErr: &serviceerror.InvalidArgument{},
+			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      "/temporal/UpdateNamespace",
 			req:         &workflowservice.UpdateNamespaceRequest{Namespace: "test-namespace"},
 		},
@@ -337,7 +337,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_StatusFromToken() {
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
-			expectedErr: &serviceerror.InvalidArgument{},
+			expectedErr: &serviceerror.NamespaceInvalidState{},
 			method:      "/temporal/RespondWorkflowTaskCompleted",
 			req: &workflowservice.RespondWorkflowTaskCompletedRequest{
 				TaskToken: taskToken,

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -169,7 +169,7 @@ func (ti *TelemetryInterceptor) handleError(
 		scope.IncCounter(metrics.ServiceErrNamespaceNotActiveCounter)
 	case *serviceerror.WorkflowExecutionAlreadyStarted:
 		scope.IncCounter(metrics.ServiceErrExecutionAlreadyStartedCounter)
-	case *serviceerror.NotFound:
+	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		scope.IncCounter(metrics.ServiceErrNotFoundCounter)
 	case *serviceerror.ResourceExhausted:
 		scope.Tagged(metrics.ResourceExhaustedCauseTag(err.Cause)).IncCounter(metrics.ServiceErrResourceExhaustedCounter)

--- a/common/util.go
+++ b/common/util.go
@@ -296,7 +296,7 @@ func IsResourceExhausted(err error) bool {
 	return false
 }
 
-// WorkflowIDToHistoryShard is used to map namespaceID-workflowID pair to a shardID
+// WorkflowIDToHistoryShard is used to map namespaceID-workflowID pair to a shardID.
 func WorkflowIDToHistoryShard(
 	namespaceID string,
 	workflowID string,

--- a/common/util.go
+++ b/common/util.go
@@ -242,6 +242,7 @@ func IsPersistenceTransientError(err error) bool {
 func IsServiceTransientError(err error) bool {
 	switch err.(type) {
 	case *serviceerror.NotFound,
+		*serviceerror.NamespaceNotFound,
 		*serviceerror.InvalidArgument,
 		*serviceerror.NamespaceNotActive,
 		*serviceerror.WorkflowExecutionAlreadyStarted:
@@ -293,11 +294,6 @@ func IsResourceExhausted(err error) bool {
 		return true
 	}
 	return false
-}
-
-func IsNotFoundError(err error) bool {
-	var notFoundError *serviceerror.NotFound
-	return errors.As(err, &notFoundError)
 }
 
 // WorkflowIDToHistoryShard is used to map namespaceID-workflowID pair to a shardID

--- a/go.mod
+++ b/go.mod
@@ -55,8 +55,6 @@ require (
 	modernc.org/sqlite v1.16.0
 )
 
-replace go.temporal.io/api v1.7.1-0.20220427183350-2fdcaf051044 => ../temporal-api-go
-
 require (
 	cloud.google.com/go v0.100.2 // indirect
 	cloud.google.com/go/compute v1.5.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.29.0
 	go.opentelemetry.io/otel/sdk v1.6.3
 	go.opentelemetry.io/otel/sdk/metric v0.29.0
-	go.temporal.io/api v1.7.1-0.20220427183350-2fdcaf051044
+	go.temporal.io/api v1.7.1-0.20220429205751-8a73b1f896d0
 	go.temporal.io/sdk v1.14.1-0.20220422211740-4e64c51b6b07
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.9.0
@@ -106,12 +106,12 @@ require (
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
 	golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 // indirect
-	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect
+	golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20220411194840-2f41105eb62f // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220426171045-31bebdecfb46 // indirect
+	google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.6.3
 	go.opentelemetry.io/otel/sdk/metric v0.29.0
 	go.temporal.io/api v1.7.1-0.20220429205751-8a73b1f896d0
-	go.temporal.io/sdk v1.14.1-0.20220422211740-4e64c51b6b07
+	go.temporal.io/sdk v1.14.1-0.20220429221638-3a2b86ebed54
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.9.0
 	go.uber.org/fx v1.17.1

--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,8 @@ require (
 	modernc.org/sqlite v1.16.0
 )
 
+replace go.temporal.io/api v1.7.1-0.20220427183350-2fdcaf051044 => ../temporal-api-go
+
 require (
 	cloud.google.com/go v0.100.2 // indirect
 	cloud.google.com/go/compute v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -450,8 +450,8 @@ go.opentelemetry.io/otel/trace v1.6.3 h1:IqN4L+5b0mPNjdXIiZ90Ni4Bl5BRkDQywePLWem
 go.opentelemetry.io/otel/trace v1.6.3/go.mod h1:GNJQusJlUgZl9/TQBPKU/Y/ty+0iVB5fjhKeJGZPGFs=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.temporal.io/api v1.7.1-0.20220422204533-60b4e0146b1c/go.mod h1:afCYZfuhZV+o/LAEf/XkVu4q0WPg/xbR8u0GqouGGyo=
-go.temporal.io/api v1.7.1-0.20220427183350-2fdcaf051044 h1:fsxssXO5gQeJDrBMln3+idupwj9axJfnmIpbzOD3h9E=
-go.temporal.io/api v1.7.1-0.20220427183350-2fdcaf051044/go.mod h1:a4GVALRWI60wEQ14xbCm/qbeZgk/zEmvgdnExf1PCxI=
+go.temporal.io/api v1.7.1-0.20220429205751-8a73b1f896d0 h1:TCljuP7nzCO0a9fMHcYsKAtacMTt92FxS1EkFzB/9NY=
+go.temporal.io/api v1.7.1-0.20220429205751-8a73b1f896d0/go.mod h1:QXFU+pt4JL280LYD40YrvLelG1jfei1TZ0GD7X3DLSg=
 go.temporal.io/sdk v1.14.1-0.20220422211740-4e64c51b6b07 h1:Rwj1peek7MuUBDS7dg/WloHgPnIuks5hgkUxaoSAkXQ=
 go.temporal.io/sdk v1.14.1-0.20220422211740-4e64c51b6b07/go.mod h1:1LB9EZ73++tB3zrcQY7tZVxc+L7IShsxED+gnPKb2X0=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
@@ -670,8 +670,9 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 h1:xHms4gcpe1YE7A3yIllJXP16CMAGuqwO2lX1mTyyRRc=
 golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3 h1:kBsBifDikLCf5sUMbcD8p73OinDtAQWQp8+n7FiyzlA=
+golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -874,8 +875,8 @@ google.golang.org/genproto v0.0.0-20220324131243-acbaeb5b85eb/go.mod h1:hAL49I2I
 google.golang.org/genproto v0.0.0-20220405205423-9d709892a2bf/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220422154200-b37d22cd5731/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
-google.golang.org/genproto v0.0.0-20220426171045-31bebdecfb46 h1:G1IeWbjrqEq9ChWxEuRPJu6laA67+XgTFHVSAvepr38=
-google.golang.org/genproto v0.0.0-20220426171045-31bebdecfb46/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
+google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e h1:gMjH4zLGs9m+dGzR7qHCHaXMOwsJHJKKkHtyXhtOrJk=
+google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/go.sum
+++ b/go.sum
@@ -449,11 +449,10 @@ go.opentelemetry.io/otel/sdk/metric v0.29.0/go.mod h1:IFkFNKI8Gq8zBdqOKdODCL9+LI
 go.opentelemetry.io/otel/trace v1.6.3 h1:IqN4L+5b0mPNjdXIiZ90Ni4Bl5BRkDQywePLWemd9bc=
 go.opentelemetry.io/otel/trace v1.6.3/go.mod h1:GNJQusJlUgZl9/TQBPKU/Y/ty+0iVB5fjhKeJGZPGFs=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
-go.temporal.io/api v1.7.1-0.20220422204533-60b4e0146b1c/go.mod h1:afCYZfuhZV+o/LAEf/XkVu4q0WPg/xbR8u0GqouGGyo=
 go.temporal.io/api v1.7.1-0.20220429205751-8a73b1f896d0 h1:TCljuP7nzCO0a9fMHcYsKAtacMTt92FxS1EkFzB/9NY=
 go.temporal.io/api v1.7.1-0.20220429205751-8a73b1f896d0/go.mod h1:QXFU+pt4JL280LYD40YrvLelG1jfei1TZ0GD7X3DLSg=
-go.temporal.io/sdk v1.14.1-0.20220422211740-4e64c51b6b07 h1:Rwj1peek7MuUBDS7dg/WloHgPnIuks5hgkUxaoSAkXQ=
-go.temporal.io/sdk v1.14.1-0.20220422211740-4e64c51b6b07/go.mod h1:1LB9EZ73++tB3zrcQY7tZVxc+L7IShsxED+gnPKb2X0=
+go.temporal.io/sdk v1.14.1-0.20220429221638-3a2b86ebed54 h1:2h9Fyc7rdARX4+3sZnup/qz6kZKW2GXF06mxYJ3PSMY=
+go.temporal.io/sdk v1.14.1-0.20220429221638-3a2b86ebed54/go.mod h1:6GXFBXb11hWtZbpHdYz7JkEWqPhjX8kMYzE4M0Vpua0=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -567,7 +566,6 @@ golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220421235706-1d1ef9303861/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4 h1:HVyaeDAYux4pnY+D/SiwmLOR36ewZ4iGQIIrtnuCjFA=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -670,7 +668,6 @@ golang.org/x/sys v0.0.0-20220128215802-99c3d69c2c27/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220328115105-d36c6a25d886/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220422013727-9388b58f7150/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3 h1:kBsBifDikLCf5sUMbcD8p73OinDtAQWQp8+n7FiyzlA=
 golang.org/x/sys v0.0.0-20220429121018-84afa8d3f7b3/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -874,7 +871,6 @@ google.golang.org/genproto v0.0.0-20220310185008-1973136f34c6/go.mod h1:kGP+zUP2
 google.golang.org/genproto v0.0.0-20220324131243-acbaeb5b85eb/go.mod h1:hAL49I2IFola2sVEjAn7MEwsja0xp51I0tlGAf9hz4E=
 google.golang.org/genproto v0.0.0-20220405205423-9d709892a2bf/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220407144326-9054f6ed7bac/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
-google.golang.org/genproto v0.0.0-20220422154200-b37d22cd5731/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e h1:gMjH4zLGs9m+dGzR7qHCHaXMOwsJHJKKkHtyXhtOrJk=
 google.golang.org/genproto v0.0.0-20220429170224-98d788798c3e/go.mod h1:8w6bsBMX6yCPbAVTeqQHvzxW0EIFigd5lZyahWgyfDo=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -215,7 +215,7 @@ func (s *integrationSuite) isMutableStateDeleted(namespaceID string, execution *
 
 	for i := 0; i < retryLimit; i++ {
 		_, err := s.testCluster.testBase.ExecutionManager.GetWorkflowExecution(NewContext(), request)
-		if _, ok := err.(*serviceerror.NotFound); ok {
+		if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 			return true
 		}
 		time.Sleep(retryBackoffTime)

--- a/host/workflow_task_test.go
+++ b/host/workflow_task_test.go
@@ -104,7 +104,7 @@ func (s *integrationSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
 			ReturnNewWorkflowTask:      true,
 			ForceCreateNewWorkflowTask: true,
 		})
-		if _, ok := err2.(*serviceerror.NotFound); ok {
+		if _, isNotFound := err2.(*serviceerror.NotFound); isNotFound {
 			hbTimeout++
 			s.IsType(&workflowservice.RespondWorkflowTaskCompletedResponse{}, resp2)
 

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -385,7 +385,7 @@ func (adh *AdminHandler) getSearchAttributes(ctx context.Context, indexName stri
 	var wfInfo *workflowpb.WorkflowExecutionInfo
 	if err != nil {
 		// NotFound can happen when no search attributes were added and the workflow has never been executed.
-		if _, notFound := err.(*serviceerror.NotFound); !notFound {
+		if _, isNotFound := err.(*serviceerror.NotFound); !isNotFound {
 			lastErr = serviceerror.NewUnavailable(fmt.Sprintf("unable to get %s workflow state: %v", addsearchattributes.WorkflowName, err))
 			adh.logger.Error("getSearchAttributes error", tag.Error(lastErr))
 		}
@@ -753,7 +753,7 @@ func (adh *AdminHandler) GetWorkflowExecutionRawHistoryV2(ctx context.Context, r
 		ShardID:       shardID,
 	})
 	if err != nil {
-		if _, ok := err.(*serviceerror.NotFound); ok {
+		if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 			// when no events can be returned from DB, DB layer will return
 			// EntityNotExistsError, this API shall return empty response
 			return &adminservice.GetWorkflowExecutionRawHistoryV2Response{
@@ -1641,7 +1641,7 @@ func (adh *AdminHandler) error(err error, scope metrics.Scope) error {
 	case *serviceerror.ResourceExhausted:
 		scope.Tagged(metrics.ResourceExhaustedCauseTag(err.Cause)).IncCounter(metrics.ServiceErrResourceExhaustedCounter)
 		return err
-	case *serviceerror.NotFound:
+	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		return err
 	}
 

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -392,7 +392,7 @@ func (h *OperatorHandlerImpl) error(err error, scope metrics.Scope, endpointName
 		scope.IncCounter(metrics.ServiceErrInvalidArgumentCounter)
 	case *serviceerror.ResourceExhausted:
 		scope.Tagged(metrics.ResourceExhaustedCauseTag(err.Cause)).IncCounter(metrics.ServiceErrResourceExhaustedCounter)
-	case *serviceerror.NotFound:
+	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 	default:
 		h.logger.Error("Unknown error.", tag.Error(err), tag.Endpoint(endpointName))
 		scope.IncCounter(metrics.ServiceFailures)

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -312,7 +312,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_NamespaceNotSet
 	config.RPS = dc.GetIntPropertyFn(10)
 	wh := s.getWorkflowHandler(config)
 
-	s.mockNamespaceCache.EXPECT().GetNamespaceID(namespace.EmptyName).Return(namespace.EmptyID, serviceerror.NewNotFound("not found")).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(namespace.EmptyName).Return(namespace.EmptyID, serviceerror.NewNamespaceNotFound("missing-namespace")).AnyTimes()
 
 	startWorkflowExecutionRequest := &workflowservice.StartWorkflowExecutionRequest{
 		// Namespace: "forget to specify",
@@ -336,7 +336,7 @@ func (s *workflowHandlerSuite) TestStartWorkflowExecution_Failed_NamespaceNotSet
 	}
 	_, err := wh.StartWorkflowExecution(context.Background(), startWorkflowExecutionRequest)
 	s.Error(err)
-	var notFound *serviceerror.NotFound
+	var notFound *serviceerror.NamespaceNotFound
 	s.ErrorAs(err, &notFound)
 }
 
@@ -567,7 +567,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Failure_InvalidArchivalURI(
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false)
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "random URI"))
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockHistoryArchiver.EXPECT().ValidateURI(gomock.Any()).Return(nil)
 	s.mockVisibilityArchiver.EXPECT().ValidateURI(gomock.Any()).Return(errors.New("invalid URI"))
 	s.mockArchiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.mockHistoryArchiver, nil)
@@ -591,7 +591,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithNoArchiv
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", testHistoryArchivalURI))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", testVisibilityArchivalURI))
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
@@ -613,7 +613,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_EnabledWithArchival
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "invalidURI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "invalidURI"))
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
@@ -640,7 +640,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_ClusterNotConfigure
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewDisabledArchvialConfig())
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewDisabledArchvialConfig())
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
@@ -663,7 +663,7 @@ func (s *workflowHandlerSuite) TestRegisterNamespace_Success_NotEnabled() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI"))
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
@@ -681,7 +681,7 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Success() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
@@ -729,7 +729,7 @@ func (s *workflowHandlerSuite) TestDeprecateNamespace_Error() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
@@ -777,7 +777,7 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Success() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)
@@ -825,7 +825,7 @@ func (s *workflowHandlerSuite) TestDeleteNamespace_Error() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockArchivalMetadata.EXPECT().GetHistoryConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("enabled"), dc.GetBoolPropertyFn(true), "disabled", "some random URI")).Times(2)
-	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
+	s.mockMetadataMgr.EXPECT().GetNamespace(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	s.mockMetadataMgr.EXPECT().CreateNamespace(gomock.Any(), gomock.Any()).Return(&persistence.CreateNamespaceResponse{
 		ID: testNamespaceID,
 	}, nil)

--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -207,7 +207,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowContextValidatedByCheck(
 			return nil, err
 		}
 		return NewWorkflowContext(wfContext, release, mutableState), nil
-	case *serviceerror.NotFound:
+	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		release(err)
 		if err := assertShardOwnership(
 			ctx,

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -783,7 +783,7 @@ func (s *engine2Suite) TestRequestCancelWorkflowExecution_NotFound() {
 		RunId:      tests.RunID,
 	}
 
-	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, &serviceerror.NotFound{})
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound(""))
 
 	err := s.historyEngine.RequestCancelWorkflowExecution(metrics.AddMetricsContext(context.Background()), &historyservice.RequestCancelWorkflowExecutionRequest{
 		NamespaceId: namespaceID.String(),

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -273,7 +273,7 @@ func (s *engineSuite) TestGetMutableState_EmptyRunID() {
 		NamespaceId: tests.NamespaceID.String(),
 		Execution:   &execution,
 	})
-	s.Equal(&serviceerror.NotFound{}, err)
+	s.IsType(&serviceerror.NotFound{}, err)
 }
 
 func (s *engineSuite) TestGetMutableStateLongPoll() {

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -32,6 +32,7 @@ import (
 	time "time"
 
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common"
 	backoff "go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
@@ -180,7 +181,12 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 		return nil
 	}
 
-	if _, ok := err.(*serviceerror.NotFound); ok {
+	if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
+		return nil
+	}
+
+	// This means that namespace is deleted, and it is safe to drop the task (=ignore the error).
+	if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
 		return nil
 	}
 

--- a/service/history/replicationTaskProcessor.go
+++ b/service/history/replicationTaskProcessor.go
@@ -542,7 +542,7 @@ func (p *ReplicationTaskProcessorImpl) emitTaskMetrics(scope int, err error) {
 	case *serviceerror.WorkflowExecutionAlreadyStarted:
 		metricsScope.IncCounter(metrics.ServiceErrExecutionAlreadyStartedCounter)
 		metricsScope.IncCounter(metrics.ReplicationTasksFailed)
-	case *serviceerror.NotFound:
+	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		metricsScope.IncCounter(metrics.ServiceErrNotFoundCounter)
 		metricsScope.IncCounter(metrics.ReplicationTasksFailed)
 	case *serviceerror.ResourceExhausted:

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -951,7 +951,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	namespaceEntry, err := s.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(key.NamespaceID))
 	deleteVisibilityRecord := true
 	if err != nil {
-		if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
+		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
 			// If namespace is not found, skip visibility record delete but proceed with other deletions.
 			// This case might happen during namespace deletion.
 			deleteVisibilityRecord = false

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -30,6 +30,7 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -199,7 +199,7 @@ func (s *transferQueueActiveTaskExecutorSuite) SetupTest() {
 	s.mockNamespaceCache.EXPECT().GetNamespace(tests.ParentNamespace).Return(tests.GlobalParentNamespaceEntry, nil).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.ChildNamespaceID).Return(tests.GlobalChildNamespaceEntry, nil).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespace(tests.ChildNamespace).Return(tests.GlobalChildNamespaceEntry, nil).AnyTimes()
-	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.MissedNamespaceID).Return(nil, serviceerror.NewNotFound("namespace is not found")).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.MissedNamespaceID).Return(nil, serviceerror.NewNamespaceNotFound(tests.MissedNamespaceID.String())).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
@@ -1233,7 +1233,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_NoParen
 	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockArchivalMetadata.EXPECT().GetVisibilityConfig().Return(archiver.NewDisabledArchvialConfig())
 
-	s.mockNamespaceCache.EXPECT().GetNamespaceID(namespace.Name("child namespace1")).Return(namespace.EmptyID, serviceerror.NewNotFound("namespace not found")).AnyTimes()
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(namespace.Name("child namespace1")).Return(namespace.EmptyID, serviceerror.NewNamespaceNotFound("missing-namespace")).AnyTimes()
 
 	err = s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.NoError(err)

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -114,7 +114,7 @@ func (t *transferQueueTaskExecutorBase) pushActivity(
 		ScheduleToStartTimeout: activityScheduleToStartTimeout,
 		Clock:                  vclock.NewShardClock(t.shard.GetShardID(), task.TaskID),
 	})
-	if _, ok := err.(*serviceerror.NotFound); ok {
+	if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 		// NotFound error is not expected for AddTasks calls
 		// but will be ignored by task error handling logic, so log it here
 		tasks.InitializeLogger(task, t.logger).Error("Matching returned not found error for AddActivityTask", tag.Error(err))
@@ -140,7 +140,7 @@ func (t *transferQueueTaskExecutorBase) pushWorkflowTask(
 		ScheduleToStartTimeout: workflowTaskScheduleToStartTimeout,
 		Clock:                  vclock.NewShardClock(t.shard.GetShardID(), task.TaskID),
 	})
-	if _, ok := err.(*serviceerror.NotFound); ok {
+	if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 		// NotFound error is not expected for AddTasks calls
 		// but will be ignored by task error handling logic, so log it here
 		tasks.InitializeLogger(task, t.logger).Error("Matching returned not found error for AddWorkflowTask", tag.Error(err))

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -171,7 +171,7 @@ func (r *TaskGeneratorImpl) GenerateWorkflowCloseTasks(
 	switch err.(type) {
 	case nil:
 		retention = namespaceEntry.Retention()
-	case *serviceerror.NotFound:
+	case *serviceerror.NamespaceNotFound:
 		// namespace is not accessible, use default value above
 	default:
 		return err

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -801,7 +801,8 @@ func operationPossiblySucceeded(err error) bool {
 		*persistence.InvalidPersistenceRequestError,
 		*persistence.TransactionSizeLimitError,
 		*serviceerror.ResourceExhausted,
-		*serviceerror.NotFound:
+		*serviceerror.NotFound,
+		*serviceerror.NamespaceNotFound:
 		// Persistence failure that means that write was definitely not committed.
 		return false
 	default:

--- a/service/history/workflow/transaction_test.go
+++ b/service/history/workflow/transaction_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/api/serviceerror"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
@@ -97,6 +98,7 @@ func (s *transactionSuite) TestOperationMayApplied() {
 		{err: &persistence.TransactionSizeLimitError{}, mayApplied: false},
 		{err: &serviceerror.ResourceExhausted{}, mayApplied: false},
 		{err: &serviceerror.NotFound{}, mayApplied: false},
+		{err: &serviceerror.NamespaceNotFound{}, mayApplied: false},
 		{err: nil, mayApplied: true},
 		{err: &persistence.TimeoutError{}, mayApplied: true},
 		{err: &serviceerror.Unavailable{}, mayApplied: true},

--- a/service/history/workflowRebuilder.go
+++ b/service/history/workflowRebuilder.go
@@ -195,7 +195,7 @@ func (r *workflowRebuilderImpl) getMutableState(
 		WorkflowID:  workflowKey.WorkflowID,
 		RunID:       workflowKey.RunID,
 	})
-	if _, ok := err.(*serviceerror.NotFound); ok {
+	if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 		return nil, 0, err
 	}
 	// only check whether the execution is nil, do as much as we can

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -888,7 +888,7 @@ func (e *matchingEngineImpl) recordWorkflowTaskStarted(
 	}
 	err := backoff.Retry(op, historyServiceOperationRetryPolicy, func(err error) bool {
 		switch err.(type) {
-		case *serviceerror.NotFound, *serviceerrors.TaskAlreadyStarted:
+		case *serviceerror.NotFound, *serviceerror.NamespaceNotFound, *serviceerrors.TaskAlreadyStarted:
 			return false
 		}
 		return true
@@ -918,7 +918,7 @@ func (e *matchingEngineImpl) recordActivityTaskStarted(
 	}
 	err := backoff.Retry(op, historyServiceOperationRetryPolicy, func(err error) bool {
 		switch err.(type) {
-		case *serviceerror.NotFound, *serviceerrors.TaskAlreadyStarted:
+		case *serviceerror.NotFound, *serviceerror.NamespaceNotFound, *serviceerrors.TaskAlreadyStarted:
 			return false
 		}
 		return true

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -403,7 +403,7 @@ func processTask(
 		err = procFn(wf.GetWorkflowId(), wf.GetRunId())
 		if err != nil {
 			// NotFound means wf is not running or deleted
-			if _, ok := err.(*serviceerror.NotFound); !ok {
+			if _, isNotFound := err.(*serviceerror.NotFound); !isNotFound {
 				return err
 			}
 		}
@@ -411,7 +411,7 @@ func processTask(
 		resp, err := sdkClient.DescribeWorkflowExecution(ctx, wf.GetWorkflowId(), wf.GetRunId())
 		if err != nil {
 			// NotFound means wf is deleted
-			if _, ok := err.(*serviceerror.NotFound); !ok {
+			if _, isNotFound := err.(*serviceerror.NotFound); !isNotFound {
 				return err
 			}
 			continue

--- a/service/worker/deletenamespace/activities.go
+++ b/service/worker/deletenamespace/activities.go
@@ -142,7 +142,7 @@ func (a *activities) GenerateDeletedNamespaceNameActivity(ctx context.Context, n
 		switch err.(type) {
 		case nil:
 			a.logger.Warn("Regenerate namespace name due to collision.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowNamespace(newName))
-		case *serviceerror.NotFound:
+		case *serviceerror.NamespaceNotFound:
 			a.logger.Info("Generated new name for deleted namespace.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowNamespace(newName))
 			return namespace.Name(newName), nil
 		default:

--- a/service/worker/migration/workflow.go
+++ b/service/worker/migration/workflow.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/sdk/activity"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
+
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
@@ -574,7 +575,7 @@ func (a *activities) generateWorkflowReplicationTask(ctx context.Context, wKey d
 
 	err := backoff.RetryContext(ctx, op, historyServiceRetryPolicy, common.IsServiceTransientError)
 	if err != nil {
-		if _, ok := err.(*serviceerror.NotFound); ok {
+		if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 			// ignore NotFound error
 			return nil
 		}

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -135,7 +135,7 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 		var err error
 		switch execution.Policy {
 		case enumspb.PARENT_CLOSE_POLICY_ABANDON:
-			//no-op
+			// no-op
 			continue
 		case enumspb.PARENT_CLOSE_POLICY_TERMINATE:
 			_, err = client.TerminateWorkflowExecution(ctx, &historyservice.TerminateWorkflowExecutionRequest{
@@ -171,7 +171,7 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 		switch typedErr := err.(type) {
 		case nil:
 			processor.metricsClient.IncCounter(metrics.ParentClosePolicyProcessorScope, metrics.ParentClosePolicyProcessorSuccess)
-		case *serviceerror.NotFound:
+		case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 			// no-op
 		case *serviceerror.NamespaceNotActive:
 			remoteExecutions[typedErr.ActiveCluster] = append(remoteExecutions[typedErr.ActiveCluster], execution)

--- a/service/worker/parentclosepolicy/workflow_test.go
+++ b/service/worker/parentclosepolicy/workflow_test.go
@@ -135,7 +135,7 @@ func (s *parentClosePolicyWorkflowSuite) TestProcessorActivity_SameCluster() {
 	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).
 		Return(&historyservice.TerminateWorkflowExecutionResponse{}, nil).Times(1)
 	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).
-		Return(nil, &serviceerror.NotFound{}).Times(1)
+		Return(nil, serviceerror.NewNotFound("")).Times(1)
 
 	_, err := env.ExecuteActivity(ProcessorActivity, request)
 	s.NoError(err)

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -497,7 +497,7 @@ func (s *Service) ensureSystemNamespaceExists(
 	switch err.(type) {
 	case nil:
 		// noop
-	case *serviceerror.NotFound:
+	case *serviceerror.NamespaceNotFound:
 		s.logger.Fatal(
 			"temporal-system namespace does not exist",
 			tag.Error(err),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `NamespaceInvalidState` and `NamespaceNotFound` errors.

<!-- Tell your future self why have you made these changes -->
**Why?**
* `NamespaceInvalidState` uses proper `codes.FailedPrecondition` gRPC error code and returned when namespace is in invalid state.
* `NamespaceNotFound` is used instead of generic `NotFound` error. Many APIs can return `NotFound` because of actual object (workflow execution or task queue) is not found or namespace is not found. Sometimes callers needs to differentiate what is not found and react properly. This change will enable it.

https://github.com/temporalio/api/pull/179
https://github.com/temporalio/api-go/pull/92
https://github.com/temporalio/sdk-go/pull/799
https://github.com/temporalio/tctl/pull/189

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
* `NamespaceInvalidState` is now returned instead of `InvalidArgument` error. It uses `codes.FailedPrecondition` instead of `codes.InvalidArgument`. There should be no client side logic relying on this error, because it is used for deleted namespace only which is not released yet.
* `NamespaceNotFound` is now returned when namespace is not found instead of `NotFound`. It may happen when namespace is deleted or user specified wrong namespace name. If there is a client side logic that relies on this, it needs to be updated to handle `NamespaceNotFound` instead of `NotFound`.
* `tctl` prints different error message based on `NotFound` error. This is small "breaking change" for `tctl`: old versions of `tctl` when connecting to the new server and specifying wrong namespace name will print generic error message "Operation DescribeNamespace failed." instead of more specific "Namespace %s does not exist.".

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.