### PR TITLE
Multi-cursor: move alert deduping to queue monitor

### DIFF
--- a/service/history/queues/mitigator_test.go
+++ b/service/history/queues/mitigator_test.go
@@ -43,6 +43,9 @@ type (
 		monitor   Monitor
 		mitigator *mitigatorImpl
 	}
+
+	testMonitor struct {
+	}
 )
 
 func TestMitigatorSuite(t *testing.T) {
@@ -73,17 +76,6 @@ func (s *mitigatorSuite) TestQueuePendingTaskAlert() {
 
 	action := s.mitigator.Mitigate(alert)
 	s.IsType(&actionQueuePendingTask{}, action)
-
-	s.Nil(
-		s.mitigator.Mitigate(alert),
-		"mitigator should have only one outstanding action for pending task alert",
-	)
-
-	action.(*actionQueuePendingTask).completionFn()
-
-	action = s.mitigator.Mitigate(alert)
-	s.NotNil(action)
-	s.IsType(&actionQueuePendingTask{}, action)
 }
 
 func (s *mitigatorSuite) TestReaderWatermarkAlert() {
@@ -96,17 +88,6 @@ func (s *mitigatorSuite) TestReaderWatermarkAlert() {
 	}
 
 	action := s.mitigator.Mitigate(alert)
-	s.IsType(&actionReaderStuck{}, action)
-
-	s.Nil(
-		s.mitigator.Mitigate(alert),
-		"mitigator should have only one outstanding action for reader watermark alert",
-	)
-
-	action.(*actionReaderStuck).completionFn()
-
-	action = s.mitigator.Mitigate(alert)
-	s.NotNil(action)
 	s.IsType(&actionReaderStuck{}, action)
 }
 
@@ -121,15 +102,19 @@ func (s *mitigatorSuite) TestSliceCountAlert() {
 
 	action := s.mitigator.Mitigate(alert)
 	s.IsType(&actionSliceCount{}, action)
+}
 
-	s.Nil(
-		s.mitigator.Mitigate(alert),
-		"mitigator should have only one outstanding action for slice count alert",
-	)
+func (s *mitigatorSuite) TestActionComplectionFn() {
+	// manually set pending alerts in monitor
+	monitor := s.monitor.(*monitorImpl)
+	monitor.pendingAlerts = map[AlertType]struct{}{
+		AlertTypeQueuePendingTaskCount: {},
+	}
 
-	action.(*actionSliceCount).completionFn()
+	s.mitigator.newActionCompletionFn(
+		AlertTypeQueuePendingTaskCount,
+		&AlertAttributesQueuePendingTaskCount{},
+	)()
 
-	action = s.mitigator.Mitigate(alert)
-	s.NotNil(action)
-	s.IsType(&actionSliceCount{}, action)
+	s.Empty(monitor.pendingAlerts)
 }

--- a/service/history/queues/mitigator_test.go
+++ b/service/history/queues/mitigator_test.go
@@ -43,9 +43,6 @@ type (
 		monitor   Monitor
 		mitigator *mitigatorImpl
 	}
-
-	testMonitor struct {
-	}
 )
 
 func TestMitigatorSuite(t *testing.T) {

--- a/service/history/queues/monitor.go
+++ b/service/history/queues/monitor.go
@@ -308,6 +308,7 @@ func (m *monitorImpl) sendAlertLocked(alert *Alert) {
 		return
 	}
 
+	// dedup alerts, we only need one outstanding alert per alert type
 	if _, ok := m.pendingAlerts[alert.AlertType]; ok {
 		return
 	}

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -120,6 +120,7 @@ func NewReader(
 	for _, slice := range slices {
 		sliceList.PushBack(slice)
 	}
+	monitor.SetSliceCount(readerID, len(slices))
 
 	return &ReaderImpl{
 		readerID:       readerID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Move queue alert dedup logic from mitigator to queue monitor

<!-- Tell your future self why have you made these changes -->
**Why?**
- The dudup logic in mitigator does work as: Alert is received from alert channel only after previously alerts's action has completed, so mitigator will never see duplicated alerts.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- New unit test. Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
