### PR TITLE
Move external-mocks to go:generate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,11 +447,6 @@ start-cdc-standby: temporal-server
 start-cdc-other: temporal-server
 	./temporal-server --env development-other start
 
-##### Generate #####
-go-generate:
-	@printf $(COLOR) "Process go:generate directives..."
-	@go generate ./...
-
 ##### Grafana #####
 update-dashboards:
 	@printf $(COLOR) "Update dashboards submodule from remote..."
@@ -466,6 +461,10 @@ update-dependencies:
 	@printf $(COLOR) "Update dependencies..."
 	@go get -u -t $(PINNED_DEPENDENCIES) ./...
 	@go mod tidy
+
+go-generate:
+	@printf $(COLOR) "Process go:generate directives..."
+	@go generate ./...
 
 ensure-no-changes:
 	@printf $(COLOR) "Check for local changes..."

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bins: temporal-server temporal-cassandra-tool temporal-sql-tool
 all: update-tools clean proto bins check test
 
 # Used by Buildkite.
-ci-build: bins build-tests update-tools shell-check check proto mocks gomodtidy ensure-no-changes
+ci-build: bins build-tests update-tools shell-check check proto go-generate gomodtidy ensure-no-changes
 
 # Delete all build artefacts.
 clean: clean-bins clean-test-results
@@ -167,7 +167,7 @@ proto-mocks: $(PROTO_OUT)
 	@printf $(COLOR) "Generate proto mocks..."
 	$(foreach PROTO_GRPC_SERVICE,$(PROTO_GRPC_SERVICES),\
 		cd $(PROTO_OUT) && \
-		mockgen -package $(call service_name,$(PROTO_GRPC_SERVICE))mock -source $(PROTO_GRPC_SERVICE) -destination $(call mock_file_name,$(PROTO_GRPC_SERVICE)) \
+		mockgen -copyright_file ../LICENSE -package $(call service_name,$(PROTO_GRPC_SERVICE))mock -source $(PROTO_GRPC_SERVICE) -destination $(call mock_file_name,$(PROTO_GRPC_SERVICE)) \
 	$(NEWLINE))
 
 update-go-api:
@@ -447,17 +447,10 @@ start-cdc-standby: temporal-server
 start-cdc-other: temporal-server
 	./temporal-server --env development-other start
 
-##### Mocks #####
-AWS_SDK_VERSION := $(lastword $(shell grep "github.com/aws/aws-sdk-go v1" go.mod))
-external-mocks:
-	@printf $(COLOR) "Generate external libraries mocks..."
-	@mockgen -copyright_file ./LICENSE -package mocks -source $(GOPATH)/pkg/mod/github.com/aws/aws-sdk-go@$(AWS_SDK_VERSION)/service/s3/s3iface/interface.go | grep -v -e "^// Source: .*" > common/archiver/s3store/mocks/S3API.go
-
+##### Generate #####
 go-generate:
 	@printf $(COLOR) "Process go:generate directives..."
 	@go generate ./...
-
-mocks: go-generate external-mocks
 
 ##### Grafana #####
 update-dashboards:

--- a/common/archiver/s3store/mocks/generate.go
+++ b/common/archiver/s3store/mocks/generate.go
@@ -1,0 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:generate ./generate.sh
+
+package mocks

--- a/common/archiver/s3store/mocks/generate.sh
+++ b/common/archiver/s3store/mocks/generate.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -e
+
+aws_sdk=$(go list -f '{{.Dir}}' github.com/aws/aws-sdk-go)
+if [[ -z $aws_sdk ]]; then
+  echo "Can't locate aws-sdk-go source code"
+  exit 1
+fi
+
+mockgen -copyright_file ../../../../LICENSE -package "$GOPACKAGE" -source "${aws_sdk}/service/s3/s3iface/interface.go" | grep -v "^// Source: .*" > S3API.go

--- a/common/archiver/s3store/mocks/generate.sh
+++ b/common/archiver/s3store/mocks/generate.sh
@@ -1,9 +1,9 @@
-#!/usr/bin/env bash
+#!/bin/sh
 
 set -e
 
 aws_sdk=$(go list -f '{{.Dir}}' github.com/aws/aws-sdk-go)
-if [[ -z $aws_sdk ]]; then
+if [ -z "$aws_sdk" ]; then
   echo "Can't locate aws-sdk-go source code"
   exit 1
 fi


### PR DESCRIPTION
**What changed?**
Move the `external-mocks` Makefile target to a script called by go:generate.
Get rid of the `mocks` target and just call `go-generate` (which does mostly mocks and also some other stuff).

**Why?**
Consistency, so that all code generation happens via go:generate and can be easily done per-package without the Makefile.

**How did you test it?**
Ran make targets.

**Potential risks**
