### PR TITLE
Delete RunID retrieval inside the validator

### DIFF
--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -41,7 +41,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
@@ -202,20 +201,7 @@ func (c *CacheImpl) validateWorkflowExecutionInfo(
 		return serviceerror.NewNotFound("Workflow not exists.")
 	}
 
-	// RunID is not provided, lets try to retrieve the RunID for current active execution
-	if execution.GetRunId() == "" {
-		response, err := c.shard.GetCurrentExecution(ctx, &persistence.GetCurrentExecutionRequest{
-			ShardID:     c.shard.GetShardID(),
-			NamespaceID: namespaceID.String(),
-			WorkflowID:  execution.GetWorkflowId(),
-		})
-
-		if err != nil {
-			return err
-		}
-
-		execution.RunId = response.RunID
-	} else if uuid.Parse(execution.GetRunId()) == nil { // immediately return if invalid runID
+	if uuid.Parse(execution.GetRunId()) == nil { // immediately return if invalid runID
 		return serviceerror.NewInvalidArgument("RunId is not valid UUID.")
 	}
 	return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Deleted RunID retrieval inside the validator.

<!-- Tell your future self why have you made these changes -->
**Why?**
To start a discussion that it's not required and show by the tests that it's not used.
It's a blocker to remove a shard dependency from the workflow/cache package.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Locally, CI.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It might be not covered by tests.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Revert.