### PR TITLE
Flush buffer event when failing workflow task

### DIFF
--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -935,6 +935,8 @@ func failWorkflowTask(
 		return nil, nextEventBatchId, err
 	}
 
+	mutableState.FlushBufferedEvents()
+
 	// Return new mutable state back to the caller for further updates
 	return mutableState, nextEventBatchId, nil
 }

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -548,6 +548,9 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		newMutableState = nil
 
 		if wtFailedCause.workflowFailure != nil {
+			// Flush buffer event before failing the workflow
+			ms.FlushBufferedEvents()
+
 			attributes := &commandpb.FailWorkflowExecutionCommandAttributes{
 				Failure: wtFailedCause.workflowFailure,
 			}
@@ -934,8 +937,6 @@ func failWorkflowTask(
 		0); err != nil {
 		return nil, nextEventBatchId, err
 	}
-
-	mutableState.FlushBufferedEvents()
 
 	// Return new mutable state back to the caller for further updates
 	return mutableState, nextEventBatchId, nil

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -127,7 +127,8 @@ type (
 		NumHistoryHosts        int
 		HistoryCountLimitError int
 		HistoryCountLimitWarn  int
-		BlobSizeError          int
+		BlobSizeLimitError     int
+		BlobSizeLimitWarn      int
 	}
 
 	// TemporalParams contains everything needed to bootstrap Temporal
@@ -700,8 +701,11 @@ func (c *temporalImpl) overrideHistoryDynamicConfig(client *dcClient) {
 	if c.historyConfig.HistoryCountLimitError != 0 {
 		client.OverrideValue(dynamicconfig.HistoryCountLimitError, c.historyConfig.HistoryCountLimitError)
 	}
-	if c.historyConfig.BlobSizeError != 0 {
-		client.OverrideValue(dynamicconfig.BlobSizeLimitError, c.historyConfig.BlobSizeError)
+	if c.historyConfig.BlobSizeLimitError != 0 {
+		client.OverrideValue(dynamicconfig.BlobSizeLimitError, c.historyConfig.BlobSizeLimitError)
+	}
+	if c.historyConfig.BlobSizeLimitWarn != 0 {
+		client.OverrideValue(dynamicconfig.BlobSizeLimitWarn, c.historyConfig.BlobSizeLimitWarn)
 	}
 
 	// For DeleteWorkflowExecution tests

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -127,6 +127,7 @@ type (
 		NumHistoryHosts        int
 		HistoryCountLimitError int
 		HistoryCountLimitWarn  int
+		BlobSizeError          int
 	}
 
 	// TemporalParams contains everything needed to bootstrap Temporal
@@ -698,6 +699,9 @@ func (c *temporalImpl) overrideHistoryDynamicConfig(client *dcClient) {
 	}
 	if c.historyConfig.HistoryCountLimitError != 0 {
 		client.OverrideValue(dynamicconfig.HistoryCountLimitError, c.historyConfig.HistoryCountLimitError)
+	}
+	if c.historyConfig.BlobSizeError != 0 {
+		client.OverrideValue(dynamicconfig.BlobSizeLimitError, c.historyConfig.BlobSizeError)
 	}
 
 	// For DeleteWorkflowExecution tests

--- a/tests/sizelimit_test.go
+++ b/tests/sizelimit_test.go
@@ -244,7 +244,7 @@ SignalLoop:
 	s.True(isCloseCorrect)
 }
 
-func (s *integrationSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
+func (s *sizeLimitIntegrationSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 
 	id := "integration-workflow-failed-large-payload"
 	wt := "integration-workflow-failed-large-payload-type"
@@ -315,7 +315,13 @@ func (s *integrationSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 	case <-sigReadyToSendChan:
 	}
 
-	err = s.sendSignal(s.namespace, &commonpb.WorkflowExecution{WorkflowId: id, RunId: we.GetRunId()}, "signal-name", nil, identity)
+	_, err = s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
+		Namespace:         s.namespace,
+		WorkflowExecution: &commonpb.WorkflowExecution{WorkflowId: id, RunId: we.GetRunId()},
+		SignalName:        "signal-name",
+		Identity:          identity,
+		RequestId:         uuid.New(),
+	})
 	s.NoError(err)
 	close(sigSendDoneChan)
 

--- a/tests/testdata/integration_sizelimit_cluster.yaml
+++ b/tests/testdata/integration_sizelimit_cluster.yaml
@@ -5,6 +5,8 @@ historyconfig:
   numhistoryhosts: 1
   historycountlimiterror: 20
   historycountlimitwarn: 10
+  blobsizelimiterror: 100
+  blobsizelimitwarn: 1
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/tests/testdata/integration_sizelimit_cluster.yaml
+++ b/tests/testdata/integration_sizelimit_cluster.yaml
@@ -5,6 +5,7 @@ historyconfig:
   numhistoryhosts: 1
   historycountlimiterror: 20
   historycountlimitwarn: 10
+  blobsizelimiterror: 100
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/tests/testdata/integration_sizelimit_cluster.yaml
+++ b/tests/testdata/integration_sizelimit_cluster.yaml
@@ -5,7 +5,6 @@ historyconfig:
   numhistoryhosts: 1
   historycountlimiterror: 20
   historycountlimitwarn: 10
-  blobsizelimiterror: 100
 workerconfig:
   enablearchiver: false
   enablereplicator: false

--- a/tests/testdata/integration_test_cluster.yaml
+++ b/tests/testdata/integration_test_cluster.yaml
@@ -3,8 +3,6 @@ clusterno: 0
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
-  blobsizelimiterror: 100
-  blobsizelimitwarn: 1
 workerconfig:
   startworkeranyway: true
   enablearchiver: true

--- a/tests/testdata/integration_test_cluster.yaml
+++ b/tests/testdata/integration_test_cluster.yaml
@@ -3,6 +3,8 @@ clusterno: 0
 historyconfig:
   numhistoryshards: 4
   numhistoryhosts: 1
+  blobsizelimiterror: 100
+  blobsizelimitwarn: 1
 workerconfig:
   startworkeranyway: true
   enablearchiver: true


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Flush buffer event when failing workflow task

<!-- Tell your future self why have you made these changes -->
**Why?**
When workflow task failed due to payload/search attribute size too large, it should flush buffer events before fail the workflow.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
