### PR TITLE
Fix error shadowing in standby executors

### DIFF
--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -522,8 +522,7 @@ func (t *timerQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 			tag.WorkflowNamespaceID(taskInfo.GetNamespaceID()),
 			tag.WorkflowID(taskInfo.GetWorkflowID()),
 			tag.WorkflowRunID(taskInfo.GetRunID()),
-			tag.ClusterName(remoteClusterName),
-			tag.Error(err))
+			tag.ClusterName(remoteClusterName))
 
 		return consts.ErrTaskRetry
 	}

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -517,50 +517,57 @@ func (t *timerQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 		return err
 	}
 	if resendInfo.lastEventID == common.EmptyEventID || resendInfo.lastEventVersion == common.EmptyVersion {
-		err = serviceerror.NewInternal("timerQueueStandbyProcessor encountered empty historyResendInfo")
-	} else {
-		ns, err := t.registry.GetNamespaceByID(namespace.ID(taskInfo.GetNamespaceID()))
-		if err != nil {
+		t.logger.Error("Error re-replicating history from remote: timerQueueStandbyProcessor encountered empty historyResendInfo.",
+			tag.ShardID(t.shard.GetShardID()),
+			tag.WorkflowNamespaceID(taskInfo.GetNamespaceID()),
+			tag.WorkflowID(taskInfo.GetWorkflowID()),
+			tag.WorkflowRunID(taskInfo.GetRunID()),
+			tag.ClusterName(remoteClusterName),
+			tag.Error(err))
+
+		return consts.ErrTaskRetry
+	}
+
+	ns, err := t.registry.GetNamespaceByID(namespace.ID(taskInfo.GetNamespaceID()))
+	if err != nil {
+		// This is most likely a NamespaceNotFound error. Don't log it and return error to stop retrying.
+		return err
+	}
+
+	if err = refreshTasks(
+		ctx,
+		adminClient,
+		ns.Name(),
+		namespace.ID(taskInfo.GetNamespaceID()),
+		taskInfo.GetWorkflowID(),
+		taskInfo.GetRunID(),
+	); err != nil {
+		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
+			// Don't log NamespaceNotFound error because it is valid case, and return error to stop retrying.
 			return err
 		}
 
-		if err := refreshTasks(
-			ctx,
-			adminClient,
-			ns.Name(),
-			namespace.ID(taskInfo.GetNamespaceID()),
-			taskInfo.GetWorkflowID(),
-			taskInfo.GetRunID(),
-		); err != nil {
-			if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
-				// Don't log NamespaceNotFound error because it is valid case, and return error to stop retry.
-				return err
-			}
-
-			t.logger.Error("Error refresh tasks from remote.",
-				tag.ShardID(t.shard.GetShardID()),
-				tag.WorkflowNamespaceID(taskInfo.GetNamespaceID()),
-				tag.WorkflowID(taskInfo.GetWorkflowID()),
-				tag.WorkflowRunID(taskInfo.GetRunID()),
-				tag.ClusterName(remoteClusterName),
-				tag.Error(err))
-		}
-
-		// NOTE: history resend may take long time and its timeout is currently
-		// controlled by a separate dynamicconfig config: StandbyTaskReReplicationContextTimeout
-		err = t.nDCHistoryResender.SendSingleWorkflowHistory(
-			remoteClusterName,
-			namespace.ID(taskInfo.GetNamespaceID()),
-			taskInfo.GetWorkflowID(),
-			taskInfo.GetRunID(),
-			resendInfo.lastEventID,
-			resendInfo.lastEventVersion,
-			common.EmptyEventID,
-			common.EmptyVersion,
-		)
+		t.logger.Error("Error refresh tasks from remote.",
+			tag.ShardID(t.shard.GetShardID()),
+			tag.WorkflowNamespaceID(taskInfo.GetNamespaceID()),
+			tag.WorkflowID(taskInfo.GetWorkflowID()),
+			tag.WorkflowRunID(taskInfo.GetRunID()),
+			tag.ClusterName(remoteClusterName),
+			tag.Error(err))
 	}
 
-	if err != nil {
+	// NOTE: history resend may take long time and its timeout is currently
+	// controlled by a separate dynamicconfig config: StandbyTaskReReplicationContextTimeout
+	if err = t.nDCHistoryResender.SendSingleWorkflowHistory(
+		remoteClusterName,
+		namespace.ID(taskInfo.GetNamespaceID()),
+		taskInfo.GetWorkflowID(),
+		taskInfo.GetRunID(),
+		resendInfo.lastEventID,
+		resendInfo.lastEventVersion,
+		common.EmptyEventID,
+		common.EmptyVersion,
+	); err != nil {
 		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
 			// Don't log NamespaceNotFound error because it is valid case, and return error to stop retry.
 			return err

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -568,7 +568,7 @@ func (t *timerQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 		common.EmptyVersion,
 	); err != nil {
 		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
-			// Don't log NamespaceNotFound error because it is valid case, and return error to stop retry.
+			// Don't log NamespaceNotFound error because it is valid case, and return error to stop retrying.
 			return err
 		}
 		t.logger.Error("Error re-replicating history from remote.",
@@ -580,7 +580,7 @@ func (t *timerQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 			tag.Error(err))
 	}
 
-	// return error so task processing logic will retry
+	// Return retryable error, so task processing will retry.
 	return consts.ErrTaskRetry
 }
 

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -658,6 +658,7 @@ func (t *transferQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 			tag.Error(err))
 	}
 
+	// Return retryable error, so task processing will retry.
 	return consts.ErrTaskRetry
 }
 

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -596,51 +596,57 @@ func (t *transferQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 		return err
 	}
 	if resendInfo.lastEventID == common.EmptyEventID || resendInfo.lastEventVersion == common.EmptyVersion {
-		err = serviceerror.NewInternal("transferQueueStandbyProcessor encountered empty historyResendInfo")
-	} else {
-		ns, err := t.registry.GetNamespaceByID(namespace.ID(taskInfo.GetNamespaceID()))
-		if err != nil {
-			return err
-		}
+		t.logger.Error("Error re-replicating history from remote: transferQueueStandbyProcessor encountered empty historyResendInfo.",
+			tag.ShardID(t.shard.GetShardID()),
+			tag.WorkflowNamespaceID(taskInfo.GetNamespaceID()),
+			tag.WorkflowID(taskInfo.GetWorkflowID()),
+			tag.WorkflowRunID(taskInfo.GetRunID()),
+			tag.SourceCluster(remoteClusterName))
 
-		if err := refreshTasks(
-			ctx,
-			adminClient,
-			ns.Name(),
-			namespace.ID(taskInfo.GetNamespaceID()),
-			taskInfo.GetWorkflowID(),
-			taskInfo.GetRunID(),
-		); err != nil {
-			if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
-				// Don't log NamespaceNotFound error because it is valid case, and return error to stop retry.
-				return err
-			}
-			t.logger.Error("Error refresh tasks from remote.",
-				tag.ShardID(t.shard.GetShardID()),
-				tag.WorkflowNamespaceID(taskInfo.GetNamespaceID()),
-				tag.WorkflowID(taskInfo.GetWorkflowID()),
-				tag.WorkflowRunID(taskInfo.GetRunID()),
-				tag.ClusterName(remoteClusterName),
-				tag.Error(err))
-		}
-
-		// NOTE: history resend may take long time and its timeout is currently
-		// controlled by a separate dynamicconfig config: StandbyTaskReReplicationContextTimeout
-		err = t.nDCHistoryResender.SendSingleWorkflowHistory(
-			remoteClusterName,
-			namespace.ID(taskInfo.GetNamespaceID()),
-			taskInfo.GetWorkflowID(),
-			taskInfo.GetRunID(),
-			resendInfo.lastEventID,
-			resendInfo.lastEventVersion,
-			0,
-			0,
-		)
+		return consts.ErrTaskRetry
 	}
 
+	ns, err := t.registry.GetNamespaceByID(namespace.ID(taskInfo.GetNamespaceID()))
 	if err != nil {
+		// This is most likely a NamespaceNotFound error. Don't log it and return error to stop retrying.
+		return err
+	}
+
+	if err = refreshTasks(
+		ctx,
+		adminClient,
+		ns.Name(),
+		namespace.ID(taskInfo.GetNamespaceID()),
+		taskInfo.GetWorkflowID(),
+		taskInfo.GetRunID(),
+	); err != nil {
 		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
-			// Don't log NamespaceNotFound error because it is valid case, and return error to stop retry.
+			// Don't log NamespaceNotFound error because it is valid case, and return error to stop retrying.
+			return err
+		}
+		t.logger.Error("Error refresh tasks from remote.",
+			tag.ShardID(t.shard.GetShardID()),
+			tag.WorkflowNamespaceID(taskInfo.GetNamespaceID()),
+			tag.WorkflowID(taskInfo.GetWorkflowID()),
+			tag.WorkflowRunID(taskInfo.GetRunID()),
+			tag.ClusterName(remoteClusterName),
+			tag.Error(err))
+	}
+
+	// NOTE: history resend may take long time and its timeout is currently
+	// controlled by a separate dynamicconfig config: StandbyTaskReReplicationContextTimeout
+	if err = t.nDCHistoryResender.SendSingleWorkflowHistory(
+		remoteClusterName,
+		namespace.ID(taskInfo.GetNamespaceID()),
+		taskInfo.GetWorkflowID(),
+		taskInfo.GetRunID(),
+		resendInfo.lastEventID,
+		resendInfo.lastEventVersion,
+		0,
+		0,
+	); err != nil {
+		if _, isNotFound := err.(*serviceerror.NamespaceNotFound); isNotFound {
+			// Don't log NamespaceNotFound error because it is valid case, and return error to stop retrying.
 			return err
 		}
 		t.logger.Error("Error re-replicating history from remote.",
@@ -652,7 +658,6 @@ func (t *transferQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 			tag.Error(err))
 	}
 
-	// return error so task processing logic will retry
 	return consts.ErrTaskRetry
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix error shadowing in standby executors.

<!-- Tell your future self why have you made these changes -->
**Why?**
`err` variable was recreated in `else` block and wasn't logged properly. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes, although error shadowing affects logging only.