### PR TITLE
Capture task processing panic

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -371,6 +371,12 @@ func IsResourceExhausted(err error) bool {
 	return false
 }
 
+// IsInternalError checks if the error is an internal error.
+func IsInternalError(err error) bool {
+	var internalErr *serviceerror.Internal
+	return errors.As(err, &internalErr)
+}
+
 // WorkflowIDToHistoryShard is used to map namespaceID-workflowID pair to a shardID.
 func WorkflowIDToHistoryShard(
 	namespaceID string,

--- a/service/history/archival_queue_task_executor_test.go
+++ b/service/history/archival_queue_task_executor_test.go
@@ -509,6 +509,7 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 				queues.NewNoopPriorityAssigner(),
 				timeSource,
 				namespaceRegistry,
+				mockMetadata,
 				nil,
 				metrics.NoopMetricsHandler,
 			)

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -110,6 +111,7 @@ type (
 		priorityAssigner  PriorityAssigner
 		timeSource        clock.TimeSource
 		namespaceRegistry namespace.Registry
+		clusterMetadata   cluster.Metadata
 
 		readerID               int32
 		loadTime               time.Time
@@ -135,6 +137,7 @@ func NewExecutable(
 	priorityAssigner PriorityAssigner,
 	timeSource clock.TimeSource,
 	namespaceRegistry namespace.Registry,
+	clusterMetadata cluster.Metadata,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
 ) Executable {
@@ -148,6 +151,7 @@ func NewExecutable(
 		priorityAssigner:  priorityAssigner,
 		timeSource:        timeSource,
 		namespaceRegistry: namespaceRegistry,
+		clusterMetadata:   clusterMetadata,
 		readerID:          readerID,
 		loadTime:          util.MaxTime(timeSource.Now(), task.GetKey().FireTime),
 		logger: log.NewLazyLogger(
@@ -163,15 +167,29 @@ func NewExecutable(
 	return executable
 }
 
-func (e *executableImpl) Execute() error {
+func (e *executableImpl) Execute() (retErr error) {
 	if e.State() == ctasks.TaskStateCancelled {
 		return nil
 	}
 
-	ctx := metrics.AddMetricsContext(context.Background())
-	namespace, _ := e.namespaceRegistry.GetNamespaceName(namespace.ID(e.GetNamespaceID()))
+	namespaceName, _ := e.namespaceRegistry.GetNamespaceName(namespace.ID(e.GetNamespaceID()))
+	ctx := headers.SetCallerInfo(
+		metrics.AddMetricsContext(context.Background()),
+		headers.NewBackgroundCallerInfo(namespaceName.String()),
+	)
 
-	ctx = headers.SetCallerInfo(ctx, headers.NewBackgroundCallerInfo(namespace.String()))
+	var panicErr error
+	defer func() {
+		if panicErr != nil {
+			retErr = panicErr
+
+			// we need to guess the metrics tags here as we don't know which execution logic
+			// is actually used which is upto the executor implementation
+			e.taggedMetricsHandler = e.metricsHandler.WithTags(e.estimateTaskMetricTag()...)
+		}
+	}()
+
+	defer log.CapturePanic(e.logger, &panicErr)
 
 	startTime := e.timeSource.Now()
 
@@ -293,6 +311,12 @@ func (e *executableImpl) IsRetryableError(err error) bool {
 	// don't retry immediately for resource exhausted which may incur more load
 	// context deadline exceed may also suggested downstream is overloaded, so don't retry immediately
 	if common.IsResourceExhausted(err) || common.IsContextDeadlineExceededErr(err) {
+		return false
+	}
+
+	// Internal error is non-retryable and usually means unexpected error has happened,
+	// e.g. unknown task, corrupted state, panic etc.
+	if common.IsInternalError(err) {
 		return false
 	}
 
@@ -424,6 +448,10 @@ func (e *executableImpl) shouldResubmitOnNack(attempt int, err error) bool {
 		return false
 	}
 
+	if common.IsInternalError(err) {
+		return false
+	}
+
 	return err != consts.ErrTaskRetry &&
 		err != consts.ErrDependencyTaskNotCompleted &&
 		err != consts.ErrNamespaceHandover
@@ -433,13 +461,14 @@ func (e *executableImpl) rescheduleTime(
 	err error,
 	attempt int,
 ) time.Time {
-	// elapsedTime (the first parameter in ComputeNextDelay) is not relevant here
+	// elapsedTime, the first parameter in ComputeNextDelay is not relevant here
 	// since reschedule policy has no expiration interval.
 
-	if err == consts.ErrTaskRetry || err == consts.ErrNamespaceHandover {
+	if err == consts.ErrTaskRetry ||
+		err == consts.ErrNamespaceHandover ||
+		common.IsInternalError(err) {
 		// using a different reschedule policy to slow down retry
-		// as the error means mutable state or namespace is not ready to handle the task,
-		// need to wait for replication.
+		// as immediate retry typically won't resolve the issue.
 		return e.timeSource.Now().Add(taskNotReadyReschedulePolicy.ComputeNextDelay(0, attempt))
 	}
 
@@ -467,5 +496,23 @@ func (e *executableImpl) updatePriority() {
 	e.priority = newPriority
 	if e.priority > e.lowestPriority {
 		e.lowestPriority = e.priority
+	}
+}
+
+func (e *executableImpl) estimateTaskMetricTag() []metrics.Tag {
+	namespaceTag := metrics.NamespaceUnknownTag()
+	isActive := true
+
+	namespace, err := e.namespaceRegistry.GetNamespaceByID(namespace.ID(e.GetNamespaceID()))
+	if err == nil {
+		namespaceTag = metrics.NamespaceTag(namespace.Name().String())
+		isActive = namespace.ActiveInCluster(e.clusterMetadata.GetCurrentClusterName())
+	}
+
+	taskType := getTaskTypeTagValue(e.Task, isActive)
+	return []metrics.Tag{
+		namespaceTag,
+		metrics.TaskTypeTag(taskType),
+		metrics.OperationTag(taskType), // for backward compatibility
 	}
 }

--- a/service/history/queues/metrics.go
+++ b/service/history/queues/metrics.go
@@ -148,3 +148,27 @@ func GetArchivalTaskTypeTagValue(
 		return ""
 	}
 }
+
+func getTaskTypeTagValue(
+	task tasks.Task,
+	isActive bool,
+) string {
+	switch task.GetCategory() {
+	case tasks.CategoryTransfer:
+		if isActive {
+			return GetActiveTransferTaskTypeTagValue(task)
+		}
+		return GetStandbyTransferTaskTypeTagValue(task)
+	case tasks.CategoryTimer:
+		if isActive {
+			return GetActiveTimerTaskTypeTagValue(task)
+		}
+		return GetStandbyTimerTaskTypeTagValue(task)
+	case tasks.CategoryVisibility:
+		return GetVisibilityTaskTypeTagValue(task)
+	case tasks.CategoryArchival:
+		return GetArchivalTaskTypeTagValue(task)
+	default:
+		return task.GetType().String()
+	}
+}

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -164,6 +164,7 @@ func newQueueBase(
 			priorityAssigner,
 			timeSource,
 			shard.GetNamespaceRegistry(),
+			shard.GetClusterMetadata(),
 			logger,
 			metricsHandler,
 		)

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -77,7 +77,7 @@ func (s *readerSuite) SetupTest() {
 	s.metricsHandler = metrics.NoopMetricsHandler
 
 	s.executableInitializer = func(readerID int32, t tasks.Task) Executable {
-		return NewExecutable(readerID, t, nil, nil, nil, NewNoopPriorityAssigner(), clock.NewRealTimeSource(), nil, nil, metrics.NoopMetricsHandler)
+		return NewExecutable(readerID, t, nil, nil, nil, NewNoopPriorityAssigner(), clock.NewRealTimeSource(), nil, nil, nil, metrics.NoopMetricsHandler)
 	}
 	s.monitor = newMonitor(tasks.CategoryTypeScheduled, &MonitorOptions{
 		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),

--- a/service/history/queues/slice_test.go
+++ b/service/history/queues/slice_test.go
@@ -69,7 +69,7 @@ func (s *sliceSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 
 	s.executableInitializer = func(readerID int32, t tasks.Task) Executable {
-		return NewExecutable(readerID, t, nil, nil, nil, NewNoopPriorityAssigner(), clock.NewRealTimeSource(), nil, nil, metrics.NoopMetricsHandler)
+		return NewExecutable(readerID, t, nil, nil, nil, NewNoopPriorityAssigner(), clock.NewRealTimeSource(), nil, nil, nil, metrics.NoopMetricsHandler)
 	}
 	s.monitor = newMonitor(tasks.CategoryTypeScheduled, &MonitorOptions{
 		PendingTasksCriticalCount:   dynamicconfig.GetIntPropertyFn(1000),

--- a/service/history/timerQueueActiveTaskExecutor_test.go
+++ b/service/history/timerQueueActiveTaskExecutor_test.go
@@ -1479,7 +1479,8 @@ func (s *timerQueueActiveTaskExecutorSuite) newTaskExecutable(
 		nil,
 		queues.NewNoopPriorityAssigner(),
 		s.mockShard.GetTimeSource(),
-		nil,
+		s.mockNamespaceCache,
+		s.mockClusterMetadata,
 		nil,
 		metrics.NoopMetricsHandler,
 	)

--- a/service/history/timerQueueStandbyTaskExecutor_test.go
+++ b/service/history/timerQueueStandbyTaskExecutor_test.go
@@ -1542,7 +1542,8 @@ func (s *timerQueueStandbyTaskExecutorSuite) newTaskExecutable(
 		nil,
 		queues.NewNoopPriorityAssigner(),
 		s.mockShard.GetTimeSource(),
-		nil,
+		s.mockNamespaceCache,
+		s.mockClusterMetadata,
 		nil,
 		metrics.NoopMetricsHandler,
 	)

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -2802,7 +2802,8 @@ func (s *transferQueueActiveTaskExecutorSuite) newTaskExecutable(
 		nil,
 		queues.NewNoopPriorityAssigner(),
 		s.mockShard.GetTimeSource(),
-		nil,
+		s.mockNamespaceCache,
+		s.mockClusterMetadata,
 		nil,
 		metrics.NoopMetricsHandler,
 	)

--- a/service/history/transferQueueStandbyTaskExecutor_test.go
+++ b/service/history/transferQueueStandbyTaskExecutor_test.go
@@ -1300,7 +1300,8 @@ func (s *transferQueueStandbyTaskExecutorSuite) newTaskExecutable(
 		nil,
 		queues.NewNoopPriorityAssigner(),
 		s.mockShard.GetTimeSource(),
-		nil,
+		s.mockNamespaceCache,
+		s.mockClusterMetadata,
 		nil,
 		metrics.NoopMetricsHandler,
 	)

--- a/service/history/visibilityQueueTaskExecutor_test.go
+++ b/service/history/visibilityQueueTaskExecutor_test.go
@@ -638,7 +638,8 @@ func (s *visibilityQueueTaskExecutorSuite) newTaskExecutable(
 		nil,
 		queues.NewNoopPriorityAssigner(),
 		s.mockShard.GetTimeSource(),
-		nil,
+		s.mockShard.GetNamespaceRegistry(),
+		s.mockShard.GetClusterMetadata(),
 		nil,
 		metrics.NoopMetricsHandler,
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Capture task processing panic

<!-- Tell your future self why have you made these changes -->
**Why?**
- We have panic wrapper for api handlers. Adding similar logic for task execution logic to prevent service from crashing when panic happens when processing tasks. The task will stuck and keep retrying (when we have dlq, it should go there), but service can continue to run and other tasks/workflows can still make progress.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
