### PR TITLE
Make mocksdk/generate.sh compatible with macos

### DIFF
--- a/common/testing/mocksdk/generate.sh
+++ b/common/testing/mocksdk/generate.sh
@@ -1,7 +1,4 @@
 #!/bin/sh
-# shellcheck disable=SC1004
-# The only portable way to embed a newline in sed is with a literal
-# backslash+newline, but shellcheck doesn't like it.
 
 # These mocks need to be manually fixed up after generation because gomock
 # uses the types in the internal package instead of the public type aliases.

--- a/common/testing/mocksdk/generate.sh
+++ b/common/testing/mocksdk/generate.sh
@@ -5,18 +5,16 @@
 
 # These mocks need to be manually fixed up after generation because gomock
 # uses the types in the internal package instead of the public type aliases.
-mockgen -copyright_file ../../../LICENSE -package "$GOPACKAGE" go.temporal.io/sdk/client Client | sed \
-	-e 's,\<internal\>,client,g' \
-	-e '/"go.temporal.io\/sdk\/converter"/d' \
-	-e 's,client "go.temporal.io/sdk/client",client "go.temporal.io/sdk/client"\
-	converter "go.temporal.io/sdk/converter",' \
-	> client_mock.go
-mockgen -copyright_file ../../../LICENSE -package "$GOPACKAGE" go.temporal.io/sdk/worker Worker | sed \
-	-e 's,internal.RegisterWorkflowOptions,workflow.RegisterOptions,g' \
-	-e 's,internal.RegisterActivityOptions,activity.RegisterOptions,g' \
-	-e 's,internal "go.temporal.io/sdk/internal",activity "go.temporal.io/sdk/activity"\
-	workflow "go.temporal.io/sdk/workflow",' \
-	> worker_mock.go
-mockgen -copyright_file ../../../LICENSE -package "$GOPACKAGE" go.temporal.io/sdk/client WorkflowRun | sed \
-	-e 's,\<internal\>,client,g' \
-	> workflowrun_mock.go
+mockgen -copyright_file ../../../LICENSE -package "$GOPACKAGE" go.temporal.io/sdk/client Client | \
+  sed -e 's,internal,client,g' | \
+  goimports > client_mock.go
+
+mockgen -copyright_file ../../../LICENSE -package "$GOPACKAGE" go.temporal.io/sdk/worker Worker | \
+  sed -e 's,internal.RegisterWorkflowOptions,workflow.RegisterOptions,g' \
+      -e 's,internal.RegisterActivityOptions,activity.RegisterOptions,g' \
+      -e 's,internal "go.temporal.io/sdk/internal",activity "go.temporal.io/sdk/activity"\n\tworkflow "go.temporal.io/sdk/workflow",' | \
+  goimports > worker_mock.go
+
+mockgen -copyright_file ../../../LICENSE -package "$GOPACKAGE" go.temporal.io/sdk/client WorkflowRun | \
+  sed -e 's,internal,client,g' | \
+  goimports > workflowrun_mock.go


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update script `common/testing/mocksdk/generate.sh` to be compatible with MacOS.

<!-- Tell your future self why have you made these changes -->
**Why?**
Default `sed` in MacOS cannot match whole words, ie., `\<word\>` and `\bword\b` don't work.
This PR removed those whole words markers as it should work without as well (at least for now).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Re-generated the files and they are the same.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In the future, if the generated code includes the word `internal` as sub-string of any word, this might mess up.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.