### PR TITLE
Cancel activity when eager execution and request cancellation are in the same WFT

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -109,8 +109,8 @@ const (
 	EnableParentClosePolicyWorker = "system.enableParentClosePolicyWorker"
 	// EnableStickyQuery indicates if sticky query should be enabled per namespace
 	EnableStickyQuery = "system.enableStickyQuery"
-	// EnableActivityLocalDispatch indicates if acitivty local dispatch is enabled per namespace
-	EnableActivityLocalDispatch = "system.enableActivityLocalDispatch"
+	// EnableActivityEagerExecution indicates if acitivty eager execution is enabled per namespace
+	EnableActivityEagerExecution = "system.enableActivityEagerExecution"
 	// NamespaceCacheRefreshInterval is the key for namespace cache refresh interval dynamic config
 	NamespaceCacheRefreshInterval = "system.namespaceCacheRefreshInterval"
 

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -270,7 +270,7 @@ type Config struct {
 	ESProcessorAckTimeout             dynamicconfig.DurationPropertyFn
 
 	EnableCrossNamespaceCommands  dynamicconfig.BoolPropertyFn
-	EnableActivityLocalDispatch   dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableActivityEagerExecution  dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	NamespaceCacheRefreshInterval dynamicconfig.DurationPropertyFn
 }
 
@@ -477,7 +477,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		ESProcessorAckTimeout:    dc.GetDurationProperty(dynamicconfig.WorkerESProcessorAckTimeout, 1*time.Minute),
 
 		EnableCrossNamespaceCommands:  dc.GetBoolProperty(dynamicconfig.EnableCrossNamespaceCommands, true),
-		EnableActivityLocalDispatch:   dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.EnableActivityLocalDispatch, false),
+		EnableActivityEagerExecution:  dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.EnableActivityEagerExecution, false),
 		NamespaceCacheRefreshInterval: dc.GetDurationProperty(dynamicconfig.NamespaceCacheRefreshInterval, 10*time.Second),
 	}
 

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -160,7 +160,7 @@ func NewDynamicConfig() *configs.Config {
 	config := configs.NewConfig(dc, 1, false, "")
 	// reduce the duration of long poll to increase test speed
 	config.LongPollExpirationInterval = dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.HistoryLongPollExpirationInterval, 10*time.Second)
-	config.EnableActivityLocalDispatch = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
+	config.EnableActivityEagerExecution = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)
 	return config
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
-  Cancel activity instead of returning an activity task to worker when schedule activity with eager execution command and request cancellation command are in the same workflow task.
- Rename the feature flag from local dispatch to eager execution

<!-- Tell your future self why have you made these changes -->
**Why?**
- Match the behavior when eager execution is disabled.
- Basically change the behavior of eager execution + cancel from performing operation schedule + start + cancel to schedule + cancel + start (no-op), so that activity will be cancelled instead of started and returned to worker.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A, sdk is still development the feature?

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- yes.