### PR TITLE
Fix bug not setting CanSkipVisibilityArchival

### DIFF
--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -242,6 +242,11 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 			}
 			require.NotNil(t, closeExecutionTask)
 			assert.Equal(t, p.DeleteAfterClose, closeExecutionTask.DeleteAfterClose)
+			assert.Equal(
+				t,
+				p.DurableArchivalEnabled && !p.DeleteAfterClose,
+				closeExecutionTask.CanSkipVisibilityArchival,
+			)
 
 			if p.ExpectCloseExecutionVisibilityTask {
 				assert.NotNil(t, closeExecutionVisibilityTask)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now set the CanSkipVisibilityArchival flag when creating archival queue tasks.

<!-- Tell your future self why have you made these changes -->
**Why?**
This was a bug. We need to set this flag when using durable archival so that we don't archive visibility twice.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added a statement in the unit test and verified that the test failed before this change.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Not used in prod yet.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No