### PR TITLE
Add ability to clear search attributes

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -32,6 +32,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"reflect"
 	"strconv"
 	"strings"
 	"time"
@@ -814,9 +815,12 @@ func (s *visibilityStore) generateESDoc(request *store.InternalVisibilityRequest
 		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to decode search attributes: %v", err))
 	}
 	for saName, saValue := range searchAttributes {
-		if saValue != nil {
-			doc[saName] = saValue
+		if saValue == nil || (reflect.TypeOf(saValue).Kind() == reflect.Slice && reflect.ValueOf(saValue).Len() == 0) {
+			// Fields with null value or empty list are not indexed by ES,
+			// so don't add them to the document.
+			continue
 		}
+		doc[saName] = saValue
 	}
 
 	return doc, nil

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -814,7 +814,9 @@ func (s *visibilityStore) generateESDoc(request *store.InternalVisibilityRequest
 		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to decode search attributes: %v", err))
 	}
 	for saName, saValue := range searchAttributes {
-		doc[saName] = saValue
+		if saValue != nil {
+			doc[saName] = saValue
+		}
 	}
 
 	return doc, nil

--- a/common/searchattribute/encode_test.go
+++ b/common/searchattribute/encode_test.go
@@ -41,16 +41,18 @@ func Test_Encode_Success(t *testing.T) {
 		"key3": true,
 		"key4": nil,
 		"key5": []string{"val2", "val3"},
+		"key6": []string{},
 	}, &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
 		"key4": enumspb.INDEXED_VALUE_TYPE_DOUBLE,
 		"key5": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"key6": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}})
 
 	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 5)
+	assert.Len(sa.IndexedFields, 6)
 	assert.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
 	assert.Equal("Text", string(sa.IndexedFields["key1"].GetMetadata()["type"]))
 	assert.Equal("2", string(sa.IndexedFields["key2"].GetData()))
@@ -63,6 +65,9 @@ func Test_Encode_Success(t *testing.T) {
 	assert.Equal(`["val2","val3"]`, string(sa.IndexedFields["key5"].GetData()))
 	assert.Equal("Keyword", string(sa.IndexedFields["key5"].GetMetadata()["type"]))
 	assert.Equal("json/plain", string(sa.IndexedFields["key5"].GetMetadata()["encoding"]))
+	assert.Equal("[]", string(sa.IndexedFields["key6"].GetData()))
+	assert.Equal("Keyword", string(sa.IndexedFields["key6"].GetMetadata()["type"]))
+	assert.Equal("json/plain", string(sa.IndexedFields["key6"].GetMetadata()["encoding"]))
 }
 func Test_Encode_NilMap(t *testing.T) {
 	assert := assert.New(t)
@@ -73,10 +78,11 @@ func Test_Encode_NilMap(t *testing.T) {
 		"key3": true,
 		"key4": nil,
 		"key5": []string{"val2", "val3"},
+		"key6": []string{},
 	}, nil)
 
 	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 5)
+	assert.Len(sa.IndexedFields, 6)
 	assert.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
 	assert.Equal("2", string(sa.IndexedFields["key2"].GetData()))
 	assert.Equal("true", string(sa.IndexedFields["key3"].GetData()))
@@ -84,6 +90,8 @@ func Test_Encode_NilMap(t *testing.T) {
 	assert.Equal("binary/null", string(sa.IndexedFields["key4"].GetMetadata()["encoding"]))
 	assert.Equal(`["val2","val3"]`, string(sa.IndexedFields["key5"].GetData()))
 	assert.Equal("json/plain", string(sa.IndexedFields["key5"].GetMetadata()["encoding"]))
+	assert.Equal("[]", string(sa.IndexedFields["key6"].GetData()))
+	assert.Equal("json/plain", string(sa.IndexedFields["key6"].GetMetadata()["encoding"]))
 }
 
 func Test_Encode_Error(t *testing.T) {
@@ -117,6 +125,7 @@ func Test_Decode_Success(t *testing.T) {
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
 		"key4": enumspb.INDEXED_VALUE_TYPE_DOUBLE,
 		"key5": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"key6": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}}
 	sa, err := Encode(map[string]interface{}{
 		"key1": "val1",
@@ -124,32 +133,36 @@ func Test_Decode_Success(t *testing.T) {
 		"key3": true,
 		"key4": nil,
 		"key5": []string{"val2", "val3"},
+		"key6": []string{},
 	}, typeMap)
 	assert.NoError(err)
 
 	vals, err := Decode(sa, typeMap)
 	assert.NoError(err)
-	assert.Len(vals, 5)
+	assert.Len(vals, 6)
 	assert.Equal("val1", vals["key1"])
 	assert.Equal(int64(2), vals["key2"])
 	assert.Equal(true, vals["key3"])
 	assert.Nil(vals["key4"])
 	assert.Equal([]string{"val2", "val3"}, vals["key5"])
+	assert.Equal([]string{}, vals["key6"])
 
 	delete(sa.IndexedFields["key1"].Metadata, "type")
 	delete(sa.IndexedFields["key2"].Metadata, "type")
 	delete(sa.IndexedFields["key3"].Metadata, "type")
 	delete(sa.IndexedFields["key4"].Metadata, "type")
 	delete(sa.IndexedFields["key5"].Metadata, "type")
+	delete(sa.IndexedFields["key6"].Metadata, "type")
 
 	vals, err = Decode(sa, typeMap)
 	assert.NoError(err)
-	assert.Len(vals, 5)
+	assert.Len(vals, 6)
 	assert.Equal("val1", vals["key1"])
 	assert.Equal(int64(2), vals["key2"])
 	assert.Equal(true, vals["key3"])
 	assert.Nil(vals["key4"])
 	assert.Equal([]string{"val2", "val3"}, vals["key5"])
+	assert.Equal([]string{}, vals["key6"])
 }
 
 func Test_Decode_NilMap(t *testing.T) {
@@ -160,6 +173,7 @@ func Test_Decode_NilMap(t *testing.T) {
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
 		"key4": enumspb.INDEXED_VALUE_TYPE_DOUBLE,
 		"key5": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"key6": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}}
 	sa, err := Encode(map[string]interface{}{
 		"key1": "val1",
@@ -167,17 +181,19 @@ func Test_Decode_NilMap(t *testing.T) {
 		"key3": true,
 		"key4": nil,
 		"key5": []string{"val2", "val3"},
+		"key6": []string{},
 	}, typeMap)
 	assert.NoError(err)
 
 	vals, err := Decode(sa, nil)
 	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 5)
+	assert.Len(sa.IndexedFields, 6)
 	assert.Equal("val1", vals["key1"])
 	assert.Equal(int64(2), vals["key2"])
 	assert.Equal(true, vals["key3"])
 	assert.Nil(vals["key4"])
 	assert.Equal([]string{"val2", "val3"}, vals["key5"])
+	assert.Equal([]string{}, vals["key6"])
 }
 
 func Test_Decode_Error(t *testing.T) {

--- a/common/searchattribute/encode_test.go
+++ b/common/searchattribute/encode_test.go
@@ -39,20 +39,30 @@ func Test_Encode_Success(t *testing.T) {
 		"key1": "val1",
 		"key2": 2,
 		"key3": true,
+		"key4": nil,
+		"key5": []string{"val2", "val3"},
 	}, &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
+		"key4": enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+		"key5": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}})
 
 	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 3)
+	assert.Len(sa.IndexedFields, 5)
 	assert.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
 	assert.Equal("Text", string(sa.IndexedFields["key1"].GetMetadata()["type"]))
 	assert.Equal("2", string(sa.IndexedFields["key2"].GetData()))
 	assert.Equal("Int", string(sa.IndexedFields["key2"].GetMetadata()["type"]))
 	assert.Equal("true", string(sa.IndexedFields["key3"].GetData()))
 	assert.Equal("Bool", string(sa.IndexedFields["key3"].GetMetadata()["type"]))
+	assert.Equal("", string(sa.IndexedFields["key4"].GetData()))
+	assert.Equal("Double", string(sa.IndexedFields["key4"].GetMetadata()["type"]))
+	assert.Equal("binary/null", string(sa.IndexedFields["key4"].GetMetadata()["encoding"]))
+	assert.Equal(`["val2","val3"]`, string(sa.IndexedFields["key5"].GetData()))
+	assert.Equal("Keyword", string(sa.IndexedFields["key5"].GetMetadata()["type"]))
+	assert.Equal("json/plain", string(sa.IndexedFields["key5"].GetMetadata()["encoding"]))
 }
 func Test_Encode_NilMap(t *testing.T) {
 	assert := assert.New(t)
@@ -61,13 +71,19 @@ func Test_Encode_NilMap(t *testing.T) {
 		"key1": "val1",
 		"key2": 2,
 		"key3": true,
+		"key4": nil,
+		"key5": []string{"val2", "val3"},
 	}, nil)
 
 	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 3)
+	assert.Len(sa.IndexedFields, 5)
 	assert.Equal(`"val1"`, string(sa.IndexedFields["key1"].GetData()))
 	assert.Equal("2", string(sa.IndexedFields["key2"].GetData()))
 	assert.Equal("true", string(sa.IndexedFields["key3"].GetData()))
+	assert.Equal("", string(sa.IndexedFields["key4"].GetData()))
+	assert.Equal("binary/null", string(sa.IndexedFields["key4"].GetMetadata()["encoding"]))
+	assert.Equal(`["val2","val3"]`, string(sa.IndexedFields["key5"].GetData()))
+	assert.Equal("json/plain", string(sa.IndexedFields["key5"].GetMetadata()["encoding"]))
 }
 
 func Test_Encode_Error(t *testing.T) {
@@ -99,31 +115,41 @@ func Test_Decode_Success(t *testing.T) {
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
+		"key4": enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+		"key5": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}}
 	sa, err := Encode(map[string]interface{}{
 		"key1": "val1",
 		"key2": 2,
 		"key3": true,
+		"key4": nil,
+		"key5": []string{"val2", "val3"},
 	}, typeMap)
 	assert.NoError(err)
 
 	vals, err := Decode(sa, typeMap)
 	assert.NoError(err)
-	assert.Len(vals, 3)
+	assert.Len(vals, 5)
 	assert.Equal("val1", vals["key1"])
 	assert.Equal(int64(2), vals["key2"])
 	assert.Equal(true, vals["key3"])
+	assert.Nil(vals["key4"])
+	assert.Equal([]string{"val2", "val3"}, vals["key5"])
 
 	delete(sa.IndexedFields["key1"].Metadata, "type")
 	delete(sa.IndexedFields["key2"].Metadata, "type")
 	delete(sa.IndexedFields["key3"].Metadata, "type")
+	delete(sa.IndexedFields["key4"].Metadata, "type")
+	delete(sa.IndexedFields["key5"].Metadata, "type")
 
 	vals, err = Decode(sa, typeMap)
 	assert.NoError(err)
-	assert.Len(vals, 3)
+	assert.Len(vals, 5)
 	assert.Equal("val1", vals["key1"])
 	assert.Equal(int64(2), vals["key2"])
 	assert.Equal(true, vals["key3"])
+	assert.Nil(vals["key4"])
+	assert.Equal([]string{"val2", "val3"}, vals["key5"])
 }
 
 func Test_Decode_NilMap(t *testing.T) {
@@ -132,21 +158,26 @@ func Test_Decode_NilMap(t *testing.T) {
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
+		"key4": enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+		"key5": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 	}}
 	sa, err := Encode(map[string]interface{}{
 		"key1": "val1",
 		"key2": 2,
 		"key3": true,
+		"key4": nil,
+		"key5": []string{"val2", "val3"},
 	}, typeMap)
 	assert.NoError(err)
 
 	vals, err := Decode(sa, nil)
 	assert.NoError(err)
-	assert.Len(sa.IndexedFields, 3)
+	assert.Len(sa.IndexedFields, 5)
 	assert.Equal("val1", vals["key1"])
 	assert.Equal(int64(2), vals["key2"])
 	assert.Equal(true, vals["key3"])
-
+	assert.Nil(vals["key4"])
+	assert.Equal([]string{"val2", "val3"}, vals["key5"])
 }
 
 func Test_Decode_Error(t *testing.T) {

--- a/common/searchattribute/encode_value.go
+++ b/common/searchattribute/encode_value.go
@@ -55,45 +55,63 @@ func DecodeValue(value *commonpb.Payload, t enumspb.IndexedValueType) (interface
 
 	switch t {
 	case enumspb.INDEXED_VALUE_TYPE_TEXT, enumspb.INDEXED_VALUE_TYPE_KEYWORD:
-		var val string
+		// It tries first to decode to *string. This is to ensure that nil values
+		// are decoded as nil instead of the respective zero value. If the decoded
+		// value is not nil, then return the value instead of the pointer.
+		var val *string
 		if err := payload.Decode(value, &val); err != nil {
 			var listVal []string
 			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
-		return val, nil
+		if val == nil {
+			return nil, nil
+		}
+		return *val, nil
 	case enumspb.INDEXED_VALUE_TYPE_INT:
-		var val int64
+		var val *int64
 		if err := payload.Decode(value, &val); err != nil {
 			var listVal []int64
 			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
-		return val, nil
+		if val == nil {
+			return nil, nil
+		}
+		return *val, nil
 	case enumspb.INDEXED_VALUE_TYPE_DOUBLE:
-		var val float64
+		var val *float64
 		if err := payload.Decode(value, &val); err != nil {
 			var listVal []float64
 			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
-		return val, nil
+		if val == nil {
+			return nil, nil
+		}
+		return *val, nil
 	case enumspb.INDEXED_VALUE_TYPE_BOOL:
-		var val bool
+		var val *bool
 		if err := payload.Decode(value, &val); err != nil {
 			var listVal []bool
 			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
-		return val, nil
+		if val == nil {
+			return nil, nil
+		}
+		return *val, nil
 	case enumspb.INDEXED_VALUE_TYPE_DATETIME:
-		var val time.Time
+		var val *time.Time
 		if err := payload.Decode(value, &val); err != nil {
 			var listVal []time.Time
 			err = payload.Decode(value, &listVal)
 			return listVal, err
 		}
-		return val, nil
+		if val == nil {
+			return nil, nil
+		}
+		return *val, nil
 	default:
 		return nil, fmt.Errorf("%w: %v", ErrInvalidType, t)
 	}

--- a/common/searchattribute/encode_value_test.go
+++ b/common/searchattribute/encode_value_test.go
@@ -50,6 +50,29 @@ func Test_DecodeValue_FromMetadata_Success(t *testing.T) {
 	decodedBool, err := DecodeValue(payloadBool, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED) // MetadataType is used.
 	assert.NoError(err)
 	assert.Equal(true, decodedBool)
+
+	payloadNil, err := payload.Encode(nil)
+	assert.NoError(err)
+	payloadNil.Metadata["type"] = []byte("Double")
+	decodedNil, err := DecodeValue(payloadNil, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
+	assert.NoError(err)
+	assert.Nil(decodedNil)
+
+	payloadSlice, err := payload.Encode([]string{"val1", "val2"})
+	assert.NoError(err)
+	payloadSlice.Metadata["type"] = []byte("Keyword")
+	decodedSlice, err := DecodeValue(payloadSlice, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
+	assert.NoError(err)
+	assert.Equal([]string{"val1", "val2"}, decodedSlice)
+
+	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
+	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
+	payloadDatetime, err := payload.Encode(timeValue)
+	assert.NoError(err)
+	payloadDatetime.Metadata["type"] = []byte("Datetime")
+	decodedDatetime, err := DecodeValue(payloadDatetime, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
+	assert.NoError(err)
+	assert.Equal(timeValue, decodedDatetime)
 }
 
 func Test_DecodeValue_FromParameter_Success(t *testing.T) {
@@ -65,6 +88,26 @@ func Test_DecodeValue_FromParameter_Success(t *testing.T) {
 	decodedInt, err := DecodeValue(payloadInt, enumspb.INDEXED_VALUE_TYPE_INT)
 	assert.NoError(err)
 	assert.Equal(int64(123), decodedInt)
+
+	payloadNil, err := payload.Encode(nil)
+	assert.NoError(err)
+	decodedNil, err := DecodeValue(payloadNil, enumspb.INDEXED_VALUE_TYPE_DOUBLE)
+	assert.NoError(err)
+	assert.Nil(decodedNil)
+
+	payloadSlice, err := payload.Encode([]string{"val1", "val2"})
+	assert.NoError(err)
+	decodedSlice, err := DecodeValue(payloadSlice, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+	assert.NoError(err)
+	assert.Equal([]string{"val1", "val2"}, decodedSlice)
+
+	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
+	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
+	payloadDatetime, err := payload.Encode(timeValue)
+	assert.NoError(err)
+	decodedDatetime, err := DecodeValue(payloadDatetime, enumspb.INDEXED_VALUE_TYPE_DATETIME)
+	assert.NoError(err)
+	assert.Equal(timeValue, decodedDatetime)
 
 	payloadInt, err = payload.Encode(123)
 	assert.NoError(err)
@@ -125,6 +168,18 @@ func Test_EncodeValue(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(`"qwe"`, string(encodedPayload.GetData()))
 	assert.Equal("Text", string(encodedPayload.Metadata["type"]))
+
+	encodedPayload, err = EncodeValue(nil, enumspb.INDEXED_VALUE_TYPE_DOUBLE)
+	assert.NoError(err)
+	assert.Equal("", string(encodedPayload.GetData()))
+	assert.Equal("Double", string(encodedPayload.Metadata["type"]))
+	assert.Equal("binary/null", string(encodedPayload.Metadata["encoding"]))
+
+	encodedPayload, err = EncodeValue([]string{"val1", "val2"}, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+	assert.NoError(err)
+	assert.Equal(`["val1","val2"]`, string(encodedPayload.GetData()))
+	assert.Equal("Keyword", string(encodedPayload.Metadata["type"]))
+	assert.Equal("json/plain", string(encodedPayload.Metadata["encoding"]))
 
 	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
 	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)

--- a/common/searchattribute/encode_value_test.go
+++ b/common/searchattribute/encode_value_test.go
@@ -65,6 +65,13 @@ func Test_DecodeValue_FromMetadata_Success(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal([]string{"val1", "val2"}, decodedSlice)
 
+	payloadEmptySlice, err := payload.Encode([]string{})
+	assert.NoError(err)
+	payloadEmptySlice.Metadata["type"] = []byte("Keyword")
+	decodedEmptySlice, err := DecodeValue(payloadEmptySlice, enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED)
+	assert.NoError(err)
+	assert.Equal([]string{}, decodedEmptySlice)
+
 	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
 	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
 	payloadDatetime, err := payload.Encode(timeValue)
@@ -100,6 +107,12 @@ func Test_DecodeValue_FromParameter_Success(t *testing.T) {
 	decodedSlice, err := DecodeValue(payloadSlice, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 	assert.NoError(err)
 	assert.Equal([]string{"val1", "val2"}, decodedSlice)
+
+	payloadEmptySlice, err := payload.Encode([]string{})
+	assert.NoError(err)
+	decodedEmptySlice, err := DecodeValue(payloadEmptySlice, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+	assert.NoError(err)
+	assert.Equal([]string{}, decodedEmptySlice)
 
 	var expectedEncodedRepresentation = "2022-03-07T21:27:35.986848-05:00"
 	timeValue, err := time.Parse(time.RFC3339, expectedEncodedRepresentation)
@@ -178,6 +191,12 @@ func Test_EncodeValue(t *testing.T) {
 	encodedPayload, err = EncodeValue([]string{"val1", "val2"}, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
 	assert.NoError(err)
 	assert.Equal(`["val1","val2"]`, string(encodedPayload.GetData()))
+	assert.Equal("Keyword", string(encodedPayload.Metadata["type"]))
+	assert.Equal("json/plain", string(encodedPayload.Metadata["encoding"]))
+
+	encodedPayload, err = EncodeValue([]string{}, enumspb.INDEXED_VALUE_TYPE_KEYWORD)
+	assert.NoError(err)
+	assert.Equal("[]", string(encodedPayload.GetData()))
 	assert.Equal("Keyword", string(encodedPayload.Metadata["type"]))
 	assert.Equal("json/plain", string(encodedPayload.Metadata["encoding"]))
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Search attributes map are encoded to `Payload` and then back to `map[string]interface{}`. When decoding `nil` values, they are currently being decoded to the respective zero value. This PR changes this behavior so that encoded `nil` values are decoded as `nil` values.

2. Just with change described above, fields with `nil` or empty slice value won't be added to ES document and essentially will be removed. This behaviour is similar to existing behaviour for empty slice values. However, I'm changing so that fields with `nil` or empty slice value are not even created.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is to support removing search attributes from ES. For example, calling `UpsertSearchAttribute([]string{"CustomField": nil})` would delete the search attribute `CustomField`.
Closes #561.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new unit tests. I also changed the `samples-go/searchattribute` example to update a field with `nil` value, and verified that the field is not written to the ES doc.
Modified existing integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there's any usage of the search attribute decoder that expects `nil` values to be decoded to the respective zero value, it might cause issues (very unlikely).

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.