### PR TITLE
Fix failover queue creation after shard reload

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -324,11 +324,17 @@ func (e *historyEngineImpl) registerNamespaceFailoverCallback() {
 
 			newNotificationVersion := nextNamespaces[len(nextNamespaces)-1].NotificationVersion() + 1
 			shardNotificationVersion := e.shard.GetNamespaceNotificationVersion()
-			if newNotificationVersion <= shardNotificationVersion {
-				// skip if this is known version. this could happen once after shard reload because we use
-				// 0 as initialNotificationVersion when RegisterNamespaceChangeCallback.
-				return
-			}
+
+			// failover notification version <= NotificationVersion
+			// there's no newNotificationVersion such that
+			// newNotificationVersion < shardNotificationVersion &&
+			// FailoverNotificationVersion >= shardNotificationVersion
+
+			// if newNotificationVersion < shardNotificationVersion {
+			// 	// skip if this is known version. this could happen once after shard reload because we use
+			// 	// 0 as initialNotificationVersion when RegisterNamespaceChangeCallback.
+			// 	return
+			// }
 
 			failoverNamespaceIDs := map[string]struct{}{}
 			for _, nextNamespace := range nextNamespaces {

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -330,9 +330,9 @@ func (e *historyEngineImpl) registerNamespaceFailoverCallback() {
 			// 2. We can return when newNotificationVersion < shardNotificationVersion. But the check
 			// is basically the same as the check in failover predicate. Because
 			// failover notification version <= NotificationVersion,
-			// there's no notification version such that
+			// there's no notification version that can make
 			// newNotificationVersion < shardNotificationVersion and
-			// FailoverNotificationVersion >= shardNotificationVersion are true at the same time
+			// failoverNotificationVersion >= shardNotificationVersion are true at the same time
 			// Meaning if the check decides to return, no namespace will pass the failover predicate.
 
 			failoverNamespaceIDs := map[string]struct{}{}

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -325,16 +325,15 @@ func (e *historyEngineImpl) registerNamespaceFailoverCallback() {
 			newNotificationVersion := nextNamespaces[len(nextNamespaces)-1].NotificationVersion() + 1
 			shardNotificationVersion := e.shard.GetNamespaceNotificationVersion()
 
-			// failover notification version <= NotificationVersion
-			// there's no newNotificationVersion such that
-			// newNotificationVersion < shardNotificationVersion &&
-			// FailoverNotificationVersion >= shardNotificationVersion
-
-			// if newNotificationVersion < shardNotificationVersion {
-			// 	// skip if this is known version. this could happen once after shard reload because we use
-			// 	// 0 as initialNotificationVersion when RegisterNamespaceChangeCallback.
-			// 	return
-			// }
+			// 1. We can't return when newNotificationVersion == shardNotificationVersion
+			// since we don't know if the previous failover queue processing has finished or not
+			// 2. We can return when newNotificationVersion < shardNotificationVersion. But the check
+			// is basically the same as the check in failover predicate. Because
+			// failover notification version <= NotificationVersion,
+			// there's no notification version such that
+			// newNotificationVersion < shardNotificationVersion and
+			// FailoverNotificationVersion >= shardNotificationVersion are true at the same time
+			// Meaning if the check decides to return, no namespace will pass the failover predicate.
 
 			failoverNamespaceIDs := map[string]struct{}{}
 			for _, nextNamespace := range nextNamespaces {

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -429,12 +429,10 @@ func (s *ContextImpl) UpdateQueueClusterAckLevel(
 	s.wLock()
 	defer s.wUnlock()
 
-	if levels, ok := s.shardInfo.FailoverLevels[category]; ok {
-		for _, failoverLevel := range levels {
-			if ackLevel.CompareTo(failoverLevel.CurrentLevel) > 0 {
-				ackLevel = failoverLevel.CurrentLevel
-			}
-		}
+	if levels, ok := s.shardInfo.FailoverLevels[category]; ok && len(levels) != 0 {
+		// do not move ack level when there's failover queue
+		// so that after shard reload we can re-create the failover queue
+		return nil
 	}
 
 	// backward compatibility (for rollback)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Currently if shard reload happens when failover queue is running, the failover queue won't be re-created after is reloaded due to the notification version check.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
