### PR TITLE
Use correct API for transfer queue

### DIFF
--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -2579,8 +2579,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 			}), nil)
 
 			mockClusterMetadata := cluster.NewMockMetadata(ctrl)
-			clusterName := namespaceEntry.ActiveClusterName()
-			mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(clusterName).AnyTimes()
 			mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false).AnyTimes()
 
 			mockShard := shard.NewMockContext(ctrl)
@@ -2616,8 +2614,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 					ackLevel = closeTransferTaskId - 1
 				}
 				mockShard.EXPECT().GetQueueState(tasks.CategoryTransfer).Return(nil, false).AnyTimes()
-				mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryTransfer,
-					clusterName).Return(tasks.NewImmediateKey(ackLevel)).AnyTimes()
+				mockShard.EXPECT().GetQueueAckLevel(tasks.CategoryTransfer).Return(tasks.NewImmediateKey(ackLevel)).AnyTimes()
 			}
 
 			mockWorkflowDeleteManager := deletemanager.NewMockDeleteManager(ctrl)

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -315,12 +315,11 @@ func (t *transferQueueTaskExecutorBase) isCloseExecutionTaskPending(ms workflow.
 	if closeTransferTaskId == 0 {
 		return false
 	}
-	currentClusterName := t.shard.GetClusterMetadata().GetCurrentClusterName()
 	// check if close execution transfer task is completed
 	transferQueueState, ok := t.shard.GetQueueState(tasks.CategoryTransfer)
 	if !ok {
 		// Use cluster ack level for transfer queue ack level because it gets updated more often.
-		transferQueueAckLevel := t.shard.GetQueueClusterAckLevel(tasks.CategoryTransfer, currentClusterName).TaskID
+		transferQueueAckLevel := t.shard.GetQueueAckLevel(tasks.CategoryTransfer).TaskID
 		return closeTransferTaskId > transferQueueAckLevel
 	}
 	fakeCloseTransferTask := &tasks.CloseExecutionTask{

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -318,7 +318,6 @@ func (t *transferQueueTaskExecutorBase) isCloseExecutionTaskPending(ms workflow.
 	// check if close execution transfer task is completed
 	transferQueueState, ok := t.shard.GetQueueState(tasks.CategoryTransfer)
 	if !ok {
-		// Use cluster ack level for transfer queue ack level because it gets updated more often.
 		transferQueueAckLevel := t.shard.GetQueueAckLevel(tasks.CategoryTransfer).TaskID
 		return closeTransferTaskId > transferQueueAckLevel
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Use GetQueueAckLevel for transfer queue, since GetQueueClusterAckLevel should only be used by replication tasks

<!-- Tell your future self why have you made these changes -->
**Why?**
See above

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A