### PR TITLE
Fix Cassandra fixed address translator unit test

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/translator/fixed_address_translator_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/translator/fixed_address_translator_test.go
@@ -76,7 +76,7 @@ func (s *fixedTranslatorPluginTestSuite) TestFixedAddressTranslator() {
 		s.Errorf(err, "fail to lookup IP for temporal.io")
 	}
 
-	ipToExpect := lookupIP[0]
+	ipToExpect := lookupIP[0].To4()
 
 	translator, err := plugin.GetTranslator(configuration)
 	translatedHost, translatedPort := translator.Translate(net.ParseIP("1.1.1.1"), 6001)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed unit test for Cassandra fixed address translator.

<!-- Tell your future self why have you made these changes -->
**Why?**
Unit test was failing because the translator converts the IP to IPv4 while in the test it was not (the function to get the `temporal.io` IP is in IPv6).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.