### PR TITLE
Use custom grpc resolver for frontend connections

### DIFF
--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -31,10 +31,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/pborman/uuid"
-
 	"go.temporal.io/server/api/adminservice/v1"
-	"go.temporal.io/server/common"
 )
 
 var _ adminservice.AdminServiceClient = (*clientImpl)(nil)
@@ -49,19 +46,19 @@ const (
 type clientImpl struct {
 	timeout      time.Duration
 	largeTimeout time.Duration
-	clients      common.ClientCache
+	client       adminservice.AdminServiceClient
 }
 
 // NewClient creates a new admin service gRPC client
 func NewClient(
 	timeout time.Duration,
 	largeTimeout time.Duration,
-	clients common.ClientCache,
+	client adminservice.AdminServiceClient,
 ) adminservice.AdminServiceClient {
 	return &clientImpl{
 		timeout:      timeout,
 		largeTimeout: largeTimeout,
-		clients:      clients,
+		client:       client,
 	}
 }
 
@@ -74,15 +71,4 @@ func (c *clientImpl) createContextWithLargeTimeout(parent context.Context) (cont
 		return context.WithTimeout(context.Background(), c.largeTimeout)
 	}
 	return context.WithTimeout(parent, c.largeTimeout)
-}
-
-func (c *clientImpl) getRandomClient() (adminservice.AdminServiceClient, error) {
-	// generate a random shard key to do load balancing
-	key := uuid.New()
-	client, err := c.clients.GetClientForKey(key)
-	if err != nil {
-		return nil, err
-	}
-
-	return client.(adminservice.AdminServiceClient), nil
 }

--- a/client/admin/client_gen.go
+++ b/client/admin/client_gen.go
@@ -38,13 +38,9 @@ func (c *clientImpl) AddOrUpdateRemoteCluster(
 	request *adminservice.AddOrUpdateRemoteClusterRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.AddOrUpdateRemoteClusterResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.AddOrUpdateRemoteCluster(ctx, request, opts...)
+	return c.client.AddOrUpdateRemoteCluster(ctx, request, opts...)
 }
 
 func (c *clientImpl) AddSearchAttributes(
@@ -52,13 +48,9 @@ func (c *clientImpl) AddSearchAttributes(
 	request *adminservice.AddSearchAttributesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.AddSearchAttributesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.AddSearchAttributes(ctx, request, opts...)
+	return c.client.AddSearchAttributes(ctx, request, opts...)
 }
 
 func (c *clientImpl) CloseShard(
@@ -66,13 +58,9 @@ func (c *clientImpl) CloseShard(
 	request *adminservice.CloseShardRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.CloseShardResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.CloseShard(ctx, request, opts...)
+	return c.client.CloseShard(ctx, request, opts...)
 }
 
 func (c *clientImpl) DeleteWorkflowExecution(
@@ -80,13 +68,9 @@ func (c *clientImpl) DeleteWorkflowExecution(
 	request *adminservice.DeleteWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.DeleteWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DeleteWorkflowExecution(ctx, request, opts...)
+	return c.client.DeleteWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) DescribeCluster(
@@ -94,13 +78,9 @@ func (c *clientImpl) DescribeCluster(
 	request *adminservice.DescribeClusterRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.DescribeClusterResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DescribeCluster(ctx, request, opts...)
+	return c.client.DescribeCluster(ctx, request, opts...)
 }
 
 func (c *clientImpl) DescribeHistoryHost(
@@ -108,13 +88,9 @@ func (c *clientImpl) DescribeHistoryHost(
 	request *adminservice.DescribeHistoryHostRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.DescribeHistoryHostResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DescribeHistoryHost(ctx, request, opts...)
+	return c.client.DescribeHistoryHost(ctx, request, opts...)
 }
 
 func (c *clientImpl) DescribeMutableState(
@@ -122,13 +98,9 @@ func (c *clientImpl) DescribeMutableState(
 	request *adminservice.DescribeMutableStateRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.DescribeMutableStateResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DescribeMutableState(ctx, request, opts...)
+	return c.client.DescribeMutableState(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetDLQMessages(
@@ -136,13 +108,9 @@ func (c *clientImpl) GetDLQMessages(
 	request *adminservice.GetDLQMessagesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.GetDLQMessagesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetDLQMessages(ctx, request, opts...)
+	return c.client.GetDLQMessages(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetDLQReplicationMessages(
@@ -150,13 +118,9 @@ func (c *clientImpl) GetDLQReplicationMessages(
 	request *adminservice.GetDLQReplicationMessagesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.GetDLQReplicationMessagesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetDLQReplicationMessages(ctx, request, opts...)
+	return c.client.GetDLQReplicationMessages(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetNamespaceReplicationMessages(
@@ -164,13 +128,9 @@ func (c *clientImpl) GetNamespaceReplicationMessages(
 	request *adminservice.GetNamespaceReplicationMessagesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.GetNamespaceReplicationMessagesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetNamespaceReplicationMessages(ctx, request, opts...)
+	return c.client.GetNamespaceReplicationMessages(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetReplicationMessages(
@@ -178,13 +138,9 @@ func (c *clientImpl) GetReplicationMessages(
 	request *adminservice.GetReplicationMessagesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.GetReplicationMessagesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContextWithLargeTimeout(ctx)
 	defer cancel()
-	return client.GetReplicationMessages(ctx, request, opts...)
+	return c.client.GetReplicationMessages(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetSearchAttributes(
@@ -192,13 +148,9 @@ func (c *clientImpl) GetSearchAttributes(
 	request *adminservice.GetSearchAttributesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.GetSearchAttributesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetSearchAttributes(ctx, request, opts...)
+	return c.client.GetSearchAttributes(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetShard(
@@ -206,13 +158,9 @@ func (c *clientImpl) GetShard(
 	request *adminservice.GetShardRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.GetShardResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetShard(ctx, request, opts...)
+	return c.client.GetShard(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetTaskQueueTasks(
@@ -220,13 +168,9 @@ func (c *clientImpl) GetTaskQueueTasks(
 	request *adminservice.GetTaskQueueTasksRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.GetTaskQueueTasksResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetTaskQueueTasks(ctx, request, opts...)
+	return c.client.GetTaskQueueTasks(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetWorkflowExecutionRawHistoryV2(
@@ -234,13 +178,9 @@ func (c *clientImpl) GetWorkflowExecutionRawHistoryV2(
 	request *adminservice.GetWorkflowExecutionRawHistoryV2Request,
 	opts ...grpc.CallOption,
 ) (*adminservice.GetWorkflowExecutionRawHistoryV2Response, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetWorkflowExecutionRawHistoryV2(ctx, request, opts...)
+	return c.client.GetWorkflowExecutionRawHistoryV2(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListClusterMembers(
@@ -248,13 +188,9 @@ func (c *clientImpl) ListClusterMembers(
 	request *adminservice.ListClusterMembersRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.ListClusterMembersResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListClusterMembers(ctx, request, opts...)
+	return c.client.ListClusterMembers(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListClusters(
@@ -262,13 +198,9 @@ func (c *clientImpl) ListClusters(
 	request *adminservice.ListClustersRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.ListClustersResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListClusters(ctx, request, opts...)
+	return c.client.ListClusters(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListHistoryTasks(
@@ -276,13 +208,9 @@ func (c *clientImpl) ListHistoryTasks(
 	request *adminservice.ListHistoryTasksRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.ListHistoryTasksResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListHistoryTasks(ctx, request, opts...)
+	return c.client.ListHistoryTasks(ctx, request, opts...)
 }
 
 func (c *clientImpl) MergeDLQMessages(
@@ -290,13 +218,9 @@ func (c *clientImpl) MergeDLQMessages(
 	request *adminservice.MergeDLQMessagesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.MergeDLQMessagesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.MergeDLQMessages(ctx, request, opts...)
+	return c.client.MergeDLQMessages(ctx, request, opts...)
 }
 
 func (c *clientImpl) PurgeDLQMessages(
@@ -304,13 +228,9 @@ func (c *clientImpl) PurgeDLQMessages(
 	request *adminservice.PurgeDLQMessagesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.PurgeDLQMessagesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.PurgeDLQMessages(ctx, request, opts...)
+	return c.client.PurgeDLQMessages(ctx, request, opts...)
 }
 
 func (c *clientImpl) ReapplyEvents(
@@ -318,13 +238,9 @@ func (c *clientImpl) ReapplyEvents(
 	request *adminservice.ReapplyEventsRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.ReapplyEventsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ReapplyEvents(ctx, request, opts...)
+	return c.client.ReapplyEvents(ctx, request, opts...)
 }
 
 func (c *clientImpl) RebuildMutableState(
@@ -332,13 +248,9 @@ func (c *clientImpl) RebuildMutableState(
 	request *adminservice.RebuildMutableStateRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.RebuildMutableStateResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RebuildMutableState(ctx, request, opts...)
+	return c.client.RebuildMutableState(ctx, request, opts...)
 }
 
 func (c *clientImpl) RefreshWorkflowTasks(
@@ -346,13 +258,9 @@ func (c *clientImpl) RefreshWorkflowTasks(
 	request *adminservice.RefreshWorkflowTasksRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.RefreshWorkflowTasksResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RefreshWorkflowTasks(ctx, request, opts...)
+	return c.client.RefreshWorkflowTasks(ctx, request, opts...)
 }
 
 func (c *clientImpl) RemoveRemoteCluster(
@@ -360,13 +268,9 @@ func (c *clientImpl) RemoveRemoteCluster(
 	request *adminservice.RemoveRemoteClusterRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.RemoveRemoteClusterResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RemoveRemoteCluster(ctx, request, opts...)
+	return c.client.RemoveRemoteCluster(ctx, request, opts...)
 }
 
 func (c *clientImpl) RemoveSearchAttributes(
@@ -374,13 +278,9 @@ func (c *clientImpl) RemoveSearchAttributes(
 	request *adminservice.RemoveSearchAttributesRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.RemoveSearchAttributesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RemoveSearchAttributes(ctx, request, opts...)
+	return c.client.RemoveSearchAttributes(ctx, request, opts...)
 }
 
 func (c *clientImpl) RemoveTask(
@@ -388,13 +288,9 @@ func (c *clientImpl) RemoveTask(
 	request *adminservice.RemoveTaskRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.RemoveTaskResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RemoveTask(ctx, request, opts...)
+	return c.client.RemoveTask(ctx, request, opts...)
 }
 
 func (c *clientImpl) ResendReplicationTasks(
@@ -402,11 +298,7 @@ func (c *clientImpl) ResendReplicationTasks(
 	request *adminservice.ResendReplicationTasksRequest,
 	opts ...grpc.CallOption,
 ) (*adminservice.ResendReplicationTasksResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ResendReplicationTasks(ctx, request, opts...)
+	return c.client.ResendReplicationTasks(ctx, request, opts...)
 }

--- a/client/clientBean.go
+++ b/client/clientBean.go
@@ -39,6 +39,8 @@ import (
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/client/admin"
 	"go.temporal.io/server/client/frontend"
+	"go.temporal.io/server/client/history"
+	"go.temporal.io/server/client/matching"
 	"go.temporal.io/server/common/cluster"
 )
 
@@ -73,7 +75,7 @@ type (
 // NewClientBean provides a collection of clients
 func NewClientBean(factory Factory, clusterMetadata cluster.Metadata) (Bean, error) {
 
-	historyClient, err := factory.NewHistoryClient()
+	historyClient, err := factory.NewHistoryClientWithTimeout(history.DefaultTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -275,7 +277,7 @@ func (h *clientBeanImpl) lazyInitMatchingClient(namespaceIDToName NamespaceIDToN
 	if cached := h.matchingClient.Load(); cached != nil {
 		return cached.(matchingservice.MatchingServiceClient), nil
 	}
-	client, err := h.factory.NewMatchingClient(namespaceIDToName)
+	client, err := h.factory.NewMatchingClientWithTimeout(namespaceIDToName, matching.DefaultTimeout, matching.DefaultLongPollTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/client/clientFactory_mock.go
+++ b/client/clientFactory_mock.go
@@ -67,21 +67,6 @@ func (m *MockFactory) EXPECT() *MockFactoryMockRecorder {
 	return m.recorder
 }
 
-// NewHistoryClient mocks base method.
-func (m *MockFactory) NewHistoryClient() (v11.HistoryServiceClient, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewHistoryClient")
-	ret0, _ := ret[0].(v11.HistoryServiceClient)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewHistoryClient indicates an expected call of NewHistoryClient.
-func (mr *MockFactoryMockRecorder) NewHistoryClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewHistoryClient", reflect.TypeOf((*MockFactory)(nil).NewHistoryClient))
-}
-
 // NewHistoryClientWithTimeout mocks base method.
 func (m *MockFactory) NewHistoryClientWithTimeout(timeout time.Duration) (v11.HistoryServiceClient, error) {
 	m.ctrl.T.Helper()
@@ -112,21 +97,6 @@ func (mr *MockFactoryMockRecorder) NewLocalAdminClientWithTimeout(timeout, large
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewLocalAdminClientWithTimeout", reflect.TypeOf((*MockFactory)(nil).NewLocalAdminClientWithTimeout), timeout, largeTimeout)
 }
 
-// NewLocalFrontendClient mocks base method.
-func (m *MockFactory) NewLocalFrontendClient() (v1.WorkflowServiceClient, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewLocalFrontendClient")
-	ret0, _ := ret[0].(v1.WorkflowServiceClient)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewLocalFrontendClient indicates an expected call of NewLocalFrontendClient.
-func (mr *MockFactoryMockRecorder) NewLocalFrontendClient() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewLocalFrontendClient", reflect.TypeOf((*MockFactory)(nil).NewLocalFrontendClient))
-}
-
 // NewLocalFrontendClientWithTimeout mocks base method.
 func (m *MockFactory) NewLocalFrontendClientWithTimeout(timeout, longPollTimeout time.Duration) (v1.WorkflowServiceClient, error) {
 	m.ctrl.T.Helper()
@@ -140,21 +110,6 @@ func (m *MockFactory) NewLocalFrontendClientWithTimeout(timeout, longPollTimeout
 func (mr *MockFactoryMockRecorder) NewLocalFrontendClientWithTimeout(timeout, longPollTimeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewLocalFrontendClientWithTimeout", reflect.TypeOf((*MockFactory)(nil).NewLocalFrontendClientWithTimeout), timeout, longPollTimeout)
-}
-
-// NewMatchingClient mocks base method.
-func (m *MockFactory) NewMatchingClient(namespaceIDToName NamespaceIDToNameFunc) (v12.MatchingServiceClient, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewMatchingClient", namespaceIDToName)
-	ret0, _ := ret[0].(v12.MatchingServiceClient)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewMatchingClient indicates an expected call of NewMatchingClient.
-func (mr *MockFactoryMockRecorder) NewMatchingClient(namespaceIDToName interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMatchingClient", reflect.TypeOf((*MockFactory)(nil).NewMatchingClient), namespaceIDToName)
 }
 
 // NewMatchingClientWithTimeout mocks base method.
@@ -184,21 +139,6 @@ func (m *MockFactory) NewRemoteAdminClientWithTimeout(rpcAddress string, timeout
 func (mr *MockFactoryMockRecorder) NewRemoteAdminClientWithTimeout(rpcAddress, timeout, largeTimeout interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRemoteAdminClientWithTimeout", reflect.TypeOf((*MockFactory)(nil).NewRemoteAdminClientWithTimeout), rpcAddress, timeout, largeTimeout)
-}
-
-// NewRemoteFrontendClient mocks base method.
-func (m *MockFactory) NewRemoteFrontendClient(rpcAddress string) (v1.WorkflowServiceClient, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewRemoteFrontendClient", rpcAddress)
-	ret0, _ := ret[0].(v1.WorkflowServiceClient)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// NewRemoteFrontendClient indicates an expected call of NewRemoteFrontendClient.
-func (mr *MockFactoryMockRecorder) NewRemoteFrontendClient(rpcAddress interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRemoteFrontendClient", reflect.TypeOf((*MockFactory)(nil).NewRemoteFrontendClient), rpcAddress)
 }
 
 // NewRemoteFrontendClientWithTimeout mocks base method.
@@ -250,57 +190,4 @@ func (m *MockFactoryProvider) NewFactory(rpcFactory common.RPCFactory, monitor m
 func (mr *MockFactoryProviderMockRecorder) NewFactory(rpcFactory, monitor, metricsClient, dc, numberOfHistoryShards, logger, throttledLogger interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewFactory", reflect.TypeOf((*MockFactoryProvider)(nil).NewFactory), rpcFactory, monitor, metricsClient, dc, numberOfHistoryShards, logger, throttledLogger)
-}
-
-// MockkeyResolver is a mock of keyResolver interface.
-type MockkeyResolver struct {
-	ctrl     *gomock.Controller
-	recorder *MockkeyResolverMockRecorder
-}
-
-// MockkeyResolverMockRecorder is the mock recorder for MockkeyResolver.
-type MockkeyResolverMockRecorder struct {
-	mock *MockkeyResolver
-}
-
-// NewMockkeyResolver creates a new mock instance.
-func NewMockkeyResolver(ctrl *gomock.Controller) *MockkeyResolver {
-	mock := &MockkeyResolver{ctrl: ctrl}
-	mock.recorder = &MockkeyResolverMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockkeyResolver) EXPECT() *MockkeyResolverMockRecorder {
-	return m.recorder
-}
-
-// GetAllAddresses mocks base method.
-func (m *MockkeyResolver) GetAllAddresses() ([]string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAllAddresses")
-	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetAllAddresses indicates an expected call of GetAllAddresses.
-func (mr *MockkeyResolverMockRecorder) GetAllAddresses() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAllAddresses", reflect.TypeOf((*MockkeyResolver)(nil).GetAllAddresses))
-}
-
-// Lookup mocks base method.
-func (m *MockkeyResolver) Lookup(key string) (string, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Lookup", key)
-	ret0, _ := ret[0].(string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Lookup indicates an expected call of Lookup.
-func (mr *MockkeyResolverMockRecorder) Lookup(key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lookup", reflect.TypeOf((*MockkeyResolver)(nil).Lookup), key)
 }

--- a/client/frontend/client_gen.go
+++ b/client/frontend/client_gen.go
@@ -38,13 +38,9 @@ func (c *clientImpl) CountWorkflowExecutions(
 	request *workflowservice.CountWorkflowExecutionsRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.CountWorkflowExecutionsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.CountWorkflowExecutions(ctx, request, opts...)
+	return c.client.CountWorkflowExecutions(ctx, request, opts...)
 }
 
 func (c *clientImpl) CreateSchedule(
@@ -52,13 +48,9 @@ func (c *clientImpl) CreateSchedule(
 	request *workflowservice.CreateScheduleRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.CreateScheduleResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.CreateSchedule(ctx, request, opts...)
+	return c.client.CreateSchedule(ctx, request, opts...)
 }
 
 func (c *clientImpl) DeleteSchedule(
@@ -66,13 +58,9 @@ func (c *clientImpl) DeleteSchedule(
 	request *workflowservice.DeleteScheduleRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.DeleteScheduleResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DeleteSchedule(ctx, request, opts...)
+	return c.client.DeleteSchedule(ctx, request, opts...)
 }
 
 func (c *clientImpl) DeprecateNamespace(
@@ -80,13 +68,9 @@ func (c *clientImpl) DeprecateNamespace(
 	request *workflowservice.DeprecateNamespaceRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.DeprecateNamespaceResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DeprecateNamespace(ctx, request, opts...)
+	return c.client.DeprecateNamespace(ctx, request, opts...)
 }
 
 func (c *clientImpl) DescribeBatchOperation(
@@ -94,13 +78,9 @@ func (c *clientImpl) DescribeBatchOperation(
 	request *workflowservice.DescribeBatchOperationRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeBatchOperationResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DescribeBatchOperation(ctx, request, opts...)
+	return c.client.DescribeBatchOperation(ctx, request, opts...)
 }
 
 func (c *clientImpl) DescribeNamespace(
@@ -108,13 +88,9 @@ func (c *clientImpl) DescribeNamespace(
 	request *workflowservice.DescribeNamespaceRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeNamespaceResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DescribeNamespace(ctx, request, opts...)
+	return c.client.DescribeNamespace(ctx, request, opts...)
 }
 
 func (c *clientImpl) DescribeSchedule(
@@ -122,13 +98,9 @@ func (c *clientImpl) DescribeSchedule(
 	request *workflowservice.DescribeScheduleRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeScheduleResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DescribeSchedule(ctx, request, opts...)
+	return c.client.DescribeSchedule(ctx, request, opts...)
 }
 
 func (c *clientImpl) DescribeTaskQueue(
@@ -136,13 +108,9 @@ func (c *clientImpl) DescribeTaskQueue(
 	request *workflowservice.DescribeTaskQueueRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeTaskQueueResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DescribeTaskQueue(ctx, request, opts...)
+	return c.client.DescribeTaskQueue(ctx, request, opts...)
 }
 
 func (c *clientImpl) DescribeWorkflowExecution(
@@ -150,13 +118,9 @@ func (c *clientImpl) DescribeWorkflowExecution(
 	request *workflowservice.DescribeWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DescribeWorkflowExecution(ctx, request, opts...)
+	return c.client.DescribeWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetClusterInfo(
@@ -164,13 +128,9 @@ func (c *clientImpl) GetClusterInfo(
 	request *workflowservice.GetClusterInfoRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetClusterInfoResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetClusterInfo(ctx, request, opts...)
+	return c.client.GetClusterInfo(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetSearchAttributes(
@@ -178,13 +138,9 @@ func (c *clientImpl) GetSearchAttributes(
 	request *workflowservice.GetSearchAttributesRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetSearchAttributesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetSearchAttributes(ctx, request, opts...)
+	return c.client.GetSearchAttributes(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetSystemInfo(
@@ -192,13 +148,9 @@ func (c *clientImpl) GetSystemInfo(
 	request *workflowservice.GetSystemInfoRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetSystemInfoResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetSystemInfo(ctx, request, opts...)
+	return c.client.GetSystemInfo(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetWorkerBuildIdOrdering(
@@ -206,13 +158,9 @@ func (c *clientImpl) GetWorkerBuildIdOrdering(
 	request *workflowservice.GetWorkerBuildIdOrderingRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetWorkerBuildIdOrderingResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetWorkerBuildIdOrdering(ctx, request, opts...)
+	return c.client.GetWorkerBuildIdOrdering(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetWorkflowExecutionHistory(
@@ -220,13 +168,9 @@ func (c *clientImpl) GetWorkflowExecutionHistory(
 	request *workflowservice.GetWorkflowExecutionHistoryRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetWorkflowExecutionHistoryResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetWorkflowExecutionHistory(ctx, request, opts...)
+	return c.client.GetWorkflowExecutionHistory(ctx, request, opts...)
 }
 
 func (c *clientImpl) GetWorkflowExecutionHistoryReverse(
@@ -234,13 +178,9 @@ func (c *clientImpl) GetWorkflowExecutionHistoryReverse(
 	request *workflowservice.GetWorkflowExecutionHistoryReverseRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.GetWorkflowExecutionHistoryReverseResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.GetWorkflowExecutionHistoryReverse(ctx, request, opts...)
+	return c.client.GetWorkflowExecutionHistoryReverse(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListArchivedWorkflowExecutions(
@@ -248,13 +188,9 @@ func (c *clientImpl) ListArchivedWorkflowExecutions(
 	request *workflowservice.ListArchivedWorkflowExecutionsRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createLongPollContext(ctx)
 	defer cancel()
-	return client.ListArchivedWorkflowExecutions(ctx, request, opts...)
+	return c.client.ListArchivedWorkflowExecutions(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListBatchOperations(
@@ -262,13 +198,9 @@ func (c *clientImpl) ListBatchOperations(
 	request *workflowservice.ListBatchOperationsRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListBatchOperationsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListBatchOperations(ctx, request, opts...)
+	return c.client.ListBatchOperations(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListClosedWorkflowExecutions(
@@ -276,13 +208,9 @@ func (c *clientImpl) ListClosedWorkflowExecutions(
 	request *workflowservice.ListClosedWorkflowExecutionsRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListClosedWorkflowExecutions(ctx, request, opts...)
+	return c.client.ListClosedWorkflowExecutions(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListNamespaces(
@@ -290,13 +218,9 @@ func (c *clientImpl) ListNamespaces(
 	request *workflowservice.ListNamespacesRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListNamespacesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListNamespaces(ctx, request, opts...)
+	return c.client.ListNamespaces(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListOpenWorkflowExecutions(
@@ -304,13 +228,9 @@ func (c *clientImpl) ListOpenWorkflowExecutions(
 	request *workflowservice.ListOpenWorkflowExecutionsRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListOpenWorkflowExecutions(ctx, request, opts...)
+	return c.client.ListOpenWorkflowExecutions(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListScheduleMatchingTimes(
@@ -318,13 +238,9 @@ func (c *clientImpl) ListScheduleMatchingTimes(
 	request *workflowservice.ListScheduleMatchingTimesRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListScheduleMatchingTimesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListScheduleMatchingTimes(ctx, request, opts...)
+	return c.client.ListScheduleMatchingTimes(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListSchedules(
@@ -332,13 +248,9 @@ func (c *clientImpl) ListSchedules(
 	request *workflowservice.ListSchedulesRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListSchedulesResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListSchedules(ctx, request, opts...)
+	return c.client.ListSchedules(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListTaskQueuePartitions(
@@ -346,13 +258,9 @@ func (c *clientImpl) ListTaskQueuePartitions(
 	request *workflowservice.ListTaskQueuePartitionsRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListTaskQueuePartitionsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListTaskQueuePartitions(ctx, request, opts...)
+	return c.client.ListTaskQueuePartitions(ctx, request, opts...)
 }
 
 func (c *clientImpl) ListWorkflowExecutions(
@@ -360,13 +268,9 @@ func (c *clientImpl) ListWorkflowExecutions(
 	request *workflowservice.ListWorkflowExecutionsRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ListWorkflowExecutionsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ListWorkflowExecutions(ctx, request, opts...)
+	return c.client.ListWorkflowExecutions(ctx, request, opts...)
 }
 
 func (c *clientImpl) PatchSchedule(
@@ -374,13 +278,9 @@ func (c *clientImpl) PatchSchedule(
 	request *workflowservice.PatchScheduleRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.PatchScheduleResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.PatchSchedule(ctx, request, opts...)
+	return c.client.PatchSchedule(ctx, request, opts...)
 }
 
 func (c *clientImpl) PollActivityTaskQueue(
@@ -388,13 +288,9 @@ func (c *clientImpl) PollActivityTaskQueue(
 	request *workflowservice.PollActivityTaskQueueRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.PollActivityTaskQueueResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createLongPollContext(ctx)
 	defer cancel()
-	return client.PollActivityTaskQueue(ctx, request, opts...)
+	return c.client.PollActivityTaskQueue(ctx, request, opts...)
 }
 
 func (c *clientImpl) PollWorkflowTaskQueue(
@@ -402,13 +298,9 @@ func (c *clientImpl) PollWorkflowTaskQueue(
 	request *workflowservice.PollWorkflowTaskQueueRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.PollWorkflowTaskQueueResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createLongPollContext(ctx)
 	defer cancel()
-	return client.PollWorkflowTaskQueue(ctx, request, opts...)
+	return c.client.PollWorkflowTaskQueue(ctx, request, opts...)
 }
 
 func (c *clientImpl) QueryWorkflow(
@@ -416,13 +308,9 @@ func (c *clientImpl) QueryWorkflow(
 	request *workflowservice.QueryWorkflowRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.QueryWorkflowResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.QueryWorkflow(ctx, request, opts...)
+	return c.client.QueryWorkflow(ctx, request, opts...)
 }
 
 func (c *clientImpl) RecordActivityTaskHeartbeat(
@@ -430,13 +318,9 @@ func (c *clientImpl) RecordActivityTaskHeartbeat(
 	request *workflowservice.RecordActivityTaskHeartbeatRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RecordActivityTaskHeartbeatResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RecordActivityTaskHeartbeat(ctx, request, opts...)
+	return c.client.RecordActivityTaskHeartbeat(ctx, request, opts...)
 }
 
 func (c *clientImpl) RecordActivityTaskHeartbeatById(
@@ -444,13 +328,9 @@ func (c *clientImpl) RecordActivityTaskHeartbeatById(
 	request *workflowservice.RecordActivityTaskHeartbeatByIdRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RecordActivityTaskHeartbeatByIdResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RecordActivityTaskHeartbeatById(ctx, request, opts...)
+	return c.client.RecordActivityTaskHeartbeatById(ctx, request, opts...)
 }
 
 func (c *clientImpl) RegisterNamespace(
@@ -458,13 +338,9 @@ func (c *clientImpl) RegisterNamespace(
 	request *workflowservice.RegisterNamespaceRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RegisterNamespaceResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RegisterNamespace(ctx, request, opts...)
+	return c.client.RegisterNamespace(ctx, request, opts...)
 }
 
 func (c *clientImpl) RequestCancelWorkflowExecution(
@@ -472,13 +348,9 @@ func (c *clientImpl) RequestCancelWorkflowExecution(
 	request *workflowservice.RequestCancelWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RequestCancelWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RequestCancelWorkflowExecution(ctx, request, opts...)
+	return c.client.RequestCancelWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) ResetStickyTaskQueue(
@@ -486,13 +358,9 @@ func (c *clientImpl) ResetStickyTaskQueue(
 	request *workflowservice.ResetStickyTaskQueueRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ResetStickyTaskQueueResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ResetStickyTaskQueue(ctx, request, opts...)
+	return c.client.ResetStickyTaskQueue(ctx, request, opts...)
 }
 
 func (c *clientImpl) ResetWorkflowExecution(
@@ -500,13 +368,9 @@ func (c *clientImpl) ResetWorkflowExecution(
 	request *workflowservice.ResetWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ResetWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ResetWorkflowExecution(ctx, request, opts...)
+	return c.client.ResetWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondActivityTaskCanceled(
@@ -514,13 +378,9 @@ func (c *clientImpl) RespondActivityTaskCanceled(
 	request *workflowservice.RespondActivityTaskCanceledRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskCanceledResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondActivityTaskCanceled(ctx, request, opts...)
+	return c.client.RespondActivityTaskCanceled(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondActivityTaskCanceledById(
@@ -528,13 +388,9 @@ func (c *clientImpl) RespondActivityTaskCanceledById(
 	request *workflowservice.RespondActivityTaskCanceledByIdRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskCanceledByIdResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondActivityTaskCanceledById(ctx, request, opts...)
+	return c.client.RespondActivityTaskCanceledById(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondActivityTaskCompleted(
@@ -542,13 +398,9 @@ func (c *clientImpl) RespondActivityTaskCompleted(
 	request *workflowservice.RespondActivityTaskCompletedRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskCompletedResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondActivityTaskCompleted(ctx, request, opts...)
+	return c.client.RespondActivityTaskCompleted(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondActivityTaskCompletedById(
@@ -556,13 +408,9 @@ func (c *clientImpl) RespondActivityTaskCompletedById(
 	request *workflowservice.RespondActivityTaskCompletedByIdRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskCompletedByIdResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondActivityTaskCompletedById(ctx, request, opts...)
+	return c.client.RespondActivityTaskCompletedById(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondActivityTaskFailed(
@@ -570,13 +418,9 @@ func (c *clientImpl) RespondActivityTaskFailed(
 	request *workflowservice.RespondActivityTaskFailedRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskFailedResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondActivityTaskFailed(ctx, request, opts...)
+	return c.client.RespondActivityTaskFailed(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondActivityTaskFailedById(
@@ -584,13 +428,9 @@ func (c *clientImpl) RespondActivityTaskFailedById(
 	request *workflowservice.RespondActivityTaskFailedByIdRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondActivityTaskFailedByIdResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondActivityTaskFailedById(ctx, request, opts...)
+	return c.client.RespondActivityTaskFailedById(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondQueryTaskCompleted(
@@ -598,13 +438,9 @@ func (c *clientImpl) RespondQueryTaskCompleted(
 	request *workflowservice.RespondQueryTaskCompletedRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondQueryTaskCompletedResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondQueryTaskCompleted(ctx, request, opts...)
+	return c.client.RespondQueryTaskCompleted(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondWorkflowTaskCompleted(
@@ -612,13 +448,9 @@ func (c *clientImpl) RespondWorkflowTaskCompleted(
 	request *workflowservice.RespondWorkflowTaskCompletedRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondWorkflowTaskCompletedResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondWorkflowTaskCompleted(ctx, request, opts...)
+	return c.client.RespondWorkflowTaskCompleted(ctx, request, opts...)
 }
 
 func (c *clientImpl) RespondWorkflowTaskFailed(
@@ -626,13 +458,9 @@ func (c *clientImpl) RespondWorkflowTaskFailed(
 	request *workflowservice.RespondWorkflowTaskFailedRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.RespondWorkflowTaskFailedResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.RespondWorkflowTaskFailed(ctx, request, opts...)
+	return c.client.RespondWorkflowTaskFailed(ctx, request, opts...)
 }
 
 func (c *clientImpl) ScanWorkflowExecutions(
@@ -640,13 +468,9 @@ func (c *clientImpl) ScanWorkflowExecutions(
 	request *workflowservice.ScanWorkflowExecutionsRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.ScanWorkflowExecutions(ctx, request, opts...)
+	return c.client.ScanWorkflowExecutions(ctx, request, opts...)
 }
 
 func (c *clientImpl) SignalWithStartWorkflowExecution(
@@ -654,13 +478,9 @@ func (c *clientImpl) SignalWithStartWorkflowExecution(
 	request *workflowservice.SignalWithStartWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.SignalWithStartWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.SignalWithStartWorkflowExecution(ctx, request, opts...)
+	return c.client.SignalWithStartWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) SignalWorkflowExecution(
@@ -668,13 +488,9 @@ func (c *clientImpl) SignalWorkflowExecution(
 	request *workflowservice.SignalWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.SignalWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.SignalWorkflowExecution(ctx, request, opts...)
+	return c.client.SignalWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) StartBatchOperation(
@@ -682,13 +498,9 @@ func (c *clientImpl) StartBatchOperation(
 	request *workflowservice.StartBatchOperationRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.StartBatchOperationResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.StartBatchOperation(ctx, request, opts...)
+	return c.client.StartBatchOperation(ctx, request, opts...)
 }
 
 func (c *clientImpl) StartWorkflowExecution(
@@ -696,13 +508,9 @@ func (c *clientImpl) StartWorkflowExecution(
 	request *workflowservice.StartWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.StartWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.StartWorkflowExecution(ctx, request, opts...)
+	return c.client.StartWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) StopBatchOperation(
@@ -710,13 +518,9 @@ func (c *clientImpl) StopBatchOperation(
 	request *workflowservice.StopBatchOperationRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.StopBatchOperationResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.StopBatchOperation(ctx, request, opts...)
+	return c.client.StopBatchOperation(ctx, request, opts...)
 }
 
 func (c *clientImpl) TerminateWorkflowExecution(
@@ -724,13 +528,9 @@ func (c *clientImpl) TerminateWorkflowExecution(
 	request *workflowservice.TerminateWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.TerminateWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.TerminateWorkflowExecution(ctx, request, opts...)
+	return c.client.TerminateWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) UpdateNamespace(
@@ -738,13 +538,9 @@ func (c *clientImpl) UpdateNamespace(
 	request *workflowservice.UpdateNamespaceRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.UpdateNamespaceResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.UpdateNamespace(ctx, request, opts...)
+	return c.client.UpdateNamespace(ctx, request, opts...)
 }
 
 func (c *clientImpl) UpdateSchedule(
@@ -752,13 +548,9 @@ func (c *clientImpl) UpdateSchedule(
 	request *workflowservice.UpdateScheduleRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.UpdateScheduleResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.UpdateSchedule(ctx, request, opts...)
+	return c.client.UpdateSchedule(ctx, request, opts...)
 }
 
 func (c *clientImpl) UpdateWorkerBuildIdOrdering(
@@ -766,13 +558,9 @@ func (c *clientImpl) UpdateWorkerBuildIdOrdering(
 	request *workflowservice.UpdateWorkerBuildIdOrderingRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.UpdateWorkerBuildIdOrderingResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.UpdateWorkerBuildIdOrdering(ctx, request, opts...)
+	return c.client.UpdateWorkerBuildIdOrdering(ctx, request, opts...)
 }
 
 func (c *clientImpl) UpdateWorkflow(
@@ -780,11 +568,7 @@ func (c *clientImpl) UpdateWorkflow(
 	request *workflowservice.UpdateWorkflowRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.UpdateWorkflowResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.UpdateWorkflow(ctx, request, opts...)
+	return c.client.UpdateWorkflow(ctx, request, opts...)
 }

--- a/cmd/tools/rpcwrappers/main.go
+++ b/cmd/tools/rpcwrappers/main.go
@@ -260,13 +260,9 @@ func (c *clientImpl) {{.Method}}(
 	request {{.RequestType}},
 	opts ...grpc.CallOption,
 ) ({{.ResponseType}}, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.create{{or .LongPoll ""}}Context{{or .WithLargeTimeout ""}}(ctx)
 	defer cancel()
-	return client.{{.Method}}(ctx, request, opts...)
+	return c.client.{{.Method}}(ctx, request, opts...)
 }
 `)
 }

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -418,10 +418,16 @@ type (
 		S3ForcePathStyle bool    `yaml:"s3ForcePathStyle"`
 	}
 
-	// PublicClient is config for connecting to temporal frontend
+	// PublicClient is config for internal nodes (history/matching/worker) connecting to
+	// temporal frontend. There are two methods of connecting:
+	// Explicit endpoint: Supply a host:port to connect to. This can resolve to multiple IPs,
+	// or a single IP that is a load-balancer.
+	// Membership resolver (new in 1.18): Leave this empty, and other nodes will use the
+	// membership service resolver to find the frontend.
+	// TODO: remove this and always use membership resolver
 	PublicClient struct {
 		// HostPort is the host port to connect on. Host can be DNS name
-		HostPort string `yaml:"hostPort" validate:"nonzero"`
+		HostPort string `yaml:"hostPort"`
 	}
 
 	// NamespaceDefaults is the default config for each namespace

--- a/common/membership/grpc_resolver.go
+++ b/common/membership/grpc_resolver.go
@@ -1,0 +1,146 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package membership
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"go.uber.org/fx"
+	"google.golang.org/grpc/resolver"
+)
+
+const GRPCResolverScheme = "membership"
+
+// Empty type used to enforce a dependency using fx so that we're guaranteed to have
+// initialized the global builder before we use it.
+type GRPCResolver struct{}
+
+var (
+	GRPCResolverModule = fx.Options(
+		fx.Provide(initializeBuilder),
+	)
+
+	globalGrpcBuilder grpcBuilder
+)
+
+func init() {
+	// This must be called in init to avoid race conditions. We don't have a Monitor yet so
+	// we'll leave it nil and initialize it with fx.
+	resolver.Register(&globalGrpcBuilder)
+}
+
+func initializeBuilder(monitor Monitor) GRPCResolver {
+	globalGrpcBuilder.monitor.Store(monitor)
+	return GRPCResolver{}
+}
+
+func (g *GRPCResolver) MakeURL(service string) string {
+	return fmt.Sprintf("%s://%s", GRPCResolverScheme, service)
+}
+
+type grpcBuilder struct {
+	monitor atomic.Value // Monitor
+}
+
+func (m *grpcBuilder) Scheme() string {
+	return GRPCResolverScheme
+}
+
+func (m *grpcBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions) (resolver.Resolver, error) {
+	monitor, ok := m.monitor.Load().(Monitor)
+	if !ok {
+		return nil, errors.New("grpc resolver has not been initialized yet")
+	}
+	// See MakeURL: the service ends up as the "host" of the parsed URL
+	service := target.URL.Host
+	r, err := monitor.GetResolver(service)
+	if err != nil {
+		return nil, err
+	}
+	resolver := &grpcResolver{
+		cc:       cc,
+		r:        r,
+		notifyCh: make(chan *ChangedEvent, 1),
+	}
+	resolver.start()
+	return resolver, nil
+}
+
+type grpcResolver struct {
+	cc       resolver.ClientConn
+	r        ServiceResolver
+	notifyCh chan *ChangedEvent
+	wg       sync.WaitGroup
+}
+
+func (m *grpcResolver) start() {
+	m.r.AddListener(fmt.Sprintf("%p", m), m.notifyCh)
+	m.wg.Add(1)
+	go m.listen()
+
+	// Try once to get address synchronously. If this fails, it's okay, we'll listen for
+	// changes and update the resolver later.
+	m.resolve()
+}
+
+func (m *grpcResolver) listen() {
+	for range m.notifyCh {
+		m.resolve()
+	}
+	m.wg.Done()
+}
+
+func (m *grpcResolver) resolve() {
+	members := m.r.Members()
+	if len(members) == 0 {
+		// grpc considers it an error if we report no addresses, and fails the connection eagerly.
+		// Instead, just poke membership and then wait until it notifies us.
+		m.r.RequestRefresh()
+		return
+	}
+	addresses := make([]resolver.Address, 0, len(members))
+	for _, hostInfo := range members {
+		addresses = append(addresses, resolver.Address{
+			Addr: hostInfo.GetAddress(),
+		})
+	}
+	m.cc.UpdateState(resolver.State{Addresses: addresses})
+}
+
+func (m *grpcResolver) ResolveNow(_ resolver.ResolveNowOptions) {
+	select {
+	case m.notifyCh <- nil:
+	default:
+	}
+}
+
+func (m *grpcResolver) Close() {
+	m.r.RemoveListener(fmt.Sprintf("%p", m))
+	close(m.notifyCh)
+	m.wg.Wait() // wait until listen() exits
+}

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -98,6 +98,8 @@ type (
 		MemberCount() int
 		// Members returns all host addresses in hashring for any particular role
 		Members() []*HostInfo
+		// Requests to rebuild the hash ring
+		RequestRefresh()
 	}
 
 	HostInfoProvider interface {

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -292,6 +292,18 @@ func (mr *MockServiceResolverMockRecorder) RemoveListener(name interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveListener", reflect.TypeOf((*MockServiceResolver)(nil).RemoveListener), name)
 }
 
+// RequestRefresh mocks base method.
+func (m *MockServiceResolver) RequestRefresh() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RequestRefresh")
+}
+
+// RequestRefresh indicates an expected call of RequestRefresh.
+func (mr *MockServiceResolverMockRecorder) RequestRefresh() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RequestRefresh", reflect.TypeOf((*MockServiceResolver)(nil).RequestRefresh))
+}
+
 // MockHostInfoProvider is a mock of HostInfoProvider interface.
 type MockHostInfoProvider struct {
 	ctrl     *gomock.Controller

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -149,6 +149,13 @@ func (r *ringpopServiceResolver) Stop() {
 	}
 }
 
+func (r *ringpopServiceResolver) RequestRefresh() {
+	select {
+	case r.refreshChan <- struct{}{}:
+	default:
+	}
+}
+
 // Lookup finds the host in the ring responsible for serving the given key
 func (r *ringpopServiceResolver) Lookup(
 	key string,
@@ -156,10 +163,7 @@ func (r *ringpopServiceResolver) Lookup(
 
 	addr, found := r.ring().Lookup(key)
 	if !found {
-		select {
-		case r.refreshChan <- struct{}{}:
-		default:
-		}
+		r.RequestRefresh()
 		return nil, ErrInsufficientHosts
 	}
 

--- a/common/rpc.go
+++ b/common/rpc.go
@@ -37,7 +37,7 @@ type (
 		GetInternodeGRPCServerOptions() ([]grpc.ServerOption, error)
 		GetGRPCListener() net.Listener
 		CreateRemoteFrontendGRPCConnection(rpcAddress string) *grpc.ClientConn
-		CreateLocalFrontendGRPCConnection(rpcAddress string) *grpc.ClientConn
+		CreateLocalFrontendGRPCConnection() *grpc.ClientConn
 		CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn
 	}
 )

--- a/common/rpc/test/rpc_localstore_tls_test.go
+++ b/common/rpc/test/rpc_localstore_tls_test.go
@@ -51,7 +51,10 @@ const (
 	frontendServerCertSerialNumber  = 150
 )
 
-var noExtraInterceptors = []grpc.UnaryClientInterceptor{}
+var (
+	frontendURL         = "dummy://" // not needed for test
+	noExtraInterceptors = []grpc.UnaryClientInterceptor{}
+)
 
 type localStoreRPCSuite struct {
 	*require.Assertions
@@ -133,7 +136,7 @@ func (s *localStoreRPCSuite) SetupSuite() {
 
 	provider, err := encryption.NewTLSConfigProviderFromConfig(serverCfgInsecure.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	insecureFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	insecureFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(insecureFactory)
 	s.insecureRPCFactory = i(insecureFactory)
 
@@ -341,22 +344,22 @@ func (s *localStoreRPCSuite) setupFrontend() {
 
 	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	frontendMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	frontendMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(frontendMutualTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	frontendServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	frontendServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(frontendServerTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSSystemWorker.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	frontendSystemWorkerMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	frontendSystemWorkerMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(frontendSystemWorkerMutualTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSWithRefresh.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	frontendMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	frontendMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(frontendMutualTLSRefreshFactory)
 
 	s.frontendMutualTLSRPCFactory = f(frontendMutualTLSFactory)
@@ -371,7 +374,7 @@ func (s *localStoreRPCSuite) setupFrontend() {
 		s.dynamicCACertPool,
 		s.wrongCACertPool)
 	s.NoError(err)
-	dynamicServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, s.dynamicConfigProvider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	dynamicServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, s.dynamicConfigProvider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.frontendDynamicTLSFactory = f(dynamicServerTLSFactory)
 	s.internodeDynamicTLSFactory = i(dynamicServerTLSFactory)
 
@@ -379,13 +382,13 @@ func (s *localStoreRPCSuite) setupFrontend() {
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreRootCAForceTLS.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	frontendRootCAForceTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	frontendRootCAForceTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(frontendServerTLSFactory)
 	s.frontendConfigRootCAForceTLSFactory = f(frontendRootCAForceTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSRemoteCluster.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	remoteClusterMutualTLSRPCFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	remoteClusterMutualTLSRPCFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(remoteClusterMutualTLSRPCFactory)
 	s.remoteClusterMutualTLSRPCFactory = r(remoteClusterMutualTLSRPCFactory)
 }
@@ -421,22 +424,22 @@ func (s *localStoreRPCSuite) setupInternode() {
 
 	provider, err := encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLS.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	internodeMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	internodeMutualTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(internodeMutualTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreServerTLS.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	internodeServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	internodeServerTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(internodeServerTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreAltMutualTLS.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	internodeMutualAltTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	internodeMutualAltTLSFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(internodeMutualAltTLSFactory)
 
 	provider, err = encryption.NewTLSConfigProviderFromConfig(localStoreMutualTLSWithRefresh.TLS, metrics.NoopClient, s.logger, nil)
 	s.NoError(err)
-	internodeMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), noExtraInterceptors)
+	internodeMutualTLSRefreshFactory := rpc.NewFactory(rpcTestCfgDefault, "tester", s.logger, provider, dynamicconfig.NewNoopCollection(), frontendURL, noExtraInterceptors)
 	s.NotNil(internodeMutualTLSRefreshFactory)
 
 	s.internodeMutualTLSRPCFactory = i(internodeMutualTLSFactory)

--- a/host/simpleServiceResolver.go
+++ b/host/simpleServiceResolver.go
@@ -66,3 +66,6 @@ func (s *simpleResolver) MemberCount() int {
 func (s *simpleResolver) Members() []*membership.HostInfo {
 	return s.hosts
 }
+
+func (s *simpleResolver) RequestRefresh() {
+}

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -104,10 +104,8 @@ func ConfigProvider(
 	)
 }
 
-func FrontendClientProvider(
-	clientFactory client.Factory,
-) (workflowservice.WorkflowServiceClient, error) {
-	return clientFactory.NewLocalFrontendClient()
+func FrontendClientProvider(bean client.Bean) workflowservice.WorkflowServiceClient {
+	return bean.GetFrontendClient()
 }
 
 func VisibilityManagerProvider(


### PR DESCRIPTION
**What changed?**
After splitting frontend rpc connections into local/remote, we can go further and push resolution and load balancing into grpc using a custom resolver. This lets us use the same mechanism for the SDK clients also.

This registers a grpc resolver using the `membership:` scheme, which takes a service name (`frontend`) and uses the service resolver (ringpop) to resolve it to a set of host+ports.

By default the existing `publicClient.hostPort` setting is used. If that setting is removed, then the new membership mechanism will be used.

**Why?**
- simplified configuration: don't need to configure an endpoint for frontend.
- consistency: internal connections to frontend use membership like connections to matching/history; sdk clients uses same mechanism as other clients.

**How did you test it?**
local tests, will do a test in production

**Potential risks**
grpc resolver/load balancer might behave differently from existing mechanisms, could be bad interactions with some TLS configs