### PR TITLE
Return NamespaceNotFound error from RespondWorkflowTaskCompleted handler

### DIFF
--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -639,7 +639,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandRequestCancelExternalWorkfl
 	if attr.GetNamespace() != "" {
 		targetNamespaceEntry, err := handler.namespaceRegistry.GetNamespace(namespace.Name(attr.GetNamespace()))
 		if err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to cancel workflow across namespace: %v.", attr.GetNamespace()))
+			return err
 		}
 		targetNamespaceID = targetNamespaceEntry.ID()
 	}
@@ -816,7 +816,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 	if attr.GetNamespace() != "" {
 		targetNamespaceEntry, err := handler.namespaceRegistry.GetNamespace(namespace.Name(attr.GetNamespace()))
 		if err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to schedule child execution across namespace %v.", attr.GetNamespace()))
+			return err
 		}
 		targetNamespace = targetNamespaceEntry.Name()
 		targetNamespaceID = targetNamespaceEntry.ID()
@@ -911,7 +911,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandSignalExternalWorkflow(
 	if attr.GetNamespace() != "" {
 		targetNamespaceEntry, err := handler.namespaceRegistry.GetNamespace(namespace.Name(attr.GetNamespace()))
 		if err != nil {
-			return serviceerror.NewUnavailable(fmt.Sprintf("Unable to signal workflow across namespace: %v.", attr.GetNamespace()))
+			return err
 		}
 		targetNamespaceID = targetNamespaceEntry.ID()
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Return `NamespaceNotFound` error from `RespondWorkflowTaskCompleted` handler.

<!-- Tell your future self why have you made these changes -->
**Why?**
There are few places where `NamespaceNotFound` can be returned from namespace registry. Previously it was substituted with `Unavailable` error and it introduces inconsistency. Original error should be returned to the caller instead.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.