### PR TITLE
Fix token count in archival rate limiter

### DIFF
--- a/service/history/archival/archiver_test.go
+++ b/service/history/archival/archiver_test.go
@@ -278,7 +278,7 @@ func TestArchiver(t *testing.T) {
 					Return(c.ArchiveVisibilityErr)
 			}
 			rateLimiter := quotas.NewMockRateLimiter(controller)
-			rateLimiter.EXPECT().WaitN(gomock.Any(), 2).Return(c.RateLimiterWaitErr)
+			rateLimiter.EXPECT().WaitN(gomock.Any(), len(c.Targets)).Return(c.RateLimiterWaitErr)
 
 			archiver := NewArchiver(archiverProvider, logRecorder, metricsHandler, rateLimiter)
 			_, err = archiver.Archive(ctx, &Request{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed a small perf. issue in the archiver.

<!-- Tell your future self why have you made these changes -->
**Why?**
We acquire 2 rate-limiter tokens when we only need one sometimes

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No