### PR TITLE
Fix errcheck in service/worker/

### DIFF
--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -151,7 +151,10 @@ func (wm *perNamespaceWorkerManager) Start(
 	// this will call namespaceCallback with current namespaces
 	wm.namespaceRegistry.RegisterStateChangeCallback(wm, wm.namespaceCallback)
 
-	wm.serviceResolver.AddListener(perNamespaceWorkerManagerListenerKey, wm.membershipChangedCh)
+	err := wm.serviceResolver.AddListener(perNamespaceWorkerManagerListenerKey, wm.membershipChangedCh)
+	if err != nil {
+		wm.logger.Fatal("Unable to register membership listener", tag.Error(err))
+	}
 	go wm.membershipChangedListener()
 
 	wm.logger.Info("", tag.LifeCycleStarted)
@@ -169,7 +172,10 @@ func (wm *perNamespaceWorkerManager) Stop() {
 	wm.logger.Info("", tag.LifeCycleStopping)
 
 	wm.namespaceRegistry.UnregisterStateChangeCallback(wm)
-	wm.serviceResolver.RemoveListener(perNamespaceWorkerManagerListenerKey)
+	err := wm.serviceResolver.RemoveListener(perNamespaceWorkerManagerListenerKey)
+	if err != nil {
+		wm.logger.Error("Unable to unregister membership listener", tag.Error(err))
+	}
 	close(wm.membershipChangedCh)
 
 	wm.lock.Lock()

--- a/service/worker/worker.go
+++ b/service/worker/worker.go
@@ -98,7 +98,9 @@ func (wm *workerManager) Start() {
 	}
 
 	for _, w := range wm.workers {
-		w.Start()
+		if err := w.Start(); err != nil {
+			wm.logger.Fatal("Unable to start worker", tag.Error(err))
+		}
 	}
 
 	wm.logger.Info("", tag.ComponentWorkerManager, tag.LifeCycleStarted)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now surface errors from code within `service/worker`. 

1. We log an error when we fail to unregister a membership listener in the per-namespace worker
1. We log a fatal error when we fail to register the membership listener during startup
1. We log a fatal error whenever any SDK workers fail to start 
1. The scheduler will retry now whenever the side effect of creating a new UUID fails (this should be rare, but we still shouldn't ignore these errors).

<!-- Tell your future self why you have made these changes -->
**Why?**
I made these changes so that we don't silently swallow these errors. Additionally, this will enable us to run `errcheck` on this directory.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I tested this using the CI. However, I made sure that the not-so-important errors, like unregistering a membership listener, are only logged, not treated as fatal.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This could cause errors on startup/shutdown that users aren't used to. 

<!-- Is this PR a hotfix candidate, or does it require notification to be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Let's note it because OSS users might see a new error and wonder why.
