### PR TITLE
Consolidate linters with golangci-lint

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,21 @@
+name: golangci-lint
+on:
+  push:
+permissions:
+  contents: read
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.19
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.50.1
+          args: --verbose --timeout 10m --fix=false

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,22 @@
+# https://golangci-lint.run/usage/configuration/#config-file
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - goimports
+    - revive # revive supersedes golint, which is now archived
+    - staticcheck
+    - vet
+run:
+  skip-dirs:
+    - ^api
+    - ^proto
+    - ^.git
+issues:
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
+  # It's a super-useful option for integration of golangci-lint into existing large codebase.
+  # It's not practical to fix all existing issues at the moment of integration:
+  # much better don't allow issues in new code.
+  new-from-rev: HEAD~
+  fix: true

--- a/Makefile
+++ b/Makefile
@@ -106,12 +106,11 @@ INTEG_TEST_COVERPKG := -coverpkg="$(MODULE_ROOT)/client/...,$(MODULE_ROOT)/commo
 ##### Tools #####
 update-checkers:
 	@printf $(COLOR) "Install/update check tools..."
-	@go install golang.org/x/lint/golint@latest
 	@go install golang.org/x/tools/cmd/goimports@latest
-	@go install honnef.co/go/tools/cmd/staticcheck@v0.3.2
-	@go install github.com/kisielk/errcheck@v1.6.1
 	@go install github.com/googleapis/api-linter/cmd/api-linter@v1.32.3
 	@go install github.com/bufbuild/buf/cmd/buf@v1.6.0
+	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
+
 
 update-mockgen:
 	@printf $(COLOR) "Install/update mockgen tool..."
@@ -222,27 +221,7 @@ copyright:
 
 lint:
 	@printf $(COLOR) "Run linter..."
-	@golint ./...
-
-vet:
-	@printf $(COLOR) "Run go vet..."
-	@go vet ./... || true
-
-goimports-check:
-	@printf $(COLOR) "Run goimports checks..."
-	@GO_IMPORTS_OUTPUT=$$(goimports -l .); if [ -n "$${GO_IMPORTS_OUTPUT}" ]; then echo "$${GO_IMPORTS_OUTPUT}" && echo "Please run 'make goimports'" && exit 1; fi
-
-goimports:
-	@printf $(COLOR) "Run goimports..."
-	@goimports -w .
-
-staticcheck:
-	@printf $(COLOR) "Run staticcheck..."
-	@staticcheck ./...
-
-errcheck:
-	@printf $(COLOR) "Run errcheck..."
-	@errcheck ./... || true
+	@golangci-lint run
 
 api-linter:
 	@printf $(COLOR) "Run api-linter..."
@@ -264,7 +243,7 @@ shell-check:
 	@printf $(COLOR) "Run shellcheck for script files..."
 	@shellcheck $(ALL_SCRIPTS)
 
-check: copyright-check goimports-check lint vet staticcheck errcheck
+check: copyright-check
 
 ##### Tests #####
 clean-test-results:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
In this PR, I added `golangci-lint` to our repo, consolidating our compatible linters with this linter aggregator. 

<!-- Tell your future self why have you made these changes -->
**Why?**
I made this change for a few reasons:
1. This linter aggregator has a GitHub action which shows violations in-line on PRs
2. This linter has a `--new` option which allows it to be applied only to new changes because we currently have a massive number of violations.
3. `golint` is deprecated
4. No actions were taken based on the issues raised by some of the previous linters--all of these warnings are blocking and actionable

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I ran it locally and saw that only new errors were checked. I also tested it locally a few times using `act`. To test this in a real example, I created a new branch here and verified that the annotations were published inline (on push), so we can see the annotations before the PR is even opened: https://github.com/temporalio/temporal/commit/d72112dead3f7949c0d0160f18a12ed6b1a1586d

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Slows down dev to fix linter warnings.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No