### PR TITLE
Fix ExecutionTime rounding when using PostgreSQL

### DIFF
--- a/common/persistence/sql/sqlplugin/postgresql/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgresql/visibility.go
@@ -137,6 +137,7 @@ func (pdb *db) InsertIntoVisibility(
 	row *sqlplugin.VisibilityRow,
 ) (sql.Result, error) {
 	row.StartTime = pdb.converter.ToPostgreSQLDateTime(row.StartTime)
+	row.ExecutionTime = pdb.converter.ToPostgreSQLDateTime(row.ExecutionTime)
 	return pdb.conn.ExecContext(ctx,
 		templateCreateWorkflowExecutionStarted,
 		row.NamespaceID,
@@ -160,6 +161,7 @@ func (pdb *db) ReplaceIntoVisibility(
 	switch {
 	case row.CloseTime != nil && row.HistoryLength != nil:
 		row.StartTime = pdb.converter.ToPostgreSQLDateTime(row.StartTime)
+		row.ExecutionTime = pdb.converter.ToPostgreSQLDateTime(row.ExecutionTime)
 		closeTime := pdb.converter.ToPostgreSQLDateTime(*row.CloseTime)
 		return pdb.conn.ExecContext(ctx,
 			templateCreateWorkflowExecutionClosed,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix `ExecutionTime` rounding when using PostgreSQL.

<!-- Tell your future self why have you made these changes -->
**Why?**
`ExecutionTime` need to be properly converted to PostgreSQL datetime format using existing `ToPostgreSQLDateTime` function. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing cron functional test should stop failing.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.