### PR TITLE
Update mysql image version to support arm64

### DIFF
--- a/develop/buildkite/docker-compose.yml
+++ b/develop/buildkite/docker-compose.yml
@@ -9,7 +9,7 @@ services:
           - cassandra
 
   mysql:
-    image: mysql:8.0.19
+    image: mysql:8.0.29-oracle
     environment:
       MYSQL_ROOT_PASSWORD: root
     volumes:

--- a/develop/docker-compose/docker-compose.yml
+++ b/develop/docker-compose/docker-compose.yml
@@ -6,7 +6,7 @@ version: "3.5"
 
 services:
   mysql:
-    image: mysql:8.0.19
+    image: mysql:8.0.29-oracle
     container_name: temporal-dev-mysql
     ports:
       - "3306:3306"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update mysql image version to support `arm64`.

<!-- Tell your future self why have you made these changes -->
**Why?**
`mysql:8.0.19` doesn't have `linux/arm64` image and `make start-dependencies` gives an error when run on arm64 (i.e. Mac M1).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run `make start-dependencies` on Mac M1.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.