### PR TITLE
Handle updating cluster metadata search attributes info when using SQL DB

### DIFF
--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -81,6 +81,10 @@ func (c *Persistence) AdvancedVisibilityConfigExist() bool {
 	return c.AdvancedVisibilityStore != ""
 }
 
+func (c *Persistence) IsSQLVisibilityStore() bool {
+	return c.StandardVisibilityConfigExist() && c.DataStores[c.VisibilityStore].SQL != nil
+}
+
 func (c *Persistence) validateAdvancedVisibility() error {
 	if !c.StandardVisibilityConfigExist() && !c.AdvancedVisibilityConfigExist() {
 		return errors.New("persistence config: one of visibilityStore or advancedVisibilityStore must be specified")

--- a/common/searchattribute/defs.go
+++ b/common/searchattribute/defs.go
@@ -28,6 +28,7 @@ import (
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 )
 
 const (
@@ -102,6 +103,37 @@ var (
 		Memo:              {},
 		VisibilityTaskKey: {},
 	}
+
+	sqlDbCustomSearchAttributes = map[string]enumspb.IndexedValueType{
+		"Bool01":        enumspb.INDEXED_VALUE_TYPE_BOOL,
+		"Bool02":        enumspb.INDEXED_VALUE_TYPE_BOOL,
+		"Bool03":        enumspb.INDEXED_VALUE_TYPE_BOOL,
+		"Datetime01":    enumspb.INDEXED_VALUE_TYPE_DATETIME,
+		"Datetime02":    enumspb.INDEXED_VALUE_TYPE_DATETIME,
+		"Datetime03":    enumspb.INDEXED_VALUE_TYPE_DATETIME,
+		"Double01":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+		"Double02":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+		"Double03":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+		"Int01":         enumspb.INDEXED_VALUE_TYPE_INT,
+		"Int02":         enumspb.INDEXED_VALUE_TYPE_INT,
+		"Int03":         enumspb.INDEXED_VALUE_TYPE_INT,
+		"Keyword01":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword02":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword03":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword04":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword05":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword06":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword07":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword08":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword09":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Keyword10":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+		"Text01":        enumspb.INDEXED_VALUE_TYPE_TEXT,
+		"Text02":        enumspb.INDEXED_VALUE_TYPE_TEXT,
+		"Text03":        enumspb.INDEXED_VALUE_TYPE_TEXT,
+		"KeywordList01": enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+		"KeywordList02": enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+		"KeywordList03": enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+	}
 )
 
 // IsReserved returns true if name is system reserved and can't be used as custom search attribute name.
@@ -127,4 +159,10 @@ func IsMappable(name string) bool {
 		return false
 	}
 	return true
+}
+
+func GetSqlDbIndexSearchAttributes() *persistencespb.IndexSearchAttributes {
+	return &persistencespb.IndexSearchAttributes{
+		CustomSearchAttributes: sqlDbCustomSearchAttributes,
+	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Register the pre-allocated custom search attributes when starting new instances of Temporal Server using SQL DB as visibility storage, or during the first start of the Server after upgrading to v1.20.

<!-- Tell your future self why have you made these changes -->
**Why?**
Support for advanced visibility using SQL DB: custom search attributes are pre-allocated and doing this automatically provides a more seamless experience to the user.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Start new Server before changes, and then after. Logs show the search attributes being registered successfully:
```
{"level":"info","ts":"2023-01-27T17:16:01.894-0800","msg":"Successfully registered search attributes.","component":"metadata-initializer","cluster-name":"active","logging-call-at":"fx.go:733"}
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.