### PR TITLE
Add action metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1854,6 +1854,8 @@ const (
 	ServiceErrUnauthorizedCounter
 	ServiceErrAuthorizeFailedCounter
 
+	ActionCounter
+
 	PersistenceRequests
 	PersistenceFailures
 	PersistenceLatency
@@ -2349,6 +2351,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ServiceErrNonDeterministicCounter:                   NewCounterDef("service_errors_nondeterministic"),
 		ServiceErrUnauthorizedCounter:                       NewCounterDef("service_errors_unauthorized"),
 		ServiceErrAuthorizeFailedCounter:                    NewCounterDef("service_errors_authorize_failed"),
+		ActionCounter:                                       NewCounterDef("action"),
 		PersistenceRequests:                                 NewCounterDef("persistence_requests"),
 		PersistenceFailures:                                 NewCounterDef("persistence_errors"),
 		PersistenceLatency:                                  NewTimerDef("persistence_latency"),

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -48,6 +48,7 @@ const (
 	activityType  = "activityType"
 	commandType   = "commandType"
 	serviceName   = "service_name"
+	actionType    = "action_type"
 
 	namespaceAllValue = "all"
 	unknownValue      = "_unknown_"
@@ -235,4 +236,8 @@ func ResourceExhaustedCauseTag(cause enumspb.ResourceExhaustedCause) Tag {
 
 func ServiceTypeTag(value string) Tag {
 	return &tagImpl{key: serviceName, value: value}
+}
+
+func ActionType(value string) Tag {
+	return &tagImpl{key: actionType, value: value}
 }


### PR DESCRIPTION
wire up interceptor

<!-- Describe what has changed in this PR -->
**What changed?**
Add action metrics

<!-- Tell your future self why have you made these changes -->
**Why?**
To measure number of actions take by work load

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run samples work load, and observed metrics:
action{action_type="command_RecordMarker_LocalActivity",namespace="default",operation="RespondWorkflowTaskCompleted",service_name="frontend"} 3
action{action_type="command_ScheduleActivityTask",namespace="default",operation="RespondWorkflowTaskCompleted",service_name="frontend"} 2
action{action_type="command_StartChildWorkflowExecution",namespace="default",operation="RespondWorkflowTaskCompleted",service_name="frontend"} 1
action{action_type="command_StartTimer",namespace="default",operation="RespondWorkflowTaskCompleted",service_name="frontend"} 1
action{action_type="grpc_RecordActivityTaskHeartbeat",namespace="default",operation="RecordActivityTaskHeartbeat",service_name="frontend"} 6
action{action_type="grpc_StartWorkflowExecution",namespace="default",operation="StartWorkflowExecution",service_name="frontend"} 5
action{action_type="activity_retry",namespace="default",operation="PollActivityTaskQueue",service_name="frontend"} 2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
