### PR TITLE
Fix potential npe in scheduler workflow update signal

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -447,10 +447,10 @@ func (s *scheduler) handleUpdateSignal(ch workflow.ReceiveChannel, _ bool) {
 
 	s.logger.Info("Schedule update", "new-schedule", req.Schedule.String())
 
-	s.Schedule.Spec = req.Schedule.Spec
-	s.Schedule.Action = req.Schedule.Action
-	s.Schedule.Policies = req.Schedule.Policies
-	s.Schedule.State = req.Schedule.State
+	s.Schedule.Spec = req.Schedule.GetSpec()
+	s.Schedule.Action = req.Schedule.GetAction()
+	s.Schedule.Policies = req.Schedule.GetPolicies()
+	s.Schedule.State = req.Schedule.GetState()
 	// don't touch Info
 
 	s.ensureFields()

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1194,6 +1194,14 @@ func (s *workflowSuite) TestUpdate() {
 		},
 		[]delayedCallback{
 			{
+				at: time.Date(2022, 6, 1, 0, 9, 5, 0, time.UTC),
+				f: func() {
+					// shouldn't crash
+					s.env.SignalWorkflow(SignalNameUpdate, nil)
+					s.env.SignalWorkflow(SignalNameUpdate, &schedspb.FullUpdateRequest{})
+				},
+			},
+			{
 				at: time.Date(2022, 6, 1, 0, 9, 7, 0, time.UTC),
 				f: func() {
 					desc := s.describe()
@@ -1234,7 +1242,7 @@ func (s *workflowSuite) TestUpdate() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
 			},
 		},
-		8,
+		10,
 	)
 }
 


### PR DESCRIPTION
**What changed?**
Fix npe if update signal payload has a nil Schedule

**Why?**
This shouldn't happen with existing clients, but if it does, the workflow would get stuck due to failing workflow tasks.

**How did you test it?**
unit test

**Potential risks**

**Is hotfix candidate?**
