### PR TITLE
Do fx logging properly

### DIFF
--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -101,6 +101,7 @@ var (
 
 // Pre-defined values for TagSysComponent
 var (
+	ComponentFX                       = component("fx")
 	ComponentTaskQueue                = component("taskqueue")
 	ComponentHistoryEngine            = component("history-engine")
 	ComponentHistoryCache             = component("history-cache")

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -452,7 +452,7 @@ func (c *temporalImpl) startFrontend(hosts map[string][]string, startWG *sync.Wa
 		temporal.ServiceTracingModule,
 		frontend.Module,
 		fx.Populate(&frontendService, &clientBean, &namespaceRegistry),
-		fx.NopLogger,
+		temporal.FxLogAdapter,
 	)
 	err = feApp.Err()
 	if err != nil {
@@ -548,7 +548,8 @@ func (c *temporalImpl) startHistory(
 			history.Module,
 			replication.Module,
 			fx.Populate(&historyService, &clientBean, &namespaceRegistry),
-			fx.NopLogger)
+			temporal.FxLogAdapter,
+		)
 		err = app.Err()
 		if err != nil {
 			c.logger.Fatal("unable to construct history service", tag.Error(err))
@@ -623,7 +624,7 @@ func (c *temporalImpl) startMatching(hosts map[string][]string, startWG *sync.Wa
 		temporal.ServiceTracingModule,
 		matching.Module,
 		fx.Populate(&matchingService, &clientBean, &namespaceRegistry),
-		fx.NopLogger,
+		temporal.FxLogAdapter,
 	)
 	err = app.Err()
 	if err != nil {
@@ -716,7 +717,7 @@ func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.Wait
 		temporal.ServiceTracingModule,
 		worker.Module,
 		fx.Populate(&workerService, &clientBean, &namespaceRegistry),
-		fx.NopLogger,
+		temporal.FxLogAdapter,
 	)
 	err = app.Err()
 	if err != nil {


### PR DESCRIPTION
**What changed?**
We got rid of fx logging with NopLogger in #2091, but that swallows some useful errors.

This integrates fx logging into our logging system, with most logs at Debug level, but errors at Error (and one at Info).

The code is adapted from https://github.com/uber-go/fx/blob/master/fxevent/zap.go, which is MIT-licensed. We already have the required attribution and copyright notice at the top of this file, so no additional attribution is needed (as far as I know).

**Why?**
So we can see errors from fx for debugging

**How did you test it?**
Manual testing

**Potential risks**
Log spam, but fx shouldn't be doing anything after startup, and I verified that a successful startup doesn't log anything.

**Is hotfix candidate?**
