### PR TITLE
Add MySQL 8 admin interface

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/admin_v8.go
+++ b/common/persistence/sql/sqlplugin/mysql/admin_v8.go
@@ -1,0 +1,39 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mysql
+
+import (
+	"fmt"
+)
+
+const (
+	// NOTE: we have to use %v because somehow mysql doesn't work with ? here
+	createDatabaseQuery_v8 = "CREATE DATABASE IF NOT EXISTS %v CHARACTER SET utf8mb4"
+)
+
+// CreateDatabase creates a database if it doesn't exist
+func (mdb *dbV8) CreateDatabase(name string) error {
+	return mdb.Exec(fmt.Sprintf(createDatabaseQuery_v8, name))
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add MySQL 8 admin overwriting `create_database` to create using the standard MySQL 8 charset.

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, it's using the MySQL 5.7, which uses old utf8 charset.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.