### PR TITLE
Add env vars to control log format and level for tests

### DIFF
--- a/common/log/zap_logger.go
+++ b/common/log/zap_logger.go
@@ -40,7 +40,9 @@ import (
 const (
 	skipForZapLogger = 3
 	// we put a default message when it is empty so that the log can be searchable/filterable
-	defaultMsgForEmpty = "none"
+	defaultMsgForEmpty  = "none"
+	testLogFormatEnvVar = "TEMPORAL_TEST_LOG_FORMAT" // set to "json" for json logs in tests
+	testLogLevelEnvVar  = "TEMPORAL_TEST_LOG_LEVEL"  // set to "debug" for debug level logs in tests
 )
 
 type (
@@ -53,12 +55,15 @@ type (
 
 var _ Logger = (*zapLogger)(nil)
 
-// NewTestLogger returns a logger at debug level and log into STDERR
+// NewTestLogger returns a logger for tests
 func NewTestLogger() *zapLogger {
+	format := os.Getenv(testLogFormatEnvVar)
+	if format == "" {
+		format = "console"
+	}
 	return NewZapLogger(BuildZapLogger(Config{
-		// Uncomment next line if you need debug level logging in tests.
-		// Level: "debug",
-		Format:      "console",
+		Level:       os.Getenv(testLogLevelEnvVar),
+		Format:      format,
 		Development: true,
 	}))
 }


### PR DESCRIPTION
**What changed?**
Add `TEMPORAL_TEST_LOG_FORMAT` and `TEMPORAL_TEST_LOG_LEVEL` environment variables to control test log output.

<!-- Tell your future self why have you made these changes -->
**Why?**
Sometimes you want to get json log output

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No, only applies to tests

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
