### PR TITLE
Fill in SupportsSchedules field

### DIFF
--- a/common/namespace/handler.go
+++ b/common/namespace/handler.go
@@ -87,6 +87,7 @@ type (
 		namespaceAttrValidator *AttrValidatorImpl
 		archivalMetadata       archiver.ArchivalMetadata
 		archiverProvider       provider.ArchiverProvider
+		supportsSchedules      dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	}
 )
 
@@ -102,6 +103,7 @@ func NewHandler(
 	namespaceReplicator Replicator,
 	archivalMetadata archiver.ArchivalMetadata,
 	archiverProvider provider.ArchiverProvider,
+	supportsSchedules dynamicconfig.BoolPropertyFnWithNamespaceFilter,
 ) *HandlerImpl {
 	return &HandlerImpl{
 		maxBadBinaryCount:      maxBadBinaryCount,
@@ -112,6 +114,7 @@ func NewHandler(
 		namespaceAttrValidator: newAttrValidator(clusterMetadata),
 		archivalMetadata:       archivalMetadata,
 		archiverProvider:       archiverProvider,
+		supportsSchedules:      supportsSchedules,
 	}
 }
 
@@ -662,6 +665,8 @@ func (d *HandlerImpl) createResponse(
 		OwnerEmail:  info.Owner,
 		Data:        info.Data,
 		Id:          info.Id,
+
+		SupportsSchedules: d.supportsSchedules(info.Name),
 	}
 
 	configResult := &namespacepb.NamespaceConfig{

--- a/common/namespace/handler_GlobalNamespaceDisabled_test.go
+++ b/common/namespace/handler_GlobalNamespaceDisabled_test.go
@@ -108,6 +108,7 @@ func (s *namespaceHandlerGlobalNamespaceDisabledSuite) SetupTest() {
 		s.mockNamespaceReplicator,
 		s.archivalMetadata,
 		s.mockArchiverProvider,
+		dc.GetBoolPropertyFnFilteredByNamespace(false),
 	)
 }
 

--- a/common/namespace/handler_GlobalNamespaceEnabled_MasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_MasterCluster_test.go
@@ -108,6 +108,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledMasterClusterSuite) SetupTest() {
 		s.mockNamespaceReplicator,
 		s.archivalMetadata,
 		s.mockArchiverProvider,
+		dc.GetBoolPropertyFnFilteredByNamespace(false),
 	)
 }
 

--- a/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
+++ b/common/namespace/handler_GlobalNamespaceEnabled_NotMasterCluster_test.go
@@ -109,6 +109,7 @@ func (s *namespaceHandlerGlobalNamespaceEnabledNotMasterClusterSuite) SetupTest(
 		s.mockNamespaceReplicator,
 		s.archivalMetadata,
 		s.mockArchiverProvider,
+		dc.GetBoolPropertyFnFilteredByNamespace(false),
 	)
 }
 

--- a/common/namespace/handler_test.go
+++ b/common/namespace/handler_test.go
@@ -26,6 +26,7 @@ package namespace
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,7 +114,7 @@ func (s *namespaceHandlerCommonSuite) SetupTest() {
 		s.mockNamespaceReplicator,
 		s.archivalMetadata,
 		s.mockArchiverProvider,
-		dc.GetBoolPropertyFnFilteredByNamespace(false),
+		func(s string) bool { return strings.HasSuffix(s, "sched") },
 	)
 }
 
@@ -282,7 +283,7 @@ func (s *namespaceHandlerCommonSuite) TestListNamespace() {
 	s.NoError(err)
 	s.Equal(&workflowservice.RegisterNamespaceResponse{}, registerResp)
 
-	namespace2 := s.getRandomNamespace()
+	namespace2 := s.getRandomNamespace() + "sched"
 	description2 := "some random description 2"
 	email2 := "some random email 2"
 	retention2 := 2 * time.Hour * 24
@@ -357,12 +358,13 @@ func (s *namespaceHandlerCommonSuite) TestListNamespace() {
 		},
 		namespace2: &workflowservice.DescribeNamespaceResponse{
 			NamespaceInfo: &namespacepb.NamespaceInfo{
-				Name:        namespace2,
-				State:       enumspb.NAMESPACE_STATE_REGISTERED,
-				Description: description2,
-				OwnerEmail:  email2,
-				Data:        data2,
-				Id:          "",
+				Name:              namespace2,
+				State:             enumspb.NAMESPACE_STATE_REGISTERED,
+				Description:       description2,
+				OwnerEmail:        email2,
+				Data:              data2,
+				Id:                "",
+				SupportsSchedules: true,
 			},
 			Config: &namespacepb.NamespaceConfig{
 				WorkflowExecutionRetentionTtl: &retention2,

--- a/common/namespace/handler_test.go
+++ b/common/namespace/handler_test.go
@@ -113,6 +113,7 @@ func (s *namespaceHandlerCommonSuite) SetupTest() {
 		s.mockNamespaceReplicator,
 		s.archivalMetadata,
 		s.mockArchiverProvider,
+		dc.GetBoolPropertyFnFilteredByNamespace(false),
 	)
 }
 

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.30.0
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/sdk/metric v0.30.0
-	go.temporal.io/api v1.7.1-0.20220527042911-3de1acf95864
+	go.temporal.io/api v1.7.1-0.20220531210845-69c8b41408d0
 	go.temporal.io/sdk v1.14.1-0.20220513214234-7ccfda678fed
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.9.0
@@ -117,13 +117,13 @@ require (
 	go.uber.org/dig v1.14.1 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/net v0.0.0-20220526153639-5463443f8c37 // indirect
+	golang.org/x/net v0.0.0-20220531201128-c960675eff93 // indirect
 	golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.10 // indirect
 	golang.org/x/xerrors v0.0.0-20220517211312-f3a8303e98df // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220526192754-51939a95c655 // indirect
+	google.golang.org/genproto v0.0.0-20220531173845-685668d2de03 // indirect
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -484,6 +484,8 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.temporal.io/api v1.7.1-0.20220510183009-449d18444c9a/go.mod h1:YU5EQaONkIr0ZRju0NqdqYNH/hCkBuwqRMDA0iaj7JM=
 go.temporal.io/api v1.7.1-0.20220527042911-3de1acf95864 h1:G7hENoDncRf7DLOZVdC6eJMsY/risBd0KgxKSSmdzzU=
 go.temporal.io/api v1.7.1-0.20220527042911-3de1acf95864/go.mod h1:jnxV+esoSDOxHGonSKKlUivh+w3dE7h4oOZeUB3h4m4=
+go.temporal.io/api v1.7.1-0.20220531210845-69c8b41408d0 h1:+cFOs2QyDq4boo15vTUBlDQOBf3HTOEA5n3bMiYHBaU=
+go.temporal.io/api v1.7.1-0.20220531210845-69c8b41408d0/go.mod h1:JMB2socWBdrPOwarYntcurp/HgKWcpkA4mQKRD6D9Y4=
 go.temporal.io/sdk v1.14.1-0.20220513214234-7ccfda678fed h1:QrZQUSnsOsTZFh4bq5wyOMvl2uZbJJ80JiW/6Gs3eUY=
 go.temporal.io/sdk v1.14.1-0.20220513214234-7ccfda678fed/go.mod h1:d1S1ETFShrybdBYxhqizQASREk0G9oi4RE2VKsYGHAk=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
@@ -606,6 +608,8 @@ golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220526153639-5463443f8c37 h1:lUkvobShwKsOesNfWWlCS5q7fnbG1MEliIzwu886fn8=
 golang.org/x/net v0.0.0-20220526153639-5463443f8c37/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93 h1:MYimHLfoXEpOhqd/zgoA/uoXzHB86AEky4LAx5ij9xA=
+golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -928,6 +932,8 @@ google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220526192754-51939a95c655 h1:56rmjc5LUAanErbiNrY+s/Nd47wDQEJkpqS7i43M1I0=
 google.golang.org/genproto v0.0.0-20220526192754-51939a95c655/go.mod h1:yKyY4AMRwFiC8yMMNaMi+RkCnjZJt9LoWuvhXjMs+To=
+google.golang.org/genproto v0.0.0-20220531173845-685668d2de03 h1:FG2YhwyltdDPC/0XuwzU0dijPcTzvfTtst0QdlDxoMU=
+google.golang.org/genproto v0.0.0-20220531173845-685668d2de03/go.mod h1:yKyY4AMRwFiC8yMMNaMi+RkCnjZJt9LoWuvhXjMs+To=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/go.sum
+++ b/go.sum
@@ -482,8 +482,6 @@ go.opentelemetry.io/otel/trace v1.7.0 h1:O37Iogk1lEkMRXewVtZ1BBTVn5JEp8GrJvP92bJ
 go.opentelemetry.io/otel/trace v1.7.0/go.mod h1:fzLSB9nqR2eXzxPXb2JW9IKE+ScyXA48yyE4TNvoHqU=
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.temporal.io/api v1.7.1-0.20220510183009-449d18444c9a/go.mod h1:YU5EQaONkIr0ZRju0NqdqYNH/hCkBuwqRMDA0iaj7JM=
-go.temporal.io/api v1.7.1-0.20220527042911-3de1acf95864 h1:G7hENoDncRf7DLOZVdC6eJMsY/risBd0KgxKSSmdzzU=
-go.temporal.io/api v1.7.1-0.20220527042911-3de1acf95864/go.mod h1:jnxV+esoSDOxHGonSKKlUivh+w3dE7h4oOZeUB3h4m4=
 go.temporal.io/api v1.7.1-0.20220531210845-69c8b41408d0 h1:+cFOs2QyDq4boo15vTUBlDQOBf3HTOEA5n3bMiYHBaU=
 go.temporal.io/api v1.7.1-0.20220531210845-69c8b41408d0/go.mod h1:JMB2socWBdrPOwarYntcurp/HgKWcpkA4mQKRD6D9Y4=
 go.temporal.io/sdk v1.14.1-0.20220513214234-7ccfda678fed h1:QrZQUSnsOsTZFh4bq5wyOMvl2uZbJJ80JiW/6Gs3eUY=
@@ -606,8 +604,6 @@ golang.org/x/net v0.0.0-20220325170049-de3da57026de/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220520000938-2e3eb7b945c2/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
-golang.org/x/net v0.0.0-20220526153639-5463443f8c37 h1:lUkvobShwKsOesNfWWlCS5q7fnbG1MEliIzwu886fn8=
-golang.org/x/net v0.0.0-20220526153639-5463443f8c37/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220531201128-c960675eff93 h1:MYimHLfoXEpOhqd/zgoA/uoXzHB86AEky4LAx5ij9xA=
 golang.org/x/net v0.0.0-20220531201128-c960675eff93/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -930,8 +926,6 @@ google.golang.org/genproto v0.0.0-20220505152158-f39f71e6c8f3/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220518221133-4f43b3371335/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220519153652-3a47de7e79bd/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
 google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP7Fh3Nc84ghnVLDPuV51xc9agzmm4Ph6i0Q4=
-google.golang.org/genproto v0.0.0-20220526192754-51939a95c655 h1:56rmjc5LUAanErbiNrY+s/Nd47wDQEJkpqS7i43M1I0=
-google.golang.org/genproto v0.0.0-20220526192754-51939a95c655/go.mod h1:yKyY4AMRwFiC8yMMNaMi+RkCnjZJt9LoWuvhXjMs+To=
 google.golang.org/genproto v0.0.0-20220531173845-685668d2de03 h1:FG2YhwyltdDPC/0XuwzU0dijPcTzvfTtst0QdlDxoMU=
 google.golang.org/genproto v0.0.0-20220531173845-685668d2de03/go.mod h1:yKyY4AMRwFiC8yMMNaMi+RkCnjZJt9LoWuvhXjMs+To=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -179,6 +179,7 @@ func NewAdminHandler(
 			namespace.NewNamespaceReplicator(args.ReplicatorNamespaceReplicationQueue, args.Logger),
 			args.ArchivalMetadata,
 			args.ArchiverProvider,
+			args.Config.EnableScheduleRPCs,
 		),
 		namespaceDLQHandler: namespace.NewDLQMessageHandler(
 			namespaceReplicationTaskExecutor,

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -179,7 +179,7 @@ func NewAdminHandler(
 			namespace.NewNamespaceReplicator(args.ReplicatorNamespaceReplicationQueue, args.Logger),
 			args.ArchivalMetadata,
 			args.ArchiverProvider,
-			args.Config.EnableScheduleRPCs,
+			args.Config.EnableSchedules,
 		),
 		namespaceDLQHandler: namespace.NewDLQMessageHandler(
 			namespaceReplicationTaskExecutor,

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -154,6 +154,7 @@ func NewWorkflowHandler(
 			namespace.NewNamespaceReplicator(namespaceReplicationQueue, logger),
 			archivalMetadata,
 			archiverProvider,
+			config.EnableScheduleRPCs,
 		),
 		getDefaultWorkflowRetrySettings: config.DefaultWorkflowRetryPolicy,
 		visibilityMrg:                   visibilityMrg,

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2983,6 +2983,7 @@ func (wh *WorkflowHandler) GetSystemInfo(ctx context.Context, request *workflows
 			SignalAndQueryHeader:            true,
 			InternalErrorDifferentiation:    true,
 			ActivityFailureIncludeHeartbeat: true,
+			SupportsSchedules:               true,
 		},
 	}, nil
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -154,7 +154,7 @@ func NewWorkflowHandler(
 			namespace.NewNamespaceReplicator(namespaceReplicationQueue, logger),
 			archivalMetadata,
 			archiverProvider,
-			config.EnableScheduleRPCs,
+			config.EnableSchedules,
 		),
 		getDefaultWorkflowRetrySettings: config.DefaultWorkflowRetryPolicy,
 		visibilityMrg:                   visibilityMrg,

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -1766,6 +1766,7 @@ func (s *workflowHandlerSuite) TestGetSystemInfo() {
 	s.True(resp.Capabilities.SignalAndQueryHeader)
 	s.True(resp.Capabilities.InternalErrorDifferentiation)
 	s.True(resp.Capabilities.ActivityFailureIncludeHeartbeat)
+	s.True(resp.Capabilities.SupportsSchedules)
 }
 
 func (s *workflowHandlerSuite) newConfig() *Config {


### PR DESCRIPTION
**What changed?**
Fill in fields added in https://github.com/temporalio/api/pull/186

**Why?**
So UI can tell if schedules are enabled at a namespace level, and SDK at a server level.

**How did you test it?**
unit tests

**Potential risks**

**Is hotfix candidate?**
