### PR TITLE
Use 60 days as history scavenger min age

### DIFF
--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -278,7 +278,7 @@ func NewConfig(dc *dynamicconfig.Collection, persistenceConfig *config.Persisten
 			),
 			HistoryScannerDataMinAge: dc.GetDurationProperty(
 				dynamicconfig.HistoryScannerDataMinAge,
-				90*24*time.Hour,
+				60*24*time.Hour,
 			),
 		},
 		EnableBatcher:      dc.GetBoolProperty(dynamicconfig.EnableBatcher, true),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change default history scavenger min age to 60 days

<!-- Tell your future self why have you made these changes -->
**Why?**
Keep same behavior as 1.17.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
