### PR TITLE
Unique owner for each shard context object

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -407,8 +407,8 @@ type (
 	// RegisterHistoryTaskReaderRequest is a hint for underlying persistence implementation
 	// that a new queue reader is created by queue processing logic
 	RegisterHistoryTaskReaderRequest struct {
-		// TODO: use shard identity = shardID + owner, instead of just shardID here.
 		ShardID      int32
+		ShardOwner   string
 		TaskCategory tasks.Category
 		ReaderID     int32
 	}
@@ -421,8 +421,8 @@ type (
 	// that a certain queue reader's process and the fact that it won't try to load tasks with
 	// key less than InclusiveMinPendingTaskKey
 	UpdateHistoryTaskReaderProgressRequest struct {
-		// TODO: use shard identity = shardID + owner, instead of just shardID here.
 		ShardID                    int32
+		ShardOwner                 string
 		TaskCategory               tasks.Category
 		ReaderID                   int32
 		InclusiveMinPendingTaskKey tasks.Key

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -250,31 +250,6 @@ func (s *TestBase) fatalOnError(msg string, err error) {
 	}
 }
 
-// GetOrCreateShard is a utility method to get/create the shard using persistence layer
-func (s *TestBase) GetOrCreateShard(ctx context.Context, shardID int32, owner string, rangeID int64) (*persistencespb.ShardInfo, error) {
-	info := &persistencespb.ShardInfo{
-		ShardId: shardID,
-		Owner:   owner,
-		RangeId: rangeID,
-	}
-	resp, err := s.ShardMgr.GetOrCreateShard(ctx, &persistence.GetOrCreateShardRequest{
-		ShardID:          shardID,
-		InitialShardInfo: info,
-	})
-	if err != nil {
-		return nil, err
-	}
-	return resp.ShardInfo, nil
-}
-
-// UpdateShard is a utility method to update the shard using persistence layer
-func (s *TestBase) UpdateShard(ctx context.Context, updatedInfo *persistencespb.ShardInfo, previousRangeID int64) error {
-	return s.ShardMgr.UpdateShard(ctx, &persistence.UpdateShardRequest{
-		ShardInfo:       updatedInfo,
-		PreviousRangeID: previousRangeID,
-	})
-}
-
 // TearDownWorkflowStore to cleanup
 func (s *TestBase) TearDownWorkflowStore() {
 	s.TaskMgr.Close()

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -210,6 +210,7 @@ type (
 	InternalUpdateShardRequest struct {
 		ShardID         int32
 		RangeID         int64
+		Owner           string
 		ShardInfo       *commonpb.DataBlob
 		PreviousRangeID int64
 	}

--- a/common/persistence/shard_manager.go
+++ b/common/persistence/shard_manager.go
@@ -107,6 +107,7 @@ func (m *shardManagerImpl) UpdateShard(
 	internalRequest := &InternalUpdateShardRequest{
 		ShardID:         request.ShardInfo.GetShardId(),
 		RangeID:         request.ShardInfo.GetRangeId(),
+		Owner:           request.ShardInfo.GetOwner(),
 		ShardInfo:       shardInfoBlob,
 		PreviousRangeID: request.PreviousRangeID,
 	}

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -58,6 +58,7 @@ type (
 
 		ShardID     int32
 		RangeID     int64
+		Owner       string
 		WorkflowKey definition.WorkflowKey
 
 		ShardManager     p.ShardManager
@@ -121,6 +122,7 @@ func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 		InitialShardInfo: &persistencespb.ShardInfo{
 			ShardId: s.ShardID,
 			RangeId: 1,
+			Owner:   "test-shard-owner",
 		},
 	})
 	s.NoError(err)
@@ -132,6 +134,7 @@ func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 	})
 	s.NoError(err)
 	s.RangeID = resp.ShardInfo.RangeId
+	s.Owner = resp.ShardInfo.Owner
 
 	s.WorkflowKey = definition.NewWorkflowKey(
 		uuid.New().String(),
@@ -142,6 +145,7 @@ func (s *ExecutionMutableStateTaskSuite) SetupTest() {
 	for _, category := range taskCategories {
 		err := s.ExecutionManager.RegisterHistoryTaskReader(s.Ctx, &p.RegisterHistoryTaskReaderRequest{
 			ShardID:      s.ShardID,
+			ShardOwner:   s.Owner,
 			TaskCategory: category,
 			ReaderID:     common.DefaultQueueReaderID,
 		})
@@ -170,6 +174,7 @@ func (s *ExecutionMutableStateTaskSuite) TearDownTest() {
 	for _, category := range taskCategories {
 		s.ExecutionManager.UnregisterHistoryTaskReader(s.Ctx, &p.UnregisterHistoryTaskReaderRequest{
 			ShardID:      s.ShardID,
+			ShardOwner:   s.Owner,
 			TaskCategory: category,
 			ReaderID:     common.DefaultQueueReaderID,
 		})

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -206,7 +206,7 @@ func newQueueBase(
 	}
 
 	exclusiveDeletionHighWatermark := exclusiveReaderHighWatermark
-	readerGroup := NewReaderGroup(shard.GetShardID(), category, readerInitializer, shard.GetExecutionManager())
+	readerGroup := NewReaderGroup(shard.GetShardID(), shard.GetOwner(), category, readerInitializer, shard.GetExecutionManager())
 	for readerID, scopes := range readerScopes {
 		if len(scopes) == 0 {
 			continue
@@ -418,6 +418,7 @@ func (p *queueBase) updateReaderProgress(
 		progress = tasks.MinKey(progress, minKey)
 		p.shard.GetExecutionManager().UpdateHistoryTaskReaderProgress(ctx, &persistence.UpdateHistoryTaskReaderProgressRequest{
 			ShardID:                    p.shard.GetShardID(),
+			ShardOwner:                 p.shard.GetOwner(),
 			TaskCategory:               p.category,
 			ReaderID:                   readerID,
 			InclusiveMinPendingTaskKey: progress,

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -612,6 +612,7 @@ func (s *queueBaseSuite) TestUpdateReaderProgress() {
 		&persistencespb.ShardInfo{
 			ShardId: 0,
 			RangeId: 10,
+			Owner:   "test-shard-owner",
 			QueueStates: map[int32]*persistencespb.QueueState{
 				tasks.CategoryIDTransfer: persistenceState,
 			},
@@ -641,6 +642,7 @@ func (s *queueBaseSuite) TestUpdateReaderProgress() {
 	mockShard.Resource.ExecutionMgr.EXPECT().UpdateHistoryTaskReaderProgress(gomock.Any(), gomock.Any()).Do(
 		func(_ context.Context, request *persistence.UpdateHistoryTaskReaderProgressRequest) {
 			s.Equal(mockShard.GetShardID(), request.ShardID)
+			s.Equal(mockShard.GetOwner(), request.ShardOwner)
 			s.Equal(tasks.CategoryTransfer, request.TaskCategory)
 			readerProgress[request.ReaderID] = request.InclusiveMinPendingTaskKey
 		},

--- a/service/history/queues/queue_scheduled_test.go
+++ b/service/history/queues/queue_scheduled_test.go
@@ -76,6 +76,7 @@ func (s *scheduledQueueSuite) SetupTest() {
 		&persistencespb.ShardInfo{
 			ShardId: 0,
 			RangeId: 1,
+			Owner:   "test-shard-owner",
 		},
 		tests.NewDynamicConfig(),
 	)
@@ -236,6 +237,7 @@ func (s *scheduledQueueSuite) TestLookAheadTask_ErrorLookAhead() {
 
 	s.mockExecutionManager.EXPECT().RegisterHistoryTaskReader(gomock.Any(), &persistence.RegisterHistoryTaskReaderRequest{
 		ShardID:      s.mockShard.GetShardID(),
+		ShardOwner:   s.mockShard.GetOwner(),
 		TaskCategory: tasks.CategoryTimer,
 		ReaderID:     lookAheadReaderID,
 	}).Times(1)
@@ -270,6 +272,7 @@ func (s *scheduledQueueSuite) setupLookAheadMock(
 
 	s.mockExecutionManager.EXPECT().RegisterHistoryTaskReader(gomock.Any(), &persistence.RegisterHistoryTaskReaderRequest{
 		ShardID:      s.mockShard.GetShardID(),
+		ShardOwner:   s.mockShard.GetOwner(),
 		TaskCategory: tasks.CategoryTimer,
 		ReaderID:     lookAheadReaderID,
 	}).Times(1)

--- a/service/history/queues/reader_group.go
+++ b/service/history/queues/reader_group.go
@@ -44,6 +44,7 @@ type (
 		sync.Mutex
 
 		shardID          int32
+		shardOwner       string
 		category         tasks.Category
 		initializer      ReaderInitializer
 		executionManager persistence.ExecutionManager
@@ -55,12 +56,14 @@ type (
 
 func NewReaderGroup(
 	shardID int32,
+	shardOwner string,
 	category tasks.Category,
 	initializer ReaderInitializer,
 	executionManager persistence.ExecutionManager,
 ) *ReaderGroup {
 	return &ReaderGroup{
 		shardID:          shardID,
+		shardOwner:       shardOwner,
 		category:         category,
 		initializer:      initializer,
 		executionManager: executionManager,
@@ -140,6 +143,7 @@ func (g *ReaderGroup) NewReader(readerID int32, slices ...Slice) Reader {
 	g.readerMap[readerID] = reader
 	err := g.executionManager.RegisterHistoryTaskReader(context.Background(), &persistence.RegisterHistoryTaskReaderRequest{
 		ShardID:      g.shardID,
+		ShardOwner:   g.shardOwner,
 		TaskCategory: g.category,
 		ReaderID:     readerID,
 	})
@@ -173,6 +177,7 @@ func (g *ReaderGroup) removeReaderLocked(readerID int32) {
 	reader.Stop()
 	g.executionManager.UnregisterHistoryTaskReader(context.Background(), &persistence.UnregisterHistoryTaskReaderRequest{
 		ShardID:      g.shardID,
+		ShardOwner:   g.shardOwner,
 		TaskCategory: g.category,
 		ReaderID:     readerID,
 	})

--- a/service/history/queues/reader_group_test.go
+++ b/service/history/queues/reader_group_test.go
@@ -46,8 +46,9 @@ type (
 		controller           *gomock.Controller
 		mockExecutionManager *persistence.MockExecutionManager
 
-		shardID  int32
-		category tasks.Category
+		shardID    int32
+		shardOwner string
+		category   tasks.Category
 
 		readerGroup *ReaderGroup
 	}
@@ -69,10 +70,12 @@ func (s *readerGroupSuite) SetupTest() {
 	s.mockExecutionManager = persistence.NewMockExecutionManager(s.controller)
 
 	s.shardID = rand.Int31()
+	s.shardOwner = "test-shard-owner"
 	s.category = tasks.CategoryTransfer
 
 	s.readerGroup = NewReaderGroup(
 		s.shardID,
+		s.shardOwner,
 		s.category,
 		func(_ int32, _ []Slice) Reader {
 			return newTestReader()
@@ -177,6 +180,7 @@ func (s *readerGroupSuite) setupRegisterReaderMock(
 ) {
 	request := &persistence.RegisterHistoryTaskReaderRequest{
 		ShardID:      s.shardID,
+		ShardOwner:   s.shardOwner,
 		TaskCategory: s.category,
 		ReaderID:     readerID,
 	}
@@ -189,6 +193,7 @@ func (s *readerGroupSuite) setupUnRegisterReaderMock(
 ) {
 	request := &persistence.UnregisterHistoryTaskReaderRequest{
 		ShardID:      s.shardID,
+		ShardOwner:   s.shardOwner,
 		TaskCategory: s.category,
 		ReaderID:     readerID,
 	}

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -287,6 +287,7 @@ func (p *ackMgrImpl) Close() {
 	for readerID := range p.registeredQueueReaders {
 		p.executionMgr.UnregisterHistoryTaskReader(closeCtx, &persistence.UnregisterHistoryTaskReaderRequest{
 			ShardID:      p.shard.GetShardID(),
+			ShardOwner:   p.shard.GetOwner(),
 			TaskCategory: tasks.CategoryReplication,
 			ReaderID:     readerID,
 		})
@@ -807,6 +808,7 @@ func (p *ackMgrImpl) clusterToReaderID(
 	if _, ok := p.registeredQueueReaders[readerID]; !ok {
 		err := p.executionMgr.RegisterHistoryTaskReader(ctx, &persistence.RegisterHistoryTaskReaderRequest{
 			ShardID:      p.shard.GetShardID(),
+			ShardOwner:   p.shard.GetOwner(),
 			TaskCategory: tasks.CategoryReplication,
 			ReaderID:     readerID,
 		})

--- a/service/history/replication/ack_manager_test.go
+++ b/service/history/replication/ack_manager_test.go
@@ -101,6 +101,7 @@ func (s *ackManagerSuite) SetupTest() {
 		&persistencespb.ShardInfo{
 			ShardId: 0,
 			RangeId: 1,
+			Owner:   "test-shard-owner",
 		},
 		tests.NewDynamicConfig(),
 	)
@@ -111,6 +112,7 @@ func (s *ackManagerSuite) SetupTest() {
 	s.mockExecutionMgr = s.mockShard.Resource.ExecutionMgr
 	s.mockExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), &persistence.RegisterHistoryTaskReaderRequest{
 		ShardID:      s.mockShard.GetShardID(),
+		ShardOwner:   s.mockShard.GetOwner(),
 		TaskCategory: tasks.CategoryReplication,
 		ReaderID:     common.DefaultQueueReaderID,
 	}).MaxTimes(1)
@@ -866,6 +868,7 @@ func (s *ackManagerSuite) TestClose() {
 		s.replicationAckManager.registeredQueueReaders[readerID] = struct{}{}
 		s.mockExecutionMgr.EXPECT().UnregisterHistoryTaskReader(gomock.Any(), &persistence.UnregisterHistoryTaskReaderRequest{
 			ShardID:      s.mockShard.GetShardID(),
+			ShardOwner:   s.mockShard.GetOwner(),
 			TaskCategory: tasks.CategoryReplication,
 			ReaderID:     readerID,
 		}).Times(1)

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -293,6 +293,7 @@ func (r *taskProcessorManagerImpl) cleanupReplicationTasks() error {
 	inclusiveMinPendingTaskKey := tasks.NewImmediateKey(*minAckedTaskID + 1)
 	r.shard.GetExecutionManager().UpdateHistoryTaskReaderProgress(ctx, &persistence.UpdateHistoryTaskReaderProgressRequest{
 		ShardID:                    r.shard.GetShardID(),
+		ShardOwner:                 r.shard.GetOwner(),
 		TaskCategory:               tasks.CategoryReplication,
 		ReaderID:                   common.DefaultQueueReaderID,
 		InclusiveMinPendingTaskKey: inclusiveMinPendingTaskKey,

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -65,6 +65,7 @@ type (
 		mockExecutionManager *persistence.MockExecutionManager
 
 		shardID     int32
+		shardOwner  string
 		config      *configs.Config
 		requestChan chan *replicationTaskRequest
 
@@ -93,6 +94,7 @@ func (s *taskProcessorManagerSuite) SetupTest() {
 	s.requestChan = make(chan *replicationTaskRequest, 10)
 
 	s.shardID = rand.Int31()
+	s.shardOwner = "test-shard-owner"
 	s.mockShard = shard.NewMockContext(s.controller)
 	s.mockEngine = shard.NewMockEngine(s.controller)
 	s.mockClientBean = client.NewMockBean(s.controller)
@@ -115,6 +117,7 @@ func (s *taskProcessorManagerSuite) SetupTest() {
 	s.mockExecutionManager = persistence.NewMockExecutionManager(s.controller)
 	s.mockShard.EXPECT().GetExecutionManager().Return(s.mockExecutionManager).AnyTimes()
 	s.mockShard.EXPECT().GetShardID().Return(s.shardID).AnyTimes()
+	s.mockShard.EXPECT().GetOwner().Return(s.shardOwner).AnyTimes()
 	s.taskProcessorManager = NewTaskProcessorManager(
 		s.config,
 		s.mockShard,
@@ -153,6 +156,7 @@ func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Cleanup() {
 		gomock.Any(),
 		&persistence.UpdateHistoryTaskReaderProgressRequest{
 			ShardID:                    s.shardID,
+			ShardOwner:                 s.shardOwner,
 			TaskCategory:               tasks.CategoryReplication,
 			ReaderID:                   common.DefaultQueueReaderID,
 			InclusiveMinPendingTaskKey: tasks.NewImmediateKey(ackedTaskID + 1),

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -55,6 +55,7 @@ type (
 	// Context represents a history engine shard
 	Context interface {
 		GetShardID() int32
+		GetOwner() string
 		GetExecutionManager() persistence.ExecutionManager
 		GetNamespaceRegistry() namespace.Registry
 		GetClusterMetadata() cluster.Metadata

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -30,8 +30,10 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/pborman/uuid"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -87,12 +89,17 @@ const (
 	pendingMaxReplicationTaskID = math.MaxInt64
 )
 
+var (
+	shardContextSequenceID int64 = 0
+)
+
 type (
 	contextState int32
 
 	ContextImpl struct {
 		// These fields are constant:
 		shardID             int32
+		owner               string
 		stringRepr          string
 		executionManager    persistence.ExecutionManager
 		metricsHandler      metrics.Handler
@@ -186,6 +193,11 @@ func (s *ContextImpl) String() string {
 func (s *ContextImpl) GetShardID() int32 {
 	// constant from initialization, no need for locks
 	return s.shardID
+}
+
+func (s *ContextImpl) GetOwner() string {
+	// constant from initialization, no need for locks
+	return s.owner
 }
 
 func (s *ContextImpl) GetExecutionManager() persistence.ExecutionManager {
@@ -1740,8 +1752,8 @@ func (s *ContextImpl) loadShardMetadata(ownershipChanged *bool) error {
 	// shardInfo is a fresh value, so we don't really need to copy, but
 	// copyShardInfo also ensures that all maps are non-nil
 	updatedShardInfo := copyShardInfo(shardInfo)
-	*ownershipChanged = shardInfo.Owner != s.hostInfoProvider.HostInfo().Identity()
-	updatedShardInfo.Owner = s.hostInfoProvider.HostInfo().Identity()
+	*ownershipChanged = shardInfo.Owner != s.owner
+	updatedShardInfo.Owner = s.owner
 
 	// initialize the cluster current time to be the same as ack level
 	remoteClusterInfos := make(map[string]*remoteClusterInfo)
@@ -1985,12 +1997,14 @@ func newContext(
 	hostInfoProvider membership.HostInfoProvider,
 ) (*ContextImpl, error) {
 	hostIdentity := hostInfoProvider.HostInfo().Identity()
+	sequenceID := atomic.AddInt64(&shardContextSequenceID, 1)
 
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 
 	shardContext := &ContextImpl{
 		state:                   contextStateInitialized,
 		shardID:                 shardID,
+		owner:                   fmt.Sprintf("%s-%v-%v", hostIdentity, sequenceID, uuid.New()),
 		stringRepr:              fmt.Sprintf("Shard(%d)", shardID),
 		executionManager:        persistenceExecutionManager,
 		metricsHandler:          metricsHandler,

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -420,6 +420,20 @@ func (mr *MockContextMockRecorder) GetNamespaceRegistry() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceRegistry", reflect.TypeOf((*MockContext)(nil).GetNamespaceRegistry))
 }
 
+// GetOwner mocks base method.
+func (m *MockContext) GetOwner() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOwner")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetOwner indicates an expected call of GetOwner.
+func (mr *MockContextMockRecorder) GetOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwner", reflect.TypeOf((*MockContext)(nil).GetOwner))
+}
+
 // GetPayloadSerializer mocks base method.
 func (m *MockContext) GetPayloadSerializer() serialization.Serializer {
 	m.ctrl.T.Helper()

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -82,6 +82,7 @@ func NewTestContext(
 	}
 	shard := &ContextImpl{
 		shardID:             shardInfo.GetShardId(),
+		owner:               shardInfo.GetOwner(),
 		stringRepr:          fmt.Sprintf("Shard(%d)", shardInfo.GetShardId()),
 		executionManager:    resourceTest.ExecutionMgr,
 		metricsHandler:      resourceTest.MetricsHandler,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Make shard info owner unique for each shard context object
- UpdateShard can also use this unique owner value to tell if it's a new shard context object
- Use shard owner in history task reader related api

<!-- Tell your future self why have you made these changes -->
**Why?**
- Persistence may need this information to tell which shard context object is issuing the request.
- Existing owner only contains host identity, which is not enough since shard context stop is async so it's possible that there're two or more shard contexts with the same shardID running on one host.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Very low risk. No implementation is actually looking at the shard info owner field and it's only for information only right now.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.