### PR TITLE
Don't check delete workflow execution transfer task version

### DIFF
--- a/common/persistence/serialization/task_serializer.go
+++ b/common/persistence/serialization/task_serializer.go
@@ -572,7 +572,6 @@ func (s *TaskSerializer) transferDeleteExecutionTaskToProto(
 		WorkflowId:     deleteExecutionTask.WorkflowKey.WorkflowID,
 		RunId:          deleteExecutionTask.WorkflowKey.RunID,
 		TaskType:       enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION,
-		Version:        deleteExecutionTask.Version,
 		TaskId:         deleteExecutionTask.TaskID,
 		VisibilityTime: timestamp.TimePtr(deleteExecutionTask.VisibilityTimestamp),
 	}
@@ -589,7 +588,6 @@ func (s *TaskSerializer) transferDeleteExecutionTaskFromProto(
 		),
 		VisibilityTimestamp: *deleteExecutionTask.VisibilityTime,
 		TaskID:              deleteExecutionTask.TaskId,
-		Version:             deleteExecutionTask.Version,
 	}
 }
 
@@ -931,7 +929,6 @@ func (s *TaskSerializer) visibilityDeleteTaskToProto(
 		WorkflowId:     deleteVisibilityTask.WorkflowKey.WorkflowID,
 		RunId:          deleteVisibilityTask.WorkflowKey.RunID,
 		TaskType:       enumsspb.TASK_TYPE_VISIBILITY_DELETE_EXECUTION,
-		Version:        deleteVisibilityTask.Version,
 		TaskId:         deleteVisibilityTask.TaskID,
 		VisibilityTime: &deleteVisibilityTask.VisibilityTimestamp,
 		StartTime:      deleteVisibilityTask.StartTime,
@@ -950,7 +947,6 @@ func (s *TaskSerializer) visibilityDeleteTaskFromProto(
 		),
 		VisibilityTimestamp: *deleteVisibilityTask.VisibilityTime,
 		TaskID:              deleteVisibilityTask.TaskId,
-		Version:             deleteVisibilityTask.Version,
 		StartTime:           deleteVisibilityTask.StartTime,
 		CloseTime:           deleteVisibilityTask.CloseTime,
 	}

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -329,10 +329,6 @@ func (e *taskExecutorImpl) cleanupWorkflowExecution(ctx context.Context, namespa
 	if err != nil {
 		return err
 	}
-	lastWriteVersion, err := mutableState.GetLastWriteVersion()
-	if err != nil {
-		return err
-	}
 
 	return e.deleteManager.DeleteWorkflowExecution(
 		ctx,
@@ -340,7 +336,6 @@ func (e *taskExecutorImpl) cleanupWorkflowExecution(ctx context.Context, namespa
 		ex,
 		wfCtx,
 		mutableState,
-		lastWriteVersion,
 		false,
 	)
 }

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -428,7 +428,7 @@ func (p *taskProcessorImpl) convertTaskToDLQTask(
 		}, nil
 
 	default:
-		return nil, fmt.Errorf("unknown replication task type")
+		return nil, fmt.Errorf("unknown replication task type: %v", replicationTask.TaskType)
 	}
 }
 

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -113,7 +113,7 @@ type (
 		GetWorkflowExecution(ctx context.Context, request *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error)
 		// DeleteWorkflowExecution deletes workflow execution, current workflow execution, and add task to delete visibility.
 		// If branchToken != nil, then delete history also, otherwise leave history.
-		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, version int64, startTime *time.Time, closeTime *time.Time) error
+		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime *time.Time, closeTime *time.Time) error
 
 		GetRemoteAdminClient(cluster string) (adminservice.AdminServiceClient, error)
 		GetHistoryClient() historyservice.HistoryServiceClient

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -906,7 +906,6 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	ctx context.Context,
 	key definition.WorkflowKey,
 	branchToken []byte,
-	newTaskVersion int64,
 	startTime *time.Time,
 	closeTime *time.Time,
 ) (retErr error) {
@@ -972,7 +971,6 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 					// TaskID is set by addTasksLocked
 					WorkflowKey:         key,
 					VisibilityTimestamp: s.timeSource.Now(),
-					Version:             newTaskVersion,
 					StartTime:           startTime,
 					CloseTime:           closeTime,
 				},

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -178,17 +178,17 @@ func (mr *MockContextMockRecorder) DeleteFailoverLevel(category, failoverID inte
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, version int64, startTime, closeTime *time.Time) error {
+func (m *MockContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime, closeTime *time.Time) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, version, startTime, closeTime)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, startTime, closeTime)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, version, startTime, closeTime interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, startTime, closeTime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, version, startTime, closeTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, startTime, closeTime)
 }
 
 // GenerateTaskID mocks base method.

--- a/service/history/tasks/delete_execution_task.go
+++ b/service/history/tasks/delete_execution_task.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 )
 
@@ -38,7 +39,6 @@ type (
 		definition.WorkflowKey
 		VisibilityTimestamp time.Time
 		TaskID              int64
-		Version             int64
 	}
 )
 
@@ -47,11 +47,10 @@ func (a *DeleteExecutionTask) GetKey() Key {
 }
 
 func (a *DeleteExecutionTask) GetVersion() int64 {
-	return a.Version
+	return common.EmptyVersion
 }
 
-func (a *DeleteExecutionTask) SetVersion(version int64) {
-	a.Version = version
+func (a *DeleteExecutionTask) SetVersion(_ int64) {
 }
 
 func (a *DeleteExecutionTask) GetTaskID() int64 {

--- a/service/history/tasks/delete_execution_task.go
+++ b/service/history/tasks/delete_execution_task.go
@@ -47,6 +47,8 @@ func (a *DeleteExecutionTask) GetKey() Key {
 }
 
 func (a *DeleteExecutionTask) GetVersion() int64 {
+	// Version is not used for DeleteExecutionTask transfer task because it is created only for
+	// explicit API call, and in this case execution needs to be deleted regardless of the version.
 	return common.EmptyVersion
 }
 

--- a/service/history/tasks/delete_visibility_task.go
+++ b/service/history/tasks/delete_visibility_task.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/definition"
 )
 
@@ -38,7 +39,6 @@ type (
 		definition.WorkflowKey
 		VisibilityTimestamp time.Time
 		TaskID              int64
-		Version             int64
 		// These two fields are needed for cassandra standard visibility.
 		// TODO (alex): Remove them when cassandra standard visibility is removed.
 		StartTime *time.Time
@@ -51,11 +51,10 @@ func (t *DeleteExecutionVisibilityTask) GetKey() Key {
 }
 
 func (t *DeleteExecutionVisibilityTask) GetVersion() int64 {
-	return t.Version
+	return common.EmptyVersion
 }
 
-func (t *DeleteExecutionVisibilityTask) SetVersion(version int64) {
-	t.Version = version
+func (t *DeleteExecutionVisibilityTask) SetVersion(_ int64) {
 }
 
 func (t *DeleteExecutionVisibilityTask) GetTaskID() int64 {

--- a/service/history/tasks/delete_visibility_task.go
+++ b/service/history/tasks/delete_visibility_task.go
@@ -51,6 +51,10 @@ func (t *DeleteExecutionVisibilityTask) GetKey() Key {
 }
 
 func (t *DeleteExecutionVisibilityTask) GetVersion() int64 {
+	// Version is not used for DeleteExecutionVisibilityTask visibility task because:
+	// 1. It is created from parent task which either check version itself (DeleteHistoryEventTask) or
+	// doesn't check version at all (DeleteExecutionTask).
+	// 2. Delete visibility task processor doesn't have access to mutable state (it is already gone).
 	return common.EmptyVersion
 }
 

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -152,7 +152,6 @@ func (t *timerQueueTaskExecutorBase) executeDeleteHistoryEventTask(
 		workflowExecution,
 		weContext,
 		mutableState,
-		task.GetVersion(),
 	)
 }
 

--- a/service/history/timerQueueTaskExecutorBase_test.go
+++ b/service/history/timerQueueTaskExecutorBase_test.go
@@ -143,7 +143,6 @@ func (s *timerQueueTaskExecutorBaseSuite) Test_executeDeleteHistoryEventTask_NoE
 		we,
 		mockWeCtx,
 		mockMutableState,
-		int64(123),
 	).Return(nil)
 
 	err := s.timerQueueTaskExecutorBase.executeDeleteHistoryEventTask(
@@ -187,7 +186,6 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_DeleteFailed() {
 		we,
 		mockWeCtx,
 		mockMutableState,
-		int64(123),
 	).Return(serviceerror.NewInternal("test error"))
 
 	err := s.timerQueueTaskExecutorBase.executeDeleteHistoryEventTask(

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -260,14 +260,8 @@ func (t *transferQueueTaskExecutorBase) deleteExecution(
 		return err
 	}
 
-	lastWriteVersion, err := mutableState.GetLastWriteVersion()
-	if err != nil {
-		return err
-	}
-	ok := VerifyTaskVersion(t.shard, t.logger, mutableState.GetNamespaceEntry(), lastWriteVersion, task.GetVersion(), task)
-	if !ok {
-		return nil
-	}
+	// Do not validate version here because DeleteExecutionTask transfer task is created only for
+	// explicit API call, and in this case execution needs to be deleted regardless of the version.
 
 	return t.workflowDeleteManager.DeleteWorkflowExecution(
 		ctx,
@@ -275,7 +269,6 @@ func (t *transferQueueTaskExecutorBase) deleteExecution(
 		workflowExecution,
 		weCtx,
 		mutableState,
-		task.GetVersion(),
 		forceDeleteFromOpenVisibility,
 	)
 }

--- a/service/history/workflow/delete_manager_mock.go
+++ b/service/history/workflow/delete_manager_mock.go
@@ -75,29 +75,29 @@ func (mr *MockDeleteManagerMockRecorder) AddDeleteWorkflowExecutionTask(ctx, nsI
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockDeleteManager) DeleteWorkflowExecution(ctx context.Context, nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, sourceTaskVersion int64, forceDeleteFromOpenVisibility bool) error {
+func (m *MockDeleteManager) DeleteWorkflowExecution(ctx context.Context, nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, forceDeleteFromOpenVisibility bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, nsID, we, weCtx, ms, sourceTaskVersion, forceDeleteFromOpenVisibility)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecution(ctx, nsID, we, weCtx, ms, sourceTaskVersion, forceDeleteFromOpenVisibility interface{}) *gomock.Call {
+func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecution(ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecution), ctx, nsID, we, weCtx, ms, sourceTaskVersion, forceDeleteFromOpenVisibility)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecution), ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility)
 }
 
 // DeleteWorkflowExecutionByRetention mocks base method.
-func (m *MockDeleteManager) DeleteWorkflowExecutionByRetention(ctx context.Context, nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, sourceTaskVersion int64) error {
+func (m *MockDeleteManager) DeleteWorkflowExecutionByRetention(ctx context.Context, nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecutionByRetention", ctx, nsID, we, weCtx, ms, sourceTaskVersion)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecutionByRetention", ctx, nsID, we, weCtx, ms)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecutionByRetention indicates an expected call of DeleteWorkflowExecutionByRetention.
-func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecutionByRetention(ctx, nsID, we, weCtx, ms, sourceTaskVersion interface{}) *gomock.Call {
+func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecutionByRetention(ctx, nsID, we, weCtx, ms interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecutionByRetention", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecutionByRetention), ctx, nsID, we, weCtx, ms, sourceTaskVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecutionByRetention", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecutionByRetention), ctx, nsID, we, weCtx, ms)
 }

--- a/service/history/workflow/delete_manager_test.go
+++ b/service/history/workflow/delete_manager_test.go
@@ -129,7 +129,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteDeletedWorkflowExecution() {
 			RunID:       tests.RunID,
 		},
 		[]byte{22, 8, 78},
-		int64(1),
 		nil,
 		&closeTime,
 	).Return(nil)
@@ -141,7 +140,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteDeletedWorkflowExecution() {
 		we,
 		mockWeCtx,
 		mockMutableState,
-		1,
 		false,
 	)
 	s.NoError(err)
@@ -168,7 +166,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteDeletedWorkflowExecution_Error() 
 			RunID:       tests.RunID,
 		},
 		[]byte{22, 8, 78},
-		int64(1),
 		nil,
 		&closeTime,
 	).Return(serviceerror.NewInternal("test error"))
@@ -179,7 +176,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteDeletedWorkflowExecution_Error() 
 		we,
 		mockWeCtx,
 		mockMutableState,
-		1,
 		false,
 	)
 	s.Error(err)
@@ -204,7 +200,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecution_OpenWorkflow() 
 			RunID:       tests.RunID,
 		},
 		[]byte{22, 8, 78},
-		int64(1),
 		&now,
 		nil,
 	).Return(nil)
@@ -216,7 +211,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecution_OpenWorkflow() 
 		we,
 		mockWeCtx,
 		mockMutableState,
-		1,
 		true,
 	)
 	s.NoError(err)
@@ -414,7 +408,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecutionRetention_Archiv
 			RunID:       tests.RunID,
 		},
 		nil,
-		int64(1),
 		nil,
 		&closeTime,
 	).Return(nil)
@@ -426,7 +419,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecutionRetention_Archiv
 		we,
 		mockWeCtx,
 		mockMutableState,
-		1,
 	)
 	s.NoError(err)
 }
@@ -476,7 +468,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecutionRetention_Archiv
 		we,
 		mockWeCtx,
 		mockMutableState,
-		1,
 	)
 	s.Error(err)
 }

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -220,13 +220,10 @@ func (r *TaskGeneratorImpl) GenerateDeleteExecutionTask(
 	now time.Time,
 ) (*tasks.DeleteExecutionTask, error) {
 
-	currentVersion := r.mutableState.GetCurrentVersion()
-
 	return &tasks.DeleteExecutionTask{
 		// TaskID is set by shard
 		WorkflowKey:         r.mutableState.GetWorkflowKey(),
 		VisibilityTimestamp: now,
-		Version:             currentVersion,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Don't check delete workflow execution transfer task version.

<!-- Tell your future self why have you made these changes -->
**Why?**
`DeleteExecutionTask` transfer task is create when workflow is explicitly deleted with `DeleteWorkflowExecution` API call.
There is no need to check task version when processing this task because API request to delete executions is considered to be higher priority than
other processes which might resurrect execution.

Also removed version from `DeleteExecutionVisibilityTask` because it is not used by processor.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes, for end to end namespace migration tests.