### PR TITLE
Remove common.Daemon from Monitor interface

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -32,7 +32,6 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/primitives"
 )
 
@@ -59,8 +58,6 @@ type (
 	// Monitor provides membership information for all temporal services.
 	// It can be used to query which member host of a service is responsible for serving a given key.
 	Monitor interface {
-		common.Daemon
-
 		WhoAmI() (HostInfo, error)
 		// EvictSelf evicts this member from the membership ring. After this method is
 		// called, other members will discover that this node is no longer part of the

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -103,30 +103,6 @@ func (mr *MockMonitorMockRecorder) GetResolver(service interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolver", reflect.TypeOf((*MockMonitor)(nil).GetResolver), service)
 }
 
-// Start mocks base method.
-func (m *MockMonitor) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start.
-func (mr *MockMonitorMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMonitor)(nil).Start))
-}
-
-// Stop mocks base method.
-func (m *MockMonitor) Stop() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Stop")
-}
-
-// Stop indicates an expected call of Stop.
-func (mr *MockMonitorMockRecorder) Stop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockMonitor)(nil).Stop))
-}
-
 // WaitUntilInitialized mocks base method.
 func (m *MockMonitor) WaitUntilInitialized(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/common/membership/ringpop/factory.go
+++ b/common/membership/ringpop/factory.go
@@ -60,11 +60,11 @@ type factory struct {
 	servicePortMap map[primitives.ServiceName]int
 	logger         log.Logger
 
-	membershipMonitor membership.Monitor
-	metadataManager   persistence.ClusterMetadataManager
-	rpcConfig         *config.RPC
-	tlsFactory        encryption.TLSConfigProvider
-	dc                *dynamicconfig.Collection
+	monitor         *monitor
+	metadataManager persistence.ClusterMetadataManager
+	rpcConfig       *config.RPC
+	tlsFactory      encryption.TLSConfigProvider
+	dc              *dynamicconfig.Collection
 
 	chOnce  sync.Once
 	monOnce sync.Once
@@ -100,12 +100,8 @@ func newFactory(
 	}, nil
 }
 
-// getMembershipMonitor return a membership monitor
-func (factory *factory) getMembershipMonitor() (membership.Monitor, error) {
-	return factory.getMembership()
-}
-
-func (factory *factory) getMembership() (membership.Monitor, error) {
+// getMonitor return a membership monitor
+func (factory *factory) getMonitor() (*monitor, error) {
 	var err error
 	factory.monOnce.Do(func() {
 		ctx, cancel := context.WithTimeout(context.Background(), persistenceOperationTimeout)
@@ -125,7 +121,7 @@ func (factory *factory) getMembership() (membership.Monitor, error) {
 		} else {
 			mrp := newService(rp, factory.config.MaxJoinDuration, factory.logger)
 
-			factory.membershipMonitor = newMonitor(
+			factory.monitor = newMonitor(
 				factory.serviceName,
 				factory.servicePortMap,
 				mrp,
@@ -136,7 +132,7 @@ func (factory *factory) getMembership() (membership.Monitor, error) {
 		}
 	})
 
-	return factory.membershipMonitor, err
+	return factory.monitor, err
 }
 
 func (factory *factory) broadcastAddressResolver() (string, error) {

--- a/common/membership/ringpop/fx.go
+++ b/common/membership/ringpop/fx.go
@@ -72,7 +72,7 @@ func membershipMonitorProvider(
 		return nil, err
 	}
 
-	monitor, err := factory.getMembershipMonitor()
+	monitor, err := factory.getMonitor()
 	if err != nil {
 		return nil, err
 	}

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -84,7 +84,7 @@ func newMonitor(
 	logger log.Logger,
 	metadataManager persistence.ClusterMetadataManager,
 	broadcastHostPortResolver func() (string, error),
-) membership.Monitor {
+) *monitor {
 	lifecycleCtx, lifecycleCancel := context.WithCancel(context.Background())
 	lifecycleCtx = headers.SetCallerInfo(
 		lifecycleCtx,

--- a/common/membership/ringpop/test_cluster.go
+++ b/common/membership/ringpop/test_cluster.go
@@ -46,7 +46,7 @@ type testCluster struct {
 	hostUUIDs    []string
 	hostAddrs    []string
 	hostInfoList []membership.HostInfo
-	rings        []membership.Monitor
+	rings        []*monitor
 	channels     []*tchannel.Channel
 	seedNode     string
 }
@@ -75,7 +75,7 @@ func newTestCluster(
 		hostUUIDs:    make([]string, size),
 		hostAddrs:    make([]string, size),
 		hostInfoList: make([]membership.HostInfo, size),
-		rings:        make([]membership.Monitor, size),
+		rings:        make([]*monitor, size),
 		channels:     make([]*tchannel.Channel, size),
 		seedNode:     seed,
 	}

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -368,7 +368,6 @@ func (s *Service) Start() {
 	s.metricsHandler.Counter(metrics.RestartCount).Record(1)
 
 	s.clusterMetadata.Start()
-	s.membershipMonitor.Start()
 	s.namespaceRegistry.Start()
 
 	hostInfo, err := s.membershipMonitor.WhoAmI()
@@ -431,7 +430,6 @@ func (s *Service) Stop() {
 	s.perNamespaceWorkerManager.Stop()
 	s.workerManager.Stop()
 	s.namespaceRegistry.Stop()
-	s.membershipMonitor.Stop()
 	s.clusterMetadata.Stop()
 	s.persistenceBean.Close()
 	s.visibilityManager.Close()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**
The Start and Stop methods of the Monitor shouldn't be required because it should be up to implementors how a monitor is started and stopped. Currently, our RingPop monitor already does this by using fx, so we don't even want users of the package to call Start and Stop in an adhoc manner.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I stepped through with a debugger and verified that the call to Start in the worker service was a no-op because start is already called as part of the fx lifecycle. I could not verify the Stop logic because I don't think Stop is even called when we shut down the server.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
