### PR TITLE
Fix bug and simplify dynamicconfig

### DIFF
--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -142,8 +142,10 @@ func (c *Collection) GetProperty(key Key, defaultValue interface{}) PropertyFn {
 }
 
 func getFilterMap(opts ...FilterOption) map[Filter]interface{} {
-	l := len(opts)
-	m := make(map[Filter]interface{}, l)
+	if len(opts) == 0 {
+		return nil
+	}
+	m := make(map[Filter]interface{}, len(opts))
 	for _, opt := range opts {
 		opt(m)
 	}

--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -142,9 +142,6 @@ func (c *Collection) GetProperty(key Key, defaultValue interface{}) PropertyFn {
 }
 
 func getOneFilterMap(opts ...FilterOption) map[Filter]interface{} {
-	if len(opts) == 0 {
-		return nil
-	}
 	m := make(map[Filter]interface{}, len(opts))
 	for _, opt := range opts {
 		opt(m)
@@ -153,6 +150,9 @@ func getOneFilterMap(opts ...FilterOption) map[Filter]interface{} {
 }
 
 func getFilterMap(opts ...FilterOption) []map[Filter]interface{} {
+	if len(opts) == 0 {
+		return nil
+	}
 	return []map[Filter]interface{}{getOneFilterMap(opts...)}
 }
 

--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -141,7 +141,7 @@ func (c *Collection) GetProperty(key Key, defaultValue interface{}) PropertyFn {
 	}
 }
 
-func getFilterMap(opts ...FilterOption) map[Filter]interface{} {
+func getOneFilterMap(opts ...FilterOption) map[Filter]interface{} {
 	if len(opts) == 0 {
 		return nil
 	}
@@ -152,12 +152,16 @@ func getFilterMap(opts ...FilterOption) map[Filter]interface{} {
 	return m
 }
 
+func getFilterMap(opts ...FilterOption) []map[Filter]interface{} {
+	return []map[Filter]interface{}{getOneFilterMap(opts...)}
+}
+
 func getFilterMapsForTaskQueue(namespace string, taskQueue string, taskType enumspb.TaskQueueType) []map[Filter]interface{} {
 	return []map[Filter]interface{}{
-		getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
-		getFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
-		getFilterMap(NamespaceFilter(namespace)),
-		getFilterMap(TaskQueueFilter(taskQueue)),
+		getOneFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue), TaskTypeFilter(taskType)),
+		getOneFilterMap(NamespaceFilter(namespace), TaskQueueFilter(taskQueue)),
+		getOneFilterMap(NamespaceFilter(namespace)),
+		getOneFilterMap(TaskQueueFilter(taskQueue)),
 	}
 }
 
@@ -188,24 +192,13 @@ func (c *Collection) GetIntPropertyFilteredByNamespace(key Key, defaultValue int
 // GetIntPropertyFilteredByTaskQueueInfo gets property with taskQueueInfo as filters and asserts that it's an integer
 func (c *Collection) GetIntPropertyFilteredByTaskQueueInfo(key Key, defaultValue int) IntPropertyFnWithTaskQueueInfoFilters {
 	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) int {
-		val := defaultValue
-		var err error
-
-		filterMaps := getFilterMapsForTaskQueue(namespace, taskQueue, taskType)
-
-		for _, filterMap := range filterMaps {
-			val, err = c.client.GetIntValue(
-				key,
-				filterMap,
-				defaultValue,
-			)
-			if err != nil {
-				c.logError(key, err)
-			}
-
-			if val != defaultValue {
-				break
-			}
+		val, err := c.client.GetIntValue(
+			key,
+			getFilterMapsForTaskQueue(namespace, taskQueue, taskType),
+			defaultValue,
+		)
+		if err != nil {
+			c.logError(key, err)
 		}
 
 		return val
@@ -271,24 +264,13 @@ func (c *Collection) GetFloatPropertyFilteredByNamespace(key Key, defaultValue f
 // GetFloatPropertyFilteredByTaskQueueInfo gets property with taskQueueInfo as filters and asserts that it's an integer
 func (c *Collection) GetFloatPropertyFilteredByTaskQueueInfo(key Key, defaultValue float64) FloatPropertyFnWithTaskQueueInfoFilters {
 	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) float64 {
-		val := defaultValue
-		var err error
-
-		filterMaps := getFilterMapsForTaskQueue(namespace, taskQueue, taskType)
-
-		for _, filterMap := range filterMaps {
-			val, err = c.client.GetFloatValue(
-				key,
-				filterMap,
-				defaultValue,
-			)
-			if err != nil {
-				c.logError(key, err)
-			}
-
-			if val != defaultValue {
-				break
-			}
+		val, err := c.client.GetFloatValue(
+			key,
+			getFilterMapsForTaskQueue(namespace, taskQueue, taskType),
+			defaultValue,
+		)
+		if err != nil {
+			c.logError(key, err)
 		}
 
 		return val
@@ -334,24 +316,13 @@ func (c *Collection) GetDurationPropertyFilteredByNamespaceID(key Key, defaultVa
 // GetDurationPropertyFilteredByTaskQueueInfo gets property with taskQueueInfo as filters and asserts that it's a duration
 func (c *Collection) GetDurationPropertyFilteredByTaskQueueInfo(key Key, defaultValue time.Duration) DurationPropertyFnWithTaskQueueInfoFilters {
 	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) time.Duration {
-		val := defaultValue
-		var err error
-
-		filterMaps := getFilterMapsForTaskQueue(namespace, taskQueue, taskType)
-
-		for _, filterMap := range filterMaps {
-			val, err = c.client.GetDurationValue(
-				key,
-				filterMap,
-				defaultValue,
-			)
-			if err != nil {
-				c.logError(key, err)
-			}
-
-			if val != defaultValue {
-				break
-			}
+		val, err := c.client.GetDurationValue(
+			key,
+			getFilterMapsForTaskQueue(namespace, taskQueue, taskType),
+			defaultValue,
+		)
+		if err != nil {
+			c.logError(key, err)
 		}
 
 		return val
@@ -461,24 +432,13 @@ func (c *Collection) GetBoolPropertyFnWithNamespaceIDFilter(key Key, defaultValu
 // GetBoolPropertyFilteredByTaskQueueInfo gets property with taskQueueInfo as filters and asserts that it's an bool
 func (c *Collection) GetBoolPropertyFilteredByTaskQueueInfo(key Key, defaultValue bool) BoolPropertyFnWithTaskQueueInfoFilters {
 	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) bool {
-		val := defaultValue
-		var err error
-
-		filterMaps := getFilterMapsForTaskQueue(namespace, taskQueue, taskType)
-
-		for _, filterMap := range filterMaps {
-			val, err = c.client.GetBoolValue(
-				key,
-				filterMap,
-				defaultValue,
-			)
-			if err != nil {
-				c.logError(key, err)
-			}
-
-			if val != defaultValue {
-				break
-			}
+		val, err := c.client.GetBoolValue(
+			key,
+			getFilterMapsForTaskQueue(namespace, taskQueue, taskType),
+			defaultValue,
+		)
+		if err != nil {
+			c.logError(key, err)
 		}
 
 		return val

--- a/common/dynamicconfig/config/testConfig.yaml
+++ b/common/dynamicconfig/config/testConfig.yaml
@@ -50,6 +50,9 @@ testGetIntPropertyKey:
   constraints:
     namespace: global-samples-namespace
     taskQueueName: test-tq
+- value: 1004
+  constraints:
+    namespace: another-namespace
 - value: 1005
   constraints:
     taskQueueName: other-test-tq

--- a/common/dynamicconfig/config_test.go
+++ b/common/dynamicconfig/config_test.go
@@ -61,12 +61,12 @@ func (mc *inMemoryClient) GetValue(key Key, defaultValue interface{}) (interface
 }
 
 func (mc *inMemoryClient) GetValueWithFilters(
-	name Key, filters map[Filter]interface{}, defaultValue interface{},
+	name Key, filters []map[Filter]interface{}, defaultValue interface{},
 ) (interface{}, error) {
 	return mc.GetValue(name, defaultValue)
 }
 
-func (mc *inMemoryClient) GetIntValue(name Key, filters map[Filter]interface{}, defaultValue int) (int, error) {
+func (mc *inMemoryClient) GetIntValue(name Key, filters []map[Filter]interface{}, defaultValue int) (int, error) {
 	v := mc.globalValues.Load().(map[Key]interface{})
 	if val, ok := v[name]; ok {
 		return val.(int), nil
@@ -74,7 +74,7 @@ func (mc *inMemoryClient) GetIntValue(name Key, filters map[Filter]interface{}, 
 	return defaultValue, errors.New("unable to find key")
 }
 
-func (mc *inMemoryClient) GetFloatValue(name Key, filters map[Filter]interface{}, defaultValue float64) (float64, error) {
+func (mc *inMemoryClient) GetFloatValue(name Key, filters []map[Filter]interface{}, defaultValue float64) (float64, error) {
 	v := mc.globalValues.Load().(map[Key]interface{})
 	if val, ok := v[name]; ok {
 		return val.(float64), nil
@@ -82,7 +82,7 @@ func (mc *inMemoryClient) GetFloatValue(name Key, filters map[Filter]interface{}
 	return defaultValue, errors.New("unable to find key")
 }
 
-func (mc *inMemoryClient) GetBoolValue(name Key, filters map[Filter]interface{}, defaultValue bool) (bool, error) {
+func (mc *inMemoryClient) GetBoolValue(name Key, filters []map[Filter]interface{}, defaultValue bool) (bool, error) {
 	v := mc.globalValues.Load().(map[Key]interface{})
 	if val, ok := v[name]; ok {
 		return val.(bool), nil
@@ -90,7 +90,7 @@ func (mc *inMemoryClient) GetBoolValue(name Key, filters map[Filter]interface{},
 	return defaultValue, errors.New("unable to find key")
 }
 
-func (mc *inMemoryClient) GetStringValue(name Key, filters map[Filter]interface{}, defaultValue string) (string, error) {
+func (mc *inMemoryClient) GetStringValue(name Key, filters []map[Filter]interface{}, defaultValue string) (string, error) {
 	v := mc.globalValues.Load().(map[Key]interface{})
 	if val, ok := v[name]; ok {
 		return val.(string), nil
@@ -99,7 +99,7 @@ func (mc *inMemoryClient) GetStringValue(name Key, filters map[Filter]interface{
 }
 
 func (mc *inMemoryClient) GetMapValue(
-	name Key, filters map[Filter]interface{}, defaultValue map[string]interface{},
+	name Key, filters []map[Filter]interface{}, defaultValue map[string]interface{},
 ) (map[string]interface{}, error) {
 	v := mc.globalValues.Load().(map[Key]interface{})
 	if val, ok := v[name]; ok {
@@ -109,7 +109,7 @@ func (mc *inMemoryClient) GetMapValue(
 }
 
 func (mc *inMemoryClient) GetDurationValue(
-	name Key, filters map[Filter]interface{}, defaultValue time.Duration,
+	name Key, filters []map[Filter]interface{}, defaultValue time.Duration,
 ) (time.Duration, error) {
 	v := mc.globalValues.Load().(map[Key]interface{})
 	if val, ok := v[name]; ok {

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -189,6 +189,25 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilteredByTaskQueueNameOnly() {
 	s.Equal(expectedValue, v)
 }
 
+func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_MatchWithoutType() {
+	cln := NewCollection(s.client, log.NewNoopLogger())
+	expectedValue := 1003
+	f := cln.GetIntPropertyFilteredByTaskQueueInfo(testGetIntPropertyKey, 0)
+	// 5 is nonsense value that doesn't match either Workflow or Activity
+	v := f("global-samples-namespace", "test-tq", 5)
+	s.Equal(expectedValue, v)
+}
+
+func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_MatchFallback() {
+	cln := NewCollection(s.client, log.NewNoopLogger())
+	// should return 1001 as the most specific match
+	f1 := cln.GetIntPropertyFilteredByTaskQueueInfo(testGetIntPropertyKey, 1001)
+	v1 := f1("global-samples-namespace", "test-tq", 1)
+	f2 := cln.GetIntPropertyFilteredByTaskQueueInfo(testGetIntPropertyKey, 0)
+	v2 := f2("global-samples-namespace", "test-tq", 1)
+	s.Equal(v1, v2)
+}
+
 func (s *fileBasedClientSuite) TestGetFloatValue() {
 	v, err := s.client.GetFloatValue(testGetFloat64PropertyKey, nil, 1)
 	s.NoError(err)

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -86,34 +86,34 @@ func (s *fileBasedClientSuite) TestGetValue_CaseInsensitie() {
 }
 
 func (s *fileBasedClientSuite) TestGetValueWithFilters() {
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace: "global-samples-namespace",
-	}
+	}}
 	v, err := s.client.GetValueWithFilters(testGetBoolPropertyKey, filters, false)
 	s.NoError(err)
 	s.Equal(true, v)
 
-	filters = map[Filter]interface{}{
+	filters = []map[Filter]interface{}{{
 		Namespace: "non-exist-namespace",
-	}
+	}}
 	v, err = s.client.GetValueWithFilters(testGetBoolPropertyKey, filters, true)
 	s.NoError(err)
 	s.Equal(false, v)
 
-	filters = map[Filter]interface{}{
+	filters = []map[Filter]interface{}{{
 		Namespace:     "samples-namespace",
 		TaskQueueName: "non-exist-taskqueue",
-	}
+	}}
 	v, err = s.client.GetValueWithFilters(testGetBoolPropertyKey, filters, false)
 	s.NoError(err)
 	s.Equal(false, v)
 }
 
 func (s *fileBasedClientSuite) TestGetValueWithFilters_UnknownFilter() {
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace:     "global-samples-namespace",
 		unknownFilter: "unknown-filter",
-	}
+	}}
 	v, err := s.client.GetValueWithFilters(testGetBoolPropertyKey, filters, false)
 	s.NoError(err)
 	s.Equal(false, v)
@@ -126,9 +126,9 @@ func (s *fileBasedClientSuite) TestGetIntValue() {
 }
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilterNotMatch() {
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace: "samples-namespace",
-	}
+	}}
 	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 500)
 	s.NoError(err)
 	s.Equal(1000, v)
@@ -136,9 +136,9 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilterNotMatch() {
 
 func (s *fileBasedClientSuite) TestGetIntValue_WrongType() {
 	defaultValue := 2000
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace: "global-samples-namespace",
-	}
+	}}
 	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, defaultValue)
 	s.Error(err)
 	s.Equal(defaultValue, v)
@@ -146,11 +146,11 @@ func (s *fileBasedClientSuite) TestGetIntValue_WrongType() {
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByWorkflowTaskQueueInfo() {
 	expectedValue := 1001
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace:     "global-samples-namespace",
 		TaskQueueName: "test-tq",
 		TaskType:      "Workflow",
-	}
+	}}
 	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
 	s.NoError(err)
 	s.Equal(expectedValue, v)
@@ -158,10 +158,10 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilteredByWorkflowTaskQueueInfo()
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByNoTaskTypeQueueInfo() {
 	expectedValue := 1003
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace:     "global-samples-namespace",
 		TaskQueueName: "test-tq",
-	}
+	}}
 	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
 	s.NoError(err)
 	s.Equal(expectedValue, v)
@@ -169,11 +169,11 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilteredByNoTaskTypeQueueInfo() {
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByActivityTaskQueueInfo() {
 	expectedValue := 1002
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace:     "global-samples-namespace",
 		TaskQueueName: "test-tq",
 		TaskType:      "Activity",
-	}
+	}}
 	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
 	s.NoError(err)
 	s.Equal(expectedValue, v)
@@ -181,9 +181,9 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilteredByActivityTaskQueueInfo()
 
 func (s *fileBasedClientSuite) TestGetIntValue_FilteredByTaskQueueNameOnly() {
 	expectedValue := 1005
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		TaskQueueName: "other-test-tq",
-	}
+	}}
 	v, err := s.client.GetIntValue(testGetIntPropertyKey, filters, 0)
 	s.NoError(err)
 	s.Equal(expectedValue, v)
@@ -215,9 +215,9 @@ func (s *fileBasedClientSuite) TestGetFloatValue() {
 }
 
 func (s *fileBasedClientSuite) TestGetFloatValue_WrongType() {
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace: "samples-namespace",
-	}
+	}}
 	defaultValue := 1.0
 	v, err := s.client.GetFloatValue(testGetFloat64PropertyKey, filters, defaultValue)
 	s.Error(err)
@@ -231,9 +231,9 @@ func (s *fileBasedClientSuite) TestGetBoolValue() {
 }
 
 func (s *fileBasedClientSuite) TestGetStringValue() {
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		TaskQueueName: "random taskqueue",
-	}
+	}}
 	v, err := s.client.GetStringValue(testGetStringPropertyKey, filters, "defaultString")
 	s.NoError(err)
 	s.Equal("constrained-string", v)
@@ -259,9 +259,9 @@ func (s *fileBasedClientSuite) TestGetMapValue() {
 
 func (s *fileBasedClientSuite) TestGetMapValue_WrongType() {
 	var defaultVal map[string]interface{}
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		TaskQueueName: "random taskqueue",
-	}
+	}}
 	v, err := s.client.GetMapValue(testGetMapPropertyKey, filters, defaultVal)
 	s.Error(err)
 	s.Equal(defaultVal, v)
@@ -274,19 +274,19 @@ func (s *fileBasedClientSuite) TestGetDurationValue() {
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_NotStringRepresentation() {
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace: "samples-namespace",
-	}
+	}}
 	v, err := s.client.GetDurationValue(testGetDurationPropertyKey, filters, time.Second)
 	s.Error(err)
 	s.Equal(time.Second, v)
 }
 
 func (s *fileBasedClientSuite) TestGetDurationValue_ParseFailed() {
-	filters := map[Filter]interface{}{
+	filters := []map[Filter]interface{}{{
 		Namespace:     "samples-namespace",
 		TaskQueueName: "longIdleTimeTaskqueue",
-	}
+	}}
 	v, err := s.client.GetDurationValue(testGetDurationPropertyKey, filters, time.Second)
 	s.Error(err)
 	s.Equal(time.Second, v)

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -198,6 +198,14 @@ func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_MatchWithoutType() {
 	s.Equal(expectedValue, v)
 }
 
+func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_NamespaceOnly() {
+	cln := NewCollection(s.client, log.NewNoopLogger())
+	expectedValue := 1004
+	f := cln.GetIntPropertyFilteredByTaskQueueInfo(testGetIntPropertyKey, 0)
+	v := f("another-namespace", "other-test-tq", 0)
+	s.Equal(expectedValue, v)
+}
+
 func (s *fileBasedClientSuite) TestGetIntValue_FilterByTQ_MatchFallback() {
 	cln := NewCollection(s.client, log.NewNoopLogger())
 	// should return 1001 as the most specific match

--- a/common/dynamicconfig/interface.go
+++ b/common/dynamicconfig/interface.go
@@ -32,20 +32,22 @@ import (
 
 // Client allows fetching values from a dynamic configuration system NOTE: This does not have async
 // options right now. In the interest of keeping it minimal, we can add when requirement arises.
+// Filters should be ordered from most to least specific. An empty filter is automatically added
+// to the end of each filters slice, so callers don't need to add it.
 type (
 	Client interface {
 		GetValue(name Key, defaultValue interface{}) (interface{}, error)
-		GetValueWithFilters(name Key, filters map[Filter]interface{}, defaultValue interface{}) (interface{}, error)
+		GetValueWithFilters(name Key, filters []map[Filter]interface{}, defaultValue interface{}) (interface{}, error)
 
-		GetIntValue(name Key, filters map[Filter]interface{}, defaultValue int) (int, error)
-		GetFloatValue(name Key, filters map[Filter]interface{}, defaultValue float64) (float64, error)
-		GetBoolValue(name Key, filters map[Filter]interface{}, defaultValue bool) (bool, error)
-		GetStringValue(name Key, filters map[Filter]interface{}, defaultValue string) (string, error)
+		GetIntValue(name Key, filters []map[Filter]interface{}, defaultValue int) (int, error)
+		GetFloatValue(name Key, filters []map[Filter]interface{}, defaultValue float64) (float64, error)
+		GetBoolValue(name Key, filters []map[Filter]interface{}, defaultValue bool) (bool, error)
+		GetStringValue(name Key, filters []map[Filter]interface{}, defaultValue string) (string, error)
 		GetMapValue(
-			name Key, filters map[Filter]interface{}, defaultValue map[string]interface{},
+			name Key, filters []map[Filter]interface{}, defaultValue map[string]interface{},
 		) (map[string]interface{}, error)
 		GetDurationValue(
-			name Key, filters map[Filter]interface{}, defaultValue time.Duration,
+			name Key, filters []map[Filter]interface{}, defaultValue time.Duration,
 		) (time.Duration, error)
 	}
 )

--- a/common/dynamicconfig/interface_mock.go
+++ b/common/dynamicconfig/interface_mock.go
@@ -59,7 +59,7 @@ func (m *MockClient) EXPECT() *MockClientMockRecorder {
 }
 
 // GetBoolValue mocks base method.
-func (m *MockClient) GetBoolValue(name Key, filters map[Filter]interface{}, defaultValue bool) (bool, error) {
+func (m *MockClient) GetBoolValue(name Key, filters []map[Filter]interface{}, defaultValue bool) (bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBoolValue", name, filters, defaultValue)
 	ret0, _ := ret[0].(bool)
@@ -74,7 +74,7 @@ func (mr *MockClientMockRecorder) GetBoolValue(name, filters, defaultValue inter
 }
 
 // GetDurationValue mocks base method.
-func (m *MockClient) GetDurationValue(name Key, filters map[Filter]interface{}, defaultValue time.Duration) (time.Duration, error) {
+func (m *MockClient) GetDurationValue(name Key, filters []map[Filter]interface{}, defaultValue time.Duration) (time.Duration, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDurationValue", name, filters, defaultValue)
 	ret0, _ := ret[0].(time.Duration)
@@ -89,7 +89,7 @@ func (mr *MockClientMockRecorder) GetDurationValue(name, filters, defaultValue i
 }
 
 // GetFloatValue mocks base method.
-func (m *MockClient) GetFloatValue(name Key, filters map[Filter]interface{}, defaultValue float64) (float64, error) {
+func (m *MockClient) GetFloatValue(name Key, filters []map[Filter]interface{}, defaultValue float64) (float64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetFloatValue", name, filters, defaultValue)
 	ret0, _ := ret[0].(float64)
@@ -104,7 +104,7 @@ func (mr *MockClientMockRecorder) GetFloatValue(name, filters, defaultValue inte
 }
 
 // GetIntValue mocks base method.
-func (m *MockClient) GetIntValue(name Key, filters map[Filter]interface{}, defaultValue int) (int, error) {
+func (m *MockClient) GetIntValue(name Key, filters []map[Filter]interface{}, defaultValue int) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetIntValue", name, filters, defaultValue)
 	ret0, _ := ret[0].(int)
@@ -119,7 +119,7 @@ func (mr *MockClientMockRecorder) GetIntValue(name, filters, defaultValue interf
 }
 
 // GetMapValue mocks base method.
-func (m *MockClient) GetMapValue(name Key, filters map[Filter]interface{}, defaultValue map[string]interface{}) (map[string]interface{}, error) {
+func (m *MockClient) GetMapValue(name Key, filters []map[Filter]interface{}, defaultValue map[string]interface{}) (map[string]interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMapValue", name, filters, defaultValue)
 	ret0, _ := ret[0].(map[string]interface{})
@@ -134,7 +134,7 @@ func (mr *MockClientMockRecorder) GetMapValue(name, filters, defaultValue interf
 }
 
 // GetStringValue mocks base method.
-func (m *MockClient) GetStringValue(name Key, filters map[Filter]interface{}, defaultValue string) (string, error) {
+func (m *MockClient) GetStringValue(name Key, filters []map[Filter]interface{}, defaultValue string) (string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetStringValue", name, filters, defaultValue)
 	ret0, _ := ret[0].(string)
@@ -164,7 +164,7 @@ func (mr *MockClientMockRecorder) GetValue(name, defaultValue interface{}) *gomo
 }
 
 // GetValueWithFilters mocks base method.
-func (m *MockClient) GetValueWithFilters(name Key, filters map[Filter]interface{}, defaultValue interface{}) (interface{}, error) {
+func (m *MockClient) GetValueWithFilters(name Key, filters []map[Filter]interface{}, defaultValue interface{}) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetValueWithFilters", name, filters, defaultValue)
 	ret0, _ := ret[0].(interface{})

--- a/common/dynamicconfig/mutable_ephemeral_client_test.go
+++ b/common/dynamicconfig/mutable_ephemeral_client_test.go
@@ -104,10 +104,10 @@ func TestMulti(t *testing.T) {
 	require.Equal(t, i, 1)
 }
 
-func composeFilters(fs ...dconf.FilterOption) map[dconf.Filter]interface{} {
+func composeFilters(fs ...dconf.FilterOption) []map[dconf.Filter]interface{} {
 	out := map[dconf.Filter]interface{}{}
 	for _, f := range fs {
 		f(out)
 	}
-	return out
+	return []map[dconf.Filter]interface{}{out}
 }

--- a/common/dynamicconfig/noop_client.go
+++ b/common/dynamicconfig/noop_client.go
@@ -50,33 +50,33 @@ func (mc *noopClient) GetValue(name Key, defaultValue interface{}) (interface{},
 	return nil, errors.New("unable to find key")
 }
 
-func (mc *noopClient) GetValueWithFilters(name Key, filters map[Filter]interface{}, defaultValue interface{}) (interface{}, error) {
+func (mc *noopClient) GetValueWithFilters(name Key, filters []map[Filter]interface{}, defaultValue interface{}) (interface{}, error) {
 	return nil, errors.New("unable to find key")
 }
 
-func (mc *noopClient) GetIntValue(name Key, filters map[Filter]interface{}, defaultValue int) (int, error) {
+func (mc *noopClient) GetIntValue(name Key, filters []map[Filter]interface{}, defaultValue int) (int, error) {
 	return defaultValue, errors.New("unable to find key")
 }
 
-func (mc *noopClient) GetFloatValue(name Key, filters map[Filter]interface{}, defaultValue float64) (float64, error) {
+func (mc *noopClient) GetFloatValue(name Key, filters []map[Filter]interface{}, defaultValue float64) (float64, error) {
 	return defaultValue, errors.New("unable to find key")
 }
 
-func (mc *noopClient) GetBoolValue(name Key, filters map[Filter]interface{}, defaultValue bool) (bool, error) {
-	if filters[Namespace] == "TestRawHistoryNamespace" {
+func (mc *noopClient) GetBoolValue(name Key, filters []map[Filter]interface{}, defaultValue bool) (bool, error) {
+	if len(filters) > 0 && filters[0][Namespace] == "TestRawHistoryNamespace" {
 		return true, errors.New("unable to find key")
 	}
 	return defaultValue, errors.New("unable to find key")
 }
 
-func (mc *noopClient) GetStringValue(name Key, filters map[Filter]interface{}, defaultValue string) (string, error) {
+func (mc *noopClient) GetStringValue(name Key, filters []map[Filter]interface{}, defaultValue string) (string, error) {
 	return defaultValue, errors.New("unable to find key")
 }
 
-func (mc *noopClient) GetMapValue(name Key, filters map[Filter]interface{}, defaultValue map[string]interface{}) (map[string]interface{}, error) {
+func (mc *noopClient) GetMapValue(name Key, filters []map[Filter]interface{}, defaultValue map[string]interface{}) (map[string]interface{}, error) {
 	return defaultValue, errors.New("unable to find key")
 }
 
-func (mc *noopClient) GetDurationValue(name Key, filters map[Filter]interface{}, defaultValue time.Duration) (time.Duration, error) {
+func (mc *noopClient) GetDurationValue(name Key, filters []map[Filter]interface{}, defaultValue time.Duration) (time.Duration, error) {
 	return defaultValue, errors.New("unable to find key")
 }

--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -71,7 +71,7 @@ func (d *dynamicClient) GetValue(name dynamicconfig.Key, defaultValue interface{
 }
 
 func (d *dynamicClient) GetValueWithFilters(
-	name dynamicconfig.Key, filters map[dynamicconfig.Filter]interface{}, defaultValue interface{},
+	name dynamicconfig.Key, filters []map[dynamicconfig.Filter]interface{}, defaultValue interface{},
 ) (interface{}, error) {
 	d.RLock()
 	if val, ok := d.overrides[name]; ok {
@@ -82,7 +82,7 @@ func (d *dynamicClient) GetValueWithFilters(
 	return d.client.GetValueWithFilters(name, filters, defaultValue)
 }
 
-func (d *dynamicClient) GetIntValue(name dynamicconfig.Key, filters map[dynamicconfig.Filter]interface{}, defaultValue int) (int, error) {
+func (d *dynamicClient) GetIntValue(name dynamicconfig.Key, filters []map[dynamicconfig.Filter]interface{}, defaultValue int) (int, error) {
 	d.RLock()
 	if val, ok := d.overrides[name]; ok {
 		if intVal, ok := val.(int); ok {
@@ -94,7 +94,7 @@ func (d *dynamicClient) GetIntValue(name dynamicconfig.Key, filters map[dynamicc
 	return d.client.GetIntValue(name, filters, defaultValue)
 }
 
-func (d *dynamicClient) GetFloatValue(name dynamicconfig.Key, filters map[dynamicconfig.Filter]interface{}, defaultValue float64) (float64, error) {
+func (d *dynamicClient) GetFloatValue(name dynamicconfig.Key, filters []map[dynamicconfig.Filter]interface{}, defaultValue float64) (float64, error) {
 	d.RLock()
 	if val, ok := d.overrides[name]; ok {
 		if floatVal, ok := val.(float64); ok {
@@ -106,7 +106,7 @@ func (d *dynamicClient) GetFloatValue(name dynamicconfig.Key, filters map[dynami
 	return d.client.GetFloatValue(name, filters, defaultValue)
 }
 
-func (d *dynamicClient) GetBoolValue(name dynamicconfig.Key, filters map[dynamicconfig.Filter]interface{}, defaultValue bool) (bool, error) {
+func (d *dynamicClient) GetBoolValue(name dynamicconfig.Key, filters []map[dynamicconfig.Filter]interface{}, defaultValue bool) (bool, error) {
 	d.RLock()
 	if val, ok := d.overrides[name]; ok {
 		if boolVal, ok := val.(bool); ok {
@@ -118,7 +118,7 @@ func (d *dynamicClient) GetBoolValue(name dynamicconfig.Key, filters map[dynamic
 	return d.client.GetBoolValue(name, filters, defaultValue)
 }
 
-func (d *dynamicClient) GetStringValue(name dynamicconfig.Key, filters map[dynamicconfig.Filter]interface{}, defaultValue string) (string, error) {
+func (d *dynamicClient) GetStringValue(name dynamicconfig.Key, filters []map[dynamicconfig.Filter]interface{}, defaultValue string) (string, error) {
 	d.RLock()
 	if val, ok := d.overrides[name]; ok {
 		if stringVal, ok := val.(string); ok {
@@ -131,7 +131,7 @@ func (d *dynamicClient) GetStringValue(name dynamicconfig.Key, filters map[dynam
 }
 
 func (d *dynamicClient) GetMapValue(
-	name dynamicconfig.Key, filters map[dynamicconfig.Filter]interface{}, defaultValue map[string]interface{},
+	name dynamicconfig.Key, filters []map[dynamicconfig.Filter]interface{}, defaultValue map[string]interface{},
 ) (map[string]interface{}, error) {
 	d.RLock()
 	if val, ok := d.overrides[name]; ok {
@@ -145,7 +145,7 @@ func (d *dynamicClient) GetMapValue(
 }
 
 func (d *dynamicClient) GetDurationValue(
-	name dynamicconfig.Key, filters map[dynamicconfig.Filter]interface{}, defaultValue time.Duration,
+	name dynamicconfig.Key, filters []map[dynamicconfig.Filter]interface{}, defaultValue time.Duration,
 ) (time.Duration, error) {
 	d.RLock()
 	if val, ok := d.overrides[name]; ok {


### PR DESCRIPTION
**What changed?**
The logic for handling multiple dynamicconfig constraints (in the case of task queue constraints) was split between `Collection` and `Client`, which led to at least one bug: a less specific value would be preferred over a more specific one if the more specific one happened to match the default value supplied by the caller.

This pushes more of the logic into `Client`, which now takes a slice of filter maps, and checks them in order (plus the non-constrained value).

**Why?**
Fix a bug, make code easier to understand.

**How did you test it?**
unit tests

**Potential risks**
This changes the interface of `dynamicconfig.Client`, so any projects that use the server as a library may have to update their code (to wrap the map in a slice). `Client` isn't used in the server itself at all, since `Collection` is a nicer interface.
