### PR TITLE
Generate ArchiveExecutionTask instead of DeleteHistoryEventTask whenever an execution is closed

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -184,6 +184,7 @@ type Config struct {
 	NumArchiveSystemWorkflows dynamicconfig.IntPropertyFn
 	ArchiveRequestRPS         dynamicconfig.IntPropertyFn
 	ArchiveSignalTimeout      dynamicconfig.DurationPropertyFn
+	DurableArchivalEnabled    dynamicconfig.BoolPropertyFn
 
 	// Size limit related settings
 	BlobSizeLimitError     dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -406,6 +407,10 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		NumArchiveSystemWorkflows: dc.GetIntProperty(dynamicconfig.NumArchiveSystemWorkflows, 1000),
 		ArchiveRequestRPS:         dc.GetIntProperty(dynamicconfig.ArchiveRequestRPS, 300), // should be much smaller than frontend RPS
 		ArchiveSignalTimeout:      dc.GetDurationProperty(dynamicconfig.ArchiveSignalTimeout, 300*time.Millisecond),
+		DurableArchivalEnabled: func() bool {
+			// Always return false for now until durable archival is tested end-to-end
+			return false
+		},
 
 		BlobSizeLimitError:     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
 		BlobSizeLimitWarn:      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitWarn, 512*1024),

--- a/service/history/workflow/task_generator_provider.go
+++ b/service/history/workflow/task_generator_provider.go
@@ -55,5 +55,6 @@ func (p *taskGeneratorProviderImpl) NewTaskGenerator(
 	return NewTaskGenerator(
 		shard.GetNamespaceRegistry(),
 		mutableState,
+		shard.GetConfig(),
 	)
 }

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -1,0 +1,200 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//
+// The MIT License
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package workflow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	historypb "go.temporal.io/api/history/v1"
+
+	"go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+)
+
+func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
+	for _, c := range []struct {
+		Name                               string
+		DurableArchivalEnabled             bool
+		DeleteAfterClose                   bool
+		ExpectCloseExecutionVisibilityTask bool
+		ExpectArchiveExecutionTask         bool
+		ExpectDeleteHistoryEventTask       bool
+	}{
+		{
+			Name:                   "Delete after retention",
+			DurableArchivalEnabled: false,
+			DeleteAfterClose:       false,
+
+			ExpectCloseExecutionVisibilityTask: true,
+			ExpectDeleteHistoryEventTask:       true,
+			ExpectArchiveExecutionTask:         false,
+		},
+		{
+			Name:                   "Use archival queue",
+			DurableArchivalEnabled: true,
+			DeleteAfterClose:       false,
+
+			ExpectCloseExecutionVisibilityTask: true,
+			ExpectDeleteHistoryEventTask:       false,
+			ExpectArchiveExecutionTask:         true,
+		},
+		{
+			Name:                   "DeleteAfterClose",
+			DurableArchivalEnabled: false,
+			DeleteAfterClose:       true,
+
+			ExpectCloseExecutionVisibilityTask: false,
+			ExpectDeleteHistoryEventTask:       false,
+			ExpectArchiveExecutionTask:         false,
+		},
+		{
+			Name:                   "DeleteAfterClose ignores durable execution flag",
+			DurableArchivalEnabled: true,
+			DeleteAfterClose:       true,
+
+			ExpectCloseExecutionVisibilityTask: false,
+			ExpectDeleteHistoryEventTask:       false,
+			ExpectArchiveExecutionTask:         false,
+		},
+	} {
+		c := c
+		t.Run(c.Name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			namespaceRegistry := namespace.NewMockRegistry(ctrl)
+			retention := 24 * time.Hour
+			namespaceEntry := tests.GlobalNamespaceEntry.Clone(namespace.WithRetention(&retention))
+			namespaceRegistry.EXPECT().GetNamespaceID(gomock.Any()).Return(namespaceEntry.ID(), nil).AnyTimes()
+			namespaceRegistry.EXPECT().GetNamespaceByID(namespaceEntry.ID()).Return(namespaceEntry, nil).AnyTimes()
+
+			mutableState := NewMockMutableState(ctrl)
+			mutableState.EXPECT().GetCurrentVersion().Return(int64(0)).AnyTimes()
+			mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
+				NamespaceId: namespaceEntry.ID().String(),
+			}).AnyTimes()
+			mutableState.EXPECT().GetWorkflowKey().Return(definition.NewWorkflowKey(
+				namespaceEntry.ID().String(), tests.WorkflowID, tests.RunID,
+			)).AnyTimes()
+			mutableState.EXPECT().GetCurrentBranchToken().Return(nil, nil)
+			taskGenerator := NewTaskGenerator(namespaceRegistry, mutableState, &configs.Config{
+				DurableArchivalEnabled: func() bool {
+					return c.DurableArchivalEnabled
+				},
+			})
+
+			closeTime := time.Unix(0, 0)
+
+			mutableState.EXPECT().AddTasks(gomock.Any()).Do(func(ts ...tasks.Task) {
+				var (
+					closeExecutionTask           *tasks.CloseExecutionTask
+					deleteHistoryEventTask       *tasks.DeleteHistoryEventTask
+					closeExecutionVisibilityTask *tasks.CloseExecutionVisibilityTask
+					archiveExecutionTask         *tasks.ArchiveExecutionTask
+				)
+				for _, task := range ts {
+					switch t := task.(type) {
+					case *tasks.CloseExecutionTask:
+						closeExecutionTask = t
+					case *tasks.DeleteHistoryEventTask:
+						deleteHistoryEventTask = t
+					case *tasks.CloseExecutionVisibilityTask:
+						closeExecutionVisibilityTask = t
+					case *tasks.ArchiveExecutionTask:
+						archiveExecutionTask = t
+					}
+				}
+				require.NotNil(t, closeExecutionTask)
+				assert.Equal(t, c.DeleteAfterClose, closeExecutionTask.DeleteAfterClose)
+
+				if c.ExpectCloseExecutionVisibilityTask {
+					assert.NotNil(t, closeExecutionVisibilityTask)
+				} else {
+					assert.Nil(t, closeExecutionVisibilityTask)
+				}
+				if c.ExpectArchiveExecutionTask {
+					require.NotNil(t, archiveExecutionTask)
+					assert.Equal(t, archiveExecutionTask.NamespaceID, namespaceEntry.ID().String())
+					assert.Equal(t, archiveExecutionTask.WorkflowID, tests.WorkflowID)
+					assert.Equal(t, archiveExecutionTask.RunID, tests.RunID)
+				} else {
+					assert.Nil(t, archiveExecutionTask)
+				}
+				if c.ExpectDeleteHistoryEventTask {
+					require.NotNil(t, deleteHistoryEventTask)
+					assert.Equal(t, deleteHistoryEventTask.NamespaceID, namespaceEntry.ID().String())
+					assert.Equal(t, deleteHistoryEventTask.WorkflowID, tests.WorkflowID)
+					assert.Equal(t, deleteHistoryEventTask.RunID, tests.RunID)
+					assert.Equal(t,
+						deleteHistoryEventTask.VisibilityTimestamp,
+						closeTime.Add(retention),
+					)
+				} else {
+					assert.Nil(t, deleteHistoryEventTask)
+				}
+			})
+
+			err := taskGenerator.GenerateWorkflowCloseTasks(&historypb.HistoryEvent{
+				Attributes: &historypb.HistoryEvent_WorkflowExecutionCompletedEventAttributes{
+					WorkflowExecutionCompletedEventAttributes: &historypb.WorkflowExecutionCompletedEventAttributes{},
+				},
+				EventTime: timestamp.TimePtr(closeTime),
+			}, c.DeleteAfterClose)
+			require.NoError(t, err)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now produce an archival task instead of a deletion timer task when an execution is closed.

<!-- Tell your future self why have you made these changes -->
**Why?**
I made these changes so that we can start consuming archival tasks to the archival queue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I tested these changes by verifying the tasks generated by this method depending on all 4 combinations of `deleteAfterClose` and `durableArchivalEnabled`. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If someone starts using this code right now, it won't work because there are still some other changes that need to happen. However, that should be mitigated by the fact that this is currently not available in our dynamic config.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.