### PR TITLE
Validate structured calendar specs and improve error messages

### DIFF
--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -201,15 +201,15 @@ func validateStructuredCalendar(scs *schedpb.StructuredCalendarSpec) error {
 
 func validateInterval(i *schedpb.IntervalSpec) error {
 	if i == nil {
-		return errors.New("Interval is nil")
+		return errors.New("interval is nil")
 	}
 	iv, phase := timestamp.DurationValue(i.Interval), timestamp.DurationValue(i.Phase)
 	if iv < time.Second {
-		return errors.New("Interval is too small")
+		return errors.New("interval is too small")
 	} else if phase < 0 {
-		return errors.New("Phase is negative")
+		return errors.New("phase is negative")
 	} else if phase >= iv {
-		return errors.New("Phase cannot be greater than Interval")
+		return errors.New("phase cannot be greater than Interval")
 	}
 	return nil
 }

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -105,6 +105,32 @@ func (s *specSuite) TestCanonicalize() {
 	})
 	s.Error(err)
 
+	// various errors in ranges
+	for _, scs := range []*schedpb.StructuredCalendarSpec{
+		{Second: []*schedpb.Range{{Start: 100}}},
+		{Second: []*schedpb.Range{{Start: -3}}},
+		{Second: []*schedpb.Range{{Start: 30, End: 60}}},
+		{Second: []*schedpb.Range{{Start: 30, End: 40, Step: -3}}},
+		{Minute: []*schedpb.Range{{Start: 60}}},
+		{Hour: []*schedpb.Range{{Start: 0, End: 24}}},
+		{Hour: []*schedpb.Range{{Start: 24, End: 26}}},
+		{Hour: []*schedpb.Range{{Start: 16, End: 12}}},
+		{DayOfMonth: []*schedpb.Range{{Start: 0}}},
+		{DayOfMonth: []*schedpb.Range{{End: 33}}},
+		{Month: []*schedpb.Range{{Start: 0}}},
+		{Month: []*schedpb.Range{{End: 13}}},
+		{DayOfWeek: []*schedpb.Range{{Start: 7}}},
+		{DayOfWeek: []*schedpb.Range{{Start: 6, End: 7}}},
+		{Year: []*schedpb.Range{{Start: 1999}}},
+		{Year: []*schedpb.Range{{Start: 2112}}},
+	} {
+		_, err = canonicalizeSpec(&schedpb.ScheduleSpec{
+			StructuredCalendar: []*schedpb.StructuredCalendarSpec{scs},
+		})
+		s.Error(err)
+	}
+
+	// check parsing and filling in defaults
 	canonical, err = canonicalizeSpec(&schedpb.ScheduleSpec{
 		Calendar: []*schedpb.CalendarSpec{
 			{Hour: "5,7", Minute: "23"},

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -961,7 +961,7 @@ func (s *workflowSuite) TestCompileError() {
 	// written using low-level mocks since it sleeps forever
 
 	s.env.RegisterDelayedCallback(func() {
-		s.Contains(s.describe().Info.InvalidScheduleError, "invalid syntax")
+		s.Contains(s.describe().Info.InvalidScheduleError, "Month is not in range [1-12]")
 	}, 1*time.Minute)
 
 	s.run(&schedpb.Schedule{


### PR DESCRIPTION
**What changed?**
- Add validation for structured calendar specs. This was already done for cron strings and calendar specs (and will now be done twice for them but that's okay).
- Improve error messages for invalid specs.

There are no behavior changes for valid calendar specs so there's no determinism risks. (Even if there was, we use sideeffect now.)

**Why?**
More and earlier validation, better error messages.

**How did you test it?**
unit tests

**Potential risks**

**Is hotfix candidate?**
yes
