### PR TITLE
add default metricoptions where nil

### DIFF
--- a/common/metrics/events.go
+++ b/common/metrics/events.go
@@ -50,12 +50,12 @@ type (
 var (
 	_ MetricProvider = (*eventsMetricProvider)(nil)
 
-	defaultOptions *MetricOptions = &MetricOptions{
+	defaultOptions = &event.MetricOptions{
 		Namespace: defaultMetricNamespace,
 		Unit:      Dimensionless,
 	}
 
-	defaultTimerOptions *MetricOptions = &MetricOptions{
+	defaultTimerOptions = &event.MetricOptions{
 		Namespace: defaultMetricNamespace,
 		Unit:      Milliseconds,
 	}
@@ -129,48 +129,35 @@ func (emp *eventsMetricProvider) WithTags(tags ...Tag) MetricProvider {
 }
 
 // Counter obtains a counter for the given name.
-func (emp *eventsMetricProvider) Counter(n string, m *MetricOptions) CounterMetric {
-	if m == nil {
-		m = defaultOptions
-	}
-
-	e := event.NewCounter(n, m)
+func (emp *eventsMetricProvider) Counter(n string) CounterMetric {
+	e := event.NewCounter(n, defaultOptions)
 	return CounterMetricFunc(func(i int64, t ...Tag) {
 		e.Record(emp.ctx, i, tagsToLabels(emp.tags, t)...)
 	})
 }
 
 // Gauge obtains a gauge for the given name.
-func (emp *eventsMetricProvider) Gauge(n string, m *MetricOptions) GaugeMetric {
-	if m == nil {
-		m = defaultOptions
-	}
-
-	e := event.NewFloatGauge(n, m)
+func (emp *eventsMetricProvider) Gauge(n string) GaugeMetric {
+	e := event.NewFloatGauge(n, defaultOptions)
 	return GaugeMetricFunc(func(f float64, t ...Tag) {
 		e.Record(emp.ctx, f, tagsToLabels(emp.tags, t)...)
 	})
 }
 
 // Timer obtains a timer for the given name.
-func (emp *eventsMetricProvider) Timer(n string, m *MetricOptions) TimerMetric {
-	if m == nil {
-		m = defaultTimerOptions
-	}
-
-	e := event.NewDuration(n, m)
+func (emp *eventsMetricProvider) Timer(n string) TimerMetric {
+	e := event.NewDuration(n, defaultTimerOptions)
 	return TimerMetricFunc(func(d time.Duration, t ...Tag) {
 		e.Record(emp.ctx, d, tagsToLabels(emp.tags, t)...)
 	})
 }
 
 // Histogram obtains a histogram for the given name.
-func (emp *eventsMetricProvider) Histogram(n string, m *MetricOptions) HistogramMetric {
-	if m == nil {
-		m = defaultOptions
-	}
-
-	e := event.NewIntDistribution(n, m)
+func (emp *eventsMetricProvider) Histogram(n string, m MetricUnit) HistogramMetric {
+	e := event.NewIntDistribution(n, &event.MetricOptions{
+		Namespace: defaultMetricNamespace,
+		Unit:      event.Unit(m),
+	})
 	return HistogramMetricFunc(func(i int64, t ...Tag) {
 		e.Record(emp.ctx, i, tagsToLabels(emp.tags, t)...)
 	})

--- a/common/metrics/events.go
+++ b/common/metrics/events.go
@@ -48,8 +48,19 @@ type (
 )
 
 var (
-	_                      MetricProvider = (*eventsMetricProvider)(nil)
-	defaultMetricNamespace                = "go.temporal.io/server"
+	_ MetricProvider = (*eventsMetricProvider)(nil)
+
+	defaultOptions *MetricOptions = &MetricOptions{
+		Namespace: defaultMetricNamespace,
+		Unit:      Dimensionless,
+	}
+
+	defaultTimerOptions *MetricOptions = &MetricOptions{
+		Namespace: defaultMetricNamespace,
+		Unit:      Milliseconds,
+	}
+
+	defaultMetricNamespace = "go.temporal.io/server"
 )
 
 // MetricHandlerFromConfig is used at startup to construct
@@ -119,6 +130,10 @@ func (emp *eventsMetricProvider) WithTags(tags ...Tag) MetricProvider {
 
 // Counter obtains a counter for the given name.
 func (emp *eventsMetricProvider) Counter(n string, m *MetricOptions) CounterMetric {
+	if m == nil {
+		m = defaultOptions
+	}
+
 	e := event.NewCounter(n, m)
 	return CounterMetricFunc(func(i int64, t ...Tag) {
 		e.Record(emp.ctx, i, tagsToLabels(emp.tags, t)...)
@@ -127,6 +142,10 @@ func (emp *eventsMetricProvider) Counter(n string, m *MetricOptions) CounterMetr
 
 // Gauge obtains a gauge for the given name.
 func (emp *eventsMetricProvider) Gauge(n string, m *MetricOptions) GaugeMetric {
+	if m == nil {
+		m = defaultOptions
+	}
+
 	e := event.NewFloatGauge(n, m)
 	return GaugeMetricFunc(func(f float64, t ...Tag) {
 		e.Record(emp.ctx, f, tagsToLabels(emp.tags, t)...)
@@ -135,6 +154,10 @@ func (emp *eventsMetricProvider) Gauge(n string, m *MetricOptions) GaugeMetric {
 
 // Timer obtains a timer for the given name.
 func (emp *eventsMetricProvider) Timer(n string, m *MetricOptions) TimerMetric {
+	if m == nil {
+		m = defaultTimerOptions
+	}
+
 	e := event.NewDuration(n, m)
 	return TimerMetricFunc(func(d time.Duration, t ...Tag) {
 		e.Record(emp.ctx, d, tagsToLabels(emp.tags, t)...)
@@ -143,6 +166,10 @@ func (emp *eventsMetricProvider) Timer(n string, m *MetricOptions) TimerMetric {
 
 // Histogram obtains a histogram for the given name.
 func (emp *eventsMetricProvider) Histogram(n string, m *MetricOptions) HistogramMetric {
+	if m == nil {
+		m = defaultOptions
+	}
+
 	e := event.NewIntDistribution(n, m)
 	return HistogramMetricFunc(func(i int64, t ...Tag) {
 		e.Record(emp.ctx, i, tagsToLabels(emp.tags, t)...)

--- a/common/metrics/events_scope.go
+++ b/common/metrics/events_scope.go
@@ -28,7 +28,6 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/exp/event"
 	"golang.org/x/exp/maps"
 )
 
@@ -81,16 +80,10 @@ func (e *eventsScope) IncCounter(counter int) {
 func (e *eventsScope) AddCounter(counter int, delta int64) {
 	m := getDefinition(e.serviceIdx, counter)
 
-	e.provider.Counter(m.metricName.String(), &MetricOptions{
-		Namespace: defaultMetricNamespace,
-		Unit:      event.Unit(m.unit),
-	}).Record(int64(delta), e.scopeTags...)
+	e.provider.Counter(m.metricName.String()).Record(int64(delta), e.scopeTags...)
 
 	if !m.metricRollupName.Empty() {
-		e.provider.Counter(m.metricRollupName.String(), &event.MetricOptions{
-			Namespace: defaultMetricNamespace,
-			Unit:      event.Unit(m.unit),
-		}).Record(int64(delta), e.scopeTags...)
+		e.provider.Counter(m.metricRollupName.String()).Record(int64(delta), e.scopeTags...)
 	}
 }
 
@@ -101,16 +94,10 @@ func (e *eventsScope) StartTimer(timer int) Stopwatch {
 
 	return &eventsStopwatch{
 		recordFunc: func(d time.Duration) {
-			e.provider.Timer(m.metricName.String(), &MetricOptions{
-				Namespace: defaultMetricNamespace,
-				Unit:      event.Unit(m.unit),
-			}).Record(d, e.scopeTags...)
+			e.provider.Timer(m.metricName.String()).Record(d, e.scopeTags...)
 
 			if !m.metricRollupName.Empty() {
-				e.provider.Timer(m.metricRollupName.String(), &MetricOptions{
-					Namespace: defaultMetricNamespace,
-					Unit:      event.Unit(m.unit),
-				}).Record(d, e.scopeTags...)
+				e.provider.Timer(m.metricRollupName.String()).Record(d, e.scopeTags...)
 			}
 		},
 		start: time.Now(),
@@ -121,16 +108,10 @@ func (e *eventsScope) StartTimer(timer int) Stopwatch {
 func (e *eventsScope) RecordTimer(timer int, d time.Duration) {
 	m := getDefinition(e.serviceIdx, timer)
 
-	e.provider.Timer(m.metricName.String(), &MetricOptions{
-		Namespace: defaultMetricNamespace,
-		Unit:      event.Unit(m.unit),
-	}).Record(d, e.scopeTags...)
+	e.provider.Timer(m.metricName.String()).Record(d, e.scopeTags...)
 
 	if !m.metricRollupName.Empty() {
-		e.provider.Timer(m.metricRollupName.String(), &event.MetricOptions{
-			Namespace: defaultMetricNamespace,
-			Unit:      event.Unit(m.unit),
-		}).Record(d, e.scopeTags...)
+		e.provider.Timer(m.metricRollupName.String()).Record(d, e.scopeTags...)
 	}
 }
 
@@ -139,16 +120,10 @@ func (e *eventsScope) RecordTimer(timer int, d time.Duration) {
 func (e *eventsScope) RecordDistribution(id int, d int) {
 	m := getDefinition(e.serviceIdx, id)
 
-	e.provider.Histogram(m.metricName.String(), &MetricOptions{
-		Namespace: defaultMetricNamespace,
-		Unit:      event.Unit(m.unit),
-	}).Record(int64(d), e.scopeTags...)
+	e.provider.Histogram(m.metricName.String(), m.unit).Record(int64(d), e.scopeTags...)
 
 	if !m.metricRollupName.Empty() {
-		e.provider.Histogram(m.metricRollupName.String(), &event.MetricOptions{
-			Namespace: defaultMetricNamespace,
-			Unit:      event.Unit(m.unit),
-		}).Record(int64(d), e.scopeTags...)
+		e.provider.Histogram(m.metricRollupName.String(), m.unit).Record(int64(d), e.scopeTags...)
 	}
 }
 
@@ -156,16 +131,10 @@ func (e *eventsScope) RecordDistribution(id int, d int) {
 func (e *eventsScope) UpdateGauge(gauge int, value float64) {
 	m := getDefinition(e.serviceIdx, gauge)
 
-	e.provider.Gauge(m.metricName.String(), &MetricOptions{
-		Namespace: defaultMetricNamespace,
-		Unit:      event.Unit(m.unit),
-	}).Record(value, e.scopeTags...)
+	e.provider.Gauge(m.metricName.String()).Record(value, e.scopeTags...)
 
 	if !m.metricRollupName.Empty() {
-		e.provider.Gauge(m.metricRollupName.String(), &event.MetricOptions{
-			Namespace: defaultMetricNamespace,
-			Unit:      event.Unit(m.unit),
-		}).Record(value, e.scopeTags...)
+		e.provider.Gauge(m.metricRollupName.String()).Record(value, e.scopeTags...)
 	}
 }
 

--- a/common/metrics/events_test.go
+++ b/common/metrics/events_test.go
@@ -154,9 +154,7 @@ func (s *eventsSuite) TestCounterMetricFunc_Record() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			emp := NewEventsMetricProvider(NewOtelMetricHandler(log.NewTestLogger(), &testProvider{meter: meterProvider.Meter("test")}, ClientConfig{}))
-			emp.Counter(tt.name, &MetricOptions{
-				Description: "what you see is not a test",
-			}).Record(tt.v, tt.tags...)
+			emp.Counter(tt.name, defaultOptions).Record(tt.v, tt.tags...)
 			testexporter.Collect(ctx)
 
 			s.NotEmpty(testexporter.Records)
@@ -212,9 +210,7 @@ func (s *eventsSuite) TestGaugeMetricFunc_Record() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			emp := NewEventsMetricProvider(NewOtelMetricHandler(log.NewTestLogger(), &testProvider{meter: meterProvider.Meter("test")}, ClientConfig{}))
-			emp.Gauge(tt.name, &MetricOptions{
-				Description: "what you see is not a test",
-			}).Record(tt.v, tt.tags...)
+			emp.Gauge(tt.name, defaultOptions).Record(tt.v, tt.tags...)
 			testexporter.Collect(ctx)
 
 			s.NotEmpty(testexporter.Records)
@@ -276,10 +272,7 @@ func (s *eventsSuite) TestTimerMetricFunc_Record() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			emp := NewEventsMetricProvider(NewOtelMetricHandler(log.NewTestLogger(), &testProvider{meter: meterProvider.Meter("test")}, ClientConfig{}))
-			emp.Timer(tt.name, &MetricOptions{
-				Description: "what you see is not a test",
-				Unit:        Milliseconds,
-			}).Record(tt.v, tt.tags...)
+			emp.Timer(tt.name, defaultTimerOptions).Record(tt.v, tt.tags...)
 			testexporter.Collect(ctx)
 
 			s.NotEmpty(testexporter.Records)
@@ -405,9 +398,7 @@ func (s *eventsSuite) TestCounterMetricWithTagsMergeFunc_Record() {
 	for _, tt := range tests {
 		s.T().Run(tt.name, func(t *testing.T) {
 			emp := NewEventsMetricProvider(NewOtelMetricHandler(log.NewTestLogger(), &testProvider{meter: meterProvider.Meter("test")}, ClientConfig{})).WithTags(tt.rootTags...).(*eventsMetricProvider)
-			emp.Counter(tt.name, &MetricOptions{
-				Description: "what you see is not a test",
-			}).Record(tt.v, tt.tags...)
+			emp.Counter(tt.name, defaultOptions).Record(tt.v, tt.tags...)
 			testexporter.Collect(ctx)
 
 			s.NotEmpty(testexporter.Records)

--- a/common/metrics/events_userscope.go
+++ b/common/metrics/events_userscope.go
@@ -38,19 +38,7 @@ type (
 	}
 )
 
-var (
-	defaultOptions *MetricOptions = &MetricOptions{
-		Namespace: defaultMetricNamespace,
-		Unit:      Dimensionless,
-	}
-
-	defaultTimerOptions *MetricOptions = &MetricOptions{
-		Namespace: defaultMetricNamespace,
-		Unit:      Milliseconds,
-	}
-
-	_ UserScope = (*eventsUserScope)(nil)
-)
+var _ UserScope = (*eventsUserScope)(nil)
 
 func newEventsUserScope(provider MetricProvider, tags map[string]string) *eventsUserScope {
 	return &eventsUserScope{

--- a/common/metrics/events_userscope.go
+++ b/common/metrics/events_userscope.go
@@ -27,7 +27,6 @@ package metrics
 import (
 	"time"
 
-	"golang.org/x/exp/event"
 	"golang.org/x/exp/maps"
 )
 
@@ -54,7 +53,7 @@ func (e *eventsUserScope) IncCounter(counter string) {
 
 // AddCounter adds delta to the counter metric
 func (e *eventsUserScope) AddCounter(counter string, delta int64) {
-	e.provider.Counter(counter, defaultOptions).Record(delta, mapToTags(e.tags)...)
+	e.provider.Counter(counter).Record(delta, mapToTags(e.tags)...)
 }
 
 // StartTimer starts a timer for the given metric name.
@@ -62,7 +61,7 @@ func (e *eventsUserScope) AddCounter(counter string, delta int64) {
 func (e *eventsUserScope) StartTimer(timer string) Stopwatch {
 	return &eventsStopwatch{
 		recordFunc: func(d time.Duration) {
-			e.provider.Timer(timer, defaultTimerOptions).Record(d, mapToTags(e.tags)...)
+			e.provider.Timer(timer).Record(d, mapToTags(e.tags)...)
 		},
 		start: time.Now(),
 	}
@@ -70,21 +69,18 @@ func (e *eventsUserScope) StartTimer(timer string) Stopwatch {
 
 // RecordTimer records a timer for the given metric name
 func (e *eventsUserScope) RecordTimer(timer string, d time.Duration) {
-	e.provider.Timer(timer, defaultTimerOptions).Record(d, mapToTags(e.tags)...)
+	e.provider.Timer(timer).Record(d, mapToTags(e.tags)...)
 }
 
 // RecordDistribution records a distribution (wrapper on top of timer) for the given
 // metric name
 func (e *eventsUserScope) RecordDistribution(id string, unit MetricUnit, d int) {
-	e.provider.Histogram(id, &MetricOptions{
-		Namespace: defaultMetricNamespace,
-		Unit:      event.Unit(unit),
-	}).Record(int64(d), mapToTags(e.tags)...)
+	e.provider.Histogram(id, unit).Record(int64(d), mapToTags(e.tags)...)
 }
 
 // UpdateGauge reports Gauge type absolute value metric
 func (e *eventsUserScope) UpdateGauge(gauge string, value float64) {
-	e.provider.Gauge(gauge, defaultOptions).Record(value, mapToTags(e.tags)...)
+	e.provider.Gauge(gauge).Record(value, mapToTags(e.tags)...)
 }
 
 // Tagged returns a new scope with added and/or overriden tags values that can be used

--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -26,16 +26,12 @@ package metrics
 
 import (
 	"time"
-
-	"golang.org/x/exp/event"
 )
 
 // Mostly cribbed from
 // https://github.com/temporalio/sdk-go/blob/master/internal/common/metrics/handler.go
 // and adapted to depend on golang.org/x/exp/event
 type (
-	MetricOptions = event.MetricOptions
-
 	// MetricProvider represents the main dependency for instrumentation
 	MetricProvider interface {
 		// WithTags creates a new MetricProvder with provided []Tag
@@ -43,16 +39,16 @@ type (
 		WithTags(...Tag) MetricProvider
 
 		// Counter obtains a counter for the given name and MetricOptions.
-		Counter(string, *MetricOptions) CounterMetric
+		Counter(string) CounterMetric
 
 		// Gauge obtains a gauge for the given name and MetricOptions.
-		Gauge(string, *MetricOptions) GaugeMetric
+		Gauge(string) GaugeMetric
 
 		// Timer obtains a timer for the given name and MetricOptions.
-		Timer(string, *MetricOptions) TimerMetric
+		Timer(string) TimerMetric
 
 		// Histogram obtains a histogram for the given name and MetricOptions.
-		Histogram(string, *MetricOptions) HistogramMetric
+		Histogram(string, MetricUnit) HistogramMetric
 	}
 
 	// CounterMetric is an ever-increasing counter.

--- a/common/metrics/runtime.go
+++ b/common/metrics/runtime.go
@@ -89,32 +89,32 @@ func (r *RuntimeMetricsReporter) report() {
 	var memStats runtime.MemStats
 	runtime.ReadMemStats(&memStats)
 
-	r.provider.Gauge(NumGoRoutinesGauge, nil).Record(float64(runtime.NumGoroutine()))
-	r.provider.Gauge(GoMaxProcsGauge, nil).Record(float64(runtime.GOMAXPROCS(0)))
-	r.provider.Gauge(MemoryAllocatedGauge, nil).Record(float64(memStats.Alloc))
-	r.provider.Gauge(MemoryHeapGauge, nil).Record(float64(memStats.HeapAlloc))
-	r.provider.Gauge(MemoryHeapIdleGauge, nil).Record(float64(memStats.HeapIdle))
-	r.provider.Gauge(MemoryHeapInuseGauge, nil).Record(float64(memStats.HeapInuse))
-	r.provider.Gauge(MemoryStackGauge, nil).Record(float64(memStats.StackInuse))
+	r.provider.Gauge(NumGoRoutinesGauge).Record(float64(runtime.NumGoroutine()))
+	r.provider.Gauge(GoMaxProcsGauge).Record(float64(runtime.GOMAXPROCS(0)))
+	r.provider.Gauge(MemoryAllocatedGauge).Record(float64(memStats.Alloc))
+	r.provider.Gauge(MemoryHeapGauge).Record(float64(memStats.HeapAlloc))
+	r.provider.Gauge(MemoryHeapIdleGauge).Record(float64(memStats.HeapIdle))
+	r.provider.Gauge(MemoryHeapInuseGauge).Record(float64(memStats.HeapInuse))
+	r.provider.Gauge(MemoryStackGauge).Record(float64(memStats.StackInuse))
 
 	// memStats.NumGC is a perpetually incrementing counter (unless it wraps at 2^32)
 	num := memStats.NumGC
 	lastNum := atomic.SwapUint32(&r.lastNumGC, num) // reset for the next iteration
 	if delta := num - lastNum; delta > 0 {
-		r.provider.Histogram(NumGCCounter, nil).Record(int64(delta))
+		r.provider.Histogram(NumGCCounter, Bytes).Record(int64(delta))
 		if delta > 255 {
 			// too many GCs happened, the timestamps buffer got wrapped around. Report only the last 256
 			lastNum = num - 256
 		}
 		for i := lastNum; i != num; i++ {
 			pause := memStats.PauseNs[i%256]
-			r.provider.Timer(GcPauseMsTimer, nil).Record(time.Duration(pause))
+			r.provider.Timer(GcPauseMsTimer).Record(time.Duration(pause))
 		}
 	}
 
 	// report build info
-	r.buildInfoProvider.Gauge(buildInfoMetricName, nil).Record(1.0)
-	r.buildInfoProvider.Gauge(buildAgeMetricName, nil).Record(float64(time.Since(r.buildTime)))
+	r.buildInfoProvider.Gauge(buildInfoMetricName).Record(1.0)
+	r.buildInfoProvider.Gauge(buildAgeMetricName).Record(float64(time.Since(r.buildTime)))
 }
 
 // Start Starts the reporter thread that periodically emits metrics.

--- a/common/sdk/metrics_handler.go
+++ b/common/sdk/metrics_handler.go
@@ -81,13 +81,13 @@ func (m *MetricsHandler) Timer(name string) sdkclient.MetricsTimer {
 }
 
 func (m metricsCounter) Inc(i int64) {
-	m.provider.Counter(m.name, nil).Record(i)
+	m.provider.Counter(m.name).Record(i)
 }
 
 func (m metricsGauge) Update(f float64) {
-	m.provider.Gauge(m.name, nil).Record(f)
+	m.provider.Gauge(m.name).Record(f)
 }
 
 func (m metricsTimer) Record(duration time.Duration) {
-	m.provider.Timer(m.name, nil).Record(duration)
+	m.provider.Timer(m.name).Record(duration)
 }

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -166,9 +166,9 @@ func (e *executableImpl) Execute() error {
 	}
 	e.userLatency += userLatency
 
-	e.metricsProvider.Counter(TaskRequests, nil).Record(1, metrics.TaskPriorityTag(e.priority.String()))
-	e.metricsProvider.Timer(TaskProcessingLatency, nil).Record(time.Since(startTime))
-	e.metricsProvider.Timer(TaskNoUserProcessingLatency, nil).Record(time.Since(startTime) - userLatency)
+	e.metricsProvider.Counter(TaskRequests).Record(1, metrics.TaskPriorityTag(e.priority.String()))
+	e.metricsProvider.Timer(TaskProcessingLatency).Record(time.Since(startTime))
+	e.metricsProvider.Timer(TaskNoUserProcessingLatency).Record(time.Since(startTime) - userLatency)
 	return err
 }
 
@@ -180,7 +180,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 
 			e.attempt++
 			if e.attempt > e.criticalRetryAttempt() {
-				e.metricsProvider.Histogram(TaskAttempt, nil).Record(int64(e.attempt))
+				e.metricsProvider.Histogram(TaskAttempt, metrics.Dimensionless).Record(int64(e.attempt))
 				e.logger.Error("Critical error processing task, retrying.", tag.Error(err), tag.OperationCritical)
 			}
 		}
@@ -200,17 +200,17 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	}
 
 	if err == consts.ErrTaskRetry {
-		e.metricsProvider.Counter(TaskStandbyRetryCounter, nil).Record(1)
+		e.metricsProvider.Counter(TaskStandbyRetryCounter).Record(1)
 		return err
 	}
 
 	if err == consts.ErrWorkflowBusy {
-		e.metricsProvider.Counter(TaskWorkflowBusyCounter, nil).Record(1)
+		e.metricsProvider.Counter(TaskWorkflowBusyCounter).Record(1)
 		return err
 	}
 
 	if err == consts.ErrTaskDiscarded {
-		e.metricsProvider.Counter(TaskDiscarded, nil).Record(1)
+		e.metricsProvider.Counter(TaskDiscarded).Record(1)
 		return nil
 	}
 
@@ -219,14 +219,14 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	//  since the new task life cycle will not give up until task processed / verified
 	if _, ok := err.(*serviceerror.NamespaceNotActive); ok {
 		if e.timeSource.Now().Sub(e.loadTime) > 2*e.namespaceCacheRefreshInterval() {
-			e.metricsProvider.Counter(TaskNotActiveCounter, nil).Record(1)
+			e.metricsProvider.Counter(TaskNotActiveCounter).Record(1)
 			return nil
 		}
 
 		return err
 	}
 
-	e.metricsProvider.Counter(TaskFailures, nil).Record(1)
+	e.metricsProvider.Counter(TaskFailures).Record(1)
 
 	e.logger.Error("Fail to process task", tag.Error(err), tag.LifeCycleProcessingFailed)
 	return err
@@ -264,14 +264,14 @@ func (e *executableImpl) Ack() {
 	e.state = ctasks.TaskStateAcked
 
 	if e.shouldProcess {
-		e.metricsProvider.Histogram(TaskAttempt, nil).Record(int64(e.attempt))
+		e.metricsProvider.Histogram(TaskAttempt, metrics.Dimensionless).Record(int64(e.attempt))
 
 		priorityTaggedProvider := e.metricsProvider.WithTags(metrics.TaskPriorityTag(e.lowestPriority.String()))
-		priorityTaggedProvider.Timer(TaskLatency, nil).Record(time.Since(e.loadTime))
-		priorityTaggedProvider.Timer(TaskQueueLatency, nil).Record(time.Since(e.GetVisibilityTime()))
-		priorityTaggedProvider.Timer(TaskUserLatency, nil).Record(e.userLatency)
-		priorityTaggedProvider.Timer(TaskNoUserLatency, nil).Record(time.Since(e.loadTime) - e.userLatency)
-		priorityTaggedProvider.Timer(TaskNoUserQueueLatency, nil).Record(time.Since(e.GetVisibilityTime()) - e.userLatency)
+		priorityTaggedProvider.Timer(TaskLatency).Record(time.Since(e.loadTime))
+		priorityTaggedProvider.Timer(TaskQueueLatency).Record(time.Since(e.GetVisibilityTime()))
+		priorityTaggedProvider.Timer(TaskUserLatency).Record(e.userLatency)
+		priorityTaggedProvider.Timer(TaskNoUserLatency).Record(time.Since(e.loadTime) - e.userLatency)
+		priorityTaggedProvider.Timer(TaskNoUserQueueLatency).Record(time.Since(e.GetVisibilityTime()) - e.userLatency)
 	}
 }
 

--- a/service/history/queues/priority_assigner.go
+++ b/service/history/queues/priority_assigner.go
@@ -74,7 +74,6 @@ func NewPriorityAssigner(
 }
 
 func (a *priorityAssignerImpl) Assign(executable Executable) error {
-
 	/*
 		Summary:
 		- High priority: active tasks from active queue processor and no-op tasks (currently ignoring overrides)
@@ -144,7 +143,7 @@ func (a *priorityAssignerImpl) Assign(executable Executable) error {
 	if !ratelimiter.Allow() {
 		executable.SetPriority(tasks.PriorityMedium)
 
-		a.metricsProvider.Counter(TaskThrottledCounter, nil).Record(
+		a.metricsProvider.Counter(TaskThrottledCounter).Record(
 			1,
 			metrics.NamespaceTag(namespaceName),
 			metrics.TaskTypeTag(executable.GetType().String()),

--- a/service/history/queues/rescheduler.go
+++ b/service/history/queues/rescheduler.go
@@ -106,7 +106,7 @@ func (r *reschedulerImpl) Reschedule(
 	r.Lock()
 	defer r.Unlock()
 
-	r.metricProvider.Histogram(TaskReschedulerPendingTasks, nil).Record(int64(r.pq.Len()))
+	r.metricProvider.Histogram(TaskReschedulerPendingTasks, metrics.Dimensionless).Record(int64(r.pq.Len()))
 
 	if targetRescheduleSize == 0 {
 		targetRescheduleSize = r.pq.Len()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding default MetricOptions where nil was passed

<!-- Tell your future self why have you made these changes -->
**Why?**
Avoids the overhead of scanning the stack to supply a namespace and helps adjust metric units where necessary

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No