### PR TITLE
Adds a retryable error for when we try to delete open executions

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -97,6 +97,10 @@ const (
 	taskNotReadyRescheduleBackoffCoefficient = 1.5
 	taskNotReadyRescheduleMaxInterval        = 3 * time.Minute
 
+	dependencyTaskNotCompletedRescheduleInitialInterval    = 10 * time.Second
+	dependencyTaskNotCompletedRescheduleBackoffCoefficient = 1.5
+	dependencyTaskNotCompletedRescheduleMaxInterval        = 3 * time.Minute
+
 	taskResourceExhaustedRescheduleInitialInterval    = 3 * time.Second
 	taskResourceExhaustedRescheduleBackoffCoefficient = 1.5
 	taskResourceExhaustedRescheduleMaxInterval        = 5 * time.Minute
@@ -231,6 +235,15 @@ func CreateTaskReschedulePolicy() backoff.RetryPolicy {
 	return backoff.NewExponentialRetryPolicy(taskRescheduleInitialInterval).
 		WithBackoffCoefficient(taskRescheduleBackoffCoefficient).
 		WithMaximumInterval(taskRescheduleMaxInterval).
+		WithExpirationInterval(backoff.NoInterval)
+}
+
+// CreateDependencyTaskNotCompletedReschedulePolicy creates a retry policy for rescheduling task with
+// ErrDependencyTaskNotCompleted
+func CreateDependencyTaskNotCompletedReschedulePolicy() backoff.RetryPolicy {
+	return backoff.NewExponentialRetryPolicy(dependencyTaskNotCompletedRescheduleInitialInterval).
+		WithBackoffCoefficient(dependencyTaskNotCompletedRescheduleBackoffCoefficient).
+		WithMaximumInterval(dependencyTaskNotCompletedRescheduleMaxInterval).
 		WithExpirationInterval(backoff.NoInterval)
 }
 

--- a/service/history/consts/const.go
+++ b/service/history/consts/const.go
@@ -44,6 +44,8 @@ var (
 	ErrTaskDiscarded = errors.New("passive task pending for too long")
 	// ErrTaskRetry is the error indicating that the standby timer / transfer task should be retried since condition in mutable state is not met.
 	ErrTaskRetry = errors.New("passive task should retry due to condition in mutable state is not met")
+	// ErrDependencyTaskNotCompleted is the error returned when a task this task depends on is not completed yet
+	ErrDependencyTaskNotCompleted = errors.New("can't delete execution which is still open")
 	// ErrDuplicate is exported temporarily for integration test
 	ErrDuplicate = errors.New("duplicate task, completing it")
 	// ErrLocateCurrentWorkflowExecution is the error returned when current workflow execution can't be located

--- a/service/history/queues/metrics.go
+++ b/service/history/queues/metrics.go
@@ -36,24 +36,25 @@ import (
 const (
 	TaskRequests = "task_requests"
 
-	TaskFailures                = "task_errors"
-	TaskDiscarded               = "task_errors_discarded"
-	TaskSkipped                 = "task_skipped"
-	TaskAttempt                 = "task_attempt"
-	TaskStandbyRetryCounter     = "task_errors_standby_retry_counter"
-	TaskWorkflowBusyCounter     = "task_errors_workflow_busy"
-	TaskNotActiveCounter        = "task_errors_not_active_counter"
-	TaskLoadLatency             = "task_latency_load"                     // latency from task generation to task loading (persistence scheduleToStart)
-	TaskScheduleLatency         = "task_latency_schedule"                 // latency from task submission to in-memory queue to processing (in-memory scheduleToStart)
-	TaskProcessingLatency       = "task_latency_processing"               // latency for processing task one time
-	TaskNoUserProcessingLatency = "task_latency_processing_nouserlatency" // same as TaskProcessingLatency, but excludes workflow lock latency
-	TaskLatency                 = "task_latency"                          // task in-memory latency across multiple attempts
-	TaskNoUserLatency           = "task_latency_nouserlatency"            // same as TaskLatency, but excludes workflow lock latency
-	TaskQueueLatency            = "task_latency_queue"                    // task e2e latency
-	TaskNoUserQueueLatency      = "task_latency_queue_nouserlatency"      // same as TaskQueueLatency, but excludes workflow lock latency
-	TaskUserLatency             = "task_latency_userlatency"              // workflow lock latency across multiple attempts
-	TaskReschedulerPendingTasks = "task_rescheduler_pending_tasks"
-	TaskThrottledCounter        = "task_throttled_counter"
+	TaskFailures                    = "task_errors"
+	TaskDiscarded                   = "task_errors_discarded"
+	TaskSkipped                     = "task_skipped"
+	TaskAttempt                     = "task_attempt"
+	TaskStandbyRetryCounter         = "task_errors_standby_retry_counter"
+	TaskWorkflowBusyCounter         = "task_errors_workflow_busy"
+	TaskNotActiveCounter            = "task_errors_not_active_counter"
+	TaskLoadLatency                 = "task_latency_load"                     // latency from task generation to task loading (persistence scheduleToStart)
+	TaskScheduleLatency             = "task_latency_schedule"                 // latency from task submission to in-memory queue to processing (in-memory scheduleToStart)
+	TaskProcessingLatency           = "task_latency_processing"               // latency for processing task one time
+	TaskNoUserProcessingLatency     = "task_latency_processing_nouserlatency" // same as TaskProcessingLatency, but excludes workflow lock latency
+	TaskLatency                     = "task_latency"                          // task in-memory latency across multiple attempts
+	TaskNoUserLatency               = "task_latency_nouserlatency"            // same as TaskLatency, but excludes workflow lock latency
+	TaskQueueLatency                = "task_latency_queue"                    // task e2e latency
+	TaskNoUserQueueLatency          = "task_latency_queue_nouserlatency"      // same as TaskQueueLatency, but excludes workflow lock latency
+	TaskUserLatency                 = "task_latency_userlatency"              // workflow lock latency across multiple attempts
+	TaskReschedulerPendingTasks     = "task_rescheduler_pending_tasks"
+	TaskThrottledCounter            = "task_throttled_counter"
+	TasksDependencyTaskNotCompleted = "task_dependency_task_not_completed"
 
 	TaskBatchCompleteCounter    = "task_batch_complete_counter"
 	NewTimerNotifyCounter       = "new_timer_notifications"


### PR DESCRIPTION
Adds a retryable error for when we try to delete open executions. This was requested by @yycptt since we want a longer retry delay for this type of error.