### PR TITLE
Fix NPE in task channelWeightFn

### DIFF
--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -33,6 +33,7 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/quotas"
@@ -122,9 +123,14 @@ func NewNamespacePriorityScheduler(
 			if !namespace.ActiveInCluster(currentClusterName) {
 				namespaceWeights = options.StandbyNamespaceWeights
 			}
+		} else {
+			// if namespace not found, treat is as active namespace and
+			// use default active namespace weight
+			logger.Warn("Unable to find namespace, using active namespace task channel weight",
+				tag.WorkflowNamespaceID(key.NamespaceID),
+				tag.Error(err),
+			)
 		}
-		// if namespace not found, treat is as active namespace and
-		// use default active namespace weight
 
 		return configs.ConvertDynamicConfigValueToWeights(
 			namespaceWeights(namespaceName.String()),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Error from GetNamespaceByID needs to be handled as it will return nil ptr. Previously the code is calling GetNamespaceName which returns empty name if namespace not found and error can be ignored.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Fix npe

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.