### PR TITLE
Fix timerGate race condition in rescheduler

### DIFF
--- a/service/history/queues/rescheduler.go
+++ b/service/history/queues/rescheduler.go
@@ -150,9 +150,8 @@ func (r *reschedulerImpl) Add(
 		rescheduleTime: rescheduleTime,
 	})
 	r.numExecutables++
-	r.Unlock()
-
 	r.timerGate.Update(rescheduleTime)
+	r.Unlock()
 
 	if r.isStopped() {
 		r.drain()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Invoke timerGate.Update in a lock

<!-- Tell your future self why have you made these changes -->
**Why?**
- TimerGate.Update() is not a concurrent safe method, and caller must sync calls to this method.
- Checked all other invocation to Update as well.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
