### PR TITLE
Return a "not found" error code for empty archival namespaces

### DIFF
--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -217,7 +217,7 @@ func (h *historyArchiver) Get(
 		return nil, serviceerror.NewInternal(err.Error())
 	}
 	if !exists {
-		return nil, serviceerror.NewInvalidArgument(archiver.ErrHistoryNotExist.Error())
+		return nil, serviceerror.NewNotFound(archiver.ErrHistoryNotExist.Error())
 	}
 
 	var token *getHistoryToken

--- a/common/archiver/filestore/historyArchiver_test.go
+++ b/common/archiver/filestore/historyArchiver_test.go
@@ -414,7 +414,7 @@ func (s *historyArchiverSuite) TestGet_Fail_DirectoryNotExist() {
 	response, err := historyArchiver.Get(context.Background(), s.testArchivalURI, request)
 	s.Nil(response)
 	s.Error(err)
-	s.IsType(&serviceerror.InvalidArgument{}, err)
+	s.IsType(&serviceerror.NotFound{}, err)
 }
 
 func (s *historyArchiverSuite) TestGet_Fail_InvalidToken() {

--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -225,6 +225,9 @@ func (h *historyArchiver) Get(ctx context.Context, URI archiver.URI, request *ar
 		if err != nil {
 			return nil, serviceerror.NewUnavailable(err.Error())
 		}
+		if highestVersion == nil {
+			return nil, serviceerror.NewNotFound(archiver.ErrHistoryNotExist.Error())
+		}
 		token = &getHistoryToken{
 			CloseFailoverVersion: *highestVersion,
 			HighestPart:          *historyhighestPart,

--- a/common/archiver/gcloud/historyArchiver_test.go
+++ b/common/archiver/gcloud/historyArchiver_test.go
@@ -566,3 +566,23 @@ func (h *historyArchiverSuite) TestGet_Success_FromToken() {
 
 	h.EqualValues(4, numOfEvents)
 }
+
+func (h *historyArchiverSuite) TestGet_NoHistory() {
+
+	ctx := context.Background()
+	storageWrapper := connector.NewMockClient(h.controller)
+	storageWrapper.EXPECT().Exist(ctx, h.testArchivalURI, "").Return(true, nil)
+	storageWrapper.EXPECT().Query(ctx, h.testArchivalURI, "141323698701063509081739672280485489488911532452831150339470").Return([]string{}, nil)
+
+	historyIterator := archiver.NewMockHistoryIterator(h.controller)
+	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)
+	request := &archiver.GetHistoryRequest{
+		NamespaceID: testNamespaceID,
+		WorkflowID:  testWorkflowID,
+		RunID:       testRunID,
+		PageSize:    2,
+	}
+
+	_, err := historyArchiver.Get(ctx, h.testArchivalURI, request)
+	h.Assert().IsType(&serviceerror.NotFound{}, err)
+}

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -292,6 +292,9 @@ func (h *historyArchiver) Get(
 	} else {
 		highestVersion, err := h.getHighestVersion(ctx, URI, request)
 		if err != nil {
+			if err == archiver.ErrHistoryNotExist {
+				return nil, serviceerror.NewNotFound(err.Error())
+			}
 			return nil, serviceerror.NewInvalidArgument(err.Error())
 		}
 		token = &getHistoryToken{

--- a/common/archiver/s3store/historyArchiver_test.go
+++ b/common/archiver/s3store/historyArchiver_test.go
@@ -630,6 +630,23 @@ func (s *historyArchiverSuite) TestGet_Success_SmallPageSize() {
 	s.Equal(append(s.historyBatchesV100[0].Body, s.historyBatchesV100[1].Body...), combinedHistory)
 }
 
+func (s *historyArchiverSuite) TestGet_EmptyHistory_ReturnsNotFoundError() {
+	historyIterator := archiver.NewMockHistoryIterator(s.controller)
+	historyArchiver := s.newTestHistoryArchiver(historyIterator)
+	URI, err := archiver.NewURI(testBucketURI + "/TestArchiveAndGet")
+	s.NoError(err)
+	getRequest := &archiver.GetHistoryRequest{
+		NamespaceID: testNamespaceID,
+		WorkflowID:  testWorkflowID,
+		RunID:       testRunID,
+		PageSize:    testPageSize,
+	}
+	response, err := historyArchiver.Get(context.Background(), URI, getRequest)
+	s.Error(err)
+	s.Nil(response)
+	s.IsType(&serviceerror.NotFound{}, err)
+}
+
 func (s *historyArchiverSuite) TestArchiveAndGet() {
 	historyIterator := archiver.NewMockHistoryIterator(s.controller)
 	gomock.InOrder(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Return a "not found" error code instead of an "invalid argument" error when fetching history for archival-enabled namespaces that have no history.


<!-- Tell your future self why have you made these changes -->
I made these changes because they were requested here: https://github.com/temporalio/temporal/issues/2130
I also verified that all other references to the `archiver.ErrHistoryNotExist` return an invalid argument error, so this one was the odd one out.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I verified that all other usages of this same error message return the same error code. I modified the unit test which executes this logic to verify that the error code is "not found".


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
This modifies a user-facing API, so if someone depends on the existing error code, this could affect them.


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
This PR is not a hot fix candidate. However, it may be wise to notify the community about this change.
