### PR TITLE
Add optional --defaultdb flag to sql tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -351,23 +351,23 @@ install-schema: temporal-cassandra-tool
 
 install-schema-mysql: temporal-sql-tool
 	@printf $(COLOR) "Install MySQL schema..."
-	./temporal-sql-tool -u temporal --pw temporal drop --db $(TEMPORAL_DB) -f
-	./temporal-sql-tool -u temporal --pw temporal create --db $(TEMPORAL_DB)
+	./temporal-sql-tool -u temporal --pw temporal --db $(TEMPORAL_DB) drop -f
+	./temporal-sql-tool -u temporal --pw temporal --db $(TEMPORAL_DB) create
 	./temporal-sql-tool -u temporal --pw temporal --db $(TEMPORAL_DB) setup-schema -v 0.0
 	./temporal-sql-tool -u temporal --pw temporal --db $(TEMPORAL_DB) update-schema -d ./schema/mysql/v57/temporal/versioned
-	./temporal-sql-tool -u temporal --pw temporal drop --db $(VISIBILITY_DB) -f
-	./temporal-sql-tool -u temporal --pw temporal create --db $(VISIBILITY_DB)
+	./temporal-sql-tool -u temporal --pw temporal --db $(VISIBILITY_DB) drop  -f
+	./temporal-sql-tool -u temporal --pw temporal --db $(VISIBILITY_DB) create
 	./temporal-sql-tool -u temporal --pw temporal --db $(VISIBILITY_DB) setup-schema -v 0.0
 	./temporal-sql-tool -u temporal --pw temporal --db $(VISIBILITY_DB) update-schema -d ./schema/mysql/v57/visibility/versioned
 
 install-schema-postgresql: temporal-sql-tool
 	@printf $(COLOR) "Install Postgres schema..."
-	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres drop --db $(TEMPORAL_DB) -f
-	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres create --db $(TEMPORAL_DB)
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db $(TEMPORAL_DB) drop -f
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db $(TEMPORAL_DB) create
 	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db $(TEMPORAL_DB) setup -v 0.0
 	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db $(TEMPORAL_DB) update-schema -d ./schema/postgresql/v96/temporal/versioned
-	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres drop --db $(VISIBILITY_DB) -f
-	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres create --db $(VISIBILITY_DB)
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db $(VISIBILITY_DB) drop -f
+	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db $(VISIBILITY_DB) create
 	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db $(VISIBILITY_DB) setup-schema -v 0.0
 	./temporal-sql-tool -u temporal -pw temporal -p 5432 --pl postgres --db $(VISIBILITY_DB) update-schema -d ./schema/postgresql/v96/visibility/versioned
 

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -87,6 +87,8 @@ const (
 	CLIOptKeyspace = "keyspace"
 	// CLIOptDatabase is the cli option for database
 	CLIOptDatabase = "database"
+	// CLIOptDefaultDb is the cli option used as defaultdb to connect to
+	CLIOptDefaultDb = "defaultdb"
 	// CLIOptPluginName is the cli option for plugin name
 	CLIOptPluginName = "plugin"
 	// CLIOptConnectAttributes is the cli option for connect attributes (key/values via a url query string)

--- a/tools/sql/README.md
+++ b/tools/sql/README.md
@@ -20,8 +20,8 @@ SQL_USER=$USERNAME SQL_PASSWORD=$PASSWD make install-schema-mysql
 - All command below are taking MySQL as example. For postgres, simply use with "--plugin postgres"
 
 ```
-temporal-sql-tool --ep $SQL_HOST_ADDR -p $port create --plugin mysql --db temporal
-temporal-sql-tool --ep $SQL_HOST_ADDR -p $port create --plugin mysql --db temporal_visibility
+temporal-sql-tool --ep $SQL_HOST_ADDR -p $port --db temporal --plugin mysql create
+temporal-sql-tool --ep $SQL_HOST_ADDR -p $port --db temporal_visibility --plugin mysql create
 ```
 
 ```

--- a/tools/sql/clitest/setuptaskTest.go
+++ b/tools/sql/clitest/setuptaskTest.go
@@ -88,8 +88,8 @@ func (s *SetupSchemaTestSuite) TestCreateDatabase() {
 		"-u", testUser,
 		"--pw", testPassword,
 		"--pl", s.pluginName,
-		"create",
 		"--db", testDatabase,
+		"create",
 	})
 	s.NoError(err)
 	err = s.conn.DropDatabase(testDatabase)
@@ -105,8 +105,8 @@ func (s *SetupSchemaTestSuite) TestCreateDatabaseIdempotent() {
 		"-u", testUser,
 		"--pw", testPassword,
 		"--pl", s.pluginName,
-		"create",
 		"--db", testDatabase,
+		"create",
 	})
 	s.NoError(err)
 
@@ -117,8 +117,8 @@ func (s *SetupSchemaTestSuite) TestCreateDatabaseIdempotent() {
 		"-u", testUser,
 		"--pw", testPassword,
 		"--pl", s.pluginName,
-		"create",
 		"--db", testDatabase,
+		"create",
 	})
 	s.NoError(err)
 

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -88,12 +88,8 @@ func createDatabase(cli *cli.Context, logger log.Logger) error {
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
-	database := cli.String(schema.CLIOptDatabase)
-	if database == "" {
-		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError("missing "+flag(schema.CLIOptDatabase)+" argument ")))
-		return err
-	}
-	err = DoCreateDatabase(cfg, database)
+	defaultDb := cli.String(schema.CLIOptDefaultDb)
+	err = DoCreateDatabase(cfg, defaultDb)
 	if err != nil {
 		logger.Error("Unable to create SQL database.", tag.Error(err))
 		return err
@@ -101,14 +97,15 @@ func createDatabase(cli *cli.Context, logger log.Logger) error {
 	return nil
 }
 
-func DoCreateDatabase(cfg *config.SQL, name string) error {
-	cfg.DatabaseName = ""
+func DoCreateDatabase(cfg *config.SQL, defaultDb string) error {
+	dbToCreate := cfg.DatabaseName
+	cfg.DatabaseName = defaultDb
 	conn, err := NewConnection(cfg)
 	if err != nil {
 		return err
 	}
 	defer conn.Close()
-	return conn.CreateDatabase(name)
+	return conn.CreateDatabase(dbToCreate)
 }
 
 // dropDatabase drops a sql database
@@ -118,12 +115,8 @@ func dropDatabase(cli *cli.Context, logger log.Logger) error {
 		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError(err.Error())))
 		return err
 	}
-	database := cli.String(schema.CLIOptDatabase)
-	if database == "" {
-		logger.Error("Unable to read config.", tag.Error(schema.NewConfigError("missing "+flag(schema.CLIOptDatabase)+" argument ")))
-		return err
-	}
-	err = DoDropDatabase(cfg, database)
+	defaultDb := cli.String(schema.CLIOptDefaultDb)
+	err = DoDropDatabase(cfg, defaultDb)
 	if err != nil {
 		logger.Error("Unable to drop SQL database.", tag.Error(err))
 		return err
@@ -131,13 +124,14 @@ func dropDatabase(cli *cli.Context, logger log.Logger) error {
 	return nil
 }
 
-func DoDropDatabase(cfg *config.SQL, name string) error {
-	cfg.DatabaseName = ""
+func DoDropDatabase(cfg *config.SQL, defaultDb string) error {
+	dbToDrop := cfg.DatabaseName
+	cfg.DatabaseName = defaultDb
 	conn, err := NewConnection(cfg)
 	if err != nil {
 		return err
 	}
-	err = conn.DropDatabase(name)
+	err = conn.DropDatabase(dbToDrop)
 	if err != nil {
 		return err
 	}

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -191,8 +191,8 @@ func BuildCLIOptions() *cli.App {
 			Usage:   "creates a database",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  schema.CLIFlagDatabase,
-					Usage: "name of the database",
+					Name:  schema.CLIOptDefaultDb,
+					Usage: "optional default db to connect to, this is not the db to be created",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -205,8 +205,8 @@ func BuildCLIOptions() *cli.App {
 			Usage:   "drops a database",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  schema.CLIFlagDatabase,
-					Usage: "name of the database",
+					Name:  schema.CLIOptDefaultDb,
+					Usage: "optional default db to connect to, not the db to be deleted",
 				},
 				cli.BoolFlag{
 					Name:  schema.CLIFlagForce,
@@ -216,7 +216,7 @@ func BuildCLIOptions() *cli.App {
 			Action: func(c *cli.Context) {
 				drop := c.Bool(schema.CLIOptForce)
 				if !drop {
-					database := c.String(schema.CLIOptDatabase)
+					database := c.GlobalString(schema.CLIOptDatabase)
 					fmt.Printf("Are you sure you want to drop database %q (y/N)? ", database)
 					y := ""
 					_, _ = fmt.Scanln(&y)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add optional `--defaultdb` flag to sql tool to be used as default db for the tool to connect to.

<!-- Tell your future self why have you made these changes -->
**Why?**
To address issue #2890. It was attempted by PR #2892 but was reverted by PR #2949. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally on both mysql and postgres, for commands `create`, `setup-schema`, `update-schema` and `drop`.
`make install-schema-mysql`
`make install-schema-postgresql`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The `--database`/`--db` local flag for create/drop is now removed. So any script trying to create/drop db will break. The fix is to use existing global flag `--database`/`--db`. 
`auto-setup` docker image scripts are changed [here](https://github.com/temporalio/docker-builds/pull/54).

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.