### PR TITLE
Fail workflow task with BadSearchAttributes cause if search attributes mapper returned an error

### DIFF
--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -817,10 +817,11 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 		namespaceName.String(),
 	)
 	if err != nil {
-		handler.stopProcessing = true
-		return err
+		return handler.failWorkflowTaskOnInvalidArgument(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, err)
 	}
 	if unaliasedSas != nil {
+		// Create a shallow copy of the `attr` to avoid modification of original `attr`,
+		// which can be needed again in case of retry.
 		newAttr := *attr
 		newAttr.SearchAttributes = unaliasedSas
 		attr = &newAttr
@@ -928,10 +929,11 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 		targetNamespace.String(),
 	)
 	if err != nil {
-		handler.stopProcessing = true
-		return err
+		return handler.failWorkflowTaskOnInvalidArgument(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, err)
 	}
 	if unaliasedSas != nil {
+		// Create a shallow copy of the `attr` to avoid modification of original `attr`,
+		// which can be needed again in case of retry.
 		newAttr := *attr
 		newAttr.SearchAttributes = unaliasedSas
 		attr = &newAttr
@@ -1072,10 +1074,11 @@ func (handler *workflowTaskHandlerImpl) handleCommandUpsertWorkflowSearchAttribu
 		namespace.String(),
 	)
 	if err != nil {
-		handler.stopProcessing = true
-		return err
+		return handler.failWorkflowTaskOnInvalidArgument(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_SEARCH_ATTRIBUTES, err)
 	}
 	if unaliasedSas != nil {
+		// Create a shallow copy of the `attr` to avoid modification of original `attr`,
+		// which can be needed again in case of retry.
 		newAttr := *attr
 		newAttr.SearchAttributes = unaliasedSas
 		attr = &newAttr


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fail workflow task with `BadSearchAttributes` cause if search attributes mapper returned an error.

<!-- Tell your future self why have you made these changes -->
**Why?**
Just returning an error from `handleCommands` causes workflow task to timeout but not to fail, which is wrong.
Failing workflow task allow to write error message to the history and expose error message in WebUI/tctl.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Upcomming functional tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks but there is small behaviour change: WTFail event will be written to the history instead of WTTimeout.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.