### PR TITLE
Merge custom search attributes from index name with empty string key

### DIFF
--- a/common/searchattribute/validator.go
+++ b/common/searchattribute/validator.go
@@ -92,10 +92,6 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		)
 	}
 
-	// TODO (rodrigozhou): this is to be backwards compatible with custom search attributes
-	// registered before v1.20. Ignoring error as this key might not exist.
-	emptyStringSaTypeMap, _ := v.searchAttributesProvider.GetSearchAttributes("", false)
-
 	for saFieldName, saPayload := range searchAttributes.GetIndexedFields() {
 		// user search attribute cannot be a system search attribute
 		if _, err = saTypeMap.getType(saFieldName, systemCategory); err == nil {
@@ -105,9 +101,6 @@ func (v *Validator) Validate(searchAttributes *commonpb.SearchAttributes, namesp
 		}
 
 		saType, err := saTypeMap.getType(saFieldName, customCategory|predefinedCategory)
-		if err != nil {
-			saType, err = emptyStringSaTypeMap.getType(saFieldName, customCategory)
-		}
 		if err != nil {
 			if errors.Is(err, ErrInvalidName) {
 				return v.validationError(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Merge custom search attributes from the index name key with the empty string key in `searchattribute.Manager.GetSearchAttributes`.

<!-- Tell your future self why have you made these changes -->
**Why?**
There was a check to handle it in the search attribute validator, but there are many more calls to `GetSearchAttributes` in the codebase. In order for than to be backwards compatible, I'm merging with the contents in the empty string key.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Unlikely to have issue. The new index name key should be empty, so merging with the contents in the empty string key should be no-op.
One situation that might have issue is if the user is using Elasticsearch and there's the empty string key in cluster metadata. This might lead to unexpected results.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.