### PR TITLE
Add an integration test for acquireShard

### DIFF
--- a/common/persistence/client/fault_injection.go
+++ b/common/persistence/client/fault_injection.go
@@ -141,16 +141,22 @@ func (d *FaultInjectionDataStoreFactory) UpdateRate(rate float64) {
 	d.Queue.UpdateRate(rate)
 	d.ClusterMDStore.UpdateRate(rate)
 }
-
 func (d *FaultInjectionDataStoreFactory) NewTaskStore() (persistence.TaskStore, error) {
 	if d.TaskStore == nil {
 		baseFactory, err := d.baseFactory.NewTaskStore()
 		if err != nil {
 			return nil, err
 		}
-		d.TaskStore, err = NewFaultInjectionTaskStore(d.ErrorGenerator.Rate(), baseFactory)
-		if err != nil {
-			return nil, err
+		if storeConfig, ok := d.config.Targets.DataStores[config.TaskStoreName]; ok {
+			d.TaskStore = &FaultInjectionTaskStore{
+				baseTaskStore:  baseFactory,
+				ErrorGenerator: NewTargetedDataStoreErrorGenerator(&storeConfig),
+			}
+		} else {
+			d.TaskStore, err = NewFaultInjectionTaskStore(d.ErrorGenerator.Rate(), baseFactory)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return d.TaskStore, nil
@@ -162,9 +168,16 @@ func (d *FaultInjectionDataStoreFactory) NewShardStore() (persistence.ShardStore
 		if err != nil {
 			return nil, err
 		}
-		d.ShardStore, err = NewFaultInjectionShardStore(d.ErrorGenerator.Rate(), baseFactory)
-		if err != nil {
-			return nil, err
+		if storeConfig, ok := d.config.Targets.DataStores[config.ShardStoreName]; ok {
+			d.ShardStore = &FaultInjectionShardStore{
+				baseShardStore: baseFactory,
+				ErrorGenerator: NewTargetedDataStoreErrorGenerator(&storeConfig),
+			}
+		} else {
+			d.ShardStore, err = NewFaultInjectionShardStore(d.ErrorGenerator.Rate(), baseFactory)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return d.ShardStore, nil
@@ -176,9 +189,16 @@ func (d *FaultInjectionDataStoreFactory) NewMetadataStore() (persistence.Metadat
 		if err != nil {
 			return nil, err
 		}
-		d.MetadataStore, err = NewFaultInjectionMetadataStore(d.ErrorGenerator.Rate(), baseStore)
-		if err != nil {
-			return nil, err
+		if storeConfig, ok := d.config.Targets.DataStores[config.MetadataStoreName]; ok {
+			d.MetadataStore = &FaultInjectionMetadataStore{
+				baseMetadataStore: baseStore,
+				ErrorGenerator:    NewTargetedDataStoreErrorGenerator(&storeConfig),
+			}
+		} else {
+			d.MetadataStore, err = NewFaultInjectionMetadataStore(d.ErrorGenerator.Rate(), baseStore)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 	return d.MetadataStore, nil
@@ -190,9 +210,16 @@ func (d *FaultInjectionDataStoreFactory) NewExecutionStore() (persistence.Execut
 		if err != nil {
 			return nil, err
 		}
-		d.ExecutionStore, err = NewFaultInjectionExecutionStore(d.ErrorGenerator.Rate(), baseStore)
-		if err != nil {
-			return nil, err
+		if storeConfig, ok := d.config.Targets.DataStores[config.ExecutionStoreName]; ok {
+			d.ExecutionStore = &FaultInjectionExecutionStore{
+				baseExecutionStore: baseStore,
+				ErrorGenerator:     NewTargetedDataStoreErrorGenerator(&storeConfig),
+			}
+		} else {
+			d.ExecutionStore, err = NewFaultInjectionExecutionStore(d.ErrorGenerator.Rate(), baseStore)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 	}
@@ -205,11 +232,17 @@ func (d *FaultInjectionDataStoreFactory) NewQueue(queueType persistence.QueueTyp
 		if err != nil {
 			return baseQueue, err
 		}
-		d.Queue, err = NewFaultInjectionQueue(d.ErrorGenerator.Rate(), baseQueue)
-		if err != nil {
-			return nil, err
+		if storeConfig, ok := d.config.Targets.DataStores[config.QueueName]; ok {
+			d.Queue = &FaultInjectionQueue{
+				baseQueue:      baseQueue,
+				ErrorGenerator: NewTargetedDataStoreErrorGenerator(&storeConfig),
+			}
+		} else {
+			d.Queue, err = NewFaultInjectionQueue(d.ErrorGenerator.Rate(), baseQueue)
+			if err != nil {
+				return nil, err
+			}
 		}
-
 	}
 	return d.Queue, nil
 }
@@ -220,9 +253,16 @@ func (d *FaultInjectionDataStoreFactory) NewClusterMetadataStore() (persistence.
 		if err != nil {
 			return nil, err
 		}
-		d.ClusterMDStore, err = NewFaultInjectionClusterMetadataStore(d.ErrorGenerator.Rate(), baseStore)
-		if err != nil {
-			return nil, err
+		if storeConfig, ok := d.config.Targets.DataStores[config.ClusterMDStoreName]; ok {
+			d.ClusterMDStore = &FaultInjectionClusterMetadataStore{
+				baseCMStore:    baseStore,
+				ErrorGenerator: NewTargetedDataStoreErrorGenerator(&storeConfig),
+			}
+		} else {
+			d.ClusterMDStore, err = NewFaultInjectionClusterMetadataStore(d.ErrorGenerator.Rate(), baseStore)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 	}

--- a/common/persistence/client/targeted_fault_injection.go
+++ b/common/persistence/client/targeted_fault_injection.go
@@ -1,0 +1,127 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package client
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"runtime"
+	"strings"
+	"time"
+
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/persistence"
+)
+
+// NewTargetedDataStoreErrorGenerator returns a new instance of a data store error generator that will inject errors
+// into the persistence layer based on the provided configuration.
+func NewTargetedDataStoreErrorGenerator(cfg *config.FaultInjectionDataStoreConfig) ErrorGenerator {
+	methods := make(map[string]ErrorGenerator, len(cfg.Methods))
+	for methodName, methodConfig := range cfg.Methods {
+		var faultWeights []FaultWeight
+		methodErrorRate := 0.0
+		for errorName, errorRate := range methodConfig.Errors {
+			err := getErrorFromName(errorName)
+			faultWeights = append(faultWeights, FaultWeight{
+				errFactory: func(data string) error {
+					return err
+				},
+				weight: errorRate,
+			})
+			methodErrorRate += errorRate
+		}
+		errorGenerator := NewDefaultErrorGenerator(methodErrorRate, faultWeights)
+		seed := methodConfig.Seed
+		if seed == 0 {
+			seed = time.Now().UnixNano()
+		}
+		errorGenerator.r = rand.New(rand.NewSource(seed))
+		methods[methodName] = errorGenerator
+	}
+	return &dataStoreErrorGenerator{MethodErrorGenerators: methods}
+}
+
+// dataStoreErrorGenerator is an implementation of ErrorGenerator that will inject errors into the persistence layer
+// using a per-method configuration.
+type dataStoreErrorGenerator struct {
+	MethodErrorGenerators map[string]ErrorGenerator
+}
+
+// Generate returns an error from the configured error types and rates for this method.
+// This method infers the fault injection target's method name from the function name of the caller.
+// As a result, this method should only be called from the persistence layer.
+// This method will panic if the method name cannot be inferred.
+// If no errors are configured for the method, or if there are some errors configured for this method,
+// but no error is sampled, then this method returns nil.
+// When this method returns nil, this causes the persistence layer to use the real implementation.
+func (d *dataStoreErrorGenerator) Generate() error {
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		panic("failed to get caller info")
+	}
+	runtimeFunc := runtime.FuncForPC(pc)
+	if runtimeFunc == nil {
+		panic("failed to get runtime function")
+	}
+	parts := strings.Split(runtimeFunc.Name(), ".")
+	methodName := parts[len(parts)-1]
+	methodErrorGenerator, ok := d.MethodErrorGenerators[methodName]
+	if !ok {
+		return nil
+	}
+	err := methodErrorGenerator.Generate()
+	return err
+}
+
+// getErrorFromName returns an error based on the provided name. If the name is not recognized, then this method will
+// panic.
+func getErrorFromName(name string) error {
+	switch name {
+	case "ShardOwnershipLostError":
+		return &persistence.ShardOwnershipLostError{}
+	case "DeadlineExceededError":
+		return context.DeadlineExceeded
+	default:
+		panic(fmt.Sprintf("unknown error type: %v", name))
+	}
+}
+
+// UpdateRate should not be called for the data store error generator since the rate is defined on a per-method basis.
+func (d *dataStoreErrorGenerator) UpdateRate(rate float64) {
+	panic("UpdateRate not supported for data store error generators")
+}
+
+// UpdateWeights should not be called for the data store error generator since the weights are defined on a per-method
+// basis.
+func (d *dataStoreErrorGenerator) UpdateWeights(weights []FaultWeight) {
+	panic("UpdateWeights not supported for data store error generators")
+}
+
+// Rate should not be called for the data store error generator since there is no global rate for the data store, only
+// per-method rates.
+func (d *dataStoreErrorGenerator) Rate() float64 {
+	panic("Rate not supported for data store error generators")
+}

--- a/common/persistence/sql/sqlPersistenceTest.go
+++ b/common/persistence/sql/sqlPersistenceTest.go
@@ -113,7 +113,7 @@ func (s *TestCluster) Config() config.Persistence {
 		DefaultStore:    "test",
 		VisibilityStore: "test",
 		DataStores: map[string]config.DataStore{
-			"test": {SQL: &cfg},
+			"test": {SQL: &cfg, FaultInjection: s.faultInjection},
 		},
 		TransactionSizeLimit: dynamicconfig.GetIntPropertyFn(common.DefaultTransactionSizeLimit),
 	}

--- a/host/acquire_shard_integration_test.go
+++ b/host/acquire_shard_integration_test.go
@@ -1,0 +1,252 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package host
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+)
+
+// acquireShardIntegrationSuite is the base test suite for testing acquire shard.
+type acquireShardIntegrationSuite struct {
+	IntegrationBase
+	logRecorder *logRecorder
+	logs        chan logRecord
+}
+
+// SetupSuite sets up the test suite by setting the log recorder.
+func (s *acquireShardIntegrationSuite) SetupSuite() {
+	s.logs = make(chan logRecord, 100)
+	s.logRecorder = newLogRecorder(s.logs)
+	s.Logger = s.logRecorder
+}
+
+// TearDownSuite tears down the test suite by shutting down the test cluster after a short delay.
+func (s *acquireShardIntegrationSuite) TearDownSuite() {
+	// we need to wait for all components to start before we can safely tear down
+	time.Sleep(time.Second * 5)
+	s.tearDownSuite()
+}
+
+// newLogRecorder creates a new log recorder. It records all the logs to the given channel.
+func newLogRecorder(logs chan logRecord) *logRecorder {
+	return &logRecorder{
+		Logger: log.NewNoopLogger(),
+		logs:   logs,
+	}
+}
+
+// logRecord represents a call to Info or Error.
+type logRecord struct {
+	msg  string
+	tags []tag.Tag
+}
+
+// logRecorder is used to record log messages
+type logRecorder struct {
+	log.Logger
+	logs chan logRecord
+}
+
+// Info records the info message
+func (r *logRecorder) Info(msg string, tags ...tag.Tag) {
+	r.record(msg, tags...)
+}
+
+// Error records the error message
+func (r *logRecorder) Error(msg string, tags ...tag.Tag) {
+	r.record(msg, tags...)
+}
+
+// Fatal ignores the fatal call
+func (r *logRecorder) Fatal(string, ...tag.Tag) {
+	// Fatal errors sometimes happen for other components we instantiate and tear down during this test.
+}
+
+// record sends a logRecord to the logs channel. If there is no active receiver, the logRecord will be dropped.
+func (r *logRecorder) record(msg string, tags ...tag.Tag) {
+	select {
+	case r.logs <- logRecord{
+		msg:  msg,
+		tags: tags,
+	}:
+	default:
+	}
+}
+
+// TestAcquireShard_OwnershipLostErrorSuite tests what happens when acquire shard returns an ownership lost error.
+func TestAcquireShard_OwnershipLostErrorSuite(t *testing.T) {
+	s := new(ownershipLostErrorSuite)
+	suite.Run(t, s)
+}
+
+// ownershipLostErrorSuite is the test suite for testing what happens when acquire shard returns an ownership lost
+// error.
+type ownershipLostErrorSuite struct {
+	acquireShardIntegrationSuite
+}
+
+// SetupSuite reads the shard ownership lost error fault injection config from the testdata folder.
+func (s *ownershipLostErrorSuite) SetupSuite() {
+	s.acquireShardIntegrationSuite.SetupSuite()
+	s.setupSuite("testdata/acquire_shard_ownership_lost_error.yaml")
+}
+
+// TestDoesNotRetry verifies that we do not retry acquiring the shard when we get an ownership lost error.
+func (s *ownershipLostErrorSuite) TestDoesNotRetry() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	numAttempts := 0
+	for {
+		select {
+		case record := <-s.logs:
+			msg := strings.ToLower(record.msg)
+			if strings.Contains(msg, "error acquiring shard") {
+				numAttempts++
+				taggedAsNonRetryable := false
+				for _, tg := range record.tags {
+					if tg == tag.IsRetryable(false) {
+						taggedAsNonRetryable = true
+					}
+				}
+				s.True(taggedAsNonRetryable, "logged error should be tagged as non-retryable")
+			} else if strings.Contains(msg, "acquired shard") {
+				s.FailNow("should not acquire shard")
+			} else if strings.Contains(msg, "couldn't acquire shard") {
+				s.Equal(1, numAttempts, "should fail after one attempt")
+				return
+			}
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for shard update error")
+		}
+	}
+}
+
+// TestAcquireShard_DeadlineExceededErrorSuite tests what happens when acquire shard returns a deadline exceeded error
+func TestAcquireShard_DeadlineExceededErrorSuite(t *testing.T) {
+	s := new(deadlineExceededErrorSuite)
+	suite.Run(t, s)
+}
+
+// deadlineExceededErrorSuite is the test suite for testing what happens when acquire shard returns a deadline exceeded.
+type deadlineExceededErrorSuite struct {
+	acquireShardIntegrationSuite
+}
+
+// SetupSuite reads the deadline exceeded error targeted fault injection config from the test data folder.
+func (s *deadlineExceededErrorSuite) SetupSuite() {
+	s.acquireShardIntegrationSuite.SetupSuite()
+	s.setupSuite("testdata/acquire_shard_deadline_exceeded_error.yaml")
+}
+
+// TestDoesRetry verifies that we do retry acquiring the shard when we get a deadline exceeded error because that should
+// be considered a transient error.
+func (s *deadlineExceededErrorSuite) TestDoesRetry() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	for numAttempts := 0; numAttempts < 2; {
+		select {
+		case record := <-s.logs:
+			msg := strings.ToLower(record.msg)
+			if strings.Contains(msg, "error acquiring shard") {
+				numAttempts++
+				taggedAsRetryable := false
+				for _, tg := range record.tags {
+					if tg == tag.IsRetryable(true) {
+						taggedAsRetryable = true
+					}
+				}
+				s.True(taggedAsRetryable, "logged error should be tagged as retryable")
+			} else if strings.Contains(msg, "acquired shard") {
+				s.FailNow("should not acquire shard")
+			}
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for retry")
+		}
+	}
+}
+
+// TestAcquireShard_EventualSuccess verifies that we eventually succeed in acquiring the shard when we get a deadline
+// exceeded error followed by a successful acquire shard call.
+// To make this test deterministic, we set the seed to in the config file to a fixed value.
+func TestAcquireShard_EventualSuccess(t *testing.T) {
+	s := new(eventualSuccessSuite)
+	suite.Run(t, s)
+}
+
+// eventualSuccessSuite is the test suite for testing what happens when acquire shard returns a deadline exceeded error
+// followed by a successful acquire shard call.
+type eventualSuccessSuite struct {
+	acquireShardIntegrationSuite
+}
+
+// SetupSuite reads the targeted eventual success fault injection config from the testdata folder.
+// This config deterministically causes the first acquire shard call to return a deadline exceeded error, and it causes
+// the next call to return a successful response.
+func (s *eventualSuccessSuite) SetupSuite() {
+	s.acquireShardIntegrationSuite.SetupSuite()
+	s.setupSuite("testdata/acquire_shard_eventual_success.yaml")
+}
+
+// TestEventuallySucceeds verifies that we eventually succeed in acquiring the shard when we get a deadline exceeded
+// error followed by a successful acquire shard call.
+func (s *eventualSuccessSuite) TestEventuallySucceeds() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
+	defer cancel()
+
+	numErrors := 0
+	for {
+		select {
+		case record := <-s.logs:
+			msg := strings.ToLower(record.msg)
+			if strings.Contains(msg, "error acquiring shard") {
+				numErrors++
+				taggedAsRetryable := false
+				for _, tg := range record.tags {
+					if tg == tag.IsRetryable(true) {
+						taggedAsRetryable = true
+					}
+				}
+				s.True(taggedAsRetryable, "logged error should be tagged as retryable")
+			} else if strings.Contains(msg, "acquired shard") {
+				s.Equal(1, numErrors, "should succeed after one error")
+				return
+			} else if strings.Contains(msg, "couldn't acquire shard") {
+				s.FailNow("should not fail to acquire shard")
+			}
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for retry")
+		}
+	}
+}

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -126,8 +126,13 @@ func (s *IntegrationBase) setupSuite(defaultClusterConfigFile string) {
 	}
 }
 
+// setupLogger sets the Logger for the test suite.
+// If the Logger is already set, this method does nothing.
+// If the Logger is not set, this method creates a new log.TestLogger which logs to stdout and stderr.
 func (s *IntegrationBase) setupLogger() {
-	s.Logger = log.NewTestLogger()
+	if s.Logger == nil {
+		s.Logger = log.NewTestLogger()
+	}
 }
 
 // GetTestClusterConfig return test cluster config

--- a/host/test_cluster.go
+++ b/host/test_cluster.go
@@ -144,10 +144,10 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 		panic(fmt.Sprintf("unknown store type: %v", options.Persistence.StoreType))
 	}
 
+	options.Persistence.FaultInjection = &options.FaultInjection
+	// If the fault injection rate command line flag is set, override the fault injection rate in the config.
 	if TestFlags.PersistenceFaultInjectionRate > 0 {
-		options.Persistence.FaultInjection = &config.FaultInjection{Rate: TestFlags.PersistenceFaultInjectionRate}
-	} else if options.Persistence.FaultInjection == nil {
-		options.Persistence.FaultInjection = &config.FaultInjection{Rate: 0}
+		options.Persistence.FaultInjection.Rate = TestFlags.PersistenceFaultInjectionRate
 	}
 
 	testBase := persistencetests.NewTestBase(&options.Persistence)

--- a/host/testdata/acquire_shard_deadline_exceeded_error.yaml
+++ b/host/testdata/acquire_shard_deadline_exceeded_error.yaml
@@ -1,0 +1,16 @@
+enablearchival: false
+clusterno: 0
+historyconfig:
+  numhistoryshards: 1
+  numhistoryhosts: 1
+workerconfig:
+  enablearchiver: false
+  enablereplicator: false
+faultinjection:
+  targets:
+    dataStores:
+      ShardStore:
+        methods:
+          UpdateShard:
+            errors:
+              DeadlineExceededError: 1.0 # 100% of the time, return a deadline exceeded error

--- a/host/testdata/acquire_shard_eventual_success.yaml
+++ b/host/testdata/acquire_shard_eventual_success.yaml
@@ -1,0 +1,17 @@
+enablearchival: false
+clusterno: 0
+historyconfig:
+  numhistoryshards: 1
+  numhistoryhosts: 1
+workerconfig:
+  enablearchiver: false
+  enablereplicator: false
+faultinjection:
+  targets:
+    dataStores:
+      ShardStore:
+        methods:
+          UpdateShard:
+            seed: 43  # deterministically generate a deadline exceeded error followed by a success
+            errors:
+              DeadlineExceededError: 0.5 # 50% of the time, return a deadline exceeded error

--- a/host/testdata/acquire_shard_ownership_lost_error.yaml
+++ b/host/testdata/acquire_shard_ownership_lost_error.yaml
@@ -1,0 +1,16 @@
+enablearchival: false
+clusterno: 0
+historyconfig:
+  numhistoryshards: 1
+  numhistoryhosts: 1
+workerconfig:
+  enablearchiver: false
+  enablereplicator: false
+faultinjection:
+  targets:
+    dataStores:
+      ShardStore:
+        methods:
+          UpdateShard:
+            errors:
+              ShardOwnershipLostError: 1.0  # 100% of the time, return a ShardOwnershipLostError


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added an integration test for the acquireShard method. To do this, I created a new targeted fault injection config.

<!-- Tell your future self why have you made these changes -->
**Why?**
I made this to give us more confidence in the acquireShard method.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
With an integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It looks like the FaultInjection config is only propagated to the persistence config in test_cluster, not anywhere else, so I don't think there's any risk to production.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.