### PR TITLE
Fix metrics for OperatorService

### DIFF
--- a/common/metrics/api_metrics.go
+++ b/common/metrics/api_metrics.go
@@ -27,6 +27,7 @@ package metrics
 import (
 	"reflect"
 
+	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/historyservice/v1"
@@ -35,6 +36,7 @@ import (
 
 const (
 	grpcWorkflowService = "/temporal.api.workflowservice.v1.WorkflowService"
+	grpcOperatorService = "/temporal.api.operatorservice.v1.OperatorService"
 	grpcAdminService    = "/temporal.server.api.adminservice.v1.AdminService"
 	grpcMatchingService = "/temporal.server.api.matchingservice.v1.MatchingService"
 	grpcHistoryService  = "/temporal.server.api.historyservice.v1.HistoryService"
@@ -53,6 +55,9 @@ func frontendAPIMetricsNames() map[string]string {
 	apiNames := getAPINames(reflect.TypeOf((*workflowservice.WorkflowServiceServer)(nil)).Elem(), grpcWorkflowService)
 	for methodName, fullName := range getAPINames(reflect.TypeOf((*adminservice.AdminServiceServer)(nil)).Elem(), grpcAdminService) {
 		apiNames["Admin"+methodName] = fullName
+	}
+	for methodName, fullName := range getAPINames(reflect.TypeOf((*operatorservice.OperatorServiceServer)(nil)).Elem(), grpcOperatorService) {
+		apiNames["Operator"+methodName] = fullName
 	}
 	return apiNames
 }

--- a/common/metrics/api_metrics_test.go
+++ b/common/metrics/api_metrics_test.go
@@ -25,6 +25,8 @@
 package metrics
 
 import (
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -51,31 +53,40 @@ func (s *apiMetricsSuite) TearDownTest() {
 
 }
 
-func (s *apiMetricsSuite) assertAllAPIHasMetricsDefined(apiNames map[string]string, scopeDef map[string]int) {
+func (s *apiMetricsSuite) assertAllAPIsHaveMetricsDefined(apiNames map[string]string, scopeDef map[string]int) {
+	var missingAPIs []string
 	for _, fullName := range apiNames {
 		if _, ok := scopeDef[fullName]; !ok {
-			s.Fail("Missing metrics scope.", "API %s does not have metrics scope defined.", fullName)
+			missingAPIs = append(missingAPIs, fullName)
 		}
+	}
+	if len(missingAPIs) > 0 {
+		sort.Strings(missingAPIs)
+		// You are here most likely because you added new API without defining metrics scope for them.
+		s.Fail(
+			"Missing metrics scope for APIs.",
+			"Missing metrics scope for below APIs:\n%s. \nPlease define them in common/metrics/def.go",
+			strings.Join(missingAPIs, ",\n"))
 	}
 }
 
 func (s *apiMetricsSuite) TestFrontendAPIMetrics() {
 	apiNames := frontendAPIMetricsNames()
 	apiNameToScope := FrontendAPIMetricsScopes()
-	s.assertAllAPIHasMetricsDefined(apiNames, apiNameToScope)
+	s.assertAllAPIsHaveMetricsDefined(apiNames, apiNameToScope)
 	s.Equal(len(apiNames), len(apiNameToScope))
 }
 
 func (s *apiMetricsSuite) TestMatchingAPIMetrics() {
 	apiNames := matchingAPIMetricsNames()
 	apiNameToScope := MatchingAPIMetricsScopes()
-	s.assertAllAPIHasMetricsDefined(apiNames, apiNameToScope)
+	s.assertAllAPIsHaveMetricsDefined(apiNames, apiNameToScope)
 	s.Equal(len(apiNames), len(apiNameToScope))
 }
 
 func (s *apiMetricsSuite) TestHistoryAPIMetrics() {
 	apiNames := historyAPIMetricsNames()
 	apiNameToScope := HistoryAPIMetricsScopes()
-	s.assertAllAPIHasMetricsDefined(apiNames, apiNameToScope)
+	s.assertAllAPIsHaveMetricsDefined(apiNames, apiNameToScope)
 	s.Equal(len(apiNames), len(apiNameToScope))
 }

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -865,6 +865,12 @@ const (
 	// OperatorListSearchAttributesScope is the metric scope for operator.ListSearchAttributes
 	OperatorListSearchAttributesScope
 	OperatorDeleteNamespaceScope
+	OperatorAddOrUpdateRemoteCluster
+	OperatorDeleteWorkflowExecution
+	OperatorDescribeCluster
+	OperatorListClusterMembers
+	OperatorListClusters
+	OperatorRemoveRemoteCluster
 
 	NumOperatorScopes
 )
@@ -1679,6 +1685,12 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		OperatorRemoveSearchAttributesScope: {operation: "OperatorRemoveSearchAttributes"},
 		OperatorListSearchAttributesScope:   {operation: "OperatorListSearchAttributes"},
 		OperatorDeleteNamespaceScope:        {operation: "OperatorDeleteNamespace"},
+		OperatorAddOrUpdateRemoteCluster:    {operation: "OperatorAddOrUpdateRemoteCluster"},
+		OperatorDeleteWorkflowExecution:     {operation: "OperatorDeleteWorkflowExecution"},
+		OperatorDescribeCluster:             {operation: "OperatorDescribeCluster"},
+		OperatorListClusterMembers:          {operation: "OperatorListClusterMembers"},
+		OperatorListClusters:                {operation: "OperatorListClusters"},
+		OperatorRemoveRemoteCluster:         {operation: "OperatorRemoveRemoteCluster"},
 		// Workflow Service API
 		FrontendStartWorkflowExecutionScope:             {operation: "StartWorkflowExecution"},
 		FrontendPollWorkflowTaskQueueScope:              {operation: "PollWorkflowTaskQueue"},

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -41,7 +41,6 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
@@ -134,8 +133,6 @@ func (h *OperatorHandlerImpl) Stop() {
 }
 
 func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *operatorservice.AddSearchAttributesRequest) (_ *operatorservice.AddSearchAttributesResponse, retError error) {
-	const endpointName = "AddSearchAttributes"
-
 	defer log.CapturePanic(h.logger, &retError)
 
 	scope, sw := h.startRequestProfile(metrics.OperatorAddSearchAttributesScope)
@@ -143,29 +140,29 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 
 	// validate request
 	if request == nil {
-		return nil, h.error(errRequestNotSet, scope, endpointName)
+		return nil, errRequestNotSet
 	}
 
 	if len(request.GetSearchAttributes()) == 0 {
-		return nil, h.error(errSearchAttributesNotSet, scope, endpointName)
+		return nil, errSearchAttributesNotSet
 	}
 
 	indexName := h.esConfig.GetVisibilityIndex()
 
 	currentSearchAttributes, err := h.saProvider.GetSearchAttributes(indexName, true)
 	if err != nil {
-		return nil, h.error(serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err)), scope, endpointName)
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}
 
 	for saName, saType := range request.GetSearchAttributes() {
 		if searchattribute.IsReserved(saName) {
-			return nil, h.error(serviceerror.NewInvalidArgument(fmt.Sprintf(errSearchAttributeIsReservedMessage, saName)), scope, endpointName)
+			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errSearchAttributeIsReservedMessage, saName))
 		}
 		if currentSearchAttributes.IsDefined(saName) {
-			return nil, h.error(serviceerror.NewAlreadyExist(fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName)), scope, endpointName)
+			return nil, serviceerror.NewAlreadyExist(fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName))
 		}
 		if _, ok := enumspb.IndexedValueType_name[int32(saType)]; !ok {
-			return nil, h.error(serviceerror.NewInvalidArgument(fmt.Sprintf(errUnknownSearchAttributeTypeMessage, saType)), scope, endpointName)
+			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errUnknownSearchAttributeTypeMessage, saType))
 		}
 	}
 
@@ -187,7 +184,7 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 		wfParams,
 	)
 	if err != nil {
-		return nil, h.error(serviceerror.NewUnavailable(fmt.Sprintf(errUnableToStartWorkflowMessage, addsearchattributes.WorkflowName, err)), scope, endpointName)
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToStartWorkflowMessage, addsearchattributes.WorkflowName, err))
 	}
 
 	// Wait for workflow to complete.
@@ -195,7 +192,7 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 	if err != nil {
 		scope.IncCounter(metrics.AddSearchAttributesWorkflowFailuresCount)
 		execution := &commonpb.WorkflowExecution{WorkflowId: addsearchattributes.WorkflowName, RunId: run.GetRunID()}
-		return nil, h.error(serviceerror.NewSystemWorkflow(execution, err), scope, endpointName)
+		return nil, serviceerror.NewSystemWorkflow(execution, err)
 	}
 	scope.IncCounter(metrics.AddSearchAttributesWorkflowSuccessCount)
 
@@ -203,59 +200,49 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 }
 
 func (h *OperatorHandlerImpl) RemoveSearchAttributes(ctx context.Context, request *operatorservice.RemoveSearchAttributesRequest) (_ *operatorservice.RemoveSearchAttributesResponse, retError error) {
-	const endpointName = "RemoveSearchAttributes"
-
 	defer log.CapturePanic(h.logger, &retError)
-
-	scope, sw := h.startRequestProfile(metrics.OperatorRemoveSearchAttributesScope)
-	defer sw.Stop()
 
 	// validate request
 	if request == nil {
-		return nil, h.error(errRequestNotSet, scope, endpointName)
+		return nil, errRequestNotSet
 	}
 
 	if len(request.GetSearchAttributes()) == 0 {
-		return nil, h.error(errSearchAttributesNotSet, scope, endpointName)
+		return nil, errSearchAttributesNotSet
 	}
 
 	indexName := h.esConfig.GetVisibilityIndex()
 
 	currentSearchAttributes, err := h.saProvider.GetSearchAttributes(indexName, true)
 	if err != nil {
-		return nil, h.error(serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err)), scope, endpointName)
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}
 
 	newCustomSearchAttributes := maps.Clone(currentSearchAttributes.Custom())
 
 	for _, saName := range request.GetSearchAttributes() {
 		if !currentSearchAttributes.IsDefined(saName) {
-			return nil, h.error(serviceerror.NewNotFound(fmt.Sprintf(errSearchAttributeDoesntExistMessage, saName)), scope, endpointName)
+			return nil, serviceerror.NewNotFound(fmt.Sprintf(errSearchAttributeDoesntExistMessage, saName))
 		}
 		if _, ok := newCustomSearchAttributes[saName]; !ok {
-			return nil, h.error(serviceerror.NewInvalidArgument(fmt.Sprintf(errUnableToRemoveNonCustomSearchAttributesMessage, saName)), scope, endpointName)
+			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errUnableToRemoveNonCustomSearchAttributesMessage, saName))
 		}
 		delete(newCustomSearchAttributes, saName)
 	}
 
 	err = h.saManager.SaveSearchAttributes(ctx, indexName, newCustomSearchAttributes)
 	if err != nil {
-		return nil, h.error(serviceerror.NewUnavailable(fmt.Sprintf(errUnableToSaveSearchAttributesMessage, err)), scope, endpointName)
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToSaveSearchAttributesMessage, err))
 	}
 
 	return &operatorservice.RemoveSearchAttributesResponse{}, nil
 }
 
 func (h *OperatorHandlerImpl) ListSearchAttributes(ctx context.Context, request *operatorservice.ListSearchAttributesRequest) (_ *operatorservice.ListSearchAttributesResponse, retError error) {
-	const endpointName = "ListSearchAttributes"
-
 	defer log.CapturePanic(h.logger, &retError)
 
-	scope, sw := h.startRequestProfile(metrics.OperatorListSearchAttributesScope)
-	defer sw.Stop()
-
 	if request == nil {
-		return nil, h.error(errRequestNotSet, scope, endpointName)
+		return nil, errRequestNotSet
 	}
 
 	indexName := h.esConfig.GetVisibilityIndex()
@@ -265,13 +252,13 @@ func (h *OperatorHandlerImpl) ListSearchAttributes(ctx context.Context, request 
 	if h.esClient != nil {
 		esMapping, lastErr = h.esClient.GetMapping(ctx, indexName)
 		if lastErr != nil {
-			lastErr = h.error(serviceerror.NewUnavailable(fmt.Sprintf("unable to get mapping from Elasticsearch: %v", lastErr)), scope, endpointName)
+			lastErr = serviceerror.NewUnavailable(fmt.Sprintf("unable to get mapping from Elasticsearch: %v", lastErr))
 		}
 	}
 
 	searchAttributes, err := h.saProvider.GetSearchAttributes(indexName, true)
 	if err != nil {
-		lastErr = h.error(serviceerror.NewUnavailable(fmt.Sprintf("unable to read custom search attributes: %v", err)), scope, endpointName)
+		lastErr = serviceerror.NewUnavailable(fmt.Sprintf("unable to read custom search attributes: %v", err))
 	}
 
 	if lastErr != nil {
@@ -286,8 +273,6 @@ func (h *OperatorHandlerImpl) ListSearchAttributes(ctx context.Context, request 
 }
 
 func (h *OperatorHandlerImpl) DeleteNamespace(ctx context.Context, request *operatorservice.DeleteNamespaceRequest) (_ *operatorservice.DeleteNamespaceResponse, retError error) {
-	const endpointName = "DeleteNamespace"
-
 	defer log.CapturePanic(h.logger, &retError)
 
 	scope, sw := h.startRequestProfile(metrics.OperatorDeleteNamespaceScope)
@@ -295,11 +280,11 @@ func (h *OperatorHandlerImpl) DeleteNamespace(ctx context.Context, request *oper
 
 	// validate request
 	if request == nil {
-		return nil, h.error(errRequestNotSet, scope, endpointName)
+		return nil, errRequestNotSet
 	}
 
 	if request.GetNamespace() == common.SystemLocalNamespace {
-		return nil, h.error(errUnableDeleteSystemNamespace, scope, endpointName)
+		return nil, errUnableDeleteSystemNamespace
 	}
 
 	// Execute workflow.
@@ -322,7 +307,7 @@ func (h *OperatorHandlerImpl) DeleteNamespace(ctx context.Context, request *oper
 		wfParams,
 	)
 	if err != nil {
-		return nil, h.error(serviceerror.NewUnavailable(fmt.Sprintf(errUnableToStartWorkflowMessage, deletenamespace.WorkflowName, err)), scope, endpointName)
+		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToStartWorkflowMessage, deletenamespace.WorkflowName, err))
 	}
 
 	// Wait for workflow to complete.
@@ -331,7 +316,7 @@ func (h *OperatorHandlerImpl) DeleteNamespace(ctx context.Context, request *oper
 	if err != nil {
 		scope.IncCounter(metrics.DeleteNamespaceWorkflowFailuresCount)
 		execution := &commonpb.WorkflowExecution{WorkflowId: deletenamespace.WorkflowName, RunId: run.GetRunID()}
-		return nil, h.error(serviceerror.NewSystemWorkflow(execution, err), scope, endpointName)
+		return nil, serviceerror.NewSystemWorkflow(execution, err)
 	}
 	scope.IncCounter(metrics.DeleteNamespaceWorkflowSuccessCount)
 
@@ -411,24 +396,4 @@ func (h *OperatorHandlerImpl) startRequestProfile(scope int) (metrics.Scope, met
 	sw := metricsScope.StartTimer(metrics.ServiceLatency)
 	metricsScope.IncCounter(metrics.ServiceRequests)
 	return metricsScope, sw
-}
-
-func (h *OperatorHandlerImpl) error(err error, scope metrics.Scope, endpointName string) error {
-	scope.Tagged(metrics.ServiceErrorTypeTag(err)).IncCounter(metrics.ServiceErrorWithType)
-
-	switch err := err.(type) {
-	case *serviceerror.Unavailable:
-		h.logger.Error("Unavailable error.", tag.Error(err), tag.Endpoint(endpointName))
-		scope.IncCounter(metrics.ServiceFailures)
-	case *serviceerror.InvalidArgument:
-		scope.IncCounter(metrics.ServiceErrInvalidArgumentCounter)
-	case *serviceerror.ResourceExhausted:
-		scope.Tagged(metrics.ResourceExhaustedCauseTag(err.Cause)).IncCounter(metrics.ServiceErrResourceExhaustedCounter)
-	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
-	default:
-		h.logger.Error("Unknown error.", tag.Error(err), tag.Endpoint(endpointName))
-		scope.IncCounter(metrics.ServiceFailures)
-	}
-
-	return err
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix metrics for operator service. Avoid duplication of the metrics from different places.

<!-- Tell your future self why have you made these changes -->
**Why?**
Metrics is handled by telemetry interceptor already, remove dup metrics from operation handler.
Also fix the operation tag on metrics emit by telemetry for operation service APIs.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally, verify metrics for operation API are emitted correctly.
service_requests{namespace="_unknown_",operation="OperatorDescribeCluster",service_name="frontend"} 1
service_error_with_type{error_type="serviceerror_Unimplemented",namespace="_unknown_",operation="OperatorDescribeCluster",service_name="frontend"} 1


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No