### PR TITLE
Remove unused method from MutableState

### DIFF
--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -236,7 +236,6 @@ type (
 		UpdateActivity(*persistencespb.ActivityInfo) error
 		UpdateActivityWithTimerHeartbeat(*persistencespb.ActivityInfo, time.Time) error
 		UpdateActivityProgress(ai *persistencespb.ActivityInfo, request *workflowservice.RecordActivityTaskHeartbeatRequest)
-		UpdateWorkflowTask(*WorkflowTaskInfo)
 		UpdateUserTimer(*persistencespb.TimerInfo) error
 		UpdateCurrentVersion(version int64, forceUpdate bool) error
 		UpdateWorkflowStateStatus(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) error

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1259,13 +1259,6 @@ func (e *MutableStateImpl) HasBufferedEvents() bool {
 	return e.hBuilder.HasBufferEvents()
 }
 
-// UpdateWorkflowTask updates a workflow task.
-func (e *MutableStateImpl) UpdateWorkflowTask(
-	workflowTask *WorkflowTaskInfo,
-) {
-	e.workflowTaskManager.UpdateWorkflowTask(workflowTask)
-}
-
 // DeleteWorkflowTask deletes a workflow task.
 func (e *MutableStateImpl) DeleteWorkflowTask() {
 	e.workflowTaskManager.DeleteWorkflowTask()

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -2403,15 +2403,3 @@ func (mr *MockMutableStateMockRecorder) UpdateWorkflowStateStatus(state, status 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowStateStatus", reflect.TypeOf((*MockMutableState)(nil).UpdateWorkflowStateStatus), state, status)
 }
-
-// UpdateWorkflowTask mocks base method.
-func (m *MockMutableState) UpdateWorkflowTask(arg0 *WorkflowTaskInfo) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateWorkflowTask", arg0)
-}
-
-// UpdateWorkflowTask indicates an expected call of UpdateWorkflowTask.
-func (mr *MockMutableStateMockRecorder) UpdateWorkflowTask(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).UpdateWorkflowTask), arg0)
-}


### PR DESCRIPTION
**What changed?**
`UpdateWorkflowTask` isn't called on `MutableState`, it's only used within `workflowTaskStateMachine`

**Why?**
less code

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit + integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
