### PR TITLE
Fix failover queue shutdown

### DIFF
--- a/service/history/historyEngineInterfaces.go
+++ b/service/history/historyEngineInterfaces.go
@@ -70,10 +70,6 @@ type (
 		queueShutdown() error
 	}
 
-	timerProcessor interface {
-		notifyNewTimers(timerTask []tasks.Task)
-	}
-
 	timerQueueAckMgr interface {
 		getFinishedChan() <-chan struct{}
 		readTimerTasks() ([]queues.Executable, *time.Time, bool, error)

--- a/service/history/historyEngineInterfaces_mock.go
+++ b/service/history/historyEngineInterfaces_mock.go
@@ -349,41 +349,6 @@ func (mr *MockprocessorMockRecorder) updateAckLevel(taskID interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "updateAckLevel", reflect.TypeOf((*Mockprocessor)(nil).updateAckLevel), taskID)
 }
 
-// MocktimerProcessor is a mock of timerProcessor interface.
-type MocktimerProcessor struct {
-	ctrl     *gomock.Controller
-	recorder *MocktimerProcessorMockRecorder
-}
-
-// MocktimerProcessorMockRecorder is the mock recorder for MocktimerProcessor.
-type MocktimerProcessorMockRecorder struct {
-	mock *MocktimerProcessor
-}
-
-// NewMocktimerProcessor creates a new mock instance.
-func NewMocktimerProcessor(ctrl *gomock.Controller) *MocktimerProcessor {
-	mock := &MocktimerProcessor{ctrl: ctrl}
-	mock.recorder = &MocktimerProcessorMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MocktimerProcessor) EXPECT() *MocktimerProcessorMockRecorder {
-	return m.recorder
-}
-
-// notifyNewTimers mocks base method.
-func (m *MocktimerProcessor) notifyNewTimers(timerTask []tasks.Task) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "notifyNewTimers", timerTask)
-}
-
-// notifyNewTimers indicates an expected call of notifyNewTimers.
-func (mr *MocktimerProcessorMockRecorder) notifyNewTimers(timerTask interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "notifyNewTimers", reflect.TypeOf((*MocktimerProcessor)(nil).notifyNewTimers), timerTask)
-}
-
 // MocktimerQueueAckMgr is a mock of timerQueueAckMgr interface.
 type MocktimerQueueAckMgr struct {
 	ctrl     *gomock.Controller

--- a/service/history/queueProcessorBase.go
+++ b/service/history/queueProcessorBase.go
@@ -209,7 +209,8 @@ eventLoop:
 			))
 			if err := p.ackMgr.updateQueueAckLevel(); shard.IsShardOwnershipLostError(err) {
 				// shard is no longer owned by this instance, bail out
-				go p.Stop()
+				// stop the entire queue processor, not just processor base.
+				go p.queueProcessor.Stop()
 				break eventLoop
 			}
 		}

--- a/service/history/queueProcessorBase.go
+++ b/service/history/queueProcessorBase.go
@@ -56,16 +56,16 @@ type (
 	}
 
 	queueProcessorBase struct {
-		clusterName string
-		shard       shard.Context
-		timeSource  clock.TimeSource
-		options     *QueueProcessorOptions
-		processor   processor
-		logger      log.Logger
-		rateLimiter quotas.RateLimiter // Read rate limiter
-		ackMgr      queueAckMgr
-		scheduler   queues.Scheduler
-		rescheduler queues.Rescheduler
+		clusterName    string
+		shard          shard.Context
+		timeSource     clock.TimeSource
+		options        *QueueProcessorOptions
+		queueProcessor common.Daemon
+		logger         log.Logger
+		rateLimiter    quotas.RateLimiter // Read rate limiter
+		ackMgr         queueAckMgr
+		scheduler      queues.Scheduler
+		rescheduler    queues.Rescheduler
 
 		lastPollTime     time.Time
 		backoffTimerLock sync.Mutex
@@ -87,7 +87,7 @@ func newQueueProcessorBase(
 	clusterName string,
 	shard shard.Context,
 	options *QueueProcessorOptions,
-	processor processor,
+	queueProcessor common.Daemon,
 	queueAckMgr queueAckMgr,
 	historyCache workflow.Cache,
 	scheduler queues.Scheduler,
@@ -97,18 +97,18 @@ func newQueueProcessorBase(
 ) *queueProcessorBase {
 
 	p := &queueProcessorBase{
-		clusterName:  clusterName,
-		shard:        shard,
-		timeSource:   shard.GetTimeSource(),
-		options:      options,
-		processor:    processor,
-		rateLimiter:  rateLimiter,
-		status:       common.DaemonStatusInitialized,
-		notifyCh:     make(chan struct{}, 1),
-		shutdownCh:   make(chan struct{}),
-		logger:       logger,
-		ackMgr:       queueAckMgr,
-		lastPollTime: time.Time{},
+		clusterName:    clusterName,
+		shard:          shard,
+		timeSource:     shard.GetTimeSource(),
+		options:        options,
+		queueProcessor: queueProcessor,
+		rateLimiter:    rateLimiter,
+		status:         common.DaemonStatusInitialized,
+		notifyCh:       make(chan struct{}, 1),
+		shutdownCh:     make(chan struct{}),
+		logger:         logger,
+		ackMgr:         queueAckMgr,
+		lastPollTime:   time.Time{},
 		readTaskRetrier: backoff.NewRetrier(
 			common.CreateReadTaskRetryPolicy(),
 			backoff.SystemClock,
@@ -190,7 +190,8 @@ eventLoop:
 			break eventLoop
 		case <-p.ackMgr.getFinishedChan():
 			// use a separate gorouting since the caller hold the shutdownWG
-			go p.Stop()
+			// stop the entire queue processor, not just processor base.
+			go p.queueProcessor.Stop()
 		case <-p.notifyCh:
 			p.processBatch()
 		case <-pollTimer.C:

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -66,7 +66,7 @@ type (
 		config           *configs.Config
 		logger           log.Logger
 		metricsClient    metrics.Client
-		timerProcessor   timerProcessor
+		timerProcessor   common.Daemon
 		timerQueueAckMgr timerQueueAckMgr
 		timerGate        timer.Gate
 		timeSource       clock.TimeSource
@@ -87,7 +87,7 @@ func newTimerQueueProcessorBase(
 	scope int,
 	shard shard.Context,
 	workflowCache workflow.Cache,
-	timerProcessor timerProcessor,
+	timerProcessor common.Daemon,
 	timerQueueAckMgr timerQueueAckMgr,
 	timerGate timer.Gate,
 	scheduler queues.Scheduler,
@@ -250,7 +250,8 @@ eventLoop:
 			// timer queue ack manager indicate that all task scanned
 			// are finished and no more tasks
 			// use a separate goroutine since the caller hold the shutdownWG
-			go t.Stop()
+			// stop the entire timer queue processor, not just processor base.
+			go t.timerProcessor.Stop()
 			return nil
 		case <-t.timerGate.FireChan():
 			nextFireTime, err := t.readAndFanoutTimerTasks()

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -282,7 +282,8 @@ eventLoop:
 			))
 			if err := t.timerQueueAckMgr.updateAckLevel(); shard.IsShardOwnershipLostError(err) {
 				// shard is closed, shutdown timerQProcessor and bail out
-				go t.Stop()
+				// stop the entire timer queue processor, not just processor base.
+				go t.timerProcessor.Stop()
 				return err
 			}
 		case <-t.newTimerCh:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix failover queue shutdown

<!-- Tell your future self why have you made these changes -->
**Why?**
- Failover queue shutdown doesn't follow the normal stop path. Instead stop is triggered from the ack manager. Currently this shutdown logic only shutdown the processor base, not the entire processor. This mean the failover queue worker pool is not stopped and lead to goroutine leak.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Will do local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.