### PR TITLE
Use latest replication task time as sync shard time

### DIFF
--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -247,12 +247,16 @@ func (p *ackMgrImpl) GetTasks(
 	p.metricsHandler.Histogram(metrics.ReplicationTasksReturned.GetMetricName(), metrics.ReplicationTasksReturned.GetMetricUnit()).
 		Record(int64(len(replicationTasks)))
 
+	replicationEventTime := timestamp.TimePtr(p.shard.GetTimeSource().Now())
+	if len(replicationTasks) > 0 {
+		replicationEventTime = replicationTasks[len(replicationTasks)-1].GetVisibilityTime()
+	}
 	return &replicationspb.ReplicationMessages{
 		ReplicationTasks:       replicationTasks,
 		HasMore:                lastTaskID < maxTaskID,
 		LastRetrievedMessageId: lastTaskID,
 		SyncShardStatus: &replicationspb.SyncShardStatus{
-			StatusTime: timestamp.TimePtr(p.shard.GetTimeSource().Now()),
+			StatusTime: replicationEventTime,
 		},
 	}, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use latest replication task time as sync shard time

<!-- Tell your future self why have you made these changes -->
**Why?**
It should use latest replication task visibility time. This represents the lag on replication. If the replication task is empty, then it can use the cluster local time.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
