### PR TITLE
Get and set queue states in shard info

### DIFF
--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -117,10 +117,6 @@ type (
 	}
 )
 
-const (
-	defaultScheduleToStartTimeout = 111
-)
-
 // NewTestBaseWithCassandra returns a persistence test base backed by cassandra datastore
 func NewTestBaseWithCassandra(options *TestBaseOptions) TestBase {
 	if options.DBName == "" {
@@ -232,9 +228,8 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	s.ReadLevel = 0
 	s.ReplicationReadLevel = 0
 	s.ShardInfo = &persistencespb.ShardInfo{
-		ShardId:        shardID,
-		RangeId:        0,
-		QueueAckLevels: make(map[int32]*persistencespb.QueueAckLevel), // TODO: is this needed?
+		ShardId: shardID,
+		RangeId: 0,
 	}
 
 	s.TaskIDGenerator = &TestTransferTaskIDGenerator{}
@@ -453,8 +448,5 @@ func GenerateRandomDBName(n int) string {
 
 func timeComparator(t1, t2 time.Time, timeTolerance time.Duration) bool {
 	diff := t2.Sub(t1)
-	if diff.Nanoseconds() <= timeTolerance.Nanoseconds() {
-		return true
-	}
-	return false
+	return diff.Nanoseconds() <= timeTolerance.Nanoseconds()
 }

--- a/common/persistence/serialization/serializer.go
+++ b/common/persistence/serialization/serializer.go
@@ -299,14 +299,9 @@ func (t *serializerImpl) ShardInfoFromBlob(data *commonpb.DataBlob, clusterName 
 	if shardInfo.GetQueueAckLevels() == nil {
 		shardInfo.QueueAckLevels = make(map[int32]*persistencespb.QueueAckLevel)
 	}
-	for category, ackLevels := range shardInfo.QueueAckLevels {
-		if ackLevels == nil {
-			ackLevels = &persistencespb.QueueAckLevel{}
-			shardInfo.QueueAckLevels[category] = ackLevels
-		}
-		if ackLevels.ClusterAckLevel == nil {
-			ackLevels.ClusterAckLevel = make(map[string]int64)
-		}
+
+	if shardInfo.GetQueueStates() == nil {
+		shardInfo.QueueStates = make(map[int32]*persistencespb.QueueState)
 	}
 
 	return shardInfo, nil

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -33,6 +33,7 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 	clockspb "go.temporal.io/server/api/clock/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -80,6 +81,8 @@ type (
 		UpdateQueueAckLevel(category tasks.Category, ackLevel tasks.Key) error
 		GetQueueClusterAckLevel(category tasks.Category, cluster string) tasks.Key
 		UpdateQueueClusterAckLevel(category tasks.Category, cluster string, ackLevel tasks.Key) error
+		GetQueueState(category tasks.Category) (*persistencespb.QueueState, bool)
+		UpdateQueueState(category tasks.Category, state *persistencespb.QueueState) error
 
 		GetReplicatorDLQAckLevel(sourceCluster string) int64
 		UpdateReplicatorDLQAckLevel(sourCluster string, ackLevel int64) error

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -38,6 +38,7 @@ import (
 	v10 "go.temporal.io/server/api/adminservice/v1"
 	v11 "go.temporal.io/server/api/clock/v1"
 	v12 "go.temporal.io/server/api/historyservice/v1"
+	v13 "go.temporal.io/server/api/persistence/v1"
 	archiver "go.temporal.io/server/common/archiver"
 	clock "go.temporal.io/server/common/clock"
 	cluster "go.temporal.io/server/common/cluster"
@@ -532,6 +533,21 @@ func (mr *MockContextMockRecorder) GetQueueExclusiveHighReadWatermark(category, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueueExclusiveHighReadWatermark", reflect.TypeOf((*MockContext)(nil).GetQueueExclusiveHighReadWatermark), category, cluster)
 }
 
+// GetQueueState mocks base method.
+func (m *MockContext) GetQueueState(category tasks.Category) (*v13.QueueState, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueueState", category)
+	ret0, _ := ret[0].(*v13.QueueState)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetQueueState indicates an expected call of GetQueueState.
+func (mr *MockContextMockRecorder) GetQueueState(category interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueueState", reflect.TypeOf((*MockContext)(nil).GetQueueState), category)
+}
+
 // GetRemoteAdminClient mocks base method.
 func (m *MockContext) GetRemoteAdminClient(cluster string) (v10.AdminServiceClient, error) {
 	m.ctrl.T.Helper()
@@ -782,6 +798,20 @@ func (m *MockContext) UpdateQueueClusterAckLevel(category tasks.Category, cluste
 func (mr *MockContextMockRecorder) UpdateQueueClusterAckLevel(category, cluster, ackLevel interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQueueClusterAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateQueueClusterAckLevel), category, cluster, ackLevel)
+}
+
+// UpdateQueueState mocks base method.
+func (m *MockContext) UpdateQueueState(category tasks.Category, state *v13.QueueState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateQueueState", category, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateQueueState indicates an expected call of UpdateQueueState.
+func (mr *MockContextMockRecorder) UpdateQueueState(category, state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQueueState", reflect.TypeOf((*MockContext)(nil).UpdateQueueState), category, state)
 }
 
 // UpdateRemoteClusterInfo mocks base method.

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -76,6 +76,9 @@ func NewTestContext(
 	if shardInfo.QueueAckLevels == nil {
 		shardInfo.QueueAckLevels = make(map[int32]*persistencespb.QueueAckLevel)
 	}
+	if shardInfo.QueueStates == nil {
+		shardInfo.QueueStates = make(map[int32]*persistencespb.QueueState)
+	}
 	shard := &ContextImpl{
 		shardID:             shardInfo.GetShardId(),
 		executionManager:    resourceTest.ExecutionMgr,
@@ -90,9 +93,9 @@ func NewTestContext(
 		state:                              contextStateAcquired,
 		engineFuture:                       future.NewFuture[Engine](),
 		shardInfo:                          shardInfo,
-		taskSequenceNumber:                 1,
-		immediateTaskExclusiveMaxReadLevel: 1,
-		maxTaskSequenceNumber:              100000,
+		taskSequenceNumber:                 shardInfo.RangeId << int64(config.RangeSizeBits),
+		immediateTaskExclusiveMaxReadLevel: shardInfo.RangeId << int64(config.RangeSizeBits),
+		maxTaskSequenceNumber:              (shardInfo.RangeId + 1) << int64(config.RangeSizeBits),
 		scheduledTaskMaxReadLevelMap:       make(map[string]time.Time),
 		remoteClusterInfos:                 make(map[string]*remoteClusterInfo),
 		handoverNamespaces:                 make(map[string]*namespaceHandOverInfo),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add shard context methods for getting and setting multi cursor queue states

<!-- Tell your future self why have you made these changes -->
**Why?**
- Multi cursor impl

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally with canary and integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A, not used anywhere.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.