### PR TITLE
Set default catchup window eagerly

### DIFF
--- a/host/schedule_test.go
+++ b/host/schedule_test.go
@@ -234,6 +234,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 
 	s.Equal(schedule.Spec, describeResp.Schedule.Spec)
 	s.Equal(enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, describeResp.Schedule.Policies.OverlapPolicy) // set to default value
+	s.EqualValues(60, describeResp.Schedule.Policies.CatchupWindow.Seconds())                   // set to default value
 
 	s.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csa].Data)
 	s.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -526,12 +526,13 @@ func (s *scheduler) getFutureActionTimes(n int) []*time.Time {
 }
 
 func (s *scheduler) handleDescribeQuery() (*schedspb.DescribeResponse, error) {
-	// this field is never read by the workflow so it's okay to modify it from a query
-	s.Info.FutureActionTimes = s.getFutureActionTimes(s.tweakables.FutureActionCount)
+	// this is a query handler, don't modify s.Info directly
+	infoCopy := *s.Info
+	infoCopy.FutureActionTimes = s.getFutureActionTimes(s.tweakables.FutureActionCount)
 
 	return &schedspb.DescribeResponse{
 		Schedule:      s.Schedule,
-		Info:          s.Info,
+		Info:          &infoCopy,
 		ConflictToken: s.State.ConflictToken,
 	}, nil
 }

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -155,8 +155,8 @@ func SchedulerWorkflow(ctx workflow.Context, args *schedspb.StartScheduleArgs) e
 func (s *scheduler) run() error {
 	s.logger.Info("Schedule starting", "schedule", s.Schedule)
 
-	s.ensureFields()
 	s.updateTweakables()
+	s.ensureFields()
 	s.compileSpec()
 
 	if err := workflow.SetQueryHandler(s.ctx, QueryNameDescribe, s.handleDescribeQuery); err != nil {
@@ -230,8 +230,11 @@ func (s *scheduler) ensureFields() {
 	if s.Schedule.Policies == nil {
 		s.Schedule.Policies = &schedpb.SchedulePolicies{}
 	}
-	// set default so it shows up in describe output
+
+	// set defaults eagerly so they show up in describe output
 	s.Schedule.Policies.OverlapPolicy = s.resolveOverlapPolicy(s.Schedule.Policies.OverlapPolicy)
+	s.Schedule.Policies.CatchupWindow = timestamp.DurationPtr(s.getCatchupWindow())
+
 	if s.Schedule.State == nil {
 		s.Schedule.State = &schedpb.ScheduleState{}
 	}
@@ -523,6 +526,7 @@ func (s *scheduler) getFutureActionTimes(n int) []*time.Time {
 }
 
 func (s *scheduler) handleDescribeQuery() (*schedspb.DescribeResponse, error) {
+	// this field is never read by the workflow so it's okay to modify it from a query
 	s.Info.FutureActionTimes = s.getFutureActionTimes(s.tweakables.FutureActionCount)
 
 	return &schedspb.DescribeResponse{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set catchup window default on create/update

<!-- Tell your future self why have you made these changes -->
**Why?**
This way, the default will be reported in describe output, so it's less confusing for users

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
