### PR TITLE
Rewrite mysql PaginateBranchesFromHistoryTree query

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -63,10 +63,10 @@ const (
 	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = ? AND tree_id = ? `
 
 	paginateBranchesQuery = `SELECT shard_id, tree_id, branch_id, data, data_encoding
-        FROM history_tree
-        WHERE (shard_id, tree_id, branch_id) > (?, ?, ?)
-        ORDER BY shard_id, tree_id, branch_id
-        LIMIT ?`
+		FROM history_tree
+		WHERE shard_id = ? AND ((tree_id = ? AND branch_id > ?) OR tree_id > ?) OR shard_id > ?
+		ORDER BY shard_id, tree_id, branch_id
+		LIMIT ?`
 
 	deleteHistoryTreeQuery = `DELETE FROM history_tree WHERE shard_id = ? AND tree_id = ? AND branch_id = ? `
 )
@@ -210,6 +210,8 @@ func (mdb *db) PaginateBranchesFromHistoryTree(
 		page.ShardID,
 		page.TreeID,
 		page.BranchID,
+		page.TreeID,
+		page.ShardID,
 		page.Limit,
 	)
 	return rows, err

--- a/common/persistence/sql/sqlplugin/mysql/events.go
+++ b/common/persistence/sql/sqlplugin/mysql/events.go
@@ -62,9 +62,11 @@ const (
 
 	getHistoryTreeQuery = `SELECT branch_id, data, data_encoding FROM history_tree WHERE shard_id = ? AND tree_id = ? `
 
+	// conceptually this query is WHERE (shard_id, tree_id, branch_id) > (?, ?, ?)
+	// but mysql doesn't execute it efficiently unless it's spelled out like this
 	paginateBranchesQuery = `SELECT shard_id, tree_id, branch_id, data, data_encoding
 		FROM history_tree
-		WHERE shard_id = ? AND ((tree_id = ? AND branch_id > ?) OR tree_id > ?) OR shard_id > ?
+		WHERE (shard_id = ? AND ((tree_id = ? AND branch_id > ?) OR tree_id > ?)) OR shard_id > ?
 		ORDER BY shard_id, tree_id, branch_id
 		LIMIT ?`
 


### PR DESCRIPTION
**What changed?**
Rewrite this query to use simple boolean expressions instead of tuple comparison.

**Why?**
For some reason mysql ends up using a full scan for this query even though the explain query plan looks reasonable.

**How did you test it?**
Tested with pre-release build on pipelines.

**Potential risks**

**Is hotfix candidate?**
yes
