### PR TITLE
Dynamic config for scheduler server worker

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -627,6 +627,8 @@ const (
 	WorkerParentCloseMaxConcurrentActivityTaskPollers = "worker.ParentCloseMaxConcurrentActivityTaskPollers"
 	// WorkerParentCloseMaxConcurrentWorkflowTaskPollers indicates worker parent close worker max concurrent workflow pollers
 	WorkerParentCloseMaxConcurrentWorkflowTaskPollers = "worker.ParentCloseMaxConcurrentWorkflowTaskPollers"
+	// WorkerEnableScheduler controls whether to start the worker for scheduled workflows
+	WorkerEnableScheduler = "worker.enableScheduler"
 )
 
 // Filter represents a filter on the dynamic config key

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -629,6 +629,8 @@ const (
 	WorkerParentCloseMaxConcurrentWorkflowTaskPollers = "worker.ParentCloseMaxConcurrentWorkflowTaskPollers"
 	// WorkerEnableScheduler controls whether to start the worker for scheduled workflows
 	WorkerEnableScheduler = "worker.enableScheduler"
+	// WorkerSchedulerNumWorkers controls number of scheduler workers to run per namespace
+	WorkerSchedulerNumWorkers = "worker.schedulerNumWorkers"
 )
 
 // Filter represents a filter on the dynamic config key

--- a/service/worker/common/interface.go
+++ b/service/worker/common/interface.go
@@ -53,11 +53,13 @@ type (
 		// Register registers Workflow and Activity types provided by this worker component.
 		// The namespace that this worker is running in is also provided.
 		Register(sdkworker.Worker, *namespace.Namespace)
-		// DedicatedWorkerOptions returns a DedicatedWorkerOptions for this worker component.
-		DedicatedWorkerOptions() *PerNSDedicatedWorkerOptions
+		// DedicatedWorkerOptions returns a PerNSDedicatedWorkerOptions for this worker component.
+		DedicatedWorkerOptions(*namespace.Namespace) *PerNSDedicatedWorkerOptions
 	}
 
 	PerNSDedicatedWorkerOptions struct {
+		// Set this to false to disable a worker for this namespace
+		Enabled bool
 		// TaskQueue is required
 		TaskQueue string
 		// How many worker nodes should run a worker per namespace


### PR DESCRIPTION
**What changed?**
- `PerNSWorkerComponent`s can disable themselves by setting `Enabled` to false in their options
- The scheduler worker component does this based on dynamic config
- It also sets NumWorkers based on dynamic config
- NumWorkers is implemented by repeated calls to Lookup

**Why?**
So we can control whether the scheduler worker runs per-namespace.

**How did you test it?**
Tested manually for now

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
