### PR TITLE
Fix schedule jitter calculation bug

### DIFF
--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -254,3 +254,25 @@ func (s *specSuite) TestSpecBoundedJitter() {
 		time.Date(2022, 3, 23, 15, 8, 3, 724000000, time.UTC),
 	)
 }
+
+func (s *specSuite) TestSpecJitterSingleRun() {
+	s.checkSequenceFull(
+		&schedpb.ScheduleSpec{
+			Calendar: []*schedpb.CalendarSpec{
+				{Hour: "13", Minute: "55", DayOfMonth: "7", Month: "4", Year: "2022"},
+			},
+		},
+		time.Date(2022, 3, 23, 11, 00, 0, 0, time.UTC),
+		time.Date(2022, 4, 7, 13, 55, 0, 0, time.UTC),
+	)
+	s.checkSequenceFull(
+		&schedpb.ScheduleSpec{
+			Calendar: []*schedpb.CalendarSpec{
+				{Hour: "13", Minute: "55", DayOfMonth: "7", Month: "4", Year: "2022"},
+			},
+			Jitter: timestamp.DurationPtr(1 * time.Hour),
+		},
+		time.Date(2022, 3, 23, 11, 00, 0, 0, time.UTC),
+		time.Date(2022, 4, 7, 13, 57, 26, 927000000, time.UTC),
+	)
+}


### PR DESCRIPTION
**What changed?**
In cases where there was exactly one future scheduled time, the jitter limit calculation didn't check that the following future time actually existed. This would result in a negative value being used, which would result in a potentially large jitter value (up to 50 days), even if no jitter was configured.

**Why?**
fixes the calculation

**How did you test it?**
new unit test plus manual tests

**Potential risks**
This may break determinism for scheduler workflows, but it's still worth it to fix since it's a correctness issue. Impacted schedules can be deleted and recreated.

**Is hotfix candidate?**
yes
