### PR TITLE
Make persistence tests consistent in handling ShardID

### DIFF
--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -86,8 +86,7 @@ func NewExecutionMutableStateSuite(
 			logger,
 			dynamicconfig.GetIntPropertyFn(4*1024*1024),
 		),
-		Logger:  logger,
-		ShardID: 1,
+		Logger: logger,
 	}
 }
 
@@ -103,7 +102,7 @@ func (s *ExecutionMutableStateSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), time.Second*30)
 
-	s.ShardID = 1 + s.ShardID
+	s.ShardID++
 	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
 		ShardID: s.ShardID,
 		InitialShardInfo: &persistencespb.ShardInfo{
@@ -113,7 +112,7 @@ func (s *ExecutionMutableStateSuite) SetupTest() {
 	})
 	s.NoError(err)
 	previousRangeID := resp.ShardInfo.RangeId
-	resp.ShardInfo.RangeId += 1
+	resp.ShardInfo.RangeId++
 	err = s.ShardManager.UpdateShard(s.Ctx, &p.UpdateShardRequest{
 		ShardInfo:       resp.ShardInfo,
 		PreviousRangeID: previousRangeID,

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -96,8 +96,7 @@ func NewExecutionMutableStateTaskSuite(
 			logger,
 			dynamicconfig.GetIntPropertyFn(4*1024*1024),
 		),
-		Logger:  logger,
-		ShardID: 1,
+		Logger: logger,
 	}
 }
 
@@ -105,7 +104,7 @@ func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), time.Second*30)
 
-	s.ShardID = 1 + s.ShardID
+	s.ShardID++
 	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
 		ShardID: s.ShardID,
 		InitialShardInfo: &persistencespb.ShardInfo{
@@ -115,7 +114,7 @@ func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 	})
 	s.NoError(err)
 	previousRangeID := resp.ShardInfo.RangeId
-	resp.ShardInfo.RangeId += 1
+	resp.ShardInfo.RangeId++
 	err = s.ShardManager.UpdateShard(s.Ctx, &p.UpdateShardRequest{
 		ShardInfo:       resp.ShardInfo,
 		PreviousRangeID: previousRangeID,

--- a/common/persistence/tests/shard.go
+++ b/common/persistence/tests/shard.go
@@ -43,6 +43,8 @@ type (
 		suite.Suite
 		*require.Assertions
 
+		ShardID int32
+
 		ShardManager p.ShardManager
 		Logger       log.Logger
 
@@ -78,6 +80,8 @@ func (s *ShardSuite) TearDownSuite() {
 func (s *ShardSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.Ctx, s.Cancel = context.WithTimeout(context.Background(), time.Second*30)
+
+	s.ShardID++
 }
 
 func (s *ShardSuite) TearDownTest() {
@@ -85,12 +89,11 @@ func (s *ShardSuite) TearDownTest() {
 }
 
 func (s *ShardSuite) TestGetOrCreateShard_Create() {
-	shardID := int32(1)
 	rangeID := rand.Int63()
-	shardInfo := RandomShardInfo(shardID, rangeID)
+	shardInfo := RandomShardInfo(s.ShardID, rangeID)
 
 	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
-		ShardID:          shardID,
+		ShardID:          s.ShardID,
 		InitialShardInfo: shardInfo,
 	})
 	s.NoError(err)
@@ -99,39 +102,37 @@ func (s *ShardSuite) TestGetOrCreateShard_Create() {
 }
 
 func (s *ShardSuite) TestGetOrCreateShard_Get() {
-	shardID := int32(2)
 	rangeID := rand.Int63()
-	shardInfo := RandomShardInfo(shardID, rangeID)
+	shardInfo := RandomShardInfo(s.ShardID, rangeID)
 
 	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
-		ShardID:          shardID,
+		ShardID:          s.ShardID,
 		InitialShardInfo: shardInfo,
 	})
 	s.NoError(err)
 	s.Equal(shardInfo, resp.ShardInfo)
 
 	resp, err = s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
-		ShardID:          shardID,
-		InitialShardInfo: RandomShardInfo(shardID, rand.Int63()),
+		ShardID:          s.ShardID,
+		InitialShardInfo: RandomShardInfo(s.ShardID, rand.Int63()),
 	})
 	s.NoError(err)
 	s.Equal(shardInfo, resp.ShardInfo)
 }
 
 func (s *ShardSuite) TestUpdateShard_OwnershipLost() {
-	shardID := int32(3)
 	rangeID := rand.Int63()
-	shardInfo := RandomShardInfo(shardID, rangeID)
+	shardInfo := RandomShardInfo(s.ShardID, rangeID)
 
 	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
-		ShardID:          shardID,
+		ShardID:          s.ShardID,
 		InitialShardInfo: shardInfo,
 	})
 	s.NoError(err)
 	s.Equal(shardInfo, resp.ShardInfo)
 
 	updateRangeID := rand.Int63()
-	updateShardInfo := RandomShardInfo(shardID, rand.Int63())
+	updateShardInfo := RandomShardInfo(s.ShardID, rand.Int63())
 	err = s.ShardManager.UpdateShard(s.Ctx, &p.UpdateShardRequest{
 		ShardInfo:       updateShardInfo,
 		PreviousRangeID: updateRangeID,
@@ -139,7 +140,7 @@ func (s *ShardSuite) TestUpdateShard_OwnershipLost() {
 	s.IsType(&p.ShardOwnershipLostError{}, err)
 
 	resp, err = s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
-		ShardID:          shardID,
+		ShardID:          s.ShardID,
 		InitialShardInfo: shardInfo,
 	})
 	s.NoError(err)
@@ -147,18 +148,17 @@ func (s *ShardSuite) TestUpdateShard_OwnershipLost() {
 }
 
 func (s *ShardSuite) TestUpdateShard_Success() {
-	shardID := int32(4)
 	rangeID := rand.Int63()
-	shardInfo := RandomShardInfo(shardID, rangeID)
+	shardInfo := RandomShardInfo(s.ShardID, rangeID)
 
 	resp, err := s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
-		ShardID:          shardID,
+		ShardID:          s.ShardID,
 		InitialShardInfo: shardInfo,
 	})
 	s.NoError(err)
 	s.Equal(shardInfo, resp.ShardInfo)
 
-	updateShardInfo := RandomShardInfo(shardID, rangeID+1)
+	updateShardInfo := RandomShardInfo(s.ShardID, rangeID+1)
 	err = s.ShardManager.UpdateShard(s.Ctx, &p.UpdateShardRequest{
 		ShardInfo:       updateShardInfo,
 		PreviousRangeID: rangeID,
@@ -166,7 +166,7 @@ func (s *ShardSuite) TestUpdateShard_Success() {
 	s.NoError(err)
 
 	resp, err = s.ShardManager.GetOrCreateShard(s.Ctx, &p.GetOrCreateShardRequest{
-		ShardID:          shardID,
+		ShardID:          s.ShardID,
 		InitialShardInfo: shardInfo,
 	})
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
In `common/persistence/tests/shard.go`, `ShardID` is not hardcoded, but auto-incremented, consistently with other test files in current directory.

<!-- Tell your future self why have you made these changes -->
**Why?**
Consistency and ground work for future features.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`make test`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.