### PR TITLE
Fix time fields of rows from GetClusterMembers

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/mysql/cluster_metadata.go
@@ -251,6 +251,11 @@ func (mdb *db) GetClusterMembers(
 	); err != nil {
 		return nil, err
 	}
+	for i := range rows {
+		rows[i].SessionStart = mdb.converter.FromMySQLDateTime(rows[i].SessionStart)
+		rows[i].LastHeartbeat = mdb.converter.FromMySQLDateTime(rows[i].LastHeartbeat)
+		rows[i].RecordExpiry = mdb.converter.FromMySQLDateTime(rows[i].RecordExpiry)
+	}
 	return rows, nil
 }
 

--- a/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/postgresql/cluster_metadata.go
@@ -260,17 +260,15 @@ func (pdb *db) GetClusterMembers(
 	err := pdb.conn.SelectContext(ctx, &rows,
 		compiledQryString,
 		operands...)
-
 	if err != nil {
 		return nil, err
 	}
-
-	convertedRows := make([]sqlplugin.ClusterMembershipRow, 0, len(rows))
-	for _, r := range rows {
-		r.SessionStart = r.SessionStart.UTC()
-		convertedRows = append(convertedRows, r)
+	for i := range rows {
+		rows[i].SessionStart = pdb.converter.FromPostgreSQLDateTime(rows[i].SessionStart)
+		rows[i].LastHeartbeat = pdb.converter.FromPostgreSQLDateTime(rows[i].LastHeartbeat)
+		rows[i].RecordExpiry = pdb.converter.FromPostgreSQLDateTime(rows[i].RecordExpiry)
 	}
-	return convertedRows, err
+	return rows, nil
 }
 
 func (pdb *db) PruneClusterMembership(

--- a/common/persistence/sql/sqlplugin/sqlite/cluster_metadata.go
+++ b/common/persistence/sql/sqlplugin/sqlite/cluster_metadata.go
@@ -251,6 +251,11 @@ func (mdb *db) GetClusterMembers(
 	); err != nil {
 		return nil, err
 	}
+	for i := range rows {
+		rows[i].SessionStart = mdb.converter.FromSQLiteDateTime(rows[i].SessionStart)
+		rows[i].LastHeartbeat = mdb.converter.FromSQLiteDateTime(rows[i].LastHeartbeat)
+		rows[i].RecordExpiry = mdb.converter.FromSQLiteDateTime(rows[i].RecordExpiry)
+	}
 	return rows, nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
In `GetClusterMembers`, fix the time fields, ie., call date time converter.

<!-- Tell your future self why have you made these changes -->
**Why?**
The times are stored in UTC in DB, but when reading, the time zone might not be set correctly. Calling the date time converter fixes it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.