### PR TITLE
Handle visibility task timeout in bulk operation

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2196,8 +2196,6 @@ const (
 
 	ElasticsearchBulkProcessorBulkSize
 
-	ElasticsearchBulkProcessorDeadlock
-
 	NumHistoryMetrics
 )
 
@@ -2676,7 +2674,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ElasticsearchBulkProcessorWaitAddLatency:   NewTimerDef("elasticsearch_bulk_processor_wait_add_latency"),
 		ElasticsearchBulkProcessorWaitStartLatency: NewTimerDef("elasticsearch_bulk_processor_wait_start_latency"),
 		ElasticsearchBulkProcessorBulkSize:         NewDimensionlessHistogramDef("elasticsearch_bulk_processor_bulk_size"),
-		ElasticsearchBulkProcessorDeadlock:         NewCounterDef("elasticsearch_bulk_processor_deadlock"),
 	},
 	Matching: {
 		PollSuccessPerTaskQueueCounter:            NewRollupCounterDef("poll_success_per_tl", "poll_success"),

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -22,7 +22,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:generate mockgen -copyright_file ../../../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination processor_mock.go
+// TODO: enable this after https://github.com/golang/mock/issues/621
+// mockgen -copyright_file ../../../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination processor_mock.go
 
 package elasticsearch
 

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -54,6 +54,7 @@ type (
 
 		// Add request to bulk processor.
 		Add(request *client.BulkableRequest, visibilityTaskKey string) <-chan bool
+		Remove(visibilityTaskKey string)
 	}
 
 	// processorImpl implements Processor, it's an agent of elastic.BulkProcessor
@@ -190,6 +191,17 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 		ackCh.recordAdd(p.metricsClient)
 	}
 	return ackCh.ackChInternal
+}
+
+func (p *processorImpl) Remove(visibilityTaskKey string) {
+	// Use RemoveIf here to prevent race condition with de-dup logic in Add method.
+	_ = p.mapToAckChan.RemoveIf(visibilityTaskKey, func(key interface{}, value interface{}) bool {
+		_, ok := value.(*ackChan)
+		if !ok {
+			p.logger.Fatal(fmt.Sprintf("mapToAckChan has item of a wrong type %T (%T expected).", value, &ackChan{}), tag.ESKey(visibilityTaskKey))
+		}
+		return true
+	})
 }
 
 // bulkBeforeAction is triggered before bulk processor commit

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -55,7 +55,7 @@ type (
 		common.Daemon
 
 		// Add request to bulk processor.
-		Add(request *client.BulkableRequest, visibilityTaskKey string) future.Future[bool]
+		Add(request *client.BulkableRequest, visibilityTaskKey string) future.FutureImpl[bool]
 	}
 
 	// processorImpl implements Processor, it's an agent of elastic.BulkProcessor

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -411,7 +411,7 @@ func newAckChan() *ackChan {
 func (a *ackChan) recordAdd(metricsClient metrics.Client) {
 	addedAt := time.Now().UTC()
 	a.addedAt.Store(addedAt)
-	metricsClient.RecordTimer(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorWaitAddLatency, addedAt.Sub(a.createdAt)) // can be replace
+	metricsClient.RecordTimer(metrics.ElasticsearchBulkProcessor, metrics.ElasticsearchBulkProcessorWaitAddLatency, addedAt.Sub(a.createdAt))
 }
 
 func (a *ackChan) recordStart(metricsClient metrics.Client) {

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -196,10 +196,12 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 func (p *processorImpl) Remove(visibilityTaskKey string) {
 	// Use RemoveIf here to prevent race condition with de-dup logic in Add method.
 	_ = p.mapToAckChan.RemoveIf(visibilityTaskKey, func(key interface{}, value interface{}) bool {
-		_, ok := value.(*ackChan)
+		ackCh, ok := value.(*ackChan)
 		if !ok {
 			p.logger.Fatal(fmt.Sprintf("mapToAckChan has item of a wrong type %T (%T expected).", value, &ackChan{}), tag.ESKey(visibilityTaskKey))
 		}
+
+		ackCh.done(false, p.metricsClient)
 		return true
 	})
 }

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -34,14 +34,13 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.temporal.io/server/common/future"
-
 	"github.com/dgryski/go-farm"
 	"github.com/olivere/elastic/v7"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/future"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"

--- a/common/persistence/visibility/store/elasticsearch/processor_mock.go
+++ b/common/persistence/visibility/store/elasticsearch/processor_mock.go
@@ -31,6 +31,8 @@ package elasticsearch
 import (
 	reflect "reflect"
 
+	"go.temporal.io/server/common/future"
+
 	gomock "github.com/golang/mock/gomock"
 	client "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 )
@@ -59,10 +61,10 @@ func (m *MockProcessor) EXPECT() *MockProcessorMockRecorder {
 }
 
 // Add mocks base method.
-func (m *MockProcessor) Add(request *client.BulkableRequest, visibilityTaskKey string) <-chan bool {
+func (m *MockProcessor) Add(request *client.BulkableRequest, visibilityTaskKey string) future.Future[bool] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Add", request, visibilityTaskKey)
-	ret0, _ := ret[0].(<-chan bool)
+	ret0, _ := ret[0].(future.Future[bool])
 	return ret0
 }
 

--- a/common/persistence/visibility/store/elasticsearch/processor_mock.go
+++ b/common/persistence/visibility/store/elasticsearch/processor_mock.go
@@ -31,8 +31,8 @@ package elasticsearch
 import (
 	reflect "reflect"
 
-	"go.temporal.io/server/common/future"
 	gomock "github.com/golang/mock/gomock"
+	"go.temporal.io/server/common/future"
 	client "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 )
 

--- a/common/persistence/visibility/store/elasticsearch/processor_mock.go
+++ b/common/persistence/visibility/store/elasticsearch/processor_mock.go
@@ -32,7 +32,6 @@ import (
 	reflect "reflect"
 
 	"go.temporal.io/server/common/future"
-
 	gomock "github.com/golang/mock/gomock"
 	client "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 )

--- a/common/persistence/visibility/store/elasticsearch/processor_mock.go
+++ b/common/persistence/visibility/store/elasticsearch/processor_mock.go
@@ -72,6 +72,18 @@ func (mr *MockProcessorMockRecorder) Add(request, visibilityTaskKey interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockProcessor)(nil).Add), request, visibilityTaskKey)
 }
 
+// Remove mocks base method.
+func (m *MockProcessor) Remove(visibilityTaskKey string) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Remove", visibilityTaskKey)
+}
+
+// Remove indicates an expected call of Remove.
+func (mr *MockProcessorMockRecorder) Remove(visibilityTaskKey interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockProcessor)(nil).Remove), visibilityTaskKey)
+}
+
 // Start mocks base method.
 func (m *MockProcessor) Start() {
 	m.ctrl.T.Helper()

--- a/common/persistence/visibility/store/elasticsearch/processor_mock.go
+++ b/common/persistence/visibility/store/elasticsearch/processor_mock.go
@@ -60,10 +60,10 @@ func (m *MockProcessor) EXPECT() *MockProcessorMockRecorder {
 }
 
 // Add mocks base method.
-func (m *MockProcessor) Add(request *client.BulkableRequest, visibilityTaskKey string) future.Future[bool] {
+func (m *MockProcessor) Add(request *client.BulkableRequest, visibilityTaskKey string) *future.FutureImpl[bool] {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Add", request, visibilityTaskKey)
-	ret0, _ := ret[0].(future.Future[bool])
+	ret0, _ := ret[0].(*future.FutureImpl[bool])
 	return ret0
 }
 

--- a/common/persistence/visibility/store/elasticsearch/processor_test.go
+++ b/common/persistence/visibility/store/elasticsearch/processor_test.go
@@ -32,14 +32,13 @@ import (
 	"testing"
 	"time"
 
-	"go.temporal.io/server/common/future"
-
 	"github.com/golang/mock/gomock"
 	"github.com/olivere/elastic/v7"
 	"github.com/stretchr/testify/suite"
 
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/future"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -259,6 +259,7 @@ func (s *visibilityStore) addBulkRequestAndWait(
 		}
 		return nil
 	case <-ackTimeoutTimer.C:
+		s.processor.Remove(visibilityTaskKey)
 		return &persistence.TimeoutError{Msg: fmt.Sprintf("visibility task %s timedout waiting for ACK after %v", visibilityTaskKey, s.processorAckTimeout())}
 	}
 }

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -247,8 +247,6 @@ func (s *visibilityStore) addBulkRequestAndWait(
 	if deadline, ok := ctx.Deadline(); ok {
 		ackTimeout = common.MinDuration(ackTimeout, time.Until(deadline))
 	}
-	ackTimeoutTimer := time.NewTimer(ackTimeout)
-	defer ackTimeoutTimer.Stop()
 	subCtx, subCtxCancelFn := context.WithTimeout(context.Background(), ackTimeout)
 	defer subCtxCancelFn()
 

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_write_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_write_test.go
@@ -30,12 +30,11 @@ import (
 	"strings"
 	"time"
 
-	"go.temporal.io/server/common/future"
-
 	"github.com/golang/mock/gomock"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 
+	"go.temporal.io/server/common/future"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility/manager"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update es processor to return future on duplicate request.

<!-- Tell your future self why have you made these changes -->
**Why?**
The visibility task may drop due to timeout and resubmit to the bulk processor. The second retry in the bulk processor may hit dedup logic and return success.

We should return the same future object for duplicated requests.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
