### PR TITLE
Multi-cursor: fix task deletion

### DIFF
--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -340,14 +340,13 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) TestUpdateWeight() {
 
 	taskWG.Add(1)
 	s.scheduler.Submit(mockTask0)
+	taskWG.Wait()
 
 	channelWeights = []int{}
 	for _, channel := range s.scheduler.channels() {
 		channelWeights = append(channelWeights, channel.Weight())
 	}
 	s.Equal([]int{8, 8, 8, 8, 5, 8, 5, 8, 5, 8, 5, 8, 5, 1, 1}, channelWeights)
-
-	taskWG.Wait()
 }
 
 func newTestTask(

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -401,11 +401,11 @@ func (s *queueBaseSuite) TestCompleteTaskAndPersistState_WithPendingTasks() {
 	)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
 
-	s.True(scopeMinKey.CompareTo(base.inclusiveLowWatermark) == 0)
+	s.True(scopeMinKey.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 
 	// set to a smaller value so that delete will be triggered
 	currentLowWatermark := tasks.MinimumKey
-	base.inclusiveLowWatermark = currentLowWatermark
+	base.exclusiveDeletionHighWatermark = currentLowWatermark
 
 	gomock.InOrder(
 		mockShard.Resource.ExecutionMgr.EXPECT().RangeCompleteHistoryTasks(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -433,7 +433,7 @@ func (s *queueBaseSuite) TestCompleteTaskAndPersistState_WithPendingTasks() {
 
 	base.checkpoint()
 
-	s.True(scopeMinKey.CompareTo(base.inclusiveLowWatermark) == 0)
+	s.True(scopeMinKey.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 }
 
 func (s *queueBaseSuite) TestCompleteTaskAndPersistState_NoPendingTasks() {
@@ -478,11 +478,11 @@ func (s *queueBaseSuite) TestCompleteTaskAndPersistState_NoPendingTasks() {
 	)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
 
-	s.True(exclusiveReaderHighWatermark.CompareTo(base.inclusiveLowWatermark) == 0)
+	s.True(exclusiveReaderHighWatermark.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 
 	// set to a smaller value so that delete will be triggered
 	currentLowWatermark := tasks.MinimumKey
-	base.inclusiveLowWatermark = currentLowWatermark
+	base.exclusiveDeletionHighWatermark = currentLowWatermark
 
 	gomock.InOrder(
 		mockShard.Resource.ExecutionMgr.EXPECT().RangeCompleteHistoryTasks(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -511,5 +511,5 @@ func (s *queueBaseSuite) TestCompleteTaskAndPersistState_NoPendingTasks() {
 
 	base.checkpoint()
 
-	s.True(exclusiveReaderHighWatermark.CompareTo(base.inclusiveLowWatermark) == 0)
+	s.True(exclusiveReaderHighWatermark.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 }

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -437,13 +437,9 @@ func (s *queueBaseSuite) TestCompleteTaskAndPersistState_WithPendingTasks() {
 }
 
 func (s *queueBaseSuite) TestCompleteTaskAndPersistState_NoPendingTasks() {
-	readerScopes := map[int32][]Scope{}
-	for _, readerID := range []int32{DefaultReaderId, 2, 3} {
-		readerScopes[readerID] = []Scope{}
-	}
 	exclusiveReaderHighWatermark := NewRandomKey()
 	queueState := &queueState{
-		readerScopes:                 readerScopes,
+		readerScopes:                 map[int32][]Scope{},
 		exclusiveReaderHighWatermark: exclusiveReaderHighWatermark,
 	}
 	persistenceState := ToPersistenceQueueState(queueState)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix task deletion: previously task deletion will be skipped if there's no pending slices in the queue. Instead, when there's no pending slices, we should delete tasks up to (<) the min of non-readable range.
- Some code refactoring
- Also uncomment the code for emitting pending task metrics.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Otherwise tasks may left in db undeleted.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added test. Tested in test cluster.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
