### PR TITLE
Fix default timer buckets

### DIFF
--- a/common/metrics/tally_metrics_handler.go
+++ b/common/metrics/tally_metrics_handler.go
@@ -88,7 +88,7 @@ func (tmp *tallyMetricsHandler) Gauge(gauge string) GaugeMetric {
 // Timer obtains a timer for the given name and MetricOptions.
 func (tmp *tallyMetricsHandler) Timer(timer string) TimerMetric {
 	return TimerMetricFunc(func(d time.Duration, tag ...Tag) {
-		tmp.scope.Tagged(tagsToMap(tag, tmp.excludeTags)).Timer(timer).Record(d)
+		tmp.scope.Tagged(tagsToMap(tag, tmp.excludeTags)).Histogram(timer, tmp.perUnitBuckets[Milliseconds]).RecordValue(d.Seconds())
 	})
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix buckets for timer metrics.

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix regression.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local manual test.
Before the test, I can see the max bucket for latency metrics was 10s.
With the fix, max bucket for latency metrics is 1000s.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.