### PR TITLE
Remove search attributes with nil values

### DIFF
--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -488,6 +488,10 @@ func (s *VisibilityStore) prepareSearchAttributesForDb(
 	}
 
 	for name, value := range searchAttributes {
+		if value == nil {
+			delete(searchAttributes, name)
+			continue
+		}
 		tp, err := saTypeMap.GetType(name)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove search attributes keys with nil values.

<!-- Tell your future self why have you made these changes -->
**Why?**
Search attributes with nil values is the syntax to remove them. In practice, it just remove from the persistence map (ie., it won't store {"key": null} for example). Other than that, it was already working as expected.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Launched server, ran workflow to set search attribute, and then set to nil or empty list. Checked the database to confirm the keys are not there.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.