### PR TITLE
Handle wrapped errors in task executable

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -355,11 +355,13 @@ func IsStickyWorkerUnavailable(err error) bool {
 
 // IsResourceExhausted checks if the error is a service busy error.
 func IsResourceExhausted(err error) bool {
-	switch err.(type) {
-	case *serviceerror.ResourceExhausted:
-		return true
-	}
-	return false
+	return IsErrorType[*serviceerror.ResourceExhausted](err)
+}
+
+// IsErrorType checks if any error in the error chain matches error type T
+func IsErrorType[T error](err error) bool {
+	var target T
+	return errors.As(err, &target)
 }
 
 // WorkflowIDToHistoryShard is used to map namespaceID-workflowID pair to a shardID.

--- a/common/util.go
+++ b/common/util.go
@@ -341,7 +341,7 @@ func IsServiceClientTransientError(err error) bool {
 }
 
 func IsServiceHandlerRetryableError(err error) bool {
-	if err.Error() == ErrNamespaceHandover.Error() {
+	if IsNamespaceHandoverErr(err) {
 		return false
 	}
 

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -455,12 +455,6 @@ func (c *ControllerImpl) ShardIDs() []int32 {
 }
 
 func IsShardOwnershipLostError(err error) bool {
-	switch err.(type) {
-	case *persistence.ShardOwnershipLostError:
-		return true
-	case *serviceerrors.ShardOwnershipLost:
-		return true
-	}
-
-	return false
+	return common.IsErrorType[*persistence.ShardOwnershipLostError](err) ||
+		common.IsErrorType[*serviceerrors.ShardOwnershipLost](err)
 }

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -437,7 +437,7 @@ pollLoop:
 				task.finish(nil)
 			default:
 				task.finish(err)
-				if err.Error() == common.ErrNamespaceHandover.Error() {
+				if common.IsNamespaceHandoverErr(err) {
 					// do not keep polling new tasks when namespace is in handover state
 					// as record start request will be rejected by history service
 					return nil, err
@@ -520,7 +520,7 @@ pollLoop:
 				task.finish(nil)
 			default:
 				task.finish(err)
-				if err.Error() == common.ErrNamespaceHandover.Error() {
+				if common.IsNamespaceHandoverErr(err) {
 					// do not keep polling new tasks when namespace is in handover state
 					// as record start request will be rejected by history service
 					return nil, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Check wrapped errors when handling task execution error

<!-- Tell your future self why have you made these changes -->
**Why?**
- So that we can wrap errors in task execution logic and log more informative error messages.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- If there's any existing error wrapping in task processing, error handling logic may go wrong. But I searched two ways of error wrapping: 
   - `Unwrap() error` method: no result in our code base
   - `%w`: either not related to task processing or the error get wrapped is not one of the error or error types we are checking for task executable.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.