### PR TITLE
Fix archival activities error handling

### DIFF
--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -60,7 +60,7 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 	sw := scope.StartTimer(metrics.ServiceLatency)
 	defer func() {
 		sw.Stop()
-		if err != nil && err.Error() == errUploadNonRetryable.Error() {
+		if err == errUploadNonRetryable {
 			scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
 		}
 	}()
@@ -102,7 +102,7 @@ func deleteHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 	sw := scope.StartTimer(metrics.ServiceLatency)
 	defer func() {
 		sw.Stop()
-		if err != nil && err.Error() == errDeleteNonRetryable.Error() {
+		if err == errDeleteNonRetryable {
 			scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
 		}
 	}()
@@ -138,7 +138,7 @@ func archiveVisibilityActivity(ctx context.Context, request ArchiveRequest) (err
 	sw := scope.StartTimer(metrics.ServiceLatency)
 	defer func() {
 		sw.Stop()
-		if err != nil && err.Error() == errArchiveVisibilityNonRetryable.Error() {
+		if err == errArchiveVisibilityNonRetryable {
 			scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
 		}
 	}()

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -124,8 +124,10 @@ func deleteHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 		return nil
 	}
 	logger := tagLoggerWithHistoryRequest(tagLoggerWithActivityInfo(container.Logger, activity.GetInfo(ctx)), &request)
-	logger.Error("failed to delete history events", tag.Error(err))
-	if !common.IsPersistenceTransientError(err) {
+	logger.Error("failed to delete workflow execution", tag.Error(err))
+	if !common.IsServiceTransientError(err) &&
+		!common.IsContextDeadlineExceededErr(err) &&
+		!common.IsContextCanceledErr(err) {
 		return errDeleteNonRetryable
 	}
 	return err

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -60,12 +60,8 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 	sw := scope.StartTimer(metrics.ServiceLatency)
 	defer func() {
 		sw.Stop()
-		if err != nil {
-			if err.Error() == errUploadNonRetryable.Error() {
-				scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
-			} else {
-				err = temporal.NewApplicationError(err.Error(), "", nil)
-			}
+		if err != nil && err.Error() == errUploadNonRetryable.Error() {
+			scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
 		}
 	}()
 	logger := tagLoggerWithHistoryRequest(tagLoggerWithActivityInfo(container.Logger, activity.GetInfo(ctx)), &request)
@@ -106,12 +102,8 @@ func deleteHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 	sw := scope.StartTimer(metrics.ServiceLatency)
 	defer func() {
 		sw.Stop()
-		if err != nil {
-			if err.Error() == errDeleteNonRetryable.Error() {
-				scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
-			} else {
-				err = temporal.NewApplicationError(err.Error(), "", nil)
-			}
+		if err != nil && err.Error() == errDeleteNonRetryable.Error() {
+			scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
 		}
 	}()
 	_, err = container.HistoryClient.DeleteWorkflowExecution(ctx, &historyservice.DeleteWorkflowExecutionRequest{
@@ -146,12 +138,8 @@ func archiveVisibilityActivity(ctx context.Context, request ArchiveRequest) (err
 	sw := scope.StartTimer(metrics.ServiceLatency)
 	defer func() {
 		sw.Stop()
-		if err != nil {
-			if err.Error() == errArchiveVisibilityNonRetryable.Error() {
-				scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
-			} else {
-				err = temporal.NewApplicationError(err.Error(), "", nil)
-			}
+		if err != nil && err.Error() == errArchiveVisibilityNonRetryable.Error() {
+			scope.IncCounter(metrics.ArchiverNonRetryableErrorCount)
 		}
 	}()
 	logger := tagLoggerWithVisibilityRequest(tagLoggerWithActivityInfo(container.Logger, activity.GetInfo(ctx)), &request)

--- a/service/worker/archiver/activities_test.go
+++ b/service/worker/archiver/activities_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"go.temporal.io/sdk/activity"
+	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/worker"
 
@@ -128,7 +129,10 @@ func (s *activitiesSuite) TestUploadHistory_Fail_InvalidURI() {
 		HistoryURI:           "some invalid URI without scheme",
 	}
 	_, err := env.ExecuteActivity(uploadHistoryActivity, request)
-	s.Equal(errUploadNonRetryable.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.True(applicationErr.NonRetryable())
+	s.Equal(errUploadNonRetryable.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestUploadHistory_Fail_GetArchiverError() {
@@ -160,7 +164,10 @@ func (s *activitiesSuite) TestUploadHistory_Fail_GetArchiverError() {
 		HistoryURI:           testArchivalURI,
 	}
 	_, err := env.ExecuteActivity(uploadHistoryActivity, request)
-	s.Equal(errUploadNonRetryable.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.True(applicationErr.NonRetryable())
+	s.Equal(errUploadNonRetryable.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveNonRetryableError() {
@@ -189,7 +196,10 @@ func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveNonRetryableError() {
 		HistoryURI:           testArchivalURI,
 	}
 	_, err := env.ExecuteActivity(uploadHistoryActivity, request)
-	s.Equal(errUploadNonRetryable.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.True(applicationErr.NonRetryable())
+	s.Equal(errUploadNonRetryable.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveRetryableError() {
@@ -218,7 +228,10 @@ func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveRetryableError() {
 		HistoryURI:           testArchivalURI,
 	}
 	_, err := env.ExecuteActivity(uploadHistoryActivity, request)
-	s.Equal(testArchiveErr.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.False(applicationErr.NonRetryable())
+	s.Equal(testArchiveErr.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestUploadHistory_Success() {
@@ -263,7 +276,6 @@ func (s *activitiesSuite) TestDeleteHistoryActivity_Fail_RetryableError() {
 		BackgroundActivityContext: context.WithValue(context.Background(), bootstrapContainerKey, container),
 	})
 
-	errNotReady := &serviceerror.WorkflowNotReady{Message: "workflow not ready"}
 	s.historyClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), &historyservice.DeleteWorkflowExecutionRequest{
 		NamespaceId: testNamespaceID,
 		WorkflowExecution: &commonpb.WorkflowExecution{
@@ -272,7 +284,7 @@ func (s *activitiesSuite) TestDeleteHistoryActivity_Fail_RetryableError() {
 		},
 		WorkflowVersion:    testCloseFailoverVersion,
 		ClosedWorkflowOnly: true,
-	}).Return(nil, errNotReady)
+	}).Return(nil, &serviceerror.WorkflowNotReady{})
 	request := ArchiveRequest{
 		NamespaceID:          testNamespaceID,
 		Namespace:            testNamespace,
@@ -284,8 +296,9 @@ func (s *activitiesSuite) TestDeleteHistoryActivity_Fail_RetryableError() {
 		HistoryURI:           testArchivalURI,
 	}
 	_, err := env.ExecuteActivity(deleteHistoryActivity, request)
-	s.Equal(errNotReady.Error(), errors.Unwrap(err).Error())
-	s.NotEqual(errDeleteNonRetryable.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.False(applicationErr.NonRetryable())
 }
 
 func (s *activitiesSuite) TestDeleteHistoryActivity_Fail_NonRetryableError() {
@@ -322,7 +335,10 @@ func (s *activitiesSuite) TestDeleteHistoryActivity_Fail_NonRetryableError() {
 		HistoryURI:           testArchivalURI,
 	}
 	_, err := env.ExecuteActivity(deleteHistoryActivity, request)
-	s.Equal(errDeleteNonRetryable.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.True(applicationErr.NonRetryable())
+	s.Equal(errDeleteNonRetryable.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_InvalidURI() {
@@ -345,7 +361,10 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_InvalidURI() {
 		VisibilityURI: "some invalid URI without scheme",
 	}
 	_, err := env.ExecuteActivity(archiveVisibilityActivity, request)
-	s.Equal(errArchiveVisibilityNonRetryable.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.True(applicationErr.NonRetryable())
+	s.Equal(errArchiveVisibilityNonRetryable.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_GetArchiverError() {
@@ -370,7 +389,10 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_GetArchiverError() 
 		VisibilityURI: testArchivalURI,
 	}
 	_, err := env.ExecuteActivity(archiveVisibilityActivity, request)
-	s.Equal(errArchiveVisibilityNonRetryable.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.True(applicationErr.NonRetryable())
+	s.Equal(errArchiveVisibilityNonRetryable.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveNonRetryableError() {
@@ -396,7 +418,10 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveNonRetryable
 		VisibilityURI: testArchivalURI,
 	}
 	_, err := env.ExecuteActivity(archiveVisibilityActivity, request)
-	s.Equal(errArchiveVisibilityNonRetryable.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.True(applicationErr.NonRetryable())
+	s.Equal(errArchiveVisibilityNonRetryable.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveRetryableError() {
@@ -422,7 +447,10 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveRetryableErr
 		VisibilityURI: testArchivalURI,
 	}
 	_, err := env.ExecuteActivity(archiveVisibilityActivity, request)
-	s.Equal(testArchiveErr.Error(), errors.Unwrap(err).Error())
+	applicationErr, ok := errors.Unwrap(err).(*temporal.ApplicationError)
+	s.True(ok)
+	s.False(applicationErr.NonRetryable())
+	s.Equal(testArchiveErr.Error(), applicationErr.Error())
 }
 
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Success() {

--- a/service/worker/archiver/handler.go
+++ b/service/worker/archiver/handler.go
@@ -167,7 +167,7 @@ func (h *handler) handleHistoryRequest(ctx workflow.Context, request *ArchiveReq
 	localActCtx := workflow.WithLocalActivityOptions(ctx, lao)
 	err = workflow.ExecuteLocalActivity(localActCtx, deleteHistoryActivity, *request).Get(localActCtx, nil)
 	if err != nil {
-		logger.Error("deleting history failed, this means zombie histories are left", tag.Error(err))
+		logger.Error("deleting workflow execution failed all retires, skip workflow deletion", tag.Error(err))
 		h.metricsClient.IncCounter(metrics.ArchiverScope, metrics.ArchiverDeleteFailedAllRetriesCount)
 	} else {
 		h.metricsClient.IncCounter(metrics.ArchiverScope, metrics.ArchiverDeleteSuccessCount)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not mark all activities errors as non-retryable 😞 
- Change the condition for what errors is non-retryable for workflow deletion, more specifically, workflow not ready error and context errors (like context deadline exceeded, since each new attempt get a new startToClose timeout) should be retryable.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Bug fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally
- Updated unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.