### PR TITLE
Add a tool to limit the number of pending child workflows

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -113,6 +113,10 @@ const (
 	MemoSizeLimitError = "limit.memoSize.error"
 	// MemoSizeLimitWarn is the per event memo size limit for warning
 	MemoSizeLimitWarn = "limit.memoSize.warn"
+	// NumPendingChildExecutionLimitError is the per workflow pending child workflow limit
+	NumPendingChildExecutionLimitError = "limit.numPendingChildExecution.error"
+	// NumPendingChildExecutionLimitWarning is the per workflow pending child workflow limit for warning
+	NumPendingChildExecutionLimitWarning = "limit.numPendingChildExecution.warn"
 	// HistorySizeLimitError is the per workflow execution history size limit
 	HistorySizeLimitError = "limit.historySize.error"
 	// HistorySizeLimitWarn is the per workflow execution history size limit for warning

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1292,6 +1292,8 @@ var (
 	HistoryCount                                  = NewDimensionlessHistogramDef("history_count")
 	SearchAttributesSize                          = NewBytesHistogramDef("search_attributes_size")
 	MemoSize                                      = NewBytesHistogramDef("memo_size")
+	NumPendingChildWorkflowsHigh                  = NewCounterDef("num_pending_child_workflows_high")
+	NumPendingChildWorkflowsTooHigh               = NewCounterDef("num_pending_child_workflows_too_high")
 
 	// Frontend
 	AddSearchAttributesWorkflowSuccessCount  = NewCounterDef("add_search_attributes_workflow_success")

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -61,12 +61,17 @@ type (
 		enableCrossNamespaceCommands    dynamicconfig.BoolPropertyFn
 	}
 
-	workflowSizeChecker struct {
-		blobSizeLimitWarn  int
-		blobSizeLimitError int
+	workflowSizeLimits struct {
+		blobSizeLimitWarn                  int
+		blobSizeLimitError                 int
+		memoSizeLimitWarn                  int
+		memoSizeLimitError                 int
+		numPendingChildExecutionLimitError int
+		numPendingChildExecutionLimitWarn  int
+	}
 
-		memoSizeLimitWarn  int
-		memoSizeLimitError int
+	workflowSizeChecker struct {
+		workflowSizeLimits
 
 		mutableState              workflow.MutableState
 		searchAttributesValidator *searchattribute.Validator
@@ -97,10 +102,7 @@ func newCommandAttrValidator(
 }
 
 func newWorkflowSizeChecker(
-	blobSizeLimitWarn int,
-	blobSizeLimitError int,
-	memoSizeLimitWarn int,
-	memoSizeLimitError int,
+	limits workflowSizeLimits,
 	mutableState workflow.MutableState,
 	searchAttributesValidator *searchattribute.Validator,
 	executionStats *persistencespb.ExecutionStats,
@@ -108,10 +110,7 @@ func newWorkflowSizeChecker(
 	logger log.Logger,
 ) *workflowSizeChecker {
 	return &workflowSizeChecker{
-		blobSizeLimitWarn:         blobSizeLimitWarn,
-		blobSizeLimitError:        blobSizeLimitError,
-		memoSizeLimitWarn:         memoSizeLimitWarn,
-		memoSizeLimitError:        memoSizeLimitError,
+		workflowSizeLimits:        limits,
 		mutableState:              mutableState,
 		searchAttributesValidator: searchAttributesValidator,
 		executionStats:            executionStats,
@@ -169,6 +168,51 @@ func (c *workflowSizeChecker) checkIfMemoSizeExceedsLimit(
 	)
 	if err != nil {
 		return fmt.Errorf(message)
+	}
+	return nil
+}
+
+func withinLimit(value int, limit int) bool {
+	if limit <= 0 {
+		// limit not defined
+		return true
+	}
+	return value < limit
+}
+
+func (c *workflowSizeChecker) checkIfNumChildWorkflowsExceedsLimit() error {
+	key := c.mutableState.GetWorkflowKey()
+	logger := log.With(
+		c.logger,
+		tag.WorkflowNamespaceID(key.NamespaceID),
+		tag.WorkflowID(key.WorkflowID),
+		tag.WorkflowRunID(key.RunID),
+	)
+
+	numPending := len(c.mutableState.GetPendingChildExecutionInfos())
+	errLimit := c.numPendingChildExecutionLimitError
+	warnLimit := c.numPendingChildExecutionLimitWarn
+	if !withinLimit(numPending, errLimit) {
+		c.metricsHandler.Counter(metrics.NumPendingChildWorkflowsTooHigh.GetMetricName()).Record(1)
+		err := fmt.Errorf(
+			"the number of pending child workflow executions, %d, "+
+				"has reached the error limit of %d established with %q",
+			numPending,
+			errLimit,
+			dynamicconfig.NumPendingChildExecutionLimitError,
+		)
+		logger.Error(err.Error(), tag.Error(err))
+		return err
+	}
+	if !withinLimit(numPending, warnLimit) {
+		c.metricsHandler.Counter(metrics.NumPendingChildWorkflowsHigh.GetMetricName()).Record(1)
+		logger.Warn(fmt.Sprintf(
+			"The number of pending child workflow executions, %d, "+
+				"has reached the warning limit of %d established with %q.",
+			numPending,
+			warnLimit,
+			dynamicconfig.NumPendingChildExecutionLimitWarning,
+		))
 	}
 	return nil
 }

--- a/service/history/commandChecker_test.go
+++ b/service/history/commandChecker_test.go
@@ -42,13 +42,18 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/tests"
+	"go.temporal.io/server/service/history/workflow"
 )
 
 var (
@@ -707,5 +712,143 @@ func (s *commandAttrValidatorSuite) TestValidateCommandSequence_InvalidTerminalC
 		))
 		s.Error(err)
 		s.IsType(&serviceerror.InvalidArgument{}, err)
+	}
+}
+
+func TestWorkflowSizeChecker_NumChildWorkflows(t *testing.T) {
+	const (
+		errMsg = "the number of pending child workflow executions, 1, " +
+			"has reached the error limit of 1 established with \"limit.numPendingChildExecution.error\""
+		warnMsg = "The number of pending child workflow executions, 1, " +
+			"has reached the warning limit of 1 established with \"limit.numPendingChildExecution.warn\"."
+	)
+	for _, c := range []struct {
+		Name string
+
+		NumPendingChildExecutions int
+		WarnLimit                 int
+		ErrorLimit                int
+
+		ExpectedWarningMsg string
+		ExpectedErrorMsg   string
+
+		ExpectedMetric string
+	}{
+		{
+			Name:                      "No limits and no child workflows",
+			NumPendingChildExecutions: 0,
+			WarnLimit:                 0,
+			ErrorLimit:                0,
+		},
+		{
+			Name:                      "No executions",
+			NumPendingChildExecutions: 0,
+			WarnLimit:                 1,
+			ErrorLimit:                1,
+		},
+		{
+			Name:                      "Neither limit exceeded",
+			NumPendingChildExecutions: 2,
+			WarnLimit:                 3,
+			ErrorLimit:                3,
+		},
+		{
+			Name:                      "Error limit exceeded without a warning limit",
+			NumPendingChildExecutions: 1,
+			WarnLimit:                 0,
+			ErrorLimit:                1,
+
+			ExpectedErrorMsg: errMsg,
+			ExpectedMetric:   "num_pending_child_workflows_too_high",
+		},
+		{
+			Name:                      "Error limit and warning limit both exceeded",
+			NumPendingChildExecutions: 1,
+			WarnLimit:                 1,
+			ErrorLimit:                1,
+
+			ExpectedErrorMsg: errMsg,
+			ExpectedMetric:   "num_pending_child_workflows_too_high",
+		},
+		{
+			Name:                      "Warning limit exceeded, but no error limit exists",
+			NumPendingChildExecutions: 1,
+			WarnLimit:                 1,
+			ErrorLimit:                0,
+
+			ExpectedWarningMsg: warnMsg,
+			ExpectedMetric:     "num_pending_child_workflows_high",
+		},
+		{
+			Name:                      "Only warning limit exceeded, and there is an error limit",
+			NumPendingChildExecutions: 1,
+			WarnLimit:                 1,
+			ErrorLimit:                2,
+
+			ExpectedWarningMsg: warnMsg,
+			ExpectedMetric:     "num_pending_child_workflows_high",
+		},
+	} {
+		t.Run(c.Name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mutableState := workflow.NewMockMutableState(ctrl)
+			logger := log.NewMockLogger(ctrl)
+			metricsHandler := metrics.NewMockMetricsHandler(ctrl)
+
+			workflowKey := definition.NewWorkflowKey(
+				"test-namespace-id",
+				"test-workflow-id",
+				"test-run-id",
+			)
+			mutableState.EXPECT().GetWorkflowKey().Return(workflowKey).AnyTimes()
+
+			executionInfos := make(map[int64]*persistencespb.ChildExecutionInfo)
+			for i := 0; i < c.NumPendingChildExecutions; i++ {
+				executionInfos[int64(i)] = new(persistencespb.ChildExecutionInfo)
+			}
+			mutableState.EXPECT().GetPendingChildExecutionInfos().Return(executionInfos)
+
+			if len(c.ExpectedMetric) > 0 {
+				counterMetric := metrics.NewMockCounterMetric(ctrl)
+				metricsHandler.EXPECT().Counter(c.ExpectedMetric).Return(counterMetric)
+				counterMetric.EXPECT().Record(int64(1))
+			}
+
+			assertMessage := func(msg string, tags ...tag.Tag) {
+				var namespaceID, workflowID, runID interface{}
+				for _, t := range tags {
+					if t.Key() == "wf-namespace-id" {
+						namespaceID = t.Value()
+					} else if t.Key() == "wf-id" {
+						workflowID = t.Value()
+					} else if t.Key() == "wf-run-id" {
+						runID = t.Value()
+					}
+				}
+				assert.Equal(t, "test-namespace-id", namespaceID)
+				assert.Equal(t, "test-workflow-id", workflowID)
+				assert.Equal(t, "test-run-id", runID)
+			}
+
+			if len(c.ExpectedWarningMsg) > 0 {
+				logger.EXPECT().Warn(c.ExpectedWarningMsg, gomock.Any()).Do(assertMessage)
+			}
+			if len(c.ExpectedErrorMsg) > 0 {
+				logger.EXPECT().Error(c.ExpectedErrorMsg, gomock.Any()).Do(assertMessage)
+			}
+
+			checker := newWorkflowSizeChecker(workflowSizeLimits{
+				numPendingChildExecutionLimitError: c.ErrorLimit,
+				numPendingChildExecutionLimitWarn:  c.WarnLimit,
+			}, mutableState, nil, nil, metricsHandler, logger)
+			err := checker.checkIfNumChildWorkflowsExceedsLimit()
+
+			if len(c.ExpectedErrorMsg) > 0 {
+				require.Error(t, err)
+				assert.Equal(t, c.ExpectedErrorMsg, err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
 	}
 }

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -188,14 +188,16 @@ type Config struct {
 	DurableArchivalEnabled    dynamicconfig.BoolPropertyFn
 
 	// Size limit related settings
-	BlobSizeLimitError     dynamicconfig.IntPropertyFnWithNamespaceFilter
-	BlobSizeLimitWarn      dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MemoSizeLimitError     dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MemoSizeLimitWarn      dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistorySizeLimitError  dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistorySizeLimitWarn   dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryCountLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryCountLimitWarn  dynamicconfig.IntPropertyFnWithNamespaceFilter
+	BlobSizeLimitError                 dynamicconfig.IntPropertyFnWithNamespaceFilter
+	BlobSizeLimitWarn                  dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MemoSizeLimitError                 dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MemoSizeLimitWarn                  dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistorySizeLimitError              dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistorySizeLimitWarn               dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCountLimitError             dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCountLimitWarn              dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingChildExecutionLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingChildExecutionLimitWarn  dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	// DefaultActivityRetryOptions specifies the out-of-box retry policy if
 	// none is configured on the Activity by the user.
@@ -426,14 +428,16 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 			return false
 		},
 
-		BlobSizeLimitError:     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
-		BlobSizeLimitWarn:      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitWarn, 512*1024),
-		MemoSizeLimitError:     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitError, 2*1024*1024),
-		MemoSizeLimitWarn:      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitWarn, 2*1024),
-		HistorySizeLimitError:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitError, 50*1024*1024),
-		HistorySizeLimitWarn:   dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitWarn, 10*1024*1024),
-		HistoryCountLimitError: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitError, 50*1024),
-		HistoryCountLimitWarn:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitWarn, 10*1024),
+		BlobSizeLimitError:                 dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
+		BlobSizeLimitWarn:                  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitWarn, 512*1024),
+		MemoSizeLimitError:                 dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitError, 2*1024*1024),
+		MemoSizeLimitWarn:                  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitWarn, 2*1024),
+		NumPendingChildExecutionLimitError: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingChildExecutionLimitError, 1000),
+		NumPendingChildExecutionLimitWarn:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingChildExecutionLimitWarning, 200),
+		HistorySizeLimitError:              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitError, 50*1024*1024),
+		HistorySizeLimitWarn:               dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitWarn, 10*1024*1024),
+		HistoryCountLimitError:             dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitError, 50*1024),
+		HistoryCountLimitWarn:              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitWarn, 10*1024),
 
 		ThrottledLogRPS:   dc.GetIntProperty(dynamicconfig.HistoryThrottledLogRPS, 4),
 		EnableStickyQuery: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.EnableStickyQuery, true),

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -449,10 +449,16 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	} else {
 		namespace := namespaceEntry.Name()
 		workflowSizeChecker := newWorkflowSizeChecker(
-			handler.config.BlobSizeLimitWarn(namespace.String()),
-			handler.config.BlobSizeLimitError(namespace.String()),
-			handler.config.MemoSizeLimitWarn(namespace.String()),
-			handler.config.MemoSizeLimitError(namespace.String()),
+			workflowSizeLimits{
+				blobSizeLimitWarn:  handler.config.BlobSizeLimitWarn(namespace.String()),
+				blobSizeLimitError: handler.config.BlobSizeLimitError(namespace.String()),
+				memoSizeLimitWarn:  handler.config.MemoSizeLimitWarn(namespace.String()),
+				memoSizeLimitError: handler.config.MemoSizeLimitError(namespace.String()),
+				numPendingChildExecutionLimitWarn: handler.config.NumPendingChildExecutionLimitWarn(namespace.
+					String()),
+				numPendingChildExecutionLimitError: handler.config.NumPendingChildExecutionLimitError(namespace.
+					String()),
+			},
 			ms,
 			handler.searchAttributesValidator,
 			executionStats,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a `checkIfNumChildWorkflowsExceedsLimit` method to our `workflowSizeChecker`.

<!-- Tell your future self why have you made these changes -->
**Why?**
In order to limit the number of child workflows is too large.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added a large suite of unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This method isn't called anywhere in prod yet, so none.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
