### PR TITLE
Match all namespace divisions in internal workflows

### DIFF
--- a/common/searchattribute/defs.go
+++ b/common/searchattribute/defs.go
@@ -67,9 +67,9 @@ const (
 
 	ReservedPrefix = "Temporal"
 
-	// Query clause that mentions TemporalNamespaceDivision (to disable special handling) and
-	// matches everything.
-	matchAllNamespaceDivisions = TemporalNamespaceDivision + ` != "__never_used__"`
+	// Query clause that mentions TemporalNamespaceDivision to disable special handling of that
+	// search attribute in visibility.
+	matchAnyNamespaceDivision = TemporalNamespaceDivision + ` != "__never_used__"`
 )
 
 var (
@@ -196,13 +196,13 @@ func GetSqlDbIndexSearchAttributes() *persistencespb.IndexSearchAttributes {
 	}
 }
 
-// QueryWithAllNamespaceDivisions returns a modified workflow visibility query that disables
+// QueryWithAnyNamespaceDivision returns a modified workflow visibility query that disables
 // special handling of namespace division and so matches workflows in all namespace divisions.
 // Normally a query that didn't explicitly mention TemporalNamespaceDivision would be limited
 // to the default (empty string) namespace division.
-func QueryWithAllNamespaceDivisions(query string) string {
+func QueryWithAnyNamespaceDivision(query string) string {
 	if strings.TrimSpace(query) == "" {
-		return matchAllNamespaceDivisions
+		return matchAnyNamespaceDivision
 	}
-	return fmt.Sprintf(`(%s) AND (%s)`, query, matchAllNamespaceDivisions)
+	return fmt.Sprintf(`(%s) AND (%s)`, query, matchAnyNamespaceDivision)
 }

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -39,6 +39,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/quotas"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 type (
@@ -92,6 +93,7 @@ func (a *Activities) GetNextPageTokenActivity(ctx context.Context, params GetNex
 		Namespace:     params.Namespace,
 		PageSize:      params.PageSize,
 		NextPageToken: params.NextPageToken,
+		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
 	}
 
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
@@ -116,6 +118,7 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 		Namespace:     params.Namespace,
 		PageSize:      params.ListPageSize,
 		NextPageToken: params.NextPageToken,
+		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -93,7 +93,7 @@ func (a *Activities) GetNextPageTokenActivity(ctx context.Context, params GetNex
 		Namespace:     params.Namespace,
 		PageSize:      params.PageSize,
 		NextPageToken: params.NextPageToken,
-		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}
 
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
@@ -118,7 +118,7 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 		Namespace:     params.Namespace,
 		PageSize:      params.ListPageSize,
 		NextPageToken: params.NextPageToken,
-		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {

--- a/service/worker/deletenamespace/deleteexecutions/workflow_test.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow_test.go
@@ -46,6 +46,7 @@ import (
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 func Test_DeleteExecutionsWorkflow_Success(t *testing.T) {
@@ -96,6 +97,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_NoExecutions(t *testing.T) {
 		Namespace:     "namespace",
 		PageSize:      1000,
 		NextPageToken: nil,
+		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions:    nil,
 		NextPageToken: nil,
@@ -258,6 +260,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: nil,
+		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -284,6 +287,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: []byte{22, 8, 78},
+		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -352,6 +356,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: nil,
+		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -378,6 +383,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: []byte{22, 8, 78},
+		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{

--- a/service/worker/deletenamespace/deleteexecutions/workflow_test.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow_test.go
@@ -97,7 +97,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_NoExecutions(t *testing.T) {
 		Namespace:     "namespace",
 		PageSize:      1000,
 		NextPageToken: nil,
-		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions:    nil,
 		NextPageToken: nil,
@@ -260,7 +260,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: nil,
-		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -287,7 +287,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: []byte{22, 8, 78},
-		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -356,7 +356,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: nil,
-		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -383,7 +383,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: []byte{22, 8, 78},
-		Query:         searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:         searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store/elasticsearch"
+	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/worker/deletenamespace/errors"
 )
 
@@ -156,6 +157,7 @@ func (a *Activities) EnsureNoExecutionsStdVisibilityActivity(ctx context.Context
 		NamespaceID: nsID,
 		Namespace:   nsName,
 		PageSize:    1,
+		Query:       searchattribute.QueryWithAllNamespaceDivisions(""),
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -157,7 +157,7 @@ func (a *Activities) EnsureNoExecutionsStdVisibilityActivity(ctx context.Context
 		NamespaceID: nsID,
 		Namespace:   nsName,
 		PageSize:    1,
-		Query:       searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:       searchattribute.QueryWithAnyNamespaceDivision(""),
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {

--- a/service/worker/deletenamespace/reclaimresources/activities_test.go
+++ b/service/worker/deletenamespace/reclaimresources/activities_test.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/visibility/manager"
+	"go.temporal.io/server/common/searchattribute"
 )
 
 func Test_EnsureNoExecutionsAdvVisibilityActivity_NoExecutions(t *testing.T) {
@@ -128,6 +129,7 @@ func Test_EnsureNoExecutionsStdVisibilityActivity_NoExecutions(t *testing.T) {
 		NamespaceID: "namespace-id",
 		Namespace:   "namespace",
 		PageSize:    1,
+		Query:       searchattribute.QueryWithAllNamespaceDivisions(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{},
 	}, nil)
@@ -151,6 +153,7 @@ func Test_EnsureNoExecutionsStdVisibilityActivity_ExecutionsExist(t *testing.T) 
 		NamespaceID: "namespace-id",
 		Namespace:   "namespace",
 		PageSize:    1,
+		Query:       searchattribute.QueryWithAllNamespaceDivisions(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{{}},
 	}, nil)

--- a/service/worker/deletenamespace/reclaimresources/activities_test.go
+++ b/service/worker/deletenamespace/reclaimresources/activities_test.go
@@ -129,7 +129,7 @@ func Test_EnsureNoExecutionsStdVisibilityActivity_NoExecutions(t *testing.T) {
 		NamespaceID: "namespace-id",
 		Namespace:   "namespace",
 		PageSize:    1,
-		Query:       searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:       searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{},
 	}, nil)
@@ -153,7 +153,7 @@ func Test_EnsureNoExecutionsStdVisibilityActivity_ExecutionsExist(t *testing.T) 
 		NamespaceID: "namespace-id",
 		Namespace:   "namespace",
 		PageSize:    1,
-		Query:       searchattribute.QueryWithAllNamespaceDivisions(""),
+		Query:       searchattribute.QueryWithAnyNamespaceDivision(""),
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{{}},
 	}, nil)

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"math"
 	"sort"
-	"strings"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -302,7 +301,7 @@ func (a *activities) UpdateActiveCluster(ctx context.Context, req updateActiveCl
 
 func (a *activities) ListWorkflows(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
 	// modify query to include all namespace divisions
-	request.Query = allNamespaceDivisions(request.Query)
+	request.Query = searchattribute.QueryWithAllNamespaceDivisions(request.Query)
 
 	resp, err := a.frontendClient.ListWorkflowExecutions(ctx, request)
 	if err != nil {
@@ -350,14 +349,4 @@ func (a *activities) GenerateReplicationTasks(ctx context.Context, request *gene
 	}
 
 	return nil
-}
-
-func allNamespaceDivisions(query string) string {
-	// This should be a value that is never used as a namespace division.
-	const matchAll = searchattribute.TemporalNamespaceDivision + ` != "__never_used__"`
-
-	if strings.TrimSpace(query) == "" {
-		return matchAll
-	}
-	return fmt.Sprintf(`(%s) AND (%s)`, query, matchAll)
 }

--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -301,7 +301,7 @@ func (a *activities) UpdateActiveCluster(ctx context.Context, req updateActiveCl
 
 func (a *activities) ListWorkflows(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*listWorkflowsResponse, error) {
 	// modify query to include all namespace divisions
-	request.Query = searchattribute.QueryWithAllNamespaceDivisions(request.Query)
+	request.Query = searchattribute.QueryWithAnyNamespaceDivision(request.Query)
 
 	resp, err := a.frontendClient.ListWorkflowExecutions(ctx, request)
 	if err != nil {

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -287,7 +287,23 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	s.WithinRange(ex0StartTime, createTime, time.Now())
 	s.True(ex0StartTime.UnixNano()%int64(5*time.Second) == 0)
 
-	// list workflows with namespace division (implementation details here, not public api)
+	// list with QueryWithAllNamespaceDivisions, we should see the scheduler workflow
+
+	wfResp, err = s.engine.ListWorkflowExecutions(NewContext(), &workflowservice.ListWorkflowExecutionsRequest{
+		Namespace: s.namespace,
+		PageSize:  5,
+		Query:     searchattribute.QueryWithAllNamespaceDivisions(`ExecutionStatus = "Running"`),
+	})
+	s.NoError(err)
+	count := 0
+	for _, ex := range wfResp.Executions {
+		if ex.Type.Name == scheduler.WorkflowType {
+			count++
+		}
+	}
+	s.EqualValues(1, count, "should see scheduler workflow")
+
+	// list workflows with an exact match on namespace division (implementation details here, not public api)
 
 	wfResp, err = s.engine.ListWorkflowExecutions(NewContext(), &workflowservice.ListWorkflowExecutionsRequest{
 		Namespace: s.namespace,

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -287,12 +287,12 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	s.WithinRange(ex0StartTime, createTime, time.Now())
 	s.True(ex0StartTime.UnixNano()%int64(5*time.Second) == 0)
 
-	// list with QueryWithAllNamespaceDivisions, we should see the scheduler workflow
+	// list with QueryWithAnyNamespaceDivision, we should see the scheduler workflow
 
 	wfResp, err = s.engine.ListWorkflowExecutions(NewContext(), &workflowservice.ListWorkflowExecutionsRequest{
 		Namespace: s.namespace,
 		PageSize:  5,
-		Query:     searchattribute.QueryWithAllNamespaceDivisions(`ExecutionStatus = "Running"`),
+		Query:     searchattribute.QueryWithAnyNamespaceDivision(`ExecutionStatus = "Running"`),
 	})
 	s.NoError(err)
 	count := 0


### PR DESCRIPTION
**What changed?**
Tweak ListWorkflows query in force-replication and delete namespace workflow to include other namespace divisions.

**Why?**
These workflows have to operate on all workflows in a namespace regardless of namespace division.

**How did you test it?**
tested queries manually, added check in schedule integration test

**Potential risks**

**Is hotfix candidate?**
yes
