### PR TITLE
Remove internal-frontend from development configs

### DIFF
--- a/config/development-active.yaml
+++ b/config/development-active.yaml
@@ -44,12 +44,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-cass-archival.yaml
+++ b/config/development-cass-archival.yaml
@@ -36,12 +36,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-cass-es.yaml
+++ b/config/development-cass-es.yaml
@@ -44,12 +44,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-cass.yaml
+++ b/config/development-cass.yaml
@@ -60,12 +60,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-mysql-es.yaml
+++ b/config/development-mysql-es.yaml
@@ -50,12 +50,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-mysql.yaml
+++ b/config/development-mysql.yaml
@@ -51,12 +51,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-other.yaml
+++ b/config/development-other.yaml
@@ -44,12 +44,6 @@ services:
       membershipPort: 9933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 9236
-      membershipPort: 9936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 9235

--- a/config/development-postgres-es.yaml
+++ b/config/development-postgres-es.yaml
@@ -63,12 +63,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-postgres.yaml
+++ b/config/development-postgres.yaml
@@ -51,12 +51,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-sqlite-file.yaml
+++ b/config/development-sqlite-file.yaml
@@ -75,12 +75,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-sqlite.yaml
+++ b/config/development-sqlite.yaml
@@ -71,12 +71,6 @@ services:
       membershipPort: 6933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 7236
-      membershipPort: 6936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 7235

--- a/config/development-standby.yaml
+++ b/config/development-standby.yaml
@@ -44,12 +44,6 @@ services:
       membershipPort: 8933
       bindOnLocalHost: true
 
-  internal-frontend:
-    rpc:
-      grpcPort: 8236
-      membershipPort: 8936
-      bindOnLocalHost: true
-
   matching:
     rpc:
       grpcPort: 8235

--- a/temporal/server_test.go
+++ b/temporal/server_test.go
@@ -44,7 +44,7 @@ func TestNewServer(t *testing.T) {
 	require.NoError(t, err)
 	cfg.DynamicConfigClient.Filepath = path.Join(configDir, "dynamicconfig", "development-sql.yaml")
 	_, err = NewServer(
-		ForServices(Services),
+		ForServices(DefaultServices),
 		WithConfig(cfg),
 	)
 	assert.NoError(t, err)


### PR DESCRIPTION
**What changed?**
Remove internal-frontend from development configs

**Why?**
Fix development config; we don't need this to test functionality during development

**How did you test it?**
Manually, will add integration test for internal-frontend elsewhere

**Potential risks**


**Is hotfix candidate?**
