### PR TITLE
Fix query termination state validator

### DIFF
--- a/service/history/workflow/query.go
+++ b/service/history/workflow/query.go
@@ -98,7 +98,6 @@ func (q *queryImpl) GetTerminationState() (*QueryTerminationState, error) {
 	}
 	return ts.(*QueryTerminationState), nil
 }
-
 func (q *queryImpl) setTerminationState(terminationState *QueryTerminationState) error {
 	if err := q.validateTerminationState(terminationState); err != nil {
 		return err
@@ -125,7 +124,6 @@ func (q *queryImpl) validateTerminationState(
 		}
 		queryResult := terminationState.QueryResult
 		validAnswered := queryResult.GetResultType() == enumspb.QUERY_RESULT_TYPE_ANSWERED &&
-			queryResult.Answer != nil &&
 			queryResult.GetErrorMessage() == ""
 		validFailed := queryResult.GetResultType() == enumspb.QUERY_RESULT_TYPE_FAILED &&
 			queryResult.Answer == nil &&

--- a/service/history/workflow/query_test.go
+++ b/service/history/workflow/query_test.go
@@ -26,6 +26,7 @@ package workflow
 
 import (
 	"errors"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -79,7 +80,7 @@ func (s *QuerySuite) TestValidateTerminationState() {
 					ResultType: enumspb.QUERY_RESULT_TYPE_ANSWERED,
 				},
 			},
-			expectErr: true,
+			expectErr: false,
 		},
 		{
 			ts: &QueryTerminationState{
@@ -165,12 +166,14 @@ func (s *QuerySuite) TestValidateTerminationState() {
 	}
 
 	queryImpl := &queryImpl{}
-	for _, tc := range testCases {
-		if tc.expectErr {
-			s.Error(queryImpl.validateTerminationState(tc.ts))
-		} else {
-			s.NoError(queryImpl.validateTerminationState(tc.ts))
-		}
+	for i, tc := range testCases {
+		s.T().Run(strconv.Itoa(i), func(t *testing.T) {
+			if tc.expectErr {
+				s.Error(queryImpl.validateTerminationState(tc.ts))
+			} else {
+				s.NoError(queryImpl.validateTerminationState(tc.ts))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix query termination state validator. 

<!-- Tell your future self why have you made these changes -->
**Why?**
It is valid case when query returns `nil` answer and empty error message. It should be considered as answered w/o answer. This is a common case for polling queries. When result is not ready they usually returns `nil`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified existing unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.