### PR TITLE
Fix workflow ID reuse when running on ScyllaDB

### DIFF
--- a/common/persistence/cassandra/errors.go
+++ b/common/persistence/cassandra/errors.go
@@ -81,6 +81,12 @@ func convertErrors(
 			continue
 		}
 
+		rowType, ok := conflictRecord["type"].(*int)
+		if !ok || rowType == nil {
+			// Scylla will return nil rows to match # of queries in a batch query (#2683)
+			continue
+		}
+
 		conflictRecords = append(conflictRecords, conflictRecord)
 		errors = append(errors, extractErrors(
 			conflictRecord,

--- a/common/persistence/cassandra/errors_test.go
+++ b/common/persistence/cassandra/errors_test.go
@@ -164,14 +164,16 @@ func (s *cassandraErrorsSuite) TestExtractShardOwnershipLostError_Failed() {
 	err := extractShardOwnershipLostError(map[string]interface{}{}, rand.Int31(), rangeID)
 	s.NoError(err)
 
+	t := rowTypeExecution
 	err = extractShardOwnershipLostError(map[string]interface{}{
-		"type":     rowTypeExecution,
+		"type":     &t,
 		"range_id": rangeID,
 	}, rand.Int31(), rangeID)
 	s.NoError(err)
 
+	t = rowTypeShard
 	err = extractShardOwnershipLostError(map[string]interface{}{
-		"type":     rowTypeShard,
+		"type":     &t,
 		"range_id": rangeID,
 	}, rand.Int31(), rangeID)
 	s.NoError(err)
@@ -179,8 +181,9 @@ func (s *cassandraErrorsSuite) TestExtractShardOwnershipLostError_Failed() {
 
 func (s *cassandraErrorsSuite) TestExtractShardOwnershipLostError_Success() {
 	rangeID := int64(1234)
+	t := rowTypeShard
 	record := map[string]interface{}{
-		"type":     rowTypeShard,
+		"type":     &t,
 		"range_id": rangeID,
 	}
 
@@ -195,22 +198,25 @@ func (s *cassandraErrorsSuite) TestExtractCurrentWorkflowConflictError_Failed() 
 	err := extractCurrentWorkflowConflictError(map[string]interface{}{}, uuid.New().String())
 	s.NoError(err)
 
+	t := rowTypeShard
 	err = extractCurrentWorkflowConflictError(map[string]interface{}{
-		"type":           rowTypeShard,
+		"type":           &t,
 		"run_id":         gocql.UUID(runID),
 		"current_run_id": gocql.UUID(currentRunID),
 	}, uuid.New().String())
 	s.NoError(err)
 
+	t = rowTypeExecution
 	err = extractCurrentWorkflowConflictError(map[string]interface{}{
-		"type":           rowTypeExecution,
+		"type":           &t,
 		"run_id":         gocql.UUID([16]byte{}),
 		"current_run_id": gocql.UUID(currentRunID),
 	}, uuid.New().String())
 	s.NoError(err)
 
+	t = rowTypeExecution
 	err = extractCurrentWorkflowConflictError(map[string]interface{}{
-		"type":           rowTypeExecution,
+		"type":           &t,
 		"run_id":         gocql.UUID(runID),
 		"current_run_id": gocql.UUID(currentRunID),
 	}, currentRunID.String())
@@ -223,8 +229,9 @@ func (s *cassandraErrorsSuite) TestExtractCurrentWorkflowConflictError_Success()
 	workflowState := &persistencespb.WorkflowExecutionState{}
 	blob, err := serialization.WorkflowExecutionStateToBlob(workflowState)
 	s.NoError(err)
+	t := rowTypeExecution
 	record := map[string]interface{}{
-		"type":                        rowTypeExecution,
+		"type":                        &t,
 		"run_id":                      gocql.UUID(runID),
 		"current_run_id":              gocql.UUID(currentRunID),
 		"execution_state":             blob.Data,
@@ -243,22 +250,25 @@ func (s *cassandraErrorsSuite) TestExtractWorkflowConflictError_Failed() {
 	err := extractWorkflowConflictError(map[string]interface{}{}, runID.String(), dbVersion, rand.Int63())
 	s.NoError(err)
 
+	t := rowTypeShard
 	err = extractWorkflowConflictError(map[string]interface{}{
-		"type":              rowTypeShard,
+		"type":              &t,
 		"run_id":            gocql.UUID(runID),
 		"db_record_version": dbVersion,
 	}, runID.String(), dbVersion+1, rand.Int63())
 	s.NoError(err)
 
+	t = rowTypeExecution
 	err = extractWorkflowConflictError(map[string]interface{}{
-		"type":              rowTypeExecution,
+		"type":              &t,
 		"run_id":            gocql.UUID([16]byte{}),
 		"db_record_version": dbVersion,
 	}, runID.String(), dbVersion+1, rand.Int63())
 	s.NoError(err)
 
+	t = rowTypeExecution
 	err = extractWorkflowConflictError(map[string]interface{}{
-		"type":              rowTypeExecution,
+		"type":              &t,
 		"run_id":            gocql.UUID(runID),
 		"db_record_version": dbVersion,
 	}, runID.String(), dbVersion, rand.Int63())
@@ -268,8 +278,9 @@ func (s *cassandraErrorsSuite) TestExtractWorkflowConflictError_Failed() {
 func (s *cassandraErrorsSuite) TestExtractWorkflowConflictError_Success() {
 	runID := uuid.New()
 	dbVersion := rand.Int63() + 1
+	t := rowTypeExecution
 	record := map[string]interface{}{
-		"type":              rowTypeExecution,
+		"type":              &t,
 		"run_id":            gocql.UUID(runID),
 		"db_record_version": dbVersion,
 	}
@@ -286,22 +297,25 @@ func (s *cassandraErrorsSuite) TestExtractWorkflowConflictError_Failed_NextEvent
 	err := extractWorkflowConflictError(map[string]interface{}{}, runID.String(), 0, nextEventID)
 	s.NoError(err)
 
+	t := rowTypeShard
 	err = extractWorkflowConflictError(map[string]interface{}{
-		"type":          rowTypeShard,
+		"type":          &t,
 		"run_id":        gocql.UUID(runID),
 		"next_event_id": nextEventID + 1,
 	}, runID.String(), 0, nextEventID)
 	s.NoError(err)
 
+	t = rowTypeExecution
 	err = extractWorkflowConflictError(map[string]interface{}{
-		"type":          rowTypeExecution,
+		"type":          &t,
 		"run_id":        gocql.UUID([16]byte{}),
 		"next_event_id": nextEventID + 1,
 	}, runID.String(), 0, nextEventID)
 	s.NoError(err)
 
+	t = rowTypeExecution
 	err = extractWorkflowConflictError(map[string]interface{}{
-		"type":          rowTypeExecution,
+		"type":          &t,
 		"run_id":        gocql.UUID(runID),
 		"next_event_id": nextEventID,
 	}, runID.String(), 0, nextEventID)
@@ -312,8 +326,9 @@ func (s *cassandraErrorsSuite) TestExtractWorkflowConflictError_Failed_NextEvent
 func (s *cassandraErrorsSuite) TestExtractWorkflowConflictError_Success_NextEventID() {
 	runID := uuid.New()
 	nextEventID := int64(1234)
+	t := rowTypeExecution
 	record := map[string]interface{}{
-		"type":          rowTypeExecution,
+		"type":          &t,
 		"run_id":        gocql.UUID(runID),
 		"next_event_id": nextEventID,
 	}

--- a/common/persistence/cassandra/mutable_state_store.go
+++ b/common/persistence/cassandra/mutable_state_store.go
@@ -453,7 +453,7 @@ func (d *MutableStateStore) CreateWorkflowExecution(
 		request.RangeID,
 	)
 
-	conflictRecord := make(map[string]interface{})
+	conflictRecord := newConflictRecord()
 	applied, conflictIter, err := d.Session.MapExecuteBatchCAS(batch, conflictRecord)
 	if err != nil {
 		return nil, gocql.ConvertError("CreateWorkflowExecution", err)
@@ -677,7 +677,7 @@ func (d *MutableStateStore) UpdateWorkflowExecution(
 		request.RangeID,
 	)
 
-	conflictRecord := make(map[string]interface{})
+	conflictRecord := newConflictRecord()
 	applied, conflictIter, err := d.Session.MapExecuteBatchCAS(batch, conflictRecord)
 	if err != nil {
 		return gocql.ConvertError("UpdateWorkflowExecution", err)
@@ -828,7 +828,7 @@ func (d *MutableStateStore) ConflictResolveWorkflowExecution(
 		request.RangeID,
 	)
 
-	conflictRecord := make(map[string]interface{})
+	conflictRecord := newConflictRecord()
 	applied, conflictIter, err := d.Session.MapExecuteBatchCAS(batch, conflictRecord)
 	if err != nil {
 		return gocql.ConvertError("ConflictResolveWorkflowExecution", err)
@@ -998,7 +998,7 @@ func (d *MutableStateStore) SetWorkflowExecution(
 		request.RangeID,
 	)
 
-	conflictRecord := make(map[string]interface{})
+	conflictRecord := newConflictRecord()
 	applied, conflictIter, err := d.Session.MapExecuteBatchCAS(batch, conflictRecord)
 	if err != nil {
 		return gocql.ConvertError("SetWorkflowExecution", err)


### PR DESCRIPTION
**What changed?**
<!-- Describe what has changed in this PR -->
Fix an issue where the history service would get stuck in a loop when reusing workflow ID's on top of ScyllaDB.

**Why?**
<!-- Tell your future self why have you made these changes -->
Closes https://github.com/temporalio/temporal/issues/2683.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
First reproduced the issue by running Temporal on top of Scylla locally; then verified that the change fixed the issue. Ran Cassandra persistence tests to ensure that this change didn't break anything else.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
As noted in the linked issue:
> Not sure if there are conditions when Cassandra might also return nullable rows.

If there are cases where we should be handling `nil` rows as real errors, this change would break that.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.