### PR TITLE
Fine-tune the Revive linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -18,4 +18,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.50.1
-          args: --verbose --timeout 10m --fix=false
+          args: --verbose --timeout 10m --fix=false --new-from-rev=HEAD~ --config=.golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,11 +12,68 @@ run:
     - ^api
     - ^proto
     - ^.git
-issues:
-  # Show only new issues: if there are unstaged changes or untracked files,
-  # only those changes are analyzed, else only changes in HEAD~ are analyzed.
-  # It's a super-useful option for integration of golangci-lint into existing large codebase.
-  # It's not practical to fix all existing issues at the moment of integration:
-  # much better don't allow issues in new code.
-  new-from-rev: HEAD~
-  fix: true
+linters-settings:
+  govet:
+    fieldalignment: 0
+  revive:
+    severity: error
+    confidence: 0.8
+    enable-all-rules: true
+    rules:
+      # Disabled rules
+      - name: add-constant
+        disabled: true
+      - name: bare-return
+        disabled: true
+      - name: banned-characters
+        disabled: true
+      - name: bool-literal-in-expr
+        disabled: true
+      - name: empty-lines
+        disabled: true
+      - name: error-naming
+        disabled: true
+      - name: errorf
+        disabled: true
+      - name: exported
+        disabled: true
+      - name: file-header
+        disabled: true
+      - name: function-length
+        disabled: true
+      - name: imports-blacklist
+        disabled: true
+      - name: increment-decrement
+        disabled: true
+      - name: line-length-limit
+        disabled: true
+      - name: max-public-structs
+        disabled: true
+      - name: nested-structs
+        disabled: true
+      - name: package-comments
+        disabled: true
+      - name: string-format
+        disabled: true
+      - name: unexported-naming
+        disabled: true
+      - name: unused-receiver
+        disabled: true
+      - name: use-any
+        disabled: true
+      - name: var-naming
+        disabled: true
+
+      # Rule tuning
+      - name: argument-limit
+        arguments:
+          - 4
+      - name: cognitive-complexity
+        arguments:
+          - 15
+      - name: cyclomatic
+        arguments:
+          - 10
+      - name: function-result-limit
+        arguments:
+          - 3


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I turned on every linter for Revive except a few handpicked ones that I thought weren't useful.

<!-- Tell your future self why have you made these changes -->
**Why?**
We don't want to enable some useless linters like `exported`, but having linters like `cyclomatic` for new code seem really useful.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I ran it locally. I also inspected the actual errors generated using this JQ query to see if they made sense:
```
golangci-lint run  --verbose --out-format=json --max-issues-per-linter=0 --max-same-issues 1 \
  | jq '.Issues | map((.Text| split(": ") | {"Rule": .[0], "Value": .[1]}) + {"Key": "./\(.Pos.Filename):\(.Pos.Line)"}) | group_by(.Rule) | map({"Rule": .[0].Rule, Violations: ([.[]] | from_entries )}) | sort_by(.Violations | length)'
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It's just a linter

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No