### PR TITLE
Fix flaky CreateIndex method

### DIFF
--- a/host/testdata/integration_elasticsearch_cluster.yaml
+++ b/host/testdata/integration_elasticsearch_cluster.yaml
@@ -12,4 +12,4 @@ esconfig:
     scheme: "http"
     host: "${ES_SEEDS}:9200"
   indices:
-    visibility: test-visibility-
+    visibility: test-visibility-ad8388-

--- a/host/testdata/integration_namespace_cluster.yaml
+++ b/host/testdata/integration_namespace_cluster.yaml
@@ -13,4 +13,4 @@ esconfig:
     scheme: "http"
     host: "${ES_SEEDS}:9200"
   indices:
-    visibility: test-visibility-
+    visibility: test-visibility-28e9c5-

--- a/host/testdata/schedule_integration_test_cluster_adv_vis.yaml
+++ b/host/testdata/schedule_integration_test_cluster_adv_vis.yaml
@@ -11,4 +11,4 @@ esconfig:
     scheme: "http"
     host: "${ES_SEEDS}:9200"
   indices:
-    visibility: test-visibility-
+    visibility: test-visibility-3c863e-

--- a/host/testdata/xdc_integration_es_clusters.yaml
+++ b/host/testdata/xdc_integration_es_clusters.yaml
@@ -25,7 +25,7 @@
       scheme: "http"
       host: "${ES_SEEDS}:9200"
     indices:
-      visibility: test-visibility-0-
+      visibility: test-visibility-4b3e75-
 
 - persistence:
     dbname: integration_standby_es
@@ -54,4 +54,4 @@
       scheme: "http"
       host: "${ES_SEEDS}:9200"
     indices:
-      visibility: test-visibility-1-
+      visibility: test-visibility-73af9f-


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now use unique index names for ElasticSearch test configs.

<!-- Tell your future self why have you made these changes -->
**Why?**
Because this method is flaky, and my last effort to just retry the creation doesn't work. This lead to failed builds like [this one](https://buildkite.com/temporal/temporal-public/builds/6882).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
CI

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This method is in the host/ directory which is only used by tests.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.