### PR TITLE
Use preemptable caller type for low priority history tasks

### DIFF
--- a/common/headers/caller_info.go
+++ b/common/headers/caller_info.go
@@ -91,7 +91,19 @@ func NewBackgroundCallerInfo(
 	}
 }
 
-// SetCallerInfo sets callerName, callerType and CcllOrigin in the context.
+// NewPreemptableCallerInfo creates a new CallerInfo with Preemptable callerType
+// and empty callOrigin.
+// This is equivalent to NewCallerInfo(callerName, CallerTypePreemptable, "")
+func NewPreemptableCallerInfo(
+	callerName string,
+) CallerInfo {
+	return CallerInfo{
+		CallerName: callerName,
+		CallerType: CallerTypePreemptable,
+	}
+}
+
+// SetCallerInfo sets callerName, callerType and CallOrigin in the context.
 // Existing values will be overwritten if new value is not empty.
 // TODO: consider only set the caller info to golang context instead of grpc metadata
 // and propagate to grpc outgoing context upon making an rpc call

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -124,6 +125,28 @@ func (s *executableSuite) TestExecute_CapturePanic() {
 		},
 	)
 	s.Error(executable.Execute())
+}
+
+func (s *executableSuite) TestExecute_CallerInfo() {
+	executable := s.newTestExecutable()
+
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).DoAndReturn(
+		func(ctx context.Context, _ Executable) ([]metrics.Tag, bool, error) {
+			s.Equal(headers.CallerTypeBackground, headers.GetCallerInfo(ctx).CallerType)
+			return nil, true, nil
+		},
+	)
+	s.NoError(executable.Execute())
+
+	// force set to low priority
+	executable.(*executableImpl).priority = ctasks.PriorityLow
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).DoAndReturn(
+		func(ctx context.Context, _ Executable) ([]metrics.Tag, bool, error) {
+			s.Equal(headers.CallerTypePreemptable, headers.GetCallerInfo(ctx).CallerType)
+			return nil, true, nil
+		},
+	)
+	s.NoError(executable.Execute())
 }
 
 func (s *executableSuite) TestExecuteHandleErr_Corrupted() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


* Use preemptable caller type for low priority history tasks

<!-- Tell your future self why have you made these changes -->
**Why?**


* https://github.com/temporalio/temporal/issues/3874
* Does the task processing part of ^, still need to adjust the caller type used for queue readers (currently always background caller type). But the load from queue reader is much lower compared to processing.
* Preemptable caller type has the lowest priority when consuming persistence rate limiting token, so when system is under heavy load, those priority tasks will be rejected first.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


* Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

