### PR TITLE
Use max join time as start timeout

### DIFF
--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -40,6 +40,7 @@ import (
 	persistenceClient "go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/resource"
+	"go.temporal.io/server/common/util"
 )
 
 type (
@@ -148,7 +149,7 @@ func (s *ServerImpl) Stop() error {
 func (s *ServerImpl) startServices() error {
 	// The membership join time may exceed the configured max join duration.
 	// Double the service start timeout to make sure there is enough time for start logic.
-	timeout := util.Max(serviceStartTimeout, 2 * s.so.config.Global.Membership.MaxJoinDuration)
+	timeout := util.Max(serviceStartTimeout, 2*s.so.config.Global.Membership.MaxJoinDuration)
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	results := make(chan startServiceResult, len(s.servicesMetadata))

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -146,8 +146,9 @@ func (s *ServerImpl) Stop() error {
 }
 
 func (s *ServerImpl) startServices() error {
-	serviceStartMaxTimeout := 3 * s.so.config.Global.Membership.MaxJoinDuration
-
+	// The membership join time may exceed the configured max join duration.
+	// Double the service start timeout to make sure there is enough time for start logic.
+	serviceStartMaxTimeout := 2 * s.so.config.Global.Membership.MaxJoinDuration
 	if serviceStartMaxTimeout < serviceStartTimeout {
 		serviceStartMaxTimeout = serviceStartTimeout
 	}

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -148,11 +148,8 @@ func (s *ServerImpl) Stop() error {
 func (s *ServerImpl) startServices() error {
 	// The membership join time may exceed the configured max join duration.
 	// Double the service start timeout to make sure there is enough time for start logic.
-	serviceStartMaxTimeout := 2 * s.so.config.Global.Membership.MaxJoinDuration
-	if serviceStartMaxTimeout < serviceStartTimeout {
-		serviceStartMaxTimeout = serviceStartTimeout
-	}
-	ctx, cancel := context.WithTimeout(context.Background(), serviceStartMaxTimeout)
+	timeout := util.Max(serviceStartTimeout, 2 * s.so.config.Global.Membership.MaxJoinDuration)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	results := make(chan startServiceResult, len(s.servicesMetadata))
 	for _, svcMeta := range s.servicesMetadata {

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -146,7 +146,12 @@ func (s *ServerImpl) Stop() error {
 }
 
 func (s *ServerImpl) startServices() error {
-	ctx, cancel := context.WithTimeout(context.Background(), serviceStartTimeout)
+	serviceStartMaxTimeout := 3 * s.so.config.Global.Membership.MaxJoinDuration
+
+	if serviceStartMaxTimeout < serviceStartTimeout {
+		serviceStartMaxTimeout = serviceStartTimeout
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), serviceStartMaxTimeout)
 	defer cancel()
 	results := make(chan startServiceResult, len(s.servicesMetadata))
 	for _, svcMeta := range s.servicesMetadata {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use max join time as start timeout.

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/uber-go/fx/pull/875/files
Fx fix the context timeout error. The server start timeout could be too short.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test:
1. Make start
2. Kill the process
3. Immediately run `./temporal-server --env development-cass --allow-no-auth start --service frontend`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Consider for https://github.com/temporalio/temporal/issues/3826