### PR TITLE
Port util.CloneMapNonNil to release branch

### DIFF
--- a/common/payload/payload.go
+++ b/common/payload/payload.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gogo/protobuf/proto"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/sdk/converter"
+	"go.temporal.io/server/common/util"
 	"golang.org/x/exp/maps"
 )
 
@@ -89,10 +90,7 @@ func MergeMapOfPayload(
 	if m2 == nil {
 		return maps.Clone(m1)
 	}
-	ret := maps.Clone(m1)
-	if ret == nil {
-		ret = make(map[string]*commonpb.Payload)
-	}
+	ret := util.CloneMapNonNil(m1)
 	for k, v := range m2 {
 		if proto.Equal(v, nilPayload) || proto.Equal(v, emptySlicePayload) {
 			delete(ret, k)

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/maps"
 )
 
 // Min returns the minimum of two comparable values.
@@ -87,4 +88,13 @@ func SliceTail[S ~[]E, E any](s S, n int) S {
 		return s[extra:]
 	}
 	return s
+}
+
+// CloneMapNonNil is like maps.Clone except it can't return nil, it will return an empty map instead.
+func CloneMapNonNil[M ~map[K]V, K comparable, V any](m M) M {
+	m = maps.Clone(m)
+	if m == nil {
+		m = make(M)
+	}
+	return m
 }

--- a/service/worker/addsearchattributes/workflow.go
+++ b/service/worker/addsearchattributes/workflow.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/util"
 )
 
 const (
@@ -173,7 +174,7 @@ func (a *activities) UpdateClusterMetadataActivity(ctx context.Context, params W
 		return fmt.Errorf("%w: %v", ErrUnableToGetSearchAttributes, err)
 	}
 
-	newCustomSearchAttributes := maps.Clone(oldSearchAttributes.Custom())
+	newCustomSearchAttributes := util.CloneMapNonNil(oldSearchAttributes.Custom())
 	maps.Copy(newCustomSearchAttributes, params.CustomAttributesToAdd)
 	err = a.saManager.SaveSearchAttributes(ctx, params.IndexName, newCustomSearchAttributes)
 	if err != nil {

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/google/uuid"
-	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -823,7 +822,7 @@ func (s *scheduler) addSearchAttributes(
 	attributes *commonpb.SearchAttributes,
 	nominal time.Time,
 ) *commonpb.SearchAttributes {
-	fields := maps.Clone(attributes.GetIndexedFields())
+	fields := util.CloneMapNonNil(attributes.GetIndexedFields())
 	if p, err := payload.Encode(nominal); err == nil {
 		fields[searchattribute.TemporalScheduledStartTime] = p
 	}


### PR DESCRIPTION
**What changed?**
Port parts of #3408, `util.CloneMapNonNil`, to 1.18 release branch.

**Why?**
This isn't necessary if building the server from the repo unmodified, but if using the server as a library, a newer version of `golang.org/x/exp` might be pulled in, which requires these changes.

**How did you test it?**
tested in master branch

**Potential risks**

**Is hotfix candidate?**
yes
