### PR TITLE
fix cassandra tool consistency readme to reflect the config default

### DIFF
--- a/tools/cassandra/README.md
+++ b/tools/cassandra/README.md
@@ -26,7 +26,7 @@ This uses Cassandra's SimpleStratagey for replication. For production, we recomm
 temporal-cassandra-tool --ep $CASSANDRA_SEEDS create -k $KEYSPACE --rf $RF
 ```
 
-See https://www.ecyrd.com/cassandracalculator for an easy way to determine how many nodes and what replication factor you will want to use.  Note that Temporal by default uses `Quorum` for read and write consistency.
+See https://www.ecyrd.com/cassandracalculator for an easy way to determine how many nodes and what replication factor you will want to use.  Note that Temporal by default uses `LOCAL_QUORUM` and `LOCAL_SERIAL` for read and write consistency.
 
 ```
 ./temporal-cassandra-tool -ep 127.0.0.1 -k temporal setup-schema -v 0.0 -- this sets up just the schema version tables with initial version of 0.0


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changes the README in the tools/cassandra directory. 

<!-- Tell your future self why have you made these changes -->
**Why?**
That README states the default consistency is `QUORUM`, but the config defaults to `LOCAL_QUORUM` at https://github.com/temporalio/temporal/blob/5ab8ab804fa3e0998f419260b4424154419428d9/common/config/config.go#L301

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Just a README change

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Potential misinformation if the behavior is not as described in the config comment and code [here](https://github.com/temporalio/temporal/blob/master/common/config/persistence.go#L146-L165) (I verified the code, but still, it's a new codebase)

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No