### PR TITLE
Enable schedules by default and add integration tests

### DIFF
--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -41,8 +41,6 @@ var (
 	staticOverrides = map[dynamicconfig.Key]any{
 		dynamicconfig.FrontendRPS:                                   3000,
 		dynamicconfig.FrontendESIndexMaxResultWindow:                defaultTestValueOfESIndexMaxResultWindow,
-		dynamicconfig.MatchingNumTaskqueueWritePartitions:           3,
-		dynamicconfig.MatchingNumTaskqueueReadPartitions:            3,
 		dynamicconfig.TimerProcessorHistoryArchivalSizeLimit:        5 * 1024,
 		dynamicconfig.ReplicationTaskProcessorErrorRetryMaxAttempts: 1,
 		dynamicconfig.AdvancedVisibilityWritingMode:                 visibility.AdvancedVisibilityWritingModeOff,

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -702,7 +702,7 @@ func (c *temporalImpl) GetExecutionManager() persistence.ExecutionManager {
 func (c *temporalImpl) overrideHistoryDynamicConfig(client *dcClient) {
 	client.OverrideValue(dynamicconfig.ReplicationTaskProcessorStartWait, time.Nanosecond)
 
-	if c.workerConfig.EnableIndexer {
+	if c.esConfig != nil {
 		client.OverrideValue(dynamicconfig.AdvancedVisibilityWritingMode, visibility.AdvancedVisibilityWritingModeDual)
 	}
 	if c.historyConfig.HistoryCountLimitWarn != 0 {

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -198,7 +198,7 @@ func NewTemporal(params *TemporalParams) *temporalImpl {
 }
 
 func (c *temporalImpl) enableWorker() bool {
-	return c.workerConfig.EnableArchiver || c.workerConfig.EnableReplicator
+	return c.workerConfig.StartWorkerAnyway || c.workerConfig.EnableArchiver || c.workerConfig.EnableReplicator
 }
 
 func (c *temporalImpl) Start() error {

--- a/host/schedule_test.go
+++ b/host/schedule_test.go
@@ -266,7 +266,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 		s.False(entry.Info.Paused)
 		s.Equal(describeResp.Info.RecentActions, entry.Info.RecentActions) // 2 is below the limit where list entry might be cut off
 		return true
-	}, 3*time.Second, 200*time.Millisecond)
+	}, 10*time.Second, 1*time.Second)
 
 	// list workflows
 
@@ -397,7 +397,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 		})
 		s.NoError(err)
 		return len(listResp.Schedules) == 0
-	}, 3*time.Second, 200*time.Millisecond)
+	}, 10*time.Second, 1*time.Second)
 }
 
 func (s *scheduleIntegrationSuite) TestInput() {

--- a/host/schedule_test.go
+++ b/host/schedule_test.go
@@ -353,7 +353,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	s.NoError(err)
 
 	time.Sleep(3*time.Second + 100*time.Millisecond)
-	s.Equal(1, atomic.LoadInt32(&runs2), "has not run again")
+	s.EqualValues(1, atomic.LoadInt32(&runs2), "has not run again")
 
 	describeResp, err = s.engine.DescribeSchedule(NewContext(), &workflowservice.DescribeScheduleRequest{
 		Namespace:  s.namespace,

--- a/host/schedule_test.go
+++ b/host/schedule_test.go
@@ -25,17 +25,27 @@
 package host
 
 import (
+	"flag"
+	"fmt"
+	"testing"
 	"time"
 
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	schedulepb "go.temporal.io/api/schedule/v1"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payload"
+	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
@@ -51,6 +61,9 @@ create schedule,
 		check that it starts a workflow again,
 		describe it again,
 		list it again,
+	pause
+		check pause in describe
+		check pause search attr
 	terminate it
 
 create schedule with bad schedule spec, check for eager error
@@ -77,7 +90,64 @@ describe updates running workflows:
 	describe again and see it stopped
 
 */
-func (s *clientIntegrationSuite) TestScheduleBase() {
+
+type (
+	scheduleIntegrationSuite struct {
+		*require.Assertions
+		IntegrationBase
+		hostPort  string
+		sdkClient sdkclient.Client
+		worker    worker.Worker
+		esClient  esclient.IntegrationTestsClient
+		taskQueue string
+	}
+)
+
+func TestScheduleIntegrationSuite(t *testing.T) {
+	flag.Parse()
+	suite.Run(t, new(scheduleIntegrationSuite))
+}
+
+func (s *scheduleIntegrationSuite) SetupSuite() {
+	s.setupSuite("testdata/schedule_integration_test_cluster.yaml")
+	s.hostPort = "127.0.0.1:7134"
+	if TestFlags.FrontendAddr != "" {
+		s.hostPort = TestFlags.FrontendAddr
+	}
+	// ES setup so we can test search attributes
+	s.esClient = CreateESClient(&s.Suite, s.testClusterConfig.ESConfig, s.Logger)
+	PutIndexTemplate(&s.Suite, s.esClient, fmt.Sprintf("testdata/es_%s_index_template.json", s.testClusterConfig.ESConfig.Version), "test-visibility-template")
+	CreateIndex(&s.Suite, s.esClient, s.testClusterConfig.ESConfig.GetVisibilityIndex())
+}
+
+func (s *scheduleIntegrationSuite) TearDownSuite() {
+	s.tearDownSuite()
+	DeleteIndex(&s.Suite, s.esClient, s.testClusterConfig.ESConfig.GetVisibilityIndex())
+}
+
+func (s *scheduleIntegrationSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+	sdkClient, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  s.hostPort,
+		Namespace: s.namespace,
+	})
+	if err != nil {
+		s.Logger.Fatal("Error when creating SDK client", tag.Error(err))
+	}
+	s.sdkClient = sdkClient
+	s.taskQueue = s.randomizeStr("tq")
+	s.worker = worker.New(s.sdkClient, s.taskQueue, worker.Options{})
+	if err := s.worker.Start(); err != nil {
+		s.Logger.Fatal("Error when starting worker", tag.Error(err))
+	}
+}
+
+func (s *scheduleIntegrationSuite) TearDownTest() {
+	s.worker.Stop()
+	s.sdkClient.Close()
+}
+
+func (s *scheduleIntegrationSuite) TestScheduleBase() {
 	sid := "sched-test-base"
 	wid := "sched-test-base-wf"
 	wt := "sched-test-base-wt"
@@ -134,13 +204,60 @@ func (s *clientIntegrationSuite) TestScheduleBase() {
 	}
 	s.worker.RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
 
+	// create
+
+	createTime := time.Now()
 	_, err := s.engine.CreateSchedule(NewContext(), req)
 	s.NoError(err)
 
-	time.Sleep(7 * time.Second)
-	// should be two or three runs so far
-	s.GreaterOrEqual(runs, 2)
-	s.LessOrEqual(runs, 3)
+	// sleep until we see two runs
+	s.Eventually(func() bool { return runs == 2 }, 8*time.Second, 200*time.Millisecond)
+
+	// describe
+
+	describeResp, err := s.engine.DescribeSchedule(NewContext(), &workflowservice.DescribeScheduleRequest{
+		Namespace:  s.namespace,
+		ScheduleId: sid,
+	})
+	s.NoError(err)
+
+	s.Equal(req.Schedule.Spec, describeResp.Schedule.Spec)
+	s.Equal(enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, describeResp.Schedule.Policies.OverlapPolicy) // set to default value
+
+	s.Equal(req.SearchAttributes.IndexedFields["CustomKeywordField"].Data, describeResp.SearchAttributes.IndexedFields["CustomKeywordField"].Data)
+	s.Equal(req.Memo.Fields["schedmemo1"].Data, describeResp.Memo.Fields["schedmemo1"].Data)
+
+	s.DurationNear(describeResp.Info.CreateTime.Sub(createTime), 0, 500*time.Millisecond)
+	s.EqualValues(2, describeResp.Info.ActionCount)
+	s.EqualValues(0, describeResp.Info.MissedCatchupWindow)
+	s.EqualValues(0, describeResp.Info.OverlapSkipped)
+	s.LessOrEqual(len(describeResp.Info.RunningWorkflows), 1) // should be short-lived but we might catch one if we get unlucky
+	s.EqualValues(2, len(describeResp.Info.RecentActions))
+
+	// list
+
+	s.Eventually(func() bool {
+		listResp, err := s.engine.ListSchedules(NewContext(), &workflowservice.ListSchedulesRequest{
+			Namespace:       s.namespace,
+			MaximumPageSize: 5,
+		})
+		if err != nil || len(listResp.Schedules) != 1 || len(listResp.Schedules[0].Info.RecentActions) < 2 {
+			return false
+		}
+		s.NoError(err)
+		entry := listResp.Schedules[0]
+		s.Equal(sid, entry.ScheduleId)
+		s.Equalf(req.SearchAttributes.IndexedFields["CustomKeywordField"].Data, entry.SearchAttributes.GetIndexedFields()["CustomKeywordField"].GetData(),
+			"missing search attributes, value is %#v", entry.SearchAttributes)
+		s.Equal(req.Memo.Fields["schedmemo1"].Data, entry.Memo.Fields["schedmemo1"].Data)
+		s.Equal(req.Schedule.Spec, entry.Info.Spec)
+		s.Equal(wt, entry.Info.WorkflowType.Name)
+		s.False(entry.Info.Paused)
+		s.Equal(describeResp.Info.RecentActions, entry.Info.RecentActions) // 2-3 is below the limit where list entry might be cut off
+		return true
+	}, 3*time.Second, 200*time.Millisecond)
+
+	// update
 
 	_, err = s.engine.DeleteSchedule(NewContext(), &workflowservice.DeleteScheduleRequest{
 		Namespace:  s.namespace,

--- a/host/schedule_test.go
+++ b/host/schedule_test.go
@@ -1,0 +1,151 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package host
+
+import (
+	"time"
+
+	"github.com/pborman/uuid"
+	commonpb "go.temporal.io/api/common/v1"
+	schedulepb "go.temporal.io/api/schedule/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/sdk/workflow"
+
+	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/primitives/timestamp"
+)
+
+/*
+stuff to test:
+
+create schedule,
+	check that it starts a workflow,
+	check that it starts _another_ workflow (can check status w/frontend),
+	describe it,
+	list it,
+	update it,
+		check that it starts a workflow again,
+		describe it again,
+		list it again,
+	terminate it
+
+create schedule with bad schedule spec, check for eager error
+
+use some dataconverter for input, check that it starts okay
+
+check last completion result and last error
+
+check: what happens to a lp watcher on worker restart?
+	get it in a state where it's waiting for a wf to exit, say with bufferone
+	restart the worker
+	terminate the wf
+	check that new one starts immediately
+
+search attribute mapping:
+	create, update, search
+
+describe updates running workflows:
+	@every 30s
+	workflow has 2s timeout
+	let it start
+	describe and see it running
+	let it time out
+	describe again and see it stopped
+
+*/
+func (s *clientIntegrationSuite) TestScheduleBase() {
+	sid := "sched-test-base"
+	wid := "sched-test-base-wf"
+	wt := "sched-test-base-wt"
+	req := &workflowservice.CreateScheduleRequest{
+		Namespace:  s.namespace,
+		ScheduleId: sid,
+		Schedule: &schedulepb.Schedule{
+			Spec: &schedulepb.ScheduleSpec{
+				Interval: []*schedulepb.IntervalSpec{
+					{Interval: timestamp.DurationPtr(3 * time.Second)},
+				},
+			},
+			Action: &schedulepb.ScheduleAction{
+				Action: &schedulepb.ScheduleAction_StartWorkflow{
+					StartWorkflow: &workflowpb.NewWorkflowExecutionInfo{
+						WorkflowId:   wid,
+						WorkflowType: &commonpb.WorkflowType{Name: wt},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: s.taskQueue},
+						Memo: &commonpb.Memo{
+							Fields: map[string]*commonpb.Payload{
+								"wfmemo1": payload.EncodeString("workflow memo"),
+							},
+						},
+						SearchAttributes: &commonpb.SearchAttributes{
+							IndexedFields: map[string]*commonpb.Payload{
+								"CustomKeywordField": payload.EncodeString("workflow value"),
+							},
+						},
+					},
+				},
+			},
+		},
+		Identity:  "test",
+		RequestId: uuid.New(),
+		Memo: &commonpb.Memo{
+			Fields: map[string]*commonpb.Payload{
+				"schedmemo1": payload.EncodeString("schedule memo"),
+			},
+		},
+		SearchAttributes: &commonpb.SearchAttributes{
+			IndexedFields: map[string]*commonpb.Payload{
+				"CustomKeywordField": payload.EncodeString("schedule value"),
+			},
+		},
+	}
+
+	runs := 0
+	workflowFn := func(ctx workflow.Context) error {
+		workflow.SideEffect(ctx, func(ctx workflow.Context) any {
+			runs++
+			return nil
+		})
+		return nil
+	}
+	s.worker.RegisterWorkflowWithOptions(workflowFn, workflow.RegisterOptions{Name: wt})
+
+	_, err := s.engine.CreateSchedule(NewContext(), req)
+	s.NoError(err)
+
+	time.Sleep(7 * time.Second)
+	// should be two or three runs so far
+	s.GreaterOrEqual(runs, 2)
+	s.LessOrEqual(runs, 3)
+
+	_, err = s.engine.DeleteSchedule(NewContext(), &workflowservice.DeleteScheduleRequest{
+		Namespace:  s.namespace,
+		ScheduleId: sid,
+		Identity:   "test",
+	})
+	s.NoError(err)
+}

--- a/host/test_cluster.go
+++ b/host/test_cluster.go
@@ -89,9 +89,10 @@ type (
 
 	// WorkerConfig is the config for enabling/disabling Temporal worker
 	WorkerConfig struct {
-		EnableArchiver   bool
-		EnableIndexer    bool
-		EnableReplicator bool
+		EnableArchiver    bool
+		EnableIndexer     bool
+		EnableReplicator  bool
+		StartWorkerAnyway bool
 	}
 )
 

--- a/host/test_cluster.go
+++ b/host/test_cluster.go
@@ -90,7 +90,6 @@ type (
 	// WorkerConfig is the config for enabling/disabling Temporal worker
 	WorkerConfig struct {
 		EnableArchiver    bool
-		EnableIndexer     bool
 		EnableReplicator  bool
 		StartWorkerAnyway bool
 	}
@@ -161,7 +160,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	var (
 		esClient esclient.Client
 	)
-	if options.WorkerConfig.EnableIndexer {
+	if options.ESConfig != nil {
 		var err error
 		esClient, err = esclient.NewClient(options.ESConfig, nil, logger)
 		if err != nil {

--- a/host/testdata/clientintegrationtestcluster.yaml
+++ b/host/testdata/clientintegrationtestcluster.yaml
@@ -6,5 +6,4 @@ historyconfig:
 workerconfig:
   enablearchiver: false
   enablereplicator: false
-  enableindexer: false
   startworkeranyway: true

--- a/host/testdata/clientintegrationtestcluster.yaml
+++ b/host/testdata/clientintegrationtestcluster.yaml
@@ -7,3 +7,4 @@ workerconfig:
   enablearchiver: false
   enablereplicator: false
   enableindexer: false
+  startworkeranyway: true

--- a/host/testdata/es_v7_index_template.json
+++ b/host/testdata/es_v7_index_template.json
@@ -15,6 +15,9 @@
       "NamespaceId": {
         "type": "keyword"
       },
+      "TemporalNamespaceDivision": {
+        "type": "keyword"
+      },
       "WorkflowId": {
         "type": "keyword"
       },
@@ -44,6 +47,15 @@
       },
       "TemporalChangeVersion": {
         "type": "keyword"
+      },
+      "TemporalScheduledStartTime": {
+        "type": "date_nanos"
+      },
+      "TemporalScheduledById": {
+        "type": "keyword"
+      },
+      "TemporalSchedulePaused": {
+        "type": "boolean"
       },
       "CustomTextField": {
         "type": "text"

--- a/host/testdata/es_v8_index_template.json
+++ b/host/testdata/es_v8_index_template.json
@@ -15,6 +15,9 @@
       "NamespaceId": {
         "type": "keyword"
       },
+      "TemporalNamespaceDivision": {
+        "type": "keyword"
+      },
       "WorkflowId": {
         "type": "keyword"
       },
@@ -44,6 +47,15 @@
       },
       "TemporalChangeVersion": {
         "type": "keyword"
+      },
+      "TemporalScheduledStartTime": {
+        "type": "date_nanos"
+      },
+      "TemporalScheduledById": {
+        "type": "keyword"
+      },
+      "TemporalSchedulePaused": {
+        "type": "boolean"
       },
       "CustomTextField": {
         "type": "text"

--- a/host/testdata/integration_elasticsearch_cluster.yaml
+++ b/host/testdata/integration_elasticsearch_cluster.yaml
@@ -6,7 +6,6 @@ historyconfig:
 workerconfig:
   enablearchiver: false
   enablereplicator: false
-  enableindexer: true
 esconfig:
   version: "${ES_VERSION}"
   url:

--- a/host/testdata/integration_namespace_cluster.yaml
+++ b/host/testdata/integration_namespace_cluster.yaml
@@ -7,7 +7,6 @@ workerconfig:
   enablearchiver: false
   # required to enable worker
   enablereplicator: true
-  enableindexer: true
 esconfig:
   version: "${ES_VERSION}"
   url:

--- a/host/testdata/integration_sizelimit_cluster.yaml
+++ b/host/testdata/integration_sizelimit_cluster.yaml
@@ -8,4 +8,3 @@ historyconfig:
 workerconfig:
   enablearchiver: false
   enablereplicator: false
-  enableindexer: false

--- a/host/testdata/integration_test_cluster.yaml
+++ b/host/testdata/integration_test_cluster.yaml
@@ -6,4 +6,3 @@ historyconfig:
 workerconfig:
   enablearchiver: true
   enablereplicator: true
-  enableindexer: false

--- a/host/testdata/ndc_integration_test_clusters.yaml
+++ b/host/testdata/ndc_integration_test_clusters.yaml
@@ -25,7 +25,6 @@
   workerconfig:
     enablearchiver: false
     enablereplicator: true
-    enableindexer: false
   clusterno: 0
   historyconfig:
     numhistoryshards: 1
@@ -57,7 +56,6 @@
   workerconfig:
     enablearchiver: false
     enablereplicator: true
-    enableindexer: false
   clusterno: 1
   historyconfig:
     numhistoryshards: 1
@@ -89,7 +87,6 @@
   workerconfig:
     enablearchiver: false
     enablereplicator: true
-    enableindexer: false
   clusterno: 2
   historyconfig:
     numhistoryshards: 1

--- a/host/testdata/schedule_integration_test_cluster.yaml
+++ b/host/testdata/schedule_integration_test_cluster.yaml
@@ -1,0 +1,15 @@
+enablearchival: false
+clusterno: 0
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+workerconfig:
+  startworkeranyway: true
+  enableindexer: true
+esconfig:
+  version: "${ES_VERSION}"
+  url:
+    scheme: "http"
+    host: "${ES_SEEDS}:9200"
+  indices:
+    visibility: test-visibility-

--- a/host/testdata/schedule_integration_test_cluster.yaml
+++ b/host/testdata/schedule_integration_test_cluster.yaml
@@ -5,7 +5,6 @@ historyconfig:
   numhistoryhosts: 1
 workerconfig:
   startworkeranyway: true
-  enableindexer: true
 esconfig:
   version: "${ES_VERSION}"
   url:

--- a/host/testdata/xdc_integration_es_clusters.yaml
+++ b/host/testdata/xdc_integration_es_clusters.yaml
@@ -15,7 +15,6 @@
   workerconfig:
     enablearchiver: false
     enablereplicator: true
-    enableindexer: true
   clusterno: 2
   historyconfig:
     numhistoryshards: 1
@@ -45,7 +44,6 @@
   workerconfig:
     enablearchiver: false
     enablereplicator: true
-    enableindexer: true
   clusterno: 3
   historyconfig:
     numhistoryshards: 1

--- a/host/testdata/xdc_integration_test_clusters.yaml
+++ b/host/testdata/xdc_integration_test_clusters.yaml
@@ -15,7 +15,6 @@
   workerconfig:
     enablearchiver: false
     enablereplicator: true
-    enableindexer: false
   clusterno: 0
   historyconfig:
     numhistoryshards: 1
@@ -37,7 +36,6 @@
   workerconfig:
     enablearchiver: false
     enablereplicator: true
-    enableindexer: false
   clusterno: 1
   historyconfig:
     numhistoryshards: 1

--- a/host/versioning_test.go
+++ b/host/versioning_test.go
@@ -235,10 +235,8 @@ func (s *versioningIntegSuite) TestVersioningChangesPropagatedToSubPartitions() 
 	s.Equal("foo", res2.CurrentDefault.GetVersion().GetWorkerBuildId())
 
 	// Verify partitions have data
-	partCountRaw, ok := s.testCluster.GetHost().dcClient.getRawValue(
-		dynamicconfig.MatchingNumTaskqueueReadPartitions)
-	s.True(ok)
-	partCount := partCountRaw.(int)
+	dcCol := dynamicconfig.NewCollection(s.testCluster.GetHost().dcClient, s.Logger)
+	partCount := dcCol.GetTaskQueuePartitionsProperty(dynamicconfig.MatchingNumTaskqueueReadPartitions)(s.namespace, tq, 0)
 	if partCount <= 1 {
 		s.T().Skip("This test makes no sense unless there are >1 partitions")
 	}

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -210,7 +210,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int32, esIndexName
 		DeleteNamespaceDeleteActivityRPS:                    dc.GetIntProperty(dynamicconfig.DeleteNamespaceDeleteActivityRPS, 100),
 		DeleteNamespaceConcurrentDeleteExecutionsActivities: dc.GetIntProperty(dynamicconfig.DeleteNamespaceConcurrentDeleteExecutionsActivities, 4),
 
-		EnableSchedules: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableSchedules, false),
+		EnableSchedules: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableSchedules, true),
 
 		MaxConcurrentBatchOperation: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, 1),
 	}

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -348,6 +348,13 @@ func (w *perNamespaceWorker) startWorker(
 	// other defaults are already large enough.
 	sdkoptions.MaxConcurrentWorkflowTaskPollers = 2 * multiplicity
 	sdkoptions.MaxConcurrentActivityTaskPollers = 2 * multiplicity
+	sdkoptions.OnFatalError = func(error) {
+		// if the sdk sees a fatal error (e.g. namespace does not exist), it will log it and
+		// Stop() the worker. that means we should not call Stop() ourself.
+		w.lock.Lock()
+		defer w.lock.Unlock()
+		w.worker = nil
+	}
 
 	sdkworker := w.wm.sdkWorkerFactory.New(client, primitives.PerNSWorkerTaskQueue, sdkoptions)
 	for _, cmp := range components {

--- a/service/worker/scheduler/fx.go
+++ b/service/worker/scheduler/fx.go
@@ -75,7 +75,7 @@ func NewResult(
 		Component: &workerComponent{
 			activityDeps: params,
 			enabledForNs: dcCollection.GetBoolPropertyFnWithNamespaceFilter(
-				dynamicconfig.WorkerEnableScheduler, false),
+				dynamicconfig.WorkerEnableScheduler, true),
 		},
 	}
 }

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -216,6 +216,8 @@ func (s *scheduler) ensureFields() {
 	if s.Schedule.Policies == nil {
 		s.Schedule.Policies = &schedpb.SchedulePolicies{}
 	}
+	// set default so it shows up in describe output
+	s.Schedule.Policies.OverlapPolicy = s.resolveOverlapPolicy(s.Schedule.Policies.OverlapPolicy)
 	if s.Schedule.State == nil {
 		s.Schedule.State = &schedpb.ScheduleState{}
 	}


### PR DESCRIPTION
**What changed?**
- Switch the default for `frontend.enableSchedules` and `worker.enableScheduler` dynamic config to true.
- Add a few integration tests for schedules.
- Resolve `OverlapPolicy` to default value (skip) eagerly.
- Fix some bugs:
  - update did not properly validate input or apply search attribute mapping
  - describe did not undo search attribute mapping
- Integration test configuration changes
  - remove override of tq partition count (so tqs will use structured default: 4, except 1 for per-ns worker)
  - get rid of `enableindexer`, just use the presence of `esconfig` to turn on advanced visibility
  - add `startworkeranyway` to force worker to be on (for scheduler)
  - add missing search attributes to `testdata/es_v{7,8}_index_template.json`
  - add timeout on shutdown. we can remove this later after fixing shutdown blocking bug

**Why?**
more tests, fix bugs, enable feature

**How did you test it?**
new integration tests

**Potential risks**
turning on scheduler worker will use more resources on clusters with large numbers of namespaces
