### PR TITLE
Add PostAuthorizationAction in authorization interceptor

### DIFF
--- a/host/onebox.go
+++ b/host/onebox.go
@@ -431,6 +431,7 @@ func (c *temporalImpl) startFrontend(hosts map[string][]string, startWG *sync.Wa
 		fx.Provide(func() authorization.Authorizer { return nil }),
 		fx.Provide(func() authorization.ClaimMapper { return nil }),
 		fx.Provide(func() authorization.JWTAudienceMapper { return nil }),
+		fx.Provide(func() authorization.PostAuthorizationAction { return nil }),
 		fx.Provide(func() client.FactoryProvider { return client.NewFactoryProvider() }),
 		fx.Provide(func() searchattribute.Mapper { return nil }),
 		// Comment the line above and uncomment the line bellow to test with search attributes mapper.

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -138,6 +138,7 @@ func GrpcServerOptionsProvider(
 	authorizer authorization.Authorizer,
 	claimMapper authorization.ClaimMapper,
 	audienceGetter authorization.JWTAudienceMapper,
+	postAuthorizationAction authorization.PostAuthorizationAction,
 	customInterceptors []grpc.UnaryServerInterceptor,
 	metricsClient metrics.Client,
 ) []grpc.ServerOption {
@@ -171,6 +172,7 @@ func GrpcServerOptionsProvider(
 			metricsClient,
 			logger,
 			audienceGetter,
+			postAuthorizationAction,
 		),
 		sdkVersionInterceptor.Intercept,
 	}

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -106,11 +106,12 @@ type (
 		ServiceResolver        resolver.ServiceResolver
 		CustomDataStoreFactory persistenceClient.AbstractDataStoreFactory
 
-		SearchAttributesMapper searchattribute.Mapper
-		CustomInterceptors     []grpc.UnaryServerInterceptor
-		Authorizer             authorization.Authorizer
-		ClaimMapper            authorization.ClaimMapper
-		AudienceGetter         authorization.JWTAudienceMapper
+		SearchAttributesMapper  searchattribute.Mapper
+		CustomInterceptors      []grpc.UnaryServerInterceptor
+		Authorizer              authorization.Authorizer
+		ClaimMapper             authorization.ClaimMapper
+		AudienceGetter          authorization.JWTAudienceMapper
+		PostAuthorizationAction authorization.PostAuthorizationAction
 
 		// below are things that could be over write by server options or may have default if not supplied by serverOptions.
 		Logger                  log.Logger
@@ -325,6 +326,7 @@ type (
 		ClusterMetadata            *cluster.Config
 		ClientFactoryProvider      client.FactoryProvider
 		AudienceGetter             authorization.JWTAudienceMapper
+		PostAuthorizationAction    authorization.PostAuthorizationAction
 		PersistenceServiceResolver resolver.ServiceResolver
 		PersistenceFactoryProvider persistenceClient.FactoryProviderFn
 		SearchAttributesMapper     searchattribute.Mapper
@@ -364,6 +366,7 @@ func HistoryServiceProvider(
 		fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return params.DataStoreFactory }),
 		fx.Provide(func() client.FactoryProvider { return params.ClientFactoryProvider }),
 		fx.Provide(func() authorization.JWTAudienceMapper { return params.AudienceGetter }),
+		fx.Provide(func() authorization.PostAuthorizationAction { return params.PostAuthorizationAction }),
 		fx.Provide(func() resolver.ServiceResolver { return params.PersistenceServiceResolver }),
 		fx.Provide(func() searchattribute.Mapper { return params.SearchAttributesMapper }),
 		fx.Provide(func() []grpc.UnaryServerInterceptor { return params.CustomInterceptors }),
@@ -422,6 +425,7 @@ func MatchingServiceProvider(
 		fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return params.DataStoreFactory }),
 		fx.Provide(func() client.FactoryProvider { return params.ClientFactoryProvider }),
 		fx.Provide(func() authorization.JWTAudienceMapper { return params.AudienceGetter }),
+		fx.Provide(func() authorization.PostAuthorizationAction { return params.PostAuthorizationAction }),
 		fx.Provide(func() resolver.ServiceResolver { return params.PersistenceServiceResolver }),
 		fx.Provide(func() searchattribute.Mapper { return params.SearchAttributesMapper }),
 		fx.Provide(func() []grpc.UnaryServerInterceptor { return params.CustomInterceptors }),
@@ -477,6 +481,7 @@ func FrontendServiceProvider(
 		fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return params.DataStoreFactory }),
 		fx.Provide(func() client.FactoryProvider { return params.ClientFactoryProvider }),
 		fx.Provide(func() authorization.JWTAudienceMapper { return params.AudienceGetter }),
+		fx.Provide(func() authorization.PostAuthorizationAction { return params.PostAuthorizationAction }),
 		fx.Provide(func() resolver.ServiceResolver { return params.PersistenceServiceResolver }),
 		fx.Provide(func() searchattribute.Mapper { return params.SearchAttributesMapper }),
 		fx.Provide(func() []grpc.UnaryServerInterceptor { return params.CustomInterceptors }),
@@ -533,6 +538,7 @@ func WorkerServiceProvider(
 		fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return params.DataStoreFactory }),
 		fx.Provide(func() client.FactoryProvider { return params.ClientFactoryProvider }),
 		fx.Provide(func() authorization.JWTAudienceMapper { return params.AudienceGetter }),
+		fx.Provide(func() authorization.PostAuthorizationAction { return params.PostAuthorizationAction }),
 		fx.Provide(func() resolver.ServiceResolver { return params.PersistenceServiceResolver }),
 		fx.Provide(func() searchattribute.Mapper { return params.SearchAttributesMapper }),
 		fx.Provide(func() []grpc.UnaryServerInterceptor { return params.CustomInterceptors }),

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -121,6 +121,15 @@ func WithAudienceGetter(audienceGetter func(cfg *config.Config) authorization.JW
 	})
 }
 
+// WithPostAuthorizationAction configures post-authorization action
+func WithPostAuthorizationAction(
+	postAuthorizationAction func(cfg *config.Config) authorization.PostAuthorizationAction,
+) ServerOption {
+	return newApplyFuncContainer(func(s *serverOptions) {
+		s.postAuthorizationAction = postAuthorizationAction(s.config)
+	})
+}
+
 // WithCustomMetricsReporter sets custom metric reporter
 // Detailed examples can be found at https://github.com/temporalio/samples-server
 //

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -60,6 +60,7 @@ type (
 		tlsConfigProvider          encryption.TLSConfigProvider
 		claimMapper                authorization.ClaimMapper
 		audienceGetter             authorization.JWTAudienceMapper
+		postAuthorizationAction    authorization.PostAuthorizationAction
 		metricsReporter            metrics.Reporter
 		persistenceServiceResolver resolver.ServiceResolver
 		elasticsearchHttpClient    *http.Client


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add PostAuthorizationResponseProcessor interface in authorization interceptor, which runs before the response is returned.


<!-- Tell your future self why have you made these changes -->
**Why?**
This allows us to add extension logic after the request is authorized and before the response is returned.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit and local testing.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No-op by default (action is not set) so little risk.


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
