### PR TITLE
Remove unused methods from Monitor interface

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -68,20 +68,8 @@ type (
 		EvictSelf() error
 		Lookup(service primitives.ServiceName, key string) (HostInfo, error)
 		GetResolver(service primitives.ServiceName) (ServiceResolver, error)
-		// AddListener adds a listener for this service.
-		// The listener will get notified on the given
-		// channel, whenever there is a membership change.
-		// @service: The service to be listened on
-		// @name: The name for identifying the listener
-		// @notifyChannel: The channel on which the caller receives notifications
-		AddListener(service primitives.ServiceName, name string, notifyChannel chan<- *ChangedEvent) error
-		// RemoveListener removes a listener for this service.
-		RemoveListener(service primitives.ServiceName, name string) error
 		// GetReachableMembers returns addresses of all members of the ring
 		GetReachableMembers() ([]string, error)
-		// GetMemberCount returns the number of reachable members
-		// currently in this node's membership list for the given service
-		GetMemberCount(service primitives.ServiceName) (int, error)
 		// WaitUntilInitialized blocks until initialization is completed and returns the result
 		// of initialization. The current implementation does log.Fatal if it can't initialize,
 		// so currently this will never return non-nil, except for context cancel/timeout. A

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -59,20 +59,6 @@ func (m *MockMonitor) EXPECT() *MockMonitorMockRecorder {
 	return m.recorder
 }
 
-// AddListener mocks base method.
-func (m *MockMonitor) AddListener(service primitives.ServiceName, name string, notifyChannel chan<- *ChangedEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AddListener", service, name, notifyChannel)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// AddListener indicates an expected call of AddListener.
-func (mr *MockMonitorMockRecorder) AddListener(service, name, notifyChannel interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddListener", reflect.TypeOf((*MockMonitor)(nil).AddListener), service, name, notifyChannel)
-}
-
 // EvictSelf mocks base method.
 func (m *MockMonitor) EvictSelf() error {
 	m.ctrl.T.Helper()
@@ -85,21 +71,6 @@ func (m *MockMonitor) EvictSelf() error {
 func (mr *MockMonitorMockRecorder) EvictSelf() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EvictSelf", reflect.TypeOf((*MockMonitor)(nil).EvictSelf))
-}
-
-// GetMemberCount mocks base method.
-func (m *MockMonitor) GetMemberCount(service primitives.ServiceName) (int, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemberCount", service)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetMemberCount indicates an expected call of GetMemberCount.
-func (mr *MockMonitorMockRecorder) GetMemberCount(service interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCount", reflect.TypeOf((*MockMonitor)(nil).GetMemberCount), service)
 }
 
 // GetReachableMembers mocks base method.
@@ -145,20 +116,6 @@ func (m *MockMonitor) Lookup(service primitives.ServiceName, key string) (HostIn
 func (mr *MockMonitorMockRecorder) Lookup(service, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Lookup", reflect.TypeOf((*MockMonitor)(nil).Lookup), service, key)
-}
-
-// RemoveListener mocks base method.
-func (m *MockMonitor) RemoveListener(service primitives.ServiceName, name string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoveListener", service, name)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// RemoveListener indicates an expected call of RemoveListener.
-func (mr *MockMonitorMockRecorder) RemoveListener(service, name interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveListener", reflect.TypeOf((*MockMonitor)(nil).RemoveListener), service, name)
 }
 
 // Start mocks base method.

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -382,32 +382,8 @@ func (rpo *monitor) Lookup(service primitives.ServiceName, key string) (membersh
 	return ring.Lookup(key)
 }
 
-func (rpo *monitor) AddListener(service primitives.ServiceName, name string, notifyChannel chan<- *membership.ChangedEvent) error {
-	ring, err := rpo.GetResolver(service)
-	if err != nil {
-		return err
-	}
-	return ring.AddListener(name, notifyChannel)
-}
-
-func (rpo *monitor) RemoveListener(service primitives.ServiceName, name string) error {
-	ring, err := rpo.GetResolver(service)
-	if err != nil {
-		return err
-	}
-	return ring.RemoveListener(name)
-}
-
 func (rpo *monitor) GetReachableMembers() ([]string, error) {
 	return rpo.rp.GetReachableMembers()
-}
-
-func (rpo *monitor) GetMemberCount(service primitives.ServiceName) (int, error) {
-	ring, err := rpo.GetResolver(service)
-	if err != nil {
-		return 0, err
-	}
-	return ring.MemberCount(), nil
 }
 
 func replaceServicePort(address string, servicePort int) (string, error) {

--- a/common/membership/ringpop/monitor_test.go
+++ b/common/membership/ringpop/monitor_test.go
@@ -60,7 +60,9 @@ func (s *RpoSuite) TestMonitor() {
 	time.Sleep(time.Second)
 
 	listenCh := make(chan *membership.ChangedEvent, 5)
-	err := rpm.AddListener(serviceName, "test-listener", listenCh)
+	r, err := rpm.GetResolver(serviceName)
+	s.NoError(err)
+	err = r.AddListener("test-listener", listenCh)
 	s.Nil(err, "AddListener failed")
 
 	host, err := rpm.Lookup(serviceName, "key")
@@ -88,7 +90,7 @@ func (s *RpoSuite) TestMonitor() {
 	s.Nil(err, "Ringpop monitor failed to find host for key")
 	s.NotEqual(testService.hostAddrs[1], host.GetAddress(), "Ringpop monitor assigned key to dead host")
 
-	err = rpm.RemoveListener(serviceName, "test-listener")
+	err = r.RemoveListener("test-listener")
 	s.Nil(err, "RemoveListener() failed")
 
 	rpm.Stop()

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -159,9 +159,6 @@ func (s *workflowHandlerSuite) SetupTest() {
 
 	s.tokenSerializer = common.NewProtoTaskTokenSerializer()
 
-	mockMonitor := s.mockResource.MembershipMonitor
-	mockMonitor.EXPECT().GetMemberCount(primitives.FrontendService).Return(5, nil).AnyTimes()
-
 	s.mockVisibilityMgr.EXPECT().GetStoreNames().Return([]string{elasticsearch.PersistenceName})
 }
 

--- a/tests/simpleMonitor.go
+++ b/tests/simpleMonitor.go
@@ -78,20 +78,8 @@ func (s *simpleMonitor) Lookup(service primitives.ServiceName, key string) (memb
 	return resolver.Lookup(key)
 }
 
-func (s *simpleMonitor) AddListener(service primitives.ServiceName, name string, notifyChannel chan<- *membership.ChangedEvent) error {
-	return nil
-}
-
-func (s *simpleMonitor) RemoveListener(service primitives.ServiceName, name string) error {
-	return nil
-}
-
 func (s *simpleMonitor) GetReachableMembers() ([]string, error) {
 	return nil, nil
-}
-
-func (s *simpleMonitor) GetMemberCount(service primitives.ServiceName) (int, error) {
-	return 0, nil
 }
 
 func (s *simpleMonitor) WaitUntilInitialized(_ context.Context) error {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the listener methods and get member count methods from the Monitor interface and the RingPop implementation.

<!-- Tell your future self why have you made these changes -->
**Why?**
They're not used (except once in a test).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
