### PR TITLE
Refactor ndc history resender to handle multiple remote clusters

### DIFF
--- a/common/xdc/nDCHistoryResender.go
+++ b/common/xdc/nDCHistoryResender.go
@@ -30,6 +30,7 @@ import (
 	"context"
 	"time"
 
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/persistence/serialization"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -58,6 +59,7 @@ type (
 	NDCHistoryResender interface {
 		// SendSingleWorkflowHistory sends multiple run IDs's history events to remote
 		SendSingleWorkflowHistory(
+			remoteClusterName string,
 			namespaceID namespace.ID,
 			workflowID string,
 			runID string,
@@ -71,7 +73,7 @@ type (
 	// NDCHistoryResenderImpl is the implementation of NDCHistoryResender
 	NDCHistoryResenderImpl struct {
 		namespaceRegistry    namespace.Registry
-		adminClient          adminservice.AdminServiceClient
+		clientBean           client.Bean
 		historyReplicationFn nDCHistoryReplicationFn
 		serializer           serialization.Serializer
 		rereplicationTimeout dynamicconfig.DurationPropertyFnWithNamespaceIDFilter
@@ -91,7 +93,7 @@ const (
 // NewNDCHistoryResender create a new NDCHistoryResenderImpl
 func NewNDCHistoryResender(
 	namespaceRegistry namespace.Registry,
-	adminClient adminservice.AdminServiceClient,
+	clientBean client.Bean,
 	historyReplicationFn nDCHistoryReplicationFn,
 	serializer serialization.Serializer,
 	rereplicationTimeout dynamicconfig.DurationPropertyFnWithNamespaceIDFilter,
@@ -100,7 +102,7 @@ func NewNDCHistoryResender(
 
 	return &NDCHistoryResenderImpl{
 		namespaceRegistry:    namespaceRegistry,
-		adminClient:          adminClient,
+		clientBean:           clientBean,
 		historyReplicationFn: historyReplicationFn,
 		serializer:           serializer,
 		rereplicationTimeout: rereplicationTimeout,
@@ -110,6 +112,7 @@ func NewNDCHistoryResender(
 
 // SendSingleWorkflowHistory sends one run IDs's history events to remote
 func (n *NDCHistoryResenderImpl) SendSingleWorkflowHistory(
+	remoteClusterName string,
 	namespaceID namespace.ID,
 	workflowID string,
 	runID string,
@@ -131,13 +134,15 @@ func (n *NDCHistoryResenderImpl) SendSingleWorkflowHistory(
 
 	historyIterator := collection.NewPagingIterator(n.getPaginationFn(
 		ctx,
+		remoteClusterName,
 		namespaceID,
 		workflowID,
 		runID,
 		startEventID,
 		startEventVersion,
 		endEventID,
-		endEventVersion))
+		endEventVersion,
+	))
 
 	for historyIterator.HasNext() {
 		batch, err := historyIterator.Next()
@@ -172,6 +177,7 @@ func (n *NDCHistoryResenderImpl) SendSingleWorkflowHistory(
 
 func (n *NDCHistoryResenderImpl) getPaginationFn(
 	ctx context.Context,
+	remoteClusterName string,
 	namespaceID namespace.ID,
 	workflowID string,
 	runID string,
@@ -185,6 +191,7 @@ func (n *NDCHistoryResenderImpl) getPaginationFn(
 
 		response, err := n.getHistory(
 			ctx,
+			remoteClusterName,
 			namespaceID,
 			workflowID,
 			runID,
@@ -244,6 +251,7 @@ func (n *NDCHistoryResenderImpl) sendReplicationRawRequest(
 
 func (n *NDCHistoryResenderImpl) getHistory(
 	ctx context.Context,
+	remoteClusterName string,
 	namespaceID namespace.ID,
 	workflowID string,
 	runID string,
@@ -266,7 +274,9 @@ func (n *NDCHistoryResenderImpl) getHistory(
 
 	ctx, cancel := rpc.NewContextFromParentWithTimeoutAndHeaders(ctx, resendContextTimeout)
 	defer cancel()
-	response, err := n.adminClient.GetWorkflowExecutionRawHistoryV2(ctx, &adminservice.GetWorkflowExecutionRawHistoryV2Request{
+
+	adminClient := n.clientBean.GetRemoteAdminClient(remoteClusterName)
+	response, err := adminClient.GetWorkflowExecutionRawHistoryV2(ctx, &adminservice.GetWorkflowExecutionRawHistoryV2Request{
 		Namespace: namespace.String(),
 		Execution: &commonpb.WorkflowExecution{
 			WorkflowId: workflowID,

--- a/common/xdc/nDCHistoryResender_mock.go
+++ b/common/xdc/nDCHistoryResender_mock.go
@@ -59,15 +59,15 @@ func (m *MockNDCHistoryResender) EXPECT() *MockNDCHistoryResenderMockRecorder {
 }
 
 // SendSingleWorkflowHistory mocks base method.
-func (m *MockNDCHistoryResender) SendSingleWorkflowHistory(namespaceID namespace.ID, workflowID, runID string, startEventID, startEventVersion, endEventID, endEventVersion int64) error {
+func (m *MockNDCHistoryResender) SendSingleWorkflowHistory(remoteClusterName string, namespaceID namespace.ID, workflowID, runID string, startEventID, startEventVersion, endEventID, endEventVersion int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SendSingleWorkflowHistory", namespaceID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion)
+	ret := m.ctrl.Call(m, "SendSingleWorkflowHistory", remoteClusterName, namespaceID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SendSingleWorkflowHistory indicates an expected call of SendSingleWorkflowHistory.
-func (mr *MockNDCHistoryResenderMockRecorder) SendSingleWorkflowHistory(namespaceID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion interface{}) *gomock.Call {
+func (mr *MockNDCHistoryResenderMockRecorder) SendSingleWorkflowHistory(remoteClusterName, namespaceID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSingleWorkflowHistory", reflect.TypeOf((*MockNDCHistoryResender)(nil).SendSingleWorkflowHistory), namespaceID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendSingleWorkflowHistory", reflect.TypeOf((*MockNDCHistoryResender)(nil).SendSingleWorkflowHistory), remoteClusterName, namespaceID, workflowID, runID, startEventID, startEventVersion, endEventID, endEventVersion)
 }

--- a/common/xdc/nDCHistoryResender_test.go
+++ b/common/xdc/nDCHistoryResender_test.go
@@ -97,7 +97,7 @@ func (s *nDCHistoryResenderSuite) SetupTest() {
 	s.mockHistoryClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
 	s.mockNamespaceCache = namespace.NewMockRegistry(s.controller)
 
-	s.mockClientBean.EXPECT().GetRemoteAdminClient(gomock.Any()).Return(s.mockAdminClient).AnyTimes()
+	s.mockClientBean.EXPECT().GetRemoteAdminClient(gomock.Any()).Return(s.mockAdminClient, nil).AnyTimes()
 
 	s.logger = log.NewTestLogger()
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()

--- a/common/xdc/nDCHistoryResender_test.go
+++ b/common/xdc/nDCHistoryResender_test.go
@@ -29,8 +29,6 @@ import (
 	"testing"
 	"time"
 
-	"go.temporal.io/server/common/persistence/serialization"
-
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
@@ -45,10 +43,12 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives/timestamp"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 )
@@ -61,6 +61,7 @@ type (
 		controller          *gomock.Controller
 		mockClusterMetadata *cluster.MockMetadata
 		mockNamespaceCache  *namespace.MockRegistry
+		mockClientBean      *client.MockBean
 		mockAdminClient     *adminservicemock.MockAdminServiceClient
 		mockHistoryClient   *historyservicemock.MockHistoryServiceClient
 
@@ -91,9 +92,12 @@ func (s *nDCHistoryResenderSuite) SetupTest() {
 
 	s.controller = gomock.NewController(s.T())
 	s.mockClusterMetadata = cluster.NewMockMetadata(s.controller)
+	s.mockClientBean = client.NewMockBean(s.controller)
 	s.mockAdminClient = adminservicemock.NewMockAdminServiceClient(s.controller)
 	s.mockHistoryClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
 	s.mockNamespaceCache = namespace.NewMockRegistry(s.controller)
+
+	s.mockClientBean.EXPECT().GetRemoteAdminClient(gomock.Any()).Return(s.mockAdminClient).AnyTimes()
 
 	s.logger = log.NewTestLogger()
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
@@ -118,7 +122,7 @@ func (s *nDCHistoryResenderSuite) SetupTest() {
 
 	s.rereplicator = NewNDCHistoryResender(
 		s.mockNamespaceCache,
-		s.mockAdminClient,
+		s.mockClientBean,
 		func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
 			_, err := s.mockHistoryClient.ReplicateEventsV2(ctx, request)
 			return err
@@ -219,6 +223,7 @@ func (s *nDCHistoryResenderSuite) TestSendSingleWorkflowHistory() {
 		}).Return(nil, nil).Times(2)
 
 	err := s.rereplicator.SendSingleWorkflowHistory(
+		cluster.TestCurrentClusterName,
 		s.namespaceID,
 		workflowID,
 		runID,
@@ -355,6 +360,7 @@ func (s *nDCHistoryResenderSuite) TestGetHistory() {
 
 	out, err := s.rereplicator.getHistory(
 		context.Background(),
+		cluster.TestCurrentClusterName,
 		s.namespaceID,
 		workflowID,
 		runID,

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -1422,7 +1422,7 @@ func (adh *AdminHandler) ResendReplicationTasks(
 
 	resender := xdc.NewNDCHistoryResender(
 		adh.namespaceRegistry,
-		adh.clientBean.GetRemoteAdminClient(request.GetRemoteCluster()),
+		adh.clientBean,
 		func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
 			_, err1 := adh.historyClient.ReplicateEventsV2(ctx, request)
 			return err1
@@ -1432,6 +1432,7 @@ func (adh *AdminHandler) ResendReplicationTasks(
 		adh.logger,
 	)
 	if err := resender.SendSingleWorkflowHistory(
+		request.GetRemoteCluster(),
 		namespace.ID(request.GetNamespaceId()),
 		request.GetWorkflowId(),
 		request.GetRunId(),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -48,6 +48,7 @@ import (
 	"go.temporal.io/server/api/matchingservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	tokenspb "go.temporal.io/server/api/token/v1"
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -119,6 +120,7 @@ type (
 // NewEngineWithShardContext creates an instance of history engine
 func NewEngineWithShardContext(
 	shard shard.Context,
+	clientBean client.Bean,
 	matchingClient matchingservice.MatchingServiceClient,
 	sdkClientFactory sdk.ClientFactory,
 	eventNotifier events.Notifier,
@@ -213,7 +215,7 @@ func NewEngineWithShardContext(
 	)
 
 	historyEngImpl.workflowTaskHandler = newWorkflowTaskHandlerCallback(historyEngImpl)
-	historyEngImpl.replicationDLQHandler = replication.NewLazyDLQHandler(shard, workflowDeleteManager, historyCache)
+	historyEngImpl.replicationDLQHandler = replication.NewLazyDLQHandler(shard, workflowDeleteManager, historyCache, clientBean)
 
 	return historyEngImpl
 }

--- a/service/history/historyEngineFactory.go
+++ b/service/history/historyEngineFactory.go
@@ -27,6 +27,7 @@ package history
 import (
 	"go.uber.org/fx"
 
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/sdk"
@@ -42,6 +43,7 @@ type (
 	HistoryEngineFactoryParams struct {
 		fx.In
 
+		ClientBean              client.Bean
 		MatchingClient          resource.MatchingClient
 		SdkClientFactory        sdk.ClientFactory
 		EventNotifier           events.Notifier
@@ -63,6 +65,7 @@ func (f *historyEngineFactory) CreateEngine(
 ) shard.Engine {
 	return NewEngineWithShardContext(
 		context,
+		f.ClientBean,
 		f.MatchingClient,
 		f.SdkClientFactory,
 		f.EventNotifier,

--- a/service/history/queueProcessorFactory.go
+++ b/service/history/queueProcessorFactory.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -81,6 +82,7 @@ type (
 
 		SchedulerParams
 
+		ClientBean       client.Bean
 		ArchivalClient   archiver.Client
 		SdkClientFactory sdk.ClientFactory
 		MatchingClient   resource.MatchingClient
@@ -92,6 +94,7 @@ type (
 
 		SchedulerParams
 
+		ClientBean     client.Bean
 		ArchivalClient archiver.Client
 		MatchingClient resource.MatchingClient
 	}
@@ -108,6 +111,7 @@ type (
 		fx.In
 
 		Config             *configs.Config
+		ClientBean         client.Bean
 		ArchivalClient     archiver.Client
 		EventSerializer    serialization.Serializer
 		TaskFetcherFactory replication.TaskFetcherFactory
@@ -177,9 +181,9 @@ func (f *transferQueueProcessorFactory) CreateProcessor(
 ) queues.Processor {
 	return newTransferQueueProcessor(
 		shard,
-		engine,
 		workflowCache,
 		f.scheduler,
+		f.ClientBean,
 		f.ArchivalClient,
 		f.SdkClientFactory,
 		f.MatchingClient,
@@ -228,9 +232,9 @@ func (f *timerQueueProcessorFactory) CreateProcessor(
 ) queues.Processor {
 	return newTimerQueueProcessor(
 		shard,
-		engine,
 		workflowCache,
 		f.scheduler,
+		f.ClientBean,
 		f.ArchivalClient,
 		f.MatchingClient,
 	)
@@ -305,5 +309,6 @@ func (f *replicationQueueProcessorFactory) CreateProcessor(
 		shard,
 		f.TaskFetcherFactory,
 		workflowCache,
+		f.ClientBean,
 	)
 }

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -31,12 +31,11 @@ import (
 	"fmt"
 	"sync"
 
-	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
-	"go.temporal.io/server/client/admin"
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/client/history"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
@@ -46,10 +45,6 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
-)
-
-var (
-	errInvalidCluster = &serviceerror.InvalidArgument{Message: "Invalid target cluster name."}
 )
 
 type (
@@ -82,6 +77,7 @@ type (
 		shard             shard.Context
 		deleteManager     workflow.DeleteManager
 		workflowCache     workflow.Cache
+		resender          xdc.NDCHistoryResender
 		logger            log.Logger
 	}
 )
@@ -90,11 +86,13 @@ func NewLazyDLQHandler(
 	shard shard.Context,
 	deleteManager workflow.DeleteManager,
 	workflowCache workflow.Cache,
+	clientBean client.Bean,
 ) DLQHandler {
 	return newDLQHandler(
 		shard,
 		deleteManager,
 		workflowCache,
+		clientBean,
 		make(map[string]TaskExecutor),
 	)
 }
@@ -103,16 +101,36 @@ func newDLQHandler(
 	shard shard.Context,
 	deleteManager workflow.DeleteManager,
 	workflowCache workflow.Cache,
+	clientBean client.Bean,
 	taskExecutors map[string]TaskExecutor,
 ) *dlqHandlerImpl {
 
 	if taskExecutors == nil {
 		panic("Failed to initialize replication DLQ handler due to nil task executors")
 	}
+
+	historyClient := shard.GetHistoryClient()
+	historyRetryableClient := history.NewRetryableClient(
+		historyClient,
+		common.CreateReplicationServiceBusyRetryPolicy(),
+		common.IsResourceExhausted,
+	)
+
 	return &dlqHandlerImpl{
 		shard:         shard,
 		deleteManager: deleteManager,
 		workflowCache: workflowCache,
+		resender: xdc.NewNDCHistoryResender(
+			shard.GetNamespaceRegistry(),
+			clientBean,
+			func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
+				_, err := historyRetryableClient.ReplicateEventsV2(ctx, request)
+				return err
+			},
+			shard.GetPayloadSerializer(),
+			shard.GetConfig().StandbyTaskReReplicationContextTimeout,
+			shard.GetLogger(),
+		),
 		taskExecutors: taskExecutors,
 		logger:        shard.GetLogger(),
 	}
@@ -184,6 +202,9 @@ func (r *dlqHandlerImpl) MergeMessages(
 		pageSize,
 		pageToken,
 	)
+	if err != nil {
+		return nil, err
+	}
 
 	taskExecutor, err := r.getOrCreateTaskExecutor(sourceCluster)
 	if err != nil {
@@ -310,33 +331,12 @@ func (r *dlqHandlerImpl) getOrCreateTaskExecutor(clusterName string) (TaskExecut
 	if err != nil {
 		return nil, err
 	}
-	adminClient := r.shard.GetRemoteAdminClient(clusterName)
-	adminRetryableClient := admin.NewRetryableClient(
-		adminClient,
-		common.CreateReplicationServiceBusyRetryPolicy(),
-		common.IsResourceExhausted,
-	)
-	historyClient := r.shard.GetHistoryClient()
-	historyRetryableClient := history.NewRetryableClient(
-		historyClient,
-		common.CreateReplicationServiceBusyRetryPolicy(),
-		common.IsResourceExhausted,
-	)
-	resender := xdc.NewNDCHistoryResender(
-		r.shard.GetNamespaceRegistry(),
-		adminRetryableClient,
-		func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
-			_, err := historyRetryableClient.ReplicateEventsV2(ctx, request)
-			return err
-		},
-		r.shard.GetPayloadSerializer(),
-		r.shard.GetConfig().StandbyTaskReReplicationContextTimeout,
-		r.shard.GetLogger(),
-	)
+
 	taskExecutor := NewTaskExecutor(
+		clusterName,
 		r.shard,
 		r.shard.GetNamespaceRegistry(),
-		resender,
+		r.resender,
 		engine,
 		r.deleteManager,
 		r.workflowCache,

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -120,6 +120,7 @@ func (s *dlqHandlerSuite) SetupTest() {
 		s.mockShard,
 		workflow.NewMockDeleteManager(s.controller),
 		workflow.NewMockCache(s.controller),
+		s.mockClientBean,
 		s.taskExecutors,
 	)
 }

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -52,6 +52,7 @@ type (
 
 	taskExecutorImpl struct {
 		currentCluster     string
+		remoteCluster      string
 		shard              shard.Context
 		namespaceRegistry  namespace.Registry
 		nDCHistoryResender xdc.NDCHistoryResender
@@ -66,6 +67,7 @@ type (
 // NewTaskExecutor creates a replication task executor
 // The executor uses by 1) DLQ replication task handler 2) history replication task processor
 func NewTaskExecutor(
+	remoteCluster string,
 	shard shard.Context,
 	namespaceRegistry namespace.Registry,
 	nDCHistoryResender xdc.NDCHistoryResender,
@@ -77,6 +79,7 @@ func NewTaskExecutor(
 ) TaskExecutor {
 	return &taskExecutorImpl{
 		currentCluster:     shard.GetClusterMetadata().GetCurrentClusterName(),
+		remoteCluster:      remoteCluster,
 		shard:              shard,
 		namespaceRegistry:  namespaceRegistry,
 		nDCHistoryResender: nDCHistoryResender,
@@ -161,6 +164,7 @@ func (e *taskExecutorImpl) handleActivityTask(
 		defer stopwatch.Stop()
 
 		resendErr := e.nDCHistoryResender.SendSingleWorkflowHistory(
+			e.remoteCluster,
 			namespace.ID(retryErr.NamespaceId),
 			retryErr.WorkflowId,
 			retryErr.RunId,
@@ -225,6 +229,7 @@ func (e *taskExecutorImpl) handleHistoryReplicationTask(
 		defer resendStopWatch.Stop()
 
 		resendErr := e.nDCHistoryResender.SendSingleWorkflowHistory(
+			e.remoteCluster,
 			namespace.ID(retryErr.NamespaceId),
 			retryErr.WorkflowId,
 			retryErr.RunId,

--- a/service/history/replication/task_executor_test.go
+++ b/service/history/replication/task_executor_test.go
@@ -34,14 +34,12 @@ import (
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 
-	"go.temporal.io/server/api/adminservicemock/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
-	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -61,15 +59,13 @@ type (
 		*require.Assertions
 		controller *gomock.Controller
 
-		currentCluster     string
+		remoteCluster      string
 		mockResource       *resource.Test
 		mockShard          *shard.ContextTest
 		mockEngine         *shard.MockEngine
 		config             *configs.Config
 		historyClient      *historyservicemock.MockHistoryServiceClient
 		mockNamespaceCache *namespace.MockRegistry
-		mockClientBean     *client.MockBean
-		adminClient        *adminservicemock.MockAdminServiceClient
 		clusterMetadata    *cluster.MockMetadata
 		nDCHistoryResender *xdc.MockNDCHistoryResender
 
@@ -93,7 +89,7 @@ func (s *taskExecutorSuite) TearDownSuite() {
 func (s *taskExecutorSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.controller = gomock.NewController(s.T())
-	s.currentCluster = cluster.TestCurrentClusterName
+	s.remoteCluster = cluster.TestAlternativeClusterName
 
 	s.config = tests.NewDynamicConfig()
 	s.mockShard = shard.NewTestContext(
@@ -112,8 +108,6 @@ func (s *taskExecutorSuite) SetupTest() {
 	s.mockEngine = shard.NewMockEngine(s.controller)
 	s.mockResource = s.mockShard.Resource
 	s.mockNamespaceCache = s.mockResource.NamespaceCache
-	s.mockClientBean = s.mockResource.ClientBean
-	s.adminClient = s.mockResource.RemoteAdminClient
 	s.clusterMetadata = s.mockResource.ClusterMetadata
 	s.nDCHistoryResender = xdc.NewMockNDCHistoryResender(s.controller)
 
@@ -122,6 +116,7 @@ func (s *taskExecutorSuite) SetupTest() {
 	s.clusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 
 	s.replicationTaskExecutor = NewTaskExecutor(
+		s.remoteCluster,
 		s.mockShard,
 		s.mockNamespaceCache,
 		s.nDCHistoryResender,
@@ -281,6 +276,7 @@ func (s *taskExecutorSuite) TestProcessTaskOnce_SyncActivityReplicationTask_Rese
 	)
 	s.mockEngine.EXPECT().SyncActivity(gomock.Any(), request).Return(resendErr)
 	s.nDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.remoteCluster,
 		namespaceID,
 		workflowID,
 		runID,
@@ -367,6 +363,7 @@ func (s *taskExecutorSuite) TestProcess_HistoryReplicationTask_Resend() {
 	)
 	s.mockEngine.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(resendErr)
 	s.nDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.remoteCluster,
 		namespaceID,
 		workflowID,
 		runID,

--- a/service/history/replication/task_processor_factory.go
+++ b/service/history/replication/task_processor_factory.go
@@ -30,7 +30,7 @@ import (
 	"sync/atomic"
 
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/client/admin"
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/client/history"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
@@ -55,6 +55,7 @@ type (
 		status                        int32
 		replicationTaskFetcherFactory TaskFetcherFactory
 		workflowCache                 workflow.Cache
+		resender                      xdc.NDCHistoryResender
 
 		taskProcessorLock sync.RWMutex
 		taskProcessors    map[string]TaskProcessor
@@ -69,6 +70,7 @@ func NewTaskProcessorFactory(
 	shard shard.Context,
 	replicationTaskFetcherFactory TaskFetcherFactory,
 	workflowCache workflow.Cache,
+	clientBean client.Bean,
 ) queues.Processor {
 	workflowDeleteManager := workflow.NewDeleteManager(
 		shard,
@@ -77,6 +79,15 @@ func NewTaskProcessorFactory(
 		archivalClient,
 		shard.GetTimeSource(),
 	)
+
+	// Intentionally use the raw client to create its own retry policy
+	historyClient := shard.GetHistoryClient()
+	historyRetryableClient := history.NewRetryableClient(
+		historyClient,
+		common.CreateReplicationServiceBusyRetryPolicy(),
+		common.IsResourceExhausted,
+	)
+
 	return &taskProcessorFactoryImpl{
 		config:                        config,
 		deleteMgr:                     workflowDeleteManager,
@@ -86,7 +97,18 @@ func NewTaskProcessorFactory(
 		status:                        common.DaemonStatusInitialized,
 		replicationTaskFetcherFactory: replicationTaskFetcherFactory,
 		workflowCache:                 workflowCache,
-		taskProcessors:                make(map[string]TaskProcessor),
+		resender: xdc.NewNDCHistoryResender(
+			shard.GetNamespaceRegistry(),
+			clientBean,
+			func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
+				_, err := historyRetryableClient.ReplicateEventsV2(ctx, request)
+				return err
+			},
+			shard.GetPayloadSerializer(),
+			shard.GetConfig().StandbyTaskReReplicationContextTimeout,
+			shard.GetLogger(),
+		),
+		taskProcessors: make(map[string]TaskProcessor),
 	}
 }
 
@@ -120,28 +142,24 @@ func (r *taskProcessorFactoryImpl) Stop() {
 	r.taskProcessorLock.Unlock()
 }
 
-func (r taskProcessorFactoryImpl) Category() tasks.Category {
+func (r *taskProcessorFactoryImpl) Category() tasks.Category {
 	return tasks.CategoryReplication
 }
 
-func (r taskProcessorFactoryImpl) NotifyNewTasks(_ string, _ []tasks.Task) {
+func (r *taskProcessorFactoryImpl) NotifyNewTasks(_ string, _ []tasks.Task) {
 	//no-op
-	return
 }
 
-func (r taskProcessorFactoryImpl) FailoverNamespace(_ map[string]struct{}) {
+func (r *taskProcessorFactoryImpl) FailoverNamespace(_ map[string]struct{}) {
 	//no-op
-	return
 }
 
-func (r taskProcessorFactoryImpl) LockTaskProcessing() {
+func (r *taskProcessorFactoryImpl) LockTaskProcessing() {
 	//no-op
-	return
 }
 
-func (r taskProcessorFactoryImpl) UnlockTaskProcessing() {
+func (r *taskProcessorFactoryImpl) UnlockTaskProcessing() {
 	//no-op
-	return
 }
 
 func (r *taskProcessorFactoryImpl) listenToClusterMetadataChange() {
@@ -175,34 +193,11 @@ func (r *taskProcessorFactoryImpl) handleClusterMetadataUpdate(
 		if clusterInfo := newClusterMetadata[clusterName]; clusterInfo != nil && clusterInfo.Enabled {
 			// Case 2 and Case 3
 			fetcher := r.replicationTaskFetcherFactory.GetOrCreateFetcher(clusterName)
-			adminClient := r.shard.GetRemoteAdminClient(clusterName)
-			adminRetryableClient := admin.NewRetryableClient(
-				adminClient,
-				common.CreateReplicationServiceBusyRetryPolicy(),
-				common.IsResourceExhausted,
-			)
-			// Intentionally use the raw client to create its own retry policy
-			historyClient := r.shard.GetHistoryClient()
-			historyRetryableClient := history.NewRetryableClient(
-				historyClient,
-				common.CreateReplicationServiceBusyRetryPolicy(),
-				common.IsResourceExhausted,
-			)
-			nDCHistoryResender := xdc.NewNDCHistoryResender(
-				r.shard.GetNamespaceRegistry(),
-				adminRetryableClient,
-				func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
-					_, err := historyRetryableClient.ReplicateEventsV2(ctx, request)
-					return err
-				},
-				r.shard.GetPayloadSerializer(),
-				r.shard.GetConfig().StandbyTaskReReplicationContextTimeout,
-				r.shard.GetLogger(),
-			)
 			replicationTaskExecutor := NewTaskExecutor(
+				clusterName,
 				r.shard,
 				r.shard.GetNamespaceRegistry(),
-				nDCHistoryResender,
+				r.resender,
 				r.engine,
 				r.deleteMgr,
 				r.workflowCache,

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -25,9 +25,12 @@
 package history
 
 import (
+	"context"
 	"time"
 
+	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/client"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/log"
@@ -57,7 +60,7 @@ func newTimerQueueStandbyProcessor(
 	matchingClient matchingservice.MatchingServiceClient,
 	clusterName string,
 	taskAllocator taskAllocator,
-	nDCHistoryResender xdc.NDCHistoryResender,
+	clientBean client.Bean,
 	logger log.Logger,
 ) *timerQueueStandbyProcessorImpl {
 
@@ -91,7 +94,20 @@ func newTimerQueueStandbyProcessor(
 		shard,
 		workflowCache,
 		workflowDeleteManager,
-		nDCHistoryResender,
+		xdc.NewNDCHistoryResender(
+			shard.GetNamespaceRegistry(),
+			clientBean,
+			func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
+				engine, err := shard.GetEngine()
+				if err != nil {
+					return err
+				}
+				return engine.ReplicateEventsV2(ctx, request)
+			},
+			shard.GetPayloadSerializer(),
+			config.StandbyTaskReReplicationContextTimeout,
+			logger,
+		),
 		matchingClient,
 		logger,
 		clusterName,

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -532,6 +532,7 @@ func (t *timerQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 		// NOTE: history resend may take long time and its timeout is currently
 		// controlled by a separate dynamicconfig config: StandbyTaskReReplicationContextTimeout
 		err = t.nDCHistoryResender.SendSingleWorkflowHistory(
+			t.clusterName,
 			namespace.ID(taskInfo.GetNamespaceID()),
 			taskInfo.GetWorkflowID(),
 			taskInfo.GetRunID(),

--- a/service/history/timerQueueStandbyTaskExecutor_test.go
+++ b/service/history/timerQueueStandbyTaskExecutor_test.go
@@ -277,6 +277,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(timerTask.NamespaceID),
 		timerTask.WorkflowID,
 		timerTask.RunID,
@@ -506,6 +507,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending(
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(timerTask.NamespaceID),
 		timerTask.WorkflowID,
 		timerTask.RunID,
@@ -850,6 +852,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowTaskTimeout_Pend
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(timerTask.NamespaceID),
 		timerTask.WorkflowID,
 		timerTask.RunID,
@@ -1005,6 +1008,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pen
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(timerTask.NamespaceID),
 		timerTask.WorkflowID,
 		timerTask.RunID,
@@ -1130,6 +1134,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending(
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(timerTask.NamespaceID),
 		timerTask.WorkflowID,
 		timerTask.RunID,
@@ -1485,6 +1490,7 @@ func (s *timerQueueStandbyTaskExecutorSuite) TestProcessActivityRetryTimer_Pendi
 		Execution: &execution,
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		s.namespaceID,
 		execution.WorkflowId,
 		execution.RunId,

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -35,13 +35,13 @@ import (
 
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/sdk"
-	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/shard"
@@ -61,13 +61,13 @@ type (
 		isGlobalNamespaceEnabled  bool
 		currentClusterName        string
 		shard                     shard.Context
-		historyEngine             shard.Engine
 		workflowCache             workflow.Cache
 		archivalClient            archiver.Client
 		sdkClientFactory          sdk.ClientFactory
 		taskAllocator             taskAllocator
 		config                    *configs.Config
 		metricsClient             metrics.Client
+		clientBean                client.Bean
 		matchingClient            matchingservice.MatchingServiceClient
 		historyClient             historyservice.HistoryServiceClient
 		ackLevel                  int64
@@ -84,9 +84,9 @@ type (
 
 func newTransferQueueProcessor(
 	shard shard.Context,
-	historyEngine shard.Engine,
 	workflowCache workflow.Cache,
 	scheduler queues.Scheduler,
+	clientBean client.Bean,
 	archivalClient archiver.Client,
 	sdkClientFactory sdk.ClientFactory,
 	matchingClient matchingservice.MatchingServiceClient,
@@ -102,13 +102,13 @@ func newTransferQueueProcessor(
 		isGlobalNamespaceEnabled: shard.GetClusterMetadata().IsGlobalNamespaceEnabled(),
 		currentClusterName:       currentClusterName,
 		shard:                    shard,
-		historyEngine:            historyEngine,
 		workflowCache:            workflowCache,
 		archivalClient:           archivalClient,
 		sdkClientFactory:         sdkClientFactory,
 		taskAllocator:            taskAllocator,
 		config:                   config,
 		metricsClient:            shard.GetMetricsClient(),
+		clientBean:               clientBean,
 		matchingClient:           matchingClient,
 		historyClient:            historyClient,
 		ackLevel:                 shard.GetQueueAckLevel(tasks.CategoryTransfer).TaskID,
@@ -355,16 +355,6 @@ func (t *transferQueueProcessorImpl) handleClusterMetadataUpdate(
 		}
 		if clusterInfo := newClusterMetadata[clusterName]; clusterInfo != nil && clusterInfo.Enabled {
 			// Case 2 and Case 3
-			nDCHistoryResender := xdc.NewNDCHistoryResender(
-				t.shard.GetNamespaceRegistry(),
-				t.shard.GetRemoteAdminClient(clusterName),
-				func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
-					return t.historyEngine.ReplicateEventsV2(ctx, request)
-				},
-				t.shard.GetPayloadSerializer(),
-				t.config.StandbyTaskReReplicationContextTimeout,
-				t.logger,
-			)
 			processor := newTransferQueueStandbyProcessor(
 				clusterName,
 				t.shard,
@@ -372,7 +362,7 @@ func (t *transferQueueProcessorImpl) handleClusterMetadataUpdate(
 				t.workflowCache,
 				t.archivalClient,
 				t.taskAllocator,
-				nDCHistoryResender,
+				t.clientBean,
 				t.logger,
 				t.matchingClient,
 			)

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -25,8 +25,12 @@
 package history
 
 import (
+	"context"
+
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
+	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -54,7 +58,7 @@ func newTransferQueueStandbyProcessor(
 	workflowCache workflow.Cache,
 	archivalClient archiver.Client,
 	taskAllocator taskAllocator,
-	nDCHistoryResender xdc.NDCHistoryResender,
+	clientBean client.Bean,
 	logger log.Logger,
 	matchingClient matchingservice.MatchingServiceClient,
 ) *transferQueueStandbyProcessorImpl {
@@ -112,7 +116,20 @@ func newTransferQueueStandbyProcessor(
 		shard,
 		workflowCache,
 		archivalClient,
-		nDCHistoryResender,
+		xdc.NewNDCHistoryResender(
+			shard.GetNamespaceRegistry(),
+			clientBean,
+			func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
+				engine, err := shard.GetEngine()
+				if err != nil {
+					return err
+				}
+				return engine.ReplicateEventsV2(ctx, request)
+			},
+			shard.GetPayloadSerializer(),
+			config.StandbyTaskReReplicationContextTimeout,
+			logger,
+		),
 		logger,
 		clusterName,
 		matchingClient,

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -612,6 +612,7 @@ func (t *transferQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 		// NOTE: history resend may take long time and its timeout is currently
 		// controlled by a separate dynamicconfig config: StandbyTaskReReplicationContextTimeout
 		err = t.nDCHistoryResender.SendSingleWorkflowHistory(
+			t.clusterName,
 			namespace.ID(taskInfo.GetNamespaceID()),
 			taskInfo.GetWorkflowID(),
 			taskInfo.GetRunID(),

--- a/service/history/transferQueueStandbyTaskExecutor_test.go
+++ b/service/history/transferQueueStandbyTaskExecutor_test.go
@@ -270,6 +270,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessActivityTask_Pending(
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(transferTask.NamespaceID),
 		transferTask.WorkflowID,
 		transferTask.RunID,
@@ -412,6 +413,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessWorkflowTask_Pending(
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(transferTask.NamespaceID),
 		transferTask.WorkflowID,
 		transferTask.RunID,
@@ -719,6 +721,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessCancelExecution_Pendi
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(transferTask.NamespaceID),
 		transferTask.WorkflowID,
 		transferTask.RunID,
@@ -874,6 +877,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessSignalExecution_Pendi
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(transferTask.NamespaceID),
 		transferTask.WorkflowID,
 		transferTask.RunID,
@@ -1028,6 +1032,7 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_P
 		},
 	}).Return(&adminservice.RefreshWorkflowTasksResponse{}, nil)
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
+		s.clusterName,
 		namespace.ID(transferTask.NamespaceID),
 		transferTask.WorkflowID,
 		transferTask.RunID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Refactor ndc history resender to handle multiple remote clusters

<!-- Tell your future self why have you made these changes -->
**Why?**
- Existing history resend is bind to particular remote cluster and can't be used for resending history from other remote clusters. This means we need to create one resender for each remote cluster and also worry about cluster metadata update. 
- Needed by https://github.com/temporalio/temporal/pull/2864, so that we don't need to refactor existing standby task executor implementation (or creating multiple standby executors and add callback for cluster metadata update) but still be able to handle standby tasks which need to resend history from different remote clusters.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
