### PR TITLE
Add durable archival dynamic config flag

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -65,6 +65,11 @@ const (
 	VisibilityArchivalState = "system.visibilityArchivalState"
 	// EnableReadFromVisibilityArchival is key for enabling reading visibility from archival store
 	EnableReadFromVisibilityArchival = "system.enableReadFromVisibilityArchival"
+	// DurableArchivalEnabled means we generate a task to archive workflow data on the archival queue instead of
+	// the transfer queue.
+	//
+	// WARNING: do not use this dynamic config flag. It is not fully implemented yet
+	DurableArchivalEnabled = "history.durableArchivalEnabled"
 	// EnableNamespaceNotActiveAutoForwarding whether enabling DC auto forwarding to active cluster
 	// for signal / start / signal with start API if namespace is not active
 	EnableNamespaceNotActiveAutoForwarding = "system.enableNamespaceNotActiveAutoForwarding"

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -27,11 +27,14 @@ package host
 import (
 	"bytes"
 	"encoding/binary"
+	"flag"
 	"fmt"
 	"strconv"
+	"testing"
 	"time"
 
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/suite"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -43,6 +46,7 @@ import (
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/convert"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
@@ -54,7 +58,34 @@ const (
 	retryBackoffTime = 500 * time.Millisecond
 )
 
-func (s *integrationSuite) TestArchival_TimerQueueProcessor() {
+type archivalSuite struct {
+	baseIntegrationSuite
+}
+
+func TestArchivalSuite(t *testing.T) {
+	flag.Parse()
+	suite.Run(t, new(archivalSuite))
+}
+
+type durableArchivalSuite struct {
+	archivalSuite
+}
+
+func (s *durableArchivalSuite) SetupSuite() {
+	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
+		dynamicconfig.DurableArchivalEnabled: dynamicconfig.BoolPropertyFn(func() bool {
+			return true
+		}),
+	}
+	s.archivalSuite.SetupSuite()
+}
+
+func TestDurableArchivalSuite(t *testing.T) {
+	flag.Parse()
+	suite.Run(t, new(durableArchivalSuite))
+}
+
+func (s *archivalSuite) TestArchival_TimerQueueProcessor() {
 	s.True(s.testCluster.archiverBase.metadata.GetHistoryConfig().ClusterConfiguredForArchival())
 
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
@@ -74,7 +105,7 @@ func (s *integrationSuite) TestArchival_TimerQueueProcessor() {
 	s.True(s.isMutableStateDeleted(namespaceID, execution))
 }
 
-func (s *integrationSuite) TestArchival_ContinueAsNew() {
+func (s *archivalSuite) TestArchival_ContinueAsNew() {
 	s.True(s.testCluster.archiverBase.metadata.GetHistoryConfig().ClusterConfiguredForArchival())
 
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
@@ -96,7 +127,7 @@ func (s *integrationSuite) TestArchival_ContinueAsNew() {
 	}
 }
 
-func (s *integrationSuite) TestArchival_ArchiverWorker() {
+func (s *archivalSuite) TestArchival_ArchiverWorker() {
 	s.T().SkipNow() // flaky test, skip for now, will reimplement archival feature.
 
 	s.True(s.testCluster.archiverBase.metadata.GetHistoryConfig().ClusterConfiguredForArchival())
@@ -117,7 +148,7 @@ func (s *integrationSuite) TestArchival_ArchiverWorker() {
 	s.True(s.isMutableStateDeleted(namespaceID, execution))
 }
 
-func (s *integrationSuite) TestVisibilityArchival() {
+func (s *archivalSuite) TestVisibilityArchival() {
 	s.True(s.testCluster.archiverBase.metadata.GetVisibilityConfig().ClusterConfiguredForArchival())
 
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
@@ -162,7 +193,7 @@ func (s *integrationSuite) TestVisibilityArchival() {
 	}
 }
 
-func (s *integrationSuite) getNamespaceID(namespace string) string {
+func (s *archivalSuite) getNamespaceID(namespace string) string {
 	namespaceResp, err := s.engine.DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
 		Namespace: s.archivalNamespace,
 	})
@@ -170,7 +201,7 @@ func (s *integrationSuite) getNamespaceID(namespace string) string {
 	return namespaceResp.NamespaceInfo.GetId()
 }
 
-func (s *integrationSuite) isHistoryArchived(namespace string, execution *commonpb.WorkflowExecution) bool {
+func (s *archivalSuite) isHistoryArchived(namespace string, execution *commonpb.WorkflowExecution) bool {
 	request := &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace: s.archivalNamespace,
 		Execution: execution,
@@ -186,7 +217,7 @@ func (s *integrationSuite) isHistoryArchived(namespace string, execution *common
 	return false
 }
 
-func (s *integrationSuite) isHistoryDeleted(execution *commonpb.WorkflowExecution) bool {
+func (s *archivalSuite) isHistoryDeleted(execution *commonpb.WorkflowExecution) bool {
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
 	shardID := common.WorkflowIDToHistoryShard(namespaceID, execution.GetWorkflowId(),
 		s.testClusterConfig.HistoryConfig.NumHistoryShards)
@@ -205,7 +236,7 @@ func (s *integrationSuite) isHistoryDeleted(execution *commonpb.WorkflowExecutio
 	return false
 }
 
-func (s *integrationSuite) isMutableStateDeleted(namespaceID string, execution *commonpb.WorkflowExecution) bool {
+func (s *archivalSuite) isMutableStateDeleted(namespaceID string, execution *commonpb.WorkflowExecution) bool {
 	shardID := common.WorkflowIDToHistoryShard(namespaceID, execution.GetWorkflowId(),
 		s.testClusterConfig.HistoryConfig.NumHistoryShards)
 	request := &persistence.GetWorkflowExecutionRequest{
@@ -225,7 +256,7 @@ func (s *integrationSuite) isMutableStateDeleted(namespaceID string, execution *
 	return false
 }
 
-func (s *integrationSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceID string, numActivities, numRuns int) []string {
+func (s *archivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceID string, numActivities, numRuns int) []string {
 	identity := "worker1"
 	activityName := "activity_type1"
 	workflowType := &commonpb.WorkflowType{

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -35,23 +35,27 @@ import (
 )
 
 type (
-	integrationSuite struct {
+	baseIntegrationSuite struct {
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions
 		IntegrationBase
 	}
+
+	integrationSuite struct {
+		baseIntegrationSuite
+	}
 )
 
-func (s *integrationSuite) SetupSuite() {
+func (s *baseIntegrationSuite) SetupSuite() {
 	s.setupSuite("testdata/integration_test_cluster.yaml")
 }
 
-func (s *integrationSuite) TearDownSuite() {
+func (s *baseIntegrationSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *integrationSuite) SetupTest() {
+func (s *baseIntegrationSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 }
@@ -61,7 +65,7 @@ func TestIntegrationSuite(t *testing.T) {
 	suite.Run(t, new(integrationSuite))
 }
 
-func (s *integrationSuite) sendSignal(namespace string, execution *commonpb.WorkflowExecution, signalName string,
+func (s *baseIntegrationSuite) sendSignal(namespace string, execution *commonpb.WorkflowExecution, signalName string,
 	input *commonpb.Payloads, identity string) error {
 	_, err := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         namespace,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -136,6 +136,7 @@ type Config struct {
 	TransferProcessorPollBackoffInterval                dynamicconfig.DurationPropertyFn
 	TransferProcessorVisibilityArchivalTimeLimit        dynamicconfig.DurationPropertyFn
 	TransferProcessorEnsureCloseBeforeDelete            dynamicconfig.BoolPropertyFn
+	DurableArchivalEnabled                              dynamicconfig.BoolPropertyFn
 
 	// ReplicatorQueueProcessor settings
 	// TODO: clean up unused replicator settings
@@ -367,6 +368,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		TransferProcessorPollBackoffInterval:                dc.GetDurationProperty(dynamicconfig.TransferProcessorPollBackoffInterval, 5*time.Second),
 		TransferProcessorVisibilityArchivalTimeLimit:        dc.GetDurationProperty(dynamicconfig.TransferProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 		TransferProcessorEnsureCloseBeforeDelete:            dc.GetBoolProperty(dynamicconfig.TransferProcessorEnsureCloseBeforeDelete, true),
+		DurableArchivalEnabled:                              dc.GetBoolProperty(dynamicconfig.DurableArchivalEnabled, false),
 
 		ReplicatorTaskBatchSize:                               dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 100),
 		ReplicatorTaskWorkerCount:                             dc.GetIntProperty(dynamicconfig.ReplicatorTaskWorkerCount, 10),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a dynamic config flag to enable durable archival. It's not fully implemented yet, though, so there's a warning to not use it.

<!-- Tell your future self why have you made these changes -->
**Why?**
To control the rollout of durable archival.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
It's not used anywhere yet, so there's nothing to test. However, I added a test which runs our existing archival integration tests with this flag on.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Nothing.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.