### PR TITLE
Improve scheduled queue lookahead logic

### DIFF
--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -142,6 +142,7 @@ func (s *queueBaseSuite) TestNewProcessBase_NoPreviousState() {
 		nil,
 		s.options,
 		s.rateLimiter,
+		NoopReaderCompletionFn,
 		s.logger,
 		s.metricsHandler,
 	)
@@ -225,6 +226,7 @@ func (s *queueBaseSuite) TestNewProcessBase_WithPreviousState() {
 		nil,
 		s.options,
 		s.rateLimiter,
+		NoopReaderCompletionFn,
 		s.logger,
 		s.metricsHandler,
 	)
@@ -284,13 +286,14 @@ func (s *queueBaseSuite) TestStartStop() {
 		nil,
 		s.options,
 		s.rateLimiter,
+		NoopReaderCompletionFn,
 		s.logger,
 		s.metricsHandler,
 	)
 
 	s.mockRescheduler.EXPECT().Start().Times(1)
 	base.Start()
-	s.NoError(base.processNewRange())
+	base.processNewRange()
 
 	<-doneCh
 	<-base.checkpointTimer.C
@@ -333,12 +336,13 @@ func (s *queueBaseSuite) TestProcessNewRange() {
 		nil,
 		s.options,
 		s.rateLimiter,
+		NoopReaderCompletionFn,
 		s.logger,
 		s.metricsHandler,
 	)
 	s.True(base.nonReadableScope.Range.Equals(NewRange(tasks.MinimumKey, tasks.MaximumKey)))
 
-	s.NoError(base.processNewRange())
+	base.processNewRange()
 	defaultReader, ok := base.readerGroup.ReaderByID(DefaultReaderId)
 	s.True(ok)
 	scopes := defaultReader.Scopes()
@@ -389,6 +393,7 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks() {
 		nil,
 		s.options,
 		s.rateLimiter,
+		NoopReaderCompletionFn,
 		s.logger,
 		s.metricsHandler,
 	)
@@ -461,6 +466,7 @@ func (s *queueBaseSuite) TestCheckPoint_NoPendingTasks() {
 		nil,
 		s.options,
 		s.rateLimiter,
+		NoopReaderCompletionFn,
 		s.logger,
 		s.metricsHandler,
 	)
@@ -548,6 +554,7 @@ func (s *queueBaseSuite) TestCheckPoint_MoveSlices() {
 		nil,
 		s.options,
 		s.rateLimiter,
+		NoopReaderCompletionFn,
 		s.logger,
 		s.metricsHandler,
 	)

--- a/service/history/queues/queue_scheduled_test.go
+++ b/service/history/queues/queue_scheduled_test.go
@@ -245,19 +245,6 @@ func (s *scheduledQueueSuite) TestLookAheadTask_ErrorLookAhead() {
 	}
 }
 
-func (s *scheduledQueueSuite) TestProcessNewRange_LookAheadPerformed() {
-	timerGate := timer.NewRemoteGate()
-	s.scheduledQueue.timerGate = timerGate
-
-	// test if look ahead if performed after processing new range
-	s.mockExecutionManager.EXPECT().GetHistoryTasks(gomock.Any(), gomock.Any()).Return(&persistence.GetHistoryTasksResponse{
-		Tasks:         []tasks.Task{},
-		NextPageToken: nil,
-	}, nil).Times(1)
-
-	s.scheduledQueue.processNewRange()
-}
-
 func (s *scheduledQueueSuite) setupLookAheadMock(
 	hasLookAheadTask bool,
 ) (lookAheadRange Range, lookAheadTask *tasks.MockTask) {

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -436,6 +436,7 @@ func (r *ReaderImpl) loadAndSubmitTasks() {
 	}
 
 	if r.nextReadSlice == nil {
+		r.completionFn(r.readerID)
 		return
 	}
 
@@ -466,6 +467,7 @@ func (r *ReaderImpl) loadAndSubmitTasks() {
 
 	if r.nextReadSlice = r.nextReadSlice.Next(); r.nextReadSlice != nil {
 		r.notify()
+		return
 	}
 
 	// no more task to load, trigger completion callback
@@ -483,7 +485,11 @@ func (r *ReaderImpl) resetNextReadSliceLocked() {
 
 	if r.nextReadSlice != nil {
 		r.notify()
+		return
 	}
+
+	// no more task to load, trigger completion callback
+	r.completionFn(r.readerID)
 }
 
 func (r *ReaderImpl) notify() {

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -111,7 +111,7 @@ func (s *readerSuite) TestStartLoadStop() {
 	}).Times(1)
 	s.mockRescheduler.EXPECT().Len().Return(0).AnyTimes()
 
-	reader := s.newTestReader(scopes, paginationFnProvider)
+	reader := s.newTestReader(scopes, paginationFnProvider, NoopReaderCompletionFn)
 	mockTimeSource := clock.NewEventTimeSource()
 	mockTimeSource.Update(scopes[0].Range.ExclusiveMax.FireTime)
 	reader.timeSource = mockTimeSource
@@ -124,7 +124,7 @@ func (s *readerSuite) TestStartLoadStop() {
 func (s *readerSuite) TestScopes() {
 	scopes := NewRandomScopes(10)
 
-	reader := s.newTestReader(scopes, nil)
+	reader := s.newTestReader(scopes, nil, NoopReaderCompletionFn)
 	actualScopes := reader.Scopes()
 	for idx, expectedScope := range scopes {
 		s.True(expectedScope.Equals(actualScopes[idx]))
@@ -133,7 +133,7 @@ func (s *readerSuite) TestScopes() {
 
 func (s *readerSuite) TestSplitSlices() {
 	scopes := NewRandomScopes(3)
-	reader := s.newTestReader(scopes, nil)
+	reader := s.newTestReader(scopes, nil, NoopReaderCompletionFn)
 
 	splitter := func(s Slice) ([]Slice, bool) {
 		// split head
@@ -174,7 +174,7 @@ func (s *readerSuite) TestSplitSlices() {
 
 func (s *readerSuite) TestMergeSlices() {
 	scopes := NewRandomScopes(rand.Intn(10))
-	reader := s.newTestReader(scopes, nil)
+	reader := s.newTestReader(scopes, nil, NoopReaderCompletionFn)
 
 	incomingScopes := NewRandomScopes(rand.Intn(10))
 	incomingSlices := make([]Slice, 0, len(incomingScopes))
@@ -201,7 +201,7 @@ func (s *readerSuite) TestAppendSlices() {
 	totalScopes := 10
 	scopes := NewRandomScopes(totalScopes)
 	currentScopes := scopes[:totalScopes/2]
-	reader := s.newTestReader(currentScopes, nil)
+	reader := s.newTestReader(currentScopes, nil, NoopReaderCompletionFn)
 
 	incomingScopes := scopes[totalScopes/2:]
 	incomingSlices := make([]Slice, 0, len(incomingScopes))
@@ -235,7 +235,7 @@ func (s *readerSuite) TestShrinkSlices() {
 		scopes[idx].Range.InclusiveMin = scopes[idx].Range.ExclusiveMax
 	}
 
-	reader := s.newTestReader(scopes, nil)
+	reader := s.newTestReader(scopes, nil, NoopReaderCompletionFn)
 	reader.ShrinkSlices()
 
 	actualScopes := reader.Scopes()
@@ -265,7 +265,7 @@ func (s *readerSuite) TestThrottle() {
 		}
 	}
 
-	reader := s.newTestReader(scopes, paginationFnProvider)
+	reader := s.newTestReader(scopes, paginationFnProvider, NoopReaderCompletionFn)
 	mockTimeSource := clock.NewEventTimeSource()
 	mockTimeSource.Update(scopes[0].Range.ExclusiveMax.FireTime)
 	reader.timeSource = mockTimeSource
@@ -293,19 +293,22 @@ func (s *readerSuite) TestThrottle() {
 func (s *readerSuite) TestLoadAndSubmitTasks_Throttled() {
 	scopes := NewRandomScopes(1)
 
-	reader := s.newTestReader(scopes, nil)
+	completionFnCalled := false
+	reader := s.newTestReader(scopes, nil, func(_ int32) { completionFnCalled = true })
 	reader.Pause(100 * time.Millisecond)
 
 	s.mockRescheduler.EXPECT().Len().Return(0).AnyTimes()
 
 	// should be no-op
 	reader.loadAndSubmitTasks()
+	s.False(completionFnCalled)
 }
 
 func (s *readerSuite) TestLoadAndSubmitTasks_TooManyPendingTasks() {
 	scopes := NewRandomScopes(1)
 
-	reader := s.newTestReader(scopes, nil)
+	completionFnCalled := false
+	reader := s.newTestReader(scopes, nil, func(_ int32) { completionFnCalled = true })
 
 	s.monitor.SetSlicePendingTaskCount(
 		reader.slices.Front().Value.(Slice),
@@ -314,6 +317,7 @@ func (s *readerSuite) TestLoadAndSubmitTasks_TooManyPendingTasks() {
 
 	// should be no-op
 	reader.loadAndSubmitTasks()
+	s.False(completionFnCalled)
 }
 
 func (s *readerSuite) TestLoadAndSubmitTasks_MoreTasks() {
@@ -333,7 +337,8 @@ func (s *readerSuite) TestLoadAndSubmitTasks_MoreTasks() {
 		}
 	}
 
-	reader := s.newTestReader(scopes, paginationFnProvider)
+	completionFnCalled := false
+	reader := s.newTestReader(scopes, paginationFnProvider, func(_ int32) { completionFnCalled = true })
 	mockTimeSource := clock.NewEventTimeSource()
 	mockTimeSource.Update(scopes[0].Range.ExclusiveMax.FireTime)
 	reader.timeSource = mockTimeSource
@@ -349,6 +354,7 @@ func (s *readerSuite) TestLoadAndSubmitTasks_MoreTasks() {
 	<-reader.notifyCh // should trigger next round of load
 	s.Equal(reader.options.BatchSize(), taskSubmitted)
 	s.True(scopes[0].Equals(reader.nextReadSlice.Value.(Slice).Scope()))
+	s.False(completionFnCalled)
 }
 
 func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_HasNextSlice() {
@@ -363,7 +369,8 @@ func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_HasNextSlice() {
 		}
 	}
 
-	reader := s.newTestReader(scopes, paginationFnProvider)
+	completionFnCalled := false
+	reader := s.newTestReader(scopes, paginationFnProvider, func(_ int32) { completionFnCalled = true })
 	mockTimeSource := clock.NewEventTimeSource()
 	mockTimeSource.Update(scopes[0].Range.ExclusiveMax.FireTime)
 	reader.timeSource = mockTimeSource
@@ -379,6 +386,7 @@ func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_HasNextSlice() {
 	<-reader.notifyCh // should trigger next round of load
 	s.Equal(1, taskSubmitted)
 	s.True(scopes[1].Equals(reader.nextReadSlice.Value.(Slice).Scope()))
+	s.False(completionFnCalled)
 }
 
 func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_NoNextSlice() {
@@ -393,7 +401,8 @@ func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_NoNextSlice() {
 		}
 	}
 
-	reader := s.newTestReader(scopes, paginationFnProvider)
+	completionFnCalled := false
+	reader := s.newTestReader(scopes, paginationFnProvider, func(_ int32) { completionFnCalled = true })
 	mockTimeSource := clock.NewEventTimeSource()
 	mockTimeSource.Update(scopes[0].Range.ExclusiveMax.FireTime)
 	reader.timeSource = mockTimeSource
@@ -414,12 +423,13 @@ func (s *readerSuite) TestLoadAndSubmitTasks_NoMoreTasks_NoNextSlice() {
 	}
 	s.Equal(1, taskSubmitted)
 	s.Nil(reader.nextReadSlice)
+	s.True(completionFnCalled)
 }
 
 func (s *readerSuite) TestSubmitTask() {
 	r := NewRandomRange()
 	scopes := []Scope{NewScope(r, predicates.Universal[tasks.Task]())}
-	reader := s.newTestReader(scopes, nil)
+	reader := s.newTestReader(scopes, nil, NoopReaderCompletionFn)
 
 	mockExecutable := NewMockExecutable(s.controller)
 
@@ -457,6 +467,7 @@ func (s *readerSuite) validateSlicesOrdered(
 func (s *readerSuite) newTestReader(
 	scopes []Scope,
 	paginationFnProvider PaginationFnProvider,
+	completionFn ReaderCompletionFn,
 ) *ReaderImpl {
 	slices := make([]Slice, 0, len(scopes))
 	for _, scope := range scopes {
@@ -477,6 +488,7 @@ func (s *readerSuite) newTestReader(
 		clock.NewRealTimeSource(),
 		NewReaderPriorityRateLimiter(func() float64 { return 20 }, 1),
 		s.monitor,
+		completionFn,
 		s.logger,
 		s.metricsHandler,
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Only trigger scheduled queue lookahead when the default reader finishes loading. Currently, whenever read/write boundary is moved, a lookahead will be triggered.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Lookahead when there're more tasks to load is unnecessary.
- If we want to pause a queue, we also don't want to lookahead to happen. Currently pause is achieved by setting pending task limit to 0, so reader won't load any task. However, the periodic 5m timer is still there for pushing the read/write boundary, so lookahead will still happen. With this change, those lookahead will also be gone.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Will test on test cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In worst case we may miss lookahead, and need to wait for the periodic poll timer to happen to load new tasks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.