### PR TITLE
Enforce memo size limit during StartWorkflow

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -134,6 +134,8 @@ const (
 var (
 	// ErrBlobSizeExceedsLimit is error for event blob size exceeds limit
 	ErrBlobSizeExceedsLimit = serviceerror.NewInvalidArgument("Blob data size exceeds limit.")
+	// ErrMemoSizeExceedsLimit is error for memo size exceeds limit
+	ErrMemoSizeExceedsLimit = serviceerror.NewInvalidArgument("Memo size exceeds limit.")
 	// ErrContextTimeoutTooShort is error for setting a very short context timeout when calling a long poll API
 	ErrContextTimeoutTooShort = serviceerror.NewInvalidArgument("Context timeout is too short.")
 	// ErrContextTimeoutNotSet is error for not setting a context timeout when calling a long poll API

--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -28,7 +28,6 @@ import (
 	"context"
 
 	commonpb "go.temporal.io/api/common/v1"
-	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
@@ -182,20 +181,16 @@ func ValidateStart(
 	config := shard.GetConfig()
 	logger := shard.GetLogger()
 	throttledLogger := shard.GetThrottledLogger()
-
 	namespaceName := namespaceEntry.Name().String()
-
-	blobSizeLimitWarn := config.BlobSizeLimitWarn(namespaceName)
-	blobSizeLimitError := config.BlobSizeLimitError(namespaceName)
 
 	if err := common.CheckEventBlobSizeLimit(
 		workflowInputSize,
-		blobSizeLimitWarn,
-		blobSizeLimitError,
+		config.BlobSizeLimitWarn(namespaceName),
+		config.BlobSizeLimitError(namespaceName),
 		namespaceName,
 		workflowID,
 		"",
-		interceptor.MetricsScope(ctx, logger).Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
+		interceptor.MetricsScope(ctx, logger).Tagged(metrics.CommandTypeTag("ValidateStart_Input")),
 		throttledLogger,
 		tag.BlobSizeViolationOperation(operation),
 	); err != nil {
@@ -204,12 +199,12 @@ func ValidateStart(
 
 	if err := common.CheckEventBlobSizeLimit(
 		workflowMemoSize,
-		blobSizeLimitWarn,
-		blobSizeLimitError,
+		config.MemoSizeLimitWarn(namespaceName),
+		config.MemoSizeLimitError(namespaceName),
 		namespaceName,
 		workflowID,
 		"",
-		interceptor.MetricsScope(ctx, logger).Tagged(metrics.CommandTypeTag(enumspb.COMMAND_TYPE_UNSPECIFIED.String())),
+		interceptor.MetricsScope(ctx, logger).Tagged(metrics.CommandTypeTag("ValidateStart_Memo")),
 		throttledLogger,
 		tag.BlobSizeViolationOperation(operation),
 	); err != nil {

--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -208,7 +208,7 @@ func ValidateStart(
 		throttledLogger,
 		tag.BlobSizeViolationOperation(operation),
 	); err != nil {
-		return err
+		return common.ErrMemoSizeExceedsLimit
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Validate memo size against correct memo size limit

<!-- Tell your future self why have you made these changes -->
**Why?**
Use the right size limit for memo size validation

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
