### PR TITLE
Fix concurrency of shard acquisition and flaky test

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -231,7 +231,7 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *hist
 	}
 	workflowID := taskToken.GetWorkflowId()
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -260,7 +260,7 @@ func (h *Handler) RecordActivityTaskStarted(ctx context.Context, request *histor
 		return nil, h.convertError(errNamespaceNotSet)
 	}
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -296,7 +296,7 @@ func (h *Handler) RecordWorkflowTaskStarted(ctx context.Context, request *histor
 		return nil, h.convertError(errTaskQueueNotSet)
 	}
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -344,7 +344,7 @@ func (h *Handler) RespondActivityTaskCompleted(ctx context.Context, request *his
 	}
 	workflowID := taskToken.GetWorkflowId()
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -383,7 +383,7 @@ func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *histor
 	}
 	workflowID := taskToken.GetWorkflowId()
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -422,7 +422,7 @@ func (h *Handler) RespondActivityTaskCanceled(ctx context.Context, request *hist
 	}
 	workflowID := taskToken.GetWorkflowId()
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -467,7 +467,7 @@ func (h *Handler) RespondWorkflowTaskCompleted(ctx context.Context, request *his
 	}
 	workflowID := token.GetWorkflowId()
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -512,7 +512,7 @@ func (h *Handler) RespondWorkflowTaskFailed(ctx context.Context, request *histor
 	}
 	workflowID := token.GetWorkflowId()
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -541,7 +541,7 @@ func (h *Handler) StartWorkflowExecution(ctx context.Context, request *historyse
 
 	startRequest := request.StartRequest
 	workflowID := startRequest.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -663,7 +663,7 @@ func (h *Handler) RebuildMutableState(ctx context.Context, request *historyservi
 
 	workflowExecution := request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -697,7 +697,7 @@ func (h *Handler) DescribeMutableState(ctx context.Context, request *historyserv
 
 	workflowExecution := request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -729,7 +729,7 @@ func (h *Handler) GetMutableState(ctx context.Context, request *historyservice.G
 
 	workflowExecution := request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -761,7 +761,7 @@ func (h *Handler) PollMutableState(ctx context.Context, request *historyservice.
 
 	workflowExecution := request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -793,7 +793,7 @@ func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *histor
 
 	workflowExecution := request.Request.Execution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -831,7 +831,7 @@ func (h *Handler) RequestCancelWorkflowExecution(ctx context.Context, request *h
 		tag.WorkflowRunID(cancelRequest.WorkflowExecution.GetRunId()))
 
 	workflowID := cancelRequest.WorkflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -865,7 +865,7 @@ func (h *Handler) SignalWorkflowExecution(ctx context.Context, request *historys
 
 	workflowExecution := request.SignalRequest.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -902,7 +902,7 @@ func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context, request 
 
 	signalWithStartRequest := request.SignalWithStartRequest
 	workflowID := signalWithStartRequest.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -959,7 +959,7 @@ func (h *Handler) RemoveSignalMutableState(ctx context.Context, request *history
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -993,7 +993,7 @@ func (h *Handler) TerminateWorkflowExecution(ctx context.Context, request *histo
 
 	workflowExecution := request.TerminateRequest.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1025,7 +1025,7 @@ func (h *Handler) DeleteWorkflowExecution(ctx context.Context, request *historys
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1059,7 +1059,7 @@ func (h *Handler) ResetWorkflowExecution(ctx context.Context, request *historyse
 
 	workflowExecution := request.ResetRequest.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1091,7 +1091,7 @@ func (h *Handler) QueryWorkflow(ctx context.Context, request *historyservice.Que
 	}
 
 	workflowID := request.GetRequest().GetExecution().GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1139,7 +1139,7 @@ func (h *Handler) ScheduleWorkflowTask(ctx context.Context, request *historyserv
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1178,7 +1178,7 @@ func (h *Handler) VerifyFirstWorkflowTaskScheduled(
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1216,7 +1216,7 @@ func (h *Handler) RecordChildExecutionCompleted(ctx context.Context, request *hi
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1253,7 +1253,7 @@ func (h *Handler) VerifyChildExecutionCompletionRecorded(
 		return nil, h.convertError(errWorkflowExecutionNotSet)
 	}
 
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, request.ParentExecution.GetWorkflowId())
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, request.ParentExecution.GetWorkflowId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1289,7 +1289,7 @@ func (h *Handler) ResetStickyTaskQueue(ctx context.Context, request *historyserv
 	}
 
 	workflowID := request.Execution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1326,7 +1326,7 @@ func (h *Handler) ReplicateEventsV2(ctx context.Context, request *historyservice
 
 	workflowExecution := request.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1364,7 +1364,7 @@ func (h *Handler) SyncShardStatus(ctx context.Context, request *historyservice.S
 		return nil, h.convertError(errTimestampNotSet)
 	}
 
-	shardContext, err := h.controller.GetShardByID(ctx, request.GetShardId())
+	shardContext, err := h.controller.GetShardByID(request.GetShardId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1408,7 +1408,7 @@ func (h *Handler) SyncActivity(ctx context.Context, request *historyservice.Sync
 	}
 
 	workflowID := request.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1445,7 +1445,7 @@ func (h *Handler) GetReplicationMessages(ctx context.Context, request *historyse
 		go func(token *replicationspb.ReplicationToken) {
 			defer wg.Done()
 
-			shardContext, err := h.controller.GetShardByID(ctx, token.GetShardId())
+			shardContext, err := h.controller.GetShardByID(token.GetShardId())
 			if err != nil {
 				h.logger.Warn("History engine not found for shard", tag.Error(err))
 				return
@@ -1521,7 +1521,6 @@ func (h *Handler) GetDLQReplicationMessages(ctx context.Context, request *histor
 		}
 
 		shardContext, err := h.controller.GetShardByNamespaceWorkflow(
-			ctx,
 			namespace.ID(taskInfos[0].GetNamespaceId()),
 			taskInfos[0].GetWorkflowId(),
 		)
@@ -1575,7 +1574,7 @@ func (h *Handler) ReapplyEvents(ctx context.Context, request *historyservice.Rea
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	workflowID := request.GetRequest().GetWorkflowExecution().GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1614,7 +1613,7 @@ func (h *Handler) GetDLQMessages(ctx context.Context, request *historyservice.Ge
 		return nil, errShuttingDown
 	}
 
-	shardContext, err := h.controller.GetShardByID(ctx, request.GetShardId())
+	shardContext, err := h.controller.GetShardByID(request.GetShardId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1640,7 +1639,7 @@ func (h *Handler) PurgeDLQMessages(ctx context.Context, request *historyservice.
 		return nil, errShuttingDown
 	}
 
-	shardContext, err := h.controller.GetShardByID(ctx, request.GetShardId())
+	shardContext, err := h.controller.GetShardByID(request.GetShardId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1665,7 +1664,7 @@ func (h *Handler) MergeDLQMessages(ctx context.Context, request *historyservice.
 		return nil, errShuttingDown
 	}
 
-	shardContext, err := h.controller.GetShardByID(ctx, request.GetShardId())
+	shardContext, err := h.controller.GetShardByID(request.GetShardId())
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1694,7 +1693,7 @@ func (h *Handler) RefreshWorkflowTasks(ctx context.Context, request *historyserv
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	execution := request.GetRequest().GetExecution()
 	workflowID := execution.GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1733,7 +1732,7 @@ func (h *Handler) GenerateLastHistoryReplicationTasks(
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	workflowID := request.GetExecution().GetWorkflowId()
-	shardContext, err := h.controller.GetShardByNamespaceWorkflow(ctx, namespaceID, workflowID)
+	shardContext, err := h.controller.GetShardByNamespaceWorkflow(namespaceID, workflowID)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1768,7 +1767,7 @@ func (h *Handler) GetReplicationStatus(
 
 	resp := &historyservice.GetReplicationStatusResponse{}
 	for _, shardID := range h.controller.ShardIDs() {
-		shardContext, err := h.controller.GetShardByID(ctx, shardID)
+		shardContext, err := h.controller.GetShardByID(shardID)
 		if err != nil {
 			return nil, h.convertError(err)
 		}

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -150,17 +150,21 @@ func (c *ControllerImpl) Status() int32 {
 	return atomic.LoadInt32(&c.status)
 }
 
+// GetShardByID returns a shard context for the given namespace and workflow.
+// The shard context may not have acquired a rangeid lease yet.
+// Callers can use GetEngine on the shard to block on rangeid lease acquisition.
 func (c *ControllerImpl) GetShardByNamespaceWorkflow(
-	ctx context.Context,
 	namespaceID namespace.ID,
 	workflowID string,
 ) (Context, error) {
 	shardID := c.config.GetShardID(namespaceID, workflowID)
-	return c.GetShardByID(ctx, shardID)
+	return c.GetShardByID(shardID)
 }
 
+// GetShardByID returns a shard context for the given shard id.
+// The shard context may not have acquired a rangeid lease yet.
+// Callers can use GetEngine on the shard to block on rangeid lease acquisition.
 func (c *ControllerImpl) GetShardByID(
-	ctx context.Context,
 	shardID int32,
 ) (Context, error) {
 	sw := c.metricsScope.StartTimer(metrics.GetEngineForShardLatency)
@@ -197,6 +201,9 @@ func (c *ControllerImpl) shardClosedCallback(shard *ContextImpl) {
 	shard.contextTaggedLogger.Info("", tag.LifeCycleStopped, tag.ComponentShardContext, tag.Number(newNumShards))
 }
 
+// getOrCreateShardContext returns a shard context for the given shard ID, creating a new one
+// if necessary. If a shard context is created, it will initialize in the background.
+// This function won't block on rangeid lease acquisition.
 func (c *ControllerImpl) getOrCreateShardContext(shardID int32) (*ContextImpl, error) {
 	c.RLock()
 	if shard, ok := c.historyShards[shardID]; ok {
@@ -325,6 +332,30 @@ func (c *ControllerImpl) acquireShards() {
 	sw := c.metricsScope.StartTimer(metrics.AcquireShardsLatency)
 	defer sw.Stop()
 
+	tryAcquire := func(shardID int32) {
+		info, err := c.historyServiceResolver.Lookup(convert.Int32ToString(shardID))
+		if err != nil {
+			c.contextTaggedLogger.Error("Error looking up host for shardID", tag.Error(err), tag.OperationFailed, tag.ShardID(shardID))
+			return
+		}
+		if info.Identity() != c.hostInfoProvider.HostInfo().Identity() {
+			// current host is not owner of shard, unload it if it is already loaded.
+			c.CloseShardByID(shardID)
+			return
+		}
+		shard, err := c.GetShardByID(shardID)
+		if err != nil {
+			c.metricsScope.IncCounter(metrics.GetEngineForShardErrorCounter)
+			c.contextTaggedLogger.Error("Unable to create history shard context", tag.Error(err), tag.OperationFailed, tag.ShardID(shardID))
+			return
+		}
+		// Wait up to 1s for the shard to acquire the rangeid lock.
+		// After 1s we will move on but the shard will continue trying in the background.
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+		_, _ = shard.GetEngineWithContext(ctx)
+	}
+
 	concurrency := util.Max(c.config.AcquireShardConcurrency(), 1)
 	shardActionCh := make(chan int32, c.config.NumberOfShards)
 	var wg sync.WaitGroup
@@ -338,23 +369,7 @@ func (c *ControllerImpl) acquireShards() {
 				case <-c.shutdownCh:
 					return
 				default:
-					if info, err := c.historyServiceResolver.Lookup(
-						convert.Int32ToString(shardID),
-					); err != nil {
-						c.contextTaggedLogger.Error("Error looking up host for shardID", tag.Error(err), tag.OperationFailed, tag.ShardID(shardID))
-					} else {
-						if info.Identity() == c.hostInfoProvider.HostInfo().Identity() {
-							ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-							if _, err := c.GetShardByID(ctx, shardID); err != nil {
-								c.metricsScope.IncCounter(metrics.GetEngineForShardErrorCounter)
-								c.contextTaggedLogger.Error("Unable to create history shard context", tag.Error(err), tag.OperationFailed, tag.ShardID(shardID))
-							}
-							cancel()
-						} else {
-							// current host is not owner of shard, unload it if it is already loaded.
-							c.CloseShardByID(shardID)
-						}
-					}
+					tryAcquire(shardID)
 				}
 			}
 		}()

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -201,7 +201,7 @@ func (s *controllerSuite) TestAcquireShardSuccess() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 	for _, shardID := range myShards {
-		shard, err := s.shardController.GetShardByID(ctx, shardID)
+		shard, err := s.shardController.GetShardByID(shardID)
 		s.NoError(err)
 		_, err = shard.GetEngineWithContext(ctx)
 		s.NoError(err)
@@ -265,7 +265,7 @@ func (s *controllerSuite) TestAcquireShardsConcurrently() {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	for _, shardID := range myShards {
-		shard, err := s.shardController.GetShardByID(ctx, shardID)
+		shard, err := s.shardController.GetShardByID(shardID)
 		s.NoError(err)
 		_, err = shard.GetEngineWithContext(ctx)
 		s.NoError(err)
@@ -282,11 +282,11 @@ func (s *controllerSuite) TestAcquireShardLookupFailure() {
 	}
 
 	s.shardController.acquireShards()
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
 	for shardID := int32(1); shardID <= numShards; shardID++ {
 		s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(nil, errors.New("ring failure"))
-		s.Nil(s.shardController.GetShardByID(ctx, shardID))
+		shard, err := s.shardController.GetShardByID(shardID)
+		s.Error(err)
+		s.Nil(shard)
 	}
 }
 
@@ -330,18 +330,21 @@ func (s *controllerSuite) TestAcquireShardRenewSuccess() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestSingleDCClusterInfo).AnyTimes()
 	s.shardController.acquireShards()
-	time.Sleep(100 * time.Millisecond) // TODO: fix this properly
 
 	for shardID := int32(1); shardID <= numShards; shardID++ {
 		s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil)
 	}
 	s.shardController.acquireShards()
-	time.Sleep(100 * time.Millisecond) // TODO: fix this properly
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	for shardID := int32(1); shardID <= numShards; shardID++ {
-		s.NotNil(s.shardController.GetShardByID(ctx, shardID))
+		shard, err := s.shardController.GetShardByID(shardID)
+		s.NoError(err)
+		s.NotNil(shard)
+		engine, err := shard.GetEngineWithContext(ctx)
+		s.NoError(err)
+		s.NotNil(engine)
 	}
 }
 
@@ -385,18 +388,21 @@ func (s *controllerSuite) TestAcquireShardRenewLookupFailed() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestSingleDCClusterInfo).AnyTimes()
 	s.shardController.acquireShards()
-	time.Sleep(100 * time.Millisecond) // TODO: fix this properly
 
 	for shardID := int32(1); shardID <= numShards; shardID++ {
 		s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(nil, errors.New("ring failure"))
 	}
 	s.shardController.acquireShards()
-	time.Sleep(100 * time.Millisecond) // TODO: fix this properly
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	for shardID := int32(1); shardID <= numShards; shardID++ {
-		s.NotNil(s.shardController.GetShardByID(ctx, shardID))
+		shard, err := s.shardController.GetShardByID(shardID)
+		s.NoError(err)
+		s.NotNil(shard)
+		engine, err := shard.GetEngineWithContext(ctx)
+		s.NoError(err)
+		s.NotNil(engine)
 	}
 }
 
@@ -431,8 +437,11 @@ func (s *controllerSuite) TestHistoryEngineClosed() {
 		go func() {
 			for attempt := 0; attempt < 10; attempt++ {
 				for shardID := int32(1); shardID <= numShards; shardID++ {
-					engine, err := s.shardController.GetShardByID(ctx, shardID)
-					s.Nil(err)
+					shard, err := s.shardController.GetShardByID(shardID)
+					s.NoError(err)
+					s.NotNil(shard)
+					engine, err := shard.GetEngineWithContext(ctx)
+					s.NoError(err)
 					s.NotNil(engine)
 				}
 			}
@@ -455,8 +464,11 @@ func (s *controllerSuite) TestHistoryEngineClosed() {
 		go func() {
 			for attempt := 0; attempt < 10; attempt++ {
 				for shardID := int32(3); shardID <= numShards; shardID++ {
-					engine, err := s.shardController.GetShardByID(ctx, shardID)
-					s.Nil(err)
+					shard, err := s.shardController.GetShardByID(shardID)
+					s.NoError(err)
+					s.NotNil(shard)
+					engine, err := shard.GetEngineWithContext(ctx)
+					s.NoError(err)
 					s.NotNil(engine)
 					time.Sleep(20 * time.Millisecond)
 				}
@@ -471,7 +483,7 @@ func (s *controllerSuite) TestHistoryEngineClosed() {
 			shardLost := false
 			for attempt := 0; !shardLost && attempt < 10; attempt++ {
 				for shardID := int32(1); shardID <= 2; shardID++ {
-					_, err := s.shardController.GetShardByID(ctx, shardID)
+					_, err := s.shardController.GetShardByID(shardID)
 					if err != nil {
 						s.logger.Error("ShardLost", tag.Error(err))
 						shardLost = true
@@ -494,7 +506,6 @@ func (s *controllerSuite) TestHistoryEngineClosed() {
 		s.mockServiceResolver.EXPECT().Lookup(convert.Int32ToString(shardID)).Return(s.hostInfo, nil).AnyTimes()
 	}
 	s.shardController.Stop()
-	time.Sleep(100 * time.Millisecond) // TODO: fix this properly
 }
 
 func (s *controllerSuite) TestShardControllerClosed() {
@@ -514,15 +525,11 @@ func (s *controllerSuite) TestShardControllerClosed() {
 		s.setupMocksForAcquireShard(shardID, mockEngine, 5, 6, true)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-
 	s.mockServiceResolver.EXPECT().AddListener(shardControllerMembershipUpdateListenerName, gomock.Any()).Return(nil).AnyTimes()
 	// when shard is initialized, it will use the 2 mock function below to initialize the "current" time of each cluster
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestSingleDCClusterInfo).AnyTimes()
 	s.shardController.Start()
-	time.Sleep(100 * time.Millisecond) // TODO: fix this properly
 
 	var workerWG sync.WaitGroup
 	for w := 0; w < 10; w++ {
@@ -531,7 +538,7 @@ func (s *controllerSuite) TestShardControllerClosed() {
 			shardLost := false
 			for attempt := 0; !shardLost && attempt < 10; attempt++ {
 				for shardID := int32(1); shardID <= numShards; shardID++ {
-					_, err := s.shardController.GetShardByID(ctx, shardID)
+					_, err := s.shardController.GetShardByID(shardID)
 					if err != nil {
 						s.logger.Error("ShardLost", tag.Error(err))
 						shardLost = true


### PR DESCRIPTION
**What changed?**
PR #2745 changed the behavior of `GetShardByID` to not block on shard acquisition, where it did before. This changed the behavior of `acquireShards` in the shard controller to not limit concurrency at all. This restores the previous behavior of `acquireShards` and fixes the flaky test.

The `ctx` parameter to `GetShardByID` and `GetShardByNamespaceWorkflow` is removed since it's unused.

Also added some comments about blocking/lease acquisition behavior.

**Why?**
Restore previous behavior. We should have some limit on shard acquisition concurrency.

**How did you test it?**
Existing tests

**Potential risks**


**Is hotfix candidate?**
