### PR TITLE
Add index name to constructor of search attribute validator

### DIFF
--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -43,6 +43,7 @@ type (
 		searchAttributesNumberOfKeysLimit dynamicconfig.IntPropertyFnWithNamespaceFilter
 		searchAttributesSizeOfValueLimit  dynamicconfig.IntPropertyFnWithNamespaceFilter
 		searchAttributesTotalSizeLimit    dynamicconfig.IntPropertyFnWithNamespaceFilter
+		indexName                         string
 	}
 )
 
@@ -53,6 +54,7 @@ func NewValidator(
 	searchAttributesNumberOfKeysLimit dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	searchAttributesSizeOfValueLimit dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	searchAttributesTotalSizeLimit dynamicconfig.IntPropertyFnWithNamespaceFilter,
+	indexName string,
 ) *Validator {
 	return &Validator{
 		searchAttributesProvider:          searchAttributesProvider,
@@ -60,12 +62,13 @@ func NewValidator(
 		searchAttributesNumberOfKeysLimit: searchAttributesNumberOfKeysLimit,
 		searchAttributesSizeOfValueLimit:  searchAttributesSizeOfValueLimit,
 		searchAttributesTotalSizeLimit:    searchAttributesTotalSizeLimit,
+		indexName:                         indexName,
 	}
 }
 
 // Validate search attributes are valid for writing.
 // The search attributes must be unaliased before calling validation.
-func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namespace string, indexName string) error {
+func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namespace string) error {
 	if searchAttributes == nil {
 		return nil
 	}
@@ -81,7 +84,7 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		)
 	}
 
-	saTypeMap, err := v.searchAttributesProvider.GetSearchAttributes(indexName, false)
+	saTypeMap, err := v.searchAttributesProvider.GetSearchAttributes(v.indexName, false)
 	if err != nil {
 		return serviceerror.NewInvalidArgument(
 			fmt.Sprintf("unable to get search attributes from cluster metadata: %v", err),

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -53,12 +53,14 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 		nil,
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
-		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit))
+		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit),
+		"",
+	)
 
 	namespace := "namespace"
 	var attr *commonpb.SearchAttributes
 
-	err := saValidator.Validate(attr, namespace, "")
+	err := saValidator.Validate(attr, namespace)
 	s.NoError(err)
 
 	intPayload, err := payload.Encode(1)
@@ -69,7 +71,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 	attr = &commonpb.SearchAttributes{
 		IndexedFields: fields,
 	}
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.NoError(err)
 
 	fields = map[string]*commonpb.Payload{
@@ -78,7 +80,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 		"CustomBoolField":    payload.EncodeString("true"),
 	}
 	attr.IndexedFields = fields
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
 	s.Equal("number of search attributes 3 exceeds limit 2", err.Error())
 
@@ -86,7 +88,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 		"InvalidKey": payload.EncodeString("1"),
 	}
 	attr.IndexedFields = fields
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
 	s.Equal("search attribute InvalidKey is not defined", err.Error())
 
@@ -95,7 +97,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 		"CustomBoolField": payload.EncodeString("123"),
 	}
 	attr.IndexedFields = fields
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
 	s.Equal("invalid value for search attribute CustomBoolField of type Bool: 123", err.Error())
 
@@ -105,14 +107,14 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 		"CustomIntField": intArrayPayload,
 	}
 	attr.IndexedFields = fields
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.NoError(err)
 
 	fields = map[string]*commonpb.Payload{
 		"StartTime": intPayload,
 	}
 	attr.IndexedFields = fields
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
 	s.Equal("StartTime attribute can't be set in SearchAttributes", err.Error())
 }
@@ -127,12 +129,14 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 		&TestMapper{},
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
-		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit))
+		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit),
+		"",
+	)
 
 	namespace := "test-namespace"
 	var attr *commonpb.SearchAttributes
 
-	err := saValidator.Validate(attr, namespace, "")
+	err := saValidator.Validate(attr, namespace)
 	s.Nil(err)
 
 	intPayload, err := payload.Encode(1)
@@ -143,7 +147,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	attr = &commonpb.SearchAttributes{
 		IndexedFields: fields,
 	}
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.NoError(err)
 
 	fields = map[string]*commonpb.Payload{
@@ -152,18 +156,18 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 	attr = &commonpb.SearchAttributes{
 		IndexedFields: fields,
 	}
-	err = saValidator.Validate(attr, "test-namespace", "")
+	err = saValidator.Validate(attr, "test-namespace")
 	s.NoError(err)
 
 	fields = map[string]*commonpb.Payload{
 		"InvalidKey": payload.EncodeString("1"),
 	}
 	attr.IndexedFields = fields
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
 	s.Equal("search attribute alias_of_InvalidKey is not defined", err.Error())
 
-	err = saValidator.Validate(attr, "error-namespace", "")
+	err = saValidator.Validate(attr, "error-namespace")
 	s.Error(err)
 	s.EqualError(err, "mapper error")
 
@@ -172,7 +176,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 		"CustomBoolField": payload.EncodeString("123"),
 	}
 	attr.IndexedFields = fields
-	err = saValidator.Validate(attr, namespace, "")
+	err = saValidator.Validate(attr, namespace)
 	s.Error(err)
 	s.Equal("invalid value for search attribute alias_of_CustomBoolField of type Bool: 123", err.Error())
 }
@@ -187,7 +191,9 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 		nil,
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
-		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit))
+		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit),
+		"",
+	)
 
 	namespace := "namespace"
 
@@ -223,7 +229,9 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper
 		&TestMapper{},
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
-		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit))
+		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit),
+		"",
+	)
 
 	namespace := "test-namespace"
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -181,7 +181,9 @@ func NewWorkflowHandler(
 			saMapper,
 			config.SearchAttributesNumberOfKeysLimit,
 			config.SearchAttributesSizeOfValueLimit,
-			config.SearchAttributesTotalSizeLimit),
+			config.SearchAttributesTotalSizeLimit,
+			config.ESIndexName,
+		),
 		archivalMetadata: archivalMetadata,
 		healthServer:     healthServer,
 		overrides:        NewOverrides(),
@@ -4271,7 +4273,7 @@ func (wh *WorkflowHandler) processOutgoingSearchAttributes(events []*historypb.H
 }
 
 func (wh *WorkflowHandler) validateSearchAttributes(searchAttributes *commonpb.SearchAttributes, namespaceName namespace.Name) error {
-	if err := wh.saValidator.Validate(searchAttributes, namespaceName.String(), wh.config.ESIndexName); err != nil {
+	if err := wh.saValidator.Validate(searchAttributes, namespaceName.String()); err != nil {
 		return err
 	}
 	if err := wh.saValidator.ValidateSize(searchAttributes, namespaceName.String()); err != nil {

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -550,7 +550,6 @@ func (v *commandAttrValidator) validateSignalExternalWorkflowExecutionAttributes
 func (v *commandAttrValidator) validateUpsertWorkflowSearchAttributes(
 	namespace namespace.Name,
 	attributes *commandpb.UpsertWorkflowSearchAttributesCommandAttributes,
-	visibilityIndexName string,
 ) (enumspb.WorkflowTaskFailedCause, error) {
 
 	const failedCause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES
@@ -563,7 +562,7 @@ func (v *commandAttrValidator) validateUpsertWorkflowSearchAttributes(
 	if len(attributes.GetSearchAttributes().GetIndexedFields()) == 0 {
 		return failedCause, serviceerror.NewInvalidArgument("IndexedFields is empty on command.")
 	}
-	if err := v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), namespace.String(), visibilityIndexName); err != nil {
+	if err := v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), namespace.String()); err != nil {
 		return failedCause, err
 	}
 
@@ -600,7 +599,6 @@ func (v *commandAttrValidator) validateContinueAsNewWorkflowExecutionAttributes(
 	namespace namespace.Name,
 	attributes *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes,
 	executionInfo *persistencespb.WorkflowExecutionInfo,
-	visibilityIndexName string,
 ) (enumspb.WorkflowTaskFailedCause, error) {
 
 	const failedCause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_CONTINUE_AS_NEW_ATTRIBUTES
@@ -664,7 +662,7 @@ func (v *commandAttrValidator) validateContinueAsNewWorkflowExecutionAttributes(
 		return failedCause, err
 	}
 
-	if err = v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), namespace.String(), visibilityIndexName); err != nil {
+	if err = v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), namespace.String()); err != nil {
 		return enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, err
 	}
 
@@ -678,7 +676,6 @@ func (v *commandAttrValidator) validateStartChildExecutionAttributes(
 	attributes *commandpb.StartChildWorkflowExecutionCommandAttributes,
 	parentInfo *persistencespb.WorkflowExecutionInfo,
 	defaultWorkflowTaskTimeoutFn dynamicconfig.DurationPropertyFnWithNamespaceFilter,
-	visibilityIndexName string,
 ) (enumspb.WorkflowTaskFailedCause, error) {
 
 	const failedCause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_START_CHILD_EXECUTION_ATTRIBUTES
@@ -733,7 +730,7 @@ func (v *commandAttrValidator) validateStartChildExecutionAttributes(
 		return failedCause, err
 	}
 
-	if err := v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), targetNamespace.String(), visibilityIndexName); err != nil {
+	if err := v.searchAttributesValidator.Validate(attributes.GetSearchAttributes(), targetNamespace.String()); err != nil {
 		return enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, err
 	}
 

--- a/service/history/commandChecker_test.go
+++ b/service/history/commandChecker_test.go
@@ -130,6 +130,7 @@ func (s *commandAttrValidatorSuite) SetupTest() {
 			config.SearchAttributesNumberOfKeysLimit,
 			config.SearchAttributesSizeOfValueLimit,
 			config.SearchAttributesTotalSizeLimit,
+			"index-name",
 		))
 }
 
@@ -190,17 +191,17 @@ func (s *commandAttrValidatorSuite) TestValidateUpsertWorkflowSearchAttributes()
 	namespace := namespace.Name("tests.Namespace")
 	var attributes *commandpb.UpsertWorkflowSearchAttributesCommandAttributes
 
-	fc, err := s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes, "index-name")
+	fc, err := s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.EqualError(err, "UpsertWorkflowSearchAttributesCommandAttributes is not set on command.")
 	s.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, fc)
 
 	attributes = &commandpb.UpsertWorkflowSearchAttributesCommandAttributes{}
-	fc, err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes, "index-name")
+	fc, err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.EqualError(err, "SearchAttributes is not set on command.")
 	s.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, fc)
 
 	attributes.SearchAttributes = &commonpb.SearchAttributes{}
-	fc, err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes, "index-name")
+	fc, err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.EqualError(err, "IndexedFields is empty on command.")
 	s.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, fc)
 
@@ -209,7 +210,7 @@ func (s *commandAttrValidatorSuite) TestValidateUpsertWorkflowSearchAttributes()
 	attributes.SearchAttributes.IndexedFields = map[string]*commonpb.Payload{
 		"CustomKeywordField": saPayload,
 	}
-	fc, err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes, "index-name")
+	fc, err = s.validator.validateUpsertWorkflowSearchAttributes(namespace, attributes)
 	s.NoError(err)
 	s.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, fc)
 }
@@ -238,7 +239,6 @@ func (s *commandAttrValidatorSuite) TestValidateContinueAsNewWorkflowExecutionAt
 		tests.Namespace,
 		attributes,
 		executionInfo,
-		"index-name",
 	)
 	s.NoError(err)
 	s.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, fc)

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -229,6 +229,7 @@ func NewEngineWithShardContext(
 		config.SearchAttributesNumberOfKeysLimit,
 		config.SearchAttributesSizeOfValueLimit,
 		config.SearchAttributesTotalSizeLimit,
+		config.DefaultVisibilityIndexName,
 	)
 
 	historyEngImpl.workflowTaskHandler = newWorkflowTaskHandlerCallback(historyEngImpl)

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -192,6 +192,7 @@ func (s *engine2Suite) SetupTest() {
 			s.config.SearchAttributesNumberOfKeysLimit,
 			s.config.SearchAttributesSizeOfValueLimit,
 			s.config.SearchAttributesTotalSizeLimit,
+			s.config.DefaultVisibilityIndexName,
 		),
 		workflowConsistencyChecker: api.NewWorkflowConsistencyChecker(mockShard, s.workflowCache),
 	}

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -784,7 +784,6 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 				namespaceName,
 				attr,
 				handler.mutableState.GetExecutionInfo(),
-				handler.config.DefaultVisibilityIndexName,
 			)
 		},
 	); err != nil || handler.stopProcessing {
@@ -899,7 +898,6 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 				attr,
 				handler.mutableState.GetExecutionInfo(),
 				handler.config.DefaultWorkflowTaskTimeout,
-				handler.config.DefaultVisibilityIndexName,
 			)
 		},
 	); err != nil || handler.stopProcessing {
@@ -1038,11 +1036,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandUpsertWorkflowSearchAttribu
 	// valid search attributes for upsert
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
-			return handler.attrValidator.validateUpsertWorkflowSearchAttributes(
-				namespace,
-				attr,
-				handler.config.DefaultVisibilityIndexName,
-			)
+			return handler.attrValidator.validateUpsertWorkflowSearchAttributes(namespace, attr)
 		},
 	); err != nil || handler.stopProcessing {
 		return err

--- a/service/history/workflowTaskHandlerCallbacks_test.go
+++ b/service/history/workflowTaskHandlerCallbacks_test.go
@@ -125,6 +125,7 @@ func (s *WorkflowTaskHandlerCallbackSuite) SetupTest() {
 			config.SearchAttributesNumberOfKeysLimit,
 			config.SearchAttributesSizeOfValueLimit,
 			config.SearchAttributesTotalSizeLimit,
+			config.DefaultVisibilityIndexName,
 		),
 		workflowConsistencyChecker: api.NewWorkflowConsistencyChecker(mockShard, workflowCache),
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added index name to constructor of search attributes validator.

<!-- Tell your future self why have you made these changes -->
**Why?**
Validator functions already require index name which should be constant throughout the execution of the Server, so moving the constructor. It will avoid needing to keep track of index name and validator objects separately in the codebase in case the validator object is passed to other structs.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There shouldn't have any risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.