### PR TITLE
Propagate CloseVisibilityTaskId to DeleteExecutionVisibilityTask

### DIFF
--- a/common/persistence/serialization/task_serializer.go
+++ b/common/persistence/serialization/task_serializer.go
@@ -936,7 +936,7 @@ func (s *TaskSerializer) visibilityDeleteTaskToProto(
 		VisibilityTime:        &deleteVisibilityTask.VisibilityTimestamp,
 		StartTime:             deleteVisibilityTask.StartTime,
 		CloseTime:             deleteVisibilityTask.CloseTime,
-		CloseVisibilityTaskId: deleteVisibilityTask.CloseVisibilityTaskID,
+		CloseVisibilityTaskId: deleteVisibilityTask.CloseExecutionVisibilityTaskID,
 	}
 }
 
@@ -949,12 +949,12 @@ func (s *TaskSerializer) visibilityDeleteTaskFromProto(
 			deleteVisibilityTask.WorkflowId,
 			deleteVisibilityTask.RunId,
 		),
-		VisibilityTimestamp:   *deleteVisibilityTask.VisibilityTime,
-		TaskID:                deleteVisibilityTask.TaskId,
-		Version:               deleteVisibilityTask.Version,
-		StartTime:             deleteVisibilityTask.StartTime,
-		CloseTime:             deleteVisibilityTask.CloseTime,
-		CloseVisibilityTaskID: deleteVisibilityTask.CloseVisibilityTaskId,
+		VisibilityTimestamp:            *deleteVisibilityTask.VisibilityTime,
+		TaskID:                         deleteVisibilityTask.TaskId,
+		Version:                        deleteVisibilityTask.Version,
+		StartTime:                      deleteVisibilityTask.StartTime,
+		CloseTime:                      deleteVisibilityTask.CloseTime,
+		CloseExecutionVisibilityTaskID: deleteVisibilityTask.CloseVisibilityTaskId,
 	}
 }
 

--- a/common/persistence/serialization/task_serializer_test.go
+++ b/common/persistence/serialization/task_serializer_test.go
@@ -332,11 +332,11 @@ func (s *taskSerializerSuite) TestReplicateHistoryTask() {
 
 func (s *taskSerializerSuite) TestDeleteExecutionVisibilityTask() {
 	replicateHistoryTask := &tasks.DeleteExecutionVisibilityTask{
-		WorkflowKey:           s.workflowKey,
-		VisibilityTimestamp:   time.Unix(0, 0).UTC(), // go == compare for location as well which is striped during marshaling/unmarshaling
-		TaskID:                rand.Int63(),
-		Version:               rand.Int63(),
-		CloseVisibilityTaskID: rand.Int63(),
+		WorkflowKey:                    s.workflowKey,
+		VisibilityTimestamp:            time.Unix(0, 0).UTC(), // go == compare for location as well which is striped during marshaling/unmarshaling
+		TaskID:                         rand.Int63(),
+		Version:                        rand.Int63(),
+		CloseExecutionVisibilityTaskID: rand.Int63(),
 	}
 
 	s.assertEqualTasks(replicateHistoryTask)

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -115,7 +115,7 @@ type (
 		GetWorkflowExecution(ctx context.Context, request *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error)
 		// DeleteWorkflowExecution deletes workflow execution, current workflow execution, and add task to delete visibility.
 		// If branchToken != nil, then delete history also, otherwise leave history.
-		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime *time.Time, closeTime *time.Time) error
+		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime *time.Time, closeTime *time.Time, closeExecutionVisibilityTaskID int64) error
 
 		GetRemoteAdminClient(cluster string) (adminservice.AdminServiceClient, error)
 		GetHistoryClient() historyservice.HistoryServiceClient

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -970,6 +970,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	branchToken []byte,
 	startTime *time.Time,
 	closeTime *time.Time,
+	closeVisibilityTaskId int64,
 ) (retErr error) {
 	// DeleteWorkflowExecution is a 4-steps process (order is very important and should not be changed):
 	// 1. Add visibility delete task, i.e. schedule visibility record delete,
@@ -1033,10 +1034,11 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 				tasks.CategoryVisibility: {
 					&tasks.DeleteExecutionVisibilityTask{
 						// TaskID is set by addTasksLocked
-						WorkflowKey:         key,
-						VisibilityTimestamp: s.timeSource.Now(),
-						StartTime:           startTime,
-						CloseTime:           closeTime,
+						WorkflowKey:                    key,
+						VisibilityTimestamp:            s.timeSource.Now(),
+						StartTime:                      startTime,
+						CloseTime:                      closeTime,
+						CloseExecutionVisibilityTaskID: closeVisibilityTaskId,
 					},
 				},
 			}

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -179,17 +179,17 @@ func (mr *MockContextMockRecorder) DeleteFailoverLevel(category, failoverID inte
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime, closeTime *time.Time) error {
+func (m *MockContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime, closeTime *time.Time, closeExecutionVisibilityTaskID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, startTime, closeTime)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, startTime, closeTime interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, startTime, closeTime)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID)
 }
 
 // GenerateTaskID mocks base method.

--- a/service/history/tasks/delete_visibility_task.go
+++ b/service/history/tasks/delete_visibility_task.go
@@ -36,10 +36,10 @@ var _ Task = (*DeleteExecutionVisibilityTask)(nil)
 type (
 	DeleteExecutionVisibilityTask struct {
 		definition.WorkflowKey
-		VisibilityTimestamp   time.Time
-		TaskID                int64
-		Version               int64
-		CloseVisibilityTaskID int64
+		VisibilityTimestamp            time.Time
+		TaskID                         int64
+		Version                        int64
+		CloseExecutionVisibilityTaskID int64
 		// These two fields are needed for cassandra standard visibility.
 		// TODO (alex): Remove them when cassandra standard visibility is removed.
 		StartTime *time.Time
@@ -84,5 +84,5 @@ func (t *DeleteExecutionVisibilityTask) GetType() enumsspb.TaskType {
 }
 
 func (t *DeleteExecutionVisibilityTask) GetCloseVisibilityTaskID() int64 {
-	return t.CloseVisibilityTaskID
+	return t.CloseExecutionVisibilityTaskID
 }

--- a/service/history/workflow/delete_manager.go
+++ b/service/history/workflow/delete_manager.go
@@ -146,9 +146,9 @@ func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
 		}
 	}
 
-	closeVisibilityTaskId := ms.GetExecutionInfo().CloseVisibilityTaskId
+	closeExecutionVisibilityTaskID := ms.GetExecutionInfo().CloseVisibilityTaskId
 	closeVisibilityTaskCheckPassed := true
-	if closeVisibilityTaskId != 0 { // taskID == 0 if workflow still running in passive cluster or closed before this field was added (v1.17).
+	if closeExecutionVisibilityTaskID != 0 { // taskID == 0 if workflow still running in passive cluster or closed before this field was added (v1.17).
 		// check if close execution visibility task is completed
 		visibilityQueueState, ok := m.shard.GetQueueState(tasks.CategoryVisibility)
 		if !ok {
@@ -158,7 +158,7 @@ func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
 		} else {
 			fakeCloseVisibiltyTask := &tasks.CloseExecutionVisibilityTask{
 				WorkflowKey: definition.NewWorkflowKey(nsID.String(), we.GetWorkflowId(), we.GetRunId()),
-				TaskID:      closeVisibilityTaskId,
+				TaskID:      closeExecutionVisibilityTaskID,
 			}
 			closeVisibilityTaskCheckPassed = queues.IsTaskAcked(fakeCloseVisibiltyTask, visibilityQueueState)
 		}
@@ -291,6 +291,7 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 		currentBranchToken,
 		startTime,
 		closeTime,
+		ms.GetExecutionInfo().GetCloseVisibilityTaskId(),
 	); err != nil {
 		return err
 	}


### PR DESCRIPTION
Propagates the CloseVisibilityTaskId to the DeleteExecutionVisibilityTask, so that we can wait on the close visibility task to complete before we delete the execution visibility.