### PR TITLE
Rename inflight WT to started WT

### DIFF
--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -183,7 +183,7 @@ func Invoke(
 		}
 	}
 
-	if pendingWorkflowTask, ok := mutableState.GetPendingWorkflowTask(); ok {
+	if pendingWorkflowTask := mutableState.GetPendingWorkflowTask(); pendingWorkflowTask != nil {
 		result.PendingWorkflowTask = &workflowpb.PendingWorkflowTaskInfo{
 			State:                 enumspb.PENDING_WORKFLOW_TASK_STATE_SCHEDULED,
 			ScheduledTime:         pendingWorkflowTask.ScheduledTime,

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -195,7 +195,7 @@ func MutableStateToGetResponse(
 		LastFirstEventId:       lastFirstEventID,
 		LastFirstEventTxnId:    lastFirstEventTxnID,
 		NextEventId:            mutableState.GetNextEventID(),
-		PreviousStartedEventId: mutableState.GetPreviousStartedEventID(),
+		PreviousStartedEventId: mutableState.GetLastWorkflowTaskStartedEventID(),
 		TaskQueue: &taskqueuepb.TaskQueue{
 			Name: executionInfo.TaskQueue,
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,

--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -109,7 +109,7 @@ func Invoke(
 				// to accept events to be reapplied
 				baseRunID := mutableState.GetExecutionState().GetRunId()
 				resetRunID := uuid.New()
-				baseRebuildLastEventID := mutableState.GetPreviousStartedEventID()
+				baseRebuildLastEventID := mutableState.GetLastWorkflowTaskStartedEventID()
 
 				// TODO when https://github.com/uber/cadence/issues/2420 is finished, remove this block,
 				//  since cannot reapply event to a finished workflow which had no workflow tasks started

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -33,6 +33,7 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+
 	tokenspb "go.temporal.io/server/api/token/v1"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -78,10 +79,9 @@ type creationParams struct {
 // mutableStateInfo is a container for the relevant mutable state information to generate a start response with an eager
 // workflow task.
 type mutableStateInfo struct {
-	branchToken      []byte
-	lastEventID      int64
-	workflowTaskInfo *workflow.WorkflowTaskInfo
-	hasInflight      bool
+	branchToken  []byte
+	lastEventID  int64
+	workflowTask *workflow.WorkflowTaskInfo
 }
 
 // NewStarter creates a new starter, fails if getting the active namespace fails.
@@ -196,9 +196,9 @@ func (s *Starter) createNewMutableState(ctx context.Context, workflowID string, 
 
 	now := s.shardCtx.GetTimeSource().Now()
 	mutableState := workflowContext.GetMutableState()
-	workflowTaskInfo, hasInflight := mutableState.GetInFlightWorkflowTask()
-	if s.requestEagerStart() && !hasInflight {
-		return nil, serviceerror.NewInternal("unexpected error: mutable state did not have an inflight workflow task")
+	workflowTaskInfo := mutableState.GetStartedWorkflowTask()
+	if s.requestEagerStart() && workflowTaskInfo == nil {
+		return nil, serviceerror.NewInternal("unexpected error: mutable state did not have a started workflow task")
 	}
 	workflowSnapshot, eventBatches, err := mutableState.CloseTransactionAsSnapshot(
 		now,
@@ -367,7 +367,7 @@ func (s *Starter) applyWorkflowIDReusePolicy(
 		if err != nil {
 			return nil, err
 		}
-		return s.generateResponse(creationParams.runID, mutableStateInfo.workflowTaskInfo, events)
+		return s.generateResponse(creationParams.runID, mutableStateInfo.workflowTask, events)
 	case consts.ErrWorkflowCompleted:
 		// previous workflow already closed
 		// fallthough to the logic for only creating the new workflow below
@@ -394,9 +394,9 @@ func (s *Starter) respondToRetriedRequest(
 		return nil, err
 	}
 
-	// The current workflow task is not inflight or not the first task or we exceeded the first attempt and fell back to
+	// The current workflow task is not started or not the first task or we exceeded the first attempt and fell back to
 	// matching based dispatch.
-	if !mutableStateInfo.hasInflight || mutableStateInfo.workflowTaskInfo.StartedEventID != 3 || mutableStateInfo.workflowTaskInfo.Attempt > 1 {
+	if mutableStateInfo.workflowTask == nil || mutableStateInfo.workflowTask.StartedEventID != 3 || mutableStateInfo.workflowTask.Attempt > 1 {
 		s.recordEagerDenied(eagerStartDeniedReasonTaskAlreadyDispatched)
 		return &historyservice.StartWorkflowExecutionResponse{
 			RunId: runID,
@@ -408,7 +408,7 @@ func (s *Starter) respondToRetriedRequest(
 		return nil, err
 	}
 
-	return s.generateResponse(runID, mutableStateInfo.workflowTaskInfo, events)
+	return s.generateResponse(runID, mutableStateInfo.workflowTask, events)
 }
 
 // getMutableStateInfo gets the relevant mutable state information while getting the state for the given run from the
@@ -443,19 +443,18 @@ func extractMutableStateInfo(mutableState workflow.MutableState) (*mutableStateI
 	}
 
 	// Future work for the request retry path: extend the task timeout (by failing / timing out the current task).
-	workflowTaskInfoSource, hasInflight := mutableState.GetInFlightWorkflowTask()
-	// The workflowTaskInfo returned from the mutable state call is generated on the fly and technically doesn't require
+	workflowTaskSource := mutableState.GetStartedWorkflowTask()
+	// The workflowTask returned from the mutable state call is generated on the fly and technically doesn't require
 	// cloning. We clone here just in case that changes.
-	var workflowTaskInfo workflow.WorkflowTaskInfo
-	if hasInflight {
-		workflowTaskInfo = *workflowTaskInfoSource
+	var workflowTask workflow.WorkflowTaskInfo
+	if workflowTaskSource != nil {
+		workflowTask = *workflowTaskSource
 	}
 
 	return &mutableStateInfo{
-		branchToken:      branchToken,
-		lastEventID:      mutableState.GetNextEventID() - 1,
-		workflowTaskInfo: &workflowTaskInfo,
-		hasInflight:      hasInflight,
+		branchToken:  branchToken,
+		lastEventID:  mutableState.GetNextEventID() - 1,
+		workflowTask: &workflowTask,
 	}, nil
 }
 

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -2830,8 +2830,8 @@ func (s *engineSuite) TestRespondActivityTaskCompletedSuccess() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
 
 	s.True(ms2.HasPendingWorkflowTask())
-	wt, ok := ms2.GetWorkflowTaskInfo(int64(8))
-	s.True(ok)
+	wt = ms2.GetWorkflowTaskByID(int64(8))
+	s.NotNil(wt)
 	s.EqualValues(int64(100), wt.WorkflowTaskTimeout.Seconds())
 	s.Equal(int64(8), wt.ScheduledEventID)
 	s.Equal(common.EmptyEventID, wt.StartedEventID)
@@ -2891,8 +2891,8 @@ func (s *engineSuite) TestRespondActivityTaskCompletedByIdSuccess() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
 
 	s.True(ms2.HasPendingWorkflowTask())
-	wt, ok := ms2.GetWorkflowTaskInfo(int64(8))
-	s.True(ok)
+	wt := ms2.GetWorkflowTaskByID(int64(8))
+	s.NotNil(wt)
 	s.EqualValues(int64(100), wt.WorkflowTaskTimeout.Seconds())
 	s.Equal(int64(8), wt.ScheduledEventID)
 	s.Equal(common.EmptyEventID, wt.StartedEventID)
@@ -3301,8 +3301,8 @@ func (s *engineSuite) TestRespondActivityTaskFailedSuccess() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
 
 	s.True(ms2.HasPendingWorkflowTask())
-	wt, ok := ms2.GetWorkflowTaskInfo(int64(8))
-	s.True(ok)
+	wt = ms2.GetWorkflowTaskByID(int64(8))
+	s.NotNil(wt)
 	s.EqualValues(int64(100), wt.WorkflowTaskTimeout.Seconds())
 	s.Equal(int64(8), wt.ScheduledEventID)
 	s.Equal(common.EmptyEventID, wt.StartedEventID)
@@ -3365,8 +3365,8 @@ func (s *engineSuite) TestRespondActivityTaskFailedWithHeartbeatSuccess() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
 
 	s.True(ms2.HasPendingWorkflowTask())
-	wt, ok := ms2.GetWorkflowTaskInfo(int64(8))
-	s.True(ok)
+	wt = ms2.GetWorkflowTaskByID(int64(8))
+	s.NotNil(wt)
 	s.EqualValues(int64(100), wt.WorkflowTaskTimeout.Seconds())
 	s.Equal(int64(8), wt.ScheduledEventID)
 	s.Equal(common.EmptyEventID, wt.StartedEventID)
@@ -3428,8 +3428,8 @@ func (s *engineSuite) TestRespondActivityTaskFailedByIdSuccess() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
 
 	s.True(ms2.HasPendingWorkflowTask())
-	wt, ok := ms2.GetWorkflowTaskInfo(int64(8))
-	s.True(ok)
+	wt := ms2.GetWorkflowTaskByID(int64(8))
+	s.NotNil(wt)
 	s.EqualValues(int64(100), wt.WorkflowTaskTimeout.Seconds())
 	s.Equal(int64(8), wt.ScheduledEventID)
 	s.Equal(common.EmptyEventID, wt.StartedEventID)
@@ -3683,8 +3683,8 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Started() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
 
 	s.True(ms2.HasPendingWorkflowTask())
-	wt, ok := ms2.GetWorkflowTaskInfo(int64(9))
-	s.True(ok)
+	wt = ms2.GetWorkflowTaskByID(int64(9))
+	s.NotNil(wt)
 	s.EqualValues(int64(100), wt.WorkflowTaskTimeout.Seconds())
 	s.Equal(int64(9), wt.ScheduledEventID)
 	s.Equal(common.EmptyEventID, wt.StartedEventID)
@@ -3744,8 +3744,8 @@ func (s *engineSuite) TestRespondActivityTaskCanceledById_Started() {
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
 
 	s.True(ms2.HasPendingWorkflowTask())
-	wt, ok := ms2.GetWorkflowTaskInfo(int64(9))
-	s.True(ok)
+	wt := ms2.GetWorkflowTaskByID(int64(9))
+	s.NotNil(wt)
 	s.EqualValues(int64(100), wt.WorkflowTaskTimeout.Seconds())
 	s.Equal(int64(9), wt.ScheduledEventID)
 	s.Equal(common.EmptyEventID, wt.StartedEventID)
@@ -3972,8 +3972,8 @@ func (s *engineSuite) TestRequestCancel_RespondWorkflowTaskCompleted_Scheduled()
 	s.Equal(int64(7), ms2.GetExecutionInfo().LastWorkflowTaskStartedEventId)
 	s.Equal(enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING, ms2.GetExecutionState().State)
 	s.True(ms2.HasPendingWorkflowTask())
-	wt2, ok := ms2.GetWorkflowTaskInfo(ms2.GetNextEventID() - 1)
-	s.True(ok)
+	wt2 = ms2.GetWorkflowTaskByID(ms2.GetNextEventID() - 1)
+	s.NotNil(wt2)
 	s.Equal(ms2.GetNextEventID()-1, wt2.ScheduledEventID)
 	s.Equal(int32(1), wt2.Attempt)
 }
@@ -5306,7 +5306,7 @@ func addWorkflowTaskStartedEventWithRequestID(ms workflow.MutableState, schedule
 }
 
 func addWorkflowTaskCompletedEvent(s *suite.Suite, ms workflow.MutableState, scheduledEventID, startedEventID int64, identity string) *historypb.HistoryEvent {
-	workflowTask, _ := ms.GetWorkflowTaskInfo(scheduledEventID)
+	workflowTask := ms.GetWorkflowTaskByID(scheduledEventID)
 	s.NotNil(workflowTask)
 	s.Equal(startedEventID, workflowTask.StartedEventID)
 

--- a/service/history/ndc/branch_manager.go
+++ b/service/history/ndc/branch_manager.go
@@ -170,7 +170,7 @@ func (r *BranchMgrImpl) flushBufferedEvents(
 	// check whether there are buffered events, if so, flush it
 	// NOTE: buffered events does not show in version history or next event id
 	if !r.mutableState.HasBufferedEvents() {
-		if r.mutableState.HasInFlightWorkflowTask() && r.mutableState.IsTransientWorkflowTask() {
+		if r.mutableState.HasStartedWorkflowTask() && r.mutableState.IsTransientWorkflowTask() {
 			if err := r.mutableState.ClearTransientWorkflowTask(); err != nil {
 				return nil, 0, err
 			}

--- a/service/history/ndc/branch_manager_test.go
+++ b/service/history/ndc/branch_manager_test.go
@@ -192,7 +192,7 @@ func (s *branchMgrSuite) TestClearTransientWorkflowTask() {
 
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastWriteVersion, nil).AnyTimes()
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().HasStartedWorkflowTask().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().ClearTransientWorkflowTask().Return(nil).AnyTimes()
 
@@ -239,7 +239,7 @@ func (s *branchMgrSuite) TestFlushBufferedEvents() {
 		ScheduledEventID: 1234,
 		StartedEventID:   2345,
 	}
-	s.mockMutableState.EXPECT().GetInFlightWorkflowTask().Return(workflowTask, true)
+	s.mockMutableState.EXPECT().GetStartedWorkflowTask().Return(workflowTask)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		VersionHistories: versionHistories,
 	}).AnyTimes()
@@ -284,7 +284,7 @@ func (s *branchMgrSuite) TestPrepareVersionHistory_BranchAppendable_NoMissingEve
 
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{VersionHistories: versionHistories}).AnyTimes()
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().HasStartedWorkflowTask().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(false).AnyTimes()
 
 	doContinue, index, err := s.nDCBranchMgr.prepareVersionHistory(
@@ -316,7 +316,7 @@ func (s *branchMgrSuite) TestPrepareVersionHistory_BranchAppendable_MissingEvent
 	s.NoError(err)
 
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().HasStartedWorkflowTask().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(false).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		NamespaceId:      s.namespaceID,
@@ -358,7 +358,7 @@ func (s *branchMgrSuite) TestPrepareVersionHistory_BranchNotAppendable_NoMissing
 	newBranchToken := []byte("some random new branch token")
 
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().HasStartedWorkflowTask().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(false).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		NamespaceId:      s.namespaceID,
@@ -418,7 +418,7 @@ func (s *branchMgrSuite) TestPrepareVersionHistory_BranchNotAppendable_MissingEv
 	})
 
 	s.mockMutableState.EXPECT().HasBufferedEvents().Return(false).AnyTimes()
-	s.mockMutableState.EXPECT().HasInFlightWorkflowTask().Return(true).AnyTimes()
+	s.mockMutableState.EXPECT().HasStartedWorkflowTask().Return(true).AnyTimes()
 	s.mockMutableState.EXPECT().IsTransientWorkflowTask().Return(false).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistencespb.WorkflowExecutionInfo{
 		NamespaceId:      s.namespaceID,

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -34,6 +34,7 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -319,7 +320,7 @@ func (r *transactionMgrImpl) backfillWorkflowEventsReapply(
 		workflowID := baseMutableState.GetExecutionInfo().WorkflowId
 		baseRunID := baseMutableState.GetExecutionState().GetRunId()
 		resetRunID := uuid.New()
-		baseRebuildLastEventID := baseMutableState.GetPreviousStartedEventID()
+		baseRebuildLastEventID := baseMutableState.GetLastWorkflowTaskStartedEventID()
 		baseVersionHistories := baseMutableState.GetExecutionInfo().GetVersionHistories()
 		baseCurrentVersionHistory, err := versionhistory.GetCurrentVersionHistory(baseVersionHistories)
 		if err != nil {

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -220,7 +220,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Closed
 		RunId: runID,
 	}).AnyTimes()
 	mutableState.EXPECT().GetNextEventID().Return(nextEventID).AnyTimes()
-	mutableState.EXPECT().GetPreviousStartedEventID().Return(lastWorkflowTaskStartedEventID)
+	mutableState.EXPECT().GetLastWorkflowTaskStartedEventID().Return(lastWorkflowTaskStartedEventID)
 
 	s.mockWorkflowResetter.EXPECT().ResetWorkflow(
 		ctx,
@@ -298,7 +298,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Closed_ResetF
 		RunId: runID,
 	}).AnyTimes()
 	mutableState.EXPECT().GetNextEventID().Return(nextEventID).AnyTimes()
-	mutableState.EXPECT().GetPreviousStartedEventID().Return(lastWorkflowTaskStartedEventID)
+	mutableState.EXPECT().GetLastWorkflowTaskStartedEventID().Return(lastWorkflowTaskStartedEventID)
 
 	s.mockWorkflowResetter.EXPECT().ResetWorkflow(
 		ctx,

--- a/service/history/ndc/workflow.go
+++ b/service/history/ndc/workflow.go
@@ -146,7 +146,7 @@ func (r *WorkflowImpl) Revive() error {
 
 	// workflow is in zombie state, need to set the state correctly accordingly
 	state = enumsspb.WORKFLOW_EXECUTION_STATE_CREATED
-	if r.mutableState.HasProcessedOrPendingWorkflowTask() {
+	if r.mutableState.HadOrHasWorkflowTask() {
 		state = enumsspb.WORKFLOW_EXECUTION_STATE_RUNNING
 	}
 	return r.mutableState.UpdateWorkflowStateStatus(
@@ -232,8 +232,8 @@ func (r *WorkflowImpl) failWorkflowTask(
 		return err
 	}
 
-	workflowTask, ok := r.mutableState.GetInFlightWorkflowTask()
-	if !ok {
+	workflowTask := r.mutableState.GetStartedWorkflowTask()
+	if workflowTask == nil {
 		return nil
 	}
 

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -475,9 +475,9 @@ func (r *workflowResetterImpl) failWorkflowTask(
 	resetReason string,
 ) error {
 
-	workflowTask, ok := resetMutableState.GetPendingWorkflowTask()
-	if !ok {
-		// TODO if resetMutableState.HasProcessedOrPendingWorkflowTask() == true
+	workflowTask := resetMutableState.GetPendingWorkflowTask()
+	if workflowTask == nil {
+		// TODO if resetMutableState.HadOrHasWorkflowTask() == true
 		//  meaning workflow history has NO workflow task ever
 		//  should also allow workflow reset, the only remaining issues are
 		//  * what if workflow is a cron workflow, e.g. should add a workflow task directly or still respect the cron job

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -348,7 +348,7 @@ func (s *workflowResetterSuite) TestFailWorkflowTask_NoWorkflowTask() {
 	resetReason := "some random reset reason"
 
 	mutableState := workflow.NewMockMutableState(s.controller)
-	mutableState.EXPECT().GetPendingWorkflowTask().Return(nil, false).AnyTimes()
+	mutableState.EXPECT().GetPendingWorkflowTask().Return(nil).AnyTimes()
 
 	err := s.workflowResetter.failWorkflowTask(
 		mutableState,
@@ -384,7 +384,7 @@ func (s *workflowResetterSuite) TestFailWorkflowTask_WorkflowTaskScheduled() {
 		RequestID:        workflowTaskSchedule.RequestID,
 		TaskQueue:        workflowTaskSchedule.TaskQueue,
 	}
-	mutableState.EXPECT().GetPendingWorkflowTask().Return(workflowTaskSchedule, true).AnyTimes()
+	mutableState.EXPECT().GetPendingWorkflowTask().Return(workflowTaskSchedule).AnyTimes()
 	mutableState.EXPECT().AddWorkflowTaskStartedEvent(
 		workflowTaskSchedule.ScheduledEventID,
 		workflowTaskSchedule.RequestID,
@@ -430,7 +430,7 @@ func (s *workflowResetterSuite) TestFailWorkflowTask_WorkflowTaskStarted() {
 			Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 		},
 	}
-	mutableState.EXPECT().GetPendingWorkflowTask().Return(workflowTask, true).AnyTimes()
+	mutableState.EXPECT().GetPendingWorkflowTask().Return(workflowTask).AnyTimes()
 	mutableState.EXPECT().AddWorkflowTaskFailedEvent(
 		workflowTask,
 		enumspb.WORKFLOW_TASK_FAILED_CAUSE_RESET_WORKFLOW,
@@ -530,7 +530,7 @@ func (s *workflowResetterSuite) TestTerminateWorkflow() {
 	mutableState := workflow.NewMockMutableState(s.controller)
 
 	mutableState.EXPECT().GetNextEventID().Return(nextEventID).AnyTimes()
-	mutableState.EXPECT().GetInFlightWorkflowTask().Return(workflowTask, true)
+	mutableState.EXPECT().GetStartedWorkflowTask().Return(workflowTask)
 	mutableState.EXPECT().AddWorkflowTaskFailedEvent(
 		workflowTask,
 		enumspb.WORKFLOW_TASK_FAILED_CAUSE_FORCE_CLOSE_COMMAND,

--- a/service/history/ndc/workflow_test.go
+++ b/service/history/ndc/workflow_test.go
@@ -279,14 +279,14 @@ func (s *workflowSuite) TestSuppressWorkflowBy_Terminate() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 
 	s.mockMutableState.EXPECT().UpdateCurrentVersion(lastEventVersion, true).Return(nil).AnyTimes()
-	inFlightWorkflowTask := &workflow.WorkflowTaskInfo{
+	startedWorkflowTask := &workflow.WorkflowTaskInfo{
 		Version:          1234,
 		ScheduledEventID: 5678,
 		StartedEventID:   9012,
 	}
-	s.mockMutableState.EXPECT().GetInFlightWorkflowTask().Return(inFlightWorkflowTask, true)
+	s.mockMutableState.EXPECT().GetStartedWorkflowTask().Return(startedWorkflowTask)
 	s.mockMutableState.EXPECT().AddWorkflowTaskFailedEvent(
-		inFlightWorkflowTask,
+		startedWorkflowTask,
 		enumspb.WORKFLOW_TASK_FAILED_CAUSE_FAILOVER_CLOSE_COMMAND,
 		nil,
 		consts.IdentityHistoryService,

--- a/service/history/timerQueueActiveTaskExecutor.go
+++ b/service/history/timerQueueActiveTaskExecutor.go
@@ -310,8 +310,8 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowTaskTimeoutTask(
 		return nil
 	}
 
-	workflowTask, ok := mutableState.GetWorkflowTaskInfo(task.EventID)
-	if !ok {
+	workflowTask := mutableState.GetWorkflowTaskByID(task.EventID)
+	if workflowTask == nil {
 		return nil
 	}
 	err = CheckTaskVersion(t.shard, t.logger, mutableState.GetNamespaceEntry(), workflowTask.Version, task.Version, task)
@@ -392,7 +392,7 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowBackoffTimerTask(
 		)
 	}
 
-	if mutableState.HasProcessedOrPendingWorkflowTask() {
+	if mutableState.HadOrHasWorkflowTask() {
 		// already has workflow task
 		return nil
 	}

--- a/service/history/timerQueueActiveTaskExecutor_test.go
+++ b/service/history/timerQueueActiveTaskExecutor_test.go
@@ -901,8 +901,8 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowTaskTimeout_Fire() {
 	_, _, err = s.timerQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(timerTask))
 	s.NoError(err)
 
-	workflowTask, ok := s.getMutableStateFromCache(s.namespaceID, execution.GetWorkflowId(), execution.GetRunId()).GetPendingWorkflowTask()
-	s.True(ok)
+	workflowTask := s.getMutableStateFromCache(s.namespaceID, execution.GetWorkflowId(), execution.GetRunId()).GetPendingWorkflowTask()
+	s.NotNil(workflowTask)
 	s.True(workflowTask.ScheduledEventID != common.EmptyEventID)
 	s.Equal(common.EmptyEventID, workflowTask.StartedEventID)
 	s.Equal(int32(2), workflowTask.Attempt)
@@ -999,8 +999,8 @@ func (s *timerQueueActiveTaskExecutorSuite) TestWorkflowBackoffTimer_Fire() {
 	_, _, err = s.timerQueueActiveTaskExecutor.Execute(context.Background(), s.newTaskExecutable(timerTask))
 	s.NoError(err)
 
-	workflowTask, ok := s.getMutableStateFromCache(s.namespaceID, execution.GetWorkflowId(), execution.GetRunId()).GetPendingWorkflowTask()
-	s.True(ok)
+	workflowTask := s.getMutableStateFromCache(s.namespaceID, execution.GetWorkflowId(), execution.GetRunId()).GetPendingWorkflowTask()
+	s.NotNil(workflowTask)
 	s.True(workflowTask.ScheduledEventID != common.EmptyEventID)
 	s.Equal(common.EmptyEventID, workflowTask.StartedEventID)
 	s.Equal(int32(1), workflowTask.Attempt)

--- a/service/history/timerQueueStandbyTaskExecutor.go
+++ b/service/history/timerQueueStandbyTaskExecutor.go
@@ -319,8 +319,8 @@ func (t *timerQueueStandbyTaskExecutor) executeWorkflowTaskTimeoutTask(
 	}
 
 	actionFn := func(_ context.Context, wfContext workflow.Context, mutableState workflow.MutableState) (interface{}, error) {
-		workflowTask, isPending := mutableState.GetWorkflowTaskInfo(timerTask.EventID)
-		if !isPending {
+		workflowTask := mutableState.GetWorkflowTaskByID(timerTask.EventID)
+		if workflowTask == nil {
 			return nil, nil
 		}
 
@@ -352,7 +352,7 @@ func (t *timerQueueStandbyTaskExecutor) executeWorkflowBackoffTimerTask(
 	timerTask *tasks.WorkflowBackoffTimerTask,
 ) error {
 	actionFn := func(_ context.Context, wfContext workflow.Context, mutableState workflow.MutableState) (interface{}, error) {
-		if mutableState.HasProcessedOrPendingWorkflowTask() {
+		if mutableState.HadOrHasWorkflowTask() {
 			// if there is one workflow task already been processed
 			// or has pending workflow task, meaning workflow has already running
 			return nil, nil

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -223,8 +223,8 @@ func (t *transferQueueActiveTaskExecutor) processWorkflowTask(
 		return nil
 	}
 
-	workflowTask, found := mutableState.GetWorkflowTaskInfo(task.ScheduledEventID)
-	if !found {
+	workflowTask := mutableState.GetWorkflowTaskByID(task.ScheduledEventID)
+	if workflowTask == nil {
 		return nil
 	}
 	err = CheckTaskVersion(t.shard, t.logger, mutableState.GetNamespaceEntry(), workflowTask.Version, task.Version, task)

--- a/service/history/transferQueueStandbyTaskExecutor.go
+++ b/service/history/transferQueueStandbyTaskExecutor.go
@@ -174,8 +174,8 @@ func (t *transferQueueStandbyTaskExecutor) processWorkflowTask(
 ) error {
 	processTaskIfClosed := false
 	actionFn := func(_ context.Context, wfContext workflow.Context, mutableState workflow.MutableState) (interface{}, error) {
-		wtInfo, ok := mutableState.GetWorkflowTaskInfo(transferTask.ScheduledEventID)
-		if !ok {
+		wtInfo := mutableState.GetWorkflowTaskByID(transferTask.ScheduledEventID)
+		if wtInfo == nil {
 			return nil, nil
 		}
 

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -166,7 +166,7 @@ type (
 		GetChildExecutionInitiatedEvent(context.Context, int64) (*historypb.HistoryEvent, error)
 		GetCompletionEvent(context.Context) (*historypb.HistoryEvent, error)
 		GetWorkflowCloseTime(ctx context.Context) (*time.Time, error)
-		GetWorkflowTaskInfo(int64) (*WorkflowTaskInfo, bool)
+		GetWorkflowTaskByID(scheduledEventID int64) *WorkflowTaskInfo
 		GetNamespaceEntry() *namespace.Namespace
 		GetStartEvent(context.Context) (*historypb.HistoryEvent, error)
 		GetSignalExternalInitiatedEvent(context.Context, int64) (*historypb.HistoryEvent, error)
@@ -175,12 +175,12 @@ type (
 		GetCurrentVersion() int64
 		GetExecutionInfo() *persistencespb.WorkflowExecutionInfo
 		GetExecutionState() *persistencespb.WorkflowExecutionState
-		GetInFlightWorkflowTask() (*WorkflowTaskInfo, bool)
-		GetPendingWorkflowTask() (*WorkflowTaskInfo, bool)
+		GetStartedWorkflowTask() *WorkflowTaskInfo
+		GetPendingWorkflowTask() *WorkflowTaskInfo
 		GetLastFirstEventIDTxnID() (int64, int64)
 		GetLastWriteVersion() (int64, error)
 		GetNextEventID() int64
-		GetPreviousStartedEventID() int64
+		GetLastWorkflowTaskStartedEventID() int64
 		GetPendingActivityInfos() map[int64]*persistencespb.ActivityInfo
 		GetPendingTimerInfos() map[string]*persistencespb.TimerInfo
 		GetPendingChildExecutionInfos() map[int64]*persistencespb.ChildExecutionInfo
@@ -199,10 +199,10 @@ type (
 		IsTransientWorkflowTask() bool
 		ClearTransientWorkflowTask() error
 		HasBufferedEvents() bool
-		HasInFlightWorkflowTask() bool
+		HasStartedWorkflowTask() bool
 		HasParentExecution() bool
 		HasPendingWorkflowTask() bool
-		HasProcessedOrPendingWorkflowTask() bool
+		HadOrHasWorkflowTask() bool
 		IsCancelRequested() bool
 		IsCurrentWorkflowGuaranteed() bool
 		IsSignalRequested(requestID string) bool

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -480,7 +480,7 @@ func (ms *MutableStateImpl) GetExecutionState() *persistencespb.WorkflowExecutio
 }
 
 func (ms *MutableStateImpl) FlushBufferedEvents() {
-	if ms.HasInFlightWorkflowTask() {
+	if ms.HasStartedWorkflowTask() {
 		return
 	}
 	ms.updatePendingEventIDs(ms.hBuilder.FlushBufferToCurrentBatch())
@@ -1249,11 +1249,9 @@ func (ms *MutableStateImpl) DeleteUserTimer(
 	return nil
 }
 
-// GetWorkflowTaskInfo returns details about the in-progress workflow task
-func (ms *MutableStateImpl) GetWorkflowTaskInfo(
-	scheduledEventID int64,
-) (*WorkflowTaskInfo, bool) {
-	return ms.workflowTaskManager.GetWorkflowTaskInfo(scheduledEventID)
+// GetWorkflowTaskByID returns details about the current workflow task by scheduled event ID.
+func (ms *MutableStateImpl) GetWorkflowTaskByID(scheduledEventID int64) *WorkflowTaskInfo {
+	return ms.workflowTaskManager.GetWorkflowTaskByID(scheduledEventID)
 }
 
 func (ms *MutableStateImpl) GetPendingActivityInfos() map[int64]*persistencespb.ActivityInfo {
@@ -1276,24 +1274,24 @@ func (ms *MutableStateImpl) GetPendingSignalExternalInfos() map[int64]*persisten
 	return ms.pendingSignalInfoIDs
 }
 
-func (ms *MutableStateImpl) HasProcessedOrPendingWorkflowTask() bool {
-	return ms.workflowTaskManager.HasProcessedOrPendingWorkflowTask()
+func (ms *MutableStateImpl) HadOrHasWorkflowTask() bool {
+	return ms.workflowTaskManager.HadOrHasWorkflowTask()
 }
 
 func (ms *MutableStateImpl) HasPendingWorkflowTask() bool {
 	return ms.workflowTaskManager.HasPendingWorkflowTask()
 }
 
-func (ms *MutableStateImpl) GetPendingWorkflowTask() (*WorkflowTaskInfo, bool) {
+func (ms *MutableStateImpl) GetPendingWorkflowTask() *WorkflowTaskInfo {
 	return ms.workflowTaskManager.GetPendingWorkflowTask()
 }
 
-func (ms *MutableStateImpl) HasInFlightWorkflowTask() bool {
-	return ms.workflowTaskManager.HasInFlightWorkflowTask()
+func (ms *MutableStateImpl) HasStartedWorkflowTask() bool {
+	return ms.workflowTaskManager.HasStartedWorkflowTask()
 }
 
-func (ms *MutableStateImpl) GetInFlightWorkflowTask() (*WorkflowTaskInfo, bool) {
-	return ms.workflowTaskManager.GetInFlightWorkflowTask()
+func (ms *MutableStateImpl) GetStartedWorkflowTask() *WorkflowTaskInfo {
+	return ms.workflowTaskManager.GetStartedWorkflowTask()
 }
 
 func (ms *MutableStateImpl) IsTransientWorkflowTask() bool {
@@ -1301,7 +1299,7 @@ func (ms *MutableStateImpl) IsTransientWorkflowTask() bool {
 }
 
 func (ms *MutableStateImpl) ClearTransientWorkflowTask() error {
-	if !ms.HasInFlightWorkflowTask() {
+	if !ms.HasStartedWorkflowTask() {
 		return serviceerror.NewInternal("cannot clear transient workflow task when task is missing")
 	}
 	if !ms.IsTransientWorkflowTask() {
@@ -1358,8 +1356,8 @@ func (ms *MutableStateImpl) GetNextEventID() int64 {
 	return ms.hBuilder.NextEventID()
 }
 
-// GetPreviousStartedEventID returns last started workflow task event ID
-func (ms *MutableStateImpl) GetPreviousStartedEventID() int64 {
+// GetLastWorkflowTaskStartedEventID returns last started workflow task event ID
+func (ms *MutableStateImpl) GetLastWorkflowTaskStartedEventID() int64 {
 	return ms.executionInfo.LastWorkflowTaskStartedEventId
 }
 
@@ -1397,7 +1395,7 @@ func (ms *MutableStateImpl) IsSignalRequested(
 func (ms *MutableStateImpl) IsWorkflowPendingOnWorkflowTaskBackoff() bool {
 
 	workflowTaskBackoff := timestamp.TimeValue(ms.executionInfo.GetExecutionTime()).After(timestamp.TimeValue(ms.executionInfo.GetStartTime()))
-	if workflowTaskBackoff && !ms.HasProcessedOrPendingWorkflowTask() {
+	if workflowTaskBackoff && !ms.HadOrHasWorkflowTask() {
 		return true
 	}
 	return false
@@ -4165,7 +4163,7 @@ func (ms *MutableStateImpl) prepareEventsAndReplicationTasks(
 		return nil, nil, false, err
 	}
 
-	historyMutation, err := ms.hBuilder.Finish(!ms.HasInFlightWorkflowTask())
+	historyMutation, err := ms.hBuilder.Finish(!ms.HasStartedWorkflowTask())
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -4368,8 +4366,8 @@ func (ms *MutableStateImpl) startTransactionHandleNamespaceMigration(
 		return nil, err
 	}
 
-	// local namespace -> global namespace && with inflight workflow task
-	if lastWriteVersion == common.EmptyVersion && namespaceEntry.FailoverVersion() > common.EmptyVersion && ms.HasInFlightWorkflowTask() {
+	// local namespace -> global namespace && with started workflow task
+	if lastWriteVersion == common.EmptyVersion && namespaceEntry.FailoverVersion() > common.EmptyVersion && ms.HasStartedWorkflowTask() {
 		localNamespaceMutation := namespace.NewPretendAsLocalNamespace(
 			ms.clusterMetadata.GetCurrentClusterName(),
 		)
@@ -4389,8 +4387,8 @@ func (ms *MutableStateImpl) startTransactionHandleWorkflowTaskFailover() (bool, 
 	// all events ending in the buffer should have the same version
 
 	// Handling mutable state turn from standby to active, while having a workflow task on the fly
-	workflowTask, ok := ms.GetInFlightWorkflowTask()
-	if !ok || workflowTask.Version >= ms.GetCurrentVersion() {
+	workflowTask := ms.GetStartedWorkflowTask()
+	if workflowTask == nil || workflowTask.Version >= ms.GetCurrentVersion() {
 		// no pending workflow tasks, no buffered events
 		// or workflow task has higher / equal version
 		return false, nil
@@ -4498,7 +4496,7 @@ func (ms *MutableStateImpl) closeTransactionHandleBufferedEventsLimit(
 	}
 
 	// Handling buffered events size issue
-	if workflowTask, ok := ms.GetInFlightWorkflowTask(); ok {
+	if workflowTask := ms.GetStartedWorkflowTask(); workflowTask != nil {
 		// we have a workflow task on the fly with a lower version, fail it
 		if err := failWorkflowTask(
 			ms,

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -161,7 +161,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 
 	newWorkflowTaskScheduleEvent, _ := s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
 
-	newWorkflowTask, _ := s.mutableState.GetWorkflowTaskInfo(newWorkflowTaskScheduleEvent.GetEventId())
+	newWorkflowTask := s.mutableState.GetWorkflowTaskByID(newWorkflowTaskScheduleEvent.GetEventId())
 	s.NotNil(newWorkflowTask)
 
 	_, err := s.mutableState.AddWorkflowTaskTimedOutEvent(
@@ -184,7 +184,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 
 	newWorkflowTaskScheduleEvent, _ := s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
 
-	newWorkflowTask, _ := s.mutableState.GetWorkflowTaskInfo(newWorkflowTaskScheduleEvent.GetEventId())
+	newWorkflowTask := s.mutableState.GetWorkflowTaskByID(newWorkflowTaskScheduleEvent.GetEventId())
 	s.NotNil(newWorkflowTask)
 
 	_, err := s.mutableState.AddWorkflowTaskFailedEvent(

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -1161,21 +1161,6 @@ func (mr *MockMutableStateMockRecorder) GetFirstRunID() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstRunID", reflect.TypeOf((*MockMutableState)(nil).GetFirstRunID))
 }
 
-// GetInFlightWorkflowTask mocks base method.
-func (m *MockMutableState) GetInFlightWorkflowTask() (*WorkflowTaskInfo, bool) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetInFlightWorkflowTask")
-	ret0, _ := ret[0].(*WorkflowTaskInfo)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
-}
-
-// GetInFlightWorkflowTask indicates an expected call of GetInFlightWorkflowTask.
-func (mr *MockMutableStateMockRecorder) GetInFlightWorkflowTask() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInFlightWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).GetInFlightWorkflowTask))
-}
-
 // GetLastFirstEventIDTxnID mocks base method.
 func (m *MockMutableState) GetLastFirstEventIDTxnID() (int64, int64) {
 	m.ctrl.T.Helper()
@@ -1189,6 +1174,20 @@ func (m *MockMutableState) GetLastFirstEventIDTxnID() (int64, int64) {
 func (mr *MockMutableStateMockRecorder) GetLastFirstEventIDTxnID() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastFirstEventIDTxnID", reflect.TypeOf((*MockMutableState)(nil).GetLastFirstEventIDTxnID))
+}
+
+// GetLastWorkflowTaskStartedEventID mocks base method.
+func (m *MockMutableState) GetLastWorkflowTaskStartedEventID() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLastWorkflowTaskStartedEventID")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetLastWorkflowTaskStartedEventID indicates an expected call of GetLastWorkflowTaskStartedEventID.
+func (mr *MockMutableStateMockRecorder) GetLastWorkflowTaskStartedEventID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLastWorkflowTaskStartedEventID", reflect.TypeOf((*MockMutableState)(nil).GetLastWorkflowTaskStartedEventID))
 }
 
 // GetLastWriteVersion mocks base method.
@@ -1305,32 +1304,17 @@ func (mr *MockMutableStateMockRecorder) GetPendingTimerInfos() *gomock.Call {
 }
 
 // GetPendingWorkflowTask mocks base method.
-func (m *MockMutableState) GetPendingWorkflowTask() (*WorkflowTaskInfo, bool) {
+func (m *MockMutableState) GetPendingWorkflowTask() *WorkflowTaskInfo {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetPendingWorkflowTask")
 	ret0, _ := ret[0].(*WorkflowTaskInfo)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	return ret0
 }
 
 // GetPendingWorkflowTask indicates an expected call of GetPendingWorkflowTask.
 func (mr *MockMutableStateMockRecorder) GetPendingWorkflowTask() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPendingWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).GetPendingWorkflowTask))
-}
-
-// GetPreviousStartedEventID mocks base method.
-func (m *MockMutableState) GetPreviousStartedEventID() int64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPreviousStartedEventID")
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-// GetPreviousStartedEventID indicates an expected call of GetPreviousStartedEventID.
-func (mr *MockMutableStateMockRecorder) GetPreviousStartedEventID() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPreviousStartedEventID", reflect.TypeOf((*MockMutableState)(nil).GetPreviousStartedEventID))
 }
 
 // GetQueryRegistry mocks base method.
@@ -1452,6 +1436,20 @@ func (mr *MockMutableStateMockRecorder) GetStartVersion() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStartVersion", reflect.TypeOf((*MockMutableState)(nil).GetStartVersion))
 }
 
+// GetStartedWorkflowTask mocks base method.
+func (m *MockMutableState) GetStartedWorkflowTask() *WorkflowTaskInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetStartedWorkflowTask")
+	ret0, _ := ret[0].(*WorkflowTaskInfo)
+	return ret0
+}
+
+// GetStartedWorkflowTask indicates an expected call of GetStartedWorkflowTask.
+func (mr *MockMutableStateMockRecorder) GetStartedWorkflowTask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStartedWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).GetStartedWorkflowTask))
+}
+
 // GetTransientWorkflowTaskInfo mocks base method.
 func (m *MockMutableState) GetTransientWorkflowTaskInfo(workflowTask *WorkflowTaskInfo, identity string) *v110.TransientWorkflowTaskInfo {
 	m.ctrl.T.Helper()
@@ -1555,19 +1553,18 @@ func (mr *MockMutableStateMockRecorder) GetWorkflowStateStatus() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowStateStatus", reflect.TypeOf((*MockMutableState)(nil).GetWorkflowStateStatus))
 }
 
-// GetWorkflowTaskInfo mocks base method.
-func (m *MockMutableState) GetWorkflowTaskInfo(arg0 int64) (*WorkflowTaskInfo, bool) {
+// GetWorkflowTaskByID mocks base method.
+func (m *MockMutableState) GetWorkflowTaskByID(scheduledEventID int64) *WorkflowTaskInfo {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWorkflowTaskInfo", arg0)
+	ret := m.ctrl.Call(m, "GetWorkflowTaskByID", scheduledEventID)
 	ret0, _ := ret[0].(*WorkflowTaskInfo)
-	ret1, _ := ret[1].(bool)
-	return ret0, ret1
+	return ret0
 }
 
-// GetWorkflowTaskInfo indicates an expected call of GetWorkflowTaskInfo.
-func (mr *MockMutableStateMockRecorder) GetWorkflowTaskInfo(arg0 interface{}) *gomock.Call {
+// GetWorkflowTaskByID indicates an expected call of GetWorkflowTaskByID.
+func (mr *MockMutableStateMockRecorder) GetWorkflowTaskByID(scheduledEventID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowTaskInfo", reflect.TypeOf((*MockMutableState)(nil).GetWorkflowTaskInfo), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowTaskByID", reflect.TypeOf((*MockMutableState)(nil).GetWorkflowTaskByID), scheduledEventID)
 }
 
 // GetWorkflowType mocks base method.
@@ -1584,6 +1581,20 @@ func (mr *MockMutableStateMockRecorder) GetWorkflowType() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowType", reflect.TypeOf((*MockMutableState)(nil).GetWorkflowType))
 }
 
+// HadOrHasWorkflowTask mocks base method.
+func (m *MockMutableState) HadOrHasWorkflowTask() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HadOrHasWorkflowTask")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// HadOrHasWorkflowTask indicates an expected call of HadOrHasWorkflowTask.
+func (mr *MockMutableStateMockRecorder) HadOrHasWorkflowTask() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HadOrHasWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).HadOrHasWorkflowTask))
+}
+
 // HasBufferedEvents mocks base method.
 func (m *MockMutableState) HasBufferedEvents() bool {
 	m.ctrl.T.Helper()
@@ -1596,20 +1607,6 @@ func (m *MockMutableState) HasBufferedEvents() bool {
 func (mr *MockMutableStateMockRecorder) HasBufferedEvents() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasBufferedEvents", reflect.TypeOf((*MockMutableState)(nil).HasBufferedEvents))
-}
-
-// HasInFlightWorkflowTask mocks base method.
-func (m *MockMutableState) HasInFlightWorkflowTask() bool {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasInFlightWorkflowTask")
-	ret0, _ := ret[0].(bool)
-	return ret0
-}
-
-// HasInFlightWorkflowTask indicates an expected call of HasInFlightWorkflowTask.
-func (mr *MockMutableStateMockRecorder) HasInFlightWorkflowTask() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasInFlightWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).HasInFlightWorkflowTask))
 }
 
 // HasParentExecution mocks base method.
@@ -1640,18 +1637,18 @@ func (mr *MockMutableStateMockRecorder) HasPendingWorkflowTask() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPendingWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).HasPendingWorkflowTask))
 }
 
-// HasProcessedOrPendingWorkflowTask mocks base method.
-func (m *MockMutableState) HasProcessedOrPendingWorkflowTask() bool {
+// HasStartedWorkflowTask mocks base method.
+func (m *MockMutableState) HasStartedWorkflowTask() bool {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasProcessedOrPendingWorkflowTask")
+	ret := m.ctrl.Call(m, "HasStartedWorkflowTask")
 	ret0, _ := ret[0].(bool)
 	return ret0
 }
 
-// HasProcessedOrPendingWorkflowTask indicates an expected call of HasProcessedOrPendingWorkflowTask.
-func (mr *MockMutableStateMockRecorder) HasProcessedOrPendingWorkflowTask() *gomock.Call {
+// HasStartedWorkflowTask indicates an expected call of HasStartedWorkflowTask.
+func (mr *MockMutableStateMockRecorder) HasStartedWorkflowTask() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasProcessedOrPendingWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).HasProcessedOrPendingWorkflowTask))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasStartedWorkflowTask", reflect.TypeOf((*MockMutableState)(nil).HasStartedWorkflowTask))
 }
 
 // IsCancelRequested mocks base method.

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -334,10 +334,10 @@ func (r *TaskGeneratorImpl) GenerateScheduleWorkflowTaskTasks(
 	workflowTaskScheduledEventID int64,
 ) error {
 
-	workflowTask, ok := r.mutableState.GetWorkflowTaskInfo(
+	workflowTask := r.mutableState.GetWorkflowTaskByID(
 		workflowTaskScheduledEventID,
 	)
-	if !ok {
+	if workflowTask == nil {
 		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending workflow task: %v", workflowTaskScheduledEventID))
 	}
 
@@ -371,11 +371,11 @@ func (r *TaskGeneratorImpl) GenerateStartWorkflowTaskTasks(
 	workflowTaskScheduledEventID int64,
 ) error {
 
-	workflowTask, ok := r.mutableState.GetWorkflowTaskInfo(
+	workflowTask := r.mutableState.GetWorkflowTaskByID(
 		workflowTaskScheduledEventID,
 	)
-	if !ok {
-		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending workflowTaskInfo: %v", workflowTaskScheduledEventID))
+	if workflowTask == nil {
+		return serviceerror.NewInternal(fmt.Sprintf("it could be a bug, cannot get pending workflow task: %v", workflowTaskScheduledEventID))
 	}
 
 	startedTime := timestamp.TimeValue(workflowTask.StartedTime)

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -182,7 +182,7 @@ func (r *TaskRefresherImpl) refreshTasksForWorkflowStart(
 	}
 
 	startAttr := startEvent.GetWorkflowExecutionStartedEventAttributes()
-	if !mutableState.HasProcessedOrPendingWorkflowTask() && timestamp.DurationValue(startAttr.GetFirstWorkflowTaskBackoff()) > 0 {
+	if !mutableState.HadOrHasWorkflowTask() && timestamp.DurationValue(startAttr.GetFirstWorkflowTaskBackoff()) > 0 {
 		if err := taskGenerator.GenerateDelayedWorkflowTasks(
 			startEvent,
 		); err != nil {
@@ -248,8 +248,8 @@ func (r *TaskRefresherImpl) refreshWorkflowTaskTasks(
 		return nil
 	}
 
-	workflowTask, ok := mutableState.GetPendingWorkflowTask()
-	if !ok {
+	workflowTask := mutableState.GetPendingWorkflowTask()
+	if workflowTask == nil {
 		return serviceerror.NewInternal("it could be a bug, cannot get pending workflow task")
 	}
 

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -87,7 +87,7 @@ func RetryWorkflow(
 	continueAsNewAttributes *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes,
 ) (MutableState, error) {
 
-	if workflowTask, ok := mutableState.GetInFlightWorkflowTask(); ok {
+	if workflowTask := mutableState.GetStartedWorkflowTask(); workflowTask != nil {
 		if err := failWorkflowTask(
 			mutableState,
 			workflowTask,
@@ -117,7 +117,7 @@ func TimeoutWorkflow(
 	continuedRunID string,
 ) error {
 
-	if workflowTask, ok := mutableState.GetInFlightWorkflowTask(); ok {
+	if workflowTask := mutableState.GetStartedWorkflowTask(); workflowTask != nil {
 		if err := failWorkflowTask(
 			mutableState,
 			workflowTask,
@@ -144,7 +144,7 @@ func TerminateWorkflow(
 	deleteAfterTerminate bool,
 ) error {
 
-	if workflowTask, ok := mutableState.GetInFlightWorkflowTask(); ok {
+	if workflowTask := mutableState.GetStartedWorkflowTask(); workflowTask != nil {
 		if err := failWorkflowTask(
 			mutableState,
 			workflowTask,

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -170,9 +170,8 @@ func (m *workflowTaskStateMachine) ReplicateWorkflowTaskStartedEvent(
 	// When this function is called from ApplyEvents, workflowTask is nil.
 	// It is safe to look up the workflow task as it does not have to deal with transient workflow task case.
 	if workflowTask == nil {
-		var ok bool
-		workflowTask, ok = m.GetWorkflowTaskInfo(scheduledEventID)
-		if !ok {
+		workflowTask = m.GetWorkflowTaskByID(scheduledEventID)
+		if workflowTask == nil {
 			return nil, serviceerror.NewInternal(fmt.Sprintf("unable to find workflow task: %v", scheduledEventID))
 		}
 		// Transient workflow task events are not replicated but attempt count in mutable state
@@ -409,8 +408,8 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskStartedEvent(
 	identity string,
 ) (*historypb.HistoryEvent, *WorkflowTaskInfo, error) {
 	opTag := tag.WorkflowActionWorkflowTaskStarted
-	workflowTask, ok := m.GetWorkflowTaskInfo(scheduledEventID)
-	if !ok || workflowTask.StartedEventID != common.EmptyEventID {
+	workflowTask := m.GetWorkflowTaskByID(scheduledEventID)
+	if workflowTask == nil || workflowTask.StartedEventID != common.EmptyEventID {
 		m.ms.logger.Warn(mutableStateInvalidHistoryActionMsg, opTag,
 			tag.WorkflowEventID(m.ms.GetNextEventID()),
 			tag.ErrorTypeInvalidHistoryAction,
@@ -719,48 +718,46 @@ func (m *workflowTaskStateMachine) HasPendingWorkflowTask() bool {
 	return m.ms.executionInfo.WorkflowTaskScheduledEventId != common.EmptyEventID
 }
 
-func (m *workflowTaskStateMachine) GetPendingWorkflowTask() (*WorkflowTaskInfo, bool) {
-	if m.ms.executionInfo.WorkflowTaskScheduledEventId == common.EmptyEventID {
-		return nil, false
+func (m *workflowTaskStateMachine) GetPendingWorkflowTask() *WorkflowTaskInfo {
+	if !m.HasPendingWorkflowTask() {
+		return nil
 	}
 
 	workflowTask := m.getWorkflowTaskInfo()
-	return workflowTask, true
+	return workflowTask
 }
 
-func (m *workflowTaskStateMachine) HasInFlightWorkflowTask() bool {
-	return m.ms.executionInfo.WorkflowTaskStartedEventId != common.EmptyEventID
+func (m *workflowTaskStateMachine) HasStartedWorkflowTask() bool {
+	return m.ms.executionInfo.WorkflowTaskScheduledEventId != common.EmptyEventID &&
+		m.ms.executionInfo.WorkflowTaskStartedEventId != common.EmptyEventID
 }
 
-func (m *workflowTaskStateMachine) GetInFlightWorkflowTask() (*WorkflowTaskInfo, bool) {
-	if m.ms.executionInfo.WorkflowTaskScheduledEventId == common.EmptyEventID ||
-		m.ms.executionInfo.WorkflowTaskStartedEventId == common.EmptyEventID {
-		return nil, false
+func (m *workflowTaskStateMachine) GetStartedWorkflowTask() *WorkflowTaskInfo {
+	if !m.HasStartedWorkflowTask() {
+		return nil
 	}
 
 	workflowTask := m.getWorkflowTaskInfo()
-	return workflowTask, true
+	return workflowTask
 }
 
-func (m *workflowTaskStateMachine) HasProcessedOrPendingWorkflowTask() bool {
-	return m.HasPendingWorkflowTask() || m.ms.GetPreviousStartedEventID() != common.EmptyEventID
+func (m *workflowTaskStateMachine) HadOrHasWorkflowTask() bool {
+	return m.HasPendingWorkflowTask() || m.ms.GetLastWorkflowTaskStartedEventID() != common.EmptyEventID
 }
 
-// GetWorkflowTaskInfo returns details about the in-progress workflow task
-func (m *workflowTaskStateMachine) GetWorkflowTaskInfo(
-	scheduledEventID int64,
-) (*WorkflowTaskInfo, bool) {
+// GetWorkflowTaskByID returns details about the current workflow task by scheduled event ID.
+func (m *workflowTaskStateMachine) GetWorkflowTaskByID(scheduledEventID int64) *WorkflowTaskInfo {
 	workflowTask := m.getWorkflowTaskInfo()
 	if scheduledEventID == workflowTask.ScheduledEventID {
-		return workflowTask, true
+		return workflowTask
 	}
 
 	workflowTask = m.tryRestoreSpeculativeWorkflowTask(scheduledEventID)
 	if workflowTask != nil {
-		return workflowTask, true
+		return workflowTask
 	}
 
-	return nil, false
+	return nil
 }
 
 func (m *workflowTaskStateMachine) tryRestoreSpeculativeWorkflowTask(

--- a/tests/max_buffered_event_test.go
+++ b/tests/max_buffered_event_test.go
@@ -100,7 +100,7 @@ func (s *clientIntegrationSuite) TestMaxBufferedEventsLimit() {
 		s.NoError(err)
 	}
 
-	// send 101 signal, this will fail the inflight workflow task
+	// send 101 signal, this will fail the started workflow task
 	err := s.sdkClient.SignalWorkflow(testCtx, wid, "", "test-signal", 100)
 	s.NoError(err)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Made few renames for better code readability:
1. `GetInFlightWorkflowTask` -> `GetStartedWorkflowTask` (same for `Has*`),
2. `GetWorkflowTaskInfo` -> `GetWorkflowTaskByID`,
3. `HasProcessedOrPendingWorkflowTask` -> `HadOrHasWorkflowTask`,
4. `GetPreviousStartedEventID` -> `GetLastWorkflowTaskStartedEventID`

<!-- Tell your future self why have you made these changes -->
**Why?**
Better readability.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.