### PR TITLE
Properly handle min task ID > max task ID case when shard is re-balancing

### DIFF
--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -267,7 +267,9 @@ func (p *ackMgrImpl) getTasks(
 	batchSize int,
 ) ([]*replicationspb.ReplicationTask, int64, error) {
 
-	if minTaskID == maxTaskID {
+	if minTaskID > maxTaskID {
+		return nil, 0, serviceerror.NewUnavailable("min task ID < max task ID, probably due to shard re-balancing")
+	} else if minTaskID == maxTaskID {
 		return []*replicationspb.ReplicationTask{}, maxTaskID, nil
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Properly handle min task ID > max task ID case by return unavailable error

<!-- Tell your future self why have you made these changes -->
**Why?**
During shard rebalancing, it is possible that a replication task poller contact new shard owner, then old shard owner: min task ID > max task ID; old shard owner should return unavailable error -> caller retry.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A