### PR TITLE
Remove global StickyTTL

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -193,9 +193,6 @@ type Config struct {
 	DefaultWorkflowRetryPolicy dynamicconfig.MapPropertyFnWithNamespaceFilter
 
 	// Workflow task settings
-	// StickyTTL is to expire a sticky taskqueue if no update more than this duration
-	// TODO https://go.temporal.io/server/issues/2357
-	StickyTTL dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	// DefaultWorkflowTaskTimeout the default workflow task timeout
 	DefaultWorkflowTaskTimeout dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	// WorkflowTaskHeartbeatTimeout is to timeout behavior of: RespondWorkflowTaskComplete with ForceCreateNewWorkflowTask == true without any workflow tasks
@@ -405,7 +402,6 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 
 		DefaultActivityRetryPolicy:   dc.GetMapPropertyFnWithNamespaceFilter(dynamicconfig.DefaultActivityRetryPolicy, common.GetDefaultRetryPolicyConfigOptions()),
 		DefaultWorkflowRetryPolicy:   dc.GetMapPropertyFnWithNamespaceFilter(dynamicconfig.DefaultWorkflowRetryPolicy, common.GetDefaultRetryPolicyConfigOptions()),
-		StickyTTL:                    dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.StickyTTL, time.Hour*24*365),
 		WorkflowTaskHeartbeatTimeout: dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.WorkflowTaskHeartbeatTimeout, time.Minute*30),
 		WorkflowTaskCriticalAttempts: dc.GetIntProperty(dynamicconfig.WorkflowTaskCriticalAttempts, 10),
 		WorkflowTaskRetryMaxInterval: dc.GetDurationProperty(dynamicconfig.WorkflowTaskRetryMaxInterval, time.Minute*10),

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -3717,8 +3717,6 @@ func (e *MutableStateImpl) StartTransaction(
 		return false, err
 	}
 
-	e.startTransactionHandleWorkflowTaskTTL()
-
 	return flushBeforeReady, nil
 }
 
@@ -4171,18 +4169,6 @@ func (e *MutableStateImpl) validateNoEventsAfterWorkflowFinish(
 			tag.WorkflowRunID(e.executionState.RunId),
 		)
 		return consts.ErrEventsAterWorkflowFinish
-	}
-}
-
-func (e *MutableStateImpl) startTransactionHandleWorkflowTaskTTL() {
-	if e.executionInfo.StickyTaskQueue == "" {
-		return
-	}
-
-	ttl := e.config.StickyTTL(e.GetNamespaceEntry().Name().String())
-	expired := e.timeSource.Now().After(timestamp.TimeValue(e.executionInfo.LastUpdateTime).Add(ttl))
-	if expired && !e.HasPendingWorkflowTask() {
-		e.ClearStickyness()
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove global StickyTTL which has default value of 1 year. The default sticky task queue ttl of 1 day is still in place.

<!-- Tell your future self why have you made these changes -->
**Why?**
With recent change to avoid 5s sticky delay, there is no need for that ttl.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
