### PR TITLE
add address translation to Cassandra persistence

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -278,6 +278,8 @@ type (
 		Consistency *CassandraStoreConsistency `yaml:"consistency"`
 		// DisableInitialHostLookup instructs the gocql client to connect only using the supplied hosts
 		DisableInitialHostLookup bool `yaml:"disableInitialHostLookup"`
+		// AddressTranslator translates Cassandra IP addresses, used for cases when IP addresses gocql driver returns are not accessible from the server
+		AddressTranslator *CassandraAddressTranslator `yaml:"addressTranslator"`
 	}
 
 	// CassandraStoreConsistency enables you to set the consistency settings for each Cassandra Persistence Store for Temporal
@@ -285,6 +287,13 @@ type (
 		// Default defines the consistency level for ALL stores.
 		// Defaults to LOCAL_QUORUM and LOCAL_SERIAL if not set
 		Default *CassandraConsistencySettings `yaml:"default"`
+	}
+
+	CassandraAddressTranslator struct {
+		// Translator defines name of translator implementation to use for Cassandra address translation
+		Translator string `yaml:"translator"`
+		// Options map of options for address translator implementation
+		Options map[string]string `yaml:"options"`
 	}
 
 	// CassandraConsistencySettings sets the default consistency level for regular & serial queries to Cassandra.

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/client.go
@@ -38,6 +38,7 @@ import (
 
 	"go.temporal.io/server/common/auth"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/translator"
 	"go.temporal.io/server/common/resolver"
 )
 
@@ -158,6 +159,18 @@ func NewCassandraCluster(
 	}
 
 	cluster.PoolConfig.HostSelectionPolicy = gocql.TokenAwareHostPolicy(gocql.RoundRobinHostPolicy())
+
+	if cfg.AddressTranslator != nil && cfg.AddressTranslator.Translator != "" {
+		addressTranslator, err := translator.LookupTranslator(cfg.AddressTranslator.Translator)
+		if err != nil {
+			return nil, err
+		}
+		cluster.AddressTranslator, err = addressTranslator.GetTranslator(&cfg)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return cluster, nil
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/translator/fixed_address_translator.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/translator/fixed_address_translator.go
@@ -1,0 +1,108 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package translator
+
+import (
+	"errors"
+	"fmt"
+	"net"
+
+	"github.com/gocql/gocql"
+	"go.temporal.io/server/common/config"
+)
+
+const (
+	fixedTranslatorName   = "fixed-address-translator"
+	advertisedHostnameKey = "advertised-hostname"
+)
+
+func init() {
+	RegisterTranslator(fixedTranslatorName, NewFixedAddressTranslatorPlugin())
+}
+
+type FixedAddressTranslatorPlugin struct {
+}
+
+func NewFixedAddressTranslatorPlugin() TranslatorPlugin {
+	return &FixedAddressTranslatorPlugin{}
+}
+
+// GetTranslator What gocql driver does is that it will connect to the first node in the list in configuration
+// (if there is more than one), if it fails to connect to it, it will pick another from that list and so on so.
+// When the connection is initialised, the driver does not know what the topology of a cluster looks like yet.
+// It just connected to a node. In order to know, for the driver itself, internally, what the topology is like,
+// it will query that node it just connected to, and it will read system.peers table. In that table,
+// there are all other nodes of a cluster as that node, gocql just connected to, sees it.
+//
+// Every other node has the very same system.peers table where all other nodes of the cluster are.
+// The returned rows, representing all other nodes in the cluster, contain IP addresses internal of that cluster.
+// They are not necessarily the same hostnames as the ones you would translate with your service resolver
+// (they are IP addresses, not hostnames, actually).
+//
+// For the case if the nodes are behind the proxy, service resolver would translate just the publicly
+// visible hostname which a user put into configuration so driver can connect to it, but that is not enough,
+// IP addresses behind a proxy are not reachable from client's perspective. These are not translatable
+// with service resolver so client can not connect to them directly - that is what gocql address
+// translator is exactly for.
+//
+// The implementation of fixed address translator plugin is fed the internal IP address from the system.peers table,
+// and it will always return same fixed ip based on what advertised-hostname is resolved to. That IP address,
+// from client's perspective, might be, for example, an IP address of a load balancer which is reachable from client.
+// As the IP address of all nodes are some, the difference between the nodes can be achieved by running them on
+// a different port for each node.
+// see also https://github.com/gocql/gocql/pull/1635
+func (plugin *FixedAddressTranslatorPlugin) GetTranslator(cfg *config.Cassandra) (gocql.AddressTranslator, error) {
+	if cfg.AddressTranslator == nil {
+		return nil, errors.New("there is no addressTranslator configuration in cassandra configuration")
+	}
+
+	opts := cfg.AddressTranslator.Options
+	if opts == nil {
+		return nil, errors.New("there are no options for translator plugin")
+	}
+
+	advertisedHostname, found := opts[advertisedHostnameKey]
+
+	if !found || len(advertisedHostname) == 0 {
+		return nil, errors.New("detected no advertised-hostname key or empty value for translator plugin options")
+	}
+
+	var resolvedIp net.IP = nil
+	ips, _ := net.LookupIP(advertisedHostname)
+	for _, ip := range ips {
+		if ipv4 := ip.To4(); ipv4 != nil {
+			resolvedIp = ipv4
+			break
+		}
+	}
+
+	if resolvedIp == nil {
+		return nil, fmt.Errorf("no resolved IP for advertised hostname %q", advertisedHostname)
+	}
+
+	return gocql.AddressTranslatorFunc(func(addr net.IP, port int) (net.IP, int) {
+		return resolvedIp, port
+	}), nil
+}

--- a/common/persistence/nosql/nosqlplugin/cassandra/translator/translator_plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/translator/translator_plugin.go
@@ -1,0 +1,60 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package translator
+
+import (
+	"errors"
+
+	"github.com/gocql/gocql"
+
+	"go.temporal.io/server/common/config"
+)
+
+var (
+	ErrInvalidTranslatorPluginName = errors.New("translator_plugin: invalid translator plugin requested")
+	translators                    = map[string]TranslatorPlugin{}
+)
+
+type (
+	// TranslatorPlugin interface for Cassandra address translation mechanism
+	TranslatorPlugin interface {
+		GetTranslator(*config.Cassandra) (gocql.AddressTranslator, error)
+	}
+)
+
+// RegisterPlugin adds an auth plugin to the plugin registry
+// it is only safe to use from a package init function
+func RegisterTranslator(name string, plugin TranslatorPlugin) {
+	translators[name] = plugin
+}
+
+func LookupTranslator(name string) (TranslatorPlugin, error) {
+	plugin, ok := translators[name]
+	if !ok {
+		return nil, ErrInvalidTranslatorPluginName
+	}
+
+	return plugin, nil
+}

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -31,6 +31,14 @@ persistence:
                     keyData: {{ default .Env.CASSANDRA_CERT_KEY_DATA "" }}
                     enableHostVerification: {{ default .Env.CASSANDRA_HOST_VERIFICATION "false" }}
                     serverName: {{ default .Env.CASSANDRA_HOST_NAME "" }}
+                {{- if .Env.CASSANDRA_ADDRESS_TRANSLATOR }}
+                addressTranslator:
+                    translator: {{ default .Env.CASSANDRA_ADDRESS_TRANSLATOR "" }}
+                    {{- if .Env.CASSANDRA_ADDRESS_TRANSLATOR_OPTIONS }}
+                    options:
+                        advertised-hostname: {{ default .Env.CASSANDRA_ADDRESS_TRANSLATOR_OPTIONS "" }}
+                    {{- end }}
+                {{- end }}
         visibility:
             cassandra:
                 {{ $visibility_seeds_default := default .Env.CASSANDRA_SEEDS "" }}
@@ -57,6 +65,14 @@ persistence:
                     keyData: {{ default .Env.CASSANDRA_CERT_KEY_DATA "" }}
                     enableHostVerification: {{ default .Env.CASSANDRA_HOST_VERIFICATION "false" }}
                     serverName: {{ default .Env.CASSANDRA_HOST_NAME "" }}
+                {{- if .Env.CASSANDRA_ADDRESS_TRANSLATOR }}
+                addressTranslator:
+                    translator: {{ default .Env.CASSANDRA_ADDRESS_TRANSLATOR "" }}
+                    {{- if .Env.CASSANDRA_ADDRESS_TRANSLATOR_OPTIONS }}
+                    options:
+                        advertised-hostname: {{ default .Env.CASSANDRA_ADDRESS_TRANSLATOR_OPTIONS "" }}
+                    {{- end }}
+                {{- end }}
         {{- else if eq $db "mysql" }}
         default:
             sql:

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -61,6 +61,7 @@ type (
 		Consistency              string
 		TLS                      *auth.TLS
 		DisableInitialHostLookup bool
+		AddressTranslator        *config.CassandraAddressTranslator
 	}
 )
 
@@ -142,6 +143,7 @@ func (cfg *CQLClientConfig) toCassandraConfig() *config.Cassandra {
 				Consistency: cfg.Consistency,
 			},
 		},
+		AddressTranslator: cfg.AddressTranslator,
 	}
 
 	return &cassandraConfig

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -101,6 +101,18 @@ func buildCLIOptions() *cli.App {
 			Usage:  "enable NetworkTopologyStrategy by providing datacenter name",
 			EnvVar: "CASSANDRA_DATACENTER",
 		},
+		cli.StringFlag{
+			Name:   schema.CLIOptAddressTranslator,
+			Value:  "",
+			Usage:  "name of address translator for cassandra hosts",
+			EnvVar: "CASSANDRA_ADDRESS_TRANSLATOR",
+		},
+		cli.StringFlag{
+			Name:   schema.CLIOptAddressTranslatorOptions,
+			Value:  "",
+			Usage:  "colon-separated list of key=value pairs as options for address translator",
+			EnvVar: "CASSANDRA_ADDRESS_TRANSLATOR_OPTIONS_CLI",
+		},
 		cli.BoolFlag{
 			Name:  schema.CLIFlagQuiet,
 			Usage: "Don't set exit status to 1 on error",

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -111,6 +111,10 @@ const (
 	CLIOptDatacenter = "datacenter"
 	// CLIOptConsistency is the cli option for consistency settings
 	CLIOptConsistency = "consistency"
+	// CLIOptAddressTranslator is the cli option for address translator for Cassandra
+	CLIOptAddressTranslator = "address-translator"
+	// CLIOptAddressTranslatorOptions is the cli option for options for address translator
+	CLIOptAddressTranslatorOptions = "address-translator-options"
 	// CLIOptQuiet is the cli option for quiet mode
 	CLIOptQuiet = "quiet"
 	// CLIOptForce is the cli option for force mode
@@ -150,6 +154,10 @@ const (
 	CLIFlagReplicationFactor = CLIOptReplicationFactor + ", rf"
 	// CLIFlagDatacenter is the cli option for NetworkTopologyStrategy datacenter
 	CLIFlagDatacenter = CLIOptDatacenter + ", dc"
+	// CLIFlagAddressTranslator is the cli option for address translator for Cassandra
+	CLIFlagAddressTranslator = CLIOptAddressTranslator + ", at"
+	// CLIFlagAddressTranslatorOptions is the cli option for address translator of Cassandra
+	CLIFlagAddressTranslatorOptions
 	// CLIFlagQuiet is the cli flag for quiet mode
 	CLIFlagQuiet = CLIOptQuiet + ", q"
 	// CLIFlagForce is the cli flag for force mode


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This PR adds the possibility to specify so called address translator for Cassandra nodes. Address translation is well-known feature in Datastax Java driver as well as in gocql driver.

Address translation is used in case the client can not resolve the IP addresses which Cassandra gocql driver returns. This happens in case when, for example, Cassandra nodes are running behind some kind of a proxy or load balancer so internal IP addresses do not make sense to the client side. Address translator solves this so the addresses are meaningful.

In Temporal context, we need to run Cassandra nodes in Amazon PrivateLink setup. This is very much deployment specific but the basic idea is that you have a running Cassandra cluster in one VPC and temporal server in the other and you are connecting to Cassandra via exposed, so called Endpoint and Endpoint service. This is very handy deployment model for businesses which would like to have their Temporal server in their vpc / account and they would like to just use Cassandra cluster as a service which is possibly deployed by 3rd entity.


WARNING: I have fixed the address translation in upstream gocql repository in this commit (1) for Cassandra 4.x nodes. For Cassandra 3.x nodes, the port will be static - 9042. gocql driver with these changes was released just yesterday (version v1.2.0). You are using version 1.1.0 so in order to leverage this feature, you need to update driver to version 1.2.0 first.

(1) https://github.com/gocql/gocql/pull/1635

**Approach**

Address translators should be pluggable because my way how I am translating addresses are not suitable for everybody so I provided my solution but it should be very easy to add any other translator and it should be possible just to switch between them via configuration.

My translator is called "fixed address translator" because from the point of view of the client, it will ever connect only to the very same domain name but the only thing which differs will be port - to recognise the instances. (each Cassadra node will run on different CQL port). That way we can make the difference between the nodes behind a load balancer when we hit different CQL port of load balancer address.

This is nothing special, we are already offering fixed address translator to Datastax Java driver
https://github.com/datastax/java-driver/pull/1597

For gocql, this driver already offers address translator mechanism but you just need to add your own translator implementation in the code. For Temporal, as it is a black box from user's point of view, we need to implement address translator in temporal codebase and provide the way how to plug it into the driver on the Temporal's initialisation.

I was looking for a way how to achieve this and I noticed you are using "auth plugin" infrastructure. I basically copied this plugging logic and I accommodated it for address translator case - this PR is about it.

**How did you test it?**

I used your docker compose setup. The way I tested it was that I run all containers in one VPC but I removed Cassandra container. I have configured compose and its exposed env variables in such a way that it will connect to remote Cassandra cluster running elsewhere, behind loadbalancer / endpoint service in Amazon PrivateLink.

I have, of course, run temporal unit tests.

Changed docker compose scripts are here:

https://github.com/instaclustr/temporalio-docker-builds/commit/ed8f5a903cdddf24de0fb3d7217f88d6c5583ee1

This will likely need to be included into docker builds script as well.

Docker compose script:

https://gist.github.com/smiklosovic/ccecfdfd280da5fbe1299eacacea4d24

**Potential risks**

Nothing is going to break when this feature is not used. This PR is no-op meaning the current depoyments are not affected. One needs to specifically enable this feature to see it in action.

**Is hotfix candidate?**

I assume this is new feature, not hotfix, and Temporal community should be informed about this feature.
