### PR TITLE
Set default values in returned calendar specs

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3259,6 +3259,8 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 	memo := describeResponse.GetWorkflowExecutionInfo().GetMemo()
 	memo = wh.cleanScheduleMemo(memo)
 
+	scheduler.CleanSpec(queryResponse.Schedule.Spec)
+
 	return &workflowservice.DescribeScheduleResponse{
 		Schedule:         queryResponse.Schedule,
 		Info:             queryResponse.Info,
@@ -4844,6 +4846,7 @@ func (wh *WorkflowHandler) decodeScheduleListInfo(memo *commonpb.Memo) *schedpb.
 		wh.logger.Error("decoding schedule list info from payload", tag.Error(err))
 		return nil
 	}
+	scheduler.CleanSpec(listInfo.Spec)
 	return &listInfo
 }
 

--- a/service/worker/scheduler/spec.go
+++ b/service/worker/scheduler/spec.go
@@ -86,6 +86,35 @@ func NewCompiledSpec(spec *schedpb.ScheduleSpec) (*CompiledSpec, error) {
 	return cspec, nil
 }
 
+// CleanSpec sets default values in ranges.
+func CleanSpec(spec *schedpb.ScheduleSpec) {
+	cleanRanges := func(ranges []*schedpb.Range) {
+		for _, r := range ranges {
+			if r.End < r.Start {
+				r.End = r.Start
+			}
+			if r.Step == 0 {
+				r.Step = 1
+			}
+		}
+	}
+	cleanCal := func(structured *schedpb.StructuredCalendarSpec) {
+		cleanRanges(structured.Second)
+		cleanRanges(structured.Minute)
+		cleanRanges(structured.Hour)
+		cleanRanges(structured.DayOfMonth)
+		cleanRanges(structured.Month)
+		cleanRanges(structured.Year)
+		cleanRanges(structured.DayOfWeek)
+	}
+	for _, structured := range spec.StructuredCalendar {
+		cleanCal(structured)
+	}
+	for _, structured := range spec.ExcludeStructuredCalendar {
+		cleanCal(structured)
+	}
+}
+
 func canonicalizeSpec(spec *schedpb.ScheduleSpec) (*schedpb.ScheduleSpec, error) {
 	// make shallow copy so we can change some fields
 	specCopy := *spec


### PR DESCRIPTION
**What changed?**
Set end and step to default values in calendar specs returned through frontend api.

**Why?**
We do a little optimization to save space in memo for calendar specs, but it's confusing to return this through the api, so we should undo it at the frontend.

**How did you test it?**
Changed integration test.

**Potential risks**

**Is hotfix candidate?**

