### PR TITLE
Revert "adding condition where creating or dropping the db would igno…

### DIFF
--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -104,9 +104,7 @@ func createDatabase(cli *cli.Context, logger log.Logger) error {
 }
 
 func DoCreateDatabase(cfg *config.SQL, name string) error {
-	if cfg.PluginName != "postgres" {
-		cfg.DatabaseName = ""
-	}
+	cfg.DatabaseName = ""
 	conn, err := NewConnection(cfg)
 	if err != nil {
 		return err
@@ -136,9 +134,7 @@ func dropDatabase(cli *cli.Context, logger log.Logger) error {
 }
 
 func DoDropDatabase(cfg *config.SQL, name string) error {
-	if cfg.PluginName != "postgres" {
-		cfg.DatabaseName = ""
-	}
+	cfg.DatabaseName = ""
 	conn, err := NewConnection(cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
…re the global --datasource value provided, which effectively requires the default db instance to be postgres or defaultdb, which might not always be the case. Based on the blame it looked like this hadn't changed in nearly 2 years and was added as part of a mysql tls support commit. Adding this in support of issue #2890. (#2892)"

This reverts commit e20960fb2a578a78836705a49915b945d57c744a.

<!-- Describe what has changed in this PR -->
**What changed?**
Revert #2892 

<!-- Tell your future self why have you made these changes -->
**Why?**
temporal-sql-tool takes 2 database names as input: the global flag --database, and the non-global flag --database. Yes, they use the same flag name. 😞 
The non-global one is the name used as new db name to be created.
The global one is used as default db name to connect to postgresql, it requires the default db already exists before connection. Before that PR 2892, the global value was always cleared so the tool always uses 2 default db names (postgres or defaultdb) to connect. The problem that PR 2892 faced was their postgres has different default db. So the fix in PR 2892 is to not clear the global value and uses it as the default db.
The annoying thing is the global flag --database is a required flag and has default value `temporal` which means now the tool will try to connect to db named `temporal` if the global value is not supplied. 
And supply 2 --database flag with different values is also very confusing.

The global --database flag is also used in setup schema command as the target database, not the default database. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No