### PR TITLE
Add dynamic config to disable frontend schedule rpcs

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -218,6 +218,8 @@ const (
 	// KeepAliveTimeout After having pinged for keepalive check, the server waits for a duration
 	// of Timeout and if no activity is seen even after that the connection is closed.
 	KeepAliveTimeout = "frontend.keepAliveTimeout"
+	// FrontendEnableSchedules enables schedule-related RPCs in the frontend
+	FrontendEnableSchedules = "frontend.enableSchedules"
 
 	// DeleteNamespaceDeleteActivityRPS is RPS per every parallel delete executions activity.
 	// Total RPS is equal to DeleteNamespaceDeleteActivityRPS * DeleteNamespaceConcurrentDeleteExecutionsActivities.

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -86,5 +86,6 @@ var (
 	errUnableToStartWorkflowMessage                   = "Unable to start %s workflow: %v."
 	errWorkflowReturnedErrorMessage                   = "Workflow %s returned an error: %v."
 
-	errListNotAllowed = serviceerror.NewPermissionDenied("List is disabled on this namespace.", "")
+	errListNotAllowed      = serviceerror.NewPermissionDenied("List is disabled on this namespace.", "")
+	errSchedulesNotAllowed = serviceerror.NewPermissionDenied("Schedules are disabled on this namespace.", "")
 )

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -138,6 +138,9 @@ type Config struct {
 	// Number of concurrent delete executions activities.
 	// Must be not greater than 256 and number of worker cores in the cluster.
 	DeleteNamespaceConcurrentDeleteExecutionsActivities dynamicconfig.IntPropertyFn
+
+	// Enable schedule-related RPCs
+	EnableSchedules dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
 
 // NewConfig returns new service config with default values
@@ -194,6 +197,8 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int32, esIndexName
 
 		DeleteNamespaceDeleteActivityRPS:                    dc.GetIntProperty(dynamicconfig.DeleteNamespaceDeleteActivityRPS, 100),
 		DeleteNamespaceConcurrentDeleteExecutionsActivities: dc.GetIntProperty(dynamicconfig.DeleteNamespaceConcurrentDeleteExecutionsActivities, 4),
+
+		EnableSchedules: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableSchedules, false),
 	}
 }
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -3033,6 +3033,10 @@ func (wh *WorkflowHandler) CreateSchedule(ctx context.Context, request *workflow
 		return nil, errRequestNotSet
 	}
 
+	if !wh.config.EnableSchedules(request.Namespace) {
+		return nil, errSchedulesNotAllowed
+	}
+
 	// a schedule id is a workflow id so validate it the same way
 	if err := wh.validateWorkflowID(request.ScheduleId); err != nil {
 		return nil, err
@@ -3160,6 +3164,10 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 
 	if request == nil {
 		return nil, errRequestNotSet
+	}
+
+	if !wh.config.EnableSchedules(request.Namespace) {
+		return nil, errSchedulesNotAllowed
 	}
 
 	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
@@ -3316,6 +3324,10 @@ func (wh *WorkflowHandler) UpdateSchedule(ctx context.Context, request *workflow
 		return nil, errRequestNotSet
 	}
 
+	if !wh.config.EnableSchedules(request.Namespace) {
+		return nil, errSchedulesNotAllowed
+	}
+
 	if len(request.GetRequestId()) > wh.config.MaxIDLengthLimit() {
 		return nil, errRequestIDTooLong
 	}
@@ -3383,6 +3395,10 @@ func (wh *WorkflowHandler) PatchSchedule(ctx context.Context, request *workflows
 		return nil, errRequestNotSet
 	}
 
+	if !wh.config.EnableSchedules(request.Namespace) {
+		return nil, errSchedulesNotAllowed
+	}
+
 	if len(request.GetRequestId()) > wh.config.MaxIDLengthLimit() {
 		return nil, errRequestIDTooLong
 	}
@@ -3442,6 +3458,10 @@ func (wh *WorkflowHandler) ListScheduleMatchingTimes(ctx context.Context, reques
 
 	if request == nil {
 		return nil, errRequestNotSet
+	}
+
+	if !wh.config.EnableSchedules(request.Namespace) {
+		return nil, errSchedulesNotAllowed
 	}
 
 	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
@@ -3510,6 +3530,10 @@ func (wh *WorkflowHandler) DeleteSchedule(ctx context.Context, request *workflow
 		return nil, errRequestNotSet
 	}
 
+	if !wh.config.EnableSchedules(request.Namespace) {
+		return nil, errSchedulesNotAllowed
+	}
+
 	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
 	if err != nil {
 		return nil, err
@@ -3545,6 +3569,10 @@ func (wh *WorkflowHandler) ListSchedules(ctx context.Context, request *workflows
 
 	if request == nil {
 		return nil, errRequestNotSet
+	}
+
+	if !wh.config.EnableSchedules(request.Namespace) {
+		return nil, errSchedulesNotAllowed
 	}
 
 	if request.GetMaximumPageSize() <= 0 {


### PR DESCRIPTION
**What changed?**
Add dynamic config setting to control schedule-related rpcs at frontend.

**Why?**
controlled roll-out of features

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
