### PR TITLE
Calculate schedule times in sideeffect

### DIFF
--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -58,14 +58,16 @@ func (s *specSuite) checkSequenceFull(spec *schedpb.ScheduleSpec, start time.Tim
 	cs, err := NewCompiledSpec(spec)
 	s.NoError(err)
 	for _, exp := range seq {
-		_, next, has := cs.getNextTime(start)
+		result := cs.getNextTime(start)
 		if exp.IsZero() {
-			s.Require().False(has)
+			s.Require().True(result.Nominal.IsZero())
+			s.Require().True(result.Next.IsZero())
 			break
 		}
-		s.Require().True(has)
-		s.Equal(exp, next)
-		start = next
+		s.Require().False(result.Nominal.IsZero())
+		s.Require().False(result.Next.IsZero())
+		s.Equal(exp, result.Next)
+		start = result.Next
 	}
 }
 

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -72,6 +72,8 @@ const (
 	// Maximum number of times to list per ListMatchingTimes query. (This is used only in a
 	// query so it can be changed without breaking history.)
 	maxListMatchingTimesCount = 1000
+
+	invalidDuration time.Duration = -1
 )
 
 type (
@@ -180,7 +182,7 @@ func (s *scheduler) run() error {
 			s.logger.Warn("Time went backwards", "from", t1, "to", t2)
 			t2 = t1
 		}
-		nextSleep, hasNext := s.processTimeRange(
+		nextSleep := s.processTimeRange(
 			t1, t2,
 			// resolve this to the schedule's policy as late as possible
 			enumspb.SCHEDULE_OVERLAP_POLICY_UNSPECIFIED,
@@ -194,7 +196,7 @@ func (s *scheduler) run() error {
 		// 1. requested time elapsed
 		// 2. we got a signal (update, request, refresh)
 		// 3. a workflow that we were watching finished
-		s.sleep(nextSleep, hasNext)
+		s.sleep(nextSleep)
 		s.updateTweakables()
 	}
 
@@ -300,25 +302,30 @@ func (s *scheduler) processTimeRange(
 	t1, t2 time.Time,
 	overlapPolicy enumspb.ScheduleOverlapPolicy,
 	manual bool,
-) (nextSleep time.Duration, hasNext bool) {
+) time.Duration {
 	s.logger.Debug("processTimeRange", "t1", t1, "t2", t2, "overlapPolicy", overlapPolicy, "manual", manual)
 
 	if s.cspec == nil {
-		return 0, false
+		return invalidDuration
 	}
 
 	catchupWindow := s.getCatchupWindow()
 
 	for {
-		nominalTime, nextTime, hasNext := s.cspec.getNextTime(t1)
-		t1 = nextTime
-		if !hasNext {
-			return 0, false
-		} else if nextTime.After(t2) {
-			return nextTime.Sub(t2), true
+		// Run this logic in a SideEffect so that we can fix bugs there without breaking
+		// existing schedule workflows.
+		var next getNextTimeResult
+		workflow.SideEffect(s.ctx, func(ctx workflow.Context) interface{} {
+			return s.cspec.getNextTime(t1)
+		}).Get(&next)
+		t1 = next.Next
+		if t1.IsZero() {
+			return invalidDuration
+		} else if t1.After(t2) {
+			return t1.Sub(t2)
 		}
-		if !manual && t2.Sub(nextTime) > catchupWindow {
-			s.logger.Warn("Schedule missed catchup window", "now", t2, "time", nextTime)
+		if !manual && t2.Sub(t1) > catchupWindow {
+			s.logger.Warn("Schedule missed catchup window", "now", t2, "time", t1)
 			s.Info.MissedCatchupWindow++
 			continue
 		}
@@ -327,9 +334,8 @@ func (s *scheduler) processTimeRange(
 		if !s.canTakeScheduledAction(manual, false) {
 			continue
 		}
-		s.addStart(nominalTime, nextTime, overlapPolicy, manual)
+		s.addStart(next.Nominal, next.Next, overlapPolicy, manual)
 	}
-	return 0, false
 }
 
 func (s *scheduler) canTakeScheduledAction(manual, decrement bool) bool {
@@ -357,7 +363,7 @@ func (s *scheduler) canTakeScheduledAction(manual, decrement bool) bool {
 	return false
 }
 
-func (s *scheduler) sleep(nextSleep time.Duration, hasNext bool) {
+func (s *scheduler) sleep(nextSleep time.Duration) {
 	sel := workflow.NewSelector(s.ctx)
 
 	upCh := workflow.GetSignalChannel(s.ctx, SignalNameUpdate)
@@ -369,7 +375,7 @@ func (s *scheduler) sleep(nextSleep time.Duration, hasNext bool) {
 	refreshCh := workflow.GetSignalChannel(s.ctx, SignalNameRefresh)
 	sel.AddReceive(refreshCh, s.handleRefreshSignal)
 
-	if hasNext {
+	if nextSleep != invalidDuration {
 		tmr := workflow.NewTimer(s.ctx, nextSleep)
 		sel.AddFuture(tmr, func(_ workflow.Future) {})
 	}
@@ -378,7 +384,7 @@ func (s *scheduler) sleep(nextSleep time.Duration, hasNext bool) {
 		sel.AddFuture(s.watchingFuture, s.wfWatcherReturned)
 	}
 
-	s.logger.Debug("sleeping", "hasNext", hasNext, "watching", s.watchingFuture != nil)
+	s.logger.Debug("sleeping", "nextSleep", nextSleep, "watching", s.watchingFuture != nil)
 	sel.Select(s.ctx)
 	for sel.HasPending() {
 		sel.Select(s.ctx)
@@ -489,9 +495,10 @@ func (s *scheduler) getFutureActionTimes(n int) []*time.Time {
 	out := make([]*time.Time, 0, n)
 	t1 := timestamp.TimeValue(s.State.LastProcessedTime)
 	for len(out) < n {
-		var has bool
-		_, t1, has = s.cspec.getNextTime(t1)
-		if !has {
+		// don't need to call getNextTime in SideEffect because this is only used in a query
+		// handler and for the UpsertMemo value
+		t1 = s.cspec.getNextTime(t1).Next
+		if t1.IsZero() {
 			break
 		}
 		out = append(out, timestamp.TimePtr(t1))
@@ -520,8 +527,9 @@ func (s *scheduler) handleListMatchingTimesQuery(req *workflowservice.ListSchedu
 	var out []*time.Time
 	t1 := timestamp.TimeValue(req.StartTime)
 	for i := 0; i < maxListMatchingTimesCount; i++ {
-		_, t1, has := s.cspec.getNextTime(t1)
-		if !has || t1.After(timestamp.TimeValue(req.EndTime)) {
+		// don't need to call getNextTime in SideEffect because this is just a query
+		t1 = s.cspec.getNextTime(t1).Next
+		if t1.IsZero() || t1.After(timestamp.TimeValue(req.EndTime)) {
 			break
 		}
 		out = append(out, timestamp.TimePtr(t1))


### PR DESCRIPTION
**What changed?**
- Wrap time calculations in scheduler workflow in SideEffect
- Batch create uuids

**Why?**
We'd like the ability to change the behavior of `getNextTime` on existing inputs (e.g. to fix bugs) without breaking determinism of this workflow.

**How did you test it?**
existing unit and integration tests

**Potential risks**

**Is hotfix candidate?**
