### PR TITLE
Use correct time for initial schedule memo

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -4969,7 +4969,7 @@ func (wh *WorkflowHandler) cleanScheduleMemo(memo *commonpb.Memo) *commonpb.Memo
 
 // This mutates request (but idempotent so safe for retries)
 func (wh *WorkflowHandler) addInitialScheduleMemo(request *workflowservice.CreateScheduleRequest, args *schedspb.StartScheduleArgs) {
-	info := scheduler.GetListInfoFromStartArgs(args)
+	info := scheduler.GetListInfoFromStartArgs(args, time.Now().UTC())
 	infoBytes, err := info.Marshal()
 	if err != nil {
 		wh.logger.Error("encoding initial schedule memo failed", tag.Error(err))

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -995,7 +995,7 @@ func panicIfErr(err error) {
 	}
 }
 
-func GetListInfoFromStartArgs(args *schedspb.StartScheduleArgs) *schedpb.ScheduleListInfo {
+func GetListInfoFromStartArgs(args *schedspb.StartScheduleArgs, now time.Time) *schedpb.ScheduleListInfo {
 	// note that this does not take into account InitialPatch
 	fakeScheduler := &scheduler{
 		StartScheduleArgs: *args,
@@ -1003,5 +1003,6 @@ func GetListInfoFromStartArgs(args *schedspb.StartScheduleArgs) *schedpb.Schedul
 	}
 	fakeScheduler.ensureFields()
 	fakeScheduler.compileSpec()
+	fakeScheduler.State.LastProcessedTime = timestamp.TimePtr(now)
 	return fakeScheduler.getListInfo()
 }

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -695,6 +695,8 @@ func (s *scheduleIntegrationSuite) TestListBeforeRun() {
 		RequestId:  uuid.New(),
 	}
 
+	startTime := time.Now()
+
 	_, err := s.engine.CreateSchedule(NewContext(), req)
 	s.NoError(err)
 
@@ -714,6 +716,7 @@ func (s *scheduleIntegrationSuite) TestListBeforeRun() {
 		s.Equal(wt, entry.Info.WorkflowType.Name)
 		s.False(entry.Info.Paused)
 		s.Greater(len(entry.Info.FutureActionTimes), 1)
+		s.True(entry.Info.FutureActionTimes[0].After(startTime))
 		return true
 	}, 10*time.Second, 1*time.Second)
 


### PR DESCRIPTION
**What changed?**
Pass current time to initial schedule memo calculation.

<!-- Tell your future self why have you made these changes -->
**Why?**
It was starting from zero time.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
