### PR TITLE
Fix merge map of payload

### DIFF
--- a/common/payload/payload.go
+++ b/common/payload/payload.go
@@ -86,10 +86,13 @@ func MergeMapOfPayload(
 	m1 map[string]*commonpb.Payload,
 	m2 map[string]*commonpb.Payload,
 ) map[string]*commonpb.Payload {
-	if m1 == nil {
-		return maps.Clone(m2)
+	if m2 == nil {
+		return maps.Clone(m1)
 	}
 	ret := maps.Clone(m1)
+	if ret == nil {
+		ret = make(map[string]*commonpb.Payload)
+	}
 	for k, v := range m2 {
 		if proto.Equal(v, nilPayload) || proto.Equal(v, emptySlicePayload) {
 			delete(ret, k)

--- a/common/payload/payload_test.go
+++ b/common/payload/payload_test.go
@@ -81,9 +81,21 @@ func TestMergeMapOfPayload(t *testing.T) {
 	resultMap := MergeMapOfPayload(currentMap, newMap)
 	assert.Equal(newMap, resultMap)
 
+	newMap = make(map[string]*commonpb.Payload)
+	resultMap = MergeMapOfPayload(currentMap, newMap)
+	assert.Equal(newMap, resultMap)
+
 	newMap = map[string]*commonpb.Payload{"key": EncodeString("val")}
 	resultMap = MergeMapOfPayload(currentMap, newMap)
 	assert.Equal(newMap, resultMap)
+
+	newMap = map[string]*commonpb.Payload{
+		"key":        EncodeString("val"),
+		"nil":        nilPayload,
+		"emptyArray": emptySlicePayload,
+	}
+	resultMap = MergeMapOfPayload(currentMap, newMap)
+	assert.Equal(map[string]*commonpb.Payload{"key": EncodeString("val")}, resultMap)
 
 	currentMap = map[string]*commonpb.Payload{"number": EncodeString("1")}
 	resultMap = MergeMapOfPayload(currentMap, newMap)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixing the function to merge map of payload. Keys with nil value or empty slice value are removed.

<!-- Tell your future self why have you made these changes -->
**Why?**
A bug was leaving keys with nil or empty slice value in the merged map when the first map is nil.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new unit tests to cover those cases.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.