### PR TITLE
Move DeleteWorkflowExecution to workflow service

### DIFF
--- a/api/adminservice/v1/service.pb.go
+++ b/api/adminservice/v1/service.pb.go
@@ -113,7 +113,7 @@ var fileDescriptor_cf5ca5e0c737570d = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -185,10 +185,10 @@ type AdminServiceClient interface {
 }
 
 type adminServiceClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewAdminServiceClient(cc *grpc.ClientConn) AdminServiceClient {
+func NewAdminServiceClient(cc grpc.ClientConnInterface) AdminServiceClient {
 	return &adminServiceClient{cc}
 }
 

--- a/api/historyservice/v1/service.pb.go
+++ b/api/historyservice/v1/service.pb.go
@@ -137,7 +137,7 @@ var fileDescriptor_655983da427ae822 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -310,10 +310,10 @@ type HistoryServiceClient interface {
 }
 
 type historyServiceClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewHistoryServiceClient(cc *grpc.ClientConn) HistoryServiceClient {
+func NewHistoryServiceClient(cc grpc.ClientConnInterface) HistoryServiceClient {
 	return &historyServiceClient{cc}
 }
 

--- a/api/matchingservice/v1/service.pb.go
+++ b/api/matchingservice/v1/service.pb.go
@@ -94,7 +94,7 @@ var fileDescriptor_1a5c83076e651916 = []byte{
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ context.Context
-var _ grpc.ClientConn
+var _ grpc.ClientConnInterface
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
@@ -146,10 +146,10 @@ type MatchingServiceClient interface {
 }
 
 type matchingServiceClient struct {
-	cc *grpc.ClientConn
+	cc grpc.ClientConnInterface
 }
 
-func NewMatchingServiceClient(cc *grpc.ClientConn) MatchingServiceClient {
+func NewMatchingServiceClient(cc grpc.ClientConnInterface) MatchingServiceClient {
 	return &matchingServiceClient{cc}
 }
 

--- a/client/frontend/client_gen.go
+++ b/client/frontend/client_gen.go
@@ -63,6 +63,20 @@ func (c *clientImpl) DeleteSchedule(
 	return c.client.DeleteSchedule(ctx, request, opts...)
 }
 
+func (c *clientImpl) DeleteWorkflowExecution(
+	ctx context.Context,
+	request *workflowservice.DeleteWorkflowExecutionRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.DeleteWorkflowExecutionResponse, error) {
+	client, err := c.getRandomClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return client.DeleteWorkflowExecution(ctx, request, opts...)
+}
+
 func (c *clientImpl) DeprecateNamespace(
 	ctx context.Context,
 	request *workflowservice.DeprecateNamespaceRequest,

--- a/client/frontend/client_gen.go
+++ b/client/frontend/client_gen.go
@@ -68,13 +68,9 @@ func (c *clientImpl) DeleteWorkflowExecution(
 	request *workflowservice.DeleteWorkflowExecutionRequest,
 	opts ...grpc.CallOption,
 ) (*workflowservice.DeleteWorkflowExecutionResponse, error) {
-	client, err := c.getRandomClient()
-	if err != nil {
-		return nil, err
-	}
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
-	return client.DeleteWorkflowExecution(ctx, request, opts...)
+	return c.client.DeleteWorkflowExecution(ctx, request, opts...)
 }
 
 func (c *clientImpl) DeprecateNamespace(

--- a/client/frontend/metric_client_gen.go
+++ b/client/frontend/metric_client_gen.go
@@ -77,6 +77,20 @@ func (c *metricClient) DeleteSchedule(
 	return c.client.DeleteSchedule(ctx, request, opts...)
 }
 
+func (c *metricClient) DeleteWorkflowExecution(
+	ctx context.Context,
+	request *workflowservice.DeleteWorkflowExecutionRequest,
+	opts ...grpc.CallOption,
+) (_ *workflowservice.DeleteWorkflowExecutionResponse, retError error) {
+
+	scope, stopwatch := c.startMetricsRecording(metrics.FrontendClientDeleteWorkflowExecutionScope)
+	defer func() {
+		c.finishMetricsRecording(scope, stopwatch, retError)
+	}()
+
+	return c.client.DeleteWorkflowExecution(ctx, request, opts...)
+}
+
 func (c *metricClient) DeprecateNamespace(
 	ctx context.Context,
 	request *workflowservice.DeprecateNamespaceRequest,

--- a/client/frontend/retryable_client_gen.go
+++ b/client/frontend/retryable_client_gen.go
@@ -80,6 +80,21 @@ func (c *retryableClient) DeleteSchedule(
 	return resp, err
 }
 
+func (c *retryableClient) DeleteWorkflowExecution(
+	ctx context.Context,
+	request *workflowservice.DeleteWorkflowExecutionRequest,
+	opts ...grpc.CallOption,
+) (*workflowservice.DeleteWorkflowExecutionResponse, error) {
+	var resp *workflowservice.DeleteWorkflowExecutionResponse
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.DeleteWorkflowExecution(ctx, request, opts...)
+		return err
+	}
+	err := backoff.ThrottleRetryContext(ctx, op, c.policy, c.isRetryable)
+	return resp, err
+}
+
 func (c *retryableClient) DeprecateNamespace(
 	ctx context.Context,
 	request *workflowservice.DeprecateNamespaceRequest,

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1775,7 +1775,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		FrontendSignalWorkflowExecutionScope:            {operation: "SignalWorkflowExecution"},
 		FrontendSignalWithStartWorkflowExecutionScope:   {operation: "SignalWithStartWorkflowExecution"},
 		FrontendTerminateWorkflowExecutionScope:         {operation: "TerminateWorkflowExecution"},
-		FrontendDeleteWorkflowExecutionScope:            {operation: "FrontendDeleteWorkflowExecution"},
+		FrontendDeleteWorkflowExecutionScope:            {operation: "DeleteWorkflowExecution"},
 		FrontendResetWorkflowExecutionScope:             {operation: "ResetWorkflowExecution"},
 		FrontendRequestCancelWorkflowExecutionScope:     {operation: "RequestCancelWorkflowExecution"},
 		FrontendListArchivedWorkflowExecutionsScope:     {operation: "ListArchivedWorkflowExecutions"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -458,6 +458,8 @@ const (
 	MatchingClientInvalidateTaskQueueMetadataScope
 	// MatchingClientGetTaskQueueMetadataScope tracks RPC calls to matching service
 	MatchingClientGetTaskQueueMetadataScope
+	// FrontendClientDeleteWorkflowExecutionScope tracks RPC calls to frontend service
+	FrontendClientDeleteWorkflowExecutionScope
 	// FrontendClientDeprecateNamespaceScope tracks RPC calls to frontend service
 	FrontendClientDeprecateNamespaceScope
 	// FrontendClientDescribeNamespaceScope tracks RPC calls to frontend service
@@ -626,6 +628,8 @@ const (
 	// AdminClientDeleteWorkflowExecutionScope tracks RPC calls to admin service
 	AdminClientDeleteWorkflowExecutionScope
 
+	// DCRedirectionDeleteWorkflowExecutionScope tracks RPC calls for dc redirection
+	DCRedirectionDeleteWorkflowExecutionScope
 	// DCRedirectionDeprecateNamespaceScope tracks RPC calls for dc redirection
 	DCRedirectionDeprecateNamespaceScope
 	// DCRedirectionDescribeNamespaceScope tracks RPC calls for dc redirection
@@ -896,7 +900,6 @@ const (
 	OperatorListSearchAttributesScope
 	OperatorDeleteNamespaceScope
 	OperatorAddOrUpdateRemoteCluster
-	OperatorDeleteWorkflowExecution
 	OperatorDescribeCluster
 	OperatorListClusterMembers
 	OperatorListClusters
@@ -951,6 +954,8 @@ const (
 	FrontendSignalWithStartWorkflowExecutionScope
 	// FrontendTerminateWorkflowExecutionScope is the metric scope for frontend.TerminateWorkflowExecution
 	FrontendTerminateWorkflowExecutionScope
+	// FrontendDeleteWorkflowExecutionScope is the metric scope for frontend.DeleteWorkflowExecution
+	FrontendDeleteWorkflowExecutionScope
 	// FrontendRequestCancelWorkflowExecutionScope is the metric scope for frontend.RequestCancelWorkflowExecution
 	FrontendRequestCancelWorkflowExecutionScope
 	// FrontendListArchivedWorkflowExecutionsScope is the metric scope for frontend.ListArchivedWorkflowExecutions
@@ -1536,6 +1541,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MatchingClientInvalidateTaskQueueMetadataScope: {operation: "MatchingClientInvalidateTaskQueueMetadata", tags: map[string]string{ServiceRoleTagName: MatchingRoleTagValue}},
 		MatchingClientGetTaskQueueMetadataScope:        {operation: "MatchingClientGetTaskQueueMetadata", tags: map[string]string{ServiceRoleTagName: MatchingRoleTagValue}},
 
+		FrontendClientDeleteWorkflowExecutionScope:            {operation: "FrontendClientDeleteWorkflowExecution", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientDeprecateNamespaceScope:                 {operation: "FrontendClientDeprecateNamespace", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientDescribeBatchOperationScope:             {operation: "FrontendClientDescribeBatchOperation", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
 		FrontendClientDescribeNamespaceScope:                  {operation: "FrontendClientDescribeNamespace", tags: map[string]string{ServiceRoleTagName: FrontendRoleTagValue}},
@@ -1621,6 +1627,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		AdminClientMergeDLQMessagesScope:                 {operation: "AdminClientMergeDLQMessages", tags: map[string]string{ServiceRoleTagName: AdminRoleTagValue}},
 		AdminClientDeleteWorkflowExecutionScope:          {operation: "AdminClientDeleteWorkflowExecution", tags: map[string]string{ServiceRoleTagName: AdminRoleTagValue}},
 
+		DCRedirectionDeleteWorkflowExecutionScope:            {operation: "DCRedirectionDeleteWorkflowExecution", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDeprecateNamespaceScope:                 {operation: "DCRedirectionDeprecateNamespace", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDescribeNamespaceScope:                  {operation: "DCRedirectionDescribeNamespace", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDescribeTaskQueueScope:                  {operation: "DCRedirectionDescribeTaskQueue", tags: map[string]string{ServiceRoleTagName: DCRedirectionRoleTagValue}},
@@ -1741,7 +1748,6 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		OperatorListSearchAttributesScope:   {operation: "OperatorListSearchAttributes"},
 		OperatorDeleteNamespaceScope:        {operation: "OperatorDeleteNamespace"},
 		OperatorAddOrUpdateRemoteCluster:    {operation: "OperatorAddOrUpdateRemoteCluster"},
-		OperatorDeleteWorkflowExecution:     {operation: "OperatorDeleteWorkflowExecution"},
 		OperatorDescribeCluster:             {operation: "OperatorDescribeCluster"},
 		OperatorListClusterMembers:          {operation: "OperatorListClusterMembers"},
 		OperatorListClusters:                {operation: "OperatorListClusters"},
@@ -1769,6 +1775,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		FrontendSignalWorkflowExecutionScope:            {operation: "SignalWorkflowExecution"},
 		FrontendSignalWithStartWorkflowExecutionScope:   {operation: "SignalWithStartWorkflowExecution"},
 		FrontendTerminateWorkflowExecutionScope:         {operation: "TerminateWorkflowExecution"},
+		FrontendDeleteWorkflowExecutionScope:            {operation: "FrontendDeleteWorkflowExecution"},
 		FrontendResetWorkflowExecutionScope:             {operation: "ResetWorkflowExecution"},
 		FrontendRequestCancelWorkflowExecutionScope:     {operation: "RequestCancelWorkflowExecution"},
 		FrontendListArchivedWorkflowExecutionsScope:     {operation: "ListArchivedWorkflowExecutions"},

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.30.0
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/sdk/metric v0.30.0
-	go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde
+	go.temporal.io/api v1.11.1-0.20220906182453-3f9531eab1d0
 	go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.10.0
@@ -123,13 +123,13 @@ require (
 	go.uber.org/dig v1.14.1 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220419223038-86c51ed26bb4 // indirect
-	golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b // indirect
-	golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 // indirect
+	golang.org/x/net v0.0.0-20220906165146-f3363e06e74c // indirect
+	golang.org/x/sys v0.0.0-20220906165534-d0df966e6959 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/tools v0.1.11 // indirect
 	golang.org/x/xerrors v0.0.0-20220609144429-65e65417b02f // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20220829144015-23454907ede3 // indirect
+	google.golang.org/genproto v0.0.0-20220902135211-223410557253 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module go.temporal.io/server
 
 go 1.18
 
-replace go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde => ../temporal-api-go
-replace go.temporal.io/sdk v1.16.0 => ../temporal-sdk-go
-
 require (
 	cloud.google.com/go/storage v1.23.0
 	github.com/aws/aws-sdk-go v1.44.41

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module go.temporal.io/server
 go 1.18
 
 replace go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde => ../temporal-api-go
+replace go.temporal.io/sdk v1.16.0 => ../temporal-sdk-go
 
 require (
 	cloud.google.com/go/storage v1.23.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module go.temporal.io/server
 
 go 1.18
 
+replace go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde => ../temporal-api-go
+
 require (
 	cloud.google.com/go/storage v1.23.0
 	github.com/aws/aws-sdk-go v1.44.41

--- a/go.sum
+++ b/go.sum
@@ -505,8 +505,8 @@ go.opentelemetry.io/proto/otlp v0.16.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI
 go.opentelemetry.io/proto/otlp v0.18.0 h1:W5hyXNComRa23tGpKwG+FRAc4rfF6ZUg1JReK+QHS80=
 go.opentelemetry.io/proto/otlp v0.18.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.temporal.io/api v1.11.1-0.20220804232755-77e12eef4f2d/go.mod h1:JWI21cif+WGqtgmar+dtxQOfYeGORmZtWUj/6/D0e9k=
-go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde h1:FMdQfWh6Q4cACnNSYbRzYsVED0QbhAirLgFPlRSdC20=
-go.temporal.io/api v1.11.1-0.20220829161602-a47c4660cfde/go.mod h1:/OVJZ4KGuvi0+W8fO//E3yGK5fJJHFLIrudrizUgXko=
+go.temporal.io/api v1.11.1-0.20220906182453-3f9531eab1d0 h1:iSLTAuhL60+r035aDbcRFwLj/gdGv+qciecbUAFtanc=
+go.temporal.io/api v1.11.1-0.20220906182453-3f9531eab1d0/go.mod h1:yZGA2AVWUri9TUol58DTosjQnQBLEMDnchA4u+v1i6E=
 go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89 h1:YgBLMeScA/oLIeGOLh9rV26p10KcatcyH46P2MEoI0Q=
 go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89/go.mod h1:XHGK393x654eIHGNf9nXw6DpOJlW4OuvivfLb8n2E34=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
@@ -636,8 +636,8 @@ golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.0.0-20220617184016-355a448f1bc9/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/net v0.0.0-20220802222814-0bcc04d9c69b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.0.0-20220822230855-b0a4917ee28c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
-golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b h1:ZmngSVLe/wycRns9MKikG9OWIEjGcGAkacif7oYQaUY=
-golang.org/x/net v0.0.0-20220826154423-83b083e8dc8b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
+golang.org/x/net v0.0.0-20220906165146-f3363e06e74c h1:yKufUcDwucU5urd+50/Opbt4AYpqthk7wHpHok8f1lo=
+golang.org/x/net v0.0.0-20220906165146-f3363e06e74c/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -749,8 +749,8 @@ golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220804214406-8e32c043e418/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220818161305-2296e01440c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64 h1:UiNENfZ8gDvpiWw7IpOMQ27spWmThO1RwwdQVbJahJM=
-golang.org/x/sys v0.0.0-20220825204002-c680a09ffe64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220906165534-d0df966e6959 h1:qSa+Hg9oBe6UJXrznE+yYvW51V9UbyIj/nj/KpDigo8=
+golang.org/x/sys v0.0.0-20220906165534-d0df966e6959/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -975,8 +975,8 @@ google.golang.org/genproto v0.0.0-20220616135557-88e70c0c3a90/go.mod h1:KEWEmljW
 google.golang.org/genproto v0.0.0-20220617124728-180714bec0ad/go.mod h1:KEWEmljWE5zPzLBa/oHl6DaEt9LmfH6WtH1OHIvleBA=
 google.golang.org/genproto v0.0.0-20220804142021-4e6b2dfa6612/go.mod h1:iHe1svFLAZg9VWz891+QbRMwUv9O/1Ww+/mngYeThbc=
 google.golang.org/genproto v0.0.0-20220822174746-9e6da59bd2fc/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
-google.golang.org/genproto v0.0.0-20220829144015-23454907ede3 h1:4wwmycAWg7WUIFWgzxP6Wumy2GBLxmATgkhgpFnJl2U=
-google.golang.org/genproto v0.0.0-20220829144015-23454907ede3/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
+google.golang.org/genproto v0.0.0-20220902135211-223410557253 h1:vXJMM8Shg7TGaYxZsQ++A/FOSlbDmDtWhS/o+3w/hj4=
+google.golang.org/genproto v0.0.0-20220902135211-223410557253/go.mod h1:dbqgFATTzChvnt+ujMdZwITVAJHFtfyN1qUhDqEiIlk=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/host/workflow_delete_execution_test.go
+++ b/host/workflow_delete_execution_test.go
@@ -34,7 +34,6 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -122,7 +121,7 @@ func (s *integrationSuite) Test_DeleteWorkflowExecution_Competed() {
 	for _, we := range wes {
 		var err error
 		for {
-			_, err = s.operatorClient.DeleteWorkflowExecution(NewContext(), &operatorservice.DeleteWorkflowExecutionRequest{
+			_, err = s.engine.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
 				Namespace: s.namespace,
 				WorkflowExecution: &commonpb.WorkflowExecution{
 					WorkflowId: we.WorkflowId,
@@ -240,7 +239,7 @@ func (s *integrationSuite) Test_DeleteWorkflowExecution_Running() {
 
 	// Delete workflow executions.
 	for _, we := range wes {
-		_, err := s.operatorClient.DeleteWorkflowExecution(NewContext(), &operatorservice.DeleteWorkflowExecutionRequest{
+		_, err := s.engine.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
 			Namespace: s.namespace,
 			WorkflowExecution: &commonpb.WorkflowExecution{
 				WorkflowId: we.WorkflowId,
@@ -361,7 +360,7 @@ func (s *integrationSuite) Test_DeleteWorkflowExecution_RunningWithTerminate() {
 		})
 		s.NoError(err)
 		for {
-			_, err = s.operatorClient.DeleteWorkflowExecution(NewContext(), &operatorservice.DeleteWorkflowExecutionRequest{
+			_, err = s.engine.DeleteWorkflowExecution(NewContext(), &workflowservice.DeleteWorkflowExecutionRequest{
 				Namespace: s.namespace,
 				WorkflowExecution: &commonpb.WorkflowExecution{
 					WorkflowId: we.WorkflowId,

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -69,6 +69,7 @@ var (
 		"GetWorkflowExecutionHistoryReverse": 2,
 		"GetWorkerBuildIdOrdering":           2,
 		"UpdateWorkerBuildIdOrdering":        2,
+		"DeleteWorkflowExecution":            2,
 
 		// priority 3
 		"ResetStickyTaskQueue":    3,

--- a/service/frontend/configs/quotas_test.go
+++ b/service/frontend/configs/quotas_test.go
@@ -128,6 +128,7 @@ func (s *quotasSuite) TestExecutionAPIs() {
 		"PollActivityTaskQueue":       {},
 		"GetWorkerBuildIdOrdering":    {},
 		"UpdateWorkerBuildIdOrdering": {},
+		"DeleteWorkflowExecution":     {},
 
 		"ResetStickyTaskQueue":    {},
 		"DescribeTaskQueue":       {},

--- a/service/frontend/interface_mock.go
+++ b/service/frontend/interface_mock.go
@@ -105,6 +105,21 @@ func (mr *MockHandlerMockRecorder) DeleteSchedule(arg0, arg1 interface{}) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteSchedule", reflect.TypeOf((*MockHandler)(nil).DeleteSchedule), arg0, arg1)
 }
 
+// DeleteWorkflowExecution mocks base method.
+func (m *MockHandler) DeleteWorkflowExecution(arg0 context.Context, arg1 *v10.DeleteWorkflowExecutionRequest) (*v10.DeleteWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", arg0, arg1)
+	ret0, _ := ret[0].(*v10.DeleteWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
+func (mr *MockHandlerMockRecorder) DeleteWorkflowExecution(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockHandler)(nil).DeleteWorkflowExecution), arg0, arg1)
+}
+
 // DeprecateNamespace mocks base method.
 func (m *MockHandler) DeprecateNamespace(arg0 context.Context, arg1 *v10.DeprecateNamespaceRequest) (*v10.DeprecateNamespaceResponse, error) {
 	m.ctrl.T.Helper()
@@ -974,21 +989,6 @@ func (m *MockOperatorHandler) DeleteNamespace(arg0 context.Context, arg1 *v1.Del
 func (mr *MockOperatorHandlerMockRecorder) DeleteNamespace(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNamespace", reflect.TypeOf((*MockOperatorHandler)(nil).DeleteNamespace), arg0, arg1)
-}
-
-// DeleteWorkflowExecution mocks base method.
-func (m *MockOperatorHandler) DeleteWorkflowExecution(arg0 context.Context, arg1 *v1.DeleteWorkflowExecutionRequest) (*v1.DeleteWorkflowExecutionResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", arg0, arg1)
-	ret0, _ := ret[0].(*v1.DeleteWorkflowExecutionResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockOperatorHandlerMockRecorder) DeleteWorkflowExecution(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockOperatorHandler)(nil).DeleteWorkflowExecution), arg0, arg1)
 }
 
 // DescribeCluster mocks base method.

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -326,37 +326,6 @@ func (h *OperatorHandlerImpl) DeleteNamespace(ctx context.Context, request *oper
 	}, nil
 }
 
-// DeleteWorkflowExecution deletes a closed workflow execution asynchronously (workflow must be completed or terminated before).
-// This method is EXPERIMENTAL and may be changed or removed in a later release.
-func (h *OperatorHandlerImpl) DeleteWorkflowExecution(ctx context.Context, request *operatorservice.DeleteWorkflowExecutionRequest) (_ *operatorservice.DeleteWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
-
-	if request == nil {
-		return nil, errRequestNotSet
-	}
-
-	if err := validateExecution(request.WorkflowExecution); err != nil {
-		return nil, err
-	}
-
-	namespaceID, err := h.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = h.historyClient.DeleteWorkflowExecution(ctx, &historyservice.DeleteWorkflowExecutionRequest{
-		NamespaceId:        namespaceID.String(),
-		WorkflowExecution:  request.GetWorkflowExecution(),
-		WorkflowVersion:    common.EmptyVersion,
-		ClosedWorkflowOnly: false,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	return &operatorservice.DeleteWorkflowExecutionResponse{}, nil
-}
-
 // AddOrUpdateRemoteCluster adds or updates the connection config to a remote cluster.
 func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 	ctx context.Context,

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -30,7 +30,6 @@ import (
 	"fmt"
 	"testing"
 
-	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/operatorservice/v1"
 	"google.golang.org/grpc/health"
 
@@ -40,10 +39,8 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 
-	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/resource"
 	"go.temporal.io/server/common/searchattribute"
@@ -456,72 +453,4 @@ func (s *operatorHandlerSuite) Test_DeleteNamespace() {
 	s.NoError(err)
 	s.NotNil(resp)
 	s.Equal("test-namespace-deleted-ka2te", resp.DeletedNamespace)
-}
-
-func (s *operatorHandlerSuite) Test_DeleteWorkflowExecution() {
-	handler := s.handler
-	ctx := context.Background()
-
-	type test struct {
-		Name     string
-		Request  *operatorservice.DeleteWorkflowExecutionRequest
-		Expected error
-	}
-	// request validation tests
-	testCases1 := []test{
-		{
-			Name:     "nil request",
-			Request:  nil,
-			Expected: &serviceerror.InvalidArgument{Message: "Request is nil."},
-		},
-		{
-			Name:     "empty request",
-			Request:  &operatorservice.DeleteWorkflowExecutionRequest{},
-			Expected: &serviceerror.InvalidArgument{Message: "Execution is not set on request."},
-		},
-		{
-			Name: "empty namespace",
-			Request: &operatorservice.DeleteWorkflowExecutionRequest{
-				WorkflowExecution: &commonpb.WorkflowExecution{
-					WorkflowId: "test-workflow-id",
-					RunId:      "wrong-run-id",
-				},
-			},
-			Expected: &serviceerror.InvalidArgument{Message: "Invalid RunId."},
-		},
-	}
-	for _, testCase := range testCases1 {
-		s.T().Run(testCase.Name, func(t *testing.T) {
-			resp, err := handler.DeleteWorkflowExecution(ctx, testCase.Request)
-			s.Equal(testCase.Expected, err)
-			s.Nil(resp)
-		})
-	}
-
-	// History call failed.
-	s.mockResource.HistoryClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil, errors.New("random error"))
-	s.mockResource.NamespaceCache.EXPECT().GetNamespaceID(namespace.Name("test-namespace")).Return(namespace.ID("test-namespace-id"), nil)
-	resp, err := handler.DeleteWorkflowExecution(ctx, &operatorservice.DeleteWorkflowExecutionRequest{
-		Namespace: "test-namespace",
-		WorkflowExecution: &commonpb.WorkflowExecution{
-			WorkflowId: "test-workflow-id",
-			RunId:      "d2595cb3-3b21-4026-a3e8-17bc32fb2a2b",
-		},
-	})
-	s.Error(err)
-	s.Equal("random error", err.Error())
-	s.Nil(resp)
-
-	// Success case.
-	s.mockResource.HistoryClient.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(&historyservice.DeleteWorkflowExecutionResponse{}, nil)
-	s.mockResource.NamespaceCache.EXPECT().GetNamespaceID(namespace.Name("test-namespace")).Return(namespace.ID("test-namespace-id"), nil)
-	resp, err = handler.DeleteWorkflowExecution(ctx, &operatorservice.DeleteWorkflowExecutionRequest{
-		Namespace: "test-namespace",
-		WorkflowExecution: &commonpb.WorkflowExecution{
-			WorkflowId: "test-workflow-id",
-			// RunId is not required.
-		},
-	})
-	s.NoError(err)
-	s.NotNil(resp)
 }

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -213,8 +213,6 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int32, esIndexName
 		EnableSchedules: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableSchedules, true),
 
 		MaxConcurrentBatchOperation: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, 1),
-
-		MaxConcurrentBatchOperation: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, 1),
 	}
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -213,6 +213,8 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int32, esIndexName
 		EnableSchedules: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableSchedules, true),
 
 		MaxConcurrentBatchOperation: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, 1),
+
+		MaxConcurrentBatchOperation: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentBatchOperationPerNamespace, 1),
 	}
 }
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2098,6 +2098,37 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(ctx context.Context, reque
 	return &workflowservice.TerminateWorkflowExecutionResponse{}, nil
 }
 
+// DeleteWorkflowExecution deletes a closed workflow execution asynchronously (workflow must be completed or terminated before).
+// This method is EXPERIMENTAL and may be changed or removed in a later release.
+func (wh *WorkflowHandler) DeleteWorkflowExecution(ctx context.Context, request *workflowservice.DeleteWorkflowExecutionRequest) (_ *workflowservice.DeleteWorkflowExecutionResponse, retError error) {
+	defer log.CapturePanic(wh.logger, &retError)
+
+	if request == nil {
+		return nil, errRequestNotSet
+	}
+
+	if err := validateExecution(request.WorkflowExecution); err != nil {
+		return nil, err
+	}
+
+	namespaceID, err := wh.namespaceRegistry.GetNamespaceID(namespace.Name(request.GetNamespace()))
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = wh.historyClient.DeleteWorkflowExecution(ctx, &historyservice.DeleteWorkflowExecutionRequest{
+		NamespaceId:        namespaceID.String(),
+		WorkflowExecution:  request.GetWorkflowExecution(),
+		WorkflowVersion:    common.EmptyVersion,
+		ClosedWorkflowOnly: false,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &workflowservice.DeleteWorkflowExecutionResponse{}, nil
+}
+
 // ListOpenWorkflowExecutions is a visibility API to list the open executions in a specific namespace.
 func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (_ *workflowservice.ListOpenWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.logger, &retError)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move `DeleteWorkflowExecution` to workflow service.

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/temporalio/api/pull/233.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Move is a breaking change, exiting clients that use `DeleteWorkflowExecution` will stop to work, but this API is used by `tctl v2` only which is in beta.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.