### PR TITLE
Add a Topic utility for doing local pub/sub

### DIFF
--- a/common/reactive/topic.go
+++ b/common/reactive/topic.go
@@ -1,0 +1,144 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package reactive provides a small set of reactive components inspired by ReactiveX to make PubSub easier,
+// without introducing too many of the foreign concepts present in RxGo.
+package reactive
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+)
+
+var (
+	ErrPublishInterrupted          = errors.New("publish event to subscribers interrupted")
+	ErrSubscriptionAlreadyCanceled = errors.New("subscription already canceled")
+)
+
+// Topic is an object that implements the PubSub pattern. Topic manages a set of subscriptions for you, and allows you
+// to Publish events to them. See ExampleTopic for a demo. It is both safe and encouraged to embed the zero-value of a
+// Topic object because there is no initialization required. Instances of Topic are thread-safe.
+type Topic[T any] struct {
+
+	// RWMutex is used to ensure thread-safety.
+	sync.RWMutex
+
+	// subscriptions is the list of active subscription objects tracking this topic. It is ok for this to be nil and
+	// uninitialized.
+	subscriptions []*subscription[T]
+
+	// nextSubscriptionID is the unique id of the next subscription that will be created when Subscribe is called.
+	nextSubscriptionID int
+}
+
+// Subscribe activates a subscription for the given channel. Any calls to Publish will attempt to send the event to the
+// supplied channel, only failing when the context supplied to Publish is canceled. You don't have to call Unsubscribe
+// on the returned Subscription because it does not spawn any goroutines.
+func (t *Topic[T]) Subscribe(subscriber chan<- T) Subscription {
+	t.Lock()
+	defer t.Unlock()
+
+	index := len(t.subscriptions)
+	id := t.nextSubscriptionID
+	s := &subscription[T]{
+		topic:      t,
+		subscriber: subscriber,
+		index:      index,
+		id:         id,
+	}
+
+	// append this subscription to the topic's set so that we can forward events to it.
+	t.subscriptions = append(t.subscriptions, s)
+
+	// increment the nextSubscriptionID so that the next subscription we create has a unique id.
+	t.nextSubscriptionID++
+
+	return s
+}
+
+// Publish attempts to send an event to the channels of all subscriptions.
+// It will fail if the supplied context is canceled and return an ErrPublishInterrupted error.
+func (t *Topic[T]) Publish(ctx context.Context, event T) error {
+	t.RLock()
+	defer t.RUnlock()
+
+	for _, s := range t.subscriptions {
+		select {
+		case s.subscriber <- event:
+		case <-ctx.Done():
+			return fmt.Errorf("%w: %v", ErrPublishInterrupted, ctx.Err())
+		}
+	}
+
+	return nil
+}
+
+// Subscription is a subscription to a Topic that you can Unsubscribe from to stop receiving updates.
+type Subscription interface {
+	// Unsubscribe stops this subscription. After this method returns, it is guaranteed that the
+	// subject will no longer send any events to the channel supplied to Subscribe.
+	Unsubscribe() error
+}
+
+// cancelSubscription removes the subscription at the index from the list of subscriptions.
+// If the index is out-of-bounds, or the item at the index has a different id, then we return an
+// ErrSubscriptionAlreadyCanceled error.
+func (t *Topic[T]) cancelSubscription(index int, id int) error {
+	t.Lock()
+	defer t.Unlock()
+
+	if index >= len(t.subscriptions) {
+		return ErrSubscriptionAlreadyCanceled
+	}
+
+	if t.subscriptions[index].id != id {
+		return ErrSubscriptionAlreadyCanceled
+	}
+
+	// delete the subscription by swapping it with the last element and then truncating the slice
+	t.subscriptions[index] = t.subscriptions[len(t.subscriptions)-1]
+	t.subscriptions[index].index = index
+	t.subscriptions = t.subscriptions[:len(t.subscriptions)-1]
+
+	return nil
+}
+
+// subscription represents a subscription to this topic's topic.
+type subscription[T any] struct {
+	// topic is the Topic that provides this subscription.
+	topic *Topic[T]
+	// id is unique amongst all of this topic's current and past subscriptions.
+	id int
+	// index is the index of this subscription within the topic's list of subscriptions.
+	index int
+	// subscriber is the channel that events are sent to.
+	subscriber chan<- T
+}
+
+// Unsubscribe stops the subscription, freeing up the resources it was using in the topic object.
+func (s *subscription[T]) Unsubscribe() error {
+	return s.topic.cancelSubscription(s.index, s.id)
+}

--- a/common/reactive/topic_test.go
+++ b/common/reactive/topic_test.go
@@ -1,0 +1,172 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package reactive
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ExampleTopic() {
+	// hostPoolChange represents a change that adds and/or removes hosts
+	type hostPoolChange struct {
+		added   []string
+		removed []string
+	}
+
+	// hostPool is the object we want to publish changes from
+	type hostPool struct {
+		// by embedding a Topic object, clients may now subscribe to the hostPool easily and the hostPool itself
+		// can easily publish changes without managing subscribers itself.
+		Topic[hostPoolChange]
+	}
+
+	// subscriber is the channel we'll read host pool changes from
+	ch := make(chan hostPoolChange)
+
+	// p is an example host pool. Note that we don't need to initialize the Topic. The zero-value is valid.
+	p := hostPool{}
+
+	// sub is a subscription to the host pool changes.
+	// Notice that we did not have to write any code to manage the set of subscribers within the hostPool object.
+	sub := p.Subscribe(ch)
+
+	// publish publishes a change from the pool to all of its subscriptions
+	publish := func(c hostPoolChange) {
+		if err := p.Publish(context.Background(), c); err != nil {
+			panic(err)
+		}
+	}
+
+	go func() {
+		// publish some changes
+		publish(hostPoolChange{
+			added: []string{"127.0.0.1:8000"},
+		})
+		publish(hostPoolChange{
+			added: []string{"127.0.0.1:8000"},
+		})
+		publish(hostPoolChange{
+			removed: []string{"127.0.0.1:8000"},
+		})
+
+		// close the channel (this is done by the subscriber's code, not managed by the topic)
+		close(ch)
+	}()
+
+	for change := range ch {
+		fmt.Printf("%+v\n", change)
+	}
+
+	if err := sub.Unsubscribe(); err != nil {
+		panic(err)
+	}
+	// Output: {added:[127.0.0.1:8000] removed:[]}
+	// {added:[127.0.0.1:8000] removed:[]}
+	// {added:[] removed:[127.0.0.1:8000]}
+}
+
+func TestTopic_Publish_Ok(t *testing.T) {
+	t.Parallel()
+
+	tp := Topic[int]{}
+	ch := make(chan int, 1)
+
+	tp.Subscribe(ch)
+
+	err := tp.Publish(context.Background(), 1)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, <-ch)
+}
+
+func TestTopic_Publish_ContextCanceled(t *testing.T) {
+	t.Parallel()
+
+	tp := Topic[int]{}
+	ch := make(chan int)
+	tp.Subscribe(ch)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	errs := make(chan error)
+
+	go func() {
+		errs <- tp.Publish(ctx, 1)
+	}()
+
+	err := <-errs
+	assert.ErrorIs(t, err, ErrPublishInterrupted)
+}
+
+func TestTopic_Unsubscribe_Ok(t *testing.T) {
+	t.Parallel()
+
+	tp := Topic[int]{}
+	ch := make(chan int)
+	sub := tp.Subscribe(ch)
+
+	err := sub.Unsubscribe()
+	assert.NoError(t, err)
+
+	// closing the channel here means that any subsequent send would cause the test to panic and fail, but we shouldn't
+	// send because we canceled the subscription.
+	close(ch)
+	assert.NoError(t, tp.Publish(context.Background(), 1))
+}
+
+func TestTopic_Unsubscribe_OutOfBounds(t *testing.T) {
+	t.Parallel()
+
+	tp := Topic[int]{}
+	ch := make(chan int)
+
+	sub := tp.Subscribe(ch)
+	_ = sub.Unsubscribe()
+
+	err := sub.Unsubscribe()
+
+	assert.ErrorIs(t, err, ErrSubscriptionAlreadyCanceled)
+}
+
+func TestTopic_Unsubscribe_AlreadyUnsubscribed(t *testing.T) {
+	t.Parallel()
+
+	tp := Topic[int]{}
+	ch := make(chan int)
+	sub := tp.Subscribe(ch)
+	tp.Subscribe(ch)
+
+	_ = sub.Unsubscribe()
+
+	err := sub.Unsubscribe()
+
+	assert.ErrorIs(t, err, ErrSubscriptionAlreadyCanceled)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a Topic utility that manages subscribers for local pubsub.

<!-- Tell your future self why have you made these changes -->
**Why?**
This utility will be used to extract the subscriber management logic from the ServiceResolver object.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This code has full test coverage. I verified that subscribers can be added and removed independently, and that all errors are handled correctly.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The risk is that this introduces too much complexity into our codebase because reactive concepts are foreign, but I think it strikes a good balance because it only extracts the most basic PubSub abstractions from ReactiveX.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
