### PR TITLE
Fix potential deadlock in shard addTask

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -892,16 +892,6 @@ func (s *ContextImpl) addTasksLocked(
 	request.RangeID = s.getRangeIDLocked()
 	err := s.executionManager.AddHistoryTasks(ctx, request)
 	return s.handleWriteErrorAndUpdateMaxReadLevelLocked(err, transferMaxReadLevel)
-
-	// if err = s.handleWriteErrorAndUpdateMaxReadLevelLocked(err, transferMaxReadLevel); err != nil {
-	// 	return err
-	// }
-	// engine, err := s.GetEngineWithContext(ctx)
-	// if err != nil {
-	// 	return err
-	// }
-	// engine.NotifyNewTasks(namespaceEntry.ActiveClusterName(), request.Tasks)
-	// return nil
 }
 
 func (s *ContextImpl) AppendHistoryEvents(

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -57,6 +57,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/vclock"
@@ -616,14 +617,25 @@ func (s *ContextImpl) AddTasks(
 		return err
 	}
 
-	s.wLock()
-	defer s.wUnlock()
-
-	if err := s.errorByStateLocked(); err != nil {
+	engine, err := s.GetEngineWithContext(ctx)
+	if err != nil {
 		return err
 	}
 
-	return s.addTasksLocked(ctx, request, namespaceEntry)
+	s.wLock()
+	if err := s.errorByStateLocked(); err != nil {
+		s.wUnlock()
+		return err
+	}
+
+	err = s.addTasksLocked(ctx, request, namespaceEntry)
+	s.wUnlock()
+
+	if OperationPossiblySucceeded(err) {
+		engine.NotifyNewTasks(namespaceEntry.ActiveClusterName(), request.Tasks)
+	}
+
+	return err
 }
 
 func (s *ContextImpl) CreateWorkflowExecution(
@@ -879,15 +891,17 @@ func (s *ContextImpl) addTasksLocked(
 
 	request.RangeID = s.getRangeIDLocked()
 	err := s.executionManager.AddHistoryTasks(ctx, request)
-	if err = s.handleWriteErrorAndUpdateMaxReadLevelLocked(err, transferMaxReadLevel); err != nil {
-		return err
-	}
-	engine, err := s.GetEngineWithContext(ctx)
-	if err != nil {
-		return err
-	}
-	engine.NotifyNewTasks(namespaceEntry.ActiveClusterName(), request.Tasks)
-	return nil
+	return s.handleWriteErrorAndUpdateMaxReadLevelLocked(err, transferMaxReadLevel)
+
+	// if err = s.handleWriteErrorAndUpdateMaxReadLevelLocked(err, transferMaxReadLevel); err != nil {
+	// 	return err
+	// }
+	// engine, err := s.GetEngineWithContext(ctx)
+	// if err != nil {
+	// 	return err
+	// }
+	// engine.NotifyNewTasks(namespaceEntry.ActiveClusterName(), request.Tasks)
+	// return nil
 }
 
 func (s *ContextImpl) AppendHistoryEvents(
@@ -935,7 +949,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	newTaskVersion int64,
 	startTime *time.Time,
 	closeTime *time.Time,
-) error {
+) (retErr error) {
 	// DeleteWorkflowExecution is a 4-steps process (order is very important and should not be changed):
 	// 1. Add visibility delete task, i.e. schedule visibility record delete,
 	// 2. Delete current workflow execution pointer,
@@ -957,6 +971,11 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	}
 	defer cancel()
 
+	engine, err := s.GetEngineWithContext(ctx)
+	if err != nil {
+		return err
+	}
+
 	// Do not get namespace cache within shard lock.
 	namespaceEntry, err := s.GetNamespaceRegistry().GetNamespaceByID(namespace.ID(key.NamespaceID))
 	deleteVisibilityRecord := true
@@ -970,6 +989,13 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 		}
 	}
 
+	var newTasks map[tasks.Category][]tasks.Task
+	defer func() {
+		if OperationPossiblySucceeded(retErr) && newTasks != nil {
+			engine.NotifyNewTasks(namespaceEntry.ActiveClusterName(), newTasks)
+		}
+	}()
+
 	s.wLock()
 	defer s.wUnlock()
 
@@ -979,24 +1005,26 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 
 	// Step 1. Delete visibility.
 	if deleteVisibilityRecord {
+		// TODO: move to existing task generator logic
+		newTasks := map[tasks.Category][]tasks.Task{
+			tasks.CategoryVisibility: {
+				&tasks.DeleteExecutionVisibilityTask{
+					// TaskID is set by addTasksLocked
+					WorkflowKey:         key,
+					VisibilityTimestamp: s.timeSource.Now(),
+					Version:             newTaskVersion,
+					StartTime:           startTime,
+					CloseTime:           closeTime,
+				},
+			},
+		}
 		addTasksRequest := &persistence.AddHistoryTasksRequest{
 			ShardID:     s.shardID,
 			NamespaceID: key.NamespaceID,
 			WorkflowID:  key.WorkflowID,
 			RunID:       key.RunID,
 
-			Tasks: map[tasks.Category][]tasks.Task{
-				tasks.CategoryVisibility: {
-					&tasks.DeleteExecutionVisibilityTask{
-						// TaskID is set by addTasksLocked
-						WorkflowKey:         key,
-						VisibilityTimestamp: s.timeSource.Now(),
-						Version:             newTaskVersion,
-						StartTime:           startTime,
-						CloseTime:           closeTime,
-					},
-				},
-			},
+			Tasks: newTasks,
 		}
 		err = s.addTasksLocked(ctx, addTasksRequest, namespaceEntry)
 		if err != nil {
@@ -1999,6 +2027,28 @@ func (s *ContextImpl) ensureMinContextTimeout(
 
 	newContext, cancel := context.WithTimeout(context.Background(), minContextTimeout)
 	return newContext, cancel, nil
+}
+
+func OperationPossiblySucceeded(err error) bool {
+	if err == consts.ErrConflict {
+		return false
+	}
+
+	switch err.(type) {
+	case *persistence.CurrentWorkflowConditionFailedError,
+		*persistence.WorkflowConditionFailedError,
+		*persistence.ConditionFailedError,
+		*persistence.ShardOwnershipLostError,
+		*persistence.InvalidPersistenceRequestError,
+		*persistence.TransactionSizeLimitError,
+		*serviceerror.ResourceExhausted,
+		*serviceerror.NotFound,
+		*serviceerror.NamespaceNotFound:
+		// Persistence failure that means that write was definitely not committed.
+		return false
+	default:
+		return true
+	}
 }
 
 func convertAckLevelToTaskKey(

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -632,6 +632,7 @@ func (s *ContextImpl) AddTasks(
 	s.wUnlock()
 
 	if OperationPossiblySucceeded(err) {
+		fmt.Println("add task notify")
 		engine.NotifyNewTasks(namespaceEntry.ActiveClusterName(), request.Tasks)
 	}
 
@@ -996,7 +997,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	// Step 1. Delete visibility.
 	if deleteVisibilityRecord {
 		// TODO: move to existing task generator logic
-		newTasks := map[tasks.Category][]tasks.Task{
+		newTasks = map[tasks.Category][]tasks.Task{
 			tasks.CategoryVisibility: {
 				&tasks.DeleteExecutionVisibilityTask{
 					// TaskID is set by addTasksLocked

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -632,7 +632,6 @@ func (s *ContextImpl) AddTasks(
 	s.wUnlock()
 
 	if OperationPossiblySucceeded(err) {
-		fmt.Println("add task notify")
 		engine.NotifyNewTasks(namespaceEntry.ActiveClusterName(), request.Tasks)
 	}
 

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -41,7 +40,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/tests"
 )
@@ -51,19 +49,15 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		controller   *gomock.Controller
-		shardContext Context
-
-		mockResource *resource.Test
-
-		namespaceID        namespace.ID
-		mockNamespaceCache *namespace.MockRegistry
-		namespaceEntry     *namespace.Namespace
-		timeSource         *clock.EventTimeSource
-
+		controller           *gomock.Controller
+		mockShard            Context
 		mockClusterMetadata  *cluster.MockMetadata
+		mockShardManager     *persistence.MockShardManager
 		mockExecutionManager *persistence.MockExecutionManager
+		mockNamespaceCache   *namespace.MockRegistry
 		mockHistoryEngine    *MockEngine
+
+		timeSource *clock.EventTimeSource
 	}
 )
 
@@ -89,20 +83,19 @@ func (s *contextSuite) SetupTest() {
 		tests.NewDynamicConfig(),
 		s.timeSource,
 	)
-	s.shardContext = shardContext
+	s.mockShard = shardContext
 
-	s.mockResource = shardContext.Resource
-	shardContext.MockHostInfoProvider.EXPECT().HostInfo().Return(s.mockResource.GetHostInfo()).AnyTimes()
+	shardContext.MockHostInfoProvider.EXPECT().HostInfo().Return(shardContext.Resource.GetHostInfo()).AnyTimes()
 
-	s.namespaceID = "namespace-Id"
-	s.namespaceEntry = namespace.NewLocalNamespaceForTest(&persistencespb.NamespaceInfo{Id: s.namespaceID.String()}, &persistencespb.NamespaceConfig{}, "")
-	s.mockNamespaceCache = s.mockResource.NamespaceCache
-	shardContext.namespaceRegistry = s.mockResource.NamespaceCache
+	s.mockNamespaceCache = shardContext.Resource.NamespaceCache
+	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(tests.LocalNamespaceEntry, nil).AnyTimes()
 
-	s.mockClusterMetadata = s.mockResource.ClusterMetadata
-	shardContext.clusterMetadata = s.mockClusterMetadata
+	s.mockClusterMetadata = shardContext.Resource.ClusterMetadata
+	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 
-	s.mockExecutionManager = s.mockResource.ExecutionMgr
+	s.mockExecutionManager = shardContext.Resource.ExecutionMgr
+	s.mockShardManager = shardContext.Resource.ShardMgr
 	s.mockHistoryEngine = NewMockEngine(s.controller)
 	shardContext.engineFuture.Set(s.mockHistoryEngine, nil)
 }
@@ -112,18 +105,6 @@ func (s *contextSuite) TearDownTest() {
 }
 
 func (s *contextSuite) TestAddTasks_Success() {
-	task := &persistencespb.TimerTaskInfo{
-		NamespaceId:     s.namespaceID.String(),
-		WorkflowId:      "workflow-id",
-		RunId:           "run-id",
-		TaskType:        enumsspb.TASK_TYPE_VISIBILITY_DELETE_EXECUTION,
-		Version:         1,
-		EventId:         2,
-		ScheduleAttempt: 1,
-		TaskId:          12345,
-		VisibilityTime:  timestamp.TimeNowPtrUtc(),
-	}
-
 	tasks := map[tasks.Category][]tasks.Task{
 		tasks.CategoryTransfer:    {&tasks.ActivityTask{}},           // Just for testing purpose. In the real code ActivityTask can't be passed to shardContext.AddTasks.
 		tasks.CategoryTimer:       {&tasks.ActivityRetryTimerTask{}}, // Just for testing purpose. In the real code ActivityRetryTimerTask can't be passed to shardContext.AddTasks.
@@ -132,20 +113,18 @@ func (s *contextSuite) TestAddTasks_Success() {
 	}
 
 	addTasksRequest := &persistence.AddHistoryTasksRequest{
-		ShardID:     s.shardContext.GetShardID(),
-		NamespaceID: task.GetNamespaceId(),
-		WorkflowID:  task.GetWorkflowId(),
-		RunID:       task.GetRunId(),
+		ShardID:     s.mockShard.GetShardID(),
+		NamespaceID: tests.NamespaceID.String(),
+		WorkflowID:  tests.WorkflowID,
+		RunID:       tests.RunID,
 
 		Tasks: tasks,
 	}
 
-	s.mockNamespaceCache.EXPECT().GetNamespaceByID(s.namespaceID).Return(s.namespaceEntry, nil)
-	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName)
 	s.mockExecutionManager.EXPECT().AddHistoryTasks(gomock.Any(), addTasksRequest).Return(nil)
 	s.mockHistoryEngine.EXPECT().NotifyNewTasks(gomock.Any(), tasks)
 
-	err := s.shardContext.AddTasks(context.Background(), addTasksRequest)
+	err := s.mockShard.AddTasks(context.Background(), addTasksRequest)
 	s.NoError(err)
 }
 
@@ -159,22 +138,20 @@ func (s *contextSuite) TestTimerMaxReadLevelInitialization() {
 			cluster.TestCurrentClusterName: timestamp.TimePtr(now),
 		},
 	}
-	s.mockResource.ShardMgr.EXPECT().GetOrCreateShard(gomock.Any(), gomock.Any()).Return(
+	s.mockShardManager.EXPECT().GetOrCreateShard(gomock.Any(), gomock.Any()).Return(
 		&persistence.GetOrCreateShardResponse{
 			ShardInfo: persistenceShardInfo,
 		},
 		nil,
 	)
-	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
-	s.mockResource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName)
 
 	// clear shardInfo and load from persistence
-	shardContextImpl := s.shardContext.(*ContextTest)
+	shardContextImpl := s.mockShard.(*ContextTest)
 	shardContextImpl.shardInfo = nil
 	err := shardContextImpl.loadShardMetadata(convert.BoolPtr(false))
 	s.NoError(err)
 
-	for clusterName, info := range s.shardContext.GetClusterMetadata().GetAllClusterInfo() {
+	for clusterName, info := range s.mockShard.GetClusterMetadata().GetAllClusterInfo() {
 		if !info.Enabled {
 			continue
 		}
@@ -189,18 +166,15 @@ func (s *contextSuite) TestTimerMaxReadLevelInitialization() {
 }
 
 func (s *contextSuite) TestTimerMaxReadLevelUpdate() {
-	clusterName := cluster.TestCurrentClusterName
-	s.mockResource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(clusterName).AnyTimes()
-
 	now := time.Now()
 	s.timeSource.Update(now)
-	maxReadLevel := s.shardContext.GetQueueMaxReadLevel(tasks.CategoryTimer, clusterName)
+	maxReadLevel := s.mockShard.GetQueueMaxReadLevel(tasks.CategoryTimer, cluster.TestCurrentClusterName)
 
 	s.timeSource.Update(now.Add(-time.Minute))
-	newMaxReadLevel := s.shardContext.GetQueueMaxReadLevel(tasks.CategoryTimer, clusterName)
+	newMaxReadLevel := s.mockShard.GetQueueMaxReadLevel(tasks.CategoryTimer, cluster.TestCurrentClusterName)
 	s.Equal(maxReadLevel, newMaxReadLevel)
 
 	s.timeSource.Update(now.Add(time.Minute))
-	newMaxReadLevel = s.shardContext.GetQueueMaxReadLevel(tasks.CategoryTimer, clusterName)
+	newMaxReadLevel = s.mockShard.GetQueueMaxReadLevel(tasks.CategoryTimer, cluster.TestCurrentClusterName)
 	s.True(newMaxReadLevel.FireTime.After(maxReadLevel.FireTime))
 }

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -87,7 +87,7 @@ func (t *TransactionImpl) CreateWorkflowExecution(
 		NewWorkflowSnapshot: *newWorkflowSnapshot,
 		NewWorkflowEvents:   newWorkflowEventsSeq,
 	})
-	if operationPossiblySucceeded(err) {
+	if shard.OperationPossiblySucceeded(err) {
 		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, clusterName)
 	}
 	if err != nil {
@@ -129,7 +129,7 @@ func (t *TransactionImpl) ConflictResolveWorkflowExecution(
 		CurrentWorkflowMutation: currentWorkflowMutation,
 		CurrentWorkflowEvents:   currentWorkflowEventsSeq,
 	})
-	if operationPossiblySucceeded(err) {
+	if shard.OperationPossiblySucceeded(err) {
 		NotifyWorkflowSnapshotTasks(engine, resetWorkflowSnapshot, clusterName)
 		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, clusterName)
 		NotifyWorkflowMutationTasks(engine, currentWorkflowMutation, clusterName)
@@ -182,7 +182,7 @@ func (t *TransactionImpl) UpdateWorkflowExecution(
 		NewWorkflowSnapshot:    newWorkflowSnapshot,
 		NewWorkflowEvents:      newWorkflowEventsSeq,
 	})
-	if operationPossiblySucceeded(err) {
+	if shard.OperationPossiblySucceeded(err) {
 		NotifyWorkflowMutationTasks(engine, currentWorkflowMutation, clusterName)
 		NotifyWorkflowSnapshotTasks(engine, newWorkflowSnapshot, clusterName)
 	}
@@ -219,7 +219,7 @@ func (t *TransactionImpl) SetWorkflowExecution(
 		// RangeID , this is set by shard context
 		SetWorkflowSnapshot: *workflowSnapshot,
 	})
-	if operationPossiblySucceeded(err) {
+	if shard.OperationPossiblySucceeded(err) {
 		NotifyWorkflowSnapshotTasks(engine, workflowSnapshot, clusterName)
 	}
 	if err != nil {
@@ -786,27 +786,4 @@ func emitCompletionMetrics(
 			completionMetric.status,
 		)
 	}
-}
-
-func operationPossiblySucceeded(err error) bool {
-	if err == consts.ErrConflict {
-		return false
-	}
-
-	switch err.(type) {
-	case *persistence.CurrentWorkflowConditionFailedError,
-		*persistence.WorkflowConditionFailedError,
-		*persistence.ConditionFailedError,
-		*persistence.ShardOwnershipLostError,
-		*persistence.InvalidPersistenceRequestError,
-		*persistence.TransactionSizeLimitError,
-		*serviceerror.ResourceExhausted,
-		*serviceerror.NotFound,
-		*serviceerror.NamespaceNotFound:
-		// Persistence failure that means that write was definitely not committed.
-		return false
-	default:
-		return true
-	}
-
 }

--- a/service/history/workflow/transaction_test.go
+++ b/service/history/workflow/transaction_test.go
@@ -106,13 +106,13 @@ func (s *transactionSuite) TestOperationMayApplied() {
 	}
 
 	for _, tc := range testCases {
-		s.Equal(tc.mayApplied, operationPossiblySucceeded(tc.err))
+		s.Equal(tc.mayApplied, shard.OperationPossiblySucceeded(tc.err))
 	}
 }
 
 func (s *transactionSuite) TestCreateWorkflowExecution_NotifyTaskWhenFailed() {
 	timeoutErr := &persistence.TimeoutError{}
-	s.True(operationPossiblySucceeded(timeoutErr))
+	s.True(shard.OperationPossiblySucceeded(timeoutErr))
 
 	s.mockShard.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, timeoutErr)
 	s.setupMockForTaskNotification()
@@ -137,7 +137,7 @@ func (s *transactionSuite) TestCreateWorkflowExecution_NotifyTaskWhenFailed() {
 
 func (s *transactionSuite) TestUpdateWorkflowExecution_NotifyTaskWhenFailed() {
 	timeoutErr := &persistence.TimeoutError{}
-	s.True(operationPossiblySucceeded(timeoutErr))
+	s.True(shard.OperationPossiblySucceeded(timeoutErr))
 
 	s.mockShard.EXPECT().UpdateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, timeoutErr)
 	s.setupMockForTaskNotification() // for current workflow mutation
@@ -165,7 +165,7 @@ func (s *transactionSuite) TestUpdateWorkflowExecution_NotifyTaskWhenFailed() {
 
 func (s *transactionSuite) TestConflictResolveWorkflowExecution_NotifyTaskWhenFailed() {
 	timeoutErr := &persistence.TimeoutError{}
-	s.True(operationPossiblySucceeded(timeoutErr))
+	s.True(shard.OperationPossiblySucceeded(timeoutErr))
 
 	s.mockShard.EXPECT().ConflictResolveWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, timeoutErr)
 	s.setupMockForTaskNotification() // for reset workflow snapshot


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not hold shard lock when calling historyEngine.NotifyNewTask, as the notify method may try to lock the shard again.
- This will happen when trying to add task for standby workflows. When notifying task to standby timer queue, the logic will try to lock shard again to get standby cluster time.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Fix deadlock

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally with https://github.com/temporalio/temporal/pull/2809

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
