### PR TITLE
Remember retention timer task state in memory for retry

### DIFF
--- a/common/persistence/serialization/task_serializer.go
+++ b/common/persistence/serialization/task_serializer.go
@@ -577,6 +577,8 @@ func (s *TaskSerializer) transferCloseTaskFromProto(
 		Version:                   closeTask.Version,
 		DeleteAfterClose:          closeTask.DeleteAfterClose,
 		CanSkipVisibilityArchival: canSkipVisibilityArchival,
+		// Delete workflow task process stage is not persisted. It is only for in memory retries.
+		DeleteProcessStage: tasks.DeleteWorkflowExecutionStageNone,
 	}
 }
 
@@ -641,6 +643,8 @@ func (s *TaskSerializer) transferDeleteExecutionTaskFromProto(
 		VisibilityTimestamp: *deleteExecutionTask.VisibilityTime,
 		TaskID:              deleteExecutionTask.TaskId,
 		Version:             deleteExecutionTask.Version,
+		// Delete workflow task process stage is not persisted. It is only for in memory retries.
+		ProcessStage: tasks.DeleteWorkflowExecutionStageNone,
 	}
 }
 
@@ -886,6 +890,8 @@ func (s *TaskSerializer) timerWorkflowCleanupTaskFromProto(
 		Version:                     workflowCleanupTimer.Version,
 		BranchToken:                 workflowCleanupTimer.BranchToken,
 		WorkflowDataAlreadyArchived: workflowCleanupTimer.AlreadyArchived,
+		// Delete workflow task process stage is not persisted. It is only for in memory retries.
+		ProcessStage: tasks.DeleteWorkflowExecutionStageNone,
 	}
 }
 

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -367,6 +367,7 @@ func (e *taskExecutorImpl) cleanupWorkflowExecution(ctx context.Context, namespa
 		wfCtx,
 		mutableState,
 		false,
+		nil, // stage is not stored during cleanup process.
 	)
 }
 

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -115,9 +115,9 @@ type (
 		SetWorkflowExecution(ctx context.Context, request *persistence.SetWorkflowExecutionRequest) (*persistence.SetWorkflowExecutionResponse, error)
 		GetCurrentExecution(ctx context.Context, request *persistence.GetCurrentExecutionRequest) (*persistence.GetCurrentExecutionResponse, error)
 		GetWorkflowExecution(ctx context.Context, request *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error)
-		// DeleteWorkflowExecution deletes workflow execution, current workflow execution, and add task to delete visibility.
+		// DeleteWorkflowExecution add task to delete visibility, current workflow execution, and deletes workflow execution.
 		// If branchToken != nil, then delete history also, otherwise leave history.
-		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime *time.Time, closeTime *time.Time, closeExecutionVisibilityTaskID int64) error
+		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime *time.Time, closeTime *time.Time, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error
 
 		GetRemoteAdminClient(cluster string) (adminservice.AdminServiceClient, error)
 		GetHistoryClient() historyservice.HistoryServiceClient

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -987,21 +987,22 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	startTime *time.Time,
 	closeTime *time.Time,
 	closeVisibilityTaskId int64,
+	stage *tasks.DeleteWorkflowExecutionStage,
 ) (retErr error) {
-	// DeleteWorkflowExecution is a 4-steps process (order is very important and should not be changed):
+	// DeleteWorkflowExecution is a 4 stages process (order is very important and should not be changed):
 	// 1. Add visibility delete task, i.e. schedule visibility record delete,
 	// 2. Delete current workflow execution pointer,
 	// 3. Delete workflow mutable state,
 	// 4. Delete history branch.
 
 	// This function is called from task processor and should not be called directly.
-	// It may fail at any step and task processor will retry. All steps are idempotent.
+	// It may fail at any stage and task processor will retry. All stages are idempotent.
 
-	// If process fails after step 1 then workflow execution becomes invisible but mutable state is still there and task can be safely retried.
-	// Step 2 doesn't affect mutable state neither and doesn't block retry.
-	// After step 3 task can't be retried because mutable state is gone and this might leave history branch in DB.
+	// If process fails after stage 1 then workflow execution becomes invisible but mutable state is still there and task can be safely retried.
+	// Stage 2 doesn't affect mutable state neither and doesn't block retry.
+	// After stage 3 task can't be retried because mutable state is gone and this might leave history branch in DB.
 	// The history branch won't be accessible (because mutable state is deleted) and special garbage collection workflow will delete it eventually.
-	// Step 4 shouldn't be done earlier because if this func fails after it, workflow execution will be accessible but won't have history (inconsistent state).
+	// Stage 4 shouldn't be done earlier because if this func fails after it, workflow execution will be accessible but won't have history (inconsistent state).
 
 	ctx, cancel, err := s.newDetachedContext(ctx)
 	if err != nil {
@@ -1034,73 +1035,88 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 		}
 	}()
 
-	// Wrap step 1 and 2 with function to release the lock with defer after step 2.
-	if err = func() error {
-		s.wLock()
-		defer s.wUnlock()
+	// Don't acquire shard lock if all stages that require lock are already processed.
+	if !stage.IsProcessed(
+		tasks.DeleteWorkflowExecutionStageVisibility |
+			tasks.DeleteWorkflowExecutionStageCurrent |
+			tasks.DeleteWorkflowExecutionStageMutableState) {
 
-		if err := s.errorByState(); err != nil {
-			return err
-		}
+		// Wrap stage 1, 2, and 3 with function to release shard lock with defer after stage 3.
+		if err = func() error {
+			s.wLock()
+			defer s.wUnlock()
 
-		// Step 1. Delete visibility.
-		if deleteVisibilityRecord {
-			// TODO: move to existing task generator logic
-			newTasks = map[tasks.Category][]tasks.Task{
-				tasks.CategoryVisibility: {
-					&tasks.DeleteExecutionVisibilityTask{
-						// TaskID is set by addTasksLocked
-						WorkflowKey:                    key,
-						VisibilityTimestamp:            s.timeSource.Now(),
-						StartTime:                      startTime,
-						CloseTime:                      closeTime,
-						CloseExecutionVisibilityTaskID: closeVisibilityTaskId,
-					},
-				},
-			}
-			addTasksRequest := &persistence.AddHistoryTasksRequest{
-				ShardID:     s.shardID,
-				NamespaceID: key.NamespaceID,
-				WorkflowID:  key.WorkflowID,
-				RunID:       key.RunID,
-
-				Tasks: newTasks,
-			}
-			err := s.addTasksLocked(ctx, addTasksRequest, namespaceEntry)
-			if err != nil {
+			if err := s.errorByState(); err != nil {
 				return err
 			}
-		}
 
-		// Step 2. Delete current workflow execution pointer.
-		delCurRequest := &persistence.DeleteCurrentWorkflowExecutionRequest{
-			ShardID:     s.shardID,
-			NamespaceID: key.NamespaceID,
-			WorkflowID:  key.WorkflowID,
-			RunID:       key.RunID,
-		}
-		if err := s.GetExecutionManager().DeleteCurrentWorkflowExecution(
-			ctx,
-			delCurRequest,
-		); err != nil {
+			// Stage 1. Delete visibility.
+			if deleteVisibilityRecord && !stage.IsProcessed(tasks.DeleteWorkflowExecutionStageVisibility) {
+				// TODO: move to existing task generator logic
+				newTasks = map[tasks.Category][]tasks.Task{
+					tasks.CategoryVisibility: {
+						&tasks.DeleteExecutionVisibilityTask{
+							// TaskID is set by addTasksLocked
+							WorkflowKey:                    key,
+							VisibilityTimestamp:            s.timeSource.Now(),
+							StartTime:                      startTime,
+							CloseTime:                      closeTime,
+							CloseExecutionVisibilityTaskID: closeVisibilityTaskId,
+						},
+					},
+				}
+				addTasksRequest := &persistence.AddHistoryTasksRequest{
+					ShardID:     s.shardID,
+					NamespaceID: key.NamespaceID,
+					WorkflowID:  key.WorkflowID,
+					RunID:       key.RunID,
+
+					Tasks: newTasks,
+				}
+				if err := s.addTasksLocked(ctx, addTasksRequest, namespaceEntry); err != nil {
+					return err
+				}
+			}
+			stage.Process(tasks.DeleteWorkflowExecutionStageVisibility)
+
+			// Stage 2. Delete current workflow execution pointer.
+			if !stage.IsProcessed(tasks.DeleteWorkflowExecutionStageCurrent) {
+				delCurRequest := &persistence.DeleteCurrentWorkflowExecutionRequest{
+					ShardID:     s.shardID,
+					NamespaceID: key.NamespaceID,
+					WorkflowID:  key.WorkflowID,
+					RunID:       key.RunID,
+				}
+				if err := s.GetExecutionManager().DeleteCurrentWorkflowExecution(
+					ctx,
+					delCurRequest,
+				); err != nil {
+					return err
+				}
+			}
+			stage.Process(tasks.DeleteWorkflowExecutionStageCurrent)
+
+			// Stage 3. Delete workflow mutable state.
+			if !stage.IsProcessed(tasks.DeleteWorkflowExecutionStageMutableState) {
+				delRequest := &persistence.DeleteWorkflowExecutionRequest{
+					ShardID:     s.shardID,
+					NamespaceID: key.NamespaceID,
+					WorkflowID:  key.WorkflowID,
+					RunID:       key.RunID,
+				}
+				if err = s.GetExecutionManager().DeleteWorkflowExecution(ctx, delRequest); err != nil {
+					return err
+				}
+			}
+			stage.Process(tasks.DeleteWorkflowExecutionStageMutableState)
+			return nil
+		}(); err != nil {
 			return err
 		}
-
-		// Step 3. Delete workflow mutable state.
-		delRequest := &persistence.DeleteWorkflowExecutionRequest{
-			ShardID:     s.shardID,
-			NamespaceID: key.NamespaceID,
-			WorkflowID:  key.WorkflowID,
-			RunID:       key.RunID,
-		}
-		err = s.GetExecutionManager().DeleteWorkflowExecution(ctx, delRequest)
-		return err
-	}(); err != nil {
-		return err
 	}
 
-	// Step 4. Delete history branch.
-	if branchToken != nil {
+	// Stage 4. Delete history branch.
+	if branchToken != nil && !stage.IsProcessed(tasks.DeleteWorkflowExecutionStageHistory) {
 		delHistoryRequest := &persistence.DeleteHistoryBranchRequest{
 			BranchToken: branchToken,
 			ShardID:     s.shardID,
@@ -1110,6 +1126,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 			return err
 		}
 	}
+	stage.Process(tasks.DeleteWorkflowExecutionStageHistory)
 	return nil
 }
 

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1077,7 +1077,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 					return err
 				}
 			}
-			stage.Process(tasks.DeleteWorkflowExecutionStageVisibility)
+			stage.MarkProcessed(tasks.DeleteWorkflowExecutionStageVisibility)
 
 			// Stage 2. Delete current workflow execution pointer.
 			if !stage.IsProcessed(tasks.DeleteWorkflowExecutionStageCurrent) {
@@ -1094,7 +1094,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 					return err
 				}
 			}
-			stage.Process(tasks.DeleteWorkflowExecutionStageCurrent)
+			stage.MarkProcessed(tasks.DeleteWorkflowExecutionStageCurrent)
 
 			// Stage 3. Delete workflow mutable state.
 			if !stage.IsProcessed(tasks.DeleteWorkflowExecutionStageMutableState) {
@@ -1108,7 +1108,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 					return err
 				}
 			}
-			stage.Process(tasks.DeleteWorkflowExecutionStageMutableState)
+			stage.MarkProcessed(tasks.DeleteWorkflowExecutionStageMutableState)
 			return nil
 		}(); err != nil {
 			return err
@@ -1126,7 +1126,7 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 			return err
 		}
 	}
-	stage.Process(tasks.DeleteWorkflowExecutionStageHistory)
+	stage.MarkProcessed(tasks.DeleteWorkflowExecutionStageHistory)
 	return nil
 }
 

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -179,17 +179,17 @@ func (mr *MockContextMockRecorder) DeleteFailoverLevel(category, failoverID inte
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime, closeTime *time.Time, closeExecutionVisibilityTaskID int64) error {
+func (m *MockContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime, closeTime *time.Time, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage)
 }
 
 // GenerateTaskID mocks base method.

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -26,6 +26,7 @@ package shard
 
 import (
 	"context"
+	"errors"
 	"math/rand"
 	"testing"
 	"time"
@@ -38,6 +39,7 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/convert"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives/timestamp"
@@ -99,10 +101,6 @@ func (s *contextSuite) SetupTest() {
 	s.mockShardManager = shardContext.Resource.ShardMgr
 	s.mockHistoryEngine = NewMockEngine(s.controller)
 	shardContext.engineFuture.Set(s.mockHistoryEngine, nil)
-}
-
-func (s *contextSuite) TearDownTest() {
-	s.controller.Finish()
 }
 
 func (s *contextSuite) TestAddTasks_Success() {
@@ -217,4 +215,153 @@ func (s *contextSuite) TestTimerMaxReadLevelUpdate_SingleProcessor() {
 	s.Len(scheduledTaskMaxReadLevelMap, 2)
 	s.True(scheduledTaskMaxReadLevelMap[cluster.TestCurrentClusterName].After(now))
 	s.True(scheduledTaskMaxReadLevelMap[cluster.TestAlternativeClusterName].After(now))
+}
+
+func (s *contextSuite) TestDeleteWorkflowExecution_Success() {
+	workflowKey := definition.WorkflowKey{
+		NamespaceID: tests.NamespaceID.String(),
+		WorkflowID:  tests.WorkflowID,
+		RunID:       tests.RunID,
+	}
+	branchToken := []byte("branchToken")
+	stage := tasks.DeleteWorkflowExecutionStageNone
+
+	s.mockExecutionManager.EXPECT().AddHistoryTasks(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockHistoryEngine.EXPECT().NotifyNewTasks(gomock.Any(), gomock.Any())
+	s.mockExecutionManager.EXPECT().DeleteCurrentWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), gomock.Any()).Return(nil)
+
+	err := s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		branchToken,
+		nil,
+		nil,
+		0,
+		&stage,
+	)
+
+	s.NoError(err)
+	s.Equal(tasks.DeleteWorkflowExecutionStageCurrent|tasks.DeleteWorkflowExecutionStageMutableState|tasks.DeleteWorkflowExecutionStageHistory|tasks.DeleteWorkflowExecutionStageVisibility, stage)
+}
+
+func (s *contextSuite) TestDeleteWorkflowExecution_Continue_Success() {
+	workflowKey := definition.WorkflowKey{
+		NamespaceID: tests.NamespaceID.String(),
+		WorkflowID:  tests.WorkflowID,
+		RunID:       tests.RunID,
+	}
+	branchToken := []byte("branchToken")
+
+	s.mockExecutionManager.EXPECT().DeleteCurrentWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), gomock.Any()).Return(nil)
+	stage := tasks.DeleteWorkflowExecutionStageVisibility
+	err := s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		branchToken,
+		nil,
+		nil,
+		0,
+		&stage,
+	)
+	s.NoError(err)
+	s.Equal(tasks.DeleteWorkflowExecutionStageCurrent|tasks.DeleteWorkflowExecutionStageMutableState|tasks.DeleteWorkflowExecutionStageHistory|tasks.DeleteWorkflowExecutionStageVisibility, stage)
+
+	s.mockExecutionManager.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), gomock.Any()).Return(nil)
+	stage = tasks.DeleteWorkflowExecutionStageVisibility | tasks.DeleteWorkflowExecutionStageCurrent
+	err = s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		branchToken,
+		nil,
+		nil,
+		0,
+		&stage,
+	)
+	s.NoError(err)
+	s.Equal(tasks.DeleteWorkflowExecutionStageCurrent|tasks.DeleteWorkflowExecutionStageMutableState|tasks.DeleteWorkflowExecutionStageHistory|tasks.DeleteWorkflowExecutionStageVisibility, stage)
+
+	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), gomock.Any()).Return(nil)
+	stage = tasks.DeleteWorkflowExecutionStageVisibility | tasks.DeleteWorkflowExecutionStageCurrent | tasks.DeleteWorkflowExecutionStageMutableState
+	err = s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		branchToken,
+		nil,
+		nil,
+		0,
+		&stage,
+	)
+	s.NoError(err)
+	s.Equal(tasks.DeleteWorkflowExecutionStageCurrent|tasks.DeleteWorkflowExecutionStageMutableState|tasks.DeleteWorkflowExecutionStageHistory|tasks.DeleteWorkflowExecutionStageVisibility, stage)
+}
+
+func (s *contextSuite) TestDeleteWorkflowExecution_ErrorAndContinue_Success() {
+	workflowKey := definition.WorkflowKey{
+		NamespaceID: tests.NamespaceID.String(),
+		WorkflowID:  tests.WorkflowID,
+		RunID:       tests.RunID,
+	}
+	branchToken := []byte("branchToken")
+
+	s.mockExecutionManager.EXPECT().AddHistoryTasks(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockHistoryEngine.EXPECT().NotifyNewTasks(gomock.Any(), gomock.Any())
+	s.mockExecutionManager.EXPECT().DeleteCurrentWorkflowExecution(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+	stage := tasks.DeleteWorkflowExecutionStageNone
+	err := s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		branchToken,
+		nil,
+		nil,
+		0,
+		&stage,
+	)
+	s.Error(err)
+	s.Equal(tasks.DeleteWorkflowExecutionStageVisibility, stage)
+
+	s.mockExecutionManager.EXPECT().DeleteCurrentWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+	err = s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		branchToken,
+		nil,
+		nil,
+		0,
+		&stage,
+	)
+	s.Error(err)
+	s.Equal(tasks.DeleteWorkflowExecutionStageVisibility|tasks.DeleteWorkflowExecutionStageCurrent, stage)
+
+	s.mockExecutionManager.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil)
+	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), gomock.Any()).Return(errors.New("some error"))
+	err = s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		branchToken,
+		nil,
+		nil,
+		0,
+		&stage,
+	)
+	s.Error(err)
+	s.Equal(tasks.DeleteWorkflowExecutionStageCurrent|tasks.DeleteWorkflowExecutionStageMutableState|tasks.DeleteWorkflowExecutionStageVisibility, stage)
+
+	s.mockExecutionManager.EXPECT().DeleteHistoryBranch(gomock.Any(), gomock.Any()).Return(nil)
+	err = s.mockShard.DeleteWorkflowExecution(
+		context.Background(),
+		workflowKey,
+		branchToken,
+		nil,
+		nil,
+		0,
+		&stage,
+	)
+	s.NoError(err)
+	s.Equal(tasks.DeleteWorkflowExecutionStageCurrent|tasks.DeleteWorkflowExecutionStageMutableState|tasks.DeleteWorkflowExecutionStageVisibility|tasks.DeleteWorkflowExecutionStageHistory, stage)
 }

--- a/service/history/tasks/close_task.go
+++ b/service/history/tasks/close_task.go
@@ -43,6 +43,7 @@ type (
 		// CanSkipVisibilityArchival means the archival of visibility records will be handled by the archival queue, so
 		// we can skip archiving visibility records here while processing this task on the transfer queue.
 		CanSkipVisibilityArchival bool
+		DeleteProcessStage        DeleteWorkflowExecutionStage
 	}
 )
 

--- a/service/history/tasks/delete_workflow_execution_stage.go
+++ b/service/history/tasks/delete_workflow_execution_stage.go
@@ -38,7 +38,7 @@ const (
 	DeleteWorkflowExecutionStageHistory
 )
 
-func (s *DeleteWorkflowExecutionStage) Process(stage DeleteWorkflowExecutionStage) {
+func (s *DeleteWorkflowExecutionStage) MarkProcessed(stage DeleteWorkflowExecutionStage) {
 	if s == nil {
 		return
 	}

--- a/service/history/tasks/delete_workflow_execution_stage.go
+++ b/service/history/tasks/delete_workflow_execution_stage.go
@@ -24,57 +24,26 @@
 
 package tasks
 
-import (
-	"time"
+// DeleteWorkflowExecutionStage used by ContextImpl.DeleteWorkflowExecution to indicate progress stage.
+type DeleteWorkflowExecutionStage byte
 
-	enumsspb "go.temporal.io/server/api/enums/v1"
-	"go.temporal.io/server/common/definition"
+const (
+	DeleteWorkflowExecutionStageNone DeleteWorkflowExecutionStage = 0
 )
 
-var _ Task = (*DeleteExecutionTask)(nil)
+const (
+	DeleteWorkflowExecutionStageVisibility DeleteWorkflowExecutionStage = 1 << iota
+	DeleteWorkflowExecutionStageCurrent
+	DeleteWorkflowExecutionStageMutableState
+	DeleteWorkflowExecutionStageHistory
+)
 
-type (
-	DeleteExecutionTask struct {
-		definition.WorkflowKey
-		VisibilityTimestamp time.Time
-		TaskID              int64
-		Version             int64
-		ProcessStage        DeleteWorkflowExecutionStage
+func (s *DeleteWorkflowExecutionStage) Process(stage DeleteWorkflowExecutionStage) {
+	if s == nil {
+		return
 	}
-)
-
-func (a *DeleteExecutionTask) GetKey() Key {
-	return NewImmediateKey(a.TaskID)
+	*s |= stage
 }
-
-func (a *DeleteExecutionTask) GetVersion() int64 {
-	return a.Version
-}
-
-func (a *DeleteExecutionTask) SetVersion(version int64) {
-	a.Version = version
-}
-
-func (a *DeleteExecutionTask) GetTaskID() int64 {
-	return a.TaskID
-}
-
-func (a *DeleteExecutionTask) SetTaskID(id int64) {
-	a.TaskID = id
-}
-
-func (a *DeleteExecutionTask) GetVisibilityTime() time.Time {
-	return a.VisibilityTimestamp
-}
-
-func (a *DeleteExecutionTask) SetVisibilityTime(timestamp time.Time) {
-	a.VisibilityTimestamp = timestamp
-}
-
-func (a *DeleteExecutionTask) GetCategory() Category {
-	return CategoryTransfer
-}
-
-func (a *DeleteExecutionTask) GetType() enumsspb.TaskType {
-	return enumsspb.TASK_TYPE_TRANSFER_DELETE_EXECUTION
+func (s *DeleteWorkflowExecutionStage) IsProcessed(stage DeleteWorkflowExecutionStage) bool {
+	return s != nil && *s&stage == stage
 }

--- a/service/history/tasks/workflow_cleanup_timer.go
+++ b/service/history/tasks/workflow_cleanup_timer.go
@@ -41,6 +41,7 @@ type (
 		Version                     int64
 		BranchToken                 []byte
 		WorkflowDataAlreadyArchived bool
+		ProcessStage                DeleteWorkflowExecutionStage
 	}
 )
 

--- a/service/history/timerQueueTaskExecutorBase.go
+++ b/service/history/timerQueueTaskExecutorBase.go
@@ -142,6 +142,7 @@ func (t *timerQueueTaskExecutorBase) executeDeleteHistoryEventTask(
 		weContext,
 		mutableState,
 		archiveIfEnabled,
+		&task.ProcessStage, // Pass stage by reference to update it inside delete manager.
 	)
 }
 

--- a/service/history/timerQueueTaskExecutorBase_test.go
+++ b/service/history/timerQueueTaskExecutorBase_test.go
@@ -142,6 +142,7 @@ func (s *timerQueueTaskExecutorBaseSuite) Test_executeDeleteHistoryEventTask_NoE
 			mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{State: enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED})
 
 			archiveIfEnabled := !alreadyArchived
+			stage := tasks.DeleteWorkflowExecutionStageNone
 			s.mockDeleteManager.EXPECT().DeleteWorkflowExecutionByRetention(
 				gomock.Any(),
 				tests.NamespaceID,
@@ -149,6 +150,7 @@ func (s *timerQueueTaskExecutorBaseSuite) Test_executeDeleteHistoryEventTask_NoE
 				mockWeCtx,
 				mockMutableState,
 				archiveIfEnabled,
+				&stage,
 			).Return(nil)
 
 			err := s.timerQueueTaskExecutorBase.executeDeleteHistoryEventTask(
@@ -192,6 +194,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_DeleteFailed() {
 			mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{State: enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED})
 
 			archiveIfEnabled := !alreadyArchived
+			stage := tasks.DeleteWorkflowExecutionStageNone
 			s.mockDeleteManager.EXPECT().DeleteWorkflowExecutionByRetention(
 				gomock.Any(),
 				tests.NamespaceID,
@@ -199,6 +202,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_DeleteFailed() {
 				mockWeCtx,
 				mockMutableState,
 				archiveIfEnabled,
+				&stage,
 			).Return(serviceerror.NewInternal("test error"))
 
 			err := s.timerQueueTaskExecutorBase.executeDeleteHistoryEventTask(

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -417,9 +417,10 @@ func (t *transferQueueActiveTaskExecutor) processCloseExecution(
 			ctx,
 			task,
 			// Visibility is not updated (to avoid race condition for visibility tasks) and workflow execution is
-			//still open there.
+			// still open there.
 			true,
 			false,
+			&task.DeleteProcessStage,
 		)
 	}
 	return err

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -1382,7 +1382,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestProcessCloseExecution_DeleteA
 	s.mockArchivalClient.EXPECT().Archive(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Times(2)
 	mockDeleteMgr := workflow.NewMockDeleteManager(s.controller)
-	mockDeleteMgr.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockDeleteMgr.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	s.transferQueueActiveTaskExecutor.workflowDeleteManager = mockDeleteMgr
 	_, _, err = s.transferQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(transferTask))
 	s.NoError(err)
@@ -2608,7 +2608,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 			mockWorkflowDeleteManager := workflow.NewMockDeleteManager(ctrl)
 			if c.ShouldDelete {
 				mockWorkflowDeleteManager.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any(), gomock.Any(),
-					gomock.Any(), gomock.Any(), gomock.Any())
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any())
 			}
 
 			executor := &transferQueueActiveTaskExecutor{

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -229,11 +229,16 @@ func (t *transferQueueTaskExecutorBase) processDeleteExecutionTask(
 	task *tasks.DeleteExecutionTask,
 	ensureNoPendingCloseTask bool,
 ) error {
-	return t.deleteExecution(ctx, task, false, ensureNoPendingCloseTask)
+	return t.deleteExecution(ctx, task, false, ensureNoPendingCloseTask, &task.ProcessStage)
 }
 
-func (t *transferQueueTaskExecutorBase) deleteExecution(ctx context.Context, task tasks.Task,
-	forceDeleteFromOpenVisibility bool, ensureNoPendingCloseTask bool) (retError error) {
+func (t *transferQueueTaskExecutorBase) deleteExecution(
+	ctx context.Context,
+	task tasks.Task,
+	forceDeleteFromOpenVisibility bool,
+	ensureNoPendingCloseTask bool,
+	stage *tasks.DeleteWorkflowExecutionStage,
+) (retError error) {
 	ctx, cancel := context.WithTimeout(ctx, taskTimeout)
 	defer cancel()
 
@@ -295,6 +300,7 @@ func (t *transferQueueTaskExecutorBase) deleteExecution(ctx context.Context, tas
 		weCtx,
 		mutableState,
 		forceDeleteFromOpenVisibility,
+		stage,
 	)
 }
 

--- a/service/history/workflow/delete_manager.go
+++ b/service/history/workflow/delete_manager.go
@@ -63,6 +63,7 @@ type (
 			weCtx Context,
 			ms MutableState,
 			forceDeleteFromOpenVisibility bool,
+			stage *tasks.DeleteWorkflowExecutionStage,
 		) error
 		DeleteWorkflowExecutionByRetention(
 			ctx context.Context,
@@ -71,6 +72,7 @@ type (
 			weCtx Context,
 			ms MutableState,
 			archiveIfEnabled bool,
+			stage *tasks.DeleteWorkflowExecutionStage,
 		) error
 	}
 
@@ -142,6 +144,7 @@ func (m *DeleteManagerImpl) DeleteWorkflowExecution(
 	weCtx Context,
 	ms MutableState,
 	forceDeleteFromOpenVisibility bool,
+	stage *tasks.DeleteWorkflowExecutionStage,
 ) error {
 
 	return m.deleteWorkflowExecutionInternal(
@@ -152,6 +155,7 @@ func (m *DeleteManagerImpl) DeleteWorkflowExecution(
 		ms,
 		false,
 		forceDeleteFromOpenVisibility,
+		stage,
 		m.metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryDeleteWorkflowExecutionScope)),
 	)
 }
@@ -163,6 +167,7 @@ func (m *DeleteManagerImpl) DeleteWorkflowExecutionByRetention(
 	weCtx Context,
 	ms MutableState,
 	archiveIfEnabled bool,
+	stage *tasks.DeleteWorkflowExecutionStage,
 ) error {
 
 	return m.deleteWorkflowExecutionInternal(
@@ -173,6 +178,7 @@ func (m *DeleteManagerImpl) DeleteWorkflowExecutionByRetention(
 		ms,
 		archiveIfEnabled,
 		false, // When retention is fired, workflow execution is always closed.
+		stage,
 		m.metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryProcessDeleteHistoryEventScope)),
 	)
 }
@@ -185,6 +191,7 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 	ms MutableState,
 	archiveIfEnabled bool,
 	forceDeleteFromOpenVisibility bool,
+	stage *tasks.DeleteWorkflowExecutionStage,
 	metricsHandler metrics.MetricsHandler,
 ) error {
 
@@ -240,6 +247,7 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 		startTime,
 		closeTime,
 		ms.GetExecutionInfo().GetCloseVisibilityTaskId(),
+		stage,
 	); err != nil {
 		return err
 	}

--- a/service/history/workflow/delete_manager_mock.go
+++ b/service/history/workflow/delete_manager_mock.go
@@ -35,6 +35,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	v1 "go.temporal.io/api/common/v1"
 	namespace "go.temporal.io/server/common/namespace"
+	tasks "go.temporal.io/server/service/history/tasks"
 )
 
 // MockDeleteManager is a mock of DeleteManager interface.
@@ -75,29 +76,29 @@ func (mr *MockDeleteManagerMockRecorder) AddDeleteWorkflowExecutionTask(ctx, nsI
 }
 
 // DeleteWorkflowExecution mocks base method.
-func (m *MockDeleteManager) DeleteWorkflowExecution(ctx context.Context, nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, forceDeleteFromOpenVisibility bool) error {
+func (m *MockDeleteManager) DeleteWorkflowExecution(ctx context.Context, nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, forceDeleteFromOpenVisibility bool, stage *tasks.DeleteWorkflowExecutionStage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility, stage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
-func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecution(ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility interface{}) *gomock.Call {
+func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecution(ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility, stage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecution), ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecution), ctx, nsID, we, weCtx, ms, forceDeleteFromOpenVisibility, stage)
 }
 
 // DeleteWorkflowExecutionByRetention mocks base method.
-func (m *MockDeleteManager) DeleteWorkflowExecutionByRetention(ctx context.Context, nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, archiveIfEnabled bool) error {
+func (m *MockDeleteManager) DeleteWorkflowExecutionByRetention(ctx context.Context, nsID namespace.ID, we v1.WorkflowExecution, weCtx Context, ms MutableState, archiveIfEnabled bool, stage *tasks.DeleteWorkflowExecutionStage) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteWorkflowExecutionByRetention", ctx, nsID, we, weCtx, ms, archiveIfEnabled)
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecutionByRetention", ctx, nsID, we, weCtx, ms, archiveIfEnabled, stage)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeleteWorkflowExecutionByRetention indicates an expected call of DeleteWorkflowExecutionByRetention.
-func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecutionByRetention(ctx, nsID, we, weCtx, ms, archiveIfEnabled interface{}) *gomock.Call {
+func (mr *MockDeleteManagerMockRecorder) DeleteWorkflowExecutionByRetention(ctx, nsID, we, weCtx, ms, archiveIfEnabled, stage interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecutionByRetention", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecutionByRetention), ctx, nsID, we, weCtx, ms, archiveIfEnabled)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecutionByRetention", reflect.TypeOf((*MockDeleteManager)(nil).DeleteWorkflowExecutionByRetention), ctx, nsID, we, weCtx, ms, archiveIfEnabled, stage)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remember retention timer task state in memory for retry.

<!-- Tell your future self why have you made these changes -->
**Why?**
Delete workflow execution is 4 stages process, and if it is throttled by persistence rate limit, it would fail and the entire task will be retried.
In the retry, same steps will be redone even if some of them already succeed.

In this PR delte process stage is stored inside task while it stays in-memory and gets retried. This allow to avoid load amplification during failure case.
Save the stage in-memory only because persisting it will be too costly for the benefit.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit tests, existing integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.