### PR TITLE
Fix typo in dynamic config for VisibilityProcessorEnsureCloseBeforeDelete

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -516,7 +516,7 @@ const (
 	// VisibilityProcessorVisibilityArchivalTimeLimit is the upper time limit for archiving visibility records
 	VisibilityProcessorVisibilityArchivalTimeLimit = "history.visibilityProcessorVisibilityArchivalTimeLimit"
 	// VisibilityProcessorEnsureCloseBeforeDelete means we ensure the visibility of an execution is closed before we delete its visibility records
-	VisibilityProcessorEnsureCloseBeforeDelete = "history.transferProcessorEnsureCloseBeforeDelete"
+	VisibilityProcessorEnsureCloseBeforeDelete = "history.visibilityProcessorEnsureCloseBeforeDelete"
 	// VisibilityProcessorEnableCloseWorkflowCleanup to clean up the mutable state after visibility
 	// close task has been processed. Must use Elasticsearch as visibility store, otherwise workflow
 	// data (eg: search attributes) will be lost after workflow is closed.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I changed the value of `VisibilityProcessorEnsureCloseBeforeDelete` from `history.transferProcessorEnsureCloseBeforeDelete` to `history.visibilityProcessorEnsureCloseBeforeDelete`.

<!-- Tell your future self why have you made these changes -->
**Why?**
I made this change because the original key used was a typo.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Code search.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Anyone that disabled `history.transferProcessorEnsureCloseBeforeDelete` in order to disable the `VisibilityProcessorEnsureCloseBeforeDelete` behavior, will now see it reset to true.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
