### PR TITLE
Fix bug in GetRepoRootDirectory code

### DIFF
--- a/common/persistence/cassandra/test.go
+++ b/common/persistence/cassandra/test.go
@@ -109,10 +109,7 @@ func (s *TestCluster) SetupTestDatabase() {
 	schemaDir := s.schemaDir + "/"
 
 	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
-		temporalPackageDir, err := testhelper.GetRepoRootDirectory()
-		if err != nil {
-			s.logger.Fatal("Unable to get package dir.", tag.Error(err))
-		}
+		temporalPackageDir := testhelper.GetRepoRootDirectory()
 		schemaDir = path.Join(temporalPackageDir, schemaDir)
 	}
 

--- a/common/persistence/sql/sqlPersistenceTest.go
+++ b/common/persistence/sql/sqlPersistenceTest.go
@@ -99,10 +99,7 @@ func (s *TestCluster) SetupTestDatabase() {
 
 	schemaDir := s.schemaDir + "/"
 	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
-		temporalPackageDir, err := testhelper.GetRepoRootDirectory()
-		if err != nil {
-			s.logger.Fatal("Unable to get package dir.", tag.Error(err))
-		}
+		temporalPackageDir := testhelper.GetRepoRootDirectory()
 		schemaDir = path.Join(temporalPackageDir, schemaDir)
 	}
 	s.LoadSchema(path.Join(schemaDir, "temporal", "schema.sql"))

--- a/tests/testhelper/source_root_test.go
+++ b/tests/testhelper/source_root_test.go
@@ -25,54 +25,29 @@
 package testhelper
 
 import (
-	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestGetRepoRootDirectory(t *testing.T) {
 	t.Run("env var set", func(t *testing.T) {
-		directory, err := GetRepoRootDirectory(WithGetenv(func(s string) string {
+		directory := GetRepoRootDirectory(WithGetenv(func(s string) string {
 			assert.Equal(t, "TEMPORAL_ROOT", s)
 			return "/tmp/temporal"
 		}))
-		require.NoError(t, err)
 		assert.Equal(t, "/tmp/temporal", directory)
 	})
 
 	t.Run("env var not set", func(t *testing.T) {
-		t.Run("getwd returns error", func(t *testing.T) {
-			_, err := GetRepoRootDirectory(WithGetenv(func(s string) string {
-				return ""
-			}), WithGetwd(func() (string, error) {
-				return "", errors.New("some error")
-			}))
-			require.Error(t, err)
-			assert.ErrorContains(t, err, "some error")
-		})
-
-		t.Run("getwd returns path not ending in temporal", func(t *testing.T) {
-			_, err := GetRepoRootDirectory(WithGetenv(func(s string) string {
-				return ""
-			}), WithGetwd(func() (string, error) {
-				return "/temp/tempura/", nil
-			}))
-			require.Error(t, err)
-			assert.ErrorContains(t, err, "unable to find repo path")
-			assert.ErrorContains(t, err, "temporal")
-			assert.ErrorContains(t, err, "tempura")
-		})
-
-		t.Run("getwd returns path ending with temporal", func(t *testing.T) {
-			directory, err := GetRepoRootDirectory(WithGetenv(func(s string) string {
-				return ""
-			}), WithGetwd(func() (string, error) {
-				return "/tmp/temporal/", nil
-			}))
-			require.NoError(t, err)
-			assert.Equal(t, "/tmp/temporal/", directory)
-		})
+		directory := GetRepoRootDirectory(WithGetenv(func(s string) string {
+			return ""
+		}))
+		assert.True(
+			t,
+			strings.HasSuffix(directory, "temporal") || strings.HasSuffix(directory, "temporal/"),
+			directory,
+		)
 	})
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Our GetRepoRootDirectory function now uses runtime.Caller instead of parsing the working directory.

<!-- Tell your future self why have you made these changes -->
**Why?**
The working directory may be totally different from the source directory, it also sometimes returns an error, and, most importantly, it doesn't work if there is "temporal" somewhere in the directory structure e.g. in `src/temporalio/temporal/temporal/some_test.go`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I used the existing unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is only used in tests, so CI should fail.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.