### PR TITLE
Randomization and configuration for scheduler throttle duration

### DIFF
--- a/common/backoff/jitter.go
+++ b/common/backoff/jitter.go
@@ -40,6 +40,10 @@ func JitDuration(duration time.Duration, coefficient float64) time.Duration {
 func JitInt64(input int64, coefficient float64) int64 {
 	validateCoefficient(coefficient)
 
+	if input == 0 {
+		return 0
+	}
+
 	base := int64(float64(input) * (1 - coefficient))
 	addon := rand.Int63n(2 * (input - base))
 	return base + addon

--- a/common/backoff/jitter_test.go
+++ b/common/backoff/jitter_test.go
@@ -25,6 +25,7 @@
 package backoff
 
 import (
+	"math/rand"
 	"testing"
 	"time"
 
@@ -82,4 +83,10 @@ func (s *jitterSuite) TestJitDuration() {
 		s.True(result >= lowerBound)
 		s.True(result < upperBound)
 	}
+}
+
+func (s *jitterSuite) TestJit_InputZeroValue() {
+	s.Zero(JitDuration(0, rand.Float64()))
+	s.Zero(JitInt64(0, rand.Float64()))
+	s.Zero(JitFloat64(0, rand.Float64()))
 }

--- a/service/history/queueFactoryBase.go
+++ b/service/history/queueFactoryBase.go
@@ -26,6 +26,7 @@ package history
 
 import (
 	"context"
+	"time"
 
 	"go.uber.org/fx"
 
@@ -45,6 +46,9 @@ import (
 
 const (
 	QueueFactoryFxGroup = "queueFactory"
+
+	HostSchedulerMaxDispatchThrottleDuration  = 3 * time.Second
+	ShardSchedulerMaxDispatchThrottleDuration = 5 * time.Second
 )
 
 type (

--- a/service/history/timerQueueFactory.go
+++ b/service/history/timerQueueFactory.go
@@ -72,10 +72,11 @@ func NewTimerQueueFactory(
 		hostScheduler = queues.NewNamespacePriorityScheduler(
 			params.ClusterMetadata.GetCurrentClusterName(),
 			queues.NamespacePrioritySchedulerOptions{
-				WorkerCount:             params.Config.TimerProcessorSchedulerWorkerCount,
-				ActiveNamespaceWeights:  params.Config.TimerProcessorSchedulerActiveRoundRobinWeights,
-				StandbyNamespaceWeights: params.Config.TimerProcessorSchedulerStandbyRoundRobinWeights,
-				EnableRateLimiter:       params.Config.TaskSchedulerEnableRateLimiter,
+				WorkerCount:                 params.Config.TimerProcessorSchedulerWorkerCount,
+				ActiveNamespaceWeights:      params.Config.TimerProcessorSchedulerActiveRoundRobinWeights,
+				StandbyNamespaceWeights:     params.Config.TimerProcessorSchedulerStandbyRoundRobinWeights,
+				EnableRateLimiter:           params.Config.TaskSchedulerEnableRateLimiter,
+				MaxDispatchThrottleDuration: HostSchedulerMaxDispatchThrottleDuration,
 			},
 			params.NamespaceRegistry,
 			params.SchedulerRateLimiter,

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -384,8 +384,9 @@ func newTimerTaskShardScheduler(
 	config := shard.GetConfig()
 	return queues.NewPriorityScheduler(
 		queues.PrioritySchedulerOptions{
-			WorkerCount:       config.TimerTaskWorkerCount,
-			EnableRateLimiter: config.TaskSchedulerEnableRateLimiter,
+			WorkerCount:                 config.TimerTaskWorkerCount,
+			EnableRateLimiter:           config.TaskSchedulerEnableRateLimiter,
+			MaxDispatchThrottleDuration: ShardSchedulerMaxDispatchThrottleDuration,
 		},
 		rateLimiter,
 		shard.GetTimeSource(),

--- a/service/history/transferQueueFactory.go
+++ b/service/history/transferQueueFactory.go
@@ -75,10 +75,11 @@ func NewTransferQueueFactory(
 		hostScheduler = queues.NewNamespacePriorityScheduler(
 			params.ClusterMetadata.GetCurrentClusterName(),
 			queues.NamespacePrioritySchedulerOptions{
-				WorkerCount:             params.Config.TransferProcessorSchedulerWorkerCount,
-				ActiveNamespaceWeights:  params.Config.TransferProcessorSchedulerActiveRoundRobinWeights,
-				StandbyNamespaceWeights: params.Config.TransferProcessorSchedulerStandbyRoundRobinWeights,
-				EnableRateLimiter:       params.Config.TaskSchedulerEnableRateLimiter,
+				WorkerCount:                 params.Config.TransferProcessorSchedulerWorkerCount,
+				ActiveNamespaceWeights:      params.Config.TransferProcessorSchedulerActiveRoundRobinWeights,
+				StandbyNamespaceWeights:     params.Config.TransferProcessorSchedulerStandbyRoundRobinWeights,
+				EnableRateLimiter:           params.Config.TaskSchedulerEnableRateLimiter,
+				MaxDispatchThrottleDuration: HostSchedulerMaxDispatchThrottleDuration,
 			},
 			params.NamespaceRegistry,
 			params.SchedulerRateLimiter,

--- a/service/history/transferQueueProcessorBase.go
+++ b/service/history/transferQueueProcessorBase.go
@@ -113,8 +113,9 @@ func newTransferTaskShardScheduler(
 	config := shard.GetConfig()
 	return queues.NewPriorityScheduler(
 		queues.PrioritySchedulerOptions{
-			WorkerCount:       config.TransferTaskWorkerCount,
-			EnableRateLimiter: config.TaskSchedulerEnableRateLimiter,
+			WorkerCount:                 config.TransferTaskWorkerCount,
+			EnableRateLimiter:           config.TaskSchedulerEnableRateLimiter,
+			MaxDispatchThrottleDuration: ShardSchedulerMaxDispatchThrottleDuration,
 		},
 		rateLimiter,
 		shard.GetTimeSource(),

--- a/service/history/visibilityQueueFactory.go
+++ b/service/history/visibilityQueueFactory.go
@@ -64,10 +64,11 @@ func NewVisibilityQueueFactory(
 		hostScheduler = queues.NewNamespacePriorityScheduler(
 			params.ClusterMetadata.GetCurrentClusterName(),
 			queues.NamespacePrioritySchedulerOptions{
-				WorkerCount:             params.Config.VisibilityProcessorSchedulerWorkerCount,
-				ActiveNamespaceWeights:  params.Config.VisibilityProcessorSchedulerActiveRoundRobinWeights,
-				StandbyNamespaceWeights: params.Config.VisibilityProcessorSchedulerStandbyRoundRobinWeights,
-				EnableRateLimiter:       params.Config.TaskSchedulerEnableRateLimiter,
+				WorkerCount:                 params.Config.VisibilityProcessorSchedulerWorkerCount,
+				ActiveNamespaceWeights:      params.Config.VisibilityProcessorSchedulerActiveRoundRobinWeights,
+				StandbyNamespaceWeights:     params.Config.VisibilityProcessorSchedulerStandbyRoundRobinWeights,
+				EnableRateLimiter:           params.Config.TaskSchedulerEnableRateLimiter,
+				MaxDispatchThrottleDuration: HostSchedulerMaxDispatchThrottleDuration,
 			},
 			params.NamespaceRegistry,
 			params.SchedulerRateLimiter,

--- a/service/history/visibilityQueueProcessor.go
+++ b/service/history/visibilityQueueProcessor.go
@@ -364,8 +364,9 @@ func newVisibilityTaskShardScheduler(
 	config := shard.GetConfig()
 	return queues.NewPriorityScheduler(
 		queues.PrioritySchedulerOptions{
-			WorkerCount:       config.VisibilityTaskWorkerCount,
-			EnableRateLimiter: config.TaskSchedulerEnableRateLimiter,
+			WorkerCount:                 config.VisibilityTaskWorkerCount,
+			EnableRateLimiter:           config.TaskSchedulerEnableRateLimiter,
+			MaxDispatchThrottleDuration: ShardSchedulerMaxDispatchThrottleDuration,
 		},
 		rateLimiter,
 		shard.GetTimeSource(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add randomization logic for throttle duration
- Allow using different max throttle duration for different scheduler (host v.s. shard)

<!-- Tell your future self why have you made these changes -->
**Why?**
- Because multiple schedulers share the same rate limiter, if they always tries to consume the token in the same order, it's possible that later scheduler never get any tokens and lead to starvation. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
