### PR TITLE
Rename NameTypeMap to IndexSearchAttributes

### DIFF
--- a/common/archiver/filestore/visibilityArchiver.go
+++ b/common/archiver/filestore/visibilityArchiver.go
@@ -144,7 +144,7 @@ func (v *visibilityArchiver) Query(
 	ctx context.Context,
 	URI archiver.URI,
 	request *archiver.QueryVisibilityRequest,
-	saTypeMap searchattribute.NameTypeMap,
+	saTypeMap searchattribute.IndexSearchAttributes,
 ) (*archiver.QueryVisibilityResponse, error) {
 	if err := v.ValidateURI(URI); err != nil {
 		return nil, serviceerror.NewInvalidArgument(archiver.ErrInvalidURI.Error())
@@ -180,7 +180,7 @@ func (v *visibilityArchiver) query(
 	ctx context.Context,
 	URI archiver.URI,
 	request *queryVisibilityRequest,
-	saTypeMap searchattribute.NameTypeMap,
+	saTypeMap searchattribute.IndexSearchAttributes,
 ) (*archiver.QueryVisibilityResponse, error) {
 	var token *queryVisibilityToken
 	if request.nextPageToken != nil {
@@ -341,7 +341,7 @@ func matchQuery(record *archiverspb.VisibilityRecord, query *parsedQuery) bool {
 	return true
 }
 
-func convertToExecutionInfo(record *archiverspb.VisibilityRecord, saTypeMap searchattribute.NameTypeMap) (*workflowpb.WorkflowExecutionInfo, error) {
+func convertToExecutionInfo(record *archiverspb.VisibilityRecord, saTypeMap searchattribute.IndexSearchAttributes) (*workflowpb.WorkflowExecutionInfo, error) {
 	searchAttributes, err := searchattribute.Parse(record.SearchAttributes, &saTypeMap)
 	if err != nil {
 		return nil, err

--- a/common/archiver/gcloud/util.go
+++ b/common/archiver/gcloud/util.go
@@ -139,7 +139,7 @@ func deserializeQueryVisibilityToken(bytes []byte) (*queryVisibilityToken, error
 	return token, err
 }
 
-func convertToExecutionInfo(record *archiverspb.VisibilityRecord, saTypeMap searchattribute.NameTypeMap) (*workflowpb.WorkflowExecutionInfo, error) {
+func convertToExecutionInfo(record *archiverspb.VisibilityRecord, saTypeMap searchattribute.IndexSearchAttributes) (*workflowpb.WorkflowExecutionInfo, error) {
 	searchAttributes, err := searchattribute.Parse(record.SearchAttributes, &saTypeMap)
 	if err != nil {
 		return nil, err

--- a/common/archiver/gcloud/visibilityArchiver.go
+++ b/common/archiver/gcloud/visibilityArchiver.go
@@ -159,7 +159,7 @@ func (v *visibilityArchiver) Query(
 	ctx context.Context,
 	URI archiver.URI,
 	request *archiver.QueryVisibilityRequest,
-	saTypeMap searchattribute.NameTypeMap,
+	saTypeMap searchattribute.IndexSearchAttributes,
 ) (*archiver.QueryVisibilityResponse, error) {
 
 	if err := v.ValidateURI(URI); err != nil {
@@ -196,7 +196,7 @@ func (v *visibilityArchiver) query(
 	ctx context.Context,
 	URI archiver.URI,
 	request *queryVisibilityRequest,
-	saTypeMap searchattribute.NameTypeMap,
+	saTypeMap searchattribute.IndexSearchAttributes,
 ) (*archiver.QueryVisibilityResponse, error) {
 
 	token := new(queryVisibilityToken)

--- a/common/archiver/gcloud/visibilityArchiver_test.go
+++ b/common/archiver/gcloud/visibilityArchiver_test.go
@@ -35,8 +35,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
 
-	"go.temporal.io/server/common/searchattribute"
-
 	archiverspb "go.temporal.io/server/api/archiver/v1"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/gcloud/connector"
@@ -44,6 +42,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 const (
@@ -164,7 +163,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidVisibilityURI() {
 		Query:       "WorkflowType='type::example' AND CloseTime='2020-02-05T11:00:00Z' AND SearchPrecision='Day'",
 	}
 
-	_, err = visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap)
+	_, err = visibilityArchiver.Query(ctx, URI, request, searchattribute.TestIndexSearchAttributes)
 	s.Error(err)
 }
 
@@ -212,7 +211,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidQuery() {
 		NamespaceID: "some random namespaceID",
 		PageSize:    10,
 		Query:       "some invalid query",
-	}, searchattribute.TestNameTypeMap)
+	}, searchattribute.TestIndexSearchAttributes)
 	s.Error(err)
 	s.Nil(response)
 }
@@ -239,7 +238,7 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidToken() {
 		PageSize:      1,
 		NextPageToken: []byte{1, 2, 3},
 	}
-	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(context.Background(), URI, request, searchattribute.TestIndexSearchAttributes)
 	s.Error(err)
 	s.Nil(response)
 }
@@ -273,12 +272,12 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 		Query:       "parsed by mockParser",
 	}
 
-	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestIndexSearchAttributes)
 	s.NoError(err)
 	s.NotNil(response)
 	s.Nil(response.NextPageToken)
 	s.Len(response.Executions, 1)
-	ei, err := convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestIndexSearchAttributes)
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
 }
@@ -317,25 +316,25 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 		Query:       "parsed by mockParser",
 	}
 
-	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap)
+	response, err := visibilityArchiver.Query(ctx, URI, request, searchattribute.TestIndexSearchAttributes)
 	s.NoError(err)
 	s.NotNil(response)
 	s.NotNil(response.NextPageToken)
 	s.Len(response.Executions, 2)
-	ei, err := convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err := convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestIndexSearchAttributes)
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
-	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestIndexSearchAttributes)
 	s.NoError(err)
 	s.Equal(ei, response.Executions[1])
 
 	request.NextPageToken = response.NextPageToken
-	response, err = visibilityArchiver.Query(ctx, URI, request, searchattribute.TestNameTypeMap)
+	response, err = visibilityArchiver.Query(ctx, URI, request, searchattribute.TestIndexSearchAttributes)
 	s.NoError(err)
 	s.NotNil(response)
 	s.Nil(response.NextPageToken)
 	s.Len(response.Executions, 1)
-	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
+	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestIndexSearchAttributes)
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
 }

--- a/common/archiver/interface.go
+++ b/common/archiver/interface.go
@@ -133,7 +133,7 @@ type (
 		// For example, it can be  some SQL-like syntax query string.
 		// Your implementation is responsible for parsing and validating the query, and also returning all visibility records that match the query.
 		// Currently the maximum context timeout passed into the method is 3 minutes, so it's acceptable if this method takes some time to run.
-		Query(ctx context.Context, uri URI, request *QueryVisibilityRequest, saTypeMap searchattribute.NameTypeMap) (*QueryVisibilityResponse, error)
+		Query(ctx context.Context, uri URI, request *QueryVisibilityRequest, saTypeMap searchattribute.IndexSearchAttributes) (*QueryVisibilityResponse, error)
 		// ValidateURI is used to define what a valid URI for an implementation is.
 		ValidateURI(uri URI) error
 	}

--- a/common/archiver/interface_mock.go
+++ b/common/archiver/interface_mock.go
@@ -151,7 +151,7 @@ func (mr *MockVisibilityArchiverMockRecorder) Archive(ctx, uri, request interfac
 }
 
 // Query mocks base method.
-func (m *MockVisibilityArchiver) Query(ctx context.Context, uri URI, request *QueryVisibilityRequest, saTypeMap searchattribute.NameTypeMap) (*QueryVisibilityResponse, error) {
+func (m *MockVisibilityArchiver) Query(ctx context.Context, uri URI, request *QueryVisibilityRequest, saTypeMap searchattribute.IndexSearchAttributes) (*QueryVisibilityResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Query", ctx, uri, request, saTypeMap)
 	ret0, _ := ret[0].(*QueryVisibilityResponse)

--- a/common/archiver/s3store/util.go
+++ b/common/archiver/s3store/util.go
@@ -252,7 +252,7 @@ func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*h
 	return lastFailoverVersion != request.CloseFailoverVersion || lastEventID+1 != request.NextEventID
 }
 
-func convertToExecutionInfo(record *archiverspb.VisibilityRecord, saTypeMap searchattribute.NameTypeMap) (*workflowpb.WorkflowExecutionInfo, error) {
+func convertToExecutionInfo(record *archiverspb.VisibilityRecord, saTypeMap searchattribute.IndexSearchAttributes) (*workflowpb.WorkflowExecutionInfo, error) {
 	searchAttributes, err := searchattribute.Parse(record.SearchAttributes, &saTypeMap)
 	if err != nil {
 		return nil, err

--- a/common/archiver/s3store/visibilityArchiver.go
+++ b/common/archiver/s3store/visibilityArchiver.go
@@ -168,7 +168,7 @@ func (v *visibilityArchiver) Query(
 	ctx context.Context,
 	URI archiver.URI,
 	request *archiver.QueryVisibilityRequest,
-	saTypeMap searchattribute.NameTypeMap,
+	saTypeMap searchattribute.IndexSearchAttributes,
 ) (*archiver.QueryVisibilityResponse, error) {
 
 	if err := SoftValidateURI(URI); err != nil {
@@ -201,7 +201,7 @@ func (v *visibilityArchiver) query(
 	ctx context.Context,
 	URI archiver.URI,
 	request *queryVisibilityRequest,
-	saTypeMap searchattribute.NameTypeMap,
+	saTypeMap searchattribute.IndexSearchAttributes,
 ) (*archiver.QueryVisibilityResponse, error) {
 	ctx, cancel := ensureContextTimeout(ctx)
 	defer cancel()

--- a/common/persistence/visibility/store/elasticsearch/query_interceptors.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors.go
@@ -41,7 +41,7 @@ type (
 	nameInterceptor struct {
 		namespace               namespace.Name
 		index                   string
-		searchAttributesTypeMap searchattribute.NameTypeMap
+		searchAttributesTypeMap searchattribute.IndexSearchAttributes
 		searchAttributesMapper  searchattribute.Mapper
 		seenNamespaceDivision   bool
 	}
@@ -51,7 +51,7 @@ type (
 func newNameInterceptor(
 	namespace namespace.Name,
 	index string,
-	saTypeMap searchattribute.NameTypeMap,
+	saTypeMap searchattribute.IndexSearchAttributes,
 	searchAttributesMapper searchattribute.Mapper,
 ) *nameInterceptor {
 	return &nameInterceptor{

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -887,7 +887,7 @@ func (s *visibilityStore) generateESDoc(request *store.InternalVisibilityRequest
 	return doc, nil
 }
 
-func (s *visibilityStore) parseESDoc(docID string, docSource json.RawMessage, saTypeMap searchattribute.NameTypeMap, namespace namespace.Name) (*store.InternalWorkflowExecutionInfo, error) {
+func (s *visibilityStore) parseESDoc(docID string, docSource json.RawMessage, saTypeMap searchattribute.IndexSearchAttributes, namespace namespace.Name) (*store.InternalWorkflowExecutionInfo, error) {
 	logParseError := func(fieldName string, fieldValue interface{}, err error, docID string) error {
 		s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.GetMetricName()).Record(1)
 		return serviceerror.NewInternal(fmt.Sprintf("Unable to parse Elasticsearch document(%s) %q field value %q: %v", docID, fieldName, fieldValue, err))

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -865,7 +865,7 @@ func (s *ESVisibilitySuite) TestParseESDoc() {
           "WorkflowId": "6bfbc1e5-6ce4-4e22-bbfb-e0faa9a7a604-1-2256",
           "WorkflowType": "TestWorkflowExecute"}`)
 	// test for open
-	info, err := s.visibilityStore.parseESDoc("", docSource, searchattribute.TestNameTypeMap, testNamespace)
+	info, err := s.visibilityStore.parseESDoc("", docSource, searchattribute.TestIndexSearchAttributes, testNamespace)
 	s.NoError(err)
 	s.NotNil(info)
 	s.Equal("6bfbc1e5-6ce4-4e22-bbfb-e0faa9a7a604-1-2256", info.WorkflowID)
@@ -889,7 +889,7 @@ func (s *ESVisibilitySuite) TestParseESDoc() {
           "StartTime": "2021-06-11T15:04:07.980-07:00",
           "WorkflowId": "6bfbc1e5-6ce4-4e22-bbfb-e0faa9a7a604-1-2256",
           "WorkflowType": "TestWorkflowExecute"}`)
-	info, err = s.visibilityStore.parseESDoc("", docSource, searchattribute.TestNameTypeMap, testNamespace)
+	info, err = s.visibilityStore.parseESDoc("", docSource, searchattribute.TestIndexSearchAttributes, testNamespace)
 	s.NoError(err)
 	s.NotNil(info)
 	s.Equal("6bfbc1e5-6ce4-4e22-bbfb-e0faa9a7a604-1-2256", info.WorkflowID)
@@ -909,7 +909,7 @@ func (s *ESVisibilitySuite) TestParseESDoc() {
 	// test for error case
 	docSource = []byte(`corrupted data`)
 	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchDocumentParseFailuresCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
-	info, err = s.visibilityStore.parseESDoc("", docSource, searchattribute.TestNameTypeMap, testNamespace)
+	info, err = s.visibilityStore.parseESDoc("", docSource, searchattribute.TestIndexSearchAttributes, testNamespace)
 	s.Error(err)
 	s.Nil(info)
 }
@@ -924,10 +924,10 @@ func (s *ESVisibilitySuite) TestParseESDoc_SearchAttributes() {
           "CustomIntField": [111,222],
           "CustomBoolField": true,
           "UnknownField": "random"}`)
-	info, err := s.visibilityStore.parseESDoc("", docSource, searchattribute.TestNameTypeMap, testNamespace)
+	info, err := s.visibilityStore.parseESDoc("", docSource, searchattribute.TestIndexSearchAttributes, testNamespace)
 	s.NoError(err)
 	s.NotNil(info)
-	customSearchAttributes, err := searchattribute.Decode(info.SearchAttributes, &searchattribute.TestNameTypeMap)
+	customSearchAttributes, err := searchattribute.Decode(info.SearchAttributes, &searchattribute.TestIndexSearchAttributes)
 	s.NoError(err)
 
 	s.Len(customSearchAttributes, 7)
@@ -973,7 +973,7 @@ func (s *ESVisibilitySuite) TestParseESDoc_SearchAttributes_WithMapper() {
 			return "AliasOf" + fieldName, nil
 		}).Times(6)
 
-	info, err := s.visibilityStore.parseESDoc("", docSource, searchattribute.TestNameTypeMap, testNamespace)
+	info, err := s.visibilityStore.parseESDoc("", docSource, searchattribute.TestIndexSearchAttributes, testNamespace)
 	s.NoError(err)
 	s.NotNil(info)
 
@@ -992,7 +992,7 @@ func (s *ESVisibilitySuite) TestParseESDoc_SearchAttributes_WithMapper() {
 		func(fieldName string, namespace string) (string, error) {
 			return "", serviceerror.NewUnavailable("error")
 		})
-	info, err = s.visibilityStore.parseESDoc("", docSource, searchattribute.TestNameTypeMap, testNamespace)
+	info, err = s.visibilityStore.parseESDoc("", docSource, searchattribute.TestIndexSearchAttributes, testNamespace)
 	s.Error(err)
 	s.Nil(info)
 

--- a/common/searchattribute/encode.go
+++ b/common/searchattribute/encode.go
@@ -34,7 +34,7 @@ import (
 // Encode encodes map of search attribute values to search attributes.
 // typeMap can be nil (then MetadataType field won't be set).
 // In case of error, it will continue to next search attribute and return last error.
-func Encode(searchAttributes map[string]interface{}, typeMap *NameTypeMap) (*commonpb.SearchAttributes, error) {
+func Encode(searchAttributes map[string]interface{}, typeMap *IndexSearchAttributes) (*commonpb.SearchAttributes, error) {
 	if len(searchAttributes) == 0 {
 		return nil, nil
 	}
@@ -67,7 +67,7 @@ func Encode(searchAttributes map[string]interface{}, typeMap *NameTypeMap) (*com
 // 1. type from typeMap,
 // 2. if typeMap is nil, type from MetadataType field is used.
 // In case of error, it will continue to next search attribute and return last error.
-func Decode(searchAttributes *commonpb.SearchAttributes, typeMap *NameTypeMap) (map[string]interface{}, error) {
+func Decode(searchAttributes *commonpb.SearchAttributes, typeMap *IndexSearchAttributes) (map[string]interface{}, error) {
 	if len(searchAttributes.GetIndexedFields()) == 0 {
 		return nil, nil
 	}

--- a/common/searchattribute/encode_test.go
+++ b/common/searchattribute/encode_test.go
@@ -42,7 +42,7 @@ func Test_Encode_Success(t *testing.T) {
 		"key4": nil,
 		"key5": []string{"val2", "val3"},
 		"key6": []string{},
-	}, &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	}, &IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
@@ -100,7 +100,7 @@ func Test_Encode_Error(t *testing.T) {
 		"key1": "val1",
 		"key2": 2,
 		"key3": true,
-	}, &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	}, &IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key4": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
@@ -119,7 +119,7 @@ func Test_Encode_Error(t *testing.T) {
 func Test_Decode_Success(t *testing.T) {
 	assert := assert.New(t)
 
-	typeMap := &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	typeMap := &IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
@@ -167,7 +167,7 @@ func Test_Decode_Success(t *testing.T) {
 
 func Test_Decode_NilMap(t *testing.T) {
 	assert := assert.New(t)
-	typeMap := &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	typeMap := &IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
@@ -199,7 +199,7 @@ func Test_Decode_NilMap(t *testing.T) {
 func Test_Decode_Error(t *testing.T) {
 	assert := assert.New(t)
 
-	typeMap := &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	typeMap := &IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
@@ -211,7 +211,7 @@ func Test_Decode_Error(t *testing.T) {
 	}, typeMap)
 	assert.NoError(err)
 
-	vals, err := Decode(sa, &NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	vals, err := Decode(sa, &IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key4": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,

--- a/common/searchattribute/index_search_attributes_test.go
+++ b/common/searchattribute/index_search_attributes_test.go
@@ -34,7 +34,7 @@ import (
 
 func Test_IsValid(t *testing.T) {
 	assert := assert.New(t)
-	typeMap := NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	typeMap := IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
@@ -47,7 +47,7 @@ func Test_IsValid(t *testing.T) {
 	isDefined = typeMap.IsDefined("key1")
 	assert.True(isDefined)
 
-	isDefined = NameTypeMap{}.IsDefined("key1")
+	isDefined = IndexSearchAttributes{}.IsDefined("key1")
 	assert.False(isDefined)
 	isDefined = typeMap.IsDefined("key4")
 	assert.False(isDefined)
@@ -57,7 +57,7 @@ func Test_IsValid(t *testing.T) {
 
 func Test_GetType(t *testing.T) {
 	assert := assert.New(t)
-	typeMap := NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	typeMap := IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_INT,
 		"key3": enumspb.INDEXED_VALUE_TYPE_BOOL,
@@ -82,7 +82,7 @@ func Test_GetType(t *testing.T) {
 	assert.Error(err)
 	assert.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ivt)
 
-	ivt, err = NameTypeMap{}.GetType("key1")
+	ivt, err = IndexSearchAttributes{}.GetType("key1")
 	assert.Error(err)
 	assert.True(errors.Is(err, ErrInvalidName))
 	assert.Equal(enumspb.INDEXED_VALUE_TYPE_UNSPECIFIED, ivt)

--- a/common/searchattribute/search_attirbute.go
+++ b/common/searchattribute/search_attirbute.go
@@ -41,7 +41,7 @@ const (
 
 type (
 	Provider interface {
-		GetSearchAttributes(indexName string, forceRefreshCache bool) (NameTypeMap, error)
+		GetSearchAttributes(indexName string, forceRefreshCache bool) (IndexSearchAttributes, error)
 	}
 
 	Manager interface {
@@ -57,7 +57,7 @@ var (
 
 // ApplyTypeMap set type for all valid search attributes which don't have it.
 // It doesn't do any validation and just skip invalid or already set search attributes.
-func ApplyTypeMap(searchAttributes *commonpb.SearchAttributes, typeMap NameTypeMap) {
+func ApplyTypeMap(searchAttributes *commonpb.SearchAttributes, typeMap IndexSearchAttributes) {
 	for saName, saPayload := range searchAttributes.GetIndexedFields() {
 		_, metadataHasValueType := saPayload.Metadata[MetadataType]
 		if metadataHasValueType {

--- a/common/searchattribute/search_attribute_mock.go
+++ b/common/searchattribute/search_attribute_mock.go
@@ -60,10 +60,10 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 }
 
 // GetSearchAttributes mocks base method.
-func (m *MockProvider) GetSearchAttributes(indexName string, forceRefreshCache bool) (NameTypeMap, error) {
+func (m *MockProvider) GetSearchAttributes(indexName string, forceRefreshCache bool) (IndexSearchAttributes, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSearchAttributes", indexName, forceRefreshCache)
-	ret0, _ := ret[0].(NameTypeMap)
+	ret0, _ := ret[0].(IndexSearchAttributes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -98,10 +98,10 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 }
 
 // GetSearchAttributes mocks base method.
-func (m *MockManager) GetSearchAttributes(indexName string, forceRefreshCache bool) (NameTypeMap, error) {
+func (m *MockManager) GetSearchAttributes(indexName string, forceRefreshCache bool) (IndexSearchAttributes, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetSearchAttributes", indexName, forceRefreshCache)
-	ret0, _ := ret[0].(NameTypeMap)
+	ret0, _ := ret[0].(IndexSearchAttributes)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/common/searchattribute/search_attribute_test.go
+++ b/common/searchattribute/search_attribute_test.go
@@ -48,7 +48,7 @@ func Test_ApplyTypeMap_Success(t *testing.T) {
 		},
 	}
 
-	validSearchAttributes := NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	validSearchAttributes := IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		"key3": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -76,7 +76,7 @@ func Test_ApplyTypeMap_Skip(t *testing.T) {
 		},
 	}
 
-	validSearchAttributes := NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	validSearchAttributes := IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 		"key2": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		"key3": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -86,7 +86,7 @@ func Test_ApplyTypeMap_Skip(t *testing.T) {
 	assert.Nil(sa.GetIndexedFields()["UnknownKey"].Metadata["type"])
 	assert.Equal("String", string(sa.GetIndexedFields()["key3"].Metadata["type"]))
 
-	validSearchAttributes = NameTypeMap{customSearchAttributes: map[string]enumspb.IndexedValueType{
+	validSearchAttributes = IndexSearchAttributes{customSearchAttributes: map[string]enumspb.IndexedValueType{
 		"key4": enumspb.IndexedValueType(100),
 	}}
 

--- a/common/searchattribute/stringify.go
+++ b/common/searchattribute/stringify.go
@@ -44,7 +44,7 @@ import (
 // In case of error, it will continue to next search attribute and return last error.
 // Single values are converted using strconv, arrays are converted using json.Marshal.
 // Search attributes with `nil` values are skipped.
-func Stringify(searchAttributes *commonpb.SearchAttributes, typeMap *NameTypeMap) (map[string]string, error) {
+func Stringify(searchAttributes *commonpb.SearchAttributes, typeMap *IndexSearchAttributes) (map[string]string, error) {
 	if len(searchAttributes.GetIndexedFields()) == 0 {
 		return nil, nil
 	}
@@ -103,7 +103,7 @@ func Stringify(searchAttributes *commonpb.SearchAttributes, typeMap *NameTypeMap
 // typeMap can be nil (values will be parsed with strconv and MetadataType field won't be set).
 // In case of error, it will continue to next search attribute and return last error.
 // Single values are parsed using strconv, arrays are parsed using json.Unmarshal.
-func Parse(searchAttributesStr map[string]string, typeMap *NameTypeMap) (*commonpb.SearchAttributes, error) {
+func Parse(searchAttributesStr map[string]string, typeMap *IndexSearchAttributes) (*commonpb.SearchAttributes, error) {
 	if len(searchAttributesStr) == 0 {
 		return nil, nil
 	}

--- a/common/searchattribute/stringify_test.go
+++ b/common/searchattribute/stringify_test.go
@@ -53,7 +53,7 @@ func (s *StringifySuite) TearDownTest() {
 }
 
 func (s *StringifySuite) Test_Stringify() {
-	typeMap := NameTypeMap{
+	typeMap := IndexSearchAttributes{
 		customSearchAttributes: map[string]enumspb.IndexedValueType{
 			"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 			"key2": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -98,7 +98,7 @@ func (s *StringifySuite) Test_Stringify() {
 }
 
 func (s *StringifySuite) Test_Stringify_Array() {
-	typeMap := NameTypeMap{
+	typeMap := IndexSearchAttributes{
 		customSearchAttributes: map[string]enumspb.IndexedValueType{
 			"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 			"key2": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -147,7 +147,7 @@ func (s *StringifySuite) Test_Parse_ValidTypeMap() {
 		"key1": "val1",
 		"key2": "2",
 		"key3": "true",
-	}, &NameTypeMap{
+	}, &IndexSearchAttributes{
 		customSearchAttributes: map[string]enumspb.IndexedValueType{
 			"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 			"key2": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -182,7 +182,7 @@ func (s *StringifySuite) Test_Parse_WrongTypesInTypeMap() {
 	sa, err := Parse(map[string]string{
 		"key1": "val1",
 		"key2": "2",
-	}, &NameTypeMap{
+	}, &IndexSearchAttributes{
 		customSearchAttributes: map[string]enumspb.IndexedValueType{
 			"key1": enumspb.INDEXED_VALUE_TYPE_INT,
 			"key2": enumspb.INDEXED_VALUE_TYPE_TEXT,
@@ -199,7 +199,7 @@ func (s *StringifySuite) Test_Parse_MissedFieldsInTypeMap() {
 	sa, err := Parse(map[string]string{
 		"key1": "val1",
 		"key2": "2",
-	}, &NameTypeMap{
+	}, &IndexSearchAttributes{
 		customSearchAttributes: map[string]enumspb.IndexedValueType{
 			"key3": enumspb.INDEXED_VALUE_TYPE_TEXT,
 			"key2": enumspb.INDEXED_VALUE_TYPE_INT,
@@ -217,7 +217,7 @@ func (s *StringifySuite) Test_Parse_Array() {
 	sa, err := Parse(map[string]string{
 		"key1": ` ["val1", "val2"] `,
 		"key2": "[2,3,4]",
-	}, &NameTypeMap{
+	}, &IndexSearchAttributes{
 		customSearchAttributes: map[string]enumspb.IndexedValueType{
 			"key1": enumspb.INDEXED_VALUE_TYPE_TEXT,
 			"key2": enumspb.INDEXED_VALUE_TYPE_INT,

--- a/common/searchattribute/system_provider.go
+++ b/common/searchattribute/system_provider.go
@@ -32,6 +32,6 @@ func NewSystemProvider() *SystemProvider {
 	return &SystemProvider{}
 }
 
-func (s *SystemProvider) GetSearchAttributes(_ string, _ bool) (NameTypeMap, error) {
-	return NameTypeMap{}, nil
+func (s *SystemProvider) GetSearchAttributes(_ string, _ bool) (IndexSearchAttributes, error) {
+	return IndexSearchAttributes{}, nil
 }

--- a/common/searchattribute/test_provider.go
+++ b/common/searchattribute/test_provider.go
@@ -33,7 +33,7 @@ type (
 )
 
 var (
-	TestNameTypeMap = NameTypeMap{
+	TestIndexSearchAttributes = IndexSearchAttributes{
 		customSearchAttributes: map[string]enumspb.IndexedValueType{
 			"CustomIntField":      enumspb.INDEXED_VALUE_TYPE_INT,
 			"CustomTextField":     enumspb.INDEXED_VALUE_TYPE_TEXT,
@@ -49,6 +49,6 @@ func NewTestProvider() *TestProvider {
 	return &TestProvider{}
 }
 
-func (s *TestProvider) GetSearchAttributes(_ string, _ bool) (NameTypeMap, error) {
-	return TestNameTypeMap, nil
+func (s *TestProvider) GetSearchAttributes(_ string, _ bool) (IndexSearchAttributes, error) {
+	return TestIndexSearchAttributes, nil
 }

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -491,7 +491,7 @@ func (s *adminHandlerSuite) Test_AddSearchAttributes() {
 	}
 
 	// Elasticsearch is not configured
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	testCases3 := []test{
 		{
 			Name: "reserved key (empty index)",
@@ -527,7 +527,7 @@ func (s *adminHandlerSuite) Test_AddSearchAttributes() {
 		},
 	}
 
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	testCases2 := []test{
 		{
 			Name: "reserved key (ES configured)",
@@ -612,7 +612,7 @@ func (s *adminHandlerSuite) Test_GetSearchAttributes() {
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(
 		&workflowservice.DescribeWorkflowExecutionResponse{}, nil)
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "").Return(map[string]string{"col": "type"}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 
 	resp, err = handler.GetSearchAttributes(ctx, &adminservice.GetSearchAttributesRequest{})
 	s.NoError(err)
@@ -628,7 +628,7 @@ func (s *adminHandlerSuite) Test_GetSearchAttributes() {
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(
 		&workflowservice.DescribeWorkflowExecutionResponse{}, nil)
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "random-index-name").Return(map[string]string{"col": "type"}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	resp, err = handler.GetSearchAttributes(ctx, &adminservice.GetSearchAttributesRequest{})
 	s.NoError(err)
 	s.NotNil(resp)
@@ -636,7 +636,7 @@ func (s *adminHandlerSuite) Test_GetSearchAttributes() {
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(
 		&workflowservice.DescribeWorkflowExecutionResponse{}, nil)
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "another-index-name").Return(map[string]string{"col": "type"}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("another-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("another-index-name", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	resp, err = handler.GetSearchAttributes(ctx, &adminservice.GetSearchAttributesRequest{IndexName: "another-index-name"})
 	s.NoError(err)
 	s.NotNil(resp)
@@ -644,7 +644,7 @@ func (s *adminHandlerSuite) Test_GetSearchAttributes() {
 	mockSdkClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), "temporal-sys-add-search-attributes-workflow", "").Return(
 		nil, errors.New("random error"))
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "random-index-name").Return(map[string]string{"col": "type"}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	resp, err = handler.GetSearchAttributes(ctx, &adminservice.GetSearchAttributesRequest{})
 	s.Error(err)
 	s.Nil(resp)
@@ -681,7 +681,7 @@ func (s *adminHandlerSuite) Test_RemoveSearchAttributes() {
 	}
 
 	// Elasticsearch is not configured
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	testCases3 := []test{
 		{
 			Name: "reserved search attribute (empty index)",
@@ -717,7 +717,7 @@ func (s *adminHandlerSuite) Test_RemoveSearchAttributes() {
 		},
 	}
 
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	testCases2 := []test{
 		{
 			Name: "reserved search attribute (ES configured)",

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -133,7 +133,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 	}
 
 	// Elasticsearch is not configured
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	testCases3 := []test{
 		{
 			Name: "reserved key (empty index)",
@@ -169,7 +169,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes() {
 		},
 	}
 
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	testCases2 := []test{
 		{
 			Name: "reserved key (ES configured)",
@@ -252,7 +252,7 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes() {
 
 	// Elasticsearch is not configured
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "").Return(map[string]string{"col": "type"}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 
 	resp, err = handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
 	s.NoError(err)
@@ -266,13 +266,13 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes() {
 	}
 
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "random-index-name").Return(map[string]string{"col": "type"}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestIndexSearchAttributes, nil)
 	resp, err = handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
 	s.NoError(err)
 	s.NotNil(resp)
 
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "random-index-name").Return(map[string]string{"col": "type"}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.NameTypeMap{}, errors.New("random error"))
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.IndexSearchAttributes{}, errors.New("random error"))
 	resp, err = handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
 	s.Error(err)
 	s.Nil(resp)
@@ -309,7 +309,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 	}
 
 	// Elasticsearch is not configured
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	testCases3 := []test{
 		{
 			Name: "reserved search attribute (empty index)",
@@ -345,7 +345,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes() {
 		},
 	}
 
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 	testCases2 := []test{
 		{
 			Name: "reserved search attribute (ES configured)",

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -263,7 +263,7 @@ func (s *workflowHandlerSuite) TestTransientTaskInjection() {
 	// Needed to execute test but not relevant
 	s.mockSearchAttributesProvider.EXPECT().
 		GetSearchAttributes(cfg.ESIndexName, false).
-		Return(searchattribute.NameTypeMap{}, nil).
+		Return(searchattribute.IndexSearchAttributes{}, nil).
 		AnyTimes()
 
 	// Install a test namespace into mock namespace registry
@@ -1403,7 +1403,7 @@ func (s *workflowHandlerSuite) TestGetHistory() {
 		Size:          1,
 	}, nil)
 
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestIndexSearchAttributes, nil)
 	s.mockSearchAttributesMapper.EXPECT().GetAlias("CustomKeywordField", namespace.String()).Return("AliasOfCustomKeyword", nil)
 
 	wh := s.getWorkflowHandler(s.newConfig())
@@ -1495,7 +1495,7 @@ func (s *workflowHandlerSuite) TestGetWorkflowExecutionHistory() {
 	}, nil).Times(2)
 
 	s.mockExecutionManager.EXPECT().TrimHistoryBranch(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
-	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestIndexSearchAttributes, nil).AnyTimes()
 
 	wh := s.getWorkflowHandler(s.newConfig())
 
@@ -1708,7 +1708,7 @@ func (s *workflowHandlerSuite) TestGetSearchAttributes() {
 	wh := s.getWorkflowHandler(s.newConfig())
 
 	ctx := context.Background()
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), false).Return(searchattribute.TestIndexSearchAttributes, nil)
 	resp, err := wh.GetSearchAttributes(ctx, &workflowservice.GetSearchAttributesRequest{})
 	s.NoError(err)
 	s.NotNil(resp)

--- a/service/history/deletemanager/delete_manager_test.go
+++ b/service/history/deletemanager/delete_manager_test.go
@@ -284,7 +284,7 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecutionRetention_Archiv
 					HistorySize: 22,
 				}, nil)
 				mockSearchAttributesProvider := searchattribute.NewMockProvider(s.controller)
-				mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any()).Return(searchattribute.TestNameTypeMap, nil)
+				mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any()).Return(searchattribute.TestIndexSearchAttributes, nil)
 				s.mockShardContext.EXPECT().GetSearchAttributesProvider().Return(mockSearchAttributesProvider)
 				s.mockArchivalClient.EXPECT().Archive(gomock.Any(), archiverClientRequestMatcher{inline: true}).Return(&archiver.ClientResponse{
 					HistoryArchivedInline: false,
@@ -360,7 +360,7 @@ func (s *deleteManagerWorkflowSuite) TestDeleteWorkflowExecutionRetention_Archiv
 					HistorySize: 22 * 1024 * 1024 * 1024,
 				}, nil)
 				mockSearchAttributesProvider := searchattribute.NewMockProvider(s.controller)
-				mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any()).Return(searchattribute.TestNameTypeMap, nil)
+				mockSearchAttributesProvider.EXPECT().GetSearchAttributes(gomock.Any(), gomock.Any()).Return(searchattribute.TestIndexSearchAttributes, nil)
 				s.mockShardContext.EXPECT().GetSearchAttributesProvider().Return(mockSearchAttributesProvider)
 				s.mockArchivalClient.EXPECT().Archive(gomock.Any(), archiverClientRequestMatcher{inline: false}).Return(nil, errors.New("failed to send signal"))
 			} else {

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -275,7 +275,7 @@ func (s *archivalSuite) isArchived(namespace string, execution *commonpb.Workflo
 					execution.GetRunId(),
 				),
 			},
-			searchattribute.NameTypeMap{},
+			searchattribute.IndexSearchAttributes{},
 		)
 		if err != nil {
 			continue

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -195,7 +195,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	err := testBase.SearchAttributesManager.SaveSearchAttributes(
 		context.Background(),
 		options.ESConfig.GetVisibilityIndex(),
-		searchattribute.TestNameTypeMap.Custom(),
+		searchattribute.TestIndexSearchAttributes.Custom(),
 	)
 	if err != nil {
 		return nil, err

--- a/tests/test_search_attribute_mapper.go
+++ b/tests/test_search_attribute_mapper.go
@@ -42,7 +42,7 @@ func NewSearchAttributeTestMapper() *SearchAttributeTestMapper {
 }
 
 func (t *SearchAttributeTestMapper) GetAlias(fieldName string, namespace string) (string, error) {
-	if _, err := searchattribute.TestNameTypeMap.GetType(fieldName); err == nil {
+	if _, err := searchattribute.TestIndexSearchAttributes.GetType(fieldName); err == nil {
 		return "AliasFor" + fieldName, nil
 	}
 	return "", serviceerror.NewInvalidArgument(fmt.Sprintf("fieldname '%s' has no search-attribute defined for '%s' namespace", fieldName, namespace))
@@ -51,7 +51,7 @@ func (t *SearchAttributeTestMapper) GetAlias(fieldName string, namespace string)
 func (t *SearchAttributeTestMapper) GetFieldName(alias string, namespace string) (string, error) {
 	if strings.HasPrefix(alias, "AliasFor") {
 		fieldName := strings.TrimPrefix(alias, "AliasFor")
-		if _, err := searchattribute.TestNameTypeMap.GetType(fieldName); err == nil {
+		if _, err := searchattribute.TestIndexSearchAttributes.GetType(fieldName); err == nil {
 			return fieldName, nil
 		}
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Rename "NameTypeMap" to "IndexSearchAttributes".

<!-- Tell your future self why have you made these changes -->
**Why?**
`NameTypeMap` is the Server type of API `persistence.IndexSearchAttributes`.
In later PR's, I'll make this type implement the `searchattribute.Mapper` interface.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.