### PR TITLE
Increase timeouts in debug mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,10 @@ temporal-sql-tool: $(ALL_SRC)
 	@printf $(COLOR) "Build temporal-sql-tool with CGO_ENABLED=$(CGO_ENABLED) for $(GOOS)/$(GOARCH)..."
 	CGO_ENABLED=$(CGO_ENABLED) go build -o temporal-sql-tool ./cmd/tools/sql
 
+temporal-server-debug: $(ALL_SRC)
+	@printf $(COLOR) "Build temporal-server-debug with CGO_ENABLED=$(CGO_ENABLED) for $(GOOS)/$(GOARCH)..."
+	CGO_ENABLED=$(CGO_ENABLED) go build -tags TEMPORAL_DEBUG -o temporal-server-debug ./cmd/server
+
 ##### Checks #####
 copyright-check:
 	@printf $(COLOR) "Check license header..."

--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -32,15 +32,16 @@ import (
 	"time"
 
 	"go.temporal.io/server/api/adminservice/v1"
+	"go.temporal.io/server/common/debug"
 )
 
 var _ adminservice.AdminServiceClient = (*clientImpl)(nil)
 
 const (
 	// DefaultTimeout is the default timeout used to make calls
-	DefaultTimeout = 10 * time.Second
+	DefaultTimeout = 10 * time.Second * debug.TimeoutMultiplier
 	// DefaultLargeTimeout is the default timeout used to make calls
-	DefaultLargeTimeout = time.Minute
+	DefaultLargeTimeout = time.Minute * debug.TimeoutMultiplier
 )
 
 type clientImpl struct {

--- a/client/frontend/client.go
+++ b/client/frontend/client.go
@@ -31,14 +31,14 @@ import (
 	"context"
 	"time"
 
-	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/debug"
 )
 
 const (
 	// DefaultTimeout is the default timeout used to make calls
-	DefaultTimeout = 10 * time.Second
+	DefaultTimeout = 10 * time.Second * debug.TimeoutMultiplier
 	// DefaultLongPollTimeout is the long poll default timeout used to make calls
-	DefaultLongPollTimeout = time.Minute * 3
+	DefaultLongPollTimeout = time.Minute * 3 * debug.TimeoutMultiplier
 )
 
 var _ workflowservice.WorkflowServiceClient = (*clientImpl)(nil)

--- a/client/frontend/client.go
+++ b/client/frontend/client.go
@@ -31,6 +31,8 @@ import (
 	"context"
 	"time"
 
+	"go.temporal.io/api/workflowservice/v1"
+
 	"go.temporal.io/server/common/debug"
 )
 

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -40,6 +40,7 @@ import (
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/convert"
+	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
@@ -49,7 +50,7 @@ var _ historyservice.HistoryServiceClient = (*clientImpl)(nil)
 
 const (
 	// DefaultTimeout is the default timeout used to make calls
-	DefaultTimeout = time.Second * 30
+	DefaultTimeout = time.Second * 30 * debug.TimeoutMultiplier
 )
 
 type clientImpl struct {

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -38,6 +38,7 @@ import (
 
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
 )
@@ -46,9 +47,9 @@ var _ matchingservice.MatchingServiceClient = (*clientImpl)(nil)
 
 const (
 	// DefaultTimeout is the default timeout used to make calls
-	DefaultTimeout = time.Minute
+	DefaultTimeout = time.Minute * debug.TimeoutMultiplier
 	// DefaultLongPollTimeout is the long poll default timeout used to make calls
-	DefaultLongPollTimeout = time.Minute * 2
+	DefaultLongPollTimeout = time.Minute * 2 * debug.TimeoutMultiplier
 )
 
 type clientImpl struct {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/common/authorization"
 	"go.temporal.io/server/common/build"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
@@ -148,6 +149,7 @@ func buildCLI() *cli.App {
 					tag.NewStringTag("go-version", build.InfoData.GoVersion),
 					tag.NewBoolTag("cgo-enabled", build.InfoData.CgoEnabled),
 					tag.NewStringTag("server-version", headers.ServerVersion),
+					tag.NewBoolTag("debug-mode", debug.Enabled),
 				)
 
 				var dynamicConfigClient dynamicconfig.Client

--- a/common/constants.go
+++ b/common/constants.go
@@ -27,6 +27,8 @@ package common
 import (
 	"math"
 	"time"
+
+	"go.temporal.io/server/common/debug"
 )
 
 const (
@@ -83,7 +85,7 @@ const (
 
 const (
 	// DefaultWorkflowTaskTimeout sets the Default Workflow Task timeout for a Workflow
-	DefaultWorkflowTaskTimeout = 10 * time.Second
+	DefaultWorkflowTaskTimeout = 10 * time.Second * debug.TimeoutMultiplier
 
 	// MaxWorkflowTaskStartToCloseTimeout sets the Max Workflow Task start to close timeout for a Workflow
 	MaxWorkflowTaskStartToCloseTimeout = 120 * time.Second

--- a/common/debug/debug.go
+++ b/common/debug/debug.go
@@ -1,7 +1,33 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 //go:build TEMPORAL_DEBUG
 
 package debug
 
 const (
+	Enabled = true
+
 	TimeoutMultiplier = 100
 )

--- a/common/debug/debug.go
+++ b/common/debug/debug.go
@@ -1,0 +1,7 @@
+//go:build TEMPORAL_DEBUG
+
+package debug
+
+const (
+	TimeoutMultiplier = 100
+)

--- a/common/debug/not_debug.go
+++ b/common/debug/not_debug.go
@@ -1,0 +1,7 @@
+//go:build !TEMPORAL_DEBUG
+
+package debug
+
+const (
+	TimeoutMultiplier = 1
+)

--- a/common/debug/not_debug.go
+++ b/common/debug/not_debug.go
@@ -1,7 +1,33 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 //go:build !TEMPORAL_DEBUG
 
 package debug
 
 const (
+	Enabled = false
+
 	TimeoutMultiplier = 1
 )

--- a/host/context.go
+++ b/host/context.go
@@ -28,11 +28,12 @@ import (
 	"context"
 	"time"
 
+	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/rpc"
 )
 
 // NewContext create new context with default timeout 90 seconds.
 func NewContext() context.Context {
-	ctx, _ := rpc.NewContextWithTimeoutAndVersionHeaders(90 * time.Second)
+	ctx, _ := rpc.NewContextWithTimeoutAndVersionHeaders(90 * time.Second * debug.TimeoutMultiplier)
 	return ctx
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Increase timeouts in debug mode.

<!-- Tell your future self why have you made these changes -->
**Why?**
Default RPC timeouts work great for production environments. While in server debugging mode it is almost impossible to step over the code with default values.
Setting `TEMPORAL_DEBUG` build constraint will increase most important timeouts (did I forget anything?) 100 times.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Debug integration tests locally. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.