### PR TITLE
History queue processor task loading host RPS limit

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -338,6 +338,8 @@ const (
 	TimerProcessorFailoverMaxPollRPS = "history.timerProcessorFailoverMaxPollRPS"
 	// TimerProcessorMaxPollRPS is max poll rate per second for timer processor
 	TimerProcessorMaxPollRPS = "history.timerProcessorMaxPollRPS"
+	// TimerProcessorMaxPollHostRPS is max poll rate per second for all timer processor on a host
+	TimerProcessorMaxPollHostRPS = "history.timerProcessorMaxPollHostRPS"
 	// TimerProcessorMaxPollInterval is max poll interval for timer processor
 	TimerProcessorMaxPollInterval = "history.timerProcessorMaxPollInterval"
 	// TimerProcessorMaxPollIntervalJitterCoefficient is the max poll interval jitter coefficient
@@ -364,6 +366,8 @@ const (
 	TransferProcessorFailoverMaxPollRPS = "history.transferProcessorFailoverMaxPollRPS"
 	// TransferProcessorMaxPollRPS is max poll rate per second for transferQueueProcessor
 	TransferProcessorMaxPollRPS = "history.transferProcessorMaxPollRPS"
+	// TransferProcessorMaxPollHostRPS is max poll rate per second for all transferQueueProcessor on a host
+	TransferProcessorMaxPollHostRPS = "history.transferProcessorMaxPollHostRPS"
 	// TransferTaskWorkerCount is number of worker for transferQueueProcessor
 	TransferTaskWorkerCount = "history.transferTaskWorkerCount"
 	// TransferTaskMaxRetryCount is max times of retry for transferQueueProcessor
@@ -412,6 +416,8 @@ const (
 	VisibilityProcessorFailoverMaxPollRPS = "history.visibilityProcessorFailoverMaxPollRPS"
 	// VisibilityProcessorMaxPollRPS is max poll rate per second for visibilityQueueProcessor
 	VisibilityProcessorMaxPollRPS = "history.visibilityProcessorMaxPollRPS"
+	// VisibilityProcessorMaxPollHostRPS is max poll rate per second for all visibilityQueueProcessor on a host
+	VisibilityProcessorMaxPollHostRPS = "history.visibilityProcessorMaxPollHostRPS"
 	// VisibilityTaskWorkerCount is number of worker for visibilityQueueProcessor
 	VisibilityTaskWorkerCount = "history.visibilityTaskWorkerCount"
 	// VisibilityTaskMaxRetryCount is max times of retry for visibilityQueueProcessor

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -96,6 +96,7 @@ type Config struct {
 	TimerProcessorCompleteTimerInterval               dynamicconfig.DurationPropertyFn
 	TimerProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
 	TimerProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
+	TimerProcessorMaxPollHostRPS                      dynamicconfig.IntPropertyFn
 	TimerProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
 	TimerProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
 	TimerProcessorRescheduleInterval                  dynamicconfig.DurationPropertyFn
@@ -119,6 +120,7 @@ type Config struct {
 	TransferProcessorCompleteTransferFailureRetryCount   dynamicconfig.IntPropertyFn
 	TransferProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
 	TransferProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
+	TransferProcessorMaxPollHostRPS                      dynamicconfig.IntPropertyFn
 	TransferProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
 	TransferProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
 	TransferProcessorUpdateAckInterval                   dynamicconfig.DurationPropertyFn
@@ -245,6 +247,7 @@ type Config struct {
 	VisibilityProcessorCompleteTaskFailureRetryCount       dynamicconfig.IntPropertyFn
 	VisibilityProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
 	VisibilityProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
+	VisibilityProcessorMaxPollHostRPS                      dynamicconfig.IntPropertyFn
 	VisibilityProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
 	VisibilityProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
 	VisibilityProcessorUpdateAckInterval                   dynamicconfig.DurationPropertyFn
@@ -325,6 +328,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		TimerProcessorCompleteTimerInterval:               dc.GetDurationProperty(dynamicconfig.TimerProcessorCompleteTimerInterval, 60*time.Second),
 		TimerProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.TimerProcessorFailoverMaxPollRPS, 1),
 		TimerProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.TimerProcessorMaxPollRPS, 20),
+		TimerProcessorMaxPollHostRPS:                      dc.GetIntProperty(dynamicconfig.TimerProcessorMaxPollHostRPS, 0),
 		TimerProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxPollInterval, 5*time.Minute),
 		TimerProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.TimerProcessorMaxPollIntervalJitterCoefficient, 0.15),
 		TimerProcessorRescheduleInterval:                  dc.GetDurationProperty(dynamicconfig.TimerProcessorRescheduleInterval, 5*time.Second),
@@ -347,6 +351,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		TransferProcessorCompleteTransferFailureRetryCount:   dc.GetIntProperty(dynamicconfig.TransferProcessorCompleteTransferFailureRetryCount, 10),
 		TransferProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.TransferProcessorFailoverMaxPollRPS, 1),
 		TransferProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollRPS, 20),
+		TransferProcessorMaxPollHostRPS:                      dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollHostRPS, 0),
 		TransferProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.TransferProcessorMaxPollInterval, 1*time.Minute),
 		TransferProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
 		TransferProcessorUpdateAckInterval:                   dc.GetDurationProperty(dynamicconfig.TransferProcessorUpdateAckInterval, 30*time.Second),
@@ -438,6 +443,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		VisibilityTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.VisibilityTaskBatchSize, 100),
 		VisibilityProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.VisibilityProcessorFailoverMaxPollRPS, 1),
 		VisibilityProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.VisibilityProcessorMaxPollRPS, 20),
+		VisibilityProcessorMaxPollHostRPS:                      dc.GetIntProperty(dynamicconfig.VisibilityProcessorMaxPollHostRPS, 0),
 		VisibilityTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.VisibilityTaskWorkerCount, 10),
 		VisibilityTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.VisibilityTaskMaxRetryCount, 100),
 		VisibilityProcessorEnablePriorityTaskScheduler:         dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnablePriorityTaskScheduler, false),

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/timer"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/queues"
@@ -60,6 +61,7 @@ func newTimerQueueActiveProcessor(
 	matchingClient matchingservice.MatchingServiceClient,
 	taskAllocator taskAllocator,
 	clientBean client.Bean,
+	rateLimiter quotas.RateLimiter,
 	logger log.Logger,
 	singleProcessor bool,
 ) *timerQueueActiveProcessorImpl {
@@ -184,7 +186,7 @@ func newTimerQueueActiveProcessor(
 		timer.NewLocalGate(shard.GetTimeSource()),
 		scheduler,
 		rescheduler,
-		config.TimerProcessorMaxPollRPS,
+		rateLimiter,
 		logger,
 		metricsClient.Scope(metrics.TimerActiveQueueProcessorScope),
 	)
@@ -203,6 +205,7 @@ func newTimerQueueFailoverProcessor(
 	maxLevel time.Time,
 	matchingClient matchingservice.MatchingServiceClient,
 	taskAllocator taskAllocator,
+	rateLimiter quotas.RateLimiter,
 	logger log.Logger,
 ) (func(ackLevel tasks.Key) error, *timerQueueActiveProcessorImpl) {
 
@@ -296,7 +299,7 @@ func newTimerQueueFailoverProcessor(
 		timer.NewLocalGate(shard.GetTimeSource()),
 		scheduler,
 		rescheduler,
-		shard.GetConfig().TimerProcessorFailoverMaxPollRPS,
+		rateLimiter,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TimerActiveQueueProcessorScope),
 	)

--- a/service/history/timerQueueActiveTaskExecutor_test.go
+++ b/service/history/timerQueueActiveTaskExecutor_test.go
@@ -53,6 +53,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/shard"
@@ -188,6 +189,9 @@ func (s *timerQueueActiveTaskExecutorSuite) SetupTest() {
 			s.mockMatchingClient,
 			newTaskAllocator(s.mockShard),
 			s.mockShard.Resource.ClientBean,
+			quotas.NewDefaultOutgoingRateLimiter(
+				func() float64 { return float64(config.TimerProcessorMaxPollRPS()) },
+			),
 			s.logger,
 			false,
 		),

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -41,7 +41,6 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
-	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -94,7 +93,7 @@ func newTimerQueueProcessorBase(
 	timerGate timer.Gate,
 	executableScheduler queues.Scheduler,
 	rescheduler queues.Rescheduler,
-	maxPollRPS dynamicconfig.IntPropertyFn,
+	rateLimiter quotas.RateLimiter,
 	logger log.Logger,
 	metricsScope metrics.Scope,
 ) *timerQueueProcessorBase {
@@ -121,10 +120,8 @@ func newTimerQueueProcessorBase(
 		lastPollTime:        time.Time{},
 		executableScheduler: executableScheduler,
 		rescheduler:         rescheduler,
-		rateLimiter: quotas.NewDefaultOutgoingRateLimiter(
-			func() float64 { return float64(maxPollRPS()) },
-		),
-		retryPolicy: common.CreatePersistenceRetryPolicy(),
+		rateLimiter:         rateLimiter,
+		retryPolicy:         common.CreatePersistenceRetryPolicy(),
 	}
 
 	return base

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/timer"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/queues"
@@ -61,6 +62,7 @@ func newTimerQueueStandbyProcessor(
 	clusterName string,
 	taskAllocator taskAllocator,
 	clientBean client.Bean,
+	rateLimiter quotas.RateLimiter,
 	logger log.Logger,
 ) *timerQueueStandbyProcessorImpl {
 
@@ -161,7 +163,7 @@ func newTimerQueueStandbyProcessor(
 		timerGate,
 		scheduler,
 		rescheduler,
-		config.TimerProcessorMaxPollRPS,
+		rateLimiter,
 		logger,
 		metricsClient.Scope(metrics.TimerStandbyQueueProcessorScope),
 	)

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -35,6 +35,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/shard"
@@ -59,6 +60,7 @@ func newTransferQueueStandbyProcessor(
 	archivalClient archiver.Client,
 	taskAllocator taskAllocator,
 	clientBean client.Bean,
+	rateLimiter quotas.RateLimiter,
 	logger log.Logger,
 	matchingClient matchingservice.MatchingServiceClient,
 ) *transferQueueStandbyProcessorImpl {
@@ -66,7 +68,6 @@ func newTransferQueueStandbyProcessor(
 	config := shard.GetConfig()
 	options := &QueueProcessorOptions{
 		BatchSize:                           config.TransferTaskBatchSize,
-		MaxPollRPS:                          config.TransferProcessorMaxPollRPS,
 		MaxPollInterval:                     config.TransferProcessorMaxPollInterval,
 		MaxPollIntervalJitterCoefficient:    config.TransferProcessorMaxPollIntervalJitterCoefficient,
 		UpdateAckInterval:                   config.TransferProcessorUpdateAckInterval,
@@ -176,6 +177,7 @@ func newTransferQueueStandbyProcessor(
 		workflowCache,
 		scheduler,
 		rescheduler,
+		rateLimiter,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TransferStandbyQueueProcessorScope),
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add host RPS limit for history queue task loading

<!-- Tell your future self why have you made these changes -->
**Why?**
- Mainly for https://github.com/temporalio/temporal/issues/2912
- But also generally we need a host level rps limit for task loading. Per shard rps limit will still consume all available persistence token on a host when all shards are busy.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- No, by default the host rps limit is disabled and we use persistence rps as fallback

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- no