### PR TITLE
Add methods to check workflow size violations for several other fields

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1345,7 +1345,10 @@ var (
 	HistoryCount                                  = NewDimensionlessHistogramDef("history_count")
 	SearchAttributesSize                          = NewBytesHistogramDef("search_attributes_size")
 	MemoSize                                      = NewBytesHistogramDef("memo_size")
-	NumPendingChildWorkflowsTooHigh               = NewCounterDef("num_pending_child_workflows_too_high")
+	TooManyPendingChildWorkflows                  = NewCounterDef("wf_too_many_pending_child_workflows")
+	TooManyPendingActivities                      = NewCounterDef("wf_too_many_pending_activities")
+	TooManyPendingCancelRequests                  = NewCounterDef("wf_too_many_pending_cancel_requests")
+	TooManyPendingSignalsToExternalWorkflows      = NewCounterDef("wf_too_many_pending_external_workflow_signals")
 
 	// Frontend
 	AddSearchAttributesWorkflowSuccessCount  = NewCounterDef("add_search_attributes_workflow_success")

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -1005,7 +1005,7 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWorkflow_Excee
 
 	s.Error(err)
 	s.Assert().Equal([]string{"the number of pending child workflow executions, 5, " +
-		"has reached the error limit of 5 established with \"limit.numPendingChildExecutions.error\""}, s.errorMessages)
+		"has reached the per-workflow limit of 5"}, s.errorMessages)
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_BrandNew() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I generalized our workflow size limit constraints to 4 fields (child workflows, activities, external signals, and cancel requests).

<!-- Tell your future self why have you made these changes -->
**Why?**
I made this change so that we can limit these fields which could potentially cause issues if they're too large.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
These new methods aren't called yet.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.