### PR TITLE
Multi-cursor: slice predicate action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ update-mockgen:
 
 update-proto-plugins:
 	@printf $(COLOR) "Install/update proto plugins..."
-	@go install github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick@master
+	@go install github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick@latest
 # This to download sources of gogo-protobuf which are required to build proto files.
 	@GO111MODULE=off go get github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ update-mockgen:
 
 update-proto-plugins:
 	@printf $(COLOR) "Install/update proto plugins..."
-	@go install github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick@latest
+	@go install github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick@master
 # This to download sources of gogo-protobuf which are required to build proto files.
 	@GO111MODULE=off go get github.com/temporalio/gogo-protobuf/protoc-gen-gogoslick
 	@go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest

--- a/service/history/queues/action_slice_predicate.go
+++ b/service/history/queues/action_slice_predicate.go
@@ -1,0 +1,114 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues
+
+import "go.temporal.io/server/service/history/tasks"
+
+const (
+	moveSliceDefaultReaderMinPendingTaskCount = 50
+	moveSliceDefaultReaderMinSliceCount       = 3
+)
+
+type (
+	// slicePredicateAction will move all slices in default reader
+	// with non-universal predicate to the next reader so that upon restart
+	// task loading for those slices won't blocking loading for other slices
+	// in the default reader.
+	//
+	// Slice.ShrinkScope() will shrink its predicate when there's few
+	// namespaces left. But those slices may still in the default reader.
+	// If there are many such slices in the default reader, then upon restart
+	// task loading for other namespace will be blocked. So we need to move those
+	// slices to a different reader.
+	//
+	// NOTE: When there's no restart/shard movement, this movement won't affect
+	// anything, as slice with non-universal predicate must have already loaded
+	// all tasks into memory.
+	slicePredicateAction struct {
+		monitor        Monitor
+		maxReaderCount int
+	}
+)
+
+func newSlicePredicateAction(
+	monitor Monitor,
+	maxReaderCount int,
+) Action {
+	return &slicePredicateAction{
+		monitor:        monitor,
+		maxReaderCount: maxReaderCount,
+	}
+}
+
+func (a *slicePredicateAction) Run(readerGroup *ReaderGroup) {
+	reader, ok := readerGroup.ReaderByID(DefaultReaderId)
+	if !ok {
+		return
+	}
+
+	if a.maxReaderCount <= DefaultReaderId+1 {
+		return
+	}
+
+	sliceCount := a.monitor.GetSliceCount(DefaultReaderId)
+	pendingTasks := 0
+	hasNonUniversalPredicate := false
+	reader.WalkSlices(func(s Slice) {
+		pendingTasks += a.monitor.GetSlicePendingTaskCount(s)
+
+		if !tasks.IsUniverisalPredicate(s.Scope().Predicate) {
+			hasNonUniversalPredicate = true
+		}
+	})
+
+	// only move slices when either default reader slice count or
+	// pending task count is high
+	if !hasNonUniversalPredicate ||
+		(pendingTasks < moveSliceDefaultReaderMinPendingTaskCount &&
+			sliceCount < moveSliceDefaultReaderMinSliceCount) {
+		return
+	}
+
+	var moveSlices []Slice
+	reader.SplitSlices(func(s Slice) (remaining []Slice, split bool) {
+		if tasks.IsUniverisalPredicate(s.Scope().Predicate) {
+			return []Slice{s}, false
+		}
+
+		moveSlices = append(moveSlices, s)
+		return nil, true
+	})
+
+	if len(moveSlices) == 0 {
+		return
+	}
+
+	nextReader, ok := readerGroup.ReaderByID(DefaultReaderId + 1)
+	if !ok {
+		readerGroup.NewReader(DefaultReaderId+1, moveSlices...)
+	} else {
+		nextReader.MergeSlices(moveSlices...)
+	}
+}

--- a/service/history/tasks/predicates.go
+++ b/service/history/tasks/predicates.go
@@ -25,10 +25,10 @@
 package tasks
 
 import (
-	"go.temporal.io/server/common/predicates"
 	"golang.org/x/exp/maps"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/predicates"
 )
 
 type (
@@ -148,6 +148,21 @@ func OrPredicates(a Predicate, b Predicate) Predicate {
 	}
 
 	return predicates.Or(a, b)
+}
+
+func IsUniverisalPredicate(p Predicate) bool {
+	_, ok := p.(*predicates.UniversalImpl[Task])
+	return ok
+}
+
+func IsNamespacePredicate(p Predicate) bool {
+	_, ok := p.(*NamespacePredicate)
+	return ok
+}
+
+func IsTypePredicate(p Predicate) bool {
+	_, ok := p.(*TypePredicate)
+	return ok
 }
 
 func intersect[K comparable](this, that map[K]struct{}) map[K]struct{} {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add slice predicate action which will be run upon checkpointing queue state

<!-- Tell your future self why have you made these changes -->
**Why?**
- slicePredicateAction will move all slices in default reader, with non-universal predicate to the next reader so that upon restart task loading for those slices won't blocking loading for other slices in the default reader.
- Slice.ShrinkScope() will shrink its predicate when there's few namespaces left. But those slices may still in the default reader. If there are many such slices in the default reader, then upon restart task loading for other namespace will be blocked. So we need to move those slices to a different reader.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
