### PR TITLE
Implement search attribute mapper

### DIFF
--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -97,9 +97,9 @@ var Module = fx.Options(
 	fx.Provide(HostNameProvider),
 	fx.Provide(TimeSourceProvider),
 	cluster.MetadataLifetimeHooksModule,
+	fx.Provide(NamespaceRegistryProvider),
 	fx.Provide(SearchAttributeProviderProvider),
 	fx.Provide(SearchAttributeManagerProvider),
-	fx.Provide(NamespaceRegistryProvider),
 	namespace.RegistryLifetimeHooksModule,
 	fx.Provide(fx.Annotate(
 		func(p namespace.Registry) common.Pingable { return p },
@@ -165,23 +165,33 @@ func TimeSourceProvider() clock.TimeSource {
 func SearchAttributeProviderProvider(
 	timeSource clock.TimeSource,
 	cmMgr persistence.ClusterMetadataManager,
+	namespaceRegistry namespace.Registry,
 	dynamicCollection *dynamicconfig.Collection,
+	persistenceConfig *config.Persistence,
 ) searchattribute.Provider {
 	return searchattribute.NewManager(
 		timeSource,
 		cmMgr,
-		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false))
+		namespaceRegistry,
+		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false),
+		persistenceConfig.StandardVisibilityConfigExist(),
+	)
 }
 
 func SearchAttributeManagerProvider(
 	timeSource clock.TimeSource,
 	cmMgr persistence.ClusterMetadataManager,
+	namespaceRegistry namespace.Registry,
 	dynamicCollection *dynamicconfig.Collection,
+	persistenceConfig *config.Persistence,
 ) searchattribute.Manager {
 	return searchattribute.NewManager(
 		timeSource,
 		cmMgr,
-		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false))
+		namespaceRegistry,
+		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false),
+		persistenceConfig.StandardVisibilityConfigExist(),
+	)
 }
 
 func NamespaceRegistryProvider(

--- a/common/searchattribute/manager_test.go
+++ b/common/searchattribute/manager_test.go
@@ -40,6 +40,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 )
 
@@ -53,6 +54,7 @@ type (
 		logger                     log.Logger
 		timeSource                 *clock.EventTimeSource
 		mockClusterMetadataManager *persistence.MockClusterMetadataManager
+		mockNamespaceRegistry      *namespace.MockRegistry
 		manager                    *managerImpl
 		forceCacheRefresh          bool
 	}
@@ -75,12 +77,15 @@ func (s *searchAttributesManagerSuite) SetupTest() {
 	s.logger = log.NewTestLogger()
 	s.timeSource = clock.NewEventTimeSource()
 	s.mockClusterMetadataManager = persistence.NewMockClusterMetadataManager(s.controller)
+	s.mockNamespaceRegistry = namespace.NewMockRegistry(s.controller)
 	s.manager = NewManager(
 		s.timeSource,
 		s.mockClusterMetadataManager,
+		s.mockNamespaceRegistry,
 		func() bool {
 			return s.forceCacheRefresh
 		},
+		false,
 	)
 }
 

--- a/common/searchattribute/search_attirbute.go
+++ b/common/searchattribute/search_attirbute.go
@@ -42,6 +42,20 @@ const (
 type (
 	Provider interface {
 		GetSearchAttributes(indexName string, forceRefreshCache bool) (NameTypeMap, error)
+
+		AliasFields(
+			mapper Mapper,
+			searchAttributes *commonpb.SearchAttributes,
+			namespace string,
+		) (*commonpb.SearchAttributes, error)
+
+		UnaliasFields(
+			mapper Mapper,
+			searchAttributes *commonpb.SearchAttributes,
+			namespace string,
+		) (*commonpb.SearchAttributes, error)
+
+		GetMapper(mapper Mapper, namespace string) (Mapper, error)
 	}
 
 	Manager interface {

--- a/common/searchattribute/search_attribute_mock.go
+++ b/common/searchattribute/search_attribute_mock.go
@@ -33,7 +33,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	v1 "go.temporal.io/api/enums/v1"
+	v1 "go.temporal.io/api/common/v1"
+	v10 "go.temporal.io/api/enums/v1"
 )
 
 // MockProvider is a mock of Provider interface.
@@ -59,6 +60,36 @@ func (m *MockProvider) EXPECT() *MockProviderMockRecorder {
 	return m.recorder
 }
 
+// AliasFields mocks base method.
+func (m *MockProvider) AliasFields(mapper Mapper, searchAttributes *v1.SearchAttributes, namespace string) (*v1.SearchAttributes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AliasFields", mapper, searchAttributes, namespace)
+	ret0, _ := ret[0].(*v1.SearchAttributes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AliasFields indicates an expected call of AliasFields.
+func (mr *MockProviderMockRecorder) AliasFields(mapper, searchAttributes, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AliasFields", reflect.TypeOf((*MockProvider)(nil).AliasFields), mapper, searchAttributes, namespace)
+}
+
+// GetMapper mocks base method.
+func (m *MockProvider) GetMapper(mapper Mapper, namespace string) (Mapper, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMapper", mapper, namespace)
+	ret0, _ := ret[0].(Mapper)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMapper indicates an expected call of GetMapper.
+func (mr *MockProviderMockRecorder) GetMapper(mapper, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMapper", reflect.TypeOf((*MockProvider)(nil).GetMapper), mapper, namespace)
+}
+
 // GetSearchAttributes mocks base method.
 func (m *MockProvider) GetSearchAttributes(indexName string, forceRefreshCache bool) (NameTypeMap, error) {
 	m.ctrl.T.Helper()
@@ -72,6 +103,21 @@ func (m *MockProvider) GetSearchAttributes(indexName string, forceRefreshCache b
 func (mr *MockProviderMockRecorder) GetSearchAttributes(indexName, forceRefreshCache interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSearchAttributes", reflect.TypeOf((*MockProvider)(nil).GetSearchAttributes), indexName, forceRefreshCache)
+}
+
+// UnaliasFields mocks base method.
+func (m *MockProvider) UnaliasFields(mapper Mapper, searchAttributes *v1.SearchAttributes, namespace string) (*v1.SearchAttributes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnaliasFields", mapper, searchAttributes, namespace)
+	ret0, _ := ret[0].(*v1.SearchAttributes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UnaliasFields indicates an expected call of UnaliasFields.
+func (mr *MockProviderMockRecorder) UnaliasFields(mapper, searchAttributes, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnaliasFields", reflect.TypeOf((*MockProvider)(nil).UnaliasFields), mapper, searchAttributes, namespace)
 }
 
 // MockManager is a mock of Manager interface.
@@ -97,6 +143,36 @@ func (m *MockManager) EXPECT() *MockManagerMockRecorder {
 	return m.recorder
 }
 
+// AliasFields mocks base method.
+func (m *MockManager) AliasFields(mapper Mapper, searchAttributes *v1.SearchAttributes, namespace string) (*v1.SearchAttributes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AliasFields", mapper, searchAttributes, namespace)
+	ret0, _ := ret[0].(*v1.SearchAttributes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AliasFields indicates an expected call of AliasFields.
+func (mr *MockManagerMockRecorder) AliasFields(mapper, searchAttributes, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AliasFields", reflect.TypeOf((*MockManager)(nil).AliasFields), mapper, searchAttributes, namespace)
+}
+
+// GetMapper mocks base method.
+func (m *MockManager) GetMapper(mapper Mapper, namespace string) (Mapper, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMapper", mapper, namespace)
+	ret0, _ := ret[0].(Mapper)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMapper indicates an expected call of GetMapper.
+func (mr *MockManagerMockRecorder) GetMapper(mapper, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMapper", reflect.TypeOf((*MockManager)(nil).GetMapper), mapper, namespace)
+}
+
 // GetSearchAttributes mocks base method.
 func (m *MockManager) GetSearchAttributes(indexName string, forceRefreshCache bool) (NameTypeMap, error) {
 	m.ctrl.T.Helper()
@@ -113,7 +189,7 @@ func (mr *MockManagerMockRecorder) GetSearchAttributes(indexName, forceRefreshCa
 }
 
 // SaveSearchAttributes mocks base method.
-func (m *MockManager) SaveSearchAttributes(ctx context.Context, indexName string, newCustomSearchAttributes map[string]v1.IndexedValueType) error {
+func (m *MockManager) SaveSearchAttributes(ctx context.Context, indexName string, newCustomSearchAttributes map[string]v10.IndexedValueType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SaveSearchAttributes", ctx, indexName, newCustomSearchAttributes)
 	ret0, _ := ret[0].(error)
@@ -124,4 +200,19 @@ func (m *MockManager) SaveSearchAttributes(ctx context.Context, indexName string
 func (mr *MockManagerMockRecorder) SaveSearchAttributes(ctx, indexName, newCustomSearchAttributes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveSearchAttributes", reflect.TypeOf((*MockManager)(nil).SaveSearchAttributes), ctx, indexName, newCustomSearchAttributes)
+}
+
+// UnaliasFields mocks base method.
+func (m *MockManager) UnaliasFields(mapper Mapper, searchAttributes *v1.SearchAttributes, namespace string) (*v1.SearchAttributes, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UnaliasFields", mapper, searchAttributes, namespace)
+	ret0, _ := ret[0].(*v1.SearchAttributes)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UnaliasFields indicates an expected call of UnaliasFields.
+func (mr *MockManagerMockRecorder) UnaliasFields(mapper, searchAttributes, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnaliasFields", reflect.TypeOf((*MockManager)(nil).UnaliasFields), mapper, searchAttributes, namespace)
 }

--- a/common/searchattribute/test_provider.go
+++ b/common/searchattribute/test_provider.go
@@ -25,6 +25,7 @@
 package searchattribute
 
 import (
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 )
 
@@ -32,15 +33,25 @@ type (
 	TestProvider struct{}
 )
 
+var _ Provider = (*TestProvider)(nil)
+
 var (
 	TestNameTypeMap = NameTypeMap{
 		customSearchAttributes: map[string]enumspb.IndexedValueType{
+			// elasticsearch visibility
 			"CustomIntField":      enumspb.INDEXED_VALUE_TYPE_INT,
 			"CustomTextField":     enumspb.INDEXED_VALUE_TYPE_TEXT,
 			"CustomKeywordField":  enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 			"CustomDatetimeField": enumspb.INDEXED_VALUE_TYPE_DATETIME,
 			"CustomDoubleField":   enumspb.INDEXED_VALUE_TYPE_DOUBLE,
 			"CustomBoolField":     enumspb.INDEXED_VALUE_TYPE_BOOL,
+			// sql visibility
+			"Int01":      enumspb.INDEXED_VALUE_TYPE_INT,
+			"Text01":     enumspb.INDEXED_VALUE_TYPE_TEXT,
+			"Keyword01":  enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"Datetime01": enumspb.INDEXED_VALUE_TYPE_DATETIME,
+			"Double01":   enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			"Bool01":     enumspb.INDEXED_VALUE_TYPE_BOOL,
 		},
 	}
 )
@@ -51,4 +62,33 @@ func NewTestProvider() *TestProvider {
 
 func (s *TestProvider) GetSearchAttributes(_ string, _ bool) (NameTypeMap, error) {
 	return TestNameTypeMap, nil
+}
+
+func (s *TestProvider) AliasFields(
+	mapper Mapper,
+	searchAttributes *commonpb.SearchAttributes,
+	namespace string,
+) (*commonpb.SearchAttributes, error) {
+	if mapper != nil {
+		return AliasFields(mapper, searchAttributes, namespace)
+	}
+	return searchAttributes, nil
+}
+
+func (s *TestProvider) UnaliasFields(
+	mapper Mapper,
+	searchAttributes *commonpb.SearchAttributes,
+	namespace string,
+) (*commonpb.SearchAttributes, error) {
+	if mapper != nil {
+		return UnaliasFields(mapper, searchAttributes, namespace)
+	}
+	return searchAttributes, nil
+}
+
+func (s *TestProvider) GetMapper(mapper Mapper, _namespace string) (Mapper, error) {
+	if mapper != nil {
+		return mapper, nil
+	}
+	return NewIdentityMapper(), nil
 }

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -182,8 +182,12 @@ func (v *Validator) validationError(msg string, saFieldName string, namespace st
 }
 
 func (v *Validator) getAlias(saFieldName string, namespace string) (string, error) {
-	if IsMappable(saFieldName) && v.searchAttributesMapper != nil {
-		return v.searchAttributesMapper.GetAlias(saFieldName, namespace)
+	if IsMappable(saFieldName) {
+		mapper, err := v.searchAttributesProvider.GetMapper(v.searchAttributesMapper, namespace)
+		if err != nil {
+			return "", err
+		}
+		return mapper.GetAlias(saFieldName, namespace)
 	}
 	return saFieldName, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -44,7 +44,7 @@ require (
 	go.opentelemetry.io/otel/metric v0.33.0
 	go.opentelemetry.io/otel/sdk v1.11.1
 	go.opentelemetry.io/otel/sdk/metric v0.31.0
-	go.temporal.io/api v1.15.1-0.20230125004443-42737e40d339
+	go.temporal.io/api v1.15.1-0.20230130221739-35f91d43296f
 	go.temporal.io/sdk v1.20.1-0.20230125015921-1fe6824cedfe
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.10.0
@@ -55,7 +55,7 @@ require (
 	golang.org/x/oauth2 v0.2.0
 	golang.org/x/time v0.2.0
 	google.golang.org/api v0.103.0
-	google.golang.org/grpc v1.52.1
+	google.golang.org/grpc v1.52.3
 	google.golang.org/grpc/examples v0.0.0-20221201195934-736197138d20
 	gopkg.in/square/go-jose.v2 v2.6.0
 	gopkg.in/validator.v2 v2.0.1
@@ -127,7 +127,7 @@ require (
 	golang.org/x/tools v0.3.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2 // indirect
+	google.golang.org/genproto v0.0.0-20230127162408-596548ed4efa // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -840,8 +840,9 @@ go.opentelemetry.io/otel/trace v1.11.1/go.mod h1:f/Q9G7vzk5u91PhbmKbg1Qn0rzH1LJ4
 go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqeYNgFYFoEGnI=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.temporal.io/api v1.15.1-0.20230125004443-42737e40d339 h1:7p2abcEmI8MVqPoBt+mbcHm6t+6fUYS3dUEEAFyzloM=
 go.temporal.io/api v1.15.1-0.20230125004443-42737e40d339/go.mod h1:dbi2T2T/PVw0jOHF0pdc8XFDFGQoMQeNq7F0ClTKwlU=
+go.temporal.io/api v1.15.1-0.20230130221739-35f91d43296f h1:wNX+g/F7lQWpzftw/Su3T9a1guXB04zqaX0lnHmPQLI=
+go.temporal.io/api v1.15.1-0.20230130221739-35f91d43296f/go.mod h1:u3qLbaVTffmcZQbf9ueB+16LKmhkftH79SJOV517MDk=
 go.temporal.io/sdk v1.20.1-0.20230125015921-1fe6824cedfe h1:mlyDvuKMuxCTcEgmeZs+Qd/x69jyT/Jwq1ULhJGfPbU=
 go.temporal.io/sdk v1.20.1-0.20230125015921-1fe6824cedfe/go.mod h1:KtPAB/8+lVNm0aP0W5wLCyxXfHoQJbYNfM4+SfVnsJc=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
@@ -1365,8 +1366,9 @@ google.golang.org/genproto v0.0.0-20221114212237-e4508ebdbee1/go.mod h1:rZS5c/ZV
 google.golang.org/genproto v0.0.0-20221117204609-8f9c96812029/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221118155620-16455021b5e6/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
 google.golang.org/genproto v0.0.0-20221201164419-0e50fba7f41c/go.mod h1:rZS5c/ZVYMaOGBfO68GWtjOw/eLaZM1X6iVtgjZ+EWg=
-google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2 h1:O97sLx/Xmb/KIZHB/2/BzofxBs5QmmR0LcihPtllmbc=
 google.golang.org/genproto v0.0.0-20230124163310-31e0e69b6fc2/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
+google.golang.org/genproto v0.0.0-20230127162408-596548ed4efa h1:GZXdWYIKckxQE2EcLHLvF+KLF+bIwoxGdMUxTZizueg=
+google.golang.org/genproto v0.0.0-20230127162408-596548ed4efa/go.mod h1:RGgjbofJ8xD9Sq1VVhDM1Vok1vRONV+rg+CjzG4SZKM=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
@@ -1405,8 +1407,9 @@ google.golang.org/grpc v1.49.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCD
 google.golang.org/grpc v1.50.0/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.50.1/go.mod h1:ZgQEeidpAuNRZ8iRrlBKXZQP1ghovWIVhdJRyCDK+GI=
 google.golang.org/grpc v1.51.0/go.mod h1:wgNDFcnuBGmxLKI/qn4T+m5BtEBYXJPvibbUPsAIPww=
-google.golang.org/grpc v1.52.1 h1:2NpOPk5g5Xtb0qebIEs7hNIa++PdtZLo2AQUpc1YnSU=
 google.golang.org/grpc v1.52.1/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
+google.golang.org/grpc v1.52.3 h1:pf7sOysg4LdgBqduXveGKrcEwbStiK2rtfghdzlUYDQ=
+google.golang.org/grpc v1.52.3/go.mod h1:pu6fVzoFb+NBYNAvQL08ic+lvB2IojljRYuun5vorUY=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/examples v0.0.0-20221201195934-736197138d20 h1:c4fmRt11lwyTYMMEA3IYCZR/xN7FEAJpwvPziaGXugs=
 google.golang.org/grpc/examples v0.0.0-20221201195934-736197138d20/go.mod h1:jMMKnsR3nPEOSsgT/Le2GxpknJOBOQms0nWb0JRgeUM=

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -94,6 +94,9 @@ var (
 	errInvalidRemoteClusterInfo                       = "Unable connect to remote cluster with invalid config: %v."
 	errUnableToStoreClusterInfo                       = "Unable to persist cluster info with error: %v."
 	errUnableToDeleteClusterInfo                      = "Unable to delete cluster info with error: %v."
+	errUnableToGetNamespaceInfoMessage                = "Unable to get namespace info with error: %v"
+	errUnableToCreateFrontendClientMessage            = "Unable to create frontend client with error: %v."
+	errTooManySearchAttributesMessage                 = "Unable to create search attributes: cannot have more than %d search attribute of type %s."
 
 	errListNotAllowed      = serviceerror.NewPermissionDenied("List is disabled on this namespace.", "")
 	errSchedulesNotAllowed = serviceerror.NewPermissionDenied("Schedules are disabled on this namespace.", "")

--- a/service/frontend/namespace_handler.go
+++ b/service/frontend/namespace_handler.go
@@ -511,6 +511,10 @@ func (d *namespaceHandlerImpl) UpdateNamespace(
 				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("Total resetBinaries cannot exceed the max limit: %v", maxLength))
 			}
 		}
+		if updatedConfig.CustomSearchAttributeAliases != nil {
+			configurationChanged = true
+			config.CustomSearchAttributeAliases = updatedConfig.CustomSearchAttributeAliases
+		}
 	}
 
 	if updateRequest.GetDeleteBadBinary() != "" {

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -36,8 +36,10 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 
 	"go.temporal.io/server/api/adminservice/v1"
@@ -45,6 +47,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	svc "go.temporal.io/server/client"
 	"go.temporal.io/server/client/admin"
+	"go.temporal.io/server/client/frontend"
 	"go.temporal.io/server/common"
 	clustermetadata "go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
@@ -52,10 +55,12 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/worker"
 	"go.temporal.io/server/service/worker/addsearchattributes"
 	"go.temporal.io/server/service/worker/deletenamespace"
@@ -151,7 +156,10 @@ func (h *OperatorHandlerImpl) Stop() {
 	}
 }
 
-func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *operatorservice.AddSearchAttributesRequest) (_ *operatorservice.AddSearchAttributesResponse, retError error) {
+func (h *OperatorHandlerImpl) AddSearchAttributes(
+	ctx context.Context,
+	request *operatorservice.AddSearchAttributesRequest,
+) (_ *operatorservice.AddSearchAttributesResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
 
 	scope, startTime := h.startRequestProfile(metrics.OperatorAddSearchAttributesScope)
@@ -167,7 +175,6 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 	}
 
 	indexName := h.visibilityMgr.GetIndexName()
-
 	currentSearchAttributes, err := h.saProvider.GetSearchAttributes(indexName, true)
 	if err != nil {
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
@@ -185,6 +192,25 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 		}
 	}
 
+	if h.visibilityMgr.GetName() == elasticsearch.PersistenceName {
+		err = h.addSearchAttributesElasticSearch(ctx, request, indexName)
+	} else {
+		err = h.addSearchAttributesSQL(ctx, request, currentSearchAttributes)
+	}
+
+	if err != nil {
+		scope.Counter(metrics.AddSearchAttributesWorkflowFailuresCount.GetMetricName()).Record(1)
+		return nil, err
+	}
+	scope.Counter(metrics.AddSearchAttributesWorkflowSuccessCount.GetMetricName()).Record(1)
+	return &operatorservice.AddSearchAttributesResponse{}, nil
+}
+
+func (h *OperatorHandlerImpl) addSearchAttributesElasticSearch(
+	ctx context.Context,
+	request *operatorservice.AddSearchAttributesRequest,
+	indexName string,
+) error {
 	// Execute workflow.
 	wfParams := addsearchattributes.WorkflowParams{
 		CustomAttributesToAdd: request.GetSearchAttributes(),
@@ -203,22 +229,89 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(ctx context.Context, request *
 		wfParams,
 	)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToStartWorkflowMessage, addsearchattributes.WorkflowName, err))
+		return serviceerror.NewUnavailable(
+			fmt.Sprintf(errUnableToStartWorkflowMessage, addsearchattributes.WorkflowName, err),
+		)
 	}
 
 	// Wait for workflow to complete.
 	err = run.Get(ctx, nil)
 	if err != nil {
-		scope.Counter(metrics.AddSearchAttributesWorkflowFailuresCount.GetMetricName()).Record(1)
-		execution := &commonpb.WorkflowExecution{WorkflowId: addsearchattributes.WorkflowName, RunId: run.GetRunID()}
-		return nil, serviceerror.NewSystemWorkflow(execution, err)
+		execution := &commonpb.WorkflowExecution{
+			WorkflowId: addsearchattributes.WorkflowName,
+			RunId:      run.GetRunID(),
+		}
+		return serviceerror.NewSystemWorkflow(execution, err)
 	}
-	scope.Counter(metrics.AddSearchAttributesWorkflowSuccessCount.GetMetricName()).Record(1)
-
-	return &operatorservice.AddSearchAttributesResponse{}, nil
+	return nil
 }
 
-func (h *OperatorHandlerImpl) RemoveSearchAttributes(ctx context.Context, request *operatorservice.RemoveSearchAttributesRequest) (_ *operatorservice.RemoveSearchAttributesResponse, retError error) {
+func (h *OperatorHandlerImpl) addSearchAttributesSQL(
+	ctx context.Context,
+	request *operatorservice.AddSearchAttributesRequest,
+	currentSearchAttributes searchattribute.NameTypeMap,
+) error {
+	client, err := h.clientFactory.NewLocalFrontendClientWithTimeout(
+		frontend.DefaultTimeout,
+		frontend.DefaultLongPollTimeout,
+	)
+	if err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToCreateFrontendClientMessage, err))
+	}
+
+	nsName := request.GetNamespace()
+	if nsName == "" {
+		return errNamespaceNotSet
+	}
+	ns, err := h.namespaceRegistry.GetNamespace(namespace.Name(nsName))
+	if err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetNamespaceInfoMessage, nsName))
+	}
+
+	customSearchAttributes := currentSearchAttributes.Custom()
+	mapper := ns.CustomSearchAttributesMapper()
+	fieldToAliasMap := util.CloneMapNonNil(mapper.FieldToAliasMap())
+	for saName, saType := range request.GetSearchAttributes() {
+		// check if alias is already in use
+		if _, err := mapper.GetFieldName(saName, nsName); err == nil {
+			return serviceerror.NewAlreadyExist(
+				fmt.Sprintf(errSearchAttributeAlreadyExistsMessage, saName),
+			)
+		}
+		// find the first available field for the given type
+		targetFieldName := ""
+		cntUsed := 0
+		for fieldName, fieldType := range customSearchAttributes {
+			if fieldType != saType {
+				continue
+			}
+			if _, ok := fieldToAliasMap[fieldName]; !ok {
+				targetFieldName = fieldName
+				break
+			}
+			cntUsed++
+		}
+		if targetFieldName == "" {
+			return serviceerror.NewInvalidArgument(
+				fmt.Sprintf(errTooManySearchAttributesMessage, cntUsed, saType.String()),
+			)
+		}
+		fieldToAliasMap[targetFieldName] = saName
+	}
+
+	_, err = client.UpdateNamespace(ctx, &workflowservice.UpdateNamespaceRequest{
+		Namespace: nsName,
+		Config: &namespacepb.NamespaceConfig{
+			CustomSearchAttributeAliases: fieldToAliasMap,
+		},
+	})
+	return err
+}
+
+func (h *OperatorHandlerImpl) RemoveSearchAttributes(
+	ctx context.Context,
+	request *operatorservice.RemoveSearchAttributesRequest,
+) (_ *operatorservice.RemoveSearchAttributesResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
 
 	// validate request
@@ -230,34 +323,94 @@ func (h *OperatorHandlerImpl) RemoveSearchAttributes(ctx context.Context, reques
 		return nil, errSearchAttributesNotSet
 	}
 
+	var err error
 	indexName := h.visibilityMgr.GetIndexName()
+	if h.visibilityMgr.GetName() == elasticsearch.PersistenceName {
+		err = h.removeSearchAttributesElasticsearch(ctx, request, indexName)
+	} else {
+		err = h.removeSearchAttributesSQL(ctx, request)
+	}
 
+	if err != nil {
+		return nil, err
+	}
+	return &operatorservice.RemoveSearchAttributesResponse{}, nil
+}
+
+func (h *OperatorHandlerImpl) removeSearchAttributesElasticsearch(
+	ctx context.Context,
+	request *operatorservice.RemoveSearchAttributesRequest,
+	indexName string,
+) error {
 	currentSearchAttributes, err := h.saProvider.GetSearchAttributes(indexName, true)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 	}
 
 	newCustomSearchAttributes := maps.Clone(currentSearchAttributes.Custom())
-
 	for _, saName := range request.GetSearchAttributes() {
 		if !currentSearchAttributes.IsDefined(saName) {
-			return nil, serviceerror.NewNotFound(fmt.Sprintf(errSearchAttributeDoesntExistMessage, saName))
+			return serviceerror.NewNotFound(fmt.Sprintf(errSearchAttributeDoesntExistMessage, saName))
 		}
 		if _, ok := newCustomSearchAttributes[saName]; !ok {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errUnableToRemoveNonCustomSearchAttributesMessage, saName))
+			return serviceerror.NewInvalidArgument(
+				fmt.Sprintf(errUnableToRemoveNonCustomSearchAttributesMessage, saName),
+			)
 		}
 		delete(newCustomSearchAttributes, saName)
 	}
 
 	err = h.saManager.SaveSearchAttributes(ctx, indexName, newCustomSearchAttributes)
 	if err != nil {
-		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToSaveSearchAttributesMessage, err))
+		return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToSaveSearchAttributesMessage, err))
 	}
-
-	return &operatorservice.RemoveSearchAttributesResponse{}, nil
+	return nil
 }
 
-func (h *OperatorHandlerImpl) ListSearchAttributes(ctx context.Context, request *operatorservice.ListSearchAttributesRequest) (_ *operatorservice.ListSearchAttributesResponse, retError error) {
+func (h *OperatorHandlerImpl) removeSearchAttributesSQL(
+	ctx context.Context,
+	request *operatorservice.RemoveSearchAttributesRequest,
+) error {
+	client, err := h.clientFactory.NewLocalFrontendClientWithTimeout(
+		frontend.DefaultTimeout,
+		frontend.DefaultLongPollTimeout,
+	)
+	if err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToCreateFrontendClientMessage, err))
+	}
+
+	nsName := request.GetNamespace()
+	if nsName == "" {
+		return errNamespaceNotSet
+	}
+	ns, err := h.namespaceRegistry.GetNamespace(namespace.Name(nsName))
+	if err != nil {
+		return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetNamespaceInfoMessage, nsName))
+	}
+
+	mapper := ns.CustomSearchAttributesMapper()
+	fieldToAliasMap := maps.Clone(mapper.FieldToAliasMap())
+	for _, saName := range request.GetSearchAttributes() {
+		fieldName, err := mapper.GetFieldName(saName, nsName)
+		if err != nil {
+			return serviceerror.NewNotFound(fmt.Sprintf(errSearchAttributeDoesntExistMessage, saName))
+		}
+		delete(fieldToAliasMap, fieldName)
+	}
+
+	_, err = client.UpdateNamespace(ctx, &workflowservice.UpdateNamespaceRequest{
+		Namespace: nsName,
+		Config: &namespacepb.NamespaceConfig{
+			CustomSearchAttributeAliases: fieldToAliasMap,
+		},
+	})
+	return err
+}
+
+func (h *OperatorHandlerImpl) ListSearchAttributes(
+	ctx context.Context,
+	request *operatorservice.ListSearchAttributesRequest,
+) (_ *operatorservice.ListSearchAttributesResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
 
 	if request == nil {
@@ -265,33 +418,56 @@ func (h *OperatorHandlerImpl) ListSearchAttributes(ctx context.Context, request 
 	}
 
 	indexName := h.visibilityMgr.GetIndexName()
+	searchAttributes, err := h.saProvider.GetSearchAttributes(indexName, true)
+	if err != nil {
+		return nil, serviceerror.NewUnavailable(
+			fmt.Sprintf("unable to read custom search attributes: %v", err),
+		)
+	}
 
-	var lastErr error
-	var esMapping map[string]string = nil
-	if h.esClient != nil {
-		esMapping, lastErr = h.esClient.GetMapping(ctx, indexName)
-		if lastErr != nil {
-			lastErr = serviceerror.NewUnavailable(fmt.Sprintf("unable to get mapping from Elasticsearch: %v", lastErr))
+	var customSearchAttributes map[string]enumspb.IndexedValueType
+	var storageSchema map[string]string
+	if h.visibilityMgr.GetName() == elasticsearch.PersistenceName {
+		customSearchAttributes = searchAttributes.Custom()
+		if h.esClient != nil {
+			storageSchema, err = h.esClient.GetMapping(ctx, indexName)
+			if err != nil {
+				return nil, serviceerror.NewUnavailable(
+					fmt.Sprintf("unable to get mapping from Elasticsearch: %v", err),
+				)
+			}
+		}
+	} else {
+		nsName := request.GetNamespace()
+		if nsName == "" {
+			return nil, errNamespaceNotSet
+		}
+		ns, err := h.namespaceRegistry.GetNamespace(namespace.Name(nsName))
+		if err != nil {
+			return nil, serviceerror.NewUnavailable(
+				fmt.Sprintf(errUnableToGetNamespaceInfoMessage, nsName),
+			)
+		}
+		mapper := ns.CustomSearchAttributesMapper()
+		customSearchAttributes = make(map[string]enumspb.IndexedValueType)
+		for field, tp := range searchAttributes.Custom() {
+			if alias, err := mapper.GetAlias(field, nsName); err == nil {
+				customSearchAttributes[alias] = tp
+			}
 		}
 	}
 
-	searchAttributes, err := h.saProvider.GetSearchAttributes(indexName, true)
-	if err != nil {
-		lastErr = serviceerror.NewUnavailable(fmt.Sprintf("unable to read custom search attributes: %v", err))
-	}
-
-	if lastErr != nil {
-		return nil, lastErr
-	}
-
 	return &operatorservice.ListSearchAttributesResponse{
-		CustomAttributes: searchAttributes.Custom(),
+		CustomAttributes: customSearchAttributes,
 		SystemAttributes: searchAttributes.System(),
-		StorageSchema:    esMapping,
+		StorageSchema:    storageSchema,
 	}, nil
 }
 
-func (h *OperatorHandlerImpl) DeleteNamespace(ctx context.Context, request *operatorservice.DeleteNamespaceRequest) (_ *operatorservice.DeleteNamespaceResponse, retError error) {
+func (h *OperatorHandlerImpl) DeleteNamespace(
+	ctx context.Context,
+	request *operatorservice.DeleteNamespaceRequest,
+) (_ *operatorservice.DeleteNamespaceResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
 
 	scope, startTime := h.startRequestProfile(metrics.OperatorDeleteNamespaceScope)

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -46,6 +46,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
 	"go.temporal.io/server/common/resourcetest"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/testing/mocksdk"
@@ -195,6 +196,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes_NonEmptyIndexName() {
 	}
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
+	s.mockResource.VisibilityManager.EXPECT().GetName().Return(elasticsearch.PersistenceName).AnyTimes()
 	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
 	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
 	for _, testCase := range testCases {
@@ -252,6 +254,7 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes_EmptyIndexName() {
 	handler := s.handler
 	ctx := context.Background()
 
+	s.mockResource.VisibilityManager.EXPECT().GetName().Return(elasticsearch.PersistenceName).AnyTimes()
 	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
 	resp, err := handler.ListSearchAttributes(ctx, nil)
 	s.Error(err)
@@ -272,6 +275,7 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes_NonEmptyIndexName() {
 	ctx := context.Background()
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
+	s.mockResource.VisibilityManager.EXPECT().GetName().Return(elasticsearch.PersistenceName).AnyTimes()
 	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
 	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "random-index-name").Return(map[string]string{"col": "type"}, nil)
 	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil)
@@ -279,7 +283,6 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes_NonEmptyIndexName() {
 	s.NoError(err)
 	s.NotNil(resp)
 
-	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "random-index-name").Return(map[string]string{"col": "type"}, nil)
 	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.NameTypeMap{}, errors.New("random error"))
 	resp, err = handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
 	s.Error(err)
@@ -309,6 +312,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_EmptyIndexName() {
 		},
 	}
 
+	s.mockResource.VisibilityManager.EXPECT().GetName().Return(elasticsearch.PersistenceName).AnyTimes()
 	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
 	for _, testCase := range testCases1 {
 		s.T().Run(testCase.Name, func(t *testing.T) {
@@ -380,6 +384,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_NonEmptyIndexName() {
 	}
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
+	s.mockResource.VisibilityManager.EXPECT().GetName().Return(elasticsearch.PersistenceName).AnyTimes()
 	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
 	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
 	for _, testCase := range testCases {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2765,7 +2765,7 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, reques
 			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 		}
 		searchattribute.ApplyTypeMap(response.GetWorkflowExecutionInfo().GetSearchAttributes(), saTypeMap)
-		aliasedSas, err := searchattribute.AliasFields(wh.saMapper, response.GetWorkflowExecutionInfo().GetSearchAttributes(), request.GetNamespace())
+		aliasedSas, err := wh.saProvider.AliasFields(wh.saMapper, response.GetWorkflowExecutionInfo().GetSearchAttributes(), request.GetNamespace())
 		if err != nil {
 			return nil, err
 		}
@@ -3112,7 +3112,7 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 			return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 		}
 		searchattribute.ApplyTypeMap(sas, saTypeMap)
-		aliasedSas, err := searchattribute.AliasFields(wh.saMapper, sas, request.GetNamespace())
+		aliasedSas, err := wh.saProvider.AliasFields(wh.saMapper, sas, request.GetNamespace())
 		if err != nil {
 			return nil, err
 		}
@@ -3156,7 +3156,7 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 				return serviceerror.NewUnavailable(fmt.Sprintf(errUnableToGetSearchAttributesMessage, err))
 			}
 			searchattribute.ApplyTypeMap(sa, saTypeMap)
-			aliasedSas, err := searchattribute.AliasFields(wh.saMapper, sa, request.Namespace)
+			aliasedSas, err := wh.saProvider.AliasFields(wh.saMapper, sa, request.Namespace)
 			if err != nil {
 				return err
 			}
@@ -4259,7 +4259,7 @@ func (wh *WorkflowHandler) processOutgoingSearchAttributes(events []*historypb.H
 		}
 		if searchAttributes != nil {
 			searchattribute.ApplyTypeMap(searchAttributes, saTypeMap)
-			aliasedSas, err := searchattribute.AliasFields(wh.saMapper, searchAttributes, namespace.String())
+			aliasedSas, err := wh.saProvider.AliasFields(wh.saMapper, searchAttributes, namespace.String())
 			if err != nil {
 				return err
 			}
@@ -4877,7 +4877,7 @@ func getBatchOperationState(workflowState enumspb.WorkflowExecutionStatus) enums
 }
 
 func (wh *WorkflowHandler) unaliasStartWorkflowExecutionRequestSearchAttributes(request *workflowservice.StartWorkflowExecutionRequest, namespaceName namespace.Name) (*workflowservice.StartWorkflowExecutionRequest, error) {
-	unaliasedSas, err := searchattribute.UnaliasFields(wh.saMapper, request.GetSearchAttributes(), namespaceName.String())
+	unaliasedSas, err := wh.saProvider.UnaliasFields(wh.saMapper, request.GetSearchAttributes(), namespaceName.String())
 	if err != nil {
 		return nil, err
 	}
@@ -4892,7 +4892,7 @@ func (wh *WorkflowHandler) unaliasStartWorkflowExecutionRequestSearchAttributes(
 }
 
 func (wh *WorkflowHandler) unaliasSignalWithStartWorkflowExecutionRequestSearchAttributes(request *workflowservice.SignalWithStartWorkflowExecutionRequest, namespaceName namespace.Name) (*workflowservice.SignalWithStartWorkflowExecutionRequest, error) {
-	unaliasedSas, err := searchattribute.UnaliasFields(wh.saMapper, request.GetSearchAttributes(), namespaceName.String())
+	unaliasedSas, err := wh.saProvider.UnaliasFields(wh.saMapper, request.GetSearchAttributes(), namespaceName.String())
 	if err != nil {
 		return nil, err
 	}
@@ -4907,13 +4907,13 @@ func (wh *WorkflowHandler) unaliasSignalWithStartWorkflowExecutionRequestSearchA
 }
 
 func (wh *WorkflowHandler) unaliasCreateScheduleRequestSearchAttributes(request *workflowservice.CreateScheduleRequest, namespaceName namespace.Name) (*workflowservice.CreateScheduleRequest, error) {
-	unaliasedSas, err := searchattribute.UnaliasFields(wh.saMapper, request.GetSearchAttributes(), namespaceName.String())
+	unaliasedSas, err := wh.saProvider.UnaliasFields(wh.saMapper, request.GetSearchAttributes(), namespaceName.String())
 	if err != nil {
 		return nil, err
 	}
 
 	startWorkflow := request.GetSchedule().GetAction().GetStartWorkflow()
-	unaliasedStartWorkflowSas, err := searchattribute.UnaliasFields(wh.saMapper, startWorkflow.GetSearchAttributes(), namespaceName.String())
+	unaliasedStartWorkflowSas, err := wh.saProvider.UnaliasFields(wh.saMapper, startWorkflow.GetSearchAttributes(), namespaceName.String())
 	if err != nil {
 		return nil, err
 	}
@@ -4949,7 +4949,7 @@ func (wh *WorkflowHandler) unaliasUpdateScheduleRequestStartWorkflowSearchAttrib
 		return request, nil
 	}
 
-	unaliasedSas, err := searchattribute.UnaliasFields(wh.saMapper, startWorkflow.GetSearchAttributes(), namespaceName.String())
+	unaliasedSas, err := wh.saProvider.UnaliasFields(wh.saMapper, startWorkflow.GetSearchAttributes(), namespaceName.String())
 	if err != nil {
 		return nil, err
 	}

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -160,6 +160,25 @@ func (s *workflowHandlerSuite) SetupTest() {
 
 	mockMonitor := s.mockResource.MembershipMonitor
 	mockMonitor.EXPECT().GetMemberCount(primitives.FrontendService).Return(5, nil).AnyTimes()
+
+	s.mockSearchAttributesProvider.EXPECT().AliasFields(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			mapper searchattribute.Mapper,
+			searchAttributes *commonpb.SearchAttributes,
+			namespace string,
+		) (*commonpb.SearchAttributes, error) {
+			return searchattribute.AliasFields(s.mockSearchAttributesMapper, searchAttributes, namespace)
+		},
+	).AnyTimes()
+	s.mockSearchAttributesProvider.EXPECT().UnaliasFields(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			mapper searchattribute.Mapper,
+			searchAttributes *commonpb.SearchAttributes,
+			namespace string,
+		) (*commonpb.SearchAttributes, error) {
+			return searchattribute.AliasFields(s.mockSearchAttributesMapper, searchAttributes, namespace)
+		},
+	).AnyTimes()
 }
 
 func (s *workflowHandlerSuite) TearDownTest() {

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -84,6 +84,7 @@ type (
 		logger                     log.Logger
 		throttledLogger            log.Logger
 		commandAttrValidator       *commandAttrValidator
+		searchAttributesProvider   searchattribute.Provider
 		searchAttributesMapper     searchattribute.Mapper
 		searchAttributesValidator  *searchattribute.Validator
 	}
@@ -106,6 +107,7 @@ func newWorkflowTaskHandlerCallback(historyEngine *historyEngineImpl) *workflowT
 			historyEngine.config,
 			historyEngine.searchAttributesValidator,
 		),
+		searchAttributesProvider:  historyEngine.shard.GetSearchAttributesProvider(),
 		searchAttributesMapper:    historyEngine.shard.GetSearchAttributesMapper(),
 		searchAttributesValidator: historyEngine.searchAttributesValidator,
 	}
@@ -479,6 +481,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			handler.metricsHandler,
 			handler.config,
 			handler.shard,
+			handler.searchAttributesProvider,
 			handler.searchAttributesMapper,
 			hasBufferedEvents,
 		)

--- a/tests/integrationbase.go
+++ b/tests/integrationbase.go
@@ -115,15 +115,7 @@ func (s *IntegrationBase) setupSuite(defaultClusterConfigFile string) {
 		s.Require().NoError(s.registerArchivalNamespace(s.archivalNamespace))
 	}
 
-	if clusterConfig.FrontendAddress == "" {
-		// Poke all the in-process namespace caches to refresh without waiting for the usual refresh interval.
-		s.testCluster.RefreshNamespaceCache()
-	} else {
-		// Wait for one whole cycle of the namespace cache v2 refresh interval to be sure that our namespaces are loaded.
-		// We are using real server so we don't know what cache refresh interval it uses. Fall back to the 10s old value.
-		serverCacheRefreshInterval := 10 * time.Second
-		time.Sleep(serverCacheRefreshInterval + time.Second)
-	}
+	s.refreshNamespaceCache()
 }
 
 // setupLogger sets the Logger for the test suite.
@@ -178,6 +170,18 @@ func (s *IntegrationBase) tearDownSuite() {
 	s.adminClient = nil
 }
 
+func (s *IntegrationBase) refreshNamespaceCache() {
+	if s.testClusterConfig.FrontendAddress == "" {
+		// Poke all the in-process namespace caches to refresh without waiting for the usual refresh interval.
+		s.testCluster.RefreshNamespaceCache()
+	} else {
+		// Wait for one whole cycle of the namespace cache v2 refresh interval to be sure that our namespaces are loaded.
+		// We are using real server so we don't know what cache refresh interval it uses. Fall back to the 10s old value.
+		serverCacheRefreshInterval := 10 * time.Second
+		time.Sleep(serverCacheRefreshInterval + time.Second)
+	}
+}
+
 func (s *IntegrationBase) registerNamespace(
 	namespace string,
 	retention time.Duration,
@@ -197,7 +201,25 @@ func (s *IntegrationBase) registerNamespace(
 		VisibilityArchivalState:          visibilityArchivalState,
 		VisibilityArchivalUri:            visibilityArchivalURI,
 	})
-
+	if err != nil {
+		return err
+	}
+	// Set up default alias for custom search attributes.
+	// Need to refresh namespace cache first to find the namespace.
+	s.refreshNamespaceCache()
+	_, err = s.engine.UpdateNamespace(ctx, &workflowservice.UpdateNamespaceRequest{
+		Namespace: namespace,
+		Config: &namespacepb.NamespaceConfig{
+			CustomSearchAttributesAlias: map[string]string{
+				"Bool01":     "CustomBoolField",
+				"Datetime01": "CustomDatetimeField",
+				"Double01":   "CustomDoubleField",
+				"Int01":      "CustomIntField",
+				"Keyword01":  "CustomKeywordField",
+				"Text01":     "CustomTextField",
+			},
+		},
+	})
 	return err
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Created a backwards compatible mapper to handle the case which the user registered custom search attributes using standard visibility (check if defined in the empty string index name key in cluster metadata).
2. Added search attributes alias mapper to namespace registry.
3. Added to search attribute provider functions `AliasFields` and `UnaliasFields`, and refactored the code to call them instead of the top-level functions in `searchattribute` module. The new functions take an optional mapper parameter to be used instead of the default one (this is to be compatible with user defined mappers).
4. For ES, use the identity mapper as default mapper.

<!-- Tell your future self why have you made these changes -->
**Why?**
Support for advanced visibility with SQL DB: implement default mapper, backward compatibility, and support user defined mappers.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Running existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
For cases not using custom search attributes, it won't make any difference.
For ES, it will use identity mapper.
For SQL, the `backCompMapper_v1_20` should handle mapping correctly.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.