### PR TITLE
Fix error handling in processParentClosePolicy

### DIFF
--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -39,8 +39,6 @@ import (
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
 
-	serviceerrors "go.temporal.io/server/common/serviceerror"
-
 	clockpb "go.temporal.io/server/api/clock/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
@@ -56,6 +54,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/sdk"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/queues"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix error handling in `processParentClosePolicy`.

<!-- Tell your future self why have you made these changes -->
**Why?**
1. There was a bug from previous PR which logs `NotFound` error and ignores all other but should do the opposite.
2. RPC calls can also return `NamespaceNotFound` error and the check was moved to higher level to cover this.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Exixting tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.