### PR TITLE
Remove shardOwnershipLost error from fault injection execution store

### DIFF
--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -386,20 +386,12 @@ func NewFaultInjectionExecutionStore(
 	rate float64,
 	executionStore persistence.ExecutionStore,
 ) (*FaultInjectionExecutionStore, error) {
+	// TODO: inject shard ownership lost ever after
+	// queue processor can notify shard upon unloading itself
+	// when shard ownership lost error is encountered.
 	errorGenerator := newErrorGenerator(
 		rate,
-		append(
-			defaultErrors,
-			FaultWeight{
-				errFactory: func(msg string) error {
-					return &persistence.ShardOwnershipLostError{
-						ShardID: -1,
-						Msg:     fmt.Sprintf("FaultInjectionQueue injected, %s", msg),
-					}
-				},
-				weight: 1,
-			},
-		),
+		defaultErrors,
 	)
 	return &FaultInjectionExecutionStore{
 		baseExecutionStore: executionStore,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Remove shardOwnershipLost error from fault injection execution store

<!-- Tell your future self why have you made these changes -->
**Why?**
- Existing implementation can't handle random shard ownership lost errors from some execution store api like rangeCompleteHistoryTasks. If returned, queue processor will shutdown itself without notifying the shard, as in this case shard context should get the same error as well from other operations. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Testing on test cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A, fault injection is test code.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No