### PR TITLE
Add metrics + max buffer size to schedule workflow

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1311,6 +1311,12 @@ const (
 	TaskTypeTimerStandbyTaskDeleteHistoryEvent     = "TimerStandbyTaskDeleteHistoryEvent"
 )
 
+// Schedule action types
+const (
+	ScheduleActionTypeTag       = "schedule_action"
+	ScheduleActionStartWorkflow = "start_workflow"
+)
+
 var (
 	ServiceRequests                               = NewCounterDef("service_requests")
 	ServicePendingRequests                        = NewGaugeDef("service_pending_requests")
@@ -1703,6 +1709,13 @@ var (
 	NamespaceReplicationEnqueueDLQCount                       = NewCounterDef("namespace_replication_dlq_enqueue_requests")
 	ParentClosePolicyProcessorSuccess                         = NewCounterDef("parent_close_policy_processor_requests")
 	ParentClosePolicyProcessorFailures                        = NewCounterDef("parent_close_policy_processor_errors")
+	ScheduleMissedCatchupWindow                               = NewCounterDef("schedule_missed_catchup_window")
+	ScheduleRateLimited                                       = NewCounterDef("schedule_rate_limited")
+	ScheduleBufferOverruns                                    = NewCounterDef("schedule_buffer_overruns")
+	ScheduleActionSuccess                                     = NewCounterDef("schedule_action_success")
+	ScheduleActionErrors                                      = NewCounterDef("schedule_action_errors")
+	ScheduleCancelWorkflowErrors                              = NewCounterDef("schedule_cancel_workflow_errors")
+	ScheduleTerminateWorkflowErrors                           = NewCounterDef("schedule_terminate_workflow_errors")
 
 	// Replication
 	NamespaceReplicationTaskAckLevelGauge = NewGaugeDef("namespace_replication_task_ack_level")


### PR DESCRIPTION
**What changed?**
- Add some metrics to scheduler workflow
- Add max buffer size to prevent it from growing indefinitely
- Reduce some log levels
- Include namespace in logs

**Why?**
Observability

**How did you test it?**
existing tests, mostly just adding metrics

**Potential risks**


**Is hotfix candidate?**
