### PR TITLE
Perf optimize interleaved weighted round robin scheduler

### DIFF
--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -107,7 +107,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Success
 	s.scheduler.Submit(mockTask)
 
 	testWaitGroup.Wait()
-	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
+	s.Equal(int64(0), atomic.LoadInt64(&s.scheduler.numInflightTask))
 }
 
 func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Fail() {
@@ -133,16 +133,27 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Fail() 
 	s.scheduler.Submit(mockTask)
 
 	testWaitGroup.Wait()
-	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
+	s.Equal(int64(0), atomic.LoadInt64(&s.scheduler.numInflightTask))
 }
 
 func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
+	// need to manually set the number of pending task to 1
+	// so schedule by task priority logic will execute
+	numTasks := atomic.AddInt64(&s.scheduler.numInflightTask, 1)
+	s.Equal(int64(1), numTasks)
+	numPendingTasks := 0
+	defer func() {
+		numTasks := atomic.AddInt64(&s.scheduler.numInflightTask, -1)
+		s.Equal(int64(numPendingTasks), numTasks)
+	}()
+
 	var channelWeights []int
 
 	channelWeights = nil
 	mockTask0 := NewMockPriorityTask(s.controller)
 	mockTask0.EXPECT().GetPriority().Return(Priority(0)).AnyTimes()
 	s.scheduler.Submit(mockTask0)
+	numPendingTasks++
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
 	}
@@ -152,6 +163,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
 	mockTask1 := NewMockPriorityTask(s.controller)
 	mockTask1.EXPECT().GetPriority().Return(Priority(1)).AnyTimes()
 	s.scheduler.Submit(mockTask1)
+	numPendingTasks++
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
 	}
@@ -161,6 +173,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
 	mockTask2 := NewMockPriorityTask(s.controller)
 	mockTask2.EXPECT().GetPriority().Return(Priority(2)).AnyTimes()
 	s.scheduler.Submit(mockTask2)
+	numPendingTasks++
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
 	}
@@ -170,6 +183,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
 	mockTask3 := NewMockPriorityTask(s.controller)
 	mockTask3.EXPECT().GetPriority().Return(Priority(3)).AnyTimes()
 	s.scheduler.Submit(mockTask3)
+	numPendingTasks++
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
 	}
@@ -180,6 +194,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
 	s.scheduler.Submit(mockTask1)
 	s.scheduler.Submit(mockTask2)
 	s.scheduler.Submit(mockTask3)
+	numPendingTasks += 4
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
 	}
@@ -229,5 +244,5 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestParallelSubmitSchedule
 	endWaitGroup.Wait()
 
 	testWaitGroup.Wait()
-	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
+	s.Equal(int64(0), atomic.LoadInt64(&s.scheduler.numInflightTask))
 }

--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -27,7 +27,6 @@ package tasks
 import (
 	"math/rand"
 	"sync"
-	"sync/atomic"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -107,7 +106,6 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Success
 	s.scheduler.Submit(mockTask)
 
 	testWaitGroup.Wait()
-	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
 }
 
 func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Fail() {
@@ -133,7 +131,6 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Fail() 
 	s.scheduler.Submit(mockTask)
 
 	testWaitGroup.Wait()
-	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
 }
 
 func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
@@ -229,5 +226,4 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestParallelSubmitSchedule
 	endWaitGroup.Wait()
 
 	testWaitGroup.Wait()
-	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
 }

--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -27,6 +27,7 @@ package tasks
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -106,6 +107,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Success
 	s.scheduler.Submit(mockTask)
 
 	testWaitGroup.Wait()
+	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
 }
 
 func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Fail() {
@@ -131,6 +133,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestSubmitSchedule_Fail() 
 	s.scheduler.Submit(mockTask)
 
 	testWaitGroup.Wait()
+	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
 }
 
 func (s *interleavedWeightedRoundRobinSchedulerSuite) TestChannels() {
@@ -226,4 +229,5 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestParallelSubmitSchedule
 	endWaitGroup.Wait()
 
 	testWaitGroup.Wait()
+	s.Equal(atomic.LoadInt64(&s.scheduler.numInflightTask), int64(0))
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Perf optimize interleaved weighted round robin scheduler
  * Bypass scheduler if there is no other task
  * Remove unnecessary shutdown check

<!-- Tell your future self why have you made these changes -->
**Why?**
```bash
before
BenchmarkInterleavedWeightedRoundRobinScheduler_Sequential-16    	 6610477	       176.0 ns/op	       8 B/op	       1 allocs/op
BenchmarkInterleavedWeightedRoundRobinScheduler_Parallel-16    	 3230086	       346.7 ns/op	       8 B/op	       1 allocs/op

after
BenchmarkInterleavedWeightedRoundRobinScheduler_Sequential-16    	26722878	        46.48 ns/op	       8 B/op	       1 allocs/op
BenchmarkInterleavedWeightedRoundRobinScheduler_Parallel-16    	 4259040	       267.4 ns/op	       8 B/op	       1 allocs/op
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated tests & benchmark

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A