### PR TITLE
Remove unused Temporal interface

### DIFF
--- a/host/onebox.go
+++ b/host/onebox.go
@@ -76,17 +76,6 @@ import (
 	"go.temporal.io/server/temporal"
 )
 
-// Temporal hosts all of temporal services in one process
-type Temporal interface {
-	Start() error
-	Stop()
-	GetAdminClient() adminservice.AdminServiceClient
-	GetFrontendClient() workflowservice.WorkflowServiceClient
-	GetHistoryClient() historyservice.HistoryServiceClient
-	GetExecutionManager() persistence.ExecutionManager
-	RefreshNamespaceCache()
-}
-
 type (
 	temporalImpl struct {
 		frontendService *frontend.Service
@@ -168,8 +157,8 @@ type (
 	listenHostPort string
 )
 
-// NewTemporal returns an instance that hosts full temporal in one process
-func NewTemporal(params *TemporalParams) *temporalImpl {
+// newTemporal returns an instance that hosts full temporal in one process
+func newTemporal(params *TemporalParams) *temporalImpl {
 	testDCClient := newTestDCClient(dynamicconfig.NewNoopClient())
 	for k, v := range params.DynamicConfigOverrides {
 		testDCClient.OverrideValue(k, v)

--- a/host/test_cluster.go
+++ b/host/test_cluster.go
@@ -224,7 +224,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 		logger.Fatal("Failed to start pprof", tag.Error(err))
 	}
 
-	cluster := NewTemporal(temporalParams)
+	cluster := newTemporal(temporalParams)
 	if err := cluster.Start(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the `Temporal` interface in `./host`, and I also made the `newTemporal` method unexported.

<!-- Tell your future self why have you made these changes -->
**Why?**
The `Temporal` interface was not used, and the `newTemporal` method returns an unexported type, so it should also be unexported.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
CI

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There could be some people who rely on this interface currently. However, the `temporalImpl` struct doesn't even implement this interface, so I'm not sure how they'd be using it.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.