### PR TITLE
Add convertion func for persistence multi-cursor queue state

### DIFF
--- a/service/history/queues/convert.go
+++ b/service/history/queues/convert.go
@@ -1,0 +1,332 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues
+
+import (
+	"fmt"
+
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/predicates"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	queueState struct {
+		readerScopes                 map[int32][]Scope
+		exclusiveReaderHighWatermark tasks.Key
+	}
+)
+
+func ToPersistenceQueueState(
+	queueState *queueState,
+) *persistencespb.QueueState {
+	readerStates := make(map[int32]*persistencespb.QueueReaderState)
+	for id, scopes := range queueState.readerScopes {
+		persistenceScopes := make([]*persistencespb.QueueSliceScope, 0, len(scopes))
+		for _, scope := range scopes {
+			persistenceScopes = append(persistenceScopes, ToPersistenceScope(scope))
+		}
+		readerStates[id] = &persistencespb.QueueReaderState{
+			Scopes: persistenceScopes,
+		}
+	}
+
+	return &persistencespb.QueueState{
+		ReaderStates:                 readerStates,
+		ExclusiveReaderHighWatermark: ToPersistenceTaskKey(queueState.exclusiveReaderHighWatermark),
+	}
+}
+
+func FromPersistenceQueueState(
+	state *persistencespb.QueueState,
+) *queueState {
+	readerScopes := make(map[int32][]Scope, len(state.ReaderStates))
+	for id, persistenceReaderState := range state.ReaderStates {
+		scopes := make([]Scope, 0, len(persistenceReaderState.Scopes))
+		for _, persistenceScope := range persistenceReaderState.Scopes {
+			scopes = append(scopes, FromPersistenceScope(persistenceScope))
+		}
+		readerScopes[id] = scopes
+	}
+
+	return &queueState{
+		readerScopes:                 readerScopes,
+		exclusiveReaderHighWatermark: FromPersistenceTaskKey(state.ExclusiveReaderHighWatermark),
+	}
+}
+
+func ToPersistenceScope(
+	scope Scope,
+) *persistencespb.QueueSliceScope {
+	return &persistencespb.QueueSliceScope{
+		Range:     ToPersistenceRange(scope.Range),
+		Predicate: ToPersistencePredicate(scope.Predicate),
+	}
+}
+
+func FromPersistenceScope(
+	scope *persistencespb.QueueSliceScope,
+) Scope {
+	return NewScope(
+		FromPersistenceRange(scope.Range),
+		FromPersistencePredicate(scope.Predicate),
+	)
+}
+
+func ToPersistenceRange(
+	r Range,
+) *persistencespb.QueueSliceRange {
+	return &persistencespb.QueueSliceRange{
+		InclusiveMin: ToPersistenceTaskKey(r.InclusiveMin),
+		ExclusiveMax: ToPersistenceTaskKey(r.ExclusiveMax),
+	}
+}
+
+func FromPersistenceRange(
+	r *persistencespb.QueueSliceRange,
+) Range {
+	return NewRange(
+		FromPersistenceTaskKey(r.InclusiveMin),
+		FromPersistenceTaskKey(r.ExclusiveMax),
+	)
+}
+
+func ToPersistenceTaskKey(
+	key tasks.Key,
+) *persistencespb.TaskKey {
+	return &persistencespb.TaskKey{
+		FireTime: timestamp.TimePtr(key.FireTime),
+		TaskId:   key.TaskID,
+	}
+}
+
+func FromPersistenceTaskKey(
+	key *persistencespb.TaskKey,
+) tasks.Key {
+	return tasks.NewKey(timestamp.TimeValue(key.FireTime), key.TaskId)
+}
+
+func ToPersistencePredicate(
+	predicate tasks.Predicate,
+) *persistencespb.Predicate {
+	switch predicate := predicate.(type) {
+	case *predicates.UniversalImpl[tasks.Task]:
+		return ToPersistenceUniversalPredicate(predicate)
+	case *predicates.EmptyImpl[tasks.Task]:
+		return ToPersistenceEmptyPredicate(predicate)
+	case *predicates.AndImpl[tasks.Task]:
+		return ToPersistenceAndPredicate(predicate)
+	case *predicates.OrImpl[tasks.Task]:
+		return ToPersistenceOrPredicate(predicate)
+	case *predicates.NotImpl[tasks.Task]:
+		return ToPersistenceNotPredicate(predicate)
+	case *tasks.NamespacePredicate:
+		return ToPersistenceNamespaceIDPredicate(predicate)
+	case *tasks.TypePredicate:
+		return ToPersistenceTaskTypePredicate(predicate)
+	default:
+		panic(fmt.Sprintf("unknown task predicate type: %T", predicate))
+	}
+}
+
+func FromPersistencePredicate(
+	predicate *persistencespb.Predicate,
+) tasks.Predicate {
+	switch predicate.GetPredicateType() {
+	case enumsspb.PREDICATE_TYPE_UNIVERSAL:
+		return FromPersistenceUniversalPredicate(predicate.GetUniversalPredicateAttributes())
+	case enumsspb.PREDICATE_TYPE_EMPTY:
+		return FromPersistenceEmptyPredicate(predicate.GetEmptyPredicateAttributes())
+	case enumsspb.PREDICATE_TYPE_AND:
+		return FromPersistenceAndPredicate(predicate.GetAndPredicateAttributes())
+	case enumsspb.PREDICATE_TYPE_OR:
+		return FromPersistenceOrPredicate(predicate.GetOrPredicateAttributes())
+	case enumsspb.PREDICATE_TYPE_NOT:
+		return FromPersistenceNotPredicate(predicate.GetNotPredicateAttributes())
+	case enumsspb.PREDICATE_TYPE_NAMESPACE_ID:
+		return FromPersistenceNamespaceIDPredicate(predicate.GetNamespaceIdPredicateAttributes())
+	case enumsspb.PREDICATE_TYPE_TASK_TYPE:
+		return FromPersistenceTaskTypePredicate(predicate.GetTaskTypePredicateAttributes())
+	default:
+		panic(fmt.Sprintf("unknown persistence task predicate type: %v", predicate.GetPredicateType()))
+	}
+}
+
+func ToPersistenceUniversalPredicate(
+	_ *predicates.UniversalImpl[tasks.Task],
+) *persistencespb.Predicate {
+	return &persistencespb.Predicate{
+		PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+		Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+	}
+}
+
+func FromPersistenceUniversalPredicate(
+	_ *persistencespb.UniversalPredicateAttributes,
+) tasks.Predicate {
+	return predicates.Universal[tasks.Task]()
+}
+
+func ToPersistenceEmptyPredicate(
+	_ *predicates.EmptyImpl[tasks.Task],
+) *persistencespb.Predicate {
+	return &persistencespb.Predicate{
+		PredicateType: enumsspb.PREDICATE_TYPE_EMPTY,
+		Attributes:    &persistencespb.Predicate_EmptyPredicateAttributes{},
+	}
+}
+
+func FromPersistenceEmptyPredicate(
+	_ *persistencespb.EmptyPredicateAttributes,
+) tasks.Predicate {
+	return predicates.Empty[tasks.Task]()
+}
+
+func ToPersistenceAndPredicate(
+	andPredicate *predicates.AndImpl[tasks.Task],
+) *persistencespb.Predicate {
+	persistencePredicates := make([]*persistencespb.Predicate, 0, len(andPredicate.Predicates))
+	for _, p := range andPredicate.Predicates {
+		persistencePredicates = append(persistencePredicates, ToPersistencePredicate(p))
+	}
+
+	return &persistencespb.Predicate{
+		PredicateType: enumsspb.PREDICATE_TYPE_AND,
+		Attributes: &persistencespb.Predicate_AndPredicateAttributes{
+			AndPredicateAttributes: &persistencespb.AndPredicateAttributes{
+				Predicates: persistencePredicates,
+			},
+		},
+	}
+}
+
+func FromPersistenceAndPredicate(
+	attributes *persistencespb.AndPredicateAttributes,
+) tasks.Predicate {
+	taskPredicates := make([]predicates.Predicate[tasks.Task], 0, len(attributes.Predicates))
+	for _, p := range attributes.Predicates {
+		taskPredicates = append(taskPredicates, FromPersistencePredicate(p))
+	}
+
+	return predicates.And(taskPredicates...)
+}
+
+func ToPersistenceOrPredicate(
+	orPredicate *predicates.OrImpl[tasks.Task],
+) *persistencespb.Predicate {
+	persistencePredicates := make([]*persistencespb.Predicate, 0, len(orPredicate.Predicates))
+	for _, p := range orPredicate.Predicates {
+		persistencePredicates = append(persistencePredicates, ToPersistencePredicate(p))
+	}
+
+	return &persistencespb.Predicate{
+		PredicateType: enumsspb.PREDICATE_TYPE_OR,
+		Attributes: &persistencespb.Predicate_OrPredicateAttributes{
+			OrPredicateAttributes: &persistencespb.OrPredicateAttributes{
+				Predicates: persistencePredicates,
+			},
+		},
+	}
+}
+
+func FromPersistenceOrPredicate(
+	attributes *persistencespb.OrPredicateAttributes,
+) tasks.Predicate {
+	taskPredicates := make([]predicates.Predicate[tasks.Task], 0, len(attributes.Predicates))
+	for _, p := range attributes.Predicates {
+		taskPredicates = append(taskPredicates, FromPersistencePredicate(p))
+	}
+
+	return predicates.Or(taskPredicates...)
+}
+
+func ToPersistenceNotPredicate(
+	notPredicate *predicates.NotImpl[tasks.Task],
+) *persistencespb.Predicate {
+	return &persistencespb.Predicate{
+		PredicateType: enumsspb.PREDICATE_TYPE_NOT,
+		Attributes: &persistencespb.Predicate_NotPredicateAttributes{
+			NotPredicateAttributes: &persistencespb.NotPredicateAttributes{
+				Predicate: ToPersistencePredicate(notPredicate.Predicate),
+			},
+		},
+	}
+}
+
+func FromPersistenceNotPredicate(
+	attributes *persistencespb.NotPredicateAttributes,
+) tasks.Predicate {
+	return predicates.Not(FromPersistencePredicate(attributes.Predicate))
+}
+
+func ToPersistenceNamespaceIDPredicate(
+	namespaceIDPredicate *tasks.NamespacePredicate,
+) *persistencespb.Predicate {
+	namespaceIDs := make([]string, 0, len(namespaceIDPredicate.NamespaceIDs))
+	for namespaceID := range namespaceIDPredicate.NamespaceIDs {
+		namespaceIDs = append(namespaceIDs, namespaceID)
+	}
+
+	return &persistencespb.Predicate{
+		PredicateType: enumsspb.PREDICATE_TYPE_NAMESPACE_ID,
+		Attributes: &persistencespb.Predicate_NamespaceIdPredicateAttributes{
+			NamespaceIdPredicateAttributes: &persistencespb.NamespaceIdPredicateAttributes{
+				NamespaceIds: namespaceIDs,
+			},
+		},
+	}
+}
+
+func FromPersistenceNamespaceIDPredicate(
+	attributes *persistencespb.NamespaceIdPredicateAttributes,
+) tasks.Predicate {
+	return tasks.NewNamespacePredicate(attributes.NamespaceIds)
+}
+
+func ToPersistenceTaskTypePredicate(
+	taskTypePredicate *tasks.TypePredicate,
+) *persistencespb.Predicate {
+	taskTypes := make([]enumsspb.TaskType, 0, len(taskTypePredicate.Types))
+	for taskType := range taskTypePredicate.Types {
+		taskTypes = append(taskTypes, taskType)
+	}
+
+	return &persistencespb.Predicate{
+		PredicateType: enumsspb.PREDICATE_TYPE_TASK_TYPE,
+		Attributes: &persistencespb.Predicate_TaskTypePredicateAttributes{
+			TaskTypePredicateAttributes: &persistencespb.TaskTypePredicateAttributes{
+				TaskTypes: taskTypes,
+			},
+		},
+	}
+}
+
+func FromPersistenceTaskTypePredicate(
+	attributes *persistencespb.TaskTypePredicateAttributes,
+) tasks.Predicate {
+	return tasks.NewTypePredicate(attributes.TaskTypes)
+}

--- a/service/history/queues/convert_test.go
+++ b/service/history/queues/convert_test.go
@@ -1,0 +1,262 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/predicates"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	convertSuite struct {
+		suite.Suite
+		*require.Assertions
+	}
+)
+
+func TestConvertSuite(t *testing.T) {
+	s := new(convertSuite)
+	suite.Run(t, s)
+}
+
+func (s *convertSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *convertSuite) TestConvertPredicate_All() {
+	predicate := predicates.Universal[tasks.Task]()
+	s.Equal(predicate, FromPersistencePredicate(ToPersistencePredicate(predicate)))
+}
+
+func (s *convertSuite) TestConvertPredicate_Empty() {
+	predicate := predicates.Empty[tasks.Task]()
+	s.Equal(predicate, FromPersistencePredicate(ToPersistencePredicate(predicate)))
+}
+
+func (s *convertSuite) TestConvertPredicate_And() {
+	predicates := []tasks.Predicate{
+		predicates.And(
+			predicates.Universal[tasks.Task](),
+			predicates.Empty[tasks.Task](),
+		),
+		predicates.And(
+			predicates.Or[tasks.Task](
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+			),
+			predicates.Or[tasks.Task](
+				tasks.NewTypePredicate([]enumsspb.TaskType{
+					enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+				}),
+				tasks.NewTypePredicate([]enumsspb.TaskType{
+					enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+				}),
+			),
+		),
+		predicates.And(
+			predicates.Not(predicates.Empty[tasks.Task]()),
+			predicates.And[tasks.Task](
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+			),
+		),
+		predicates.And(
+			predicates.Not(predicates.Empty[tasks.Task]()),
+			predicates.And[tasks.Task](
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+				tasks.NewTypePredicate([]enumsspb.TaskType{
+					enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+				}),
+			),
+		),
+	}
+
+	for _, predicate := range predicates {
+		s.Equal(predicate, FromPersistencePredicate(ToPersistencePredicate(predicate)))
+	}
+}
+
+func (s *convertSuite) TestConvertPredicate_Or() {
+	predicates := []tasks.Predicate{
+		predicates.Or(
+			predicates.Universal[tasks.Task](),
+			predicates.Empty[tasks.Task](),
+		),
+		predicates.Or(
+			predicates.And[tasks.Task](
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+			),
+			predicates.And[tasks.Task](
+				tasks.NewTypePredicate([]enumsspb.TaskType{
+					enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+				}),
+				tasks.NewTypePredicate([]enumsspb.TaskType{
+					enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+				}),
+			),
+		),
+		predicates.Or(
+			predicates.Not(predicates.Empty[tasks.Task]()),
+			predicates.And[tasks.Task](
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+			),
+		),
+		predicates.Or(
+			predicates.Not(predicates.Empty[tasks.Task]()),
+			predicates.And[tasks.Task](
+				tasks.NewNamespacePredicate([]string{uuid.New()}),
+				tasks.NewTypePredicate([]enumsspb.TaskType{
+					enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+				}),
+			),
+		),
+	}
+
+	for _, predicate := range predicates {
+		s.Equal(predicate, FromPersistencePredicate(ToPersistencePredicate(predicate)))
+	}
+}
+
+func (s *convertSuite) TestConvertPredicate_Not() {
+	predicates := []tasks.Predicate{
+		predicates.Not(predicates.Universal[tasks.Task]()),
+		predicates.Not(predicates.Empty[tasks.Task]()),
+		predicates.Not(predicates.And[tasks.Task](
+			tasks.NewNamespacePredicate([]string{uuid.New()}),
+			tasks.NewTypePredicate([]enumsspb.TaskType{}),
+		)),
+		predicates.Not(predicates.Or[tasks.Task](
+			tasks.NewNamespacePredicate([]string{uuid.New()}),
+			tasks.NewTypePredicate([]enumsspb.TaskType{}),
+		)),
+		predicates.Not(predicates.Not(predicates.Empty[tasks.Task]())),
+		predicates.Not[tasks.Task](tasks.NewNamespacePredicate([]string{uuid.New()})),
+		predicates.Not[tasks.Task](tasks.NewTypePredicate([]enumsspb.TaskType{
+			enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+		})),
+	}
+
+	for _, predicate := range predicates {
+		s.Equal(predicate, FromPersistencePredicate(ToPersistencePredicate(predicate)))
+	}
+}
+
+func (s *convertSuite) TestConvertPredicate_NamespaceID() {
+	predicates := []tasks.Predicate{
+		tasks.NewNamespacePredicate(nil),
+		tasks.NewNamespacePredicate([]string{}),
+		tasks.NewNamespacePredicate([]string{uuid.New(), uuid.New(), uuid.New()}),
+	}
+
+	for _, predicate := range predicates {
+		s.Equal(predicate, FromPersistencePredicate(ToPersistencePredicate(predicate)))
+	}
+}
+
+func (s *convertSuite) TestConvertPredicate_TaskType() {
+	predicates := []tasks.Predicate{
+		tasks.NewTypePredicate(nil),
+		tasks.NewTypePredicate([]enumsspb.TaskType{}),
+		tasks.NewTypePredicate([]enumsspb.TaskType{
+			enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+			enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
+			enumsspb.TASK_TYPE_DELETE_HISTORY_EVENT,
+		}),
+	}
+
+	for _, predicate := range predicates {
+		s.Equal(predicate, FromPersistencePredicate(ToPersistencePredicate(predicate)))
+	}
+}
+
+func (s *convertSuite) TestConvertTaskKey() {
+	key := NewRandomKey()
+	s.Equal(key, FromPersistenceTaskKey(
+		ToPersistenceTaskKey(key),
+	))
+}
+
+func (s *convertSuite) TestConvertTaskRange() {
+	r := NewRandomRange()
+	s.Equal(r, FromPersistenceRange(
+		ToPersistenceRange(r),
+	))
+}
+
+func (s *convertSuite) TestConvertScope() {
+	scope := NewScope(
+		NewRandomRange(),
+		tasks.NewNamespacePredicate([]string{uuid.New(), uuid.New()}),
+	)
+
+	s.Equal(scope, FromPersistenceScope(
+		ToPersistenceScope(scope),
+	))
+}
+
+func (s *convertSuite) TestConvertQueueState() {
+	readerScopes := map[int32][]Scope{
+		0: {},
+		1: {
+			NewScope(
+				NewRandomRange(),
+				tasks.NewNamespacePredicate([]string{uuid.New(), uuid.New()}),
+			),
+		},
+		123: {
+			NewScope(
+				NewRandomRange(),
+				tasks.NewNamespacePredicate([]string{uuid.New(), uuid.New()}),
+			),
+			NewScope(
+				NewRandomRange(),
+				tasks.NewTypePredicate([]enumsspb.TaskType{
+					enumsspb.TASK_TYPE_ACTIVITY_TIMEOUT,
+					enumsspb.TASK_TYPE_ACTIVITY_RETRY_TIMER,
+				}),
+			),
+		},
+	}
+
+	queueState := &queueState{
+		readerScopes:                 readerScopes,
+		exclusiveReaderHighWatermark: tasks.NewKey(time.Unix(0, rand.Int63()).UTC(), 0),
+	}
+
+	s.Equal(queueState, FromPersistenceQueueState(
+		ToPersistenceQueueState(queueState),
+	))
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add util function for converting persistence queue state definition into in-memory representation

<!-- Tell your future self why have you made these changes -->
**Why?**
- Multicursor queue impl

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A, not used

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- no.