### PR TITLE
Fix last heartbeat time for pending activity

### DIFF
--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -129,7 +129,7 @@ func Invoke(
 			} else {
 				p.State = enumspb.PENDING_ACTIVITY_STATE_SCHEDULED
 			}
-			if !timestamp.TimeValue(ai.LastHeartbeatUpdateTime).IsZero() {
+			if timestamp.TimeValue(ai.LastHeartbeatUpdateTime).After(timestamp.TimeValue(ai.StartedTime)) {
 				p.LastHeartbeatTime = ai.LastHeartbeatUpdateTime
 				p.HeartbeatDetails = ai.LastHeartbeatDetails
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Show heartbeat time only if it is after start time.

<!-- Tell your future self why have you made these changes -->
**Why?**
Server sets last heartbeat time to start time when activity starts. That is needed for other reason, but it confuses the caller of DescribeWorkflow. 
This is to show last heartbeat time only if it is after start time.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
NO