### PR TITLE
Tweak schedule test timeouts

### DIFF
--- a/common/testing/mocksdk/client_mock.go
+++ b/common/testing/mocksdk/client_mock.go
@@ -34,6 +34,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	enums "go.temporal.io/api/enums/v1"
+	operatorservice "go.temporal.io/api/operatorservice/v1"
 	workflowservice "go.temporal.io/api/workflowservice/v1"
 	client "go.temporal.io/sdk/client"
 	converter "go.temporal.io/sdk/converter"
@@ -297,6 +298,20 @@ func (m *MockClient) ListWorkflow(arg0 context.Context, arg1 *workflowservice.Li
 func (mr *MockClientMockRecorder) ListWorkflow(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkflow", reflect.TypeOf((*MockClient)(nil).ListWorkflow), arg0, arg1)
+}
+
+// OperatorService mocks base method.
+func (m *MockClient) OperatorService() operatorservice.OperatorServiceClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OperatorService")
+	ret0, _ := ret[0].(operatorservice.OperatorServiceClient)
+	return ret0
+}
+
+// OperatorService indicates an expected call of OperatorService.
+func (mr *MockClientMockRecorder) OperatorService() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OperatorService", reflect.TypeOf((*MockClient)(nil).OperatorService))
 }
 
 // QueryWorkflow mocks base method.

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.7.0
 	go.opentelemetry.io/otel/sdk/metric v0.30.0
 	go.temporal.io/api v1.11.1-0.20220907050538-6de5285cf463
-	go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89
+	go.temporal.io/sdk v1.16.1-0.20220906192533-d884fe6f5ca8
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.10.0
 	go.uber.org/fx v1.17.1

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ go.opentelemetry.io/proto/otlp v0.18.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI
 go.temporal.io/api v1.11.1-0.20220804232755-77e12eef4f2d/go.mod h1:JWI21cif+WGqtgmar+dtxQOfYeGORmZtWUj/6/D0e9k=
 go.temporal.io/api v1.11.1-0.20220907050538-6de5285cf463 h1:ylSAQ8ldG7ZRu/0nuvcHBAvfSEZr/T4I9ZnSWe5xpWQ=
 go.temporal.io/api v1.11.1-0.20220907050538-6de5285cf463/go.mod h1:yZGA2AVWUri9TUol58DTosjQnQBLEMDnchA4u+v1i6E=
-go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89 h1:YgBLMeScA/oLIeGOLh9rV26p10KcatcyH46P2MEoI0Q=
-go.temporal.io/sdk v1.16.1-0.20220901175455-d1f860c19f89/go.mod h1:XHGK393x654eIHGNf9nXw6DpOJlW4OuvivfLb8n2E34=
+go.temporal.io/sdk v1.16.1-0.20220906192533-d884fe6f5ca8 h1:ZiumPrlf4rAC7Mw+GpDXZnjUwVntk2mGp2qisyU2tus=
+go.temporal.io/sdk v1.16.1-0.20220906192533-d884fe6f5ca8/go.mod h1:XHGK393x654eIHGNf9nXw6DpOJlW4OuvivfLb8n2E34=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=

--- a/host/schedule_test.go
+++ b/host/schedule_test.go
@@ -217,7 +217,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 
 	// sleep until we see two runs, plus a bit more
 	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 2 }, 8*time.Second, 200*time.Millisecond)
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	// describe
 
@@ -235,7 +235,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	s.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csa].Data)
 	s.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
 
-	s.DurationNear(describeResp.Info.CreateTime.Sub(createTime), 0, 500*time.Millisecond)
+	s.DurationNear(describeResp.Info.CreateTime.Sub(createTime), 0, 1*time.Second)
 	s.EqualValues(2, describeResp.Info.ActionCount)
 	s.EqualValues(0, describeResp.Info.MissedCatchupWindow)
 	s.EqualValues(0, describeResp.Info.OverlapSkipped)
@@ -244,7 +244,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	action0 := describeResp.Info.RecentActions[0]
 	s.WithinRange(*action0.ScheduleTime, createTime, time.Now())
 	s.True(action0.ScheduleTime.UnixNano()%int64(3*time.Second) == 0)
-	s.DurationNear(action0.ActualTime.Sub(*action0.ScheduleTime), 0, 500*time.Millisecond)
+	s.DurationNear(action0.ActualTime.Sub(*action0.ScheduleTime), 0, 1*time.Second)
 
 	// list
 
@@ -319,8 +319,8 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	s.NoError(err)
 
 	// wait for one new run
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs2) == 1 }, 4*time.Second, 200*time.Millisecond)
-	time.Sleep(100 * time.Millisecond)
+	s.Eventually(func() bool { return atomic.LoadInt32(&runs2) == 1 }, 5*time.Second, 200*time.Millisecond)
+	time.Sleep(200 * time.Millisecond)
 
 	// describe again
 	describeResp, err = s.engine.DescribeSchedule(NewContext(), &workflowservice.DescribeScheduleRequest{
@@ -334,7 +334,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	s.Equal(wfSAValue.Data, describeResp.Schedule.Action.GetStartWorkflow().SearchAttributes.IndexedFields[csa].Data)
 	s.Equal(wfMemo.Data, describeResp.Schedule.Action.GetStartWorkflow().Memo.Fields["wfmemo1"].Data)
 
-	s.DurationNear(describeResp.Info.UpdateTime.Sub(updateTime), 0, 500*time.Millisecond)
+	s.DurationNear(describeResp.Info.UpdateTime.Sub(updateTime), 0, 1*time.Second)
 	s.EqualValues(3, len(describeResp.Info.RecentActions))
 	action2 := describeResp.Info.RecentActions[2]
 	s.True(action2.ScheduleTime.UnixNano()%int64(3*time.Second) == 1000000000, action2.ScheduleTime.UnixNano())
@@ -352,7 +352,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	})
 	s.NoError(err)
 
-	time.Sleep(3*time.Second + 100*time.Millisecond)
+	time.Sleep(3*time.Second + 500*time.Millisecond)
 	s.EqualValues(1, atomic.LoadInt32(&runs2), "has not run again")
 
 	describeResp, err = s.engine.DescribeSchedule(NewContext(), &workflowservice.DescribeScheduleRequest{
@@ -457,7 +457,7 @@ func (s *scheduleIntegrationSuite) TestInput() {
 
 	_, err = s.engine.CreateSchedule(NewContext(), req)
 	s.NoError(err)
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 4*time.Second, 200*time.Millisecond)
+	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 5*time.Second, 200*time.Millisecond)
 }
 
 func (s *scheduleIntegrationSuite) TestRefresh() {
@@ -507,7 +507,7 @@ func (s *scheduleIntegrationSuite) TestRefresh() {
 
 	_, err := s.engine.CreateSchedule(NewContext(), req)
 	s.NoError(err)
-	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 3*time.Second, 100*time.Millisecond)
+	s.Eventually(func() bool { return atomic.LoadInt32(&runs) == 1 }, 4*time.Second, 100*time.Millisecond)
 
 	// workflow has started but is now sleeping. it will timeout in 2 seconds.
 


### PR DESCRIPTION
**What changed?**
- Increase some timeouts in schedule integration test
- Bump sdk version to pick up fix for double-close

**Why?**
less flaky test

**How did you test it?**
ran repeatedly locally

**Potential risks**

**Is hotfix candidate?**
