### PR TITLE
[Advanced Visibility with SQL] Adding PostgreSQL 12 schema and interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -372,6 +372,17 @@ install-schema-postgresql: temporal-sql-tool
 	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(VISIBILITY_DB) setup-schema -v 0.0
 	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(VISIBILITY_DB) update-schema -d ./schema/postgresql/v96/visibility/versioned
 
+install-schema-postgresql12: temporal-sql-tool
+	@printf $(COLOR) "Install Postgres schema..."
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(TEMPORAL_DB) drop -f
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(TEMPORAL_DB) create
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(TEMPORAL_DB) setup -v 0.0
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(TEMPORAL_DB) update-schema -d ./schema/postgresql/v12/temporal/versioned
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(VISIBILITY_DB) drop -f
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(VISIBILITY_DB) create
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(VISIBILITY_DB) setup-schema -v 0.0
+	./temporal-sql-tool -u $(SQL_USER) --pw $(SQL_PASSWORD) -p 5432 --pl postgres --db $(VISIBILITY_DB) update-schema -d ./schema/postgresql/v12/visibility/versioned
+
 install-schema-es:
 	@printf $(COLOR) "Install Elasticsearch schema..."
 	curl --fail -X PUT "http://127.0.0.1:9200/_cluster/settings" -H "Content-Type: application/json" --data-binary @./schema/elasticsearch/visibility/cluster_settings_v7.json --write-out "\n"
@@ -435,6 +446,9 @@ start-mysql-es: temporal-server
 
 start-postgres: temporal-server
 	./temporal-server --env development-postgres --allow-no-auth start
+
+start-postgres12: temporal-server
+	./temporal-server --env development-postgres12 --allow-no-auth start
 
 start-sqlite: temporal-server
 	./temporal-server --env development-sqlite --allow-no-auth start

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -138,7 +138,7 @@ func NewTestBaseWithSQL(options *TestBaseOptions) TestBase {
 		switch options.SQLDBPluginName {
 		case mysql.PluginName:
 			options.DBPort = environment.GetMySQLPort()
-		case postgresql.PluginName:
+		case postgresql.PluginName, postgresql.PluginNameV12:
 			options.DBPort = environment.GetPostgreSQLPort()
 		case sqlite.PluginName:
 			options.DBPort = 0

--- a/common/persistence/persistence-tests/setup.go
+++ b/common/persistence/persistence-tests/setup.go
@@ -37,9 +37,10 @@ const (
 	testMySQLPassword  = "temporal"
 	testMySQLSchemaDir = "schema/mysql/v57"
 
-	testPostgreSQLUser      = "temporal"
-	testPostgreSQLPassword  = "temporal"
-	testPostgreSQLSchemaDir = "schema/postgresql/v96"
+	testPostgreSQLUser        = "temporal"
+	testPostgreSQLPassword    = "temporal"
+	testPostgreSQLSchemaDir   = "schema/postgresql/v96"
+	testPostgreSQL12SchemaDir = "schema/postgresql/v12"
 
 	testSQLiteUser      = ""
 	testSQLitePassword  = ""
@@ -70,6 +71,19 @@ func GetPostgreSQLTestClusterOption() *TestBaseOptions {
 		DBHost:          environment.GetPostgreSQLAddress(),
 		DBPort:          environment.GetPostgreSQLPort(),
 		SchemaDir:       testPostgreSQLSchemaDir,
+		StoreType:       config.StoreTypeSQL,
+	}
+}
+
+// GetPostgreSQL12TestClusterOption return test options
+func GetPostgreSQL12TestClusterOption() *TestBaseOptions {
+	return &TestBaseOptions{
+		SQLDBPluginName: postgresql.PluginName,
+		DBUsername:      testPostgreSQLUser,
+		DBPassword:      testPostgreSQLPassword,
+		DBHost:          environment.GetPostgreSQLAddress(),
+		DBPort:          environment.GetPostgreSQLPort(),
+		SchemaDir:       testPostgreSQL12SchemaDir,
 		StoreType:       config.StoreTypeSQL,
 	}
 }

--- a/common/persistence/sql/sqlplugin/postgresql/plugin_v12.go
+++ b/common/persistence/sql/sqlplugin/postgresql/plugin_v12.go
@@ -1,0 +1,75 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package postgresql
+
+import (
+	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/persistence/sql"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin"
+	"go.temporal.io/server/common/resolver"
+)
+
+const (
+	// PluginName is the name of the plugin
+	PluginNameV12 = "postgres12"
+)
+
+type pluginV12 struct {
+	plugin
+}
+
+var _ sqlplugin.Plugin = (*pluginV12)(nil)
+
+func init() {
+	sql.RegisterPlugin(PluginNameV12, &pluginV12{})
+}
+
+// CreateDB initialize the db object
+func (d *pluginV12) CreateDB(
+	dbKind sqlplugin.DbKind,
+	cfg *config.SQL,
+	r resolver.ServiceResolver,
+) (sqlplugin.DB, error) {
+	conn, err := d.createDBConnection(cfg, r)
+	if err != nil {
+		return nil, err
+	}
+	db := newDBV12(dbKind, cfg.DatabaseName, conn, nil)
+	return db, nil
+}
+
+// CreateAdminDB initialize the adminDB object
+func (d *pluginV12) CreateAdminDB(
+	dbKind sqlplugin.DbKind,
+	cfg *config.SQL,
+	r resolver.ServiceResolver,
+) (sqlplugin.AdminDB, error) {
+	conn, err := d.createDBConnection(cfg, r)
+	if err != nil {
+		return nil, err
+	}
+	db := newDBV12(dbKind, cfg.DatabaseName, conn, nil)
+	return db, nil
+}

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -148,6 +148,13 @@ func TestPostgreSQLVisibilityPersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+func TestPostgreSQL12VisibilityPersistenceSuite(t *testing.T) {
+	s := &VisibilityPersistenceSuite{
+		TestBase: persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQL12TestClusterOption()),
+	}
+	suite.Run(t, s)
+}
+
 // TODO: Merge persistence-tests into the tests directory.
 
 func TestPostgreSQLHistoryV2PersistenceSuite(t *testing.T) {
@@ -188,6 +195,27 @@ FAIL: TestPostgreSQLQueuePersistence/TestNamespaceReplicationQueue (0.26s)
 //	s.TestBase.Setup()
 //	suite.Run(t, s)
 //}
+
+func TestPostgreSQL12HistoryV2PersistenceSuite(t *testing.T) {
+	s := new(persistencetests.HistoryV2PersistenceSuite)
+	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQL12TestClusterOption())
+	s.TestBase.Setup(nil)
+	suite.Run(t, s)
+}
+
+func TestPostgreSQL12MetadataPersistenceSuiteV2(t *testing.T) {
+	s := new(persistencetests.MetadataPersistenceSuiteV2)
+	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQL12TestClusterOption())
+	s.TestBase.Setup(nil)
+	suite.Run(t, s)
+}
+
+func TestPostgreSQL12ClusterMetadataPersistence(t *testing.T) {
+	s := new(persistencetests.ClusterMetadataManagerSuite)
+	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQL12TestClusterOption())
+	s.TestBase.Setup(nil)
+	suite.Run(t, s)
+}
 
 // SQL store tests
 

--- a/common/persistence/tests/postgresql_test_util.go
+++ b/common/persistence/tests/postgresql_test_util.go
@@ -38,7 +38,7 @@ import (
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/sql"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
-	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/shuffle"
 	"go.temporal.io/server/environment"
@@ -56,8 +56,8 @@ const (
 
 	// TODO hard code this dir for now
 	//  need to merge persistence test config / initialization in one place
-	testPostgreSQLExecutionSchema  = "../../../schema/postgresql/v96/temporal/schema.sql"
-	testPostgreSQLVisibilitySchema = "../../../schema/postgresql/v96/visibility/schema.sql"
+	testPostgreSQLExecutionSchema  = "../../../schema/postgresql/v12/temporal/schema.sql"
+	testPostgreSQLVisibilitySchema = "../../../schema/postgresql/v12/visibility/schema.sql"
 )
 
 type (
@@ -100,7 +100,7 @@ func NewPostgreSQLConfig() *config.SQL {
 			strconv.Itoa(environment.GetPostgreSQLPort()),
 		),
 		ConnectProtocol: testPostgreSQLConnectionProtocol,
-		PluginName:      "postgres",
+		PluginName:      postgresql.PluginNameV12,
 		DatabaseName:    testPostgreSQLDatabaseNamePrefix + shuffle.String(testPostgreSQLDatabaseNameSuffix),
 	}
 }

--- a/config/development-postgres12.yaml
+++ b/config/development-postgres12.yaml
@@ -1,0 +1,117 @@
+log:
+  stdout: true
+  level: info
+
+persistence:
+  defaultStore: postgres-default
+  visibilityStore: postgres-visibility
+  numHistoryShards: 4
+  datastores:
+    postgres-default:
+      sql:
+        pluginName: "postgres12"
+        databaseName: "temporal"
+        connectAddr: "127.0.0.1:5432"
+        connectProtocol: "tcp"
+        user: "temporal"
+        password: "temporal"
+        maxConns: 20
+        maxIdleConns: 20
+        maxConnLifetime: "1h"
+    postgres-visibility:
+      sql:
+        pluginName: "postgres12"
+        databaseName: "temporal_visibility"
+        connectAddr: "127.0.0.1:5432"
+        connectProtocol: "tcp"
+        user: "temporal"
+        password: "temporal"
+        maxConns: 2
+        maxIdleConns: 2
+        maxConnLifetime: "1h"
+
+global:
+  membership:
+    maxJoinDuration: 30s
+    broadcastAddress: "127.0.0.1"
+  pprof:
+    port: 7936
+  metrics:
+    prometheus:
+#      # specify framework to use new approach for initializing metrics and/or use opentelemetry
+#      framework: "opentelemetry"
+      framework: "tally"
+      timerType: "histogram"
+      listenAddress: "127.0.0.1:8000"
+
+services:
+  frontend:
+    rpc:
+      grpcPort: 7233
+      membershipPort: 6933
+      bindOnLocalHost: true
+
+  matching:
+    rpc:
+      grpcPort: 7235
+      membershipPort: 6935
+      bindOnLocalHost: true
+
+  history:
+    rpc:
+      grpcPort: 7234
+      membershipPort: 6934
+      bindOnLocalHost: true
+
+  worker:
+    rpc:
+      grpcPort: 7239
+      membershipPort: 6939
+      bindOnLocalHost: true
+
+clusterMetadata:
+  enableGlobalNamespace: false
+  failoverVersionIncrement: 10
+  masterClusterName: "active"
+  currentClusterName: "active"
+  clusterInformation:
+    active:
+      enabled: true
+      initialFailoverVersion: 1
+      rpcName: "frontend"
+      rpcAddress: "localhost:7233"
+
+dcRedirectionPolicy:
+  policy: "noop"
+  toDC: ""
+
+archival:
+  history:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+      gstorage:
+        credentialsPath: "/tmp/gcloud/keyfile.json"
+  visibility:
+    state: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+
+namespaceDefaults:
+  archival:
+    history:
+      state: "disabled"
+      URI: "file:///tmp/temporal_archival/development"
+    visibility:
+      state: "disabled"
+      URI: "file:///tmp/temporal_vis_archival/development"
+
+dynamicConfigClient:
+  filepath: "config/dynamicconfig/development-sql.yaml"
+  pollInterval: "10s"

--- a/schema/postgresql/v12/temporal/database.sql
+++ b/schema/postgresql/v12/temporal/database.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE temporal;

--- a/schema/postgresql/v12/temporal/schema.sql
+++ b/schema/postgresql/v12/temporal/schema.sql
@@ -1,0 +1,298 @@
+CREATE TABLE namespaces(
+  partition_id INTEGER NOT NULL,
+  id BYTEA NOT NULL,
+  name VARCHAR(255) UNIQUE NOT NULL,
+  notification_version BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  is_global BOOLEAN NOT NULL,
+  PRIMARY KEY(partition_id, id)
+);
+
+CREATE TABLE namespace_metadata (
+  partition_id INTEGER NOT NULL,
+  notification_version BIGINT NOT NULL,
+  PRIMARY KEY(partition_id)
+);
+
+INSERT INTO namespace_metadata (partition_id, notification_version) VALUES (54321, 1);
+
+CREATE TABLE shards (
+  shard_id INTEGER NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id)
+);
+
+CREATE TABLE executions(
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  --
+  next_event_id BIGINT NOT NULL,
+  last_write_version BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  state BYTEA NOT NULL,
+  state_encoding VARCHAR(16) NOT NULL,
+  db_record_version BIGINT NOT NULL DEFAULT 0,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id)
+);
+
+CREATE TABLE current_executions(
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  --
+  run_id BYTEA NOT NULL,
+  create_request_id VARCHAR(255) NOT NULL,
+  state INTEGER NOT NULL,
+  status INTEGER NOT NULL,
+  start_version BIGINT NOT NULL DEFAULT 0,
+  last_write_version BIGINT NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id)
+);
+
+CREATE TABLE buffered_events (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  id BIGSERIAL NOT NULL UNIQUE,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, id)
+);
+
+CREATE TABLE tasks (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, task_id)
+);
+
+CREATE TABLE task_queues (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id)
+);
+
+CREATE TABLE history_immediate_tasks(
+  shard_id INTEGER NOT NULL,
+  category_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, task_id)
+);
+
+CREATE TABLE history_scheduled_tasks (
+  shard_id INTEGER NOT NULL,
+  category_id INTEGER NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, visibility_timestamp, task_id)
+);
+
+CREATE TABLE transfer_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE timer_tasks (
+  shard_id INTEGER NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, visibility_timestamp, task_id)
+);
+
+CREATE TABLE replication_tasks (
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE replication_tasks_dlq (
+  source_cluster_name VARCHAR(255) NOT NULL,
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (source_cluster_name, shard_id, task_id)
+);
+
+CREATE TABLE visibility_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE activity_info_maps (
+-- each row corresponds to one key of one map<string, ActivityInfo>
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  schedule_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, schedule_id)
+);
+
+CREATE TABLE timer_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  timer_id VARCHAR(255) NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, timer_id)
+);
+
+CREATE TABLE child_execution_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE request_cancel_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signal_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signals_requested_sets (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  signal_id VARCHAR(255) NOT NULL,
+  --
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, signal_id)
+);
+
+-- history eventsV2: history_node stores history event data
+CREATE TABLE history_node (
+  shard_id       INTEGER NOT NULL,
+  tree_id        BYTEA NOT NULL,
+  branch_id      BYTEA NOT NULL,
+  node_id        BIGINT NOT NULL,
+  txn_id         BIGINT NOT NULL,
+  --
+  prev_txn_id    BIGINT NOT NULL DEFAULT 0,
+  data           BYTEA NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, tree_id, branch_id, node_id, txn_id)
+);
+
+-- history eventsV2: history_tree stores branch metadata
+CREATE TABLE history_tree (
+  shard_id       INTEGER NOT NULL,
+  tree_id        BYTEA NOT NULL,
+  branch_id      BYTEA NOT NULL,
+  --
+  data           BYTEA NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, tree_id, branch_id)
+);
+
+CREATE TABLE queue (
+  queue_type        INTEGER NOT NULL,
+  message_id        BIGINT NOT NULL,
+  message_payload   BYTEA NOT NULL,
+  message_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY(queue_type, message_id)
+);
+
+CREATE TABLE queue_metadata (
+  queue_type     INTEGER NOT NULL,
+  data BYTEA     NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  version        BIGINT NOT NULL,
+  PRIMARY KEY(queue_type)
+);
+
+CREATE TABLE cluster_metadata_info (
+  metadata_partition        INTEGER NOT NULL,
+  cluster_name              VARCHAR(255) NOT NULL,
+  data                      BYTEA NOT NULL,
+  data_encoding             VARCHAR(16) NOT NULL,
+  version                   BIGINT NOT NULL,
+  PRIMARY KEY(metadata_partition, cluster_name)
+);
+
+CREATE TABLE cluster_membership
+(
+    membership_partition INTEGER NOT NULL,
+    host_id              BYTEA NOT NULL,
+    rpc_address          VARCHAR(128) NOT NULL,
+    rpc_port             SMALLINT NOT NULL,
+    role                 SMALLINT NOT NULL,
+    session_start        TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
+    last_heartbeat       TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
+    record_expiry        TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
+    PRIMARY KEY (membership_partition, host_id)
+);
+
+CREATE UNIQUE INDEX cm_idx_rolehost ON cluster_membership (role, host_id);
+CREATE INDEX cm_idx_rolelasthb ON cluster_membership (role, last_heartbeat);
+CREATE INDEX cm_idx_rpchost ON cluster_membership (rpc_address, role);
+CREATE INDEX cm_idx_lasthb ON cluster_membership (last_heartbeat);
+CREATE INDEX cm_idx_recordexpiry ON cluster_membership (record_expiry);

--- a/schema/postgresql/v12/temporal/versioned/v1.0/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.0",
+  "MinCompatibleVersion": "0.1",
+  "Description": "base version of schema",
+  "SchemaUpdateCqlFiles": [
+    "schema.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.0/schema.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.0/schema.sql
@@ -1,0 +1,261 @@
+CREATE TABLE namespaces(
+  partition_id INTEGER NOT NULL,
+  id BYTEA NOT NULL,
+  name VARCHAR(255) UNIQUE NOT NULL,
+  notification_version BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  is_global BOOLEAN NOT NULL,
+  PRIMARY KEY(partition_id, id)
+);
+
+CREATE TABLE namespace_metadata (
+  partition_id INTEGER NOT NULL,
+  notification_version BIGINT NOT NULL,
+  PRIMARY KEY(partition_id)
+);
+
+INSERT INTO namespace_metadata (partition_id, notification_version) VALUES (54321, 1);
+
+CREATE TABLE shards (
+  shard_id INTEGER NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id)
+);
+
+CREATE TABLE transfer_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE executions(
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  --
+  next_event_id BIGINT NOT NULL,
+  last_write_version BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  state BYTEA NOT NULL,
+  state_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id)
+);
+
+CREATE TABLE current_executions(
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  --
+  run_id BYTEA NOT NULL,
+  create_request_id VARCHAR(64) NOT NULL,
+  state INTEGER NOT NULL,
+  status INTEGER NOT NULL,
+  start_version BIGINT NOT NULL,
+  last_write_version BIGINT NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id)
+);
+
+CREATE TABLE buffered_events (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  id BIGSERIAL NOT NULL UNIQUE,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, id)
+);
+
+CREATE TABLE tasks (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id, task_id)
+);
+
+CREATE TABLE task_queues (
+  range_hash BIGINT NOT NULL,
+  task_queue_id BYTEA NOT NULL,
+  --
+  range_id BIGINT NOT NULL,
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (range_hash, task_queue_id)
+);
+
+CREATE TABLE replication_tasks (
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);
+
+CREATE TABLE replication_tasks_dlq (
+  source_cluster_name VARCHAR(255) NOT NULL,
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (source_cluster_name, shard_id, task_id)
+);
+
+CREATE TABLE timer_tasks (
+  shard_id INTEGER NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, visibility_timestamp, task_id)
+);
+
+CREATE TABLE activity_info_maps (
+-- each row corresponds to one key of one map<string, ActivityInfo>
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  schedule_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, schedule_id)
+);
+
+CREATE TABLE timer_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  timer_id VARCHAR(255) NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, timer_id)
+);
+
+CREATE TABLE child_execution_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE request_cancel_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signal_info_maps (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  initiated_id BIGINT NOT NULL,
+--
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16),
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, initiated_id)
+);
+
+CREATE TABLE signals_requested_sets (
+  shard_id INTEGER NOT NULL,
+  namespace_id BYTEA NOT NULL,
+  workflow_id VARCHAR(255) NOT NULL,
+  run_id BYTEA NOT NULL,
+  signal_id VARCHAR(64) NOT NULL,
+  --
+  PRIMARY KEY (shard_id, namespace_id, workflow_id, run_id, signal_id)
+);
+
+-- history eventsV2: history_node stores history event data
+CREATE TABLE history_node (
+  shard_id       INTEGER NOT NULL,
+  tree_id        BYTEA NOT NULL,
+  branch_id      BYTEA NOT NULL,
+  node_id        BIGINT NOT NULL,
+  txn_id         BIGINT NOT NULL,
+  --
+  data           BYTEA NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, tree_id, branch_id, node_id, txn_id)
+);
+
+-- history eventsV2: history_tree stores branch metadata
+CREATE TABLE history_tree (
+  shard_id       INTEGER NOT NULL,
+  tree_id        BYTEA NOT NULL,
+  branch_id      BYTEA NOT NULL,
+  --
+  data           BYTEA NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, tree_id, branch_id)
+);
+
+CREATE TABLE queue (
+  queue_type INTEGER NOT NULL,
+  message_id BIGINT NOT NULL,
+  message_payload BYTEA NOT NULL,
+  PRIMARY KEY(queue_type, message_id)
+);
+
+CREATE TABLE queue_metadata (
+  queue_type INTEGER NOT NULL,
+  data BYTEA NOT NULL,
+  PRIMARY KEY(queue_type)
+);
+
+CREATE TABLE cluster_metadata (
+  metadata_partition        INTEGER NOT NULL,
+  immutable_data            BYTEA NOT NULL,
+  immutable_data_encoding   VARCHAR(16) NOT NULL,
+  PRIMARY KEY(metadata_partition)
+);
+
+CREATE TABLE cluster_membership
+(
+    membership_partition INTEGER NOT NULL,
+    host_id              BYTEA NOT NULL,
+    rpc_address          VARCHAR(15) NOT NULL,
+    rpc_port             SMALLINT NOT NULL,
+    role                 SMALLINT NOT NULL,
+    session_start        TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
+    last_heartbeat       TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
+    record_expiry        TIMESTAMP DEFAULT '1970-01-01 00:00:01+00:00',
+    PRIMARY KEY (membership_partition, host_id)
+);
+
+CREATE UNIQUE INDEX cm_idx_rolehost ON cluster_membership (role, host_id);
+CREATE INDEX cm_idx_rolelasthb ON cluster_membership (role, last_heartbeat);
+CREATE INDEX cm_idx_rpchost ON cluster_membership (rpc_address, role);
+CREATE INDEX cm_idx_lasthb ON cluster_membership (last_heartbeat);
+CREATE INDEX cm_idx_recordexpiry ON cluster_membership (record_expiry);

--- a/schema/postgresql/v12/temporal/versioned/v1.1/cluster_metadata.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.1/cluster_metadata.sql
@@ -1,0 +1,3 @@
+ALTER TABLE cluster_metadata ADD data BYTEA NOT NULL DEFAULT '';
+ALTER TABLE cluster_metadata ADD data_encoding VARCHAR(16) NOT NULL DEFAULT 'Proto3';
+ALTER TABLE cluster_metadata ADD version BIGINT NOT NULL DEFAULT 1;

--- a/schema/postgresql/v12/temporal/versioned/v1.1/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.1/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.1",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for cluster metadata",
+  "SchemaUpdateCqlFiles": [
+    "cluster_metadata.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.2/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.2/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.2",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for RPC replication",
+  "SchemaUpdateCqlFiles": [
+    "queue.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.2/queue.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.2/queue.sql
@@ -1,0 +1,2 @@
+ALTER TABLE queue ADD message_encoding VARCHAR(16) NOT NULL DEFAULT 'Json';
+ALTER TABLE queue_metadata ADD data_encoding VARCHAR(16) NOT NULL DEFAULT 'Json';

--- a/schema/postgresql/v12/temporal/versioned/v1.3/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.3/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.3",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for kafka deprecation",
+  "SchemaUpdateCqlFiles": [
+    "visibility_tasks.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.3/visibility_tasks.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.3/visibility_tasks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE visibility_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);

--- a/schema/postgresql/v12/temporal/versioned/v1.4/cluster_metadata.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.4/cluster_metadata.sql
@@ -1,0 +1,2 @@
+ALTER TABLE cluster_metadata DROP immutable_data;
+ALTER TABLE cluster_metadata DROP immutable_data_encoding;

--- a/schema/postgresql/v12/temporal/versioned/v1.4/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.4/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.4",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for cluster metadata cleanup",
+  "SchemaUpdateCqlFiles": [
+    "cluster_metadata.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.5/cluster_membership.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.5/cluster_membership.sql
@@ -1,0 +1,1 @@
+ALTER TABLE cluster_membership ALTER COLUMN rpc_address TYPE VARCHAR(128);

--- a/schema/postgresql/v12/temporal/versioned/v1.5/event.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.5/event.sql
@@ -1,0 +1,1 @@
+ALTER TABLE history_node ADD prev_txn_id BIGINT NOT NULL DEFAULT 0;

--- a/schema/postgresql/v12/temporal/versioned/v1.5/executions.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.5/executions.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions ADD db_record_version BIGINT NOT NULL DEFAULT 0;

--- a/schema/postgresql/v12/temporal/versioned/v1.5/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.5/manifest.json
@@ -1,0 +1,10 @@
+{
+  "CurrVersion": "1.5",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for cluster_membership, executions and history_node tables",
+  "SchemaUpdateCqlFiles": [
+    "event.sql",
+    "executions.sql",
+    "cluster_membership.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.6/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.6",
+  "MinCompatibleVersion": "1.0",
+  "Description": "schema update for queue_metadata",
+  "SchemaUpdateCqlFiles": [
+    "queue_metadata.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.6/queue_metadata.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.6/queue_metadata.sql
@@ -1,0 +1,1 @@
+ALTER TABLE queue_metadata ADD version BIGINT NOT NULL DEFAULT 0;

--- a/schema/postgresql/v12/temporal/versioned/v1.7/cluster_metadata_info.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.7/cluster_metadata_info.sql
@@ -1,0 +1,8 @@
+CREATE TABLE cluster_metadata_info (
+  metadata_partition        INTEGER NOT NULL,
+  cluster_name              VARCHAR(255) NOT NULL,
+  data                      BYTEA NOT NULL,
+  data_encoding             VARCHAR(16) NOT NULL,
+  version                   BIGINT NOT NULL,
+  PRIMARY KEY(metadata_partition, cluster_name)
+);

--- a/schema/postgresql/v12/temporal/versioned/v1.7/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.7/manifest.json
@@ -1,0 +1,10 @@
+{
+  "CurrVersion": "1.7",
+  "MinCompatibleVersion": "1.0",
+  "Description": "create cluster metadata info table to store cluster information and executions to store tiered storage queue",
+  "SchemaUpdateCqlFiles": [
+    "cluster_metadata_info.sql",
+    "no_start_version.sql",
+    "tiered_storage_tasks.sql"
+  ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.7/no_start_version.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.7/no_start_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE current_executions ALTER COLUMN start_version SET DEFAULT 0;

--- a/schema/postgresql/v12/temporal/versioned/v1.7/tiered_storage_tasks.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.7/tiered_storage_tasks.sql
@@ -1,0 +1,8 @@
+CREATE TABLE tiered_storage_tasks(
+  shard_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, task_id)
+);

--- a/schema/postgresql/v12/temporal/versioned/v1.8/alter_columns.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.8/alter_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE current_executions ALTER COLUMN create_request_id TYPE VARCHAR(255);
+ALTER TABLE signals_requested_sets ALTER COLUMN signal_id TYPE VARCHAR(255);

--- a/schema/postgresql/v12/temporal/versioned/v1.8/drop_unused_tasks_table.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.8/drop_unused_tasks_table.sql
@@ -1,0 +1,1 @@
+DROP TABLE tiered_storage_tasks;

--- a/schema/postgresql/v12/temporal/versioned/v1.8/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.8/manifest.json
@@ -1,0 +1,9 @@
+{
+    "CurrVersion": "1.8",
+    "MinCompatibleVersion": "1.0",
+    "Description": "drop unused tasks table; Expand VARCHAR columns governed by maxIDLength to VARCHAR(255)",
+    "SchemaUpdateCqlFiles": [
+        "drop_unused_tasks_table.sql",
+        "alter_columns.sql"
+    ]
+}

--- a/schema/postgresql/v12/temporal/versioned/v1.9/history_tasks_table.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.9/history_tasks_table.sql
@@ -1,0 +1,20 @@
+CREATE TABLE history_immediate_tasks(
+  shard_id INTEGER NOT NULL,
+  category_id INTEGER NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, task_id)
+);
+
+CREATE TABLE history_scheduled_tasks (
+  shard_id INTEGER NOT NULL,
+  category_id INTEGER NOT NULL,
+  visibility_timestamp TIMESTAMP NOT NULL,
+  task_id BIGINT NOT NULL,
+  --
+  data BYTEA NOT NULL,
+  data_encoding VARCHAR(16) NOT NULL,
+  PRIMARY KEY (shard_id, category_id, visibility_timestamp, task_id)
+);

--- a/schema/postgresql/v12/temporal/versioned/v1.9/manifest.json
+++ b/schema/postgresql/v12/temporal/versioned/v1.9/manifest.json
@@ -1,0 +1,8 @@
+{
+    "CurrVersion": "1.9",
+    "MinCompatibleVersion": "1.0",
+    "Description": "add history tasks table",
+    "SchemaUpdateCqlFiles": [
+        "history_tasks_table.sql"
+    ]
+}

--- a/schema/postgresql/v12/version.go
+++ b/schema/postgresql/v12/version.go
@@ -1,0 +1,35 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package v12
+
+// NOTE: whenever there is a new database schema update, plz update the following versions
+
+// Version is the Postgres database release version
+// Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
+const Version = "1.9"
+
+// VisibilityVersion is the Postgres visibility database release version
+// Temporal supports both MySQL and Postgres officially, so upgrade should be performed for both MySQL and Postgres
+const VisibilityVersion = "1.2"

--- a/schema/postgresql/v12/visibility/database.sql
+++ b/schema/postgresql/v12/visibility/database.sql
@@ -1,0 +1,1 @@
+CREATE DATABASE temporal_visibility;

--- a/schema/postgresql/v12/visibility/schema.sql
+++ b/schema/postgresql/v12/visibility/schema.sql
@@ -1,0 +1,26 @@
+CREATE TABLE executions_visibility (
+  namespace_id        CHAR(64)      NOT NULL,
+  run_id              CHAR(64)      NOT NULL,
+  start_time          TIMESTAMP     NOT NULL,
+  execution_time      TIMESTAMP     NOT NULL,
+  workflow_id         VARCHAR(255)  NOT NULL,
+  workflow_type_name  VARCHAR(255)  NOT NULL,
+  status              INTEGER       NOT NULL,  -- enum WorkflowExecutionStatus {RUNNING, COMPLETED, FAILED, CANCELED, TERMINATED, CONTINUED_AS_NEW, TIMED_OUT}
+  close_time          TIMESTAMP     NULL,
+  history_length      BIGINT        NULL,
+  memo                BYTEA         NULL,
+  encoding            VARCHAR(64)   NOT NULL,
+  task_queue          VARCHAR(255)  NOT NULL DEFAULT '',
+
+  PRIMARY KEY  (namespace_id, run_id)
+);
+
+CREATE INDEX by_type_start_time ON executions_visibility (namespace_id, workflow_type_name, status, start_time DESC, run_id);
+CREATE INDEX by_workflow_id_start_time ON executions_visibility (namespace_id, workflow_id, status, start_time DESC, run_id);
+CREATE INDEX by_status_by_start_time ON executions_visibility (namespace_id, status, start_time DESC, run_id);
+CREATE INDEX by_type_close_time ON executions_visibility (namespace_id, workflow_type_name, status, close_time DESC, run_id);
+CREATE INDEX by_workflow_id_close_time ON executions_visibility (namespace_id, workflow_id, status, close_time DESC, run_id);
+CREATE INDEX by_status_by_close_time ON executions_visibility (namespace_id, status, close_time DESC, run_id);
+CREATE INDEX by_close_time_by_status ON executions_visibility (namespace_id, close_time DESC, run_id, status);
+
+

--- a/schema/postgresql/v12/visibility/versioned/v1.0/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.0/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.0",
+  "MinCompatibleVersion": "0.1",
+  "Description": "base version of visibility schema",
+  "SchemaUpdateCqlFiles": [
+    "schema.sql"
+  ]
+}

--- a/schema/postgresql/v12/visibility/versioned/v1.0/schema.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.0/schema.sql
@@ -1,0 +1,25 @@
+CREATE TABLE executions_visibility (
+  namespace_id         CHAR(64) NOT NULL,
+  run_id               CHAR(64) NOT NULL,
+  start_time           TIMESTAMP NOT NULL,
+  execution_time       TIMESTAMP NOT NULL,
+  workflow_id          VARCHAR(255) NOT NULL,
+  workflow_type_name   VARCHAR(255) NOT NULL,
+  status               INTEGER NOT NULL,  -- enum WorkflowExecutionStatus {RUNNING, COMPLETED, FAILED, CANCELED, TERMINATED, CONTINUED_AS_NEW, TIMED_OUT}
+  close_time           TIMESTAMP NULL,
+  history_length       BIGINT,
+  memo                 BYTEA,
+  encoding             VARCHAR(64) NOT NULL,
+  task_queue           VARCHAR(255) DEFAULT '' NOT NULL,
+
+  PRIMARY KEY  (namespace_id, run_id)
+);
+
+CREATE INDEX by_type_start_time ON executions_visibility (namespace_id, workflow_type_name, status, start_time DESC, run_id);
+CREATE INDEX by_workflow_id_start_time ON executions_visibility (namespace_id, workflow_id, status, start_time DESC, run_id);
+CREATE INDEX by_status_by_start_time ON executions_visibility (namespace_id, status, start_time DESC, run_id);
+CREATE INDEX by_type_close_time ON executions_visibility (namespace_id, workflow_type_name, status, close_time DESC, run_id);
+CREATE INDEX by_workflow_id_close_time ON executions_visibility (namespace_id, workflow_id, status, close_time DESC, run_id);
+CREATE INDEX by_status_by_close_time ON executions_visibility (namespace_id, status, close_time DESC, run_id);
+
+

--- a/schema/postgresql/v12/visibility/versioned/v1.1/index.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.1/index.sql
@@ -1,0 +1,1 @@
+CREATE INDEX by_close_time_by_status ON executions_visibility (namespace_id, close_time DESC, run_id, status);

--- a/schema/postgresql/v12/visibility/versioned/v1.1/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.1/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.1",
+  "MinCompatibleVersion": "0.1",
+  "Description": "add close time & status index",
+  "SchemaUpdateCqlFiles": [
+    "index.sql"
+  ]
+}

--- a/schema/postgresql/v12/visibility/versioned/v1.2/manifest.json
+++ b/schema/postgresql/v12/visibility/versioned/v1.2/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "1.2",
+  "MinCompatibleVersion": "0.1",
+  "Description": "update schema to support advanced visibility",
+  "SchemaUpdateCqlFiles": [
+    "advanced_visibility.sql"
+  ]
+}

--- a/schema/postgresql/v96/version.go
+++ b/schema/postgresql/v96/version.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package postgresql
+package v96
 
 // NOTE: whenever there is a new database schema update, plz update the following versions
 

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -127,6 +127,8 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 			ops = persistencetests.GetMySQLTestClusterOption()
 		case postgresql.PluginName:
 			ops = persistencetests.GetPostgreSQLTestClusterOption()
+		case postgresql.PluginNameV12:
+			ops = persistencetests.GetPostgreSQL12TestClusterOption()
 		case sqlite.PluginName:
 			ops = persistencetests.GetSQLiteMemoryTestClusterOption()
 		default:

--- a/tools/tests/postgresql_cli_test.go
+++ b/tools/tests/postgresql_cli_test.go
@@ -32,7 +32,8 @@ import (
 
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/postgresql"
 	"go.temporal.io/server/environment"
-	postgresqlversion "go.temporal.io/server/schema/postgresql"
+	postgresqlversionV12 "go.temporal.io/server/schema/postgresql/v12"
+	postgresqlversionV96 "go.temporal.io/server/schema/postgresql/v96"
 	"go.temporal.io/server/tools/sql/clitest"
 )
 
@@ -76,9 +77,9 @@ func TestPostgreSQLUpdateSchemaTestSuite(t *testing.T) {
 		postgresql.PluginName,
 		testPostgreSQLQuery,
 		testPostgreSQLExecutionSchemaVersionDir,
-		postgresqlversion.Version,
+		postgresqlversionV96.Version,
 		testPostgreSQLVisibilitySchemaVersionDir,
-		postgresqlversion.VisibilityVersion,
+		postgresqlversionV96.VisibilityVersion,
 	))
 }
 
@@ -91,5 +92,64 @@ func TestPostgreSQLVersionTestSuite(t *testing.T) {
 		postgresql.PluginName,
 		testPostgreSQLExecutionSchemaFile,
 		testPostgreSQLVisibilitySchemaFile,
+	))
+}
+
+func TestPostgreSQL12ConnTestSuite(t *testing.T) {
+	suite.Run(t, clitest.NewSQLConnTestSuite(
+		environment.GetPostgreSQLAddress(),
+		strconv.Itoa(environment.GetPostgreSQLPort()),
+		postgresql.PluginNameV12,
+		testPostgreSQLQuery,
+	))
+}
+
+func TestPostgreSQL12HandlerTestSuite(t *testing.T) {
+	suite.Run(t, clitest.NewHandlerTestSuite(
+		environment.GetPostgreSQLAddress(),
+		strconv.Itoa(environment.GetPostgreSQLPort()),
+		postgresql.PluginNameV12,
+	))
+}
+
+func TestPostgreSQL12SetupSchemaTestSuite(t *testing.T) {
+	t.Setenv("SQL_HOST", environment.GetPostgreSQLAddress())
+	t.Setenv("SQL_PORT", strconv.Itoa(environment.GetPostgreSQLPort()))
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
+	suite.Run(t, clitest.NewSetupSchemaTestSuite(
+		environment.GetPostgreSQLAddress(),
+		strconv.Itoa(environment.GetPostgreSQLPort()),
+		postgresql.PluginNameV12,
+		testPostgreSQLQuery,
+	))
+}
+
+func TestPostgreSQL12UpdateSchemaTestSuite(t *testing.T) {
+	t.Setenv("SQL_HOST", environment.GetPostgreSQLAddress())
+	t.Setenv("SQL_PORT", strconv.Itoa(environment.GetPostgreSQLPort()))
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
+	suite.Run(t, clitest.NewUpdateSchemaTestSuite(
+		environment.GetPostgreSQLAddress(),
+		strconv.Itoa(environment.GetPostgreSQLPort()),
+		postgresql.PluginNameV12,
+		testPostgreSQLQuery,
+		testPostgreSQL12ExecutionSchemaVersionDir,
+		postgresqlversionV12.Version,
+		testPostgreSQL12VisibilitySchemaVersionDir,
+		postgresqlversionV12.VisibilityVersion,
+	))
+}
+
+func TestPostgreSQL12VersionTestSuite(t *testing.T) {
+	t.Setenv("SQL_USER", testUser)
+	t.Setenv("SQL_PASSWORD", testPassword)
+	suite.Run(t, clitest.NewVersionTestSuite(
+		environment.GetPostgreSQLAddress(),
+		strconv.Itoa(environment.GetPostgreSQLPort()),
+		postgresql.PluginNameV12,
+		testPostgreSQL12ExecutionSchemaFile,
+		testPostgreSQL12VisibilitySchemaFile,
 	))
 }

--- a/tools/tests/test_data.go
+++ b/tools/tests/test_data.go
@@ -67,7 +67,13 @@ CREATE TABLE current_executions(
 	testPostgreSQLVisibilitySchemaFile       = "../../schema/postgresql/v96/visibility/schema.sql"
 	testPostgreSQLExecutionSchemaVersionDir  = "../../schema/postgresql/v96/temporal/versioned"
 	testPostgreSQLVisibilitySchemaVersionDir = "../../schema/postgresql/v96/visibility/versioned"
-	testPostgreSQLQuery                      = `
+
+	testPostgreSQL12ExecutionSchemaFile        = "../../schema/postgresql/v12/temporal/schema.sql"
+	testPostgreSQL12VisibilitySchemaFile       = "../../schema/postgresql/v12/visibility/schema.sql"
+	testPostgreSQL12ExecutionSchemaVersionDir  = "../../schema/postgresql/v12/temporal/versioned"
+	testPostgreSQL12VisibilitySchemaVersionDir = "../../schema/postgresql/v12/visibility/versioned"
+
+	testPostgreSQLQuery = `
 -- test sql file content
 
 CREATE TABLE executions(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added PostgreSQL 12 schemas:
- For main Temporal storage, it's just a copy from PostgreSQL v96 schema
- For visibility:
  - v1.0, v1.1: It's a copy from v96 (to support migration).
  - v1.2: Changes to support advanced visibility:
    - Added search attributes JSON map.
    - Added generated columns to extract the search attributes fields from JSON.
    - Deleted old indices and created new ones.

<!-- Tell your future self why have you made these changes -->
**Why?**
Advanced visibility with SQL databases.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started temporal using PostgreSQL 12, and copied existing unit tests for PostgreSQL to use the new interface.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.