### PR TITLE
Move update registry from mutable state to workflow context

### DIFF
--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -75,7 +75,7 @@ func Invoke(
 		return nil, consts.ErrWorkflowExecutionNotFound
 	}
 
-	upd, duplicate, removeFn := ms.UpdateRegistry().Add(req.GetRequest().GetRequest())
+	upd, duplicate, removeFn := weCtx.GetContext().UpdateRegistry().Add(req.GetRequest().GetRequest())
 	if removeFn != nil {
 		defer removeFn()
 	}

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -45,7 +45,6 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
 	"go.temporal.io/server/service/history/workflow"
-	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type (
@@ -226,7 +225,6 @@ func (s *workflowCacheSuite) TestHistoryCacheClear() {
 
 	s.NotNil(ctx.(*workflow.ContextImpl).MutableState)
 	mock.EXPECT().GetQueryRegistry().Return(workflow.NewQueryRegistry())
-	mock.EXPECT().UpdateRegistry().Return(update.NewRegistry())
 	release(errors.New("some random error message"))
 
 	// since last time, the release function receive a non-nil error
@@ -279,7 +277,6 @@ func (s *workflowCacheSuite) TestHistoryCacheConcurrentAccess_Release() {
 		// all we need is a fake MutableState
 		mock := workflow.NewMockMutableState(s.controller)
 		mock.EXPECT().GetQueryRegistry().Return(workflow.NewQueryRegistry())
-		mock.EXPECT().UpdateRegistry().Return(update.NewRegistry())
 		ctx.(*workflow.ContextImpl).MutableState = mock
 		release(errors.New("some random error message"))
 	}

--- a/service/history/workflow/context_mock.go
+++ b/service/history/workflow/context_mock.go
@@ -37,6 +37,7 @@ import (
 	v1 "go.temporal.io/server/api/persistence/v1"
 	definition "go.temporal.io/server/common/definition"
 	persistence "go.temporal.io/server/common/persistence"
+	update "go.temporal.io/server/service/history/workflow/update"
 )
 
 // MockContext is a mock of Context interface.
@@ -239,6 +240,20 @@ func (m *MockContext) Unlock(caller CallerType) {
 func (mr *MockContextMockRecorder) Unlock(caller interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unlock", reflect.TypeOf((*MockContext)(nil).Unlock), caller)
+}
+
+// UpdateRegistry mocks base method.
+func (m *MockContext) UpdateRegistry() update.Registry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRegistry")
+	ret0, _ := ret[0].(update.Registry)
+	return ret0
+}
+
+// UpdateRegistry indicates an expected call of UpdateRegistry.
+func (mr *MockContextMockRecorder) UpdateRegistry() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRegistry", reflect.TypeOf((*MockContext)(nil).UpdateRegistry))
 }
 
 // UpdateWorkflowExecutionAsActive mocks base method.

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -49,7 +49,6 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/tasks"
-	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type TransactionPolicy int
@@ -198,8 +197,6 @@ type (
 		GetWorkflowStateStatus() (enumsspb.WorkflowExecutionState, enumspb.WorkflowExecutionStatus)
 		GetQueryRegistry() QueryRegistry
 		IsTransientWorkflowTask() bool
-		// TODO (alex-update): move this out from mutable state.
-		UpdateRegistry() update.Registry
 		ClearTransientWorkflowTask() error
 		HasBufferedEvents() bool
 		HasInFlightWorkflowTask() bool

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -70,7 +70,6 @@ import (
 	"go.temporal.io/server/service/history/events"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
-	"go.temporal.io/server/service/history/workflow/update"
 )
 
 const (
@@ -171,7 +170,6 @@ type (
 		taskGenerator       TaskGenerator
 		workflowTaskManager *workflowTaskStateMachine
 		QueryRegistry       QueryRegistry
-		updateRegistry      update.Registry
 
 		shard           shard.Context
 		clusterMetadata cluster.Metadata
@@ -230,8 +228,7 @@ func NewMutableState(
 		appliedEvents:    make(map[string]struct{}),
 		InsertTasks:      make(map[tasks.Category][]tasks.Task),
 
-		QueryRegistry:  NewQueryRegistry(),
-		updateRegistry: update.NewRegistry(),
+		QueryRegistry: NewQueryRegistry(),
 
 		shard:           shard,
 		clusterMetadata: shard.GetClusterMetadata(),
@@ -634,10 +631,6 @@ func (ms *MutableStateImpl) GetWorkflowType() *commonpb.WorkflowType {
 
 func (ms *MutableStateImpl) GetQueryRegistry() QueryRegistry {
 	return ms.QueryRegistry
-}
-
-func (ms *MutableStateImpl) UpdateRegistry() update.Registry {
-	return ms.updateRegistry
 }
 
 func (ms *MutableStateImpl) GetActivityScheduledEvent(

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -52,7 +52,6 @@ import (
 	namespace "go.temporal.io/server/common/namespace"
 	persistence "go.temporal.io/server/common/persistence"
 	tasks "go.temporal.io/server/service/history/tasks"
-	update "go.temporal.io/server/service/history/workflow/update"
 )
 
 // MockMutableState is a mock of MutableState interface.
@@ -2547,20 +2546,6 @@ func (m *MockMutableState) UpdateDuplicatedResource(resourceDedupKey definition.
 func (mr *MockMutableStateMockRecorder) UpdateDuplicatedResource(resourceDedupKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDuplicatedResource", reflect.TypeOf((*MockMutableState)(nil).UpdateDuplicatedResource), resourceDedupKey)
-}
-
-// UpdateRegistry mocks base method.
-func (m *MockMutableState) UpdateRegistry() update.Registry {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRegistry")
-	ret0, _ := ret[0].(update.Registry)
-	return ret0
-}
-
-// UpdateRegistry indicates an expected call of UpdateRegistry.
-func (mr *MockMutableStateMockRecorder) UpdateRegistry() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRegistry", reflect.TypeOf((*MockMutableState)(nil).UpdateRegistry))
 }
 
 // UpdateUserTimer mocks base method.

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -56,6 +56,7 @@ import (
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/history/workflow/update"
 )
 
 type (
@@ -212,7 +213,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 			if workflowTask.StartedEventID != common.EmptyEventID {
 				// If workflow task is started as part of the current request scope then return a positive response
 				if workflowTask.RequestID == requestID {
-					resp, err = handler.createRecordWorkflowTaskStartedResponse(mutableState, workflowTask, req.PollRequest.GetIdentity())
+					resp, err = handler.createRecordWorkflowTaskStartedResponse(mutableState, workflowContext.GetContext().UpdateRegistry(), workflowTask, req.PollRequest.GetIdentity())
 					if err != nil {
 						return nil, err
 					}
@@ -249,7 +250,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 				metrics.TaskQueueTypeTag(enumspb.TASK_QUEUE_TYPE_WORKFLOW),
 			)
 
-			resp, err = handler.createRecordWorkflowTaskStartedResponse(mutableState, workflowTask, req.PollRequest.GetIdentity())
+			resp, err = handler.createRecordWorkflowTaskStartedResponse(mutableState, workflowContext.GetContext().UpdateRegistry(), workflowTask, req.PollRequest.GetIdentity())
 			if err != nil {
 				return nil, err
 			}
@@ -450,7 +451,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		newMutableState             workflow.MutableState
 	)
 	// hasPendingUpdates indicates if there are more pending updates (excluding those which are accepted/rejected by this workflow task).
-	hasPendingUpdates := ms.UpdateRegistry().HasPending(request.GetMessages())
+	hasPendingUpdates := weContext.UpdateRegistry().HasPending(request.GetMessages())
 	hasBufferedEvents := ms.HasBufferedEvents()
 	if err := namespaceEntry.VerifyBinaryChecksum(request.GetBinaryChecksum()); err != nil {
 		wtFailedCause = newWorkflowTaskFailedCause(
@@ -671,7 +672,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	}
 
 	// Send update results to gRPC API callers.
-	err = ms.UpdateRegistry().ProcessIncomingMessages(req.GetCompleteRequest().GetMessages())
+	err = weContext.UpdateRegistry().ProcessIncomingMessages(req.GetCompleteRequest().GetMessages())
 	if err != nil {
 		return nil, err
 	}
@@ -690,7 +691,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	resp := &historyservice.RespondWorkflowTaskCompletedResponse{}
 	if request.GetReturnNewWorkflowTask() && createNewWorkflowTask {
 		workflowTask, _ := ms.GetWorkflowTaskInfo(newWorkflowTaskScheduledEventID)
-		resp.StartedResponse, err = handler.createRecordWorkflowTaskStartedResponse(ms, workflowTask, request.GetIdentity())
+		resp.StartedResponse, err = handler.createRecordWorkflowTaskStartedResponse(ms, weContext.UpdateRegistry(), workflowTask, request.GetIdentity())
 		if err != nil {
 			return nil, err
 		}
@@ -754,6 +755,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) verifyFirstWorkflowTaskSchedule
 
 func (handler *workflowTaskHandlerCallbacksImpl) createRecordWorkflowTaskStartedResponse(
 	ms workflow.MutableState,
+	updateRegistry update.Registry,
 	workflowTask *workflow.WorkflowTaskInfo,
 	identity string,
 ) (*historyservice.RecordWorkflowTaskStartedResponse, error) {
@@ -801,7 +803,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) createRecordWorkflowTaskStarted
 		}
 	}
 
-	response.Messages, err = ms.UpdateRegistry().CreateOutgoingMessages(workflowTask.StartedEventID)
+	response.Messages, err = updateRegistry.CreateOutgoingMessages(workflowTask.StartedEventID)
 	if err != nil {
 		return nil, err
 	}

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -1489,7 +1489,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_FailWT() {
 		updateResultCh <- struct{}{}
 	}
 	go updateWorkflowFn()
-	time.Sleep(500 * time.Millisecond) // This is to make sure that update gets to the server.
+	time.Sleep(time.Second) // This is to make sure that update gets to the server.
 
 	// Try to accept update in workflow: get malformed response.
 	_, err = poller.PollAndProcessWorkflowTask(false, false)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -1329,7 +1329,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_1stAccept_2ndRej
  17 WorkflowExecutionCompleted`, events)
 }
 
-func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_FailWT() {
+func (s *integrationSuite) TestUpdateWorkflow_FailWorkflowTask() {
 	id := "integration-update-workflow-test-7"
 	wt := "integration-update-workflow-test-7-type"
 	tq := "integration-update-workflow-test-7-task-queue"
@@ -1489,7 +1489,6 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_FailWT() {
 		updateResultCh <- struct{}{}
 	}
 	go updateWorkflowFn()
-	time.Sleep(time.Second) // This is to make sure that update gets to the server.
 
 	// Try to accept update in workflow: get malformed response.
 	_, err = poller.PollAndProcessWorkflowTask(false, false)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -25,6 +25,7 @@
 package tests
 
 import (
+	"context"
 	"errors"
 	"strconv"
 	"testing"
@@ -41,7 +42,7 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
 
-	"go.temporal.io/server/common/debug"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
 )
@@ -1328,7 +1329,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_1stAccept_2ndRej
  17 WorkflowExecutionCompleted`, events)
 }
 
-func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_BadAcceptMessage() {
+func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_FailWT() {
 	id := "integration-update-workflow-test-7"
 	wt := "integration-update-workflow-test-7-type"
 	tq := "integration-update-workflow-test-7-task-queue"
@@ -1342,8 +1343,6 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_BadAcceptMessage
 		WorkflowId:   id,
 		WorkflowType: workflowType,
 		TaskQueue:    taskQueue,
-		// Some short but reasonable timeout because there is a wait for it in the test.
-		WorkflowTaskTimeout: timestamp.DurationPtr(1 * time.Second * debug.TimeoutMultiplier),
 	}
 
 	startResp, err := s.engine.StartWorkflowExecution(NewContext(), request)
@@ -1382,6 +1381,9 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_BadAcceptMessage
 			s.Fail("should not be called because messageHandler returns error")
 			return nil, nil
 		case 4:
+			s.Fail("should not be called because messageHandler returns error")
+			return nil, nil
+		case 5:
 			s.EqualHistory(`
   1 WorkflowExecutionStarted
   2 WorkflowTaskScheduled
@@ -1429,13 +1431,21 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_BadAcceptMessage
 				},
 			}, nil
 		case 3:
-			// 2nd attempt doesn't have any updates attached to it.
-			s.Empty(task.Messages)
+			// 2nd attempt has same updates attached to it.
+			updRequestMsg := task.Messages[0]
+			s.EqualValues(9, updRequestMsg.GetEventId())
 			wtHandlerCalls++ // because it won't be called for case 3 but counter should be in sync.
 			// Fail WT one more time. Although 2nd attempt is normal WT, it is also transient and shouldn't appear in the history.
 			// Returning error will cause the poller to fail WT.
 			return nil, errors.New("malformed request")
 		case 4:
+			// 3rd attempt doesn't have any updates attached to it because UpdateWorkflowExecution call has timed out.
+			s.Empty(task.Messages)
+			wtHandlerCalls++ // because it won't be called for case 4 but counter should be in sync.
+			// Fail WT one more time. This is transient WT and shouldn't appear in the history.
+			// Returning error will cause the poller to fail WT.
+			return nil, errors.New("malformed request")
+		case 5:
 			return nil, nil
 		default:
 			s.Failf("msgHandler called too many times", "msgHandler shouldn't be called %d times", msgHandlerCalls)
@@ -1457,13 +1467,11 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_BadAcceptMessage
 	_, err = poller.PollAndProcessWorkflowTask(true, false)
 	s.NoError(err)
 
-	type UpdateResult struct {
-		Response *workflowservice.UpdateWorkflowExecutionResponse
-		Err      error
-	}
-	updateResultCh := make(chan UpdateResult)
+	updateResultCh := make(chan struct{})
 	updateWorkflowFn := func() {
-		updateResponse, err1 := s.engine.UpdateWorkflowExecution(NewContext(), &workflowservice.UpdateWorkflowExecutionRequest{
+		ctx1, cancel := context.WithTimeout(NewContext(), 2*time.Second)
+		defer cancel()
+		updateResponse, err1 := s.engine.UpdateWorkflowExecution(ctx1, &workflowservice.UpdateWorkflowExecutionRequest{
 			Namespace:         s.namespace,
 			WorkflowExecution: we,
 			Request: &updatepb.Request{
@@ -1474,8 +1482,11 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_BadAcceptMessage
 				},
 			},
 		})
-		s.NoError(err1)
-		updateResultCh <- UpdateResult{Response: updateResponse, Err: err1}
+		s.Error(err1)
+		// UpdateWorkflowExecution is timed out after 2 seconds.
+		s.True(common.IsContextDeadlineExceededErr(err1))
+		s.Nil(updateResponse)
+		updateResultCh <- struct{}{}
 	}
 	go updateWorkflowFn()
 	time.Sleep(500 * time.Millisecond) // This is to make sure that update gets to the server.
@@ -1486,12 +1497,16 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_BadAcceptMessage
 	s.Equal(err.Error(), "BadUpdateWorkflowExecutionMessage: accepted_request is not set on update.Acceptance message body.")
 	// New normal (but transient) WT will be created but not returned.
 
-	updateResult := <-updateResultCh
-	s.NoError(updateResult.Err)
-	// TODO (alex-update): this is wrong. Caller shouldn't get this error if WT failed.
-	s.Equal("update cleared, please retry", updateResult.Response.GetOutcome().GetFailure().GetMessage())
-
 	// Try to accept update in workflow 2nd time: get error. Poller will fail WT.
+	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
+	s.NoError(err)
+
+	// Wait for UpdateWorkflowExecution to timeout.
+	// This will also remove update from registry and next WT won't have any updates attached to it.
+	<-updateResultCh
+
+	// Try to accept update in workflow 3rd time: get error. Poller will fail WT.
 	_, err = poller.PollAndProcessWorkflowTask(false, false)
 	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
 	s.NoError(err)
@@ -1500,8 +1515,8 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstWorkflowTask_BadAcceptMessage
 	_, err = poller.PollAndProcessWorkflowTask(false, false)
 	s.NoError(err)
 
-	s.Equal(4, wtHandlerCalls)
-	s.Equal(4, msgHandlerCalls)
+	s.Equal(5, wtHandlerCalls)
+	s.Equal(5, msgHandlerCalls)
 
 	events := s.getHistory(s.namespace, we)
 	s.EqualHistoryEvents(`


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move update registry from mutable state to workflow context.

<!-- Tell your future self why have you made these changes -->
**Why?**
When workflow task is failed, mutable state is cleared and refreshed. This also clears update registry which might have updates not related to failed workflow task.
This PR moves updated registry one level above -- to workflow context. This allows mutable state to be cleared w/o clearing update registry. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Modified integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.