### PR TITLE
Fixes an issue where last-heartbeat time was set to the first event's timestamp

### DIFF
--- a/service/history/nDCActivityReplicator.go
+++ b/service/history/nDCActivityReplicator.go
@@ -266,7 +266,8 @@ func (r *nDCActivityReplicatorImpl) testActivity(
 	// activityInfo.Version == version & activityInfo.Attempt == attempt
 
 	// last heartbeat after existing heartbeat & should update activity
-	if activityInfo.LastHeartbeatUpdateTime != nil && activityInfo.LastHeartbeatUpdateTime.After(lastHeartbeatTime) {
+	if !timestamp.TimeValue(activityInfo.LastHeartbeatUpdateTime).IsZero() &&
+		activityInfo.LastHeartbeatUpdateTime.After(lastHeartbeatTime) {
 		// this should not retry, can be caused by out of order delivery
 		return false
 	}

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -376,17 +376,11 @@ func (p *ackMgrImpl) generateSyncActivityTask(
 				return nil, nil
 			}
 
+			// The activity may be in a scheduled state
 			var startedTime *time.Time
-			var heartbeatTime *time.Time
-			scheduledTime := activityInfo.ScheduledTime
-
-			// Todo: Comment why this exists? Why not set?
 			if activityInfo.StartedEventId != common.EmptyEventID {
 				startedTime = activityInfo.StartedTime
 			}
-
-			// LastHeartbeatUpdateTime must be valid when getting the sync activity replication task
-			heartbeatTime = activityInfo.LastHeartbeatUpdateTime
 
 			// Version history uses when replicate the sync activity task
 			versionHistories := mutableState.GetExecutionInfo().GetVersionHistories()
@@ -404,10 +398,10 @@ func (p *ackMgrImpl) generateSyncActivityTask(
 						RunId:              runID,
 						Version:            activityInfo.Version,
 						ScheduledEventId:   activityInfo.ScheduledEventId,
-						ScheduledTime:      scheduledTime,
+						ScheduledTime:      activityInfo.ScheduledTime,
 						StartedEventId:     activityInfo.StartedEventId,
 						StartedTime:        startedTime,
-						LastHeartbeatTime:  heartbeatTime,
+						LastHeartbeatTime:  activityInfo.LastHeartbeatUpdateTime,
 						Details:            activityInfo.LastHeartbeatDetails,
 						Attempt:            activityInfo.Attempt,
 						LastFailure:        activityInfo.RetryLastFailure,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1962,7 +1962,7 @@ func (e *MutableStateImpl) ReplicateActivityTaskScheduledEvent(
 		HeartbeatTimeout:        attributes.GetHeartbeatTimeout(),
 		CancelRequested:         false,
 		CancelRequestId:         common.EmptyEventID,
-		LastHeartbeatUpdateTime: timestamp.TimePtr(time.Time{}),
+		LastHeartbeatUpdateTime: nil,
 		TimerTaskStatus:         TimerTaskStatusNone,
 		TaskQueue:               attributes.TaskQueue.GetName(),
 		HasRetryPolicy:          attributes.RetryPolicy != nil,
@@ -2047,7 +2047,6 @@ func (e *MutableStateImpl) AddActivityTaskStartedEvent(
 	ai.StartedEventId = common.TransientEventID
 	ai.RequestId = requestID
 	ai.StartedTime = timestamp.TimePtr(e.timeSource.Now())
-	ai.LastHeartbeatUpdateTime = ai.StartedTime
 	ai.StartedIdentity = identity
 	if err := e.UpdateActivity(ai); err != nil {
 		return nil, err
@@ -2075,7 +2074,6 @@ func (e *MutableStateImpl) ReplicateActivityTaskStartedEvent(
 	ai.StartedEventId = event.GetEventId()
 	ai.RequestId = attributes.GetRequestId()
 	ai.StartedTime = event.GetEventTime()
-	ai.LastHeartbeatUpdateTime = ai.StartedTime
 	e.updateActivityInfos[ai.ScheduledEventId] = ai
 	return nil
 }

--- a/service/history/workflow/timer_sequence.go
+++ b/service/history/workflow/timer_sequence.go
@@ -361,7 +361,7 @@ func (t *timerSequenceImpl) getActivityHeartbeatTimeout(
 		lastHeartbeat = timestamp.TimeValue(activityInfo.StartedTime)
 	}
 
-	if activityInfo.LastHeartbeatUpdateTime != nil && activityInfo.LastHeartbeatUpdateTime.After(lastHeartbeat) {
+	if !timestamp.TimeValue(activityInfo.LastHeartbeatUpdateTime).IsZero() && activityInfo.LastHeartbeatUpdateTime.After(lastHeartbeat) {
 		lastHeartbeat = timestamp.TimeValue(activityInfo.LastHeartbeatUpdateTime)
 	}
 


### PR DESCRIPTION
This PR fixes a [bug](https://github.com/temporalio/temporal/issues/3358) where the first event for a pending activity would set its LastHeartbeatTime to the event time. I tested the fix by writing a test which calls the `ReplicateActivityTaskStartedEvent` method which had this issue, and verifies that the `LastHeartbeatDetails` are nil (as long as they were previously nil). The biggest risk to this change is if someone was depending on `LastHeartbeatDetails` on their pending activities being non-nil. 
