### PR TITLE
Flush buffer event with single cluster namespace

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4387,8 +4387,7 @@ func (ms *MutableStateImpl) startTransactionHandleNamespaceMigration(
 
 func (ms *MutableStateImpl) startTransactionHandleWorkflowTaskFailover() (bool, error) {
 
-	if !ms.IsWorkflowExecutionRunning() ||
-		!ms.canReplicateEvents() {
+	if !ms.IsWorkflowExecutionRunning() {
 		return false, nil
 	}
 

--- a/tests/xdc/integration_failover_test.go
+++ b/tests/xdc/integration_failover_test.go
@@ -1692,7 +1692,7 @@ func (s *integrationClustersTestSuite) TestForceWorkflowTaskClose_WithClusterRec
 	})
 	s.NoError(err)
 
-	// Update the namespace in cluster 2 to be a single cluster namespace
+	// Update the namespace in cluster 2 to be a multi cluster namespace
 	upReq2 := &workflowservice.UpdateNamespaceRequest{
 		Namespace: namespace,
 		ReplicationConfig: &replicationpb.NamespaceReplicationConfig{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Flush buffer event with single cluster namespace.

<!-- Tell your future self why have you made these changes -->
**Why?**
For namespace which update its cluster list from multi cluster to single cluster, it should still check buffer event and flush them if needed. This is the correct behavior of handling buffer events with different versions.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes.