### PR TITLE
Do not panic if passive processor is missing

### DIFF
--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -197,7 +197,8 @@ func (t *timerQueueProcessorImpl) NotifyNewTasks(
 	standbyTimerProcessor, ok := t.standbyTimerProcessors[clusterName]
 	t.standbyTimerProcessorsLock.RUnlock()
 	if !ok {
-		panic(fmt.Sprintf("Cannot find timer processor for %s.", clusterName))
+		t.logger.Warn(fmt.Sprintf("Cannot find timer processor for %s.", clusterName))
+		return
 	}
 	standbyTimerProcessor.setCurrentTime(t.shard.GetCurrentTime(clusterName))
 	standbyTimerProcessor.notifyNewTimers(timerTasks)

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -198,7 +198,8 @@ func (t *transferQueueProcessorImpl) NotifyNewTasks(
 	standbyTaskProcessor, ok := t.standbyTaskProcessors[clusterName]
 	t.standbyTaskProcessorsLock.RUnlock()
 	if !ok {
-		panic(fmt.Sprintf("Cannot find transfer processor for %s.", clusterName))
+		t.logger.Warn(fmt.Sprintf("Cannot find transfer processor for %s.", clusterName))
+		return
 	}
 	if len(transferTasks) != 0 {
 		standbyTaskProcessor.notifyNewTask()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* During cluster disconnection, sync shard status invocation can be delayed and unable to find target passive processor. Instead of panic-ing, logic should log warn and move on.

<!-- Tell your future self why have you made these changes -->
**Why?**
See above

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A