### PR TITLE
Keep multi cursor default reader always running

### DIFF
--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -356,7 +356,9 @@ func (p *queueBase) checkpoint() {
 		scopes := reader.Scopes()
 
 		if len(scopes) == 0 {
-			p.readerGroup.RemoveReader(readerID)
+			if readerID != DefaultReaderId {
+				p.readerGroup.RemoveReader(readerID)
+			}
 			continue
 		}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Keep multi cursor default reader always running

<!-- Tell your future self why have you made these changes -->
**Why?**
- otherwise when traffic is low, default reader will keep start/stop and generate lots of log message for starting/stopping which pollutes the log. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
