### PR TITLE
Fix deleteexecutions iterator

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2368,6 +2368,7 @@ const (
 	RenameNamespaceFailuresCount
 	ReadNamespaceFailuresCount
 	ListExecutionsFailuresCount
+	CountExecutionsFailuresCount
 	DeleteExecutionFailuresCount
 	DeleteExecutionNotFoundCount
 	RateLimiterFailuresCount
@@ -2840,6 +2841,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		RenameNamespaceFailuresCount: NewCounterDef("rename_namespace_failures"),
 		ReadNamespaceFailuresCount:   NewCounterDef("read_namespace_failures"),
 		ListExecutionsFailuresCount:  NewCounterDef("list_executions_failures"),
+		CountExecutionsFailuresCount: NewCounterDef("count_executions_failures"),
 		DeleteExecutionFailuresCount: NewCounterDef("delete_execution_failures"),
 		DeleteExecutionNotFoundCount: NewCounterDef("delete_execution_not_found"),
 		RateLimiterFailuresCount:     NewCounterDef("rate_limiter_failures"),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix `deleteexecutions` iterator.

<!-- Tell your future self why have you made these changes -->
**Why?**
Due to concurrency between `DeleteExecutionsActivity` and `GetNextPageTokenActivity` previous version could skip records.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Running locally with 20k workflow executions in namespace.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks** 
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No, because workflow has retry policy and eventually all executions are deleted.