### PR TITLE
Remove RunId from visibility query sort for ES 7

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -724,25 +724,20 @@ func (s *visibilityStore) convertQuery(
 }
 
 func (s *visibilityStore) setDefaultFieldSort(fieldSorts []*elastic.FieldSort) []elastic.Sorter {
-	_, isV7 := s.esClient.(client.ClientV7)
-
 	if len(fieldSorts) == 0 {
-		if isV7 {
+		if _, isV7 := s.esClient.(client.ClientV7); isV7 {
 			return defaultSorterV7
 		} else {
 			return defaultSorter
 		}
 	}
 
-	res := make([]elastic.Sorter, len(fieldSorts))
+	res := make([]elastic.Sorter, len(fieldSorts)+1)
 	for i, fs := range fieldSorts {
 		res[i] = fs
 	}
-
-	if !isV7 {
-		// Add RunID as explicit tiebreaker.
-		res = append(res, elastic.NewFieldSort(searchattribute.RunID).Desc())
-	}
+	// RunID is explicit tiebreaker.
+	res[len(res)-1] = elastic.NewFieldSort(searchattribute.RunID).Desc()
 
 	return res
 }

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -62,7 +62,16 @@ const (
 
 // Default sort by uses the sorting order defined in the index template, so no
 // additional sorting is needed during query.
+// Keep RunID as tiebreaker because ES v6 date precision is milliseconds.
+// ES v7 date precision is nanoseconds which is good enough for tie breaking.
+// Remove this when we drop support for ES v6.
 var defaultSorter = []elastic.Sorter{
+	elastic.NewFieldSort(searchattribute.CloseTime).Desc().Missing("_first"),
+	elastic.NewFieldSort(searchattribute.StartTime).Desc().Missing("_first"),
+	elastic.NewFieldSort(searchattribute.RunID).Desc().Missing("_first"),
+}
+
+var defaultSorterV7 = []elastic.Sorter{
 	elastic.NewFieldSort(searchattribute.CloseTime).Desc().Missing("_first"),
 	elastic.NewFieldSort(searchattribute.StartTime).Desc().Missing("_first"),
 }
@@ -636,7 +645,12 @@ func (s *visibilityStore) buildSearchParameters(
 		Index:    s.index,
 		Query:    boolQuery,
 		PageSize: request.PageSize,
-		Sorter:   defaultSorter,
+	}
+
+	if _, isV7 := s.esClient.(client.ClientV7); isV7 {
+		params.Sorter = defaultSorterV7
+	} else {
+		params.Sorter = defaultSorter
 	}
 
 	if token != nil && len(token.SearchAfter) > 0 {
@@ -711,7 +725,11 @@ func (s *visibilityStore) convertQuery(
 
 func (s *visibilityStore) setDefaultFieldSort(fieldSorts []*elastic.FieldSort) []elastic.Sorter {
 	if len(fieldSorts) == 0 {
-		return defaultSorter
+		if _, isV7 := s.esClient.(client.ClientV7); isV7 {
+			return defaultSorterV7
+		} else {
+			return defaultSorter
+		}
 	}
 
 	res := make([]elastic.Sorter, len(fieldSorts)+1)

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -65,7 +65,6 @@ const (
 var defaultSorter = []elastic.Sorter{
 	elastic.NewFieldSort(searchattribute.CloseTime).Desc().Missing("_first"),
 	elastic.NewFieldSort(searchattribute.StartTime).Desc().Missing("_first"),
-	elastic.NewFieldSort(searchattribute.RunID).Desc().Missing("_first"),
 }
 
 type (

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -724,20 +724,25 @@ func (s *visibilityStore) convertQuery(
 }
 
 func (s *visibilityStore) setDefaultFieldSort(fieldSorts []*elastic.FieldSort) []elastic.Sorter {
+	_, isV7 := s.esClient.(client.ClientV7)
+
 	if len(fieldSorts) == 0 {
-		if _, isV7 := s.esClient.(client.ClientV7); isV7 {
+		if isV7 {
 			return defaultSorterV7
 		} else {
 			return defaultSorter
 		}
 	}
 
-	res := make([]elastic.Sorter, len(fieldSorts)+1)
+	res := make([]elastic.Sorter, len(fieldSorts))
 	for i, fs := range fieldSorts {
 		res[i] = fs
 	}
-	// RunID is explicit tiebreaker.
-	res[len(res)-1] = elastic.NewFieldSort(searchattribute.RunID).Desc()
+
+	if !isV7 {
+		// Add RunID as explicit tiebreaker.
+		res = append(res, elastic.NewFieldSort(searchattribute.RunID).Desc())
+	}
 
 	return res
 }

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -310,7 +310,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParameters() {
 		Query:       boolQuery,
 		SearchAfter: []interface{}{json.Number("1528358645123456789"), "qwe"},
 		PageSize:    testPageSize,
-		Sorter:      defaultSorter,
+		Sorter:      defaultSorterV7,
 	}, p)
 
 	// test request latestTime overflow
@@ -324,7 +324,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParameters() {
 		Query:       boolQuery,
 		SearchAfter: []interface{}{json.Number("1528358645123456789"), "qwe"},
 		PageSize:    testPageSize,
-		Sorter:      defaultSorter,
+		Sorter:      defaultSorterV7,
 	}, p)
 	request = createTestRequest() // revert
 
@@ -338,7 +338,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParameters() {
 		Query:       boolQuery,
 		SearchAfter: nil,
 		PageSize:    testPageSize,
-		Sorter:      defaultSorter,
+		Sorter:      defaultSorterV7,
 	}, p)
 
 	// test for additional boolQuery
@@ -352,7 +352,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParameters() {
 		Query:       boolQuery,
 		SearchAfter: nil,
 		PageSize:    testPageSize,
-		Sorter:      defaultSorter,
+		Sorter:      defaultSorterV7,
 	}, p)
 
 	// test for search after
@@ -369,7 +369,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParameters() {
 		Query:       boolQuery,
 		SearchAfter: token.SearchAfter,
 		PageSize:    testPageSize,
-		Sorter:      defaultSorter,
+		Sorter:      defaultSorterV7,
 	}, p)
 	request = createTestRequest() // revert
 
@@ -384,7 +384,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParameters() {
 		Query:       boolQuery,
 		PageSize:    testPageSize,
 		SearchAfter: nil,
-		Sorter:      defaultSorter,
+		Sorter:      defaultSorterV7,
 	}, p)
 }
 
@@ -409,7 +409,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 		SearchAfter: nil,
 		PointInTime: nil,
 		PageSize:    testPageSize,
-		Sorter:      defaultSorter,
+		Sorter:      defaultSorterV7,
 	}, p)
 	request.Query = ""
 
@@ -426,7 +426,6 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 		PageSize:    testPageSize,
 		Sorter: []elastic.Sorter{
 			elastic.NewFieldSort(searchattribute.WorkflowID).Asc(),
-			elastic.NewFieldSort(searchattribute.RunID).Desc(),
 		},
 	}, p)
 	request.Query = ""
@@ -463,7 +462,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2DisableOrderByClause() {
 		SearchAfter: nil,
 		PointInTime: nil,
 		PageSize:    testPageSize,
-		Sorter:      defaultSorter,
+		Sorter:      defaultSorterV7,
 	}, p)
 	request.Query = ""
 

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -426,6 +426,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 		PageSize:    testPageSize,
 		Sorter: []elastic.Sorter{
 			elastic.NewFieldSort(searchattribute.WorkflowID).Asc(),
+			elastic.NewFieldSort(searchattribute.RunID).Desc(),
 		},
 	}, p)
 	request.Query = ""


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove `RunId` from visibility query sort for ES v7.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve query performance

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually sending queries to ES

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Duplicate or missing entries when doing pagination.
Although this is unlikely because both closed time and start time has nano seconds precision in ES v7.
For ES v6 this is not changed because date has only milliseconds precision and collisions are more likely.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Could be.