### PR TITLE
Add missing NewHistoryBranch

### DIFF
--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -672,7 +672,7 @@ func (p *executionRateLimitedPersistenceClient) ReadHistoryBranch(
 	return response, err
 }
 
-// ReadHistoryBranch returns history node data for a branch
+// ReadHistoryBranchReverse returns history node data for a branch
 func (p *executionRateLimitedPersistenceClient) ReadHistoryBranchReverse(
 	ctx context.Context,
 	request *ReadHistoryBranchReverseRequest,

--- a/common/persistence/persistenceRetryableClients.go
+++ b/common/persistence/persistenceRetryableClients.go
@@ -473,6 +473,22 @@ func (p *executionRetryablePersistenceClient) AppendRawHistoryNodes(
 	return response, err
 }
 
+// NewHistoryBranch initializes a new history branch
+func (p *executionRetryablePersistenceClient) NewHistoryBranch(
+	ctx context.Context,
+	request *NewHistoryBranchRequest,
+) (*NewHistoryBranchResponse, error) {
+	var response *NewHistoryBranchResponse
+	op := func(ctx context.Context) error {
+		var err error
+		response, err = p.persistence.NewHistoryBranch(ctx, request)
+		return err
+	}
+
+	err := backoff.ThrottleRetryContext(ctx, op, p.policy, p.isRetryable)
+	return response, err
+}
+
 // ReadHistoryBranch returns history node data for a branch
 func (p *executionRetryablePersistenceClient) ReadHistoryBranch(
 	ctx context.Context,


### PR DESCRIPTION
There was a git merge race condition lately between introducing the new
executionRetryablePersistenceClient definition and introducing the new
NewHistoryBranch interface function that was uncaught by the auto merge.

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
