### PR TITLE
docs: add specific make step to README on the tools/sql path

### DIFF
--- a/tools/sql/README.md
+++ b/tools/sql/README.md
@@ -11,7 +11,7 @@ SQL_USER=$USERNAME SQL_PASSWORD=$PASSWD make install-schema-mysql
 ## For production
 
 ### Create the binaries
-- Run `make`
+- Run `make temporal-sql-tool` on the root of repositroy
 - You should see an executable `temporal-sql-tool`
 - Temporal officially support MySQL and Postgres for SQL. 
 - For other SQL database, you can add it easily as we do for MySQL/Postgres following our code in sql-extensions  

--- a/tools/sql/README.md
+++ b/tools/sql/README.md
@@ -10,7 +10,7 @@ SQL_USER=$USERNAME SQL_PASSWORD=$PASSWD make install-schema-mysql
 
 ## For production
 
-### Create the binaries
+### Create the binary
 - Run `make temporal-sql-tool` on the root of repositroy
 - You should see an executable `temporal-sql-tool`
 - Temporal officially support MySQL and Postgres for SQL. 
@@ -20,8 +20,8 @@ SQL_USER=$USERNAME SQL_PASSWORD=$PASSWD make install-schema-mysql
 - All command below are taking MySQL as example. For postgres, simply use with "--plugin postgres"
 
 ```
-temporal-sql-tool --ep $SQL_HOST -p $port --db temporal --plugin mysql create
-temporal-sql-tool --ep $SQL_HOST -p $port --db temporal_visibility --plugin mysql create
+./temporal-sql-tool --ep $SQL_HOST -p $port --db temporal --plugin mysql create
+./temporal-sql-tool --ep $SQL_HOST -p $port --db temporal_visibility --plugin mysql create
 ```
 
 ```


### PR DESCRIPTION
docs: add specific make step to README on the tools/sql path for creating easily temporal-sql-tool binary

<!-- Describe what has changed in this PR -->
I've added a specific make step to README on the tools/sql path 

<!-- Tell your future self why have you made these changes -->
so that users don't have to struggle to find the make step

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
improve README only


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
there is no potential risk because only editing README


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
no
