### PR TITLE
Per-namespace workers should only run on active cluster

### DIFF
--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -141,7 +141,7 @@ type (
 		Refresh()
 		// Registers callback for namespace state changes. This is regrettably
 		// different from the above RegisterNamespaceChangeCallback because we
-		// need different semantics (and that one is going away).
+		// need different semantics.
 		RegisterStateChangeCallback(key any, cb StateChangeCallbackFn)
 		UnregisterStateChangeCallback(key any)
 	}
@@ -489,7 +489,12 @@ UpdateLoop:
 			newEntries = append(newEntries, namespace)
 		}
 
-		if oldNSAnyVersion == nil || oldNSAnyVersion.State() != namespace.State() {
+		// this test should include anything that might affect whether a namespace is active on
+		// this cluster.
+		if oldNSAnyVersion == nil ||
+			oldNSAnyVersion.State() != namespace.State() ||
+			oldNSAnyVersion.IsGlobalNamespace() != namespace.IsGlobalNamespace() ||
+			oldNSAnyVersion.ActiveClusterName() != namespace.ActiveClusterName() {
 			stateChanged = append(stateChanged, namespace)
 		}
 	}

--- a/service/worker/pernamespaceworker_test.go
+++ b/service/worker/pernamespaceworker_test.go
@@ -124,7 +124,7 @@ func (s *perNsWorkerManagerSuite) TestDisabled() {
 	time.Sleep(50 * time.Millisecond)
 }
 
-func (s *perNsWorkerManagerSuite) TestInActive() {
+func (s *perNsWorkerManagerSuite) TestInactive() {
 	ns := testInactiveNS("ns1", enumspb.NAMESPACE_STATE_REGISTERED)
 
 	s.cmp1.EXPECT().DedicatedWorkerOptions(gomock.Any()).Return(&workercommon.PerNSDedicatedWorkerOptions{


### PR DESCRIPTION
**What changed?**
Check whether a namespace is active on this cluster before starting per-namespace worker.

**Why?**
No need to run workers for passive namespaces, save resources.

**How did you test it?**
unit test and manual test

**Potential risks**


**Is hotfix candidate?**
yes
