### PR TITLE
Enable Scan API in SQL visibility store

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -149,7 +149,9 @@ func (c *QueryConverter) BuildSelectStmt(
 	if err != nil {
 		return nil, err
 	}
-	orderByClause := c.getOrderByClause(withOrderBy)
+	if withDefaultOrderBy {
+		orderByClause := c.getDefaultOrderByClause()
+	}
 	queryString, queryArgs := c.buildSelectStmt(
 		c.namespaceID,
 		queryString,

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -139,7 +139,7 @@ func newQueryConverterInternal(
 func (c *QueryConverter) BuildSelectStmt(
 	pageSize int,
 	nextPageToken []byte,
-	withOrderBy bool,
+	withDefaultOrderBy bool,
 ) (*sqlplugin.VisibilitySelectFilter, error) {
 	token, err := deserializePageToken(nextPageToken)
 	if err != nil {

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -620,3 +620,13 @@ func isSupportedTypeRangeCond(saType enumspb.IndexedValueType) bool {
 	}
 	return false
 }
+
+func removeOrderByFromSelectQuery(queryString string) (string, error) {
+	stmt, err := sqlparser.Parse(queryString)
+	if err != nil {
+		return "", err
+	}
+	selectStmt, _ := stmt.(*sqlparser.Select)
+	selectStmt.OrderBy = nil
+	return sqlparser.String(selectStmt), nil
+}

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -139,7 +139,7 @@ func newQueryConverterInternal(
 func (c *QueryConverter) BuildSelectStmt(
 	pageSize int,
 	nextPageToken []byte,
-	withDefaultOrderBy bool,
+	orderByClause string,
 ) (*sqlplugin.VisibilitySelectFilter, error) {
 	token, err := deserializePageToken(nextPageToken)
 	if err != nil {
@@ -149,9 +149,7 @@ func (c *QueryConverter) BuildSelectStmt(
 	if err != nil {
 		return nil, err
 	}
-	if withDefaultOrderBy {
-		orderByClause := c.getDefaultOrderByClause()
-	}
+
 	queryString, queryArgs := c.buildSelectStmt(
 		c.namespaceID,
 		queryString,

--- a/common/persistence/visibility/store/sql/query_converter.go
+++ b/common/persistence/visibility/store/sql/query_converter.go
@@ -597,16 +597,12 @@ func (c *QueryConverter) convertIsExpr(exprRef *sqlparser.Expr) error {
 	return nil
 }
 
-func (c *QueryConverter) getOrderByClause(withOrderBy bool) string {
-	orderByClause := ""
-	if withOrderBy {
-		orderByClause = fmt.Sprintf("ORDER BY %s DESC, %s DESC, %s",
-			sqlparser.String(c.getCoalesceCloseTimeExpr()),
-			searchattribute.GetSqlDbColName(searchattribute.StartTime),
-			searchattribute.GetSqlDbColName(searchattribute.RunID),
-		)
-	}
-	return orderByClause
+func (c *QueryConverter) getDefaultOrderByClause() string {
+	return fmt.Sprintf("ORDER BY %s DESC, %s DESC, %s",
+		sqlparser.String(c.getCoalesceCloseTimeExpr()),
+		searchattribute.GetSqlDbColName(searchattribute.StartTime),
+		searchattribute.GetSqlDbColName(searchattribute.RunID),
+	)
 }
 func isSupportedOperator(supportedOperators []string, operator string) bool {
 	for _, op := range supportedOperators {

--- a/common/persistence/visibility/store/sql/query_converter_mysql.go
+++ b/common/persistence/visibility/store/sql/query_converter_mysql.go
@@ -214,6 +214,7 @@ func (c *mysqlQueryConverter) buildSelectStmt(
 	queryString string,
 	pageSize int,
 	token *pageToken,
+	orderByClause string,
 ) (string, []any) {
 	var whereClauses []string
 	var queryArgs []any
@@ -260,15 +261,13 @@ func (c *mysqlQueryConverter) buildSelectStmt(
 		LEFT JOIN custom_search_attributes
 		USING (%s, %s)
 		WHERE %s
-		ORDER BY %s DESC, %s DESC, %s
+		%s
 		LIMIT ?`,
 		strings.Join(addPrefix("ev.", sqlplugin.DbFields), ", "),
 		searchattribute.GetSqlDbColName(searchattribute.NamespaceID),
 		searchattribute.GetSqlDbColName(searchattribute.RunID),
 		strings.Join(whereClauses, " AND "),
-		sqlparser.String(c.getCoalesceCloseTimeExpr()),
-		searchattribute.GetSqlDbColName(searchattribute.StartTime),
-		searchattribute.GetSqlDbColName(searchattribute.RunID),
+		orderByClause,
 	), queryArgs
 }
 

--- a/common/persistence/visibility/store/sql/query_converter_postgresql.go
+++ b/common/persistence/visibility/store/sql/query_converter_postgresql.go
@@ -221,6 +221,7 @@ func (c *pgQueryConverter) buildSelectStmt(
 	queryString string,
 	pageSize int,
 	token *pageToken,
+	orderByClause string,
 ) (string, []any) {
 	var whereClauses []string
 	var queryArgs []any
@@ -265,13 +266,11 @@ func (c *pgQueryConverter) buildSelectStmt(
 		`SELECT %s
 		FROM executions_visibility
 		WHERE %s
-		ORDER BY %s DESC, %s DESC, %s
+		%s
 		LIMIT ?`,
 		strings.Join(sqlplugin.DbFields, ", "),
 		strings.Join(whereClauses, " AND "),
-		sqlparser.String(c.getCoalesceCloseTimeExpr()),
-		searchattribute.GetSqlDbColName(searchattribute.StartTime),
-		searchattribute.GetSqlDbColName(searchattribute.RunID),
+		orderByClause,
 	), queryArgs
 }
 

--- a/common/persistence/visibility/store/sql/query_converter_sqlite.go
+++ b/common/persistence/visibility/store/sql/query_converter_sqlite.go
@@ -234,6 +234,7 @@ func (c *sqliteQueryConverter) buildSelectStmt(
 	queryString string,
 	pageSize int,
 	token *pageToken,
+	orderByClause string,
 ) (string, []any) {
 	var whereClauses []string
 	var queryArgs []any
@@ -278,13 +279,11 @@ func (c *sqliteQueryConverter) buildSelectStmt(
 		`SELECT %s
 		FROM executions_visibility
 		WHERE %s
-		ORDER BY %s DESC, %s DESC, %s
+		%s
 		LIMIT ?`,
 		strings.Join(sqlplugin.DbFields, ", "),
 		strings.Join(whereClauses, " AND "),
-		sqlparser.String(c.getCoalesceCloseTimeExpr()),
-		searchattribute.GetSqlDbColName(searchattribute.StartTime),
-		searchattribute.GetSqlDbColName(searchattribute.RunID),
+		orderByClause,
 	), queryArgs
 }
 

--- a/common/persistence/visibility/store/sql/visibility_store.go
+++ b/common/persistence/visibility/store/sql/visibility_store.go
@@ -425,10 +425,14 @@ func (s *VisibilityStore) ListWorkflowExecutions(
 }
 
 func (s *VisibilityStore) ScanWorkflowExecutions(
-	_ context.Context,
-	_ *manager.ListWorkflowExecutionsRequestV2,
+	ctx context.Context,
+	request *manager.ListWorkflowExecutionsRequestV2,
 ) (*store.InternalListWorkflowExecutionsResponse, error) {
-	return nil, store.OperationNotSupportedErr
+	// custom order is not supported by Scan API
+	if strings.Contains(strings.ToLower(request.Query), "order by") {
+		return nil, serviceerror.NewInvalidArgument("ORDER BY clause is not supported")
+	}
+	return s.ListWorkflowExecutions(ctx, request)
 }
 
 func (s *VisibilityStore) CountWorkflowExecutions(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Enabled Scan API in SQL visibility store. The Scan API does not support 'ORDER
BY' clause otherwise behaves the same as List API.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
NO
