### PR TITLE
Handle data loss error in replication read history

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -659,6 +659,8 @@ const (
 	ReplicationTaskProcessorHostQPS = "history.ReplicationTaskProcessorHostQPS"
 	// ReplicationTaskProcessorShardQPS is the qps of task processing rate limiter on shard level
 	ReplicationTaskProcessorShardQPS = "history.ReplicationTaskProcessorShardQPS"
+	// ReplicationBypassCorruptedData is the flag to bypass corrupted workflow data in source cluster
+	ReplicationBypassCorruptedData = "history.ReplicationBypassCorruptedData"
 
 	// keys for worker
 

--- a/common/persistence/history_manager.go
+++ b/common/persistence/history_manager.go
@@ -33,6 +33,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/persistence/serialization"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -1159,9 +1160,9 @@ func (m *executionManagerImpl) filterHistoryNodes(
 
 		switch {
 		case node.NodeID < lastNodeID:
-			return nil, serviceerror.NewUnavailable("corrupted data, nodeID cannot decrease")
+			return nil, serviceerror.NewDataLoss("corrupted data, nodeID cannot decrease")
 		case node.NodeID == lastNodeID:
-			return nil, serviceerror.NewUnavailable("corrupted data, same nodeID must have smaller txnID")
+			return nil, serviceerror.NewDataLoss("corrupted data, same nodeID must have smaller txnID")
 		default: // row.NodeID > lastNodeID:
 			// NOTE: when row.nodeID > lastNodeID, we expect the one with largest txnID comes first
 			lastTransactionID = node.TransactionID
@@ -1188,7 +1189,7 @@ func (m *executionManagerImpl) filterHistoryNodesReverse(
 
 		switch {
 		case node.NodeID > lastNodeID:
-			return nil, serviceerror.NewUnavailable("corrupted data, nodeID cannot decrease")
+			return nil, serviceerror.NewDataLoss("corrupted data, nodeID cannot decrease")
 		default:
 			lastTransactionID = node.PrevTransactionID
 			lastNodeID = node.NodeID

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -240,6 +240,7 @@ type Config struct {
 	ReplicationTaskProcessorCleanupJitterCoefficient     dynamicconfig.FloatPropertyFnWithShardIDFilter
 	ReplicationTaskProcessorHostQPS                      dynamicconfig.FloatPropertyFn
 	ReplicationTaskProcessorShardQPS                     dynamicconfig.FloatPropertyFn
+	ReplicationBypassCorruptedData                       dynamicconfig.BoolPropertyFnWithNamespaceIDFilter
 
 	// The following are used by consistent query
 	MaxBufferedQueryCount dynamicconfig.IntPropertyFn
@@ -419,6 +420,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int32, isAdvancedVis
 		ReplicatorProcessorFetchTasksBatchSize:                dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 25),
 		ReplicationTaskProcessorHostQPS:                       dc.GetFloat64Property(dynamicconfig.ReplicationTaskProcessorHostQPS, 1500),
 		ReplicationTaskProcessorShardQPS:                      dc.GetFloat64Property(dynamicconfig.ReplicationTaskProcessorShardQPS, 30),
+		ReplicationBypassCorruptedData:                        dc.GetBoolPropertyFnWithNamespaceIDFilter(dynamicconfig.ReplicationBypassCorruptedData, false),
 
 		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
 		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MaximumSignalsPerExecution, 0),

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -453,7 +453,7 @@ func (p *ackMgrImpl) generateHistoryReplicationTask(
 			switch err.(type) {
 			case nil:
 				// continue to generate replication task.
-			case *serviceerror.NotFound, *serviceerror.DataLoss:
+			case *serviceerror.NotFound, *serviceerror.DataLoss, *serviceerror.Unavailable:
 				// bypass this corrupted workflow to unblock the replication queue.
 				p.logger.Error("Cannot get history from corrupted workflow",
 					tag.WorkflowNamespaceID(namespaceID.String()),
@@ -667,7 +667,7 @@ func (p *ackMgrImpl) processNewRunReplication(
 		switch err.(type) {
 		case nil:
 			// continue to generate replication task.
-		case *serviceerror.NotFound, *serviceerror.DataLoss:
+		case *serviceerror.NotFound, *serviceerror.DataLoss, *serviceerror.Unavailable:
 			// bypass this corrupted workflow to unblock the replication queue.
 			p.logger.Error("Cannot get history from corrupted workflow",
 				tag.WorkflowNamespaceID(namespaceID.String()),

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -673,6 +673,7 @@ func (p *ackMgrImpl) processNewRunReplication(
 				tag.WorkflowNamespaceID(namespaceID.String()),
 				tag.WorkflowID(workflowID),
 				tag.WorkflowRunID(newRunID))
+			// only return the task with current run and bypass the new run.
 			return task, nil
 		default:
 			return nil, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Use data loss error for corrupted data case.
2. Ability to bypass corrupted data in replication.

<!-- Tell your future self why have you made these changes -->
**Why?**
We should aware of the corrupted data but also need to ability to bypass this error so it will not block the replication.
This is a clean version of https://github.com/temporalio/temporal/pull/3691

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.