### PR TITLE
Fix query

### DIFF
--- a/client/history/metricClient.go
+++ b/client/history/metricClient.go
@@ -662,6 +662,7 @@ func (c *metricClient) finishMetricsRecording(
 			*serviceerror.NotFound,
 			*serviceerror.QueryFailed,
 			*serviceerror.NamespaceNotFound,
+			*serviceerror.WorkflowNotReady,
 			*serviceerror.WorkflowExecutionAlreadyStarted:
 			// noop - not interest and too many logs
 		default:

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -159,7 +159,8 @@ func (ti *TelemetryInterceptor) handleError(
 	}
 
 	switch err := err.(type) {
-	case *serviceerrors.StickyWorkerUnavailable:
+	case *serviceerror.WorkflowNotReady,
+		*serviceerrors.StickyWorkerUnavailable:
 		// we emit service_errors_with_type metrics, no need to emit specific metric for this error type.
 		// TODO deprecate all metrics below
 	case *serviceerrors.ShardOwnershipLost:

--- a/host/query_workflow_test.go
+++ b/host/query_workflow_test.go
@@ -26,11 +26,15 @@ package host
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/temporal"
+	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/service/history/consts"
 
 	"go.temporal.io/server/common/log/tag"
 )
@@ -137,4 +141,116 @@ func (s *clientIntegrationSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 
 	// verify query sees all signals before it
 	s.Equal("pauseabc", queryResultStr)
+}
+
+func (s *clientIntegrationSuite) TestQueryWorkflow_QueryWhileBackoff() {
+	firstWorkflowDone := make(chan struct{}, 1)
+	workflowFn := func(ctx workflow.Context) (string, error) {
+		workflow.SetQueryHandler(ctx, "test", func() (string, error) {
+			return "should-reach-here", nil
+		})
+
+		// only for test: to notify the test is ready for a query
+		select {
+		case firstWorkflowDone <- struct{}{}:
+		default:
+		}
+
+		return "", temporal.NewApplicationError("retry-me", "test-error")
+	}
+
+	s.worker.RegisterWorkflow(workflowFn)
+
+	id := "test-query-before-backoff"
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:                 id,
+		TaskQueue:          s.taskQueue,
+		WorkflowRunTimeout: 20 * time.Second,
+		RetryPolicy: &temporal.RetryPolicy{
+			InitialInterval: 10 * time.Second,
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	workflowRun, err := s.sdkClient.ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	if err != nil {
+		s.Logger.Fatal("Start workflow failed with err", tag.Error(err))
+	}
+
+	s.NotNil(workflowRun)
+	s.True(workflowRun.GetRunID() != "")
+
+	// block until first workflow is done
+	select {
+	case <-firstWorkflowDone:
+		// unblock, no-op
+	case <-time.After(time.Second * 5):
+		s.Logger.Fatal("first workflow is not done in 5s")
+	}
+
+	_, err = s.sdkClient.QueryWorkflow(ctx, id, "", "test")
+	s.Error(err)
+	s.ErrorContains(err, consts.ErrWorkflowTaskNotScheduled.Error())
+}
+
+func (s *clientIntegrationSuite) TestQueryWorkflow_QueryBeforeStart() {
+	// stop the worker, so the workflow won't be started before query
+	s.worker.Stop()
+
+	workflowFn := func(ctx workflow.Context) (string, error) {
+		status := "initialized"
+		workflow.SetQueryHandler(ctx, "test", func() (string, error) {
+			return status, nil
+		})
+
+		status = "started"
+		workflow.Sleep(ctx, time.Hour)
+		return "", nil
+	}
+
+	id := "test-query-before-start"
+	workflowOptions := sdkclient.StartWorkflowOptions{
+		ID:                 id,
+		TaskQueue:          s.taskQueue,
+		WorkflowRunTimeout: 20 * time.Second,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	workflowRun, err := s.sdkClient.ExecuteWorkflow(ctx, workflowOptions, workflowFn)
+	if err != nil {
+		s.Logger.Fatal("Start workflow failed with err", tag.Error(err))
+	}
+
+	s.NotNil(workflowRun)
+	s.True(workflowRun.GetRunID() != "")
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+
+		startTime := time.Now()
+		queryResult, err := s.sdkClient.QueryWorkflow(ctx, id, "", "test")
+		endTime := time.Now()
+		s.NoError(err)
+		var queryResultStr string
+		err = queryResult.Get(&queryResultStr)
+		s.NoError(err)
+
+		// verify query sees all signals before it
+		s.Equal("started", queryResultStr)
+
+		s.True(endTime.Sub(startTime) > time.Second)
+	}()
+
+	// delay 2s to start worker, this will block query for 2s
+	time.Sleep(time.Second * 2)
+	s.worker = worker.New(s.sdkClient, s.taskQueue, worker.Options{})
+	s.worker.RegisterWorkflow(workflowFn)
+	if err := s.worker.Start(); err != nil {
+		s.Logger.Fatal("Error when start worker", tag.Error(err))
+	}
+
+	// wait query
+	wg.Wait()
 }

--- a/service/history/consts/const.go
+++ b/service/history/consts/const.go
@@ -84,6 +84,8 @@ var (
 	ErrChildExecutionNotFound = serviceerror.NewNotFound("Pending child execution not found.")
 	// ErrWorkflowNotReady is error indicating workflow mutable state is missing necessary information for handling the request
 	ErrWorkflowNotReady = serviceerror.NewWorkflowNotReady("Workflow state is not ready to handle the request.")
+	// ErrWorkflowTaskNotScheduled is error indicating workflow task is not scheduled yet.
+	ErrWorkflowTaskNotScheduled = serviceerror.NewWorkflowNotReady("Workflow task is not scheduled yet.")
 
 	// FailedWorkflowStatuses is a set of failed workflow close states, used for start workflow policy
 	// for start workflow execution API


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix query for 2 cases:
1) no workflow task has ever scheduled, usually due to firstWorkflowTaskBackoff. In this case, return WorkflowNotReady error.
2) no workflow task has ever started yet, usually due to race condition or worker is down. In this case, do not dispatch query directly, instead buffer query and sent it with next workflow task. The query might timeout if no worker pick up the scheduled workflow task.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix query.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Will add test soon (in this same PR).

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
