### PR TITLE
Add GetIndexName method to visibility manager

### DIFF
--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -57,6 +57,10 @@ func (m *SqlStore) GetName() string {
 	return m.Db.PluginName()
 }
 
+func (m *SqlStore) GetDbName() string {
+	return m.Db.DbName()
+}
+
 func (m *SqlStore) Close() {
 	if m.Db != nil {
 		err := m.Db.Close()

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -110,6 +110,7 @@ type (
 
 		BeginTx(ctx context.Context) (Tx, error)
 		PluginName() string
+		DbName() string
 		IsDupEntryError(err error) bool
 		Close() error
 	}

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -111,6 +111,11 @@ func (mdb *db) PluginName() string {
 	return PluginName
 }
 
+// DbName returns the name of the database
+func (mdb *db) DbName() string {
+	return mdb.dbName
+}
+
 // ExpectedVersion returns expected version.
 func (mdb *db) ExpectedVersion() string {
 	switch mdb.dbKind {

--- a/common/persistence/sql/sqlplugin/postgresql/db.go
+++ b/common/persistence/sql/sqlplugin/postgresql/db.go
@@ -110,6 +110,11 @@ func (pdb *db) PluginName() string {
 	return PluginName
 }
 
+// DbName returns the name of the database
+func (pdb *db) DbName() string {
+	return pdb.dbName
+}
+
 // ExpectedVersion returns expected version.
 func (pdb *db) ExpectedVersion() string {
 	switch pdb.dbKind {

--- a/common/persistence/sql/sqlplugin/sqlite/db.go
+++ b/common/persistence/sql/sqlplugin/sqlite/db.go
@@ -122,6 +122,11 @@ func (mdb *db) PluginName() string {
 	return PluginName
 }
 
+// DbName returns the name of the database
+func (mdb *db) DbName() string {
+	return mdb.dbName
+}
+
 // ExpectedVersion returns expected version.
 func (mdb *db) ExpectedVersion() string {
 	switch mdb.dbKind {

--- a/common/persistence/visibility/manager/visibility_manager.go
+++ b/common/persistence/visibility/manager/visibility_manager.go
@@ -44,6 +44,7 @@ type (
 	VisibilityManager interface {
 		persistence.Closeable
 		GetName() string
+		GetIndexName() string
 
 		// Write APIs.
 		RecordWorkflowExecutionStarted(ctx context.Context, request *RecordWorkflowExecutionStartedRequest) error

--- a/common/persistence/visibility/manager/visibility_manager_mock.go
+++ b/common/persistence/visibility/manager/visibility_manager_mock.go
@@ -99,6 +99,20 @@ func (mr *MockVisibilityManagerMockRecorder) DeleteWorkflowExecution(ctx, reques
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockVisibilityManager)(nil).DeleteWorkflowExecution), ctx, request)
 }
 
+// GetIndexName mocks base method.
+func (m *MockVisibilityManager) GetIndexName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIndexName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetIndexName indicates an expected call of GetIndexName.
+func (mr *MockVisibilityManagerMockRecorder) GetIndexName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexName", reflect.TypeOf((*MockVisibilityManager)(nil).GetIndexName))
+}
+
 // GetName mocks base method.
 func (m *MockVisibilityManager) GetName() string {
 	m.ctrl.T.Helper()

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -130,6 +130,10 @@ func (s *visibilityStore) GetName() string {
 	return PersistenceName
 }
 
+func (s *visibilityStore) GetIndexName() string {
+	return s.index
+}
+
 func (s *visibilityStore) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *store.InternalRecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/store/standard/cassandra/visibility_store.go
+++ b/common/persistence/visibility/store/standard/cassandra/visibility_store.go
@@ -140,6 +140,7 @@ type (
 	visibilityStore struct {
 		session      gocql.Session
 		lowConslevel gocql.Consistency
+		keyspace     string
 	}
 )
 
@@ -158,11 +159,16 @@ func NewVisibilityStore(
 	return &visibilityStore{
 		session:      session,
 		lowConslevel: gocql.One,
+		keyspace:     cfg.Keyspace,
 	}, nil
 }
 
 func (v *visibilityStore) GetName() string {
 	return CassandraPersistenceName
+}
+
+func (v *visibilityStore) GetIndexName() string {
+	return v.keyspace
 }
 
 // Close releases the resources held by this object

--- a/common/persistence/visibility/store/standard/sql/visibility_store.go
+++ b/common/persistence/visibility/store/standard/sql/visibility_store.go
@@ -80,6 +80,10 @@ func (s *visibilityStore) GetName() string {
 	return s.sqlStore.GetName()
 }
 
+func (s *visibilityStore) GetIndexName() string {
+	return s.sqlStore.GetDbName()
+}
+
 func (s *visibilityStore) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *store.InternalRecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/store/standard/visibility_store.go
+++ b/common/persistence/visibility/store/standard/visibility_store.go
@@ -73,6 +73,10 @@ func (s *standardStore) GetName() string {
 	return s.store.GetName()
 }
 
+func (s *standardStore) GetIndexName() string {
+	return s.store.GetIndexName()
+}
+
 func (s *standardStore) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *store.InternalRecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/store/visibility_store.go
+++ b/common/persistence/visibility/store/visibility_store.go
@@ -43,6 +43,7 @@ type (
 	VisibilityStore interface {
 		persistence.Closeable
 		GetName() string
+		GetIndexName() string
 
 		// Write APIs.
 		RecordWorkflowExecutionStarted(ctx context.Context, request *InternalRecordWorkflowExecutionStartedRequest) error

--- a/common/persistence/visibility/store/visibility_store_mock.go
+++ b/common/persistence/visibility/store/visibility_store_mock.go
@@ -100,6 +100,20 @@ func (mr *MockVisibilityStoreMockRecorder) DeleteWorkflowExecution(ctx, request 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockVisibilityStore)(nil).DeleteWorkflowExecution), ctx, request)
 }
 
+// GetIndexName mocks base method.
+func (m *MockVisibilityStore) GetIndexName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetIndexName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetIndexName indicates an expected call of GetIndexName.
+func (mr *MockVisibilityStoreMockRecorder) GetIndexName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIndexName", reflect.TypeOf((*MockVisibilityStore)(nil).GetIndexName))
+}
+
 // GetName mocks base method.
 func (m *MockVisibilityStore) GetName() string {
 	m.ctrl.T.Helper()

--- a/common/persistence/visibility/visibility_manager_dual.go
+++ b/common/persistence/visibility/visibility_manager_dual.go
@@ -64,6 +64,10 @@ func (v *visibilityManagerDual) GetName() string {
 	return strings.Join([]string{v.visibilityManager.GetName(), v.secondaryVisibilityManager.GetName()}, ",")
 }
 
+func (v *visibilityManagerDual) GetIndexName() string {
+	return v.visibilityManager.GetIndexName()
+}
+
 func (v *visibilityManagerDual) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *manager.RecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -76,6 +76,10 @@ func (p *visibilityManagerImpl) GetName() string {
 	return p.store.GetName()
 }
 
+func (p *visibilityManagerImpl) GetIndexName() string {
+	return p.store.GetIndexName()
+}
+
 func (p *visibilityManagerImpl) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *manager.RecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/visibility_manager_rate_limited.go
+++ b/common/persistence/visibility/visibility_manager_rate_limited.go
@@ -67,6 +67,10 @@ func (m *visibilityManagerRateLimited) GetName() string {
 	return m.delegate.GetName()
 }
 
+func (m *visibilityManagerRateLimited) GetIndexName() string {
+	return m.delegate.GetIndexName()
+}
+
 // Below are write APIs.
 
 func (m *visibilityManagerRateLimited) RecordWorkflowExecutionStarted(

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -69,6 +69,10 @@ func (m *visibilityManagerMetrics) GetName() string {
 	return m.delegate.GetName()
 }
 
+func (m *visibilityManagerMetrics) GetIndexName() string {
+	return m.delegate.GetIndexName()
+}
+
 func (m *visibilityManagerMetrics) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *manager.RecordWorkflowExecutionStartedRequest,

--- a/common/resourcetest/resourceTest.go
+++ b/common/resourcetest/resourceTest.go
@@ -51,6 +51,7 @@ import (
 	"go.temporal.io/server/common/persistence"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/persistence/visibility/manager"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
@@ -96,6 +97,7 @@ type (
 		ClientBean           *client.MockBean
 		ClientFactory        *client.MockFactory
 		ESClient             *esclient.MockClient
+		VisibilityManager    *manager.MockVisibilityManager
 
 		// persistence clients
 
@@ -206,6 +208,7 @@ func NewTest(
 		ClientBean:           clientBean,
 		ClientFactory:        clientFactory,
 		ESClient:             esclient.NewMockClient(controller),
+		VisibilityManager:    manager.NewMockVisibilityManager(controller),
 
 		// persistence clients
 
@@ -371,6 +374,11 @@ func (t *Test) GetClientBean() client.Bean {
 // GetClientFactory for testing
 func (t *Test) GetClientFactory() client.Factory {
 	return t.ClientFactory
+}
+
+// GetVisibilityManager for testing
+func (t *Test) GetVisibilityManager() manager.VisibilityManager {
+	return t.VisibilityManager
 }
 
 // persistence clients

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -97,7 +97,6 @@ type (
 
 		logger                      log.Logger
 		numberOfHistoryShards       int32
-		ESConfig                    *esclient.Config
 		ESClient                    esclient.Client
 		config                      *Config
 		namespaceHandler            namespace.Handler
@@ -127,7 +126,6 @@ type (
 		Config                              *Config
 		NamespaceReplicationQueue           persistence.NamespaceReplicationQueue
 		ReplicatorNamespaceReplicationQueue persistence.NamespaceReplicationQueue
-		EsConfig                            *esclient.Config
 		EsClient                            esclient.Client
 		VisibilityMrg                       manager.VisibilityManager
 		Logger                              log.Logger
@@ -192,7 +190,6 @@ func NewAdminHandler(
 		),
 		eventSerializer:             args.EventSerializer,
 		visibilityMgr:               args.VisibilityMrg,
-		ESConfig:                    args.EsConfig,
 		ESClient:                    args.EsClient,
 		persistenceExecutionManager: args.PersistenceExecutionManager,
 		namespaceReplicationQueue:   args.NamespaceReplicationQueue,
@@ -257,7 +254,7 @@ func (adh *AdminHandler) AddSearchAttributes(ctx context.Context, request *admin
 
 	indexName := request.GetIndexName()
 	if indexName == "" {
-		indexName = adh.ESConfig.GetVisibilityIndex()
+		indexName = adh.visibilityMgr.GetIndexName()
 	}
 
 	currentSearchAttributes, err := adh.saProvider.GetSearchAttributes(indexName, true)
@@ -322,7 +319,7 @@ func (adh *AdminHandler) RemoveSearchAttributes(ctx context.Context, request *ad
 
 	indexName := request.GetIndexName()
 	if indexName == "" {
-		indexName = adh.ESConfig.GetVisibilityIndex()
+		indexName = adh.visibilityMgr.GetIndexName()
 	}
 
 	currentSearchAttributes, err := adh.saProvider.GetSearchAttributes(indexName, true)
@@ -359,7 +356,7 @@ func (adh *AdminHandler) GetSearchAttributes(ctx context.Context, request *admin
 
 	indexName := request.GetIndexName()
 	if indexName == "" {
-		indexName = adh.ESConfig.GetVisibilityIndex()
+		indexName = adh.visibilityMgr.GetIndexName()
 	}
 
 	resp, err := adh.getSearchAttributes(ctx, indexName, "")

--- a/service/frontend/dcRedirectionHandler_test.go
+++ b/service/frontend/dcRedirectionHandler_test.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/resourcetest"
 )
 
@@ -56,6 +57,7 @@ type (
 		mockFrontendHandler      *workflowservicemock.MockWorkflowServiceServer
 		mockRemoteFrontendClient *workflowservicemock.MockWorkflowServiceClient
 		mockClusterMetadata      *cluster.MockMetadata
+		mockVisibilityMgr        *manager.MockVisibilityManager
 
 		mockDCRedirectionPolicy *MockDCRedirectionPolicy
 
@@ -102,17 +104,19 @@ func (s *dcRedirectionHandlerSuite) SetupTest() {
 	s.mockResource = resourcetest.NewTest(s.controller, metrics.Frontend)
 	s.mockClusterMetadata = s.mockResource.ClusterMetadata
 	s.mockRemoteFrontendClient = s.mockResource.RemoteFrontendClient
+	s.mockVisibilityMgr = s.mockResource.VisibilityManager
 
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(s.currentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
 
-	s.config = NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewNoopClient(), s.mockResource.GetLogger()), 0, "", false)
+	s.mockVisibilityMgr.EXPECT().GetIndexName().Return("").AnyTimes()
+	s.config = NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewNoopClient(), s.mockResource.GetLogger()), 0, false)
 
 	frontendHandlerGRPC := NewWorkflowHandler(
 		s.config,
 		nil,
-		nil,
-		s.mockResource.Logger,
+		s.mockResource.GetVisibilityManager(),
+		s.mockResource.GetLogger(),
 		s.mockResource.GetThrottledLogger(),
 		s.mockResource.GetExecutionManager(),
 		s.mockResource.GetClusterMetadataManager(),

--- a/service/frontend/dcRedirectionPolicy_test.go
+++ b/service/frontend/dcRedirectionPolicy_test.go
@@ -138,7 +138,7 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) SetupTest() {
 
 	logger := log.NewTestLogger()
 
-	s.mockConfig = NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewNoopClient(), logger), 0, "", false)
+	s.mockConfig = NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewNoopClient(), logger), 0, false)
 	s.mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(true).AnyTimes()
 	s.policy = NewSelectedAPIsForwardingPolicy(
 		s.currentClusterName,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -213,12 +213,10 @@ func GrpcServerOptionsProvider(
 func ConfigProvider(
 	dc *dynamicconfig.Collection,
 	persistenceConfig config.Persistence,
-	esConfig *esclient.Config,
 ) *Config {
 	return NewConfig(
 		dc,
 		persistenceConfig.NumHistoryShards,
-		esConfig.GetVisibilityIndex(),
 		persistenceConfig.AdvancedVisibilityConfigExist(),
 	)
 }
@@ -418,7 +416,6 @@ func AdminHandlerProvider(
 	persistenceConfig *config.Persistence,
 	config *Config,
 	replicatorNamespaceReplicationQueue FEReplicatorNamespaceReplicationQueue,
-	esConfig *esclient.Config,
 	esClient esclient.Client,
 	visibilityMrg manager.VisibilityManager,
 	logger log.SnTaggedLogger,
@@ -448,7 +445,6 @@ func AdminHandlerProvider(
 		config,
 		namespaceReplicationQueue,
 		replicatorNamespaceReplicationQueue,
-		esConfig,
 		esClient,
 		visibilityMrg,
 		logger,
@@ -477,11 +473,11 @@ func AdminHandlerProvider(
 
 func OperatorHandlerProvider(
 	config *Config,
-	esConfig *esclient.Config,
 	esClient esclient.Client,
 	logger log.SnTaggedLogger,
 	sdkClientFactory sdk.ClientFactory,
 	metricsHandler metrics.Handler,
+	visibilityMgr manager.VisibilityManager,
 	saProvider searchattribute.Provider,
 	saManager searchattribute.Manager,
 	healthServer *health.Server,
@@ -493,11 +489,11 @@ func OperatorHandlerProvider(
 ) *OperatorHandlerImpl {
 	args := NewOperatorHandlerImplArgs{
 		config,
-		esConfig,
 		esClient,
 		logger,
 		sdkClientFactory,
 		metricsHandler,
+		visibilityMgr,
 		saProvider,
 		saManager,
 		healthServer,

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -46,7 +46,6 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/resourcetest"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/testing/mocksdk"
@@ -79,11 +78,11 @@ func (s *operatorHandlerSuite) SetupTest() {
 
 	args := NewOperatorHandlerImplArgs{
 		&Config{NumHistoryShards: 4},
-		nil,
 		s.mockResource.ESClient,
 		s.mockResource.Logger,
 		s.mockResource.GetSDKClientFactory(),
 		s.mockResource.GetMetricsHandler(),
+		s.mockResource.GetVisibilityManager(),
 		s.mockResource.GetSearchAttributesProvider(),
 		s.mockResource.GetSearchAttributesManager(),
 		health.NewServer(),
@@ -102,7 +101,7 @@ func (s *operatorHandlerSuite) TearDownTest() {
 	s.handler.Stop()
 }
 
-func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
+func (s *operatorHandlerSuite) Test_AddSearchAttributes_EmptyIndexName() {
 	handler := s.handler
 	ctx := context.Background()
 
@@ -124,6 +123,8 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 			Expected: &serviceerror.InvalidArgument{Message: "SearchAttributes are not set on request."},
 		},
 	}
+
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
 	for _, testCase := range testCases1 {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.AddSearchAttributes(ctx, testCase.Request)
@@ -134,7 +135,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 
 	// Elasticsearch is not configured
 	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
-	testCases3 := []test{
+	testCases2 := []test{
 		{
 			Name: "reserved key (empty index)",
 			Request: &operatorservice.AddSearchAttributesRequest{
@@ -154,23 +155,25 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 			Expected: &serviceerror.AlreadyExists{Message: "Search attribute CustomTextField already exists."},
 		},
 	}
-	for _, testCase := range testCases3 {
+	for _, testCase := range testCases2 {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.AddSearchAttributes(ctx, testCase.Request)
 			s.Equal(testCase.Expected, err)
 			s.Nil(resp)
 		})
 	}
+}
 
-	// Configure Elasticsearch: add advanced visibility store config with index name.
-	handler.esConfig = &client.Config{
-		Indices: map[string]string{
-			"visibility": "random-index-name",
-		},
+func (s *operatorHandlerSuite) Test_AddSearchAttributes_NonEmptyIndexName() {
+	handler := s.handler
+	ctx := context.Background()
+
+	type test struct {
+		Name     string
+		Request  *operatorservice.AddSearchAttributesRequest
+		Expected error
 	}
-
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
-	testCases2 := []test{
+	testCases := []test{
 		{
 			Name: "reserved key (ES configured)",
 			Request: &operatorservice.AddSearchAttributesRequest{
@@ -190,7 +193,11 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 			Expected: &serviceerror.AlreadyExists{Message: "Search attribute CustomTextField already exists."},
 		},
 	}
-	for _, testCase := range testCases2 {
+
+	// Configure Elasticsearch: add advanced visibility store config with index name.
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	for _, testCase := range testCases {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.AddSearchAttributes(ctx, testCase.Request)
 			s.Equal(testCase.Expected, err)
@@ -241,10 +248,11 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 	s.NotNil(resp)
 }
 
-func (s *operatorHandlerSuite) Test_ListSearchAttributes() {
+func (s *operatorHandlerSuite) Test_ListSearchAttributes_EmptyIndexName() {
 	handler := s.handler
 	ctx := context.Background()
 
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
 	resp, err := handler.ListSearchAttributes(ctx, nil)
 	s.Error(err)
 	s.Equal(&serviceerror.InvalidArgument{Message: "Request is nil."}, err)
@@ -257,17 +265,17 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes() {
 	resp, err = handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
 	s.NoError(err)
 	s.NotNil(resp)
+}
+
+func (s *operatorHandlerSuite) Test_ListSearchAttributes_NonEmptyIndexName() {
+	handler := s.handler
+	ctx := context.Background()
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
-	handler.esConfig = &client.Config{
-		Indices: map[string]string{
-			"visibility": "random-index-name",
-		},
-	}
-
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "random-index-name").Return(map[string]string{"col": "type"}, nil)
 	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil)
-	resp, err = handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
+	resp, err := handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
 	s.NoError(err)
 	s.NotNil(resp)
 
@@ -278,7 +286,7 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes() {
 	s.Nil(resp)
 }
 
-func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
+func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_EmptyIndexName() {
 	handler := s.handler
 	ctx := context.Background()
 
@@ -300,6 +308,8 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 			Expected: &serviceerror.InvalidArgument{Message: "SearchAttributes are not set on request."},
 		},
 	}
+
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
 	for _, testCase := range testCases1 {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.RemoveSearchAttributes(ctx, testCase.Request)
@@ -310,7 +320,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 
 	// Elasticsearch is not configured
 	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
-	testCases3 := []test{
+	testCases2 := []test{
 		{
 			Name: "reserved search attribute (empty index)",
 			Request: &operatorservice.RemoveSearchAttributesRequest{
@@ -330,23 +340,25 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 			Expected: &serviceerror.NotFound{Message: "Search attribute ProductId doesn't exist."},
 		},
 	}
-	for _, testCase := range testCases3 {
+	for _, testCase := range testCases2 {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.RemoveSearchAttributes(ctx, testCase.Request)
 			s.Equal(testCase.Expected, err)
 			s.Nil(resp)
 		})
 	}
+}
 
-	// Configure Elasticsearch: add advanced visibility store config with index name.
-	handler.esConfig = &client.Config{
-		Indices: map[string]string{
-			"visibility": "random-index-name",
-		},
+func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_NonEmptyIndexName() {
+	handler := s.handler
+	ctx := context.Background()
+
+	type test struct {
+		Name     string
+		Request  *operatorservice.RemoveSearchAttributesRequest
+		Expected error
 	}
-
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
-	testCases2 := []test{
+	testCases := []test{
 		{
 			Name: "reserved search attribute (ES configured)",
 			Request: &operatorservice.RemoveSearchAttributesRequest{
@@ -366,7 +378,11 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 			Expected: &serviceerror.NotFound{Message: "Search attribute ProductId doesn't exist."},
 		},
 	}
-	for _, testCase := range testCases2 {
+
+	// Configure Elasticsearch: add advanced visibility store config with index name.
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	for _, testCase := range testCases {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.RemoveSearchAttributes(ctx, testCase.Request)
 			s.Equal(testCase.Expected, err)

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -55,7 +55,6 @@ import (
 // Config represents configuration for frontend service
 type Config struct {
 	NumHistoryShards                      int32
-	ESIndexName                           string
 	PersistenceMaxQPS                     dynamicconfig.IntPropertyFn
 	PersistenceGlobalMaxQPS               dynamicconfig.IntPropertyFn
 	PersistenceNamespaceMaxQPS            dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -169,10 +168,9 @@ type Config struct {
 }
 
 // NewConfig returns new service config with default values
-func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int32, esIndexName string, enableReadFromES bool) *Config {
+func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int32, enableReadFromES bool) *Config {
 	return &Config{
 		NumHistoryShards:                      numHistoryShards,
-		ESIndexName:                           esIndexName,
 		PersistenceMaxQPS:                     dc.GetIntProperty(dynamicconfig.FrontendPersistenceMaxQPS, 2000),
 		PersistenceGlobalMaxQPS:               dc.GetIntProperty(dynamicconfig.FrontendPersistenceGlobalMaxQPS, 0),
 		PersistenceNamespaceMaxQPS:            dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendPersistenceNamespaceMaxQPS, 0),

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -182,7 +182,7 @@ func NewWorkflowHandler(
 			config.SearchAttributesNumberOfKeysLimit,
 			config.SearchAttributesSizeOfValueLimit,
 			config.SearchAttributesTotalSizeLimit,
-			config.ESIndexName,
+			visibilityMrg.GetIndexName(),
 		),
 		archivalMetadata: archivalMetadata,
 		healthServer:     healthServer,
@@ -2439,7 +2439,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(ctx context.Context, r
 		Query:         request.GetQuery(),
 	}
 
-	searchAttributes, err := wh.saProvider.GetSearchAttributes(wh.config.ESIndexName, false)
+	searchAttributes, err := wh.saProvider.GetSearchAttributes(wh.visibilityMrg.GetIndexName(), false)
 	if err != nil {
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}
@@ -2553,7 +2553,7 @@ func (wh *WorkflowHandler) GetSearchAttributes(ctx context.Context, _ *workflows
 		return nil, errShuttingDown
 	}
 
-	searchAttributes, err := wh.saProvider.GetSearchAttributes(wh.config.ESIndexName, false)
+	searchAttributes, err := wh.saProvider.GetSearchAttributes(wh.visibilityMrg.GetIndexName(), false)
 	if err != nil {
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}
@@ -2760,7 +2760,7 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, reques
 	}
 
 	if response.GetWorkflowExecutionInfo().GetSearchAttributes() != nil {
-		saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.config.ESIndexName, false)
+		saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.visibilityMrg.GetIndexName(), false)
 		if err != nil {
 			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 		}
@@ -3107,7 +3107,7 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 
 	// map search attributes
 	if sas := executionInfo.GetSearchAttributes(); sas != nil {
-		saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.config.ESIndexName, false)
+		saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.visibilityMrg.GetIndexName(), false)
 		if err != nil {
 			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 		}
@@ -3151,7 +3151,7 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 
 		// map action search attributes
 		if sa := queryResponse.Schedule.Action.GetStartWorkflow().SearchAttributes; sa != nil {
-			saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.config.ESIndexName, false)
+			saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.visibilityMrg.GetIndexName(), false)
 			if err != nil {
 				return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 			}
@@ -4241,7 +4241,7 @@ func (wh *WorkflowHandler) getHistoryReverse(
 }
 
 func (wh *WorkflowHandler) processOutgoingSearchAttributes(events []*historypb.HistoryEvent, namespace namespace.Name) error {
-	saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.config.ESIndexName, false)
+	saTypeMap, err := wh.saProvider.GetSearchAttributes(wh.visibilityMrg.GetIndexName(), false)
 	if err != nil {
 		return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -159,13 +159,25 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	pConfig.NumHistoryShards = options.HistoryConfig.NumHistoryShards
 
 	var (
-		esClient esclient.Client
+		indexName string
+		esClient  esclient.Client
 	)
 	if options.ESConfig != nil {
+		// Disable standard to elasticsearch dual visibility
+		pConfig.VisibilityStore = ""
+		indexName = options.ESConfig.GetVisibilityIndex()
 		var err error
 		esClient, err = esclient.NewClient(options.ESConfig, nil, logger)
 		if err != nil {
 			return nil, err
+		}
+	} else {
+		storeConfig := pConfig.DataStores[pConfig.VisibilityStore]
+		switch {
+		case storeConfig.Cassandra != nil:
+			indexName = storeConfig.Cassandra.Keyspace
+		case storeConfig.SQL != nil:
+			indexName = storeConfig.SQL.DatabaseName
 		}
 	}
 
@@ -194,7 +206,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	// Actual Elasticsearch fields are created from index template (testdata/es_v7_index_template.json).
 	err := testBase.SearchAttributesManager.SaveSearchAttributes(
 		context.Background(),
-		options.ESConfig.GetVisibilityIndex(),
+		indexName,
 		searchattribute.TestNameTypeMap.Custom(),
 	)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding a interface to get the visibility storage schema name, ie., for ES the index name, and for SQL DB the table name.

<!-- Tell your future self why have you made these changes -->
**Why?**
It will allow to abstract the schema name without needing to read from config. The visibility manager already is an abstraction of the underlying storage, so it makes it easier to get the schema name.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Maybe will have some issue with cluster metadata when using SQL DB since it was using empty string as "index name".

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.