### PR TITLE
Add metrics scopes for the archival queue

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -694,6 +694,14 @@ const (
 	PersistenceRangeCompleteVisibilityTasksScope = "RangeCompleteVisibilityTasks"
 	// PersistenceGetReplicationTaskScope tracks GetReplicationTask calls made by service to persistence layer
 	PersistenceGetReplicationTaskScope = "GetReplicationTask"
+	// PersistenceGetArchivalTaskScope tracks GetArchivalTask calls made by service to persistence layer
+	PersistenceGetArchivalTaskScope = "GetArchivalTask"
+	// PersistenceGetArchivalTasksScope tracks GetArchivalTasks calls made by service to persistence layer
+	PersistenceGetArchivalTasksScope = "GetArchivalTasks"
+	// PersistenceCompleteArchivalTaskScope tracks CompleteArchivalTasks calls made by service to persistence layer
+	PersistenceCompleteArchivalTaskScope = "CompleteArchivalTask"
+	// PersistenceRangeCompleteArchivalTasksScope tracks CompleteArchivalTasks calls made by service to persistence layer
+	PersistenceRangeCompleteArchivalTasksScope = "RangeCompleteArchivalTasks"
 	// PersistenceGetReplicationTasksScope tracks GetReplicationTasks calls made by service to persistence layer
 	PersistenceGetReplicationTasksScope = "GetReplicationTasks"
 	// PersistenceCompleteReplicationTaskScope tracks CompleteReplicationTasks calls made by service to persistence layer

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -331,6 +331,8 @@ func (p *executionPersistenceClient) GetHistoryTask(
 		operation = metrics.PersistenceGetVisibilityTaskScope
 	case tasks.CategoryIDReplication:
 		operation = metrics.PersistenceGetReplicationTaskScope
+	case tasks.CategoryIDArchival:
+		operation = metrics.PersistenceGetArchivalTaskScope
 	default:
 		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
 	}
@@ -357,6 +359,8 @@ func (p *executionPersistenceClient) GetHistoryTasks(
 		operation = metrics.PersistenceGetVisibilityTasksScope
 	case tasks.CategoryIDReplication:
 		operation = metrics.PersistenceGetReplicationTasksScope
+	case tasks.CategoryIDArchival:
+		operation = metrics.PersistenceGetArchivalTasksScope
 	default:
 		return nil, serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
 	}
@@ -383,6 +387,8 @@ func (p *executionPersistenceClient) CompleteHistoryTask(
 		operation = metrics.PersistenceCompleteVisibilityTaskScope
 	case tasks.CategoryIDReplication:
 		operation = metrics.PersistenceCompleteReplicationTaskScope
+	case tasks.CategoryIDArchival:
+		operation = metrics.PersistenceCompleteArchivalTaskScope
 	default:
 		return serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
 	}
@@ -409,6 +415,8 @@ func (p *executionPersistenceClient) RangeCompleteHistoryTasks(
 		operation = metrics.PersistenceRangeCompleteVisibilityTasksScope
 	case tasks.CategoryIDReplication:
 		operation = metrics.PersistenceRangeCompleteReplicationTasksScope
+	case tasks.CategoryIDArchival:
+		operation = metrics.PersistenceRangeCompleteArchivalTasksScope
 	default:
 		return serviceerror.NewInternal(fmt.Sprintf("unknown task category type: %v", request.TaskCategory))
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added some metrics scopes for the archival queue.

<!-- Tell your future self why have you made these changes -->
**Why?**
I added these changes because our queue processor will crash if it can't find the metrics scope for the archival category.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I ran the archival queue in our integration testing environment and watched the errors go away.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This isn't wired into any production entry points. However, it will increase `NumCommonScopes`. It doesn't look like anyone is using this variable outside of tests, though.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
