### PR TITLE
Fix tally timer metric

### DIFF
--- a/common/metrics/tally_metrics_handler.go
+++ b/common/metrics/tally_metrics_handler.go
@@ -48,16 +48,7 @@ func NewTallyMetricsHandler(cfg ClientConfig, scope tally.Scope) *tallyMetricsHa
 	perUnitBuckets := make(map[MetricUnit]tally.Buckets)
 
 	for unit, boundariesList := range cfg.PerUnitHistogramBoundaries {
-		if unit != Milliseconds {
-			perUnitBuckets[MetricUnit(unit)] = tally.ValueBuckets(boundariesList)
-			continue
-		}
-
-		durations := make([]time.Duration, 0, len(boundariesList))
-		for _, duration := range boundariesList {
-			durations = append(durations, time.Duration(duration)*time.Millisecond)
-		}
-		perUnitBuckets[MetricUnit(unit)] = tally.DurationBuckets(durations)
+		perUnitBuckets[MetricUnit(unit)] = tally.ValueBuckets(boundariesList)
 	}
 
 	return &tallyMetricsHandler{
@@ -93,7 +84,7 @@ func (tmp *tallyMetricsHandler) Gauge(gauge string) GaugeMetric {
 // Timer obtains a timer for the given name and MetricOptions.
 func (tmp *tallyMetricsHandler) Timer(timer string) TimerMetric {
 	return TimerMetricFunc(func(d time.Duration, tag ...Tag) {
-		tmp.scope.Tagged(tagsToMap(tag, tmp.excludeTags)).Histogram(timer, tmp.perUnitBuckets[Milliseconds]).RecordDuration(d)
+		tmp.scope.Tagged(tagsToMap(tag, tmp.excludeTags)).Timer(timer).Record(d)
 	})
 }
 

--- a/common/metrics/tally_metrics_handler_test.go
+++ b/common/metrics/tally_metrics_handler_test.go
@@ -50,7 +50,7 @@ func TestTallyScope(t *testing.T) {
 	recordTallyMetrics(mp)
 
 	snap := scope.Snapshot()
-	counters, gauges, timers, histograms := snap.Counters(), snap.Gauges(), snap.Histograms(), snap.Histograms()
+	counters, gauges, timers, histograms := snap.Counters(), snap.Gauges(), snap.Timers(), snap.Histograms()
 
 	assert.EqualValues(t, 8, counters["test.hits+"].Value())
 	assert.EqualValues(t, map[string]string{}, counters["test.hits+"].Tags())
@@ -66,14 +66,10 @@ func TestTallyScope(t *testing.T) {
 		"location": "Mare Imbrium",
 	}, gauges["test.temp+location=Mare Imbrium"].Tags())
 
-	assert.EqualValues(t, map[time.Duration]int64{
-		10 * time.Millisecond:    0,
-		500 * time.Millisecond:   0,
-		1000 * time.Millisecond:  0,
-		5000 * time.Millisecond:  1,
-		10000 * time.Millisecond: 1,
-		math.MaxInt64:            0,
-	}, timers["test.latency+"].Durations())
+	assert.EqualValues(t, []time.Duration{
+		1248 * time.Millisecond,
+		5255 * time.Millisecond,
+	}, timers["test.latency+"].Values())
 	assert.EqualValues(t, map[string]string{}, timers["test.latency+"].Tags())
 
 	assert.EqualValues(t, map[float64]int64{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Switch back to tally.Timer instead of histogram for timer metrics. The reason is that when using histogram.RecordDuration, if the duration is higher than the max bucket defined, an Inf value will be added to the sum metric emitted and breaks the average calculation. When using histogram.RecordValue, if value is higher than the max bucket defined, no metric will be emitted for the sum metric, and make it inaccurate. Also for RecordValue, the value added to the sum metric is always the defined bucket boundary instead of the actual metric value. 
- tally.Timer implementation has none of the problems mentioned above.
- However there's no when to specify the buckets when emitting tally.Timer metric, and the default reporter bucket will be used. So wired up the code to specify the default bucket for reporter, which is only used by Timer metric.
- Bring back the code path for `DefaultHistogramBuckets` and `DefaultHistogramBoundaries` so that the code is backward compatible with older versions. Since value defined in `ClientConfig.PerUnitHistogramBoundaries` was not previously used, it will only be used when neither `DefaultHistogramBuckets` nor `DefaultHistogramBoundaries` is specified.
- Also added more comments for `DefaultHistogramBuckets` and `DefaultHistogramBoundaries` config fields.


<!-- Tell your future self why have you made these changes -->
**Why?**
- Fix tally timer metric


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.