### PR TITLE
Update replication timestamp with no task

### DIFF
--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -479,6 +479,7 @@ func (p *taskProcessorImpl) paginationFn(_ []byte) ([]interface{}, []byte, error
 		}
 		p.maxRxReceivedTaskID = resp.GetLastRetrievedMessageId()
 		if len(tasks) == 0 {
+			// Update processed timestamp to the source cluster time when there is no replication task
 			p.maxRxProcessedTimestamp = timestamp.TimeValue(resp.GetSyncShardStatus().GetStatusTime())
 		}
 

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -478,6 +478,10 @@ func (p *taskProcessorImpl) paginationFn(_ []byte) ([]interface{}, []byte, error
 			tasks = append(tasks, task)
 		}
 		p.maxRxReceivedTaskID = resp.GetLastRetrievedMessageId()
+		if len(tasks) == 0 {
+			p.maxRxProcessedTimestamp = timestamp.TimeValue(resp.GetSyncShardStatus().GetStatusTime())
+		}
+
 		if resp.GetHasMore() {
 			p.rxTaskBackoff = time.Duration(0)
 		} else {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update replication timestamp with no task

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, the replication acked timestamp will not be updated if there is no replication task. We should use the source cluster time if there is no replication task to indicate the replication is up-to-date.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
