### PR TITLE
Do not hold lock when running namespace change callback

### DIFF
--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -559,25 +559,46 @@ func (r *registry) publishCacheUpdate(
 	updateCache func() (Namespaces, Namespaces),
 ) {
 	now := r.clock.Now()
-	r.callbackLock.Lock()
-	defer r.callbackLock.Unlock()
-	r.triggerNamespaceChangePrepareCallbackLocked()
+
+	prepareCallbacks, callbacks := r.getNamespaceChangeCallbacks()
+
+	r.triggerNamespaceChangePrepareCallback(prepareCallbacks)
 	oldEntries, newEntries := updateCache()
-	r.triggerNamespaceChangeCallbackLocked(oldEntries, newEntries)
+	r.triggerNamespaceChangeCallback(callbacks, oldEntries, newEntries)
 	r.lastRefreshTime.Store(now)
 }
 
-func (r *registry) triggerNamespaceChangePrepareCallbackLocked() {
+func (r *registry) getNamespaceChangeCallbacks() ([]PrepareCallbackFn, []CallbackFn) {
+	r.callbackLock.Lock()
+	defer r.callbackLock.Unlock()
+
+	prepareCallbacks := make([]PrepareCallbackFn, 0, len(r.prepareCallbacks))
+	for _, prepareCallback := range r.prepareCallbacks {
+		prepareCallbacks = append(prepareCallbacks, prepareCallback)
+	}
+
+	callbacks := make([]CallbackFn, 0, len(r.callbacks))
+	for _, callback := range r.callbacks {
+		callbacks = append(callbacks, callback)
+	}
+
+	return prepareCallbacks, callbacks
+}
+
+func (r *registry) triggerNamespaceChangePrepareCallback(
+	prepareCallbacks []PrepareCallbackFn,
+) {
 	sw := r.metricsClient.StartTimer(
 		metrics.NamespaceCacheScope, metrics.NamespaceCachePrepareCallbacksLatency)
 	defer sw.Stop()
 
-	for _, prepareCallback := range r.prepareCallbacks {
+	for _, prepareCallback := range prepareCallbacks {
 		prepareCallback()
 	}
 }
 
-func (r *registry) triggerNamespaceChangeCallbackLocked(
+func (r *registry) triggerNamespaceChangeCallback(
+	callbacks []CallbackFn,
 	oldNamespaces []*Namespace,
 	newNamespaces []*Namespace,
 ) {
@@ -586,17 +607,9 @@ func (r *registry) triggerNamespaceChangeCallbackLocked(
 		metrics.NamespaceCacheScope, metrics.NamespaceCacheCallbacksLatency)
 	defer sw.Stop()
 
-	for _, callback := range r.callbacks {
+	for _, callback := range callbacks {
 		callback(oldNamespaces, newNamespaces)
 	}
-}
-
-func byName(name Name) *persistence.GetNamespaceRequest {
-	return &persistence.GetNamespaceRequest{Name: name.String()}
-}
-
-func byID(id ID) *persistence.GetNamespaceRequest {
-	return &persistence.GetNamespaceRequest{ID: id.String()}
 }
 
 // This is https://pkg.go.dev/golang.org/x/exp/maps#Values except that it works


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not hold lock when running namespace change callback

<!-- Tell your future self why have you made these changes -->
**Why?**
- Prevent deadlock in one shard from affecting all other shards on a host and block shard controller.
- No need to hold the lock anyway when running callback

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes