### PR TITLE
Run one per-ns worker per namespace instead of namespace × component

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -636,10 +636,10 @@ const (
 	WorkerParentCloseMaxConcurrentActivityTaskPollers = "worker.ParentCloseMaxConcurrentActivityTaskPollers"
 	// WorkerParentCloseMaxConcurrentWorkflowTaskPollers indicates worker parent close worker max concurrent workflow pollers
 	WorkerParentCloseMaxConcurrentWorkflowTaskPollers = "worker.ParentCloseMaxConcurrentWorkflowTaskPollers"
+	// WorkerPerNSNumWorkers controls number of per-ns (scheduler, batcher, etc.) workers to run per namespace
+	WorkerPerNSNumWorkers = "worker.perNSNumWorkers"
 	// WorkerEnableScheduler controls whether to start the worker for scheduled workflows
 	WorkerEnableScheduler = "worker.enableScheduler"
-	// WorkerSchedulerNumWorkers controls number of scheduler workers to run per namespace
-	WorkerSchedulerNumWorkers = "worker.schedulerNumWorkers"
 )
 
 // Filter represents a filter on the dynamic config key

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -636,8 +636,8 @@ const (
 	WorkerParentCloseMaxConcurrentActivityTaskPollers = "worker.ParentCloseMaxConcurrentActivityTaskPollers"
 	// WorkerParentCloseMaxConcurrentWorkflowTaskPollers indicates worker parent close worker max concurrent workflow pollers
 	WorkerParentCloseMaxConcurrentWorkflowTaskPollers = "worker.ParentCloseMaxConcurrentWorkflowTaskPollers"
-	// WorkerPerNSNumWorkers controls number of per-ns (scheduler, batcher, etc.) workers to run per namespace
-	WorkerPerNSNumWorkers = "worker.perNSNumWorkers"
+	// WorkerPerNamespaceWorkerCount controls number of per-ns (scheduler, batcher, etc.) workers to run per namespace
+	WorkerPerNamespaceWorkerCount = "worker.perNamespaceWorkerCount"
 	// WorkerEnableScheduler controls whether to start the worker for scheduled workflows
 	WorkerEnableScheduler = "worker.enableScheduler"
 )

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -74,6 +74,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/searchattribute"
+	workercommon "go.temporal.io/server/service/worker/common"
 	"go.temporal.io/server/service/worker/scheduler"
 )
 
@@ -3132,7 +3133,7 @@ func (wh *WorkflowHandler) CreateSchedule(ctx context.Context, request *workflow
 		Namespace:             request.Namespace,
 		WorkflowId:            request.ScheduleId,
 		WorkflowType:          &commonpb.WorkflowType{Name: scheduler.WorkflowType},
-		TaskQueue:             &taskqueuepb.TaskQueue{Name: scheduler.TaskQueueName},
+		TaskQueue:             &taskqueuepb.TaskQueue{Name: workercommon.PerNSWorkerTaskQueue},
 		Input:                 inputPayload,
 		Identity:              request.Identity,
 		RequestId:             request.RequestId,

--- a/service/worker/common/interface.go
+++ b/service/worker/common/interface.go
@@ -31,6 +31,11 @@ import (
 	"go.temporal.io/server/common/namespace"
 )
 
+const (
+	// All per-ns workers share one task queue
+	PerNSWorkerTaskQueue = "temporal-sys-per-ns-tq"
+)
+
 type (
 	// WorkerComponent represents a type of work needed for worker role
 	WorkerComponent interface {
@@ -60,13 +65,7 @@ type (
 	}
 
 	PerNSDedicatedWorkerOptions struct {
-		// Set this to false to disable a worker for this namespace
+		// Set this to false to disable this worker for this namespace
 		Enabled bool
-		// TaskQueue is required
-		TaskQueue string
-		// How many worker nodes should run a worker per namespace
-		NumWorkers int
-		// Other worker options
-		Options sdkworker.Options
 	}
 )

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -25,6 +25,7 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"sync"
@@ -35,9 +36,11 @@ import (
 	sdkclient "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.uber.org/fx"
+	"golang.org/x/exp/maps"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
@@ -59,6 +62,7 @@ type (
 		SdkWorkerFactory  sdk.WorkerFactory
 		NamespaceRegistry namespace.Registry
 		HostName          resource.HostName
+		Config            *Config
 		Components        []workercommon.PerNSWorkerComponent `group:"perNamespaceWorkerComponent"`
 	}
 
@@ -72,28 +76,26 @@ type (
 		namespaceRegistry namespace.Registry
 		self              *membership.HostInfo
 		hostName          resource.HostName
+		config            *Config
 		serviceResolver   membership.ServiceResolver
 		components        []workercommon.PerNSWorkerComponent
 		initialRetry      time.Duration
 
 		membershipChangedCh chan *membership.ChangedEvent
 
-		lock       sync.Mutex
-		workerSets map[namespace.ID]*workerSet
+		lock    sync.Mutex
+		workers map[namespace.ID]*perNamespaceWorker
 	}
 
-	workerSet struct {
+	perNamespaceWorker struct {
 		wm *perNamespaceWorkerManager
 
-		lock    sync.Mutex // protects below fields
-		ns      *namespace.Namespace
-		deleted bool
-		workers map[workercommon.PerNSWorkerComponent]*worker
-	}
-
-	worker struct {
-		client sdkclient.Client
-		worker sdkworker.Worker
+		lock         sync.Mutex // protects below fields
+		ns           *namespace.Namespace
+		deleted      bool
+		componentSet string
+		client       sdkclient.Client
+		worker       sdkworker.Worker
 	}
 )
 
@@ -104,10 +106,11 @@ func NewPerNamespaceWorkerManager(params perNamespaceWorkerManagerInitParams) *p
 		sdkWorkerFactory:    params.SdkWorkerFactory,
 		namespaceRegistry:   params.NamespaceRegistry,
 		hostName:            params.HostName,
+		config:              params.Config,
 		components:          params.Components,
 		initialRetry:        1 * time.Second,
 		membershipChangedCh: make(chan *membership.ChangedEvent),
-		workerSets:          make(map[namespace.ID]*workerSet),
+		workers:             make(map[namespace.ID]*perNamespaceWorker),
 	}
 }
 
@@ -157,12 +160,13 @@ func (wm *perNamespaceWorkerManager) Stop() {
 	close(wm.membershipChangedCh)
 
 	wm.lock.Lock()
-	defer wm.lock.Unlock()
+	workers := maps.Values(wm.workers)
+	wm.lock.Unlock()
 
-	for _, ws := range wm.workerSets {
+	for _, worker := range workers {
 		// this will see that the perNamespaceWorkerManager is not running
 		// anymore and stop all workers
-		ws.refresh(nil, false)
+		worker.refresh(nil, false)
 	}
 
 	wm.logger.Info("", tag.ComponentPerNSWorkerManager, tag.LifeCycleStopped)
@@ -175,45 +179,45 @@ func (wm *perNamespaceWorkerManager) namespaceCallback(ns *namespace.Namespace, 
 func (wm *perNamespaceWorkerManager) membershipChangedListener() {
 	for range wm.membershipChangedCh {
 		wm.lock.Lock()
-		for _, ws := range wm.workerSets {
-			go ws.refresh(nil, false)
+		for _, worker := range wm.workers {
+			go worker.refresh(nil, false)
 		}
 		wm.lock.Unlock()
 	}
 }
 
-func (wm *perNamespaceWorkerManager) getWorkerSet(ns *namespace.Namespace) *workerSet {
+func (wm *perNamespaceWorkerManager) getWorkerSet(ns *namespace.Namespace) *perNamespaceWorker {
 	wm.lock.Lock()
 	defer wm.lock.Unlock()
 
-	if ws, ok := wm.workerSets[ns.ID()]; ok {
-		return ws
+	if worker, ok := wm.workers[ns.ID()]; ok {
+		return worker
 	}
 
-	ws := &workerSet{
-		wm:      wm,
-		ns:      ns,
-		workers: make(map[workercommon.PerNSWorkerComponent]*worker),
+	worker := &perNamespaceWorker{
+		wm: wm,
+		ns: ns,
 	}
 
-	wm.workerSets[ns.ID()] = ws
-	return ws
+	wm.workers[ns.ID()] = worker
+	return worker
 }
 
 func (wm *perNamespaceWorkerManager) removeWorkerSet(ns *namespace.Namespace) {
 	wm.lock.Lock()
 	defer wm.lock.Unlock()
-	delete(wm.workerSets, ns.ID())
+	delete(wm.workers, ns.ID())
 }
 
-func (wm *perNamespaceWorkerManager) responsibleForNamespace(ns *namespace.Namespace, queueName string, num int) (int, error) {
-	// This can result in fewer than the intended number of workers if num > 1, because
+func (wm *perNamespaceWorkerManager) responsibleForNamespace(ns *namespace.Namespace) (int, error) {
+	numWorkers := wm.config.PerNSNumWorkers(ns.Name().String())
+	// This can result in fewer than the intended number of workers if numWorkers > 1, because
 	// multiple lookups might land on the same node. To compensate, we increase the number of
 	// pollers in that case, but it would be better to try to spread them across our nodes.
 	// TODO: implement this properly using LookupN in serviceResolver
 	multiplicity := 0
-	for i := 0; i < num; i++ {
-		key := fmt.Sprintf("%s/%s/%d", ns.ID().String(), queueName, i)
+	for i := 0; i < numWorkers; i++ {
+		key := fmt.Sprintf("%s/%d", ns.ID().String(), i)
 		target, err := wm.serviceResolver.Lookup(key)
 		if err != nil {
 			return 0, err
@@ -225,127 +229,145 @@ func (wm *perNamespaceWorkerManager) responsibleForNamespace(ns *namespace.Names
 	return multiplicity, nil
 }
 
-// called after change to this namespace state _or_ any membership change in the
-// server worker ring
-func (ws *workerSet) refresh(newNs *namespace.Namespace, newDeleted bool) {
-	ws.lock.Lock()
+// This is called after change to this namespace state _or_ any membership change in the server
+// worker ring. It runs in its own goroutine (except for server shutdown), and multiple
+// goroutines for the same namespace may be running at once. That's okay because they should
+// eventually converge on the same state (running or not running, set of components) and exit.
+func (w *perNamespaceWorker) refresh(newNs *namespace.Namespace, newDeleted bool) {
+	w.lock.Lock()
 	if newNs != nil {
-		ws.ns = newNs
-		ws.deleted = newDeleted
+		w.ns = newNs
+		w.deleted = newDeleted
 	}
-	ns, deleted := ws.ns, ws.deleted
-	ws.lock.Unlock()
+	ns, deleted := w.ns, w.deleted
 
-	for _, wc := range ws.wm.components {
-		ws.refreshComponent(wc, ns, deleted)
+	if !w.wm.Running() || ns.State() == enumspb.NAMESPACE_STATE_DELETED || deleted {
+		// stop everything
+		w.stopWorkerLocked()
+		w.lock.Unlock()
+
+		if deleted {
+			// if namespace is fully deleted from db, we can remove from our map also
+			w.wm.removeWorkerSet(ns)
+		}
+		return
 	}
+	w.lock.Unlock()
 
-	if deleted {
-		// if fully deleted from db, we can remove from our map also
-		ws.wm.removeWorkerSet(ns)
-	}
-}
-
-func (ws *workerSet) refreshComponent(
-	cmp workercommon.PerNSWorkerComponent,
-	ns *namespace.Namespace,
-	deleted bool,
-) {
 	op := func() error {
-		// we should run only if all four are true:
-		// 1. perNamespaceWorkerManager is running
-		// 2. this namespace is not deleted
-		// 3. the component says we should be (can filter by namespace)
-		// 4. we are responsible for this namespace
-		multiplicity := 0
-		var options *workercommon.PerNSDedicatedWorkerOptions
-		if ws.wm.Running() && ns.State() != enumspb.NAMESPACE_STATE_DELETED && !deleted {
-			options = cmp.DedicatedWorkerOptions(ns)
+		// figure out which components are enabled at all for this namespace
+		var enabledComponents []workercommon.PerNSWorkerComponent
+		var componentSet string
+		for _, cmp := range w.wm.components {
+			options := cmp.DedicatedWorkerOptions(ns)
 			if options.Enabled {
-				var err error
-				multiplicity, err = ws.wm.responsibleForNamespace(ns, options.TaskQueue, options.NumWorkers)
-				if err != nil {
-					return err
-				}
+				enabledComponents = append(enabledComponents, cmp)
+				componentSet += fmt.Sprintf("%p,", cmp)
 			}
 		}
 
-		if multiplicity > 0 {
-			ws.lock.Lock()
-			if _, ok := ws.workers[cmp]; ok {
-				// worker is already running. it's possible that it started with a different
-				// multiplicity. we don't bother changing it in that case.
-				ws.lock.Unlock()
-				return nil
-			}
-			ws.lock.Unlock()
-
-			worker, err := ws.startWorker(cmp, ns, options, multiplicity)
-			if err != nil {
-				return err
-			}
-
-			ws.lock.Lock()
-			defer ws.lock.Unlock()
-
-			// check again in case we had a race
-			if _, ok := ws.workers[cmp]; ok || !ws.wm.Running() {
-				worker.stop()
-				return nil
-			}
-
-			ws.workers[cmp] = worker
-
-			return nil
-		} else {
-			ws.lock.Lock()
-			defer ws.lock.Unlock()
-
-			if worker, ok := ws.workers[cmp]; ok {
-				worker.stop()
-				delete(ws.workers, cmp)
-			}
-
+		if len(enabledComponents) == 0 {
+			// no components enabled, we don't need a worker
+			w.stopWorker()
 			return nil
 		}
+
+		// check if we are responsible for this namespace at all
+		multiplicity, err := w.wm.responsibleForNamespace(ns)
+		if err != nil {
+			// TODO: add metric for errors here
+			return err
+		}
+		if multiplicity == 0 {
+			// not ours, don't need a worker
+			w.stopWorker()
+			return nil
+		}
+
+		// we do need a worker, but maybe we have one already
+		w.lock.Lock()
+		if componentSet == w.componentSet {
+			// no change in set of components enabled
+			w.lock.Unlock()
+			return nil
+		}
+		// set of components changed, need to recreate worker. first stop old one
+		w.stopWorkerLocked()
+		w.lock.Unlock()
+
+		// create worker outside of lock
+		client, worker, err := w.startWorker(enabledComponents, ns, multiplicity)
+		if err != nil {
+			// TODO: add metric for errors here
+			return err
+		}
+
+		w.lock.Lock()
+		defer w.lock.Unlock()
+		// maybe there was a race and someone else created a client already. stop ours
+		if w.client != nil || w.worker != nil {
+			worker.Stop()
+			client.Close()
+			return nil
+		}
+		w.client = client
+		w.worker = worker
+		w.componentSet = componentSet
+		return nil
 	}
-	policy := backoff.NewExponentialRetryPolicy(ws.wm.initialRetry)
+	policy := backoff.NewExponentialRetryPolicy(w.wm.initialRetry)
+	policy.SetMaximumInterval(1 * time.Minute)
+	policy.SetExpirationInterval(backoff.NoInterval)
 	backoff.ThrottleRetry(op, policy, nil)
 }
 
-func (ws *workerSet) startWorker(
-	wc workercommon.PerNSWorkerComponent,
+func (w *perNamespaceWorker) startWorker(
+	components []workercommon.PerNSWorkerComponent,
 	ns *namespace.Namespace,
-	options *workercommon.PerNSDedicatedWorkerOptions,
 	multiplicity int,
-) (*worker, error) {
+) (sdkclient.Client, sdkworker.Worker, error) {
 	nsName := ns.Name().String()
-	client, err := ws.wm.sdkClientFactory.NewClient(nsName, ws.wm.logger)
+	client, err := w.wm.sdkClientFactory.NewClient(nsName, w.wm.logger)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	sdkoptions := options.Options
-	sdkoptions.Identity = fmt.Sprintf("%d@%s@%s@%s@%T", os.Getpid(), ws.wm.hostName, nsName, options.TaskQueue, wc)
+	var sdkoptions sdkworker.Options
+	sdkoptions.BackgroundActivityContext = headers.SetCallerInfo(context.Background(), headers.NewCallerInfo(headers.CallerTypeBackground))
+	sdkoptions.Identity = fmt.Sprintf("%d@%s@%s", os.Getpid(), w.wm.hostName, nsName)
 	// sdk default is 2, we increase it if we're supposed to run with more multiplicity.
 	// other defaults are already large enough.
 	sdkoptions.MaxConcurrentWorkflowTaskPollers = 2 * multiplicity
 	sdkoptions.MaxConcurrentActivityTaskPollers = 2 * multiplicity
 
-	sdkworker := ws.wm.sdkWorkerFactory.New(client, options.TaskQueue, sdkoptions)
-	wc.Register(sdkworker, ns)
+	sdkworker := w.wm.sdkWorkerFactory.New(client, workercommon.PerNSWorkerTaskQueue, sdkoptions)
+	for _, cmp := range components {
+		cmp.Register(sdkworker, ns)
+	}
 	// TODO: use Run() and handle post-startup errors by recreating worker
-	// (after sdk supports returning post-startup errors from Run)
 	err = sdkworker.Start()
 	if err != nil {
 		client.Close()
-		return nil, err
+		return nil, nil, err
 	}
 
-	return &worker{client: client, worker: sdkworker}, nil
+	return client, sdkworker, nil
 }
 
-func (w *worker) stop() {
-	w.worker.Stop()
-	w.client.Close()
+func (w *perNamespaceWorker) stopWorker() {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	w.stopWorkerLocked()
+}
+
+func (w *perNamespaceWorker) stopWorkerLocked() {
+	if w.worker != nil {
+		w.worker.Stop()
+		w.worker = nil
+	}
+	if w.client != nil {
+		w.client.Close()
+		w.client = nil
+	}
+	w.componentSet = ""
 }

--- a/service/worker/pernamespaceworker_test.go
+++ b/service/worker/pernamespaceworker_test.go
@@ -41,7 +41,6 @@ import (
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/testing/mocksdk"
 	"go.temporal.io/server/common/util"
-	"go.temporal.io/server/service/worker/common"
 	workercommon "go.temporal.io/server/service/worker/common"
 )
 
@@ -56,8 +55,8 @@ type perNsWorkerManagerSuite struct {
 	hostInfo        *membership.HostInfo
 	serviceResolver *membership.MockServiceResolver
 
-	cmp1 *common.MockPerNSWorkerComponent
-	cmp2 *common.MockPerNSWorkerComponent
+	cmp1 *workercommon.MockPerNSWorkerComponent
+	cmp2 *workercommon.MockPerNSWorkerComponent
 
 	manager *perNamespaceWorkerManager
 }
@@ -75,8 +74,8 @@ func (s *perNsWorkerManagerSuite) SetupTest() {
 	s.registry = namespace.NewMockRegistry(s.controller)
 	s.hostInfo = membership.NewHostInfo("self", nil)
 	s.serviceResolver = membership.NewMockServiceResolver(s.controller)
-	s.cmp1 = common.NewMockPerNSWorkerComponent(s.controller)
-	s.cmp2 = common.NewMockPerNSWorkerComponent(s.controller)
+	s.cmp1 = workercommon.NewMockPerNSWorkerComponent(s.controller)
+	s.cmp2 = workercommon.NewMockPerNSWorkerComponent(s.controller)
 
 	s.manager = NewPerNamespaceWorkerManager(perNamespaceWorkerManagerInitParams{
 		Logger:            s.logger,
@@ -89,7 +88,7 @@ func (s *perNsWorkerManagerSuite) SetupTest() {
 				return util.Max(1, map[string]int{"ns1": 1, "ns2": 2, "ns3": 3}[ns])
 			},
 		},
-		Components: []common.PerNSWorkerComponent{s.cmp1, s.cmp2},
+		Components: []workercommon.PerNSWorkerComponent{s.cmp1, s.cmp2},
 	})
 	s.manager.initialRetry = 1 * time.Millisecond
 
@@ -109,10 +108,10 @@ func (s *perNsWorkerManagerSuite) TearDownTest() {
 func (s *perNsWorkerManagerSuite) TestDisabled() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
@@ -123,10 +122,10 @@ func (s *perNsWorkerManagerSuite) TestDisabled() {
 func (s *perNsWorkerManagerSuite) TestEnabledButResolvedToOther() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: true,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
@@ -140,10 +139,10 @@ func (s *perNsWorkerManagerSuite) TestEnabledButResolvedToOther() {
 func (s *perNsWorkerManagerSuite) TestEnabled() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: true,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
@@ -166,10 +165,10 @@ func (s *perNsWorkerManagerSuite) TestEnabled() {
 func (s *perNsWorkerManagerSuite) TestMultiplicity() {
 	ns := testns("ns3", enumspb.NAMESPACE_STATE_REGISTERED) // three workers
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: true,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
@@ -243,10 +242,10 @@ func (s *perNsWorkerManagerSuite) TestTwoNamespacesTwoComponents() {
 func (s *perNsWorkerManagerSuite) TestDeleteNs() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: true,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
@@ -291,10 +290,10 @@ func (s *perNsWorkerManagerSuite) TestDeleteNs() {
 func (s *perNsWorkerManagerSuite) TestMembershipChanged() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: true,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
@@ -328,10 +327,10 @@ func (s *perNsWorkerManagerSuite) TestMembershipChanged() {
 func (s *perNsWorkerManagerSuite) TestServiceResolverError() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: true,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
@@ -357,10 +356,10 @@ func (s *perNsWorkerManagerSuite) TestServiceResolverError() {
 func (s *perNsWorkerManagerSuite) TestNewClientError() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: true,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
@@ -387,10 +386,10 @@ func (s *perNsWorkerManagerSuite) TestNewClientError() {
 func (s *perNsWorkerManagerSuite) TestStartWorkerError() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: true,
 	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 

--- a/service/worker/pernamespaceworker_test.go
+++ b/service/worker/pernamespaceworker_test.go
@@ -40,7 +40,9 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/testing/mocksdk"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/worker/common"
+	workercommon "go.temporal.io/server/service/worker/common"
 )
 
 type perNsWorkerManagerSuite struct {
@@ -82,7 +84,12 @@ func (s *perNsWorkerManagerSuite) SetupTest() {
 		SdkWorkerFactory:  s.wfactory,
 		NamespaceRegistry: s.registry,
 		HostName:          "self",
-		Components:        []common.PerNSWorkerComponent{s.cmp1, s.cmp2},
+		Config: &Config{
+			PerNamespaceWorkerCount: func(ns string) int {
+				return util.Max(1, map[string]int{"ns1": 1, "ns2": 2, "ns3": 3}[ns])
+			},
+		},
+		Components: []common.PerNSWorkerComponent{s.cmp1, s.cmp2},
 	})
 	s.manager.initialRetry = 1 * time.Millisecond
 
@@ -117,16 +124,13 @@ func (s *perNsWorkerManagerSuite) TestEnabledButResolvedToOther() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 2,
+		Enabled: true,
 	}).AnyTimes()
 	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("other1", nil), nil)
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/1").Return(membership.NewHostInfo("other2", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("other1", nil), nil)
 
 	s.manager.namespaceCallback(ns, false)
 	// main work happens in a goroutine
@@ -137,19 +141,17 @@ func (s *perNsWorkerManagerSuite) TestEnabled() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 1,
+		Enabled: true,
 	}).AnyTimes()
 	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("self", nil), nil)
 	cli1 := mocksdk.NewMockClient(s.controller)
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli1, nil)
 	wkr1 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Return(wkr1)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr1)
 	s.cmp1.EXPECT().Register(wkr1, ns)
 	wkr1.EXPECT().Start()
 
@@ -162,24 +164,22 @@ func (s *perNsWorkerManagerSuite) TestEnabled() {
 }
 
 func (s *perNsWorkerManagerSuite) TestMultiplicity() {
-	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
+	ns := testns("ns3", enumspb.NAMESPACE_STATE_REGISTERED) // three workers
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 3,
+		Enabled: true,
 	}).AnyTimes()
 	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil)
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/1").Return(membership.NewHostInfo("other", nil), nil)
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/2").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns3/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns3/1").Return(membership.NewHostInfo("other", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns3/2").Return(membership.NewHostInfo("self", nil), nil)
 	cli1 := mocksdk.NewMockClient(s.controller)
-	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli1, nil)
+	s.cfactory.EXPECT().NewClient("ns3", gomock.Any()).Return(cli1, nil)
 	wkr1 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Do(func(_, _ any, options sdkworker.Options) {
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Do(func(_, _ any, options sdkworker.Options) {
 		s.Equal(4, options.MaxConcurrentWorkflowTaskPollers)
 		s.Equal(4, options.MaxConcurrentActivityTaskPollers)
 	}).Return(wkr1)
@@ -197,83 +197,64 @@ func (s *perNsWorkerManagerSuite) TestTwoNamespacesTwoComponents() {
 	ns1 := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 	ns2 := testns("ns2", enumspb.NAMESPACE_STATE_REGISTERED)
 
-	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 1,
-	}).AnyTimes()
-	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq2",
-		NumWorkers: 1,
-	}).AnyTimes()
+	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).DoAndReturn(
+		func(ns *namespace.Namespace) *workercommon.PerNSDedicatedWorkerOptions {
+			return &workercommon.PerNSDedicatedWorkerOptions{Enabled: true}
+		}).AnyTimes()
+	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).DoAndReturn(
+		func(ns *namespace.Namespace) *workercommon.PerNSDedicatedWorkerOptions {
+			// only enabled on ns1
+			return &workercommon.PerNSDedicatedWorkerOptions{Enabled: ns.Name().String() == "ns1"}
+		}).AnyTimes()
 
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil)
-	s.serviceResolver.EXPECT().Lookup("ns1/tq2/0").Return(membership.NewHostInfo("self", nil), nil)
-	s.serviceResolver.EXPECT().Lookup("ns2/tq1/0").Return(membership.NewHostInfo("self", nil), nil)
-	s.serviceResolver.EXPECT().Lookup("ns2/tq2/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns2/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns2/1").Return(membership.NewHostInfo("self", nil), nil)
 
-	cli11 := mocksdk.NewMockClient(s.controller)
-	cli12 := mocksdk.NewMockClient(s.controller)
-	cli21 := mocksdk.NewMockClient(s.controller)
-	cli22 := mocksdk.NewMockClient(s.controller)
+	cli1 := mocksdk.NewMockClient(s.controller)
+	cli2 := mocksdk.NewMockClient(s.controller)
 
-	wkr11 := mocksdk.NewMockWorker(s.controller)
-	wkr12 := mocksdk.NewMockWorker(s.controller)
-	wkr21 := mocksdk.NewMockWorker(s.controller)
-	wkr22 := mocksdk.NewMockWorker(s.controller)
+	wkr1 := mocksdk.NewMockWorker(s.controller)
+	wkr2 := mocksdk.NewMockWorker(s.controller)
 
-	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli11, nil)
-	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli12, nil)
-	s.cfactory.EXPECT().NewClient("ns2", gomock.Any()).Return(cli21, nil)
-	s.cfactory.EXPECT().NewClient("ns2", gomock.Any()).Return(cli22, nil)
+	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli1, nil)
+	s.cfactory.EXPECT().NewClient("ns2", gomock.Any()).Return(cli2, nil)
 
-	s.wfactory.EXPECT().New(cli11, "tq1", gomock.Any()).Return(wkr11)
-	s.wfactory.EXPECT().New(cli12, "tq2", gomock.Any()).Return(wkr12)
-	s.wfactory.EXPECT().New(cli21, "tq1", gomock.Any()).Return(wkr21)
-	s.wfactory.EXPECT().New(cli22, "tq2", gomock.Any()).Return(wkr22)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr1)
+	s.wfactory.EXPECT().New(cli2, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr2)
 
-	s.cmp1.EXPECT().Register(wkr11, ns1)
-	s.cmp2.EXPECT().Register(wkr12, ns1)
-	s.cmp1.EXPECT().Register(wkr21, ns2)
-	s.cmp2.EXPECT().Register(wkr22, ns2)
+	s.cmp1.EXPECT().Register(wkr1, ns1)
+	s.cmp1.EXPECT().Register(wkr2, ns2)
+	s.cmp2.EXPECT().Register(wkr1, ns1)
 
-	wkr11.EXPECT().Start()
-	wkr12.EXPECT().Start()
-	wkr21.EXPECT().Start()
-	wkr22.EXPECT().Start()
+	wkr1.EXPECT().Start()
+	wkr2.EXPECT().Start()
 
 	s.manager.namespaceCallback(ns1, false)
 	s.manager.namespaceCallback(ns2, false)
 	time.Sleep(50 * time.Millisecond)
 
-	wkr11.EXPECT().Stop()
-	wkr12.EXPECT().Stop()
-	wkr21.EXPECT().Stop()
-	wkr22.EXPECT().Stop()
-	cli11.EXPECT().Close()
-	cli12.EXPECT().Close()
-	cli21.EXPECT().Close()
-	cli22.EXPECT().Close()
+	wkr1.EXPECT().Stop()
+	wkr2.EXPECT().Stop()
+	cli1.EXPECT().Close()
+	cli2.EXPECT().Close()
 }
 
 func (s *perNsWorkerManagerSuite) TestDeleteNs() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 1,
+		Enabled: true,
 	}).AnyTimes()
 	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("self", nil), nil)
 	cli1 := mocksdk.NewMockClient(s.controller)
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli1, nil)
 	wkr1 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Return(wkr1)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr1)
 	s.cmp1.EXPECT().Register(wkr1, ns)
 	wkr1.EXPECT().Start()
 
@@ -289,11 +270,11 @@ func (s *perNsWorkerManagerSuite) TestDeleteNs() {
 
 	// restore it
 	nsRestored := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("self", nil), nil)
 	cli2 := mocksdk.NewMockClient(s.controller)
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli2, nil)
 	wkr2 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Return(wkr2)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr2)
 	s.cmp1.EXPECT().Register(wkr2, ns)
 	wkr2.EXPECT().Start()
 
@@ -311,26 +292,24 @@ func (s *perNsWorkerManagerSuite) TestMembershipChanged() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 1,
+		Enabled: true,
 	}).AnyTimes()
 	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
 	// we don't own it at first
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("other", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("other", nil), nil)
 
 	s.manager.namespaceCallback(ns, false)
 	time.Sleep(50 * time.Millisecond)
 
 	// now we own it
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("self", nil), nil)
 	cli1 := mocksdk.NewMockClient(s.controller)
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli1, nil)
 	wkr1 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Return(wkr1)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr1)
 	s.cmp1.EXPECT().Register(wkr1, ns)
 	wkr1.EXPECT().Start()
 
@@ -338,7 +317,7 @@ func (s *perNsWorkerManagerSuite) TestMembershipChanged() {
 	time.Sleep(50 * time.Millisecond)
 
 	// now we don't own it anymore
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("other", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("other", nil), nil)
 	wkr1.EXPECT().Stop()
 	cli1.EXPECT().Close()
 
@@ -350,22 +329,20 @@ func (s *perNsWorkerManagerSuite) TestServiceResolverError() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 1,
+		Enabled: true,
 	}).AnyTimes()
 	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(nil, errors.New("resolver error"))
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(nil, errors.New("resolver error again"))
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil)
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(nil, errors.New("resolver error"))
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(nil, errors.New("resolver error again"))
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("self", nil), nil)
 
 	cli1 := mocksdk.NewMockClient(s.controller)
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli1, nil)
 	wkr1 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Return(wkr1)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr1)
 	s.cmp1.EXPECT().Register(wkr1, ns)
 	wkr1.EXPECT().Start()
 
@@ -381,15 +358,13 @@ func (s *perNsWorkerManagerSuite) TestNewClientError() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 1,
+		Enabled: true,
 	}).AnyTimes()
 	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil).AnyTimes()
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("self", nil), nil).AnyTimes()
 
 	cli1 := mocksdk.NewMockClient(s.controller)
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(nil, errors.New("new client error"))
@@ -397,7 +372,7 @@ func (s *perNsWorkerManagerSuite) TestNewClientError() {
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli1, nil)
 
 	wkr1 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Return(wkr1)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr1)
 	s.cmp1.EXPECT().Register(wkr1, ns)
 	wkr1.EXPECT().Start()
 
@@ -413,20 +388,18 @@ func (s *perNsWorkerManagerSuite) TestStartWorkerError() {
 	ns := testns("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
-		Enabled:    true,
-		TaskQueue:  "tq1",
-		NumWorkers: 1,
+		Enabled: true,
 	}).AnyTimes()
 	s.cmp2.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&common.PerNSDedicatedWorkerOptions{
 		Enabled: false,
 	}).AnyTimes()
 
-	s.serviceResolver.EXPECT().Lookup("ns1/tq1/0").Return(membership.NewHostInfo("self", nil), nil).AnyTimes()
+	s.serviceResolver.EXPECT().Lookup("ns1/0").Return(membership.NewHostInfo("self", nil), nil).AnyTimes()
 
 	cli1 := mocksdk.NewMockClient(s.controller)
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli1, nil)
 	wkr1 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Return(wkr1)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr1)
 	s.cmp1.EXPECT().Register(wkr1, ns)
 
 	// first try fails to start
@@ -437,7 +410,7 @@ func (s *perNsWorkerManagerSuite) TestStartWorkerError() {
 	cli2 := mocksdk.NewMockClient(s.controller)
 	s.cfactory.EXPECT().NewClient("ns1", gomock.Any()).Return(cli2, nil)
 	wkr2 := mocksdk.NewMockWorker(s.controller)
-	s.wfactory.EXPECT().New(cli1, "tq1", gomock.Any()).Return(wkr2)
+	s.wfactory.EXPECT().New(cli1, workercommon.PerNSWorkerTaskQueue, gomock.Any()).Return(wkr2)
 	s.cmp1.EXPECT().Register(wkr2, ns)
 	wkr2.EXPECT().Start()
 

--- a/service/worker/scheduler/fx.go
+++ b/service/worker/scheduler/fx.go
@@ -25,8 +25,6 @@
 package scheduler
 
 import (
-	"context"
-
 	"go.uber.org/fx"
 
 	"go.temporal.io/api/workflowservice/v1"
@@ -34,7 +32,6 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
-	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -42,15 +39,13 @@ import (
 )
 
 const (
-	WorkflowType  = "temporal-sys-scheduler-workflow"
-	TaskQueueName = "temporal-sys-scheduler-tq"
+	WorkflowType = "temporal-sys-scheduler-workflow"
 )
 
 type (
 	workerComponent struct {
 		activityDeps activityDeps
 		enabledForNs dynamicconfig.BoolPropertyFnWithNamespaceFilter
-		numWorkers   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	}
 
 	activityDeps struct {
@@ -80,20 +75,13 @@ func NewResult(
 			activityDeps: params,
 			enabledForNs: dcCollection.GetBoolPropertyFnWithNamespaceFilter(
 				dynamicconfig.WorkerEnableScheduler, false),
-			numWorkers: dcCollection.GetIntPropertyFilteredByNamespace(
-				dynamicconfig.WorkerSchedulerNumWorkers, 1),
 		},
 	}
 }
 
 func (s *workerComponent) DedicatedWorkerOptions(ns *namespace.Namespace) *workercommon.PerNSDedicatedWorkerOptions {
 	return &workercommon.PerNSDedicatedWorkerOptions{
-		Enabled:    s.enabledForNs(ns.Name().String()),
-		TaskQueue:  TaskQueueName,
-		NumWorkers: s.numWorkers(ns.Name().String()),
-		Options: sdkworker.Options{
-			BackgroundActivityContext: headers.SetCallerInfo(context.Background(), headers.NewCallerInfo(headers.CallerTypeBackground)),
-		},
+		Enabled: s.enabledForNs(ns.Name().String()),
 	}
 }
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -110,6 +110,7 @@ type (
 		EnablePersistencePriorityRateLimiting dynamicconfig.BoolPropertyFn
 		EnableBatcher                         dynamicconfig.BoolPropertyFn
 		EnableParentClosePolicyWorker         dynamicconfig.BoolPropertyFn
+		PerNSNumWorkers                       dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 		StandardVisibilityPersistenceMaxReadQPS   dynamicconfig.IntPropertyFn
 		StandardVisibilityPersistenceMaxWriteQPS  dynamicconfig.IntPropertyFn
@@ -297,6 +298,10 @@ func NewConfig(dc *dynamicconfig.Collection, persistenceConfig *config.Persisten
 		EnableParentClosePolicyWorker: dc.GetBoolProperty(
 			dynamicconfig.EnableParentClosePolicyWorker,
 			true,
+		),
+		PerNSNumWorkers: dc.GetIntPropertyFilteredByNamespace(
+			dynamicconfig.WorkerPerNSNumWorkers,
+			1,
 		),
 		ThrottledLogRPS: dc.GetIntProperty(
 			dynamicconfig.WorkerThrottledLogRPS,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -110,7 +110,7 @@ type (
 		EnablePersistencePriorityRateLimiting dynamicconfig.BoolPropertyFn
 		EnableBatcher                         dynamicconfig.BoolPropertyFn
 		EnableParentClosePolicyWorker         dynamicconfig.BoolPropertyFn
-		PerNSNumWorkers                       dynamicconfig.IntPropertyFnWithNamespaceFilter
+		PerNamespaceWorkerCount               dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 		StandardVisibilityPersistenceMaxReadQPS   dynamicconfig.IntPropertyFn
 		StandardVisibilityPersistenceMaxWriteQPS  dynamicconfig.IntPropertyFn
@@ -299,8 +299,8 @@ func NewConfig(dc *dynamicconfig.Collection, persistenceConfig *config.Persisten
 			dynamicconfig.EnableParentClosePolicyWorker,
 			true,
 		),
-		PerNSNumWorkers: dc.GetIntPropertyFilteredByNamespace(
-			dynamicconfig.WorkerPerNSNumWorkers,
+		PerNamespaceWorkerCount: dc.GetIntPropertyFilteredByNamespace(
+			dynamicconfig.WorkerPerNamespaceWorkerCount,
 			1,
 		),
 		ThrottledLogRPS: dc.GetIntProperty(


### PR DESCRIPTION
**What changed?**
Rearrange per-namespace worker manager to always run all components in the same worker+client+task queue.

**Why?**
Reduces load when we have more than one component.

**How did you test it?**
updated unit test

**Potential risks**

**Is hotfix candidate?**
