### PR TITLE
Fix wrap user query string in parenthesis

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -218,6 +218,17 @@ func (c *QueryConverter) convertSelectStmt(sel *sqlparser.Select) error {
 		if err != nil {
 			return err
 		}
+
+		// Wrap user's query in parenthesis. This is to ensure that further changes
+		// to the query won't affect the user's query.
+		switch sel.Where.Expr.(type) {
+		case *sqlparser.ParenExpr:
+			// no-op: top-level expression is already a parenthesis
+		default:
+			sel.Where.Expr = &sqlparser.ParenExpr{
+				Expr: sel.Where.Expr,
+			}
+		}
 	}
 
 	// This logic comes from elasticsearch/visibility_store.go#convertQuery function.

--- a/common/persistence/visibility/store/sql/query_converter_mysql.go
+++ b/common/persistence/visibility/store/sql/query_converter_mysql.go
@@ -222,7 +222,7 @@ func (c *mysqlQueryConverter) buildSelectStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
+		whereClauses = append(whereClauses, queryString)
 	}
 
 	if token != nil {
@@ -283,7 +283,7 @@ func (c *mysqlQueryConverter) buildCountStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
+		whereClauses = append(whereClauses, queryString)
 	}
 
 	return fmt.Sprintf(

--- a/common/persistence/visibility/store/sql/query_converter_postgresql.go
+++ b/common/persistence/visibility/store/sql/query_converter_postgresql.go
@@ -229,7 +229,7 @@ func (c *pgQueryConverter) buildSelectStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
+		whereClauses = append(whereClauses, queryString)
 	}
 
 	if token != nil {
@@ -286,7 +286,7 @@ func (c *pgQueryConverter) buildCountStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
+		whereClauses = append(whereClauses, queryString)
 	}
 
 	return fmt.Sprintf(

--- a/common/persistence/visibility/store/sql/query_converter_sqlite.go
+++ b/common/persistence/visibility/store/sql/query_converter_sqlite.go
@@ -240,7 +240,7 @@ func (c *sqliteQueryConverter) buildSelectStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
+		whereClauses = append(whereClauses, queryString)
 	}
 
 	if token != nil {
@@ -328,7 +328,7 @@ func (c *sqliteQueryConverter) buildCountStmt(
 	queryArgs = append(queryArgs, namespaceID.String())
 
 	if len(queryString) > 0 {
-		whereClauses = append(whereClauses, fmt.Sprintf("(%s)", queryString))
+		whereClauses = append(whereClauses, queryString)
 	}
 
 	return fmt.Sprintf(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Wrap user's query string in parenthesis right after query converter is done parsing.

<!-- Tell your future self why have you made these changes -->
**Why?**
I had wrapped later in the plugin query converter, but I noticed that TemporalNamespaceDivision condition could be added before, and it could affect the user's query if not wrapped in parenthesis.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Writing query converter tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.