### PR TITLE
Default to one partition for system scheduler task queue

### DIFF
--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -84,10 +84,8 @@ func NewLoadBalancer(
 ) LoadBalancer {
 	return &defaultLoadBalancer{
 		namespaceIDToName: namespaceIDToName,
-		nReadPartitions: dc.GetIntPropertyFilteredByTaskQueueInfo(
-			dynamicconfig.MatchingNumTaskqueueReadPartitions, dynamicconfig.DefaultNumTaskQueuePartitions),
-		nWritePartitions: dc.GetIntPropertyFilteredByTaskQueueInfo(
-			dynamicconfig.MatchingNumTaskqueueWritePartitions, dynamicconfig.DefaultNumTaskQueuePartitions),
+		nReadPartitions:   dc.GetTaskQueuePartitionsProperty(dynamicconfig.MatchingNumTaskqueueReadPartitions),
+		nWritePartitions:  dc.GetTaskQueuePartitionsProperty(dynamicconfig.MatchingNumTaskqueueWritePartitions),
 	}
 }
 

--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -444,3 +444,16 @@ func (c *Collection) GetBoolPropertyFilteredByTaskQueueInfo(key Key, defaultValu
 		return val
 	}
 }
+
+// Task queue partitions use a dedicated function to handle defaults.
+func (c *Collection) GetTaskQueuePartitionsProperty(key Key) IntPropertyFnWithTaskQueueInfoFilters {
+	fn := c.GetIntPropertyFilteredByTaskQueueInfo(key, -1)
+	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) int {
+		if p := fn(namespace, taskQueue, taskType); p > 0 {
+			return p
+		} else if p == 0 {
+			return 1
+		}
+		return defaultNumTaskQueuePartitions(taskQueue)
+	}
+}

--- a/common/dynamicconfig/task_queue_partitions.go
+++ b/common/dynamicconfig/task_queue_partitions.go
@@ -1,0 +1,36 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dynamicconfig
+
+import "go.temporal.io/server/common/names"
+
+func defaultNumTaskQueuePartitions(taskQueue string) int {
+	switch taskQueue {
+	case names.SchedulerTaskQueueName:
+		return 1
+	default:
+		return 4
+	}
+}

--- a/common/names/names.go
+++ b/common/names/names.go
@@ -22,6 +22,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package dynamicconfig
+package names
 
-const DefaultNumTaskQueuePartitions = 4
+const (
+	// Shared workflow and task queue names
+	SchedulerWorkflowType  = "temporal-sys-scheduler-workflow"
+	SchedulerTaskQueueName = "temporal-sys-scheduler-tq"
+)

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -63,6 +63,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/names"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
@@ -3127,8 +3128,8 @@ func (wh *WorkflowHandler) CreateSchedule(ctx context.Context, request *workflow
 	startReq := &workflowservice.StartWorkflowExecutionRequest{
 		Namespace:             request.Namespace,
 		WorkflowId:            request.ScheduleId,
-		WorkflowType:          &commonpb.WorkflowType{Name: scheduler.WorkflowType},
-		TaskQueue:             &taskqueuepb.TaskQueue{Name: scheduler.TaskQueueName},
+		WorkflowType:          &commonpb.WorkflowType{Name: names.SchedulerWorkflowType},
+		TaskQueue:             &taskqueuepb.TaskQueue{Name: names.SchedulerTaskQueueName},
 		Input:                 inputPayload,
 		Identity:              request.Identity,
 		RequestId:             request.RequestId,
@@ -3612,7 +3613,7 @@ func (wh *WorkflowHandler) ListSchedules(ctx context.Context, request *workflows
 			EarliestStartTime: minTime,
 			LatestStartTime:   maxTime,
 		},
-		WorkflowTypeName: scheduler.WorkflowType,
+		WorkflowTypeName: names.SchedulerWorkflowType,
 	})
 	if err != nil {
 		return nil, err

--- a/service/worker/scheduler/fx.go
+++ b/service/worker/scheduler/fx.go
@@ -34,13 +34,9 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/names"
 	"go.temporal.io/server/common/namespace"
 	workercommon "go.temporal.io/server/service/worker/common"
-)
-
-const (
-	WorkflowType  = "temporal-sys-scheduler-workflow"
-	TaskQueueName = "temporal-sys-scheduler-tq"
 )
 
 type (
@@ -86,13 +82,13 @@ func NewResult(
 func (s *workerComponent) DedicatedWorkerOptions(ns *namespace.Namespace) *workercommon.PerNSDedicatedWorkerOptions {
 	return &workercommon.PerNSDedicatedWorkerOptions{
 		Enabled:    s.enabledForNs(ns.Name().String()),
-		TaskQueue:  TaskQueueName,
+		TaskQueue:  names.SchedulerTaskQueueName,
 		NumWorkers: s.numWorkers(ns.Name().String()),
 	}
 }
 
 func (s *workerComponent) Register(worker sdkworker.Worker, ns *namespace.Namespace) {
-	worker.RegisterWorkflowWithOptions(SchedulerWorkflow, workflow.RegisterOptions{Name: WorkflowType})
+	worker.RegisterWorkflowWithOptions(SchedulerWorkflow, workflow.RegisterOptions{Name: names.SchedulerWorkflowType})
 	worker.RegisterActivity(s.activities(ns.Name(), ns.ID()))
 }
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -45,6 +45,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 
 	schedspb "go.temporal.io/server/api/schedule/v1"
+	"go.temporal.io/server/common/names"
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
@@ -201,7 +202,7 @@ func (s *scheduler) run() error {
 	// Any watcher activities will get cancelled automatically if running.
 
 	s.logger.Info("Schedule doing continue-as-new")
-	return workflow.NewContinueAsNewError(s.ctx, WorkflowType, &s.StartScheduleArgs)
+	return workflow.NewContinueAsNewError(s.ctx, names.SchedulerWorkflowType, &s.StartScheduleArgs)
 }
 
 func (s *scheduler) ensureFields() {


### PR DESCRIPTION
**What changed?**
Add a new function to get task queue partition counts from dynamic config, which handles defaults. Use it in matching and history.

**Why?**
This lets us have different defaults for different task queues.

One caveat is that if users override the partition count settings with no task queue constraints, they'll override these defaults also, which might not be desirable.

**How did you test it?**
ran server, saw that it used only one partition for this task queue

**Potential risks**

