### PR TITLE
Improve task scheduler namespace change callback

### DIFF
--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -181,6 +181,18 @@ func (s *schedulerImpl) Start() {
 			0,
 			func() {}, // no-op
 			func(oldNamespaces, newNamespaces []*namespace.Namespace) {
+				namespaceFailover := false
+				for idx := range oldNamespaces {
+					if oldNamespaces[idx].FailoverVersion() != newNamespaces[idx].FailoverVersion() {
+						namespaceFailover = true
+						break
+					}
+				}
+
+				if !namespaceFailover {
+					return
+				}
+
 				select {
 				case s.channelWeightUpdateCh <- struct{}{}:
 				default:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Improve task scheduler namespace change callback so that task channel weight update is only trigger upon namespace failover.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Namespace registry will invoke the callback on every namespace cache refresh, even though there's no namespace update.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
