### PR TITLE
Don't index search attribute used for passing data through visibility

### DIFF
--- a/schema/elasticsearch/visibility/versioned/v2/index_template_v6.json
+++ b/schema/elasticsearch/visibility/versioned/v2/index_template_v6.json
@@ -75,7 +75,7 @@
           "type": "boolean"
         },
         "TemporalScheduleInfoJSON": {
-          "type": "keyword"
+          "type": "keyword", "index": false
         }
       }
     }

--- a/schema/elasticsearch/visibility/versioned/v2/index_template_v7.json
+++ b/schema/elasticsearch/visibility/versioned/v2/index_template_v7.json
@@ -75,7 +75,7 @@
         "type": "boolean"
       },
       "TemporalScheduleInfoJSON": {
-        "type": "keyword"
+        "type": "keyword", "index": false
       }
     }
   },

--- a/schema/elasticsearch/visibility/versioned/v2/upgrade.sh
+++ b/schema/elasticsearch/visibility/versioned/v2/upgrade.sh
@@ -46,7 +46,7 @@ new_mapping='
       "type": "boolean"
     },
     "TemporalScheduleInfoJSON": {
-      "type": "keyword"
+      "type": "keyword", "index": false
     }
   }
 }


### PR DESCRIPTION
**What changed?**
Turn off indexing for `TemporalScheduleInfoJSON`, which is only used for passing data through and never for querying.

Modifying the versioned schema normally wouldn't be okay, but we haven't done a release with the new schema yet.

**Why?**
Maintaining an index for this field is useless, so we can disable it to reduce ES costs.

**How did you test it?**
manual test

**Potential risks**

**Is hotfix candidate?**
