### PR TITLE
Allow dynamic config filter by namespace or task queue name only

### DIFF
--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -154,6 +154,7 @@ func getFilterMapsForTaskQueue(namespace string, taskQueue string, taskType enum
 	return []map[Filter]interface{}{
 		getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
 		getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
+		getFilterMap(NamespaceFilter(namespace)),
 		getFilterMap(TaskQueueFilter(taskQueue)),
 	}
 }

--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -150,6 +150,14 @@ func getFilterMap(opts ...FilterOption) map[Filter]interface{} {
 	return m
 }
 
+func getFilterMapsForTaskQueue(namespace string, taskQueue string, taskType enumspb.TaskQueueType) []map[Filter]interface{} {
+	return []map[Filter]interface{}{
+		getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
+		getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
+		getFilterMap(TaskQueueFilter(taskQueue)),
+	}
+}
+
 // GetIntProperty gets property and asserts that it's an integer
 func (c *Collection) GetIntProperty(key Key, defaultValue int) IntPropertyFn {
 	return func(opts ...FilterOption) int {
@@ -180,10 +188,7 @@ func (c *Collection) GetIntPropertyFilteredByTaskQueueInfo(key Key, defaultValue
 		val := defaultValue
 		var err error
 
-		filterMaps := []map[Filter]interface{}{
-			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
-			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
-		}
+		filterMaps := getFilterMapsForTaskQueue(namespace, taskQueue, taskType)
 
 		for _, filterMap := range filterMaps {
 			val, err = c.client.GetIntValue(
@@ -266,10 +271,7 @@ func (c *Collection) GetFloatPropertyFilteredByTaskQueueInfo(key Key, defaultVal
 		val := defaultValue
 		var err error
 
-		filterMaps := []map[Filter]interface{}{
-			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
-			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
-		}
+		filterMaps := getFilterMapsForTaskQueue(namespace, taskQueue, taskType)
 
 		for _, filterMap := range filterMaps {
 			val, err = c.client.GetFloatValue(
@@ -332,10 +334,7 @@ func (c *Collection) GetDurationPropertyFilteredByTaskQueueInfo(key Key, default
 		val := defaultValue
 		var err error
 
-		filterMaps := []map[Filter]interface{}{
-			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
-			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
-		}
+		filterMaps := getFilterMapsForTaskQueue(namespace, taskQueue, taskType)
 
 		for _, filterMap := range filterMaps {
 			val, err = c.client.GetDurationValue(
@@ -462,10 +461,7 @@ func (c *Collection) GetBoolPropertyFilteredByTaskQueueInfo(key Key, defaultValu
 		val := defaultValue
 		var err error
 
-		filterMaps := []map[Filter]interface{}{
-			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
-			getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
-		}
+		filterMaps := getFilterMapsForTaskQueue(namespace, taskQueue, taskType)
 
 		for _, filterMap := range filterMaps {
 			val, err = c.client.GetBoolValue(

--- a/common/dynamicconfig/config/testConfig.yaml
+++ b/common/dynamicconfig/config/testConfig.yaml
@@ -50,6 +50,9 @@ testGetIntPropertyKey:
   constraints:
     namespace: global-samples-namespace
     taskQueueName: test-tq
+- value: 1005
+  constraints:
+    taskQueueName: other-test-tq
 testGetMapPropertyKey:
 - value:
     key1: "1"

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -179,6 +179,16 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilteredByActivityTaskQueueInfo()
 	s.Equal(expectedValue, v)
 }
 
+func (s *fileBasedClientSuite) TestGetIntValue_FilteredByTaskQueueNameOnly() {
+	expectedValue := 1005
+	filters := map[Filter]interface{}{
+		TaskQueueName: "other-test-tq",
+	}
+	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
+	s.NoError(err)
+	s.Equal(expectedValue, v)
+}
+
 func (s *fileBasedClientSuite) TestGetFloatValue() {
 	v, err := s.client.GetFloatValue(testGetFloat64PropertyKey, nil, 1)
 	s.NoError(err)


### PR DESCRIPTION
**What changed?**
Dynamic config filtered by task queue can take &lt;namespace, task queue, task queue type&gt; or &lt;namespace, task queue&gt; constraints. This adds &lt;namespace&gt; and &lt;task queue&gt; as a possible sets of constraints.

**Why?**
We can have server workers that listen on a specific task queue in all user namespaces. This lets us apply dynamic config to those.

**How did you test it?**
unit test

**Potential risks**

**Is hotfix candidate?**
