### PR TITLE
Remove obsolete nil CloseTime check

### DIFF
--- a/common/persistence/visibility/store/standard/cassandra/visibility_store.go
+++ b/common/persistence/visibility/store/standard/cassandra/visibility_store.go
@@ -471,7 +471,7 @@ func (v *visibilityStore) DeleteWorkflowExecution(
 			request.RunID,
 		).WithContext(ctx)
 	} else {
-		panic("both StartTime and CloseTime are nil")
+		panic("Cassandra visibility store: DeleteWorkflowExecution: both StartTime and CloseTime are nil")
 	}
 
 	if err := query.Consistency(v.lowConslevel).Exec(); err != nil {

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -422,12 +422,6 @@ func (t *visibilityQueueTaskExecutor) processDeleteExecution(
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 
-	if task.CloseTime == nil {
-		// CloseTime is not set for workflow executions with TTL (old version).
-		// They will be deleted using Cassandra TTL and this task should be ignored.
-		return nil
-	}
-
 	request := &manager.VisibilityDeleteWorkflowExecutionRequest{
 		NamespaceID: namespace.ID(task.NamespaceID),
 		WorkflowID:  task.WorkflowID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove obsolete `nil` `CloseTime` check.

<!-- Tell your future self why have you made these changes -->
**Why?**
`DeleteExecutionVisibilityTask` can be created with empty `CloseTime` and it means that visibility records needs to be deleted for open workflow execution. It is valid case and it can happen in replication stack. Obsolete case with Cassandra TTL is not valid anymore because visibility tasks are short lived and TTL was removed few releases ago.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Current tests and integration tests in upcoming PR.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.