### PR TITLE
Fix schedule catchup window metric calculation while paused

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -358,15 +358,15 @@ func (s *scheduler) processTimeRange(
 		if t1.IsZero() || t1.After(t2) {
 			return t1
 		}
+		// Peek at paused/remaining actions state and don't bother if we're not going to
+		// take an action now. (Don't count as missed catchup window either.)
+		if !s.canTakeScheduledAction(manual, false) {
+			continue
+		}
 		if !manual && t2.Sub(t1) > catchupWindow {
 			s.logger.Warn("Schedule missed catchup window", "now", t2, "time", t1)
 			s.metrics.Counter(metrics.ScheduleMissedCatchupWindow.GetMetricName()).Inc(1)
 			s.Info.MissedCatchupWindow++
-			continue
-		}
-		// Peek at paused/remaining actions state and don't even bother adding
-		// to buffer if we're not going to take an action now.
-		if !s.canTakeScheduledAction(manual, false) {
 			continue
 		}
 		s.addStart(next.Nominal, next.Next, overlapPolicy, manual)


### PR DESCRIPTION
**What changed?**
Previously the workflow assumed that it would wake up at scheduled times while paused, but #3670 changed that, so now it might register "missed catchup window" when woken up after a pause. This fixes it to check paused first.

**How did you test it?**
unit test

**Potential risks**
This is technically not a deterministic change, but it only affects logging, metrics, and fields in the schedule Info, which are not used by the logic itself, only returned by a query, so it should be safe.
