### PR TITLE
Fix range variable in archiver_test not being captured

### DIFF
--- a/service/history/archival/archiver_test.go
+++ b/service/history/archival/archiver_test.go
@@ -27,7 +27,6 @@ package archival
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -244,6 +243,7 @@ func TestArchiver(t *testing.T) {
 			},
 		},
 	} {
+		c := c // capture range variable
 		t.Run(c.Name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()
@@ -324,9 +324,9 @@ func (r *errorLogRecorder) Error(msg string, tags ...tag.Tag) {
 	for _, t := range tags {
 		if t.Key() == "error" {
 			value := t.Value()
-			message, ok := value.(fmt.Stringer)
+			message, ok := value.(string)
 			require.True(r.T, ok)
-			r.ErrorMessages = append(r.ErrorMessages, message.String())
+			r.ErrorMessages = append(r.ErrorMessages, message)
 		}
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I had a parallel test that looped over some configs, but I forgot to capture the range loop, so the behavior of the test was non-deterministic. I fixed it by capturing the range variable.

<!-- Tell your future self why have you made these changes -->
**Why?**
Because this was a bug (only in tests though).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I reran the test, with coverage, and I verified that the coverage is 94.2%. Before, only some tests were run so it was only 29%.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No