### PR TITLE
Use more reliable workflow mutation check

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4224,21 +4224,17 @@ func (ms *MutableStateImpl) eventsToReplicationTask(
 	transactionPolicy TransactionPolicy,
 	events []*historypb.HistoryEvent,
 ) error {
-
-	if transactionPolicy == TransactionPolicyPassive ||
-		!ms.canReplicateEvents() ||
-		len(events) == 0 {
+	switch transactionPolicy {
+	case TransactionPolicyActive:
+		if ms.generateReplicationTask() {
+			return ms.taskGenerator.GenerateHistoryReplicationTasks(events)
+		}
 		return nil
+	case TransactionPolicyPassive:
+		return nil
+	default:
+		panic(fmt.Sprintf("unknown transaction policy: %v", transactionPolicy))
 	}
-
-	currentBranchToken, err := ms.GetCurrentBranchToken()
-	if err != nil {
-		return err
-	}
-	return ms.taskGenerator.GenerateHistoryReplicationTasks(
-		currentBranchToken,
-		events,
-	)
 }
 
 func (ms *MutableStateImpl) syncActivityToReplicationTask(
@@ -4246,21 +4242,26 @@ func (ms *MutableStateImpl) syncActivityToReplicationTask(
 	transactionPolicy TransactionPolicy,
 ) []tasks.Task {
 
-	if transactionPolicy == TransactionPolicyPassive ||
-		!ms.canReplicateEvents() {
+	switch transactionPolicy {
+	case TransactionPolicyActive:
+		if ms.generateReplicationTask() {
+			return convertSyncActivityInfos(
+				now,
+				definition.NewWorkflowKey(
+					ms.executionInfo.NamespaceId,
+					ms.executionInfo.WorkflowId,
+					ms.executionState.RunId,
+				),
+				ms.pendingActivityInfoIDs,
+				ms.syncActivityTasks,
+			)
+		}
+		return nil
+	case TransactionPolicyPassive:
 		return emptyTasks
+	default:
+		panic(fmt.Sprintf("unknown transaction policy: %v", transactionPolicy))
 	}
-
-	return convertSyncActivityInfos(
-		now,
-		definition.NewWorkflowKey(
-			ms.executionInfo.NamespaceId,
-			ms.executionInfo.WorkflowId,
-			ms.executionState.RunId,
-		),
-		ms.pendingActivityInfoIDs,
-		ms.syncActivityTasks,
-	)
 }
 
 func (ms *MutableStateImpl) updatePendingEventIDs(
@@ -4302,10 +4303,6 @@ func (ms *MutableStateImpl) updateWithLastWriteEvent(
 	ms.executionInfo.LastEventTaskId = lastEvent.GetTaskId()
 
 	return nil
-}
-
-func (ms *MutableStateImpl) canReplicateEvents() bool {
-	return ms.namespaceEntry.ReplicationPolicy() == namespace.ReplicationPolicyMultiCluster
 }
 
 // validateNoEventsAfterWorkflowFinish perform check on history event batch
@@ -4463,23 +4460,24 @@ func (ms *MutableStateImpl) startTransactionHandleWorkflowTaskFailover() (bool, 
 func (ms *MutableStateImpl) closeTransactionWithPolicyCheck(
 	transactionPolicy TransactionPolicy,
 ) error {
+	switch transactionPolicy {
+	case TransactionPolicyActive:
+		// Cannot use ms.namespaceEntry.ActiveClusterName() because currentVersion may be updated during this transaction in
+		// passive cluster. For example: if passive cluster sees conflict and decided to terminate this workflow. The
+		// currentVersion on mutable state would be updated to point to last write version which is current (passive) cluster.
+		activeCluster := ms.clusterMetadata.ClusterNameForFailoverVersion(ms.namespaceEntry.IsGlobalNamespace(), ms.GetCurrentVersion())
+		currentCluster := ms.clusterMetadata.GetCurrentClusterName()
 
-	if transactionPolicy == TransactionPolicyPassive ||
-		!ms.canReplicateEvents() {
+		if activeCluster != currentCluster {
+			namespaceID := ms.GetExecutionInfo().NamespaceId
+			return serviceerror.NewNamespaceNotActive(namespaceID, currentCluster, activeCluster)
+		}
 		return nil
+	case TransactionPolicyPassive:
+		return nil
+	default:
+		panic(fmt.Sprintf("unknown transaction policy: %v", transactionPolicy))
 	}
-
-	// Cannot use ms.namespaceEntry.ActiveClusterName() because currentVersion may be updated during this transaction in
-	// passive cluster. For example: if passive cluster sees conflict and decided to terminate this workflow. The
-	// currentVersion on mutable state would be updated to point to last write version which is current (passive) cluster.
-	activeCluster := ms.clusterMetadata.ClusterNameForFailoverVersion(ms.namespaceEntry.IsGlobalNamespace(), ms.GetCurrentVersion())
-	currentCluster := ms.clusterMetadata.GetCurrentClusterName()
-
-	if activeCluster != currentCluster {
-		namespaceID := ms.GetExecutionInfo().NamespaceId
-		return serviceerror.NewNamespaceNotActive(namespaceID, currentCluster, activeCluster)
-	}
-	return nil
 }
 
 func (ms *MutableStateImpl) closeTransactionHandleBufferedEventsLimit(
@@ -4558,17 +4556,24 @@ func (ms *MutableStateImpl) closeTransactionHandleWorkflowReset(
 func (ms *MutableStateImpl) closeTransactionHandleActivityUserTimerTasks(
 	transactionPolicy TransactionPolicy,
 ) error {
-
-	if transactionPolicy == TransactionPolicyPassive ||
-		!ms.IsWorkflowExecutionRunning() {
+	switch transactionPolicy {
+	case TransactionPolicyActive:
+		if !ms.IsWorkflowExecutionRunning() {
+			return nil
+		}
+		if err := ms.taskGenerator.GenerateActivityTimerTasks(); err != nil {
+			return err
+		}
+		return ms.taskGenerator.GenerateUserTimerTasks()
+	case TransactionPolicyPassive:
 		return nil
+	default:
+		panic(fmt.Sprintf("unknown transaction policy: %v", transactionPolicy))
 	}
+}
 
-	if err := ms.taskGenerator.GenerateActivityTimerTasks(); err != nil {
-		return err
-	}
-
-	return ms.taskGenerator.GenerateUserTimerTasks()
+func (ms *MutableStateImpl) generateReplicationTask() bool {
+	return len(ms.namespaceEntry.ClusterNames()) > 1
 }
 
 func (ms *MutableStateImpl) checkMutability(

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -99,7 +99,6 @@ type (
 
 		// replication tasks
 		GenerateHistoryReplicationTasks(
-			branchToken []byte,
 			events []*historypb.HistoryEvent,
 		) error
 		GenerateMigrationTasks() (tasks.Task, error)
@@ -569,9 +568,12 @@ func (r *TaskGeneratorImpl) GenerateUserTimerTasks() error {
 }
 
 func (r *TaskGeneratorImpl) GenerateHistoryReplicationTasks(
-	branchToken []byte,
 	events []*historypb.HistoryEvent,
 ) error {
+	if len(events) == 0 {
+		return nil
+	}
+
 	firstEvent := events[0]
 	lastEvent := events[len(events)-1]
 	if firstEvent.GetVersion() != lastEvent.GetVersion() {

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -34,6 +34,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	history "go.temporal.io/api/history/v1"
+
 	tasks "go.temporal.io/server/service/history/tasks"
 )
 
@@ -160,17 +161,17 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateDeleteHistoryEventTask(closeTim
 }
 
 // GenerateHistoryReplicationTasks mocks base method.
-func (m *MockTaskGenerator) GenerateHistoryReplicationTasks(branchToken []byte, events []*history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateHistoryReplicationTasks(events []*history.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateHistoryReplicationTasks", branchToken, events)
+	ret := m.ctrl.Call(m, "GenerateHistoryReplicationTasks", events)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateHistoryReplicationTasks indicates an expected call of GenerateHistoryReplicationTasks.
-func (mr *MockTaskGeneratorMockRecorder) GenerateHistoryReplicationTasks(branchToken, events interface{}) *gomock.Call {
+func (mr *MockTaskGeneratorMockRecorder) GenerateHistoryReplicationTasks(events interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateHistoryReplicationTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateHistoryReplicationTasks), branchToken, events)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateHistoryReplicationTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateHistoryReplicationTasks), events)
 }
 
 // GenerateMigrationTasks mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Make workflow mutation check more reliable

<!-- Tell your future self why have you made these changes -->
**Why?**
Namespace migration breaks one of the assumption of XDC
XDC assumes there will be no case which a namespace has only one cluster & the cluster is not itself, apparently namespace migration can break this assumption

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A