### PR TITLE
Return error when cluster info is not found

### DIFF
--- a/client/clientBean.go
+++ b/client/clientBean.go
@@ -32,7 +32,6 @@ import (
 	"sync/atomic"
 
 	"go.temporal.io/api/serviceerror"
-
 	"go.temporal.io/api/workflowservice/v1"
 
 	"go.temporal.io/server/api/adminservice/v1"

--- a/client/clientBean.go
+++ b/client/clientBean.go
@@ -28,9 +28,10 @@ package client
 
 import (
 	"fmt"
-	"go.temporal.io/api/serviceerror"
 	"sync"
 	"sync/atomic"
+
+	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/api/workflowservice/v1"
 

--- a/client/clientBean_mock.go
+++ b/client/clientBean_mock.go
@@ -105,11 +105,12 @@ func (mr *MockBeanMockRecorder) GetMatchingClient(namespaceIDToName interface{})
 }
 
 // GetRemoteAdminClient mocks base method.
-func (m *MockBean) GetRemoteAdminClient(cluster string) v10.AdminServiceClient {
+func (m *MockBean) GetRemoteAdminClient(cluster string) (v10.AdminServiceClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRemoteAdminClient", cluster)
 	ret0, _ := ret[0].(v10.AdminServiceClient)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetRemoteAdminClient indicates an expected call of GetRemoteAdminClient.
@@ -119,11 +120,12 @@ func (mr *MockBeanMockRecorder) GetRemoteAdminClient(cluster interface{}) *gomoc
 }
 
 // GetRemoteFrontendClient mocks base method.
-func (m *MockBean) GetRemoteFrontendClient(cluster string) v1.WorkflowServiceClient {
+func (m *MockBean) GetRemoteFrontendClient(cluster string) (v1.WorkflowServiceClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRemoteFrontendClient", cluster)
 	ret0, _ := ret[0].(v1.WorkflowServiceClient)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetRemoteFrontendClient indicates an expected call of GetRemoteFrontendClient.

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -134,8 +134,8 @@ func NewTest(
 	clientBean.EXPECT().GetFrontendClient().Return(frontendClient).AnyTimes()
 	clientBean.EXPECT().GetMatchingClient(gomock.Any()).Return(matchingClient, nil).AnyTimes()
 	clientBean.EXPECT().GetHistoryClient().Return(historyClient).AnyTimes()
-	clientBean.EXPECT().GetRemoteAdminClient(gomock.Any()).Return(remoteAdminClient).AnyTimes()
-	clientBean.EXPECT().GetRemoteFrontendClient(gomock.Any()).Return(remoteFrontendClient).AnyTimes()
+	clientBean.EXPECT().GetRemoteAdminClient(gomock.Any()).Return(remoteAdminClient, nil).AnyTimes()
+	clientBean.EXPECT().GetRemoteFrontendClient(gomock.Any()).Return(remoteFrontendClient, nil).AnyTimes()
 	clientFactory := client.NewMockFactory(controller)
 
 	metadataMgr := persistence.NewMockMetadataManager(controller)

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -1419,10 +1419,13 @@ func (adh *AdminHandler) ResendReplicationTasks(
 	if request == nil {
 		return nil, adh.error(errRequestNotSet, scope)
 	}
-
+	remoteClient, err := adh.clientBean.GetRemoteAdminClient(request.GetRemoteCluster())
+	if err != nil {
+		return nil, err
+	}
 	resender := xdc.NewNDCHistoryResender(
 		adh.namespaceRegistry,
-		adh.clientBean.GetRemoteAdminClient(request.GetRemoteCluster()),
+		remoteClient,
 		func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
 			_, err1 := adh.historyClient.ReplicateEventsV2(ctx, request)
 			return err1

--- a/service/frontend/dcRedirectionHandler.go
+++ b/service/frontend/dcRedirectionHandler.go
@@ -208,7 +208,11 @@ func (handler *DCRedirectionHandlerImpl) DescribeTaskQueue(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.DescribeTaskQueue(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.DescribeTaskQueue(ctx, request)
 		}
 		return err
@@ -238,7 +242,11 @@ func (handler *DCRedirectionHandlerImpl) DescribeWorkflowExecution(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.DescribeWorkflowExecution(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.DescribeWorkflowExecution(ctx, request)
 		}
 		return err
@@ -268,7 +276,11 @@ func (handler *DCRedirectionHandlerImpl) GetWorkflowExecutionHistory(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.GetWorkflowExecutionHistory(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.GetWorkflowExecutionHistory(ctx, request)
 		}
 		return err
@@ -298,7 +310,11 @@ func (handler *DCRedirectionHandlerImpl) GetWorkflowExecutionHistoryReverse(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.GetWorkflowExecutionHistoryReverse(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.GetWorkflowExecutionHistoryReverse(ctx, request)
 		}
 		return err
@@ -328,7 +344,11 @@ func (handler *DCRedirectionHandlerImpl) ListArchivedWorkflowExecutions(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ListArchivedWorkflowExecutions(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ListArchivedWorkflowExecutions(ctx, request)
 		}
 		return err
@@ -358,7 +378,11 @@ func (handler *DCRedirectionHandlerImpl) ListClosedWorkflowExecutions(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ListClosedWorkflowExecutions(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ListClosedWorkflowExecutions(ctx, request)
 		}
 		return err
@@ -388,7 +412,11 @@ func (handler *DCRedirectionHandlerImpl) ListOpenWorkflowExecutions(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ListOpenWorkflowExecutions(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ListOpenWorkflowExecutions(ctx, request)
 		}
 		return err
@@ -418,7 +446,11 @@ func (handler *DCRedirectionHandlerImpl) ListWorkflowExecutions(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ListWorkflowExecutions(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ListWorkflowExecutions(ctx, request)
 		}
 		return err
@@ -447,7 +479,11 @@ func (handler *DCRedirectionHandlerImpl) ScanWorkflowExecutions(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ScanWorkflowExecutions(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ScanWorkflowExecutions(ctx, request)
 		}
 		return err
@@ -477,7 +513,11 @@ func (handler *DCRedirectionHandlerImpl) CountWorkflowExecutions(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.CountWorkflowExecutions(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.CountWorkflowExecutions(ctx, request)
 		}
 		return err
@@ -523,7 +563,11 @@ func (handler *DCRedirectionHandlerImpl) PollActivityTaskQueue(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.PollActivityTaskQueue(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.PollActivityTaskQueue(ctx, request)
 		}
 		return err
@@ -553,7 +597,11 @@ func (handler *DCRedirectionHandlerImpl) PollWorkflowTaskQueue(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.PollWorkflowTaskQueue(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.PollWorkflowTaskQueue(ctx, request)
 		}
 		return err
@@ -582,7 +630,11 @@ func (handler *DCRedirectionHandlerImpl) QueryWorkflow(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.QueryWorkflow(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.QueryWorkflow(ctx, request)
 		}
 		return err
@@ -617,7 +669,11 @@ func (handler *DCRedirectionHandlerImpl) RecordActivityTaskHeartbeat(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RecordActivityTaskHeartbeat(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RecordActivityTaskHeartbeat(ctx, request)
 		}
 		return err
@@ -647,7 +703,11 @@ func (handler *DCRedirectionHandlerImpl) RecordActivityTaskHeartbeatById(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RecordActivityTaskHeartbeatById(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RecordActivityTaskHeartbeatById(ctx, request)
 		}
 		return err
@@ -677,7 +737,11 @@ func (handler *DCRedirectionHandlerImpl) RequestCancelWorkflowExecution(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RequestCancelWorkflowExecution(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RequestCancelWorkflowExecution(ctx, request)
 		}
 		return err
@@ -707,7 +771,11 @@ func (handler *DCRedirectionHandlerImpl) ResetStickyTaskQueue(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ResetStickyTaskQueue(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ResetStickyTaskQueue(ctx, request)
 		}
 		return err
@@ -737,7 +805,11 @@ func (handler *DCRedirectionHandlerImpl) ResetWorkflowExecution(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ResetWorkflowExecution(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ResetWorkflowExecution(ctx, request)
 		}
 		return err
@@ -772,7 +844,11 @@ func (handler *DCRedirectionHandlerImpl) RespondActivityTaskCanceled(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondActivityTaskCanceled(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondActivityTaskCanceled(ctx, request)
 		}
 		return err
@@ -802,7 +878,11 @@ func (handler *DCRedirectionHandlerImpl) RespondActivityTaskCanceledById(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondActivityTaskCanceledById(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondActivityTaskCanceledById(ctx, request)
 		}
 		return err
@@ -837,7 +917,11 @@ func (handler *DCRedirectionHandlerImpl) RespondActivityTaskCompleted(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondActivityTaskCompleted(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondActivityTaskCompleted(ctx, request)
 		}
 		return err
@@ -867,7 +951,11 @@ func (handler *DCRedirectionHandlerImpl) RespondActivityTaskCompletedById(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondActivityTaskCompletedById(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondActivityTaskCompletedById(ctx, request)
 		}
 		return err
@@ -902,7 +990,11 @@ func (handler *DCRedirectionHandlerImpl) RespondActivityTaskFailed(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondActivityTaskFailed(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondActivityTaskFailed(ctx, request)
 		}
 		return err
@@ -932,7 +1024,11 @@ func (handler *DCRedirectionHandlerImpl) RespondActivityTaskFailedById(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondActivityTaskFailedById(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondActivityTaskFailedById(ctx, request)
 		}
 		return err
@@ -967,7 +1063,11 @@ func (handler *DCRedirectionHandlerImpl) RespondWorkflowTaskCompleted(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondWorkflowTaskCompleted(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondWorkflowTaskCompleted(ctx, request)
 		}
 		return err
@@ -1002,7 +1102,11 @@ func (handler *DCRedirectionHandlerImpl) RespondWorkflowTaskFailed(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondWorkflowTaskFailed(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondWorkflowTaskFailed(ctx, request)
 		}
 		return err
@@ -1037,7 +1141,11 @@ func (handler *DCRedirectionHandlerImpl) RespondQueryTaskCompleted(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.RespondQueryTaskCompleted(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.RespondQueryTaskCompleted(ctx, request)
 		}
 		return err
@@ -1067,7 +1175,11 @@ func (handler *DCRedirectionHandlerImpl) SignalWithStartWorkflowExecution(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.SignalWithStartWorkflowExecution(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.SignalWithStartWorkflowExecution(ctx, request)
 		}
 		return err
@@ -1097,7 +1209,11 @@ func (handler *DCRedirectionHandlerImpl) SignalWorkflowExecution(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.SignalWorkflowExecution(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.SignalWorkflowExecution(ctx, request)
 		}
 		return err
@@ -1126,7 +1242,11 @@ func (handler *DCRedirectionHandlerImpl) StartWorkflowExecution(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.StartWorkflowExecution(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.StartWorkflowExecution(ctx, request)
 		}
 		return err
@@ -1156,7 +1276,11 @@ func (handler *DCRedirectionHandlerImpl) TerminateWorkflowExecution(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.TerminateWorkflowExecution(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.TerminateWorkflowExecution(ctx, request)
 		}
 		return err
@@ -1186,7 +1310,11 @@ func (handler *DCRedirectionHandlerImpl) ListTaskQueuePartitions(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ListTaskQueuePartitions(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ListTaskQueuePartitions(ctx, request)
 		}
 		return err
@@ -1231,7 +1359,11 @@ func (handler *DCRedirectionHandlerImpl) CreateSchedule(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.CreateSchedule(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.CreateSchedule(ctx, request)
 		}
 		return err
@@ -1260,7 +1392,11 @@ func (handler *DCRedirectionHandlerImpl) DescribeSchedule(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.DescribeSchedule(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.DescribeSchedule(ctx, request)
 		}
 		return err
@@ -1289,7 +1425,11 @@ func (handler *DCRedirectionHandlerImpl) UpdateSchedule(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.UpdateSchedule(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.UpdateSchedule(ctx, request)
 		}
 		return err
@@ -1318,7 +1458,11 @@ func (handler *DCRedirectionHandlerImpl) PatchSchedule(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.PatchSchedule(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.PatchSchedule(ctx, request)
 		}
 		return err
@@ -1347,7 +1491,11 @@ func (handler *DCRedirectionHandlerImpl) ListScheduleMatchingTimes(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ListScheduleMatchingTimes(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ListScheduleMatchingTimes(ctx, request)
 		}
 		return err
@@ -1376,7 +1524,11 @@ func (handler *DCRedirectionHandlerImpl) DeleteSchedule(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.DeleteSchedule(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.DeleteSchedule(ctx, request)
 		}
 		return err
@@ -1405,7 +1557,11 @@ func (handler *DCRedirectionHandlerImpl) ListSchedules(
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.ListSchedules(ctx, request)
 		default:
-			remoteClient := handler.clientBean.GetRemoteFrontendClient(targetDC)
+			var remoteClient workflowservice.WorkflowServiceClient
+			remoteClient, err = handler.clientBean.GetRemoteFrontendClient(targetDC)
+			if err != nil {
+				return err
+			}
 			resp, err = remoteClient.ListSchedules(ctx, request)
 		}
 		return err

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -250,7 +250,10 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 	}
 	pageToken = resp.NextPageToken
 
-	remoteAdminClient := r.shard.GetRemoteAdminClient(sourceCluster)
+	remoteAdminClient, err := r.shard.GetRemoteAdminClient(sourceCluster)
+	if err != nil {
+		return nil, ackLevel, nil, err
+	}
 	taskInfo := make([]*replicationspb.ReplicationTaskInfo, 0, len(resp.Tasks))
 	for _, task := range resp.Tasks {
 		switch task := task.(type) {
@@ -310,7 +313,10 @@ func (r *dlqHandlerImpl) getOrCreateTaskExecutor(clusterName string) (TaskExecut
 	if err != nil {
 		return nil, err
 	}
-	adminClient := r.shard.GetRemoteAdminClient(clusterName)
+	adminClient, err := r.shard.GetRemoteAdminClient(clusterName)
+	if err != nil {
+		return nil, err
+	}
 	adminRetryableClient := admin.NewRetryableClient(
 		adminClient,
 		common.CreateReplicationServiceBusyRetryPolicy(),

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -187,7 +187,7 @@ func (s *dlqHandlerSuite) TestReadMessages_OK() {
 		SourceClusterName: s.sourceCluster,
 	}).Return(dbResp, nil)
 
-	s.mockClientBean.EXPECT().GetRemoteAdminClient(s.sourceCluster).Return(s.adminClient).AnyTimes()
+	s.mockClientBean.EXPECT().GetRemoteAdminClient(s.sourceCluster).Return(s.adminClient, nil).AnyTimes()
 	s.adminClient.EXPECT().GetDLQReplicationMessages(ctx, gomock.Any()).
 		Return(&adminservice.GetDLQReplicationMessagesResponse{
 			ReplicationTasks: []*replicationspb.ReplicationTask{remoteTask},
@@ -276,7 +276,7 @@ func (s *dlqHandlerSuite) TestMergeMessages() {
 		SourceClusterName: s.sourceCluster,
 	}).Return(dbResp, nil)
 
-	s.mockClientBean.EXPECT().GetRemoteAdminClient(s.sourceCluster).Return(s.adminClient).AnyTimes()
+	s.mockClientBean.EXPECT().GetRemoteAdminClient(s.sourceCluster).Return(s.adminClient, nil).AnyTimes()
 	s.adminClient.EXPECT().GetDLQReplicationMessages(ctx, gomock.Any()).
 		Return(&adminservice.GetDLQReplicationMessagesResponse{
 			ReplicationTasks: []*replicationspb.ReplicationTask{remoteTask},

--- a/service/history/replication/task_fetcher.go
+++ b/service/history/replication/task_fetcher.go
@@ -422,7 +422,10 @@ func (f *replicationTaskFetcherWorker) getMessages() error {
 		Tokens:      tokens,
 		ClusterName: f.currentCluster,
 	}
-	remoteClient := f.clientBean.GetRemoteAdminClient(f.sourceCluster)
+	remoteClient, err := f.clientBean.GetRemoteAdminClient(f.sourceCluster)
+	if err != nil {
+		return err
+	}
 	response, err := remoteClient.GetReplicationMessages(ctx, request)
 	if err != nil {
 		f.logger.Error("Failed to get replication tasks", tag.Error(err))

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -114,7 +114,7 @@ type (
 		// If branchToken != nil, then delete history also, otherwise leave history.
 		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, version int64, startTime *time.Time, closeTime *time.Time) error
 
-		GetRemoteAdminClient(cluster string) adminservice.AdminServiceClient
+		GetRemoteAdminClient(cluster string) (adminservice.AdminServiceClient, error)
 		GetHistoryClient() historyservice.HistoryServiceClient
 		GetPayloadSerializer() serialization.Serializer
 

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1992,7 +1992,7 @@ func copyShardInfo(shardInfo *persistence.ShardInfoWithFailover) *persistence.Sh
 	return shardInfoCopy
 }
 
-func (s *ContextImpl) GetRemoteAdminClient(cluster string) adminservice.AdminServiceClient {
+func (s *ContextImpl) GetRemoteAdminClient(cluster string) (adminservice.AdminServiceClient, error) {
 	return s.clientBean.GetRemoteAdminClient(cluster)
 }
 func (s *ContextImpl) GetPayloadSerializer() serialization.Serializer {

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -519,11 +519,12 @@ func (mr *MockContextMockRecorder) GetQueueMaxReadLevel(category, cluster interf
 }
 
 // GetRemoteAdminClient mocks base method.
-func (m *MockContext) GetRemoteAdminClient(cluster string) v10.AdminServiceClient {
+func (m *MockContext) GetRemoteAdminClient(cluster string) (v10.AdminServiceClient, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRemoteAdminClient", cluster)
 	ret0, _ := ret[0].(v10.AdminServiceClient)
-	return ret0
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetRemoteAdminClient indicates an expected call of GetRemoteAdminClient.

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -356,10 +356,16 @@ func (t *timerQueueProcessorImpl) handleClusterMetadataUpdate(
 			delete(t.standbyTimerProcessors, clusterName)
 		}
 		if clusterInfo := newClusterMetadata[clusterName]; clusterInfo != nil && clusterInfo.Enabled {
+			remoteAdminClient, err := t.shard.GetRemoteAdminClient(clusterName)
+			if err != nil {
+				// Cannot find remote cluster info.
+				// This should never happen as cluster metadata should have the up-to-date data.
+				panic(fmt.Sprintf("Bug found in cluster metadata with error %v", err))
+			}
 			// Case 2 and Case 3
 			nDCHistoryResender := xdc.NewNDCHistoryResender(
 				t.shard.GetNamespaceRegistry(),
-				t.shard.GetRemoteAdminClient(clusterName),
+				remoteAdminClient,
 				func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
 					return t.historyEngine.ReplicateEventsV2(ctx, request)
 				},

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -849,7 +849,10 @@ func (c *ContextImpl) ReapplyEvents(
 	// The active cluster of the namespace is differ from the current cluster
 	// Use frontend client to route this request to the active cluster
 	// Reapplication only happens in active cluster
-	sourceCluster := c.shard.GetRemoteAdminClient(activeCluster)
+	sourceCluster, err := c.shard.GetRemoteAdminClient(activeCluster)
+	if err != nil {
+		return err
+	}
 	if sourceCluster == nil {
 		return serviceerror.NewInternal(fmt.Sprintf("cannot find cluster config %v to do reapply", activeCluster))
 	}

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -206,8 +206,10 @@ func signalRemoteCluster(
 	numWorkflows int,
 ) error {
 	for cluster, executions := range remoteExecutions {
-		remoteClient := clientBean.GetRemoteFrontendClient(cluster)
-
+		remoteClient, err := clientBean.GetRemoteFrontendClient(cluster)
+		if err != nil {
+			return err
+		}
 		signalValue := Request{
 			ParentExecution: parentExecution,
 			Executions:      executions,

--- a/service/worker/parentclosepolicy/workflow_test.go
+++ b/service/worker/parentclosepolicy/workflow_test.go
@@ -77,7 +77,7 @@ func (s *parentClosePolicyWorkflowSuite) SetupTest() {
 	s.mockRemoteClient = workflowservicemock.NewMockWorkflowServiceClient(s.controller)
 
 	s.mockClientBean.EXPECT().GetHistoryClient().Return(s.mockHistoryClient).AnyTimes()
-	s.mockClientBean.EXPECT().GetRemoteFrontendClient(gomock.Any()).Return(s.mockRemoteClient).AnyTimes()
+	s.mockClientBean.EXPECT().GetRemoteFrontendClient(gomock.Any()).Return(s.mockRemoteClient, nil).AnyTimes()
 
 	s.processor = &Processor{
 		metricsClient: metrics.NoopClient,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Return error when cluster info is not found

<!-- Tell your future self why have you made these changes -->
**Why?**
The cluster info and namespace are both updated in frontend. There is a race conditional in history service, the namespace is updated earlier than the cluster info. This should recover after retries.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
