### PR TITLE
Add equals check for task predicate

### DIFF
--- a/common/predicates/all.go
+++ b/common/predicates/all.go
@@ -25,15 +25,20 @@
 package predicates
 
 type (
-	Predicate[T any] interface {
-		// Test checks if the given entity statisfy the predicate or not
-		Test(T) bool
-
-		// Equals recursively checks if the given Predicate has the same
-		// structure and value as the caller Predicate
-		// NOTE: the result will contain false negatives, meaning even if
-		// two predicates are mathmatically equivalent, Equals may still
-		// return false.
-		Equals(Predicate[T]) bool
-	}
+	AllImpl[T any] struct{}
 )
+
+func All[T any]() Predicate[T] {
+	return &AllImpl[T]{}
+}
+
+func (a *AllImpl[T]) Test(t T) bool {
+	return true
+}
+
+func (a *AllImpl[T]) Equals(
+	predicate Predicate[T],
+) bool {
+	_, ok := predicate.(*AllImpl[T])
+	return ok
+}

--- a/common/predicates/all_test.go
+++ b/common/predicates/all_test.go
@@ -53,7 +53,7 @@ func (s *allSuite) SetupTest() {
 }
 
 func (s *allSuite) TestAll_Test() {
-	for i := 1; i != 10; i++ {
+	for i := 0; i != 10; i++ {
 		s.True(s.all.Test(rand.Int()))
 	}
 }

--- a/common/predicates/all_test.go
+++ b/common/predicates/all_test.go
@@ -24,16 +24,53 @@
 
 package predicates
 
-type (
-	Predicate[T any] interface {
-		// Test checks if the given entity statisfy the predicate or not
-		Test(T) bool
+import (
+	"math/rand"
+	"testing"
 
-		// Equals recursively checks if the given Predicate has the same
-		// structure and value as the caller Predicate
-		// NOTE: the result will contain false negatives, meaning even if
-		// two predicates are mathmatically equivalent, Equals may still
-		// return false.
-		Equals(Predicate[T]) bool
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type (
+	allSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		all Predicate[int]
 	}
 )
+
+func TestAllSuite(t *testing.T) {
+	s := new(allSuite)
+	suite.Run(t, s)
+}
+
+func (s *allSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.all = All[int]()
+}
+
+func (s *allSuite) TestAll_Test() {
+	for i := 1; i != 10; i++ {
+		s.True(s.all.Test(rand.Int()))
+	}
+}
+
+func (s *allSuite) TestAll_Equals() {
+	s.True(s.all.Equals(s.all))
+	s.True(s.all.Equals(All[int]()))
+
+	s.False(s.all.Equals(newTestPredicate(1, 2, 3)))
+	s.False(s.all.Equals(And[int](
+		newTestPredicate(1, 2, 3),
+		newTestPredicate(2, 3, 4),
+	)))
+	s.False(s.all.Equals(Or[int](
+		newTestPredicate(1, 2, 3),
+		newTestPredicate(4, 5, 6),
+	)))
+	s.False(s.all.Equals(Not[int](newTestPredicate(1, 2, 3))))
+	s.False(s.all.Equals(Empty[int]()))
+}

--- a/common/predicates/and.go
+++ b/common/predicates/and.go
@@ -1,0 +1,121 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package predicates
+
+import (
+	"fmt"
+)
+
+type (
+	AndImpl[T any] struct {
+		Predicates []Predicate[T]
+	}
+)
+
+func And[T any](
+	predicates ...Predicate[T],
+) Predicate[T] {
+	if len(predicates) < 2 {
+		panic(fmt.Sprintf("And requires at least 2 predicates, got %v", len(predicates)))
+	}
+
+	flattened := make([]Predicate[T], 0, len(predicates))
+	for _, p := range predicates {
+		switch p := p.(type) {
+		case *AndImpl[T]:
+			flattened = append(flattened, p.Predicates...)
+		case *AllImpl[T]:
+			continue
+		case *EmptyImpl[T]:
+			return p
+		default:
+			flattened = append(flattened, p)
+		}
+	}
+
+	switch len(flattened) {
+	case 0:
+		return All[T]()
+	case 1:
+		return flattened[0]
+	default:
+		return &AndImpl[T]{
+			Predicates: flattened,
+		}
+	}
+}
+
+func (a *AndImpl[T]) Test(t T) bool {
+	for _, p := range a.Predicates {
+		if !p.Test(t) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (a *AndImpl[T]) Equals(
+	predicate Predicate[T],
+) bool {
+	andPredicate, ok := predicate.(*AndImpl[T])
+	if !ok {
+		return false
+	}
+
+	return predicatesEqual(a.Predicates, andPredicate.Predicates)
+}
+
+func predicatesEqual[T any](
+	this []Predicate[T],
+	that []Predicate[T],
+) bool {
+	if len(this) != len(that) {
+		return false
+	}
+
+	matchedThatIndex := make(map[int]struct{}, len(that))
+	for _, thisPredicate := range this {
+		foundEqual := false
+
+		for idx, thatPredicate := range that {
+			if _, ok := matchedThatIndex[idx]; ok {
+				continue
+			}
+
+			if thisPredicate.Equals(thatPredicate) {
+				matchedThatIndex[idx] = struct{}{}
+				foundEqual = true
+				break
+			}
+		}
+
+		if !foundEqual {
+			return false
+		}
+	}
+
+	return true
+}

--- a/common/predicates/and.go
+++ b/common/predicates/and.go
@@ -30,6 +30,7 @@ import (
 
 type (
 	AndImpl[T any] struct {
+		// TODO: see if we can somehow order arbitrary predicats and store a sorted list
 		Predicates []Predicate[T]
 	}
 )

--- a/common/predicates/and_test.go
+++ b/common/predicates/and_test.go
@@ -1,0 +1,118 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type (
+	andSuite struct {
+		suite.Suite
+		*require.Assertions
+	}
+)
+
+func TestAndSuite(t *testing.T) {
+	s := new(andSuite)
+	suite.Run(t, s)
+}
+
+func (s *andSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *andSuite) TestAnd_Normal() {
+	p1 := newTestPredicate(1, 2, 6)
+	p2 := And[int](
+		newTestPredicate(3, 4, 6),
+		newTestPredicate(4, 5, 6),
+	)
+	p := And[int](p1, p2)
+
+	for i := 1; i != 6; i++ {
+		s.False(p.Test(i))
+	}
+	s.True(p.Test(6))
+}
+
+func (s *andSuite) TestAnd_All() {
+	p := And[int](
+		newTestPredicate(1, 2, 3),
+		All[int](),
+	)
+
+	for i := 1; i != 4; i++ {
+		s.True(p.Test(i))
+	}
+	for i := 4; i != 7; i++ {
+		s.False(p.Test(i))
+	}
+
+	p = And(
+		All[int](),
+		All[int](),
+	)
+	for i := 1; i != 7; i++ {
+		s.True(p.Test(i))
+	}
+}
+
+func (s *andSuite) TestAnd_None() {
+	p := And[int](
+		newTestPredicate(1, 2, 3),
+		Empty[int](),
+	)
+
+	for i := 1; i != 7; i++ {
+		s.False(p.Test(i))
+	}
+}
+
+func (s *andSuite) TestAnd_Equals() {
+	p1 := newTestPredicate(1, 2, 3)
+	p2 := newTestPredicate(2, 3, 4)
+	p := And[int](p1, p2)
+
+	s.True(p.Equals(p))
+	s.True(p.Equals(And[int](p1, p2)))
+	s.True(p.Equals(And[int](p2, p1)))
+	s.True(p.Equals(And[int](
+		newTestPredicate(4, 3, 2),
+		newTestPredicate(3, 2, 1),
+	)))
+
+	s.False(p.Equals(p1))
+	s.False(p.Equals(And[int](p2, p2)))
+	s.False(p.Equals(And[int](p1, p1, p2)))
+	s.False(p.Equals(And[int](p2, newTestPredicate(5, 6, 7))))
+	s.False(p.Equals(Or[int](p1, p2)))
+	s.False(p.Equals(Not(p)))
+	s.False(p.Equals(Empty[int]()))
+	s.False(p.Equals(All[int]()))
+}

--- a/common/predicates/and_test.go
+++ b/common/predicates/and_test.go
@@ -94,6 +94,32 @@ func (s *andSuite) TestAnd_None() {
 	}
 }
 
+func (s *andSuite) TestAnd_Duplication() {
+	p1 := newTestPredicate(1, 2, 3)
+	p2 := newTestPredicate(2, 3, 4)
+	p3 := newTestPredicate(3, 4, 5)
+
+	_, ok := And[int](p1, p1).(*testPredicate)
+	s.True(ok)
+
+	p := And[int](p1, p2)
+	pAnd, ok := And[int](p, p1).(*AndImpl[int])
+	s.True(ok)
+	s.Len(pAnd.Predicates, 2)
+
+	pAnd, ok = And(p, p).(*AndImpl[int])
+	s.True(ok)
+	s.Len(pAnd.Predicates, 2)
+
+	pAnd, ok = And(p, And[int](p1, p2)).(*AndImpl[int])
+	s.True(ok)
+	s.Len(pAnd.Predicates, 2)
+
+	pAnd, ok = And(p, And[int](p1, p2, p3)).(*AndImpl[int])
+	s.True(ok)
+	s.Len(pAnd.Predicates, 3)
+}
+
 func (s *andSuite) TestAnd_Equals() {
 	p1 := newTestPredicate(1, 2, 3)
 	p2 := newTestPredicate(2, 3, 4)
@@ -102,6 +128,7 @@ func (s *andSuite) TestAnd_Equals() {
 	s.True(p.Equals(p))
 	s.True(p.Equals(And[int](p1, p2)))
 	s.True(p.Equals(And[int](p2, p1)))
+	s.True(p.Equals(And[int](p1, p1, p2)))
 	s.True(p.Equals(And[int](
 		newTestPredicate(4, 3, 2),
 		newTestPredicate(3, 2, 1),
@@ -109,7 +136,6 @@ func (s *andSuite) TestAnd_Equals() {
 
 	s.False(p.Equals(p1))
 	s.False(p.Equals(And[int](p2, p2)))
-	s.False(p.Equals(And[int](p1, p1, p2)))
 	s.False(p.Equals(And[int](p2, newTestPredicate(5, 6, 7))))
 	s.False(p.Equals(Or[int](p1, p2)))
 	s.False(p.Equals(Not(p)))

--- a/common/predicates/empty.go
+++ b/common/predicates/empty.go
@@ -25,15 +25,20 @@
 package predicates
 
 type (
-	Predicate[T any] interface {
-		// Test checks if the given entity statisfy the predicate or not
-		Test(T) bool
-
-		// Equals recursively checks if the given Predicate has the same
-		// structure and value as the caller Predicate
-		// NOTE: the result will contain false negatives, meaning even if
-		// two predicates are mathmatically equivalent, Equals may still
-		// return false.
-		Equals(Predicate[T]) bool
-	}
+	EmptyImpl[T any] struct{}
 )
+
+func Empty[T any]() Predicate[T] {
+	return &EmptyImpl[T]{}
+}
+
+func (n *EmptyImpl[T]) Test(t T) bool {
+	return false
+}
+
+func (n *EmptyImpl[T]) Equals(
+	predicate Predicate[T],
+) bool {
+	_, ok := predicate.(*EmptyImpl[T])
+	return ok
+}

--- a/common/predicates/empty_test.go
+++ b/common/predicates/empty_test.go
@@ -24,16 +24,52 @@
 
 package predicates
 
-type (
-	Predicate[T any] interface {
-		// Test checks if the given entity statisfy the predicate or not
-		Test(T) bool
+import (
+	"testing"
 
-		// Equals recursively checks if the given Predicate has the same
-		// structure and value as the caller Predicate
-		// NOTE: the result will contain false negatives, meaning even if
-		// two predicates are mathmatically equivalent, Equals may still
-		// return false.
-		Equals(Predicate[T]) bool
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type (
+	emptySuite struct {
+		suite.Suite
+		*require.Assertions
+
+		emtpy Predicate[int]
 	}
 )
+
+func TestNoneSuite(t *testing.T) {
+	s := new(emptySuite)
+	suite.Run(t, s)
+}
+
+func (s *emptySuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.emtpy = Empty[int]()
+}
+
+func (s *emptySuite) TestEmpty_Test() {
+	for i := 1; i != 10; i++ {
+		s.False(s.emtpy.Test(i))
+	}
+}
+
+func (s *emptySuite) TestEmpty_Equals() {
+	s.True(s.emtpy.Equals(s.emtpy))
+	s.True(s.emtpy.Equals(Empty[int]()))
+
+	s.False(s.emtpy.Equals(newTestPredicate(1, 2, 3)))
+	s.False(s.emtpy.Equals(And[int](
+		newTestPredicate(1, 2, 3),
+		newTestPredicate(2, 3, 4),
+	)))
+	s.False(s.emtpy.Equals(Or[int](
+		newTestPredicate(1, 2, 3),
+		newTestPredicate(4, 5, 6),
+	)))
+	s.False(s.emtpy.Equals(Not[int](newTestPredicate(1, 2, 3))))
+	s.False(s.emtpy.Equals(All[int]()))
+}

--- a/common/predicates/empty_test.go
+++ b/common/predicates/empty_test.go
@@ -52,7 +52,7 @@ func (s *emptySuite) SetupTest() {
 }
 
 func (s *emptySuite) TestEmpty_Test() {
-	for i := 1; i != 10; i++ {
+	for i := 0; i != 10; i++ {
 		s.False(s.emtpy.Test(i))
 	}
 }

--- a/common/predicates/not_test.go
+++ b/common/predicates/not_test.go
@@ -1,0 +1,100 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type (
+	notSuite struct {
+		suite.Suite
+		*require.Assertions
+	}
+)
+
+func TestNotSuite(t *testing.T) {
+	s := new(notSuite)
+	suite.Run(t, s)
+}
+
+func (s *notSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *notSuite) TestNot_Test() {
+	p1 := newTestPredicate(1, 2, 3)
+	p := Not[int](p1)
+
+	for i := 1; i != 4; i++ {
+		s.False(p.Test(i))
+	}
+	for i := 4; i != 7; i++ {
+		s.True(p.Test(i))
+	}
+
+	p = Not(p)
+	for i := 1; i != 4; i++ {
+		s.True(p.Test(i))
+	}
+	for i := 4; i != 7; i++ {
+		s.False(p.Test(i))
+	}
+
+	p = Not(All[int]())
+	for i := 1; i != 7; i++ {
+		s.False(p.Test(i))
+	}
+
+	p = Not(Empty[int]())
+	for i := 1; i != 7; i++ {
+		s.True(p.Test(i))
+	}
+}
+
+func (s *notSuite) TestNot_Equals() {
+	p1 := newTestPredicate(1, 2, 3)
+	p := Not[int](p1)
+
+	s.True(p.Equals(p))
+	s.True(p.Equals(Not[int](p1)))
+	s.True(p.Equals(Not[int](newTestPredicate(3, 2, 1))))
+
+	s.False(p.Equals(newTestPredicate(1, 2, 3)))
+	s.False(p.Equals(Not[int](newTestPredicate(4, 5, 6))))
+	s.False(p.Equals(And[int](
+		newTestPredicate(1, 2, 3),
+		newTestPredicate(2, 3, 4),
+	)))
+	s.False(p.Equals(Or[int](
+		newTestPredicate(1, 2, 3),
+		newTestPredicate(4, 5, 6),
+	)))
+	s.False(p.Equals(Empty[int]()))
+	s.False(p.Equals(All[int]()))
+}

--- a/common/predicates/or.go
+++ b/common/predicates/or.go
@@ -45,13 +45,13 @@ func Or[T any](
 	for _, p := range predicates {
 		switch p := p.(type) {
 		case *OrImpl[T]:
-			flattened = append(flattened, p.Predicates...)
+			flattened = appendPredicates(flattened, p.Predicates...)
 		case *AllImpl[T]:
 			return p
 		case *EmptyImpl[T]:
 			continue
 		default:
-			flattened = append(flattened, p)
+			flattened = appendPredicates(flattened, p)
 		}
 	}
 

--- a/common/predicates/or.go
+++ b/common/predicates/or.go
@@ -30,6 +30,7 @@ import (
 
 type (
 	OrImpl[T any] struct {
+		// TODO: see if we can somehow order arbitrary predicats and store a sorted list
 		Predicates []Predicate[T]
 	}
 )

--- a/common/predicates/or_test.go
+++ b/common/predicates/or_test.go
@@ -94,6 +94,32 @@ func (s *orSuite) TestOr_None() {
 	}
 }
 
+func (s *orSuite) TestOr_Duplication() {
+	p1 := newTestPredicate(1, 2, 3)
+	p2 := newTestPredicate(2, 3, 4)
+	p3 := newTestPredicate(3, 4, 5)
+
+	_, ok := Or[int](p1, p1).(*testPredicate)
+	s.True(ok)
+
+	p := Or[int](p1, p2)
+	pOr, ok := Or[int](p, p1).(*OrImpl[int])
+	s.True(ok)
+	s.Len(pOr.Predicates, 2)
+
+	pOr, ok = Or(p, p).(*OrImpl[int])
+	s.True(ok)
+	s.Len(pOr.Predicates, 2)
+
+	pOr, ok = Or(p, Or[int](p1, p2)).(*OrImpl[int])
+	s.True(ok)
+	s.Len(pOr.Predicates, 2)
+
+	pOr, ok = Or(p, Or[int](p1, p2, p3)).(*OrImpl[int])
+	s.True(ok)
+	s.Len(pOr.Predicates, 3)
+}
+
 func (s *orSuite) TestOr_Equals() {
 	p1 := newTestPredicate(1, 2, 3)
 	p2 := newTestPredicate(2, 3, 4)
@@ -102,6 +128,7 @@ func (s *orSuite) TestOr_Equals() {
 	s.True(p.Equals(p))
 	s.True(p.Equals(Or[int](p1, p2)))
 	s.True(p.Equals(Or[int](p2, p1)))
+	s.True(p.Equals(Or[int](p1, p1, p2)))
 	s.True(p.Equals(Or[int](
 		newTestPredicate(4, 3, 2),
 		newTestPredicate(3, 2, 1),
@@ -109,7 +136,6 @@ func (s *orSuite) TestOr_Equals() {
 
 	s.False(p.Equals(p1))
 	s.False(p.Equals(Or[int](p2, p2)))
-	s.False(p.Equals(Or[int](p1, p1, p2)))
 	s.False(p.Equals(Or[int](p2, newTestPredicate(5, 6, 7))))
 	s.False(p.Equals(And[int](p1, p2)))
 	s.False(p.Equals(Not(p)))

--- a/common/predicates/or_test.go
+++ b/common/predicates/or_test.go
@@ -1,0 +1,118 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package predicates
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type (
+	orSuite struct {
+		suite.Suite
+		*require.Assertions
+	}
+)
+
+func TestOrSuite(t *testing.T) {
+	s := new(orSuite)
+	suite.Run(t, s)
+}
+
+func (s *orSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *orSuite) TestOr_Normal() {
+	p1 := newTestPredicate(1, 2, 6)
+	p2 := Or[int](
+		newTestPredicate(3, 4, 6),
+		newTestPredicate(4, 5, 6),
+	)
+	p := Or[int](p1, p2)
+
+	for i := 1; i != 7; i++ {
+		s.True(p.Test(i))
+	}
+	s.False(p.Test(7))
+}
+
+func (s *orSuite) TestOr_All() {
+	p := Or[int](
+		newTestPredicate(1, 2, 3),
+		All[int](),
+	)
+
+	for i := 1; i != 7; i++ {
+		s.True(p.Test(i))
+	}
+}
+
+func (s *orSuite) TestOr_None() {
+	p := Or[int](
+		newTestPredicate(1, 2, 3),
+		Empty[int](),
+	)
+
+	for i := 1; i != 4; i++ {
+		s.True(p.Test(i))
+	}
+	for i := 4; i != 7; i++ {
+		s.False(p.Test(i))
+	}
+
+	p = Or(
+		Empty[int](),
+		Empty[int](),
+	)
+	for i := 1; i != 7; i++ {
+		s.False(p.Test(i))
+	}
+}
+
+func (s *orSuite) TestOr_Equals() {
+	p1 := newTestPredicate(1, 2, 3)
+	p2 := newTestPredicate(2, 3, 4)
+	p := Or[int](p1, p2)
+
+	s.True(p.Equals(p))
+	s.True(p.Equals(Or[int](p1, p2)))
+	s.True(p.Equals(Or[int](p2, p1)))
+	s.True(p.Equals(Or[int](
+		newTestPredicate(4, 3, 2),
+		newTestPredicate(3, 2, 1),
+	)))
+
+	s.False(p.Equals(p1))
+	s.False(p.Equals(Or[int](p2, p2)))
+	s.False(p.Equals(Or[int](p1, p1, p2)))
+	s.False(p.Equals(Or[int](p2, newTestPredicate(5, 6, 7))))
+	s.False(p.Equals(And[int](p1, p2)))
+	s.False(p.Equals(Not(p)))
+	s.False(p.Equals(Empty[int]()))
+	s.False(p.Equals(All[int]()))
+}

--- a/common/predicates/predicates_test.go
+++ b/common/predicates/predicates_test.go
@@ -25,173 +25,16 @@
 package predicates
 
 import (
-	"testing"
-
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
+	"golang.org/x/exp/maps"
 )
 
 var _ Predicate[int] = (*testPredicate)(nil)
 
 type (
-	predicatesSuite struct {
-		suite.Suite
-		*require.Assertions
-	}
-
 	testPredicate struct {
 		nums map[int]struct{}
 	}
 )
-
-func TestPredicateSuite(t *testing.T) {
-	s := new(predicatesSuite)
-	suite.Run(t, s)
-}
-
-func (s *predicatesSuite) SetupTest() {
-	s.Assertions = require.New(s.T())
-}
-
-func (s *predicatesSuite) TestAnd_Normal() {
-	p1 := newTestPredicate(1, 2, 6)
-	p2 := And[int](
-		newTestPredicate(3, 4, 6),
-		newTestPredicate(4, 5, 6),
-	)
-	p := And[int](p1, p2)
-
-	for i := 1; i != 6; i++ {
-		s.False(p.Test(i))
-	}
-	s.True(p.Test(6))
-}
-
-func (s *predicatesSuite) TestAnd_All() {
-	p := And[int](
-		newTestPredicate(1, 2, 3),
-		All[int](),
-	)
-
-	for i := 1; i != 4; i++ {
-		s.True(p.Test(i))
-	}
-	for i := 4; i != 7; i++ {
-		s.False(p.Test(i))
-	}
-
-	p = And(
-		All[int](),
-		All[int](),
-	)
-	for i := 1; i != 7; i++ {
-		s.True(p.Test(i))
-	}
-}
-
-func (s *predicatesSuite) TestAnd_None() {
-	p := And[int](
-		newTestPredicate(1, 2, 3),
-		None[int](),
-	)
-
-	for i := 1; i != 7; i++ {
-		s.False(p.Test(i))
-	}
-}
-
-func (s *predicatesSuite) TestOr_Normal() {
-	p1 := newTestPredicate(1, 2, 6)
-	p2 := Or[int](
-		newTestPredicate(3, 4, 6),
-		newTestPredicate(4, 5, 6),
-	)
-	p := Or[int](p1, p2)
-
-	for i := 1; i != 7; i++ {
-		s.True(p.Test(i))
-	}
-	s.False(p.Test(7))
-}
-
-func (s *predicatesSuite) TestOr_All() {
-	p := Or[int](
-		newTestPredicate(1, 2, 3),
-		All[int](),
-	)
-
-	for i := 1; i != 7; i++ {
-		s.True(p.Test(i))
-	}
-}
-
-func (s *predicatesSuite) TestOr_None() {
-	p := Or[int](
-		newTestPredicate(1, 2, 3),
-		None[int](),
-	)
-
-	for i := 1; i != 4; i++ {
-		s.True(p.Test(i))
-	}
-	for i := 4; i != 7; i++ {
-		s.False(p.Test(i))
-	}
-
-	p = Or(
-		None[int](),
-		None[int](),
-	)
-	for i := 1; i != 7; i++ {
-		s.False(p.Test(i))
-	}
-}
-
-func (s *predicatesSuite) TestNot() {
-	p1 := newTestPredicate(1, 2, 3)
-	p := Not[int](p1)
-
-	for i := 1; i != 4; i++ {
-		s.False(p.Test(i))
-	}
-	for i := 4; i != 7; i++ {
-		s.True(p.Test(i))
-	}
-
-	p = Not(p)
-	for i := 1; i != 4; i++ {
-		s.True(p.Test(i))
-	}
-	for i := 4; i != 7; i++ {
-		s.False(p.Test(i))
-	}
-
-	p = Not(All[int]())
-	for i := 1; i != 7; i++ {
-		s.False(p.Test(i))
-	}
-
-	p = Not(None[int]())
-	for i := 1; i != 7; i++ {
-		s.True(p.Test(i))
-	}
-}
-
-func (s *predicatesSuite) TestAll() {
-	p := All[int]()
-
-	for i := 1; i != 10; i++ {
-		s.True(p.Test(i))
-	}
-}
-
-func (s *predicatesSuite) TestNone() {
-	p := None[int]()
-
-	for i := 1; i != 10; i++ {
-		s.False(p.Test(i))
-	}
-}
 
 func newTestPredicate(nums ...int) *testPredicate {
 	numsMap := make(map[int]struct{}, len(nums))
@@ -206,4 +49,13 @@ func newTestPredicate(nums ...int) *testPredicate {
 func (p *testPredicate) Test(x int) bool {
 	_, ok := p.nums[x]
 	return ok
+}
+
+func (p *testPredicate) Equals(predicate Predicate[int]) bool {
+	testPrediate, ok := predicate.(*testPredicate)
+	if !ok {
+		return false
+	}
+
+	return maps.Equal(p.nums, testPrediate.nums)
 }

--- a/service/history/queues/scope.go
+++ b/service/history/queues/scope.go
@@ -91,9 +91,8 @@ func (s *Scope) SplitByPredicate(
 func (s *Scope) CanMergeByRange(
 	incomingScope Scope,
 ) bool {
-	// TODO: validate two scopes' predicates are equal
-
-	return s.Range.CanMerge(incomingScope.Range)
+	return s.Range.CanMerge(incomingScope.Range) &&
+		s.Predicate.Equals(incomingScope.Predicate)
 }
 
 func (s *Scope) MergeByRange(

--- a/service/history/tasks/predicates.go
+++ b/service/history/tasks/predicates.go
@@ -25,8 +25,10 @@
 package tasks
 
 import (
-	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common/predicates"
+	"golang.org/x/exp/maps"
+
+	enumsspb "go.temporal.io/server/api/enums/v1"
 )
 
 type (
@@ -66,6 +68,15 @@ func (n *NamespacePredicate) Test(task Task) bool {
 	return ok
 }
 
+func (n *NamespacePredicate) Equals(predicate Predicate) bool {
+	nsPrediate, ok := predicate.(*NamespacePredicate)
+	if !ok {
+		return false
+	}
+
+	return maps.Equal(n.NamespaceIDs, nsPrediate.NamespaceIDs)
+}
+
 func NewTypePredicate(
 	types []enumsspb.TaskType,
 ) *TypePredicate {
@@ -82,4 +93,13 @@ func NewTypePredicate(
 func (t *TypePredicate) Test(task Task) bool {
 	_, ok := t.Types[task.GetType()]
 	return ok
+}
+
+func (t *TypePredicate) Equals(predicate Predicate) bool {
+	typePrediate, ok := predicate.(*TypePredicate)
+	if !ok {
+		return false
+	}
+
+	return maps.Equal(t.Types, typePrediate.Types)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add best effort Equals check for task predicates. Since the check won't try to re-arrange the predicates, the result will contains false negatives even if mathematically two predicates are equivalent.
- ^ is ok as 1. in most cases our predicates are quite simple and should be equal even when form is taken into consideration 2. When false negatives are returned we will simply not merge (attach) two queue slices and there's no cost for correctness and performance. (All it costs is some additional storage costs for storing an additional queue slice scope data, which is negligible)
- Rename `None` predicate to `Empty`
- Split implementations in `common/predicates` to separate files.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Only two queue slices or queue scopes with equivalent predicate can be merged by range.
- `Equals` check is a sufficient (though not necessary) condition for equivalence.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A, code not used yet

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.