### PR TITLE
Drop namespace replication task if it does not live in current cluster

### DIFF
--- a/common/namespace/replicationTaskExecutor_test.go
+++ b/common/namespace/replicationTaskExecutor_test.go
@@ -67,7 +67,7 @@ func (s *namespaceReplicationTaskExecutorSuite) SetupTest() {
 	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup(nil)
 	logger := log.NewTestLogger()
-	s.namespaceReplicator = NewReplicationTaskExecutor(
+	s.namespaceReplicator = NewReplicationTaskExecutor("some random standby cluster name",
 		s.MetadataManager,
 		logger,
 	).(*namespaceReplicationTaskExecutorImpl)
@@ -128,6 +128,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_RegisterNamespaceTas
 		FailoverVersion: failoverVersion,
 	}
 
+	s.namespaceReplicator.currentCluster = clusterStandby
 	err := s.namespaceReplicator.Execute(context.Background(), task)
 	s.Nil(err)
 
@@ -410,6 +411,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
+	s.namespaceReplicator.currentCluster = updateClusterStandby
 	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
 	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})
@@ -538,6 +540,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
+	s.namespaceReplicator.currentCluster = updateClusterStandby
 	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
 	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})
@@ -662,6 +665,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 	metadata, err := s.MetadataManager.GetMetadata(context.Background())
 	s.Nil(err)
 	notificationVersion := metadata.NotificationVersion
+	s.namespaceReplicator.currentCluster = updateClusterStandby
 	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
 	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})
@@ -785,6 +789,7 @@ func (s *namespaceReplicationTaskExecutorSuite) TestExecute_UpdateNamespaceTask_
 		ConfigVersion:   updateConfigVersion,
 		FailoverVersion: updateFailoverVersion,
 	}
+	s.namespaceReplicator.currentCluster = updateClusterStandby
 	err = s.namespaceReplicator.Execute(context.Background(), updateTask)
 	s.Nil(err)
 	resp, err := s.MetadataManager.GetNamespace(context.Background(), &persistence.GetNamespaceRequest{Name: name})

--- a/host/test_cluster.go
+++ b/host/test_cluster.go
@@ -213,7 +213,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 		HistoryConfig:                    options.HistoryConfig,
 		WorkerConfig:                     options.WorkerConfig,
 		MockAdminClient:                  options.MockAdminClient,
-		NamespaceReplicationTaskExecutor: namespace.NewReplicationTaskExecutor(testBase.MetadataManager, logger),
+		NamespaceReplicationTaskExecutor: namespace.NewReplicationTaskExecutor(options.ClusterMetadata.CurrentClusterName, testBase.MetadataManager, logger),
 	}
 
 	err = newPProfInitializerImpl(logger, pprofTestPort).Start()

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -158,8 +158,8 @@ var (
 func NewAdminHandler(
 	args NewAdminHandlerArgs,
 ) *AdminHandler {
-
 	namespaceReplicationTaskExecutor := namespace.NewReplicationTaskExecutor(
+		args.ClusterMetadata.GetCurrentClusterName(),
 		args.PersistenceMetadataManager,
 		args.Logger,
 	)

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -147,6 +147,7 @@ func (s *adminHandlerSuite) SetupTest() {
 		health.NewServer(),
 		serialization.NewSerializer(),
 	}
+	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New()).AnyTimes()
 	s.handler = NewAdminHandler(args)
 	s.handler.Start()
 }
@@ -767,7 +768,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordFound_Success() 
 	var clusterId = uuid.New()
 	var recordVersion int64 = 5
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(0))
 	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
@@ -807,7 +807,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordNotFound_Success
 	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(0))
 	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
@@ -844,17 +843,15 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_RecordNotFound_Success
 
 func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_ValidationError_ClusterNameConflict() {
 	var rpcAddress = uuid.New()
-	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(clusterName)
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
 		s.mockAdminClient,
 	)
 	s.mockAdminClient.EXPECT().DescribeCluster(gomock.Any(), &adminservice.DescribeClusterRequest{}).Return(
 		&adminservice.DescribeClusterResponse{
 			ClusterId:                clusterId,
-			ClusterName:              clusterName,
+			ClusterName:              s.mockMetadata.GetCurrentClusterName(),
 			HistoryShardCount:        0,
 			FailoverVersionIncrement: 0,
 			InitialFailoverVersion:   0,
@@ -870,7 +867,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_ValidationError_Failov
 	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(1))
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
 		s.mockAdminClient,
@@ -894,7 +890,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_ValidationError_ShardC
 	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(0))
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
 		s.mockAdminClient,
@@ -918,7 +913,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_ValidationError_Global
 	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(0))
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
 		s.mockAdminClient,
@@ -942,7 +936,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_ValidationError_Initia
 	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(0))
 	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
 		uuid.New(): {InitialFailoverVersion: 0},
@@ -983,7 +976,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_GetClusterMetadata_Err
 	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(0))
 	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
@@ -1011,7 +1003,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata_Er
 	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(0))
 	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
@@ -1051,7 +1042,6 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata_No
 	var clusterName = uuid.New()
 	var clusterId = uuid.New()
 
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(uuid.New())
 	s.mockMetadata.EXPECT().GetFailoverVersionIncrement().Return(int64(0))
 	s.mockMetadata.EXPECT().GetAllClusterInfo().Return(make(map[string]cluster.ClusterInformation))
 	s.mockClientFactory.EXPECT().NewAdminClientWithTimeout(rpcAddress, gomock.Any(), gomock.Any()).Return(
@@ -1088,10 +1078,8 @@ func (s *adminHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata_No
 }
 
 func (s *adminHandlerSuite) Test_DescribeCluster_CurrentCluster_Success() {
-	var clusterName = uuid.New()
 	var clusterId = uuid.New()
-
-	s.mockMetadata.EXPECT().GetCurrentClusterName().Return(clusterName)
+	clusterName := s.mockMetadata.GetCurrentClusterName()
 	s.mockResource.MembershipMonitor.EXPECT().WhoAmI().Return(&membership.HostInfo{}, nil)
 	s.mockResource.MembershipMonitor.EXPECT().GetReachableMembers().Return(nil, nil)
 	s.mockResource.HistoryServiceResolver.EXPECT().Members().Return([]*membership.HostInfo{})

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -454,6 +454,7 @@ func (s *Service) startScanner() {
 
 func (s *Service) startReplicator() {
 	namespaceReplicationTaskExecutor := namespace.NewReplicationTaskExecutor(
+		s.clusterMetadata.GetCurrentClusterName(),
 		s.metadataManager,
 		s.logger,
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ignore namespace replication task if the namespace does not live in current cluster.

<!-- Tell your future self why have you made these changes -->
**Why?**
When dynamically connect any clusters, we don't need namespace to be replicated everywhere. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit test / integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
