### PR TITLE
Auto clear stickiness

### DIFF
--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -227,13 +227,15 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 
 			// Assuming a workflow is running on a sticky task queue by a workerA.
 			// After workerA is dead for more than 10s, matching will return StickyWorkerUnavailable error when history
-			// trying to push a new workflow task. When history sees that error, it will fall back to push the task to
+			// tries to push a new workflow task. When history sees that error, it will fall back to push the task to
 			// its original normal task queue without clear its stickiness to avoid an extra persistence write.
 			// We will clear the stickiness here when that task is delivered to another worker polling from normal queue.
 			// The stickiness info is used by frontend to decide if it should send down partial history or full history.
 			// Sending down partial history will cost the worker an extra fetch to server for the full history.
 			if mutableState.IsStickyTaskQueueEnabled() &&
 				mutableState.TaskQueue().GetName() != req.PollRequest.TaskQueue.GetName() {
+				// req.PollRequest.TaskQueue.GetName() may include partition, but we only check when sticky is enabled,
+				// and sticky queue never has partition, so it does not matter.
 				mutableState.ClearStickyness()
 			}
 

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -163,7 +163,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 	ctx context.Context,
 	req *historyservice.RecordWorkflowTaskStartedRequest,
 ) (*historyservice.RecordWorkflowTaskStartedResponse, error) {
-
 	namespaceEntry, err := api.GetActiveNamespace(handler.shard, namespace.ID(req.GetNamespaceId()))
 	if err != nil {
 		return nil, err
@@ -224,6 +223,18 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 				// Looks like WorkflowTask already started as a result of another call.
 				// It is OK to drop the task at this point.
 				return nil, serviceerrors.NewTaskAlreadyStarted("Workflow")
+			}
+
+			// Assuming a workflow is running on a sticky task queue by a workerA.
+			// After workerA is dead for more than 10s, matching will return StickyWorkerUnavailable error when history
+			// trying to push a new workflow task. When history sees that error, it will fall back to push the task to
+			// its original normal task queue without clear its stickiness to avoid an extra persistence write.
+			// We will clear the stickiness here when that task is delivered to another worker polling from normal queue.
+			// The stickiness info is used by frontend to decide if it should send down partial history or full history.
+			// Sending down partial history will cost the worker an extra fetch to server for the full history.
+			if mutableState.IsStickyTaskQueueEnabled() &&
+				mutableState.TaskQueue().GetName() != req.PollRequest.TaskQueue.GetName() {
+				mutableState.ClearStickyness()
 			}
 
 			_, workflowTask, err = mutableState.AddWorkflowTaskStartedEvent(
@@ -772,7 +783,9 @@ func (handler *workflowTaskHandlerCallbacksImpl) createRecordWorkflowTaskStarted
 	// before it was started.
 	response.ScheduledEventId = workflowTask.ScheduledEventID
 	response.StartedEventId = workflowTask.StartedEventID
-	response.StickyExecutionEnabled = ms.IsStickyTaskQueueEnabled()
+	if ms.IsStickyTaskQueueEnabled() {
+		response.StickyExecutionEnabled = true
+	}
 	response.NextEventId = ms.GetNextEventID()
 	response.Attempt = workflowTask.Attempt
 	response.WorkflowExecutionTaskQueue = &taskqueuepb.TaskQueue{

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -399,10 +399,7 @@ pollLoop:
 				return emptyPollWorkflowTaskQueueResponse, nil
 			}
 
-			isStickyEnabled := false
-			if len(mutableStateResp.StickyTaskQueue.GetName()) != 0 {
-				isStickyEnabled = true
-			}
+			isStickyEnabled := taskQueueName == mutableStateResp.StickyTaskQueue.GetName()
 			resp := &historyservice.RecordWorkflowTaskStartedResponse{
 				PreviousStartedEventId:     mutableStateResp.PreviousStartedEventId,
 				NextEventId:                mutableStateResp.NextEventId,

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -399,6 +399,9 @@ pollLoop:
 				return emptyPollWorkflowTaskQueueResponse, nil
 			}
 
+			// A non-sticky poll may get task for a workflow that has sticky still set in its mutable state after
+			// their sticky worker is dead for longer than 10s. In such case, we should set this to false so that
+			// frontend returns full history.
 			isStickyEnabled := taskQueueName == mutableStateResp.StickyTaskQueue.GetName()
 			resp := &historyservice.RecordWorkflowTaskStartedResponse{
 				PreviousStartedEventId:     mutableStateResp.PreviousStartedEventId,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Server would sent down full history when polling from original queue.

<!-- Tell your future self why have you made these changes -->
**Why?**
To avoid send workflow task with partial history if it is polling from original task queue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No