### PR TITLE
Wrap user's visibility query string in parenthesis

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter_mysql.go
+++ b/common/persistence/visibility/store/sql/query_converter_mysql.go
@@ -207,7 +207,7 @@ func (c *mysqlQueryConverter) buildSelectStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, queryString)
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
 	}
 
 	if token != nil {

--- a/common/persistence/visibility/store/sql/query_converter_postgresql.go
+++ b/common/persistence/visibility/store/sql/query_converter_postgresql.go
@@ -214,7 +214,7 @@ func (c *pgQueryConverter) buildSelectStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, queryString)
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
 	}
 
 	if token != nil {

--- a/common/persistence/visibility/store/sql/query_converter_sqlite.go
+++ b/common/persistence/visibility/store/sql/query_converter_sqlite.go
@@ -234,7 +234,7 @@ func (c *sqliteQueryConverter) buildSelectStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, queryString)
+		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
 	}
 
 	if token != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Wrap user's visibility query string in parenthesis.

<!-- Tell your future self why have you made these changes -->
**Why?**
`AND` has precedence over `OR`, so without parenthesis, if the user's query contains `OR`, it might mix results with other namespaces.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran a few workflows in different namespaces, and queried with `OR` expressions.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.