### PR TITLE
Fix timer task visibility timestamp for workflow refresh

### DIFF
--- a/service/history/nDCHistoryReplicator_test.go
+++ b/service/history/nDCHistoryReplicator_test.go
@@ -136,6 +136,8 @@ func (s *nDCHistoryReplicatorSuite) Test_ApplyWorkflowState_BrandNew() {
 	}
 	historyBranch, err := serialization.HistoryBranchToBlob(branchInfo)
 	s.NoError(err)
+	completionEventBatchId := int64(5)
+	nextEventID := int64(7)
 	request := &historyservice.ReplicateWorkflowStateRequest{
 		WorkflowState: &persistencespb.WorkflowMutableState{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
@@ -155,12 +157,14 @@ func (s *nDCHistoryReplicatorSuite) Test_ApplyWorkflowState_BrandNew() {
 						},
 					},
 				},
+				CompletionEventBatchId: completionEventBatchId,
 			},
 			ExecutionState: &persistencespb.WorkflowExecutionState{
 				RunId:  s.runID,
 				State:  enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
 				Status: enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
 			},
+			NextEventId: nextEventID,
 		},
 		RemoteCluster: "test",
 	}
@@ -209,7 +213,13 @@ func (s *nDCHistoryReplicatorSuite) Test_ApplyWorkflowState_BrandNew() {
 			WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{},
 		},
 	}
+	fakeCompletionEvent := &historypb.HistoryEvent{
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionTerminatedEventAttributes{
+			WorkflowExecutionTerminatedEventAttributes: &historypb.WorkflowExecutionTerminatedEventAttributes{},
+		},
+	}
 	s.mockEventCache.EXPECT().GetEvent(gomock.Any(), gomock.Any(), common.FirstEventID, gomock.Any()).Return(fakeStartHistory, nil).AnyTimes()
+	s.mockEventCache.EXPECT().GetEvent(gomock.Any(), gomock.Any(), completionEventBatchId, gomock.Any()).Return(fakeCompletionEvent, nil).AnyTimes()
 	err = s.historyReplicator.ApplyWorkflowState(context.Background(), request)
 	s.NoError(err)
 }
@@ -235,6 +245,8 @@ func (s *nDCHistoryReplicatorSuite) Test_ApplyWorkflowState_Ancestors() {
 	}
 	historyBranch, err := serialization.HistoryBranchToBlob(branchInfo)
 	s.NoError(err)
+	completionEventBatchId := int64(5)
+	nextEventID := int64(7)
 	request := &historyservice.ReplicateWorkflowStateRequest{
 		WorkflowState: &persistencespb.WorkflowMutableState{
 			ExecutionInfo: &persistencespb.WorkflowExecutionInfo{
@@ -254,12 +266,14 @@ func (s *nDCHistoryReplicatorSuite) Test_ApplyWorkflowState_Ancestors() {
 						},
 					},
 				},
+				CompletionEventBatchId: completionEventBatchId,
 			},
 			ExecutionState: &persistencespb.WorkflowExecutionState{
 				RunId:  s.runID,
 				State:  enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED,
 				Status: enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED,
 			},
+			NextEventId: nextEventID,
 		},
 		RemoteCluster: "test",
 	}
@@ -370,7 +384,13 @@ func (s *nDCHistoryReplicatorSuite) Test_ApplyWorkflowState_Ancestors() {
 			WorkflowExecutionStartedEventAttributes: &historypb.WorkflowExecutionStartedEventAttributes{},
 		},
 	}
+	fakeCompletionEvent := &historypb.HistoryEvent{
+		Attributes: &historypb.HistoryEvent_WorkflowExecutionTerminatedEventAttributes{
+			WorkflowExecutionTerminatedEventAttributes: &historypb.WorkflowExecutionTerminatedEventAttributes{},
+		},
+	}
 	s.mockEventCache.EXPECT().GetEvent(gomock.Any(), gomock.Any(), common.FirstEventID, gomock.Any()).Return(fakeStartHistory, nil).AnyTimes()
+	s.mockEventCache.EXPECT().GetEvent(gomock.Any(), gomock.Any(), completionEventBatchId, gomock.Any()).Return(fakeCompletionEvent, nil).AnyTimes()
 	err = s.historyReplicator.ApplyWorkflowState(context.Background(), request)
 	s.NoError(err)
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -2387,6 +2387,7 @@ func (e *MutableStateImpl) AddCompletedWorkflowEvent(
 	// TODO merge active & passive task generation
 	if err := e.taskGenerator.GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	); err != nil {
 		return nil, err
@@ -2432,6 +2433,7 @@ func (e *MutableStateImpl) AddFailWorkflowEvent(
 	// TODO merge active & passive task generation
 	if err := e.taskGenerator.GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	); err != nil {
 		return nil, err
@@ -2476,6 +2478,7 @@ func (e *MutableStateImpl) AddTimeoutWorkflowEvent(
 	// TODO merge active & passive task generation
 	if err := e.taskGenerator.GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	); err != nil {
 		return nil, err
@@ -2557,6 +2560,7 @@ func (e *MutableStateImpl) AddWorkflowExecutionCanceledEvent(
 	// TODO merge active & passive task generation
 	if err := e.taskGenerator.GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	); err != nil {
 		return nil, err
@@ -3103,6 +3107,7 @@ func (e *MutableStateImpl) AddWorkflowExecutionTerminatedEvent(
 	// TODO merge active & passive task generation
 	if err := e.taskGenerator.GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		deleteAfterTerminate,
 	); err != nil {
 		return nil, err
@@ -3235,6 +3240,7 @@ func (e *MutableStateImpl) AddContinueAsNewEvent(
 	// TODO merge active & passive task generation
 	if err := e.taskGenerator.GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(continueAsNewEvent.GetEventTime()),
+		continueAsNewEvent,
 		false,
 	); err != nil {
 		return nil, nil, err

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -535,6 +535,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				timestamp.TimeValue(event.GetEventTime()),
+				event,
 				false,
 			); err != nil {
 				return nil, err
@@ -550,6 +551,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				timestamp.TimeValue(event.GetEventTime()),
+				event,
 				false,
 			); err != nil {
 				return nil, err
@@ -565,6 +567,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				timestamp.TimeValue(event.GetEventTime()),
+				event,
 				false,
 			); err != nil {
 				return nil, err
@@ -580,6 +583,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				timestamp.TimeValue(event.GetEventTime()),
+				event,
 				false,
 			); err != nil {
 				return nil, err
@@ -595,6 +599,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				timestamp.TimeValue(event.GetEventTime()),
+				event,
 				false,
 			); err != nil {
 				return nil, err
@@ -642,6 +647,7 @@ func (b *MutableStateRebuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				timestamp.TimeValue(event.GetEventTime()),
+				event,
 				false,
 			); err != nil {
 				return nil, err

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -289,6 +289,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut()
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyness()
@@ -321,6 +322,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyness()
@@ -352,6 +354,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed() {
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyness()
@@ -384,6 +387,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted(
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyness()
@@ -416,6 +420,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCanceled()
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(event.GetEventTime()),
+		event,
 		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyness()
@@ -514,6 +519,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	s.mockUpdateVersion(continueAsNewEvent)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(continueAsNewEvent.GetEventTime()),
+		continueAsNewEvent,
 		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyness()
@@ -578,6 +584,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	s.mockUpdateVersion(continueAsNewEvent)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		timestamp.TimeValue(continueAsNewEvent.GetEventTime()),
+		continueAsNewEvent,
 		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyness()

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -273,17 +273,17 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateUserTimerTasks(now interface{})
 }
 
 // GenerateWorkflowCloseTasks mocks base method.
-func (m *MockTaskGenerator) GenerateWorkflowCloseTasks(now time.Time, deleteAfterClose bool) error {
+func (m *MockTaskGenerator) GenerateWorkflowCloseTasks(now time.Time, closeEvent *history.HistoryEvent, deleteAfterClose bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateWorkflowCloseTasks", now, deleteAfterClose)
+	ret := m.ctrl.Call(m, "GenerateWorkflowCloseTasks", now, closeEvent, deleteAfterClose)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateWorkflowCloseTasks indicates an expected call of GenerateWorkflowCloseTasks.
-func (mr *MockTaskGeneratorMockRecorder) GenerateWorkflowCloseTasks(now, deleteAfterClose interface{}) *gomock.Call {
+func (mr *MockTaskGeneratorMockRecorder) GenerateWorkflowCloseTasks(now, closeEvent, deleteAfterClose interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowCloseTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateWorkflowCloseTasks), now, deleteAfterClose)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowCloseTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateWorkflowCloseTasks), now, closeEvent, deleteAfterClose)
 }
 
 // GenerateWorkflowResetTasks mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix `DeleteHistoryEventTask` and `WorkflowBackoffTimerTask`'s visibility timestamp when they are generated by workflow refresh

<!-- Tell your future self why have you made these changes -->
**Why?**
- Workflow refresh will use the refresh time instead of workflow close/start time to generated those two tasks.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tried workflow refresh locally and verified time for generated DeleteHistoryEventTask and WorkflowBackoffTimerTask

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Maybe