### PR TITLE
Fix host level task scheduler start/stop

### DIFF
--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -36,3 +36,21 @@
 #    constraints: {}
 #system.enableParentClosePolicyWorker:
 #  - value: true
+history.timerProcessorEnablePriorityTaskScheduler:
+- value: true
+  constraints: {}
+history.transferProcessorEnablePriorityTaskScheduler:
+- value: true
+  constraints: {}
+history.visibilityProcessorEnablePriorityTaskScheduler:
+- value: true
+  constraints: {}
+history.timerTaskMaxRetryCount:
+- value: 10
+  constraints: {}
+history.transferTaskMaxRetryCount:
+- value: 10
+  constraints: {}
+history.visibilityTaskMaxRetryCount:
+- value: 10
+  constraints: {}

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -36,21 +36,3 @@
 #    constraints: {}
 #system.enableParentClosePolicyWorker:
 #  - value: true
-history.timerProcessorEnablePriorityTaskScheduler:
-- value: true
-  constraints: {}
-history.transferProcessorEnablePriorityTaskScheduler:
-- value: true
-  constraints: {}
-history.visibilityProcessorEnablePriorityTaskScheduler:
-- value: true
-  constraints: {}
-history.timerTaskMaxRetryCount:
-- value: 10
-  constraints: {}
-history.transferTaskMaxRetryCount:
-- value: 10
-  constraints: {}
-history.visibilityTaskMaxRetryCount:
-- value: 10
-  constraints: {}

--- a/service/history/queueProcessorFactory.go
+++ b/service/history/queueProcessorFactory.go
@@ -25,6 +25,9 @@
 package history
 
 import (
+	"context"
+	"fmt"
+
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -33,7 +36,6 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/resource"
@@ -41,7 +43,6 @@ import (
 	ctasks "go.temporal.io/server/common/tasks"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/queues"
-	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/worker/archiver"
@@ -62,6 +63,7 @@ var QueueProcessorModule = fx.Options(
 			Target: NewVisibilityQueueProcessorFactory,
 		},
 	),
+	fx.Invoke(QueueProcessorFactoryLifetimeHooks),
 )
 
 type (
@@ -105,41 +107,55 @@ type (
 		VisibilityMgr manager.VisibilityManager
 	}
 
-	replicationQueueProcessorFactoryParams struct {
-		fx.In
-
-		Config             *configs.Config
-		ClientBean         client.Bean
-		ArchivalClient     archiver.Client
-		EventSerializer    serialization.Serializer
-		TaskFetcherFactory replication.TaskFetcherFactory
+	queueProcessorFactoryBase struct {
+		scheduler       queues.Scheduler
+		hostRateLimiter quotas.RateLimiter
 	}
 
 	transferQueueProcessorFactory struct {
 		transferQueueProcessorFactoryParams
-
-		scheduler       queues.Scheduler
-		hostRateLimiter quotas.RateLimiter
+		queueProcessorFactoryBase
 	}
 
 	timerQueueProcessorFactory struct {
 		timerQueueProcessorFactoryParams
-
-		scheduler       queues.Scheduler
-		hostRateLimiter quotas.RateLimiter
+		queueProcessorFactoryBase
 	}
 
 	visibilityQueueProcessorFactory struct {
 		visibilityQueueProcessorFactoryParams
-
-		scheduler       queues.Scheduler
-		hostRateLimiter quotas.RateLimiter
+		queueProcessorFactoryBase
 	}
 
-	replicationQueueProcessorFactory struct {
-		replicationQueueProcessorFactoryParams
+	QueueProcessorFactoriesLifetimeHookParams struct {
+		fx.In
+
+		Lifecycle fx.Lifecycle
+		Factories []queues.ProcessorFactory `group:"queueProcessorFactory"`
 	}
 )
+
+func QueueProcessorFactoryLifetimeHooks(
+	params QueueProcessorFactoriesLifetimeHookParams,
+) {
+	params.Lifecycle.Append(
+		fx.Hook{
+			OnStart: func(context.Context) error {
+				fmt.Println("QueueProcessorFactoryLifetimeHooks for ", len(params.Factories))
+				for _, factory := range params.Factories {
+					factory.Start()
+				}
+				return nil
+			},
+			OnStop: func(context.Context) error {
+				for _, factory := range params.Factories {
+					factory.Stop()
+				}
+				return nil
+			},
+		},
+	)
+}
 
 func NewTransferQueueProcessorFactory(
 	params transferQueueProcessorFactoryParams,
@@ -171,11 +187,13 @@ func NewTransferQueueProcessorFactory(
 	}
 	return &transferQueueProcessorFactory{
 		transferQueueProcessorFactoryParams: params,
-		scheduler:                           scheduler,
-		hostRateLimiter: newQueueProcessorHostRateLimiter(
-			params.Config.TransferProcessorMaxPollHostRPS,
-			params.Config.PersistenceMaxQPS,
-		),
+		queueProcessorFactoryBase: queueProcessorFactoryBase{
+			scheduler: scheduler,
+			hostRateLimiter: newQueueProcessorHostRateLimiter(
+				params.Config.TransferProcessorMaxPollHostRPS,
+				params.Config.PersistenceMaxQPS,
+			),
+		},
 	}
 }
 
@@ -227,11 +245,13 @@ func NewTimerQueueProcessorFactory(
 	}
 	return &timerQueueProcessorFactory{
 		timerQueueProcessorFactoryParams: params,
-		scheduler:                        scheduler,
-		hostRateLimiter: newQueueProcessorHostRateLimiter(
-			params.Config.TimerProcessorMaxPollHostRPS,
-			params.Config.PersistenceMaxQPS,
-		),
+		queueProcessorFactoryBase: queueProcessorFactoryBase{
+			scheduler: scheduler,
+			hostRateLimiter: newQueueProcessorHostRateLimiter(
+				params.Config.TimerProcessorMaxPollHostRPS,
+				params.Config.PersistenceMaxQPS,
+			),
+		},
 	}
 }
 
@@ -255,7 +275,7 @@ func NewVisibilityQueueProcessorFactory(
 	params visibilityQueueProcessorFactoryParams,
 ) queues.ProcessorFactory {
 	var scheduler queues.Scheduler
-	if params.Config.TimerProcessorEnablePriorityTaskScheduler() {
+	if params.Config.VisibilityProcessorEnablePriorityTaskScheduler() {
 		scheduler = queues.NewScheduler(
 			queues.NewPriorityAssigner(
 				params.ClusterMetadata.GetCurrentClusterName(),
@@ -281,11 +301,13 @@ func NewVisibilityQueueProcessorFactory(
 	}
 	return &visibilityQueueProcessorFactory{
 		visibilityQueueProcessorFactoryParams: params,
-		scheduler:                             scheduler,
-		hostRateLimiter: newQueueProcessorHostRateLimiter(
-			params.Config.VisibilityProcessorMaxPollHostRPS,
-			params.Config.PersistenceMaxQPS,
-		),
+		queueProcessorFactoryBase: queueProcessorFactoryBase{
+			scheduler: scheduler,
+			hostRateLimiter: newQueueProcessorHostRateLimiter(
+				params.Config.VisibilityProcessorMaxPollHostRPS,
+				params.Config.PersistenceMaxQPS,
+			),
+		},
 	}
 }
 
@@ -301,6 +323,18 @@ func (f *visibilityQueueProcessorFactory) CreateProcessor(
 		f.VisibilityMgr,
 		f.hostRateLimiter,
 	)
+}
+
+func (f *queueProcessorFactoryBase) Start() {
+	if f.scheduler != nil {
+		f.scheduler.Start()
+	}
+}
+
+func (f *queueProcessorFactoryBase) Stop() {
+	if f.scheduler != nil {
+		f.scheduler.Stop()
+	}
 }
 
 func newQueueProcessorHostRateLimiter(

--- a/service/history/queueProcessorFactory.go
+++ b/service/history/queueProcessorFactory.go
@@ -26,7 +26,6 @@ package history
 
 import (
 	"context"
-	"fmt"
 
 	"go.uber.org/fx"
 
@@ -141,7 +140,6 @@ func QueueProcessorFactoryLifetimeHooks(
 	params.Lifecycle.Append(
 		fx.Hook{
 			OnStart: func(context.Context) error {
-				fmt.Println("QueueProcessorFactoryLifetimeHooks for ", len(params.Factories))
 				for _, factory := range params.Factories {
 					factory.Start()
 				}

--- a/service/history/queues/queue.go
+++ b/service/history/queues/queue.go
@@ -44,6 +44,8 @@ type (
 	}
 
 	ProcessorFactory interface {
+		common.Daemon
+
 		// TODO: remove the cache parameter after workflow cache become a host level component
 		// and it can be provided as a parameter when creating a ProcessorFactory instance.
 		// Currently, workflow cache is shard level, but we can't get it from shard or engine interface,

--- a/service/history/queues/queue_mock.go
+++ b/service/history/queues/queue_mock.go
@@ -182,3 +182,27 @@ func (mr *MockProcessorFactoryMockRecorder) CreateProcessor(shard, engine, cache
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateProcessor", reflect.TypeOf((*MockProcessorFactory)(nil).CreateProcessor), shard, engine, cache)
 }
+
+// Start mocks base method.
+func (m *MockProcessorFactory) Start() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start")
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockProcessorFactoryMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockProcessorFactory)(nil).Start))
+}
+
+// Stop mocks base method.
+func (m *MockProcessorFactory) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockProcessorFactoryMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockProcessorFactory)(nil).Stop))
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix host level task scheduler start/stop

<!-- Tell your future self why have you made these changes -->
**Why?**
- Currently task scheduler start/stop is always done on shard level, even when the scheduler is a host level scheduler.
- When shard movement happens, the host level scheduler will also get stopped. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally using canary with both host level pool enabled and disabled. Also randomly closing shards.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
