### PR TITLE
Bypass ack level check for delete workflow execution in standby cluster

### DIFF
--- a/service/history/workflow/delete_manager.go
+++ b/service/history/workflow/delete_manager.go
@@ -95,16 +95,25 @@ func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
 	visibilityQueueAckLevel int64,
 ) error {
 
-	// Create delete workflow execution task only if workflow is closed successfully and all pending tasks are completed (if in active cluster).
-	// Otherwise, mutable state might be deleted before close tasks are executed.
-	// Unfortunately, queue ack levels are updated with delay (default 30s),
-	// therefore this API will return error if workflow is deleted within 30 seconds after close.
-	// The check is on API call side, not on task processor side because visibility delete task doesn't have access to mutable state.
+	// Create `DeleteWorkflowExecutionTask` only if workflow is closed successfully and all pending tasks are completed (if in active cluster).
+	// Otherwise, mutable state might be deleted before close tasks are executed (race condition between close and delete tasks).
+	// Unfortunately, queue ack levels are updated with delay (default 60s),
+	// therefore this API will return error if workflow is deleted within 60 seconds after close.
+	// The check is on API call side, not on task processor side, because delete visibility task doesn't have access to mutable state.
 	if (ms.GetExecutionInfo().CloseTransferTaskId != 0 && // Workflow execution still might be running in passive cluster.
 		ms.GetExecutionInfo().CloseTransferTaskId > transferQueueAckLevel) || // Transfer close task wasn't executed.
 		(ms.GetExecutionInfo().CloseVisibilityTaskId != 0 && // Workflow execution still might be running in passive cluster.
 			ms.GetExecutionInfo().CloseVisibilityTaskId > visibilityQueueAckLevel) {
-		return consts.ErrWorkflowNotReady
+
+		namespaceRegistryEntry, err := m.shard.GetNamespaceRegistry().GetNamespaceByID(nsID)
+		if err != nil {
+			return err
+		}
+		// The logic above is only for active cluster. Standby cluster bypasses ack level check,
+		// because race condition doesn't break anything there.
+		if namespaceRegistryEntry.ActiveInCluster(m.shard.GetClusterMetadata().GetCurrentClusterName()) {
+			return consts.ErrWorkflowNotReady
+		}
 	}
 
 	taskGenerator := taskGeneratorProvider.NewTaskGenerator(m.shard, ms)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Bypass ack level check for delete workflow execution in standby cluster.

<!-- Tell your future self why have you made these changes -->
**Why?**
Standby cluster can bypass ack level check, because race condition doesn't break anything there.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.