### PR TITLE
Remove internal-frontend from default services

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -111,7 +111,7 @@ func buildCLI() *cli.App {
 				&cli.StringSliceFlag{
 					Name:    "service",
 					Aliases: []string{"svc"},
-					Value:   cli.NewStringSlice(temporal.Services...),
+					Value:   cli.NewStringSlice(temporal.DefaultServices...),
 					Usage:   "service(s) to start",
 				},
 			},

--- a/temporal/server.go
+++ b/temporal/server.go
@@ -43,12 +43,21 @@ type (
 	}
 )
 
-// Services is the list of all valid temporal services as strings (needs to be strings to keep
-// ServerOptions interface stable)
 var (
+	// Services is the set of all valid temporal services as strings (needs to be strings to
+	// keep ServerOptions interface stable)
 	Services = []string{
 		string(primitives.FrontendService),
 		string(primitives.InternalFrontendService),
+		string(primitives.HistoryService),
+		string(primitives.MatchingService),
+		string(primitives.WorkerService),
+	}
+
+	// DefaultServices is the set of services to start by default if services are not given on
+	// the command line.
+	DefaultServices = []string{
+		string(primitives.FrontendService),
 		string(primitives.HistoryService),
 		string(primitives.MatchingService),
 		string(primitives.WorkerService),


### PR DESCRIPTION
**What changed?**
If running without a `--service` flag (e.g. in development or a tiny test environment), don't run internal-frontend (and don't require it in the static config).

**Why?**
So that the new version works with old static config files.

**How did you test it?**
Manually

**Potential risks**
Only affects running without `--service`, which shouldn't happen in production environments
