### PR TITLE
Add archival category conditionally

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -643,7 +643,11 @@ func (e *historyEngineImpl) NotifyNewTasks(
 		}
 
 		if len(tasksByCategory) > 0 {
-			e.queueProcessors[category].NotifyNewTasks(tasksByCategory)
+			processor, ok := e.queueProcessors[category]
+			if !ok {
+				continue
+			}
+			processor.NotifyNewTasks(tasksByCategory)
 		}
 	}
 }

--- a/service/history/queueFactoryBase.go
+++ b/service/history/queueFactoryBase.go
@@ -42,6 +42,7 @@ import (
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tasks"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
 )
 
@@ -137,6 +138,8 @@ func getQueueFactories(
 		queueFactorySet.VisibilityQueueFactory,
 	}
 	if archivalMetadata.GetHistoryConfig().StaticClusterState() == archiver.ArchivalEnabled || archivalMetadata.GetVisibilityConfig().StaticClusterState() == archiver.ArchivalEnabled {
+		c := tasks.CategoryArchival
+		tasks.NewCategory(c.ID(), c.Type(), c.Name())
 		factories = append(factories, queueFactorySet.ArchivalQueueFactory)
 	}
 	return factories

--- a/service/history/tasks/category.go
+++ b/service/history/tasks/category.go
@@ -25,7 +25,6 @@
 package tasks
 
 import (
-	"fmt"
 	"strconv"
 	"sync"
 
@@ -115,7 +114,7 @@ var (
 
 // NewCategory creates a new Category and register the created Category
 // Registered Categories can be retrieved via GetCategories() or GetCategoryByID()
-// NewCategory panics when a Category with the same ID has already been registered
+// NewCategory does nothing if a Category with the same ID is already registered
 func NewCategory(
 	id int32,
 	categoryType CategoryType,
@@ -125,7 +124,7 @@ func NewCategory(
 	defer categories.Unlock()
 
 	if category, ok := categories.m[id]; ok {
-		panic(fmt.Sprintf("category id: %v has already been defined as type %v and name %v", id, category.cType, category.name))
+		return category
 	}
 
 	newCategory := Category{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now conditionally register the archival category whenever the server starts up if archival is enabled

<!-- Tell your future self why have you made these changes -->
**Why?**
So the system knows which categories there are for telemetry, etc.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Nothing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If this category is enabled but there is no archival queue running, then there could be a panic. However, this code is in the same branch that we add the archival queue factory in, so that should be impossible.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
