### PR TITLE
Create visibility GetWorkflowExecution API

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -299,6 +299,8 @@ const (
 	VisibilityPersistenceScanWorkflowExecutionsScope
 	// VisibilityPersistenceCountWorkflowExecutionsScope tracks CountWorkflowExecutions calls made by service to visibility persistence layer
 	VisibilityPersistenceCountWorkflowExecutionsScope
+	// VisibilityPersistenceGetWorkflowExecutionScope tracks GetWorkflowExecution calls made by service to visibility persistence layer
+	VisibilityPersistenceGetWorkflowExecutionScope
 
 	// PersistenceEnqueueMessageScope tracks Enqueue calls made by service to persistence layer
 	PersistenceEnqueueMessageScope
@@ -1444,6 +1446,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		VisibilityPersistenceListWorkflowExecutionsScope:                   {operation: "ListWorkflowExecutions", tags: map[string]string{visibilityTypeTagName: unknownValue}},
 		VisibilityPersistenceScanWorkflowExecutionsScope:                   {operation: "ScanWorkflowExecutions", tags: map[string]string{visibilityTypeTagName: unknownValue}},
 		VisibilityPersistenceCountWorkflowExecutionsScope:                  {operation: "CountWorkflowExecutions", tags: map[string]string{visibilityTypeTagName: unknownValue}},
+		VisibilityPersistenceGetWorkflowExecutionScope:                     {operation: "GetWorkflowExecution", tags: map[string]string{visibilityTypeTagName: unknownValue}},
 
 		PersistenceAppendHistoryNodesScope:         {operation: "AppendHistoryNodes"},
 		PersistenceAppendRawHistoryNodesScope:      {operation: "AppendRawHistoryNodes"},

--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -86,6 +86,22 @@ const (
 		 WHERE namespace_id = ? AND status != 1
 		 AND run_id = ?`
 
+	templateGetWorkflowExecution = `
+		SELECT
+			workflow_id,
+			run_id,
+			start_time,
+			execution_time,
+			memo,
+			encoding,
+			close_time,
+			workflow_type_name,
+			status,
+			history_length,
+			task_queue 
+		FROM executions_visibility
+		WHERE namespace_id = ? AND run_id = ?`
+
 	templateDeleteWorkflowExecution = "DELETE FROM executions_visibility WHERE namespace_id = ? AND run_id = ?"
 )
 
@@ -265,4 +281,22 @@ func (mdb *db) SelectFromVisibility(
 		}
 	}
 	return rows, nil
+}
+
+// GetFromVisibility reads one row from visibility table
+func (mdb *db) GetFromVisibility(
+	ctx context.Context,
+	filter sqlplugin.VisibilityGetFilter,
+) (*sqlplugin.VisibilityRow, error) {
+	var row sqlplugin.VisibilityRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		templateGetWorkflowExecution,
+		filter.NamespaceID,
+		filter.RunID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
 }

--- a/common/persistence/sql/sqlplugin/postgresql/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgresql/visibility.go
@@ -109,6 +109,22 @@ const (
 		 WHERE namespace_id = $1 AND status != 1
 		 AND run_id = $2`
 
+	templateGetWorkflowExecution = `
+		SELECT
+			workflow_id,
+			run_id,
+			start_time,
+			execution_time,
+			memo,
+			encoding,
+			close_time,
+			workflow_type_name,
+			status,
+			history_length,
+			task_queue
+		FROM executions_visibility
+		WHERE namespace_id = $1 AND run_id = $2`
+
 	templateDeleteWorkflowExecution = "DELETE FROM executions_visibility WHERE namespace_id = $1 AND run_id = $2"
 )
 
@@ -285,4 +301,22 @@ func (pdb *db) SelectFromVisibility(
 		rows[i].RunID = strings.TrimSpace(rows[i].RunID)
 	}
 	return rows, nil
+}
+
+// GetFromVisibility reads one row from visibility table
+func (mdb *db) GetFromVisibility(
+	ctx context.Context,
+	filter sqlplugin.VisibilityGetFilter,
+) (*sqlplugin.VisibilityRow, error) {
+	var row sqlplugin.VisibilityRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		templateGetWorkflowExecution,
+		filter.NamespaceID,
+		filter.RunID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
 }

--- a/common/persistence/sql/sqlplugin/sqlite/visibility.go
+++ b/common/persistence/sql/sqlplugin/sqlite/visibility.go
@@ -85,6 +85,22 @@ const (
 		 WHERE namespace_id = ? AND status != 1
 		 AND run_id = ?`
 
+	templateGetWorkflowExecution = `
+		SELECT
+			workflow_id,
+			run_id,
+			start_time,
+			execution_time,
+			memo,
+			encoding,
+			close_time,
+			workflow_type_name,
+			status,
+			history_length,
+			task_queue 
+		FROM executions_visibility
+		WHERE namespace_id = ? AND run_id = ?`
+
 	templateDeleteWorkflowExecution = "DELETE FROM executions_visibility WHERE namespace_id = ? AND run_id = ?"
 )
 
@@ -262,4 +278,22 @@ func (mdb *db) SelectFromVisibility(
 		}
 	}
 	return rows, nil
+}
+
+// GetFromVisibility reads one row from visibility table
+func (mdb *db) GetFromVisibility(
+	ctx context.Context,
+	filter sqlplugin.VisibilityGetFilter,
+) (*sqlplugin.VisibilityRow, error) {
+	var row sqlplugin.VisibilityRow
+	err := mdb.conn.GetContext(ctx,
+		&row,
+		templateGetWorkflowExecution,
+		filter.NamespaceID,
+		filter.RunID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
 }

--- a/common/persistence/sql/sqlplugin/visibility.go
+++ b/common/persistence/sql/sqlplugin/visibility.go
@@ -60,6 +60,11 @@ type (
 		PageSize         *int
 	}
 
+	VisibilityGetFilter struct {
+		NamespaceID string
+		RunID       string
+	}
+
 	VisibilityDeleteFilter struct {
 		NamespaceID string
 		RunID       string
@@ -80,6 +85,7 @@ type (
 		//   - OPTIONALLY specify one of following params
 		//     - workflowID, workflowTypeName, status (along with closed=true)
 		SelectFromVisibility(ctx context.Context, filter VisibilitySelectFilter) ([]VisibilityRow, error)
+		GetFromVisibility(ctx context.Context, filter VisibilityGetFilter) (*VisibilityRow, error)
 		DeleteFromVisibility(ctx context.Context, filter VisibilityDeleteFilter) (sql.Result, error)
 	}
 )

--- a/common/persistence/visibility/manager/visibility_manager.go
+++ b/common/persistence/visibility/manager/visibility_manager.go
@@ -62,6 +62,7 @@ type (
 		ListWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error)
 		ScanWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequestV2) (*ListWorkflowExecutionsResponse, error)
 		CountWorkflowExecutions(ctx context.Context, request *CountWorkflowExecutionsRequest) (*CountWorkflowExecutionsResponse, error)
+		GetWorkflowExecution(ctx context.Context, request *GetWorkflowExecutionRequest) (*GetWorkflowExecutionResponse, error)
 	}
 
 	VisibilityRequestBase struct {
@@ -172,6 +173,21 @@ type (
 		TaskID      int64
 		StartTime   *time.Time // if start time is not empty, delete record from open_execution for cassandra db
 		CloseTime   *time.Time // if end time is not empty, delete record from closed_execution for cassandra db
+	}
+
+	// GetWorkflowExecutionRequest is request from GetWorkflowExecution
+	GetWorkflowExecutionRequest struct {
+		NamespaceID namespace.ID
+		Namespace   namespace.Name // namespace.Name is not persisted
+		RunID       string
+		WorkflowID  string
+		StartTime   *time.Time // if start time is not empty, search record from open_execution for cassandra db
+		CloseTime   *time.Time // if end time is not empty, search record from closed_execution for cassandra db
+	}
+
+	// GetWorkflowExecutionResponse is response to GetWorkflowExecution
+	GetWorkflowExecutionResponse struct {
+		Execution *workflowpb.WorkflowExecutionInfo
 	}
 )
 

--- a/common/persistence/visibility/manager/visibility_manager_mock.go
+++ b/common/persistence/visibility/manager/visibility_manager_mock.go
@@ -113,6 +113,21 @@ func (mr *MockVisibilityManagerMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockVisibilityManager)(nil).GetName))
 }
 
+// GetWorkflowExecution mocks base method.
+func (m *MockVisibilityManager) GetWorkflowExecution(ctx context.Context, request *GetWorkflowExecutionRequest) (*GetWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowExecution", ctx, request)
+	ret0, _ := ret[0].(*GetWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkflowExecution indicates an expected call of GetWorkflowExecution.
+func (mr *MockVisibilityManagerMockRecorder) GetWorkflowExecution(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockVisibilityManager)(nil).GetWorkflowExecution), ctx, request)
+}
+
 // ListClosedWorkflowExecutions mocks base method.
 func (m *MockVisibilityManager) ListClosedWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()

--- a/common/persistence/visibility/store/elasticsearch/client/client.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client.go
@@ -42,6 +42,7 @@ const (
 type (
 	// Client is a wrapper around Elasticsearch client library.
 	Client interface {
+		Get(ctx context.Context, index string, docID string) (*elastic.GetResult, error)
 		Search(ctx context.Context, p *SearchParameters) (*elastic.SearchResult, error)
 		Count(ctx context.Context, index string, query elastic.Query) (int64, error)
 		RunBulkProcessor(ctx context.Context, p *BulkProcessorParameters) (BulkProcessor, error)

--- a/common/persistence/visibility/store/elasticsearch/client/client_mock.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_mock.go
@@ -104,6 +104,21 @@ func (mr *MockClientMockRecorder) Count(ctx, index, query interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Count", reflect.TypeOf((*MockClient)(nil).Count), ctx, index, query)
 }
 
+// Get mocks base method.
+func (m *MockClient) Get(ctx context.Context, index, docID string) (*v7.GetResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, index, docID)
+	ret0, _ := ret[0].(*v7.GetResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockClientMockRecorder) Get(ctx, index, docID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockClient)(nil).Get), ctx, index, docID)
+}
+
 // GetMapping mocks base method.
 func (m *MockClient) GetMapping(ctx context.Context, index string) (map[string]string, error) {
 	m.ctrl.T.Helper()
@@ -317,6 +332,21 @@ func (m *MockCLIClient) Delete(ctx context.Context, indexName, docID string, ver
 func (mr *MockCLIClientMockRecorder) Delete(ctx, indexName, docID, version interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCLIClient)(nil).Delete), ctx, indexName, docID, version)
+}
+
+// Get mocks base method.
+func (m *MockCLIClient) Get(ctx context.Context, index, docID string) (*v7.GetResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", ctx, index, docID)
+	ret0, _ := ret[0].(*v7.GetResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get.
+func (mr *MockCLIClientMockRecorder) Get(ctx, index, docID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCLIClient)(nil).Get), ctx, index, docID)
 }
 
 // GetMapping mocks base method.

--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -120,6 +120,10 @@ func newClient(cfg *Config, httpClient *http.Client, logger log.Logger) (*client
 	}, nil
 }
 
+func (c *clientImpl) Get(ctx context.Context, index string, docID string) (*elastic.GetResult, error) {
+	return c.esClient.Get().Index(index).Id(docID).Do(ctx)
+}
+
 func (c *clientImpl) Search(ctx context.Context, p *SearchParameters) (*elastic.SearchResult, error) {
 	searchSource := elastic.NewSearchSource().
 		Query(p.Query).

--- a/common/persistence/visibility/store/standard/sql/visibility_store.go
+++ b/common/persistence/visibility/store/standard/sql/visibility_store.go
@@ -323,6 +323,23 @@ func (s *visibilityStore) CountWorkflowExecutions(
 	return nil, store.OperationNotSupportedErr
 }
 
+func (s *visibilityStore) GetWorkflowExecution(
+	ctx context.Context,
+	request *manager.GetWorkflowExecutionRequest,
+) (*store.InternalGetWorkflowExecutionResponse, error) {
+	row, err := s.sqlStore.Db.GetFromVisibility(ctx, sqlplugin.VisibilityGetFilter{
+		NamespaceID: request.NamespaceID.String(),
+		RunID:       request.RunID,
+	})
+	if err != nil {
+		return nil, serviceerror.NewUnavailable(
+			fmt.Sprintf("GetWorkflowExecution operation failed. Select failed: %v", err))
+	}
+	return &store.InternalGetWorkflowExecutionResponse{
+		Execution: s.rowToInfo(row),
+	}, nil
+}
+
 func (s *visibilityStore) rowToInfo(
 	row *sqlplugin.VisibilityRow,
 ) *store.InternalWorkflowExecutionInfo {

--- a/common/persistence/visibility/store/standard/visibility_store.go
+++ b/common/persistence/visibility/store/standard/visibility_store.go
@@ -164,6 +164,13 @@ func (s *standardStore) CountWorkflowExecutions(
 	return s.store.CountWorkflowExecutions(ctx, request)
 }
 
+func (s *standardStore) GetWorkflowExecution(
+	ctx context.Context,
+	request *manager.GetWorkflowExecutionRequest,
+) (*store.InternalGetWorkflowExecutionResponse, error) {
+	return s.store.GetWorkflowExecution(ctx, request)
+}
+
 func (s *standardStore) ListWorkflowExecutions(
 	ctx context.Context,
 	request *manager.ListWorkflowExecutionsRequestV2,

--- a/common/persistence/visibility/store/visibility_store.go
+++ b/common/persistence/visibility/store/visibility_store.go
@@ -61,6 +61,7 @@ type (
 		ListWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error)
 		ScanWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequestV2) (*InternalListWorkflowExecutionsResponse, error)
 		CountWorkflowExecutions(ctx context.Context, request *manager.CountWorkflowExecutionsRequest) (*manager.CountWorkflowExecutionsResponse, error)
+		GetWorkflowExecution(ctx context.Context, request *manager.GetWorkflowExecutionRequest) (*InternalGetWorkflowExecutionResponse, error)
 	}
 
 	// InternalWorkflowExecutionInfo is visibility info for internal response
@@ -86,6 +87,11 @@ type (
 		// Token to read next page if there are more workflow executions beyond page size.
 		// Use this to set NextPageToken on ListWorkflowExecutionsRequest to read the next page.
 		NextPageToken []byte
+	}
+
+	// InternalGetWorkflowExecutionResponse is response from GetWorkflowExecution
+	InternalGetWorkflowExecutionResponse struct {
+		Execution *InternalWorkflowExecutionInfo
 	}
 
 	// InternalVisibilityRequestBase is a base request to visibility APIs.

--- a/common/persistence/visibility/store/visibility_store_mock.go
+++ b/common/persistence/visibility/store/visibility_store_mock.go
@@ -114,6 +114,21 @@ func (mr *MockVisibilityStoreMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockVisibilityStore)(nil).GetName))
 }
 
+// GetWorkflowExecution mocks base method.
+func (m *MockVisibilityStore) GetWorkflowExecution(ctx context.Context, request *manager.GetWorkflowExecutionRequest) (*InternalGetWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowExecution", ctx, request)
+	ret0, _ := ret[0].(*InternalGetWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkflowExecution indicates an expected call of GetWorkflowExecution.
+func (mr *MockVisibilityStoreMockRecorder) GetWorkflowExecution(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockVisibilityStore)(nil).GetWorkflowExecution), ctx, request)
+}
+
 // ListClosedWorkflowExecutions mocks base method.
 func (m *MockVisibilityStore) ListClosedWorkflowExecutions(ctx context.Context, request *manager.ListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()

--- a/common/persistence/visibility/visibility_manager_dual.go
+++ b/common/persistence/visibility/visibility_manager_dual.go
@@ -201,3 +201,10 @@ func (v *visibilityManagerDual) CountWorkflowExecutions(
 ) (*manager.CountWorkflowExecutionsResponse, error) {
 	return v.managerSelector.readManager(request.Namespace).CountWorkflowExecutions(ctx, request)
 }
+
+func (v *visibilityManagerDual) GetWorkflowExecution(
+	ctx context.Context,
+	request *manager.GetWorkflowExecutionRequest,
+) (*manager.GetWorkflowExecutionResponse, error) {
+	return v.managerSelector.readManager(request.Namespace).GetWorkflowExecution(ctx, request)
+}

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -247,6 +247,21 @@ func (p *visibilityManagerImpl) CountWorkflowExecutions(
 	return response, err
 }
 
+func (p *visibilityManagerImpl) GetWorkflowExecution(
+	ctx context.Context,
+	request *manager.GetWorkflowExecutionRequest,
+) (*manager.GetWorkflowExecutionResponse, error) {
+	response, err := p.store.GetWorkflowExecution(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+	execution, err := p.convertInternalWorkflowExecutionInfo(response.Execution)
+	if err != nil {
+		return nil, err
+	}
+	return &manager.GetWorkflowExecutionResponse{Execution: execution}, err
+}
+
 func (p *visibilityManagerImpl) newInternalVisibilityRequestBase(request *manager.VisibilityRequestBase) (*store.InternalVisibilityRequestBase, error) {
 	if request == nil {
 		return nil, nil

--- a/common/persistence/visibility/visibility_manager_rate_limited.go
+++ b/common/persistence/visibility/visibility_manager_rate_limited.go
@@ -210,3 +210,13 @@ func (m *visibilityManagerRateLimited) CountWorkflowExecutions(
 	}
 	return m.delegate.CountWorkflowExecutions(ctx, request)
 }
+
+func (m *visibilityManagerRateLimited) GetWorkflowExecution(
+	ctx context.Context,
+	request *manager.GetWorkflowExecutionRequest,
+) (*manager.GetWorkflowExecutionResponse, error) {
+	if ok := m.readRateLimiter.Allow(); !ok {
+		return nil, persistence.ErrPersistenceLimitExceeded
+	}
+	return m.delegate.GetWorkflowExecution(ctx, request)
+}

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -208,6 +208,16 @@ func (m *visibilityManagerMetrics) CountWorkflowExecutions(
 	return response, m.updateErrorMetric(scope, err)
 }
 
+func (m *visibilityManagerMetrics) GetWorkflowExecution(
+	ctx context.Context,
+	request *manager.GetWorkflowExecutionRequest,
+) (*manager.GetWorkflowExecutionResponse, error) {
+	scope, sw := m.tagScope(metrics.VisibilityPersistenceGetWorkflowExecutionScope)
+	response, err := m.delegate.GetWorkflowExecution(ctx, request)
+	sw.Stop()
+	return response, m.updateErrorMetric(scope, err)
+}
+
 func (m *visibilityManagerMetrics) tagScope(scope int) (metrics.Scope, metrics.Stopwatch) {
 	taggedScope := m.metricClient.Scope(scope, m.visibilityTypeMetricsTag)
 	taggedScope.IncCounter(metrics.VisibilityPersistenceRequests)

--- a/service/frontend/configs/quotas_test.go
+++ b/service/frontend/configs/quotas_test.go
@@ -149,6 +149,7 @@ func (s *quotasSuite) TestExecutionAPIs() {
 
 func (s *quotasSuite) TestVisibilityAPIs() {
 	apis := map[string]struct{}{
+		"GetWorkflowExecution":           {},
 		"CountWorkflowExecutions":        {},
 		"ScanWorkflowExecutions":         {},
 		"ListOpenWorkflowExecutions":     {},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Creating visibility API to get a single workflow execution by run id.

<!-- Tell your future self why have you made these changes -->
**Why?**
This will be used to get search attributes and memo from visibility for closed workflows.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In SQL template query to get closed workflow by run id, I removed the filter to exclude running workflows. It means that, with this change, the query will return a record if the workflow is found by run id, but its status is running. I'm not sure where this specific query is used though.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.