### PR TITLE
Refactor gocql.NewSession to allow passing in cluster config factory method

### DIFF
--- a/common/persistence/cassandra/test.go
+++ b/common/persistence/cassandra/test.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gocql/gocql"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/debug"
@@ -36,7 +37,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	p "go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/environment"
 	"go.temporal.io/server/tests/testutils"
@@ -50,7 +51,7 @@ const (
 type TestCluster struct {
 	keyspace       string
 	schemaDir      string
-	session        gocql.Session
+	session        commongocql.Session
 	cfg            config.Cassandra
 	faultInjection *config.FaultInjection
 	logger         log.Logger
@@ -133,21 +134,25 @@ func (s *TestCluster) CreateSession(
 	}
 
 	var err error
-	s.session, err = gocql.NewSession(
-		config.Cassandra{
-			Hosts:    s.cfg.Hosts,
-			Port:     s.cfg.Port,
-			User:     s.cfg.User,
-			Password: s.cfg.Password,
-			Keyspace: keyspace,
-			Consistency: &config.CassandraStoreConsistency{
-				Default: &config.CassandraConsistencySettings{
-					Consistency: "ONE",
+	s.session, err = commongocql.NewSession(
+		func() (*gocql.ClusterConfig, error) {
+			return commongocql.NewCassandraCluster(
+				config.Cassandra{
+					Hosts:    s.cfg.Hosts,
+					Port:     s.cfg.Port,
+					User:     s.cfg.User,
+					Password: s.cfg.Password,
+					Keyspace: keyspace,
+					Consistency: &config.CassandraStoreConsistency{
+						Default: &config.CassandraConsistencySettings{
+							Consistency: "ONE",
+						},
+					},
+					ConnectTimeout: s.cfg.ConnectTimeout,
 				},
-			},
-			ConnectTimeout: s.cfg.ConnectTimeout,
+				resolver.NewNoopResolver(),
+			)
 		},
-		resolver.NewNoopResolver(),
 		log.NewNoopLogger(),
 	)
 	if err != nil {

--- a/common/persistence/cassandra/version_checker.go
+++ b/common/persistence/cassandra/version_checker.go
@@ -25,9 +25,10 @@
 package cassandra
 
 import (
+	"github.com/gocql/gocql"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/persistence/schema"
 	"go.temporal.io/server/common/resolver"
 	cassandraschema "go.temporal.io/server/schema/cassandra"
@@ -81,7 +82,12 @@ func CheckCompatibleVersion(
 	expectedVersion string,
 ) error {
 
-	session, err := gocql.NewSession(cfg, r, log.NewNoopLogger())
+	session, err := commongocql.NewSession(
+		func() (*gocql.ClusterConfig, error) {
+			return commongocql.NewCassandraCluster(cfg, r)
+		},
+		log.NewNoopLogger(),
+	)
 	if err != nil {
 		return err
 	}

--- a/common/persistence/tests/cassandra_test_util.go
+++ b/common/persistence/tests/cassandra_test_util.go
@@ -34,13 +34,14 @@ import (
 	"testing"
 
 	"github.com/blang/semver/v4"
+	"github.com/gocql/gocql"
 	"go.uber.org/zap/zaptest"
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/cassandra"
-	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/shuffle"
 	"go.temporal.io/server/environment"
@@ -98,7 +99,12 @@ func SetUpCassandraDatabase(cfg *config.Cassandra, logger log.Logger) {
 	// NOTE need to connect with empty name to create new database
 	adminCfg.Keyspace = "system"
 
-	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver(), logger)
+	session, err := commongocql.NewSession(
+		func() (*gocql.ClusterConfig, error) {
+			return commongocql.NewCassandraCluster(adminCfg, resolver.NewNoopResolver())
+		},
+		logger,
+	)
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}
@@ -121,7 +127,12 @@ func SetUpCassandraSchema(cfg *config.Cassandra, logger log.Logger) {
 }
 
 func ApplySchemaUpdate(cfg *config.Cassandra, schemaFile string, logger log.Logger) {
-	session, err := gocql.NewSession(*cfg, resolver.NewNoopResolver(), logger)
+	session, err := commongocql.NewSession(
+		func() (*gocql.ClusterConfig, error) {
+			return commongocql.NewCassandraCluster(*cfg, resolver.NewNoopResolver())
+		},
+		logger,
+	)
 	if err != nil {
 		panic(err)
 	}
@@ -150,7 +161,12 @@ func TearDownCassandraKeyspace(cfg *config.Cassandra) {
 	// NOTE need to connect with empty name to create new database
 	adminCfg.Keyspace = "system"
 
-	session, err := gocql.NewSession(adminCfg, resolver.NewNoopResolver(), log.NewNoopLogger())
+	session, err := commongocql.NewSession(
+		func() (*gocql.ClusterConfig, error) {
+			return commongocql.NewCassandraCluster(adminCfg, resolver.NewNoopResolver())
+		},
+		log.NewNoopLogger(),
+	)
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
 	}

--- a/common/persistence/visibility/store/standard/cassandra/visibility_store.go
+++ b/common/persistence/visibility/store/standard/cassandra/visibility_store.go
@@ -28,13 +28,14 @@ import (
 	"context"
 	"time"
 
+	"github.com/gocql/gocql"
 	enumspb "go.temporal.io/api/enums/v1"
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
 	"go.temporal.io/server/common/resolver"
@@ -138,8 +139,8 @@ const (
 
 type (
 	visibilityStore struct {
-		session      gocql.Session
-		lowConslevel gocql.Consistency
+		session      commongocql.Session
+		lowConslevel commongocql.Consistency
 	}
 )
 
@@ -150,14 +151,19 @@ func NewVisibilityStore(
 	r resolver.ServiceResolver,
 	logger log.Logger,
 ) (*visibilityStore, error) {
-	session, err := gocql.NewSession(cfg, r, logger)
+	session, err := commongocql.NewSession(
+		func() (*gocql.ClusterConfig, error) {
+			return commongocql.NewCassandraCluster(cfg, r)
+		},
+		logger,
+	)
 	if err != nil {
 		logger.Fatal("unable to initialize cassandra session", tag.Error(err))
 	}
 
 	return &visibilityStore{
 		session:      session,
-		lowConslevel: gocql.One,
+		lowConslevel: commongocql.One,
 	}, nil
 }
 
@@ -198,14 +204,14 @@ func (v *visibilityStore) RecordWorkflowExecutionStarted(
 	// default timestamp, default one will always win because they are 1000 times bigger.
 	query = query.WithTimestamp(persistence.UnixMilliseconds(request.StartTime))
 	err := query.Exec()
-	return gocql.ConvertError("RecordWorkflowExecutionStarted", err)
+	return commongocql.ConvertError("RecordWorkflowExecutionStarted", err)
 }
 
 func (v *visibilityStore) RecordWorkflowExecutionClosed(
 	ctx context.Context,
 	request *store.InternalRecordWorkflowExecutionClosedRequest,
 ) error {
-	batch := v.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	batch := v.session.NewBatch(commongocql.LoggedBatch).WithContext(ctx)
 
 	// First, remove execution from the open table
 	batch.Query(templateDeleteWorkflowExecutionStarted,
@@ -248,7 +254,7 @@ func (v *visibilityStore) RecordWorkflowExecutionClosed(
 
 	batch = batch.WithTimestamp(persistence.UnixMilliseconds(batchTimestamp))
 	err := v.session.ExecuteBatch(batch)
-	return gocql.ConvertError("RecordWorkflowExecutionClosed", err)
+	return commongocql.ConvertError("RecordWorkflowExecutionClosed", err)
 }
 
 func (v *visibilityStore) UpsertWorkflowExecution(
@@ -284,7 +290,7 @@ func (v *visibilityStore) ListOpenWorkflowExecutions(
 		response.NextPageToken = iter.PageState()
 	}
 	if err := iter.Close(); err != nil {
-		return nil, gocql.ConvertError("ListOpenWorkflowExecutions", err)
+		return nil, commongocql.ConvertError("ListOpenWorkflowExecutions", err)
 	}
 	return response, nil
 }
@@ -315,7 +321,7 @@ func (v *visibilityStore) ListOpenWorkflowExecutionsByType(
 		response.NextPageToken = iter.PageState()
 	}
 	if err := iter.Close(); err != nil {
-		return nil, gocql.ConvertError("ListOpenWorkflowExecutionsByType", err)
+		return nil, commongocql.ConvertError("ListOpenWorkflowExecutionsByType", err)
 	}
 	return response, nil
 }
@@ -346,7 +352,7 @@ func (v *visibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
 		response.NextPageToken = iter.PageState()
 	}
 	if err := iter.Close(); err != nil {
-		return nil, gocql.ConvertError("ListOpenWorkflowExecutionsByWorkflowID", err)
+		return nil, commongocql.ConvertError("ListOpenWorkflowExecutionsByWorkflowID", err)
 	}
 	return response, nil
 }
@@ -375,7 +381,7 @@ func (v *visibilityStore) ListClosedWorkflowExecutions(
 		response.NextPageToken = iter.PageState()
 	}
 	if err := iter.Close(); err != nil {
-		return nil, gocql.ConvertError("ListClosedWorkflowExecutions", err)
+		return nil, commongocql.ConvertError("ListClosedWorkflowExecutions", err)
 	}
 	return response, nil
 }
@@ -406,7 +412,7 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByType(
 		response.NextPageToken = iter.PageState()
 	}
 	if err := iter.Close(); err != nil {
-		return nil, gocql.ConvertError("ListClosedWorkflowExecutionsByType", err)
+		return nil, commongocql.ConvertError("ListClosedWorkflowExecutionsByType", err)
 	}
 	return response, nil
 }
@@ -436,7 +442,7 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
 		response.NextPageToken = iter.PageState()
 	}
 	if err := iter.Close(); err != nil {
-		return nil, gocql.ConvertError("ListClosedWorkflowExecutionsByWorkflowID", err)
+		return nil, commongocql.ConvertError("ListClosedWorkflowExecutionsByWorkflowID", err)
 	}
 	return response, nil
 }
@@ -466,7 +472,7 @@ func (v *visibilityStore) ListClosedWorkflowExecutionsByStatus(
 		response.NextPageToken = iter.PageState()
 	}
 	if err := iter.Close(); err != nil {
-		return nil, gocql.ConvertError("ListClosedWorkflowExecutionsByStatus", err)
+		return nil, commongocql.ConvertError("ListClosedWorkflowExecutionsByStatus", err)
 	}
 	return response, nil
 }
@@ -475,7 +481,7 @@ func (v *visibilityStore) DeleteWorkflowExecution(
 	ctx context.Context,
 	request *manager.VisibilityDeleteWorkflowExecutionRequest,
 ) error {
-	var query gocql.Query
+	var query commongocql.Query
 	if request.StartTime != nil {
 		query = v.session.Query(templateDeleteWorkflowExecutionStarted,
 			request.NamespaceID.String(),
@@ -495,7 +501,7 @@ func (v *visibilityStore) DeleteWorkflowExecution(
 	}
 
 	if err := query.Exec(); err != nil {
-		return gocql.ConvertError("DeleteWorkflowExecution", err)
+		return commongocql.ConvertError("DeleteWorkflowExecution", err)
 	}
 	return nil
 }
@@ -581,7 +587,7 @@ func (v *visibilityStore) getClosedWorkflowExecution(
 	return wfexecution, nil
 }
 
-func readOpenWorkflowExecutionRecord(iter gocql.Iter) (*store.InternalWorkflowExecutionInfo, bool) {
+func readOpenWorkflowExecutionRecord(iter commongocql.Iter) (*store.InternalWorkflowExecutionInfo, bool) {
 	var workflowID string
 	var runID string
 	var typeName string
@@ -606,7 +612,7 @@ func readOpenWorkflowExecutionRecord(iter gocql.Iter) (*store.InternalWorkflowEx
 	return nil, false
 }
 
-func readClosedWorkflowExecutionRecord(iter gocql.Iter) (*store.InternalWorkflowExecutionInfo, bool) {
+func readClosedWorkflowExecutionRecord(iter commongocql.Iter) (*store.InternalWorkflowExecutionInfo, bool) {
 	var workflowID string
 	var runID string
 	var typeName string


### PR DESCRIPTION
…method

<!-- Describe what has changed in this PR -->
**What changed?**
Change commongocql.NewSession interface to allow user to pass in custom gocql.ClusterConfig.


<!-- Tell your future self why have you made these changes -->
**Why?**
Allows extension.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
