### PR TITLE
change custom datastore config map type

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -329,8 +329,8 @@ type (
 	CustomDatastoreConfig struct {
 		// Name of the custom datastore
 		Name string `yaml:"name"`
-		// Options is a set of key-value attributes that can be used by AbstractDatastoreFactory implementation
-		Options map[string]string `yaml:"options"`
+		// Options to be used by AbstractDatastoreFactory implementation
+		Options map[string]any `yaml:"options"`
 	}
 
 	// Replicator describes the configuration of replicator


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Change the options type for a `CustomDataStoreConfig` to a more general mapping of string -> any, instead of the restrictive string to string.

<!-- Tell your future self why have you made these changes -->
**Why?**
This allows specifying more complex configurations in easier ways.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Any existing saved configuration will continue to work, but new code will need to perform type conversions to strings.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No