### PR TITLE
Frontend health check waits until membership initialized

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -27,6 +27,7 @@
 package membership
 
 import (
+	"context"
 	"errors"
 
 	"go.temporal.io/api/serviceerror"
@@ -82,6 +83,11 @@ type (
 		// GetMemberCount returns the number of reachable members
 		// currently in this node's membership list for the given service
 		GetMemberCount(service primitives.ServiceName) (int, error)
+		// WaitUntilInitialized blocks until initialization is completed and returns the result
+		// of initialization. The current implementation does log.Fatal if it can't initialize,
+		// so currently this will never return non-nil, except for context cancel/timeout. A
+		// future implementation might return more errors.
+		WaitUntilInitialized(context.Context) error
 	}
 
 	// ServiceResolver provides membership information for a specific temporal service.

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -29,6 +29,7 @@
 package membership
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -182,6 +183,20 @@ func (m *MockMonitor) Stop() {
 func (mr *MockMonitorMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockMonitor)(nil).Stop))
+}
+
+// WaitUntilInitialized mocks base method.
+func (m *MockMonitor) WaitUntilInitialized(arg0 context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilInitialized", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilInitialized indicates an expected call of WaitUntilInitialized.
+func (mr *MockMonitorMockRecorder) WaitUntilInitialized(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilInitialized", reflect.TypeOf((*MockMonitor)(nil).WaitUntilInitialized), arg0)
 }
 
 // WhoAmI mocks base method.

--- a/common/resourcetest/resourceTest.go
+++ b/common/resourcetest/resourceTest.go
@@ -166,6 +166,7 @@ func NewTest(
 	membershipMonitor.EXPECT().GetResolver(primitives.MatchingService).Return(matchingServiceResolver, nil).AnyTimes()
 	membershipMonitor.EXPECT().GetResolver(primitives.HistoryService).Return(historyServiceResolver, nil).AnyTimes()
 	membershipMonitor.EXPECT().GetResolver(primitives.WorkerService).Return(workerServiceResolver, nil).AnyTimes()
+	membershipMonitor.EXPECT().WaitUntilInitialized(gomock.Any()).Return(nil).AnyTimes()
 
 	scope := tally.NewTestScope("test", nil)
 	serviceName, _ := metrics.MetricsServiceIdxToServiceName(serviceMetricsIndex)

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -555,6 +555,7 @@ func HandlerProvider(
 	clusterMetadata cluster.Metadata,
 	archivalMetadata archiver.ArchivalMetadata,
 	healthServer *health.Server,
+	membershipMonitor membership.Monitor,
 ) Handler {
 	wfHandler := NewWorkflowHandler(
 		serviceConfig,
@@ -576,6 +577,7 @@ func HandlerProvider(
 		archivalMetadata,
 		healthServer,
 		timeSource,
+		membershipMonitor,
 	)
 	return wfHandler
 }

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -190,6 +190,7 @@ func (s *workflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 		s.mockResource.GetArchivalMetadata(),
 		health.NewServer(),
 		clock.NewRealTimeSource(),
+		s.mockResource.GetMembershipMonitor(),
 	)
 }
 

--- a/tests/simpleMonitor.go
+++ b/tests/simpleMonitor.go
@@ -25,6 +25,7 @@
 package tests
 
 import (
+	"context"
 	"fmt"
 
 	"go.temporal.io/server/common/membership"
@@ -91,4 +92,8 @@ func (s *simpleMonitor) GetReachableMembers() ([]string, error) {
 
 func (s *simpleMonitor) GetMemberCount(service primitives.ServiceName) (int, error) {
 	return 0, nil
+}
+
+func (s *simpleMonitor) WaitUntilInitialized(_ context.Context) error {
+	return nil
 }


### PR DESCRIPTION
**What changed?**
Frontend shouldn't return SERVING (for `temporal.api.workflowservice.v1.WorkflowService`) until it has initialized ringpop.

**Why?**
During this period any rpc sent to frontend that requires a history or matching backend will fail, so it shouldn't accept them.

**How did you test it?**
Manually, will test in staging environment

**Potential risks**


**Is hotfix candidate?**
