### PR TITLE
Fix test merge map of payload

### DIFF
--- a/common/payload/payload_test.go
+++ b/common/payload/payload_test.go
@@ -79,7 +79,7 @@ func TestMergeMapOfPayload(t *testing.T) {
 	var currentMap map[string]*commonpb.Payload
 	var newMap map[string]*commonpb.Payload
 	resultMap := MergeMapOfPayload(currentMap, newMap)
-	assert.Equal(make(map[string]*commonpb.Payload), resultMap)
+	assert.Equal(newMap, resultMap)
 
 	newMap = map[string]*commonpb.Payload{"key": EncodeString("val")}
 	resultMap = MergeMapOfPayload(currentMap, newMap)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixing test for merge map of payload.

<!-- Tell your future self why have you made these changes -->
**Why?**
Release of 1.18.0 showed that the test was passing with `assert.Equal(empty map, nil)`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run unit test in release branch.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.