### PR TITLE
Check visibility ack level in standby cluster for DeleteWorkflowExecution

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2027,9 +2027,9 @@ func (e *historyEngineImpl) DeleteWorkflowExecution(
 	// Open and Close workflow executions are deleted differently.
 	// Open workflow execution is deleted by terminating with special flag `deleteAfterTerminate` set to true.
 	// This flag will be carried over with CloseExecutionTask and workflow will be deleted as the last step while processing the task.
-
+	//
 	// Close workflow execution is deleted using DeleteExecutionTask.
-
+	//
 	// DeleteWorkflowExecution is not replicated automatically. Workflow executions must be deleted separately in each cluster.
 	// Although running workflows in active cluster are terminated first and the termination event might be replicated.
 	// In passive cluster, workflow executions are just deleted in regardless of its state.

--- a/service/history/workflow/delete_manager.go
+++ b/service/history/workflow/delete_manager.go
@@ -96,12 +96,12 @@ func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
 ) error {
 
 	// In active cluster, create `DeleteWorkflowExecutionTask` only if workflow is closed successfully
-	// and all pending transfer tasks are completed.
+	// and all pending transfer and visibility tasks are completed.
 	// This check is required to avoid race condition between close and delete tasks.
-	// Otherwise, mutable state might be deleted before close transfer task is executed, and therefore close task will be dropped.
+	// Otherwise, mutable state might be deleted before close task is executed, and therefore close task will be dropped.
 	//
 	// In passive cluster, transfer task queue check can be ignored but not visibility task queue.
-	// If visibility close task is executed after visibility is deleted then it will resurrect visibility record in closed state.
+	// If visibility close task is executed after visibility record is deleted then it will resurrect record in closed state.
 	//
 	// Unfortunately, queue ack levels are updated with delay (default 30s),
 	// therefore this API will return error if workflow is deleted within 30 seconds after close.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Check visibility ack level in standby cluster for `DeleteWorkflowExecution`.

<!-- Tell your future self why have you made these changes -->
**Why?**
Visibility queue ack level must be checked in standby cluster too to avoid resurrection of visibility record in standby cluster.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.