### PR TITLE
Support arbitrary history task category in SQL persistence

### DIFF
--- a/common/persistence/cassandra/mutable_state_task_store.go
+++ b/common/persistence/cassandra/mutable_state_task_store.go
@@ -76,8 +76,8 @@ const (
 		`and workflow_id = ? ` +
 		`and run_id = ? ` +
 		`and visibility_ts = ? ` +
-		`and task_id > ? ` +
-		`and task_id <= ?`
+		`and task_id >= ? ` +
+		`and task_id < ?`
 
 	templateGetHistoryScheduledTasksQuery = `SELECT task_data, task_encoding ` +
 		`FROM executions ` +

--- a/common/persistence/sql/sqlplugin/history_immediate_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_immediate_tasks.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package sqlplugin
 
 import (

--- a/common/persistence/sql/sqlplugin/history_immediate_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_immediate_tasks.go
@@ -1,0 +1,49 @@
+package sqlplugin
+
+import (
+	"context"
+	"database/sql"
+)
+
+type (
+	// HistoryImmediateTasksRow represents a row in history_immediate_tasks table
+	HistoryImmediateTasksRow struct {
+		ShardID      int32
+		CategoryID   int32
+		TaskID       int64
+		Data         []byte
+		DataEncoding string
+	}
+
+	// HistoryImmediateTasksFilter contains the column names within history_immediate_tasks table that
+	// can be used to filter results through a WHERE clause
+	HistoryImmediateTasksFilter struct {
+		ShardID    int32
+		CategoryID int32
+		TaskID     int64
+	}
+
+	// HistoryImmediateTasksRangeFilter contains the column names within history_immediate_tasks table that
+	// can be used to filter results through a WHERE clause
+	HistoryImmediateTasksRangeFilter struct {
+		ShardID            int32
+		CategoryID         int32
+		InclusiveMinTaskID int64
+		ExclusiveMaxTaskID int64
+		PageSize           int
+	}
+
+	// HistoryImmediateTask is the SQL persistence interface for history immediate tasks
+	HistoryImmediateTask interface {
+		InsertIntoHistoryImmediateTasks(ctx context.Context, rows []HistoryImmediateTasksRow) (sql.Result, error)
+		// SelectFromHistoryImmediateTasks returns rows that match filter criteria from history_immediate_tasks table.
+		SelectFromHistoryImmediateTasks(ctx context.Context, filter HistoryImmediateTasksFilter) ([]HistoryImmediateTasksRow, error)
+		// RangeSelectFromHistoryImmediateTasks returns rows that match filter criteria from history_immediate_tasks table.
+		RangeSelectFromHistoryImmediateTasks(ctx context.Context, filter HistoryImmediateTasksRangeFilter) ([]HistoryImmediateTasksRow, error)
+		// DeleteFromHistoryImmediateTasks deletes one rows from history_immediate_tasks table.
+		DeleteFromHistoryImmediateTasks(ctx context.Context, filter HistoryImmediateTasksFilter) (sql.Result, error)
+		// RangeDeleteFromHistoryImmediateTasks deletes one or more rows from history_immediate_tasks table.
+		//  HistoryImmediateTasksRangeFilter - {PageSize} will be ignored
+		RangeDeleteFromHistoryImmediateTasks(ctx context.Context, filter HistoryImmediateTasksRangeFilter) (sql.Result, error)
+	}
+)

--- a/common/persistence/sql/sqlplugin/history_immediate_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_immediate_tasks.go
@@ -59,6 +59,7 @@ type (
 
 	// HistoryImmediateTask is the SQL persistence interface for history immediate tasks
 	HistoryImmediateTask interface {
+		// InsertIntoHistoryImmediateTasks inserts rows that into history_immediate_tasks table.
 		InsertIntoHistoryImmediateTasks(ctx context.Context, rows []HistoryImmediateTasksRow) (sql.Result, error)
 		// SelectFromHistoryImmediateTasks returns rows that match filter criteria from history_immediate_tasks table.
 		SelectFromHistoryImmediateTasks(ctx context.Context, filter HistoryImmediateTasksFilter) ([]HistoryImmediateTasksRow, error)

--- a/common/persistence/sql/sqlplugin/history_replication_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_replication_tasks.go
@@ -56,6 +56,7 @@ type (
 
 	// HistoryReplicationTask is the SQL persistence interface for history replication tasks
 	HistoryReplicationTask interface {
+		// InsertIntoReplicationTasks inserts rows that into replication_tasks table.
 		InsertIntoReplicationTasks(ctx context.Context, rows []ReplicationTasksRow) (sql.Result, error)
 		// SelectFromReplicationTasks returns one or more rows from replication_tasks table
 		SelectFromReplicationTasks(ctx context.Context, filter ReplicationTasksFilter) ([]ReplicationTasksRow, error)

--- a/common/persistence/sql/sqlplugin/history_scheduled_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_scheduled_tasks.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package sqlplugin
 
 import (

--- a/common/persistence/sql/sqlplugin/history_scheduled_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_scheduled_tasks.go
@@ -63,6 +63,7 @@ type (
 
 	// HistoryScheduledTask is the SQL persistence interface for history scheduled tasks
 	HistoryScheduledTask interface {
+		// InsertIntoHistoryScheduledTasks inserts rows that into history_scheduled_tasks table.
 		InsertIntoHistoryScheduledTasks(ctx context.Context, rows []HistoryScheduledTasksRow) (sql.Result, error)
 		// SelectFromScheduledTasks returns one or more rows from history_scheduled_tasks table
 		SelectFromHistoryScheduledTasks(ctx context.Context, filter HistoryScheduledTasksFilter) ([]HistoryScheduledTasksRow, error)

--- a/common/persistence/sql/sqlplugin/history_scheduled_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_scheduled_tasks.go
@@ -1,0 +1,53 @@
+package sqlplugin
+
+import (
+	"context"
+	"database/sql"
+	"time"
+)
+
+type (
+	// HistoryScheduledTasksRow represents a row in history_scheduled_tasks table
+	HistoryScheduledTasksRow struct {
+		ShardID             int32
+		CategoryID          int32
+		VisibilityTimestamp time.Time
+		TaskID              int64
+		Data                []byte
+		DataEncoding        string
+	}
+
+	// HistoryScheduledTasksFilter contains the column names within history_scheduled_tasks table that
+	// can be used to filter results through a WHERE clause
+	HistoryScheduledTasksFilter struct {
+		ShardID             int32
+		CategoryID          int32
+		TaskID              int64
+		VisibilityTimestamp time.Time
+	}
+
+	// HistoryScheduledTasksFilter contains the column names within history_scheduled_tasks table that
+	// can be used to filter results through a WHERE clause
+	HistoryScheduledTasksRangeFilter struct {
+		ShardID                         int32
+		CategoryID                      int32
+		InclusiveMinTaskID              int64
+		InclusiveMinVisibilityTimestamp time.Time
+		ExclusiveMaxVisibilityTimestamp time.Time
+		PageSize                        int
+	}
+
+	// HistoryScheduledTask is the SQL persistence interface for history scheduled tasks
+	HistoryScheduledTask interface {
+		InsertIntoHistoryScheduledTasks(ctx context.Context, rows []HistoryScheduledTasksRow) (sql.Result, error)
+		// SelectFromScheduledTasks returns one or more rows from history_scheduled_tasks table
+		SelectFromHistoryScheduledTasks(ctx context.Context, filter HistoryScheduledTasksFilter) ([]HistoryScheduledTasksRow, error)
+		// RangeSelectFromScheduledTasks returns one or more rows from history_scheduled_tasks table
+		RangeSelectFromHistoryScheduledTasks(ctx context.Context, filter HistoryScheduledTasksRangeFilter) ([]HistoryScheduledTasksRow, error)
+		// DeleteFromScheduledTasks deletes one or more rows from history_scheduled_tasks table
+		DeleteFromHistoryScheduledTasks(ctx context.Context, filter HistoryScheduledTasksFilter) (sql.Result, error)
+		// RangeDeleteFromScheduledTasks deletes one or more rows from history_scheduled_tasks table
+		//  ScheduledTasksRangeFilter - {TaskID, PageSize} will be ignored
+		RangeDeleteFromHistoryScheduledTasks(ctx context.Context, filter HistoryScheduledTasksRangeFilter) (sql.Result, error)
+	}
+)

--- a/common/persistence/sql/sqlplugin/history_timer_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_timer_tasks.go
@@ -60,6 +60,7 @@ type (
 
 	// HistoryTimerTask is the SQL persistence interface for history timer tasks
 	HistoryTimerTask interface {
+		// InsertIntoTimerTasks inserts rows that into timer_tasks table.
 		InsertIntoTimerTasks(ctx context.Context, rows []TimerTasksRow) (sql.Result, error)
 		// SelectFromTimerTasks returns one or more rows from timer_tasks table
 		SelectFromTimerTasks(ctx context.Context, filter TimerTasksFilter) ([]TimerTasksRow, error)

--- a/common/persistence/sql/sqlplugin/history_transfer_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_transfer_tasks.go
@@ -56,6 +56,7 @@ type (
 
 	// HistoryTransferTask is the SQL persistence interface for history transfer tasks
 	HistoryTransferTask interface {
+		// InsertIntoTransferTasks inserts rows that into transfer_tasks table.
 		InsertIntoTransferTasks(ctx context.Context, rows []TransferTasksRow) (sql.Result, error)
 		// SelectFromTransferTasks returns rows that match filter criteria from transfer_tasks table.
 		SelectFromTransferTasks(ctx context.Context, filter TransferTasksFilter) ([]TransferTasksRow, error)

--- a/common/persistence/sql/sqlplugin/history_visibility_tasks.go
+++ b/common/persistence/sql/sqlplugin/history_visibility_tasks.go
@@ -56,6 +56,7 @@ type (
 
 	// HistoryVisibilityTask is the SQL persistence interface for history visibility tasks
 	HistoryVisibilityTask interface {
+		// InsertIntoVisibilityTasks inserts rows that into visibility_tasks table.
 		InsertIntoVisibilityTasks(ctx context.Context, rows []VisibilityTasksRow) (sql.Result, error)
 		// SelectFromVisibilityTasks returns rows that match filter criteria from visibility_tasks table.
 		SelectFromVisibilityTasks(ctx context.Context, filter VisibilityTasksFilter) ([]VisibilityTasksRow, error)

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -74,6 +74,8 @@ type (
 		HistoryExecutionSignal
 		HistoryExecutionSignalRequest
 
+		HistoryImmediateTask
+		HistoryScheduledTask
 		HistoryTransferTask
 		HistoryTimerTask
 		HistoryReplicationTask

--- a/common/persistence/sql/sqlplugin/mysql/execution.go
+++ b/common/persistence/sql/sqlplugin/mysql/execution.go
@@ -83,6 +83,32 @@ namespace_id = :namespace_id AND
 workflow_id = :workflow_id
 `
 
+	createHistoryImmediateTasksQuery = `INSERT INTO history_immediate_tasks(shard_id, category_id, task_id, data, data_encoding) 
+ VALUES(:shard_id, :category_id, :task_id, :data, :data_encoding)`
+
+	getHistoryImmediateTaskQuery = `SELECT task_id, data, data_encoding 
+ FROM history_immediate_tasks WHERE shard_id = ? AND category_id = ? AND task_id = ?`
+	getHistoryImmediateTasksQuery = `SELECT task_id, data, data_encoding 
+ FROM history_immediate_tasks WHERE shard_id = ? AND category_id = ? AND task_id >= ? AND task_id < ? ORDER BY task_id LIMIT ?`
+
+	deleteHistoryImmediateTaskQuery       = `DELETE FROM history_immediate_tasks WHERE shard_id = ? AND category_id = ? AND task_id = ?`
+	rangeDeleteHistoryImmediateTasksQuery = `DELETE FROM history_immediate_tasks WHERE shard_id = ? AND category_id = ? AND task_id >= ? AND task_id < ?`
+
+	createHistoryScheduledTasksQuery = `INSERT INTO history_scheduled_tasks (shard_id, category_id, visibility_timestamp, task_id, data, data_encoding)
+  VALUES (:shard_id, :category_id, :visibility_timestamp, :task_id, :data, :data_encoding)`
+
+	getHistoryScheduledTaskQuery = `SELECT visibility_timestamp, task_id, data, data_encoding FROM history_scheduled_tasks 
+  WHERE shard_id = ? AND category_id = ? AND visibility_timestamp = ? AND task_id = ?`
+	getHistoryScheduledTasksQuery = `SELECT visibility_timestamp, task_id, data, data_encoding FROM history_scheduled_tasks 
+  WHERE shard_id = ? 
+  AND category_id = ? 
+  AND ((visibility_timestamp >= ? AND task_id >= ?) OR visibility_timestamp > ?) 
+  AND visibility_timestamp < ?
+  ORDER BY visibility_timestamp,task_id LIMIT ?`
+
+	deleteHistoryScheduledTaskQuery       = `DELETE FROM history_scheduled_tasks WHERE shard_id = ? AND category_id = ? AND visibility_timestamp = ? AND task_id = ?`
+	rangeDeleteHistoryScheduledTasksQuery = `DELETE FROM history_scheduled_tasks WHERE shard_id = ? AND category_id = ? AND visibility_timestamp >= ? AND visibility_timestamp < ?`
+
 	createTransferTasksQuery = `INSERT INTO transfer_tasks(shard_id, task_id, data, data_encoding) 
  VALUES(:shard_id, :task_id, :data, :data_encoding)`
 
@@ -348,6 +374,179 @@ func (mdb *db) LockCurrentExecutionsJoinExecutions(
 		filter.WorkflowID,
 	)
 	return rows, err
+}
+
+// InsertIntoHistoryImmediateTasks inserts one or more rows into history_immediate_tasks table
+func (mdb *db) InsertIntoHistoryImmediateTasks(
+	ctx context.Context,
+	rows []sqlplugin.HistoryImmediateTasksRow,
+) (sql.Result, error) {
+	return mdb.conn.NamedExecContext(ctx,
+		createHistoryImmediateTasksQuery,
+		rows,
+	)
+}
+
+// SelectFromHistoryImmediateTasks reads one or more rows from transfer_tasks table
+func (mdb *db) SelectFromHistoryImmediateTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryImmediateTasksFilter,
+) ([]sqlplugin.HistoryImmediateTasksRow, error) {
+	var rows []sqlplugin.HistoryImmediateTasksRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getHistoryImmediateTaskQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.TaskID,
+	); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// RangeSelectFromHistoryImmediateTasks reads one or more rows from transfer_tasks table
+func (mdb *db) RangeSelectFromHistoryImmediateTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryImmediateTasksRangeFilter,
+) ([]sqlplugin.HistoryImmediateTasksRow, error) {
+	var rows []sqlplugin.HistoryImmediateTasksRow
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getHistoryImmediateTasksQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+		filter.PageSize,
+	); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
+// DeleteFromHistoryImmediateTasks deletes one or more rows from transfer_tasks table
+func (mdb *db) DeleteFromHistoryImmediateTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryImmediateTasksFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		deleteHistoryImmediateTaskQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromHistoryImmediateTasks deletes one or more rows from transfer_tasks table
+func (mdb *db) RangeDeleteFromHistoryImmediateTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryImmediateTasksRangeFilter,
+) (sql.Result, error) {
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteHistoryImmediateTasksQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.InclusiveMinTaskID,
+		filter.ExclusiveMaxTaskID,
+	)
+}
+
+// InsertIntoHistoryScheduledTasks inserts one or more rows into timer_tasks table
+func (mdb *db) InsertIntoHistoryScheduledTasks(
+	ctx context.Context,
+	rows []sqlplugin.HistoryScheduledTasksRow,
+) (sql.Result, error) {
+	for i := range rows {
+		rows[i].VisibilityTimestamp = mdb.converter.ToMySQLDateTime(rows[i].VisibilityTimestamp)
+	}
+	return mdb.conn.NamedExecContext(
+		ctx,
+		createHistoryScheduledTasksQuery,
+		rows,
+	)
+}
+
+// SelectFromHistoryScheduledTasks reads one or more rows from timer_tasks table
+func (mdb *db) SelectFromHistoryScheduledTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryScheduledTasksFilter,
+) ([]sqlplugin.HistoryScheduledTasksRow, error) {
+	var rows []sqlplugin.HistoryScheduledTasksRow
+	filter.VisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.VisibilityTimestamp)
+	err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getHistoryScheduledTaskQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.VisibilityTimestamp,
+		filter.TaskID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i].VisibilityTimestamp = mdb.converter.FromMySQLDateTime(rows[i].VisibilityTimestamp)
+	}
+	return rows, nil
+}
+
+// RangeSelectFromHistoryScheduledTasks reads one or more rows from timer_tasks table
+func (mdb *db) RangeSelectFromHistoryScheduledTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryScheduledTasksRangeFilter,
+) ([]sqlplugin.HistoryScheduledTasksRow, error) {
+	var rows []sqlplugin.HistoryScheduledTasksRow
+	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.InclusiveMinVisibilityTimestamp)
+	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
+	if err := mdb.conn.SelectContext(ctx,
+		&rows,
+		getHistoryScheduledTasksQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.InclusiveMinTaskID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.ExclusiveMaxVisibilityTimestamp,
+		filter.PageSize,
+	); err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i].VisibilityTimestamp = mdb.converter.FromMySQLDateTime(rows[i].VisibilityTimestamp)
+	}
+	return rows, nil
+}
+
+// DeleteFromHistoryScheduledTasks deletes one or more rows from timer_tasks table
+func (mdb *db) DeleteFromHistoryScheduledTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryScheduledTasksFilter,
+) (sql.Result, error) {
+	filter.VisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.VisibilityTimestamp)
+	return mdb.conn.ExecContext(ctx,
+		deleteHistoryScheduledTaskQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.VisibilityTimestamp,
+		filter.TaskID,
+	)
+}
+
+// RangeDeleteFromHistoryScheduledTasks deletes one or more rows from timer_tasks table
+func (mdb *db) RangeDeleteFromHistoryScheduledTasks(
+	ctx context.Context,
+	filter sqlplugin.HistoryScheduledTasksRangeFilter,
+) (sql.Result, error) {
+	filter.InclusiveMinVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.InclusiveMinVisibilityTimestamp)
+	filter.ExclusiveMaxVisibilityTimestamp = mdb.converter.ToMySQLDateTime(filter.ExclusiveMaxVisibilityTimestamp)
+	return mdb.conn.ExecContext(ctx,
+		rangeDeleteHistoryScheduledTasksQuery,
+		filter.ShardID,
+		filter.CategoryID,
+		filter.InclusiveMinVisibilityTimestamp,
+		filter.ExclusiveMaxVisibilityTimestamp,
+	)
 }
 
 // InsertIntoTransferTasks inserts one or more rows into transfer_tasks table

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -148,7 +148,7 @@ func (s *ExecutionMutableStateTaskSuite) TearDownTest() {
 
 func (s *ExecutionMutableStateTaskSuite) TestAddGetRangeCompleteImmediateTasks_Multiple() {
 	numTasks := 20
-	fakeImmediateTaskCategory := tasks.NewCategory(123, tasks.CategoryTypeImmediate, "fake-immediate")
+	fakeImmediateTaskCategory := tasks.NewCategory(1234, tasks.CategoryTypeImmediate, "fake-immediate")
 	immediateTasks := s.AddRandomTasks(
 		fakeImmediateTaskCategory,
 		numTasks,
@@ -191,7 +191,7 @@ func (s *ExecutionMutableStateTaskSuite) TestAddGetRangeCompleteImmediateTasks_M
 
 func (s *ExecutionMutableStateTaskSuite) TestAddGetRangeCompleteScheduledTasks_Multiple() {
 	numTasks := 20
-	fakeScheduledTaskCategory := tasks.NewCategory(rand.Int31(), tasks.CategoryTypeScheduled, "fake-scheduled")
+	fakeScheduledTaskCategory := tasks.NewCategory(2345, tasks.CategoryTypeScheduled, "fake-scheduled")
 	scheduledTasks := s.AddRandomTasks(
 		fakeScheduledTaskCategory,
 		numTasks,

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -70,6 +70,11 @@ type (
 	}
 )
 
+var (
+	fakeImmediateTaskCategory = tasks.NewCategory(1234, tasks.CategoryTypeImmediate, "fake-immediate")
+	fakeScheduledTaskCategory = tasks.NewCategory(2345, tasks.CategoryTypeScheduled, "fake-scheduled")
+)
+
 func NewExecutionMutableStateTaskSuite(
 	t *testing.T,
 	shardStore p.ShardStore,
@@ -148,7 +153,6 @@ func (s *ExecutionMutableStateTaskSuite) TearDownTest() {
 
 func (s *ExecutionMutableStateTaskSuite) TestAddGetRangeCompleteImmediateTasks_Multiple() {
 	numTasks := 20
-	fakeImmediateTaskCategory := tasks.NewCategory(1234, tasks.CategoryTypeImmediate, "fake-immediate")
 	immediateTasks := s.AddRandomTasks(
 		fakeImmediateTaskCategory,
 		numTasks,
@@ -191,7 +195,6 @@ func (s *ExecutionMutableStateTaskSuite) TestAddGetRangeCompleteImmediateTasks_M
 
 func (s *ExecutionMutableStateTaskSuite) TestAddGetRangeCompleteScheduledTasks_Multiple() {
 	numTasks := 20
-	fakeScheduledTaskCategory := tasks.NewCategory(2345, tasks.CategoryTypeScheduled, "fake-scheduled")
 	scheduledTasks := s.AddRandomTasks(
 		fakeScheduledTaskCategory,
 		numTasks,

--- a/schema/mysql/v57/temporal/schema.sql
+++ b/schema/mysql/v57/temporal/schema.sql
@@ -89,6 +89,27 @@ CREATE TABLE task_queues (
   PRIMARY KEY (range_hash, task_queue_id)
 );
 
+CREATE TABLE history_immediate_tasks(
+  shard_id INT NOT NULL,
+  category_id INT NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, task_id)
+);
+
+CREATE TABLE history_scheduled_tasks (
+  shard_id INT NOT NULL,
+  category_id INT NOT NULL,
+  visibility_timestamp DATETIME(6) NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, visibility_timestamp, task_id)
+);
+
 CREATE TABLE transfer_tasks(
   shard_id INT NOT NULL,
   task_id BIGINT NOT NULL,
@@ -264,9 +285,9 @@ CREATE TABLE cluster_membership
     rpc_address          VARCHAR(128) NOT NULL,
     rpc_port             SMALLINT NOT NULL,
     role                 TINYINT NOT NULL,
-    session_start        TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
-    last_heartbeat       TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
-    record_expiry        TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
+    session_start        TIMESTAMP DEFAULT '1970-01-02 00:00:01',
+    last_heartbeat       TIMESTAMP DEFAULT '1970-01-02 00:00:01',
+    record_expiry        TIMESTAMP DEFAULT '1970-01-02 00:00:01',
     INDEX (role, host_id),
     INDEX (role, last_heartbeat),
     INDEX (rpc_address, role),
@@ -274,4 +295,3 @@ CREATE TABLE cluster_membership
     INDEX (record_expiry),
     PRIMARY KEY (membership_partition, host_id)
 );
-

--- a/schema/mysql/v57/temporal/versioned/v1.9/history_tasks_table.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.9/history_tasks_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE history_immediate_tasks(
+  shard_id INT NOT NULL,
+  category_id INT NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, task_id)
+);
+
+CREATE TABLE history_scheduled_tasks (
+  shard_id INT NOT NULL,
+  category_id INT NOT NULL,
+  visibility_timestamp DATETIME(6) NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, visibility_timestamp, task_id)
+);

--- a/schema/mysql/v57/temporal/versioned/v1.9/manifest.json
+++ b/schema/mysql/v57/temporal/versioned/v1.9/manifest.json
@@ -1,0 +1,8 @@
+{
+    "CurrVersion": "1.9",
+    "MinCompatibleVersion": "1.0",
+    "Description": "add history tasks table",
+    "SchemaUpdateCqlFiles": [
+        "history_tasks_table.sql"
+    ]
+}

--- a/schema/mysql/version.go
+++ b/schema/mysql/version.go
@@ -27,7 +27,7 @@ package mysql
 // NOTE: whenever there is a new database schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "1.8"
+const Version = "1.9"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "1.1"

--- a/schema/postgresql/v96/temporal/schema.sql
+++ b/schema/postgresql/v96/temporal/schema.sql
@@ -89,6 +89,27 @@ CREATE TABLE task_queues (
   PRIMARY KEY (range_hash, task_queue_id)
 );
 
+CREATE TABLE history_immediate_tasks(
+  shard_id INTEGER NOT NULL,
+  category_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, task_id)
+);
+
+CREATE TABLE history_scheduled_tasks (
+  shard_id INTEGER NOT NULL,
+  category_id INTEGER NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, visibility_timestamp, task_id)
+);
+
 CREATE TABLE transfer_tasks(
   shard_id INTEGER NOT NULL,
   task_id BIGINT NOT NULL,

--- a/schema/postgresql/v96/temporal/versioned/v1.9/history_tasks_table.sql
+++ b/schema/postgresql/v96/temporal/versioned/v1.9/history_tasks_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE history_immediate_tasks(
+  shard_id INTEGER NOT NULL,
+  category_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, task_id)
+);
+
+CREATE TABLE history_scheduled_tasks (
+  shard_id INTEGER NOT NULL,
+  category_id INTEGER NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, visibility_timestamp, task_id)
+);

--- a/schema/postgresql/v96/temporal/versioned/v1.9/manifest.json
+++ b/schema/postgresql/v96/temporal/versioned/v1.9/manifest.json
@@ -1,0 +1,8 @@
+{
+    "CurrVersion": "1.9",
+    "MinCompatibleVersion": "1.0",
+    "Description": "add history tasks table",
+    "SchemaUpdateCqlFiles": [
+        "history_tasks_table.sql"
+    ]
+}

--- a/schema/postgresql/version.go
+++ b/schema/postgresql/version.go
@@ -28,7 +28,7 @@ package postgresql
 
 // Version is the Postgres database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
-const Version = "1.8"
+const Version = "1.9"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres

--- a/schema/sqlite/v3/temporal/schema.sql
+++ b/schema/sqlite/v3/temporal/schema.sql
@@ -88,6 +88,27 @@ CREATE TABLE task_queues (
 	PRIMARY KEY (range_hash, task_queue_id)
 );
 
+CREATE TABLE history_immediate_tasks(
+  shard_id INT NOT NULL,
+  category_id INT NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, task_id)
+);
+
+CREATE TABLE history_scheduled_tasks (
+  shard_id INT NOT NULL,
+  category_id INT NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data MEDIUMBLOB NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, visibility_timestamp, task_id)
+);
+
 CREATE TABLE transfer_tasks(
 	shard_id INT NOT NULL,
 	task_id BIGINT NOT NULL,

--- a/service/history/tasks/fake_task.go
+++ b/service/history/tasks/fake_task.go
@@ -33,7 +33,7 @@ import (
 )
 
 type (
-	fakeTask struct {
+	FakeTask struct {
 		definition.WorkflowKey
 		VisibilityTimestamp time.Time
 		TaskID              int64
@@ -47,7 +47,7 @@ func NewFakeTask(
 	category Category,
 	visibilityTimestamp time.Time,
 ) Task {
-	return &fakeTask{
+	return &FakeTask{
 		WorkflowKey:         workflowKey,
 		TaskID:              common.EmptyEventTaskID,
 		Version:             common.EmptyVersion,
@@ -56,38 +56,38 @@ func NewFakeTask(
 	}
 }
 
-func (f *fakeTask) GetKey() Key {
+func (f *FakeTask) GetKey() Key {
 	return NewKey(f.VisibilityTimestamp, f.TaskID)
 }
 
-func (f *fakeTask) GetVersion() int64 {
+func (f *FakeTask) GetVersion() int64 {
 	return f.Version
 }
 
-func (f *fakeTask) SetVersion(version int64) {
+func (f *FakeTask) SetVersion(version int64) {
 	f.Version = version
 }
 
-func (f *fakeTask) GetTaskID() int64 {
+func (f *FakeTask) GetTaskID() int64 {
 	return f.TaskID
 }
 
-func (f *fakeTask) SetTaskID(id int64) {
+func (f *FakeTask) SetTaskID(id int64) {
 	f.TaskID = id
 }
 
-func (f *fakeTask) GetVisibilityTime() time.Time {
+func (f *FakeTask) GetVisibilityTime() time.Time {
 	return f.VisibilityTimestamp
 }
 
-func (f *fakeTask) SetVisibilityTime(t time.Time) {
+func (f *FakeTask) SetVisibilityTime(t time.Time) {
 	f.VisibilityTimestamp = t
 }
 
-func (f *fakeTask) GetCategory() Category {
+func (f *FakeTask) GetCategory() Category {
 	return f.Category
 }
 
-func (f *fakeTask) GetType() enumsspb.TaskType {
+func (f *FakeTask) GetType() enumsspb.TaskType {
 	return enumsspb.TASK_TYPE_UNSPECIFIED
 }

--- a/service/history/tasks/utils.go
+++ b/service/history/tasks/utils.go
@@ -92,7 +92,7 @@ func GetTransferTaskEventID(
 		eventID = task.InitiatedEventID
 	case *ResetWorkflowTask:
 		eventID = common.FirstEventID
-	case *fakeTask:
+	case *FakeTask:
 		// no-op
 	default:
 		panic(serviceerror.NewInternal("unknown transfer task"))
@@ -120,7 +120,7 @@ func GetTimerTaskEventID(
 		eventID = common.FirstEventID
 	case *DeleteHistoryEventTask:
 		eventID = common.FirstEventID
-	case *fakeTask:
+	case *FakeTask:
 		// no-op
 	default:
 		panic(serviceerror.NewInternal("unknown timer task"))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Support arbitrary history task category in SQL persistence

<!-- Tell your future self why have you made these changes -->
**Why?**
- Currently only cassandra impl support arbitrary task category, need sql support as well since new task queue need to be supported by both cassandra and sql

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A. Currently no task category will use those code paths.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- no