### PR TITLE
Fix passing pointer of slice element in SQL query converter

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -466,8 +466,8 @@ func (c *QueryConverter) convertValueExpr(
 		return nil
 	case sqlparser.ValTuple:
 		// This is "in (1,2,3)" case.
-		for _, subExpr := range e {
-			err := c.convertValueExpr(&subExpr, saName, saType)
+		for i := range e {
+			err := c.convertValueExpr(&e[i], saName, saType)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Pass pointer of slice element when calling `convertValueExpr` so it's converted in-place.

<!-- Tell your future self why have you made these changes -->
**Why?**
Query converter parses and changes expressions in-place, and all literal strings are expected to be converted to `unsafeSQLString`.
My previous PR https://github.com/temporalio/temporal/pull/3950 refactoring the code broke tuple parsing.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Writing unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.