### PR TITLE
increase archival signal timeout

### DIFF
--- a/service/worker/archiver/client_test.go
+++ b/service/worker/archiver/client_test.go
@@ -81,7 +81,7 @@ func (s *clientSuite) SetupTest() {
 		s.sdkClientFactory,
 		dynamicconfig.GetIntPropertyFn(1000),
 		dynamicconfig.GetIntPropertyFn(1000),
-		dynamicconfig.GetDurationPropertyFn(300*time.Millisecond),
+		dynamicconfig.GetDurationPropertyFn(3000*time.Millisecond),
 		s.archiverProvider,
 	).(*client)
 }


### PR DESCRIPTION
 Increased archival signal timeout 
Had to Increaes from 300 ms to 3000 ms

<!-- Tell your future self why have you made these changes -->
 In most cases archival to s3 gets delayed at scale and the 300 ms is too low

**How did you test it?**
have changed the config and tested for workflows, was able to find similar posts. in  temporal community 


No CodeBreaking Changes 


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
Yes