### PR TITLE
Fix inline history archival

### DIFF
--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -28,8 +28,6 @@ import (
 	"context"
 	"net"
 
-	"go.temporal.io/server/api/historyservice/v1"
-
 	"go.uber.org/fx"
 	"google.golang.org/grpc"
 
@@ -272,7 +270,6 @@ func ArchivalClientProvider(
 	logger log.Logger,
 	metricsClient metrics.Client,
 	config *configs.Config,
-	historyClient historyservice.HistoryServiceClient,
 ) warchiver.Client {
 	return warchiver.NewClient(
 		metricsClient,
@@ -281,7 +278,6 @@ func ArchivalClientProvider(
 		config.NumArchiveSystemWorkflows,
 		config.ArchiveRequestRPS,
 		archiverProvider,
-		historyClient,
 	)
 }
 

--- a/service/history/workflow/delete_manager_test.go
+++ b/service/history/workflow/delete_manager_test.go
@@ -374,9 +374,9 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecutionRetention_Archiv
 	mockMutableState := NewMockMutableState(s.controller)
 
 	mockMutableState.EXPECT().GetCurrentBranchToken().Return([]byte{22, 8, 78}, nil)
-	mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{State: enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED}).Times(0)
+	mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{State: enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED})
 	closeTime := time.Date(1978, 8, 22, 1, 2, 3, 4, time.UTC)
-	mockMutableState.EXPECT().GetWorkflowCloseTime(gomock.Any()).Return(&closeTime, nil).Times(0)
+	mockMutableState.EXPECT().GetWorkflowCloseTime(gomock.Any()).Return(&closeTime, nil)
 
 	// ====================== Archival mocks =======================================
 	mockMutableState.EXPECT().GetNamespaceEntry().Return(namespace.NewLocalNamespaceForTest(
@@ -408,19 +408,6 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecutionRetention_Archiv
 	}, nil)
 	// =============================================================
 
-	s.mockShardContext.EXPECT().DeleteWorkflowExecution(
-		gomock.Any(),
-		definition.WorkflowKey{
-			NamespaceID: tests.NamespaceID.String(),
-			WorkflowID:  tests.WorkflowID,
-			RunID:       tests.RunID,
-		},
-		nil,
-		nil,
-		&closeTime,
-	).Return(nil).Times(0)
-	mockWeCtx.EXPECT().Clear().Times(0)
-
 	err := s.deleteManager.DeleteWorkflowExecutionByRetention(
 		context.Background(),
 		tests.NamespaceID,
@@ -441,6 +428,9 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecutionRetention_Archiv
 	mockMutableState := NewMockMutableState(s.controller)
 
 	mockMutableState.EXPECT().GetCurrentBranchToken().Return([]byte{22, 8, 78}, nil)
+	mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{State: enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED})
+	closeTime := time.Date(1978, 8, 22, 1, 2, 3, 4, time.UTC)
+	mockMutableState.EXPECT().GetWorkflowCloseTime(gomock.Any()).Return(&closeTime, nil)
 
 	// ====================== Archival mocks =======================================
 	mockMutableState.EXPECT().GetNamespaceEntry().Return(namespace.NewLocalNamespaceForTest(

--- a/service/worker/archiver/client_test.go
+++ b/service/worker/archiver/client_test.go
@@ -30,9 +30,6 @@ import (
 	"fmt"
 	"testing"
 
-	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/api/historyservicemock/v1"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -59,7 +56,6 @@ type clientSuite struct {
 	metricsScope       *metrics.MockScope
 	sdkClientFactory   *sdk.MockClientFactory
 	sdkClient          *mocksdk.MockClient
-	historyClient      *historyservicemock.MockHistoryServiceClient
 	client             *client
 }
 
@@ -80,7 +76,6 @@ func (s *clientSuite) SetupTest() {
 	s.sdkClient = mocksdk.NewMockClient(s.controller)
 	s.sdkClientFactory = sdk.NewMockClientFactory(s.controller)
 	s.sdkClientFactory.EXPECT().GetSystemClient(gomock.Any()).Return(s.sdkClient).AnyTimes()
-	s.historyClient = historyservicemock.NewMockHistoryServiceClient(s.controller)
 	s.client = NewClient(
 		s.metricsClient,
 		log.NewNoopLogger(),
@@ -88,7 +83,6 @@ func (s *clientSuite) SetupTest() {
 		dynamicconfig.GetIntPropertyFn(1000),
 		dynamicconfig.GetIntPropertyFn(1000),
 		s.archiverProvider,
-		s.historyClient,
 	).(*client)
 }
 
@@ -163,8 +157,6 @@ func (s *clientSuite) TestArchiveHistoryInlineSuccess() {
 	s.historyArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	s.metricsScope.EXPECT().IncCounter(metrics.ArchiverClientHistoryRequestCount)
 	s.metricsScope.EXPECT().IncCounter(metrics.ArchiverClientHistoryInlineArchiveAttemptCount)
-	s.historyClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).
-		Return(&historyservice.DeleteWorkflowExecutionResponse{}, nil)
 	resp, err := s.client.Archive(context.Background(), &ClientRequest{
 		ArchiveRequest: &ArchiveRequest{
 			HistoryURI: "test:///history/archival",
@@ -252,8 +244,6 @@ func (s *clientSuite) TestArchiveInline_VisibilityFail_HistorySuccess() {
 	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.historyArchiver, nil)
 	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.visibilityArchiver, nil)
 	s.historyArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	s.historyClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).
-		Return(&historyservice.DeleteWorkflowExecutionResponse{}, nil)
 	s.visibilityArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("some random error"))
 	s.metricsScope.EXPECT().IncCounter(metrics.ArchiverClientHistoryRequestCount)
 	s.metricsScope.EXPECT().IncCounter(metrics.ArchiverClientHistoryInlineArchiveAttemptCount)
@@ -309,8 +299,6 @@ func (s *clientSuite) TestArchiveInline_VisibilitySuccess_HistorySuccess() {
 	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), gomock.Any()).Return(s.historyArchiver, nil)
 	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), gomock.Any()).Return(s.visibilityArchiver, nil)
 	s.historyArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	s.historyClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).
-		Return(&historyservice.DeleteWorkflowExecutionResponse{}, nil)
 	s.visibilityArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	s.metricsScope.EXPECT().IncCounter(metrics.ArchiverClientHistoryRequestCount)
 	s.metricsScope.EXPECT().IncCounter(metrics.ArchiverClientHistoryInlineArchiveAttemptCount)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- The fix depends on https://github.com/temporalio/temporal/pull/3148
- Do not call history client to delete workflow execution after inline archival is done
- Get workflow close event (for getting close time) before attempting archival.

<!-- Tell your future self why have you made these changes -->
**Why?**
- When deleting workflow execution, we already held the workflow lock. Calling history client delete workflow execution will try to lock the workflow again, which is guaranteed to fail. 
- Old versions (before the linked PR) of archival workflow will delete history after history archival is done. If workflow close event is read after sending archival request, the history may already gone and result in infinity task retry.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.