### PR TITLE
Fix TestUpdateWeight

### DIFF
--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -86,7 +86,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) SetupTest() {
 		2: 2,
 		3: 1,
 	}
-	s.channelWeightUpdateCh = make(chan struct{})
+	s.channelWeightUpdateCh = make(chan struct{}, 1)
 	logger := log.NewTestLogger()
 
 	s.scheduler = NewInterleavedWeightedRoundRobinScheduler(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix TestUpdateWeight

<!-- Tell your future self why have you made these changes -->
**Why?**
- Update channel was wrongly initialized with 0 capacity in test. Production code don't have this problem

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`go test -run TestInterleavedWeightedRoundRobinSchedulerSuite -testify.m TestUpdateWeight -count=100`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no, only fixing test

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no