### PR TITLE
Better error message in ES query converter

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -678,7 +678,7 @@ func (s *ESVisibilitySuite) Test_convertQuery_Mapper() {
 	_, _, err = s.visibilityStore.convertQuery(testNamespace, testNamespaceID, query)
 	s.Error(err)
 	s.ErrorAs(err, &invalidArgumentErr)
-	s.EqualError(err, "invalid query: unable to convert filter expression: unable to convert left part of comparison expression: invalid search attribute: AliasForUnknownField")
+	s.EqualError(err, "invalid query: unable to convert filter expression: unable to convert left side of \"AliasForUnknownField = 'pid'\": invalid search attribute: AliasForUnknownField")
 
 	query = `order by ExecutionTime`
 	qry, srt, err = s.visibilityStore.convertQuery(testNamespace, testNamespaceID, query)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Better error message in ES query converter.

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/temporalio/temporal/issues/3494

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
$ tctl workflow list --query "ExecutionStatus = Running"
Error: Failed to list workflow.
Error Details: invalid query: unable to convert filter expression: unable to convert right side of "ExecutionStatus = Running": operation is not supported: column name on the right side of comparison expression (did you forget to quote "Running"?)
('export TEMPORAL_CLI_SHOW_STACKS=1' to see stack traces)
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.