### PR TITLE
Multi-cursor: fix timer task precision

### DIFF
--- a/service/history/queues/queue_scheduled.go
+++ b/service/history/queues/queue_scheduled.go
@@ -266,3 +266,14 @@ func (p *scheduledQueue) lookAheadTask() {
 
 	// no look ahead task, wait for max poll interval or new task notification
 }
+
+// IsTimeExpired checks if the testing time is equal or before
+// the reference time. The precision of the comparison is millisecond.
+func IsTimeExpired(
+	referenceTime time.Time,
+	testingTime time.Time,
+) bool {
+	referenceTime = referenceTime.Truncate(scheduledTaskPrecision)
+	testingTime = testingTime.Truncate(scheduledTaskPrecision)
+	return !testingTime.After(referenceTime)
+}

--- a/service/history/timerQueueActiveTaskExecutor.go
+++ b/service/history/timerQueueActiveTaskExecutor.go
@@ -149,7 +149,7 @@ Loop:
 			return serviceerror.NewInternal(errString)
 		}
 
-		if expired := timerSequence.IsExpired(referenceTime, timerSequenceID); !expired {
+		if !queues.IsTimeExpired(referenceTime, timerSequenceID.Timestamp) {
 			// timer sequence IDs are sorted, once there is one timer
 			// sequence ID not expired, all after that wil not expired
 			break Loop
@@ -201,7 +201,7 @@ func (t *timerQueueActiveTaskExecutor) executeActivityTimeoutTask(
 	// created.
 	isHeartBeatTask := task.TimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
 	activityInfo, heartbeatTimeoutVis, ok := mutableState.GetActivityInfoWithTimerHeartbeat(task.EventID)
-	if isHeartBeatTask && ok && (heartbeatTimeoutVis.Before(task.GetVisibilityTime()) || heartbeatTimeoutVis.Equal(task.GetVisibilityTime())) {
+	if isHeartBeatTask && ok && queues.IsTimeExpired(task.GetVisibilityTime(), heartbeatTimeoutVis) {
 		activityInfo.TimerTaskStatus = activityInfo.TimerTaskStatus &^ workflow.TimerTaskStatusCreatedHeartbeat
 		if err := mutableState.UpdateActivity(activityInfo); err != nil {
 			return err
@@ -222,7 +222,7 @@ Loop:
 			continue Loop
 		}
 
-		if expired := timerSequence.IsExpired(referenceTime, timerSequenceID); !expired {
+		if !queues.IsTimeExpired(referenceTime, timerSequenceID.Timestamp) {
 			// timer sequence IDs are sorted, once there is one timer
 			// sequence ID not expired, all after that wil not expired
 			break Loop

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -128,10 +128,10 @@ func (t *timerQueueStandbyTaskExecutor) executeUserTimerTimeoutTask(
 				return nil, serviceerror.NewInternal(errString)
 			}
 
-			if isExpired := timerSequence.IsExpired(
+			if queues.IsTimeExpired(
 				timerTask.GetVisibilityTime(),
-				timerSequenceID,
-			); isExpired {
+				timerSequenceID.Timestamp,
+			) {
 				return getHistoryResendInfo(mutableState)
 			}
 			// Since the user timers are already sorted, then if there is one timer which is not expired,
@@ -171,7 +171,6 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 	//
 	// the overall solution is to attempt to generate a new activity timer task whenever the
 	// task passed in is safe to be throw away.
-
 	actionFn := func(ctx context.Context, wfContext workflow.Context, mutableState workflow.MutableState) (interface{}, error) {
 		timerSequence := t.getTimerSequence(mutableState)
 		updateMutableState := false
@@ -185,10 +184,10 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 				return nil, serviceerror.NewInternal(errString)
 			}
 
-			if isExpired := timerSequence.IsExpired(
+			if queues.IsTimeExpired(
 				timerTask.GetVisibilityTime(),
-				timerSequenceID,
-			); isExpired {
+				timerSequenceID.Timestamp,
+			) {
 				return getHistoryResendInfo(mutableState)
 			}
 			// Since the activity timers are already sorted, then if there is one timer which is not expired,
@@ -211,8 +210,7 @@ func (t *timerQueueStandbyTaskExecutor) executeActivityTimeoutTask(
 		// created.
 		isHeartBeatTask := timerTask.TimeoutType == enumspb.TIMEOUT_TYPE_HEARTBEAT
 		activityInfo, heartbeatTimeoutVis, ok := mutableState.GetActivityInfoWithTimerHeartbeat(timerTask.EventID)
-		fireTimer := timerTask.GetVisibilityTime()
-		if isHeartBeatTask && ok && (heartbeatTimeoutVis.Before(fireTimer) || heartbeatTimeoutVis.Equal(fireTimer)) {
+		if isHeartBeatTask && ok && queues.IsTimeExpired(timerTask.GetVisibilityTime(), heartbeatTimeoutVis) {
 			activityInfo.TimerTaskStatus = activityInfo.TimerTaskStatus &^ workflow.TimerTaskStatusCreatedHeartbeat
 			if err := mutableState.UpdateActivity(activityInfo); err != nil {
 				return nil, err

--- a/service/history/workflow/timer_sequence.go
+++ b/service/history/workflow/timer_sequence.go
@@ -69,8 +69,6 @@ type (
 	TimerSequenceIDs []TimerSequenceID
 
 	TimerSequence interface {
-		IsExpired(referenceTime time.Time, timerSequenceID TimerSequenceID) bool
-
 		CreateNextUserTimer() (bool, error)
 		CreateNextActivityTimer() (bool, error)
 
@@ -91,15 +89,6 @@ func NewTimerSequence(
 	return &timerSequenceImpl{
 		mutableState: mutableState,
 	}
-}
-
-func (t *timerSequenceImpl) IsExpired(
-	referenceTime time.Time,
-	timerSequenceID TimerSequenceID,
-) bool {
-	// TODO: Cassandra Timestamp resolution is in millisecond.
-	// Verify if it can create any problem here.
-	return !timerSequenceID.Timestamp.After(referenceTime)
 }
 
 func (t *timerSequenceImpl) CreateNextUserTimer() (bool, error) {

--- a/service/history/workflow/timer_sequence_mock.go
+++ b/service/history/workflow/timer_sequence_mock.go
@@ -30,7 +30,6 @@ package workflow
 
 import (
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -86,20 +85,6 @@ func (m *MockTimerSequence) CreateNextUserTimer() (bool, error) {
 func (mr *MockTimerSequenceMockRecorder) CreateNextUserTimer() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNextUserTimer", reflect.TypeOf((*MockTimerSequence)(nil).CreateNextUserTimer))
-}
-
-// IsExpired mocks base method.
-func (m *MockTimerSequence) IsExpired(referenceTime time.Time, timerSequenceID TimerSequenceID) bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "IsExpired", referenceTime, timerSequenceID)
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// IsExpired indicates an expected call of IsExpired.
-func (mr *MockTimerSequenceMockRecorder) IsExpired(referenceTime, timerSequenceID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsExpired", reflect.TypeOf((*MockTimerSequence)(nil).IsExpired), referenceTime, timerSequenceID)
 }
 
 // LoadAndSortActivityTimers mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Use millisecond as precision when determine if timer has expired.

<!-- Tell your future self why have you made these changes -->
**Why?**
Background context here: https://github.com/temporalio/temporal/pull/3255
- Multi-cursor impl will truncate tasks visibility timestamp into millisecond so that tasks returns from cassandra are ordered.
- However, some task processing logic will use the truncated timestamp to check if a timer is expired or not. This will fail as task visibility timestamp has been truncated, but the time stored in mutable state is not. So when doing comparison, we need to truncate both.
- Note this won't make timer fire one millisecond before the schedule time as
   - For multi-cursor, we manually added one ms back when scheduling the task
   - For non multi- cursor, task timestamp is not truncated and if task timestamp is before now, task will be discarded. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested in test cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
