### PR TITLE
Fix fail of speculative workflow task

### DIFF
--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -1017,8 +1017,9 @@ func (s *engine2Suite) TestRespondWorkflowTaskCompleted_StartChildWorkflow_Excee
 	})
 
 	s.Error(err)
-	s.Assert().Equal([]string{"the number of pending child workflow executions, 5, has reached the per-workflow" +
-		" limit of 5"}, s.errorMessages)
+	s.IsType(&serviceerror.InvalidArgument{}, err)
+	s.Len(s.errorMessages, 1)
+	s.Equal("the number of pending child workflow executions, 5, has reached the per-workflow limit of 5", s.errorMessages[0])
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_BrandNew() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix fail of speculative workflow task. If speculative workflow task is failing, corresponding WTScheduled and WTStarted events are added (similar to WTCompleted), and next workflow task is created as transient.

<!-- Tell your future self why have you made these changes -->
**Why?**
Consistency with normal workflow task.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.