### PR TITLE
Remove unused HostsUpdated field from ChangedEvent

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -53,7 +53,6 @@ type (
 	// ChangedEvent describes a change in membership
 	ChangedEvent struct {
 		HostsAdded   []HostInfo
-		HostsUpdated []HostInfo
 		HostsRemoved []HostInfo
 	}
 

--- a/common/membership/ringpop/monitor_test.go
+++ b/common/membership/ringpop/monitor_test.go
@@ -80,7 +80,6 @@ func (s *RpoSuite) TestMonitor() {
 		s.Equal(1, len(e.HostsRemoved), "ringpop monitor event does not report the removed host")
 		s.Equal(testService.hostAddrs[1], e.HostsRemoved[0].GetAddress(), "ringpop monitor reported that a wrong host was removed")
 		s.Nil(e.HostsAdded, "Unexpected host reported to be added by ringpop monitor")
-		s.Nil(e.HostsUpdated, "Unexpected host reported to be updated by ringpop monitor")
 	case <-time.After(time.Minute):
 		s.Fail("Timed out waiting for failure to be detected by ringpop")
 	}
@@ -122,9 +121,6 @@ func (s *RpoSuite) verifyMemberDiff(curr []string, new []string, expectedDiff []
 		var diff []string
 		for _, a := range event.HostsAdded {
 			diff = append(diff, "+"+a.GetAddress())
-		}
-		for _, a := range event.HostsUpdated {
-			diff = append(diff, "~"+a.GetAddress())
 		}
 		for _, a := range event.HostsRemoved {
 			diff = append(diff, "-"+a.GetAddress())

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -368,7 +368,7 @@ func (c *ControllerImpl) shardManagementPump() {
 			c.contextTaggedLogger.Info("", tag.ValueRingMembershipChangedEvent,
 				tag.NumberProcessed(len(changedEvent.HostsAdded)),
 				tag.NumberDeleted(len(changedEvent.HostsRemoved)),
-				tag.Number(int64(len(changedEvent.HostsUpdated))))
+			)
 			c.acquireShards()
 		}
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the HostsUpdated field from the ChangedEvent.

<!-- Tell your future self why have you made these changes -->
**Why?**
This field isn't used. It simplifies future Monitor implementations.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
