### PR TITLE
Handle workflow already completed when verifying first workflow task scheduled

### DIFF
--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -295,6 +295,8 @@ func (t *transferQueueStandbyTaskExecutor) processCloseExecution(
 			})
 			switch err.(type) {
 			case nil, *serviceerror.NotFound, *serviceerror.NamespaceNotFound, *serviceerror.Unimplemented:
+				// NOTE: NotFound is only returned when workflow already completed
+				// If workflow can't be found at all, WorkflowNotReady error will be returned.
 				return nil, nil
 			case *serviceerror.WorkflowNotReady:
 				return verifyChildCompletionRecordedInfo, nil
@@ -449,6 +451,8 @@ func (t *transferQueueStandbyTaskExecutor) processStartChildExecution(
 		})
 		switch err.(type) {
 		case nil, *serviceerror.NotFound, *serviceerror.NamespaceNotFound, *serviceerror.Unimplemented:
+			// NOTE: NotFound is only returned when workflow already completed
+			// If workflow can't be found at all, WorkflowNotReady error will be returned.
 			return nil, nil
 		case *serviceerror.WorkflowNotReady:
 			return &startChildExecutionPostActionInfo{}, nil

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -448,7 +448,7 @@ func (t *transferQueueStandbyTaskExecutor) processStartChildExecution(
 			Clock: childWorkflowInfo.Clock,
 		})
 		switch err.(type) {
-		case nil, *serviceerror.NamespaceNotFound, *serviceerror.Unimplemented:
+		case nil, *serviceerror.NotFound, *serviceerror.NamespaceNotFound, *serviceerror.Unimplemented:
 			return nil, nil
 		case *serviceerror.WorkflowNotReady:
 			return &startChildExecutionPostActionInfo{}, nil

--- a/service/history/transferQueueStandbyTaskExecutor_test.go
+++ b/service/history/transferQueueStandbyTaskExecutor_test.go
@@ -1054,7 +1054,11 @@ func (s *transferQueueStandbyTaskExecutorSuite) TestProcessStartChildExecution_P
 	_, err = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.Nil(err)
 
-	s.mockHistoryClient.EXPECT().VerifyFirstWorkflowTaskScheduled(gomock.Any(), gomock.Any()).Return(nil, &serviceerror.WorkflowNotReady{})
+	s.mockHistoryClient.EXPECT().VerifyFirstWorkflowTaskScheduled(gomock.Any(), gomock.Any()).Return(nil, consts.ErrWorkflowCompleted)
+	_, err = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
+	s.Nil(err)
+
+	s.mockHistoryClient.EXPECT().VerifyFirstWorkflowTaskScheduled(gomock.Any(), gomock.Any()).Return(nil, consts.ErrWorkflowNotReady)
 	_, err = s.transferQueueStandbyTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.Equal(consts.ErrTaskRetry, err)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Handle workflow already completed error when verifying first workflow task scheduled

<!-- Tell your future self why have you made these changes -->
**Why?**
- We should not retry verification when workflow is already completed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes