### PR TITLE
Skip task namespaceNotActive check in single queue mode

### DIFF
--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -158,10 +158,14 @@ func (s *executableSuite) TestHandleErr_NamespaceNotActiveError() {
 	s.timeSource.Update(now)
 	s.NoError(executable.HandleErr(err))
 
+	s.timeSource.Update(now.Add(-namespaceCacheRefreshInterval * time.Duration(3)))
+	executable = s.newTestExecutable(nil)
+	s.timeSource.Update(now)
+	s.Equal(err, executable.HandleErr(err))
+
 	executable = s.newTestExecutable(func(_ tasks.Task) bool {
 		return true
 	})
-
 	s.Equal(err, executable.HandleErr(err))
 }
 

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -120,7 +120,7 @@ func newTimerQueueActiveProcessor(
 	// if single cursor is enabled, then this processor is responsible for both active and standby tasks
 	// and we need to customize some parameters for ack manager and task executable
 	if singleProcessor {
-		timerTaskFilter = func(task tasks.Task) bool { return true }
+		timerTaskFilter = nil
 		taskExecutor = queues.NewExecutorWrapper(
 			currentClusterName,
 			shard.GetNamespaceRegistry(),

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -148,7 +148,7 @@ func newTransferQueueActiveProcessor(
 	// if single cursor is enabled, then this processor is responsible for both active and standby tasks
 	// and we need to customize some parameters for ack manager and task executable
 	if singleProcessor {
-		transferTaskFilter = func(task tasks.Task) bool { return true }
+		transferTaskFilter = nil
 		taskExecutor = queues.NewExecutorWrapper(
 			currentClusterName,
 			shard.GetNamespaceRegistry(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Skip task namespaceNotActive check in single queue mode

<!-- Tell your future self why have you made these changes -->
**Why?**
- When there's only one queue, we should not give up upon namespace not active error. A task should either be executed as active or verified as standby (though standby logic can decide to discard).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
