### PR TITLE
Do not double execute close execution task if visibility archival is disabled

### DIFF
--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -86,9 +86,13 @@ func newTransferQueueStandbyProcessor(
 		case enumsspb.TASK_TYPE_TRANSFER_RESET_WORKFLOW:
 			// no reset needed for standby
 			return false
-		case enumsspb.TASK_TYPE_TRANSFER_CLOSE_EXECUTION,
-			enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION:
+		case enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION:
 			return true
+		case enumsspb.TASK_TYPE_TRANSFER_CLOSE_EXECUTION:
+			if shard.GetArchivalMetadata().GetVisibilityConfig().ClusterConfiguredForArchival() {
+				return true
+			}
+			fallthrough
 		default:
 			return taskAllocator.verifyStandbyTask(clusterName, namespace.ID(task.GetNamespaceID()), task)
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not double execute close execution task if visibility archival is disabled

<!-- Tell your future self why have you made these changes -->
**Why?**
- For standby task that doesn't have side effect, we don't have to force execute it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes