### PR TITLE
Remove task version and visibility timestamp override

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -3744,8 +3744,6 @@ func (e *MutableStateImpl) CloseTransactionAsMutation(
 		}
 	}
 
-	setTaskInfo(e.GetCurrentVersion(), now, e.InsertTasks)
-
 	// update last update time
 	e.executionInfo.LastUpdateTime = &now
 	e.executionInfo.StateTransitionCount += 1
@@ -3829,8 +3827,6 @@ func (e *MutableStateImpl) CloseTransactionAsSnapshot(
 			return nil, nil, err
 		}
 	}
-
-	setTaskInfo(e.GetCurrentVersion(), now, e.InsertTasks)
 
 	// update last update time
 	e.executionInfo.LastUpdateTime = &now

--- a/service/history/workflow/mutable_state_util.go
+++ b/service/history/workflow/mutable_state_util.go
@@ -55,27 +55,3 @@ func convertSyncActivityInfos(
 	}
 	return outputs
 }
-
-// TODO: can we deprecate this method and
-// let task generator correctly set task version and
-// visibility timestamp?
-func setTaskInfo(
-	version int64,
-	timestamp time.Time,
-	insertTasks map[tasks.Category][]tasks.Task,
-) {
-	// set the task version,
-	// as well as the Timestamp if not scheduled task
-	for category, tasksByCategory := range insertTasks {
-		if category == tasks.CategoryReplication {
-			continue
-		}
-
-		for _, task := range tasksByCategory {
-			task.SetVersion(version)
-			if category.Type() == tasks.CategoryTypeImmediate {
-				task.SetVisibilityTime(timestamp)
-			}
-		}
-	}
-}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Remove `setTaskInfo` which overrides task version and visibility timestamp for immediate tasks

<!-- Tell your future self why have you made these changes -->
**Why?**
- All tasks, when created already specified the desired version and visibility timestamp, no need to override
- The overriding version is always namespace current version which may not be the right version for the task. and may cause the task to be dropped.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested in test cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Maybe.