### PR TITLE
Fail integration tests on shutdown errors

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -155,7 +155,9 @@ func (p *processorImpl) Stop() {
 
 	err := p.bulkProcessor.Stop()
 	if err != nil {
-		p.logger.Fatal("Unable to stop Elasticsearch processor.", tag.LifeCycleStopFailed, tag.Error(err))
+		// This could happen if ES is down when we're trying to shut down the server.
+		p.logger.Error("Unable to stop Elasticsearch processor.", tag.LifeCycleStopFailed, tag.Error(err))
+		return
 	}
 	p.mapToAckFuture = nil
 	p.bulkProcessor = nil

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -164,7 +164,7 @@ func (s *IntegrationBase) tearDownSuite() {
 	}
 
 	if s.testCluster != nil {
-		s.testCluster.TearDownCluster()
+		s.NoError(s.testCluster.TearDownCluster())
 		s.testCluster = nil
 	}
 

--- a/host/ndc/ndc_integration_test.go
+++ b/host/ndc/ndc_integration_test.go
@@ -195,7 +195,7 @@ func (s *nDCIntegrationTestSuite) TearDownSuite() {
 	if s.generator != nil {
 		s.generator.Reset()
 	}
-	s.active.TearDownCluster()
+	s.NoError(s.active.TearDownCluster())
 }
 
 func (s *nDCIntegrationTestSuite) TestSingleBranch() {

--- a/host/test_cluster.go
+++ b/host/test_cluster.go
@@ -307,13 +307,14 @@ func (tc *TestCluster) SetFaultInjectionRate(rate float64) {
 }
 
 // TearDownCluster tears down the test cluster
-func (tc *TestCluster) TearDownCluster() {
+func (tc *TestCluster) TearDownCluster() error {
 	tc.SetFaultInjectionRate(0)
-	tc.host.Stop()
+	err := tc.host.Stop()
 	tc.host = nil
 	tc.testBase.TearDownWorkflowStore()
 	os.RemoveAll(tc.archiverBase.historyStoreDirectory)
 	os.RemoveAll(tc.archiverBase.visibilityStoreDirectory)
+	return err
 }
 
 // GetFrontendClient returns a frontend client from the test cluster

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -157,8 +157,8 @@ func (s *integrationClustersTestSuite) SetupTest() {
 }
 
 func (s *integrationClustersTestSuite) TearDownSuite() {
-	s.cluster1.TearDownCluster()
-	s.cluster2.TearDownCluster()
+	s.NoError(s.cluster1.TearDownCluster())
+	s.NoError(s.cluster2.TearDownCluster())
 }
 
 func (s *integrationClustersTestSuite) decodePayloadsString(ps *commonpb.Payloads) (r string) {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -874,7 +874,10 @@ var ServiceTracingModule = fx.Options(
 	),
 	fx.Provide(func(lc fx.Lifecycle, opts []otelsdktrace.TracerProviderOption) trace.TracerProvider {
 		tp := otelsdktrace.NewTracerProvider(opts...)
-		lc.Append(fx.Hook{OnStop: tp.Shutdown})
+		lc.Append(fx.Hook{OnStop: func(ctx context.Context) error {
+			tp.Shutdown(ctx)
+			return nil // do not pass this up to fx
+		}})
 		return tp
 	}),
 	// Haven't had use for baggage propagation yet


### PR DESCRIPTION
**What changed?**
Integration tests catch errors during app shutdown and fail.

To get this to work a couple things that do raise errors have to be ignored:
- elastic bulk processor: Flush and Stop will block if all servers are unreachable. So run them in a goroutine with a timeout (an error will be logged but not passed up through fx).
- otel tracing provider: similarly, ignore shutdown errors because it couldn't contact a server.

**Why?**
Clean shutdowns are good, but some errors are not that useful

**How did you test it?**
tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
