### PR TITLE
Multi-cursor: shrink slice predicate

### DIFF
--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -388,16 +388,6 @@ func (e *executableImpl) GetPriority() ctasks.Priority {
 	return e.priority
 }
 
-func (e *executableImpl) SetPriority(priority ctasks.Priority) {
-	e.Lock()
-	defer e.Unlock()
-
-	e.priority = priority
-	if e.priority > e.lowestPriority {
-		e.lowestPriority = e.priority
-	}
-}
-
 func (e *executableImpl) Attempt() int {
 	e.Lock()
 	defer e.Unlock()
@@ -456,4 +446,7 @@ func (e *executableImpl) updatePriority() {
 	e.Lock()
 	defer e.Unlock()
 	e.priority = newPriority
+	if e.priority > e.lowestPriority {
+		e.lowestPriority = e.priority
+	}
 }

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -53,6 +53,18 @@ const (
 	nonDefaultReaderMaxPendingTaskCoefficient = 0.8
 
 	queueIOTimeout = 5 * time.Second
+
+	// Force creating new slice every forceNewSliceDuration
+	// so that the last slice in the default reader won't grow
+	// infinitely.
+	// The benefit of forcing new slice is:
+	// 1. As long as the last slice won't grow infinitly, task loading
+	// for that slice will complete and it's scope (both range and
+	// predicate) is able to shrink
+	// 2. Current task loading implementation can only unload the entire
+	// slice. If there's only one slice, we may unload all tasks for a
+	// given namespace.
+	forceNewSliceDuration = 5 * time.Minute
 )
 
 type (
@@ -84,6 +96,7 @@ type (
 		nonReadableScope      Scope
 		readerGroup           *ReaderGroup
 		lastPollTime          time.Time
+		nextForceNewSliceTime time.Time
 
 		checkpointRetrier backoff.Retrier
 		checkpointTimer   *time.Timer
@@ -318,6 +331,12 @@ func (p *queueBase) processNewRange() {
 	reader, ok := p.readerGroup.ReaderByID(DefaultReaderId)
 	if !ok {
 		p.readerGroup.NewReader(DefaultReaderId, newSlice)
+		return
+	}
+
+	if now := p.timeSource.Now(); now.After(p.nextForceNewSliceTime) {
+		reader.AppendSlices(newSlice)
+		p.nextForceNewSliceTime = now.Add(forceNewSliceDuration)
 	} else {
 		reader.MergeSlices(newSlice)
 	}

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -55,6 +55,7 @@ type (
 		WalkSlices(SliceIterator)
 		SplitSlices(SliceSplitter)
 		MergeSlices(...Slice)
+		AppendSlices(...Slice)
 		ClearSlices(SlicePredicate)
 		CompactSlices(SlicePredicate)
 		ShrinkSlices()
@@ -243,24 +244,53 @@ func (r *ReaderImpl) MergeSlices(incomingSlices ...Slice) {
 		incomingSlice := incomingSlices[incomingSliceIdx]
 
 		if currentSlice.Scope().Range.InclusiveMin.CompareTo(incomingSlice.Scope().Range.InclusiveMin) < 0 {
-			appendSlice(mergedSlices, currentSlice)
+			mergeOrAppendSlice(mergedSlices, currentSlice)
 			currentSliceElement = currentSliceElement.Next()
 		} else {
-			appendSlice(mergedSlices, incomingSlice)
+			mergeOrAppendSlice(mergedSlices, incomingSlice)
 			incomingSliceIdx++
 		}
 	}
 
 	for ; currentSliceElement != nil; currentSliceElement = currentSliceElement.Next() {
-		appendSlice(mergedSlices, currentSliceElement.Value.(Slice))
+		mergeOrAppendSlice(mergedSlices, currentSliceElement.Value.(Slice))
 	}
 	for _, slice := range incomingSlices[incomingSliceIdx:] {
-		appendSlice(mergedSlices, slice)
+		mergeOrAppendSlice(mergedSlices, slice)
 	}
 
 	// clear existing list
 	r.slices.Init()
 	r.slices = mergedSlices
+
+	r.resetNextReadSliceLocked()
+	r.monitor.SetSliceCount(r.readerID, r.slices.Len())
+}
+
+func (r *ReaderImpl) AppendSlices(incomingSlices ...Slice) {
+	if len(incomingSlices) == 0 {
+		return
+	}
+
+	validateSlicesOrderedDisjoint(incomingSlices)
+	if back := r.slices.Back(); back != nil {
+		lastSliceRange := back.Value.(Slice).Scope().Range
+		firstIncomingRange := incomingSlices[0].Scope().Range
+		if lastSliceRange.ExclusiveMax.CompareTo(firstIncomingRange.InclusiveMin) > 0 {
+			panic(fmt.Sprintf(
+				"Can not append slice to existing list of slices, incoming slice range: %v, existing slice range: %v ",
+				firstIncomingRange,
+				lastSliceRange,
+			))
+		}
+	}
+
+	r.Lock()
+	defer r.Unlock()
+
+	for _, incomingSlice := range incomingSlices {
+		r.slices.PushBack(incomingSlice)
+	}
 
 	r.resetNextReadSliceLocked()
 	r.monitor.SetSliceCount(r.readerID, r.slices.Len())
@@ -319,7 +349,7 @@ func (r *ReaderImpl) ShrinkSlices() {
 		next = element.Next()
 
 		slice := element.Value.(Slice)
-		slice.ShrinkRange()
+		slice.ShrinkScope()
 		if scope := slice.Scope(); scope.IsEmpty() {
 			r.slices.Remove(element)
 		}
@@ -453,7 +483,7 @@ func (r *ReaderImpl) verifyPendingTaskSize() bool {
 	return r.monitor.GetTotalPendingTaskCount() < r.options.MaxPendingTasksCount()
 }
 
-func appendSlice(
+func mergeOrAppendSlice(
 	slices *list.List,
 	incomingSlice Slice,
 ) {

--- a/service/history/queues/reader_group_test.go
+++ b/service/history/queues/reader_group_test.go
@@ -116,6 +116,7 @@ func (r *testReader) Scopes() []Scope              { panic("not implemented") }
 func (r *testReader) WalkSlices(SliceIterator)     { panic("not implemented") }
 func (r *testReader) SplitSlices(SliceSplitter)    { panic("not implemented") }
 func (r *testReader) MergeSlices(...Slice)         { panic("not implemented") }
+func (r *testReader) AppendSlices(...Slice)        { panic("not implemented") }
 func (r *testReader) ClearSlices(SlicePredicate)   { panic("not implemented") }
 func (r *testReader) CompactSlices(SlicePredicate) { panic("not implemented") }
 func (r *testReader) ShrinkSlices()                { panic("not implemented") }

--- a/service/history/queues/slice_test.go
+++ b/service/history/queues/slice_test.go
@@ -328,7 +328,7 @@ func (s *sliceSuite) TestCompactWithSlice() {
 	s.Panics(func() { slice2.stateSanityCheck() })
 }
 
-func (s *sliceSuite) TestShrinkRange() {
+func (s *sliceSuite) TestShrinkScope_ShrinkRange() {
 	r := NewRandomRange()
 	predicate := predicates.Universal[tasks.Task]()
 
@@ -361,7 +361,7 @@ func (s *sliceSuite) TestShrinkRange() {
 		slice.pendingExecutables[executable.GetKey()] = executable
 	}
 
-	slice.ShrinkRange()
+	slice.ShrinkScope()
 	s.Len(slice.pendingExecutables, len(executables)-numAcked)
 	s.validateSliceState(slice)
 
@@ -375,6 +375,47 @@ func (s *sliceSuite) TestShrinkRange() {
 	}
 
 	s.Equal(NewRange(newInclusiveMin, r.ExclusiveMax), slice.Scope().Range)
+}
+
+func (s *sliceSuite) TestShrinkScope_ShrinkPredicate() {
+	r := NewRandomRange()
+	predicate := predicates.Universal[tasks.Task]()
+
+	slice := NewSlice(nil, s.executableInitializer, s.monitor, NewScope(r, predicate))
+	slice.iterators = []Iterator{} // manually set iterators to be empty to trigger predicate update
+
+	executables := s.randomExecutablesInRange(r, 100)
+	slices.SortFunc(executables, func(a, b Executable) bool {
+		return a.GetKey().CompareTo(b.GetKey()) < 0
+	})
+
+	pendingNamespaceID := []string{uuid.New(), uuid.New()}
+	s.True(len(pendingNamespaceID) <= shrinkPredicateMaxPendingNamespaces)
+	for _, executable := range executables {
+		mockExecutable := executable.(*MockExecutable)
+
+		mockExecutable.EXPECT().GetTask().Return(mockExecutable).AnyTimes()
+
+		acked := rand.Intn(10) < 8
+		if acked {
+			mockExecutable.EXPECT().GetNamespaceID().Return(uuid.New()).AnyTimes()
+			mockExecutable.EXPECT().State().Return(ctasks.TaskStateAcked).MaxTimes(1)
+		} else {
+			mockExecutable.EXPECT().GetNamespaceID().Return(pendingNamespaceID[rand.Intn(len(pendingNamespaceID))]).AnyTimes()
+			mockExecutable.EXPECT().State().Return(ctasks.TaskStatePending).MaxTimes(1)
+		}
+
+		slice.executableTracker.add(executable)
+	}
+
+	slice.ShrinkScope()
+	s.validateSliceState(slice)
+
+	namespacePredicate, ok := slice.Scope().Predicate.(*tasks.NamespacePredicate)
+	s.True(ok)
+	for namespaceID := range namespacePredicate.NamespaceIDs {
+		s.True(slices.Index(pendingNamespaceID, namespaceID) != -1)
+	}
 }
 
 func (s *sliceSuite) TestSelectTasks_NoError() {

--- a/service/history/queues/tracker.go
+++ b/service/history/queues/tracker.go
@@ -117,6 +117,12 @@ func (t *executableTracker) shrink() tasks.Key {
 		minPendingTaskKey = tasks.MinKey(minPendingTaskKey, key)
 	}
 
+	for namespaceID, numPending := range t.pendingPerNamesapce {
+		if numPending == 0 {
+			delete(t.pendingPerNamesapce, namespaceID)
+		}
+	}
+
 	return minPendingTaskKey
 }
 

--- a/service/history/timerQueueFactory.go
+++ b/service/history/timerQueueFactory.go
@@ -71,7 +71,7 @@ func NewTimerQueueFactory(
 			},
 			params.NamespaceRegistry,
 			params.TimeSource,
-			params.MetricsHandler,
+			params.MetricsHandler.WithTags(metrics.OperationTag(queues.OperationTimerQueueProcessor)),
 			params.Logger,
 		)
 	}

--- a/service/history/transferQueueFactory.go
+++ b/service/history/transferQueueFactory.go
@@ -74,7 +74,7 @@ func NewTransferQueueFactory(
 			},
 			params.NamespaceRegistry,
 			params.TimeSource,
-			params.MetricsHandler,
+			params.MetricsHandler.WithTags(metrics.OperationTag(queues.OperationTransferQueueProcessor)),
 			params.Logger,
 		)
 	}

--- a/service/history/visibilityQueueFactory.go
+++ b/service/history/visibilityQueueFactory.go
@@ -64,7 +64,7 @@ func NewVisibilityQueueFactory(
 			},
 			params.NamespaceRegistry,
 			params.TimeSource,
-			params.MetricsHandler,
+			params.MetricsHandler.WithTags(metrics.OperationTag(queues.OperationVisibilityQueueProcessor)),
 			params.Logger,
 		)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Shrink queue slice predicate when # of pending namespaces are low.
- Force create new queue slice every 5mins

<!-- Tell your future self why have you made these changes -->
**Why?**
- Shrink predicate is another way of checkpoint processing progress so that upon reload few # of tasks needs to be reprocessed
- Shrink predicate is only possible when all tasks for a slice has been loaded. But this may not be true for the last slice in default reader and new slice may keep merge into it. So force create new slice every 5mins, and rely on slice count monitoring & action to combine them if # of slices becomes large.
- Force creating new slice also means if task unloading is needed, we won't unload all tasks for a namespace at once. But can unload only tasks from some slices, while others are still in memory for processing.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests, added new unit test, running in test cluster.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
