### PR TITLE
Rename queryTermination to queryCompletion

### DIFF
--- a/service/history/workflow/query_registry.go
+++ b/service/history/workflow/query_registry.go
@@ -50,10 +50,10 @@ type (
 
 		GetQueryTermCh(string) (<-chan struct{}, error)
 		GetQueryInput(string) (*querypb.WorkflowQuery, error)
-		GetTerminationState(string) (*QueryTerminationState, error)
+		GetCompletionState(string) (*QueryCompletionState, error)
 
 		BufferQuery(queryInput *querypb.WorkflowQuery) (string, <-chan struct{})
-		SetTerminationState(string, *QueryTerminationState) error
+		SetCompletionState(string, *QueryCompletionState) error
 		RemoveQuery(id string)
 		Clear()
 	}
@@ -132,7 +132,7 @@ func (r *queryRegistryImpl) GetQueryTermCh(id string) (<-chan struct{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return q.getQueryTermCh(), nil
+	return q.getCompletionCh(), nil
 }
 
 func (r *queryRegistryImpl) GetQueryInput(id string) (*querypb.WorkflowQuery, error) {
@@ -145,42 +145,42 @@ func (r *queryRegistryImpl) GetQueryInput(id string) (*querypb.WorkflowQuery, er
 	return q.getQueryInput(), nil
 }
 
-func (r *queryRegistryImpl) GetTerminationState(id string) (*QueryTerminationState, error) {
+func (r *queryRegistryImpl) GetCompletionState(id string) (*QueryCompletionState, error) {
 	r.RLock()
 	defer r.RUnlock()
 	q, err := r.getQueryNoLock(id)
 	if err != nil {
 		return nil, err
 	}
-	return q.GetTerminationState()
+	return q.GetCompletionState()
 }
 
 func (r *queryRegistryImpl) BufferQuery(queryInput *querypb.WorkflowQuery) (string, <-chan struct{}) {
 	r.Lock()
 	defer r.Unlock()
 	q := newQuery(queryInput)
-	id := q.getQueryID()
+	id := q.getID()
 	r.buffered[id] = q
-	return id, q.getQueryTermCh()
+	return id, q.getCompletionCh()
 }
 
-func (r *queryRegistryImpl) SetTerminationState(id string, terminationState *QueryTerminationState) error {
+func (r *queryRegistryImpl) SetCompletionState(id string, completionState *QueryCompletionState) error {
 	r.Lock()
 	defer r.Unlock()
 	q, ok := r.buffered[id]
 	if !ok {
 		return errQueryNotExists
 	}
-	if err := q.setTerminationState(terminationState); err != nil {
+	if err := q.setCompletionState(completionState); err != nil {
 		return err
 	}
 	delete(r.buffered, id)
-	switch terminationState.QueryTerminationType {
-	case QueryTerminationTypeCompleted:
+	switch completionState.Type {
+	case QueryCompletionTypeSucceeded:
 		r.completed[id] = q
-	case QueryTerminationTypeUnblocked:
+	case QueryCompletionTypeUnblocked:
 		r.unblocked[id] = q
-	case QueryTerminationTypeFailed:
+	case QueryCompletionTypeFailed:
 		r.failed[id] = q
 	}
 	return nil
@@ -199,9 +199,9 @@ func (r *queryRegistryImpl) Clear() {
 	r.Lock()
 	defer r.Unlock()
 	for id, q := range r.buffered {
-		q.setTerminationState(&QueryTerminationState{
-			QueryTerminationType: QueryTerminationTypeFailed,
-			Failure:              consts.ErrBufferedQueryCleared,
+		_ = q.setCompletionState(&QueryCompletionState{
+			Type: QueryCompletionTypeFailed,
+			Err:  consts.ErrBufferedQueryCleared,
 		})
 		r.failed[id] = q
 	}

--- a/service/history/workflow/query_registry_test.go
+++ b/service/history/workflow/query_registry_test.go
@@ -62,9 +62,9 @@ func (s *QueryRegistrySuite) TestQueryRegistry() {
 	s.assertChanState(false, termChans...)
 
 	for i := 0; i < 25; i++ {
-		err := qr.SetTerminationState(ids[i], &QueryTerminationState{
-			QueryTerminationType: QueryTerminationTypeCompleted,
-			QueryResult: &querypb.WorkflowQueryResult{
+		err := qr.SetCompletionState(ids[i], &QueryCompletionState{
+			Type: QueryCompletionTypeSucceeded,
+			Result: &querypb.WorkflowQueryResult{
 				ResultType: enumspb.QUERY_RESULT_TYPE_ANSWERED,
 				Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 			},
@@ -79,8 +79,8 @@ func (s *QueryRegistrySuite) TestQueryRegistry() {
 	s.assertChanState(false, termChans[25:]...)
 
 	for i := 25; i < 50; i++ {
-		err := qr.SetTerminationState(ids[i], &QueryTerminationState{
-			QueryTerminationType: QueryTerminationTypeUnblocked,
+		err := qr.SetCompletionState(ids[i], &QueryCompletionState{
+			Type: QueryCompletionTypeUnblocked,
 		})
 		s.NoError(err)
 	}
@@ -93,9 +93,9 @@ func (s *QueryRegistrySuite) TestQueryRegistry() {
 	s.assertChanState(false, termChans[50:]...)
 
 	for i := 50; i < 75; i++ {
-		err := qr.SetTerminationState(ids[i], &QueryTerminationState{
-			QueryTerminationType: QueryTerminationTypeFailed,
-			Failure:              errors.New("err"),
+		err := qr.SetCompletionState(ids[i], &QueryCompletionState{
+			Type: QueryCompletionTypeFailed,
+			Err:  errors.New("err"),
 		})
 		s.NoError(err)
 	}
@@ -111,18 +111,18 @@ func (s *QueryRegistrySuite) TestQueryRegistry() {
 	for i := 0; i < 75; i++ {
 		switch i % 3 {
 		case 0:
-			s.Equal(errQueryNotExists, qr.SetTerminationState(ids[i], &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeCompleted,
-				QueryResult:          &querypb.WorkflowQueryResult{},
+			s.Equal(errQueryNotExists, qr.SetCompletionState(ids[i], &QueryCompletionState{
+				Type:   QueryCompletionTypeSucceeded,
+				Result: &querypb.WorkflowQueryResult{},
 			}))
 		case 1:
-			s.Equal(errQueryNotExists, qr.SetTerminationState(ids[i], &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeUnblocked,
+			s.Equal(errQueryNotExists, qr.SetCompletionState(ids[i], &QueryCompletionState{
+				Type: QueryCompletionTypeUnblocked,
 			}))
 		case 2:
-			s.Equal(errQueryNotExists, qr.SetTerminationState(ids[i], &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeFailed,
-				Failure:              errors.New("err"),
+			s.Equal(errQueryNotExists, qr.SetCompletionState(ids[i], &QueryCompletionState{
+				Type: QueryCompletionTypeFailed,
+				Err:  errors.New("err"),
 			}))
 		}
 	}
@@ -167,9 +167,9 @@ func (s *QueryRegistrySuite) assertBufferedState(qr QueryRegistry, ids ...string
 		input, err := qr.GetQueryInput(id)
 		s.NoError(err)
 		s.NotNil(input)
-		termState, err := qr.GetTerminationState(id)
-		s.Equal(errQueryNotInTerminalState, err)
-		s.Nil(termState)
+		completionState, err := qr.GetCompletionState(id)
+		s.Equal(errQueryNotInCompletionState, err)
+		s.Nil(completionState)
 	}
 }
 
@@ -181,12 +181,12 @@ func (s *QueryRegistrySuite) assertCompletedState(qr QueryRegistry, ids ...strin
 		input, err := qr.GetQueryInput(id)
 		s.NoError(err)
 		s.NotNil(input)
-		termState, err := qr.GetTerminationState(id)
+		completionState, err := qr.GetCompletionState(id)
 		s.NoError(err)
-		s.NotNil(termState)
-		s.Equal(QueryTerminationTypeCompleted, termState.QueryTerminationType)
-		s.NotNil(termState.QueryResult)
-		s.Nil(termState.Failure)
+		s.NotNil(completionState)
+		s.Equal(QueryCompletionTypeSucceeded, completionState.Type)
+		s.NotNil(completionState.Result)
+		s.Nil(completionState.Err)
 	}
 }
 
@@ -198,12 +198,12 @@ func (s *QueryRegistrySuite) assertUnblockedState(qr QueryRegistry, ids ...strin
 		input, err := qr.GetQueryInput(id)
 		s.NoError(err)
 		s.NotNil(input)
-		termState, err := qr.GetTerminationState(id)
+		completionState, err := qr.GetCompletionState(id)
 		s.NoError(err)
-		s.NotNil(termState)
-		s.Equal(QueryTerminationTypeUnblocked, termState.QueryTerminationType)
-		s.Nil(termState.QueryResult)
-		s.Nil(termState.Failure)
+		s.NotNil(completionState)
+		s.Equal(QueryCompletionTypeUnblocked, completionState.Type)
+		s.Nil(completionState.Result)
+		s.Nil(completionState.Err)
 	}
 }
 
@@ -215,12 +215,12 @@ func (s *QueryRegistrySuite) assertFailedState(qr QueryRegistry, ids ...string) 
 		input, err := qr.GetQueryInput(id)
 		s.NoError(err)
 		s.NotNil(input)
-		termState, err := qr.GetTerminationState(id)
+		completionState, err := qr.GetCompletionState(id)
 		s.NoError(err)
-		s.NotNil(termState)
-		s.Equal(QueryTerminationTypeFailed, termState.QueryTerminationType)
-		s.Nil(termState.QueryResult)
-		s.NotNil(termState.Failure)
+		s.NotNil(completionState)
+		s.Equal(QueryCompletionTypeFailed, completionState.Type)
+		s.Nil(completionState.Result)
+		s.NotNil(completionState.Err)
 	}
 }
 

--- a/service/history/workflow/query_test.go
+++ b/service/history/workflow/query_test.go
@@ -49,9 +49,9 @@ func (s *QuerySuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 }
 
-func (s *QuerySuite) TestValidateTerminationState() {
+func (s *QuerySuite) TestValidateCompletionState() {
 	testCases := []struct {
-		ts        *QueryTerminationState
+		ts        *QueryCompletionState
 		expectErr bool
 	}{
 		{
@@ -59,32 +59,32 @@ func (s *QuerySuite) TestValidateTerminationState() {
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeCompleted,
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeSucceeded,
 			},
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeCompleted,
-				QueryResult:          &querypb.WorkflowQueryResult{},
-				Failure:              errors.New("err"),
+			ts: &QueryCompletionState{
+				Type:   QueryCompletionTypeSucceeded,
+				Result: &querypb.WorkflowQueryResult{},
+				Err:    errors.New("err"),
 			},
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeCompleted,
-				QueryResult: &querypb.WorkflowQueryResult{
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeSucceeded,
+				Result: &querypb.WorkflowQueryResult{
 					ResultType: enumspb.QUERY_RESULT_TYPE_ANSWERED,
 				},
 			},
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeCompleted,
-				QueryResult: &querypb.WorkflowQueryResult{
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeSucceeded,
+				Result: &querypb.WorkflowQueryResult{
 					ResultType:   enumspb.QUERY_RESULT_TYPE_ANSWERED,
 					Answer:       payloads.EncodeBytes([]byte{1, 2, 3}),
 					ErrorMessage: "err",
@@ -93,9 +93,9 @@ func (s *QuerySuite) TestValidateTerminationState() {
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeCompleted,
-				QueryResult: &querypb.WorkflowQueryResult{
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeSucceeded,
+				Result: &querypb.WorkflowQueryResult{
 					ResultType: enumspb.QUERY_RESULT_TYPE_FAILED,
 					Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 				},
@@ -103,9 +103,9 @@ func (s *QuerySuite) TestValidateTerminationState() {
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeCompleted,
-				QueryResult: &querypb.WorkflowQueryResult{
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeSucceeded,
+				Result: &querypb.WorkflowQueryResult{
 					ResultType:   enumspb.QUERY_RESULT_TYPE_FAILED,
 					ErrorMessage: "err",
 				},
@@ -113,9 +113,9 @@ func (s *QuerySuite) TestValidateTerminationState() {
 			expectErr: false,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeCompleted,
-				QueryResult: &querypb.WorkflowQueryResult{
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeSucceeded,
+				Result: &querypb.WorkflowQueryResult{
 					ResultType: enumspb.QUERY_RESULT_TYPE_ANSWERED,
 					Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 				},
@@ -123,42 +123,42 @@ func (s *QuerySuite) TestValidateTerminationState() {
 			expectErr: false,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeUnblocked,
-				QueryResult:          &querypb.WorkflowQueryResult{},
+			ts: &QueryCompletionState{
+				Type:   QueryCompletionTypeUnblocked,
+				Result: &querypb.WorkflowQueryResult{},
 			},
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeUnblocked,
-				Failure:              errors.New("err"),
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeUnblocked,
+				Err:  errors.New("err"),
 			},
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeUnblocked,
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeUnblocked,
 			},
 			expectErr: false,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeFailed,
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeFailed,
 			},
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeFailed,
-				QueryResult:          &querypb.WorkflowQueryResult{},
+			ts: &QueryCompletionState{
+				Type:   QueryCompletionTypeFailed,
+				Result: &querypb.WorkflowQueryResult{},
 			},
 			expectErr: true,
 		},
 		{
-			ts: &QueryTerminationState{
-				QueryTerminationType: QueryTerminationTypeFailed,
-				Failure:              errors.New("err"),
+			ts: &QueryCompletionState{
+				Type: QueryCompletionTypeFailed,
+				Err:  errors.New("err"),
 			},
 			expectErr: false,
 		},
@@ -167,60 +167,60 @@ func (s *QuerySuite) TestValidateTerminationState() {
 	queryImpl := &queryImpl{}
 	for _, tc := range testCases {
 		if tc.expectErr {
-			s.Error(queryImpl.validateTerminationState(tc.ts))
+			s.Error(queryImpl.validateCompletionState(tc.ts))
 		} else {
-			s.NoError(queryImpl.validateTerminationState(tc.ts))
+			s.NoError(queryImpl.validateCompletionState(tc.ts))
 		}
 	}
 }
 
-func (s *QuerySuite) TestTerminationState_Failed() {
-	failedTerminationState := &QueryTerminationState{
-		QueryTerminationType: QueryTerminationTypeFailed,
-		Failure:              errors.New("err"),
+func (s *QuerySuite) TestCompletionState_Failed() {
+	completionStateFailed := &QueryCompletionState{
+		Type: QueryCompletionTypeFailed,
+		Err:  errors.New("err"),
 	}
-	s.testSetTerminationState(failedTerminationState)
+	s.testSetCompletionState(completionStateFailed)
 }
 
-func (s *QuerySuite) TestTerminationState_Completed() {
-	answeredTerminationState := &QueryTerminationState{
-		QueryTerminationType: QueryTerminationTypeCompleted,
-		QueryResult: &querypb.WorkflowQueryResult{
+func (s *QuerySuite) TestCompletionState_Completed() {
+	answeredCompletionState := &QueryCompletionState{
+		Type: QueryCompletionTypeSucceeded,
+		Result: &querypb.WorkflowQueryResult{
 			ResultType: enumspb.QUERY_RESULT_TYPE_ANSWERED,
 			Answer:     payloads.EncodeBytes([]byte{1, 2, 3}),
 		},
 	}
-	s.testSetTerminationState(answeredTerminationState)
+	s.testSetCompletionState(answeredCompletionState)
 }
 
-func (s *QuerySuite) TestTerminationState_Unblocked() {
-	unblockedTerminationState := &QueryTerminationState{
-		QueryTerminationType: QueryTerminationTypeUnblocked,
+func (s *QuerySuite) TestCompletionState_Unblocked() {
+	unblockedCompletionState := &QueryCompletionState{
+		Type: QueryCompletionTypeUnblocked,
 	}
-	s.testSetTerminationState(unblockedTerminationState)
+	s.testSetCompletionState(unblockedCompletionState)
 }
 
-func (s *QuerySuite) testSetTerminationState(terminationState *QueryTerminationState) {
+func (s *QuerySuite) testSetCompletionState(completionState *QueryCompletionState) {
 	query := newQuery(nil)
-	ts, err := query.GetTerminationState()
-	s.Equal(errQueryNotInTerminalState, err)
+	ts, err := query.GetCompletionState()
+	s.Equal(errQueryNotInCompletionState, err)
 	s.Nil(ts)
-	s.False(closed(query.getQueryTermCh()))
-	s.Equal(errTerminationStateInvalid, query.setTerminationState(nil))
-	s.NoError(query.setTerminationState(terminationState))
-	s.True(closed(query.getQueryTermCh()))
-	actualTerminationState, err := query.GetTerminationState()
+	s.False(closed(query.getCompletionCh()))
+	s.Equal(errCompletionStateInvalid, query.setCompletionState(nil))
+	s.NoError(query.setCompletionState(completionState))
+	s.True(closed(query.getCompletionCh()))
+	actualCompletionState, err := query.GetCompletionState()
 	s.NoError(err)
-	s.assertTerminationStateEqual(terminationState, actualTerminationState)
+	s.assertCompletionStateEqual(completionState, actualCompletionState)
 }
 
-func (s *QuerySuite) assertTerminationStateEqual(expected *QueryTerminationState, actual *QueryTerminationState) {
-	s.Equal(expected.QueryTerminationType, actual.QueryTerminationType)
-	if expected.Failure != nil {
-		s.Equal(expected.Failure.Error(), actual.Failure.Error())
+func (s *QuerySuite) assertCompletionStateEqual(expected *QueryCompletionState, actual *QueryCompletionState) {
+	s.Equal(expected.Type, actual.Type)
+	if expected.Err != nil {
+		s.Equal(expected.Err.Error(), actual.Err.Error())
 	}
-	if expected.QueryResult != nil {
-		s.EqualValues(actual.QueryResult, expected.QueryResult)
+	if expected.Result != nil {
+		s.EqualValues(actual.Result, expected.Result)
 	}
 }
 

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -754,13 +754,13 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(msBuilder
 				tag.WorkflowRunID(runID),
 				tag.QueryID(id),
 				tag.Error(err))
-			failedTerminationState := &workflow.QueryTerminationState{
-				QueryTerminationType: workflow.QueryTerminationTypeFailed,
-				Failure:              err,
+			failedCompletionState := &workflow.QueryCompletionState{
+				Type: workflow.QueryCompletionTypeFailed,
+				Err:  err,
 			}
-			if err := queryRegistry.SetTerminationState(id, failedTerminationState); err != nil {
+			if err := queryRegistry.SetCompletionState(id, failedCompletionState); err != nil {
 				handler.logger.Error(
-					"failed to set query termination state to failed",
+					"failed to set query completion state to failed",
 					tag.WorkflowNamespace(namespaceName.String()),
 					tag.WorkflowID(workflowID),
 					tag.WorkflowRunID(runID),
@@ -769,13 +769,13 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(msBuilder
 				scope.IncCounter(metrics.QueryRegistryInvalidStateCount)
 			}
 		} else {
-			completedTerminationState := &workflow.QueryTerminationState{
-				QueryTerminationType: workflow.QueryTerminationTypeCompleted,
-				QueryResult:          result,
+			succeededCompletionState := &workflow.QueryCompletionState{
+				Type:   workflow.QueryCompletionTypeSucceeded,
+				Result: result,
 			}
-			if err := queryRegistry.SetTerminationState(id, completedTerminationState); err != nil {
+			if err := queryRegistry.SetCompletionState(id, succeededCompletionState); err != nil {
 				handler.logger.Error(
-					"failed to set query termination state to completed",
+					"failed to set query completion state to succeeded",
 					tag.WorkflowNamespace(namespaceName.String()),
 					tag.WorkflowID(workflowID),
 					tag.WorkflowRunID(runID),
@@ -791,12 +791,12 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(msBuilder
 	if !createNewWorkflowTask {
 		buffered := queryRegistry.GetBufferedIDs()
 		for _, id := range buffered {
-			unblockTerminationState := &workflow.QueryTerminationState{
-				QueryTerminationType: workflow.QueryTerminationTypeUnblocked,
+			unblockCompletionState := &workflow.QueryCompletionState{
+				Type: workflow.QueryCompletionTypeUnblocked,
 			}
-			if err := queryRegistry.SetTerminationState(id, unblockTerminationState); err != nil {
+			if err := queryRegistry.SetCompletionState(id, unblockCompletionState); err != nil {
 				handler.logger.Error(
-					"failed to set query termination state to unblocked",
+					"failed to set query completion state to unblocked",
 					tag.WorkflowNamespace(namespaceName.String()),
 					tag.WorkflowID(workflowID),
 					tag.WorkflowRunID(runID),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Rename `queryTermination` to `queryCompletion`.

<!-- Tell your future self why have you made these changes -->
**Why?**
"Termination" is a bad word to indicate completed query. For me is sounds like something bad happened to query and it gets terminated just like `TerminateWorkflow` works. "Completion" sounds better for me.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.