### PR TITLE
Create internal API to force delete workflow

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -79,13 +79,14 @@ import (
 	"go.temporal.io/server/service/history/api/verifychildworkflowcompletionrecorded"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
-	deletemanager "go.temporal.io/server/service/history/deletemanager"
+	"go.temporal.io/server/service/history/deletemanager"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/ndc"
 	"go.temporal.io/server/service/history/queues"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.temporal.io/server/service/worker/archiver"
 )
@@ -747,4 +748,41 @@ func (e *historyEngineImpl) GetReplicationStatus(
 	request *historyservice.GetReplicationStatusRequest,
 ) (_ *historyservice.ShardReplicationStatus, retError error) {
 	return replicationapi.GetStatus(ctx, request, e.shard, e.replicationAckMgr)
+}
+
+func (e *historyEngineImpl) ForceDeleteWorkflowExecution(
+	ctx context.Context,
+	workflowKey definition.WorkflowKey,
+) (retError error) {
+	workflowCache := e.workflowConsistencyChecker.GetWorkflowCache()
+	wfCtx, releaseFn, err := workflowCache.GetOrCreateWorkflowExecution(
+		ctx,
+		namespace.ID(workflowKey.NamespaceID),
+		commonpb.WorkflowExecution{
+			WorkflowId: workflowKey.WorkflowID,
+			RunId:      workflowKey.RunID,
+		},
+		workflow.CallerTypeTask,
+	)
+	if err != nil {
+		return err
+	}
+	defer func() { releaseFn(retError) }()
+
+	mutableState, err := wfCtx.LoadMutableState(ctx)
+	if err != nil {
+		return err
+	}
+	return e.workflowDeleteManager.DeleteWorkflowExecution(
+		ctx,
+		namespace.ID(workflowKey.NamespaceID),
+		commonpb.WorkflowExecution{
+			WorkflowId: workflowKey.WorkflowID,
+			RunId:      workflowKey.RunID,
+		},
+		wfCtx,
+		mutableState,
+		false,
+		nil, // stage is not stored during cleanup process.
+	)
 }

--- a/service/history/shard/engine.go
+++ b/service/history/shard/engine.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/tasks"
@@ -87,6 +88,7 @@ type (
 		GenerateLastHistoryReplicationTasks(ctx context.Context, request *historyservice.GenerateLastHistoryReplicationTasksRequest) (*historyservice.GenerateLastHistoryReplicationTasksResponse, error)
 		GetReplicationStatus(ctx context.Context, request *historyservice.GetReplicationStatusRequest) (*historyservice.ShardReplicationStatus, error)
 		UpdateWorkflowExecution(ctx context.Context, request *historyservice.UpdateWorkflowExecutionRequest) (*historyservice.UpdateWorkflowExecutionResponse, error)
+		ForceDeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey) error
 
 		NotifyNewHistoryEvent(event *events.Notification)
 		NotifyNewTasks(tasks map[tasks.Category][]tasks.Task)

--- a/service/history/shard/engine_mock.go
+++ b/service/history/shard/engine_mock.go
@@ -38,6 +38,7 @@ import (
 	history "go.temporal.io/api/history/v1"
 	historyservice "go.temporal.io/server/api/historyservice/v1"
 	repication "go.temporal.io/server/api/replication/v1"
+	definition "go.temporal.io/server/common/definition"
 	namespace "go.temporal.io/server/common/namespace"
 	events "go.temporal.io/server/service/history/events"
 	tasks "go.temporal.io/server/service/history/tasks"
@@ -109,6 +110,20 @@ func (m *MockEngine) DescribeWorkflowExecution(ctx context.Context, request *his
 func (mr *MockEngineMockRecorder) DescribeWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeWorkflowExecution", reflect.TypeOf((*MockEngine)(nil).DescribeWorkflowExecution), ctx, request)
+}
+
+// ForceDeleteWorkflowExecution mocks base method.
+func (m *MockEngine) ForceDeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForceDeleteWorkflowExecution", ctx, workflowKey)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForceDeleteWorkflowExecution indicates an expected call of ForceDeleteWorkflowExecution.
+func (mr *MockEngineMockRecorder) ForceDeleteWorkflowExecution(ctx, workflowKey interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceDeleteWorkflowExecution", reflect.TypeOf((*MockEngine)(nil).ForceDeleteWorkflowExecution), ctx, workflowKey)
 }
 
 // GenerateLastHistoryReplicationTasks mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


* Create internal API to force delete workflow
Logic is same as https://github.com/temporalio/temporal/blob/efb3bc100024f30ab48cb4a1ad06b96ae56de9de/service/history/replication/task_executor.go#L360-L385

<!-- Tell your future self why have you made these changes -->
**Why?**
So replication task executor can remove reference to workflow cache & delete manager;
Ref: https://github.com/temporalio/temporal/blob/efb3bc100024f30ab48cb4a1ad06b96ae56de9de/service/history/replication/task_executor.go#L95-L96

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A

