### PR TITLE
Add refresh to force update dynamic rate limiter

### DIFF
--- a/common/quotas/dynamic_rate_limiter_impl.go
+++ b/common/quotas/dynamic_rate_limiter_impl.go
@@ -133,11 +133,15 @@ func (d *DynamicRateLimiterImpl) Burst() int {
 	return d.rateLimiter.Burst()
 }
 
+func (d *DynamicRateLimiterImpl) Refresh() {
+	d.rateLimiter.SetRateBurst(d.rateBurstFn.Rate(), d.rateBurstFn.Burst())
+}
+
 func (d *DynamicRateLimiterImpl) maybeRefresh() {
 	select {
 	case <-d.refreshTimer.C:
 		d.refreshTimer.Reset(d.refreshInterval)
-		d.rateLimiter.SetRateBurst(d.rateBurstFn.Rate(), d.rateBurstFn.Burst())
+		d.Refresh()
 
 	default:
 		// noop


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add refresh method to dynamic rate limiter to force update rate

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix the 1m delay for task queue rate limiter

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
