### PR TITLE
Add fuzz-style test for shard controller

### DIFF
--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -628,6 +628,8 @@ func (s *controllerSuite) TestShardExplicitUnloadCancelGetOrCreate() {
 	s.Less(time.Since(start), 500*time.Millisecond)
 }
 
+// Tests random concurrent sequence of shard load/acquire/unload to catch any race conditions
+// that were not covered by specific tests.
 func (s *controllerSuite) TestShardControllerFuzz() {
 	s.config.NumberOfShards = 10
 


### PR DESCRIPTION
**What changed?**
Add test that does random sequences of shard load/unload concurrenctly

**Why?**
To catch potential bugs in shard controller and shard context load/unload logic

**How did you test it?**
is a test

**Potential risks**

**Is hotfix candidate?**
