### PR TITLE
Update Cassandra install guide for MacBook with ARM chip

### DIFF
--- a/develop/docs/macos/cassandra.md
+++ b/develop/docs/macos/cassandra.md
@@ -5,6 +5,11 @@
 brew install cassandra@3.11
 ```
 
+For MacBook with ARM chip, you need to replace the JNA library with a recent version.
+1. Locate the JNA file (`find $(brew --prefix) -name "jna-*.jar"`) and remove it.
+2. Download a recent version of JNA jar file (5.8+) from [Maven](https://search.maven.org/artifact/net.java.dev.jna/jna).
+3. Move the file you downloaded to the folder in step 1.
+
 ### Start
 ```bash
 cassandra -f


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updating Cassandra install guide to work with MacBook with ARM chip.

<!-- Tell your future self why have you made these changes -->
**Why?**
Default Cassandra installation comes with an old version of JNA jar file that doesn't include patches to work with Apple ARM chips (ie. M1).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started Cassandra with `cassandra -f`, and Temporal server with `make start`.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
