### PR TITLE
Move notifyQueueProcessor to acquireShard

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1661,7 +1661,7 @@ func (s *ContextImpl) transition(request contextRequest) error {
 func (s *ContextImpl) notifyQueueProcessor() {
 	// use a cancelled ctx so the method won't be blocked if engineFuture is not ready
 	cancelledCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	cancel()
 
 	// we will get the engine when the Future is ready
 	engine, err := s.engineFuture.Get(cancelledCtx)

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1860,9 +1860,11 @@ func (s *ContextImpl) acquireShard() {
 
 		err = s.transition(contextRequestAcquired{engine: engine})
 
-		if err != nil && engine != nil {
-			// We tried to set the engine but the context was already stopped
-			engine.Stop()
+		if err != nil {
+			if engine != nil {
+				// We tried to set the engine but the context was already stopped
+				engine.Stop()
+			}
 			return err
 		}
 

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1615,14 +1615,6 @@ func (s *ContextImpl) transition(request contextRequest) error {
 				return errInvalidTransition
 			}
 
-			engine, err := s.engineFuture.Get(s.lifecycleCtx)
-			if err != nil {
-				// this should not happen, already checked engineFuture is ready above
-				s.contextTaggedLogger.Warn("transition to acquired but unable to get engine", tag.Error(err))
-				return errInvalidTransition
-			}
-			s.notifyQueueProcessor(engine)
-
 			return nil
 		case contextRequestLost:
 			return nil // nothing to do, already acquiring
@@ -1873,6 +1865,14 @@ func (s *ContextImpl) acquireShard() {
 			engine.Stop()
 			return err
 		}
+
+		engine, err = s.engineFuture.Get(s.lifecycleCtx)
+		if err != nil {
+			// this should not happen, already checked engineFuture is ready when transition to acquired state
+			s.contextTaggedLogger.Warn("acquired the shard but unable to get engine", tag.Error(err))
+			return err
+		}
+		s.notifyQueueProcessor(engine)
 
 		return nil
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Move notifyQueueProcessor to acquireShard

<!-- Tell your future self why have you made these changes -->
**Why?**
- Notify queue processor without hold the shard state lock

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
