### PR TITLE
Disable eager activities for Python 0.1b1 too

### DIFF
--- a/service/frontend/overrides.go
+++ b/service/frontend/overrides.go
@@ -45,7 +45,7 @@ func NewOverrides() *Overrides {
 }
 
 func (o *Overrides) shouldForceDisableEagerDispatch(sdkName, sdkVersion string) bool {
-	if sdkName == headers.ClientNamePythonSDK && sdkVersion == "0.1b2" {
+	if sdkName == headers.ClientNamePythonSDK && (sdkVersion == "0.1b1" || sdkVersion == "0.1b2") {
 		return true
 	} else if sdkName == headers.ClientNameTypeScriptSDK {
 		ver, err := semver.Parse(sdkVersion)

--- a/service/frontend/overrides.go
+++ b/service/frontend/overrides.go
@@ -45,7 +45,7 @@ func NewOverrides() *Overrides {
 }
 
 func (o *Overrides) shouldForceDisableEagerDispatch(sdkName, sdkVersion string) bool {
-	if sdkName == headers.ClientNamePythonSDK && (sdkVersion == "0.1b1" || sdkVersion == "0.1b2") {
+	if sdkName == headers.ClientNamePythonSDK && (sdkVersion == "0.1a1" || sdkVersion == "0.1a2" || sdkVersion == "0.1b1" || sdkVersion == "0.1b2") {
 		return true
 	} else if sdkName == headers.ClientNameTypeScriptSDK {
 		ver, err := semver.Parse(sdkVersion)

--- a/service/frontend/overrides_test.go
+++ b/service/frontend/overrides_test.go
@@ -48,8 +48,8 @@ func TestDisableEagerActivityDispatchForBuggyClients(t *testing.T) {
 		{sdkName: headers.ClientNameGoSDK, sdkVersion: "1.18.1", eagerAllowed: true},
 		{sdkName: headers.ClientNameTypeScriptSDK, sdkVersion: "1.4.1", eagerAllowed: false},
 		{sdkName: headers.ClientNameTypeScriptSDK, sdkVersion: "1.4.4", eagerAllowed: true},
+		{sdkName: headers.ClientNamePythonSDK, sdkVersion: "0.1a1", eagerAllowed: false},
 		{sdkName: headers.ClientNamePythonSDK, sdkVersion: "0.1b2", eagerAllowed: false},
-		{sdkName: headers.ClientNamePythonSDK, sdkVersion: "0.1b1", eagerAllowed: true},
 		{sdkName: headers.ClientNamePythonSDK, sdkVersion: "0.1b3", eagerAllowed: true},
 	}
 	for _, testCase := range cases {


### PR DESCRIPTION
Apparently Python 0.1b1 also has a buggy implementation of eager activities, disable eager activity dispatch for that version.