### PR TITLE
Improve execution scavenger

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1651,6 +1651,7 @@ var (
 	ArchiverWorkflowStoppingCount                             = NewCounterDef("archiver_workflow_stopping")
 	ScavengerValidationRequestsCount                          = NewCounterDef("scavenger_validation_requests")
 	ScavengerValidationFailuresCount                          = NewCounterDef("scavenger_validation_failures")
+	ScavengerValidationSkipsCount                             = NewCounterDef("scavenger_validation_skips")
 	AddSearchAttributesFailuresCount                          = NewCounterDef("add_search_attributes_failures")
 	DeleteNamespaceSuccessCount                               = NewCounterDef("delete_namespace_success")
 	RenameNamespaceSuccessCount                               = NewCounterDef("rename_namespace_success")

--- a/service/worker/scanner/executions/mutable_state_validator.go
+++ b/service/worker/scanner/executions/mutable_state_validator.go
@@ -91,6 +91,20 @@ func (v *mutableStateValidator) Validate(
 
 	var results []MutableStateValidationResult
 
+	// First， to check if the data is expired on retention time.
+	retentionResult, err := v.validateRetention(
+		mutableState.GetExecutionInfo(),
+		mutableState.GetExecutionState().GetState(),
+	)
+	if err != nil {
+		return results, err
+	}
+	if retentionResult != nil {
+		// Skip all validation if the data is expired.
+		results = append(results, *retentionResult)
+		return results, nil
+	}
+
 	results = append(results, v.validateActivity(
 		mutableState.ActivityInfos,
 		lastItem.GetEventId())...,
@@ -115,17 +129,6 @@ func (v *mutableStateValidator) Validate(
 		mutableState.SignalInfos,
 		lastItem.GetEventId())...,
 	)
-
-	retentionResult, err := v.validateRetention(
-		mutableState.GetExecutionInfo(),
-		mutableState.GetExecutionState().GetState(),
-	)
-	if err != nil {
-		return results, err
-	}
-	if retentionResult != nil {
-		results = append(results, *retentionResult)
-	}
 
 	return results, nil
 }

--- a/service/worker/scanner/executions/task.go
+++ b/service/worker/scanner/executions/task.go
@@ -94,7 +94,7 @@ func newTask(
 		historyClient:    historyClient,
 		adminClient:      adminClient,
 
-		metricsHandler: metricsHandler,
+		metricsHandler: metricsHandler.WithTags(metrics.OperationTag(metrics.ExecutionsScavengerScope)),
 		logger:         logger,
 		scavenger:      scavenger,
 
@@ -117,6 +117,7 @@ func (t *task) Run() executor.TaskStatus {
 		_ = t.rateLimiter.Wait(t.ctx)
 		record, err := iter.Next()
 		if err != nil {
+			t.metricsHandler.Counter(metrics.ScavengerValidationSkipsCount.GetMetricName()).Record(1)
 			// continue validation process and retry after all workflow records has been iterated.
 			t.logger.Error("unable to paginate concrete execution", tag.ShardID(t.shardID), tag.Error(err))
 			retryTask = true
@@ -134,6 +135,7 @@ func (t *task) Run() executor.TaskStatus {
 		if err != nil {
 			// continue validation process and retry after all workflow records has been iterated.
 			executionInfo := mutableState.GetExecutionInfo()
+			t.metricsHandler.Counter(metrics.ScavengerValidationSkipsCount.GetMetricName()).Record(1)
 			t.logger.Error("unable to process failure result",
 				tag.ShardID(t.shardID),
 				tag.Error(err),
@@ -271,15 +273,14 @@ func printValidationResult(
 	metricsHandler metrics.MetricsHandler,
 	logger log.Logger,
 ) {
-	handler := metricsHandler.WithTags(metrics.OperationTag(metrics.ExecutionsScavengerScope), metrics.FailureTag(""))
-	handler.Counter(metrics.ScavengerValidationRequestsCount.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.ScavengerValidationRequestsCount.GetMetricName()).Record(1)
 	if len(results) == 0 {
 		return
 	}
 
-	handler.Counter(metrics.ScavengerValidationFailuresCount.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.ScavengerValidationFailuresCount.GetMetricName()).Record(1)
 	for _, result := range results {
-		handler.Counter(metrics.ScavengerValidationFailuresCount.GetMetricName()).Record(1, metrics.FailureTag(result.failureType))
+		metricsHandler.Counter(metrics.ScavengerValidationFailuresCount.GetMetricName()).Record(1, metrics.FailureTag(result.failureType))
 		logger.Info(
 			"validation failed for execution.",
 			tag.WorkflowNamespaceID(mutableState.GetExecutionInfo().GetNamespaceId()),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Skip history validation if the mutable state validation failed. 
2. Improve the execution scavenger task to continue iterate all records if error encounters.

<!-- Tell your future self why have you made these changes -->
**Why?**
1. fail fast if mutable state is corrupted. It indicates bugs or DB issues.
2. Improve the efficiency to scan all records.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No