### PR TITLE
Resource aware operation retry

### DIFF
--- a/client/admin/retryable_client_gen.go
+++ b/client/admin/retryable_client_gen.go
@@ -41,12 +41,12 @@ func (c *retryableClient) AddOrUpdateRemoteCluster(
 	opts ...grpc.CallOption,
 ) (*adminservice.AddOrUpdateRemoteClusterResponse, error) {
 	var resp *adminservice.AddOrUpdateRemoteClusterResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.AddOrUpdateRemoteCluster(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -56,12 +56,12 @@ func (c *retryableClient) AddSearchAttributes(
 	opts ...grpc.CallOption,
 ) (*adminservice.AddSearchAttributesResponse, error) {
 	var resp *adminservice.AddSearchAttributesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.AddSearchAttributes(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -71,12 +71,12 @@ func (c *retryableClient) CloseShard(
 	opts ...grpc.CallOption,
 ) (*adminservice.CloseShardResponse, error) {
 	var resp *adminservice.CloseShardResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.CloseShard(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -86,12 +86,12 @@ func (c *retryableClient) DeleteWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*adminservice.DeleteWorkflowExecutionResponse, error) {
 	var resp *adminservice.DeleteWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DeleteWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -101,12 +101,12 @@ func (c *retryableClient) DescribeCluster(
 	opts ...grpc.CallOption,
 ) (*adminservice.DescribeClusterResponse, error) {
 	var resp *adminservice.DescribeClusterResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeCluster(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -116,12 +116,12 @@ func (c *retryableClient) DescribeHistoryHost(
 	opts ...grpc.CallOption,
 ) (*adminservice.DescribeHistoryHostResponse, error) {
 	var resp *adminservice.DescribeHistoryHostResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeHistoryHost(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -131,12 +131,12 @@ func (c *retryableClient) DescribeMutableState(
 	opts ...grpc.CallOption,
 ) (*adminservice.DescribeMutableStateResponse, error) {
 	var resp *adminservice.DescribeMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeMutableState(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -146,12 +146,12 @@ func (c *retryableClient) GetDLQMessages(
 	opts ...grpc.CallOption,
 ) (*adminservice.GetDLQMessagesResponse, error) {
 	var resp *adminservice.GetDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDLQMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -161,12 +161,12 @@ func (c *retryableClient) GetDLQReplicationMessages(
 	opts ...grpc.CallOption,
 ) (*adminservice.GetDLQReplicationMessagesResponse, error) {
 	var resp *adminservice.GetDLQReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDLQReplicationMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -176,12 +176,12 @@ func (c *retryableClient) GetNamespaceReplicationMessages(
 	opts ...grpc.CallOption,
 ) (*adminservice.GetNamespaceReplicationMessagesResponse, error) {
 	var resp *adminservice.GetNamespaceReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetNamespaceReplicationMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -191,12 +191,12 @@ func (c *retryableClient) GetReplicationMessages(
 	opts ...grpc.CallOption,
 ) (*adminservice.GetReplicationMessagesResponse, error) {
 	var resp *adminservice.GetReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetReplicationMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -206,12 +206,12 @@ func (c *retryableClient) GetSearchAttributes(
 	opts ...grpc.CallOption,
 ) (*adminservice.GetSearchAttributesResponse, error) {
 	var resp *adminservice.GetSearchAttributesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetSearchAttributes(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -221,12 +221,12 @@ func (c *retryableClient) GetShard(
 	opts ...grpc.CallOption,
 ) (*adminservice.GetShardResponse, error) {
 	var resp *adminservice.GetShardResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetShard(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -236,12 +236,12 @@ func (c *retryableClient) GetTaskQueueTasks(
 	opts ...grpc.CallOption,
 ) (*adminservice.GetTaskQueueTasksResponse, error) {
 	var resp *adminservice.GetTaskQueueTasksResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetTaskQueueTasks(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -251,12 +251,12 @@ func (c *retryableClient) GetWorkflowExecutionRawHistoryV2(
 	opts ...grpc.CallOption,
 ) (*adminservice.GetWorkflowExecutionRawHistoryV2Response, error) {
 	var resp *adminservice.GetWorkflowExecutionRawHistoryV2Response
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetWorkflowExecutionRawHistoryV2(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -266,12 +266,12 @@ func (c *retryableClient) ListClusterMembers(
 	opts ...grpc.CallOption,
 ) (*adminservice.ListClusterMembersResponse, error) {
 	var resp *adminservice.ListClusterMembersResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListClusterMembers(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -281,12 +281,12 @@ func (c *retryableClient) ListClusters(
 	opts ...grpc.CallOption,
 ) (*adminservice.ListClustersResponse, error) {
 	var resp *adminservice.ListClustersResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListClusters(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -296,12 +296,12 @@ func (c *retryableClient) ListHistoryTasks(
 	opts ...grpc.CallOption,
 ) (*adminservice.ListHistoryTasksResponse, error) {
 	var resp *adminservice.ListHistoryTasksResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListHistoryTasks(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -311,12 +311,12 @@ func (c *retryableClient) MergeDLQMessages(
 	opts ...grpc.CallOption,
 ) (*adminservice.MergeDLQMessagesResponse, error) {
 	var resp *adminservice.MergeDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.MergeDLQMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -326,12 +326,12 @@ func (c *retryableClient) PurgeDLQMessages(
 	opts ...grpc.CallOption,
 ) (*adminservice.PurgeDLQMessagesResponse, error) {
 	var resp *adminservice.PurgeDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PurgeDLQMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -341,12 +341,12 @@ func (c *retryableClient) ReapplyEvents(
 	opts ...grpc.CallOption,
 ) (*adminservice.ReapplyEventsResponse, error) {
 	var resp *adminservice.ReapplyEventsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ReapplyEvents(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -356,12 +356,12 @@ func (c *retryableClient) RebuildMutableState(
 	opts ...grpc.CallOption,
 ) (*adminservice.RebuildMutableStateResponse, error) {
 	var resp *adminservice.RebuildMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RebuildMutableState(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -371,12 +371,12 @@ func (c *retryableClient) RefreshWorkflowTasks(
 	opts ...grpc.CallOption,
 ) (*adminservice.RefreshWorkflowTasksResponse, error) {
 	var resp *adminservice.RefreshWorkflowTasksResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RefreshWorkflowTasks(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -386,12 +386,12 @@ func (c *retryableClient) RemoveRemoteCluster(
 	opts ...grpc.CallOption,
 ) (*adminservice.RemoveRemoteClusterResponse, error) {
 	var resp *adminservice.RemoveRemoteClusterResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RemoveRemoteCluster(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -401,12 +401,12 @@ func (c *retryableClient) RemoveSearchAttributes(
 	opts ...grpc.CallOption,
 ) (*adminservice.RemoveSearchAttributesResponse, error) {
 	var resp *adminservice.RemoveSearchAttributesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RemoveSearchAttributes(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -416,12 +416,12 @@ func (c *retryableClient) RemoveTask(
 	opts ...grpc.CallOption,
 ) (*adminservice.RemoveTaskResponse, error) {
 	var resp *adminservice.RemoveTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RemoveTask(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -431,11 +431,11 @@ func (c *retryableClient) ResendReplicationTasks(
 	opts ...grpc.CallOption,
 ) (*adminservice.ResendReplicationTasksResponse, error) {
 	var resp *adminservice.ResendReplicationTasksResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResendReplicationTasks(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }

--- a/client/frontend/retryable_client_gen.go
+++ b/client/frontend/retryable_client_gen.go
@@ -41,12 +41,12 @@ func (c *retryableClient) CountWorkflowExecutions(
 	opts ...grpc.CallOption,
 ) (*workflowservice.CountWorkflowExecutionsResponse, error) {
 	var resp *workflowservice.CountWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.CountWorkflowExecutions(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -56,12 +56,12 @@ func (c *retryableClient) CreateSchedule(
 	opts ...grpc.CallOption,
 ) (*workflowservice.CreateScheduleResponse, error) {
 	var resp *workflowservice.CreateScheduleResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.CreateSchedule(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -71,12 +71,12 @@ func (c *retryableClient) DeleteSchedule(
 	opts ...grpc.CallOption,
 ) (*workflowservice.DeleteScheduleResponse, error) {
 	var resp *workflowservice.DeleteScheduleResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DeleteSchedule(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -86,12 +86,12 @@ func (c *retryableClient) DeprecateNamespace(
 	opts ...grpc.CallOption,
 ) (*workflowservice.DeprecateNamespaceResponse, error) {
 	var resp *workflowservice.DeprecateNamespaceResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DeprecateNamespace(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -101,12 +101,12 @@ func (c *retryableClient) DescribeNamespace(
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeNamespaceResponse, error) {
 	var resp *workflowservice.DescribeNamespaceResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeNamespace(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -116,12 +116,12 @@ func (c *retryableClient) DescribeSchedule(
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeScheduleResponse, error) {
 	var resp *workflowservice.DescribeScheduleResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeSchedule(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -131,12 +131,12 @@ func (c *retryableClient) DescribeTaskQueue(
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeTaskQueueResponse, error) {
 	var resp *workflowservice.DescribeTaskQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -146,12 +146,12 @@ func (c *retryableClient) DescribeWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
 	var resp *workflowservice.DescribeWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -161,12 +161,12 @@ func (c *retryableClient) GetClusterInfo(
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetClusterInfoResponse, error) {
 	var resp *workflowservice.GetClusterInfoResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetClusterInfo(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -176,12 +176,12 @@ func (c *retryableClient) GetSearchAttributes(
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetSearchAttributesResponse, error) {
 	var resp *workflowservice.GetSearchAttributesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetSearchAttributes(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -191,12 +191,12 @@ func (c *retryableClient) GetSystemInfo(
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetSystemInfoResponse, error) {
 	var resp *workflowservice.GetSystemInfoResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetSystemInfo(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -206,12 +206,12 @@ func (c *retryableClient) GetWorkerBuildIdOrdering(
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetWorkerBuildIdOrderingResponse, error) {
 	var resp *workflowservice.GetWorkerBuildIdOrderingResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetWorkerBuildIdOrdering(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -221,12 +221,12 @@ func (c *retryableClient) GetWorkflowExecutionHistory(
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetWorkflowExecutionHistoryResponse, error) {
 	var resp *workflowservice.GetWorkflowExecutionHistoryResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetWorkflowExecutionHistory(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -236,12 +236,12 @@ func (c *retryableClient) GetWorkflowExecutionHistoryReverse(
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetWorkflowExecutionHistoryReverseResponse, error) {
 	var resp *workflowservice.GetWorkflowExecutionHistoryReverseResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetWorkflowExecutionHistoryReverse(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -251,12 +251,12 @@ func (c *retryableClient) ListArchivedWorkflowExecutions(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
 	var resp *workflowservice.ListArchivedWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListArchivedWorkflowExecutions(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -266,12 +266,12 @@ func (c *retryableClient) ListClosedWorkflowExecutions(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
 	var resp *workflowservice.ListClosedWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListClosedWorkflowExecutions(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -281,12 +281,12 @@ func (c *retryableClient) ListNamespaces(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListNamespacesResponse, error) {
 	var resp *workflowservice.ListNamespacesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListNamespaces(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -296,12 +296,12 @@ func (c *retryableClient) ListOpenWorkflowExecutions(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
 	var resp *workflowservice.ListOpenWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListOpenWorkflowExecutions(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -311,12 +311,12 @@ func (c *retryableClient) ListScheduleMatchingTimes(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListScheduleMatchingTimesResponse, error) {
 	var resp *workflowservice.ListScheduleMatchingTimesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListScheduleMatchingTimes(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -326,12 +326,12 @@ func (c *retryableClient) ListSchedules(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListSchedulesResponse, error) {
 	var resp *workflowservice.ListSchedulesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListSchedules(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -341,12 +341,12 @@ func (c *retryableClient) ListTaskQueuePartitions(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListTaskQueuePartitionsResponse, error) {
 	var resp *workflowservice.ListTaskQueuePartitionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListTaskQueuePartitions(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -356,12 +356,12 @@ func (c *retryableClient) ListWorkflowExecutions(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListWorkflowExecutionsResponse, error) {
 	var resp *workflowservice.ListWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListWorkflowExecutions(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -371,12 +371,12 @@ func (c *retryableClient) PatchSchedule(
 	opts ...grpc.CallOption,
 ) (*workflowservice.PatchScheduleResponse, error) {
 	var resp *workflowservice.PatchScheduleResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PatchSchedule(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -386,12 +386,12 @@ func (c *retryableClient) PollActivityTaskQueue(
 	opts ...grpc.CallOption,
 ) (*workflowservice.PollActivityTaskQueueResponse, error) {
 	var resp *workflowservice.PollActivityTaskQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollActivityTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -401,12 +401,12 @@ func (c *retryableClient) PollWorkflowTaskQueue(
 	opts ...grpc.CallOption,
 ) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
 	var resp *workflowservice.PollWorkflowTaskQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollWorkflowTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -416,12 +416,12 @@ func (c *retryableClient) QueryWorkflow(
 	opts ...grpc.CallOption,
 ) (*workflowservice.QueryWorkflowResponse, error) {
 	var resp *workflowservice.QueryWorkflowResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.QueryWorkflow(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -431,12 +431,12 @@ func (c *retryableClient) RecordActivityTaskHeartbeat(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RecordActivityTaskHeartbeatResponse, error) {
 	var resp *workflowservice.RecordActivityTaskHeartbeatResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordActivityTaskHeartbeat(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -446,12 +446,12 @@ func (c *retryableClient) RecordActivityTaskHeartbeatById(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RecordActivityTaskHeartbeatByIdResponse, error) {
 	var resp *workflowservice.RecordActivityTaskHeartbeatByIdResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordActivityTaskHeartbeatById(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -461,12 +461,12 @@ func (c *retryableClient) RegisterNamespace(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RegisterNamespaceResponse, error) {
 	var resp *workflowservice.RegisterNamespaceResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RegisterNamespace(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -476,12 +476,12 @@ func (c *retryableClient) RequestCancelWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RequestCancelWorkflowExecutionResponse, error) {
 	var resp *workflowservice.RequestCancelWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RequestCancelWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -491,12 +491,12 @@ func (c *retryableClient) ResetStickyTaskQueue(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ResetStickyTaskQueueResponse, error) {
 	var resp *workflowservice.ResetStickyTaskQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResetStickyTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -506,12 +506,12 @@ func (c *retryableClient) ResetWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ResetWorkflowExecutionResponse, error) {
 	var resp *workflowservice.ResetWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResetWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -521,12 +521,12 @@ func (c *retryableClient) RespondActivityTaskCanceled(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskCanceledResponse, error) {
 	var resp *workflowservice.RespondActivityTaskCanceledResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskCanceled(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -536,12 +536,12 @@ func (c *retryableClient) RespondActivityTaskCanceledById(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskCanceledByIdResponse, error) {
 	var resp *workflowservice.RespondActivityTaskCanceledByIdResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskCanceledById(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -551,12 +551,12 @@ func (c *retryableClient) RespondActivityTaskCompleted(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
 	var resp *workflowservice.RespondActivityTaskCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskCompleted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -566,12 +566,12 @@ func (c *retryableClient) RespondActivityTaskCompletedById(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskCompletedByIdResponse, error) {
 	var resp *workflowservice.RespondActivityTaskCompletedByIdResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskCompletedById(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -581,12 +581,12 @@ func (c *retryableClient) RespondActivityTaskFailed(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskFailedResponse, error) {
 	var resp *workflowservice.RespondActivityTaskFailedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskFailed(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -596,12 +596,12 @@ func (c *retryableClient) RespondActivityTaskFailedById(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskFailedByIdResponse, error) {
 	var resp *workflowservice.RespondActivityTaskFailedByIdResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskFailedById(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -611,12 +611,12 @@ func (c *retryableClient) RespondQueryTaskCompleted(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
 	var resp *workflowservice.RespondQueryTaskCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondQueryTaskCompleted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -626,12 +626,12 @@ func (c *retryableClient) RespondWorkflowTaskCompleted(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
 	var resp *workflowservice.RespondWorkflowTaskCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondWorkflowTaskCompleted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -641,12 +641,12 @@ func (c *retryableClient) RespondWorkflowTaskFailed(
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondWorkflowTaskFailedResponse, error) {
 	var resp *workflowservice.RespondWorkflowTaskFailedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondWorkflowTaskFailed(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -656,12 +656,12 @@ func (c *retryableClient) ScanWorkflowExecutions(
 	opts ...grpc.CallOption,
 ) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
 	var resp *workflowservice.ScanWorkflowExecutionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ScanWorkflowExecutions(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -671,12 +671,12 @@ func (c *retryableClient) SignalWithStartWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*workflowservice.SignalWithStartWorkflowExecutionResponse, error) {
 	var resp *workflowservice.SignalWithStartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SignalWithStartWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -686,12 +686,12 @@ func (c *retryableClient) SignalWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*workflowservice.SignalWorkflowExecutionResponse, error) {
 	var resp *workflowservice.SignalWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SignalWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -701,12 +701,12 @@ func (c *retryableClient) StartWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*workflowservice.StartWorkflowExecutionResponse, error) {
 	var resp *workflowservice.StartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.StartWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -716,12 +716,12 @@ func (c *retryableClient) TerminateWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*workflowservice.TerminateWorkflowExecutionResponse, error) {
 	var resp *workflowservice.TerminateWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.TerminateWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -731,12 +731,12 @@ func (c *retryableClient) UpdateNamespace(
 	opts ...grpc.CallOption,
 ) (*workflowservice.UpdateNamespaceResponse, error) {
 	var resp *workflowservice.UpdateNamespaceResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateNamespace(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -746,12 +746,12 @@ func (c *retryableClient) UpdateSchedule(
 	opts ...grpc.CallOption,
 ) (*workflowservice.UpdateScheduleResponse, error) {
 	var resp *workflowservice.UpdateScheduleResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateSchedule(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -761,11 +761,11 @@ func (c *retryableClient) UpdateWorkerBuildIdOrdering(
 	opts ...grpc.CallOption,
 ) (*workflowservice.UpdateWorkerBuildIdOrderingResponse, error) {
 	var resp *workflowservice.UpdateWorkerBuildIdOrderingResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateWorkerBuildIdOrdering(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }

--- a/client/history/retryable_client_gen.go
+++ b/client/history/retryable_client_gen.go
@@ -41,12 +41,12 @@ func (c *retryableClient) CloseShard(
 	opts ...grpc.CallOption,
 ) (*historyservice.CloseShardResponse, error) {
 	var resp *historyservice.CloseShardResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.CloseShard(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -56,12 +56,12 @@ func (c *retryableClient) DeleteWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*historyservice.DeleteWorkflowExecutionResponse, error) {
 	var resp *historyservice.DeleteWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DeleteWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -71,12 +71,12 @@ func (c *retryableClient) DeleteWorkflowVisibilityRecord(
 	opts ...grpc.CallOption,
 ) (*historyservice.DeleteWorkflowVisibilityRecordResponse, error) {
 	var resp *historyservice.DeleteWorkflowVisibilityRecordResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DeleteWorkflowVisibilityRecord(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -86,12 +86,12 @@ func (c *retryableClient) DescribeHistoryHost(
 	opts ...grpc.CallOption,
 ) (*historyservice.DescribeHistoryHostResponse, error) {
 	var resp *historyservice.DescribeHistoryHostResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeHistoryHost(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -101,12 +101,12 @@ func (c *retryableClient) DescribeMutableState(
 	opts ...grpc.CallOption,
 ) (*historyservice.DescribeMutableStateResponse, error) {
 	var resp *historyservice.DescribeMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeMutableState(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -116,12 +116,12 @@ func (c *retryableClient) DescribeWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*historyservice.DescribeWorkflowExecutionResponse, error) {
 	var resp *historyservice.DescribeWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -131,12 +131,12 @@ func (c *retryableClient) GenerateLastHistoryReplicationTasks(
 	opts ...grpc.CallOption,
 ) (*historyservice.GenerateLastHistoryReplicationTasksResponse, error) {
 	var resp *historyservice.GenerateLastHistoryReplicationTasksResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GenerateLastHistoryReplicationTasks(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -146,12 +146,12 @@ func (c *retryableClient) GetDLQMessages(
 	opts ...grpc.CallOption,
 ) (*historyservice.GetDLQMessagesResponse, error) {
 	var resp *historyservice.GetDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDLQMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -161,12 +161,12 @@ func (c *retryableClient) GetDLQReplicationMessages(
 	opts ...grpc.CallOption,
 ) (*historyservice.GetDLQReplicationMessagesResponse, error) {
 	var resp *historyservice.GetDLQReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetDLQReplicationMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -176,12 +176,12 @@ func (c *retryableClient) GetMutableState(
 	opts ...grpc.CallOption,
 ) (*historyservice.GetMutableStateResponse, error) {
 	var resp *historyservice.GetMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetMutableState(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -191,12 +191,12 @@ func (c *retryableClient) GetReplicationMessages(
 	opts ...grpc.CallOption,
 ) (*historyservice.GetReplicationMessagesResponse, error) {
 	var resp *historyservice.GetReplicationMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetReplicationMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -206,12 +206,12 @@ func (c *retryableClient) GetReplicationStatus(
 	opts ...grpc.CallOption,
 ) (*historyservice.GetReplicationStatusResponse, error) {
 	var resp *historyservice.GetReplicationStatusResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetReplicationStatus(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -221,12 +221,12 @@ func (c *retryableClient) GetShard(
 	opts ...grpc.CallOption,
 ) (*historyservice.GetShardResponse, error) {
 	var resp *historyservice.GetShardResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetShard(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -236,12 +236,12 @@ func (c *retryableClient) MergeDLQMessages(
 	opts ...grpc.CallOption,
 ) (*historyservice.MergeDLQMessagesResponse, error) {
 	var resp *historyservice.MergeDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.MergeDLQMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -251,12 +251,12 @@ func (c *retryableClient) PollMutableState(
 	opts ...grpc.CallOption,
 ) (*historyservice.PollMutableStateResponse, error) {
 	var resp *historyservice.PollMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollMutableState(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -266,12 +266,12 @@ func (c *retryableClient) PurgeDLQMessages(
 	opts ...grpc.CallOption,
 ) (*historyservice.PurgeDLQMessagesResponse, error) {
 	var resp *historyservice.PurgeDLQMessagesResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PurgeDLQMessages(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -281,12 +281,12 @@ func (c *retryableClient) QueryWorkflow(
 	opts ...grpc.CallOption,
 ) (*historyservice.QueryWorkflowResponse, error) {
 	var resp *historyservice.QueryWorkflowResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.QueryWorkflow(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -296,12 +296,12 @@ func (c *retryableClient) ReapplyEvents(
 	opts ...grpc.CallOption,
 ) (*historyservice.ReapplyEventsResponse, error) {
 	var resp *historyservice.ReapplyEventsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ReapplyEvents(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -311,12 +311,12 @@ func (c *retryableClient) RebuildMutableState(
 	opts ...grpc.CallOption,
 ) (*historyservice.RebuildMutableStateResponse, error) {
 	var resp *historyservice.RebuildMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RebuildMutableState(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -326,12 +326,12 @@ func (c *retryableClient) RecordActivityTaskHeartbeat(
 	opts ...grpc.CallOption,
 ) (*historyservice.RecordActivityTaskHeartbeatResponse, error) {
 	var resp *historyservice.RecordActivityTaskHeartbeatResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordActivityTaskHeartbeat(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -341,12 +341,12 @@ func (c *retryableClient) RecordActivityTaskStarted(
 	opts ...grpc.CallOption,
 ) (*historyservice.RecordActivityTaskStartedResponse, error) {
 	var resp *historyservice.RecordActivityTaskStartedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordActivityTaskStarted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -356,12 +356,12 @@ func (c *retryableClient) RecordChildExecutionCompleted(
 	opts ...grpc.CallOption,
 ) (*historyservice.RecordChildExecutionCompletedResponse, error) {
 	var resp *historyservice.RecordChildExecutionCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordChildExecutionCompleted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -371,12 +371,12 @@ func (c *retryableClient) RecordWorkflowTaskStarted(
 	opts ...grpc.CallOption,
 ) (*historyservice.RecordWorkflowTaskStartedResponse, error) {
 	var resp *historyservice.RecordWorkflowTaskStartedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RecordWorkflowTaskStarted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -386,12 +386,12 @@ func (c *retryableClient) RefreshWorkflowTasks(
 	opts ...grpc.CallOption,
 ) (*historyservice.RefreshWorkflowTasksResponse, error) {
 	var resp *historyservice.RefreshWorkflowTasksResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RefreshWorkflowTasks(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -401,12 +401,12 @@ func (c *retryableClient) RemoveSignalMutableState(
 	opts ...grpc.CallOption,
 ) (*historyservice.RemoveSignalMutableStateResponse, error) {
 	var resp *historyservice.RemoveSignalMutableStateResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RemoveSignalMutableState(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -416,12 +416,12 @@ func (c *retryableClient) RemoveTask(
 	opts ...grpc.CallOption,
 ) (*historyservice.RemoveTaskResponse, error) {
 	var resp *historyservice.RemoveTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RemoveTask(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -431,12 +431,12 @@ func (c *retryableClient) ReplicateEventsV2(
 	opts ...grpc.CallOption,
 ) (*historyservice.ReplicateEventsV2Response, error) {
 	var resp *historyservice.ReplicateEventsV2Response
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ReplicateEventsV2(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -446,12 +446,12 @@ func (c *retryableClient) RequestCancelWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*historyservice.RequestCancelWorkflowExecutionResponse, error) {
 	var resp *historyservice.RequestCancelWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RequestCancelWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -461,12 +461,12 @@ func (c *retryableClient) ResetStickyTaskQueue(
 	opts ...grpc.CallOption,
 ) (*historyservice.ResetStickyTaskQueueResponse, error) {
 	var resp *historyservice.ResetStickyTaskQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResetStickyTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -476,12 +476,12 @@ func (c *retryableClient) ResetWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*historyservice.ResetWorkflowExecutionResponse, error) {
 	var resp *historyservice.ResetWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ResetWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -491,12 +491,12 @@ func (c *retryableClient) RespondActivityTaskCanceled(
 	opts ...grpc.CallOption,
 ) (*historyservice.RespondActivityTaskCanceledResponse, error) {
 	var resp *historyservice.RespondActivityTaskCanceledResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskCanceled(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -506,12 +506,12 @@ func (c *retryableClient) RespondActivityTaskCompleted(
 	opts ...grpc.CallOption,
 ) (*historyservice.RespondActivityTaskCompletedResponse, error) {
 	var resp *historyservice.RespondActivityTaskCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskCompleted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -521,12 +521,12 @@ func (c *retryableClient) RespondActivityTaskFailed(
 	opts ...grpc.CallOption,
 ) (*historyservice.RespondActivityTaskFailedResponse, error) {
 	var resp *historyservice.RespondActivityTaskFailedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondActivityTaskFailed(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -536,12 +536,12 @@ func (c *retryableClient) RespondWorkflowTaskCompleted(
 	opts ...grpc.CallOption,
 ) (*historyservice.RespondWorkflowTaskCompletedResponse, error) {
 	var resp *historyservice.RespondWorkflowTaskCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondWorkflowTaskCompleted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -551,12 +551,12 @@ func (c *retryableClient) RespondWorkflowTaskFailed(
 	opts ...grpc.CallOption,
 ) (*historyservice.RespondWorkflowTaskFailedResponse, error) {
 	var resp *historyservice.RespondWorkflowTaskFailedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondWorkflowTaskFailed(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -566,12 +566,12 @@ func (c *retryableClient) ScheduleWorkflowTask(
 	opts ...grpc.CallOption,
 ) (*historyservice.ScheduleWorkflowTaskResponse, error) {
 	var resp *historyservice.ScheduleWorkflowTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ScheduleWorkflowTask(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -581,12 +581,12 @@ func (c *retryableClient) SignalWithStartWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*historyservice.SignalWithStartWorkflowExecutionResponse, error) {
 	var resp *historyservice.SignalWithStartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SignalWithStartWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -596,12 +596,12 @@ func (c *retryableClient) SignalWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*historyservice.SignalWorkflowExecutionResponse, error) {
 	var resp *historyservice.SignalWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SignalWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -611,12 +611,12 @@ func (c *retryableClient) StartWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*historyservice.StartWorkflowExecutionResponse, error) {
 	var resp *historyservice.StartWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.StartWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -626,12 +626,12 @@ func (c *retryableClient) SyncActivity(
 	opts ...grpc.CallOption,
 ) (*historyservice.SyncActivityResponse, error) {
 	var resp *historyservice.SyncActivityResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SyncActivity(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -641,12 +641,12 @@ func (c *retryableClient) SyncShardStatus(
 	opts ...grpc.CallOption,
 ) (*historyservice.SyncShardStatusResponse, error) {
 	var resp *historyservice.SyncShardStatusResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.SyncShardStatus(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -656,12 +656,12 @@ func (c *retryableClient) TerminateWorkflowExecution(
 	opts ...grpc.CallOption,
 ) (*historyservice.TerminateWorkflowExecutionResponse, error) {
 	var resp *historyservice.TerminateWorkflowExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.TerminateWorkflowExecution(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -671,12 +671,12 @@ func (c *retryableClient) VerifyChildExecutionCompletionRecorded(
 	opts ...grpc.CallOption,
 ) (*historyservice.VerifyChildExecutionCompletionRecordedResponse, error) {
 	var resp *historyservice.VerifyChildExecutionCompletionRecordedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.VerifyChildExecutionCompletionRecorded(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -686,11 +686,11 @@ func (c *retryableClient) VerifyFirstWorkflowTaskScheduled(
 	opts ...grpc.CallOption,
 ) (*historyservice.VerifyFirstWorkflowTaskScheduledResponse, error) {
 	var resp *historyservice.VerifyFirstWorkflowTaskScheduledResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.VerifyFirstWorkflowTaskScheduled(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }

--- a/client/matching/retryable_client_gen.go
+++ b/client/matching/retryable_client_gen.go
@@ -41,12 +41,12 @@ func (c *retryableClient) AddActivityTask(
 	opts ...grpc.CallOption,
 ) (*matchingservice.AddActivityTaskResponse, error) {
 	var resp *matchingservice.AddActivityTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.AddActivityTask(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -56,12 +56,12 @@ func (c *retryableClient) AddWorkflowTask(
 	opts ...grpc.CallOption,
 ) (*matchingservice.AddWorkflowTaskResponse, error) {
 	var resp *matchingservice.AddWorkflowTaskResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.AddWorkflowTask(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -71,12 +71,12 @@ func (c *retryableClient) CancelOutstandingPoll(
 	opts ...grpc.CallOption,
 ) (*matchingservice.CancelOutstandingPollResponse, error) {
 	var resp *matchingservice.CancelOutstandingPollResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.CancelOutstandingPoll(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -86,12 +86,12 @@ func (c *retryableClient) DescribeTaskQueue(
 	opts ...grpc.CallOption,
 ) (*matchingservice.DescribeTaskQueueResponse, error) {
 	var resp *matchingservice.DescribeTaskQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.DescribeTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -101,12 +101,12 @@ func (c *retryableClient) GetWorkerBuildIdOrdering(
 	opts ...grpc.CallOption,
 ) (*matchingservice.GetWorkerBuildIdOrderingResponse, error) {
 	var resp *matchingservice.GetWorkerBuildIdOrderingResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.GetWorkerBuildIdOrdering(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -116,12 +116,12 @@ func (c *retryableClient) ListTaskQueuePartitions(
 	opts ...grpc.CallOption,
 ) (*matchingservice.ListTaskQueuePartitionsResponse, error) {
 	var resp *matchingservice.ListTaskQueuePartitionsResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.ListTaskQueuePartitions(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -131,12 +131,12 @@ func (c *retryableClient) PollActivityTaskQueue(
 	opts ...grpc.CallOption,
 ) (*matchingservice.PollActivityTaskQueueResponse, error) {
 	var resp *matchingservice.PollActivityTaskQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollActivityTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -146,12 +146,12 @@ func (c *retryableClient) PollWorkflowTaskQueue(
 	opts ...grpc.CallOption,
 ) (*matchingservice.PollWorkflowTaskQueueResponse, error) {
 	var resp *matchingservice.PollWorkflowTaskQueueResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.PollWorkflowTaskQueue(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -161,12 +161,12 @@ func (c *retryableClient) QueryWorkflow(
 	opts ...grpc.CallOption,
 ) (*matchingservice.QueryWorkflowResponse, error) {
 	var resp *matchingservice.QueryWorkflowResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.QueryWorkflow(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -176,12 +176,12 @@ func (c *retryableClient) RespondQueryTaskCompleted(
 	opts ...grpc.CallOption,
 ) (*matchingservice.RespondQueryTaskCompletedResponse, error) {
 	var resp *matchingservice.RespondQueryTaskCompletedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.RespondQueryTaskCompleted(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 
@@ -191,11 +191,11 @@ func (c *retryableClient) UpdateWorkerBuildIdOrdering(
 	opts ...grpc.CallOption,
 ) (*matchingservice.UpdateWorkerBuildIdOrderingResponse, error) {
 	var resp *matchingservice.UpdateWorkerBuildIdOrderingResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.UpdateWorkerBuildIdOrdering(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }

--- a/cmd/tools/rpcwrappers/main.go
+++ b/cmd/tools/rpcwrappers/main.go
@@ -426,12 +426,12 @@ func (c *retryableClient) {{.Method}}(
 	opts ...grpc.CallOption,
 ) ({{.ResponseType}}, error) {
 	var resp {{.ResponseType}}
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = c.client.{{.Method}}(ctx, request, opts...)
 		return err
 	}
-	err := backoff.Retry(op, c.policy, c.isRetryable)
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
 	return resp, err
 }
 `)

--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -300,7 +300,7 @@ func (h *historyArchiver) ValidateURI(URI archiver.URI) error {
 
 func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIterator) (*archiverspb.HistoryBlob, error) {
 	historyBlob, err := historyIterator.Next()
-	op := func() error {
+	op := func(_ context.Context) error {
 		historyBlob, err = historyIterator.Next()
 		return err
 	}
@@ -311,7 +311,7 @@ func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIte
 		if contextExpired(ctx) {
 			return nil, archiver.ErrContextTimeout
 		}
-		err = backoff.Retry(op, common.CreatePersistenceRetryPolicy(), common.IsPersistenceTransientError)
+		err = backoff.ThrottleRetryContext(ctx, op, common.CreatePersistenceRetryPolicy(), common.IsPersistenceTransientError)
 	}
 	return historyBlob, nil
 }

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -362,7 +362,7 @@ func (h *historyArchiver) ValidateURI(URI archiver.URI) error {
 
 func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIterator) (*archiverspb.HistoryBlob, error) {
 	historyBlob, err := historyIterator.Next()
-	op := func() error {
+	op := func(_ context.Context) error {
 		historyBlob, err = historyIterator.Next()
 		return err
 	}
@@ -373,7 +373,7 @@ func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIte
 		if contextExpired(ctx) {
 			return nil, archiver.ErrContextTimeout
 		}
-		err = backoff.Retry(op, common.CreatePersistenceRetryPolicy(), common.IsPersistenceTransientError)
+		err = backoff.ThrottleRetryContext(ctx, op, common.CreatePersistenceRetryPolicy(), common.IsPersistenceTransientError)
 	}
 	return historyBlob, nil
 }

--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -160,14 +160,14 @@ func RetryContext(
 	return ctx.Err()
 }
 
-// ThrottleRetry is a resource awawe version of Retry.
+// ThrottleRetry is a resource aware version of Retry.
 // Resource exhausted error will be retried using a different throttle retry policy, instead of the specified one.
 func ThrottleRetry(operation Operation, policy RetryPolicy, isRetryable IsRetryable) error {
 	ctxOp := func(context.Context) error { return operation() }
 	return ThrottleRetryContext(context.Background(), ctxOp, policy, isRetryable)
 }
 
-// ThrottleRetryContext is a context and resource awawe version of Retry.
+// ThrottleRetryContext is a context and resource aware version of Retry.
 // Context timeout/cancellation errors are never retried, regardless of IsRetryable.
 // Resource exhausted error will be retried using a different throttle retry policy, instead of the specified one.
 // TODO: allow customizing throttle retry policy and what kind of error are categorized as throttle error.

--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -28,6 +28,18 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"go.temporal.io/api/serviceerror"
+)
+
+const (
+	throttleRetryInitialInterval    = time.Second
+	throttleRetryMaxInterval        = 10 * time.Second
+	throttleRetryExpirationInterval = NoInterval
+)
+
+var (
+	throttleRetryPolicy = createThrottleRetryPolicy()
 )
 
 type (
@@ -100,6 +112,7 @@ func NewConcurrentRetrier(retryPolicy RetryPolicy) *ConcurrentRetrier {
 // Retry function can be used to wrap any call with retry logic using the passed
 // in policy. A `nil` IsRetryable predicate will retry all errors. There is a
 // context-aware version of this function: RetryContext.
+// Deprecated: Use ThrottleRetry
 func Retry(operation Operation, policy RetryPolicy, isRetryable IsRetryable) error {
 	ctxOp := func(context.Context) error { return operation() }
 	return RetryContext(context.Background(), ctxOp, policy, isRetryable)
@@ -107,6 +120,7 @@ func Retry(operation Operation, policy RetryPolicy, isRetryable IsRetryable) err
 
 // RetryContext is a context-aware version of Retry. Context
 // timeout/cancellation errors are never retried, regardless of IsRetryable.
+// Deprecated: use ThrottleRetryContext,
 func RetryContext(
 	ctx context.Context,
 	operation OperationCtx,
@@ -141,9 +155,65 @@ func RetryContext(
 		case <-t.C:
 		case <-ctx.Done():
 			t.Stop()
-			break
 		}
 	}
+	return ctx.Err()
+}
+
+// ThrottleRetry is a resource awawe version of Retry.
+// Resource exhausted error will be retried using a different throttle retry policy, instead of the specified one.
+func ThrottleRetry(operation Operation, policy RetryPolicy, isRetryable IsRetryable) error {
+	ctxOp := func(context.Context) error { return operation() }
+	return ThrottleRetryContext(context.Background(), ctxOp, policy, isRetryable)
+}
+
+// ThrottleRetryContext is a context and resource awawe version of Retry.
+// Context timeout/cancellation errors are never retried, regardless of IsRetryable.
+// Resource exhausted error will be retried using a different throttle retry policy, instead of the specified one.
+// TODO: allow customizing throttle retry policy and what kind of error are categorized as throttle error.
+func ThrottleRetryContext(
+	ctx context.Context,
+	operation OperationCtx,
+	policy RetryPolicy,
+	isRetryable IsRetryable,
+) error {
+	var err error
+	var next time.Duration
+
+	if isRetryable == nil {
+		isRetryable = func(error) bool { return true }
+	}
+
+	r := NewRetrier(policy, SystemClock)
+	t := NewRetrier(throttleRetryPolicy, SystemClock)
+	for ctx.Err() == nil {
+		if err = operation(ctx); err == nil {
+			return nil
+		}
+
+		if next = r.NextBackOff(); next == done {
+			return err
+		}
+
+		if err == ctx.Err() || !isRetryable(err) {
+			return err
+		}
+
+		if _, ok := err.(*serviceerror.ResourceExhausted); ok {
+			throttleBackoff := t.NextBackOff()
+			if throttleBackoff > next {
+				next = throttleBackoff
+			}
+		}
+
+		timer := time.NewTimer(next)
+		select {
+		case <-timer.C:
+		case <-ctx.Done():
+			timer.Stop()
+		}
+	}
+
 	return ctx.Err()
 }
 
@@ -158,4 +228,12 @@ func IgnoreErrors(errorsToExclude []error) func(error) bool {
 
 		return true
 	}
+}
+
+func createThrottleRetryPolicy() RetryPolicy {
+	policy := NewExponentialRetryPolicy(throttleRetryInitialInterval)
+	policy.SetMaximumInterval(throttleRetryMaxInterval)
+	policy.SetExpirationInterval(throttleRetryExpirationInterval)
+
+	return policy
 }

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -251,8 +251,8 @@ func (s *RetrySuite) TestThrottleRetryContext() {
 	s.Equal(&someError{}, err)
 	s.GreaterOrEqual(
 		time.Since(start),
-		throttleInitialInterval,
-		"Resource exhausted error should have a longer initial interval",
+		throttleInitialInterval/2, // due to jitter
+		"Resource exhausted error should use throttle retry policy",
 	)
 
 	// test if context timeout is respected

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/api/serviceerror"
 )
 
 type (
@@ -222,6 +223,62 @@ func (s *RetrySuite) TestContextErrorFromSomeOtherContext() {
 		NewExponentialRetryPolicy(1*time.Millisecond),
 		retryEverything)
 	s.NoError(err)
+}
+
+func (s *RetrySuite) TestThrottleRetryContext() {
+	throttleInitialInterval := 100 * time.Millisecond
+	testThrottleRetryPolicy := NewExponentialRetryPolicy(throttleInitialInterval)
+	testThrottleRetryPolicy.SetMaximumInterval(throttleRetryMaxInterval)
+	testThrottleRetryPolicy.SetExpirationInterval(throttleRetryExpirationInterval)
+	throttleRetryPolicy = testThrottleRetryPolicy
+
+	policy := NewExponentialRetryPolicy(10 * time.Millisecond)
+	policy.SetMaximumAttempts(1)
+
+	// test if throttle retry policy is used on resource exhausted error
+	attempt := 1
+	op := func(_ context.Context) error {
+		if attempt == 1 {
+			attempt++
+			return &serviceerror.ResourceExhausted{}
+		}
+
+		return &someError{}
+	}
+
+	start := SystemClock.Now()
+	err := ThrottleRetryContext(context.Background(), op, policy, retryEverything)
+	s.Equal(&someError{}, err)
+	s.GreaterOrEqual(
+		time.Since(start),
+		throttleInitialInterval,
+		"Resource exhausted error should have a longer initial interval",
+	)
+
+	// test if context timeout is respected
+	start = SystemClock.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	err = ThrottleRetryContext(ctx, func(_ context.Context) error { return &serviceerror.ResourceExhausted{} }, policy, retryEverything)
+	s.Equal(ctx.Err(), err)
+	s.LessOrEqual(
+		time.Since(start),
+		throttleInitialInterval,
+		"Context timeout should be respected",
+	)
+	cancel()
+
+	// test if retry will stop if there's no more retry indicated by the retry policy
+	attempt = 0
+	op = func(_ context.Context) error {
+		attempt++
+		return &serviceerror.ResourceExhausted{}
+	}
+	err = ThrottleRetryContext(context.Background(), op, policy, retryEverything)
+	s.Equal(&serviceerror.ResourceExhausted{}, err)
+	s.Equal(2, attempt)
+
+	// set the default global throttle retry policy back to its original value
+	throttleRetryPolicy = createThrottleRetryPolicy()
 }
 
 var retryEverything IsRetryable = nil

--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -726,7 +726,7 @@ func (s *HistoryV2PersistenceSuite) deleteHistoryBranch(branch []byte) error {
 		return err
 	}
 
-	return backoff.Retry(op, historyTestRetryPolicy, isConditionFail)
+	return backoff.ThrottleRetry(op, historyTestRetryPolicy, isConditionFail)
 }
 
 // persistence helper
@@ -822,7 +822,7 @@ func (s *HistoryV2PersistenceSuite) append(branch []byte, events []*historypb.Hi
 		return err
 	}
 
-	err := backoff.Retry(op, historyTestRetryPolicy, isConditionFail)
+	err := backoff.ThrottleRetry(op, historyTestRetryPolicy, isConditionFail)
 	if err != nil {
 		return err
 	}
@@ -850,6 +850,6 @@ func (s *HistoryV2PersistenceSuite) fork(forkBranch []byte, forkNodeID int64) ([
 		return err
 	}
 
-	err := backoff.Retry(op, historyTestRetryPolicy, isConditionFail)
+	err := backoff.ThrottleRetry(op, historyTestRetryPolicy, isConditionFail)
 	return bi, err
 }

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -321,7 +321,7 @@ func (s *TestBase) Publish(
 	retryPolicy.SetBackoffCoefficient(1.5)
 	retryPolicy.SetMaximumAttempts(5)
 
-	return backoff.Retry(
+	return backoff.ThrottleRetry(
 		func() error {
 			return s.NamespaceReplicationQueue.Publish(ctx, message)
 		},
@@ -370,7 +370,7 @@ func (s *TestBase) PublishToNamespaceDLQ(
 	retryPolicy.SetBackoffCoefficient(1.5)
 	retryPolicy.SetMaximumAttempts(5)
 
-	return backoff.RetryContext(
+	return backoff.ThrottleRetryContext(
 		ctx,
 		func(ctx context.Context) error {
 			return s.NamespaceReplicationQueue.PublishToDLQ(ctx, message)

--- a/common/sdk/factory.go
+++ b/common/sdk/factory.go
@@ -79,7 +79,7 @@ func (f *clientFactory) NewClient(namespaceName string, logger log.Logger) (sdkc
 	var client sdkclient.Client
 
 	// Retry for up to 1m, handles frontend service not ready
-	err := backoff.Retry(func() error {
+	err := backoff.ThrottleRetry(func() error {
 		sdkClient, err := sdkclient.Dial(sdkclient.Options{
 			HostPort:       f.hostPort,
 			Namespace:      namespaceName,

--- a/common/tasks/parallel_processor.go
+++ b/common/tasks/parallel_processor.go
@@ -214,7 +214,7 @@ func (p *ParallelProcessor) executeTask(
 		return !p.isStopped() && task.IsRetryableError(err)
 	}
 
-	if err := backoff.Retry(operation, task.RetryPolicy(), isRetryable); err != nil {
+	if err := backoff.ThrottleRetry(operation, task.RetryPolicy(), isRetryable); err != nil {
 		if p.isStopped() {
 			task.Reschedule()
 			return

--- a/common/testing/mocksdk/client_mock.go
+++ b/common/testing/mocksdk/client_mock.go
@@ -35,8 +35,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	enums "go.temporal.io/api/enums/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
-	client "go.temporal.io/sdk/client"
-	converter "go.temporal.io/sdk/converter"
+	internal "go.temporal.io/sdk/internal"
 )
 
 // MockClient is a mock of Client interface.
@@ -77,10 +76,10 @@ func (mr *MockClientMockRecorder) CancelWorkflow(arg0, arg1, arg2 interface{}) *
 }
 
 // CheckHealth mocks base method.
-func (m *MockClient) CheckHealth(arg0 context.Context, arg1 *client.CheckHealthRequest) (*client.CheckHealthResponse, error) {
+func (m *MockClient) CheckHealth(arg0 context.Context, arg1 *internal.CheckHealthRequest) (*internal.CheckHealthResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckHealth", arg0, arg1)
-	ret0, _ := ret[0].(*client.CheckHealthResponse)
+	ret0, _ := ret[0].(*internal.CheckHealthResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -177,14 +176,14 @@ func (mr *MockClientMockRecorder) DescribeWorkflowExecution(arg0, arg1, arg2 int
 }
 
 // ExecuteWorkflow mocks base method.
-func (m *MockClient) ExecuteWorkflow(arg0 context.Context, arg1 client.StartWorkflowOptions, arg2 interface{}, arg3 ...interface{}) (client.WorkflowRun, error) {
+func (m *MockClient) ExecuteWorkflow(arg0 context.Context, arg1 internal.StartWorkflowOptions, arg2 interface{}, arg3 ...interface{}) (internal.WorkflowRun, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ExecuteWorkflow", varargs...)
-	ret0, _ := ret[0].(client.WorkflowRun)
+	ret0, _ := ret[0].(internal.WorkflowRun)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -212,10 +211,10 @@ func (mr *MockClientMockRecorder) GetSearchAttributes(arg0 interface{}) *gomock.
 }
 
 // GetWorkflow mocks base method.
-func (m *MockClient) GetWorkflow(arg0 context.Context, arg1, arg2 string) client.WorkflowRun {
+func (m *MockClient) GetWorkflow(arg0 context.Context, arg1, arg2 string) internal.WorkflowRun {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflow", arg0, arg1, arg2)
-	ret0, _ := ret[0].(client.WorkflowRun)
+	ret0, _ := ret[0].(internal.WorkflowRun)
 	return ret0
 }
 
@@ -226,10 +225,10 @@ func (mr *MockClientMockRecorder) GetWorkflow(arg0, arg1, arg2 interface{}) *gom
 }
 
 // GetWorkflowHistory mocks base method.
-func (m *MockClient) GetWorkflowHistory(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 enums.HistoryEventFilterType) client.HistoryEventIterator {
+func (m *MockClient) GetWorkflowHistory(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 enums.HistoryEventFilterType) internal.HistoryEventIterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowHistory", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(client.HistoryEventIterator)
+	ret0, _ := ret[0].(internal.HistoryEventIterator)
 	return ret0
 }
 
@@ -320,10 +319,10 @@ func (mr *MockClientMockRecorder) QueryWorkflow(arg0, arg1, arg2, arg3 interface
 }
 
 // QueryWorkflowWithOptions mocks base method.
-func (m *MockClient) QueryWorkflowWithOptions(arg0 context.Context, arg1 *client.QueryWorkflowWithOptionsRequest) (*client.QueryWorkflowWithOptionsResponse, error) {
+func (m *MockClient) QueryWorkflowWithOptions(arg0 context.Context, arg1 *internal.QueryWorkflowWithOptionsRequest) (*internal.QueryWorkflowWithOptionsResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueryWorkflowWithOptions", arg0, arg1)
-	ret0, _ := ret[0].(*client.QueryWorkflowWithOptionsResponse)
+	ret0, _ := ret[0].(*internal.QueryWorkflowWithOptionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -403,14 +402,14 @@ func (mr *MockClientMockRecorder) ScanWorkflow(arg0, arg1 interface{}) *gomock.C
 }
 
 // SignalWithStartWorkflow mocks base method.
-func (m *MockClient) SignalWithStartWorkflow(arg0 context.Context, arg1, arg2 string, arg3 interface{}, arg4 client.StartWorkflowOptions, arg5 interface{}, arg6 ...interface{}) (client.WorkflowRun, error) {
+func (m *MockClient) SignalWithStartWorkflow(arg0 context.Context, arg1, arg2 string, arg3 interface{}, arg4 internal.StartWorkflowOptions, arg5 interface{}, arg6 ...interface{}) (internal.WorkflowRun, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2, arg3, arg4, arg5}
 	for _, a := range arg6 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "SignalWithStartWorkflow", varargs...)
-	ret0, _ := ret[0].(client.WorkflowRun)
+	ret0, _ := ret[0].(internal.WorkflowRun)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/common/testing/mocksdk/client_mock.go
+++ b/common/testing/mocksdk/client_mock.go
@@ -35,7 +35,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	enums "go.temporal.io/api/enums/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
-	internal "go.temporal.io/sdk/internal"
+	client "go.temporal.io/sdk/client"
+	converter "go.temporal.io/sdk/converter"
 )
 
 // MockClient is a mock of Client interface.
@@ -76,10 +77,10 @@ func (mr *MockClientMockRecorder) CancelWorkflow(arg0, arg1, arg2 interface{}) *
 }
 
 // CheckHealth mocks base method.
-func (m *MockClient) CheckHealth(arg0 context.Context, arg1 *internal.CheckHealthRequest) (*internal.CheckHealthResponse, error) {
+func (m *MockClient) CheckHealth(arg0 context.Context, arg1 *client.CheckHealthRequest) (*client.CheckHealthResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckHealth", arg0, arg1)
-	ret0, _ := ret[0].(*internal.CheckHealthResponse)
+	ret0, _ := ret[0].(*client.CheckHealthResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -176,14 +177,14 @@ func (mr *MockClientMockRecorder) DescribeWorkflowExecution(arg0, arg1, arg2 int
 }
 
 // ExecuteWorkflow mocks base method.
-func (m *MockClient) ExecuteWorkflow(arg0 context.Context, arg1 internal.StartWorkflowOptions, arg2 interface{}, arg3 ...interface{}) (internal.WorkflowRun, error) {
+func (m *MockClient) ExecuteWorkflow(arg0 context.Context, arg1 client.StartWorkflowOptions, arg2 interface{}, arg3 ...interface{}) (client.WorkflowRun, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2}
 	for _, a := range arg3 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "ExecuteWorkflow", varargs...)
-	ret0, _ := ret[0].(internal.WorkflowRun)
+	ret0, _ := ret[0].(client.WorkflowRun)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -211,10 +212,10 @@ func (mr *MockClientMockRecorder) GetSearchAttributes(arg0 interface{}) *gomock.
 }
 
 // GetWorkflow mocks base method.
-func (m *MockClient) GetWorkflow(arg0 context.Context, arg1, arg2 string) internal.WorkflowRun {
+func (m *MockClient) GetWorkflow(arg0 context.Context, arg1, arg2 string) client.WorkflowRun {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflow", arg0, arg1, arg2)
-	ret0, _ := ret[0].(internal.WorkflowRun)
+	ret0, _ := ret[0].(client.WorkflowRun)
 	return ret0
 }
 
@@ -225,10 +226,10 @@ func (mr *MockClientMockRecorder) GetWorkflow(arg0, arg1, arg2 interface{}) *gom
 }
 
 // GetWorkflowHistory mocks base method.
-func (m *MockClient) GetWorkflowHistory(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 enums.HistoryEventFilterType) internal.HistoryEventIterator {
+func (m *MockClient) GetWorkflowHistory(arg0 context.Context, arg1, arg2 string, arg3 bool, arg4 enums.HistoryEventFilterType) client.HistoryEventIterator {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWorkflowHistory", arg0, arg1, arg2, arg3, arg4)
-	ret0, _ := ret[0].(internal.HistoryEventIterator)
+	ret0, _ := ret[0].(client.HistoryEventIterator)
 	return ret0
 }
 
@@ -319,10 +320,10 @@ func (mr *MockClientMockRecorder) QueryWorkflow(arg0, arg1, arg2, arg3 interface
 }
 
 // QueryWorkflowWithOptions mocks base method.
-func (m *MockClient) QueryWorkflowWithOptions(arg0 context.Context, arg1 *internal.QueryWorkflowWithOptionsRequest) (*internal.QueryWorkflowWithOptionsResponse, error) {
+func (m *MockClient) QueryWorkflowWithOptions(arg0 context.Context, arg1 *client.QueryWorkflowWithOptionsRequest) (*client.QueryWorkflowWithOptionsResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueryWorkflowWithOptions", arg0, arg1)
-	ret0, _ := ret[0].(*internal.QueryWorkflowWithOptionsResponse)
+	ret0, _ := ret[0].(*client.QueryWorkflowWithOptionsResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -402,14 +403,14 @@ func (mr *MockClientMockRecorder) ScanWorkflow(arg0, arg1 interface{}) *gomock.C
 }
 
 // SignalWithStartWorkflow mocks base method.
-func (m *MockClient) SignalWithStartWorkflow(arg0 context.Context, arg1, arg2 string, arg3 interface{}, arg4 internal.StartWorkflowOptions, arg5 interface{}, arg6 ...interface{}) (internal.WorkflowRun, error) {
+func (m *MockClient) SignalWithStartWorkflow(arg0 context.Context, arg1, arg2 string, arg3 interface{}, arg4 client.StartWorkflowOptions, arg5 interface{}, arg6 ...interface{}) (client.WorkflowRun, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0, arg1, arg2, arg3, arg4, arg5}
 	for _, a := range arg6 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "SignalWithStartWorkflow", varargs...)
-	ret0, _ := ret[0].(internal.WorkflowRun)
+	ret0, _ := ret[0].(client.WorkflowRun)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/common/testing/mocksdk/workflowrun_mock.go
+++ b/common/testing/mocksdk/workflowrun_mock.go
@@ -33,7 +33,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	client "go.temporal.io/sdk/client"
+	internal "go.temporal.io/sdk/internal"
 )
 
 // MockWorkflowRun is a mock of WorkflowRun interface.
@@ -102,7 +102,7 @@ func (mr *MockWorkflowRunMockRecorder) GetRunID() *gomock.Call {
 }
 
 // GetWithOptions mocks base method.
-func (m *MockWorkflowRun) GetWithOptions(arg0 context.Context, arg1 interface{}, arg2 client.WorkflowRunGetOptions) error {
+func (m *MockWorkflowRun) GetWithOptions(arg0 context.Context, arg1 interface{}, arg2 internal.WorkflowRunGetOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWithOptions", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/common/testing/mocksdk/workflowrun_mock.go
+++ b/common/testing/mocksdk/workflowrun_mock.go
@@ -33,7 +33,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	internal "go.temporal.io/sdk/internal"
+	client "go.temporal.io/sdk/client"
 )
 
 // MockWorkflowRun is a mock of WorkflowRun interface.
@@ -102,7 +102,7 @@ func (mr *MockWorkflowRunMockRecorder) GetRunID() *gomock.Call {
 }
 
 // GetWithOptions mocks base method.
-func (m *MockWorkflowRun) GetWithOptions(arg0 context.Context, arg1 interface{}, arg2 internal.WorkflowRunGetOptions) error {
+func (m *MockWorkflowRun) GetWithOptions(arg0 context.Context, arg1 interface{}, arg2 client.WorkflowRunGetOptions) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetWithOptions", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1101,7 +1101,7 @@ func (h *Handler) QueryWorkflow(ctx context.Context, request *historyservice.Que
 	}
 
 	var resp *historyservice.QueryWorkflowResponse
-	err2 := backoff.RetryContext(ctx, func(ctx context.Context) error {
+	err2 := backoff.ThrottleRetryContext(ctx, func(ctx context.Context) error {
 		var err error
 		resp, err = engine.QueryWorkflow(ctx, request)
 		return err

--- a/service/history/queueAckMgr.go
+++ b/service/history/queueAckMgr.go
@@ -131,7 +131,7 @@ func (a *queueAckMgrImpl) readQueueTasks() ([]queues.Executable, bool, error) {
 		return err
 	}
 
-	err := backoff.Retry(op, workflow.PersistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	err := backoff.ThrottleRetry(op, workflow.PersistenceOperationRetryPolicy, common.IsPersistenceTransientError)
 	if err != nil {
 		return nil, false, err
 	}

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -307,13 +307,13 @@ func (p *ackMgrImpl) taskInfoToTask(
 	task tasks.Task,
 ) (*replicationspb.ReplicationTask, error) {
 	var replicationTask *replicationspb.ReplicationTask
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		replicationTask, err = p.toReplicationTask(ctx, task)
 		return err
 	}
 
-	if err := backoff.Retry(op, p.retryPolicy, common.IsPersistenceTransientError); err != nil {
+	if err := backoff.ThrottleRetryContext(ctx, op, p.retryPolicy, common.IsPersistenceTransientError); err != nil {
 		return nil, err
 	}
 	return replicationTask, nil

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -341,7 +341,7 @@ func (p *taskProcessorImpl) handleReplicationTask(
 		p.emitTaskMetrics(scope, err)
 		return err
 	}
-	return backoff.Retry(operation, p.taskRetryPolicy, p.isRetryableError)
+	return backoff.ThrottleRetry(operation, p.taskRetryPolicy, p.isRetryableError)
 }
 
 func (p *taskProcessorImpl) handleReplicationDLQTask(
@@ -366,7 +366,7 @@ func (p *taskProcessorImpl) handleReplicationDLQTask(
 		float64(request.TaskInfo.GetTaskId()),
 	)
 	// The following is guaranteed to success or retry forever until processor is shutdown.
-	return backoff.Retry(func() error {
+	return backoff.ThrottleRetry(func() error {
 		err := p.shard.GetExecutionManager().PutReplicationTaskToDLQ(context.TODO(), request)
 		if err != nil {
 			p.logger.Error("failed to enqueue replication task to DLQ", tag.Error(err))

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1782,7 +1782,7 @@ func (s *ContextImpl) acquireShard() {
 		return nil
 	}
 
-	err := backoff.Retry(op, policy, common.IsPersistenceTransientError)
+	err := backoff.ThrottleRetry(op, policy, common.IsPersistenceTransientError)
 	if err == errStoppingContext {
 		// State changed since this goroutine started, exit silently.
 		return

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -1237,7 +1237,7 @@ func (t *transferQueueActiveTaskExecutor) requestCancelExternalExecutionWithRetr
 		return err
 	}
 
-	err := backoff.RetryContext(
+	err := backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		workflow.PersistenceOperationRetryPolicy,
@@ -1281,7 +1281,7 @@ func (t *transferQueueActiveTaskExecutor) signalExternalExecutionWithRetry(
 		return err
 	}
 
-	return backoff.RetryContext(
+	return backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		workflow.PersistenceOperationRetryPolicy,
@@ -1339,7 +1339,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflowWithRetry(
 		return err
 	}
 
-	if err = backoff.RetryContext(
+	if err = backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		workflow.PersistenceOperationRetryPolicy,

--- a/service/history/workflow/cache.go
+++ b/service/history/workflow/cache.go
@@ -230,14 +230,14 @@ func (c *CacheImpl) getCurrentExecutionWithRetry(
 ) (*persistence.GetCurrentExecutionResponse, error) {
 
 	var response *persistence.GetCurrentExecutionResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		response, err = c.shard.GetCurrentExecution(ctx, request)
 
 		return err
 	}
 
-	err := backoff.Retry(op, PersistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	err := backoff.ThrottleRetryContext(ctx, op, PersistenceOperationRetryPolicy, common.IsPersistenceTransientError)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/workflow/delete_manager.go
+++ b/service/history/workflow/delete_manager.go
@@ -221,7 +221,7 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 		}
 	}
 
-	op := func() error {
+	op := func(ctx context.Context) error {
 		return m.shard.DeleteWorkflowExecution(
 			ctx,
 			definition.WorkflowKey{
@@ -234,7 +234,8 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 			closeTime,
 		)
 	}
-	if err = backoff.Retry(
+	if err = backoff.ThrottleRetryContext(
+		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
 		common.IsPersistenceTransientError,

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -332,7 +332,7 @@ func appendHistoryV2EventsWithRetry(
 		return err
 	}
 
-	err := backoff.RetryContext(
+	err := backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
@@ -354,7 +354,7 @@ func createWorkflowExecutionWithRetry(
 		return err
 	}
 
-	err := backoff.RetryContext(
+	err := backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
@@ -404,7 +404,7 @@ func conflictResolveWorkflowExecutionWithRetry(
 		return err
 	}
 
-	err := backoff.RetryContext(
+	err := backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
@@ -464,7 +464,7 @@ func getWorkflowExecutionWithRetry(
 		return err
 	}
 
-	err := backoff.RetryContext(
+	err := backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
@@ -511,7 +511,7 @@ func updateWorkflowExecutionWithRetry(
 		return err
 	}
 
-	err = backoff.RetryContext(
+	err = backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		PersistenceOperationRetryPolicy,
@@ -570,7 +570,7 @@ func setWorkflowExecutionWithRetry(
 		return err
 	}
 
-	err = backoff.RetryContext(
+	err = backoff.ThrottleRetryContext(
 		ctx,
 		op,
 		PersistenceOperationRetryPolicy,

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -943,12 +943,12 @@ func (e *matchingEngineImpl) recordWorkflowTaskStarted(
 		PollRequest:       pollReq,
 	}
 	var resp *historyservice.RecordWorkflowTaskStartedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = e.historyService.RecordWorkflowTaskStarted(ctx, request)
 		return err
 	}
-	err := backoff.Retry(op, historyServiceOperationRetryPolicy, func(err error) bool {
+	err := backoff.ThrottleRetryContext(ctx, op, historyServiceOperationRetryPolicy, func(err error) bool {
 		switch err.(type) {
 		case *serviceerror.NotFound, *serviceerror.NamespaceNotFound, *serviceerrors.TaskAlreadyStarted:
 			return false
@@ -973,12 +973,12 @@ func (e *matchingEngineImpl) recordActivityTaskStarted(
 		PollRequest:       pollReq,
 	}
 	var resp *historyservice.RecordActivityTaskStartedResponse
-	op := func() error {
+	op := func(ctx context.Context) error {
 		var err error
 		resp, err = e.historyService.RecordActivityTaskStarted(ctx, request)
 		return err
 	}
-	err := backoff.Retry(op, historyServiceOperationRetryPolicy, func(err error) bool {
+	err := backoff.ThrottleRetryContext(ctx, op, historyServiceOperationRetryPolicy, func(err error) bool {
 		switch err.(type) {
 		case *serviceerror.NotFound, *serviceerror.NamespaceNotFound, *serviceerrors.TaskAlreadyStarted:
 			return false

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -283,7 +283,7 @@ func (c *taskQueueManagerImpl) AddTask(
 	}
 
 	var syncMatch bool
-	err := executeWithRetry(func() error {
+	err := executeWithRetry(ctx, func(_ context.Context) error {
 		taskInfo := params.taskInfo
 
 		namespaceEntry, err := c.namespaceRegistry.GetNamespaceByID(namespace.ID(taskInfo.GetNamespaceId()))
@@ -493,7 +493,7 @@ func (c *taskQueueManagerImpl) completeTask(task *persistencespb.AllocatedTaskIn
 		// again the underlying reason for failing to start will be resolved.
 		// Note that RecordTaskStarted only fails after retrying for a long time, so a single task will not be
 		// re-written to persistence frequently.
-		err = executeWithRetry(func() error {
+		err = executeWithRetry(context.Background(), func(_ context.Context) error {
 			wf := &commonpb.WorkflowExecution{WorkflowId: task.Data.GetWorkflowId(), RunId: task.Data.GetRunId()}
 			_, err := c.taskWriter.appendTask(wf, task.Data)
 			return err
@@ -527,9 +527,10 @@ func rangeIDToTaskIDBlock(rangeID int64, rangeSize int64) taskIDBlock {
 
 // Retry operation on transient error.
 func executeWithRetry(
-	operation func() error,
+	ctx context.Context,
+	operation func(context.Context) error,
 ) error {
-	err := backoff.Retry(operation, persistenceOperationRetryPolicy, func(err error) bool {
+	err := backoff.ThrottleRetryContext(ctx, operation, persistenceOperationRetryPolicy, func(err error) bool {
 		if common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err) {
 			return false
 		}

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -198,8 +198,8 @@ Loop:
 func (tr *taskReader) getTaskBatchWithRange(readLevel int64, maxReadLevel int64) ([]*persistencespb.AllocatedTaskInfo, error) {
 	var response *persistence.GetTasksResponse
 	var err error
-	err = executeWithRetry(func() error {
-		response, err = tr.tlMgr.db.GetTasks(context.TODO(), readLevel+1, maxReadLevel+1, tr.tlMgr.config.GetTasksBatchSize())
+	err = executeWithRetry(context.TODO(), func(ctx context.Context) error {
+		response, err = tr.tlMgr.db.GetTasks(ctx, readLevel+1, maxReadLevel+1, tr.tlMgr.config.GetTasksBatchSize())
 		return err
 	})
 	if err != nil {

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -299,7 +299,7 @@ func (w *taskWriter) renewLeaseWithRetry(
 		return
 	}
 	w.tlMgr.metricScope.IncCounter(metrics.LeaseRequestPerTaskQueueCounter)
-	err := backoff.RetryContext(ctx, op, retryPolicy, retryErrors)
+	err := backoff.ThrottleRetryContext(ctx, op, retryPolicy, retryErrors)
 	if err != nil {
 		w.tlMgr.metricScope.IncCounter(metrics.LeaseFailurePerTaskQueueCounter)
 		return newState, err

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -254,7 +254,7 @@ func (a *activities) generateWorkflowReplicationTask(ctx context.Context, wKey d
 		return err
 	}
 
-	err := backoff.RetryContext(ctx, op, historyServiceRetryPolicy, common.IsServiceTransientError)
+	err := backoff.ThrottleRetryContext(ctx, op, historyServiceRetryPolicy, common.IsServiceTransientError)
 	if err != nil {
 		if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 			// ignore NotFound error

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -310,7 +310,7 @@ func (ws *workerSet) refreshComponent(
 		}
 	}
 	policy := backoff.NewExponentialRetryPolicy(ws.wm.initialRetry)
-	backoff.Retry(op, policy, nil)
+	backoff.ThrottleRetry(op, policy, nil)
 }
 
 func (ws *workerSet) startWorker(

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -172,7 +172,7 @@ func (s *Scanner) startWorkflowWithRetry(
 	policy := backoff.NewExponentialRetryPolicy(time.Second)
 	policy.SetMaximumInterval(time.Minute)
 	policy.SetExpirationInterval(backoff.NoInterval)
-	err := backoff.Retry(func() error {
+	err := backoff.ThrottleRetry(func() error {
 		return s.startWorkflow(s.context.sdkSystemClient, options, workflowType, workflowArgs...)
 	}, policy, func(err error) bool {
 		return true

--- a/service/worker/scanner/taskqueue/db.go
+++ b/service/worker/scanner/taskqueue/db.go
@@ -85,7 +85,7 @@ func (s *Scavenger) listTaskQueue(pageSize int, pageToken []byte) (*p.ListTaskQu
 
 func (s *Scavenger) deleteTaskQueue(key *p.TaskQueueKey, rangeID int64) error {
 	// retry only on service busy errors
-	return backoff.Retry(func() error {
+	return backoff.ThrottleRetry(func() error {
 		return s.db.DeleteTaskQueue(context.TODO(), &p.DeleteTaskQueueRequest{
 			TaskQueue: &p.TaskQueueKey{
 				NamespaceID:   key.NamespaceID,
@@ -101,7 +101,7 @@ func (s *Scavenger) deleteTaskQueue(key *p.TaskQueueKey, rangeID int64) error {
 }
 
 func (s *Scavenger) retryForever(op func() error) error {
-	return backoff.Retry(op, retryForeverPolicy, s.isRetryable)
+	return backoff.ThrottleRetry(op, retryForeverPolicy, s.isRetryable)
 }
 
 func newRetryForeverPolicy() backoff.RetryPolicy {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add new backoff.ThrottleRetry and ThrottleRetryContext util function
- Throttle retry will use a special throttle retry policy instead of the passed in retry policy upon resource exhausted error.
- Change all usage of backoff.Retry and RetryContext to their throttle version.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Improve retry policy and don't create a retry storm upon service busy

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test WIP

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- yes.