### PR TITLE
Refactor transient workflow task state machine

### DIFF
--- a/service/history/ndc/branch_manager.go
+++ b/service/history/ndc/branch_manager.go
@@ -170,7 +170,7 @@ func (r *BranchMgrImpl) flushBufferedEvents(
 	// check whether there are buffered events, if so, flush it
 	// NOTE: buffered events does not show in version history or next event id
 	if !r.mutableState.HasBufferedEvents() {
-		if r.mutableState.HasTransientWorkflowTask() {
+		if r.mutableState.HasInFlightWorkflowTask() && r.mutableState.IsTransientWorkflowTask() {
 			if err := r.mutableState.ClearTransientWorkflowTask(); err != nil {
 				return nil, 0, err
 			}

--- a/service/history/ndc/branch_manager_test.go
+++ b/service/history/ndc/branch_manager_test.go
@@ -193,7 +193,8 @@ func (s *branchMgrSuite) TestClearTransientWorkflowTask() {
 
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastWriteVersion, nil).AnyTimes()
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasTransientWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().ClearTransientWorkflowTask().Return(nil).AnyTimes()
 
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
@@ -285,7 +286,8 @@ func (s *branchMgrSuite) TestPrepareVersionHistory_BranchAppendable_NoMissingEve
 
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{VersionHistories: versionHistories}).AnyTimes()
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasTransientWorkflowTask().Return(false).AnyTimes()
+	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(false).AnyTimes()
 
 	doContinue, index, err := s.nDCBranchMgr.prepareVersionHistory(
 		context.Background(),
@@ -316,7 +318,8 @@ func (s *branchMgrSuite) TestPrepareVersionHistory_BranchAppendable_MissingEvent
 	s.NoError(err)
 
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasTransientWorkflowTask().Return(false).AnyTimes()
+	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(false).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		NamespaceId:      s.namespaceID,
 		WorkflowId:       s.workflowID,
@@ -357,7 +360,8 @@ func (s *branchMgrSuite) TestPrepareVersionHistory_BranchNotAppendable_NoMissing
 	newBranchToken := []byte("some random new branch token")
 
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasTransientWorkflowTask().Return(false).AnyTimes()
+	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(false).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		NamespaceId:      s.namespaceID,
 		WorkflowId:       s.workflowID,
@@ -416,7 +420,8 @@ func (s *branchMgrSuite) TestPrepareVersionHistory_BranchNotAppendable_MissingEv
 	})
 
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasTransientWorkflowTask().Return(false).AnyTimes()
+	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(false).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		NamespaceId:      s.namespaceID,
 		WorkflowId:       s.workflowID,

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -182,7 +182,7 @@ type (
 		GetWorkflowType() *commonpb.WorkflowType
 		GetWorkflowStateStatus() (enumsspb.WorkflowExecutionState, enumspb.WorkflowExecutionStatus)
 		GetQueryRegistry() QueryRegistry
-		HasTransientWorkflowTask() bool
+		IsTransientWorkflowTask() bool
 		ClearTransientWorkflowTask() error
 		HasBufferedEvents() bool
 		HasInFlightWorkflowTask() bool

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -1622,20 +1622,6 @@ func (mr *MockMutableStateMockRecorder) HasProcessedOrPendingWorkflowTask() *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProcessedOrPendingWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).HasProcessedOrPendingWorkflowTask))
 }
 
-// HasTransientWorkflowTask mocks base method.
-func (m *MockMutableState) HasTransientWorkflowTask() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasTransientWorkflowTask")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// HasTransientWorkflowTask indicates an expected call of HasTransientWorkflowTask.
-func (mr *MockMutableStateMockRecorder) HasTransientWorkflowTask() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasTransientWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).HasTransientWorkflowTask))
-}
-
 // IsCancelRequested mocks base method.
 func (m *MockMutableState) IsCancelRequested() bool {
 	m.ctrl.T.Helper()
@@ -1704,6 +1690,20 @@ func (m *MockMutableState) IsStickyTaskQueueEnabled() bool {
 func (mr *MockMutableStateMockRecorder) IsStickyTaskQueueEnabled() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsStickyTaskQueueEnabled", reflect.TypeOf((*MockMutableState)(nil).IsStickyTaskQueueEnabled))
+}
+
+// IsTransientWorkflowTask mocks base method.
+func (m *MockMutableState) IsTransientWorkflowTask() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsTransientWorkflowTask")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsTransientWorkflowTask indicates an expected call of IsTransientWorkflowTask.
+func (mr *MockMutableStateMockRecorder) IsTransientWorkflowTask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsTransientWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).IsTransientWorkflowTask))
 }
 
 // IsWorkflowExecutionRunning mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor transient workflow task state machine. Added `IsTransientWorkflowTask()` method to mutable state and use it everywhere to determinate if workflow task is transient or not.

Also significantly improved comments about transient workflow task state machine logic.

<!-- Tell your future self why have you made these changes -->
**Why?**
Consistent behaviour based on attempts count but not on event ids.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.