### PR TITLE
Enable Create or Drop Database Command for Postgres to Use Global Database Option

### DIFF
--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -104,7 +104,9 @@ func createDatabase(cli *cli.Context, logger log.Logger) error {
 }
 
 func DoCreateDatabase(cfg *config.SQL, name string) error {
-	cfg.DatabaseName = ""
+	if cfg.PluginName != "postgres" {
+		cfg.DatabaseName = ""
+	}
 	conn, err := NewConnection(cfg)
 	if err != nil {
 		return err
@@ -134,7 +136,9 @@ func dropDatabase(cli *cli.Context, logger log.Logger) error {
 }
 
 func DoDropDatabase(cfg *config.SQL, name string) error {
-	cfg.DatabaseName = ""
+	if cfg.PluginName != "postgres" {
+		cfg.DatabaseName = ""
+	}
 	conn, err := NewConnection(cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**
adding condition to the temporal-sql-tool command where the create or drop commands were ignoring the global --datasource value provided, which effectively forced the connection to fall back to the default db instance name, which the fallback mechanism was hard-coding as one of two values: postgres or defaultdb. 


<!-- Tell your future self why have you made these changes -->
**Why?**
Default postgres db instance might not be postgres or defaultdb. The create and drop commands should allow --database definitions to override what the default db instance name is in the case it's not one of the two hard-coded values. Also, based on the blame it looks like the `cfg.DatabaseName = ""` line hasn't changed in nearly 2 years and when it was added it was part of a mysql tls support commit. I added the `if cfg.PluginName != "postgres"` check in case mysql required the db name reset. Adding this in support of issue #2890.



<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran `make` to build the `temporal-sql-tool` executable locally and executed the tool to create a db instance using the --database parameter to ensure that non-default instance names could be used for the create or drop commands. 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Given that the create and drop commands are not invoked except for instances when a new environment is provisioned, I don't see how this could negatively impact any runtime components. Also, this would only impact postgres db create/drop commands.


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
