### PR TITLE
add variadic dial opts to rpc dialer

### DIFF
--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -61,7 +61,7 @@ const (
 // The hostName syntax is defined in
 // https://github.com/grpc/grpc/blob/master/doc/naming.md.
 // e.g. to use dns resolver, a "dns:///" prefix should be applied to the target.
-func Dial(hostName string, tlsConfig *tls.Config, logger log.Logger) (*grpc.ClientConn, error) {
+func Dial(hostName string, tlsConfig *tls.Config, logger log.Logger, customDialOptions ...grpc.DialOption) (*grpc.ClientConn, error) {
 	// Default to insecure
 	grpcSecureOpt := grpc.WithInsecure()
 	if tlsConfig != nil {
@@ -91,6 +91,7 @@ func Dial(hostName string, tlsConfig *tls.Config, logger log.Logger) (*grpc.Clie
 		grpc.WithDisableServiceConfig(),
 		grpc.WithConnectParams(cp),
 	}
+	dialOptions = append(dialOptions, customDialOptions...)
 
 	return grpc.Dial(
 		hostName,

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -184,7 +184,7 @@ func getListenIP(cfg *config.RPC, logger log.Logger) net.IP {
 }
 
 // CreateFrontendGRPCConnection creates connection for gRPC calls
-func (d *RPCFactory) CreateFrontendGRPCConnection(rpcAddress string) *grpc.ClientConn {
+func (d *RPCFactory) CreateFrontendGRPCConnection(rpcAddress string, dialOpts ...grpc.DialOption) *grpc.ClientConn {
 	var tlsClientConfig *tls.Config
 	var err error
 	if d.tlsFactory != nil {
@@ -206,11 +206,11 @@ func (d *RPCFactory) CreateFrontendGRPCConnection(rpcAddress string) *grpc.Clien
 		}
 	}
 
-	return d.dial(rpcAddress, tlsClientConfig)
+	return d.dial(rpcAddress, tlsClientConfig, dialOpts...)
 }
 
 // CreateInternodeGRPCConnection creates connection for gRPC calls
-func (d *RPCFactory) CreateInternodeGRPCConnection(hostName string) *grpc.ClientConn {
+func (d *RPCFactory) CreateInternodeGRPCConnection(hostName string, dialOpts ...grpc.DialOption) *grpc.ClientConn {
 	var tlsClientConfig *tls.Config
 	var err error
 	if d.tlsFactory != nil {
@@ -221,11 +221,11 @@ func (d *RPCFactory) CreateInternodeGRPCConnection(hostName string) *grpc.Client
 		}
 	}
 
-	return d.dial(hostName, tlsClientConfig)
+	return d.dial(hostName, tlsClientConfig, dialOpts...)
 }
 
-func (d *RPCFactory) dial(hostName string, tlsClientConfig *tls.Config) *grpc.ClientConn {
-	connection, err := Dial(hostName, tlsClientConfig, d.logger)
+func (d *RPCFactory) dial(hostName string, tlsClientConfig *tls.Config, dialOpts ...grpc.DialOption) *grpc.ClientConn {
+	connection, err := Dial(hostName, tlsClientConfig, d.logger, dialOpts...)
 	if err != nil {
 		d.logger.Fatal("Failed to create gRPC connection", tag.Error(err))
 		return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`rpc.Dial` accepts variadic grpc DialOptions. These are merged with the existing pre-configured options. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The existing `WithClientFactoryProvider` allows for configuring the underlying rpc factory that controls internode and frontend grpc connection. This allows custom rpc factories to extend the existing dial logic without needing to copy its implementation. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally, unit tests pass.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No