### PR TITLE
Multi-cursor: Improve slice count action

### DIFF
--- a/service/history/queues/action_slice_count.go
+++ b/service/history/queues/action_slice_count.go
@@ -25,7 +25,6 @@
 package queues
 
 import (
-	"go.temporal.io/server/common/predicates"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/history/tasks"
 	"golang.org/x/exp/slices"
@@ -79,13 +78,8 @@ func (a *actionSliceCount) Run(readerGroup *ReaderGroup) {
 
 	isDefaultReader := func(readerID int32) bool { return readerID == DefaultReaderId }
 	isNotDefaultReader := func(readerID int32) bool { return !isDefaultReader(readerID) }
-	isUniversalPredicate := func(s Slice) bool {
-		_, ok := s.Scope().Predicate.(*predicates.UniversalImpl[tasks.Task])
-		return ok
-	}
-	isNotUniversalPredicate := func(s Slice) bool {
-		return !isUniversalPredicate(s)
-	}
+	isUniversalPredicate := func(s Slice) bool { return tasks.IsUniverisalPredicate(s.Scope().Predicate) }
+	isNotUniversalPredicate := func(s Slice) bool { return !isUniversalPredicate(s) }
 
 	// peform compaction in four stages:
 	// 1. compact slices in non-default reader with non-universal predicate


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Take slice predicate into consideration when compacting slices.
- Refactor slice count action implementation

<!-- Tell your future self why have you made these changes -->
**Why?**
- When compacting two slices, the resulting predicate will be the union of the two predicates. If one of them is Universal, then the resulting one will also be universal. In the worst case, this will make all slices in a reader to have universal predicate and causing all tasks to be reprocessed upon shard reload.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Testing locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
