### PR TITLE
Add random delay to ArchiveExecutionTask

### DIFF
--- a/common/backoff/jitter.go
+++ b/common/backoff/jitter.go
@@ -43,6 +43,9 @@ func JitInt64(input int64, coefficient float64) int64 {
 	if input == 0 {
 		return 0
 	}
+	if coefficient == 0 {
+		return input
+	}
 
 	base := int64(float64(input) * (1 - coefficient))
 	addon := rand.Int63n(2 * (input - base))

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -550,6 +550,8 @@ const (
 	// ArchivalProcessorPollBackoffInterval is the poll backoff interval if task redispatcher's size exceeds limit for
 	// archivalQueueProcessor
 	ArchivalProcessorPollBackoffInterval = "history.archivalProcessorPollBackoffInterval"
+	// ArchivalProcessorArchiveDelay is the delay before archivalQueueProcessor starts to process archival tasks
+	ArchivalProcessorArchiveDelay = "history.archivalProcessorArchiveDelay"
 
 	// ReplicatorTaskBatchSize is batch size for ReplicatorProcessor
 	ReplicatorTaskBatchSize = "history.replicatorTaskBatchSize"

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -303,6 +303,7 @@ type Config struct {
 	ArchivalProcessorMaxPollIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
 	ArchivalProcessorUpdateAckInterval                  dynamicconfig.DurationPropertyFn
 	ArchivalProcessorUpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	ArchivalProcessorArchiveDelay                       dynamicconfig.DurationPropertyFn
 }
 
 const (
@@ -541,6 +542,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		ArchivalProcessorUpdateAckIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.
 			ArchivalProcessorUpdateAckIntervalJitterCoefficient, 0.15),
 		ArchivalProcessorPollBackoffInterval: dc.GetDurationProperty(dynamicconfig.ArchivalProcessorPollBackoffInterval, 5*time.Second),
+		ArchivalProcessorArchiveDelay:        dc.GetDurationProperty(dynamicconfig.ArchivalProcessorArchiveDelay, 5*time.Minute),
 	}
 
 	return cfg

--- a/service/history/tasks/category.go
+++ b/service/history/tasks/category.go
@@ -94,7 +94,7 @@ var (
 
 	CategoryArchival = Category{
 		id:    CategoryIDArchival,
-		cType: CategoryTypeImmediate,
+		cType: CategoryTypeScheduled,
 		name:  CategoryNameArchival,
 	}
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. I made the archival queue a scheduled queue instead of a timer queue.
2. I added a random delay to each task we produce

<!-- Tell your future self why have you made these changes -->
**Why?**
I did this to prevent us from having a ton of archive execution tasks arrive concurrently if many workflows close simultaneously.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added unit tests that verify edge cases like setting the dynamic config upper bound to 0.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Does not run via any production entrypoints. 


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
