### PR TITLE
Change Scan API to have no Order(ES)

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -745,11 +745,12 @@ func (s *visibilityStore) convertQuery(
 }
 
 func (s *visibilityStore) getScanFieldSorter(fieldSorts []*elastic.FieldSort) ([]elastic.Sorter, error) {
-	if len(fieldSorts) == 0 {
-		return docSorter, nil
-	}
 	// custom order is not supported by Scan API
-	return nil, serviceerror.NewInvalidArgument("ORDER BY clause is not supported")
+	if len(fieldSorts) > 0 {
+		return nil, serviceerror.NewInvalidArgument("ORDER BY clause is not supported")
+	}
+
+	return docSorter, nil
 }
 
 func (s *visibilityStore) getListFieldSorter(fieldSorts []*elastic.FieldSort) ([]elastic.Sorter, error) {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -414,24 +414,51 @@ func (s *ESVisibilitySuite) TestBuildSearchParameters() {
 	}, p)
 }
 
-func (s *ESVisibilitySuite) TestSetDefaultFieldSort() {
-	// test defaultSorter is retunred when not isScan
-	fieldSorts := make([]*elastic.FieldSort, 0)
-	sorter := s.visibilityStore.setDefaultFieldSort(fieldSorts, false)
-	s.Equal(defaultSorter, sorter)
+func (s *ESVisibilitySuite) TestGetListFieldSorter() {
 
-	// test docSorter is returned when isScan
-	sorter = s.visibilityStore.setDefaultFieldSort(fieldSorts, true)
-	s.Equal(docSorter, sorter)
+	// test defaultSorter is returned when fieldSorts is empty
+	fieldSorts := make([]*elastic.FieldSort, 0)
+	sorter, err := s.visibilityStore.getListFieldSorter(fieldSorts)
+	s.NoError(err)
+	s.Equal(defaultSorter, sorter)
 
 	// test passing non-empty fieldSorts
 	testFieldSorts := [2]*elastic.FieldSort{elastic.NewFieldSort("_test"), elastic.NewFieldSort("_second_tes")}
 	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
-	sorter = s.visibilityStore.setDefaultFieldSort(testFieldSorts[:], true)
+	sorter, err = s.visibilityStore.getFieldSorter(testFieldSorts[:])
 	expectedSorter := make([]elastic.Sorter, len(testFieldSorts)+1)
 	expectedSorter[0] = testFieldSorts[0]
 	expectedSorter[1] = testFieldSorts[1]
 	expectedSorter[2] = elastic.NewFieldSort(searchattribute.RunID).Desc()
+	s.NoError(err)
+	s.Equal(expectedSorter, sorter)
+
+}
+
+func (s *ESVisibilitySuite) TestGetScanFieldSorter() {
+	// test docSorter is returned when fieldSorts is empty
+	fieldSorts := make([]*elastic.FieldSort, 0)
+	sorter, err := s.visibilityStore.getScanFieldSorter(fieldSorts)
+	s.NoError(err)
+	s.Equal(docSorter, sorter)
+
+	// test error is returned if fieldSorts is not empty
+	testFieldSorts := [2]*elastic.FieldSort{elastic.NewFieldSort("_test"), elastic.NewFieldSort("_second_tes")}
+	sorter, err = s.visibilityStore.getScanFieldSorter(testFieldSorts[:])
+	s.Error(err)
+	s.Nil(sorter)
+}
+func (s *ESVisibilitySuite) TestGetFieldSorter() {
+
+	// test passing non-empty fieldSorts and not sortByDoc
+	testFieldSorts := [2]*elastic.FieldSort{elastic.NewFieldSort("_test"), elastic.NewFieldSort("_second_tes")}
+	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	sorter, err := s.visibilityStore.getFieldSorter(testFieldSorts[:])
+	expectedSorter := make([]elastic.Sorter, len(testFieldSorts)+1)
+	expectedSorter[0] = testFieldSorts[0]
+	expectedSorter[1] = testFieldSorts[1]
+	expectedSorter[2] = elastic.NewFieldSort(searchattribute.RunID).Desc()
+	s.NoError(err)
 	s.Equal(expectedSorter, sorter)
 }
 
@@ -449,7 +476,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	request.Query = `WorkflowId="guid-2208"`
 	filterQuery := elastic.NewBoolQuery().Filter(elastic.NewMatchQuery(searchattribute.WorkflowID, "guid-2208"))
 	boolQuery := elastic.NewBoolQuery().Filter(matchNamespaceQuery, filterQuery).MustNot(namespaceDivisionExists)
-	p, err := s.visibilityStore.buildSearchParametersV2(request, false)
+	p, err := s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getListFieldSorter)
 	s.NoError(err)
 	s.Equal(&client.SearchParameters{
 		Index:       testIndex,
@@ -466,7 +493,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	// note namespace division appears in the filterQuery, not the boolQuery like the negative version
 	filterQuery = elastic.NewBoolQuery().Filter(elastic.NewMatchQuery(searchattribute.WorkflowID, "guid-2208"), matchNSDivision)
 	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery, filterQuery)
-	p, err = s.visibilityStore.buildSearchParametersV2(request, false)
+	p, err = s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getListFieldSorter)
 	s.NoError(err)
 	s.Equal(&client.SearchParameters{
 		Index:       testIndex,
@@ -482,7 +509,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	request.Query = `Order bY WorkflowId`
 	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery).MustNot(namespaceDivisionExists)
 	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
-	p, err = s.visibilityStore.buildSearchParametersV2(request, false)
+	p, err = s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getListFieldSorter)
 	s.NoError(err)
 	s.Equal(&client.SearchParameters{
 		Index:       testIndex,
@@ -501,7 +528,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	request.Query = `WorkflowId="guid-2208"`
 	filterQuery = elastic.NewBoolQuery().Filter(elastic.NewMatchQuery(searchattribute.WorkflowID, "guid-2208"))
 	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery, filterQuery).MustNot(namespaceDivisionExists)
-	p, err = s.visibilityStore.buildSearchParametersV2(request, true)
+	p, err = s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getScanFieldSorter)
 	s.NoError(err)
 	s.Equal(&client.SearchParameters{
 		Index:       testIndex,
@@ -513,9 +540,16 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	}, p)
 	request.Query = ""
 
+	// test with Scan API with custom sort
+	request.Query = `Order bY WorkflowId`
+	p, err = s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getScanFieldSorter)
+	s.Error(err)
+	s.Nil(p)
+	request.Query = ""
+
 	// test for wrong query
 	request.Query = "invalid query"
-	p, err = s.visibilityStore.buildSearchParametersV2(request, false)
+	p, err = s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getListFieldSorter)
 	s.Nil(p)
 	s.Error(err)
 	request.Query = ""
@@ -537,7 +571,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2DisableOrderByClause() {
 	request.Query = `WorkflowId="guid-2208"`
 	filterQuery := elastic.NewBoolQuery().Filter(elastic.NewMatchQuery(searchattribute.WorkflowID, "guid-2208"))
 	boolQuery := elastic.NewBoolQuery().Filter(matchNamespaceQuery, filterQuery).MustNot(namespaceDivisionExists)
-	p, err := s.visibilityStore.buildSearchParametersV2(request, false)
+	p, err := s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getListFieldSorter)
 	s.NoError(err)
 	s.Equal(&client.SearchParameters{
 		Index:       testIndex,
@@ -551,7 +585,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2DisableOrderByClause() {
 
 	// test invalid query with ORDER BY
 	request.Query = `ORDER BY WorkflowId`
-	p, err = s.visibilityStore.buildSearchParametersV2(request, false)
+	p, err = s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getListFieldSorter)
 	s.Nil(p)
 	s.Error(err)
 	var invalidArgumentErr *serviceerror.InvalidArgument

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -425,7 +425,7 @@ func (s *ESVisibilitySuite) TestGetListFieldSorter() {
 	// test passing non-empty fieldSorts
 	testFieldSorts := [2]*elastic.FieldSort{elastic.NewFieldSort("_test"), elastic.NewFieldSort("_second_tes")}
 	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
-	sorter, err = s.visibilityStore.getFieldSorter(testFieldSorts[:])
+	sorter, err = s.visibilityStore.getListFieldSorter(testFieldSorts[:])
 	expectedSorter := make([]elastic.Sorter, len(testFieldSorts)+1)
 	expectedSorter[0] = testFieldSorts[0]
 	expectedSorter[1] = testFieldSorts[1]
@@ -453,12 +453,11 @@ func (s *ESVisibilitySuite) TestGetFieldSorter() {
 	// test passing non-empty fieldSorts and not sortByDoc
 	testFieldSorts := [2]*elastic.FieldSort{elastic.NewFieldSort("_test"), elastic.NewFieldSort("_second_tes")}
 	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
-	sorter, err := s.visibilityStore.getFieldSorter(testFieldSorts[:])
+	sorter := s.visibilityStore.getFieldSorter(testFieldSorts[:])
 	expectedSorter := make([]elastic.Sorter, len(testFieldSorts)+1)
 	expectedSorter[0] = testFieldSorts[0]
 	expectedSorter[1] = testFieldSorts[1]
 	expectedSorter[2] = elastic.NewFieldSort(searchattribute.RunID).Desc()
-	s.NoError(err)
 	s.Equal(expectedSorter, sorter)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed ElasticSearch Scan API to have no order (use "_doc"). 


<!-- Tell your future self why have you made these changes -->
**Why?**
Using sort order "\_doc" when using Scan API has some optimizations in ES that
makes it faster to iterate over all workflows. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
