### PR TITLE
Enforce the per-workflow pending signal limit

### DIFF
--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -955,6 +955,9 @@ func (handler *workflowTaskHandlerImpl) handleCommandSignalExternalWorkflow(
 	); err != nil || handler.stopProcessing {
 		return err
 	}
+	if err := handler.sizeLimitChecker.checkIfNumPendingSignalsExceedsLimit(); err != nil {
+		return handler.failCommand(enumspb.WORKFLOW_TASK_FAILED_CAUSE_PENDING_SIGNALS_LIMIT_EXCEEDED, err)
+	}
 
 	if err := handler.sizeLimitChecker.checkIfPayloadSizeExceedsLimit(
 		metrics.CommandTypeTag(enumspb.COMMAND_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION.String()),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now fail any command that would exceed the sending workflow's capacity for pending signals.

<!-- Tell your future self why have you made these changes -->
**Why?**
To keep workflow state small.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added an integration test similar to the other three.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Users that send a lot of signals in one command may see their workflows fail.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Notification required.