### PR TITLE
Add EncodedFailureAttributes to supported capabilities

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2962,6 +2962,7 @@ func (wh *WorkflowHandler) GetSystemInfo(ctx context.Context, request *workflows
 			InternalErrorDifferentiation:    true,
 			ActivityFailureIncludeHeartbeat: true,
 			SupportsSchedules:               true,
+			EncodedFailureAttributes:        true,
 		},
 	}, nil
 }

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -1857,6 +1857,7 @@ func (s *workflowHandlerSuite) TestGetSystemInfo() {
 	s.True(resp.Capabilities.InternalErrorDifferentiation)
 	s.True(resp.Capabilities.ActivityFailureIncludeHeartbeat)
 	s.True(resp.Capabilities.SupportsSchedules)
+	s.True(resp.Capabilities.EncodedFailureAttributes)
 }
 
 func (s *workflowHandlerSuite) newConfig() *Config {


### PR DESCRIPTION
Required for SDK to know whether it can send the server encoded failures.