### PR TITLE
Fix memo/search attribute size validation when upserting

### DIFF
--- a/common/payload/payload_test.go
+++ b/common/payload/payload_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	commonpb "go.temporal.io/api/common/v1"
 )
 
 type testStruct struct {
@@ -70,4 +71,34 @@ func TestToString(t *testing.T) {
 
 	result = ToString(nil)
 	assert.Equal("", result)
+}
+
+func TestMergeMapOfPayload(t *testing.T) {
+	assert := assert.New(t)
+
+	var currentMap map[string]*commonpb.Payload
+	var newMap map[string]*commonpb.Payload
+	resultMap := MergeMapOfPayload(currentMap, newMap)
+	assert.Equal(make(map[string]*commonpb.Payload), resultMap)
+
+	newMap = map[string]*commonpb.Payload{"key": EncodeString("val")}
+	resultMap = MergeMapOfPayload(currentMap, newMap)
+	assert.Equal(newMap, resultMap)
+
+	currentMap = map[string]*commonpb.Payload{"number": EncodeString("1")}
+	resultMap = MergeMapOfPayload(currentMap, newMap)
+	assert.Equal(
+		map[string]*commonpb.Payload{"number": EncodeString("1"), "key": EncodeString("val")},
+		resultMap,
+	)
+
+	newValue, _ := Encode(nil)
+	newMap = map[string]*commonpb.Payload{"number": newValue}
+	resultMap = MergeMapOfPayload(currentMap, newMap)
+	assert.Equal(0, len(resultMap))
+
+	newValue, _ = Encode([]int{})
+	newMap = map[string]*commonpb.Payload{"number": newValue}
+	resultMap = MergeMapOfPayload(currentMap, newMap)
+	assert.Equal(0, len(resultMap))
 }

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -173,15 +173,15 @@ func (c *workflowSizeChecker) failWorkflowIfPayloadSizeExceedsLimit(
 }
 
 func (c *workflowSizeChecker) failWorkflowIfMemoSizeExceedsLimit(
+	memo *commonpb.Memo,
 	commandTypeTag metrics.Tag,
-	memoSize int,
 	message string,
 ) (bool, error) {
 
 	executionInfo := c.mutableState.GetExecutionInfo()
 	executionState := c.mutableState.GetExecutionState()
 	err := common.CheckEventBlobSizeLimit(
-		memoSize,
+		memo.Size(),
 		c.memoSizeLimitWarn,
 		c.memoSizeLimitError,
 		executionInfo.NamespaceId,

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -47,7 +47,6 @@ import (
 	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
@@ -319,21 +318,6 @@ func (s *mutableStateSuite) TestChecksumShouldInvalidate() {
 		return float64((s.mutableState.executionInfo.LastUpdateTime.UnixNano() / int64(time.Second)) - 1)
 	}
 	s.False(s.mutableState.shouldInvalidateCheckum())
-}
-
-func (s *mutableStateSuite) TestMergeMapOfPayload() {
-	var currentMap map[string]*commonpb.Payload
-	var newMap map[string]*commonpb.Payload
-	resultMap := mergeMapOfPayload(currentMap, newMap)
-	s.Equal(make(map[string]*commonpb.Payload), resultMap)
-
-	newMap = map[string]*commonpb.Payload{"key": payload.EncodeString("val")}
-	resultMap = mergeMapOfPayload(currentMap, newMap)
-	s.Equal(newMap, resultMap)
-
-	currentMap = map[string]*commonpb.Payload{"number": payload.EncodeString("1")}
-	resultMap = mergeMapOfPayload(currentMap, newMap)
-	s.Equal(2, len(resultMap))
 }
 
 func (s *mutableStateSuite) TestEventReapplied() {

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -46,6 +46,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
@@ -1124,9 +1125,12 @@ func (handler *workflowTaskHandlerImpl) handleCommandModifyWorkflowProperties(
 		return err
 	}
 
+	newMemo := &commonpb.Memo{
+		Fields: payload.MergeMapOfPayload(executionInfo.Memo, attr.GetUpsertedMemo().GetFields()),
+	}
 	failWorkflow, err = handler.sizeLimitChecker.failWorkflowIfMemoSizeExceedsLimit(
 		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_MODIFY_WORKFLOW_PROPERTIES.String()),
-		attr.GetUpsertedMemo().Size(),
+		newMemo.Size(),
 		"ModifyWorkflowPropertiesCommandAttributes. Memo exceeds size limit.",
 	)
 	if err != nil || failWorkflow {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixing the validation for memo size and search attribute size when upserting. The validation for them should be for the final map, not the upserting map.

<!-- Tell your future self why have you made these changes -->
**Why?**
It's bug that could make the memo/search attribute sizes grow beyond their limits.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Existing workflows that are taking advantage of this bug (ie, doing multiple upserts to store more data) will start to fail.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.