### PR TITLE
Add history size to SQL visibility for closed workflows

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -41,10 +41,10 @@ const (
 		`run_id=VALUES(run_id)`
 
 	templateCreateWorkflowExecutionClosed = `INSERT INTO executions_visibility (` +
-		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding, task_queue) ` +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ` +
+		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding, task_queue, history_size_bytes) ` +
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ` +
 		`ON DUPLICATE KEY UPDATE workflow_id = VALUES(workflow_id), start_time = VALUES(start_time), execution_time = VALUES(execution_time), workflow_type_name = VALUES(workflow_type_name), ` +
-		`close_time = VALUES(close_time), status = VALUES(status), history_length = VALUES(history_length), memo = VALUES(memo), encoding = VALUES(encoding), task_queue = VALUES(task_queue)`
+		`close_time = VALUES(close_time), status = VALUES(status), history_length = VALUES(history_length), memo = VALUES(memo), encoding = VALUES(encoding), task_queue = VALUES(task_queue), history_size_bytes = `
 
 	// RunID condition is needed for correct pagination
 	templateConditions = ` AND namespace_id = ?
@@ -138,6 +138,7 @@ func (mdb *db) ReplaceIntoVisibility(
 			row.Memo,
 			row.Encoding,
 			row.TaskQueue,
+			*row.HistorySizeBytes,
 		)
 	default:
 		return nil, errCloseParams

--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -44,7 +44,7 @@ const (
 		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding, task_queue, history_size_bytes) ` +
 		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ` +
 		`ON DUPLICATE KEY UPDATE workflow_id = VALUES(workflow_id), start_time = VALUES(start_time), execution_time = VALUES(execution_time), workflow_type_name = VALUES(workflow_type_name), ` +
-		`close_time = VALUES(close_time), status = VALUES(status), history_length = VALUES(history_length), memo = VALUES(memo), encoding = VALUES(encoding), task_queue = VALUES(task_queue), history_size_bytes = `
+		`close_time = VALUES(close_time), status = VALUES(status), history_length = VALUES(history_length), memo = VALUES(memo), encoding = VALUES(encoding), task_queue = VALUES(task_queue), history_size_bytes = VALUES(history_size_bytes)`
 
 	// RunID condition is needed for correct pagination
 	templateConditions = ` AND namespace_id = ?
@@ -64,7 +64,7 @@ const (
 	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, status, memo, encoding, task_queue`
 	templateOpenSelect     = `SELECT ` + templateOpenFieldNames + ` FROM executions_visibility WHERE status = 1 `
 
-	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, history_length
+	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, history_length, history_size_bytes
 		 FROM executions_visibility WHERE status != 1 `
 
 	templateGetOpenWorkflowExecutions = templateOpenSelect + templateConditions
@@ -81,7 +81,7 @@ const (
 
 	templateGetClosedWorkflowExecutionsByStatus = templateClosedSelect + `AND status = ?` + templateConditionsClosedWorkflows
 
-	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, status, history_length, task_queue 
+	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, status, history_length, task_queue, history_size_bytes 
 		 FROM executions_visibility
 		 WHERE namespace_id = ? AND status != 1
 		 AND run_id = ?`

--- a/common/persistence/sql/sqlplugin/postgresql/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgresql/visibility.go
@@ -41,8 +41,8 @@ const (
          ON CONFLICT (namespace_id, run_id) DO NOTHING`
 
 	templateCreateWorkflowExecutionClosed = `INSERT INTO executions_visibility (` +
-		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding, task_queue) ` +
-		`VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding, task_queue, history_size_bytes) ` +
+		`VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
 		ON CONFLICT (namespace_id, run_id) DO UPDATE 
 		  SET workflow_id = excluded.workflow_id,
 		      start_time = excluded.start_time,
@@ -53,7 +53,8 @@ const (
 			  history_length = excluded.history_length,
 			  memo = excluded.memo,
 			  encoding = excluded.encoding,
-			  task_queue = excluded.task_queue`
+			  task_queue = excluded.task_queue,
+			  history_size_bytes = excluded.history_size_bytes`
 
 	// RunID condition is needed for correct pagination
 	templateConditions1 = ` AND namespace_id = $1
@@ -159,6 +160,7 @@ func (pdb *db) ReplaceIntoVisibility(
 			row.Memo,
 			row.Encoding,
 			row.TaskQueue,
+			*row.HistorySizeBytes,
 		)
 	default:
 		return nil, errCloseParams

--- a/common/persistence/sql/sqlplugin/postgresql/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgresql/visibility.go
@@ -88,7 +88,7 @@ const (
 	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, status, memo, encoding, task_queue`
 	templateOpenSelect     = `SELECT ` + templateOpenFieldNames + ` FROM executions_visibility WHERE status = 1 `
 
-	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, history_length
+	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, history_length, history_size_bytes
 		 FROM executions_visibility WHERE status != 1 `
 
 	templateGetOpenWorkflowExecutions = templateOpenSelect + templateConditions1
@@ -105,7 +105,7 @@ const (
 
 	templateGetClosedWorkflowExecutionsByStatus = templateClosedSelect + `AND status = $1` + templateConditionsClosedWorkflow2
 
-	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, status, history_length, task_queue
+	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, status, history_length, task_queue, history_size_bytes
 		 FROM executions_visibility
 		 WHERE namespace_id = $1 AND status != 1
 		 AND run_id = $2`

--- a/common/persistence/sql/sqlplugin/sqlite/visibility.go
+++ b/common/persistence/sql/sqlplugin/sqlite/visibility.go
@@ -42,8 +42,8 @@ const (
 		`ON CONFLICT (namespace_id, run_id) DO NOTHING`
 
 	templateCreateWorkflowExecutionClosed = `REPLACE INTO executions_visibility (` +
-		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding, task_queue) ` +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) `
+		`namespace_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, status, history_length, memo, encoding, task_queue, history_size_bytes) ` +
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) `
 
 	// RunID condition is needed for correct pagination
 	templateConditions = ` AND namespace_id = ?
@@ -135,6 +135,7 @@ func (mdb *db) ReplaceIntoVisibility(
 			row.Memo,
 			row.Encoding,
 			row.TaskQueue,
+			*row.HistorySizeBytes,
 		)
 	default:
 		return nil, errCloseParams

--- a/common/persistence/sql/sqlplugin/sqlite/visibility.go
+++ b/common/persistence/sql/sqlplugin/sqlite/visibility.go
@@ -63,7 +63,7 @@ const (
 	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, status, memo, encoding, task_queue`
 	templateOpenSelect     = `SELECT ` + templateOpenFieldNames + ` FROM executions_visibility WHERE status = 1 `
 
-	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, history_length
+	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, history_length, history_size_bytes
 		 FROM executions_visibility WHERE status != 1 `
 
 	templateGetOpenWorkflowExecutions = templateOpenSelect + templateConditions
@@ -80,7 +80,7 @@ const (
 
 	templateGetClosedWorkflowExecutionsByStatus = templateClosedSelect + `AND status = ?` + templateConditionsClosedWorkflows
 
-	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, status, history_length, task_queue 
+	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, status, history_length, task_queue, history_size_bytes 
 		 FROM executions_visibility
 		 WHERE namespace_id = ? AND status != 1
 		 AND run_id = ?`

--- a/common/persistence/sql/sqlplugin/tests/visibility_test.go
+++ b/common/persistence/sql/sqlplugin/tests/visibility_test.go
@@ -105,6 +105,7 @@ func (s *visibilitySuite) TestInsertSelect_NonExists() {
 	status := int32(0)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -116,6 +117,7 @@ func (s *visibilitySuite) TestInsertSelect_NonExists() {
 		status,
 		closeTime,
 		historyLength,
+		historySizeBytes,
 	)
 	result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -145,6 +147,7 @@ func (s *visibilitySuite) TestInsertSelect_Exists() {
 	status := int32(0)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 
 	visibility1 := s.newRandomVisibilityRow(
 		namespaceID,
@@ -156,6 +159,7 @@ func (s *visibilitySuite) TestInsertSelect_Exists() {
 		status,
 		closeTime,
 		historyLength,
+		historySizeBytes,
 	)
 	result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility1)
 	s.NoError(err)
@@ -173,6 +177,7 @@ func (s *visibilitySuite) TestInsertSelect_Exists() {
 		status,
 		closeTime,
 		historyLength,
+		historySizeBytes,
 	)
 	_, err = s.store.InsertIntoVisibility(newVisibilityContext(), &visibility2)
 	s.NoError(err)
@@ -202,6 +207,7 @@ func (s *visibilitySuite) TestReplaceSelect_NonExists() {
 	status := int32(0)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -213,6 +219,7 @@ func (s *visibilitySuite) TestReplaceSelect_NonExists() {
 		status,
 		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
+		convert.Int64Ptr(historySizeBytes),
 	)
 	result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -242,6 +249,7 @@ func (s *visibilitySuite) TestReplaceSelect_Exists() {
 	status := int32(0)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -253,6 +261,7 @@ func (s *visibilitySuite) TestReplaceSelect_Exists() {
 		status,
 		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
+		convert.Int64Ptr(historySizeBytes),
 	)
 	result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -270,6 +279,7 @@ func (s *visibilitySuite) TestReplaceSelect_Exists() {
 		status,
 		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
+		convert.Int64Ptr(historySizeBytes),
 	)
 	_, err = s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -321,6 +331,7 @@ func (s *visibilitySuite) TestInsertDeleteSelect() {
 	status := int32(0)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -332,6 +343,7 @@ func (s *visibilitySuite) TestInsertDeleteSelect() {
 		status,
 		closeTime,
 		historyLength,
+		historySizeBytes,
 	)
 	result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -367,6 +379,7 @@ func (s *visibilitySuite) TestReplaceDeleteSelect() {
 	status := int32(0)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -378,6 +391,7 @@ func (s *visibilitySuite) TestReplaceDeleteSelect() {
 		status,
 		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
+		convert.Int64Ptr(historySizeBytes),
 	)
 	result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -415,6 +429,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -426,6 +441,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 		status,
 		closeTime,
 		historyLength,
+		historySizeBytes,
 	)
 	result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -469,6 +485,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 	for i := 0; i < numStartTime; i++ {
 		for j := 0; j < visibilityPerStartTime; j++ {
 			runID := primitives.NewUUID()
@@ -483,6 +500,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 				status,
 				closeTime,
 				historyLength,
+				historySizeBytes,
 			)
 			result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility)
 			s.NoError(err)
@@ -540,6 +558,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -551,6 +570,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 		status,
 		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
+		convert.Int64Ptr(historySizeBytes),
 	)
 	result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -592,6 +612,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 	minStartTime := closeTime
 	maxStartTime := closeTime.Add(time.Duration(numStartTime) * time.Second)
 	for i := 0; i < numStartTime; i++ {
@@ -608,6 +629,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowID_Status
 				status,
 				timestamp.TimePtr(closeTime),
 				convert.Int64Ptr(historyLength),
+				convert.Int64Ptr(historySizeBytes),
 			)
 			result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 			s.NoError(err)
@@ -664,6 +686,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -675,6 +698,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 		status,
 		closeTime,
 		historyLength,
+		historySizeBytes,
 	)
 	result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -718,6 +742,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 	for i := 0; i < numStartTime; i++ {
 		for j := 0; j < visibilityPerStartTime; j++ {
 			workflowID := shuffle.String(testVisibilityWorkflowID)
@@ -732,6 +757,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 				status,
 				closeTime,
 				historyLength,
+				historySizeBytes,
 			)
 			result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility)
 			s.NoError(err)
@@ -789,6 +815,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -800,6 +827,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 		status,
 		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
+		convert.Int64Ptr(historySizeBytes),
 	)
 	result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -841,6 +869,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 	minStartTime := closeTime
 	maxStartTime := closeTime.Add(time.Duration(numStartTime) * time.Second)
 	for i := 0; i < numStartTime; i++ {
@@ -857,6 +886,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_WorkflowTypeName_
 				status,
 				timestamp.TimePtr(closeTime),
 				convert.Int64Ptr(historyLength),
+				convert.Int64Ptr(historySizeBytes),
 			)
 			result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 			s.NoError(err)
@@ -913,6 +943,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusOpen_Single
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -924,6 +955,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusOpen_Single
 		status,
 		closeTime,
 		historyLength,
+		historySizeBytes,
 	)
 	result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -966,6 +998,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusOpen_Multip
 	status := int32(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING)
 	closeTime := (*time.Time)(nil)
 	historyLength := (*int64)(nil)
+	historySizeBytes := (*int64)(nil)
 	for i := 0; i < numStartTime; i++ {
 		for j := 0; j < visibilityPerStartTime; j++ {
 			workflowID := shuffle.String(testVisibilityWorkflowID)
@@ -981,6 +1014,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusOpen_Multip
 				status,
 				closeTime,
 				historyLength,
+				historySizeBytes,
 			)
 			result, err := s.store.InsertIntoVisibility(newVisibilityContext(), &visibility)
 			s.NoError(err)
@@ -1045,6 +1079,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseSingle(
 	executionTime := startTime.Add(time.Second)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -1056,6 +1091,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseSingle(
 		int32(status),
 		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
+		convert.Int64Ptr(historySizeBytes),
 	)
 	result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -1096,6 +1132,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusClose_Multi
 
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 	minStartTime := closeTime
 	maxStartTime := closeTime.Add(time.Duration(numStartTime) * time.Second)
 	for i := 0; i < numStartTime; i++ {
@@ -1114,6 +1151,7 @@ func (s *visibilitySuite) TestSelect_MinStartTime_MaxStartTime_StatusClose_Multi
 				status,
 				timestamp.TimePtr(closeTime),
 				convert.Int64Ptr(historyLength),
+				convert.Int64Ptr(historySizeBytes),
 			)
 			result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 			s.NoError(err)
@@ -1177,6 +1215,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeSin
 	executionTime := startTime.Add(time.Second)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 
 	visibility := s.newRandomVisibilityRow(
 		namespaceID,
@@ -1188,6 +1227,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeSin
 		int32(status),
 		timestamp.TimePtr(closeTime),
 		convert.Int64Ptr(historyLength),
+		convert.Int64Ptr(historySizeBytes),
 	)
 	result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 	s.NoError(err)
@@ -1235,6 +1275,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeMul
 	executionTime := startTime.Add(time.Second)
 	closeTime := executionTime.Add(time.Second)
 	historyLength := rand.Int63()
+	historySizeBytes := rand.Int63()
 	minStartTime := closeTime
 	maxStartTime := closeTime.Add(time.Duration(numStartTime) * time.Second)
 	for i := 0; i < numStartTime; i++ {
@@ -1252,6 +1293,7 @@ func (s *visibilitySuite) testSelectMinStartTimeMaxStartTimeStatusCloseByTypeMul
 				int32(status),
 				timestamp.TimePtr(closeTime),
 				convert.Int64Ptr(historyLength),
+				convert.Int64Ptr(historySizeBytes),
 			)
 			result, err := s.store.ReplaceIntoVisibility(newVisibilityContext(), &visibility)
 			s.NoError(err)
@@ -1363,6 +1405,7 @@ func (s *visibilitySuite) newRandomVisibilityRow(
 	status int32,
 	closeTime *time.Time,
 	historyLength *int64,
+	historySizeBytes *int64,
 ) sqlplugin.VisibilityRow {
 	return sqlplugin.VisibilityRow{
 		NamespaceID:      namespaceID.String(),
@@ -1376,5 +1419,6 @@ func (s *visibilitySuite) newRandomVisibilityRow(
 		HistoryLength:    historyLength,
 		Memo:             shuffle.Bytes(testVisibilityData),
 		Encoding:         testVisibilityEncoding,
+		HistorySizeBytes: historySizeBytes,
 	}
 }

--- a/common/persistence/sql/sqlplugin/visibility.go
+++ b/common/persistence/sql/sqlplugin/visibility.go
@@ -45,6 +45,7 @@ type (
 		Memo             []byte
 		Encoding         string
 		TaskQueue        string
+		HistorySizeBytes *int64
 	}
 
 	// VisibilitySelectFilter contains the column names within executions_visibility table that

--- a/common/persistence/visibility/store/standard/sql/visibility_store.go
+++ b/common/persistence/visibility/store/standard/sql/visibility_store.go
@@ -117,6 +117,7 @@ func (s *visibilityStore) RecordWorkflowExecutionClosed(
 		Memo:             request.Memo.Data,
 		Encoding:         request.Memo.EncodingType.String(),
 		TaskQueue:        request.TaskQueue,
+		HistorySizeBytes: &request.HistorySizeBytes,
 	})
 	if err != nil {
 		return err

--- a/schema/mysql/v57/visibility/schema.sql
+++ b/schema/mysql/v57/visibility/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE executions_visibility (
   memo                 BLOB,
   encoding             VARCHAR(64) NOT NULL,
   task_queue           VARCHAR(255) DEFAULT '' NOT NULL,
+  history_size_bytes   BIGINT,
 
   PRIMARY KEY  (namespace_id, run_id)
 );

--- a/schema/mysql/v57/visibility/versioned/v1.2/add_history_size.sql
+++ b/schema/mysql/v57/visibility/versioned/v1.2/add_history_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions_visibility ADD history_size_bytes BIGINT NOT NULL DEFAULT 0;

--- a/schema/mysql/v57/visibility/versioned/v1.2/manifest.json
+++ b/schema/mysql/v57/visibility/versioned/v1.2/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.2",
+  "MinCompatibleVersion": "1.0",
+  "Description": "add history size to closed_executions",
+  "SchemaUpdateCqlFiles": [
+    "add_history_size.sql"
+  ]
+}

--- a/schema/mysql/version.go
+++ b/schema/mysql/version.go
@@ -30,4 +30,4 @@ package mysql
 const Version = "1.8"
 
 // VisibilityVersion is the MySQL visibility database release version
-const VisibilityVersion = "1.1"
+const VisibilityVersion = "1.2"

--- a/schema/postgresql/v96/visibility/schema.sql
+++ b/schema/postgresql/v96/visibility/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE executions_visibility (
   memo                 BYTEA,
   encoding             VARCHAR(64) NOT NULL,
   task_queue           VARCHAR(255) DEFAULT '' NOT NULL,
+  history_size_bytes   BIGINT,
 
   PRIMARY KEY  (namespace_id, run_id)
 );

--- a/schema/postgresql/v96/visibility/versioned/v1.2/add_history_size.sql
+++ b/schema/postgresql/v96/visibility/versioned/v1.2/add_history_size.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions_visibility ADD history_size_bytes BIGINT NOT NULL DEFAULT 0;

--- a/schema/postgresql/v96/visibility/versioned/v1.2/manifest.json
+++ b/schema/postgresql/v96/visibility/versioned/v1.2/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.2",
+  "MinCompatibleVersion": "1.0",
+  "Description": "add history size to closed_executions",
+  "SchemaUpdateCqlFiles": [
+    "add_history_size.sql"
+  ]
+}

--- a/schema/postgresql/version.go
+++ b/schema/postgresql/version.go
@@ -32,4 +32,4 @@ const Version = "1.8"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
-const VisibilityVersion = "1.1"
+const VisibilityVersion = "1.2"

--- a/schema/sqlite/v3/visibility/schema.sql
+++ b/schema/sqlite/v3/visibility/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE executions_visibility (
 	memo BLOB,
 	encoding VARCHAR(64) NOT NULL,
 	task_queue VARCHAR(255) DEFAULT '' NOT NULL,
+    history_size_bytes BIGINT,
 
 	PRIMARY KEY (namespace_id, run_id)
 );


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Same change as https://github.com/temporalio/temporal/pull/3451, but for SQL visibility

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
