### PR TITLE
Fix sanitize mutable state after replication

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -52,6 +52,8 @@ const (
 	LastBlobNextPageToken = -1
 	// EndMessageID is the id of the end message, here we use the int64 max
 	EndMessageID int64 = 1<<63 - 1
+	// EmptyTaskID is the id of the empty task
+	EmptyTaskID int64 = 0
 )
 
 const (

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -45,6 +45,7 @@ import (
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	filterpb "go.temporal.io/api/filter/v1"
 	historypb "go.temporal.io/api/history/v1"
 	querypb "go.temporal.io/api/query/v1"
 	replicationpb "go.temporal.io/api/replication/v1"
@@ -2175,6 +2176,21 @@ func (s *integrationClustersTestSuite) TestLocalNamespaceMigration() {
 	s.Equal(1, len(nsResp.ReplicationConfig.Clusters))
 	time.Sleep(cacheRefreshInterval)
 
+	// Start wf1 (in local ns)
+	workflowID8 := "global-ns-wf-1"
+	run8, err := client1.ExecuteWorkflow(testCtx, sdkclient.StartWorkflowOptions{
+		ID:                 workflowID8,
+		TaskQueue:          taskqueue,
+		WorkflowRunTimeout: time.Second * 30,
+	}, testWorkflowFn, time.Millisecond*10)
+
+	s.NoError(err)
+	s.NotEmpty(run8.GetRunID())
+	s.logger.Info("start wf8", tag.WorkflowRunID(run8.GetRunID()))
+	// wait until wf1 complete
+	err = run8.Get(testCtx, nil)
+	s.NoError(err)
+
 	// this will buffer after ns promotion
 	err = client1.SignalWorkflow(testCtx, workflowID7, run7.GetRunID(), "signal-name", "signal-value")
 	s.NoError(err)
@@ -2301,6 +2317,19 @@ func (s *integrationClustersTestSuite) TestLocalNamespaceMigration() {
 		})
 		s.NoError(err)
 		s.True(len(resp.GetHistory().GetEvents()) > 0)
+		listWorkflowResp, err := feClient2.ListClosedWorkflowExecutions(
+			testCtx,
+			&workflowservice.ListClosedWorkflowExecutionsRequest{
+				Namespace:       namespace,
+				MaximumPageSize: 1000,
+				Filters: &workflowservice.ListClosedWorkflowExecutionsRequest_ExecutionFilter{
+					ExecutionFilter: &filterpb.WorkflowExecutionFilter{
+						WorkflowId: wfID,
+					}},
+			},
+		)
+		s.NoError(err)
+		s.True(len(listWorkflowResp.GetExecutions()) > 0)
 	}
 	verify(workflowID, run1.GetRunID())
 	verify(workflowID2, run2.GetRunID())

--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -289,6 +289,7 @@ func (r *HistoryReplicatorImpl) ApplyWorkflowState(
 		ns,
 		request.GetWorkflowState(),
 		lastFirstTxnID,
+		lastEventItem.GetVersion(),
 	)
 	if err != nil {
 		return err

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -687,6 +687,7 @@ func (s *ContextImpl) CreateWorkflowExecution(
 	); err != nil {
 		return nil, err
 	}
+	s.updateCloseTaskIDs(request.NewWorkflowSnapshot.ExecutionInfo, request.NewWorkflowSnapshot.Tasks)
 
 	currentRangeID := s.getRangeIDLocked()
 	request.RangeID = currentRangeID

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -357,6 +357,7 @@ func NewSanitizedMutableState(
 	logger log.Logger,
 	namespaceEntry *namespace.Namespace,
 	mutableStateRecord *persistencespb.WorkflowMutableState,
+	lastFirstEventTxnID int64,
 ) (*MutableStateImpl, error) {
 
 	mutableState, err := newMutableStateFromDB(shard, eventsCache, logger, namespaceEntry, mutableStateRecord, 1)
@@ -365,7 +366,9 @@ func NewSanitizedMutableState(
 	}
 
 	// sanitize data
-	mutableState.executionInfo.LastFirstEventTxnId = common.EmptyVersion
+	mutableState.executionInfo.LastFirstEventTxnId = lastFirstEventTxnID
+	mutableState.executionInfo.CloseVisibilityTaskId = common.EmptyVersion
+	mutableState.executionInfo.CloseTransferTaskId = common.EmptyVersion
 	// TODO: after adding cluster to clock info, no need to reset clock here
 	mutableState.executionInfo.ParentClock = nil
 	for _, childExecutionInfo := range mutableState.pendingChildExecutionInfoIDs {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -358,6 +358,7 @@ func NewSanitizedMutableState(
 	namespaceEntry *namespace.Namespace,
 	mutableStateRecord *persistencespb.WorkflowMutableState,
 	lastFirstEventTxnID int64,
+	lastWriteVersion int64,
 ) (*MutableStateImpl, error) {
 
 	mutableState, err := newMutableStateFromDB(shard, eventsCache, logger, namespaceEntry, mutableStateRecord, 1)
@@ -374,6 +375,7 @@ func NewSanitizedMutableState(
 	for _, childExecutionInfo := range mutableState.pendingChildExecutionInfoIDs {
 		childExecutionInfo.Clock = nil
 	}
+	mutableState.currentVersion = lastWriteVersion
 	return mutableState, nil
 }
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -429,7 +429,7 @@ func (s *mutableStateSuite) TestSanitizedMutableState() {
 	}}
 
 	mutableStateProto := mutableState.CloneToProto()
-	sanitizedMutableState, err := NewSanitizedMutableState(s.mockShard, s.mockEventsCache, s.logger, tests.LocalNamespaceEntry, mutableStateProto)
+	sanitizedMutableState, err := NewSanitizedMutableState(s.mockShard, s.mockEventsCache, s.logger, tests.LocalNamespaceEntry, mutableStateProto, 0)
 	s.NoError(err)
 	s.Equal(int64(0), sanitizedMutableState.executionInfo.LastFirstEventTxnId)
 	s.Nil(sanitizedMutableState.executionInfo.ParentClock)

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -429,7 +429,7 @@ func (s *mutableStateSuite) TestSanitizedMutableState() {
 	}}
 
 	mutableStateProto := mutableState.CloneToProto()
-	sanitizedMutableState, err := NewSanitizedMutableState(s.mockShard, s.mockEventsCache, s.logger, tests.LocalNamespaceEntry, mutableStateProto, 0)
+	sanitizedMutableState, err := NewSanitizedMutableState(s.mockShard, s.mockEventsCache, s.logger, tests.LocalNamespaceEntry, mutableStateProto, 0, 0)
 	s.NoError(err)
 	s.Equal(int64(0), sanitizedMutableState.executionInfo.LastFirstEventTxnId)
 	s.Nil(sanitizedMutableState.executionInfo.ParentClock)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix sanitize mutable state after replication

<!-- Tell your future self why have you made these changes -->
**Why?**
1. The LastFirstTxnID should use the one from append history node. Otherwise, it will break getReverseHistory.
2. Sanitize closeTaskID and closeVisibilityTaskID in CreateAsClose case.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
