### PR TITLE
Return an error whenever we exceed the number of pending child executions

### DIFF
--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -94,8 +94,9 @@ type (
 		historyEngine    *historyEngineImpl
 		mockExecutionMgr *persistence.MockExecutionManager
 
-		config *configs.Config
-		logger log.Logger
+		config        *configs.Config
+		logger        *log.MockLogger
+		errorMessages []string
 	}
 )
 
@@ -153,7 +154,14 @@ func (s *engine2Suite) SetupTest() {
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(false, common.EmptyVersion).Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, tests.Version).Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.workflowCache = workflow.NewCache(s.mockShard)
-	s.logger = s.mockShard.GetLogger()
+	s.logger = log.NewMockLogger(s.controller)
+	s.logger.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+	s.logger.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
+	s.logger.EXPECT().Warn(gomock.Any(), gomock.Any()).AnyTimes()
+	s.errorMessages = make([]string, 0)
+	s.logger.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes().Do(func(msg string, tags ...tag.Tag) {
+		s.errorMessages = append(s.errorMessages, msg)
+	})
 
 	h := &historyEngineImpl{
 		currentClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
@@ -914,6 +922,90 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWithSearchAttr
 		},
 	})
 	s.Nil(err)
+}
+
+func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWorkflow_ExceedsLimit() {
+	namespaceID := tests.NamespaceID
+	taskQueue := "testTaskQueue"
+	identity := "testIdentity"
+	workflowType := "testWorkflowType"
+
+	we := commonpb.WorkflowExecution{
+		WorkflowId: tests.WorkflowID,
+		RunId:      tests.RunID,
+	}
+	ms := workflow.TestLocalMutableState(
+		s.historyEngine.shard,
+		s.mockEventsCache,
+		tests.LocalNamespaceEntry,
+		log.NewTestLogger(),
+		we.GetRunId(),
+	)
+
+	addWorkflowExecutionStartedEvent(
+		ms,
+		we,
+		workflowType,
+		taskQueue,
+		nil,
+		time.Minute,
+		time.Minute,
+		time.Minute,
+		identity,
+	)
+
+	s.mockNamespaceCache.EXPECT().GetNamespace(tests.Namespace).Return(tests.LocalNamespaceEntry, nil).AnyTimes()
+
+	var commands []*commandpb.Command
+	for i := 0; i < 6; i++ {
+		commands = append(
+			commands,
+			&commandpb.Command{
+				CommandType: enumspb.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION,
+				Attributes: &commandpb.Command_StartChildWorkflowExecutionCommandAttributes{
+					StartChildWorkflowExecutionCommandAttributes: &commandpb.StartChildWorkflowExecutionCommandAttributes{
+						Namespace:    tests.Namespace.String(),
+						WorkflowId:   tests.WorkflowID,
+						WorkflowType: &commonpb.WorkflowType{Name: workflowType},
+						TaskQueue:    &taskqueuepb.TaskQueue{Name: taskQueue},
+					}},
+			},
+		)
+	}
+
+	wt := addWorkflowTaskScheduledEvent(ms)
+	addWorkflowTaskStartedEvent(
+		ms,
+		wt.ScheduledEventID,
+		taskQueue,
+		identity,
+	)
+	taskToken := &tokenspb.Task{
+		Attempt:          1,
+		NamespaceId:      namespaceID.String(),
+		WorkflowId:       tests.WorkflowID,
+		RunId:            we.GetRunId(),
+		ScheduledEventId: 2,
+	}
+	taskTokenBytes, _ := taskToken.Marshal()
+	response := &persistence.GetWorkflowExecutionResponse{State: workflow.TestCloneToProto(ms)}
+	s.mockExecutionMgr.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(response, nil).AnyTimes()
+
+	s.historyEngine.shard.GetConfig().NumPendingChildExecutionLimitError = func(namespace string) int {
+		return 5
+	}
+	_, err := s.historyEngine.RespondWorkflowTaskCompleted(metrics.AddMetricsContext(context.Background()), &historyservice.RespondWorkflowTaskCompletedRequest{
+		NamespaceId: tests.NamespaceID.String(),
+		CompleteRequest: &workflowservice.RespondWorkflowTaskCompletedRequest{
+			TaskToken: taskTokenBytes,
+			Commands:  commands,
+			Identity:  identity,
+		},
+	})
+
+	s.Error(err)
+	s.Assert().Equal([]string{"the number of pending child workflow executions, 5, " +
+		"has reached the error limit of 5 established with \"limit.numPendingChildExecution.error\""}, s.errorMessages)
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_BrandNew() {

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -895,6 +895,11 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 		return handler.failWorkflow(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_START_CHILD_EXECUTION_ATTRIBUTES, err)
 	}
 
+	// child workflow limit
+	if err := handler.sizeLimitChecker.checkIfNumChildWorkflowsExceedsLimit(); err != nil {
+		return handler.failCommand(enumspb.WORKFLOW_TASK_FAILED_CAUSE_PENDING_CHILD_WORKFLOWS_LIMIT_EXCEEDED, err)
+	}
+
 	enabled := handler.config.EnableParentClosePolicy(parentNamespace.String())
 	if enabled {
 		enums.SetDefaultParentClosePolicy(&attr.ParentClosePolicy)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now return an error whenever the number of pending child executions is too high.

<!-- Tell your future self why have you made these changes -->
**Why?**
I made this change to prevent our mutable state from becoming too large when there are too many child workflows.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added an integration test that sets the limit to 1 and then tries to create a child workflow while there is another one pending. I also added a unit test that verifies the exact error message.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If this logic is faulty or the limit is too low, it could prevent new child workflows from being spawned.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.