### PR TITLE
Ensure timer max query level never less than min query level

### DIFF
--- a/service/history/timerQueueAckMgr.go
+++ b/service/history/timerQueueAckMgr.go
@@ -31,17 +31,17 @@ import (
 	"sync"
 	"time"
 
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
 	ctasks "go.temporal.io/server/common/tasks"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
-
-	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/persistence"
 )
 
 var (
@@ -177,6 +177,7 @@ func (t *timerQueueAckMgrImpl) getFinishedChan() <-chan struct{} {
 func (t *timerQueueAckMgrImpl) readTimerTasks() ([]queues.Executable, *time.Time, bool, error) {
 	if t.maxQueryLevel == t.minQueryLevel {
 		t.maxQueryLevel = t.shard.GetQueueMaxReadLevel(tasks.CategoryTimer, t.clusterName).FireTime
+		t.maxQueryLevel = common.MaxTime(t.minQueryLevel, t.maxQueryLevel)
 	}
 	minQueryLevel := t.minQueryLevel
 	maxQueryLevel := t.maxQueryLevel


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Ensure timer max query level always equal to or above min query level

<!-- Tell your future self why have you made these changes -->
**Why?**
- When adding a new cluster, the initial remote cluster time is time.Time{}. The time (plus some offset) will be used as the timer max query level when attempting a read. However the min query level is from the overall queue ack level which is a quite recent time. So we have min query level > max query level, and the logic in timer ack manager will found there's nothing more to read and set min query level to be max query level. Now min query level becomes 0 and we will start to read from very beginning of the timer queue and encounter tombstone or resurrection issues.
- Note the fix here is not making sure min query level can't move backward to a lower max query level, instead ensuring max query level never below min query level. The reason is that when we do timer lookahead, we use the range [max query level, max query level + 5min), so if max query level is 0, we will still load old timer tasks (tombstones)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- yes