### PR TITLE
Fix task rescheduler flaky test

### DIFF
--- a/service/history/queues/rescheduler_test.go
+++ b/service/history/queues/rescheduler_test.go
@@ -90,7 +90,7 @@ func (s *rescheudulerSuite) TestStartStop() {
 	rescheduler.Start()
 
 	numTasks := 20
-	taskCh := make(chan struct{})
+	taskCh := make(chan struct{}, numTasks)
 	s.mockScheduler.EXPECT().TrySubmit(gomock.Any()).DoAndReturn(func(_ Executable) (bool, error) {
 		taskCh <- struct{}{}
 		return true, nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix task rescheduler flaky test

<!-- Tell your future self why have you made these changes -->
**Why?**
- In this test, if a mock task's reschedule time is very short and rescheduling happens before all tasks are added to the rescheduler, later task won't be able to be added because the rescheduler's lock is held by the reschedule loop, which is blocked on the un-buffered `taskCh` defined on L93.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
