### PR TITLE
Remove Start/Stop methods from Monitor interface

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -32,7 +32,6 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/primitives"
 )
 
@@ -60,8 +59,6 @@ type (
 	// Monitor provides membership information for all temporal services.
 	// It can be used to query which member host of a service is responsible for serving a given key.
 	Monitor interface {
-		common.Daemon
-
 		WhoAmI() (HostInfo, error)
 		// EvictSelf evicts this member from the membership ring. After this method is
 		// called, other members will discover that this node is no longer part of the

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -161,30 +161,6 @@ func (mr *MockMonitorMockRecorder) RemoveListener(service, name interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveListener", reflect.TypeOf((*MockMonitor)(nil).RemoveListener), service, name)
 }
 
-// Start mocks base method.
-func (m *MockMonitor) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start.
-func (mr *MockMonitorMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMonitor)(nil).Start))
-}
-
-// Stop mocks base method.
-func (m *MockMonitor) Stop() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Stop")
-}
-
-// Stop indicates an expected call of Stop.
-func (mr *MockMonitorMockRecorder) Stop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockMonitor)(nil).Stop))
-}
-
 // WaitUntilInitialized mocks base method.
 func (m *MockMonitor) WaitUntilInitialized(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/common/membership/ringpop/fx.go
+++ b/common/membership/ringpop/fx.go
@@ -58,7 +58,7 @@ func membershipMonitorProvider(
 
 	rpcConfig := cfg.Services[string(svcName)].RPC
 
-	factory, err := newFactory(
+	f, err := newFactory(
 		&cfg.Global.Membership,
 		svcName,
 		servicePortMap,
@@ -72,7 +72,7 @@ func membershipMonitorProvider(
 		return nil, err
 	}
 
-	monitor, err := factory.getMembershipMonitor()
+	m, err := f.getMembershipMonitor()
 	if err != nil {
 		return nil, err
 	}
@@ -80,16 +80,16 @@ func membershipMonitorProvider(
 	lc.Append(
 		fx.Hook{
 			OnStart: func(context.Context) error {
-				monitor.Start()
+				m.Start()
 				return nil
 			},
 			OnStop: func(context.Context) error {
-				monitor.Stop()
-				factory.closeTChannel()
+				m.Stop()
+				f.closeTChannel()
 				return nil
 			},
 		},
 	)
 
-	return monitor, nil
+	return m, nil
 }

--- a/common/membership/ringpop/fx.go
+++ b/common/membership/ringpop/fx.go
@@ -72,7 +72,7 @@ func membershipMonitorProvider(
 		return nil, err
 	}
 
-	m, err := f.getMembershipMonitor()
+	m, err := f.getMonitor()
 	if err != nil {
 		return nil, err
 	}

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -107,8 +107,8 @@ func newMonitor(
 		hostID:                    uuid.NewUUID(),
 		initialized:               future.NewFuture[struct{}](),
 	}
-	for service, port := range services {
-		rpo.rings[service] = newServiceResolver(service, port, rp, logger)
+	for s, port := range services {
+		rpo.rings[s] = newServiceResolver(s, port, rp, logger)
 	}
 	return rpo
 }

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -84,7 +84,7 @@ func newMonitor(
 	logger log.Logger,
 	metadataManager persistence.ClusterMetadataManager,
 	broadcastHostPortResolver func() (string, error),
-) membership.Monitor {
+) *monitor {
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	lifecycleCtx = headers.SetCallerInfo(
 		lifecycleCtx,

--- a/common/membership/ringpop/test_cluster.go
+++ b/common/membership/ringpop/test_cluster.go
@@ -45,8 +45,8 @@ import (
 type testCluster struct {
 	hostUUIDs    []string
 	hostAddrs    []string
-	hostInfoList []membership.HostInfo
-	rings        []membership.Monitor
+	hostInfoList []*hostInfo
+	rings        []*monitor
 	channels     []*tchannel.Channel
 	seedNode     string
 }
@@ -74,8 +74,8 @@ func newTestCluster(
 	cluster := &testCluster{
 		hostUUIDs:    make([]string, size),
 		hostAddrs:    make([]string, size),
-		hostInfoList: make([]membership.HostInfo, size),
-		rings:        make([]membership.Monitor, size),
+		hostInfoList: make([]*hostInfo, size),
+		rings:        make([]*monitor, size),
 		channels:     make([]*tchannel.Channel, size),
 		seedNode:     seed,
 	}
@@ -198,7 +198,11 @@ func (c *testCluster) Stop() {
 
 // GetHostInfoList returns the list of all hosts within the cluster
 func (c *testCluster) GetHostInfoList() []membership.HostInfo {
-	return c.hostInfoList
+	hostInfoList := make([]membership.HostInfo, len(c.hostInfoList))
+	for i := 0; i < len(c.hostInfoList); i++ {
+		hostInfoList[i] = c.hostInfoList[i]
+	}
+	return hostInfoList
 }
 
 // GetHostAddrs returns all host addrs within the cluster

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -368,7 +368,6 @@ func (s *Service) Start() {
 	s.metricsHandler.Counter(metrics.RestartCount).Record(1)
 
 	s.clusterMetadata.Start()
-	s.membershipMonitor.Start()
 	s.namespaceRegistry.Start()
 
 	hostInfo, err := s.membershipMonitor.WhoAmI()
@@ -431,7 +430,6 @@ func (s *Service) Stop() {
 	s.perNamespaceWorkerManager.Stop()
 	s.workerManager.Stop()
 	s.namespaceRegistry.Stop()
-	s.membershipMonitor.Stop()
 	s.clusterMetadata.Stop()
 	s.persistenceBean.Close()
 	s.visibilityManager.Close()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The Monitor interface no longer provides Start/Stop methods.

<!-- Tell your future self why have you made these changes -->
**Why?**
To move lifecycle management to Monitor implementations, e.g. when they are provided to fx. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
The Module is the only exported symbol in this package, and so it is the only way to get a ringpop.monitor. Within that module, the ringpop.monitor is provided by a function which also registers the Start and Stop methods in the fx lifecycle. This guarantees that the Start and Stop method will be registered any time a ringpop.monitor is produced.

Also, I stepped through with a debugger to see that the call to monitor.Start() in the service worker did nothing because Start is already called.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
