### PR TITLE
Slow down task scheduling upon resource exhausted

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -97,6 +97,10 @@ const (
 	taskNotReadyRescheduleBackoffCoefficient = 1.5
 	taskNotReadyRescheduleMaxInterval        = 3 * time.Minute
 
+	taskResourceExhaustedRescheduleInitialInterval    = 3 * time.Second
+	taskResourceExhaustedRescheduleBackoffCoefficient = 1.5
+	taskResourceExhaustedRescheduleMaxInterval        = 5 * time.Minute
+
 	sdkClientFactoryRetryInitialInterval    = 200 * time.Millisecond
 	sdkClientFactoryRetryMaxInterval        = 5 * time.Second
 	sdkClientFactoryRetryExpirationInterval = time.Minute
@@ -216,30 +220,32 @@ func CreateCompleteTaskRetryPolicy() backoff.RetryPolicy {
 
 // CreateTaskProcessingRetryPolicy creates a retry policy for task processing
 func CreateTaskProcessingRetryPolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(taskProcessingRetryInitialInterval).
+	return backoff.NewExponentialRetryPolicy(taskProcessingRetryInitialInterval).
 		WithMaximumAttempts(taskProcessingRetryMaxAttempts)
-
-	return policy
 }
 
 // CreateTaskReschedulePolicy creates a retry policy for rescheduling task with errors not equal to ErrTaskRetry
 func CreateTaskReschedulePolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(taskRescheduleInitialInterval).
+	return backoff.NewExponentialRetryPolicy(taskRescheduleInitialInterval).
 		WithBackoffCoefficient(taskRescheduleBackoffCoefficient).
 		WithMaximumInterval(taskRescheduleMaxInterval).
 		WithExpirationInterval(backoff.NoInterval)
-
-	return policy
 }
 
 // CreateTaskNotReadyReschedulePolicy creates a retry policy for rescheduling task with ErrTaskRetry
 func CreateTaskNotReadyReschedulePolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(taskNotReadyRescheduleInitialInterval).
+	return backoff.NewExponentialRetryPolicy(taskNotReadyRescheduleInitialInterval).
 		WithBackoffCoefficient(taskNotReadyRescheduleBackoffCoefficient).
 		WithMaximumInterval(taskNotReadyRescheduleMaxInterval).
 		WithExpirationInterval(backoff.NoInterval)
+}
 
-	return policy
+// CreateTaskResourceExhaustedReschedulePolicy creates a retry policy for rescheduling task with resource exhausted error
+func CreateTaskResourceExhaustedReschedulePolicy() backoff.RetryPolicy {
+	return backoff.NewExponentialRetryPolicy(taskResourceExhaustedRescheduleInitialInterval).
+		WithBackoffCoefficient(taskResourceExhaustedRescheduleBackoffCoefficient).
+		WithMaximumInterval(taskResourceExhaustedRescheduleMaxInterval).
+		WithExpirationInterval(backoff.NoInterval)
 }
 
 // CreateSdkClientFactoryRetryPolicy creates a retry policy to handle SdkClientFactory NewClient when frontend service is not ready

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -88,6 +88,8 @@ var (
 const (
 	// resubmitMaxAttempts is the max number of attempts we may skip rescheduler when a task is Nacked.
 	// check the comment in shouldResubmitOnNack() for more details
+	// TODO: evaluate the performance when this numbers is greatly reduced to a number like 3.
+	// especially, if that will increase the latency for workflow busy case by a lot.
 	resubmitMaxAttempts = 10
 	// resourceExhaustedResubmitMaxAttempts is the same as resubmitMaxAttempts but only applies to resource
 	// exhausted error

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -80,14 +80,18 @@ var (
 	schedulerRetryPolicy = common.CreateTaskProcessingRetryPolicy()
 	// reschedulePolicy is the policy for determine reschedule backoff duration
 	// across multiple submissions to scheduler
-	reschedulePolicy             = common.CreateTaskReschedulePolicy()
-	taskNotReadyReschedulePolicy = common.CreateTaskNotReadyReschedulePolicy()
+	reschedulePolicy                      = common.CreateTaskReschedulePolicy()
+	taskNotReadyReschedulePolicy          = common.CreateTaskNotReadyReschedulePolicy()
+	taskResourceExhuastedReschedulePolicy = common.CreateTaskNotReadyReschedulePolicy()
 )
 
 const (
 	// resubmitMaxAttempts is the max number of attempts we may skip rescheduler when a task is Nacked.
 	// check the comment in shouldResubmitOnNack() for more details
 	resubmitMaxAttempts = 10
+	// resourceExhaustedResubmitMaxAttempts is the same as resubmitMaxAttempts but only applies to resource
+	// exhausted error
+	resourceExhaustedResubmitMaxAttempts = 1
 )
 
 type (
@@ -112,6 +116,7 @@ type (
 		scheduledTime                 time.Time
 		userLatency                   time.Duration
 		lastActiveness                bool
+		resourceExhaustedCount        int
 		logger                        log.Logger
 		metricsHandler                metrics.MetricsHandler
 		taggedMetricsHandler          metrics.MetricsHandler
@@ -227,6 +232,12 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 			if e.attempt > e.criticalRetryAttempt() {
 				e.metricsHandler.Histogram(TaskAttempt, metrics.Dimensionless).Record(int64(e.attempt))
 				e.logger.Error("Critical error processing task, retrying.", tag.Error(err), tag.OperationCritical)
+			}
+
+			if common.IsResourceExhausted(retErr) {
+				e.resourceExhaustedCount++
+			} else {
+				e.resourceExhaustedCount = 0
 			}
 		}
 	}()
@@ -411,7 +422,12 @@ func (e *executableImpl) shouldResubmitOnNack(attempt int, err error) bool {
 	// this is an optimization for skipping rescheduler and retry the task sooner.
 	// this is useful for errors like workflow busy, which doesn't have to wait for
 	// the longer rescheduling backoff.
-	if e.Attempt() > resubmitMaxAttempts {
+	if attempt > resubmitMaxAttempts {
+		return false
+	}
+
+	if common.IsResourceExhausted(err) &&
+		e.resourceExhaustedCount > resourceExhaustedResubmitMaxAttempts {
 		return false
 	}
 
@@ -436,7 +452,15 @@ func (e *executableImpl) rescheduleTime(
 		e.timeSource.Now().Add(taskNotReadyReschedulePolicy.ComputeNextDelay(0, attempt))
 	}
 
-	return e.timeSource.Now().Add(reschedulePolicy.ComputeNextDelay(0, attempt))
+	backoff := reschedulePolicy.ComputeNextDelay(0, attempt)
+	if common.IsResourceExhausted(err) {
+		// try a different reschedule policy to slow down retry
+		// upon resource exhausted error and pick the longer backoff
+		// duration
+		backoff = util.Max(backoff, taskResourceExhuastedReschedulePolicy.ComputeNextDelay(0, e.resourceExhaustedCount))
+	}
+
+	return e.timeSource.Now().Add(backoff)
 }
 
 func (e *executableImpl) updatePriority() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Slow down task scheduling upon resource exhausted based on the # of continuous resource exhausted errors

<!-- Tell your future self why have you made these changes -->
**Why?**
- Existing impl reschedules task too aggressively upon resource exhausted.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
