### PR TITLE
Disable eager activity dispatch for buggy clients

### DIFF
--- a/common/headers/versionChecker.go
+++ b/common/headers/versionChecker.go
@@ -42,6 +42,7 @@ const (
 	ClientNameJavaSDK       = "temporal-java"
 	ClientNamePHPSDK        = "temporal-php"
 	ClientNameTypeScriptSDK = "temporal-typescript"
+	ClientNamePythonSDK     = "temporal-python"
 	ClientNameCLI           = "temporal-cli"
 	ClientNameUI            = "temporal-ui"
 

--- a/service/frontend/overrides.go
+++ b/service/frontend/overrides.go
@@ -45,9 +45,9 @@ func NewOverrides() *Overrides {
 }
 
 func (o *Overrides) shouldForceDisableEagerDispatch(sdkName, sdkVersion string) bool {
-	if sdkName == "temporal-python" && sdkVersion == "0.1b2" {
+	if sdkName == headers.ClientNamePythonSDK && sdkVersion == "0.1b2" {
 		return true
-	} else if sdkName == "temporal-typescript" {
+	} else if sdkName == headers.ClientNameTypeScriptSDK {
 		ver, err := semver.Parse(sdkVersion)
 		// Don't bother with non semver
 		if err != nil {

--- a/service/frontend/overrides.go
+++ b/service/frontend/overrides.go
@@ -1,0 +1,82 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package frontend
+
+import (
+	"context"
+
+	"github.com/blang/semver/v4"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/headers"
+)
+
+// Overrides defines a set of special case behaviors like compensating for buggy
+// SDK implementations
+type Overrides struct {
+	minTypeScriptEagerActivitySupportedVersion semver.Version
+}
+
+func NewOverrides() *Overrides {
+	return &Overrides{
+		minTypeScriptEagerActivitySupportedVersion: semver.MustParse("1.4.4"),
+	}
+}
+
+func (o *Overrides) shouldForceDisableEagerDispatch(sdkName, sdkVersion string) bool {
+	if sdkName == "temporal-python" && sdkVersion == "0.1b2" {
+		return true
+	} else if sdkName == "temporal-typescript" {
+		ver, err := semver.Parse(sdkVersion)
+		// Don't bother with non semver
+		if err != nil {
+			return false
+		}
+		return ver.LT(o.minTypeScriptEagerActivitySupportedVersion)
+	}
+	return false
+}
+
+func (o *Overrides) disableEagerDispatch(
+	request *workflowservice.RespondWorkflowTaskCompletedRequest,
+) {
+	for _, cmd := range request.GetCommands() {
+		attrs := cmd.GetScheduleActivityTaskCommandAttributes()
+		if attrs != nil {
+			attrs.RequestEagerExecution = false
+		}
+	}
+}
+
+// DisableEagerActivityDispatchForBuggyClients compensates for SDK versions
+// that have buggy implementations of eager activity dispatch
+func (o *Overrides) DisableEagerActivityDispatchForBuggyClients(
+	ctx context.Context,
+	request *workflowservice.RespondWorkflowTaskCompletedRequest,
+) {
+	sdkName, sdkVersion := headers.GetClientNameAndVersion(ctx)
+	if o.shouldForceDisableEagerDispatch(sdkName, sdkVersion) {
+		o.disableEagerDispatch(request)
+	}
+}

--- a/service/frontend/overrides_test.go
+++ b/service/frontend/overrides_test.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package frontend
 
 import (

--- a/service/frontend/overrides_test.go
+++ b/service/frontend/overrides_test.go
@@ -1,0 +1,42 @@
+package frontend
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.temporal.io/api/command/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/headers"
+)
+
+func TestDisableEagerActivityDispatchForBuggyClients(t *testing.T) {
+	overrides := NewOverrides()
+
+	type Case struct {
+		sdkVersion   string
+		sdkName      string
+		eagerAllowed bool
+	}
+
+	cases := []Case{
+		{sdkName: headers.ClientNameGoSDK, sdkVersion: "1.18.1", eagerAllowed: true},
+		{sdkName: headers.ClientNameTypeScriptSDK, sdkVersion: "1.4.1", eagerAllowed: false},
+		{sdkName: headers.ClientNameTypeScriptSDK, sdkVersion: "1.4.4", eagerAllowed: true},
+		{sdkName: headers.ClientNamePythonSDK, sdkVersion: "0.1b2", eagerAllowed: false},
+		{sdkName: headers.ClientNamePythonSDK, sdkVersion: "0.1b1", eagerAllowed: true},
+		{sdkName: headers.ClientNamePythonSDK, sdkVersion: "0.1b3", eagerAllowed: true},
+	}
+	for _, testCase := range cases {
+		ctx := headers.SetVersionsForTests(context.Background(), testCase.sdkVersion, testCase.sdkName, headers.SupportedServerVersions, headers.AllFeatures)
+		req := &workflowservice.RespondWorkflowTaskCompletedRequest{
+			Commands: []*command.Command{
+				{Attributes: &command.Command_ScheduleActivityTaskCommandAttributes{ScheduleActivityTaskCommandAttributes: &command.ScheduleActivityTaskCommandAttributes{RequestEagerExecution: true}}},
+			},
+		}
+		overrides.DisableEagerActivityDispatchForBuggyClients(ctx, req)
+
+		assert.Equal(t, req.GetCommands()[0].GetScheduleActivityTaskCommandAttributes().GetRequestEagerExecution(), testCase.eagerAllowed)
+	}
+}

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -119,6 +119,7 @@ type (
 		saValidator                     *searchattribute.Validator
 		archivalMetadata                archiver.ArchivalMetadata
 		healthServer                    *health.Server
+		overrides                       *Overrides
 	}
 )
 
@@ -182,6 +183,7 @@ func NewWorkflowHandler(
 			config.SearchAttributesTotalSizeLimit),
 		archivalMetadata: archivalMetadata,
 		healthServer:     healthServer,
+		overrides:        NewOverrides(),
 	}
 
 	return handler
@@ -942,6 +944,8 @@ func (wh *WorkflowHandler) RespondWorkflowTaskCompleted(
 		return nil, err
 	}
 	namespaceId := namespace.ID(taskToken.GetNamespaceId())
+
+	wh.overrides.DisableEagerActivityDispatchForBuggyClients(ctx, request)
 
 	histResp, err := wh.historyClient.RespondWorkflowTaskCompleted(ctx, &historyservice.RespondWorkflowTaskCompletedRequest{
 		NamespaceId:     namespaceId.String(),


### PR DESCRIPTION
**What changed?**

Disable eager activity dispatch for buggy clients.
Known buggy implementations are Core based SDKs - TypeScript and Python.
The bug in Core was fixed in TS `1.4.4` and Python `0.1b3`.

**Why?**

The Core bug is pretty severe, it causes a panic on the Rust side stopping worker progress altogether.
The bug effects workflow-only workers which is relatively rare but still worth server side compensation.

**How did you test it?**

Added unit test
