### PR TITLE
Release shard lock earlier during delete workflow execution

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -973,7 +973,6 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 						// TaskID is set by addTasksLocked
 						WorkflowKey:         key,
 						VisibilityTimestamp: s.timeSource.Now(),
-
 						StartTime:           startTime,
 						CloseTime:           closeTime,
 					},

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -956,7 +956,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	}()
 
 	s.wLock()
-	defer s.wUnlock()
+	// Explicitly release the lock (not with defer) after 2 of 4 steps.
 
 	if err := s.errorByStateLocked(); err != nil {
 		return err
@@ -1001,6 +1001,8 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	if err != nil {
 		return err
 	}
+
+	s.wUnlock()
 
 	// Step 3. Delete workflow mutable state.
 	delRequest := &persistence.DeleteWorkflowExecutionRequest{

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -955,54 +955,58 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 		}
 	}()
 
-	s.wLock()
-	// Explicitly release the lock (not with defer) after 2 of 4 steps.
+	// Wrap step 1 and 2 with function to release the lock with defer after step 2.
+	err = func() error {
+		s.wLock()
+		defer s.wUnlock()
 
-	if err := s.errorByStateLocked(); err != nil {
-		return err
-	}
-
-	// Step 1. Delete visibility.
-	if deleteVisibilityRecord {
-		// TODO: move to existing task generator logic
-		newTasks = map[tasks.Category][]tasks.Task{
-			tasks.CategoryVisibility: {
-				&tasks.DeleteExecutionVisibilityTask{
-					// TaskID is set by addTasksLocked
-					WorkflowKey:         key,
-					VisibilityTimestamp: s.timeSource.Now(),
-					StartTime:           startTime,
-					CloseTime:           closeTime,
-				},
-			},
+		if err := s.errorByStateLocked(); err != nil {
+			return err
 		}
-		addTasksRequest := &persistence.AddHistoryTasksRequest{
+
+		// Step 1. Delete visibility.
+		if deleteVisibilityRecord {
+			// TODO: move to existing task generator logic
+			newTasks = map[tasks.Category][]tasks.Task{
+				tasks.CategoryVisibility: {
+					&tasks.DeleteExecutionVisibilityTask{
+						// TaskID is set by addTasksLocked
+						WorkflowKey:         key,
+						VisibilityTimestamp: s.timeSource.Now(),
+
+						StartTime:           startTime,
+						CloseTime:           closeTime,
+					},
+				},
+			}
+			addTasksRequest := &persistence.AddHistoryTasksRequest{
+				ShardID:     s.shardID,
+				NamespaceID: key.NamespaceID,
+				WorkflowID:  key.WorkflowID,
+				RunID:       key.RunID,
+
+				Tasks: newTasks,
+			}
+			err = s.addTasksLocked(ctx, addTasksRequest, namespaceEntry)
+			if err != nil {
+				return err
+			}
+		}
+
+		// Step 2. Delete current workflow execution pointer.
+		delCurRequest := &persistence.DeleteCurrentWorkflowExecutionRequest{
 			ShardID:     s.shardID,
 			NamespaceID: key.NamespaceID,
 			WorkflowID:  key.WorkflowID,
 			RunID:       key.RunID,
-
-			Tasks: newTasks,
 		}
-		err = s.addTasksLocked(ctx, addTasksRequest, namespaceEntry)
-		if err != nil {
-			return err
-		}
-	}
+		err = s.GetExecutionManager().DeleteCurrentWorkflowExecution(ctx, delCurRequest)
+		return err
+	}()
 
-	// Step 2. Delete current workflow execution pointer.
-	delCurRequest := &persistence.DeleteCurrentWorkflowExecutionRequest{
-		ShardID:     s.shardID,
-		NamespaceID: key.NamespaceID,
-		WorkflowID:  key.WorkflowID,
-		RunID:       key.RunID,
-	}
-	err = s.GetExecutionManager().DeleteCurrentWorkflowExecution(ctx, delCurRequest)
 	if err != nil {
 		return err
 	}
-
-	s.wUnlock()
 
 	// Step 3. Delete workflow mutable state.
 	delRequest := &persistence.DeleteWorkflowExecutionRequest{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Release shard lock earlier during delete workflow execution.

<!-- Tell your future self why have you made these changes -->
**Why?**
Delete workflow execution is 4 step process. Shard lock needs to be holded only during first 2 steps, not all 4.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Exisitng tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.