### PR TITLE
Change max namespace count limit to per poller type

### DIFF
--- a/common/rpc/interceptor/namespace_count_limit.go
+++ b/common/rpc/interceptor/namespace_count_limit.go
@@ -51,7 +51,7 @@ type (
 		tokens  map[string]int
 
 		sync.Mutex
-		namespaceToCount map[namespace.Name]*int32
+		activeTokensCount map[string]*int32
 	}
 )
 
@@ -68,8 +68,7 @@ func NewNamespaceCountLimitInterceptor(
 		logger:            logger,
 		countFn:           countFn,
 		tokens:            tokens,
-
-		namespaceToCount: make(map[namespace.Name]*int32),
+		activeTokensCount: make(map[string]*int32),
 	}
 }
 
@@ -84,13 +83,15 @@ func (ni *NamespaceCountLimitInterceptor) Intercept(
 	token := ni.tokens[methodName]
 	if token != 0 {
 		nsName := GetNamespace(ni.namespaceRegistry, req)
-		counter := ni.counter(nsName)
+		counter := ni.counter(nsName, methodName)
 		count := atomic.AddInt32(counter, int32(token))
 		defer atomic.AddInt32(counter, -int32(token))
 
 		handler := GetMetricsHandlerFromContext(ctx, ni.logger)
 		handler.Gauge(metrics.ServicePendingRequests.GetMetricName()).Record(float64(count))
 
+		// frontend.namespaceCount is applied per poller type temporarily to prevent
+		// one poller type to take all token waiting in the long poll.
 		if int(count) > ni.countFn(nsName.String()) {
 			return nil, ErrNamespaceCountLimitServerBusy
 		}
@@ -101,15 +102,24 @@ func (ni *NamespaceCountLimitInterceptor) Intercept(
 
 func (ni *NamespaceCountLimitInterceptor) counter(
 	namespace namespace.Name,
+	methodName string,
 ) *int32 {
+	key := ni.getTokenKey(namespace, methodName)
+
 	ni.Lock()
 	defer ni.Unlock()
 
-	count, ok := ni.namespaceToCount[namespace]
+	counter, ok := ni.activeTokensCount[key]
 	if !ok {
-		counter := int32(0)
-		count = &counter
-		ni.namespaceToCount[namespace] = count
+		counter = new(int32)
+		ni.activeTokensCount[key] = counter
 	}
-	return count
+	return counter
+}
+
+func (ni *NamespaceCountLimitInterceptor) getTokenKey(
+	namespace namespace.Name,
+	methodName string,
+) string {
+	return namespace.String() + "/" + methodName
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Making `frontend.namespaceCount` to be the max concurrent poller for each type (ie. activity and workflow pollers).

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, the config is for the total amount of pollers, which can make one type of poller to take all token while waiting in the long poll. This is prevent the other poller type to get tasks if there are pending tasks. This issue happens when there are more worker pollers than the maximum allowed by the server.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started a worker with more pollers than the server allows it, and created a job to create many workflows. Currently, after a couple of minutes, almost all tokens are taken by activity pollers making workflow pollers to fail to get tasks. With this PR change, workflow pollers can get new tasks since now they don't share tokens anymore.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Since it's allowing more pollers to connect with server (double amount), it might cause server to overload.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.