### PR TITLE
Move ServiceName to primitives and use everywhere

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -32,6 +32,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
@@ -372,8 +373,8 @@ func shardupdate(shardupdate string) ZapTag {
 // general
 
 // Service returns tag for Service
-func Service(sv string) ZapTag {
-	return NewStringTag("service", sv)
+func Service(sv primitives.ServiceName) ZapTag {
+	return NewStringTag("service", string(sv))
 }
 
 // Addresses returns tag for Addresses

--- a/common/membership/grpc_resolver.go
+++ b/common/membership/grpc_resolver.go
@@ -30,9 +30,10 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"go.temporal.io/server/common/primitives"
 	"go.uber.org/fx"
 	"google.golang.org/grpc/resolver"
+
+	"go.temporal.io/server/common/primitives"
 )
 
 const GRPCResolverScheme = "membership"

--- a/common/membership/grpc_resolver.go
+++ b/common/membership/grpc_resolver.go
@@ -30,6 +30,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"go.temporal.io/server/common/primitives"
 	"go.uber.org/fx"
 	"google.golang.org/grpc/resolver"
 )
@@ -59,8 +60,8 @@ func initializeBuilder(monitor Monitor) GRPCResolver {
 	return GRPCResolver{}
 }
 
-func (g *GRPCResolver) MakeURL(service string) string {
-	return fmt.Sprintf("%s://%s", GRPCResolverScheme, service)
+func (g *GRPCResolver) MakeURL(service primitives.ServiceName) string {
+	return fmt.Sprintf("%s://%s", GRPCResolverScheme, string(service))
 }
 
 type grpcBuilder struct {
@@ -78,7 +79,7 @@ func (m *grpcBuilder) Build(target resolver.Target, cc resolver.ClientConn, opts
 	}
 	// See MakeURL: the service ends up as the "host" of the parsed URL
 	service := target.URL.Host
-	r, err := monitor.GetResolver(service)
+	r, err := monitor.GetResolver(primitives.ServiceName(service))
 	if err != nil {
 		return nil, err
 	}

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/primitives"
 )
 
 // ErrUnknownService is thrown for a service that is not tracked by this instance
@@ -65,22 +66,22 @@ type (
 		// called, other members will discover that this node is no longer part of the
 		// ring. This primitive is useful to carry out graceful host shutdown during deployments.
 		EvictSelf() error
-		Lookup(service string, key string) (*HostInfo, error)
-		GetResolver(service string) (ServiceResolver, error)
+		Lookup(service primitives.ServiceName, key string) (*HostInfo, error)
+		GetResolver(service primitives.ServiceName) (ServiceResolver, error)
 		// AddListener adds a listener for this service.
 		// The listener will get notified on the given
 		// channel, whenever there is a membership change.
 		// @service: The service to be listened on
 		// @name: The name for identifying the listener
 		// @notifyChannel: The channel on which the caller receives notifications
-		AddListener(service string, name string, notifyChannel chan<- *ChangedEvent) error
+		AddListener(service primitives.ServiceName, name string, notifyChannel chan<- *ChangedEvent) error
 		// RemoveListener removes a listener for this service.
-		RemoveListener(service string, name string) error
+		RemoveListener(service primitives.ServiceName, name string) error
 		// GetReachableMembers returns addresses of all members of the ring
 		GetReachableMembers() ([]string, error)
 		// GetMemberCount returns the number of reachable members
-		// currently in this node's membership list for the given role
-		GetMemberCount(role string) (int, error)
+		// currently in this node's membership list for the given service
+		GetMemberCount(service primitives.ServiceName) (int, error)
 	}
 
 	// ServiceResolver provides membership information for a specific temporal service.

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -32,6 +32,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	primitives "go.temporal.io/server/common/primitives"
 )
 
 // MockMonitor is a mock of Monitor interface.
@@ -58,7 +59,7 @@ func (m *MockMonitor) EXPECT() *MockMonitorMockRecorder {
 }
 
 // AddListener mocks base method.
-func (m *MockMonitor) AddListener(service, name string, notifyChannel chan<- *ChangedEvent) error {
+func (m *MockMonitor) AddListener(service primitives.ServiceName, name string, notifyChannel chan<- *ChangedEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddListener", service, name, notifyChannel)
 	ret0, _ := ret[0].(error)
@@ -86,18 +87,18 @@ func (mr *MockMonitorMockRecorder) EvictSelf() *gomock.Call {
 }
 
 // GetMemberCount mocks base method.
-func (m *MockMonitor) GetMemberCount(role string) (int, error) {
+func (m *MockMonitor) GetMemberCount(service primitives.ServiceName) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemberCount", role)
+	ret := m.ctrl.Call(m, "GetMemberCount", service)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMemberCount indicates an expected call of GetMemberCount.
-func (mr *MockMonitorMockRecorder) GetMemberCount(role interface{}) *gomock.Call {
+func (mr *MockMonitorMockRecorder) GetMemberCount(service interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCount", reflect.TypeOf((*MockMonitor)(nil).GetMemberCount), role)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCount", reflect.TypeOf((*MockMonitor)(nil).GetMemberCount), service)
 }
 
 // GetReachableMembers mocks base method.
@@ -116,7 +117,7 @@ func (mr *MockMonitorMockRecorder) GetReachableMembers() *gomock.Call {
 }
 
 // GetResolver mocks base method.
-func (m *MockMonitor) GetResolver(service string) (ServiceResolver, error) {
+func (m *MockMonitor) GetResolver(service primitives.ServiceName) (ServiceResolver, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResolver", service)
 	ret0, _ := ret[0].(ServiceResolver)
@@ -131,7 +132,7 @@ func (mr *MockMonitorMockRecorder) GetResolver(service interface{}) *gomock.Call
 }
 
 // Lookup mocks base method.
-func (m *MockMonitor) Lookup(service, key string) (*HostInfo, error) {
+func (m *MockMonitor) Lookup(service primitives.ServiceName, key string) (*HostInfo, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Lookup", service, key)
 	ret0, _ := ret[0].(*HostInfo)
@@ -146,7 +147,7 @@ func (mr *MockMonitorMockRecorder) Lookup(service, key interface{}) *gomock.Call
 }
 
 // RemoveListener mocks base method.
-func (m *MockMonitor) RemoveListener(service, name string) error {
+func (m *MockMonitor) RemoveListener(service primitives.ServiceName, name string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RemoveListener", service, name)
 	ret0, _ := ret[0].(error)

--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -61,10 +61,10 @@ type ringpopMonitor struct {
 	lifecycleCtx    context.Context
 	lifecycleCancel context.CancelFunc
 
-	serviceName               string
-	services                  map[string]int
+	serviceName               primitives.ServiceName
+	services                  map[primitives.ServiceName]int
 	rp                        *RingPop
-	rings                     map[string]*ringpopServiceResolver
+	rings                     map[primitives.ServiceName]*ringpopServiceResolver
 	logger                    log.Logger
 	metadataManager           persistence.ClusterMetadataManager
 	broadcastHostPortResolver func() (string, error)
@@ -75,8 +75,8 @@ var _ Monitor = (*ringpopMonitor)(nil)
 
 // NewRingpopMonitor returns a ringpop-based membership monitor
 func NewRingpopMonitor(
-	serviceName string,
-	services map[string]int,
+	serviceName primitives.ServiceName,
+	services map[primitives.ServiceName]int,
 	rp *RingPop,
 	logger log.Logger,
 	metadataManager persistence.ClusterMetadataManager,
@@ -98,7 +98,7 @@ func NewRingpopMonitor(
 		serviceName:               serviceName,
 		services:                  services,
 		rp:                        rp,
-		rings:                     make(map[string]*ringpopServiceResolver),
+		rings:                     make(map[primitives.ServiceName]*ringpopServiceResolver),
 		logger:                    logger,
 		metadataManager:           metadataManager,
 		broadcastHostPortResolver: broadcastHostPortResolver,
@@ -145,7 +145,7 @@ func (rpo *ringpopMonitor) Start() {
 		rpo.logger.Fatal("unable to set ring pop ServicePort label", tag.Error(err))
 	}
 
-	if err = labels.Set(RoleKey, rpo.serviceName); err != nil {
+	if err = labels.Set(RoleKey, string(rpo.serviceName)); err != nil {
 		rpo.logger.Fatal("unable to set ring pop ServiceRole label", tag.Error(err))
 	}
 
@@ -154,7 +154,7 @@ func (rpo *ringpopMonitor) Start() {
 	}
 }
 
-func ServiceNameToServiceTypeEnum(name string) (persistence.ServiceType, error) {
+func ServiceNameToServiceTypeEnum(name primitives.ServiceName) (persistence.ServiceType, error) {
 	switch name {
 	case primitives.AllServices:
 		return persistence.All, nil
@@ -355,7 +355,7 @@ func (rpo *ringpopMonitor) EvictSelf() error {
 	return rpo.rp.SelfEvict()
 }
 
-func (rpo *ringpopMonitor) GetResolver(service string) (ServiceResolver, error) {
+func (rpo *ringpopMonitor) GetResolver(service primitives.ServiceName) (ServiceResolver, error) {
 	ring, found := rpo.rings[service]
 	if !found {
 		return nil, ErrUnknownService
@@ -363,7 +363,7 @@ func (rpo *ringpopMonitor) GetResolver(service string) (ServiceResolver, error) 
 	return ring, nil
 }
 
-func (rpo *ringpopMonitor) Lookup(service string, key string) (*HostInfo, error) {
+func (rpo *ringpopMonitor) Lookup(service primitives.ServiceName, key string) (*HostInfo, error) {
 	ring, err := rpo.GetResolver(service)
 	if err != nil {
 		return nil, err
@@ -371,7 +371,7 @@ func (rpo *ringpopMonitor) Lookup(service string, key string) (*HostInfo, error)
 	return ring.Lookup(key)
 }
 
-func (rpo *ringpopMonitor) AddListener(service string, name string, notifyChannel chan<- *ChangedEvent) error {
+func (rpo *ringpopMonitor) AddListener(service primitives.ServiceName, name string, notifyChannel chan<- *ChangedEvent) error {
 	ring, err := rpo.GetResolver(service)
 	if err != nil {
 		return err
@@ -379,7 +379,7 @@ func (rpo *ringpopMonitor) AddListener(service string, name string, notifyChanne
 	return ring.AddListener(name, notifyChannel)
 }
 
-func (rpo *ringpopMonitor) RemoveListener(service string, name string) error {
+func (rpo *ringpopMonitor) RemoveListener(service primitives.ServiceName, name string) error {
 	ring, err := rpo.GetResolver(service)
 	if err != nil {
 		return err
@@ -391,7 +391,7 @@ func (rpo *ringpopMonitor) GetReachableMembers() ([]string, error) {
 	return rpo.rp.GetReachableMembers()
 }
 
-func (rpo *ringpopMonitor) GetMemberCount(service string) (int, error) {
+func (rpo *ringpopMonitor) GetMemberCount(service primitives.ServiceName) (int, error) {
 	ring, err := rpo.GetResolver(service)
 	if err != nil {
 		return 0, err

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/primitives"
 )
 
 const (
@@ -62,7 +63,7 @@ const (
 
 type ringpopServiceResolver struct {
 	status      int32
-	service     string
+	service     primitives.ServiceName
 	port        int
 	rp          *RingPop
 	refreshChan chan struct{}
@@ -83,7 +84,7 @@ type ringpopServiceResolver struct {
 var _ ServiceResolver = (*ringpopServiceResolver)(nil)
 
 func newRingpopServiceResolver(
-	service string,
+	service primitives.ServiceName,
 	port int,
 	rp *RingPop,
 	logger log.Logger,
@@ -286,7 +287,7 @@ func (r *ringpopServiceResolver) refreshNoLock() (*ChangedEvent, error) {
 }
 
 func (r *ringpopServiceResolver) getReachableMembers() ([]string, error) {
-	members, err := r.rp.GetReachableMemberObjects(swim.MemberWithLabelAndValue(RoleKey, r.service))
+	members, err := r.rp.GetReachableMemberObjects(swim.MemberWithLabelAndValue(RoleKey, string(r.service)))
 	if err != nil {
 		return nil, err
 	}
@@ -361,7 +362,7 @@ func (r *ringpopServiceResolver) ring() *hashring.HashRing {
 
 func (r *ringpopServiceResolver) getLabelsMap() map[string]string {
 	labels := make(map[string]string)
-	labels[RoleKey] = r.service
+	labels[RoleKey] = string(r.service)
 	return labels
 }
 

--- a/common/membership/rp_cluster_test.go
+++ b/common/membership/rp_cluster_test.go
@@ -37,6 +37,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/primitives"
 )
 
 // TestRingpopCluster is a type that represents a test ringpop cluster
@@ -58,7 +59,7 @@ func NewTestRingpopCluster(
 	size int,
 	listenIPAddr string,
 	seed string,
-	serviceName string,
+	serviceName primitives.ServiceName,
 	broadcastAddress string,
 ) *TestRingpopCluster {
 	logger := log.NewTestLogger()
@@ -156,7 +157,7 @@ func NewTestRingpopCluster(
 		_, port, _ := SplitHostPortTyped(cluster.hostAddrs[i])
 		cluster.rings[i] = NewRingpopMonitor(
 			serviceName,
-			map[string]int{serviceName: int(port)}, // use same port for "grpc" port
+			map[primitives.ServiceName]int{serviceName: int(port)}, // use same port for "grpc" port
 			rpWrapper,
 			logger,
 			mockMgr,

--- a/common/metrics/common.go
+++ b/common/metrics/common.go
@@ -33,7 +33,7 @@ import (
 )
 
 // GetMetricsServiceIdx returns service id corresponding to serviceName
-func GetMetricsServiceIdx(serviceName string, logger log.Logger) ServiceIdx {
+func GetMetricsServiceIdx(serviceName primitives.ServiceName, logger log.Logger) ServiceIdx {
 	switch serviceName {
 	case primitives.FrontendService:
 		return Frontend
@@ -54,7 +54,7 @@ func GetMetricsServiceIdx(serviceName string, logger log.Logger) ServiceIdx {
 }
 
 // GetMetricsServiceIdx returns service id corresponding to serviceName
-func MetricsServiceIdxToServiceName(serviceIdx ServiceIdx) (string, error) {
+func MetricsServiceIdxToServiceName(serviceIdx ServiceIdx) (primitives.ServiceName, error) {
 	switch serviceIdx {
 	case Server:
 		return primitives.ServerService, nil

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/common/primitives"
 )
 
 const (
@@ -245,8 +246,8 @@ func ResourceExhaustedCauseTag(cause enumspb.ResourceExhaustedCause) Tag {
 	return &tagImpl{key: resourceExhaustedTag, value: cause.String()}
 }
 
-func ServiceNameTag(value string) Tag {
-	return &tagImpl{key: serviceName, value: value}
+func ServiceNameTag(value primitives.ServiceName) Tag {
+	return &tagImpl{key: serviceName, value: string(value)}
 }
 
 func ActionType(value string) Tag {

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
+
 	"go.temporal.io/server/common/primitives"
 )
 

--- a/common/namespace/handler.go
+++ b/common/namespace/handler.go
@@ -808,7 +808,7 @@ func (d *HandlerImpl) validateHistoryArchivalURI(URIString string) error {
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme(), primitives.FrontendService)
+	archiver, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.FrontendService))
 	if err != nil {
 		return err
 	}
@@ -822,7 +822,7 @@ func (d *HandlerImpl) validateVisibilityArchivalURI(URIString string) error {
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme(), primitives.FrontendService)
+	archiver, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.FrontendService))
 	if err != nil {
 		return err
 	}

--- a/common/primitives/role.go
+++ b/common/primitives/role.go
@@ -26,7 +26,7 @@ package primitives
 
 type ServiceName string
 
-// These const represent role strings
+// These constants represent service roles
 const (
 	AllServices     ServiceName = "all"
 	FrontendService ServiceName = "frontend"

--- a/common/primitives/role.go
+++ b/common/primitives/role.go
@@ -24,13 +24,15 @@
 
 package primitives
 
+type ServiceName string
+
 // These const represent role strings
 const (
-	AllServices     = "all"
-	FrontendService = "frontend"
-	HistoryService  = "history"
-	MatchingService = "matching"
-	WorkerService   = "worker"
-	ServerService   = "server"
-	UnitTestService = "unittest"
+	AllServices     ServiceName = "all"
+	FrontendService ServiceName = "frontend"
+	HistoryService  ServiceName = "history"
+	MatchingService ServiceName = "matching"
+	WorkerService   ServiceName = "worker"
+	ServerService   ServiceName = "server"
+	UnitTestService ServiceName = "unittest"
 )

--- a/common/ringpop/ringpop.go
+++ b/common/ringpop/ringpop.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/rpc/encryption"
 )
 
@@ -59,8 +60,8 @@ var (
 type ringpopFactory struct {
 	config         *config.Membership
 	channel        *tchannel.Channel
-	serviceName    string
-	servicePortMap map[string]int
+	serviceName    primitives.ServiceName
+	servicePortMap map[primitives.ServiceName]int
 	logger         log.Logger
 
 	membershipMonitor membership.Monitor
@@ -77,8 +78,8 @@ type ringpopFactory struct {
 // to the underlying configuration
 func NewRingpopFactory(
 	rpConfig *config.Membership,
-	serviceName string,
-	servicePortMap map[string]int,
+	serviceName primitives.ServiceName,
+	servicePortMap map[primitives.ServiceName]int,
 	logger log.Logger,
 	metadataManager persistence.ClusterMetadataManager,
 	rpcConfig *config.RPC,

--- a/common/ringpop/ringpop_test.go
+++ b/common/ringpop/ringpop_test.go
@@ -35,6 +35,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/tests/testhelper"
 
@@ -158,7 +159,7 @@ maxJoinDuration: 30s`
 }
 
 func newTestRingpopFactory(
-	serviceName string,
+	serviceName primitives.ServiceName,
 	logger log.Logger,
 	rpcConfig *config.RPC,
 	tlsProvider encryption.TLSConfigProvider,

--- a/common/rpc/rpc.go
+++ b/common/rpc/rpc.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/rpc/encryption"
 )
 
@@ -46,7 +47,7 @@ var _ common.RPCFactory = (*RPCFactory)(nil)
 // RPCFactory is an implementation of common.RPCFactory interface
 type RPCFactory struct {
 	config      *config.RPC
-	serviceName string
+	serviceName primitives.ServiceName
 	logger      log.Logger
 	dc          *dynamicconfig.Collection
 	frontendURL string
@@ -61,7 +62,7 @@ type RPCFactory struct {
 // conforming to the underlying configuration
 func NewFactory(
 	cfg *config.RPC,
-	sName string,
+	sName primitives.ServiceName,
 	logger log.Logger,
 	tlsProvider encryption.TLSConfigProvider,
 	dc *dynamicconfig.Collection,

--- a/host/simpleMonitor.go
+++ b/host/simpleMonitor.go
@@ -28,21 +28,22 @@ import (
 	"fmt"
 
 	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/primitives"
 )
 
 type simpleMonitor struct {
 	hostInfo  *membership.HostInfo
-	resolvers map[string]membership.ServiceResolver
+	resolvers map[primitives.ServiceName]membership.ServiceResolver
 }
 
 // NewSimpleMonitor returns a simple monitor interface
-func newSimpleMonitor(serviceName string, hosts map[string][]string) membership.Monitor {
-	resolvers := make(map[string]membership.ServiceResolver, len(hosts))
+func newSimpleMonitor(serviceName primitives.ServiceName, hosts map[primitives.ServiceName][]string) membership.Monitor {
+	resolvers := make(map[primitives.ServiceName]membership.ServiceResolver, len(hosts))
 	for service, hostList := range hosts {
 		resolvers[service] = newSimpleResolver(service, hostList)
 	}
 
-	hostInfo := membership.NewHostInfo(hosts[serviceName][0], map[string]string{membership.RoleKey: serviceName})
+	hostInfo := membership.NewHostInfo(hosts[serviceName][0], map[string]string{membership.RoleKey: string(serviceName)})
 	return &simpleMonitor{hostInfo, resolvers}
 }
 
@@ -60,11 +61,11 @@ func (s *simpleMonitor) WhoAmI() (*membership.HostInfo, error) {
 	return s.hostInfo, nil
 }
 
-func (s *simpleMonitor) GetResolver(service string) (membership.ServiceResolver, error) {
+func (s *simpleMonitor) GetResolver(service primitives.ServiceName) (membership.ServiceResolver, error) {
 	return s.resolvers[service], nil
 }
 
-func (s *simpleMonitor) Lookup(service string, key string) (*membership.HostInfo, error) {
+func (s *simpleMonitor) Lookup(service primitives.ServiceName, key string) (*membership.HostInfo, error) {
 	resolver, ok := s.resolvers[service]
 	if !ok {
 		return nil, fmt.Errorf("cannot lookup host for service %v", service)
@@ -72,11 +73,11 @@ func (s *simpleMonitor) Lookup(service string, key string) (*membership.HostInfo
 	return resolver.Lookup(key)
 }
 
-func (s *simpleMonitor) AddListener(service string, name string, notifyChannel chan<- *membership.ChangedEvent) error {
+func (s *simpleMonitor) AddListener(service primitives.ServiceName, name string, notifyChannel chan<- *membership.ChangedEvent) error {
 	return nil
 }
 
-func (s *simpleMonitor) RemoveListener(service string, name string) error {
+func (s *simpleMonitor) RemoveListener(service primitives.ServiceName, name string) error {
 	return nil
 }
 
@@ -84,6 +85,6 @@ func (s *simpleMonitor) GetReachableMembers() ([]string, error) {
 	return nil, nil
 }
 
-func (s *simpleMonitor) GetMemberCount(service string) (int, error) {
+func (s *simpleMonitor) GetMemberCount(service primitives.ServiceName) (int, error) {
 	return 0, nil
 }

--- a/host/simpleServiceResolver.go
+++ b/host/simpleServiceResolver.go
@@ -28,6 +28,7 @@ import (
 	"github.com/dgryski/go-farm"
 
 	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/primitives"
 )
 
 type simpleResolver struct {
@@ -37,10 +38,10 @@ type simpleResolver struct {
 
 // newSimpleResolver returns a service resolver that maintains static mapping
 // between services and host info
-func newSimpleResolver(service string, hosts []string) membership.ServiceResolver {
+func newSimpleResolver(service primitives.ServiceName, hosts []string) membership.ServiceResolver {
 	hostInfos := make([]*membership.HostInfo, 0, len(hosts))
 	for _, host := range hosts {
-		hostInfos = append(hostInfos, membership.NewHostInfo(host, map[string]string{membership.RoleKey: service}))
+		hostInfos = append(hostInfos, membership.NewHostInfo(host, map[string]string{membership.RoleKey: string(service)}))
 	}
 	return &simpleResolver{hostInfos, farm.Fingerprint32}
 }

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -804,7 +804,12 @@ func (adh *AdminHandler) DescribeCluster(
 		membershipInfo.ReachableMembers = members
 
 		var rings []*clusterspb.RingInfo
-		for _, role := range []string{primitives.FrontendService, primitives.HistoryService, primitives.MatchingService, primitives.WorkerService} {
+		for _, role := range []primitives.ServiceName{
+			primitives.FrontendService,
+			primitives.HistoryService,
+			primitives.MatchingService,
+			primitives.WorkerService,
+		} {
 			resolver, err := monitor.GetResolver(role)
 			if err != nil {
 				return nil, err
@@ -818,7 +823,7 @@ func (adh *AdminHandler) DescribeCluster(
 			}
 
 			rings = append(rings, &clusterspb.RingInfo{
-				Role:        role,
+				Role:        string(role),
 				MemberCount: int32(resolver.MemberCount()),
 				Members:     servers,
 			})

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2425,7 +2425,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 		return nil, err
 	}
 
-	visibilityArchiver, err := wh.archiverProvider.GetVisibilityArchiver(URI.Scheme(), primitives.FrontendService)
+	visibilityArchiver, err := wh.archiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.FrontendService))
 	if err != nil {
 		return nil, err
 	}
@@ -4552,7 +4552,7 @@ func (wh *WorkflowHandler) getArchivedHistory(
 		return nil, err
 	}
 
-	historyArchiver, err := wh.archiverProvider.GetHistoryArchiver(URI.Scheme(), primitives.FrontendService)
+	historyArchiver, err := wh.archiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.FrontendService))
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/deletemanager/delete_manager.go
+++ b/service/history/deletemanager/delete_manager.go
@@ -300,7 +300,7 @@ func (m *DeleteManagerImpl) archiveWorkflowIfEnabled(
 			BranchToken:          currentBranchToken,
 			CloseFailoverVersion: closeFailoverVersion,
 		},
-		CallerService:        primitives.HistoryService,
+		CallerService:        string(primitives.HistoryService),
 		AttemptArchiveInline: false, // archive in workflow by default
 	}
 	executionStats, err := weCtx.LoadExecutionStats(ctx)

--- a/service/history/deletemanager/delete_manager_test.go
+++ b/service/history/deletemanager/delete_manager_test.go
@@ -411,7 +411,7 @@ type (
 
 func (m archiverClientRequestMatcher) Matches(x interface{}) bool {
 	req := x.(*archiver.ClientRequest)
-	return req.CallerService == primitives.HistoryService &&
+	return req.CallerService == string(primitives.HistoryService) &&
 		req.AttemptArchiveInline == m.inline &&
 		req.ArchiveRequest.Targets[0] == archiver.ArchiveTargetHistory
 }

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -219,7 +219,7 @@ func (t *transferQueueTaskExecutorBase) archiveVisibility(
 			HistoryURI:       namespaceEntry.HistoryArchivalState().URI,
 			Targets:          []archiver.ArchivalTarget{archiver.ArchiveTargetVisibility},
 		},
-		CallerService:        primitives.HistoryService,
+		CallerService:        string(primitives.HistoryService),
 		AttemptArchiveInline: true, // archive visibility inline by default
 	})
 

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -74,7 +74,7 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 		logger.Error(carchiver.ArchiveNonRetryableErrorMsg, tag.ArchivalArchiveFailReason("failed to get history archival uri"), tag.ArchivalURI(request.HistoryURI), tag.Error(err))
 		return errUploadNonRetryable
 	}
-	historyArchiver, err := container.ArchiverProvider.GetHistoryArchiver(URI.Scheme(), primitives.WorkerService)
+	historyArchiver, err := container.ArchiverProvider.GetHistoryArchiver(URI.Scheme(), string(primitives.WorkerService))
 	if err != nil {
 		logger.Error(carchiver.ArchiveNonRetryableErrorMsg, tag.ArchivalArchiveFailReason("failed to get history archiver"), tag.Error(err))
 		return errUploadNonRetryable
@@ -154,7 +154,7 @@ func archiveVisibilityActivity(ctx context.Context, request ArchiveRequest) (err
 		logger.Error(carchiver.ArchiveNonRetryableErrorMsg, tag.ArchivalArchiveFailReason("failed to get visibility archival uri"), tag.ArchivalURI(request.VisibilityURI), tag.Error(err))
 		return errArchiveVisibilityNonRetryable
 	}
-	visibilityArchiver, err := container.ArchiverProvider.GetVisibilityArchiver(URI.Scheme(), primitives.WorkerService)
+	visibilityArchiver, err := container.ArchiverProvider.GetVisibilityArchiver(URI.Scheme(), string(primitives.WorkerService))
 	if err != nil {
 		logger.Error(carchiver.ArchiveNonRetryableErrorMsg, tag.ArchivalArchiveFailReason("failed to get visibility archiver"), tag.Error(err))
 		return errArchiveVisibilityNonRetryable

--- a/service/worker/archiver/activities_test.go
+++ b/service/worker/archiver/activities_test.go
@@ -138,7 +138,7 @@ func (s *activitiesSuite) TestUploadHistory_Fail_GetArchiverError() {
 		metrics.OperationTag(metrics.ArchiverUploadHistoryActivityScope), []metrics.Tag{metrics.NamespaceTag(testNamespace)},
 	).Return(s.metricsHandler)
 	s.metricsHandler.EXPECT().Counter(metrics.ArchiverNonRetryableErrorCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
-	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), primitives.WorkerService).Return(
+	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), string(primitives.WorkerService)).Return(
 		nil, errors.New("failed to get archiver"),
 	)
 	container := &BootstrapContainer{
@@ -172,7 +172,7 @@ func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveNonRetryableError() {
 	s.metricsHandler.EXPECT().WithTags(metrics.OperationTag(metrics.ArchiverUploadHistoryActivityScope), []metrics.Tag{metrics.NamespaceTag(testNamespace)}).Return(s.metricsHandler)
 	s.metricsHandler.EXPECT().Counter(metrics.ArchiverNonRetryableErrorCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
 	s.historyArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errUploadNonRetryable)
-	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), primitives.WorkerService).Return(s.historyArchiver, nil)
+	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), string(primitives.WorkerService)).Return(s.historyArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsHandler:   s.metricsHandler,
@@ -204,7 +204,7 @@ func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveRetryableError() {
 	s.metricsHandler.EXPECT().WithTags(metrics.OperationTag(metrics.ArchiverUploadHistoryActivityScope), []metrics.Tag{metrics.NamespaceTag(testNamespace)}).Return(s.metricsHandler)
 	testArchiveErr := errors.New("some transient error")
 	s.historyArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testArchiveErr)
-	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), primitives.WorkerService).Return(s.historyArchiver, nil)
+	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), string(primitives.WorkerService)).Return(s.historyArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsHandler:   s.metricsHandler,
@@ -235,7 +235,7 @@ func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveRetryableError() {
 func (s *activitiesSuite) TestUploadHistory_Success() {
 	s.metricsHandler.EXPECT().WithTags(metrics.OperationTag(metrics.ArchiverUploadHistoryActivityScope), []metrics.Tag{metrics.NamespaceTag(testNamespace)}).Return(s.metricsHandler)
 	s.historyArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), primitives.WorkerService).Return(s.historyArchiver, nil)
+	s.archiverProvider.EXPECT().GetHistoryArchiver(gomock.Any(), string(primitives.WorkerService)).Return(s.historyArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsHandler:   s.metricsHandler,
@@ -365,7 +365,7 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_InvalidURI() {
 
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_GetArchiverError() {
 	s.metricsHandler.EXPECT().WithTags(metrics.OperationTag(metrics.ArchiverArchiveVisibilityActivityScope), []metrics.Tag{metrics.NamespaceTag(testNamespace)}).Return(s.metricsHandler)
-	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), primitives.WorkerService).Return(nil, errors.New("failed to get archiver"))
+	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), string(primitives.WorkerService)).Return(nil, errors.New("failed to get archiver"))
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsHandler:   s.metricsHandler,
@@ -393,7 +393,7 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_GetArchiverError() 
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveNonRetryableError() {
 	s.metricsHandler.EXPECT().WithTags(metrics.OperationTag(metrics.ArchiverArchiveVisibilityActivityScope), []metrics.Tag{metrics.NamespaceTag(testNamespace)}).Return(s.metricsHandler)
 	s.visibilityArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errArchiveVisibilityNonRetryable)
-	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), primitives.WorkerService).Return(s.visibilityArchiver, nil)
+	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), string(primitives.WorkerService)).Return(s.visibilityArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsHandler:   s.metricsHandler,
@@ -422,7 +422,7 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveRetryableErr
 	s.metricsHandler.EXPECT().WithTags(metrics.OperationTag(metrics.ArchiverArchiveVisibilityActivityScope), []metrics.Tag{metrics.NamespaceTag(testNamespace)}).Return(s.metricsHandler)
 	testArchiveErr := errors.New("some transient error")
 	s.visibilityArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testArchiveErr)
-	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), primitives.WorkerService).Return(s.visibilityArchiver, nil)
+	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), string(primitives.WorkerService)).Return(s.visibilityArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsHandler:   s.metricsHandler,
@@ -450,7 +450,7 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveRetryableErr
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Success() {
 	s.metricsHandler.EXPECT().WithTags(metrics.OperationTag(metrics.ArchiverArchiveVisibilityActivityScope), []metrics.Tag{metrics.NamespaceTag(testNamespace)}).Return(s.metricsHandler)
 	s.visibilityArchiver.EXPECT().Archive(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), primitives.WorkerService).Return(s.visibilityArchiver, nil)
+	s.archiverProvider.EXPECT().GetVisibilityArchiver(gomock.Any(), string(primitives.WorkerService)).Return(s.visibilityArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsHandler:   s.metricsHandler,

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -226,7 +226,7 @@ func signalRemoteCluster(
 				},
 				Input:                 nil,
 				WorkflowTaskTimeout:   timestamp.DurationPtr(workflowTaskTimeout),
-				Identity:              currentCluster + "-" + primitives.WorkerService + "-service",
+				Identity:              currentCluster + "-" + string(primitives.WorkerService) + "-service",
 				WorkflowIdReusePolicy: workflowIDReusePolicy,
 				SignalName:            processorChannelName,
 				SignalInput:           signalInput,

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -43,13 +43,14 @@ type (
 	}
 )
 
-// Services is the list of all valid temporal services
+// Services is the list of all valid temporal services as strings (needs to be strings to keep
+// ServerOptions interface stable)
 var (
 	Services = []string{
-		primitives.FrontendService,
-		primitives.HistoryService,
-		primitives.MatchingService,
-		primitives.WorkerService,
+		string(primitives.FrontendService),
+		string(primitives.HistoryService),
+		string(primitives.MatchingService),
+		string(primitives.WorkerService),
 	}
 )
 

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	persistenceclient "go.temporal.io/server/common/persistence/client"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/searchattribute"
@@ -68,9 +69,9 @@ func WithConfigLoader(configDir string, env string, zone string) ServerOption {
 // ForServices indicates which supplied services (e.g. frontend, history, matching, worker) within the server to start
 func ForServices(names []string) ServerOption {
 	return applyFunc(func(s *serverOptions) {
-		s.serviceNames = make(map[string]struct{})
+		s.serviceNames = make(map[primitives.ServiceName]struct{})
 		for _, name := range names {
-			s.serviceNames[name] = struct{}{}
+			s.serviceNames[primitives.ServiceName(name)] = struct{}{}
 		}
 	})
 }

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/searchattribute"
@@ -45,7 +46,7 @@ import (
 
 type (
 	serverOptions struct {
-		serviceNames map[string]struct{}
+		serviceNames map[primitives.ServiceName]struct{}
 
 		config    *config.Config
 		configDir string
@@ -86,7 +87,7 @@ func newServerOptions(opts []ServerOption) *serverOptions {
 
 func (so *serverOptions) loadAndValidate() error {
 	for serviceName := range so.serviceNames {
-		if !slices.Contains(Services, serviceName) {
+		if !slices.Contains(Services, string(serviceName)) {
 			return fmt.Errorf("invalid service %q in service list %v", serviceName, so.serviceNames)
 		}
 	}
@@ -122,7 +123,7 @@ func (so *serverOptions) validateConfig() error {
 	}
 
 	for name := range so.serviceNames {
-		if _, ok := so.config.Services[name]; !ok {
+		if _, ok := so.config.Services[string(name)]; !ok {
 			return fmt.Errorf("%q service is missing in config", name)
 		}
 	}

--- a/tools/tdbg/commands.go
+++ b/tools/tdbg/commands.go
@@ -409,7 +409,7 @@ func AdminListGossipMembers(c *cli.Context) error {
 	}
 
 	members := response.MembershipInfo.Rings
-	if roleFlag != primitives.AllServices {
+	if roleFlag != string(primitives.AllServices) {
 		all := members
 
 		members = members[:0]


### PR DESCRIPTION
**What changed?**
- Moves `resource.ServiceName` into `primitives`
- Use in more places

**Why?**
- Type safety
- Can refer to `ServiceName` from packages that are imported by resource without creating a cycle (to use in another PR)

**How did you test it?**
CI

**Potential risks**
I tried to avoid changing anything used by ServerOptions so this shouldn't break anyone importing the server as a library, but the membership interface did change

**Is hotfix candidate?**
