### PR TITLE
Implement default mapper for SQL visibility

### DIFF
--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -165,9 +165,15 @@ func TimeSourceProvider() clock.TimeSource {
 
 func SearchAttributeMapperProviderProvider(
 	saMapper searchattribute.Mapper,
+	namespaceRegistry namespace.Registry,
+	searchAttributeProvider searchattribute.Provider,
+	persistenceConfig *config.Persistence,
 ) searchattribute.MapperProvider {
 	return searchattribute.NewMapperProvider(
 		saMapper,
+		namespaceRegistry,
+		searchAttributeProvider,
+		persistenceConfig.IsSQLVisibilityStore(),
 	)
 }
 

--- a/common/searchattribute/test_provider.go
+++ b/common/searchattribute/test_provider.go
@@ -51,6 +51,13 @@ var (
 			"CustomDatetimeField": enumspb.INDEXED_VALUE_TYPE_DATETIME,
 			"CustomDoubleField":   enumspb.INDEXED_VALUE_TYPE_DOUBLE,
 			"CustomBoolField":     enumspb.INDEXED_VALUE_TYPE_BOOL,
+
+			"Int01":      enumspb.INDEXED_VALUE_TYPE_INT,
+			"Text01":     enumspb.INDEXED_VALUE_TYPE_TEXT,
+			"Keyword01":  enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"Datetime01": enumspb.INDEXED_VALUE_TYPE_DATETIME,
+			"Double01":   enumspb.INDEXED_VALUE_TYPE_DOUBLE,
+			"Bool01":     enumspb.INDEXED_VALUE_TYPE_BOOL,
 		},
 	}
 )
@@ -102,5 +109,5 @@ func (t *TestMapper) GetFieldName(alias string, namespace string) (string, error
 }
 
 func NewTestMapperProvider(customMapper Mapper) MapperProvider {
-	return NewMapperProvider(customMapper)
+	return NewMapperProvider(customMapper, nil, NewTestProvider(), false)
 }

--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -92,6 +92,10 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		)
 	}
 
+	// TODO (rodrigozhou): this is to be backwards compatible with custom search attributes
+	// registered before v1.20. Ignoring error as this key might not exist.
+	emptyStringSaTypeMap, _ := v.searchAttributesProvider.GetSearchAttributes("", false)
+
 	for saFieldName, saPayload := range searchAttributes.GetIndexedFields() {
 		// user search attribute cannot be a system search attribute
 		if _, err = saTypeMap.getType(saFieldName, systemCategory); err == nil {
@@ -101,6 +105,9 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		}
 
 		saType, err := saTypeMap.getType(saFieldName, customCategory|predefinedCategory)
+		if err != nil {
+			saType, err = emptyStringSaTypeMap.getType(saFieldName, customCategory)
+		}
 		if err != nil {
 			if errors.Is(err, ErrInvalidName) {
 				return v.validationError(

--- a/develop/buildkite/docker-compose.yml
+++ b/develop/buildkite/docker-compose.yml
@@ -137,6 +137,33 @@ services:
         aliases:
           - integration-test
 
+  integration-test-mysql8:
+    build:
+      context: ../..
+      dockerfile: ./develop/buildkite/Dockerfile
+    environment:
+      - "MYSQL_SEEDS=mysql"
+      - "ES_SEEDS=elasticsearch"
+      - "ES_VERSION=v7"
+      - "PERSISTENCE_TYPE=sql"
+      - "PERSISTENCE_DRIVER=mysql8"
+      - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+    depends_on:
+      - mysql
+      - elasticsearch
+    volumes:
+      - ../..:/temporal
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+    networks:
+      services-network:
+        aliases:
+          - integration-test
+
   integration-test-postgresql:
     build:
       context: ../..
@@ -147,6 +174,33 @@ services:
       - "ES_VERSION=v7"
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_DRIVER=postgres"
+      - "TEST_TAG=esintegration"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+    depends_on:
+      - postgresql
+      - elasticsearch
+    volumes:
+      - ../..:/temporal
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+    networks:
+      services-network:
+        aliases:
+          - integration-test
+
+  integration-test-postgresql12:
+    build:
+      context: ../..
+      dockerfile: ./develop/buildkite/Dockerfile
+    environment:
+      - "POSTGRES_SEEDS=postgresql"
+      - "ES_SEEDS=elasticsearch"
+      - "ES_VERSION=v7"
+      - "PERSISTENCE_TYPE=sql"
+      - "PERSISTENCE_DRIVER=postgres12"
       - "TEST_TAG=esintegration"
       - "TEMPORAL_VERSION_CHECK_DISABLED=1"
       - BUILDKITE_AGENT_ACCESS_TOKEN
@@ -240,6 +294,34 @@ services:
         aliases:
           - integration-test-xdc
 
+  integration-test-xdc-mysql8:
+    build:
+      context: ../..
+      dockerfile: ./develop/buildkite/Dockerfile
+    environment:
+      - "MYSQL_SEEDS=mysql"
+      - "ES_SEEDS=elasticsearch"
+      - "ES_VERSION=v7"
+      - "PERSISTENCE_TYPE=sql"
+      - "PERSISTENCE_DRIVER=mysql8"
+      - "TEST_TAG=esintegration"
+      - "TEST_RUN_COUNT=10"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+    depends_on:
+      - mysql
+      - elasticsearch
+    volumes:
+      - ../..:/temporal
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+    networks:
+      services-network:
+        aliases:
+          - integration-test-xdc
+
   integration-test-xdc-postgresql:
     build:
       context: ../..
@@ -250,6 +332,34 @@ services:
       - "ES_VERSION=v7"
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_DRIVER=postgres"
+      - "TEST_TAG=esintegration"
+      - "TEST_RUN_COUNT=10"
+      - "TEMPORAL_VERSION_CHECK_DISABLED=1"
+      - BUILDKITE_AGENT_ACCESS_TOKEN
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_ID
+      - BUILDKITE_BUILD_NUMBER
+    depends_on:
+      - postgresql
+      - elasticsearch
+    volumes:
+      - ../..:/temporal
+      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
+    networks:
+      services-network:
+        aliases:
+          - integration-test-xdc
+
+  integration-test-xdc-postgresql12:
+    build:
+      context: ../..
+      dockerfile: ./develop/buildkite/Dockerfile
+    environment:
+      - "POSTGRES_SEEDS=postgresql"
+      - "ES_SEEDS=elasticsearch"
+      - "ES_VERSION=v7"
+      - "PERSISTENCE_TYPE=sql"
+      - "PERSISTENCE_DRIVER=postgres12"
       - "TEST_TAG=esintegration"
       - "TEST_RUN_COUNT=10"
       - "TEMPORAL_VERSION_CHECK_DISABLED=1"

--- a/develop/buildkite/pipeline.yml
+++ b/develop/buildkite/pipeline.yml
@@ -140,6 +140,51 @@ steps:
           run: integration-test-xdc-mysql
           config: ./develop/buildkite/docker-compose.yml
 
+  - label: ":golang: functional test with mysql 8"
+    agents:
+      queue: "default"
+      docker: "*"
+    command: "make functional-test-coverage"
+    artifact_paths:
+      - ".coverage/*.out"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - docker-compose#v3.8.0:
+          run: integration-test-mysql8
+          config: ./develop/buildkite/docker-compose.yml
+
+  - label: ":golang: functional xdc test with mysql 8"
+    agents:
+      queue: "default"
+      docker: "*"
+    command: "make functional-test-xdc-coverage"
+    artifact_paths:
+      - ".coverage/*.out"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - docker-compose#v3.8.0:
+          run: integration-test-xdc-mysql8
+          config: ./develop/buildkite/docker-compose.yml
+
+  - label: ":golang: functional ndc test with mysql 8"
+    agents:
+      queue: "default"
+      docker: "*"
+    command: "make functional-test-ndc-coverage"
+    artifact_paths:
+      - ".coverage/*.out"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - docker-compose#v3.8.0:
+          run: integration-test-xdc-mysql8
+          config: ./develop/buildkite/docker-compose.yml
+
   - label: ":golang: functional test with postgresql"
     agents:
       queue: "default"
@@ -183,6 +228,51 @@ steps:
     plugins:
       - docker-compose#v3.8.0:
           run: integration-test-xdc-postgresql
+          config: ./develop/buildkite/docker-compose.yml
+
+  - label: ":golang: functional test with postgresql 12"
+    agents:
+      queue: "default"
+      docker: "*"
+    command: "make functional-test-coverage"
+    artifact_paths:
+      - ".coverage/*.out"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - docker-compose#v3.8.0:
+          run: integration-test-postgresql12
+          config: ./develop/buildkite/docker-compose.yml
+
+  - label: ":golang: functional xdc test with postgresql 12"
+    agents:
+      queue: "default"
+      docker: "*"
+    command: "make functional-test-xdc-coverage"
+    artifact_paths:
+      - ".coverage/*.out"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - docker-compose#v3.8.0:
+          run: integration-test-xdc-postgresql12
+          config: ./develop/buildkite/docker-compose.yml
+
+  - label: ":golang: functional ndc test with postgresql 12"
+    agents:
+      queue: "default"
+      docker: "*"
+    command: "make functional-test-ndc-coverage"
+    artifact_paths:
+      - ".coverage/*.out"
+    retry:
+      automatic:
+        limit: 1
+    plugins:
+      - docker-compose#v3.8.0:
+          run: integration-test-xdc-postgresql12
           config: ./develop/buildkite/docker-compose.yml
 
   - label: ":golang: functional test with sqlite"

--- a/develop/buildkite/scripts/coverage-report.sh
+++ b/develop/buildkite/scripts/coverage-report.sh
@@ -20,10 +20,20 @@ buildkite-agent artifact download ".coverage/functional_mysql_coverprofile.out" 
 buildkite-agent artifact download ".coverage/functional_xdc_mysql_coverprofile.out" . --step ":golang: functional xdc test with mysql" --build "${BUILDKITE_BUILD_ID}"
 buildkite-agent artifact download ".coverage/functional_ndc_mysql_coverprofile.out" . --step ":golang: functional ndc test with mysql" --build "${BUILDKITE_BUILD_ID}"
 
+# MySQL 8.
+buildkite-agent artifact download ".coverage/functional_mysql8_coverprofile.out" . --step ":golang: functional test with mysql 8" --build "${BUILDKITE_BUILD_ID}"
+buildkite-agent artifact download ".coverage/functional_xdc_mysql8_coverprofile.out" . --step ":golang: functional xdc test with mysql 8" --build "${BUILDKITE_BUILD_ID}"
+buildkite-agent artifact download ".coverage/functional_ndc_mysql8_coverprofile.out" . --step ":golang: functional ndc test with mysql 8" --build "${BUILDKITE_BUILD_ID}"
+
 # PostgreSQL.
 buildkite-agent artifact download ".coverage/functional_postgres_coverprofile.out" . --step ":golang: functional test with postgresql" --build "${BUILDKITE_BUILD_ID}"
 buildkite-agent artifact download ".coverage/functional_xdc_postgres_coverprofile.out" . --step ":golang: functional xdc test with postgresql" --build "${BUILDKITE_BUILD_ID}"
 buildkite-agent artifact download ".coverage/functional_ndc_postgres_coverprofile.out" . --step ":golang: functional ndc test with postgresql" --build "${BUILDKITE_BUILD_ID}"
+
+# PostgreSQL 12.
+buildkite-agent artifact download ".coverage/functional_postgres12_coverprofile.out" . --step ":golang: functional test with postgresql 12" --build "${BUILDKITE_BUILD_ID}"
+buildkite-agent artifact download ".coverage/functional_xdc_postgres12_coverprofile.out" . --step ":golang: functional xdc test with postgresql 12" --build "${BUILDKITE_BUILD_ID}"
+buildkite-agent artifact download ".coverage/functional_ndc_postgres12_coverprofile.out" . --step ":golang: functional ndc test with postgresql 12" --build "${BUILDKITE_BUILD_ID}"
 
 # SQLite.
 buildkite-agent artifact download ".coverage/functional_sqlite_coverprofile.out" . --step ":golang: functional test with sqlite" --build "${BUILDKITE_BUILD_ID}"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated `searchattribute.MapperProvider` to support the mapper from namespace config.
Created wrapper mapper to be backwards compatible with custom search attributes registered while using SQL DB.
Added integration tests using mysql8 and postgres12 plugins.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is the default mapper when using SQL DB for advanced visibility.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit tests. Needs more tests to cover new case, but postponing to another PR.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.