### PR TITLE
Skip ratelimiting for some persistence APIs

### DIFF
--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -653,9 +653,11 @@ func (p *executionRateLimitedPersistenceClient) ParseHistoryBranchInfo(
 	ctx context.Context,
 	request *ParseHistoryBranchInfoRequest,
 ) (*ParseHistoryBranchInfoResponse, error) {
-	if ok := allow(ctx, "ParseHistoryBranchInfo", p.rateLimiter); !ok {
-		return nil, ErrPersistenceLimitExceeded
-	}
+	// ParseHistoryBranchInfo implementation currently doesn't actually query DB
+	// TODO: uncomment if necessary
+	// if ok := allow(ctx, "ParseHistoryBranchInfo", p.rateLimiter); !ok {
+	// 	return nil, ErrPersistenceLimitExceeded
+	// }
 	return p.persistence.ParseHistoryBranchInfo(ctx, request)
 }
 
@@ -664,9 +666,11 @@ func (p *executionRateLimitedPersistenceClient) UpdateHistoryBranchInfo(
 	ctx context.Context,
 	request *UpdateHistoryBranchInfoRequest,
 ) (*UpdateHistoryBranchInfoResponse, error) {
-	if ok := allow(ctx, "UpdateHistoryBranchInfo", p.rateLimiter); !ok {
-		return nil, ErrPersistenceLimitExceeded
-	}
+	// UpdateHistoryBranchInfo implementation currently doesn't actually query DB
+	// TODO: uncomment if necessary
+	// if ok := allow(ctx, "UpdateHistoryBranchInfo", p.rateLimiter); !ok {
+	// 	return nil, ErrPersistenceLimitExceeded
+	// }
 	return p.persistence.UpdateHistoryBranchInfo(ctx, request)
 }
 
@@ -675,11 +679,12 @@ func (p *executionRateLimitedPersistenceClient) NewHistoryBranch(
 	ctx context.Context,
 	request *NewHistoryBranchRequest,
 ) (*NewHistoryBranchResponse, error) {
-	if ok := allow(ctx, "NewHistoryBranch", p.rateLimiter); !ok {
-		return nil, ErrPersistenceLimitExceeded
-	}
-	response, err := p.persistence.NewHistoryBranch(ctx, request)
-	return response, err
+	// NewHistoryBranch implementation currently doesn't actually query DB
+	// TODO: uncomment if necessary
+	// if ok := allow(ctx, "NewHistoryBranch", p.rateLimiter); !ok {
+	// 	return nil, ErrPersistenceLimitExceeded
+	// }
+	return p.persistence.NewHistoryBranch(ctx, request)
 }
 
 // ReadHistoryBranch returns history node data for a branch


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Skip ratelimiting for persistence APIs that doesn't actually query DB.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Those apis doesn't actually DB but consumes persistence ratelimiting token
- May cause more service busy errors upon service restart, when we are already seeing some persistence busy errors.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
