### PR TITLE
Default to unix time 0, instead of time.Time{}

### DIFF
--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -275,11 +275,11 @@ func AdminListShardTasks(c *cli.Context) error {
 		pageSize = c.Int(FlagPageSize)
 	}
 
-	minFireTime, err := parseTime(c.String(FlagMinVisibilityTimestamp), time.Time{}, time.Now().UTC())
+	minFireTime, err := parseTime(c.String(FlagMinVisibilityTimestamp), time.Unix(0, 0), time.Now().UTC())
 	if err != nil {
 		return err
 	}
-	maxFireTime, err := parseTime(c.String(FlagMaxVisibilityTimestamp), time.Time{}, time.Now().UTC())
+	maxFireTime, err := parseTime(c.String(FlagMaxVisibilityTimestamp), time.Unix(0, 0), time.Now().UTC())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Default to unix time 0, instead of time.Time{}

<!-- Tell your future self why have you made these changes -->
**Why?**
UnixNano of time.Time is not well defined
```
Note that this means the result of calling UnixNano on the zero Time is undefined.
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A