### PR TITLE
Fix docker config template to set only one visibility

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -5,10 +5,11 @@ log:
 persistence:
     numHistoryShards: {{ default .Env.NUM_HISTORY_SHARDS "4" }}
     defaultStore: default
-    visibilityStore: visibility
     {{- $es := default .Env.ENABLE_ES "false" | lower -}}
     {{- if eq $es "true" }}
     advancedVisibilityStore: es-visibility
+    {{- else }}
+    visibilityStore: visibility
     {{- end }}
     datastores:
         {{- $db := default .Env.DB "cassandra" | lower -}}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix docker config template to set up only one visibility store.

<!-- Tell your future self why have you made these changes -->
**Why?**
Having both standard and advanced visibility store configs make the Server to set up dual visibility store, which messes up with search attributes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Build docker images, ran it, and checked logs.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.