### PR TITLE
sample showing circular imports

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -47,6 +47,7 @@ import (
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow/cache"
 )
 
 //go:generate mockgen -copyright_file ../../../LICENSE -package $GOPACKAGE -source $GOFILE -destination context_mock.go
@@ -59,6 +60,7 @@ type (
 		GetNamespaceRegistry() namespace.Registry
 		GetClusterMetadata() cluster.Metadata
 		GetConfig() *configs.Config
+		GetWorkflowCache() cache.Cache
 		GetEventsCache() events.Cache
 		GetLogger() log.Logger
 		GetThrottledLogger() log.Logger

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -32,7 +32,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"go.opentelemetry.io/otel/trace"
+	"go.opencensus.io/otel/trace"
 
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/client"
@@ -52,6 +52,7 @@ import (
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/events"
 )
 
 const (
@@ -271,6 +272,17 @@ func (c *ControllerImpl) getOrCreateShardContext(shardID int32) (*ContextImpl, e
 	shard, err := newContext(
 		shardID,
 		c.engineFactory,
+		nil,
+		events.NewEventsCache(
+			shardID,
+			c.config.EventsCacheInitialSize(),
+			c.config.EventsCacheMaxSize(),
+			c.config.EventsCacheTTL(),
+			c.persistenceExecutionManager,
+			false,
+			c.logger,
+			c.metricsHandler,
+		),
 		c.config,
 		c.shardClosedCallback,
 		c.logger,


### PR DESCRIPTION
service/history/shard/controller_impl.go:35:2: no required module provides package go.opencensus.io/otel/trace; to add it:
	go get go.opencensus.io/otel/trace
package go.temporal.io/server/cmd/server
	imports go.temporal.io/server/temporal
	imports go.temporal.io/server/service/history
	imports go.temporal.io/server/service/history/api
	imports go.temporal.io/server/service/history/shard
	imports go.temporal.io/server/service/history/workflow/cache
	imports go.temporal.io/server/service/history/shard: import cycle not allowed