### PR TITLE
Make task processing worker count config truly dynamic

### DIFF
--- a/common/tasks/parallel_processor.go
+++ b/common/tasks/parallel_processor.go
@@ -93,7 +93,7 @@ func (p *ParallelProcessor) Start() {
 	p.startWorkers(p.options.WorkerCount())
 
 	p.shutdownWG.Add(1)
-	go p.workerMonitor(defaultMonitorTickerDuration)
+	go p.workerMonitor()
 
 	p.logger.Info("Parallel task processor started")
 }
@@ -127,9 +127,7 @@ func (p *ParallelProcessor) Submit(task Task) {
 	}
 }
 
-func (p *ParallelProcessor) workerMonitor(
-	tickerDuration time.Duration,
-) {
+func (p *ParallelProcessor) workerMonitor() {
 	defer p.shutdownWG.Done()
 
 	timer := time.NewTimer(backoff.JitDuration(defaultMonitorTickerDuration, defaultMonitorTickerJitter))

--- a/common/tasks/parallel_processor_test.go
+++ b/common/tasks/parallel_processor_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/uber-go/tally/v4"
 
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 )
@@ -62,20 +63,8 @@ func (s *parallelProcessorSuite) SetupTest() {
 
 	s.controller = gomock.NewController(s.T())
 
-	metricsClient, err := metrics.NewClient(&metrics.ClientConfig{}, tally.NoopScope, metrics.History)
-	if err != nil {
-		s.NoError(err, "metrics.NewClient")
-	}
-
-	s.processor = NewParallelProcessor(
-		&ParallelProcessorOptions{
-			QueueSize:   1,
-			WorkerCount: 1,
-		},
-		metricsClient,
-		log.NewNoopLogger(),
-	)
 	s.retryPolicy = backoff.NewExponentialRetryPolicy(time.Millisecond)
+	s.processor = s.newTestProcessor()
 	s.processor.Start()
 }
 
@@ -203,4 +192,38 @@ func (s *parallelProcessorSuite) TestParallelSubmitProcess() {
 	endWaitGroup.Wait()
 
 	testWaitGroup.Wait()
+}
+
+func (s *parallelProcessorSuite) TestStartStopWorkers() {
+	processor := s.newTestProcessor()
+	// don't start the processor,
+	// manually add/remove workers here to test the start/stop logic
+
+	numWorkers := 10
+	processor.startWorkers(numWorkers)
+	s.Len(processor.workerShutdownCh, numWorkers)
+
+	processor.stopWorkers(numWorkers / 2)
+	s.Len(processor.workerShutdownCh, numWorkers/2)
+
+	processor.stopWorkers(len(processor.workerShutdownCh))
+	s.Empty(processor.workerShutdownCh)
+
+	processor.shutdownWG.Wait()
+}
+
+func (s *parallelProcessorSuite) newTestProcessor() *ParallelProcessor {
+	metricsClient, err := metrics.NewClient(&metrics.ClientConfig{}, tally.NoopScope, metrics.History)
+	if err != nil {
+		s.NoError(err, "metrics.NewClient")
+	}
+
+	return NewParallelProcessor(
+		&ParallelProcessorOptions{
+			QueueSize:   1,
+			WorkerCount: dynamicconfig.GetIntPropertyFn(1),
+		},
+		metricsClient,
+		log.NewNoopLogger(),
+	)
 }

--- a/service/history/queueProcessorFactory.go
+++ b/service/history/queueProcessorFactory.go
@@ -157,7 +157,7 @@ func NewTransferQueueProcessorFactory(
 			),
 			queues.SchedulerOptions{
 				ParallelProcessorOptions: ctasks.ParallelProcessorOptions{
-					WorkerCount: params.Config.TransferProcessorSchedulerWorkerCount(),
+					WorkerCount: params.Config.TransferProcessorSchedulerWorkerCount,
 					QueueSize:   params.Config.TransferProcessorSchedulerQueueSize(),
 				},
 				InterleavedWeightedRoundRobinSchedulerOptions: ctasks.InterleavedWeightedRoundRobinSchedulerOptions{
@@ -208,7 +208,7 @@ func NewTimerQueueProcessorFactory(
 			),
 			queues.SchedulerOptions{
 				ParallelProcessorOptions: ctasks.ParallelProcessorOptions{
-					WorkerCount: params.Config.TimerProcessorSchedulerWorkerCount(),
+					WorkerCount: params.Config.TimerProcessorSchedulerWorkerCount,
 					QueueSize:   params.Config.TimerProcessorSchedulerQueueSize(),
 				},
 				InterleavedWeightedRoundRobinSchedulerOptions: ctasks.InterleavedWeightedRoundRobinSchedulerOptions{
@@ -257,7 +257,7 @@ func NewVisibilityQueueProcessorFactory(
 			),
 			queues.SchedulerOptions{
 				ParallelProcessorOptions: ctasks.ParallelProcessorOptions{
-					WorkerCount: params.Config.VisibilityProcessorSchedulerWorkerCount(),
+					WorkerCount: params.Config.VisibilityProcessorSchedulerWorkerCount,
 					QueueSize:   params.Config.VisibilityProcessorSchedulerQueueSize(),
 				},
 				InterleavedWeightedRoundRobinSchedulerOptions: ctasks.InterleavedWeightedRoundRobinSchedulerOptions{

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -382,7 +382,7 @@ func newTimerTaskScheduler(
 		queues.NewNoopPriorityAssigner(),
 		queues.SchedulerOptions{
 			ParallelProcessorOptions: ctasks.ParallelProcessorOptions{
-				WorkerCount: config.TimerTaskWorkerCount(),
+				WorkerCount: config.TimerTaskWorkerCount,
 				QueueSize:   config.TimerTaskWorkerCount() * config.TimerTaskBatchSize(),
 			},
 			InterleavedWeightedRoundRobinSchedulerOptions: ctasks.InterleavedWeightedRoundRobinSchedulerOptions{

--- a/service/history/transferQueueProcessorBase.go
+++ b/service/history/transferQueueProcessorBase.go
@@ -114,7 +114,7 @@ func newTransferTaskScheduler(
 		queues.NewNoopPriorityAssigner(),
 		queues.SchedulerOptions{
 			ParallelProcessorOptions: ctasks.ParallelProcessorOptions{
-				WorkerCount: config.TransferTaskWorkerCount(),
+				WorkerCount: config.TransferTaskWorkerCount,
 				QueueSize:   config.TransferTaskBatchSize(),
 			},
 			InterleavedWeightedRoundRobinSchedulerOptions: ctasks.InterleavedWeightedRoundRobinSchedulerOptions{

--- a/service/history/visibilityQueueProcessor.go
+++ b/service/history/visibilityQueueProcessor.go
@@ -350,7 +350,7 @@ func newVisibilityTaskScheduler(
 		queues.NewNoopPriorityAssigner(),
 		queues.SchedulerOptions{
 			ParallelProcessorOptions: ctasks.ParallelProcessorOptions{
-				WorkerCount: config.VisibilityTaskWorkerCount(),
+				WorkerCount: config.VisibilityTaskWorkerCount,
 				QueueSize:   config.VisibilityTaskBatchSize(),
 			},
 			InterleavedWeightedRoundRobinSchedulerOptions: ctasks.InterleavedWeightedRoundRobinSchedulerOptions{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Make task processing worker count config truly dynamic

<!-- Tell your future self why have you made these changes -->
**Why?**
- When tuning worker pool size, only need to change the dynamicconfig value. No need to restart the host or reload shard.
- Prepare for making the scheduler worker count config cluster level instead of host level.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- unit test, tested locally with canary and change timer worker count

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
