### PR TITLE
Lock current execution on start workflow

### DIFF
--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -46,6 +46,7 @@ import (
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/history/workflow/cache"
 )
 
 type eagerStartDeniedReason metrics.ReasonString
@@ -166,6 +167,14 @@ func (s *Starter) Invoke(
 	if err != nil {
 		return nil, err
 	}
+
+	// grab current workflow context as a lock so that user latency can be computed
+	currentRelease, err := s.lockCurrentWorkflowExecution(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { currentRelease(retError) }()
+
 	err = s.createBrandNew(ctx, creationParams)
 	if err == nil {
 		return s.generateResponse(creationParams.runID, creationParams.workflowTaskInfo, extractHistoryEvents(creationParams.workflowEventBatches))
@@ -176,6 +185,21 @@ func (s *Starter) Invoke(
 	}
 	// The history and mutable state we generated above should be deleted by a background process.
 	return s.handleConflict(ctx, creationParams, currentWorkflowConditionFailedError)
+}
+
+func (s *Starter) lockCurrentWorkflowExecution(
+	ctx context.Context,
+) (cache.ReleaseCacheFunc, error) {
+	_, currentRelease, err := s.workflowConsistencyChecker.GetWorkflowCache().GetOrCreateCurrentWorkflowExecution(
+		ctx,
+		s.namespace.ID(),
+		s.request.StartRequest.WorkflowId,
+		workflow.CallerTypeAPI,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return currentRelease, nil
 }
 
 // createNewMutableState creates a new workflow context, and closes its mutable state transaction as snapshot.

--- a/service/history/workflow/cache/cache_mock.go
+++ b/service/history/workflow/cache/cache_mock.go
@@ -61,6 +61,22 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 	return m.recorder
 }
 
+// GetOrCreateCurrentWorkflowExecution mocks base method.
+func (m *MockCache) GetOrCreateCurrentWorkflowExecution(ctx context.Context, namespaceID namespace.ID, workflowID string, caller workflow.CallerType) (workflow.Context, ReleaseCacheFunc, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrCreateCurrentWorkflowExecution", ctx, namespaceID, workflowID, caller)
+	ret0, _ := ret[0].(workflow.Context)
+	ret1, _ := ret[1].(ReleaseCacheFunc)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetOrCreateCurrentWorkflowExecution indicates an expected call of GetOrCreateCurrentWorkflowExecution.
+func (mr *MockCacheMockRecorder) GetOrCreateCurrentWorkflowExecution(ctx, namespaceID, workflowID, caller interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateCurrentWorkflowExecution", reflect.TypeOf((*MockCache)(nil).GetOrCreateCurrentWorkflowExecution), ctx, namespaceID, workflowID, caller)
+}
+
 // GetOrCreateWorkflowExecution mocks base method.
 func (m *MockCache) GetOrCreateWorkflowExecution(ctx context.Context, namespaceID namespace.ID, execution v1.WorkflowExecution, caller workflow.CallerType) (workflow.Context, ReleaseCacheFunc, error) {
 	m.ctrl.T.Helper()

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -41,6 +41,7 @@ import (
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tests"
@@ -361,4 +362,39 @@ func (s *workflowCacheSuite) TestHistoryCacheConcurrentAccess_Pin() {
 		go testFn(i, runIDs[i%runIDCount], &runIDRefCounter[i%runIDCount])
 	}
 	stopGroup.Wait()
+}
+
+func (s *workflowCacheSuite) TestHistoryCache_CacheLatencyMetricContext() {
+	s.cache = NewCache(s.mockShard)
+
+	ctx := metrics.AddMetricsContext(context.Background())
+	_, currentRelease, err := s.cache.GetOrCreateCurrentWorkflowExecution(
+		ctx,
+		tests.NamespaceID,
+		tests.WorkflowID,
+		workflow.CallerTypeAPI,
+	)
+	s.NoError(err)
+	defer currentRelease(nil)
+
+	latency1, ok := metrics.ContextCounterGet(ctx, metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName())
+	s.True(ok)
+	s.NotZero(latency1)
+
+	_, release, err := s.cache.GetOrCreateWorkflowExecution(
+		ctx,
+		tests.NamespaceID,
+		commonpb.WorkflowExecution{
+			WorkflowId: tests.WorkflowID,
+			RunId:      tests.RunID,
+		},
+		workflow.CallerTypeAPI,
+	)
+	s.Nil(err)
+	defer release(nil)
+
+	latency2, ok := metrics.ContextCounterGet(ctx, metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName())
+	s.True(ok)
+	s.Greater(latency2, latency1)
+
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Lock current workflow execution on StartWorkflowExecution
- Basically revert https://github.com/temporalio/temporal/pull/2872

<!-- Tell your future self why have you made these changes -->
**Why?**
- Block on workflow lock instead of shard lock -> prevent noisy neighbor issue
- Workflow lock latency will be subtracted when calculating service no-user latency -> reduce noisy alerts. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Add unit test
- Will try locally to see the metrics

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.