### PR TITLE
Improve test log format

### DIFF
--- a/common/log/config.go
+++ b/common/log/config.go
@@ -33,5 +33,9 @@ type (
 		Level string `yaml:"level"`
 		// OutputFile is the path to the log output file
 		OutputFile string `yaml:"outputFile"`
+		// Format determines the format of each log file printed to the output.
+		// Acceptable values are "json" or "console". The default is "json".
+		// Use "console" if you want stack traces to appear on multiple lines.
+		Format string `yaml:"format"`
 	}
 )

--- a/common/log/zap_logger.go
+++ b/common/log/zap_logger.go
@@ -58,6 +58,7 @@ func NewTestLogger() *zapLogger {
 	return NewZapLogger(BuildZapLogger(Config{
 		// Uncomment next line if you need debug level logging in tests.
 		// Level: "debug",
+		Format: "console",
 	}))
 }
 
@@ -197,11 +198,16 @@ func buildZapLogger(cfg Config, disableCaller bool) *zap.Logger {
 		outputPath = "stdout"
 	}
 
+	encoding := "json"
+	if cfg.Format == "console" {
+		encoding = "console"
+	}
+
 	config := zap.Config{
 		Level:            zap.NewAtomicLevelAt(parseZapLevel(cfg.Level)),
 		Development:      false,
 		Sampling:         nil,
-		Encoding:         "json",
+		Encoding:         encoding,
 		EncoderConfig:    encodeConfig,
 		OutputPaths:      []string{outputPath},
 		ErrorOutputPaths: []string{outputPath},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I changed the Zap encoding of our logs to "console" instead of "json" during tests.

<!-- Tell your future self why have you made these changes -->
**Why?**
I made this change because it will give us more human-readable output when running tests, without affecting production. For example, stack traces will appear across multiple lines instead of a newline-escaped string on one line of JSON.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Logs with this change:
```
=== RUN   TestTransferQueueStandbyTaskExecutorSuite/TestProcessActivityTask_Pending
2022-11-21T10:44:48.580-0800	error	example error	{"logging-call-at": "transferQueueStandbyTaskExecutor.go:78"}
go.temporal.io/server/common/log.(*zapLogger).Error
	/Users/michael.snowden/src/temporalio/temporal/common/log/zap_logger.go:144
go.temporal.io/server/service/history.newTransferQueueStandbyTaskExecutor
	/Users/michael.snowden/src/temporalio/temporal/service/history/transferQueueStandbyTaskExecutor.go:78
go.temporal.io/server/service/history.(*transferQueueStandbyTaskExecutorSuite).SetupTest
	/Users/michael.snowden/src/temporalio/temporal/service/history/transferQueueStandbyTaskExecutor_test.go:208
github.com/stretchr/testify/suite.Run.func1
	/Users/michael.snowden/go/1.19.2/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:165
testing.tRunner
	/Users/michael.snowden/.goenv/versions/1.19.2/src/testing/testing.go:1446
2022-11-21T10:44:48.582-0800	info	none	{"lifecycle": "Stopping", "component": "shard-engine", "logging-call-at": "context_impl.go:1525"}
2022-11-21T10:44:48.582-0800	info	none	{"lifecycle": "Stopped", "component": "shard-engine", "logging-call-at": "context_impl.go:1527"}
--- PASS: TestTransferQueueStandbyTaskExecutorSuite (0.00s)
    --- PASS: TestTransferQueueStandbyTaskExecutorSuite/TestProcessActivityTask_Pending (0.00s)
PASS
```

Logs without this change:
```
=== RUN   TestTransferQueueStandbyTaskExecutorSuite/TestProcessActivityTask_Pending
{"level":"error","ts":"2022-11-21T10:45:16.669-0800","msg":"example error","logging-call-at":"transferQueueStandbyTaskExecutor.go:78","stacktrace":"go.temporal.io/server/common/log.(*zapLogger).Error\n\t/Users/michael.snowden/src/temporalio/temporal/common/log/zap_logger.go:144\ngo.temporal.io/server/service/history.newTransferQueueStandbyTaskExecutor\n\t/Users/michael.snowden/src/temporalio/temporal/service/history/transferQueueStandbyTaskExecutor.go:78\ngo.temporal.io/server/service/history.(*transferQueueStandbyTaskExecutorSuite).SetupTest\n\t/Users/michael.snowden/src/temporalio/temporal/service/history/transferQueueStandbyTaskExecutor_test.go:208\ngithub.com/stretchr/testify/suite.Run.func1\n\t/Users/michael.snowden/go/1.19.2/pkg/mod/github.com/stretchr/testify@v1.8.1/suite/suite.go:165\ntesting.tRunner\n\t/Users/michael.snowden/.goenv/versions/1.19.2/src/testing/testing.go:1446"}
{"level":"info","ts":"2022-11-21T10:45:16.670-0800","msg":"none","lifecycle":"Stopping","component":"shard-engine","logging-call-at":"context_impl.go:1525"}
{"level":"info","ts":"2022-11-21T10:45:16.671-0800","msg":"none","lifecycle":"Stopped","component":"shard-engine","logging-call-at":"context_impl.go:1527"}
--- PASS: TestTransferQueueStandbyTaskExecutorSuite (0.00s)
    --- PASS: TestTransferQueueStandbyTaskExecutorSuite/TestProcessActivityTask_Pending (0.00s)
PASS
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Anything that depends on this test output being JSON will be broken by this change. 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.