### PR TITLE
Improve task processing retry behavior

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -89,8 +89,8 @@ const (
 	retryTaskProcessingInitialInterval = 50 * time.Millisecond
 	retryTaskProcessingMaxAttempts     = 1
 
-	rescheduleTaskRetryInitialInterval    = 3 * time.Second
-	rescheduleTaskRetryBackoffCoefficient = 1.05
+	rescheduleTaskRetryInitialInterval    = 1 * time.Second
+	rescheduleTaskRetryBackoffCoefficient = 1.1
 	rescheduleTaskRetryMaxInterval        = 3 * time.Minute
 
 	sdkClientFactoryRetryInitialInterval    = 200 * time.Millisecond

--- a/common/util.go
+++ b/common/util.go
@@ -86,12 +86,16 @@ const (
 	completeTaskRetryMaxInterval     = 1 * time.Second
 	completeTaskRetryMaxAttempts     = 10
 
-	retryTaskProcessingInitialInterval = 50 * time.Millisecond
-	retryTaskProcessingMaxAttempts     = 1
+	taskProcessingRetryInitialInterval = 50 * time.Millisecond
+	taskProcessingRetryMaxAttempts     = 1
 
-	rescheduleTaskRetryInitialInterval    = 1 * time.Second
-	rescheduleTaskRetryBackoffCoefficient = 1.1
-	rescheduleTaskRetryMaxInterval        = 3 * time.Minute
+	taskRescheduleInitialInterval    = 1 * time.Second
+	taskRescheduleBackoffCoefficient = 1.1
+	taskRescheduleMaxInterval        = 3 * time.Minute
+
+	taskNotReadyRescheduleInitialInterval    = 3 * time.Second
+	taskNotReadyRescheduleBackoffCoefficient = 1.5
+	taskNotReadyRescheduleMaxInterval        = 3 * time.Minute
 
 	sdkClientFactoryRetryInitialInterval    = 200 * time.Millisecond
 	sdkClientFactoryRetryMaxInterval        = 5 * time.Second
@@ -229,17 +233,27 @@ func CreateCompleteTaskRetryPolicy() backoff.RetryPolicy {
 
 // CreateTaskProcessingRetryPolicy creates a retry policy for task processing
 func CreateTaskProcessingRetryPolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(retryTaskProcessingInitialInterval)
-	policy.SetMaximumAttempts(retryTaskProcessingMaxAttempts)
+	policy := backoff.NewExponentialRetryPolicy(taskProcessingRetryInitialInterval)
+	policy.SetMaximumAttempts(taskProcessingRetryMaxAttempts)
 
 	return policy
 }
 
-// CreateTaskReschedulePolicy creates a retry policy for task processing
+// CreateTaskReschedulePolicy creates a retry policy for rescheduling task with errors not equal to ErrTaskRetry
 func CreateTaskReschedulePolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(rescheduleTaskRetryInitialInterval)
-	policy.SetBackoffCoefficient(rescheduleTaskRetryBackoffCoefficient)
-	policy.SetMaximumInterval(rescheduleTaskRetryMaxInterval)
+	policy := backoff.NewExponentialRetryPolicy(taskRescheduleInitialInterval)
+	policy.SetBackoffCoefficient(taskRescheduleBackoffCoefficient)
+	policy.SetMaximumInterval(taskRescheduleMaxInterval)
+	policy.SetExpirationInterval(backoff.NoInterval)
+
+	return policy
+}
+
+// CreateTaskNotReadyReschedulePolicy creates a retry policy for rescheduling task with ErrTaskRetry
+func CreateTaskNotReadyReschedulePolicy() backoff.RetryPolicy {
+	policy := backoff.NewExponentialRetryPolicy(taskNotReadyRescheduleInitialInterval)
+	policy.SetBackoffCoefficient(taskNotReadyRescheduleBackoffCoefficient)
+	policy.SetMaximumInterval(taskNotReadyRescheduleMaxInterval)
 	policy.SetExpirationInterval(backoff.NoInterval)
 
 	return policy

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -373,7 +373,7 @@ func (e *executableImpl) QueueType() QueueType {
 func (e *executableImpl) shouldResubmitOnNack(attempt int, err error) bool {
 	// this is an optimization for skipping rescheduler and retry the task sooner
 	// this can be useful for errors like unable to get workflow lock, which doesn't
-	// have to backoff for a long time and wait for the periodic rescheduling.
+	// have to backoff for a long time and wait for the longer rescheduling backoff.
 	if e.Attempt() > resubmitMaxAttempts {
 		return false
 	}

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -371,9 +371,9 @@ func (e *executableImpl) QueueType() QueueType {
 }
 
 func (e *executableImpl) shouldResubmitOnNack(attempt int, err error) bool {
-	// this is an optimization for skipping rescheduler and retry the task sooner
-	// this can be useful for errors like unable to get workflow lock, which doesn't
-	// have to backoff for a long time and wait for the longer rescheduling backoff.
+	// this is an optimization for skipping rescheduler and retry the task sooner.
+	// this is useful for errors like workflow busy, which doesn't have to wait for
+	// the longer rescheduling backoff.
 	if e.Attempt() > resubmitMaxAttempts {
 		return false
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Allow task to be re-submitted (put to the end of the task channel) upon resource exhausted errors
(Persistence will prioritize frontend/API requests anyway, so this won't be an issue. )
- Reduce initial task reschedule interval, as now the task rescheduling is triggered based on needs, not periodically. Also reduced resubmitMaxAttempts now that the initial task rescheduling interval is reduced.
- Use different reschedule policy for ErrTaskRetry, which can only be resolve by waiting for replication to happen.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Previous penalty for task processing upon resource exhausted error seems too high and greatly increased the task latency (after removing all the retries during task processing, done by the simplify retry PR).  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested in test cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.