### PR TITLE
Add metrics to detect no poller issue

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2318,6 +2318,7 @@ const (
 	TaskWriteThrottlePerTaskQueueCounter
 	TaskWriteLatencyPerTaskQueue
 	TaskLagPerTaskQueueGauge
+	NoRecentPollerTasksPerTaskQueueCounter
 
 	NumMatchingMetrics
 )
@@ -2796,6 +2797,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskWriteThrottlePerTaskQueueCounter:      NewRollupCounterDef("task_write_throttle_count_per_tl", "task_write_throttle_count"),
 		TaskWriteLatencyPerTaskQueue:              NewRollupTimerDef("task_write_latency_per_tl", "task_write_latency"),
 		TaskLagPerTaskQueueGauge:                  NewGaugeDef("task_lag_per_tl"),
+		NoRecentPollerTasksPerTaskQueueCounter:    NewRollupCounterDef("no_poller_tasks_per_tl", "no_poller_tasks"),
 	},
 	Worker: {
 		ReplicatorMessages:                            NewCounterDef("replicator_messages"),

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2797,7 +2797,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskWriteThrottlePerTaskQueueCounter:      NewRollupCounterDef("task_write_throttle_count_per_tl", "task_write_throttle_count"),
 		TaskWriteLatencyPerTaskQueue:              NewRollupTimerDef("task_write_latency_per_tl", "task_write_latency"),
 		TaskLagPerTaskQueueGauge:                  NewGaugeDef("task_lag_per_tl"),
-		NoRecentPollerTasksPerTaskQueueCounter:    NewRollupCounterDef("no_poller_tasks_per_tl", "no_poller_tasks"),
+		NoRecentPollerTasksPerTaskQueueCounter:    NewRollupCounterDef("no_poller_tasks_per_task_queue", "no_poller_tasks"),
 	},
 	Worker: {
 		ReplicatorMessages:                            NewCounterDef("replicator_messages"),

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2797,7 +2797,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskWriteThrottlePerTaskQueueCounter:      NewRollupCounterDef("task_write_throttle_count_per_tl", "task_write_throttle_count"),
 		TaskWriteLatencyPerTaskQueue:              NewRollupTimerDef("task_write_latency_per_tl", "task_write_latency"),
 		TaskLagPerTaskQueueGauge:                  NewGaugeDef("task_lag_per_tl"),
-		NoRecentPollerTasksPerTaskQueueCounter:    NewRollupCounterDef("no_poller_tasks_per_task_queue", "no_poller_tasks"),
+		NoRecentPollerTasksPerTaskQueueCounter:    NewRollupCounterDef("no_poller_tasks_per_tl", "no_poller_tasks"),
 	},
 	Worker: {
 		ReplicatorMessages:                            NewCounterDef("replicator_messages"),

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -65,6 +65,9 @@ const (
 	syncMatchTaskId = -137
 
 	ioTimeout = 5 * time.Second
+
+	// Threshold for counting a AddTask call as a no recent poller call
+	noPollerThreshold = time.Minute
 )
 
 type (
@@ -296,6 +299,11 @@ func (c *taskQueueManagerImpl) AddTask(
 	if params.forwardedFrom == "" {
 		// request sent by history service
 		c.liveness.markAlive(time.Now())
+	}
+
+	if params.forwardedFrom != "" {
+		// Only checks recent pollers in the root partition
+		c.checkRecentPollers()
 	}
 
 	var syncMatch bool

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -67,7 +67,7 @@ const (
 	ioTimeout = 5 * time.Second
 
 	// Threshold for counting a AddTask call as a no recent poller call
-	noPollerThreshold = time.Minute
+	noPollerThreshold = time.Minute * 2
 )
 
 type (
@@ -301,9 +301,9 @@ func (c *taskQueueManagerImpl) AddTask(
 		c.liveness.markAlive(time.Now())
 	}
 
-	if params.forwardedFrom != "" {
+	if c.QueueID().IsRoot() && !c.HasPollerAfter(time.Now().Add(-noPollerThreshold)) {
 		// Only checks recent pollers in the root partition
-		c.checkRecentPollers()
+		c.metricScope.IncCounter(metrics.NoRecentPollerTasksPerTaskQueueCounter)
 	}
 
 	var syncMatch bool


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**Add a new metric counter `NoRecentPollerTasksPerTaskQueueCounter` to track # of AddTask calls when no recent pollers exist.**


<!-- Tell your future self why have you made these changes -->
[Issue](https://github.com/temporalio/temporal/issues/3144)


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**Tested locally via prometheus**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
