### PR TITLE
Make shard.GetEngine always take Context

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -234,7 +234,7 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *hist
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -263,7 +263,7 @@ func (h *Handler) RecordActivityTaskStarted(ctx context.Context, request *histor
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -299,7 +299,7 @@ func (h *Handler) RecordWorkflowTaskStarted(ctx context.Context, request *histor
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		h.logger.Error("RecordWorkflowTaskStarted failed.",
 			tag.Error(err),
@@ -347,7 +347,7 @@ func (h *Handler) RespondActivityTaskCompleted(ctx context.Context, request *his
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -386,7 +386,7 @@ func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *histor
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -425,7 +425,7 @@ func (h *Handler) RespondActivityTaskCanceled(ctx context.Context, request *hist
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -470,7 +470,7 @@ func (h *Handler) RespondWorkflowTaskCompleted(ctx context.Context, request *his
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -515,7 +515,7 @@ func (h *Handler) RespondWorkflowTaskFailed(ctx context.Context, request *histor
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -544,7 +544,7 @@ func (h *Handler) StartWorkflowExecution(ctx context.Context, request *historyse
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -666,7 +666,7 @@ func (h *Handler) RebuildMutableState(ctx context.Context, request *historyservi
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -700,7 +700,7 @@ func (h *Handler) DescribeMutableState(ctx context.Context, request *historyserv
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -732,7 +732,7 @@ func (h *Handler) GetMutableState(ctx context.Context, request *historyservice.G
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -764,7 +764,7 @@ func (h *Handler) PollMutableState(ctx context.Context, request *historyservice.
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -796,7 +796,7 @@ func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *histor
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -834,7 +834,7 @@ func (h *Handler) RequestCancelWorkflowExecution(ctx context.Context, request *h
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -868,7 +868,7 @@ func (h *Handler) SignalWorkflowExecution(ctx context.Context, request *historys
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -905,7 +905,7 @@ func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context, request 
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -962,7 +962,7 @@ func (h *Handler) RemoveSignalMutableState(ctx context.Context, request *history
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -996,7 +996,7 @@ func (h *Handler) TerminateWorkflowExecution(ctx context.Context, request *histo
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1028,7 +1028,7 @@ func (h *Handler) DeleteWorkflowExecution(ctx context.Context, request *historys
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1062,7 +1062,7 @@ func (h *Handler) ResetWorkflowExecution(ctx context.Context, request *historyse
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1094,7 +1094,7 @@ func (h *Handler) QueryWorkflow(ctx context.Context, request *historyservice.Que
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1142,7 +1142,7 @@ func (h *Handler) ScheduleWorkflowTask(ctx context.Context, request *historyserv
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1181,7 +1181,7 @@ func (h *Handler) VerifyFirstWorkflowTaskScheduled(
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1219,7 +1219,7 @@ func (h *Handler) RecordChildExecutionCompleted(ctx context.Context, request *hi
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1256,7 +1256,7 @@ func (h *Handler) VerifyChildExecutionCompletionRecorded(
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1292,7 +1292,7 @@ func (h *Handler) ResetStickyTaskQueue(ctx context.Context, request *historyserv
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1329,7 +1329,7 @@ func (h *Handler) ReplicateEventsV2(ctx context.Context, request *historyservice
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1367,7 +1367,7 @@ func (h *Handler) SyncShardStatus(ctx context.Context, request *historyservice.S
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1411,7 +1411,7 @@ func (h *Handler) SyncActivity(ctx context.Context, request *historyservice.Sync
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1449,7 +1449,7 @@ func (h *Handler) GetReplicationMessages(ctx context.Context, request *historyse
 				h.logger.Warn("History engine not found for shard", tag.Error(err))
 				return
 			}
-			engine, err := shardContext.GetEngineWithContext(ctx)
+			engine, err := shardContext.GetEngine(ctx)
 			if err != nil {
 				h.logger.Warn("History engine not found for shard", tag.Error(err))
 				return
@@ -1527,7 +1527,7 @@ func (h *Handler) GetDLQReplicationMessages(ctx context.Context, request *histor
 			h.logger.Warn("History engine not found for workflow ID.", tag.Error(err))
 			return
 		}
-		engine, err := shardContext.GetEngineWithContext(ctx)
+		engine, err := shardContext.GetEngine(ctx)
 		if err != nil {
 			h.logger.Warn("History engine not found for workflow ID.", tag.Error(err))
 			return
@@ -1577,7 +1577,7 @@ func (h *Handler) ReapplyEvents(ctx context.Context, request *historyservice.Rea
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1616,7 +1616,7 @@ func (h *Handler) GetDLQMessages(ctx context.Context, request *historyservice.Ge
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1642,7 +1642,7 @@ func (h *Handler) PurgeDLQMessages(ctx context.Context, request *historyservice.
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1667,7 +1667,7 @@ func (h *Handler) MergeDLQMessages(ctx context.Context, request *historyservice.
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1696,7 +1696,7 @@ func (h *Handler) RefreshWorkflowTasks(ctx context.Context, request *historyserv
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1735,7 +1735,7 @@ func (h *Handler) GenerateLastHistoryReplicationTasks(
 	if err != nil {
 		return nil, h.convertError(err)
 	}
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}
@@ -1770,7 +1770,7 @@ func (h *Handler) GetReplicationStatus(
 		if err != nil {
 			return nil, h.convertError(err)
 		}
-		engine, err := shardContext.GetEngineWithContext(ctx)
+		engine, err := shardContext.GetEngine(ctx)
 		if err != nil {
 			return nil, h.convertError(err)
 		}
@@ -1845,7 +1845,6 @@ func (h *Handler) UpdateWorkflow(
 	}
 
 	shardContext, err := h.controller.GetShardByNamespaceWorkflow(
-		ctx,
 		namespace.ID(request.GetNamespaceId()),
 		request.GetRequest().GetWorkflowExecution().GetWorkflowId(),
 	)
@@ -1853,7 +1852,7 @@ func (h *Handler) UpdateWorkflow(
 		return nil, h.convertError(err)
 	}
 
-	engine, err := shardContext.GetEngineWithContext(ctx)
+	engine, err := shardContext.GetEngine(ctx)
 	if err != nil {
 		return nil, h.convertError(err)
 	}

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -211,7 +211,7 @@ func (r *dlqHandlerImpl) MergeMessages(
 		return nil, err
 	}
 
-	taskExecutor, err := r.getOrCreateTaskExecutor(sourceCluster)
+	taskExecutor, err := r.getOrCreateTaskExecutor(ctx, sourceCluster)
 	if err != nil {
 		return nil, err
 	}
@@ -329,13 +329,13 @@ func (r *dlqHandlerImpl) readMessagesWithAckLevel(
 	return dlqResponse.ReplicationTasks, ackLevel, pageToken, nil
 }
 
-func (r *dlqHandlerImpl) getOrCreateTaskExecutor(clusterName string) (TaskExecutor, error) {
+func (r *dlqHandlerImpl) getOrCreateTaskExecutor(ctx context.Context, clusterName string) (TaskExecutor, error) {
 	r.taskExecutorsLock.Lock()
 	defer r.taskExecutorsLock.Unlock()
 	if executor, ok := r.taskExecutors[clusterName]; ok {
 		return executor, nil
 	}
-	engine, err := r.shard.GetEngine()
+	engine, err := r.shard.GetEngine(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -66,8 +66,7 @@ type (
 		GetMetricsHandler() metrics.MetricsHandler
 		GetTimeSource() clock.TimeSource
 
-		GetEngine() (Engine, error)
-		GetEngineWithContext(ctx context.Context) (Engine, error)
+		GetEngine(ctx context.Context) (Engine, error)
 
 		AssertOwnership(ctx context.Context) error
 		NewVectorClock() (*clockspb.VectorClock, error)

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -185,11 +185,7 @@ func (s *ContextImpl) GetExecutionManager() persistence.ExecutionManager {
 	return s.executionManager
 }
 
-func (s *ContextImpl) GetEngine() (Engine, error) {
-	return s.engineFuture.Get(s.lifecycleCtx)
-}
-
-func (s *ContextImpl) GetEngineWithContext(
+func (s *ContextImpl) GetEngine(
 	ctx context.Context,
 ) (Engine, error) {
 	return s.engineFuture.Get(ctx)
@@ -631,7 +627,7 @@ func (s *ContextImpl) AddTasks(
 		return err
 	}
 
-	engine, err := s.GetEngineWithContext(ctx)
+	engine, err := s.GetEngine(ctx)
 	if err != nil {
 		return err
 	}
@@ -991,7 +987,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	}
 	defer cancel()
 
-	engine, err := s.GetEngineWithContext(ctx)
+	engine, err := s.GetEngine(ctx)
 	if err != nil {
 		return err
 	}

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -308,33 +308,18 @@ func (mr *MockContextMockRecorder) GetCurrentTime(cluster interface{}) *gomock.C
 }
 
 // GetEngine mocks base method.
-func (m *MockContext) GetEngine() (Engine, error) {
+func (m *MockContext) GetEngine(ctx context.Context) (Engine, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEngine")
+	ret := m.ctrl.Call(m, "GetEngine", ctx)
 	ret0, _ := ret[0].(Engine)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetEngine indicates an expected call of GetEngine.
-func (mr *MockContextMockRecorder) GetEngine() *gomock.Call {
+func (mr *MockContextMockRecorder) GetEngine(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEngine", reflect.TypeOf((*MockContext)(nil).GetEngine))
-}
-
-// GetEngineWithContext mocks base method.
-func (m *MockContext) GetEngineWithContext(ctx context.Context) (Engine, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetEngineWithContext", ctx)
-	ret0, _ := ret[0].(Engine)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetEngineWithContext indicates an expected call of GetEngineWithContext.
-func (mr *MockContextMockRecorder) GetEngineWithContext(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEngineWithContext", reflect.TypeOf((*MockContext)(nil).GetEngineWithContext), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEngine", reflect.TypeOf((*MockContext)(nil).GetEngine), ctx)
 }
 
 // GetEventsCache mocks base method.

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -353,7 +353,7 @@ func (c *ControllerImpl) acquireShards() {
 		// After 1s we will move on but the shard will continue trying in the background.
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
-		_, _ = shard.GetEngineWithContext(ctx)
+		_, _ = shard.GetEngine(ctx)
 	}
 
 	concurrency := util.Max(c.config.AcquireShardConcurrency(), 1)

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -203,7 +203,7 @@ func (s *controllerSuite) TestAcquireShardSuccess() {
 	for _, shardID := range myShards {
 		shard, err := s.shardController.GetShardByID(shardID)
 		s.NoError(err)
-		_, err = shard.GetEngineWithContext(ctx)
+		_, err = shard.GetEngine(ctx)
 		s.NoError(err)
 		count++
 	}
@@ -267,7 +267,7 @@ func (s *controllerSuite) TestAcquireShardsConcurrently() {
 	for _, shardID := range myShards {
 		shard, err := s.shardController.GetShardByID(shardID)
 		s.NoError(err)
-		_, err = shard.GetEngineWithContext(ctx)
+		_, err = shard.GetEngine(ctx)
 		s.NoError(err)
 		count++
 	}
@@ -342,7 +342,7 @@ func (s *controllerSuite) TestAcquireShardRenewSuccess() {
 		shard, err := s.shardController.GetShardByID(shardID)
 		s.NoError(err)
 		s.NotNil(shard)
-		engine, err := shard.GetEngineWithContext(ctx)
+		engine, err := shard.GetEngine(ctx)
 		s.NoError(err)
 		s.NotNil(engine)
 	}
@@ -400,7 +400,7 @@ func (s *controllerSuite) TestAcquireShardRenewLookupFailed() {
 		shard, err := s.shardController.GetShardByID(shardID)
 		s.NoError(err)
 		s.NotNil(shard)
-		engine, err := shard.GetEngineWithContext(ctx)
+		engine, err := shard.GetEngine(ctx)
 		s.NoError(err)
 		s.NotNil(engine)
 	}
@@ -440,7 +440,7 @@ func (s *controllerSuite) TestHistoryEngineClosed() {
 					shard, err := s.shardController.GetShardByID(shardID)
 					s.NoError(err)
 					s.NotNil(shard)
-					engine, err := shard.GetEngineWithContext(ctx)
+					engine, err := shard.GetEngine(ctx)
 					s.NoError(err)
 					s.NotNil(engine)
 				}
@@ -467,7 +467,7 @@ func (s *controllerSuite) TestHistoryEngineClosed() {
 					shard, err := s.shardController.GetShardByID(shardID)
 					s.NoError(err)
 					s.NotNil(shard)
-					engine, err := shard.GetEngineWithContext(ctx)
+					engine, err := shard.GetEngine(ctx)
 					s.NoError(err)
 					s.NotNil(engine)
 					time.Sleep(20 * time.Millisecond)

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -134,7 +134,7 @@ func newTimerQueueActiveProcessor(
 					shard.GetNamespaceRegistry(),
 					clientBean,
 					func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
-						engine, err := shard.GetEngine()
+						engine, err := shard.GetEngine(ctx)
 						if err != nil {
 							return err
 						}

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -103,7 +103,7 @@ func newTimerQueueStandbyProcessor(
 			shard.GetNamespaceRegistry(),
 			clientBean,
 			func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
-				engine, err := shard.GetEngine()
+				engine, err := shard.GetEngine(ctx)
 				if err != nil {
 					return err
 				}

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -161,7 +161,7 @@ func newTransferQueueActiveProcessor(
 					shard.GetNamespaceRegistry(),
 					clientBean,
 					func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
-						engine, err := shard.GetEngine()
+						engine, err := shard.GetEngine(ctx)
 						if err != nil {
 							return err
 						}

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -126,7 +126,7 @@ func newTransferQueueStandbyProcessor(
 			shard.GetNamespaceRegistry(),
 			clientBean,
 			func(ctx context.Context, request *historyservice.ReplicateEventsV2Request) error {
-				engine, err := shard.GetEngine()
+				engine, err := shard.GetEngine(ctx)
 				if err != nil {
 					return err
 				}

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -367,7 +367,7 @@ func (c *ContextImpl) CreateWorkflowExecution(
 	}
 	c.SetHistorySize(int64(resp.NewMutableStateStats.HistoryStatistics.SizeDiff))
 
-	engine, err := c.shard.GetEngine()
+	engine, err := c.shard.GetEngine(ctx)
 	if err != nil {
 		return err
 	}
@@ -826,7 +826,7 @@ func (c *ContextImpl) ReapplyEvents(
 
 	activeCluster := namespaceEntry.ActiveClusterName()
 	if activeCluster == c.shard.GetClusterMetadata().GetCurrentClusterName() {
-		engine, err := c.shard.GetEngine()
+		engine, err := c.shard.GetEngine(ctx)
 		if err != nil {
 			return err
 		}

--- a/service/history/workflow/transaction_impl.go
+++ b/service/history/workflow/transaction_impl.go
@@ -75,7 +75,7 @@ func (t *TransactionImpl) CreateWorkflowExecution(
 	clusterName string,
 ) (int64, error) {
 
-	engine, err := t.shard.GetEngine()
+	engine, err := t.shard.GetEngine(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -113,7 +113,7 @@ func (t *TransactionImpl) ConflictResolveWorkflowExecution(
 	clusterName string,
 ) (int64, int64, int64, error) {
 
-	engine, err := t.shard.GetEngine()
+	engine, err := t.shard.GetEngine(ctx)
 	if err != nil {
 		return 0, 0, 0, err
 	}
@@ -169,7 +169,7 @@ func (t *TransactionImpl) UpdateWorkflowExecution(
 	clusterName string,
 ) (int64, int64, error) {
 
-	engine, err := t.shard.GetEngine()
+	engine, err := t.shard.GetEngine(ctx)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -210,7 +210,7 @@ func (t *TransactionImpl) SetWorkflowExecution(
 	clusterName string,
 ) error {
 
-	engine, err := t.shard.GetEngine()
+	engine, err := t.shard.GetEngine(ctx)
 	if err != nil {
 		return err
 	}

--- a/service/history/workflow/transaction_test.go
+++ b/service/history/workflow/transaction_test.go
@@ -73,7 +73,7 @@ func (s *transactionSuite) SetupTest() {
 	s.logger = log.NewTestLogger()
 
 	s.mockShard.EXPECT().GetShardID().Return(int32(1)).AnyTimes()
-	s.mockShard.EXPECT().GetEngine().Return(s.mockEngine, nil).AnyTimes()
+	s.mockShard.EXPECT().GetEngine(gomock.Any()).Return(s.mockEngine, nil).AnyTimes()
 	s.mockShard.EXPECT().GetNamespaceRegistry().Return(s.mockNamespaceCache).AnyTimes()
 	s.mockShard.EXPECT().GetLogger().Return(s.logger).AnyTimes()
 	s.mockNamespaceCache.EXPECT().GetNamespaceByID(tests.NamespaceID).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()


### PR DESCRIPTION
**What changed?**
Every use of `GetEngine` has a `Context` available, so we can just always use the `WithContext` version, and then we can rename it to just `GetEngine` to be clearer.

**Why?**
simpler interface

**How did you test it?**
unit tests

**Potential risks**
not much

**Is hotfix candidate?**
