### PR TITLE
Revert #3755

### DIFF
--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -790,9 +790,7 @@ func (s *controllerSuite) TestShardControllerFuzz() {
 			shardID := int32(rand.Intn(int(s.config.NumberOfShards))) + 1
 			switch rand.Intn(5) {
 			case 0:
-				if _, err := s.shardController.GetShardByID(shardID); err != nil {
-					return err
-				}
+				_, _ = s.shardController.GetShardByID(shardID)
 			case 1:
 				if shard, err := s.shardController.GetShardByID(shardID); err == nil {
 					_, _ = shard.GetEngine(ctx)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This change reverts a commit which added error-checking to service/history/shard, and it makes our code explicitly ignore those errors.

<!-- Tell your future self why have you made these changes -->
**Why?**
1. We don't want the controller to be aware of these errors
2. The usage of multierr may cause explicit error type checks to fail
3. Error logging is already in place

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
It's a small PR, so I verified the diff was only the intended changes, and you can see the `multierr` import is removed.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Nothing, reverting to the behavior in 1.19.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No