### PR TITLE
Send ringpopServiceResolver events on diffs instead of ringpop events

### DIFF
--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -212,10 +212,8 @@ func (r *ringpopServiceResolver) Members() []*HostInfo {
 func (r *ringpopServiceResolver) HandleEvent(
 	event events.Event,
 ) {
-
 	// We only care about RingChangedEvent
-	e, ok := event.(events.RingChangedEvent)
-	if ok {
+	if _, ok := event.(events.RingChangedEvent); ok {
 		r.logger.Debug("Received a ring changed event")
 		// Note that we receive events asynchronously, possibly out of order.
 		// We cannot rely on the content of the event, rather we load everything
@@ -223,35 +221,50 @@ func (r *ringpopServiceResolver) HandleEvent(
 		if err := r.refresh(); err != nil {
 			r.logger.Error("error refreshing ring when receiving a ring changed event", tag.Error(err))
 		}
-		r.emitEvent(e)
 	}
 }
 
 func (r *ringpopServiceResolver) refresh() error {
+	var event *ChangedEvent
+	var err error
+	defer func() {
+		if event != nil {
+			r.emitEvent(event)
+		}
+	}()
 	r.refreshLock.Lock()
 	defer r.refreshLock.Unlock()
-	return r.refreshNoLock()
+	event, err = r.refreshNoLock()
+	return err
 }
 
 func (r *ringpopServiceResolver) refreshWithBackoff() error {
+	var event *ChangedEvent
+	var err error
+	defer func() {
+		if event != nil {
+			r.emitEvent(event)
+		}
+	}()
 	r.refreshLock.Lock()
 	defer r.refreshLock.Unlock()
 	if r.lastRefreshTime.After(time.Now().UTC().Add(-minRefreshInternal)) {
 		// refresh too frequently
 		return nil
 	}
-	return r.refreshNoLock()
+	event, err = r.refreshNoLock()
+	return err
 }
 
-func (r *ringpopServiceResolver) refreshNoLock() error {
+func (r *ringpopServiceResolver) refreshNoLock() (*ChangedEvent, error) {
 	addrs, err := r.getReachableMembers()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	newMembersMap, changed := r.compareMembers(addrs)
-	if !changed {
-		return nil
+	newMembersMap, changedEvent := r.compareMembers(addrs)
+	if changedEvent == nil {
+		return nil, nil
 	}
 
 	ring := newHashRing()
@@ -264,7 +277,8 @@ func (r *ringpopServiceResolver) refreshNoLock() error {
 	r.lastRefreshTime = time.Now().UTC()
 	r.ringValue.Store(ring)
 	r.logger.Info("Current reachable members", tag.Addresses(addrs))
-	return nil
+
+	return changedEvent, nil
 }
 
 func (r *ringpopServiceResolver) getReachableMembers() ([]string, error) {
@@ -301,22 +315,7 @@ func (r *ringpopServiceResolver) getReachableMembers() ([]string, error) {
 	return hostPorts, nil
 }
 
-func (r *ringpopServiceResolver) emitEvent(
-	rpEvent events.RingChangedEvent,
-) {
-
-	// Marshall the event object into the required type
-	event := &ChangedEvent{}
-	for _, addr := range rpEvent.ServersAdded {
-		event.HostsAdded = append(event.HostsAdded, NewHostInfo(addr, r.getLabelsMap()))
-	}
-	for _, addr := range rpEvent.ServersRemoved {
-		event.HostsRemoved = append(event.HostsRemoved, NewHostInfo(addr, r.getLabelsMap()))
-	}
-	for _, addr := range rpEvent.ServersUpdated {
-		event.HostsUpdated = append(event.HostsUpdated, NewHostInfo(addr, r.getLabelsMap()))
-	}
-
+func (r *ringpopServiceResolver) emitEvent(event *ChangedEvent) {
 	// Notify listeners
 	r.listenerLock.RLock()
 	defer r.listenerLock.RUnlock()
@@ -342,7 +341,7 @@ func (r *ringpopServiceResolver) refreshRingWorker() {
 			return
 		case <-r.refreshChan:
 			if err := r.refreshWithBackoff(); err != nil {
-				r.logger.Error("error periodically refreshing ring", tag.Error(err))
+				r.logger.Error("error refreshing ring by request", tag.Error(err))
 			}
 		case <-refreshTicker.C:
 			if err := r.refreshWithBackoff(); err != nil {
@@ -362,22 +361,27 @@ func (r *ringpopServiceResolver) getLabelsMap() map[string]string {
 	return labels
 }
 
-func (r *ringpopServiceResolver) compareMembers(addrs []string) (map[string]struct{}, bool) {
+func (r *ringpopServiceResolver) compareMembers(addrs []string) (map[string]struct{}, *ChangedEvent) {
+	event := &ChangedEvent{}
 	changed := false
 	newMembersMap := make(map[string]struct{}, len(addrs))
 	for _, addr := range addrs {
 		newMembersMap[addr] = struct{}{}
 		if _, ok := r.membersMap[addr]; !ok {
+			event.HostsAdded = append(event.HostsAdded, NewHostInfo(addr, r.getLabelsMap()))
 			changed = true
 		}
 	}
 	for addr := range r.membersMap {
 		if _, ok := newMembersMap[addr]; !ok {
+			event.HostsRemoved = append(event.HostsRemoved, NewHostInfo(addr, r.getLabelsMap()))
 			changed = true
-			break
 		}
 	}
-	return newMembersMap, changed
+	if changed {
+		return newMembersMap, event
+	}
+	return newMembersMap, nil
 }
 
 // BuildBroadcastHostPort return the listener hostport from an existing tchannel

--- a/common/membership/rp_cluster_test.go
+++ b/common/membership/rp_cluster_test.go
@@ -153,9 +153,10 @@ func NewTestRingpopCluster(
 			return nil
 		}
 		rpWrapper := NewRingPop(ringPop, time.Second*2, logger)
+		_, port, _ := SplitHostPortTyped(cluster.hostAddrs[i])
 		cluster.rings[i] = NewRingpopMonitor(
 			serviceName,
-			map[string]int{serviceName: 0},
+			map[string]int{serviceName: int(port)}, // use same port for "grpc" port
 			rpWrapper,
 			logger,
 			mockMgr,


### PR DESCRIPTION
**What changed?**
Currently, `ringpopServiceResolver` listens for events from ringpop, translates them to our own types, and sends them to registered listeners on the `ringpopServiceResolver`. Events are sent when and only when it gets an event from ringpop.

But sometimes there can be an observable change to the hash ring without ringpop sending an event. This seems to happen during startup, when `refresh` gets called to rebuild the ring. `refresh` is called on every event from ringpop, but it's also called periodically, or after a failed lookup, and apparently those calls can cause observable changes also.

This change moves the generation of our events into `refresh`, so we're sure to always generate an event on any observable change. Also, the addresses in the event now have the grpc ports instead of ringpop ports. No clients currently make use of the detailed event information so this doesn't matter.

**Why?**
A client of ServiceResolver should be able to rely on getting an event for any observable change.

**How did you test it?**
unit tests and semi-manual tests of startup behavior

**Potential risks**
This changes the number of events generated by `ringpopServiceMonitor`. It _should_ generate a superset of events than it did before, but it's possible it could miss a case and mess up service discovery.

**Is hotfix candidate?**
