### PR TITLE
Retry attempts to delete open workflow executions

### DIFF
--- a/service/history/consts/const.go
+++ b/service/history/consts/const.go
@@ -45,7 +45,7 @@ var (
 	// ErrTaskRetry is the error indicating that the standby timer / transfer task should be retried since condition in mutable state is not met.
 	ErrTaskRetry = errors.New("passive task should retry due to condition in mutable state is not met")
 	// ErrDependencyTaskNotCompleted is the error returned when a task this task depends on is not completed yet
-	ErrDependencyTaskNotCompleted = errors.New("can't delete execution which is still open")
+	ErrDependencyTaskNotCompleted = errors.New("a task which this task depends on has not been completed yet")
 	// ErrDuplicate is exported temporarily for integration test
 	ErrDuplicate = errors.New("duplicate task, completing it")
 	// ErrLocateCurrentWorkflowExecution is the error returned when current workflow execution can't be located

--- a/service/history/tasks/delete_visibility_task.go
+++ b/service/history/tasks/delete_visibility_task.go
@@ -82,7 +82,3 @@ func (t *DeleteExecutionVisibilityTask) GetCategory() Category {
 func (t *DeleteExecutionVisibilityTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_VISIBILITY_DELETE_EXECUTION
 }
-
-func (t *DeleteExecutionVisibilityTask) GetCloseVisibilityTaskID() int64 {
-	return t.CloseExecutionVisibilityTaskID
-}

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -119,7 +119,7 @@ func (t *transferQueueStandbyTaskExecutor) Execute(
 	case *tasks.CloseExecutionTask:
 		err = t.processCloseExecution(ctx, task)
 	case *tasks.DeleteExecutionTask:
-		err = t.processDeleteExecutionTask(ctx, task)
+		err = t.processDeleteExecutionTask(ctx, task, false)
 	default:
 		err = errUnknownTransferTask
 	}


### PR DESCRIPTION
This is for https://github.com/temporalio/temporal/issues/3368. It adds a check to our transfer task processor which ensures that tasks are closed before deleting them.