### PR TITLE
Add stats report component to emit open workflow count metrics

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -87,10 +87,19 @@ const (
 	EnableParentClosePolicyWorker = "system.enableParentClosePolicyWorker"
 	// EnableStickyQuery indicates if sticky query should be enabled per namespace
 	EnableStickyQuery = "system.enableStickyQuery"
-	// EnableActivityEagerExecution indicates if acitivty eager execution is enabled per namespace
+	// EnableActivityEagerExecution indicates if activity eager execution is enabled per namespace
 	EnableActivityEagerExecution = "system.enableActivityEagerExecution"
 	// NamespaceCacheRefreshInterval is the key for namespace cache refresh interval dynamic config
 	NamespaceCacheRefreshInterval = "system.namespaceCacheRefreshInterval"
+
+	// EnableNamespaceStatsReporter indicates if we allow reporting namespace stats
+	EnableNamespaceStatsReporter = "system.enableNamespaceStatsReporter"
+	// NamespaceStatsReportInterval is the interval between stats reports
+	NamespaceStatsReportInterval = "system.namespaceStatsReportInterval"
+	// EmitOpenWorkflowCount determines if we emit open workflow count metrics for a namespace
+	EmitOpenWorkflowCount = "system.emitOpenWorkflowCount"
+	// StatsReporterCountWorkflowMaxQPS is the max allowed QPS for querying workflow count from visibility
+	StatsReporterCountWorkflowMaxQPS = "system.statsReporterCountWorkflowMaxQPS"
 
 	// Whether the deadlock detector should dump goroutines
 	DeadlockDumpGoroutines = "system.deadlock.DumpGoroutines"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -94,8 +94,8 @@ const (
 
 	// EnableNamespaceStatsReporter indicates if we allow reporting namespace stats
 	EnableNamespaceStatsReporter = "system.enableNamespaceStatsReporter"
-	// NamespaceStatsReportInterval is the interval between stats reports
-	NamespaceStatsReportInterval = "system.namespaceStatsReportInterval"
+	// NamespaceStatsReportBaseInterval is the expected interval between stats reports
+	NamespaceStatsReportBaseInterval = "system.namespaceStatsReportBaseInterval"
 	// EmitOpenWorkflowCount determines if we emit open workflow count metrics for a namespace
 	EmitOpenWorkflowCount = "system.emitOpenWorkflowCount"
 	// StatsReporterCountWorkflowMaxQPS is the max allowed QPS for querying workflow count from visibility

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1626,6 +1626,7 @@ var (
 	NamespaceReplicationEnqueueDLQCount                       = NewCounterDef("namespace_replication_dlq_enqueue_requests")
 	ParentClosePolicyProcessorSuccess                         = NewCounterDef("parent_close_policy_processor_requests")
 	ParentClosePolicyProcessorFailures                        = NewCounterDef("parent_close_policy_processor_errors")
+	NamespaceOpenWorkflowsGauge                               = NewGaugeDef("namespace_open_workflows_count")
 
 	// Replication
 	NamespaceReplicationTaskAckLevelGauge = NewGaugeDef("namespace_replication_task_ack_level")

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -115,7 +115,7 @@ type (
 		EnableParentClosePolicyWorker         dynamicconfig.BoolPropertyFn
 		PerNamespaceWorkerCount               dynamicconfig.IntPropertyFnWithNamespaceFilter
 		EnableNamespaceStatsReporter          dynamicconfig.BoolPropertyFn
-		NamespaceStatsReportInterval          dynamicconfig.DurationPropertyFn
+		NamespaceStatsReportBaseInterval      dynamicconfig.DurationPropertyFn
 		EmitOpenWorkflowCount                 dynamicconfig.BoolPropertyFnWithNamespaceFilter
 		StatsReporterCountWorkflowMaxQPS      dynamicconfig.IntPropertyFn
 
@@ -342,7 +342,7 @@ func NewConfig(dc *dynamicconfig.Collection, persistenceConfig *config.Persisten
 		),
 
 		EnableNamespaceStatsReporter:     dc.GetBoolProperty(dynamicconfig.EnableNamespaceStatsReporter, false),
-		NamespaceStatsReportInterval:     dc.GetDurationProperty(dynamicconfig.NamespaceStatsReportInterval, 3*time.Minute),
+		NamespaceStatsReportBaseInterval: dc.GetDurationProperty(dynamicconfig.NamespaceStatsReportBaseInterval, time.Minute),
 		EmitOpenWorkflowCount:            dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.EmitOpenWorkflowCount, true),
 		StatsReporterCountWorkflowMaxQPS: dc.GetIntProperty(dynamicconfig.StatsReporterCountWorkflowMaxQPS, 10),
 
@@ -564,9 +564,10 @@ func (s *Service) startStatsReporter() {
 		MetricsHandler:        s.metricsHandler,
 		MetadataManager:       s.metadataManager,
 		VisibilityManager:     s.visibilityManager,
-		ReportInterval:        s.config.NamespaceStatsReportInterval,
+		BaseReportInterval:    s.config.NamespaceStatsReportBaseInterval,
 		EmitOpenWorkflowCount: s.config.EmitOpenWorkflowCount,
 		CountWorkflowMaxQPS:   s.config.StatsReporterCountWorkflowMaxQPS,
+		ServiceResolver:       s.workerServiceResolver,
 	}
 	reporter.Start()
 }

--- a/service/worker/statsreporter/statsreporter.go
+++ b/service/worker/statsreporter/statsreporter.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package statsreporter
 
 import (

--- a/service/worker/statsreporter/statsreporter.go
+++ b/service/worker/statsreporter/statsreporter.go
@@ -1,0 +1,129 @@
+package statsreporter
+
+import (
+	"context"
+	"math"
+	"math/rand"
+	"sync/atomic"
+	"time"
+
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	ns "go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/internal/goro"
+)
+
+const listNamespacePageSize = 100
+
+type StatsReporter struct {
+	status                int32
+	Logger                log.Logger
+	MetricsHandler        metrics.MetricsHandler
+	reporter              *goro.Handle
+	MetadataManager       persistence.MetadataManager
+	VisibilityManager     manager.VisibilityManager
+	ReportInterval        dynamicconfig.DurationPropertyFn
+	EmitOpenWorkflowCount dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	CountWorkflowMaxQPS   dynamicconfig.IntPropertyFn
+	visibilityRateLimiter quotas.RateLimiter
+}
+
+// Start is called to start replicator
+func (r *StatsReporter) Start() {
+	if !atomic.CompareAndSwapInt32(
+		&r.status,
+		common.DaemonStatusInitialized,
+		common.DaemonStatusStarted,
+	) {
+		return
+	}
+
+	r.reporter = goro.NewHandle(context.Background()).Go(r.queryLoop)
+	r.visibilityRateLimiter = quotas.NewDefaultOutgoingRateLimiter(
+		func() float64 { return float64(r.CountWorkflowMaxQPS()) },
+	)
+	r.Logger.Info("Stats reporter started.")
+}
+
+// Stop is called to stop replicator
+func (r *StatsReporter) Stop() {
+	if !atomic.CompareAndSwapInt32(
+		&r.status,
+		common.DaemonStatusStarted,
+		common.DaemonStatusStopped,
+	) {
+		return
+	}
+
+	r.reporter.Cancel()
+	<-r.reporter.Done()
+}
+
+func (r *StatsReporter) queryLoop(ctx context.Context) error {
+	timer := time.NewTicker(r.ReportInterval())
+
+	for {
+		select {
+		case <-timer.C:
+			r.reportNamespaceStats(ctx)
+			jitter := time.Second * time.Duration(math.Round(rand.Float64()*120))
+			timer.Reset(r.ReportInterval() + jitter)
+		case <-ctx.Done():
+			timer.Stop()
+			return nil
+		}
+	}
+}
+
+func (r *StatsReporter) reportNamespaceStats(ctx context.Context) {
+	var nextPageToken []byte
+	for {
+		listRequest := &persistence.ListNamespacesRequest{
+			PageSize:      listNamespacePageSize,
+			NextPageToken: nextPageToken,
+		}
+		listResponse, err := r.MetadataManager.ListNamespaces(ctx, listRequest)
+		if err != nil {
+			r.Logger.Error("Failed to list namespace.", tag.Error(err))
+			return
+		}
+
+		for _, namespace := range listResponse.Namespaces {
+			if r.EmitOpenWorkflowCount(namespace.Namespace.Info.GetName()) {
+				r.emitOpenWorkflowCountForNamespace(ctx, namespace.Namespace.Info.GetName(), namespace.Namespace.Info.GetId())
+			}
+		}
+
+		if listResponse.NextPageToken == nil {
+			return
+		}
+		nextPageToken = listResponse.NextPageToken
+	}
+}
+
+func (r *StatsReporter) emitOpenWorkflowCountForNamespace(ctx context.Context, namespace string, namespaceID string) {
+	if err := r.visibilityRateLimiter.Wait(ctx); err != nil {
+		r.Logger.Error("Failed to wait for visibility rate limiter.", tag.Error(err))
+		return
+	}
+	countRequest := &manager.CountWorkflowExecutionsRequest{
+		NamespaceID: ns.ID(namespaceID),
+		Namespace:   ns.Name(namespace),
+		Query:       "ExecutionStatus='Running'",
+	}
+	countResponse, err := r.VisibilityManager.CountWorkflowExecutions(ctx, countRequest)
+	if err != nil {
+		r.Logger.Warn("Failed to count workflow executions.", tag.WorkflowNamespace(namespace), tag.WorkflowNamespaceID(namespaceID), tag.Error(err))
+		return
+	}
+
+	count := countResponse.Count
+	r.MetricsHandler.Gauge(metrics.NamespaceOpenWorkflowsGauge.GetMetricName()).Record(float64(count), metrics.NamespaceTag(namespace))
+	r.Logger.Info("Open workflow count.", tag.Counter(int(count)), tag.WorkflowNamespace(namespace), tag.WorkflowNamespaceID(namespaceID))
+}

--- a/service/worker/statsreporter/statsreporter.go
+++ b/service/worker/statsreporter/statsreporter.go
@@ -26,7 +26,6 @@ package statsreporter
 
 import (
 	"context"
-	"go.temporal.io/server/common/membership"
 	"math"
 	"math/rand"
 	"sync/atomic"
@@ -36,6 +35,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	ns "go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"

--- a/service/worker/statsreporter/statsreporter_test.go
+++ b/service/worker/statsreporter/statsreporter_test.go
@@ -1,0 +1,116 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package statsreporter
+
+import (
+	"context"
+	"testing"
+
+	enumspb "go.temporal.io/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/quotas"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+)
+
+type statsReporterTestSuite struct {
+	suite.Suite
+	controller    *gomock.Controller
+	logger        log.Logger
+	metricHandler metrics.MetricsHandler
+
+	metadataManager       *persistence.MockMetadataManager
+	visibilityManager     *manager.MockVisibilityManager
+	serviceResolver       *membership.MockServiceResolver
+	visibilityRateLimiter *quotas.MockRateLimiter
+}
+
+func (s *statsReporterTestSuite) SetupTest() {
+	s.controller = gomock.NewController(s.T())
+	s.metadataManager = persistence.NewMockMetadataManager(s.controller)
+	s.visibilityManager = manager.NewMockVisibilityManager(s.controller)
+	s.serviceResolver = membership.NewMockServiceResolver(s.controller)
+	s.visibilityRateLimiter = quotas.NewMockRateLimiter(s.controller)
+}
+
+func TestStatsReporter(t *testing.T) {
+	suite.Run(t, new(statsReporterTestSuite))
+}
+
+func (s *statsReporterTestSuite) TestReportStats() {
+	s.visibilityRateLimiter.EXPECT().Wait(gomock.Any()).Times(1)
+	ns1 := &persistence.GetNamespaceResponse{
+		Namespace: &persistencespb.NamespaceDetail{
+			Info: &persistencespb.NamespaceInfo{
+				Id:    namespace.NewID().String(),
+				Name:  "ns1",
+				State: enumspb.NAMESPACE_STATE_REGISTERED,
+			},
+		},
+	}
+	ns2 := &persistence.GetNamespaceResponse{
+		Namespace: &persistencespb.NamespaceDetail{
+			Info: &persistencespb.NamespaceInfo{
+				Id:    namespace.NewID().String(),
+				Name:  "ns2",
+				State: enumspb.NAMESPACE_STATE_REGISTERED,
+			},
+		},
+	}
+	s.metadataManager.EXPECT().ListNamespaces(gomock.Any(), &persistence.ListNamespacesRequest{
+		PageSize:      listNamespacePageSize,
+		NextPageToken: nil,
+	}).Return(&persistence.ListNamespacesResponse{
+		Namespaces: []*persistence.GetNamespaceResponse{ns1, ns2},
+	}, nil)
+
+	s.visibilityManager.EXPECT().CountWorkflowExecutions(gomock.Any(), &manager.CountWorkflowExecutionsRequest{
+		NamespaceID: namespace.ID(ns1.Namespace.Info.Id),
+		Namespace:   namespace.Name(ns1.Namespace.Info.Name),
+		Query:       "ExecutionStatus='Running'",
+	}).Return(&manager.CountWorkflowExecutionsResponse{Count: 5}, nil)
+
+	statsReporter := &StatsReporter{
+		Logger:            log.NewTestLogger(),
+		MetricsHandler:    metrics.NoopMetricsHandler,
+		MetadataManager:   s.metadataManager,
+		VisibilityManager: s.visibilityManager,
+		EmitOpenWorkflowCount: func(namespace string) bool {
+			if namespace == ns1.Namespace.Info.Name {
+				return true
+			}
+			return false
+		},
+		VisibilityRateLimiter: s.visibilityRateLimiter,
+	}
+	statsReporter.reportNamespaceStats(context.Background())
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This is an experimental feature. It is turned off by default.
The goal is to emit open workflow count gauge metrics for namespaces in Temporal.
It only works if the underlying visibility store supports count operation.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
