### PR TITLE
Add task count metric

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1857,6 +1857,7 @@ const (
 	PersistenceRequests
 	PersistenceFailures
 	PersistenceLatency
+	PersistenceTaskCount
 	PersistenceErrShardExistsCounter
 	PersistenceErrShardOwnershipLostCounter
 	PersistenceErrConditionFailedCounter
@@ -2352,6 +2353,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		PersistenceRequests:                                 NewCounterDef("persistence_requests"),
 		PersistenceFailures:                                 NewCounterDef("persistence_errors"),
 		PersistenceLatency:                                  NewTimerDef("persistence_latency"),
+		PersistenceTaskCount:                                NewDimensionlessHistogramDef("persistence_task_count"),
 		PersistenceErrShardExistsCounter:                    NewCounterDef("persistence_errors_shard_exists"),
 		PersistenceErrShardOwnershipLostCounter:             NewCounterDef("persistence_errors_shard_ownership_lost"),
 		PersistenceErrConditionFailedCounter:                NewCounterDef("persistence_errors_condition_failed"),

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1857,7 +1857,6 @@ const (
 	PersistenceRequests
 	PersistenceFailures
 	PersistenceLatency
-	PersistenceTaskCount
 	PersistenceErrShardExistsCounter
 	PersistenceErrShardOwnershipLostCounter
 	PersistenceErrConditionFailedCounter
@@ -2112,6 +2111,7 @@ const (
 	SignalInfoCount
 	RequestCancelInfoCount
 	BufferedEventsCount
+	TaskCount
 	WorkflowRetryBackoffTimerCount
 	WorkflowCronBackoffTimerCount
 	WorkflowCleanupDeleteCount
@@ -2353,7 +2353,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		PersistenceRequests:                                 NewCounterDef("persistence_requests"),
 		PersistenceFailures:                                 NewCounterDef("persistence_errors"),
 		PersistenceLatency:                                  NewTimerDef("persistence_latency"),
-		PersistenceTaskCount:                                NewDimensionlessHistogramDef("persistence_task_count"),
 		PersistenceErrShardExistsCounter:                    NewCounterDef("persistence_errors_shard_exists"),
 		PersistenceErrShardOwnershipLostCounter:             NewCounterDef("persistence_errors_shard_ownership_lost"),
 		PersistenceErrConditionFailedCounter:                NewCounterDef("persistence_errors_condition_failed"),
@@ -2594,6 +2593,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		SignalInfoCount:                                   NewDimensionlessHistogramDef("signal_info_count"),
 		RequestCancelInfoCount:                            NewDimensionlessHistogramDef("request_cancel_info_count"),
 		BufferedEventsCount:                               NewDimensionlessHistogramDef("buffered_events_count"),
+		TaskCount:                                         NewDimensionlessHistogramDef("task_count"),
 		WorkflowRetryBackoffTimerCount:                    NewCounterDef("workflow_retry_backoff_timer"),
 		WorkflowCronBackoffTimerCount:                     NewCounterDef("workflow_cron_backoff_timer"),
 		WorkflowCleanupDeleteCount:                        NewCounterDef("workflow_cleanup_delete"),

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -688,6 +688,7 @@ type (
 		SignalInfoCount        int
 		SignalRequestIDCount   int
 		BufferedEventsCount    int
+		TaskCountByCategory    map[string]int
 	}
 
 	HistoryStatistics struct {

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -249,7 +249,6 @@ func (p *executionPersistenceClient) SetWorkflowExecution(
 ) (*SetWorkflowExecutionResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceSetWorkflowExecutionScope, metrics.PersistenceRequests)
 
-	p.emitPerCategoryTaskMetrics(metrics.PersistenceSetWorkflowExecutionScope, &request.SetWorkflowSnapshot.Tasks)
 	sw := p.metricClient.StartTimer(metrics.PersistenceSetWorkflowExecutionScope, metrics.PersistenceLatency)
 	response, err := p.persistence.SetWorkflowExecution(ctx, request)
 	sw.Stop()
@@ -267,7 +266,6 @@ func (p *executionPersistenceClient) UpdateWorkflowExecution(
 ) (*UpdateWorkflowExecutionResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceUpdateWorkflowExecutionScope, metrics.PersistenceRequests)
 
-	p.emitPerCategoryTaskMetrics(metrics.PersistenceUpdateWorkflowExecutionScope, &request.UpdateWorkflowMutation.Tasks)
 	sw := p.metricClient.StartTimer(metrics.PersistenceUpdateWorkflowExecutionScope, metrics.PersistenceLatency)
 	resp, err := p.persistence.UpdateWorkflowExecution(ctx, request)
 	sw.Stop()
@@ -277,12 +275,6 @@ func (p *executionPersistenceClient) UpdateWorkflowExecution(
 	}
 
 	return resp, err
-}
-
-func (p *executionPersistenceClient) emitPerCategoryTaskMetrics(scope int, t *map[tasks.Category][]tasks.Task) {
-	for k, v := range *t {
-		p.metricClient.Scope(scope, metrics.TaskCategoryTag(k.Name())).RecordDistribution(metrics.PersistenceTaskCount, len(v))
-	}
 }
 
 func (p *executionPersistenceClient) ConflictResolveWorkflowExecution(

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -27,6 +27,7 @@ package persistence
 import (
 	"context"
 	"fmt"
+
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
 

--- a/common/persistence/size.go
+++ b/common/persistence/size.go
@@ -24,6 +24,8 @@
 
 package persistence
 
+import "go.temporal.io/server/service/history/tasks"
+
 func statusOfInternalWorkflow(
 	state *InternalWorkflowMutableState,
 	historyStatistics *HistoryStatistics,
@@ -144,7 +146,8 @@ func statusOfInternalWorkflowMutation(
 		bufferedEventsSize = mutation.NewBufferedEvents.Size()
 	}
 
-	// TODO what about tasks?
+	taskCountByCategory := taskCountsByCategory(&mutation.Tasks)
+
 	// TODO what about checksum?
 
 	totalSize := executionInfoSize
@@ -184,7 +187,17 @@ func statusOfInternalWorkflowMutation(
 
 		BufferedEventsSize:  bufferedEventsSize,
 		BufferedEventsCount: bufferedEventsCount,
+
+		TaskCountByCategory: taskCountByCategory,
 	}
+}
+
+func taskCountsByCategory(t *map[tasks.Category][]InternalHistoryTask) map[string]int {
+	counts := make(map[string]int)
+	for category, tasks := range *t {
+		counts[category.Name()] = len(tasks)
+	}
+	return counts
 }
 
 func statusOfInternalWorkflowSnapshot(
@@ -229,6 +242,8 @@ func statusOfInternalWorkflowSnapshot(
 	totalSize += signalRequestIDSize
 	totalSize += bufferedEventsSize
 
+	taskCountByCategory := taskCountsByCategory(&snapshot.Tasks)
+
 	return &MutableStateStatistics{
 		TotalSize:         totalSize,
 		HistoryStatistics: historyStatistics,
@@ -256,5 +271,7 @@ func statusOfInternalWorkflowSnapshot(
 
 		BufferedEventsSize:  bufferedEventsSize,
 		BufferedEventsCount: bufferedEventsCount,
+
+		TaskCountByCategory: taskCountByCategory,
 	}
 }

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -78,6 +78,10 @@ func emitMutableStateStatus(
 		scope.RecordDistribution(metrics.HistorySize, stats.HistoryStatistics.SizeDiff)
 		scope.RecordDistribution(metrics.HistoryCount, stats.HistoryStatistics.CountDiff)
 	}
+
+	for category, taskCount := range stats.TaskCountByCategory {
+		scope.Tagged(metrics.TaskCategoryTag(category)).RecordDistribution(metrics.TaskCount, taskCount)
+	}
 }
 
 func emitWorkflowCompletionStats(


### PR DESCRIPTION
**What changed?**
This adds a metric that tracks the number of tasks in each workflow execution update.

**Why?**
We already had metrics that show the processing rate - this lets us compare creation rate to processing rate to detect task backlogs.

**How did you test it?**
`make start` + benchmark workflows.
In prometheus, expressions like `sum(rate(task_count_sum{task_category="transfer"}[30s]))` work

**Potential risks**
Additional metrics break some customers' prometheus scrapers.

**Is hotfix candidate?**
No