### PR TITLE
Remove unused exporter from openTelemetryProviderImpl

### DIFF
--- a/common/metrics/opentelemetry_provider.go
+++ b/common/metrics/opentelemetry_provider.go
@@ -50,10 +50,9 @@ type (
 	}
 
 	openTelemetryProviderImpl struct {
-		exporter *exporters.Exporter
-		meter    metric.Meter
-		config   *PrometheusConfig
-		server   *http.Server
+		meter  metric.Meter
+		config *PrometheusConfig
+		server *http.Server
 	}
 )
 
@@ -90,10 +89,9 @@ func NewOpenTelemetryProvider(
 	metricServer := initPrometheusListener(prometheusConfig, reg, logger)
 	meter := provider.Meter("temporal")
 	reporter := &openTelemetryProviderImpl{
-		exporter: exporter,
-		meter:    meter,
-		config:   prometheusConfig,
-		server:   metricServer,
+		meter:  meter,
+		config: prometheusConfig,
+		server: metricServer,
 	}
 
 	return reporter, nil


### PR DESCRIPTION
Doesn't seem like this field is actually used while `meter`, `config`, and `server` are:

https://github.com/temporalio/temporal/blob/cdd1a218f83aac371d15fa4ebe5739cf71e623cc/common/metrics/opentelemetry_provider.go#L126-L136