### PR TITLE
Add `--allow-no-auth` flag to allow noopAuthorizer

### DIFF
--- a/common/authorization/authorizer.go
+++ b/common/authorization/authorizer.go
@@ -90,3 +90,8 @@ func GetAuthorizerFromConfig(config *config.Authorization) (Authorizer, error) {
 	}
 	return nil, fmt.Errorf("unknown authorizer: %s", config.Authorizer)
 }
+
+func IsNoopAuthorizer(authorizer Authorizer) bool {
+	_, ok := authorizer.(*noopAuthorizer)
+	return ok
+}

--- a/common/config/loader.go
+++ b/common/config/loader.go
@@ -46,8 +46,8 @@ const (
 	// included a typo. This is deprecated and only here to support backwards
 	// compatibility.
 	EnvKeyAvailabilityZoneTypo = "TEMPORAL_AVAILABILTY_ZONE"
-	// EnvKeyNoAuth is the environment variable key for setting no authorizer
-	EnvKeyNoAuth = "TEMPORAL_NO_AUTH"
+	// EnvKeyAllowNoAuth is the environment variable key for setting no authorizer
+	EnvKeyAllowNoAuth = "TEMPORAL_ALLOW_NO_AUTH"
 )
 
 const (

--- a/common/config/loader.go
+++ b/common/config/loader.go
@@ -46,6 +46,8 @@ const (
 	// included a typo. This is deprecated and only here to support backwards
 	// compatibility.
 	EnvKeyAvailabilityZoneTypo = "TEMPORAL_AVAILABILTY_ZONE"
+	// EnvKeyNoAuth is the environment variable key for setting no authorizer
+	EnvKeyNoAuth = "TEMPORAL_NO_AUTH"
 )
 
 const (


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Creating the flag `--no-auth` to disable authorizer, ie., use the `noopAuthorizer` which allows everything. Also adding a warning log if no authorizer is set in config and the flag is missing.

<!-- Tell your future self why have you made these changes -->
**Why?**
Issue #3171: we want to make explicit that no authorizer is being used, and enforce in the future the use of an authorizer.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started temporal server in different ways using `--no-auth` flag and the env var `TEMPORAL_NO_AUTH`.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.