### PR TITLE
Remove TerminateWorkflowExecution call when deleting namespace

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2226,8 +2226,6 @@ const (
 	RenameNamespaceFailuresCount
 	ReadNamespaceFailuresCount
 	ListExecutionsFailuresCount
-	TerminateExecutionFailuresCount
-	TerminateExecutionNotFoundCount
 	DeleteExecutionFailuresCount
 	DeleteExecutionNotFoundCount
 	RateLimiterFailuresCount
@@ -2690,19 +2688,17 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		CatchUpReadyShardCountGauge:                   NewGaugeDef("catchup_ready_shard_count"),
 		HandoverReadyShardCountGauge:                  NewGaugeDef("handover_ready_shard_count"),
 
-		DeleteNamespaceSuccessCount:     NewCounterDef("delete_namespace_success"),
-		RenameNamespaceSuccessCount:     NewCounterDef("rename_namespace_success"),
-		DeleteExecutionsSuccessCount:    NewCounterDef("delete_executions_success"),
-		DeleteNamespaceFailuresCount:    NewCounterDef("delete_namespace_failures"),
-		UpdateNamespaceFailuresCount:    NewCounterDef("update_namespace_failures"),
-		RenameNamespaceFailuresCount:    NewCounterDef("rename_namespace_failures"),
-		ReadNamespaceFailuresCount:      NewCounterDef("read_namespace_failures"),
-		ListExecutionsFailuresCount:     NewCounterDef("list_executions_failures"),
-		TerminateExecutionFailuresCount: NewCounterDef("terminate_executions_failures"),
-		TerminateExecutionNotFoundCount: NewCounterDef("terminate_executions_not_found"),
-		DeleteExecutionFailuresCount:    NewCounterDef("delete_execution_failures"),
-		DeleteExecutionNotFoundCount:    NewCounterDef("delete_execution_not_found"),
-		RateLimiterFailuresCount:        NewCounterDef("rate_limiter_failures"),
+		DeleteNamespaceSuccessCount:  NewCounterDef("delete_namespace_success"),
+		RenameNamespaceSuccessCount:  NewCounterDef("rename_namespace_success"),
+		DeleteExecutionsSuccessCount: NewCounterDef("delete_executions_success"),
+		DeleteNamespaceFailuresCount: NewCounterDef("delete_namespace_failures"),
+		UpdateNamespaceFailuresCount: NewCounterDef("update_namespace_failures"),
+		RenameNamespaceFailuresCount: NewCounterDef("rename_namespace_failures"),
+		ReadNamespaceFailuresCount:   NewCounterDef("read_namespace_failures"),
+		ListExecutionsFailuresCount:  NewCounterDef("list_executions_failures"),
+		DeleteExecutionFailuresCount: NewCounterDef("delete_execution_failures"),
+		DeleteExecutionNotFoundCount: NewCounterDef("delete_execution_not_found"),
+		RateLimiterFailuresCount:     NewCounterDef("rate_limiter_failures"),
 	},
 	Server: {
 		TlsCertsExpired:  NewGaugeDef("certificates_expired"),

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -160,7 +160,8 @@ func (ti *TelemetryInterceptor) handleError(
 
 	switch err := err.(type) {
 	case *serviceerror.WorkflowNotReady,
-		*serviceerrors.StickyWorkerUnavailable:
+		*serviceerrors.StickyWorkerUnavailable,
+		*serviceerror.NamespaceInvalidState:
 		// we emit service_errors_with_type metrics, no need to emit specific metric for this error type.
 		// TODO deprecate all metrics below
 	case *serviceerrors.ShardOwnershipLost:

--- a/service/worker/deletenamespace/deleteexecutions/workflow_test.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow_test.go
@@ -291,8 +291,6 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 	historyClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	// NotFound errors should not affect the error count.
 	historyClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found")).Times(2)
-	historyClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, nil)
-	historyClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewNotFound("not found"))
 
 	a := &Activities{
 		visibilityManager: visibilityManager,
@@ -380,8 +378,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 	}, nil).Times(2)
 
 	historyClient := historyservicemock.NewMockHistoryServiceClient(ctrl)
-	historyClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewUnavailable("random")).Times(2)
-	historyClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewUnavailable("random")).Times(2)
+	historyClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, serviceerror.NewUnavailable("random")).Times(4)
 
 	a := &Activities{
 		visibilityManager: visibilityManager,

--- a/service/worker/deletenamespace/errors/errors.go
+++ b/service/worker/deletenamespace/errors/errors.go
@@ -31,13 +31,15 @@ import (
 )
 
 const (
-	ExecutionsStillExistErrType = "ExecutionsStillExist"
-	NoProgressErrType           = "NoProgress"
+	ExecutionsStillExistErrType           = "ExecutionsStillExist"
+	NoProgressErrType                     = "NoProgress"
+	NotDeletedExecutionsStillExistErrType = "NotDeletedExecutionsStillExist"
 )
 
 var (
-	ErrUnableToExecuteActivity      = errors.New("unable to execute activity")
-	ErrUnableToExecuteChildWorkflow = errors.New("unable to execute child workflow")
-	ErrExecutionsStillExist         = temporal.NewApplicationError("executions are still exist", ExecutionsStillExistErrType)
-	ErrNoProgress                   = temporal.NewNonRetryableApplicationError("no progress were made", NoProgressErrType, nil)
+	ErrUnableToExecuteActivity        = errors.New("unable to execute activity")
+	ErrUnableToExecuteChildWorkflow   = errors.New("unable to execute child workflow")
+	ErrExecutionsStillExist           = temporal.NewApplicationError("executions are still exist", ExecutionsStillExistErrType)
+	ErrNoProgress                     = temporal.NewNonRetryableApplicationError("no progress were made", NoProgressErrType, nil)
+	ErrNotDeletedExecutionsStillExist = temporal.NewNonRetryableApplicationError("not deleted executions are still exist", NotDeletedExecutionsStillExistErrType, nil)
 )

--- a/service/worker/deletenamespace/reclaimresources/workflow_test.go
+++ b/service/worker/deletenamespace/reclaimresources/workflow_test.go
@@ -67,7 +67,7 @@ func Test_ReclaimResourcesWorkflow_Success(t *testing.T) {
 	}, nil).Once()
 
 	env.OnActivity(a.IsAdvancedVisibilityActivity, mock.Anything).Return(true, nil).Once()
-	env.OnActivity(a.EnsureNoExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace")).Return(nil).Once()
+	env.OnActivity(a.EnsureNoExecutionsAdvVisibilityActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace"), 0).Return(nil).Once()
 
 	env.OnActivity(a.DeleteNamespaceActivity, mock.Anything, namespace.ID("namespace-id"), namespace.Name("namespace")).Return(nil).Once()
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove `TerminateWorkflowExecution` call when deleting namespace.

<!-- Tell your future self why have you made these changes -->
**Why?**
With recent changes `DeleteWorkflowExecution` supports delete of running workflows and there is no need to terminate it first.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually for now. Integration tests are pending.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.