### PR TITLE
Add service name tag to metrics emitted using metrics handler

### DIFF
--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -38,10 +38,8 @@ type (
 var _ Client = (*client)(nil)
 
 func NewClient(provider MetricsHandler, idx ServiceIdx) *client {
-	serviceTypeTagValue, _ := MetricsServiceIdxToServiceName(idx)
-
 	return &client{
-		provider:   provider.WithTags(ServiceTypeTag(serviceTypeTagValue), NamespaceTag(namespaceAllValue)),
+		provider:   provider,
 		serviceIdx: idx,
 	}
 }

--- a/common/metrics/scope_test.go
+++ b/common/metrics/scope_test.go
@@ -31,7 +31,7 @@ import (
 
 func BenchmarkAllTheMetricsScope(b *testing.B) {
 	var emp MetricsHandler = NoopMetricsHandler.WithTags(OperationTag("everything-is-awesome-3"))
-	var us Scope = newScope(emp, UnitTestService, TestScope1).Tagged(ServiceRoleTag("testing"), ServiceTypeTag("test"))
+	var us Scope = newScope(emp, UnitTestService, TestScope1).Tagged(ServiceRoleTag("testing"), ServiceNameTag("test"))
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -245,7 +245,7 @@ func ResourceExhaustedCauseTag(cause enumspb.ResourceExhaustedCause) Tag {
 	return &tagImpl{key: resourceExhaustedTag, value: cause.String()}
 }
 
-func ServiceTypeTag(value string) Tag {
+func ServiceNameTag(value string) Tag {
 	return &tagImpl{key: serviceName, value: value}
 }
 

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -165,8 +165,11 @@ func NewTest(
 	membershipMonitor.EXPECT().GetResolver(common.WorkerServiceName).Return(workerServiceResolver, nil).AnyTimes()
 
 	scope := tally.NewTestScope("test", nil)
+	serviceName, _ := metrics.MetricsServiceIdxToServiceName(serviceMetricsIndex)
 	metricClient := metrics.NewClient(
-		metrics.NewTallyMetricsHandler(metrics.ClientConfig{}, scope),
+		metrics.NewTallyMetricsHandler(metrics.ClientConfig{}, scope).WithTags(
+			metrics.ServiceNameTag(serviceName),
+		),
 		serviceMetricsIndex,
 	)
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -225,7 +225,7 @@ func (s *mutableStateSuite) TestChecksum() {
 	}
 
 	loadErrorsFunc := func() int64 {
-		counter := s.testScope.Snapshot().Counters()["test.mutable_state_checksum_mismatch+namespace=all,operation=WorkflowContext,service_name=history"]
+		counter := s.testScope.Snapshot().Counters()["test.mutable_state_checksum_mismatch+operation=WorkflowContext,service_name=history"]
 		if counter != nil {
 			return counter.Value()
 		}

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -64,6 +64,7 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
@@ -729,7 +730,7 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 	// So we can get snapshots
 	scope := tally.NewTestScope("test", nil)
-	s.matchingEngine.metricsClient = metrics.NewClient(metrics.NewTallyMetricsHandler(metrics.ClientConfig{}, scope), metrics.Matching)
+	s.matchingEngine.metricsClient = metrics.NewClient(metrics.NewTallyMetricsHandler(metrics.ClientConfig{}, scope).WithTags(metrics.ServiceNameTag(primitives.MatchingService)), metrics.Matching)
 
 	var err error
 	s.taskManager.getTaskQueueManager(tlID).rangeID = initialRangeID
@@ -936,7 +937,7 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	dispatchLimitFn func(int, int64) float64,
 ) int64 {
 	scope := tally.NewTestScope("test", nil)
-	s.matchingEngine.metricsClient = metrics.NewClient(metrics.NewTallyMetricsHandler(metrics.ClientConfig{}, scope), metrics.Matching)
+	s.matchingEngine.metricsClient = metrics.NewClient(metrics.NewTallyMetricsHandler(metrics.ClientConfig{}, scope).WithTags(metrics.ServiceNameTag(primitives.MatchingService)), metrics.Matching)
 	runID := uuid.NewRandom().String()
 	workflowID := "workflow1"
 	workflowExecution := &commonpb.WorkflowExecution{RunId: runID, WorkflowId: workflowID}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add service name tag to metrics emitted using metrics handler

<!-- Tell your future self why have you made these changes -->
**Why?**
- Currently only metrics emitted using metrics client has service name tag, but we are deprecating metrics client and in favor of metrics handler.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally and see metrics emitted by both metrics handler and metrics client have service name tag. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- probably