### PR TITLE
Bugfix: conditional variable broadcast channel size

### DIFF
--- a/common/locks/condition_variable_impl.go
+++ b/common/locks/condition_variable_impl.go
@@ -46,7 +46,7 @@ func NewConditionVariable(
 		lock: lock,
 
 		chanLock: sync.Mutex{},
-		channel:  make(chan struct{}, 1),
+		channel:  newCVChannel(),
 	}
 }
 
@@ -64,7 +64,7 @@ func (c *ConditionVariableImpl) Signal() {
 
 // Broadcast wakes all goroutines waiting on this condition variable.
 func (c *ConditionVariableImpl) Broadcast() {
-	newChannel := make(chan struct{})
+	newChannel := newCVChannel()
 
 	c.chanLock.Lock()
 	defer c.chanLock.Unlock()
@@ -103,4 +103,8 @@ func (c *ConditionVariableImpl) Wait(
 	case <-interrupt:
 		// interrupted
 	}
+}
+
+func newCVChannel() chan struct{} {
+	return make(chan struct{}, 1)
 }

--- a/common/locks/condition_variable_test.go
+++ b/common/locks/condition_variable_test.go
@@ -40,7 +40,7 @@ type (
 		suite.Suite
 
 		lock sync.Locker
-		cv   ConditionVariable
+		cv   *ConditionVariableImpl
 	}
 )
 
@@ -65,6 +65,34 @@ func (s *conditionVariableSuite) SetupTest() {
 
 func (s *conditionVariableSuite) TearDownTest() {
 
+}
+
+func (s *conditionVariableSuite) TestChannelSize_New() {
+	s.testChannelSize(s.cv.channel)
+}
+
+func (s *conditionVariableSuite) TestChannelSize_Broadcast() {
+	s.cv.Broadcast()
+	s.testChannelSize(s.cv.channel)
+}
+
+func (s *conditionVariableSuite) testChannelSize(
+	channel chan struct{},
+) {
+	// assert channel size == 1
+	select {
+	case channel <- struct{}{}:
+		// noop
+	default:
+		s.Fail("conditional variable size should be 1")
+	}
+
+	select {
+	case channel <- struct{}{}:
+		s.Fail("conditional variable size should be 1")
+	default:
+		// noop
+	}
 }
 
 func (s *conditionVariableSuite) TestSignal() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Conditional variable broadcast function should create channel with size 1, not 0

<!-- Tell your future self why have you made these changes -->
**Why?**
0 size channel does not guarantee ordering

when the conditional is initialized, [the signal channel is correctly initialized with size 1](https://github.com/temporalio/temporal/blob/v1.19.0/common/locks/condition_variable_impl.go#L49)
however (the bug) [incorrectly re-initialized the signal channel with size 0](https://github.com/temporalio/temporal/blob/v1.19.0/common/locks/condition_variable_impl.go#L67)
when a coroutine waits for notification, there is a time gap & lock gap between [accessing the signal channel](https://github.com/temporalio/temporal/blob/v1.19.0/common/locks/condition_variable_impl.go#L84) and [selecting on the signal channel](https://github.com/temporalio/temporal/blob/v1.19.0/common/locks/condition_variable_impl.go#L101)
so signal delivered during the above gap can be dropped

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Loop go test -race && UT
```zsh
temporal|bugfix-broadcast ⇒ while true; do go test -timeout=24s -race -count=128 ./common/locks -run ^TestConditionVariableSuite$ -testify.m TestCase_ProducerConsumer; done
ok  	go.temporal.io/server/common/locks	16.358s
ok  	go.temporal.io/server/common/locks	16.246s
ok  	go.temporal.io/server/common/locks	16.822s
ok  	go.temporal.io/server/common/locks	16.794s
ok  	go.temporal.io/server/common/locks	16.939s
ok  	go.temporal.io/server/common/locks	16.488s
ok  	go.temporal.io/server/common/locks	16.330s
ok  	go.temporal.io/server/common/locks	16.996s
ok  	go.temporal.io/server/common/locks	16.890s
ok  	go.temporal.io/server/common/locks	16.540s
ok  	go.temporal.io/server/common/locks	16.594s
ok  	go.temporal.io/server/common/locks	16.265s
ok  	go.temporal.io/server/common/locks	16.357s
ok  	go.temporal.io/server/common/locks	16.696s
ok  	go.temporal.io/server/common/locks	17.341s
ok  	go.temporal.io/server/common/locks	16.577s
ok  	go.temporal.io/server/common/locks	16.688s
ok  	go.temporal.io/server/common/locks	17.062s
ok  	go.temporal.io/server/common/locks	16.724s
ok  	go.temporal.io/server/common/locks	17.180s
ok  	go.temporal.io/server/common/locks	16.966s
ok  	go.temporal.io/server/common/locks	17.273s
ok  	go.temporal.io/server/common/locks	17.278s
ok  	go.temporal.io/server/common/locks	17.191s
ok  	go.temporal.io/server/common/locks	17.747s
ok  	go.temporal.io/server/common/locks	17.489s
ok  	go.temporal.io/server/common/locks	17.556s
ok  	go.temporal.io/server/common/locks	17.292s
ok  	go.temporal.io/server/common/locks	16.914s
ok  	go.temporal.io/server/common/locks	16.687s
ok  	go.temporal.io/server/common/locks	16.700s
ok  	go.temporal.io/server/common/locks	16.817s
ok  	go.temporal.io/server/common/locks	17.129s
ok  	go.temporal.io/server/common/locks	16.757s
ok  	go.temporal.io/server/common/locks	17.299s
ok  	go.temporal.io/server/common/locks	17.389s
ok  	go.temporal.io/server/common/locks	17.355s
ok  	go.temporal.io/server/common/locks	17.013s
ok  	go.temporal.io/server/common/locks	16.998s
ok  	go.temporal.io/server/common/locks	17.156s
ok  	go.temporal.io/server/common/locks	16.782s
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No, broadcast function implemented but not used in production logic