### PR TITLE
Config Template support for 'secondary_visibility'

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -98,7 +98,7 @@ persistence:
                     enableHostVerification: {{ default .Env.SQL_HOST_VERIFICATION "false" }}
                     serverName: {{ default .Env.SQL_HOST_NAME "" }}
         visibility:
-            sql:                
+            sql:
                 {{ $visibility_seeds_default := default .Env.MYSQL_SEEDS "" }}
                 {{ $visibility_seeds := default .Env.VISIBILITY_MYSQL_SEEDS $visibility_seeds_default }}
                 {{ $visibility_port_default := default .Env.DB_PORT "3306" }}
@@ -184,6 +184,9 @@ persistence:
                 password: "{{ default .Env.ES_PWD "" }}"
                 indices:
                     visibility: "{{ default .Env.ES_VIS_INDEX "temporal_visibility_v1_dev" }}"
+                    {{- if .Env.ES_SEC_VIS_INDEX }}
+                    secondary_visibility: "{{ default .Env.ES_SEC_VIS_INDEX "" }}"
+                    {{- end }}
         {{- end }}
 
 global:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set **secondary_visibility** for ES-visibility if environment variable `ES_SEC_VIS_INDEX` is set.

<!-- Tell your future self why have you made these changes -->
**Why?**
PR #2359 added support for dual write to different ES indices. There was no change to the config template to enable this feature. 

Reported as https://github.com/temporalio/temporal/issues/3916

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran locally and checked that `secondary_visibility` was set.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This will just set a variable, if you mess up it's on you.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No

