### PR TITLE
Don't dispatch expired tasks from taskReader buffer

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -1091,9 +1091,9 @@ type (
 		// its mandatory to specify it. On success this method returns the number of rows
 		// actually deleted. If the underlying storage doesn't support "limit", all rows
 		// less than or equal to taskID will be deleted.
-		// On success, this method returns:
-		//  - number of rows actually deleted, if limit is honored
-		//  - UnknownNumRowsDeleted, when all rows below value are deleted
+		// On success, this method returns either:
+		//  - UnknownNumRowsAffected (this means all rows below value are deleted)
+		//  - number of rows deleted, which may be equal to limit
 		CompleteTasksLessThan(ctx context.Context, request *CompleteTasksLessThanRequest) (int, error)
 	}
 

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -114,6 +114,14 @@ dispatchLoop:
 			}
 			task := newInternalTask(taskInfo, tr.tlMgr.completeTask, enumsspb.TASK_SOURCE_DB_BACKLOG, "", false)
 			for {
+				// We checked if the task was expired before putting it in the buffer, but it
+				// might have expired while it sat in the buffer, so we should check again.
+				if taskqueue.IsTaskExpired(taskInfo) {
+					task.finish(nil)
+					tr.scope().IncCounter(metrics.ExpiredTasksPerTaskQueueCounter)
+					// Don't try to set read level here because it may have been advanced already.
+					break
+				}
 				err := tr.tlMgr.DispatchTask(ctx, task)
 				if err == nil {
 					break

--- a/service/worker/scanner/taskqueue/handler.go
+++ b/service/worker/scanner/taskqueue/handler.go
@@ -148,8 +148,6 @@ func (s *Scavenger) deleteHandlerLog(key *p.TaskQueueKey, state *taskQueueState,
 //  1. if task has valid TTL -> TTL reached -> delete
 //  2. if task has 0 TTL / no TTL -> logic need to additionally check if corresponding workflow still exists
 func IsTaskExpired(t *persistencespb.AllocatedTaskInfo) bool {
-	tExpiry := timestamp.TimeValue(t.Data.ExpiryTime)
-	tEpoch := time.Unix(0, 0).UTC()
-	tNow := time.Now().UTC()
-	return tExpiry.After(tEpoch) && tNow.After(tExpiry)
+	expiry := timestamp.TimeValue(t.GetData().GetExpiryTime())
+	return expiry.Unix() > 0 && expiry.Before(time.Now())
 }


### PR DESCRIPTION
**What changed?**
Check for task expiration after tasks come out of the task buffer, before they're dispatched. This is before the rate limiter is checked, so these tasks won't consume rate limit tokens.

**Why?**
Fixes #3150 

**How did you test it?**
Modified unit test

**Potential risks**

**Is hotfix candidate?**
