### PR TITLE
Log warning only when there is an error in SA size validation

### DIFF
--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -176,11 +176,18 @@ func (c *workflowSizeChecker) checkIfSearchAttributesSizeExceedsLimit(
 	namespace namespace.Name,
 	commandTypeTag metrics.Tag,
 ) error {
-	c.metricsScope.Tagged(commandTypeTag).RecordDistribution(metrics.SearchAttributesSize, searchAttributes.Size())
-
+	c.metricsScope.Tagged(commandTypeTag).RecordDistribution(
+		metrics.SearchAttributesSize,
+		searchAttributes.Size(),
+	)
 	err := c.searchAttributesValidator.ValidateSize(searchAttributes, namespace.String())
-	c.logger.Warn("Search attributes size exceeds limits. Fail workflow.", tag.Error(err), tag.WorkflowNamespace(namespace.String()))
-
+	if err != nil {
+		c.logger.Warn(
+			"Search attributes size exceeds limits. Fail workflow.",
+			tag.Error(err),
+			tag.WorkflowNamespace(namespace.String()),
+		)
+	}
 	return err
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Log error of search attributes map size validation only when there's an error.

<!-- Tell your future self why have you made these changes -->
**Why?**
Size validation of search attributes map is always logging error even when there's no error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran search attributes integration test before and after changes, and verified the logs are no longer showing up.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.