### PR TITLE
Conditionally register archival category

### DIFF
--- a/service/history/queue_factory_base_test.go
+++ b/service/history/queue_factory_base_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
 
@@ -45,6 +46,7 @@ import (
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/service/history/archival"
 	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/worker/archiver"
 )
@@ -93,7 +95,7 @@ type moduleTestCase struct {
 
 // Run runs the test case.
 func (c *moduleTestCase) Run(t *testing.T) {
-	t.Parallel()
+
 	controller := gomock.NewController(t)
 	dependencies := getModuleDependencies(controller, c)
 	var factories []QueueFactory
@@ -135,8 +137,10 @@ func (c *moduleTestCase) Run(t *testing.T) {
 	require.NotNil(t, viq)
 	if c.ExpectArchivalQueue {
 		require.NotNil(t, aq)
+		assert.Contains(t, tasks.GetCategories(), tasks.CategoryIDArchival)
 	} else {
 		require.Nil(t, aq)
+		assert.NotContains(t, tasks.GetCategories(), tasks.CategoryIDArchival)
 	}
 }
 

--- a/service/history/tasks/category.go
+++ b/service/history/tasks/category.go
@@ -145,6 +145,14 @@ func GetCategories() map[int32]Category {
 	return maps.Clone(categories.m)
 }
 
+// RemoveCategory removes a registered Category.
+// This should only be used for testing.
+func RemoveCategory(id int32) {
+	categories.Lock()
+	defer categories.Unlock()
+	delete(categories.m, id)
+}
+
 // GetCategoryByID returns a registered Category with the same ID
 func GetCategoryByID(id int32) (Category, bool) {
 	categories.RLock()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now only register the archival category when archival is enabled.

<!-- Tell your future self why have you made these changes -->
**Why?**
Because if this category exists when the archival queue processor isn't running, our code will panic when NotifyNewTasks is run.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added an assertion in a unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This may interfere with tiered storage.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No