### PR TITLE
Move replication task cleanup to processor manager

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -237,6 +237,7 @@ func NewEngineWithShardContext(
 		eventSerializer,
 		replicationTaskFetcherFactory,
 		replicationTaskExecutorProvider,
+
 	)
 	return historyEngImpl
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -237,7 +237,6 @@ func NewEngineWithShardContext(
 		eventSerializer,
 		replicationTaskFetcherFactory,
 		replicationTaskExecutorProvider,
-
 	)
 	return historyEngImpl
 }

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -95,8 +95,8 @@ func NewAckManager(
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 	config := shard.GetConfig()
 
-	retryPolicy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
-	retryPolicy.SetMaximumAttempts(10)
+	retryPolicy := backoff.NewExponentialRetryPolicy(200 * time.Millisecond)
+	retryPolicy.SetMaximumAttempts(5)
 	retryPolicy.SetBackoffCoefficient(1)
 
 	return &ackMgrImpl{

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -53,7 +53,6 @@ import (
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/shard"
-	"go.temporal.io/server/service/history/tasks"
 )
 
 const (
@@ -90,8 +89,6 @@ type (
 		taskRetryPolicy backoff.RetryPolicy
 		dlqRetryPolicy  backoff.RetryPolicy
 
-		// send side
-		minTxAckedTaskID int64
 		// recv side
 		maxRxProcessedTaskID    int64
 		maxRxProcessedTimestamp time.Time
@@ -154,7 +151,6 @@ func NewTaskProcessor(
 		requestChan:          replicationTaskFetcher.getRequestChan(),
 		syncShardChan:        make(chan *replicationspb.SyncShardStatus, 1),
 		shutdownChan:         make(chan struct{}),
-		minTxAckedTaskID:     persistence.EmptyQueueMessageID,
 		maxRxProcessedTaskID: persistence.EmptyQueueMessageID,
 		maxRxReceivedTaskID:  persistence.EmptyQueueMessageID,
 	}
@@ -191,19 +187,11 @@ func (p *taskProcessorImpl) Stop() {
 }
 
 func (p *taskProcessorImpl) eventLoop() {
-	shardID := p.shard.GetShardID()
-
 	syncShardTimer := time.NewTimer(backoff.JitDuration(
 		p.config.ShardSyncMinInterval(),
 		p.config.ShardSyncTimerJitterCoefficient(),
 	))
 	defer syncShardTimer.Stop()
-
-	cleanupTimer := time.NewTimer(backoff.JitDuration(
-		p.config.ReplicationTaskProcessorCleanupInterval(shardID),
-		p.config.ReplicationTaskProcessorCleanupJitterCoefficient(shardID),
-	))
-	defer cleanupTimer.Stop()
 
 	replicationTimer := time.NewTimer(0)
 	defer replicationTimer.Stop()
@@ -221,16 +209,6 @@ func (p *taskProcessorImpl) eventLoop() {
 			syncShardTimer.Reset(backoff.JitDuration(
 				p.config.ShardSyncMinInterval(),
 				p.config.ShardSyncTimerJitterCoefficient(),
-			))
-
-		case <-cleanupTimer.C:
-			if err := p.cleanupReplicationTasks(); err != nil {
-				p.logger.Error("Failed to clean up replication messages.", tag.Error(err))
-				p.metricsClient.Scope(metrics.ReplicationTaskCleanupScope).IncCounter(metrics.ReplicationTaskCleanupFailure)
-			}
-			cleanupTimer.Reset(backoff.JitDuration(
-				p.config.ReplicationTaskProcessorCleanupInterval(shardID),
-				p.config.ReplicationTaskProcessorCleanupJitterCoefficient(shardID),
 			))
 
 		case <-p.shutdownChan:
@@ -500,48 +478,6 @@ func (p *taskProcessorImpl) paginationFn(_ []byte) ([]interface{}, []byte, error
 	case <-p.shutdownChan:
 		return nil, nil, nil
 	}
-}
-
-func (p *taskProcessorImpl) cleanupReplicationTasks() error {
-
-	clusterMetadata := p.shard.GetClusterMetadata()
-	currentCluster := clusterMetadata.GetCurrentClusterName()
-	var minAckedTaskID *int64
-	for clusterName, clusterInfo := range clusterMetadata.GetAllClusterInfo() {
-		if !clusterInfo.Enabled || clusterName == currentCluster {
-			continue
-		}
-
-		ackLevel := p.shard.GetQueueClusterAckLevel(tasks.CategoryReplication, clusterName).TaskID
-		if minAckedTaskID == nil || ackLevel < *minAckedTaskID {
-			minAckedTaskID = &ackLevel
-		}
-	}
-	if minAckedTaskID == nil || *minAckedTaskID <= p.minTxAckedTaskID {
-		return nil
-	}
-
-	p.logger.Debug("cleaning up replication task queue", tag.ReadLevel(*minAckedTaskID))
-	p.metricsClient.Scope(metrics.ReplicationTaskCleanupScope).IncCounter(metrics.ReplicationTaskCleanupCount)
-	p.metricsClient.Scope(
-		metrics.ReplicationTaskFetcherScope,
-		metrics.TargetClusterTag(p.currentCluster),
-	).RecordDistribution(
-		metrics.ReplicationTasksLag,
-		int(p.shard.GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication, currentCluster).Prev().TaskID-*minAckedTaskID),
-	)
-	err := p.shard.GetExecutionManager().RangeCompleteHistoryTasks(
-		context.TODO(),
-		&persistence.RangeCompleteHistoryTasksRequest{
-			ShardID:             p.shard.GetShardID(),
-			TaskCategory:        tasks.CategoryReplication,
-			ExclusiveMaxTaskKey: tasks.NewImmediateKey(*minAckedTaskID + 1),
-		},
-	)
-	if err == nil {
-		p.minTxAckedTaskID = *minAckedTaskID
-	}
-	return err
 }
 
 func (p *taskProcessorImpl) emitTaskMetrics(scope int, err error) {

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -241,7 +241,13 @@ func (r *taskProcessorManagerImpl) cleanupReplicationTasks() error {
 			continue
 		}
 
-		ackLevel := r.shard.GetQueueClusterAckLevel(tasks.CategoryReplication, clusterName).TaskID
+		var ackLevel int64
+		if clusterName == currentCluster {
+			ackLevel = r.shard.GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication, clusterName).TaskID
+		} else {
+			ackLevel = r.shard.GetQueueClusterAckLevel(tasks.CategoryReplication, clusterName).TaskID
+		}
+
 		if minAckedTaskID == nil || ackLevel < *minAckedTaskID {
 			minAckedTaskID = &ackLevel
 		}

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -26,8 +26,15 @@ package replication
 
 import (
 	"context"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/tasks"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/client"
@@ -42,8 +49,8 @@ import (
 )
 
 type (
-	// taskProcessorFactoryImpl is to manage replication task processors
-	taskProcessorFactoryImpl struct {
+	// taskProcessorManagerImpl is to manage replication task processors
+	taskProcessorManagerImpl struct {
 		config                        *configs.Config
 		deleteMgr                     workflow.DeleteManager
 		engine                        shard.Engine
@@ -54,13 +61,17 @@ type (
 		workflowCache                 workflow.Cache
 		resender                      xdc.NDCHistoryResender
 		taskExecutorProvider          TaskExecutorProvider
+		metricsClient                 metrics.Client
+		logger                        log.Logger
 
 		taskProcessorLock sync.RWMutex
 		taskProcessors    map[string]TaskProcessor
+		minTxAckedTaskID  int64
+		shutdownChan      chan struct{}
 	}
 )
 
-var _ common.Daemon = (*taskProcessorFactoryImpl)(nil)
+var _ common.Daemon = (*taskProcessorManagerImpl)(nil)
 
 func NewTaskProcessorManager(
 	config *configs.Config,
@@ -72,7 +83,7 @@ func NewTaskProcessorManager(
 	eventSerializer serialization.Serializer,
 	replicationTaskFetcherFactory TaskFetcherFactory,
 	taskExecutorProvider TaskExecutorProvider,
-) *taskProcessorFactoryImpl {
+) *taskProcessorManagerImpl {
 
 	// Intentionally use the raw client to create its own retry policy
 	historyClient := shard.GetHistoryClient()
@@ -82,7 +93,7 @@ func NewTaskProcessorManager(
 		common.IsResourceExhausted,
 	)
 
-	return &taskProcessorFactoryImpl{
+	return &taskProcessorManagerImpl{
 		config:                        config,
 		deleteMgr:                     workflowDeleteManager,
 		engine:                        engine,
@@ -102,12 +113,16 @@ func NewTaskProcessorManager(
 			shard.GetConfig().StandbyTaskReReplicationContextTimeout,
 			shard.GetLogger(),
 		),
+		logger:               shard.GetLogger(),
+		metricsClient:        shard.GetMetricsClient(),
 		taskProcessors:       make(map[string]TaskProcessor),
 		taskExecutorProvider: taskExecutorProvider,
+		minTxAckedTaskID:     persistence.EmptyQueueMessageID,
+		shutdownChan:         make(chan struct{}),
 	}
 }
 
-func (r *taskProcessorFactoryImpl) Start() {
+func (r *taskProcessorManagerImpl) Start() {
 	if !atomic.CompareAndSwapInt32(
 		&r.status,
 		common.DaemonStatusInitialized,
@@ -120,7 +135,7 @@ func (r *taskProcessorFactoryImpl) Start() {
 	r.listenToClusterMetadataChange()
 }
 
-func (r *taskProcessorFactoryImpl) Stop() {
+func (r *taskProcessorManagerImpl) Stop() {
 	if !atomic.CompareAndSwapInt32(
 		&r.status,
 		common.DaemonStatusStarted,
@@ -128,6 +143,8 @@ func (r *taskProcessorFactoryImpl) Stop() {
 	) {
 		return
 	}
+
+	close(r.shutdownChan)
 
 	r.shard.GetClusterMetadata().UnRegisterMetadataChangeCallback(r)
 	r.taskProcessorLock.Lock()
@@ -137,7 +154,31 @@ func (r *taskProcessorFactoryImpl) Stop() {
 	r.taskProcessorLock.Unlock()
 }
 
-func (r *taskProcessorFactoryImpl) listenToClusterMetadataChange() {
+func (r *taskProcessorManagerImpl) completeReplicationTaskLoop() {
+	shardID := r.shard.GetShardID()
+	cleanupTimer := time.NewTimer(backoff.JitDuration(
+		r.config.ReplicationTaskProcessorCleanupInterval(shardID),
+		r.config.ReplicationTaskProcessorCleanupJitterCoefficient(shardID),
+	))
+	defer cleanupTimer.Stop()
+	for {
+		select {
+		case <-cleanupTimer.C:
+			if err := r.cleanupReplicationTasks(); err != nil {
+				r.logger.Error("Failed to clean up replication messages.", tag.Error(err))
+				r.metricsClient.Scope(metrics.ReplicationTaskCleanupScope).IncCounter(metrics.ReplicationTaskCleanupFailure)
+			}
+			cleanupTimer.Reset(backoff.JitDuration(
+				r.config.ReplicationTaskProcessorCleanupInterval(shardID),
+				r.config.ReplicationTaskProcessorCleanupJitterCoefficient(shardID),
+			))
+		case <-r.shutdownChan:
+			return
+		}
+	}
+}
+
+func (r *taskProcessorManagerImpl) listenToClusterMetadataChange() {
 	clusterMetadata := r.shard.GetClusterMetadata()
 	clusterMetadata.RegisterMetadataChangeCallback(
 		r,
@@ -145,7 +186,7 @@ func (r *taskProcessorFactoryImpl) listenToClusterMetadataChange() {
 	)
 }
 
-func (r *taskProcessorFactoryImpl) handleClusterMetadataUpdate(
+func (r *taskProcessorManagerImpl) handleClusterMetadataUpdate(
 	oldClusterMetadata map[string]*cluster.ClusterInformation,
 	newClusterMetadata map[string]*cluster.ClusterInformation,
 ) {
@@ -189,4 +230,44 @@ func (r *taskProcessorFactoryImpl) handleClusterMetadataUpdate(
 			r.taskProcessors[clusterName] = replicationTaskProcessor
 		}
 	}
+}
+
+func (r *taskProcessorManagerImpl) cleanupReplicationTasks() error {
+	clusterMetadata := r.shard.GetClusterMetadata()
+	currentCluster := clusterMetadata.GetCurrentClusterName()
+	var minAckedTaskID *int64
+	for clusterName, clusterInfo := range clusterMetadata.GetAllClusterInfo() {
+		if !clusterInfo.Enabled {
+			continue
+		}
+
+		ackLevel := r.shard.GetQueueClusterAckLevel(tasks.CategoryReplication, clusterName).TaskID
+		if minAckedTaskID == nil || ackLevel < *minAckedTaskID {
+			minAckedTaskID = &ackLevel
+		}
+	}
+	if minAckedTaskID == nil || *minAckedTaskID <= r.minTxAckedTaskID {
+		return nil
+	}
+
+	r.logger.Debug("cleaning up replication task queue", tag.ReadLevel(*minAckedTaskID))
+	r.metricsClient.Scope(metrics.ReplicationTaskCleanupScope).IncCounter(metrics.ReplicationTaskCleanupCount)
+	r.metricsClient.Scope(
+		metrics.ReplicationTaskFetcherScope,
+	).RecordDistribution(
+		metrics.ReplicationTasksLag,
+		int(r.shard.GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication, currentCluster).Prev().TaskID-*minAckedTaskID),
+	)
+	err := r.shard.GetExecutionManager().RangeCompleteHistoryTasks(
+		context.TODO(),
+		&persistence.RangeCompleteHistoryTasksRequest{
+			ShardID:             r.shard.GetShardID(),
+			TaskCategory:        tasks.CategoryReplication,
+			ExclusiveMaxTaskKey: tasks.NewImmediateKey(*minAckedTaskID + 1),
+		},
+	)
+	if err == nil {
+		r.minTxAckedTaskID = *minAckedTaskID
+	}
+	return err
 }

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -26,12 +26,6 @@ package replication
 
 import (
 	"context"
-	"go.temporal.io/server/common/backoff"
-	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/service/history/tasks"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -40,11 +34,17 @@ import (
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/client/history"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
 )
 

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -25,8 +25,6 @@
 package replication
 
 import (
-	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/metrics"
 	"math/rand"
 	"testing"
 	"time"
@@ -34,10 +32,13 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
 	"go.temporal.io/server/api/adminservicemock/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -1,0 +1,162 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package replication
+
+import (
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/api/adminservicemock/v1"
+	"go.temporal.io/server/api/historyservicemock/v1"
+	"go.temporal.io/server/client"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+)
+
+type (
+	taskProcessorManagerSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		controller                        *gomock.Controller
+		mockShard                         *shard.MockContext
+		mockEngine                        *shard.MockEngine
+		mockNamespaceCache                *namespace.MockRegistry
+		mockClientBean                    *client.MockBean
+		mockAdminClient                   *adminservicemock.MockAdminServiceClient
+		mockClusterMetadata               *cluster.MockMetadata
+		mockHistoryClient                 *historyservicemock.MockHistoryServiceClient
+		mockReplicationTaskExecutor       *MockTaskExecutor
+		mockReplicationTaskFetcherFactory *MockTaskFetcherFactory
+
+		mockExecutionManager *persistence.MockExecutionManager
+
+		shardID     int32
+		config      *configs.Config
+		requestChan chan *replicationTaskRequest
+
+		taskProcessorManager *taskProcessorManagerImpl
+	}
+)
+
+func TestTaskProcessorManagerSuite(t *testing.T) {
+	s := new(taskProcessorManagerSuite)
+	suite.Run(t, s)
+}
+
+func (s *taskProcessorManagerSuite) SetupSuite() {
+	rand.Seed(time.Now().UnixNano())
+}
+
+func (s *taskProcessorManagerSuite) TearDownSuite() {
+
+}
+
+func (s *taskProcessorManagerSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+	s.controller = gomock.NewController(s.T())
+
+	s.config = tests.NewDynamicConfig()
+	s.requestChan = make(chan *replicationTaskRequest, 10)
+
+	s.shardID = rand.Int31()
+	s.mockShard = shard.NewMockContext(s.controller)
+	s.mockEngine = shard.NewMockEngine(s.controller)
+
+	s.mockReplicationTaskExecutor = NewMockTaskExecutor(s.controller)
+	s.mockHistoryClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
+	s.mockReplicationTaskFetcherFactory = NewMockTaskFetcherFactory(s.controller)
+	serializer := serialization.NewSerializer()
+	s.mockClusterMetadata = cluster.NewMockMetadata(s.controller)
+	s.mockShard.EXPECT().GetClusterMetadata().Return(s.mockClusterMetadata).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
+	s.mockShard.EXPECT().GetHistoryClient().Return(nil).AnyTimes()
+	s.mockShard.EXPECT().GetNamespaceRegistry().Return(namespace.NewMockRegistry(s.controller)).AnyTimes()
+	s.mockShard.EXPECT().GetConfig().Return(s.config).AnyTimes()
+	s.mockShard.EXPECT().GetLogger().Return(log.NewNoopLogger()).AnyTimes()
+	s.mockShard.EXPECT().GetMetricsClient().Return(metrics.NoopClient).AnyTimes()
+	s.mockShard.EXPECT().GetPayloadSerializer().Return(serializer).AnyTimes()
+	s.mockExecutionManager = persistence.NewMockExecutionManager(s.controller)
+	s.mockShard.EXPECT().GetExecutionManager().Return(s.mockExecutionManager).AnyTimes()
+	s.mockShard.EXPECT().GetShardID().Return(s.shardID).AnyTimes()
+	s.taskProcessorManager = NewTaskProcessorManager(
+		s.config,
+		s.mockShard,
+		s.mockEngine,
+		nil,
+		nil,
+		s.mockClientBean,
+		serializer,
+		s.mockReplicationTaskFetcherFactory,
+		func(params TaskExecutorParams) TaskExecutor {
+			return s.mockReplicationTaskExecutor
+		},
+	)
+}
+
+func (s *taskProcessorManagerSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Noop() {
+	ackedTaskID := int64(12345)
+	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestCurrentClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
+	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
+
+	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID
+	err := s.taskProcessorManager.cleanupReplicationTasks()
+	s.NoError(err)
+}
+
+func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Cleanup() {
+	ackedTaskID := int64(12345)
+	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestCurrentClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
+	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
+	s.mockShard.EXPECT().GetQueueExclusiveHighReadWatermark(gomock.Any(), gomock.Any()).Return(tasks.NewKey(time.Now(), ackedTaskID))
+	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID - 1
+	s.mockExecutionManager.EXPECT().RangeCompleteHistoryTasks(
+		gomock.Any(),
+		&persistence.RangeCompleteHistoryTasksRequest{
+			ShardID:             s.shardID,
+			TaskCategory:        tasks.CategoryReplication,
+			ExclusiveMaxTaskKey: tasks.NewImmediateKey(ackedTaskID + 1),
+		},
+	).Return(nil)
+	err := s.taskProcessorManager.cleanupReplicationTasks()
+	s.NoError(err)
+}

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -135,7 +135,7 @@ func (s *taskProcessorManagerSuite) TearDownTest() {
 
 func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Noop() {
 	ackedTaskID := int64(12345)
-	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestCurrentClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
+	s.mockShard.EXPECT().GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication, cluster.TestCurrentClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
 	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
 
 	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID
@@ -145,9 +145,8 @@ func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Noop() {
 
 func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Cleanup() {
 	ackedTaskID := int64(12345)
-	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestCurrentClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
+	s.mockShard.EXPECT().GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication, cluster.TestCurrentClusterName).Return(tasks.NewImmediateKey(ackedTaskID)).Times(2)
 	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
-	s.mockShard.EXPECT().GetQueueExclusiveHighReadWatermark(gomock.Any(), gomock.Any()).Return(tasks.NewKey(time.Now(), ackedTaskID))
 	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID - 1
 	s.mockExecutionManager.EXPECT().RangeCompleteHistoryTasks(
 		gomock.Any(),

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -430,36 +430,6 @@ func (s *taskProcessorSuite) TestConvertTaskToDLQTask_History() {
 	s.Equal(request, dlqTask)
 }
 
-func (s *taskProcessorSuite) TestCleanupReplicationTask_Noop() {
-	ackedTaskID := int64(12345)
-	s.mockResource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
-	err := s.mockShard.UpdateQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName, tasks.NewImmediateKey(ackedTaskID))
-	s.NoError(err)
-
-	s.replicationTaskProcessor.minTxAckedTaskID = ackedTaskID
-	err = s.replicationTaskProcessor.cleanupReplicationTasks()
-	s.NoError(err)
-}
-
-func (s *taskProcessorSuite) TestCleanupReplicationTask_Cleanup() {
-	ackedTaskID := int64(12345)
-	s.mockResource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(nil)
-	err := s.mockShard.UpdateQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName, tasks.NewImmediateKey(ackedTaskID))
-	s.NoError(err)
-
-	s.replicationTaskProcessor.minTxAckedTaskID = ackedTaskID - 1
-	s.mockExecutionManager.EXPECT().RangeCompleteHistoryTasks(
-		gomock.Any(),
-		&persistence.RangeCompleteHistoryTasksRequest{
-			ShardID:             s.shardID,
-			TaskCategory:        tasks.CategoryReplication,
-			ExclusiveMaxTaskKey: tasks.NewImmediateKey(ackedTaskID + 1),
-		},
-	).Return(nil)
-	err = s.replicationTaskProcessor.cleanupReplicationTasks()
-	s.NoError(err)
-}
-
 func (s *taskProcessorSuite) TestPaginationFn_Success_More() {
 	namespaceID := uuid.NewRandom().String()
 	workflowID := uuid.New()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Move replication task cleanup to processor manager.
2. Use less aggressive retry in fetching tasks

<!-- Tell your future self why have you made these changes -->
**Why?**
The current logic only do cleanup when there is remote cluster connected. If all remote cluster disconnect, it should cleanup all the tasks.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
