### PR TITLE
Return an error when we fail to instantiate the server

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,7 +181,7 @@ func buildCLI() *cli.App {
 				if err != nil {
 					return cli.Exit(fmt.Sprintf("Unable to instantiate claim mapper: %v.", err), 1)
 				}
-				s := temporal.NewServer(
+				s, err := temporal.NewServer(
 					temporal.ForServices(services),
 					temporal.WithConfig(cfg),
 					temporal.WithDynamicConfigClient(dynamicConfigClient),
@@ -192,6 +192,9 @@ func buildCLI() *cli.App {
 						return claimMapper
 					}),
 				)
+				if err != nil {
+					return cli.Exit(fmt.Sprintf("Unable to create server. Error: %v.", err), 1)
+				}
 
 				err = s.Start()
 				if err != nil {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -131,7 +131,7 @@ type (
 	}
 )
 
-func NewServerFx(opts ...ServerOption) *ServerFx {
+func NewServerFx(opts ...ServerOption) (*ServerFx, error) {
 	app := fx.New(
 		pprof.Module,
 		ServerFxImplModule,
@@ -152,7 +152,7 @@ func NewServerFx(opts ...ServerOption) *ServerFx {
 	s := &ServerFx{
 		app,
 	}
-	return s
+	return s, app.Err()
 }
 
 func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now return an error when FX fails to build the server.

<!-- Tell your future self why have you made these changes -->
**Why?**
I made this change so that we can verify that a new server can be instantiated for all services without failing, but that failures will be detected.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I tested this by adding unit tests for the happy path and an error path (invalid config path). I also ran it locally with race detection on.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is a new error message, and some invalid configs may trigger this error path when they didn't before.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.