### PR TITLE
Implement GetAllHistoryTreeBranches for SQL persistence backends

### DIFF
--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -122,11 +122,6 @@ func (s *HistoryV2PersistenceSuite) TestGenUUIDs() {
 
 // TestScanAllTrees test
 func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
-	// TODO https://go.temporal.io/server/issues/2458
-	if s.ExecutionManager.GetName() != "cassandra" {
-		return
-	}
-
 	resp, err := s.ExecutionManager.GetAllHistoryTreeBranches(s.ctx, &p.GetAllHistoryTreeBranchesRequest{
 		PageSize: 1,
 	})

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -155,7 +155,9 @@ type (
 		DeleteHistoryBranch(ctx context.Context, request *InternalDeleteHistoryBranchRequest) error
 		// GetHistoryTree returns all branch information of a tree
 		GetHistoryTree(ctx context.Context, request *GetHistoryTreeRequest) (*InternalGetHistoryTreeResponse, error)
-		// GetAllHistoryTreeBranches returns all branches of all trees
+		// GetAllHistoryTreeBranches returns all branches of all trees.
+		// Note that branches may be skipped or duplicated across pages if there are branches created or deleted while
+		// paginating through results.
 		GetAllHistoryTreeBranches(ctx context.Context, request *GetAllHistoryTreeBranchesRequest) (*InternalGetAllHistoryTreeBranchesResponse, error)
 	}
 

--- a/common/persistence/sql/sqlplugin/history_tree.go
+++ b/common/persistence/sql/sqlplugin/history_tree.go
@@ -56,10 +56,19 @@ type (
 		BranchID primitives.UUID
 	}
 
-	// HistoryNode is the SQL persistence interface for history trees
+	// HistoryTreeBranchPage is a struct which represents a page of history tree branches to query.
+	HistoryTreeBranchPage struct {
+		ShardID  int32
+		TreeID   primitives.UUID
+		BranchID primitives.UUID
+		Limit    int
+	}
+
+	// HistoryTree is the SQL persistence interface for history trees
 	HistoryTree interface {
 		InsertIntoHistoryTree(ctx context.Context, row *HistoryTreeRow) (sql.Result, error)
 		SelectFromHistoryTree(ctx context.Context, filter HistoryTreeSelectFilter) ([]HistoryTreeRow, error)
 		DeleteFromHistoryTree(ctx context.Context, filter HistoryTreeDeleteFilter) (sql.Result, error)
+		PaginateBranchesFromHistoryTree(ctx context.Context, filter HistoryTreeBranchPage) ([]HistoryTreeRow, error)
 	}
 )

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -62,6 +62,12 @@ const (
 
 	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = ? AND tree_id = ? `
 
+	paginateBranchesQuery = `SELECT shard_id, tree_id, branch_id, data, data_encoding
+        FROM history_tree
+        WHERE (shard_id, tree_id, branch_id) > (?, ?, ?)
+        ORDER BY shard_id, tree_id, branch_id
+        LIMIT ?`
+
 	deleteHistoryTreeQuery = `DELETE FROM history_tree WHERE shard_id = ? AND tree_id = ? AND branch_id = ? `
 )
 
@@ -186,6 +192,25 @@ func (mdb *db) SelectFromHistoryTree(
 		getHistoryTreeQuery,
 		filter.ShardID,
 		filter.TreeID,
+	)
+	return rows, err
+}
+
+// PaginateBranchesFromHistoryTree reads up to page.Limit rows from the history_tree table sorted by their primary key,
+// while skipping the first page.Offset rows.
+func (mdb *db) PaginateBranchesFromHistoryTree(
+	ctx context.Context,
+	page sqlplugin.HistoryTreeBranchPage,
+) ([]sqlplugin.HistoryTreeRow, error) {
+	var rows []sqlplugin.HistoryTreeRow
+	err := mdb.conn.SelectContext(
+		ctx,
+		&rows,
+		paginateBranchesQuery,
+		page.ShardID,
+		page.TreeID,
+		page.BranchID,
+		page.Limit,
 	)
 	return rows, err
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
In this PR, I've added an implementation of the GetAllHistoryTreeBranches function for all of our SQL backends. 

<!-- Tell your future self why have you made these changes -->
I made these changes for https://github.com/temporalio/temporal/issues/3419. This change will allow the history scavenger to prune branches in clusters that use SQL backends for history storage. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
There are existing test suites which verify that we can fetch all history branches after creating some. However, those tests were disabled for non-Cassandra databases. I removed that constraint, and watched the tests fail (because the GetAllHistoryTreeBranches method just panicked before this change). I then applied my fix, and watched the tests pass. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Worst case scenario, we somehow return the wrong data in GetAllHistoryTreeBranches, and that causes the scavenger to delete branches which it should not delete.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
This change should not require a notification to the broader community, but there are some reactions on the description of the original issue, so we should notify them that this is now implemented.
