### PR TITLE
Move RingPop config validation to membership package

### DIFF
--- a/common/membership/config.go
+++ b/common/membership/config.go
@@ -1,0 +1,40 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package membership
+
+import (
+	"fmt"
+	"net"
+
+	"go.temporal.io/server/common/config"
+)
+
+// ValidateConfig validates that the membership config is parseable and valid
+func ValidateConfig(cfg *config.Membership) error {
+	if cfg.BroadcastAddress != "" && net.ParseIP(cfg.BroadcastAddress) == nil {
+		return fmt.Errorf("ringpop config malformed `broadcastAddress` param")
+	}
+	return nil
+}

--- a/common/membership/config_test.go
+++ b/common/membership/config_test.go
@@ -1,0 +1,42 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package membership
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"go.temporal.io/server/common/config"
+)
+
+func TestInvalidConfig(t *testing.T) {
+	var cfg config.Membership
+	cfg.MaxJoinDuration = time.Minute
+	assert.NoError(t, ValidateConfig(&cfg))
+	cfg.BroadcastAddress = "sjhdfskdjhf"
+	assert.Error(t, ValidateConfig(&cfg))
+}

--- a/common/membership/ringpop/factory.go
+++ b/common/membership/ringpop/factory.go
@@ -86,7 +86,7 @@ func newFactory(
 	tlsProvider encryption.TLSConfigProvider,
 	dc *dynamicconfig.Collection,
 ) (*factory, error) {
-	if err := ValidateConfig(rpConfig); err != nil {
+	if err := membership.ValidateConfig(rpConfig); err != nil {
 		return nil, err
 	}
 	if rpConfig.MaxJoinDuration == 0 {
@@ -102,14 +102,6 @@ func newFactory(
 		tlsFactory:      tlsProvider,
 		dc:              dc,
 	}, nil
-}
-
-// ValidateConfig validates that ringpop config is parseable and valid
-func ValidateConfig(cfg *config.Membership) error {
-	if cfg.BroadcastAddress != "" && net.ParseIP(cfg.BroadcastAddress) == nil {
-		return fmt.Errorf("ringpop config malformed `broadcastAddress` param")
-	}
-	return nil
 }
 
 // getMembershipMonitor return a membership monitor

--- a/common/membership/ringpop/factory_test.go
+++ b/common/membership/ringpop/factory_test.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/rpc/encryption"
@@ -137,19 +138,11 @@ func (s *RingpopSuite) TestHostsMode() {
 	s.Nil(err)
 	s.Equal("1.2.3.4", cfg.BroadcastAddress)
 	s.Equal(time.Second*30, cfg.MaxJoinDuration)
-	err = ValidateConfig(&cfg)
+	err = membership.ValidateConfig(&cfg)
 	s.Nil(err)
 	f, err := newFactory(&cfg, "test", nil, log.NewNoopLogger(), nil, nil, nil, nil)
 	s.Nil(err)
 	s.NotNil(f)
-}
-
-func (s *RingpopSuite) TestInvalidConfig() {
-	var cfg config.Membership
-	cfg.MaxJoinDuration = time.Minute
-	s.NoError(ValidateConfig(&cfg))
-	cfg.BroadcastAddress = "sjhdfskdjhf"
-	s.Error(ValidateConfig(&cfg))
 }
 
 func getHostsConfig() string {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -52,7 +52,7 @@ import (
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
-	"go.temporal.io/server/common/membership/ringpop"
+	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/cassandra"
@@ -169,7 +169,7 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 		return serverOptionsProvider{}, err
 	}
 
-	err = ringpop.ValidateConfig(&so.config.Global.Membership)
+	err = membership.ValidateConfig(&so.config.Global.Membership)
 	if err != nil {
 		return serverOptionsProvider{}, fmt.Errorf("ringpop config validation error: %w", err)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The ValidateConfig method has moved from the ringpop package to the membership package.

<!-- Tell your future self why have you made these changes -->
**Why?**
The `temporal` package should not depend on RingPop. The ringpop.ValidateConfig method is used for all Membership configs, regardless of whether they are used in RingPop or not.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No semantic runtime changes here--the only error here could be from a compile-time dependency issue like a cycle.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
