### PR TITLE
Revert "Remove unused history event check (#3373)"

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -672,12 +672,15 @@ func (c *ContextImpl) SetWorkflowExecution(ctx context.Context, now time.Time) (
 		}
 	}()
 
-	resetWorkflowSnapshot, _, err := c.MutableState.CloseTransactionAsSnapshot(
+	resetWorkflowSnapshot, resetWorkflowEventsSeq, err := c.MutableState.CloseTransactionAsSnapshot(
 		now,
 		TransactionPolicyPassive,
 	)
 	if err != nil {
 		return err
+	}
+	if len(resetWorkflowEventsSeq) != 0 {
+		return serviceerror.NewInternal("SetWorkflowExecution encountered new events")
 	}
 
 	resetWorkflowSnapshot.ExecutionInfo.ExecutionStats = &persistencespb.ExecutionStats{


### PR DESCRIPTION
This reverts commit 5e6b2d7dd77e16426f13f27122c21a61df936a5b.

<!-- Describe what has changed in this PR -->
**What changed?**
Bring back the sanity check

<!-- Tell your future self why have you made these changes -->
**Why?**
This is fixed in https://github.com/temporalio/temporal/pull/3388

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
