### PR TITLE
Change search attribute validator to expect field names instead of alias

### DIFF
--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -201,7 +201,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 	attr.IndexedFields = fields
 	err := saValidator.ValidateSize(attr, namespace)
 	s.Error(err)
-	s.Equal("search attribute CustomKeywordField value of size 8: exceeds size limit 5", err.Error())
+	s.Equal("search attribute CustomKeywordField value size 8 exceeds size limit 5", err.Error())
 
 	fields = map[string]*commonpb.Payload{
 		"CustomKeywordField": payload.EncodeString("123"),
@@ -210,7 +210,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 	attr.IndexedFields = fields
 	err = saValidator.ValidateSize(attr, namespace)
 	s.Error(err)
-	s.Equal("total size of search attributes 106: exceeds size limit 20", err.Error())
+	s.Equal("total size of search attributes 106 exceeds size limit 20", err.Error())
 }
 
 func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper() {
@@ -237,7 +237,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper
 	attr.IndexedFields = fields
 	err := saValidator.ValidateSize(attr, namespace)
 	s.Error(err)
-	s.Equal("search attribute alias_of_CustomKeywordField value of size 8: exceeds size limit 5", err.Error())
+	s.Equal("search attribute alias_of_CustomKeywordField value size 8 exceeds size limit 5", err.Error())
 
 	fields = map[string]*commonpb.Payload{
 		"CustomKeywordField": payload.EncodeString("123"),
@@ -246,5 +246,5 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper
 	attr.IndexedFields = fields
 	err = saValidator.ValidateSize(attr, namespace)
 	s.Error(err)
-	s.Equal("total size of search attributes 106: exceeds size limit 20", err.Error())
+	s.Equal("total size of search attributes 106 exceeds size limit 20", err.Error())
 }

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -146,10 +146,6 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	err = saValidator.Validate(attr, namespace, "")
 	s.NoError(err)
 
-	err = saValidator.Validate(attr, "error-namespace", "")
-	s.Error(err)
-	s.EqualError(err, "mapper error")
-
 	fields = map[string]*commonpb.Payload{
 		"CustomIntField": intPayload,
 	}
@@ -166,6 +162,10 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	err = saValidator.Validate(attr, namespace, "")
 	s.Error(err)
 	s.Equal("search attribute alias_of_InvalidKey is not defined", err.Error())
+
+	err = saValidator.Validate(attr, "error-namespace", "")
+	s.Error(err)
+	s.EqualError(err, "mapper error")
 
 	fields = map[string]*commonpb.Payload{
 		"CustomTextField": payload.EncodeString("1"),

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -903,7 +903,11 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWithSearchAttr
 
 	s.mockShard.Resource.SearchAttributesMapper.EXPECT().
 		GetFieldName("AliasForCustomTextField", tests.Namespace.String()).Return("CustomTextField", nil).
-		Times(2) // One for validator, one for actual mapper
+		Times(1) // one for mapper
+
+	s.mockShard.Resource.SearchAttributesMapper.EXPECT().
+		GetAlias("CustomTextField", tests.Namespace.String()).Return("AliasForCustomTextField", nil).
+		Times(1) // one for validator
 
 	_, err := s.historyEngine.RespondWorkflowTaskCompleted(metrics.AddMetricsContext(context.Background()), &historyservice.RespondWorkflowTaskCompletedRequest{
 		NamespaceId: tests.NamespaceID.String(),

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -905,10 +905,6 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWithSearchAttr
 		GetFieldName("AliasForCustomTextField", tests.Namespace.String()).Return("CustomTextField", nil).
 		Times(1) // one for mapper
 
-	s.mockShard.Resource.SearchAttributesMapper.EXPECT().
-		GetAlias("CustomTextField", tests.Namespace.String()).Return("AliasForCustomTextField", nil).
-		Times(1) // one for validator
-
 	_, err := s.historyEngine.RespondWorkflowTaskCompleted(metrics.AddMetricsContext(context.Background()), &historyservice.RespondWorkflowTaskCompletedRequest{
 		NamespaceId: tests.NamespaceID.String(),
 		CompleteRequest: &workflowservice.RespondWorkflowTaskCompletedRequest{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed search attribute validator to expect the map to contain field names instead of alias.

Changed error type in `ValidateSize` to `serviceerror.InvalidArgument` so it can go through gRPC correctly.

Fixed the validation for upsert search attribute as it was merging a map with field names with a map with alias names.

<!-- Tell your future self why have you made these changes -->
**Why?**
`ValidateSize` should be for field names instead of alias since field names are the values to be stored. In order to be consistent, `Validate` was also changed to expect the same input.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Small search attribute alias might increase in size as being mapped to field name, and fail the size validation.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.