### PR TITLE
Fix queue rate limiting busy loop

### DIFF
--- a/service/frontend/dcRedirectionHandler.go
+++ b/service/frontend/dcRedirectionHandler.go
@@ -1656,14 +1656,15 @@ func (handler *DCRedirectionHandlerImpl) UpdateWorkflow(
 		switch {
 		case targetDC == handler.currentClusterName:
 			resp, err = handler.frontendHandler.UpdateWorkflow(ctx, request)
+			return err
 		default:
 			remoteClient, err := handler.clientBean.GetRemoteFrontendClient(targetDC)
 			if err != nil {
 				return err
 			}
 			resp, err = remoteClient.UpdateWorkflow(ctx, request)
+			return err
 		}
-		return err
 	})
 
 	return resp, err

--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -216,11 +216,6 @@ eventLoop:
 }
 
 func (p *queueProcessorBase) processBatch() {
-
-	if !p.verifyReschedulerSize() {
-		return
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), loadQueueTaskThrottleRetryDelay)
 	if err := p.rateLimiter.Wait(ctx); err != nil {
 		cancel()
@@ -228,6 +223,10 @@ func (p *queueProcessorBase) processBatch() {
 		return
 	}
 	cancel()
+
+	if !p.verifyReschedulerSize() {
+		return
+	}
 
 	p.lastPollTime = p.timeSource.Now()
 	tasks, more, err := p.ackMgr.readQueueTasks()

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -414,12 +414,14 @@ func newQueueProcessorRateLimiter(
 ) quotas.RateLimiter {
 	return quotas.NewMultiRateLimiter(
 		[]quotas.RateLimiter{
+			// consume from host rate limiter as it's usually the one throttles the traffic
+			// and avoid unnecessary consume and cancel on shard level rate limiter
+			hostRateLimiter,
 			quotas.NewDefaultOutgoingRateLimiter(
 				func() float64 {
 					return float64(shardMaxPollRPS())
 				},
 			),
-			hostRateLimiter,
 		},
 	)
 }

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -414,14 +414,12 @@ func newQueueProcessorRateLimiter(
 ) quotas.RateLimiter {
 	return quotas.NewMultiRateLimiter(
 		[]quotas.RateLimiter{
-			// consume from host rate limiter as it's usually the one throttles the traffic
-			// and avoid unnecessary consume and cancel on shard level rate limiter
-			hostRateLimiter,
 			quotas.NewDefaultOutgoingRateLimiter(
 				func() float64 {
 					return float64(shardMaxPollRPS())
 				},
 			),
+			hostRateLimiter,
 		},
 	)
 }

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -299,10 +299,6 @@ eventLoop:
 }
 
 func (t *timerQueueProcessorBase) readAndFanoutTimerTasks() (*time.Time, error) {
-	if !t.verifyReschedulerSize() {
-		return nil, nil
-	}
-
 	ctx, cancel := context.WithTimeout(context.Background(), loadTimerTaskThrottleRetryDelay)
 	if err := t.rateLimiter.Wait(ctx); err != nil {
 		cancel()
@@ -310,6 +306,10 @@ func (t *timerQueueProcessorBase) readAndFanoutTimerTasks() (*time.Time, error) 
 		return nil, nil
 	}
 	cancel()
+
+	if !t.verifyReschedulerSize() {
+		return nil, nil
+	}
 
 	t.lastPollTime = t.timeSource.Now()
 	timerTasks, nextFireTime, moreTasks, err := t.timerQueueAckMgr.readTimerTasks()

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -301,8 +301,9 @@ eventLoop:
 func (t *timerQueueProcessorBase) readAndFanoutTimerTasks() (*time.Time, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), loadTimerTaskThrottleRetryDelay)
 	if err := t.rateLimiter.Wait(ctx); err != nil {
+		deadline, _ := ctx.Deadline()
+		t.notifyNewTimer(deadline) // re-enqueue the event
 		cancel()
-		t.notifyNewTimer(time.Time{}) // re-enqueue the event
 		return nil, nil
 	}
 	cancel()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Consume ratelimiting token from host level rate limiter first and then the shard level one.
- Check rescheduler size after ratelimiting check

<!-- Tell your future self why have you made these changes -->
**Why?**
- Avoid unnecessary ratelimiter reserve & cancel (for shard level ratelimiter)
- Avoid unnecessary dynamic config loading/checking

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- yes