### PR TITLE
Convert query converter error to invalid argument

### DIFF
--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -26,6 +26,7 @@ package sql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -42,6 +43,7 @@ import (
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
+	"go.temporal.io/server/common/persistence/visibility/store/query"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/common/searchattribute"
 )
@@ -374,6 +376,11 @@ func (s *VisibilityStore) ListWorkflowExecutions(
 	)
 	selectFilter, err := converter.BuildSelectStmt(request.PageSize, request.NextPageToken)
 	if err != nil {
+		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be only mapper errors).
+		var converterErr *query.ConverterError
+		if errors.As(err, &converterErr) {
+			return nil, converterErr.ToInvalidArgument()
+		}
 		return nil, err
 	}
 
@@ -447,6 +454,11 @@ func (s *VisibilityStore) CountWorkflowExecutions(
 	)
 	selectFilter, err := converter.BuildCountStmt()
 	if err != nil {
+		// Convert ConverterError to InvalidArgument and pass through all other errors (which should be only mapper errors).
+		var converterErr *query.ConverterError
+		if errors.As(err, &converterErr) {
+			return nil, converterErr.ToInvalidArgument()
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Convert `query.ConverterError` to `serviceerror.InvalidArgument`.

<!-- Tell your future self why have you made these changes -->
**Why?**
Query converter error should be non-retryable as it's from an user input.
Converting the error to `serviceerror.InvalidArgument` does the trick.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started local server, and tried submitting List request through temporal CLI with invalid query, and now it returns the error message from query converter instead of `context deadline exceeded` message.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.