### PR TITLE
Share grpc connections across sdk clients

### DIFF
--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -388,7 +388,12 @@ func ArchiverProviderProvider(cfg *config.Config) provider.ArchiverProvider {
 	return provider.NewArchiverProvider(cfg.Archival.History.Provider, cfg.Archival.Visibility.Provider)
 }
 
-func SdkClientFactoryProvider(cfg *config.Config, tlsConfigProvider encryption.TLSConfigProvider, provider metrics.MetricsHandler) (sdk.ClientFactory, error) {
+func SdkClientFactoryProvider(
+	cfg *config.Config,
+	tlsConfigProvider encryption.TLSConfigProvider,
+	provider metrics.MetricsHandler,
+	logger SnTaggedLogger,
+) (sdk.ClientFactory, error) {
 	tlsFrontendConfig, err := tlsConfigProvider.GetFrontendClientConfig()
 	if err != nil {
 		return nil, fmt.Errorf("unable to load frontend TLS configuration: %w", err)
@@ -398,6 +403,7 @@ func SdkClientFactoryProvider(cfg *config.Config, tlsConfigProvider encryption.T
 		cfg.PublicClient.HostPort,
 		tlsFrontendConfig,
 		sdk.NewMetricsHandler(provider),
+		logger,
 	), nil
 }
 

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -391,7 +391,7 @@ func ArchiverProviderProvider(cfg *config.Config) provider.ArchiverProvider {
 func SdkClientFactoryProvider(
 	cfg *config.Config,
 	tlsConfigProvider encryption.TLSConfigProvider,
-	provider metrics.MetricsHandler,
+	metricsHandler metrics.MetricsHandler,
 	logger SnTaggedLogger,
 ) (sdk.ClientFactory, error) {
 	tlsFrontendConfig, err := tlsConfigProvider.GetFrontendClientConfig()
@@ -402,7 +402,7 @@ func SdkClientFactoryProvider(
 	return sdk.NewClientFactory(
 		cfg.PublicClient.HostPort,
 		tlsFrontendConfig,
-		sdk.NewMetricsHandler(provider),
+		metricsHandler,
 		logger,
 	), nil
 }

--- a/common/sdk/factory.go
+++ b/common/sdk/factory.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives"
 )
 
@@ -75,13 +76,13 @@ var (
 func NewClientFactory(
 	hostPort string,
 	tlsConfig *tls.Config,
-	metricsHandler *MetricsHandler,
+	metricsHandler metrics.MetricsHandler,
 	logger log.Logger,
 ) *clientFactory {
 	return &clientFactory{
 		hostPort:       hostPort,
 		tlsConfig:      tlsConfig,
-		metricsHandler: metricsHandler,
+		metricsHandler: NewMetricsHandler(metricsHandler),
 		logger:         logger,
 		sdklogger:      log.NewSdkLogger(logger),
 	}

--- a/common/sdk/factory.go
+++ b/common/sdk/factory.go
@@ -111,6 +111,7 @@ func (f *clientFactory) GetSystemClient() sdkclient.Client {
 		err := backoff.ThrottleRetry(func() error {
 			sdkClient, err := sdkclient.Dial(f.options(primitives.SystemLocalNamespace))
 			if err != nil {
+				f.logger.Warn("error creating sdk client", tag.Error(err))
 				return err
 			}
 			f.systemSdkClient = sdkClient

--- a/common/sdk/factory_mock.go
+++ b/common/sdk/factory_mock.go
@@ -75,12 +75,11 @@ func (mr *MockClientFactoryMockRecorder) GetSystemClient(logger interface{}) *go
 }
 
 // NewClient mocks base method.
-func (m *MockClientFactory) NewClient(namespaceName string, logger log.Logger) (client.Client, error) {
+func (m *MockClientFactory) NewClient(namespaceName string, logger log.Logger) client.Client {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewClient", namespaceName, logger)
 	ret0, _ := ret[0].(client.Client)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // NewClient indicates an expected call of NewClient.

--- a/common/sdk/factory_mock.go
+++ b/common/sdk/factory_mock.go
@@ -34,7 +34,6 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	client "go.temporal.io/sdk/client"
 	worker "go.temporal.io/sdk/worker"
-	log "go.temporal.io/server/common/log"
 )
 
 // MockClientFactory is a mock of ClientFactory interface.
@@ -61,31 +60,31 @@ func (m *MockClientFactory) EXPECT() *MockClientFactoryMockRecorder {
 }
 
 // GetSystemClient mocks base method.
-func (m *MockClientFactory) GetSystemClient(logger log.Logger) client.Client {
+func (m *MockClientFactory) GetSystemClient() client.Client {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetSystemClient", logger)
+	ret := m.ctrl.Call(m, "GetSystemClient")
 	ret0, _ := ret[0].(client.Client)
 	return ret0
 }
 
 // GetSystemClient indicates an expected call of GetSystemClient.
-func (mr *MockClientFactoryMockRecorder) GetSystemClient(logger interface{}) *gomock.Call {
+func (mr *MockClientFactoryMockRecorder) GetSystemClient() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSystemClient", reflect.TypeOf((*MockClientFactory)(nil).GetSystemClient), logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSystemClient", reflect.TypeOf((*MockClientFactory)(nil).GetSystemClient))
 }
 
 // NewClient mocks base method.
-func (m *MockClientFactory) NewClient(namespaceName string, logger log.Logger) client.Client {
+func (m *MockClientFactory) NewClient(namespaceName string) client.Client {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewClient", namespaceName, logger)
+	ret := m.ctrl.Call(m, "NewClient", namespaceName)
 	ret0, _ := ret[0].(client.Client)
 	return ret0
 }
 
 // NewClient indicates an expected call of NewClient.
-func (mr *MockClientFactoryMockRecorder) NewClient(namespaceName, logger interface{}) *gomock.Call {
+func (mr *MockClientFactoryMockRecorder) NewClient(namespaceName interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewClient", reflect.TypeOf((*MockClientFactory)(nil).NewClient), namespaceName, logger)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewClient", reflect.TypeOf((*MockClientFactory)(nil).NewClient), namespaceName)
 }
 
 // MockWorkerFactory is a mock of WorkerFactory interface.

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/sdk/metric v0.30.0
 	go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde
-	go.temporal.io/sdk v1.16.0
+	go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.10.0
 	go.uber.org/fx v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -504,11 +504,11 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v0.16.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.18.0 h1:W5hyXNComRa23tGpKwG+FRAc4rfF6ZUg1JReK+QHS80=
 go.opentelemetry.io/proto/otlp v0.18.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.temporal.io/api v1.11.0/go.mod h1:Z1uAa6iqyq/lu0+41qOG+BNO2JsxXxrgUe8UJv2iNZI=
+go.temporal.io/api v1.11.1-0.20220804232755-77e12eef4f2d/go.mod h1:JWI21cif+WGqtgmar+dtxQOfYeGORmZtWUj/6/D0e9k=
 go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde h1:FMdQfWh6Q4cACnNSYbRzYsVED0QbhAirLgFPlRSdC20=
 go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde/go.mod h1:/OVJZ4KGuvi0+W8fO//E3yGK5fJJHFLIrudrizUgXko=
-go.temporal.io/sdk v1.16.0 h1:aWo7gJnrjGstqwRs/yfaIVIB3dX3oEak9A7f/Erb5nE=
-go.temporal.io/sdk v1.16.0/go.mod h1:rnOV6mudCFB0n3/CJk/W9I89NVYuSjcCErrirzPGNP8=
+go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89 h1:YgBLMeScA/oLIeGOLh9rV26p10KcatcyH46P2MEoI0Q=
+go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89/go.mod h1:XHGK393x654eIHGNf9nXw6DpOJlW4OuvivfLb8n2E34=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -634,7 +634,8 @@ golang.org/x/net v0.0.0-20220412020605-290c469a71a5/go.mod h1:CfG3xpIq0wQ8r1q4Su
 golang.org/x/net v0.0.0-20220425223048-2871e0cb64e4/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20220728181054-f92ba40d432d/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
 golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -746,6 +747,8 @@ golang.org/x/sys v0.0.0-20220610221304-9f5ed59c137d/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220615213510-4f61da869c0c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220818161305-2296e01440c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 h1:UiNENfZ8gDvpiWw7IpOMQ27spWmThO1RwwdQVbJahJM=
 golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
@@ -970,7 +973,8 @@ google.golang.org/genproto v0.0.0-20220523171625-347a074981d8/go.mod h1:RAyBrSAP
 google.golang.org/genproto v0.0.0-20220608133413-ed9918b62aac/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
-google.golang.org/genproto v0.0.0-20220725144611-272f38e5d71b/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
+google.golang.org/genproto v0.0.0-20220804142021-4e6b2dfa6612/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
+google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
 google.golang.org/genproto v0.0.0-20220829144015-23454907ede3 h1:4wwmycAWg7WUIFWgzxP6Wumy2GBLxmATgkhgpFnJl2U=
 google.golang.org/genproto v0.0.0-20220829144015-23454907ede3/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -374,13 +374,7 @@ func (c *temporalImpl) startFrontend(hosts map[string][]string, startWG *sync.Wa
 		fx.Provide(func() *cluster.Config { return c.clusterMetadataConfig }),
 		fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 		fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
-		fx.Provide(func() sdk.ClientFactory {
-			return sdk.NewClientFactory(
-				c.FrontendGRPCAddress(),
-				nil,
-				sdk.NewMetricsHandler(metrics.NoopMetricsHandler),
-			)
-		}),
+		fx.Provide(c.sdkClientFactoryProvider),
 		fx.Provide(func() metrics.MetricsHandler { return metrics.NoopMetricsHandler }),
 		fx.Provide(func() []grpc.UnaryServerInterceptor { return nil }),
 		fx.Provide(func() authorization.Authorizer { return nil }),
@@ -471,13 +465,7 @@ func (c *temporalImpl) startHistory(
 			fx.Provide(func() *cluster.Config { return c.clusterMetadataConfig }),
 			fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 			fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
-			fx.Provide(func() sdk.ClientFactory {
-				return sdk.NewClientFactory(
-					c.FrontendGRPCAddress(),
-					nil,
-					sdk.NewMetricsHandler(metrics.NoopMetricsHandler),
-				)
-			}),
+			fx.Provide(c.sdkClientFactoryProvider),
 			fx.Provide(func() client.FactoryProvider { return client.NewFactoryProvider() }),
 			fx.Provide(func() searchattribute.Mapper { return nil }),
 			// Comment the line above and uncomment the line bellow to test with search attributes mapper.
@@ -649,13 +637,7 @@ func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.Wait
 		fx.Provide(func() *cluster.Config { return &clusterConfigCopy }),
 		fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 		fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
-		fx.Provide(func() sdk.ClientFactory {
-			return sdk.NewClientFactory(
-				c.FrontendGRPCAddress(),
-				nil,
-				sdk.NewMetricsHandler(metrics.NoopMetricsHandler),
-			)
-		}),
+		fx.Provide(c.sdkClientFactoryProvider),
 		fx.Provide(func() sdk.WorkerFactory { return sdk.NewWorkerFactory() }),
 		fx.Provide(func() client.FactoryProvider { return client.NewFactoryProvider() }),
 		fx.Provide(func() searchattribute.Mapper { return nil }),
@@ -685,6 +667,18 @@ func (c *temporalImpl) startWorker(hosts map[string][]string, startWG *sync.Wait
 	startWG.Done()
 	<-c.shutdownCh
 	c.shutdownWG.Done()
+}
+
+func (c *temporalImpl) sdkClientFactoryProvider(
+	metricsHandler metrics.MetricsHandler,
+	logger log.Logger,
+) sdk.ClientFactory {
+	return sdk.NewClientFactory(
+		c.FrontendGRPCAddress(),
+		nil,
+		metricsHandler,
+		logger,
+	)
 }
 
 func (c *temporalImpl) createSystemNamespace() error {

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -283,7 +283,7 @@ func (adh *AdminHandler) AddSearchAttributes(ctx context.Context, request *admin
 		SkipSchemaUpdate:      request.GetSkipSchemaUpdate(),
 	}
 
-	sdkClient := adh.sdkClientFactory.GetSystemClient(adh.logger)
+	sdkClient := adh.sdkClientFactory.GetSystemClient()
 	run, err := sdkClient.ExecuteWorkflow(
 		ctx,
 		sdkclient.StartWorkflowOptions{
@@ -372,7 +372,7 @@ func (adh *AdminHandler) GetSearchAttributes(ctx context.Context, request *admin
 func (adh *AdminHandler) getSearchAttributes(ctx context.Context, indexName string, runID string) (*adminservice.GetSearchAttributesResponse, error) {
 	var lastErr error
 
-	sdkClient := adh.sdkClientFactory.GetSystemClient(adh.logger)
+	sdkClient := adh.sdkClientFactory.GetSystemClient()
 	descResp, err := sdkClient.DescribeWorkflowExecution(ctx, addsearchattributes.WorkflowName, runID)
 	var wfInfo *workflowpb.WorkflowExecutionInfo
 	if err != nil {

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -558,7 +558,7 @@ func (s *adminHandlerSuite) Test_AddSearchAttributes() {
 	}
 
 	mockSdkClient := mocksdk.NewMockClient(s.controller)
-	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient(gomock.Any()).Return(mockSdkClient).AnyTimes()
+	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient().Return(mockSdkClient).AnyTimes()
 
 	// Start workflow failed.
 	mockSdkClient.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), "temporal-sys-add-search-attributes-workflow", gomock.Any()).Return(nil, errors.New("start failed"))
@@ -607,7 +607,7 @@ func (s *adminHandlerSuite) Test_GetSearchAttributes() {
 	s.Nil(resp)
 
 	mockSdkClient := mocksdk.NewMockClient(s.controller)
-	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient(gomock.Any()).Return(mockSdkClient).AnyTimes()
+	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient().Return(mockSdkClient).AnyTimes()
 
 	// Elasticsearch is not configured
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -174,7 +174,7 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 		SkipSchemaUpdate:      false,
 	}
 
-	sdkClient := h.sdkClientFactory.GetSystemClient(h.logger)
+	sdkClient := h.sdkClientFactory.GetSystemClient()
 	run, err := sdkClient.ExecuteWorkflow(
 		ctx,
 		sdkclient.StartWorkflowOptions{
@@ -297,7 +297,7 @@ func (h *OperatorHandlerImpl) DeleteNamespace(ctx context.Context, request *oper
 		},
 	}
 
-	sdkClient := h.sdkClientFactory.GetSystemClient(h.logger)
+	sdkClient := h.sdkClientFactory.GetSystemClient()
 	run, err := sdkClient.ExecuteWorkflow(
 		ctx,
 		sdkclient.StartWorkflowOptions{

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -193,7 +193,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 	}
 
 	mockSdkClient := mocksdk.NewMockClient(s.controller)
-	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient(gomock.Any()).Return(mockSdkClient).AnyTimes()
+	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient().Return(mockSdkClient).AnyTimes()
 
 	// Start workflow failed.
 	mockSdkClient.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), "temporal-sys-add-search-attributes-workflow", gomock.Any()).Return(nil, errors.New("start failed"))
@@ -411,7 +411,7 @@ func (s *operatorHandlerSuite) Test_DeleteNamespace() {
 	}
 
 	mockSdkClient := mocksdk.NewMockClient(s.controller)
-	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient(gomock.Any()).Return(mockSdkClient).AnyTimes()
+	s.mockResource.SDKClientFactory.EXPECT().GetSystemClient().Return(mockSdkClient).AnyTimes()
 
 	handler.config = &Config{
 		DeleteNamespaceDeleteActivityRPS:                    dynamicconfig.GetIntPropertyFn(22),

--- a/service/worker/archiver/client.go
+++ b/service/worker/archiver/client.go
@@ -296,7 +296,7 @@ func (c *client) sendArchiveSignal(ctx context.Context, request *ArchiveRequest,
 	signalCtx, cancel := context.WithTimeout(context.Background(), signalTimeout)
 	defer cancel()
 
-	sdkClient := c.sdkClientFactory.GetSystemClient(c.logger)
+	sdkClient := c.sdkClientFactory.GetSystemClient()
 	_, err := sdkClient.SignalWithStartWorkflow(signalCtx, workflowID, signalName, *request, workflowOptions, archivalWorkflowFnName, nil)
 	if err != nil {
 		taggedLogger.Error("failed to send signal to archival system workflow",

--- a/service/worker/archiver/client_test.go
+++ b/service/worker/archiver/client_test.go
@@ -75,7 +75,7 @@ func (s *clientSuite) SetupTest() {
 	s.metricsClient.EXPECT().Scope(metrics.ArchiverClientScope, gomock.Any()).Return(s.metricsScope)
 	s.sdkClient = mocksdk.NewMockClient(s.controller)
 	s.sdkClientFactory = sdk.NewMockClientFactory(s.controller)
-	s.sdkClientFactory.EXPECT().GetSystemClient(gomock.Any()).Return(s.sdkClient).AnyTimes()
+	s.sdkClientFactory.EXPECT().GetSystemClient().Return(s.sdkClient).AnyTimes()
 	s.client = NewClient(
 		s.metricsClient,
 		log.NewNoopLogger(),

--- a/service/worker/archiver/client_worker.go
+++ b/service/worker/archiver/client_worker.go
@@ -111,7 +111,7 @@ func NewClientWorker(container *BootstrapContainer) ClientWorker {
 	actCtx := context.WithValue(context.Background(), bootstrapContainerKey, container)
 	actCtx = headers.SetCallerInfo(actCtx, headers.SystemBackgroundCallerInfo)
 
-	sdkClient := container.SdkClientFactory.GetSystemClient(container.Logger)
+	sdkClient := container.SdkClientFactory.GetSystemClient()
 	wo := worker.Options{
 		MaxConcurrentActivityExecutionSize:     container.Config.MaxConcurrentActivityExecutionSize(),
 		MaxConcurrentWorkflowTaskExecutionSize: container.Config.MaxConcurrentWorkflowTaskExecutionSize(),

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -71,11 +71,7 @@ func (a *activities) BatchActivity(ctx context.Context, batchParams BatchParams)
 		return hbd, err
 	}
 
-	sdkClient, err := a.ClientFactory.NewClient(batchParams.Namespace, logger)
-	if err != nil {
-		logger.Error("Unable to create SDK client for namespace.", tag.Error(err), tag.WorkflowNamespace(batchParams.Namespace))
-		return hbd, err
-	}
+	sdkClient := a.ClientFactory.NewClient(batchParams.Namespace, logger)
 
 	startOver := true
 	if activity.HasHeartbeatDetails(ctx) {

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -71,7 +71,7 @@ func (a *activities) BatchActivity(ctx context.Context, batchParams BatchParams)
 		return hbd, err
 	}
 
-	sdkClient := a.ClientFactory.NewClient(batchParams.Namespace, logger)
+	sdkClient := a.ClientFactory.NewClient(batchParams.Namespace)
 
 	startOver := true
 	if activity.HasHeartbeatDetails(ctx) {

--- a/service/worker/batcher/batcher.go
+++ b/service/worker/batcher/batcher.go
@@ -80,7 +80,7 @@ func (s *Batcher) Start() error {
 	workerOpts := worker.Options{
 		BackgroundActivityContext: ctx,
 	}
-	sdkClient := s.sdkClientFactory.GetSystemClient(s.logger)
+	sdkClient := s.sdkClientFactory.GetSystemClient()
 	batchWorker := worker.New(sdkClient, taskQueueName, workerOpts)
 	batchWorker.RegisterWorkflowWithOptions(BatchWorkflow, workflow.RegisterOptions{Name: BatchWFTypeName})
 	batchWorker.RegisterActivity(&activities{

--- a/service/worker/parentclosepolicy/client.go
+++ b/service/worker/parentclosepolicy/client.go
@@ -90,7 +90,7 @@ func (c *clientImpl) SendParentClosePolicyRequest(ctx context.Context, request R
 	signalCtx, cancel := context.WithTimeout(ctx, signalTimeout)
 	defer cancel()
 
-	sdkClient := c.sdkClientFactory.GetSystemClient(c.logger)
+	sdkClient := c.sdkClientFactory.GetSystemClient()
 	_, err := sdkClient.SignalWithStartWorkflow(signalCtx, workflowID, processorChannelName, request, workflowOptions, processorWFTypeName, nil)
 	return err
 }

--- a/service/worker/parentclosepolicy/processor.go
+++ b/service/worker/parentclosepolicy/processor.go
@@ -92,7 +92,7 @@ func New(params *BootstrapParams) *Processor {
 
 // Start starts the scanner
 func (s *Processor) Start() error {
-	svcClient := s.svcClientFactory.GetSystemClient(s.logger)
+	svcClient := s.svcClientFactory.GetSystemClient()
 	processorWorker := worker.New(svcClient, processorTaskQueueName, getWorkerOptions(s))
 	processorWorker.RegisterWorkflowWithOptions(ProcessorWorkflow, workflow.RegisterOptions{Name: processorWFTypeName})
 	processorWorker.RegisterActivityWithOptions(ProcessorActivity, activity.RegisterOptions{Name: processorActivityName})

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -335,10 +335,7 @@ func (w *perNamespaceWorker) startWorker(
 	multiplicity int,
 ) (sdkclient.Client, sdkworker.Worker, error) {
 	nsName := ns.Name().String()
-	client, err := w.wm.sdkClientFactory.NewClient(nsName, w.wm.logger)
-	if err != nil {
-		return nil, nil, err
-	}
+	client := w.wm.sdkClientFactory.NewClient(nsName, w.wm.logger)
 
 	var sdkoptions sdkworker.Options
 	sdkoptions.BackgroundActivityContext = headers.SetCallerInfo(context.Background(), headers.NewBackgroundCallerInfo(ns.Name().String()))
@@ -353,7 +350,7 @@ func (w *perNamespaceWorker) startWorker(
 		cmp.Register(sdkworker, ns)
 	}
 	// TODO: use Run() and handle post-startup errors by recreating worker
-	err = sdkworker.Start()
+	err := sdkworker.Start()
 	if err != nil {
 		client.Close()
 		return nil, nil, err

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -335,7 +335,7 @@ func (w *perNamespaceWorker) startWorker(
 	multiplicity int,
 ) (sdkclient.Client, sdkworker.Worker, error) {
 	nsName := ns.Name().String()
-	client := w.wm.sdkClientFactory.NewClient(nsName, w.wm.logger)
+	client := w.wm.sdkClientFactory.NewClient(nsName)
 
 	var sdkoptions sdkworker.Options
 	sdkoptions.BackgroundActivityContext = headers.SetCallerInfo(context.Background(), headers.NewBackgroundCallerInfo(ns.Name().String()))

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -335,7 +335,6 @@ func (w *perNamespaceWorker) startWorker(
 	multiplicity int,
 ) (sdkclient.Client, sdkworker.Worker, error) {
 	nsName := ns.Name().String()
-	// TODO: after sdk supports cloning clients to share connections, use that here
 	client, err := w.wm.sdkClientFactory.NewClient(nsName, w.wm.logger)
 	if err != nil {
 		return nil, nil, err

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -453,7 +453,7 @@ func (s *Service) startScanner() {
 	sc := scanner.New(
 		s.logger,
 		s.config.ScannerCfg,
-		s.sdkClientFactory.GetSystemClient(s.logger),
+		s.sdkClientFactory.GetSystemClient(),
 		s.metricsClient,
 		s.executionManager,
 		s.taskManager,

--- a/service/worker/worker.go
+++ b/service/worker/worker.go
@@ -80,7 +80,7 @@ func (wm *workerManager) Start() {
 		// TODO: add dynamic config for worker options
 		BackgroundActivityContext: headers.SetCallerType(context.Background(), headers.CallerTypeBackground),
 	}
-	sdkClient := wm.sdkClientFactory.GetSystemClient(wm.logger)
+	sdkClient := wm.sdkClientFactory.GetSystemClient()
 	defaultWorker := sdkworker.New(sdkClient, DefaultWorkerTaskQueue, defaultWorkerOptions)
 	wm.workers = []sdkworker.Worker{defaultWorker}
 


### PR DESCRIPTION
**What changed?**
Use a new feature in https://github.com/temporalio/sdk-go/pull/881 to share a single grpc connection across all sdk clients in one service.

The GetSystemClient/NewClient methods now don't take a logger, they get it from fx. This was confusing anyway since there are several calls to GetSystemClient with differently-tagged loggers and the first one will "win".

**Why?**
Reduce resource usage on worker and frontend when using many sdk clients.

**How did you test it?**
integration tests. will do another scale test later after some more related changes.

**Potential risks**

**Is hotfix candidate?**
