### PR TITLE
Reorder grpc interceptors

### DIFF
--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -71,7 +71,7 @@ var (
 )
 
 var _ grpc.UnaryServerInterceptor = (*NamespaceValidatorInterceptor)(nil).StateValidationIntercept
-var _ grpc.UnaryServerInterceptor = (*NamespaceValidatorInterceptor)(nil).SizeValidationIntercept
+var _ grpc.UnaryServerInterceptor = (*NamespaceValidatorInterceptor)(nil).LengthValidationIntercept
 
 func NewNamespaceValidatorInterceptor(
 	namespaceRegistry namespace.Registry,
@@ -86,7 +86,7 @@ func NewNamespaceValidatorInterceptor(
 	}
 }
 
-func (ni *NamespaceValidatorInterceptor) SizeValidationIntercept(
+func (ni *NamespaceValidatorInterceptor) LengthValidationIntercept(
 	ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -39,21 +39,18 @@ import (
 )
 
 type (
-	// NamespaceValidatorInterceptor validates:
-	// 1. Namespace is specified in task token if there is a `task_token` field.
-	// 2. Namespace is specified in request if there is a `namespace` field and no `task_token` field.
-	// 3. Namespace exists.
-	// 4. Namespace from request match namespace from task token, if check is enabled with dynamic config.
-	// 5. Namespace is in correct state.
+	// NamespaceValidatorInterceptor contains SizeValidationIntercept and StateValidationIntercept
 	NamespaceValidatorInterceptor struct {
 		namespaceRegistry               namespace.Registry
 		tokenSerializer                 common.TaskTokenSerializer
 		enableTokenNamespaceEnforcement dynamicconfig.BoolPropertyFn
+		maxNamespaceLength              dynamicconfig.IntPropertyFn
 	}
 )
 
 var (
 	ErrNamespaceNotSet            = serviceerror.NewInvalidArgument("Namespace not set on request.")
+	errNamespaceTooLong           = serviceerror.NewInvalidArgument("Namespace length exceeds limit.")
 	errNamespaceHandover          = serviceerror.NewUnavailable(fmt.Sprintf("Namespace replication in %s state.", enumspb.REPLICATION_STATE_HANDOVER.String()))
 	errTaskTokenNotSet            = serviceerror.NewInvalidArgument("Task token not set on request.")
 	errTaskTokenNamespaceMismatch = serviceerror.NewInvalidArgument("Operation requested with a token from a different namespace.")
@@ -73,20 +70,46 @@ var (
 	}
 )
 
-var _ grpc.UnaryServerInterceptor = (*NamespaceValidatorInterceptor)(nil).Intercept
+var _ grpc.UnaryServerInterceptor = (*NamespaceValidatorInterceptor)(nil).StateValidationIntercept
+var _ grpc.UnaryServerInterceptor = (*NamespaceValidatorInterceptor)(nil).SizeValidationIntercept
 
 func NewNamespaceValidatorInterceptor(
 	namespaceRegistry namespace.Registry,
 	enableTokenNamespaceEnforcement dynamicconfig.BoolPropertyFn,
+	maxNamespaceLength dynamicconfig.IntPropertyFn,
 ) *NamespaceValidatorInterceptor {
 	return &NamespaceValidatorInterceptor{
 		namespaceRegistry:               namespaceRegistry,
 		tokenSerializer:                 common.NewProtoTaskTokenSerializer(),
 		enableTokenNamespaceEnforcement: enableTokenNamespaceEnforcement,
+		maxNamespaceLength:              maxNamespaceLength,
 	}
 }
 
-func (ni *NamespaceValidatorInterceptor) Intercept(
+func (ni *NamespaceValidatorInterceptor) SizeValidationIntercept(
+	ctx context.Context,
+	req interface{},
+	info *grpc.UnaryServerInfo,
+	handler grpc.UnaryHandler,
+) (interface{}, error) {
+	reqWithNamespace, hasNamespace := req.(NamespaceNameGetter)
+	if hasNamespace {
+		namespaceName := namespace.Name(reqWithNamespace.GetNamespace())
+		if len(namespaceName) > ni.maxNamespaceLength() {
+			return nil, errNamespaceTooLong
+		}
+	}
+
+	return handler(ctx, req)
+}
+
+// StateValidationIntercept validates:
+// 1. Namespace is specified in task token if there is a `task_token` field.
+// 2. Namespace is specified in request if there is a `namespace` field and no `task_token` field.
+// 3. Namespace exists.
+// 4. Namespace from request match namespace from task token, if check is enabled with dynamic config.
+// 5. Namespace is in correct state.
+func (ni *NamespaceValidatorInterceptor) StateValidationIntercept(
 	ctx context.Context,
 	req interface{},
 	info *grpc.UnaryServerInfo,

--- a/common/rpc/interceptor/namespace_validator.go
+++ b/common/rpc/interceptor/namespace_validator.go
@@ -39,7 +39,7 @@ import (
 )
 
 type (
-	// NamespaceValidatorInterceptor contains SizeValidationIntercept and StateValidationIntercept
+	// NamespaceValidatorInterceptor contains LengthValidationIntercept and StateValidationIntercept
 	NamespaceValidatorInterceptor struct {
 		namespaceRegistry               namespace.Registry
 		tokenSerializer                 common.TaskTokenSerializer

--- a/common/rpc/interceptor/namespace_validator_test.go
+++ b/common/rpc/interceptor/namespace_validator_test.go
@@ -569,7 +569,7 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_TokenNamespaceEn
 
 		nvi := NewNamespaceValidatorInterceptor(
 			s.mockRegistry,
-			dynamicconfig.GetBoolPropertyFn(false),
+			dynamicconfig.GetBoolPropertyFn(testCase.enableTokenNamespaceEnforcement),
 			dynamicconfig.GetIntPropertyFn(100))
 		serverInfo := &grpc.UnaryServerInfo{
 			FullMethod: "/temporal/RandomMethod",
@@ -597,7 +597,7 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_TokenNamespaceEn
 	}
 }
 
-func (s *namespaceValidatorSuite) Test_SizeValidationIntercept() {
+func (s *namespaceValidatorSuite) Test_LengthValidationIntercept() {
 	nvi := NewNamespaceValidatorInterceptor(
 		s.mockRegistry,
 		dynamicconfig.GetBoolPropertyFn(false),
@@ -608,7 +608,7 @@ func (s *namespaceValidatorSuite) Test_SizeValidationIntercept() {
 
 	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "namespace"}
 	handlerCalled := false
-	_, err := nvi.SizeValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err := nvi.LengthValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.StartWorkflowExecutionResponse{}, nil
 	})
@@ -617,7 +617,7 @@ func (s *namespaceValidatorSuite) Test_SizeValidationIntercept() {
 
 	req = &workflowservice.StartWorkflowExecutionRequest{Namespace: "namespaceTooLong"}
 	handlerCalled = false
-	_, err = nvi.SizeValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err = nvi.LengthValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.StartWorkflowExecutionResponse{}, nil
 	})

--- a/common/rpc/interceptor/namespace_validator_test.go
+++ b/common/rpc/interceptor/namespace_validator_test.go
@@ -76,13 +76,16 @@ func (s *namespaceValidatorSuite) TearDownTest() {
 	s.controller.Finish()
 }
 
-func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotSet() {
+func (s *namespaceValidatorSuite) Test_StateValidationIntercept_NamespaceNotSet() {
 	taskToken, _ := common.NewProtoTaskTokenSerializer().Serialize(&tokenspb.Task{
 		NamespaceId: "",
 		WorkflowId:  "wid",
 	})
 
-	nvi := NewNamespaceValidatorInterceptor(s.mockRegistry, dynamicconfig.GetBoolPropertyFn(false))
+	nvi := NewNamespaceValidatorInterceptor(
+		s.mockRegistry,
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetIntPropertyFn(100))
 	serverInfo := &grpc.UnaryServerInfo{
 		FullMethod: "/temporal/random",
 	}
@@ -113,7 +116,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotSet() {
 
 	for _, testCase := range testCases {
 		handlerCalled := false
-		_, err := nvi.Intercept(context.Background(), testCase.req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		_, err := nvi.StateValidationIntercept(context.Background(), testCase.req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 			handlerCalled = true
 			return &workflowservice.StartWorkflowExecutionResponse{}, nil
 		})
@@ -128,9 +131,12 @@ func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotSet() {
 	}
 }
 
-func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotFound() {
+func (s *namespaceValidatorSuite) Test_StateValidationIntercept_NamespaceNotFound() {
 
-	nvi := NewNamespaceValidatorInterceptor(s.mockRegistry, dynamicconfig.GetBoolPropertyFn(false))
+	nvi := NewNamespaceValidatorInterceptor(
+		s.mockRegistry,
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetIntPropertyFn(100))
 	serverInfo := &grpc.UnaryServerInfo{
 		FullMethod: "/temporal/random",
 	}
@@ -138,7 +144,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotFound() {
 	s.mockRegistry.EXPECT().GetNamespace(namespace.Name("not-found-namespace")).Return(nil, serviceerror.NewNamespaceNotFound("missing-namespace"))
 	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "not-found-namespace"}
 	handlerCalled := false
-	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err := nvi.StateValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.StartWorkflowExecutionResponse{}, nil
 	})
@@ -155,7 +161,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotFound() {
 		TaskToken: taskToken,
 	}
 	handlerCalled = false
-	_, err = nvi.Intercept(context.Background(), tokenReq, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err = nvi.StateValidationIntercept(context.Background(), tokenReq, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.RespondWorkflowTaskCompletedResponse{}, nil
 	})
@@ -164,7 +170,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_NamespaceNotFound() {
 	s.False(handlerCalled)
 }
 
-func (s *namespaceValidatorSuite) Test_Intercept_StatusFromNamespace() {
+func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromNamespace() {
 	testCases := []struct {
 		state            enumspb.NamespaceState
 		replicationState enumspb.ReplicationState
@@ -296,13 +302,16 @@ func (s *namespaceValidatorSuite) Test_Intercept_StatusFromNamespace() {
 					}), nil)
 			}
 
-			nvi := NewNamespaceValidatorInterceptor(s.mockRegistry, dynamicconfig.GetBoolPropertyFn(false))
+			nvi := NewNamespaceValidatorInterceptor(
+				s.mockRegistry,
+				dynamicconfig.GetBoolPropertyFn(false),
+				dynamicconfig.GetIntPropertyFn(100))
 			serverInfo := &grpc.UnaryServerInfo{
 				FullMethod: testCase.method,
 			}
 
 			handlerCalled := false
-			_, err := nvi.Intercept(context.Background(), testCase.req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+			_, err := nvi.StateValidationIntercept(context.Background(), testCase.req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 				handlerCalled = true
 				return &workflowservice.StartWorkflowExecutionResponse{}, nil
 			})
@@ -318,7 +327,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_StatusFromNamespace() {
 	}
 }
 
-func (s *namespaceValidatorSuite) Test_Intercept_StatusFromToken() {
+func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromToken() {
 	taskToken, _ := common.NewProtoTaskTokenSerializer().Serialize(&tokenspb.Task{
 		NamespaceId: "test-namespace-id",
 	})
@@ -368,13 +377,16 @@ func (s *namespaceValidatorSuite) Test_Intercept_StatusFromToken() {
 				},
 			}), nil)
 
-		nvi := NewNamespaceValidatorInterceptor(s.mockRegistry, dynamicconfig.GetBoolPropertyFn(false))
+		nvi := NewNamespaceValidatorInterceptor(
+			s.mockRegistry,
+			dynamicconfig.GetBoolPropertyFn(false),
+			dynamicconfig.GetIntPropertyFn(100))
 		serverInfo := &grpc.UnaryServerInfo{
 			FullMethod: testCase.method,
 		}
 
 		handlerCalled := false
-		_, err := nvi.Intercept(context.Background(), testCase.req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		_, err := nvi.StateValidationIntercept(context.Background(), testCase.req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 			handlerCalled = true
 			return &workflowservice.RespondWorkflowTaskCompletedResponse{}, nil
 		})
@@ -389,15 +401,18 @@ func (s *namespaceValidatorSuite) Test_Intercept_StatusFromToken() {
 	}
 }
 
-func (s *namespaceValidatorSuite) Test_Intercept_DescribeNamespace_Id() {
-	nvi := NewNamespaceValidatorInterceptor(s.mockRegistry, dynamicconfig.GetBoolPropertyFn(false))
+func (s *namespaceValidatorSuite) Test_StateValidationIntercept_DescribeNamespace_Id() {
+	nvi := NewNamespaceValidatorInterceptor(
+		s.mockRegistry,
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetIntPropertyFn(100))
 	serverInfo := &grpc.UnaryServerInfo{
 		FullMethod: "/temporal/random",
 	}
 
 	req := &workflowservice.DescribeNamespaceRequest{Id: "test-namespace-id"}
 	handlerCalled := false
-	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err := nvi.StateValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.DescribeNamespaceResponse{}, nil
 	})
@@ -407,7 +422,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_DescribeNamespace_Id() {
 
 	req = &workflowservice.DescribeNamespaceRequest{}
 	handlerCalled = false
-	_, err = nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err = nvi.StateValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.DescribeNamespaceResponse{}, nil
 	})
@@ -416,8 +431,11 @@ func (s *namespaceValidatorSuite) Test_Intercept_DescribeNamespace_Id() {
 	s.False(handlerCalled)
 }
 
-func (s *namespaceValidatorSuite) Test_Intercept_GetClusterInfo() {
-	nvi := NewNamespaceValidatorInterceptor(s.mockRegistry, dynamicconfig.GetBoolPropertyFn(false))
+func (s *namespaceValidatorSuite) Test_StateValidationIntercept_GetClusterInfo() {
+	nvi := NewNamespaceValidatorInterceptor(
+		s.mockRegistry,
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetIntPropertyFn(100))
 	serverInfo := &grpc.UnaryServerInfo{
 		FullMethod: "/temporal/random",
 	}
@@ -425,7 +443,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_GetClusterInfo() {
 	// Example of API which doesn't have namespace field.
 	req := &workflowservice.GetClusterInfoRequest{}
 	handlerCalled := false
-	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err := nvi.StateValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.GetClusterInfoResponse{}, nil
 	})
@@ -435,14 +453,17 @@ func (s *namespaceValidatorSuite) Test_Intercept_GetClusterInfo() {
 }
 
 func (s *namespaceValidatorSuite) Test_Intercept_RegisterNamespace() {
-	nvi := NewNamespaceValidatorInterceptor(s.mockRegistry, dynamicconfig.GetBoolPropertyFn(false))
+	nvi := NewNamespaceValidatorInterceptor(
+		s.mockRegistry,
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetIntPropertyFn(100))
 	serverInfo := &grpc.UnaryServerInfo{
 		FullMethod: "/temporal/random",
 	}
 
 	req := &workflowservice.RegisterNamespaceRequest{Namespace: "new-namespace"}
 	handlerCalled := false
-	_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err := nvi.StateValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.RegisterNamespaceResponse{}, nil
 	})
@@ -452,7 +473,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_RegisterNamespace() {
 
 	req = &workflowservice.RegisterNamespaceRequest{}
 	handlerCalled = false
-	_, err = nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+	_, err = nvi.StateValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 		handlerCalled = true
 		return &workflowservice.RegisterNamespaceResponse{}, nil
 	})
@@ -461,7 +482,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_RegisterNamespace() {
 	s.False(handlerCalled)
 }
 
-func (s *namespaceValidatorSuite) Test_Interceptor_TokenNamespaceEnforcement() {
+func (s *namespaceValidatorSuite) Test_StateValidationIntercept_TokenNamespaceEnforcement() {
 	testCases := []struct {
 		tokenNamespaceID                namespace.ID
 		tokenNamespaceName              namespace.Name
@@ -546,17 +567,20 @@ func (s *namespaceValidatorSuite) Test_Interceptor_TokenNamespaceEnforcement() {
 		s.mockRegistry.EXPECT().GetNamespace(testCase.requestNamespaceName).Return(requestNamespace, nil).Times(2)
 		s.mockRegistry.EXPECT().GetNamespaceByID(testCase.tokenNamespaceID).Return(tokenNamespace, nil).Times(2)
 
-		nvi := NewNamespaceValidatorInterceptor(s.mockRegistry, dynamicconfig.GetBoolPropertyFn(testCase.enableTokenNamespaceEnforcement))
+		nvi := NewNamespaceValidatorInterceptor(
+			s.mockRegistry,
+			dynamicconfig.GetBoolPropertyFn(false),
+			dynamicconfig.GetIntPropertyFn(100))
 		serverInfo := &grpc.UnaryServerInfo{
 			FullMethod: "/temporal/RandomMethod",
 		}
 
 		handlerCalled := false
-		_, err := nvi.Intercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		_, err := nvi.StateValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 			handlerCalled = true
 			return &workflowservice.RespondWorkflowTaskCompletedResponse{}, nil
 		})
-		_, queryErr := nvi.Intercept(context.Background(), queryReq, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		_, queryErr := nvi.StateValidationIntercept(context.Background(), queryReq, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
 			handlerCalled = true
 			return &workflowservice.RespondQueryTaskCompletedResponse{}, nil
 		})
@@ -571,4 +595,32 @@ func (s *namespaceValidatorSuite) Test_Interceptor_TokenNamespaceEnforcement() {
 			s.True(handlerCalled)
 		}
 	}
+}
+
+func (s *namespaceValidatorSuite) Test_SizeValidationIntercept() {
+	nvi := NewNamespaceValidatorInterceptor(
+		s.mockRegistry,
+		dynamicconfig.GetBoolPropertyFn(false),
+		dynamicconfig.GetIntPropertyFn(10))
+	serverInfo := &grpc.UnaryServerInfo{
+		FullMethod: "/temporal/random",
+	}
+
+	req := &workflowservice.StartWorkflowExecutionRequest{Namespace: "namespace"}
+	handlerCalled := false
+	_, err := nvi.SizeValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return &workflowservice.StartWorkflowExecutionResponse{}, nil
+	})
+	s.True(handlerCalled)
+	s.NoError(err)
+
+	req = &workflowservice.StartWorkflowExecutionRequest{Namespace: "namespaceTooLong"}
+	handlerCalled = false
+	_, err = nvi.SizeValidationIntercept(context.Background(), req, serverInfo, func(ctx context.Context, req interface{}) (interface{}, error) {
+		handlerCalled = true
+		return &workflowservice.StartWorkflowExecutionResponse{}, nil
+	})
+	s.False(handlerCalled)
+	s.Error(err)
 }

--- a/common/rpc/interceptor/retry.go
+++ b/common/rpc/interceptor/retry.go
@@ -27,8 +27,9 @@ package interceptor
 import (
 	"context"
 
-	"go.temporal.io/server/common/backoff"
 	"google.golang.org/grpc"
+
+	"go.temporal.io/server/common/backoff"
 )
 
 type (

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -165,7 +165,7 @@ func GrpcServerOptionsProvider(
 	interceptors := []grpc.UnaryServerInterceptor{
 		// Service Error Interceptor should be the most outer interceptor on error handling
 		rpc.ServiceErrorInterceptor,
-		namespaceValidatorInterceptor.SizeValidationIntercept,
+		namespaceValidatorInterceptor.LengthValidationIntercept,
 		namespaceLogInterceptor.Intercept, // TODO: Deprecate this with a outer custom interceptor
 		grpc.UnaryServerInterceptor(traceInterceptor),
 		metrics.NewServerMetricsContextInjectorInterceptor(),

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -165,9 +165,9 @@ func GrpcServerOptionsProvider(
 	interceptors := []grpc.UnaryServerInterceptor{
 		// Service Error Interceptor should be the most outer interceptor on error handling
 		rpc.ServiceErrorInterceptor,
+		namespaceValidatorInterceptor.SizeValidationIntercept,
 		namespaceLogInterceptor.Intercept, // TODO: Deprecate this with a outer custom interceptor
 		grpc.UnaryServerInterceptor(traceInterceptor),
-		namespaceValidatorInterceptor.Intercept,
 		metrics.NewServerMetricsContextInjectorInterceptor(),
 		telemetryInterceptor.Intercept,
 		authorization.NewAuthorizationInterceptor(
@@ -177,6 +177,7 @@ func GrpcServerOptionsProvider(
 			logger,
 			audienceGetter,
 		),
+		namespaceValidatorInterceptor.StateValidationIntercept,
 		namespaceCountLimiterInterceptor.Intercept,
 		namespaceRateLimiterInterceptor.Intercept,
 		rateLimitInterceptor.Intercept,
@@ -312,6 +313,7 @@ func NamespaceValidatorInterceptorProvider(
 	return interceptor.NewNamespaceValidatorInterceptor(
 		namespaceRegistry,
 		serviceConfig.EnableTokenNamespaceEnforcement,
+		serviceConfig.MaxIDLengthLimit,
 	)
 }
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -167,7 +167,6 @@ func GrpcServerOptionsProvider(
 		rpc.ServiceErrorInterceptor,
 		grpc.UnaryServerInterceptor(traceInterceptor),
 		metrics.NewServerMetricsContextInjectorInterceptor(),
-		retryableInterceptor.Intercept,
 		telemetryInterceptor.Intercept,
 		namespaceValidatorInterceptor.Intercept,
 		namespaceCountLimiterInterceptor.Intercept,
@@ -186,6 +185,8 @@ func GrpcServerOptionsProvider(
 	if len(customInterceptors) > 0 {
 		interceptors = append(interceptors, customInterceptors...)
 	}
+	// retry interceptor should be the last as other interceptors may modify context values
+	interceptors = append(interceptors, retryableInterceptor.Intercept)
 
 	return append(
 		grpcServerOptions,

--- a/service/fx.go
+++ b/service/fx.go
@@ -102,9 +102,9 @@ func GrpcServerOptionsProvider(
 			grpc.UnaryServerInterceptor(tracingInterceptor),
 			metrics.NewServerMetricsContextInjectorInterceptor(),
 			metrics.NewServerMetricsTrailerPropagatorInterceptor(logger),
-			retryableInterceptor.Intercept,
 			telemetryInterceptor.Intercept,
 			rateLimitInterceptor.Intercept,
+			retryableInterceptor.Intercept,
 		),
 	)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Reorder interceptors 

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Move interceptors that modify context between the retry interceptor and upstream.
2. Move namespaceValidatorInterceptor before ratelimiterInterceptor as it should not take rate limit quota.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
