### PR TITLE
Add priority tag for task processing metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -99,6 +99,7 @@ const (
 	FailureTagName        = "failure"
 	TaskCategoryTagName   = "task_category"
 	TaskTypeTagName       = "task_type"
+	TaskPriorityTagName   = "task_priority"
 	QueueTypeTagName      = "queue_type"
 	visibilityTypeTagName = "visibility_type"
 	ErrorTypeTagName      = "error_type"

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -195,6 +195,13 @@ func TaskTypeTag(value string) Tag {
 	return &tagImpl{key: TaskTypeTagName, value: value}
 }
 
+func TaskPriorityTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return &tagImpl{key: TaskPriorityTagName, value: value}
+}
+
 func QueueTypeTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue

--- a/common/tasks/benchmark_test.go
+++ b/common/tasks/benchmark_test.go
@@ -46,7 +46,7 @@ var (
 )
 
 func BenchmarkInterleavedWeightedRoundRobinScheduler(b *testing.B) {
-	priorityToWeight := map[int]int{
+	priorityToWeight := map[Priority]int{
 		0: 5,
 		1: 3,
 		2: 2,
@@ -89,5 +89,5 @@ func (n *noopTask) Ack()                             { n.Done() }
 func (n *noopTask) Nack(err error)                   { panic("implement me") }
 func (n *noopTask) Reschedule()                      { panic("implement me") }
 func (n *noopTask) State() State                     { panic("implement me") }
-func (n *noopTask) GetPriority() int                 { return 0 }
-func (n *noopTask) SetPriority(i int)                { panic("implement me") }
+func (n *noopTask) GetPriority() Priority            { return 0 }
+func (n *noopTask) SetPriority(i Priority)           { panic("implement me") }

--- a/common/tasks/interleaved_weighted_round_robin.go
+++ b/common/tasks/interleaved_weighted_round_robin.go
@@ -40,7 +40,7 @@ type (
 	// InterleavedWeightedRoundRobinSchedulerOptions is the config for
 	// interleaved weighted round robin scheduler
 	InterleavedWeightedRoundRobinSchedulerOptions struct {
-		PriorityToWeight map[int]int
+		PriorityToWeight map[Priority]int
 	}
 
 	// InterleavedWeightedRoundRobinScheduler is a round robin scheduler implementation
@@ -56,11 +56,11 @@ type (
 		shutdownChan chan struct{}
 
 		sync.RWMutex
-		priorityToWeight     map[int]int
+		priorityToWeight     map[Priority]int
 		weightToTaskChannels map[int]*WeightedChannel
 		// precalculated / flattened task chan according to weight
 		// e.g. if
-		// priorityToWeight := map[int]int{
+		// priorityToWeight := map[Priority]int{
 		//		0: 5,
 		//		1: 3,
 		//		2: 2,

--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -66,7 +66,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockProcessor = NewMockProcessor(s.controller)
 
-	priorityToWeight := map[int]int{
+	priorityToWeight := map[Priority]int{
 		0: 5,
 		1: 3,
 		2: 2,
@@ -98,7 +98,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Success
 	testWaitGroup.Add(1)
 
 	mockTask := NewMockPriorityTask(s.controller)
-	mockTask.EXPECT().GetPriority().Return(0).AnyTimes()
+	mockTask.EXPECT().GetPriority().Return(Priority(0)).AnyTimes()
 	s.mockProcessor.EXPECT().Submit(mockTask).Do(func(task Task) {
 		testWaitGroup.Done()
 	})
@@ -118,7 +118,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Fail() 
 	testWaitGroup.Add(1)
 
 	mockTask := NewMockPriorityTask(s.controller)
-	mockTask.EXPECT().GetPriority().Return(0).AnyTimes()
+	mockTask.EXPECT().GetPriority().Return(Priority(0)).AnyTimes()
 	// either drain immediately
 	mockTask.EXPECT().Reschedule().Do(func() {
 		testWaitGroup.Done()
@@ -138,7 +138,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
 
 	channelWeights = nil
 	mockTask0 := NewMockPriorityTask(s.controller)
-	mockTask0.EXPECT().GetPriority().Return(0).AnyTimes()
+	mockTask0.EXPECT().GetPriority().Return(Priority(0)).AnyTimes()
 	s.scheduler.Submit(mockTask0)
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
@@ -147,7 +147,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
 
 	channelWeights = nil
 	mockTask1 := NewMockPriorityTask(s.controller)
-	mockTask1.EXPECT().GetPriority().Return(1).AnyTimes()
+	mockTask1.EXPECT().GetPriority().Return(Priority(1)).AnyTimes()
 	s.scheduler.Submit(mockTask1)
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
@@ -156,7 +156,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
 
 	channelWeights = nil
 	mockTask2 := NewMockPriorityTask(s.controller)
-	mockTask2.EXPECT().GetPriority().Return(2).AnyTimes()
+	mockTask2.EXPECT().GetPriority().Return(Priority(2)).AnyTimes()
 	s.scheduler.Submit(mockTask2)
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
@@ -165,7 +165,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
 
 	channelWeights = nil
 	mockTask3 := NewMockPriorityTask(s.controller)
-	mockTask3.EXPECT().GetPriority().Return(3).AnyTimes()
+	mockTask3.EXPECT().GetPriority().Return(Priority(3)).AnyTimes()
 	s.scheduler.Submit(mockTask3)
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
@@ -203,7 +203,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestParallelSubmitSchedule
 		channel := make(chan PriorityTask, numTasks)
 		for j := 0; j < numTasks; j++ {
 			mockTask := NewMockPriorityTask(s.controller)
-			mockTask.EXPECT().GetPriority().Return(rand.Intn(4)).AnyTimes()
+			mockTask.EXPECT().GetPriority().Return(Priority(rand.Intn(4))).AnyTimes()
 			s.mockProcessor.EXPECT().Submit(mockTask).Do(func(task Task) {
 				testWaitGroup.Done()
 			}).Times(1)

--- a/common/tasks/priority.go
+++ b/common/tasks/priority.go
@@ -1,4 +1,3 @@
-// The MIT License
 //
 // Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
 //
@@ -22,23 +21,60 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package queues
+package tasks
 
-import (
-	"go.temporal.io/server/common/tasks"
-)
+import "strconv"
 
 type (
-	noopPriorityAssignerImpl struct{}
+	Priority int
 )
 
-var noopPriorityAssigner = &noopPriorityAssignerImpl{}
+const (
+	numBitsPerLevel = 3
+)
 
-func NewNoopPriorityAssigner() PriorityAssigner {
-	return noopPriorityAssigner
+const (
+	highPriorityClass Priority = iota << numBitsPerLevel
+	mediumPriorityClass
+	lowPriorityClass
+)
+
+const (
+	highPrioritySubclass Priority = iota
+	mediumPrioritySubclass
+	lowPrioritySubclass
+)
+
+var (
+	PriorityHigh   = getPriority(highPriorityClass, mediumPrioritySubclass)
+	PriorityMedium = getPriority(mediumPriorityClass, mediumPrioritySubclass)
+	PriorityLow    = getPriority(lowPriorityClass, mediumPrioritySubclass)
+)
+
+var (
+	PriorityName = map[Priority]string{
+		PriorityHigh:   "high",
+		PriorityMedium: "medium",
+		PriorityLow:    "low",
+	}
+
+	PriorityValue = map[string]Priority{
+		"high":   PriorityHigh,
+		"medium": PriorityMedium,
+		"low":    PriorityLow,
+	}
+)
+
+func (p Priority) String() string {
+	s, ok := PriorityName[p]
+	if ok {
+		return s
+	}
+	return strconv.Itoa(int(p))
 }
 
-func (a *noopPriorityAssignerImpl) Assign(execuable Executable) error {
-	execuable.SetPriority(tasks.PriorityHigh)
-	return nil
+func getPriority(
+	class, subClass Priority,
+) Priority {
+	return class | subClass
 }

--- a/common/tasks/priority.go
+++ b/common/tasks/priority.go
@@ -1,3 +1,4 @@
+// The MIT License
 //
 // Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
 //

--- a/common/tasks/task.go
+++ b/common/tasks/task.go
@@ -66,8 +66,8 @@ type (
 	PriorityTask interface {
 		Task
 		// GetPriority returns the priority of the task
-		GetPriority() int
+		GetPriority() Priority
 		// SetPriority sets the priority of the task
-		SetPriority(int)
+		SetPriority(Priority)
 	}
 )

--- a/common/tasks/task_mock.go
+++ b/common/tasks/task_mock.go
@@ -214,10 +214,10 @@ func (mr *MockPriorityTaskMockRecorder) Execute() *gomock.Call {
 }
 
 // GetPriority mocks base method.
-func (m *MockPriorityTask) GetPriority() int {
+func (m *MockPriorityTask) GetPriority() Priority {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPriority")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(Priority)
 	return ret0
 }
 
@@ -294,7 +294,7 @@ func (mr *MockPriorityTaskMockRecorder) RetryPolicy() *gomock.Call {
 }
 
 // SetPriority mocks base method.
-func (m *MockPriorityTask) SetPriority(arg0 int) {
+func (m *MockPriorityTask) SetPriority(arg0 Priority) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetPriority", arg0)
 }

--- a/service/history/queues/executable_mock.go
+++ b/service/history/queues/executable_mock.go
@@ -148,10 +148,10 @@ func (mr *MockExecutableMockRecorder) GetNamespaceID() *gomock.Call {
 }
 
 // GetPriority mocks base method.
-func (m *MockExecutable) GetPriority() int {
+func (m *MockExecutable) GetPriority() tasks.Priority {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPriority")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(tasks.Priority)
 	return ret0
 }
 
@@ -354,7 +354,7 @@ func (mr *MockExecutableMockRecorder) RetryPolicy() *gomock.Call {
 }
 
 // SetPriority mocks base method.
-func (m *MockExecutable) SetPriority(arg0 int) {
+func (m *MockExecutable) SetPriority(arg0 tasks.Priority) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "SetPriority", arg0)
 }

--- a/service/history/queues/priority_assigner_test.go
+++ b/service/history/queues/priority_assigner_test.go
@@ -36,8 +36,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/service/history/configs"
-	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/common/tasks"
 	"go.temporal.io/server/service/history/tests"
 )
 
@@ -82,7 +81,7 @@ func (s *priorityAssignerSuite) TearDownTest() {
 func (s *priorityAssignerSuite) TestAssign_CriticalAttempts() {
 	mockExecutable := NewMockExecutable(s.controller)
 	mockExecutable.EXPECT().Attempt().Return(1000).AnyTimes()
-	mockExecutable.EXPECT().SetPriority(configs.TaskPriorityLow)
+	mockExecutable.EXPECT().SetPriority(tasks.PriorityLow)
 
 	err := s.priorityAssigner.Assign(mockExecutable)
 	s.NoError(err)
@@ -95,7 +94,7 @@ func (s *priorityAssignerSuite) TestAssign_StandbyNamespaceStandbyQueue() {
 	mockExecutable.EXPECT().Attempt().Return(10).AnyTimes()
 	mockExecutable.EXPECT().GetNamespaceID().Return(tests.NamespaceID.String()).AnyTimes()
 	mockExecutable.EXPECT().QueueType().Return(QueueTypeStandbyTransfer).AnyTimes()
-	mockExecutable.EXPECT().SetPriority(configs.TaskPriorityLow)
+	mockExecutable.EXPECT().SetPriority(tasks.PriorityLow)
 
 	err := s.priorityAssigner.Assign(mockExecutable)
 	s.NoError(err)
@@ -108,7 +107,7 @@ func (s *priorityAssignerSuite) TestAssign_NoopExecuable() {
 	mockExecutable.EXPECT().Attempt().Return(10).AnyTimes()
 	mockExecutable.EXPECT().GetNamespaceID().Return(tests.NamespaceID.String()).AnyTimes()
 	mockExecutable.EXPECT().QueueType().Return(QueueTypeActiveTransfer).AnyTimes()
-	mockExecutable.EXPECT().SetPriority(configs.TaskPriorityHigh)
+	mockExecutable.EXPECT().SetPriority(tasks.PriorityHigh)
 
 	err := s.priorityAssigner.Assign(mockExecutable)
 	s.NoError(err)
@@ -123,7 +122,7 @@ func (s *priorityAssignerSuite) TestAssign_SelectedTaskTypes() {
 	mockExecutable.EXPECT().GetType().Return(enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT).AnyTimes()
 
 	mockExecutable.EXPECT().QueueType().Return(QueueTypeActiveTransfer).AnyTimes()
-	mockExecutable.EXPECT().SetPriority(configs.TaskPriorityDefault)
+	mockExecutable.EXPECT().SetPriority(tasks.PriorityMedium)
 
 	err := s.priorityAssigner.Assign(mockExecutable)
 	s.NoError(err)
@@ -137,10 +136,9 @@ func (s *priorityAssignerSuite) TestAssign_Throttled() {
 	mockExecutable.EXPECT().Attempt().Return(10).AnyTimes()
 	mockExecutable.EXPECT().GetNamespaceID().Return(tests.NamespaceID.String()).AnyTimes()
 	mockExecutable.EXPECT().GetType().Return(enumsspb.TASK_TYPE_UNSPECIFIED).AnyTimes()
-	mockExecutable.EXPECT().GetCategory().Return(tasks.CategoryTransfer).AnyTimes()
 	mockExecutable.EXPECT().QueueType().Return(QueueTypeActiveTransfer).AnyTimes()
 
-	mockExecutable.EXPECT().SetPriority(configs.TaskPriorityHigh).Times(1)
+	mockExecutable.EXPECT().SetPriority(tasks.PriorityHigh).Times(1)
 	err := s.priorityAssigner.Assign(mockExecutable)
 	s.NoError(err)
 
@@ -150,7 +148,7 @@ func (s *priorityAssignerSuite) TestAssign_Throttled() {
 		s.NoError(err)
 	}
 
-	mockExecutable.EXPECT().SetPriority(configs.TaskPriorityDefault).Times(1)
+	mockExecutable.EXPECT().SetPriority(tasks.PriorityMedium).Times(1)
 	err = s.priorityAssigner.Assign(mockExecutable)
 	s.NoError(err)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add priority tag for task processing related metrics: task request, task_latency & task_latency_queue family (those showing latency for queuing & multiple attempts)
- Use task type tag instead of task category tag for task throttling metrics
- Make task priority strong type & move definitions to common/tasks package

<!-- Tell your future self why have you made these changes -->
**Why?**
- Improve task processing metrics

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing metrics

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Low, only changing metrics

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.