### PR TITLE
Fix errcheck in ./common/persistence/

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -1044,6 +1044,7 @@ type (
 	}
 
 	// Closeable is an interface for any entity that supports a close operation to release resources
+	// TODO: allow this method to return errors
 	Closeable interface {
 		Close()
 	}

--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -59,7 +59,10 @@ func (m *SqlStore) GetName() string {
 
 func (m *SqlStore) Close() {
 	if m.Db != nil {
-		m.Db.Close()
+		err := m.Db.Close()
+		if err != nil {
+			m.logger.Error("Error closing SQL database", tag.Error(err))
+		}
 	}
 }
 

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -30,6 +30,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 
 	"go.temporal.io/server/common/config"
@@ -179,7 +180,9 @@ func TestSQLiteTaskQueueTaskSuite(t *testing.T) {
 func TestSQLiteFileExecutionMutableStateStoreSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	defer os.Remove(cfg.DatabaseName)
+	defer func() {
+		assert.NoError(t, os.Remove(cfg.DatabaseName))
+	}()
 	logger := log.NewNoopLogger()
 	factory := sql.NewFactory(
 		*cfg,
@@ -212,7 +215,9 @@ func TestSQLiteFileExecutionMutableStateStoreSuite(t *testing.T) {
 func TestSQLiteFileExecutionMutableStateTaskStoreSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	defer os.Remove(cfg.DatabaseName)
+	defer func() {
+		assert.NoError(t, os.Remove(cfg.DatabaseName))
+	}()
 	logger := log.NewNoopLogger()
 	factory := sql.NewFactory(
 		*cfg,
@@ -245,7 +250,9 @@ func TestSQLiteFileExecutionMutableStateTaskStoreSuite(t *testing.T) {
 func TestSQLiteFileHistoryStoreSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	defer os.Remove(cfg.DatabaseName)
+	defer func() {
+		assert.NoError(t, os.Remove(cfg.DatabaseName))
+	}()
 	logger := log.NewNoopLogger()
 	factory := sql.NewFactory(
 		*cfg,
@@ -268,7 +275,9 @@ func TestSQLiteFileHistoryStoreSuite(t *testing.T) {
 func TestSQLiteFileTaskQueueSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	defer os.Remove(cfg.DatabaseName)
+	defer func() {
+		assert.NoError(t, os.Remove(cfg.DatabaseName))
+	}()
 	logger := log.NewNoopLogger()
 	factory := sql.NewFactory(
 		*cfg,
@@ -291,7 +300,9 @@ func TestSQLiteFileTaskQueueSuite(t *testing.T) {
 func TestSQLiteFileTaskQueueTaskSuite(t *testing.T) {
 	cfg := NewSQLiteFileConfig()
 	SetupSQLiteDatabase(cfg)
-	defer os.Remove(cfg.DatabaseName)
+	defer func() {
+		assert.NoError(t, os.Remove(cfg.DatabaseName))
+	}()
 	logger := log.NewNoopLogger()
 	factory := sql.NewFactory(
 		*cfg,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
^

<!-- Tell your future self why have you made these changes -->
**Why?**
This will surface errors if we fail to close SQL databases in prod and in tests

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Reran errcheck

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None because this just logs the close error instead of failing

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No