### PR TITLE
Fix MySQL visibility select query

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter_mysql.go
+++ b/common/persistence/visibility/store/sql/query_converter_mysql.go
@@ -223,7 +223,7 @@ func (c *mysqlQueryConverter) buildSelectStmt(
 	return fmt.Sprintf(
 		`SELECT %s
 		FROM executions_visibility ev
-		INNER JOIN custom_search_attributes
+		LEFT JOIN custom_search_attributes
 		USING (%s, %s)
 		WHERE %s
 		ORDER BY %s DESC, %s DESC, %s


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
MySQL select query for visibility change to do `LEFT JOIN` instead of `INNER JOIN`.

<!-- Tell your future self why have you made these changes -->
**Why?**
For backward compatibility, old workflows won't have a corresponding row in `custom_search_attributes` table, but they are valid workflows. Doing a left join makes sure that all executions are listed correctly.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started Server using standard visibility, created workflows, upgraded DB schema to support advanced visibility, and restarted Server. Open UI to list all workflows, and now it's listing everything.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.