### PR TITLE
Disable cgo by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOOS        ?= $(shell go env GOOS)
 GOARCH      ?= $(shell go env GOARCH)
 GOPATH      ?= $(shell go env GOPATH)
 # Disable cgo by default.
-export CGO_ENABLED ?= 0
+CGO_ENABLED ?= 0
 
 PERSISTENCE_TYPE ?= nosql
 PERSISTENCE_DRIVER ?= cassandra
@@ -186,15 +186,15 @@ clean-bins:
 
 temporal-server:
 	@printf $(COLOR) "Build temporal-server with CGO_ENABLED=$(CGO_ENABLED) for $(GOOS)/$(GOARCH)..."
-	go build -o temporal-server ./cmd/server
+	CGO_ENABLED=$(CGO_ENABLED) go build -o temporal-server ./cmd/server
 
 temporal-cassandra-tool:
 	@printf $(COLOR) "Build temporal-cassandra-tool with CGO_ENABLED=$(CGO_ENABLED) for $(GOOS)/$(GOARCH)..."
-	go build -o temporal-cassandra-tool ./cmd/tools/cassandra
+	CGO_ENABLED=$(CGO_ENABLED) go build -o temporal-cassandra-tool ./cmd/tools/cassandra
 
 temporal-sql-tool:
 	@printf $(COLOR) "Build temporal-sql-tool with CGO_ENABLED=$(CGO_ENABLED) for $(GOOS)/$(GOARCH)..."
-	go build -o temporal-sql-tool ./cmd/tools/sql
+	CGO_ENABLED=$(CGO_ENABLED) go build -o temporal-sql-tool ./cmd/tools/sql
 
 ##### Checks #####
 copyright-check:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOOS        ?= $(shell go env GOOS)
 GOARCH      ?= $(shell go env GOARCH)
 GOPATH      ?= $(shell go env GOPATH)
 # Disable cgo by default.
-CGO_ENABLED ?= 0
+export CGO_ENABLED ?= 0
 
 PERSISTENCE_TYPE ?= nosql
 PERSISTENCE_DRIVER ?= cassandra


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Disable cgo by default.

<!-- Tell your future self why have you made these changes -->
**Why?**
> When `make` runs a recipe, variables defined in the makefile are placed into the environment of each shell. This allows you to pass values to sub-make invocations (see [Recursive Use of make](https://www.gnu.org/software/make/manual/html_node/Recursion.html#Recursion)). By default, only variables that came from the environment or the command line are passed to recursive invocations. You can use the `export` directive to pass other variables. See [Communicating Variables to a Sub-make](https://www.gnu.org/software/make/manual/html_node/Variables_002fRecursion.html#Variables_002fRecursion), for full details.

![image](https://user-images.githubusercontent.com/2232524/169423518-2254daed-0a34-492b-9980-5ff59ca04d6f.png)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run manually.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.