### PR TITLE
Handle unknown cluster in replication

### DIFF
--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -48,7 +48,8 @@ const (
 	defaultClusterMetadataPageSize = 100
 	refreshInterval                = time.Minute
 
-	FakeClusterForEmptyVersion = "fake-cluster-for-empty-version"
+	FakeClusterForEmptyVersion       = "fake-cluster-for-empty-version"
+	FakeClusterNameForUnknownVersion = "fake_cluster-name"
 )
 
 var ErrUnknownCluster = fmt.Errorf("unknown cluster")
@@ -378,7 +379,7 @@ func (m *metadataImpl) ClusterNameForFailoverVersion(isGlobalNamespace bool, fai
 			m.clusterInfo,
 			m.failoverVersionIncrement,
 		))
-		return "", ErrUnknownCluster
+		return FakeClusterNameForUnknownVersion, ErrUnknownCluster
 	}
 	return clusterName, nil
 }

--- a/common/cluster/metadata_test.go
+++ b/common/cluster/metadata_test.go
@@ -137,7 +137,7 @@ func (s *metadataSuite) Test_ClusterNameForFailoverVersion() {
 
 	clusterName3, err := s.metadata.ClusterNameForFailoverVersion(true, 217)
 	s.ErrorIs(err, ErrUnknownCluster)
-	s.Equal("", clusterName3)
+	s.Equal(FakeClusterNameForUnknownVersion, clusterName3)
 }
 
 func (s *metadataSuite) Test_RegisterMetadataChangeCallback() {

--- a/service/history/ndc/replication_task.go
+++ b/service/history/ndc/replication_task.go
@@ -128,7 +128,7 @@ func newReplicationTask(
 	version := firstEvent.GetVersion()
 
 	sourceCluster, err := clusterMetadata.ClusterNameForFailoverVersion(true, version)
-	if err != nil {
+	if err != nil && err != cluster.ErrUnknownCluster {
 		return nil, err
 	}
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4323,7 +4323,7 @@ func (e *MutableStateImpl) startTransactionHandleWorkflowTaskFailover() (bool, e
 	}
 
 	lastWriteSourceCluster, err := e.clusterMetadata.ClusterNameForFailoverVersion(e.namespaceEntry.IsGlobalNamespace(), lastWriteVersion)
-	if err != nil {
+	if err != nil && err != cluster.ErrUnknownCluster {
 		return false, err
 	}
 	currentVersionCluster, err := e.clusterMetadata.ClusterNameForFailoverVersion(e.namespaceEntry.IsGlobalNamespace(), currentVersion)
@@ -4398,7 +4398,7 @@ func (e *MutableStateImpl) closeTransactionWithPolicyCheck(
 	// passive cluster. For example: if passive cluster sees conflict and decided to terminate this workflow. The
 	// currentVersion on mutable state would be updated to point to last write version which is current (passive) cluster.
 	activeCluster, err := e.clusterMetadata.ClusterNameForFailoverVersion(e.namespaceEntry.IsGlobalNamespace(), e.GetCurrentVersion())
-	if err != nil {
+	if err != nil && err != cluster.ErrUnknownCluster {
 		return err
 	}
 	currentCluster := e.clusterMetadata.GetCurrentClusterName()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Handle unknown cluster in replication

<!-- Tell your future self why have you made these changes -->
**Why?**
We should handle this unknown cluster in replication so we can replication open workflow.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local tests:
1. Describe/Admin Describe workflow after fully migration.
2. Reset workflow after fully migration.
3. Terminate workflow after fully migration.
4. Signal workflow after fully migration.
5. Get workflow history after fully migration.
6. Cancel workflow after fully migration.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In the worst case, the workflow after migration could be in a broken state.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No