### PR TITLE
Retry CreateIndex in integration tests request upon failure

### DIFF
--- a/host/util.go
+++ b/host/util.go
@@ -26,10 +26,13 @@ package host
 
 import (
 	"context"
+	"fmt"
 	"os"
+	"time"
 
 	"github.com/stretchr/testify/suite"
 
+	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/log"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 )
@@ -62,9 +65,19 @@ func CreateIndex(s *suite.Suite, esClient esclient.IntegrationTestsClient, index
 		s.Require().True(acknowledged)
 	}
 
-	acknowledged, err := esClient.CreateIndex(context.Background(), indexName)
-	s.Require().NoError(err)
-	s.Require().True(acknowledged)
+	// we need to retry because DeleteIndex is not synchronous
+	err = backoff.ThrottleRetry(func() error {
+		acknowledged, err := esClient.CreateIndex(context.Background(), indexName)
+		if err != nil {
+			return err
+		}
+		if !acknowledged {
+			return fmt.Errorf("create request not acknowledged")
+		}
+		return nil
+	}, backoff.NewExponentialRetryPolicy(100*time.Millisecond), func(err error) bool { return true })
+
+	s.NoError(err)
 }
 
 // DeleteIndex delete test index


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now retry creating our elasticsearch index in our integration test setup.

<!-- Tell your future self why have you made these changes -->
**Why?**
This can fail because the delete operation that precedes it is not synchronous.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Will wait for CI to build.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Can't think of any.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.