### PR TITLE
Add String method to ContextImpl to fix a race

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -173,6 +173,11 @@ const (
 	minContextTimeout        = 2 * time.Second
 )
 
+func (s *ContextImpl) String() string {
+	// constant from initialization, no need for locks
+	return fmt.Sprintf("Shard(%d)", s.shardID)
+}
+
 func (s *ContextImpl) GetShardID() int32 {
 	// constant from initialization, no need for locks
 	return s.shardID


### PR DESCRIPTION
**What changed?**
Add a `String` method (`fmt.Stringer`) to `ContextImpl`.

Also simplify `contextMatcher` implementation and move `getOrCreateShardRequestMatcher` to the bottom of the file just so the matchers are in one place.

**Why?**
This is a weird one: in some tests, we use a gomock matcher to differentiate between `Context`s in `CreateEngine`, to return the right value. Internally, gomock evaluates all its matchers, but for the failing ones (and there will always be failing ones if there's more than one), it constructs an error message using `Sprintf("%v")` and then throws it away when it finds a match. The default `"%v"` formatter reads private fields of the value being matched. Some of those private fields (e.g. `state`) are protected by a mutex, but it doesn't know that and reads them anyway. This triggers the race detector. We can just provide a `String` to bypass the default `"%v"` behavior.

**How did you test it?**
ran test with -race -count 1000

