### PR TITLE
Add RefreshPerNSWorkerManager and RemoveOverride for tests

### DIFF
--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -194,13 +194,17 @@ func (wm *perNamespaceWorkerManager) namespaceCallback(ns *namespace.Namespace, 
 	go wm.getWorkerByNamespace(ns).refreshWithNewNamespace(ns, deleted)
 }
 
+func (wm *perNamespaceWorkerManager) refreshAll() {
+	wm.lock.Lock()
+	defer wm.lock.Unlock()
+	for _, worker := range wm.workers {
+		go worker.refreshWithExistingNamespace()
+	}
+}
+
 func (wm *perNamespaceWorkerManager) membershipChangedListener() {
 	for range wm.membershipChangedCh {
-		wm.lock.Lock()
-		for _, worker := range wm.workers {
-			go worker.refreshWithExistingNamespace()
-		}
-		wm.lock.Unlock()
+		wm.refreshAll()
 	}
 }
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -564,3 +564,8 @@ func (s *Service) ensureSystemNamespaceExists(
 		)
 	}
 }
+
+// This is intended for use by integration tests only.
+func (s *Service) RefreshPerNSWorkerManager() {
+	s.perNamespaceWorkerManager.refreshAll()
+}

--- a/tests/dynamicconfig.go
+++ b/tests/dynamicconfig.go
@@ -81,6 +81,12 @@ func (d *dcClient) OverrideValue(name dynamicconfig.Key, value any) {
 	d.overrides[name] = value
 }
 
+func (d *dcClient) RemoveOverride(name dynamicconfig.Key) {
+	d.Lock()
+	defer d.Unlock()
+	delete(d.overrides, name)
+}
+
 // newTestDCClient - returns a dynamic config client for integration testing
 func newTestDCClient(fallback dynamicconfig.Client) *dcClient {
 	return &dcClient{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `RefreshPerNSWorkerManager` to worker service, and `RemoveOverride` to integration test dynamic config.

<!-- Tell your future self why have you made these changes -->
**Why?**
These can be used to adjust dynamic config that applies to per-ns-worker or its components, for a single integration test. These will be used in upcoming PRs.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Used in upcoming PRs

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Only used in tests

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
