### PR TITLE
Remove matching.useOldRouting dynamic config

### DIFF
--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -157,7 +157,6 @@ func (cf *rpcClientFactory) NewMatchingClientWithTimeout(
 		longPollTimeout,
 		common.NewClientCache(keyResolver, clientProvider),
 		matching.NewLoadBalancer(namespaceIDToName, cf.dynConfig),
-		cf.dynConfig.GetBoolProperty(dynamicconfig.MatchingUseOldRouting, true),
 	)
 
 	if cf.metricsHandler != nil {

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -317,8 +317,6 @@ const (
 	MatchingShutdownDrainDuration = "matching.shutdownDrainDuration"
 	// MatchingMetadataPollFrequency is how often non-root partitions will poll the root partition for fresh metadata
 	MatchingMetadataPollFrequency = "matching.metadataPollFrequency"
-	// MatchingUseOldRouting is whether to use old task queue routing (name only) instead of namespace+name+type.
-	MatchingUseOldRouting = "matching.useOldRouting"
 
 	// keys for history
 


### PR DESCRIPTION
**What changed?**
This dynamic config was introduced in 1.18 to use during the upgrade process and should be set everywhere by now.

**Why?**
Clean up old code.

**How did you test it?**
CI

**Potential risks**
If users haven't manually set the dynamic config to false, they'll have disrupted task dispatch during the upgrade to 1.20.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
