### PR TITLE
Fix replication task nil case

### DIFF
--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -579,7 +579,7 @@ func (p *ackMgrImpl) processReplication(
 	ms, err := context.LoadMutableState(ctx)
 	switch err.(type) {
 	case nil:
-		if !processTaskIfClosed && !ms.IsWorkflowExecutionRunning() {
+		if !processTaskIfClosed {
 			// workflow already finished, no need to process the replication task
 			return nil, nil
 		}
@@ -601,6 +601,9 @@ func (p *ackMgrImpl) processNewRunReplication(
 	task *replicationspb.ReplicationTask,
 ) (retReplicationTask *replicationspb.ReplicationTask, retError error) {
 
+	if task == nil {
+		return nil, nil
+	}
 	attr, ok := task.Attributes.(*replicationspb.ReplicationTask_HistoryTaskAttributes)
 	if !ok {
 		return nil, serviceerror.NewInternal("Wrong replication task to process new run replication.")

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -579,7 +579,8 @@ func (p *ackMgrImpl) processReplication(
 	ms, err := context.LoadMutableState(ctx)
 	switch err.(type) {
 	case nil:
-		if !processTaskIfClosed {
+		if !processTaskIfClosed && !ms.IsWorkflowExecutionRunning() {
+			// workflow already finished, no need to process the replication task
 			return nil, nil
 		}
 		return action(ms)

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -580,7 +580,6 @@ func (p *ackMgrImpl) processReplication(
 	switch err.(type) {
 	case nil:
 		if !processTaskIfClosed {
-			// workflow already finished, no need to process the replication task
 			return nil, nil
 		}
 		return action(ms)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix replication task nil case

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Handle if the replication task is nil, we don't need to handle new run case.
2. We should generate replication task even if the workflow is closed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
