### PR TITLE
DeleteExecutions workflow: pass nextPageToken with ContinueAsNewError

### DIFF
--- a/service/worker/deletenamespace/deleteexecutions/workflow.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow.go
@@ -50,6 +50,7 @@ type (
 		PreviousSuccessCount int
 		PreviousErrorCount   int
 		ContinueAsNewCount   int
+		NextPageToken        []byte
 	}
 
 	DeleteExecutionsResult struct {
@@ -105,7 +106,7 @@ func DeleteExecutionsWorkflow(ctx workflow.Context, params DeleteExecutionsParam
 	logger.Info("Effective config.", tag.Value(params.Config.String()))
 
 	var a *Activities
-	var nextPageToken []byte
+	nextPageToken := params.NextPageToken
 	runningDeleteExecutionsActivityCount := 0
 	runningDeleteExecutionsSelector := workflow.NewSelector(ctx)
 	var lastDeleteExecutionsActivityErr error
@@ -186,6 +187,7 @@ func DeleteExecutionsWorkflow(ctx workflow.Context, params DeleteExecutionsParam
 	params.PreviousSuccessCount = result.SuccessCount
 	params.PreviousErrorCount = result.ErrorCount
 	params.ContinueAsNewCount++
+	params.NextPageToken = nextPageToken
 
 	logger.Info("There are more workflows to delete. Continuing workflow as new.", tag.WorkflowType(WorkflowName), tag.WorkflowNamespace(params.Namespace.String()), tag.DeletedExecutionsCount(result.SuccessCount), tag.DeletedExecutionsErrorCount(result.ErrorCount), tag.Counter(params.ContinueAsNewCount))
 	return result, workflow.NewContinueAsNewError(ctx, DeleteExecutionsWorkflow, params)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
DeleteExecutions workflow: pass `nextPageToken` with `ContinueAsNewError`.

<!-- Tell your future self why have you made these changes -->
**Why?**
To prevent DeleteExecutions workflow to start from the begining with every "continue as new" iteration.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified existing test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.