### PR TITLE
Don't log a warning when the number of child workflows is high

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -115,8 +115,6 @@ const (
 	MemoSizeLimitWarn = "limit.memoSize.warn"
 	// NumPendingChildExecutionLimitError is the per workflow pending child workflow limit
 	NumPendingChildExecutionLimitError = "limit.numPendingChildExecution.error"
-	// NumPendingChildExecutionLimitWarning is the per workflow pending child workflow limit for warning
-	NumPendingChildExecutionLimitWarning = "limit.numPendingChildExecution.warn"
 	// HistorySizeLimitError is the per workflow execution history size limit
 	HistorySizeLimitError = "limit.historySize.error"
 	// HistorySizeLimitWarn is the per workflow execution history size limit for warning

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1345,7 +1345,6 @@ var (
 	HistoryCount                                  = NewDimensionlessHistogramDef("history_count")
 	SearchAttributesSize                          = NewBytesHistogramDef("search_attributes_size")
 	MemoSize                                      = NewBytesHistogramDef("memo_size")
-	NumPendingChildWorkflowsHigh                  = NewCounterDef("num_pending_child_workflows_high")
 	NumPendingChildWorkflowsTooHigh               = NewCounterDef("num_pending_child_workflows_too_high")
 
 	// Frontend

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -197,7 +197,6 @@ type Config struct {
 	HistoryCountLimitError             dynamicconfig.IntPropertyFnWithNamespaceFilter
 	HistoryCountLimitWarn              dynamicconfig.IntPropertyFnWithNamespaceFilter
 	NumPendingChildExecutionLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter
-	NumPendingChildExecutionLimitWarn  dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	// DefaultActivityRetryOptions specifies the out-of-box retry policy if
 	// none is configured on the Activity by the user.
@@ -433,7 +432,6 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		MemoSizeLimitError:                 dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitError, 2*1024*1024),
 		MemoSizeLimitWarn:                  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitWarn, 2*1024),
 		NumPendingChildExecutionLimitError: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingChildExecutionLimitError, 1000),
-		NumPendingChildExecutionLimitWarn:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingChildExecutionLimitWarning, 200),
 		HistorySizeLimitError:              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitError, 50*1024*1024),
 		HistorySizeLimitWarn:               dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitWarn, 10*1024*1024),
 		HistoryCountLimitError:             dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitError, 50*1024),

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -454,8 +454,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 				blobSizeLimitError: handler.config.BlobSizeLimitError(namespace.String()),
 				memoSizeLimitWarn:  handler.config.MemoSizeLimitWarn(namespace.String()),
 				memoSizeLimitError: handler.config.MemoSizeLimitError(namespace.String()),
-				numPendingChildExecutionLimitWarn: handler.config.NumPendingChildExecutionLimitWarn(namespace.
-					String()),
 				numPendingChildExecutionLimitError: handler.config.NumPendingChildExecutionLimitError(namespace.
 					String()),
 			},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the warning that we log when the number of child workflows is high.

<!-- Tell your future self why have you made these changes -->
**Why?**
I did this because we decided that it would be too noisy.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I tested this just by removing the test cases for warnings. Since there's no expected warning logs, the tests would fail if this change didn't work.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This dynamic config hasn't even been released yet, so there's no risk.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.