### PR TITLE
Shorten timeout used for recording task started

### DIFF
--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -120,6 +120,10 @@ func (task *internalTask) isForwarded() bool {
 	return task.forwardedFrom != ""
 }
 
+func (task *internalTask) isSyncMatchTask() bool {
+	return task.responseC != nil
+}
+
 func (task *internalTask) workflowExecution() *commonpb.WorkflowExecution {
 	switch {
 	case task.event != nil:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Use shorter timeout for recording workflow/activity task started.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Please check in-line comment in the PR. Main idea is currently is using long poll context timeout which is too long.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
