### PR TITLE
Increase default sendArchiveSignal timeout and make it configurable

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -501,6 +501,8 @@ const (
 	NumArchiveSystemWorkflows = "history.numArchiveSystemWorkflows"
 	// ArchiveRequestRPS is the rate limit on the number of archive request per second
 	ArchiveRequestRPS = "history.archiveRequestRPS"
+	// ArchiveSignalTimeout is the signal timeout used when starting an archive system workflow
+	ArchiveSignalTimeout = "history.archiveSignalTimeout"
 	// DefaultActivityRetryPolicy represents the out-of-box retry policy for activities where
 	// the user has not specified an explicit RetryPolicy
 	DefaultActivityRetryPolicy = "history.defaultActivityRetryPolicy"

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -396,7 +396,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 
 		NumArchiveSystemWorkflows: dc.GetIntProperty(dynamicconfig.NumArchiveSystemWorkflows, 1000),
 		ArchiveRequestRPS:         dc.GetIntProperty(dynamicconfig.ArchiveRequestRPS, 300), // should be much smaller than frontend RPS
-		ArchiveSignalTimeout:      dc.GetDurationProperty(dynamicconfig.ArchiveSignalTimeout, 1*time.Second),
+		ArchiveSignalTimeout:      dc.GetDurationProperty(dynamicconfig.ArchiveSignalTimeout, 300*time.Millisecond),
 
 		BlobSizeLimitError:     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
 		BlobSizeLimitWarn:      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitWarn, 512*1024),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -179,6 +179,7 @@ type Config struct {
 	// Archival settings
 	NumArchiveSystemWorkflows dynamicconfig.IntPropertyFn
 	ArchiveRequestRPS         dynamicconfig.IntPropertyFn
+	ArchiveSignalTimeout      dynamicconfig.DurationPropertyFn
 
 	// Size limit related settings
 	BlobSizeLimitError     dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -395,6 +396,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 
 		NumArchiveSystemWorkflows: dc.GetIntProperty(dynamicconfig.NumArchiveSystemWorkflows, 1000),
 		ArchiveRequestRPS:         dc.GetIntProperty(dynamicconfig.ArchiveRequestRPS, 300), // should be much smaller than frontend RPS
+		ArchiveSignalTimeout:      dc.GetDurationProperty(dynamicconfig.ArchiveSignalTimeout, 1*time.Second),
 
 		BlobSizeLimitError:     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
 		BlobSizeLimitWarn:      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitWarn, 512*1024),

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -278,6 +278,7 @@ func ArchivalClientProvider(
 		sdkClientFactory,
 		config.NumArchiveSystemWorkflows,
 		config.ArchiveRequestRPS,
+		config.ArchiveSignalTimeout,
 		archiverProvider,
 	)
 }

--- a/service/worker/archiver/client_test.go
+++ b/service/worker/archiver/client_test.go
@@ -83,7 +83,7 @@ func (s *clientSuite) SetupTest() {
 		s.sdkClientFactory,
 		dynamicconfig.GetIntPropertyFn(1000),
 		dynamicconfig.GetIntPropertyFn(1000),
-		dynamicconfig.GetDurationPropertyFn(1*time.Second),
+		dynamicconfig.GetDurationPropertyFn(300*time.Millisecond),
 		s.archiverProvider,
 	).(*client)
 }

--- a/service/worker/archiver/client_test.go
+++ b/service/worker/archiver/client_test.go
@@ -29,6 +29,7 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -82,6 +83,7 @@ func (s *clientSuite) SetupTest() {
 		s.sdkClientFactory,
 		dynamicconfig.GetIntPropertyFn(1000),
 		dynamicconfig.GetIntPropertyFn(1000),
+		dynamicconfig.GetDurationPropertyFn(1*time.Second),
 		s.archiverProvider,
 	).(*client)
 }


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
This moves a hard-coded timeout to a dynamic config and bumps up the default value from 300ms to 1 second (a fairly arbitrary choice).

<!-- Tell your future self why have you made these changes -->
**Why?**
To resolve https://github.com/temporalio/temporal/issues/2655

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually by deploying this in a pre-prod environment. I also ran `docker-compose run unit-test make unit-test-coverage` and `docker-compose run integration-test-mysql make integration-test-coverage` locally.

**Potential risks**
Potential for previously failing calls to start succeeding with the higher default timeout and increase load related to archival.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
