### PR TITLE
Adds ability to pass in PerNSWorkerComponents via ServerOptions

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -72,6 +72,8 @@ import (
 	"go.temporal.io/server/service/history/workflow"
 	"go.temporal.io/server/service/matching"
 	"go.temporal.io/server/service/worker"
+
+	workercommon "go.temporal.io/server/service/worker/common"
 )
 
 type (
@@ -119,15 +121,16 @@ type (
 		ClaimMapper            authorization.ClaimMapper
 		AudienceGetter         authorization.JWTAudienceMapper
 
-		// below are things that could be over write by server options or may have default if not supplied by serverOptions.
-		Logger                  log.Logger
-		ClientFactoryProvider   client.FactoryProvider
-		DynamicConfigClient     dynamicconfig.Client
-		DynamicConfigCollection *dynamicconfig.Collection
-		TLSConfigProvider       encryption.TLSConfigProvider
-		EsConfig                *esclient.Config
-		EsClient                esclient.Client
-		MetricsHandler          metrics.Handler
+		// below are things that could be overwritten by server options or may have a default if not supplied by serverOptions.
+		Logger                       log.Logger
+		ClientFactoryProvider        client.FactoryProvider
+		DynamicConfigClient          dynamicconfig.Client
+		DynamicConfigCollection      *dynamicconfig.Collection
+		TLSConfigProvider            encryption.TLSConfigProvider
+		EsConfig                     *esclient.Config
+		EsClient                     esclient.Client
+		MetricsHandler               metrics.Handler
+		PerNamespaceWorkerComponents []workercommon.PerNSWorkerComponent `group:"perNamespaceWorkerComponent,flatten"`
 	}
 )
 
@@ -265,14 +268,15 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 		ClaimMapper:            so.claimMapper,
 		AudienceGetter:         so.audienceGetter,
 
-		Logger:                  logger,
-		ClientFactoryProvider:   clientFactoryProvider,
-		DynamicConfigClient:     dcClient,
-		DynamicConfigCollection: dynamicconfig.NewCollection(dcClient, logger),
-		TLSConfigProvider:       tlsConfigProvider,
-		EsConfig:                esConfig,
-		EsClient:                esClient,
-		MetricsHandler:          metricHandler,
+		Logger:                       logger,
+		ClientFactoryProvider:        clientFactoryProvider,
+		DynamicConfigClient:          dcClient,
+		DynamicConfigCollection:      dynamicconfig.NewCollection(dcClient, logger),
+		TLSConfigProvider:            tlsConfigProvider,
+		EsConfig:                     esConfig,
+		EsClient:                     esClient,
+		MetricsHandler:               metricHandler,
+		PerNamespaceWorkerComponents: so.perNamespaceWorkerComponents,
 	}, nil
 }
 

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/searchattribute"
+	workercommon "go.temporal.io/server/service/worker/common"
 )
 
 type (
@@ -187,5 +188,13 @@ func WithChainedFrontendGrpcInterceptors(
 func WithCustomMetricsHandler(provider metrics.Handler) ServerOption {
 	return applyFunc(func(s *serverOptions) {
 		s.metricHandler = provider
+	})
+}
+
+// WithPerNamespaceWorkerComponent will register a component that, if enabled on a namespace,
+// runs within the context of that namespace. Workflow executions are within the Temporal Worker Service
+func WithPerNamespaceWorkerComponent(component workercommon.PerNSWorkerComponent) ServerOption {
+	return applyFunc(func(s *serverOptions) {
+		s.perNamespaceWorkerComponents = append(s.perNamespaceWorkerComponents, component)
 	})
 }

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -42,6 +42,7 @@ import (
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/rpc/encryption"
 	"go.temporal.io/server/common/searchattribute"
+	workercommon "go.temporal.io/server/service/worker/common"
 )
 
 type (
@@ -56,20 +57,21 @@ type (
 		interruptCh   <-chan interface{}
 		blockingStart bool
 
-		logger                     log.Logger
-		namespaceLogger            log.Logger
-		authorizer                 authorization.Authorizer
-		tlsConfigProvider          encryption.TLSConfigProvider
-		claimMapper                authorization.ClaimMapper
-		audienceGetter             authorization.JWTAudienceMapper
-		persistenceServiceResolver resolver.ServiceResolver
-		elasticsearchHttpClient    *http.Client
-		dynamicConfigClient        dynamicconfig.Client
-		customDataStoreFactory     persistenceClient.AbstractDataStoreFactory
-		clientFactoryProvider      client.FactoryProvider
-		searchAttributesMapper     searchattribute.Mapper
-		customInterceptors         []grpc.UnaryServerInterceptor
-		metricHandler              metrics.Handler
+		logger                       log.Logger
+		namespaceLogger              log.Logger
+		authorizer                   authorization.Authorizer
+		tlsConfigProvider            encryption.TLSConfigProvider
+		claimMapper                  authorization.ClaimMapper
+		audienceGetter               authorization.JWTAudienceMapper
+		persistenceServiceResolver   resolver.ServiceResolver
+		elasticsearchHttpClient      *http.Client
+		dynamicConfigClient          dynamicconfig.Client
+		customDataStoreFactory       persistenceClient.AbstractDataStoreFactory
+		clientFactoryProvider        client.FactoryProvider
+		searchAttributesMapper       searchattribute.Mapper
+		customInterceptors           []grpc.UnaryServerInterceptor
+		metricHandler                metrics.Handler
+		perNamespaceWorkerComponents []workercommon.PerNSWorkerComponent
 	}
 )
 


### PR DESCRIPTION
Adds additional ServerOption that enables specification of additional PerNamespaceWorkerComponents. This will enable injection of additional workflows that run on the temporal worker and within the context of a specific namespace.
