### PR TITLE
Fix MySQL visibility index for full text search

### DIFF
--- a/schema/mysql/v8/visibility/schema.sql
+++ b/schema/mysql/v8/visibility/schema.sql
@@ -135,9 +135,9 @@ CREATE INDEX by_keyword_07        ON custom_search_attributes (namespace_id, Key
 CREATE INDEX by_keyword_08        ON custom_search_attributes (namespace_id, Keyword08);
 CREATE INDEX by_keyword_09        ON custom_search_attributes (namespace_id, Keyword09);
 CREATE INDEX by_keyword_10        ON custom_search_attributes (namespace_id, Keyword10);
-CREATE FULLTEXT INDEX by_text_01  ON custom_search_attributes (namespace_id, Text01);
-CREATE FULLTEXT INDEX by_text_02  ON custom_search_attributes (namespace_id, Text02);
-CREATE FULLTEXT INDEX by_text_03  ON custom_search_attributes (namespace_id, Text03);
+CREATE FULLTEXT INDEX by_text_01  ON custom_search_attributes (Text01);
+CREATE FULLTEXT INDEX by_text_02  ON custom_search_attributes (Text02);
+CREATE FULLTEXT INDEX by_text_03  ON custom_search_attributes (Text03);
 CREATE INDEX by_keyword_list_01   ON custom_search_attributes (namespace_id, (CAST(KeywordList01 AS CHAR(255) ARRAY)));
 CREATE INDEX by_keyword_list_02   ON custom_search_attributes (namespace_id, (CAST(KeywordList02 AS CHAR(255) ARRAY)));
 CREATE INDEX by_keyword_list_03   ON custom_search_attributes (namespace_id, (CAST(KeywordList03 AS CHAR(255) ARRAY)));

--- a/schema/mysql/v8/visibility/versioned/v1.2/advanced_visibility.sql
+++ b/schema/mysql/v8/visibility/versioned/v1.2/advanced_visibility.sql
@@ -121,9 +121,9 @@ CREATE INDEX by_keyword_07        ON custom_search_attributes (namespace_id, Key
 CREATE INDEX by_keyword_08        ON custom_search_attributes (namespace_id, Keyword08);
 CREATE INDEX by_keyword_09        ON custom_search_attributes (namespace_id, Keyword09);
 CREATE INDEX by_keyword_10        ON custom_search_attributes (namespace_id, Keyword10);
-CREATE FULLTEXT INDEX by_text_01  ON custom_search_attributes (namespace_id, Text01);
-CREATE FULLTEXT INDEX by_text_02  ON custom_search_attributes (namespace_id, Text02);
-CREATE FULLTEXT INDEX by_text_03  ON custom_search_attributes (namespace_id, Text03);
+CREATE FULLTEXT INDEX by_text_01  ON custom_search_attributes (Text01);
+CREATE FULLTEXT INDEX by_text_02  ON custom_search_attributes (Text02);
+CREATE FULLTEXT INDEX by_text_03  ON custom_search_attributes (Text03);
 CREATE INDEX by_keyword_list_01   ON custom_search_attributes (namespace_id, (CAST(KeywordList01 AS CHAR(255) ARRAY)));
 CREATE INDEX by_keyword_list_02   ON custom_search_attributes (namespace_id, (CAST(KeywordList02 AS CHAR(255) ARRAY)));
 CREATE INDEX by_keyword_list_03   ON custom_search_attributes (namespace_id, (CAST(KeywordList03 AS CHAR(255) ARRAY)));


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removing `namespace_id` from MySQL full text search index.

<!-- Tell your future self why have you made these changes -->
**Why?**
`namespace_id` cannot be included to the index since there's no easy way to enforce namespace id value with the actual query string to be matched.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started server, and run workflows querying Text type search attribute. Checked that it return empty result when no word matches the content.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.