### PR TITLE
Fix some bugs in the archival queue task executor

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -67,6 +67,9 @@ const (
 
 	MutableStateCacheTypeTagValue = "mutablestate"
 	EventsCacheTypeTagValue       = "events"
+
+	InvalidHistoryURITagValue    = "invalid_history_uri"
+	InvalidVisibilityURITagValue = "invalid_visibility_uri"
 )
 
 // Common service base metrics

--- a/service/history/archival_queue_task_executor.go
+++ b/service/history/archival_queue_task_executor.go
@@ -112,9 +112,11 @@ func (e *archivalQueueTaskExecutor) processArchiveExecutionTask(ctx context.Cont
 	if err != nil {
 		return err
 	}
-	_, err = e.archiver.Archive(ctx, request)
-	if err != nil {
-		return err
+	if len(request.Targets) > 0 {
+		_, err = e.archiver.Archive(ctx, request)
+		if err != nil {
+			return err
+		}
 	}
 	return e.addDeletionTask(ctx, logger, task, request.CloseTime)
 }
@@ -154,52 +156,47 @@ func (e *archivalQueueTaskExecutor) getArchiveTaskRequest(
 		return nil, err
 	}
 
+	var historyURI, visibilityURI carchiver.URI
 	var targets []archival.Target
 	if e.shardContext.GetArchivalMetadata().GetVisibilityConfig().ClusterConfiguredForArchival() &&
 		namespaceEntry.VisibilityArchivalState().State == enumspb.ARCHIVAL_STATE_ENABLED {
 		targets = append(targets, archival.TargetVisibility)
+		visibilityURIString := namespaceEntry.VisibilityArchivalState().URI
+		visibilityURI, err = carchiver.NewURI(visibilityURIString)
+		if err != nil {
+			e.metricsHandler.Counter(metrics.ArchivalTaskInvalidURI.GetMetricName()).Record(
+				1,
+				metrics.NamespaceTag(namespaceName.String()),
+				metrics.FailureTag(metrics.InvalidVisibilityURITagValue),
+			)
+			logger.Error(
+				"Failed to parse visibility URI.",
+				tag.ArchivalURI(visibilityURIString),
+				tag.Error(err),
+			)
+			return nil, fmt.Errorf("failed to parse visibility URI for archival task: %w", err)
+		}
 	}
 	if e.shardContext.GetArchivalMetadata().GetHistoryConfig().ClusterConfiguredForArchival() &&
 		namespaceEntry.HistoryArchivalState().State == enumspb.ARCHIVAL_STATE_ENABLED {
+		historyURIString := namespaceEntry.HistoryArchivalState().URI
+		historyURI, err = carchiver.NewURI(historyURIString)
+		if err != nil {
+			e.metricsHandler.Counter(metrics.ArchivalTaskInvalidURI.GetMetricName()).Record(
+				1,
+				metrics.NamespaceTag(namespaceName.String()),
+				metrics.FailureTag(metrics.InvalidHistoryURITagValue),
+			)
+			logger.Error(
+				"Failed to parse history URI.",
+				tag.ArchivalURI(historyURIString),
+				tag.Error(err),
+			)
+			return nil, fmt.Errorf("failed to parse history URI for archival task: %w", err)
+		}
 		targets = append(targets, archival.TargetHistory)
 	}
-	if len(targets) == 0 {
-		return nil, fmt.Errorf(
-			"no archival targets configured for archive execution task: %+v",
-			task.WorkflowKey,
-		)
-	}
 
-	historyURIString := namespaceEntry.HistoryArchivalState().URI
-	historyURI, err := carchiver.NewURI(historyURIString)
-	if err != nil {
-		e.metricsHandler.Counter(metrics.ArchivalTaskInvalidURI.GetMetricName()).Record(
-			1,
-			metrics.NamespaceTag(namespaceName.String()),
-			metrics.FailureTag("invalid_history_uri"),
-		)
-		logger.Error(
-			"Failed to parse history URI.",
-			tag.ArchivalURI(historyURIString),
-			tag.Error(err),
-		)
-		return nil, fmt.Errorf("failed to parse history URI for archival task: %w", err)
-	}
-	visibilityURIString := namespaceEntry.VisibilityArchivalState().URI
-	visibilityURI, err := carchiver.NewURI(visibilityURIString)
-	if err != nil {
-		e.metricsHandler.Counter(metrics.ArchivalTaskInvalidURI.GetMetricName()).Record(
-			1,
-			metrics.NamespaceTag(namespaceName.String()),
-			metrics.FailureTag("invalid_visibility_uri"),
-		)
-		logger.Error(
-			"Failed to parse visibility URI.",
-			tag.ArchivalURI(visibilityURIString),
-			tag.Error(err),
-		)
-		return nil, fmt.Errorf("failed to parse visibility URI for archival task: %w", err)
-	}
 	workflowAttributes, err := e.relocatableAttributesFetcher.Fetch(ctx, mutableState)
 	if err != nil {
 		return nil, err

--- a/service/history/archival_queue_task_executor_test.go
+++ b/service/history/archival_queue_task_executor_test.go
@@ -74,6 +74,18 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 			},
 		},
 		{
+			Name: "URIs are not read for empty targets",
+			Configure: func(p *params) {
+				p.HistoryConfig.ClusterEnabled = false
+				p.VisibilityConfig.ClusterEnabled = false
+				// we set the URIs to invalid values which would produce errors if they were read
+				// we should not read these URIs because history and visibility archival are disabled
+				p.HistoryURI = "invalid_uri"
+				p.VisibilityURI = "invalid_uri"
+				p.ExpectArchive = false
+			},
+		},
+		{
 			Name: "history archival disabled for namespace",
 			Configure: func(p *params) {
 				p.HistoryConfig.NamespaceArchivalState = carchiver.ArchivalDisabled
@@ -105,11 +117,7 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 			Configure: func(p *params) {
 				p.VisibilityConfig.NamespaceArchivalState = carchiver.ArchivalDisabled
 				p.HistoryConfig.NamespaceArchivalState = carchiver.ArchivalDisabled
-				p.ExpectedErrorSubstrings = []string{
-					"no archival targets",
-				}
 				p.ExpectArchive = false
-				p.ExpectAddTask = false
 			},
 		},
 		{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
After manual testing, I spotted a few issues in this code.
1. We fail the task if there are zero enabled targets for archival, which might happen if a task is produced and then archival is disabled before the task is executed. In this case, we should continue processing the task, skipping archival but generating the deletion task.
1. We are parsing archival URIs unconditionally here, but we should only parse them for enabled targets. We cannot assume that those URIs will be valid when the corresponding target is disabled.

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fixes

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I modified the unit tests. I also reverted the code changes other than the test code and verified that the tests "URIs are not read for empty targets" and "both history and visibility archival disabled" failed.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None, just bug fixes.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
