### PR TITLE
Fix flaky TestClusterMembershipReadFiltersCorrectly

### DIFF
--- a/common/persistence/persistence-tests/clusterMetadataManagerTest.go
+++ b/common/persistence/persistence-tests/clusterMetadataManagerTest.go
@@ -176,7 +176,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipReadFiltersCorrectly(
 		RPCPort:      123,
 		Role:         p.Frontend,
 		SessionStart: now,
-		RecordExpiry: time.Second * 2,
+		RecordExpiry: time.Second * 5,
 	}
 
 	err := s.ClusterMetadataManager.UpsertClusterMembership(s.ctx, req)

--- a/common/persistence/persistence-tests/clusterMetadataManagerTest.go
+++ b/common/persistence/persistence-tests/clusterMetadataManagerTest.go
@@ -176,7 +176,7 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipReadFiltersCorrectly(
 		RPCPort:      123,
 		Role:         p.Frontend,
 		SessionStart: now,
-		RecordExpiry: time.Second * 5,
+		RecordExpiry: time.Second * 4,
 	}
 
 	err := s.ClusterMetadataManager.UpsertClusterMembership(s.ctx, req)
@@ -224,6 +224,9 @@ func (s *ClusterMetadataManagerSuite) TestClusterMembershipReadFiltersCorrectly(
 
 	s.validateUpsert(req, resp, err)
 
+	time.Sleep(time.Second * 3)
+	err = s.ClusterMetadataManager.PruneClusterMembership(s.ctx, &p.PruneClusterMembershipRequest{MaxRecordsPruned: 1000})
+	s.NoError(err)
 }
 
 // TestClusterMembershipUpsertExpiresCorrectly verifies RecordExpiry functions properly for ClusterMembership records


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Increase record expiry time in TestClusterMembershipReadFiltersCorrectly

<!-- Tell your future self why have you made these changes -->
**Why?**
- This test is flaky: https://buildkite.com/temporal/temporal-public/builds/3519#ff1160da-f066-439e-9891-9ae72a3c77ec/594-599

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- no