### PR TITLE
Fix namespace handover replication queue notification

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -576,7 +576,14 @@ func (s *ContextImpl) UpdateHandoverNamespace(ns *namespace.Namespace, deletedFr
 	}
 
 	s.wUnlock()
-	s.notifyReplicationQueueProcessor(maxReplicationTaskID)
+
+	if maxReplicationTaskID != pendingMaxReplicationTaskID {
+		// notification is for making sure replication queue is able to
+		// ack to the recorded taskID. If the taskID is pending, then
+		// don't notify. Otherwise, replication queue will think (for a period of time)
+		// that the max generated taskID is pendingMaxReplicationTaskID which is MaxInt64.
+		s.notifyReplicationQueueProcessor(maxReplicationTaskID)
+	}
 }
 
 func (s *ContextImpl) AddTasks(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not notify replication queue if max replication taskID is pending (maxInt64)
- This is only a problem when there're concurrent namespace migrations (one in handover, one in catch up stage) and when a shard seeing a namespace in handover state for the first time is also in an invalid state. 
- When is happens, there's a (small) chance the migration in wait catch up state will get stuck, because it thinks the replication taskID is maxInt64. This is not user impact. We just need to re-run the migration workflow.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Bug fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added unit test & existing integration test for migration

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
yes