### PR TITLE
Enforce concurrent count limit to all long poll calls

### DIFF
--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -33,8 +33,11 @@ import (
 
 var (
 	ExecutionAPICountLimitOverride = map[string]int{
-		"PollActivityTaskQueue": 1,
-		"PollWorkflowTaskQueue": 1,
+		"PollActivityTaskQueue":       1,
+		"PollWorkflowTaskQueue":       1,
+		"QueryWorkflow":               1,
+		"UpdateWorkflowExecution":     1,
+		"GetWorkflowExecutionHistory": 1,
 	}
 
 	ExecutionAPIToPriority = map[string]int{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Enforce concurrent request count limit on all long poll APIs

<!-- Tell your future self why have you made these changes -->
**Why?**
Existing code only enforce 2 long poll APIs.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manually test locally, verify through metrics.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Maybe