### PR TITLE
Run task rescheduler in background

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -346,10 +346,6 @@ const (
 	TimerProcessorMaxPollInterval = "history.timerProcessorMaxPollInterval"
 	// TimerProcessorMaxPollIntervalJitterCoefficient is the max poll interval jitter coefficient
 	TimerProcessorMaxPollIntervalJitterCoefficient = "history.timerProcessorMaxPollIntervalJitterCoefficient"
-	// TimerProcessorRescheduleInterval is the redispatch interval for timer processor
-	TimerProcessorRescheduleInterval = "history.timerProcessorRescheduleInterval"
-	// TimerProcessorRescheduleIntervalJitterCoefficient is the redispatch interval jitter coefficient
-	TimerProcessorRescheduleIntervalJitterCoefficient = "history.timerProcessorRescheduleIntervalJitterCoefficient"
 	// TimerProcessorMaxReschedulerSize is the threshold of the number of tasks in the redispatch queue for timer processor
 	TimerProcessorMaxReschedulerSize = "history.timerProcessorMaxReschedulerSize"
 	// TimerProcessorPollBackoffInterval is the poll backoff interval if task redispatcher's size exceeds limit for timer processor
@@ -399,10 +395,6 @@ const (
 	TransferProcessorUpdateAckIntervalJitterCoefficient = "history.transferProcessorUpdateAckIntervalJitterCoefficient"
 	// TransferProcessorCompleteTransferInterval is complete timer interval for transferQueueProcessor
 	TransferProcessorCompleteTransferInterval = "history.transferProcessorCompleteTransferInterval"
-	// TransferProcessorRescheduleInterval is the redispatch interval for transferQueueProcessor
-	TransferProcessorRescheduleInterval = "history.transferProcessorRescheduleInterval"
-	// TransferProcessorRescheduleIntervalJitterCoefficient is the redispatch interval jitter coefficient
-	TransferProcessorRescheduleIntervalJitterCoefficient = "history.transferProcessorRescheduleIntervalJitterCoefficient"
 	// TransferProcessorMaxReschedulerSize is the threshold of the number of tasks in the redispatch queue for transferQueueProcessor
 	TransferProcessorMaxReschedulerSize = "history.transferProcessorMaxReschedulerSize"
 	// TransferProcessorPollBackoffInterval is the poll backoff interval if task redispatcher's size exceeds limit for transferQueueProcessor
@@ -444,10 +436,6 @@ const (
 	VisibilityProcessorUpdateAckIntervalJitterCoefficient = "history.visibilityProcessorUpdateAckIntervalJitterCoefficient"
 	// VisibilityProcessorCompleteTaskInterval is complete timer interval for visibilityQueueProcessor
 	VisibilityProcessorCompleteTaskInterval = "history.visibilityProcessorCompleteTaskInterval"
-	// VisibilityProcessorRescheduleInterval is the redispatch interval for visibilityQueueProcessor
-	VisibilityProcessorRescheduleInterval = "history.visibilityProcessorRescheduleInterval"
-	// VisibilityProcessorRescheduleIntervalJitterCoefficient is the redispatch interval jitter coefficient
-	VisibilityProcessorRescheduleIntervalJitterCoefficient = "history.visibilityProcessorRescheduleIntervalJitterCoefficient"
 	// VisibilityProcessorMaxReschedulerSize is the threshold of the number of tasks in the redispatch queue for visibilityQueueProcessor
 	VisibilityProcessorMaxReschedulerSize = "history.visibilityProcessorMaxReschedulerSize"
 	// VisibilityProcessorPollBackoffInterval is the poll backoff interval if task redispatcher's size exceeds limit for visibilityQueueProcessor
@@ -471,10 +459,6 @@ const (
 	ReplicatorProcessorUpdateAckInterval = "history.replicatorProcessorUpdateAckInterval"
 	// ReplicatorProcessorUpdateAckIntervalJitterCoefficient is the update interval jitter coefficient
 	ReplicatorProcessorUpdateAckIntervalJitterCoefficient = "history.replicatorProcessorUpdateAckIntervalJitterCoefficient"
-	// ReplicatorProcessorRescheduleInterval is the redispatch interval for ReplicatorProcessor
-	ReplicatorProcessorRescheduleInterval = "history.replicatorProcessorRescheduleInterval"
-	// ReplicatorProcessorRescheduleIntervalJitterCoefficient is the redispatch interval jitter coefficient
-	ReplicatorProcessorRescheduleIntervalJitterCoefficient = "history.replicatorProcessorRescheduleIntervalJitterCoefficient"
 	// ReplicatorProcessorMaxReschedulerSize is the threshold of the number of tasks in the redispatch queue for ReplicatorProcessor
 	ReplicatorProcessorMaxReschedulerSize = "history.replicatorProcessorMaxReschedulerSize"
 	// ReplicatorProcessorEnablePriorityTaskProcessor indicates whether priority task processor should be used for ReplicatorProcessor

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -81,72 +81,66 @@ type Config struct {
 	StandbyTaskMissingEventsDiscardDelay dynamicconfig.DurationPropertyFn
 
 	// TimerQueueProcessor settings
-	TimerTaskHighPriorityRPS                          dynamicconfig.IntPropertyFnWithNamespaceFilter
-	TimerTaskBatchSize                                dynamicconfig.IntPropertyFn
-	TimerTaskWorkerCount                              dynamicconfig.IntPropertyFn
-	TimerTaskMaxRetryCount                            dynamicconfig.IntPropertyFn
-	TimerProcessorEnableSingleCursor                  dynamicconfig.BoolPropertyFn
-	TimerProcessorEnablePriorityTaskScheduler         dynamicconfig.BoolPropertyFn
-	TimerProcessorSchedulerWorkerCount                dynamicconfig.IntPropertyFn
-	TimerProcessorSchedulerQueueSize                  dynamicconfig.IntPropertyFn
-	TimerProcessorSchedulerRoundRobinWeights          dynamicconfig.MapPropertyFn
-	TimerProcessorCompleteTimerFailureRetryCount      dynamicconfig.IntPropertyFn
-	TimerProcessorUpdateAckInterval                   dynamicconfig.DurationPropertyFn
-	TimerProcessorUpdateAckIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
-	TimerProcessorCompleteTimerInterval               dynamicconfig.DurationPropertyFn
-	TimerProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
-	TimerProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
-	TimerProcessorMaxPollHostRPS                      dynamicconfig.IntPropertyFn
-	TimerProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
-	TimerProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
-	TimerProcessorRescheduleInterval                  dynamicconfig.DurationPropertyFn
-	TimerProcessorRescheduleIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
-	TimerProcessorMaxReschedulerSize                  dynamicconfig.IntPropertyFn
-	TimerProcessorPollBackoffInterval                 dynamicconfig.DurationPropertyFn
-	TimerProcessorMaxTimeShift                        dynamicconfig.DurationPropertyFn
-	TimerProcessorHistoryArchivalSizeLimit            dynamicconfig.IntPropertyFn
-	TimerProcessorArchivalTimeLimit                   dynamicconfig.DurationPropertyFn
+	TimerTaskHighPriorityRPS                         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	TimerTaskBatchSize                               dynamicconfig.IntPropertyFn
+	TimerTaskWorkerCount                             dynamicconfig.IntPropertyFn
+	TimerTaskMaxRetryCount                           dynamicconfig.IntPropertyFn
+	TimerProcessorEnableSingleCursor                 dynamicconfig.BoolPropertyFn
+	TimerProcessorEnablePriorityTaskScheduler        dynamicconfig.BoolPropertyFn
+	TimerProcessorSchedulerWorkerCount               dynamicconfig.IntPropertyFn
+	TimerProcessorSchedulerQueueSize                 dynamicconfig.IntPropertyFn
+	TimerProcessorSchedulerRoundRobinWeights         dynamicconfig.MapPropertyFn
+	TimerProcessorCompleteTimerFailureRetryCount     dynamicconfig.IntPropertyFn
+	TimerProcessorUpdateAckInterval                  dynamicconfig.DurationPropertyFn
+	TimerProcessorUpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	TimerProcessorCompleteTimerInterval              dynamicconfig.DurationPropertyFn
+	TimerProcessorFailoverMaxPollRPS                 dynamicconfig.IntPropertyFn
+	TimerProcessorMaxPollRPS                         dynamicconfig.IntPropertyFn
+	TimerProcessorMaxPollHostRPS                     dynamicconfig.IntPropertyFn
+	TimerProcessorMaxPollInterval                    dynamicconfig.DurationPropertyFn
+	TimerProcessorMaxPollIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
+	TimerProcessorMaxReschedulerSize                 dynamicconfig.IntPropertyFn
+	TimerProcessorPollBackoffInterval                dynamicconfig.DurationPropertyFn
+	TimerProcessorMaxTimeShift                       dynamicconfig.DurationPropertyFn
+	TimerProcessorHistoryArchivalSizeLimit           dynamicconfig.IntPropertyFn
+	TimerProcessorArchivalTimeLimit                  dynamicconfig.DurationPropertyFn
 
 	// TransferQueueProcessor settings
-	TransferTaskHighPriorityRPS                          dynamicconfig.IntPropertyFnWithNamespaceFilter
-	TransferTaskBatchSize                                dynamicconfig.IntPropertyFn
-	TransferTaskWorkerCount                              dynamicconfig.IntPropertyFn
-	TransferTaskMaxRetryCount                            dynamicconfig.IntPropertyFn
-	TransferProcessorEnableSingleCursor                  dynamicconfig.BoolPropertyFn
-	TransferProcessorEnablePriorityTaskScheduler         dynamicconfig.BoolPropertyFn
-	TransferProcessorSchedulerWorkerCount                dynamicconfig.IntPropertyFn
-	TransferProcessorSchedulerQueueSize                  dynamicconfig.IntPropertyFn
-	TransferProcessorSchedulerRoundRobinWeights          dynamicconfig.MapPropertyFn
-	TransferProcessorCompleteTransferFailureRetryCount   dynamicconfig.IntPropertyFn
-	TransferProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
-	TransferProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
-	TransferProcessorMaxPollHostRPS                      dynamicconfig.IntPropertyFn
-	TransferProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
-	TransferProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
-	TransferProcessorUpdateAckInterval                   dynamicconfig.DurationPropertyFn
-	TransferProcessorUpdateAckIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
-	TransferProcessorCompleteTransferInterval            dynamicconfig.DurationPropertyFn
-	TransferProcessorRescheduleInterval                  dynamicconfig.DurationPropertyFn
-	TransferProcessorRescheduleIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
-	TransferProcessorMaxReschedulerSize                  dynamicconfig.IntPropertyFn
-	TransferProcessorPollBackoffInterval                 dynamicconfig.DurationPropertyFn
-	TransferProcessorVisibilityArchivalTimeLimit         dynamicconfig.DurationPropertyFn
+	TransferTaskHighPriorityRPS                         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	TransferTaskBatchSize                               dynamicconfig.IntPropertyFn
+	TransferTaskWorkerCount                             dynamicconfig.IntPropertyFn
+	TransferTaskMaxRetryCount                           dynamicconfig.IntPropertyFn
+	TransferProcessorEnableSingleCursor                 dynamicconfig.BoolPropertyFn
+	TransferProcessorEnablePriorityTaskScheduler        dynamicconfig.BoolPropertyFn
+	TransferProcessorSchedulerWorkerCount               dynamicconfig.IntPropertyFn
+	TransferProcessorSchedulerQueueSize                 dynamicconfig.IntPropertyFn
+	TransferProcessorSchedulerRoundRobinWeights         dynamicconfig.MapPropertyFn
+	TransferProcessorCompleteTransferFailureRetryCount  dynamicconfig.IntPropertyFn
+	TransferProcessorFailoverMaxPollRPS                 dynamicconfig.IntPropertyFn
+	TransferProcessorMaxPollRPS                         dynamicconfig.IntPropertyFn
+	TransferProcessorMaxPollHostRPS                     dynamicconfig.IntPropertyFn
+	TransferProcessorMaxPollInterval                    dynamicconfig.DurationPropertyFn
+	TransferProcessorMaxPollIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
+	TransferProcessorUpdateAckInterval                  dynamicconfig.DurationPropertyFn
+	TransferProcessorUpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	TransferProcessorCompleteTransferInterval           dynamicconfig.DurationPropertyFn
+	TransferProcessorMaxReschedulerSize                 dynamicconfig.IntPropertyFn
+	TransferProcessorPollBackoffInterval                dynamicconfig.DurationPropertyFn
+	TransferProcessorVisibilityArchivalTimeLimit        dynamicconfig.DurationPropertyFn
 
 	// ReplicatorQueueProcessor settings
 	// TODO: clean up unused replicator settings
-	ReplicatorTaskBatchSize                                dynamicconfig.IntPropertyFn
-	ReplicatorTaskWorkerCount                              dynamicconfig.IntPropertyFn
-	ReplicatorTaskMaxRetryCount                            dynamicconfig.IntPropertyFn
-	ReplicatorProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
-	ReplicatorProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
-	ReplicatorProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
-	ReplicatorProcessorUpdateAckInterval                   dynamicconfig.DurationPropertyFn
-	ReplicatorProcessorUpdateAckIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
-	ReplicatorProcessorRescheduleInterval                  dynamicconfig.DurationPropertyFn
-	ReplicatorProcessorRescheduleIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
-	ReplicatorProcessorMaxReschedulerSize                  dynamicconfig.IntPropertyFn
-	ReplicatorProcessorEnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
-	ReplicatorProcessorFetchTasksBatchSize                 dynamicconfig.IntPropertyFn
+	ReplicatorTaskBatchSize                               dynamicconfig.IntPropertyFn
+	ReplicatorTaskWorkerCount                             dynamicconfig.IntPropertyFn
+	ReplicatorTaskMaxRetryCount                           dynamicconfig.IntPropertyFn
+	ReplicatorProcessorMaxPollRPS                         dynamicconfig.IntPropertyFn
+	ReplicatorProcessorMaxPollInterval                    dynamicconfig.DurationPropertyFn
+	ReplicatorProcessorMaxPollIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
+	ReplicatorProcessorUpdateAckInterval                  dynamicconfig.DurationPropertyFn
+	ReplicatorProcessorUpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	ReplicatorProcessorMaxReschedulerSize                 dynamicconfig.IntPropertyFn
+	ReplicatorProcessorEnablePriorityTaskProcessor        dynamicconfig.BoolPropertyFn
+	ReplicatorProcessorFetchTasksBatchSize                dynamicconfig.IntPropertyFn
 
 	// System Limits
 	MaximumBufferedEventsBatch dynamicconfig.IntPropertyFn
@@ -236,28 +230,26 @@ type Config struct {
 
 	// ===== Visibility related =====
 	// VisibilityQueueProcessor settings
-	VisibilityTaskHighPriorityRPS                          dynamicconfig.IntPropertyFnWithNamespaceFilter
-	VisibilityTaskBatchSize                                dynamicconfig.IntPropertyFn
-	VisibilityTaskWorkerCount                              dynamicconfig.IntPropertyFn
-	VisibilityTaskMaxRetryCount                            dynamicconfig.IntPropertyFn
-	VisibilityProcessorEnablePriorityTaskScheduler         dynamicconfig.BoolPropertyFn
-	VisibilityProcessorSchedulerWorkerCount                dynamicconfig.IntPropertyFn
-	VisibilityProcessorSchedulerQueueSize                  dynamicconfig.IntPropertyFn
-	VisibilityProcessorSchedulerRoundRobinWeights          dynamicconfig.MapPropertyFn
-	VisibilityProcessorCompleteTaskFailureRetryCount       dynamicconfig.IntPropertyFn
-	VisibilityProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
-	VisibilityProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
-	VisibilityProcessorMaxPollHostRPS                      dynamicconfig.IntPropertyFn
-	VisibilityProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
-	VisibilityProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
-	VisibilityProcessorUpdateAckInterval                   dynamicconfig.DurationPropertyFn
-	VisibilityProcessorUpdateAckIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
-	VisibilityProcessorCompleteTaskInterval                dynamicconfig.DurationPropertyFn
-	VisibilityProcessorRescheduleInterval                  dynamicconfig.DurationPropertyFn
-	VisibilityProcessorRescheduleIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
-	VisibilityProcessorMaxReschedulerSize                  dynamicconfig.IntPropertyFn
-	VisibilityProcessorPollBackoffInterval                 dynamicconfig.DurationPropertyFn
-	VisibilityProcessorVisibilityArchivalTimeLimit         dynamicconfig.DurationPropertyFn
+	VisibilityTaskHighPriorityRPS                         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	VisibilityTaskBatchSize                               dynamicconfig.IntPropertyFn
+	VisibilityTaskWorkerCount                             dynamicconfig.IntPropertyFn
+	VisibilityTaskMaxRetryCount                           dynamicconfig.IntPropertyFn
+	VisibilityProcessorEnablePriorityTaskScheduler        dynamicconfig.BoolPropertyFn
+	VisibilityProcessorSchedulerWorkerCount               dynamicconfig.IntPropertyFn
+	VisibilityProcessorSchedulerQueueSize                 dynamicconfig.IntPropertyFn
+	VisibilityProcessorSchedulerRoundRobinWeights         dynamicconfig.MapPropertyFn
+	VisibilityProcessorCompleteTaskFailureRetryCount      dynamicconfig.IntPropertyFn
+	VisibilityProcessorFailoverMaxPollRPS                 dynamicconfig.IntPropertyFn
+	VisibilityProcessorMaxPollRPS                         dynamicconfig.IntPropertyFn
+	VisibilityProcessorMaxPollHostRPS                     dynamicconfig.IntPropertyFn
+	VisibilityProcessorMaxPollInterval                    dynamicconfig.DurationPropertyFn
+	VisibilityProcessorMaxPollIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
+	VisibilityProcessorUpdateAckInterval                  dynamicconfig.DurationPropertyFn
+	VisibilityProcessorUpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	VisibilityProcessorCompleteTaskInterval               dynamicconfig.DurationPropertyFn
+	VisibilityProcessorMaxReschedulerSize                 dynamicconfig.IntPropertyFn
+	VisibilityProcessorPollBackoffInterval                dynamicconfig.DurationPropertyFn
+	VisibilityProcessorVisibilityArchivalTimeLimit        dynamicconfig.DurationPropertyFn
 
 	SearchAttributesNumberOfKeysLimit dynamicconfig.IntPropertyFnWithNamespaceFilter
 	SearchAttributesSizeOfValueLimit  dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -313,71 +305,65 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		StandbyTaskMissingEventsResendDelay:  dc.GetDurationProperty(dynamicconfig.StandbyTaskMissingEventsResendDelay, 10*time.Minute),
 		StandbyTaskMissingEventsDiscardDelay: dc.GetDurationProperty(dynamicconfig.StandbyTaskMissingEventsDiscardDelay, 15*time.Minute),
 
-		TimerTaskHighPriorityRPS:                          dc.GetIntPropertyFilteredByNamespace(dynamicconfig.TimerTaskHighPriorityRPS, 500),
-		TimerTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.TimerTaskBatchSize, 100),
-		TimerTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.TimerTaskWorkerCount, 10),
-		TimerTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.TimerTaskMaxRetryCount, 20),
-		TimerProcessorEnableSingleCursor:                  dc.GetBoolProperty(dynamicconfig.TimerProcessorEnableSingleCursor, false),
-		TimerProcessorEnablePriorityTaskScheduler:         dc.GetBoolProperty(dynamicconfig.TimerProcessorEnablePriorityTaskScheduler, false),
-		TimerProcessorSchedulerWorkerCount:                dc.GetIntProperty(dynamicconfig.TimerProcessorSchedulerWorkerCount, 200),
-		TimerProcessorSchedulerQueueSize:                  dc.GetIntProperty(dynamicconfig.TimerProcessorSchedulerQueueSize, 10),
-		TimerProcessorSchedulerRoundRobinWeights:          dc.GetMapProperty(dynamicconfig.TimerProcessorSchedulerRoundRobinWeights, ConvertWeightsToDynamicConfigValue(DefaultTaskPriorityWeight)),
-		TimerProcessorCompleteTimerFailureRetryCount:      dc.GetIntProperty(dynamicconfig.TimerProcessorCompleteTimerFailureRetryCount, 10),
-		TimerProcessorUpdateAckInterval:                   dc.GetDurationProperty(dynamicconfig.TimerProcessorUpdateAckInterval, 30*time.Second),
-		TimerProcessorUpdateAckIntervalJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.TimerProcessorUpdateAckIntervalJitterCoefficient, 0.15),
-		TimerProcessorCompleteTimerInterval:               dc.GetDurationProperty(dynamicconfig.TimerProcessorCompleteTimerInterval, 60*time.Second),
-		TimerProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.TimerProcessorFailoverMaxPollRPS, 1),
-		TimerProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.TimerProcessorMaxPollRPS, 20),
-		TimerProcessorMaxPollHostRPS:                      dc.GetIntProperty(dynamicconfig.TimerProcessorMaxPollHostRPS, 0),
-		TimerProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxPollInterval, 5*time.Minute),
-		TimerProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.TimerProcessorMaxPollIntervalJitterCoefficient, 0.15),
-		TimerProcessorRescheduleInterval:                  dc.GetDurationProperty(dynamicconfig.TimerProcessorRescheduleInterval, 3*time.Second),
-		TimerProcessorRescheduleIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TimerProcessorRescheduleIntervalJitterCoefficient, 0.15),
-		TimerProcessorMaxReschedulerSize:                  dc.GetIntProperty(dynamicconfig.TimerProcessorMaxReschedulerSize, 10000),
-		TimerProcessorPollBackoffInterval:                 dc.GetDurationProperty(dynamicconfig.TimerProcessorPollBackoffInterval, 5*time.Second),
-		TimerProcessorMaxTimeShift:                        dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxTimeShift, 1*time.Second),
-		TimerProcessorHistoryArchivalSizeLimit:            dc.GetIntProperty(dynamicconfig.TimerProcessorHistoryArchivalSizeLimit, 500*1024),
-		TimerProcessorArchivalTimeLimit:                   dc.GetDurationProperty(dynamicconfig.TimerProcessorArchivalTimeLimit, 1*time.Second),
+		TimerTaskHighPriorityRPS:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.TimerTaskHighPriorityRPS, 500),
+		TimerTaskBatchSize:                               dc.GetIntProperty(dynamicconfig.TimerTaskBatchSize, 100),
+		TimerTaskWorkerCount:                             dc.GetIntProperty(dynamicconfig.TimerTaskWorkerCount, 10),
+		TimerTaskMaxRetryCount:                           dc.GetIntProperty(dynamicconfig.TimerTaskMaxRetryCount, 20),
+		TimerProcessorEnableSingleCursor:                 dc.GetBoolProperty(dynamicconfig.TimerProcessorEnableSingleCursor, false),
+		TimerProcessorEnablePriorityTaskScheduler:        dc.GetBoolProperty(dynamicconfig.TimerProcessorEnablePriorityTaskScheduler, false),
+		TimerProcessorSchedulerWorkerCount:               dc.GetIntProperty(dynamicconfig.TimerProcessorSchedulerWorkerCount, 200),
+		TimerProcessorSchedulerQueueSize:                 dc.GetIntProperty(dynamicconfig.TimerProcessorSchedulerQueueSize, 10),
+		TimerProcessorSchedulerRoundRobinWeights:         dc.GetMapProperty(dynamicconfig.TimerProcessorSchedulerRoundRobinWeights, ConvertWeightsToDynamicConfigValue(DefaultTaskPriorityWeight)),
+		TimerProcessorCompleteTimerFailureRetryCount:     dc.GetIntProperty(dynamicconfig.TimerProcessorCompleteTimerFailureRetryCount, 10),
+		TimerProcessorUpdateAckInterval:                  dc.GetDurationProperty(dynamicconfig.TimerProcessorUpdateAckInterval, 30*time.Second),
+		TimerProcessorUpdateAckIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TimerProcessorUpdateAckIntervalJitterCoefficient, 0.15),
+		TimerProcessorCompleteTimerInterval:              dc.GetDurationProperty(dynamicconfig.TimerProcessorCompleteTimerInterval, 60*time.Second),
+		TimerProcessorFailoverMaxPollRPS:                 dc.GetIntProperty(dynamicconfig.TimerProcessorFailoverMaxPollRPS, 1),
+		TimerProcessorMaxPollRPS:                         dc.GetIntProperty(dynamicconfig.TimerProcessorMaxPollRPS, 20),
+		TimerProcessorMaxPollHostRPS:                     dc.GetIntProperty(dynamicconfig.TimerProcessorMaxPollHostRPS, 0),
+		TimerProcessorMaxPollInterval:                    dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxPollInterval, 5*time.Minute),
+		TimerProcessorMaxPollIntervalJitterCoefficient:   dc.GetFloat64Property(dynamicconfig.TimerProcessorMaxPollIntervalJitterCoefficient, 0.15),
+		TimerProcessorMaxReschedulerSize:                 dc.GetIntProperty(dynamicconfig.TimerProcessorMaxReschedulerSize, 10000),
+		TimerProcessorPollBackoffInterval:                dc.GetDurationProperty(dynamicconfig.TimerProcessorPollBackoffInterval, 5*time.Second),
+		TimerProcessorMaxTimeShift:                       dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxTimeShift, 1*time.Second),
+		TimerProcessorHistoryArchivalSizeLimit:           dc.GetIntProperty(dynamicconfig.TimerProcessorHistoryArchivalSizeLimit, 500*1024),
+		TimerProcessorArchivalTimeLimit:                  dc.GetDurationProperty(dynamicconfig.TimerProcessorArchivalTimeLimit, 1*time.Second),
 
-		TransferTaskHighPriorityRPS:                          dc.GetIntPropertyFilteredByNamespace(dynamicconfig.TransferTaskHighPriorityRPS, 500),
-		TransferTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.TransferTaskBatchSize, 100),
-		TransferTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.TransferTaskWorkerCount, 10),
-		TransferTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.TransferTaskMaxRetryCount, 20),
-		TransferProcessorEnableSingleCursor:                  dc.GetBoolProperty(dynamicconfig.TransferProcessorEnableSingleCursor, false),
-		TransferProcessorEnablePriorityTaskScheduler:         dc.GetBoolProperty(dynamicconfig.TransferProcessorEnablePriorityTaskScheduler, false),
-		TransferProcessorSchedulerWorkerCount:                dc.GetIntProperty(dynamicconfig.TransferProcessorSchedulerWorkerCount, 200),
-		TransferProcessorSchedulerQueueSize:                  dc.GetIntProperty(dynamicconfig.TransferProcessorSchedulerQueueSize, 10),
-		TransferProcessorSchedulerRoundRobinWeights:          dc.GetMapProperty(dynamicconfig.TransferProcessorSchedulerRoundRobinWeights, ConvertWeightsToDynamicConfigValue(DefaultTaskPriorityWeight)),
-		TransferProcessorCompleteTransferFailureRetryCount:   dc.GetIntProperty(dynamicconfig.TransferProcessorCompleteTransferFailureRetryCount, 10),
-		TransferProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.TransferProcessorFailoverMaxPollRPS, 1),
-		TransferProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollRPS, 20),
-		TransferProcessorMaxPollHostRPS:                      dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollHostRPS, 0),
-		TransferProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.TransferProcessorMaxPollInterval, 1*time.Minute),
-		TransferProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
-		TransferProcessorUpdateAckInterval:                   dc.GetDurationProperty(dynamicconfig.TransferProcessorUpdateAckInterval, 30*time.Second),
-		TransferProcessorUpdateAckIntervalJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.TransferProcessorUpdateAckIntervalJitterCoefficient, 0.15),
-		TransferProcessorCompleteTransferInterval:            dc.GetDurationProperty(dynamicconfig.TransferProcessorCompleteTransferInterval, 60*time.Second),
-		TransferProcessorRescheduleInterval:                  dc.GetDurationProperty(dynamicconfig.TransferProcessorRescheduleInterval, 3*time.Second),
-		TransferProcessorRescheduleIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TransferProcessorRescheduleIntervalJitterCoefficient, 0.15),
-		TransferProcessorMaxReschedulerSize:                  dc.GetIntProperty(dynamicconfig.TransferProcessorMaxReschedulerSize, 10000),
-		TransferProcessorPollBackoffInterval:                 dc.GetDurationProperty(dynamicconfig.TransferProcessorPollBackoffInterval, 5*time.Second),
-		TransferProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.TransferProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
+		TransferTaskHighPriorityRPS:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.TransferTaskHighPriorityRPS, 500),
+		TransferTaskBatchSize:                               dc.GetIntProperty(dynamicconfig.TransferTaskBatchSize, 100),
+		TransferTaskWorkerCount:                             dc.GetIntProperty(dynamicconfig.TransferTaskWorkerCount, 10),
+		TransferTaskMaxRetryCount:                           dc.GetIntProperty(dynamicconfig.TransferTaskMaxRetryCount, 20),
+		TransferProcessorEnableSingleCursor:                 dc.GetBoolProperty(dynamicconfig.TransferProcessorEnableSingleCursor, false),
+		TransferProcessorEnablePriorityTaskScheduler:        dc.GetBoolProperty(dynamicconfig.TransferProcessorEnablePriorityTaskScheduler, false),
+		TransferProcessorSchedulerWorkerCount:               dc.GetIntProperty(dynamicconfig.TransferProcessorSchedulerWorkerCount, 200),
+		TransferProcessorSchedulerQueueSize:                 dc.GetIntProperty(dynamicconfig.TransferProcessorSchedulerQueueSize, 10),
+		TransferProcessorSchedulerRoundRobinWeights:         dc.GetMapProperty(dynamicconfig.TransferProcessorSchedulerRoundRobinWeights, ConvertWeightsToDynamicConfigValue(DefaultTaskPriorityWeight)),
+		TransferProcessorCompleteTransferFailureRetryCount:  dc.GetIntProperty(dynamicconfig.TransferProcessorCompleteTransferFailureRetryCount, 10),
+		TransferProcessorFailoverMaxPollRPS:                 dc.GetIntProperty(dynamicconfig.TransferProcessorFailoverMaxPollRPS, 1),
+		TransferProcessorMaxPollRPS:                         dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollRPS, 20),
+		TransferProcessorMaxPollHostRPS:                     dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollHostRPS, 0),
+		TransferProcessorMaxPollInterval:                    dc.GetDurationProperty(dynamicconfig.TransferProcessorMaxPollInterval, 1*time.Minute),
+		TransferProcessorMaxPollIntervalJitterCoefficient:   dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
+		TransferProcessorUpdateAckInterval:                  dc.GetDurationProperty(dynamicconfig.TransferProcessorUpdateAckInterval, 30*time.Second),
+		TransferProcessorUpdateAckIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TransferProcessorUpdateAckIntervalJitterCoefficient, 0.15),
+		TransferProcessorCompleteTransferInterval:           dc.GetDurationProperty(dynamicconfig.TransferProcessorCompleteTransferInterval, 60*time.Second),
+		TransferProcessorMaxReschedulerSize:                 dc.GetIntProperty(dynamicconfig.TransferProcessorMaxReschedulerSize, 10000),
+		TransferProcessorPollBackoffInterval:                dc.GetDurationProperty(dynamicconfig.TransferProcessorPollBackoffInterval, 5*time.Second),
+		TransferProcessorVisibilityArchivalTimeLimit:        dc.GetDurationProperty(dynamicconfig.TransferProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
-		ReplicatorTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 100),
-		ReplicatorTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.ReplicatorTaskWorkerCount, 10),
-		ReplicatorTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.ReplicatorTaskMaxRetryCount, 100),
-		ReplicatorProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxPollRPS, 20),
-		ReplicatorProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorMaxPollInterval, 1*time.Minute),
-		ReplicatorProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorMaxPollIntervalJitterCoefficient, 0.15),
-		ReplicatorProcessorUpdateAckInterval:                   dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorUpdateAckInterval, 5*time.Second),
-		ReplicatorProcessorUpdateAckIntervalJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorUpdateAckIntervalJitterCoefficient, 0.15),
-		ReplicatorProcessorRescheduleInterval:                  dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorRescheduleInterval, 5*time.Second),
-		ReplicatorProcessorRescheduleIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorRescheduleIntervalJitterCoefficient, 0.15),
-		ReplicatorProcessorMaxReschedulerSize:                  dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxReschedulerSize, 10000),
-		ReplicatorProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.ReplicatorProcessorEnablePriorityTaskProcessor, false),
-		ReplicatorProcessorFetchTasksBatchSize:                 dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 25),
-		ReplicationTaskProcessorHostQPS:                        dc.GetFloat64Property(dynamicconfig.ReplicationTaskProcessorHostQPS, 1500),
-		ReplicationTaskProcessorShardQPS:                       dc.GetFloat64Property(dynamicconfig.ReplicationTaskProcessorShardQPS, 30),
+		ReplicatorTaskBatchSize:                               dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 100),
+		ReplicatorTaskWorkerCount:                             dc.GetIntProperty(dynamicconfig.ReplicatorTaskWorkerCount, 10),
+		ReplicatorTaskMaxRetryCount:                           dc.GetIntProperty(dynamicconfig.ReplicatorTaskMaxRetryCount, 100),
+		ReplicatorProcessorMaxPollRPS:                         dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxPollRPS, 20),
+		ReplicatorProcessorMaxPollInterval:                    dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorMaxPollInterval, 1*time.Minute),
+		ReplicatorProcessorMaxPollIntervalJitterCoefficient:   dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorMaxPollIntervalJitterCoefficient, 0.15),
+		ReplicatorProcessorUpdateAckInterval:                  dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorUpdateAckInterval, 5*time.Second),
+		ReplicatorProcessorUpdateAckIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorUpdateAckIntervalJitterCoefficient, 0.15),
+		ReplicatorProcessorMaxReschedulerSize:                 dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxReschedulerSize, 10000),
+		ReplicatorProcessorEnablePriorityTaskProcessor:        dc.GetBoolProperty(dynamicconfig.ReplicatorProcessorEnablePriorityTaskProcessor, false),
+		ReplicatorProcessorFetchTasksBatchSize:                dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 25),
+		ReplicationTaskProcessorHostQPS:                       dc.GetFloat64Property(dynamicconfig.ReplicationTaskProcessorHostQPS, 1500),
+		ReplicationTaskProcessorShardQPS:                      dc.GetFloat64Property(dynamicconfig.ReplicationTaskProcessorShardQPS, 30),
 
 		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
 		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MaximumSignalsPerExecution, 0),
@@ -439,28 +425,26 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		SkipReapplicationByNamespaceID: dc.GetBoolPropertyFnWithNamespaceIDFilter(dynamicconfig.SkipReapplicationByNamespaceID, false),
 
 		// ===== Visibility related =====
-		VisibilityTaskHighPriorityRPS:                          dc.GetIntPropertyFilteredByNamespace(dynamicconfig.VisibilityTaskHighPriorityRPS, 500),
-		VisibilityTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.VisibilityTaskBatchSize, 100),
-		VisibilityProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.VisibilityProcessorFailoverMaxPollRPS, 1),
-		VisibilityProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.VisibilityProcessorMaxPollRPS, 20),
-		VisibilityProcessorMaxPollHostRPS:                      dc.GetIntProperty(dynamicconfig.VisibilityProcessorMaxPollHostRPS, 0),
-		VisibilityTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.VisibilityTaskWorkerCount, 10),
-		VisibilityTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.VisibilityTaskMaxRetryCount, 20),
-		VisibilityProcessorEnablePriorityTaskScheduler:         dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnablePriorityTaskScheduler, false),
-		VisibilityProcessorSchedulerWorkerCount:                dc.GetIntProperty(dynamicconfig.VisibilityProcessorSchedulerWorkerCount, 200),
-		VisibilityProcessorSchedulerQueueSize:                  dc.GetIntProperty(dynamicconfig.VisibilityProcessorSchedulerQueueSize, 10),
-		VisibilityProcessorSchedulerRoundRobinWeights:          dc.GetMapProperty(dynamicconfig.VisibilityProcessorSchedulerRoundRobinWeights, ConvertWeightsToDynamicConfigValue(DefaultTaskPriorityWeight)),
-		VisibilityProcessorCompleteTaskFailureRetryCount:       dc.GetIntProperty(dynamicconfig.VisibilityProcessorCompleteTaskFailureRetryCount, 10),
-		VisibilityProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.VisibilityProcessorMaxPollInterval, 1*time.Minute),
-		VisibilityProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.VisibilityProcessorMaxPollIntervalJitterCoefficient, 0.15),
-		VisibilityProcessorUpdateAckInterval:                   dc.GetDurationProperty(dynamicconfig.VisibilityProcessorUpdateAckInterval, 30*time.Second),
-		VisibilityProcessorUpdateAckIntervalJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.VisibilityProcessorUpdateAckIntervalJitterCoefficient, 0.15),
-		VisibilityProcessorCompleteTaskInterval:                dc.GetDurationProperty(dynamicconfig.VisibilityProcessorCompleteTaskInterval, 60*time.Second),
-		VisibilityProcessorRescheduleInterval:                  dc.GetDurationProperty(dynamicconfig.VisibilityProcessorRescheduleInterval, 3*time.Second),
-		VisibilityProcessorRescheduleIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.VisibilityProcessorRescheduleIntervalJitterCoefficient, 0.15),
-		VisibilityProcessorMaxReschedulerSize:                  dc.GetIntProperty(dynamicconfig.VisibilityProcessorMaxReschedulerSize, 10000),
-		VisibilityProcessorPollBackoffInterval:                 dc.GetDurationProperty(dynamicconfig.VisibilityProcessorPollBackoffInterval, 5*time.Second),
-		VisibilityProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.VisibilityProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
+		VisibilityTaskHighPriorityRPS:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.VisibilityTaskHighPriorityRPS, 500),
+		VisibilityTaskBatchSize:                               dc.GetIntProperty(dynamicconfig.VisibilityTaskBatchSize, 100),
+		VisibilityProcessorFailoverMaxPollRPS:                 dc.GetIntProperty(dynamicconfig.VisibilityProcessorFailoverMaxPollRPS, 1),
+		VisibilityProcessorMaxPollRPS:                         dc.GetIntProperty(dynamicconfig.VisibilityProcessorMaxPollRPS, 20),
+		VisibilityProcessorMaxPollHostRPS:                     dc.GetIntProperty(dynamicconfig.VisibilityProcessorMaxPollHostRPS, 0),
+		VisibilityTaskWorkerCount:                             dc.GetIntProperty(dynamicconfig.VisibilityTaskWorkerCount, 10),
+		VisibilityTaskMaxRetryCount:                           dc.GetIntProperty(dynamicconfig.VisibilityTaskMaxRetryCount, 20),
+		VisibilityProcessorEnablePriorityTaskScheduler:        dc.GetBoolProperty(dynamicconfig.VisibilityProcessorEnablePriorityTaskScheduler, false),
+		VisibilityProcessorSchedulerWorkerCount:               dc.GetIntProperty(dynamicconfig.VisibilityProcessorSchedulerWorkerCount, 200),
+		VisibilityProcessorSchedulerQueueSize:                 dc.GetIntProperty(dynamicconfig.VisibilityProcessorSchedulerQueueSize, 10),
+		VisibilityProcessorSchedulerRoundRobinWeights:         dc.GetMapProperty(dynamicconfig.VisibilityProcessorSchedulerRoundRobinWeights, ConvertWeightsToDynamicConfigValue(DefaultTaskPriorityWeight)),
+		VisibilityProcessorCompleteTaskFailureRetryCount:      dc.GetIntProperty(dynamicconfig.VisibilityProcessorCompleteTaskFailureRetryCount, 10),
+		VisibilityProcessorMaxPollInterval:                    dc.GetDurationProperty(dynamicconfig.VisibilityProcessorMaxPollInterval, 1*time.Minute),
+		VisibilityProcessorMaxPollIntervalJitterCoefficient:   dc.GetFloat64Property(dynamicconfig.VisibilityProcessorMaxPollIntervalJitterCoefficient, 0.15),
+		VisibilityProcessorUpdateAckInterval:                  dc.GetDurationProperty(dynamicconfig.VisibilityProcessorUpdateAckInterval, 30*time.Second),
+		VisibilityProcessorUpdateAckIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.VisibilityProcessorUpdateAckIntervalJitterCoefficient, 0.15),
+		VisibilityProcessorCompleteTaskInterval:               dc.GetDurationProperty(dynamicconfig.VisibilityProcessorCompleteTaskInterval, 60*time.Second),
+		VisibilityProcessorMaxReschedulerSize:                 dc.GetIntProperty(dynamicconfig.VisibilityProcessorMaxReschedulerSize, 10000),
+		VisibilityProcessorPollBackoffInterval:                dc.GetDurationProperty(dynamicconfig.VisibilityProcessorPollBackoffInterval, 5*time.Second),
+		VisibilityProcessorVisibilityArchivalTimeLimit:        dc.GetDurationProperty(dynamicconfig.VisibilityProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
 		SearchAttributesNumberOfKeysLimit: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.SearchAttributesNumberOfKeysLimit, 100),
 		SearchAttributesSizeOfValueLimit:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.SearchAttributesSizeOfValueLimit, 2*1024),

--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -46,16 +46,14 @@ import (
 type (
 	// QueueProcessorOptions is options passed to queue processor implementation
 	QueueProcessorOptions struct {
-		BatchSize                           dynamicconfig.IntPropertyFn
-		MaxPollInterval                     dynamicconfig.DurationPropertyFn
-		MaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
-		UpdateAckInterval                   dynamicconfig.DurationPropertyFn
-		UpdateAckIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
-		RescheduleInterval                  dynamicconfig.DurationPropertyFn
-		RescheduleIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
-		MaxReschdulerSize                   dynamicconfig.IntPropertyFn
-		PollBackoffInterval                 dynamicconfig.DurationPropertyFn
-		MetricScope                         int
+		BatchSize                          dynamicconfig.IntPropertyFn
+		MaxPollInterval                    dynamicconfig.DurationPropertyFn
+		MaxPollIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
+		UpdateAckInterval                  dynamicconfig.DurationPropertyFn
+		UpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+		MaxReschdulerSize                  dynamicconfig.IntPropertyFn
+		PollBackoffInterval                dynamicconfig.DurationPropertyFn
+		MetricScope                        int
 	}
 
 	queueProcessorBase struct {
@@ -128,6 +126,8 @@ func (p *queueProcessorBase) Start() {
 	p.logger.Info("", tag.LifeCycleStarting, tag.ComponentTransferQueue)
 	defer p.logger.Info("", tag.LifeCycleStarted, tag.ComponentTransferQueue)
 
+	p.rescheduler.Start()
+
 	p.shutdownWG.Add(1)
 	p.notifyNewTask()
 	go p.processorPump()
@@ -140,6 +140,8 @@ func (p *queueProcessorBase) Stop() {
 
 	p.logger.Info("", tag.LifeCycleStopping, tag.ComponentTransferQueue)
 	defer p.logger.Info("", tag.LifeCycleStopped, tag.ComponentTransferQueue)
+
+	p.rescheduler.Stop()
 
 	close(p.shutdownCh)
 
@@ -170,12 +172,6 @@ func (p *queueProcessorBase) processorPump() {
 		p.options.UpdateAckIntervalJitterCoefficient(),
 	))
 	defer updateAckTimer.Stop()
-
-	rescheduleTimer := time.NewTimer(backoff.JitDuration(
-		p.options.RescheduleInterval(),
-		p.options.RescheduleIntervalJitterCoefficient(),
-	))
-	defer rescheduleTimer.Stop()
 
 eventLoop:
 	for {
@@ -213,12 +209,6 @@ eventLoop:
 				go p.Stop()
 				break eventLoop
 			}
-		case <-rescheduleTimer.C:
-			p.rescheduler.Reschedule(0) // reschedule all
-			rescheduleTimer.Reset(backoff.JitDuration(
-				p.options.RescheduleInterval(),
-				p.options.RescheduleIntervalJitterCoefficient(),
-			))
 		}
 	}
 
@@ -269,14 +259,7 @@ func (p *queueProcessorBase) processBatch() {
 }
 
 func (p *queueProcessorBase) verifyReschedulerSize() bool {
-	length := p.rescheduler.Len()
-	maxLength := p.options.MaxReschdulerSize()
-	buffer := p.options.BatchSize() * 2
-	if length+buffer > maxLength {
-		p.rescheduler.Reschedule(length + buffer - maxLength)
-	}
-
-	passed := p.rescheduler.Len() < maxLength
+	passed := p.rescheduler.Len() < p.options.MaxReschdulerSize()
 	if passed && p.backoffTimer != nil {
 		p.backoffTimer.Stop()
 		p.backoffTimer = nil

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -195,7 +195,7 @@ func (s *executableSuite) TestTaskNack_Reschedule() {
 		return true
 	})
 
-	s.mockRescheduler.EXPECT().Add(executable, gomock.AssignableToTypeOf(time.Second))
+	s.mockRescheduler.EXPECT().Add(executable, gomock.AssignableToTypeOf(time.Now()))
 
 	executable.Nack(consts.ErrTaskRetry) // this error won't trigger re-submit
 	s.Equal(ctasks.TaskStatePending, executable.State())

--- a/service/history/queues/rescheduler_mock.go
+++ b/service/history/queues/rescheduler_mock.go
@@ -59,15 +59,15 @@ func (m *MockRescheduler) EXPECT() *MockReschedulerMockRecorder {
 }
 
 // Add mocks base method.
-func (m *MockRescheduler) Add(task Executable, backoff time.Duration) {
+func (m *MockRescheduler) Add(task Executable, rescheduleTime time.Time) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Add", task, backoff)
+	m.ctrl.Call(m, "Add", task, rescheduleTime)
 }
 
 // Add indicates an expected call of Add.
-func (mr *MockReschedulerMockRecorder) Add(task, backoff interface{}) *gomock.Call {
+func (mr *MockReschedulerMockRecorder) Add(task, rescheduleTime interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockRescheduler)(nil).Add), task, backoff)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Add", reflect.TypeOf((*MockRescheduler)(nil).Add), task, rescheduleTime)
 }
 
 // Len mocks base method.

--- a/service/history/queues/rescheduler_mock.go
+++ b/service/history/queues/rescheduler_mock.go
@@ -84,14 +84,26 @@ func (mr *MockReschedulerMockRecorder) Len() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockRescheduler)(nil).Len))
 }
 
-// Reschedule mocks base method.
-func (m *MockRescheduler) Reschedule(targetRescheduleSize int) {
+// Start mocks base method.
+func (m *MockRescheduler) Start() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Reschedule", targetRescheduleSize)
+	m.ctrl.Call(m, "Start")
 }
 
-// Reschedule indicates an expected call of Reschedule.
-func (mr *MockReschedulerMockRecorder) Reschedule(targetRescheduleSize interface{}) *gomock.Call {
+// Start indicates an expected call of Start.
+func (mr *MockReschedulerMockRecorder) Start() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reschedule", reflect.TypeOf((*MockRescheduler)(nil).Reschedule), targetRescheduleSize)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockRescheduler)(nil).Start))
+}
+
+// Stop mocks base method.
+func (m *MockRescheduler) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockReschedulerMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockRescheduler)(nil).Stop))
 }

--- a/service/history/queues/rescheduler_test.go
+++ b/service/history/queues/rescheduler_test.go
@@ -84,10 +84,12 @@ func (s *rescheudulerSuite) TestReschedule_NoRescheduleLimit() {
 
 	numExecutable := 10
 	for i := 0; i != numExecutable/2; i++ {
+		mockTask := NewMockExecutable(s.controller)
 		s.rescheduler.Add(
-			NewMockExecutable(s.controller),
+			mockTask,
 			time.Duration(rand.Int63n(rescheduleInterval.Nanoseconds())),
 		)
+
 		s.rescheduler.Add(
 			NewMockExecutable(s.controller),
 			rescheduleInterval+time.Duration(rand.Int63n(time.Minute.Nanoseconds())),
@@ -109,8 +111,9 @@ func (s *rescheudulerSuite) TestReschedule_SubmissionFailed() {
 
 	numExecutable := 10
 	for i := 0; i != numExecutable; i++ {
+		mockTask := NewMockExecutable(s.controller)
 		s.rescheduler.Add(
-			NewMockExecutable(s.controller),
+			mockTask,
 			time.Duration(rand.Int63n(rescheduleInterval.Nanoseconds())),
 		)
 	}

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -98,6 +98,7 @@ func newTimerQueueActiveProcessor(
 	rescheduler := queues.NewRescheduler(
 		scheduler,
 		shard.GetTimeSource(),
+		logger,
 		metricProvider.WithTags(metrics.OperationTag(queues.OperationTimerActiveQueueProcessor)),
 	)
 
@@ -271,6 +272,7 @@ func newTimerQueueFailoverProcessor(
 	rescheduler := queues.NewRescheduler(
 		scheduler,
 		shard.GetTimeSource(),
+		logger,
 		metricProvider.WithTags(metrics.OperationTag(queues.OperationTimerActiveQueueProcessor)),
 	)
 

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -131,6 +131,8 @@ func (t *timerQueueProcessorBase) Start() {
 		return
 	}
 
+	t.rescheduler.Start()
+
 	t.shutdownWG.Add(1)
 	// notify a initial scan
 	t.notifyNewTimer(time.Time{})
@@ -143,6 +145,8 @@ func (t *timerQueueProcessorBase) Stop() {
 	if !atomic.CompareAndSwapInt32(&t.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
+
+	t.rescheduler.Stop()
 
 	t.timerGate.Close()
 	close(t.shutdownCh)
@@ -223,12 +227,6 @@ func (t *timerQueueProcessorBase) internalProcessor() error {
 	))
 	defer updateAckTimer.Stop()
 
-	rescheduleTimer := time.NewTimer(backoff.JitDuration(
-		t.config.TimerProcessorRescheduleInterval(),
-		t.config.TimerProcessorRescheduleIntervalJitterCoefficient(),
-	))
-	defer rescheduleTimer.Stop()
-
 eventLoop:
 	for {
 		// prioritize shutdown
@@ -294,12 +292,6 @@ eventLoop:
 			// New Timer has arrived.
 			t.metricsClient.IncCounter(t.scope, metrics.NewTimerNotifyCounter)
 			t.timerGate.Update(newTime)
-		case <-rescheduleTimer.C:
-			t.rescheduler.Reschedule(0) // reschedule all
-			rescheduleTimer.Reset(backoff.JitDuration(
-				t.config.TimerProcessorRescheduleInterval(),
-				t.config.TimerProcessorRescheduleIntervalJitterCoefficient(),
-			))
 		}
 	}
 
@@ -347,13 +339,7 @@ func (t *timerQueueProcessorBase) readAndFanoutTimerTasks() (*time.Time, error) 
 }
 
 func (t *timerQueueProcessorBase) verifyReschedulerSize() bool {
-	length := t.rescheduler.Len()
-	maxLength := t.config.TimerProcessorMaxReschedulerSize()
-	if length > maxLength {
-		t.rescheduler.Reschedule(length - maxLength + t.config.TimerTaskBatchSize()*2)
-	}
-
-	passed := t.rescheduler.Len() < maxLength
+	passed := t.rescheduler.Len() < t.config.TimerProcessorMaxReschedulerSize()
 	if !passed {
 		// set backoff timer
 		t.notifyNewTimer(t.timeSource.Now().Add(t.config.TimerProcessorPollBackoffInterval()))

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -132,6 +132,7 @@ func newTimerQueueStandbyProcessor(
 	rescheduler := queues.NewRescheduler(
 		scheduler,
 		shard.GetTimeSource(),
+		logger,
 		metricProvider.WithTags(metrics.OperationTag(queues.OperationTimerStandbyQueueProcessor)),
 	)
 

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -75,16 +75,14 @@ func newTransferQueueActiveProcessor(
 ) *transferQueueActiveProcessorImpl {
 	config := shard.GetConfig()
 	options := &QueueProcessorOptions{
-		BatchSize:                           config.TransferTaskBatchSize,
-		MaxPollInterval:                     config.TransferProcessorMaxPollInterval,
-		MaxPollIntervalJitterCoefficient:    config.TransferProcessorMaxPollIntervalJitterCoefficient,
-		UpdateAckInterval:                   config.TransferProcessorUpdateAckInterval,
-		UpdateAckIntervalJitterCoefficient:  config.TransferProcessorUpdateAckIntervalJitterCoefficient,
-		RescheduleInterval:                  config.TransferProcessorRescheduleInterval,
-		RescheduleIntervalJitterCoefficient: config.TransferProcessorRescheduleIntervalJitterCoefficient,
-		MaxReschdulerSize:                   config.TransferProcessorMaxReschedulerSize,
-		PollBackoffInterval:                 config.TransferProcessorPollBackoffInterval,
-		MetricScope:                         metrics.TransferActiveQueueProcessorScope,
+		BatchSize:                          config.TransferTaskBatchSize,
+		MaxPollInterval:                    config.TransferProcessorMaxPollInterval,
+		MaxPollIntervalJitterCoefficient:   config.TransferProcessorMaxPollIntervalJitterCoefficient,
+		UpdateAckInterval:                  config.TransferProcessorUpdateAckInterval,
+		UpdateAckIntervalJitterCoefficient: config.TransferProcessorUpdateAckIntervalJitterCoefficient,
+		MaxReschdulerSize:                  config.TransferProcessorMaxReschedulerSize,
+		PollBackoffInterval:                config.TransferProcessorPollBackoffInterval,
+		MetricScope:                        metrics.TransferActiveQueueProcessorScope,
 	}
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 	logger = log.With(logger, tag.ClusterName(currentClusterName))
@@ -127,6 +125,7 @@ func newTransferQueueActiveProcessor(
 	rescheduler := queues.NewRescheduler(
 		scheduler,
 		shard.GetTimeSource(),
+		logger,
 		metricProvider.WithTags(metrics.OperationTag(queues.OperationTransferActiveQueueProcessor)),
 	)
 
@@ -248,16 +247,14 @@ func newTransferQueueFailoverProcessor(
 ) (func(ackLevel int64) error, *transferQueueActiveProcessorImpl) {
 	config := shard.GetConfig()
 	options := &QueueProcessorOptions{
-		BatchSize:                           config.TransferTaskBatchSize,
-		MaxPollInterval:                     config.TransferProcessorMaxPollInterval,
-		MaxPollIntervalJitterCoefficient:    config.TransferProcessorMaxPollIntervalJitterCoefficient,
-		UpdateAckInterval:                   config.TransferProcessorUpdateAckInterval,
-		UpdateAckIntervalJitterCoefficient:  config.TransferProcessorUpdateAckIntervalJitterCoefficient,
-		RescheduleInterval:                  config.TransferProcessorRescheduleInterval,
-		RescheduleIntervalJitterCoefficient: config.TransferProcessorRescheduleIntervalJitterCoefficient,
-		MaxReschdulerSize:                   config.TransferProcessorMaxReschedulerSize,
-		PollBackoffInterval:                 config.TransferProcessorPollBackoffInterval,
-		MetricScope:                         metrics.TransferActiveQueueProcessorScope,
+		BatchSize:                          config.TransferTaskBatchSize,
+		MaxPollInterval:                    config.TransferProcessorMaxPollInterval,
+		MaxPollIntervalJitterCoefficient:   config.TransferProcessorMaxPollIntervalJitterCoefficient,
+		UpdateAckInterval:                  config.TransferProcessorUpdateAckInterval,
+		UpdateAckIntervalJitterCoefficient: config.TransferProcessorUpdateAckIntervalJitterCoefficient,
+		MaxReschdulerSize:                  config.TransferProcessorMaxReschedulerSize,
+		PollBackoffInterval:                config.TransferProcessorPollBackoffInterval,
+		MetricScope:                        metrics.TransferActiveQueueProcessorScope,
 	}
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 	failoverUUID := uuid.New()
@@ -322,6 +319,7 @@ func newTransferQueueFailoverProcessor(
 	rescheduler := queues.NewRescheduler(
 		scheduler,
 		shard.GetTimeSource(),
+		logger,
 		metricProvider.WithTags(metrics.OperationTag(queues.OperationTransferActiveQueueProcessor)),
 	)
 

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -70,16 +70,14 @@ func newTransferQueueStandbyProcessor(
 ) *transferQueueStandbyProcessorImpl {
 	config := shard.GetConfig()
 	options := &QueueProcessorOptions{
-		BatchSize:                           config.TransferTaskBatchSize,
-		MaxPollInterval:                     config.TransferProcessorMaxPollInterval,
-		MaxPollIntervalJitterCoefficient:    config.TransferProcessorMaxPollIntervalJitterCoefficient,
-		UpdateAckInterval:                   config.TransferProcessorUpdateAckInterval,
-		UpdateAckIntervalJitterCoefficient:  config.TransferProcessorUpdateAckIntervalJitterCoefficient,
-		RescheduleInterval:                  config.TransferProcessorRescheduleInterval,
-		RescheduleIntervalJitterCoefficient: config.TransferProcessorRescheduleIntervalJitterCoefficient,
-		MaxReschdulerSize:                   config.TransferProcessorMaxReschedulerSize,
-		PollBackoffInterval:                 config.TransferProcessorPollBackoffInterval,
-		MetricScope:                         metrics.TransferStandbyQueueProcessorScope,
+		BatchSize:                          config.TransferTaskBatchSize,
+		MaxPollInterval:                    config.TransferProcessorMaxPollInterval,
+		MaxPollIntervalJitterCoefficient:   config.TransferProcessorMaxPollIntervalJitterCoefficient,
+		UpdateAckInterval:                  config.TransferProcessorUpdateAckInterval,
+		UpdateAckIntervalJitterCoefficient: config.TransferProcessorUpdateAckIntervalJitterCoefficient,
+		MaxReschdulerSize:                  config.TransferProcessorMaxReschedulerSize,
+		PollBackoffInterval:                config.TransferProcessorPollBackoffInterval,
+		MetricScope:                        metrics.TransferStandbyQueueProcessorScope,
 	}
 	logger = log.With(logger, tag.ClusterName(clusterName))
 
@@ -148,6 +146,7 @@ func newTransferQueueStandbyProcessor(
 	rescheduler := queues.NewRescheduler(
 		scheduler,
 		shard.GetTimeSource(),
+		logger,
 		metricProvider.WithTags(metrics.OperationTag(queues.OperationTransferStandbyQueueProcessor)),
 	)
 

--- a/service/history/visibilityQueueProcessor.go
+++ b/service/history/visibilityQueueProcessor.go
@@ -86,16 +86,14 @@ func newVisibilityQueueProcessor(
 	metricsClient := shard.GetMetricsClient()
 
 	options := &QueueProcessorOptions{
-		BatchSize:                           config.VisibilityTaskBatchSize,
-		MaxPollInterval:                     config.VisibilityProcessorMaxPollInterval,
-		MaxPollIntervalJitterCoefficient:    config.VisibilityProcessorMaxPollIntervalJitterCoefficient,
-		UpdateAckInterval:                   config.VisibilityProcessorUpdateAckInterval,
-		UpdateAckIntervalJitterCoefficient:  config.VisibilityProcessorUpdateAckIntervalJitterCoefficient,
-		RescheduleInterval:                  config.VisibilityProcessorRescheduleInterval,
-		RescheduleIntervalJitterCoefficient: config.VisibilityProcessorRescheduleIntervalJitterCoefficient,
-		MaxReschdulerSize:                   config.VisibilityProcessorMaxReschedulerSize,
-		PollBackoffInterval:                 config.VisibilityProcessorPollBackoffInterval,
-		MetricScope:                         metrics.VisibilityQueueProcessorScope,
+		BatchSize:                          config.VisibilityTaskBatchSize,
+		MaxPollInterval:                    config.VisibilityProcessorMaxPollInterval,
+		MaxPollIntervalJitterCoefficient:   config.VisibilityProcessorMaxPollIntervalJitterCoefficient,
+		UpdateAckInterval:                  config.VisibilityProcessorUpdateAckInterval,
+		UpdateAckIntervalJitterCoefficient: config.VisibilityProcessorUpdateAckIntervalJitterCoefficient,
+		MaxReschdulerSize:                  config.VisibilityProcessorMaxReschedulerSize,
+		PollBackoffInterval:                config.VisibilityProcessorPollBackoffInterval,
+		MetricScope:                        metrics.VisibilityQueueProcessorScope,
 	}
 	visibilityTaskFilter := func(taskInfo tasks.Task) bool {
 		return true
@@ -150,6 +148,7 @@ func newVisibilityQueueProcessor(
 	rescheduler := queues.NewRescheduler(
 		scheduler,
 		shard.GetTimeSource(),
+		logger,
 		metricProvider.WithTags(metrics.OperationTag(queues.OperationVisibilityQueueProcessor)),
 	)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Make task rescheduler has its own goroutine for rescheduling and run in background.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Currently task rescheduling needs to be explicitly triggered and the trigging is done periodically. This create unnecessary timer/load when there's nothing to reschedule. It also means the task backoff period calculated won't be respected since rescheduling is periodic.
- In multi-cursor implementation, we need to handle the case where a timer task is loaded but not ready for process. In that case, we can directly send the task to rescheduler. But this approach can't work if rescheduling is periodic as that will greatly increase task latency.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added new test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Rescheduler stop working in existing queue impl

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.