### PR TITLE
Ensure queue processor cluster ack level is below failover ack level

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -424,9 +424,11 @@ func (s *ContextImpl) UpdateQueueClusterAckLevel(
 	s.wLock()
 	defer s.wUnlock()
 
-	for _, failoverLevel := range s.GetAllFailoverLevels(category) {
-		if ackLevel.CompareTo(failoverLevel.CurrentLevel) > 0 {
-			ackLevel = failoverLevel.CurrentLevel
+	if levels, ok := s.shardInfo.FailoverLevels[category]; ok {
+		for _, failoverLevel := range levels {
+			if ackLevel.CompareTo(failoverLevel.CurrentLevel) > 0 {
+				ackLevel = failoverLevel.CurrentLevel
+			}
 		}
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Ensure queue processor cluster ack level is below failover ack (current) level

<!-- Tell your future self why have you made these changes -->
**Why?**
- Handle task lost issue during failover when shard movement happens before failover queue tasks are processed but after persisting new active/standby queue ack level update. Task may lost because upon shard reload, the range for the new failover queue is calculated based on the updated active/standby queue ack level.
- Verified that when deleting tasks, the failover queue's level is taken into consideration.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- eyeballing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- if failover level is never deleted, then active/standby queue processor's ack level will be stuck.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- maybe