### PR TITLE
Add a basic test that the server can be constructed for all services in a single process

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,7 +181,8 @@ func buildCLI() *cli.App {
 				if err != nil {
 					return cli.Exit(fmt.Sprintf("Unable to instantiate claim mapper: %v.", err), 1)
 				}
-				s := temporal.NewServer(
+				// TODO: check err here
+				s, _ := temporal.NewServer(
 					temporal.ForServices(services),
 					temporal.WithConfig(cfg),
 					temporal.WithDynamicConfigClient(dynamicConfigClient),

--- a/common/persistence/cassandra/test.go
+++ b/common/persistence/cassandra/test.go
@@ -25,9 +25,7 @@
 package cassandra
 
 import (
-	"os"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -40,6 +38,7 @@ import (
 	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/environment"
+	"go.temporal.io/server/tests"
 )
 
 const (
@@ -110,7 +109,7 @@ func (s *TestCluster) SetupTestDatabase() {
 	schemaDir := s.schemaDir + "/"
 
 	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
-		temporalPackageDir, err := getTemporalPackageDir()
+		temporalPackageDir, err := tests.GetTemporalPackageDir()
 		if err != nil {
 			s.logger.Fatal("Unable to get package dir.", tag.Error(err))
 		}
@@ -185,25 +184,4 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 			s.logger.Fatal("LoadSchema", tag.Error(err))
 		}
 	}
-}
-
-func getTemporalPackageDir() (string, error) {
-	var err error
-	temporalPackageDir := os.Getenv("TEMPORAL_ROOT")
-	if temporalPackageDir == "" {
-		temporalPackageDir, err = os.Getwd()
-		if err != nil {
-			panic(err)
-		}
-		temporalPackageDir = filepath.ToSlash(temporalPackageDir)
-		temporalIndex := strings.LastIndex(temporalPackageDir, "/temporal/")
-		if temporalIndex == -1 {
-			panic("Unable to find repo path. Use env var TEMPORAL_ROOT or clone the repo into folder named 'temporal'")
-		}
-		temporalPackageDir = temporalPackageDir[:temporalIndex+len("/temporal/")]
-		if err != nil {
-			panic(err)
-		}
-	}
-	return temporalPackageDir, err
 }

--- a/common/persistence/sql/sqlPersistenceTest.go
+++ b/common/persistence/sql/sqlPersistenceTest.go
@@ -38,6 +38,7 @@ import (
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/resolver"
+	"go.temporal.io/server/tests"
 )
 
 // TestCluster allows executing cassandra operations in testing.
@@ -98,7 +99,7 @@ func (s *TestCluster) SetupTestDatabase() {
 
 	schemaDir := s.schemaDir + "/"
 	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
-		temporalPackageDir, err := getTemporalPackageDir()
+		temporalPackageDir, err := tests.GetTemporalPackageDir()
 		if err != nil {
 			s.logger.Fatal("Unable to get package dir.", tag.Error(err))
 		}
@@ -205,21 +206,4 @@ func (s *TestCluster) LoadSchema(schemaFile string) {
 			s.logger.Fatal("LoadSchema", tag.Error(err))
 		}
 	}
-}
-
-func getTemporalPackageDir() (string, error) {
-	var err error
-	temporalPackageDir := os.Getenv("TEMPORAL_ROOT")
-	if temporalPackageDir == "" {
-		temporalPackageDir, err = os.Getwd()
-		if err != nil {
-			panic(err)
-		}
-		temporalIndex := strings.LastIndex(temporalPackageDir, "/temporal/")
-		if temporalIndex == -1 {
-			panic("Unable to find repo path. Use env var TEMPORAL_ROOT or clone the repo into folder named 'temporal'")
-		}
-		temporalPackageDir = temporalPackageDir[:temporalIndex+len("/temporal/")]
-	}
-	return temporalPackageDir, err
 }

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -131,7 +131,7 @@ type (
 	}
 )
 
-func NewServerFx(opts ...ServerOption) *ServerFx {
+func NewServerFx(opts ...ServerOption) (*ServerFx, error) {
 	app := fx.New(
 		pprof.Module,
 		ServerFxImplModule,
@@ -152,7 +152,7 @@ func NewServerFx(opts ...ServerOption) *ServerFx {
 	s := &ServerFx{
 		app,
 	}
-	return s
+	return s, app.Err()
 }
 
 func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {

--- a/tests/temporal_package_dir.go
+++ b/tests/temporal_package_dir.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+func GetTemporalPackageDir() (string, error) {
+	var err error
+	temporalPackageDir := os.Getenv("TEMPORAL_ROOT")
+	if temporalPackageDir == "" {
+		temporalPackageDir, err = os.Getwd()
+		if err != nil {
+			panic(err)
+		}
+		temporalPackageDir = filepath.ToSlash(temporalPackageDir)
+		temporalIndex := strings.LastIndex(temporalPackageDir, "/temporal/")
+		if temporalIndex == -1 {
+			panic("Unable to find repo path. Use env var TEMPORAL_ROOT or clone the repo into folder named 'temporal'")
+		}
+		temporalPackageDir = temporalPackageDir[:temporalIndex+len("/temporal/")]
+		if err != nil {
+			panic(err)
+		}
+	}
+	return temporalPackageDir, err
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a test which verifies that we can construct the Temporal server for all services, in a single process.

<!-- Tell your future self why have you made these changes -->
**Why?**
I made these changes because we are currently lacking a test suite for running all services in a single process, leading to some issues with fx not being caught. Our CI pipeline generally starts services in isolation.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I tested this change by re-introducing the issue I originally had (a dependency cycle when constructing an SdkSystemClient, which depends on the server running, within the server's Start method), and then watching the test fail.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This change doesn't affect any production code, it just adds a new test.  The worst case would be that it's flaky and breaks our pipelines.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
This PR is not a hot fix candidate. It's just a test.
