### PR TITLE
Support empty queries when listing archived workflows

### DIFF
--- a/common/archiver/filestore/queryParser.go
+++ b/common/archiver/filestore/queryParser.go
@@ -82,15 +82,18 @@ func NewQueryParser() QueryParser {
 }
 
 func (p *queryParser) Parse(query string) (*parsedQuery, error) {
+	parsedQuery := &parsedQuery{
+		earliestCloseTime: time.Time{},
+		latestCloseTime:   time.Now().UTC(),
+	}
+	if strings.TrimSpace(query) == "" {
+		return parsedQuery, nil
+	}
 	stmt, err := sqlparser.Parse(fmt.Sprintf(queryTemplate, query))
 	if err != nil {
 		return nil, err
 	}
 	whereExpr := stmt.(*sqlparser.Select).Where.Expr
-	parsedQuery := &parsedQuery{
-		earliestCloseTime: time.Time{},
-		latestCloseTime:   time.Now().UTC(),
-	}
 	if err := p.convertWhereExpr(whereExpr, parsedQuery); err != nil {
 		return nil, err
 	}

--- a/common/archiver/gcloud/visibilityArchiver_test.go
+++ b/common/archiver/gcloud/visibilityArchiver_test.go
@@ -34,6 +34,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflow/v1"
 
 	"go.temporal.io/server/common/searchattribute"
 
@@ -47,8 +49,11 @@ import (
 )
 
 const (
-	testWorkflowTypeName    = "test-workflow-type"
-	exampleVisibilityRecord = `{"namespaceId":"test-namespace-id","namespace":"test-namespace","workflowId":"test-workflow-id","runId":"test-run-id","workflowTypeName":"test-workflow-type","startTime":"2020-02-05T09:56:14.804475Z","closeTime":"2020-02-05T09:56:15.946478Z","status":"Completed","historyLength":36,"memo":null,"searchAttributes":null,"historyArchivalUri":"gs://my-bucket-cad/temporal_archival/development"}`
+	testWorkflowTypeName     = "test-workflow-type"
+	exampleVisibilityRecord  = `{"namespaceId":"test-namespace-id","namespace":"test-namespace","workflowId":"test-workflow-id","runId":"test-run-id","workflowTypeName":"test-workflow-type","startTime":"2020-02-05T09:56:14.804475Z","closeTime":"2020-02-05T09:56:15.946478Z","status":"Completed","historyLength":36,"memo":null,"searchAttributes":null,"historyArchivalUri":"gs://my-bucket-cad/temporal_archival/development"}`
+	exampleVisibilityRecord2 = `{"namespaceId":"test-namespace-id","namespace":"test-namespace",
+"workflowId":"test-workflow-id2","runId":"test-run-id","workflowTypeName":"test-workflow-type",
+"startTime":"2020-02-05T09:56:14.804475Z","closeTime":"2020-02-05T09:56:15.946478Z","status":"Completed","historyLength":36,"memo":null,"searchAttributes":null,"historyArchivalUri":"gs://my-bucket-cad/temporal_archival/development"}`
 )
 
 func (s *visibilityArchiverSuite) SetupTest() {
@@ -228,9 +233,11 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidToken() {
 	mockParser := NewMockQueryParser(s.controller)
 	startTime, _ := time.Parse(time.RFC3339, "2019-10-04T11:00:00+00:00")
 	closeTime := startTime.Add(time.Hour)
+	precision := PrecisionDay
 	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
-		closeTime: closeTime,
-		startTime: startTime,
+		closeTime:       closeTime,
+		startTime:       startTime,
+		searchPrecision: &precision,
 	}, nil)
 	visibilityArchiver.queryParser = mockParser
 	request := &archiver.QueryVisibilityRequest{
@@ -257,7 +264,7 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 	s.NoError(err)
 
 	mockParser := NewMockQueryParser(s.controller)
-	dayPrecision := string("Day")
+	dayPrecision := "Day"
 	closeTime, _ := time.Parse(time.RFC3339, "2019-10-04T11:00:00+00:00")
 	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
 		closeTime:       closeTime,
@@ -338,4 +345,123 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 	ei, err = convertToExecutionInfo(s.expectedVisibilityRecords[0], searchattribute.TestNameTypeMap)
 	s.NoError(err)
 	s.Equal(ei, response.Executions[0])
+}
+
+func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_InvalidNamespace() {
+	URI, err := archiver.NewURI("gs://my-bucket-cad/temporal_archival/visibility")
+	s.NoError(err)
+	storageWrapper := connector.NewMockClient(s.controller)
+	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(false, nil)
+	arc := newVisibilityArchiver(s.container, storageWrapper)
+	req := &archiver.QueryVisibilityRequest{
+		NamespaceID:   "",
+		PageSize:      1,
+		NextPageToken: nil,
+		Query:         "",
+	}
+	_, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap)
+
+	var svcErr *serviceerror.InvalidArgument
+
+	s.ErrorAs(err, &svcErr)
+}
+
+func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_ZeroPageSize() {
+	URI, err := archiver.NewURI("gs://my-bucket-cad/temporal_archival/visibility")
+	s.NoError(err)
+	storageWrapper := connector.NewMockClient(s.controller)
+	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(false, nil)
+	arc := newVisibilityArchiver(s.container, storageWrapper)
+
+	req := &archiver.QueryVisibilityRequest{
+		NamespaceID:   testNamespaceID,
+		PageSize:      0,
+		NextPageToken: nil,
+		Query:         "",
+	}
+	_, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap)
+
+	var svcErr *serviceerror.InvalidArgument
+
+	s.ErrorAs(err, &svcErr)
+}
+
+func (s *visibilityArchiverSuite) TestQuery_EmptyQuery_Pagination() {
+	URI, err := archiver.NewURI("gs://my-bucket-cad/temporal_archival/visibility")
+	s.NoError(err)
+	storageWrapper := connector.NewMockClient(s.controller)
+	storageWrapper.EXPECT().Exist(gomock.Any(), URI, gomock.Any()).Return(true, nil).Times(2)
+	storageWrapper.EXPECT().QueryWithFilters(
+		gomock.Any(),
+		URI,
+		gomock.Any(),
+		1,
+		0,
+		gomock.Any(),
+	).Return(
+		[]string{"closeTimeout_2020-02-05T09:56:14Z_test-workflow-id_MobileOnlyWorkflow::processMobileOnly_test-run-id.visibility"},
+		false,
+		1,
+		nil,
+	)
+	storageWrapper.EXPECT().QueryWithFilters(
+		gomock.Any(),
+		URI,
+		gomock.Any(),
+		1,
+		1,
+		gomock.Any(),
+	).Return(
+		[]string{"closeTimeout_2020-02-05T09:56:14Z_test-workflow-id2_MobileOnlyWorkflow::processMobileOnly_test-run" +
+			"-id.visibility"},
+		true,
+		2,
+		nil,
+	)
+	storageWrapper.EXPECT().Get(
+		gomock.Any(),
+		URI,
+		"test-namespace-id/closeTimeout_2020-02-05T09:56:14Z_test-workflow-id_MobileOnlyWorkflow::processMobileOnly_test-run-id.visibility",
+	).Return([]byte(exampleVisibilityRecord), nil)
+	storageWrapper.EXPECT().Get(gomock.Any(), URI,
+		"test-namespace-id/closeTimeout_2020-02-05T09:56:14Z_test-workflow-id2_MobileOnlyWorkflow"+
+			"::processMobileOnly_test-run-id.visibility").Return([]byte(exampleVisibilityRecord2), nil)
+
+	arc := newVisibilityArchiver(s.container, storageWrapper)
+
+	response := &archiver.QueryVisibilityResponse{
+		Executions:    nil,
+		NextPageToken: nil,
+	}
+
+	limit := 10
+	executions := make(map[string]*workflow.WorkflowExecutionInfo, limit)
+
+	numPages := 2
+	for i := 0; i < numPages; i++ {
+		req := &archiver.QueryVisibilityRequest{
+			NamespaceID:   testNamespaceID,
+			PageSize:      1,
+			NextPageToken: response.NextPageToken,
+			Query:         "",
+		}
+		response, err = arc.Query(context.Background(), URI, req, searchattribute.TestNameTypeMap)
+		s.NoError(err)
+		s.NotNil(response)
+		s.Len(response.Executions, 1)
+
+		s.Equal(
+			i == numPages-1,
+			response.NextPageToken == nil,
+			"should have no next page token on the last iteration",
+		)
+
+		for _, execution := range response.Executions {
+			key := execution.Execution.GetWorkflowId() +
+				"/" + execution.Execution.GetRunId() +
+				"/" + execution.CloseTime.String()
+			executions[key] = execution
+		}
+	}
+	s.Len(executions, 2, "there should be exactly 2 unique executions")
 }

--- a/common/archiver/s3store/util.go
+++ b/common/archiver/s3store/util.go
@@ -166,15 +166,40 @@ func constructTimeBasedSearchKey(path, namespaceID, primaryIndexKey, primaryInde
 		timeFormat = "2006-01-02T" + timeFormat
 	}
 
-	return fmt.Sprintf("%s/%s", constructVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey), t.Format(timeFormat))
+	return fmt.Sprintf(
+		"%s/%s",
+		constructIndexedVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey),
+		t.Format(timeFormat),
+	)
 }
 
 func constructTimestampIndex(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey string, secondaryIndexValue time.Time, runID string) string {
-	return fmt.Sprintf("%s/%s/%s", constructVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey), secondaryIndexValue.Format(time.RFC3339), runID)
+	return fmt.Sprintf(
+		"%s/%s/%s",
+		constructIndexedVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexKey),
+		secondaryIndexValue.Format(time.RFC3339),
+		runID,
+	)
 }
 
-func constructVisibilitySearchPrefix(path, namespaceID, primaryIndexKey, primaryIndexValue, secondaryIndexType string) string {
-	return strings.TrimLeft(strings.Join([]string{path, namespaceID, "visibility", primaryIndexKey, primaryIndexValue, secondaryIndexType}, "/"), "/")
+func constructIndexedVisibilitySearchPrefix(
+	path string,
+	namespaceID string,
+	primaryIndexKey string,
+	primaryIndexValue string,
+	secondaryIndexType string,
+) string {
+	return strings.TrimLeft(
+		strings.Join(
+			[]string{path, namespaceID, "visibility", primaryIndexKey, primaryIndexValue, secondaryIndexType},
+			"/",
+		),
+		"/",
+	)
+}
+
+func constructVisibilitySearchPrefix(path, namespaceID string) string {
+	return strings.TrimLeft(strings.Join([]string{path, namespaceID, "visibility"}, "/"), "/")
 }
 
 func ensureContextTimeout(ctx context.Context) (context.Context, context.CancelFunc) {

--- a/common/archiver/s3store/util_test.go
+++ b/common/archiver/s3store/util_test.go
@@ -1,0 +1,58 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package s3store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConstructVisibilitySearchPrefix(t *testing.T) {
+	t.Parallel()
+	assert.Equal(
+		t,
+		constructVisibilitySearchPrefix(
+			"path",
+			"namespaceID",
+		),
+		"path/namespaceID/visibility",
+	)
+}
+
+func TestConstructIndexedVisibilitySearchPrefix(t *testing.T) {
+	t.Parallel()
+	assert.Equal(
+		t,
+		constructIndexedVisibilitySearchPrefix(
+			"/path",
+			"namespaceID",
+			"primaryIndexKey",
+			"primaryIndexValue",
+			"secondaryIndexType",
+		),
+		"path/namespaceID/visibility/primaryIndexKey/primaryIndexValue/secondaryIndexType",
+	)
+}

--- a/common/archiver/util.go
+++ b/common/archiver/util.go
@@ -41,7 +41,6 @@ var (
 	errEmptyWorkflowTypeName = errors.New("field WorkflowTypeName is empty")
 	errEmptyStartTime        = errors.New("field StartTime is empty")
 	errEmptyCloseTime        = errors.New("field CloseTime is empty")
-	errEmptyQuery            = errors.New("field Query is empty")
 )
 
 // TagLoggerWithArchiveHistoryRequestAndURI tags logger with fields in the archive history request and the URI
@@ -142,9 +141,6 @@ func ValidateQueryRequest(request *QueryVisibilityRequest) error {
 	}
 	if request.PageSize == 0 {
 		return errInvalidPageSize
-	}
-	if request.Query == "" {
-		return errEmptyQuery
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now allow empty queries to the s3 visibility archival backend. 


<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/temporalio/ui/issues/572

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added unit tests for all of the different branches introduced. I also ran a manual end-to-end test verifying that this works for some locally archived workflows against my local stack instance. I verified that pagination works too: 
<img width="1400" alt="image" src="https://user-images.githubusercontent.com/5942963/223590125-ae1e90b8-0840-4c35-b716-aa3fb599a743.png">


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It's fixing a page that is currently broken, so it can't do much more harm.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
