### PR TITLE
Attempt to unify queue state

### DIFF
--- a/api/persistence/v1/executions.pb.go
+++ b/api/persistence/v1/executions.pb.go
@@ -77,6 +77,7 @@ type ShardInfo struct {
 	NamespaceNotificationVersion int64            `protobuf:"varint,9,opt,name=namespace_notification_version,json=namespaceNotificationVersion,proto3" json:"namespace_notification_version,omitempty"`
 	ReplicationDlqAckLevel       map[string]int64 `protobuf:"bytes,13,rep,name=replication_dlq_ack_level,json=replicationDlqAckLevel,proto3" json:"replication_dlq_ack_level,omitempty" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"varint,2,opt,name=value,proto3"`
 	// Map from task category to ack levels of the corresponding queue processor
+	// Deprecated. Use queue_states instead.
 	QueueAckLevels map[int32]*QueueAckLevel `protobuf:"bytes,16,rep,name=queue_ack_levels,json=queueAckLevels,proto3" json:"queue_ack_levels,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 	QueueStates    map[int32]*QueueState    `protobuf:"bytes,17,rep,name=queue_states,json=queueStates,proto3" json:"queue_states,omitempty" protobuf_key:"varint,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
 }

--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -29,6 +29,7 @@ package cluster
 import (
 	"context"
 	"fmt"
+	"math"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -158,8 +159,8 @@ func NewMetadata(
 		panic("Master cluster name is empty")
 	} else if len(currentClusterName) == 0 {
 		panic("Current cluster name is empty")
-	} else if failoverVersionIncrement == 0 {
-		panic("Version increment is 0")
+	} else if failoverVersionIncrement == 0 || failoverVersionIncrement > math.MaxInt32 {
+		panic("Version increment <= 0 or > 2147483647")
 	}
 
 	versionToClusterName := updateVersionToClusterName(clusterInfo, failoverVersionIncrement)

--- a/common/persistence/serialization/blob.go
+++ b/common/persistence/serialization/blob.go
@@ -111,6 +111,15 @@ func QueueMetadataFromBlob(blob []byte, encoding string) (*persistencespb.QueueM
 	return result, decode(blob, encoding, result)
 }
 
+func QueueStateToBlob(info *persistencespb.QueueState) (commonpb.DataBlob, error) {
+	return proto3Encode(info)
+}
+
+func QueueStateFromBlob(blob []byte, encoding string) (*persistencespb.QueueState, error) {
+	result := &persistencespb.QueueState{}
+	return result, proto3Decode(blob, encoding, result)
+}
+
 func encode(
 	object proto.Message,
 	encoding enumspb.EncodingType,

--- a/common/util.go
+++ b/common/util.go
@@ -420,6 +420,31 @@ func MapShardID(
 	}
 }
 
+func VerifyShardIDMapping(
+	thisShardCount int32,
+	thatShardCount int32,
+	thisShardID int32,
+	thatShardID int32,
+) error {
+	if thisShardCount%thatShardCount != 0 && thatShardCount%thisShardCount != 0 {
+		panic(fmt.Sprintf("cannot verify shard ID mapping between diff shard count: %v vs %v",
+			thisShardCount, thatShardCount))
+	}
+	shardCountMin := thisShardCount
+	if shardCountMin > thatShardCount {
+		shardCountMin = thatShardCount
+	}
+	if thisShardID%shardCountMin == thatShardID%shardCountMin {
+		return nil
+	}
+	return serviceerror.NewInternal(
+		fmt.Sprintf("shard ID mapping verification failed; shard count: %v vs %v, shard ID: %v vs %v",
+			thisShardCount, thatShardCount,
+			thisShardID, thatShardID,
+		),
+	)
+}
+
 func PrettyPrint[T proto.Message](msgs []T, header ...string) {
 	var sb strings.Builder
 	_, _ = sb.WriteString("==========================================================================\n")

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -498,3 +498,22 @@ func TestMapShardID_16To4(t *testing.T) {
 	targetShards = MapShardID(sourceShardCount, targetShardCount, 1)
 	require.Equal(t, []int32{1}, targetShards)
 }
+
+func TestVerifyShardIDMapping_1VS4(t *testing.T) {
+	require.NoError(t, VerifyShardIDMapping(1, 4, 1, 1))
+	require.NoError(t, VerifyShardIDMapping(1, 4, 1, 2))
+	require.NoError(t, VerifyShardIDMapping(1, 4, 1, 3))
+	require.NoError(t, VerifyShardIDMapping(1, 4, 1, 4))
+}
+
+func TestVerifyShardIDMapping_2VS4(t *testing.T) {
+	require.NoError(t, VerifyShardIDMapping(2, 4, 1, 1))
+	require.Error(t, VerifyShardIDMapping(2, 4, 1, 2))
+	require.NoError(t, VerifyShardIDMapping(2, 4, 1, 3))
+	require.Error(t, VerifyShardIDMapping(2, 4, 1, 4))
+
+	require.Error(t, VerifyShardIDMapping(2, 4, 2, 1))
+	require.NoError(t, VerifyShardIDMapping(2, 4, 2, 2))
+	require.Error(t, VerifyShardIDMapping(2, 4, 2, 3))
+	require.NoError(t, VerifyShardIDMapping(2, 4, 2, 4))
+}

--- a/config/development-cluster-b.yaml
+++ b/config/development-cluster-b.yaml
@@ -5,7 +5,7 @@ log:
 persistence:
   defaultStore: cass-default
   visibilityStore: es-visibility
-  numHistoryShards: 32
+  numHistoryShards: 16
   datastores:
     cass-default:
       cassandra:

--- a/proto/internal/temporal/server/api/persistence/v1/executions.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/executions.proto
@@ -62,6 +62,7 @@ message ShardInfo {
     reserved 14;
     reserved 15;
     // Map from task category to ack levels of the corresponding queue processor
+    // Deprecated. Use queue_states instead.
     map<int32, QueueAckLevel> queue_ack_levels = 16;
     map<int32, QueueState> queue_states = 17;
 }

--- a/service/history/queues/mitigator.go
+++ b/service/history/queues/mitigator.go
@@ -131,6 +131,6 @@ func runAction(
 		return err
 	}
 
-	logger.Info("Queue action completed")
+	logger.Debug("Queue action completed")
 	return nil
 }

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -144,7 +144,7 @@ func newQueueBase(
 		readerScopes = queueState.readerScopes
 		exclusiveReaderHighWatermark = queueState.exclusiveReaderHighWatermark
 	} else {
-		ackLevel := shard.GetQueueAckLevel(category)
+		ackLevel := tasks.NewKey(tasks.DefaultFireTime, 0)
 		if category.Type() == tasks.CategoryTypeImmediate {
 			// convert to exclusive ack level
 			ackLevel = ackLevel.Next()

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -737,6 +737,7 @@ func (s *queueBaseSuite) QueueStateEqual(
 	this *persistencespb.QueueState,
 	that *persistencespb.QueueState,
 ) {
+	// ser/de so to equal will not take timezone into consideration
 	thisBlob, err := serialization.QueueStateToBlob(this)
 	s.NoError(err)
 	this, err = serialization.QueueStateFromBlob(thisBlob.Data, thisBlob.EncodingType.String())

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/predicates"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/quotas"
@@ -505,7 +506,7 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks() {
 		).Times(1),
 		mockShard.Resource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, request *persistence.UpdateShardRequest) error {
-				s.Equal(persistenceState, request.ShardInfo.QueueStates[tasks.CategoryIDTimer])
+				s.QueueStateEqual(persistenceState, request.ShardInfo.QueueStates[tasks.CategoryIDTimer])
 				return nil
 			},
 		).Times(1),
@@ -579,7 +580,7 @@ func (s *queueBaseSuite) TestCheckPoint_NoPendingTasks() {
 		).Times(1),
 		mockShard.Resource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, request *persistence.UpdateShardRequest) error {
-				s.Equal(persistenceState, request.ShardInfo.QueueStates[tasks.CategoryIDTimer])
+				s.QueueStateEqual(persistenceState, request.ShardInfo.QueueStates[tasks.CategoryIDTimer])
 				return nil
 			},
 		).Times(1),
@@ -655,7 +656,7 @@ func (s *queueBaseSuite) TestCheckPoint_MoveSlices() {
 		mockShard.Resource.ExecutionMgr.EXPECT().RangeCompleteHistoryTasks(gomock.Any(), gomock.Any()).Return(nil).Times(1),
 		mockShard.Resource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).DoAndReturn(
 			func(_ context.Context, request *persistence.UpdateShardRequest) error {
-				s.Equal(expectedPersistenceState, request.ShardInfo.QueueStates[tasks.CategoryIDTimer])
+				s.QueueStateEqual(expectedPersistenceState, request.ShardInfo.QueueStates[tasks.CategoryIDTimer])
 				return nil
 			},
 		).Times(1),
@@ -730,4 +731,21 @@ func (s *queueBaseSuite) TestUpdateReaderProgress() {
 		DefaultReaderId + 2: tasks.NewImmediateKey(25),
 		DefaultReaderId + 3: tasks.NewImmediateKey(25),
 	}, readerProgress)
+}
+
+func (s *queueBaseSuite) QueueStateEqual(
+	this *persistencespb.QueueState,
+	that *persistencespb.QueueState,
+) {
+	thisBlob, err := serialization.QueueStateToBlob(this)
+	s.NoError(err)
+	this, err = serialization.QueueStateFromBlob(thisBlob.Data, thisBlob.EncodingType.String())
+	s.NoError(err)
+
+	thatBlob, err := serialization.QueueStateToBlob(that)
+	s.NoError(err)
+	that, err = serialization.QueueStateFromBlob(thatBlob.Data, thatBlob.EncodingType.String())
+	s.NoError(err)
+
+	s.Equal(this, that)
 }

--- a/service/history/replication/stream_receiver_monitor_test.go
+++ b/service/history/replication/stream_receiver_monitor_test.go
@@ -209,6 +209,8 @@ func (s *streamReceiverMonitorSuite) TestGenerateStreamKeys_4To1() {
 }
 
 func (s *streamReceiverMonitorSuite) TestDoReconcileStreams_Add() {
+	s.clusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
+
 	clientKey := NewClusterShardKey(s.clientClusterID, rand.Int31())
 	serverKey := NewClusterShardKey(s.serverClusterID, rand.Int31())
 
@@ -236,6 +238,8 @@ func (s *streamReceiverMonitorSuite) TestDoReconcileStreams_Add() {
 }
 
 func (s *streamReceiverMonitorSuite) TestDoReconcileStreams_Remove() {
+	s.clusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
+
 	clientKey := NewClusterShardKey(s.clientClusterID, rand.Int31())
 	serverKey := NewClusterShardKey(s.serverClusterID, rand.Int31())
 	stream := NewStreamReceiver(s.streamReceiverMonitor.ProcessToolBox, clientKey, serverKey)
@@ -259,6 +263,8 @@ func (s *streamReceiverMonitorSuite) TestDoReconcileStreams_Remove() {
 }
 
 func (s *streamReceiverMonitorSuite) TestDoReconcileStreams_Reactivate() {
+	s.clusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
+
 	clientKey := NewClusterShardKey(s.clientClusterID, rand.Int31())
 	serverKey := NewClusterShardKey(s.serverClusterID, rand.Int31())
 	stream := NewStreamReceiver(s.streamReceiverMonitor.ProcessToolBox, clientKey, serverKey)

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -362,13 +362,4 @@ func minInt64(
 		return accumulateMin
 	}
 	return minCursor
-	//if accumulateMin == nil {
-	//	return convert.Int64Ptr(minCursor)
-	//}
-	//
-	//if *accumulateMin <= minCursor {
-	//	return accumulateMin
-	//} else {
-	//	return convert.Int64Ptr(minCursor)
-	//}
 }

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -42,6 +42,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/common/xdc"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/deletemanager"
@@ -280,9 +281,9 @@ func (r *taskProcessorManagerImpl) cleanupReplicationTasks() error {
 	) {
 		readerState, ok := queueStates.ReaderStates[readerID]
 		if !ok {
-			minAckedTaskID = minInt64(minAckedTaskID, 0)
+			minAckedTaskID = util.Min[int64](minAckedTaskID, 0)
 		} else {
-			minAckedTaskID = minInt64(minAckedTaskID, readerState.Scopes[0].Range.InclusiveMin.TaskId-1)
+			minAckedTaskID = util.Min[int64](minAckedTaskID, readerState.Scopes[0].Range.InclusiveMin.TaskId-1)
 		}
 	}
 
@@ -352,14 +353,4 @@ func targetReaderIDs(
 		}
 	}
 	return readerIDs
-}
-
-func minInt64(
-	accumulateMin int64,
-	minCursor int64,
-) int64 {
-	if accumulateMin <= minCursor {
-		return accumulateMin
-	}
-	return minCursor
 }

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -25,6 +25,7 @@
 package replication
 
 import (
+	"math"
 	"math/rand"
 	"testing"
 	"time"
@@ -33,7 +34,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservicemock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
@@ -139,8 +142,28 @@ func (s *taskProcessorManagerSuite) TearDownTest() {
 
 func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Noop() {
 	ackedTaskID := int64(12345)
-	s.mockShard.EXPECT().GetImmediateQueueExclusiveHighReadWatermark().Return(tasks.NewImmediateKey(ackedTaskID))
-	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
+	s.mockShard.EXPECT().GetImmediateQueueExclusiveHighReadWatermark().Return(tasks.NewImmediateKey(ackedTaskID + 2)).AnyTimes()
+	s.mockShard.EXPECT().GetQueueState(tasks.CategoryReplication).Return(&persistencespb.QueueState{
+		ExclusiveReaderHighWatermark: nil,
+		ReaderStates: map[int64]*persistencespb.QueueReaderState{
+			shard.ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, s.shardID): {
+				Scopes: []*persistencespb.QueueSliceScope{{
+					Range: &persistencespb.QueueSliceRange{
+						InclusiveMin: shard.ConvertToPersistenceTaskKey(
+							tasks.NewImmediateKey(ackedTaskID + 1),
+						),
+						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
+							tasks.NewImmediateKey(math.MaxInt64),
+						),
+					},
+					Predicate: &persistencespb.Predicate{
+						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+					},
+				}},
+			},
+		},
+	}, true)
 
 	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID
 	err := s.taskProcessorManager.cleanupReplicationTasks()
@@ -149,8 +172,28 @@ func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Noop() {
 
 func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Cleanup() {
 	ackedTaskID := int64(12345)
-	s.mockShard.EXPECT().GetImmediateQueueExclusiveHighReadWatermark().Return(tasks.NewImmediateKey(ackedTaskID)).Times(2)
-	s.mockShard.EXPECT().GetQueueClusterAckLevel(tasks.CategoryReplication, cluster.TestAlternativeClusterName).Return(tasks.NewImmediateKey(ackedTaskID))
+	s.mockShard.EXPECT().GetImmediateQueueExclusiveHighReadWatermark().Return(tasks.NewImmediateKey(ackedTaskID + 2)).AnyTimes()
+	s.mockShard.EXPECT().GetQueueState(tasks.CategoryReplication).Return(&persistencespb.QueueState{
+		ExclusiveReaderHighWatermark: nil,
+		ReaderStates: map[int64]*persistencespb.QueueReaderState{
+			shard.ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, s.shardID): {
+				Scopes: []*persistencespb.QueueSliceScope{{
+					Range: &persistencespb.QueueSliceRange{
+						InclusiveMin: shard.ConvertToPersistenceTaskKey(
+							tasks.NewImmediateKey(ackedTaskID + 1),
+						),
+						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
+							tasks.NewImmediateKey(math.MaxInt64),
+						),
+					},
+					Predicate: &persistencespb.Predicate{
+						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+					},
+				}},
+			},
+		},
+	}, true)
 	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID - 1
 	s.mockExecutionManager.EXPECT().UpdateHistoryTaskReaderProgress(
 		gomock.Any(),

--- a/service/history/shard/compatibility.go
+++ b/service/history/shard/compatibility.go
@@ -1,0 +1,283 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"fmt"
+	"math"
+
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+func loadShardInfoCompatibilityCheck(
+	clusterMetadata cluster.Metadata,
+	shardInfo *persistencespb.ShardInfo,
+) *persistencespb.ShardInfo {
+	// TODO this section maintains the forward / backward compatibility
+	//  should be removed once the migration is done
+	//  also see ShardInfoToBlob
+
+	allClusterInfo := clusterMetadata.GetAllClusterInfo()
+	shardInfo = loadShardInfoCompatibilityCheckWithoutReplication(shardInfo)
+	shardInfo = loadShardInfoCompatibilityCheckWithReplication(allClusterInfo, shardInfo)
+
+	// clear QueueAckLevels to force new logic to only use QueueStates
+	shardInfo.QueueAckLevels = nil
+	return shardInfo
+}
+
+func loadShardInfoCompatibilityCheckWithoutReplication(
+	shardInfo *persistencespb.ShardInfo,
+) *persistencespb.ShardInfo {
+	for queueCategoryID, queueAckLevel := range shardInfo.QueueAckLevels {
+		if queueCategoryID == tasks.CategoryIDReplication {
+			continue
+		}
+
+		queueCategory, ok := tasks.GetCategoryByID(queueCategoryID)
+		if !ok {
+			panic(fmt.Sprintf("unable to find queue category by queye category ID: %v", queueCategoryID))
+		}
+		minCursor := convertPersistenceAckLevelToTaskKey(queueCategory.Type(), queueAckLevel.AckLevel)
+		if queueCategory.Type() == tasks.CategoryTypeImmediate && minCursor.TaskID > 0 {
+			// for immediate task type, the ack level is inclusive
+			// for scheduled task type, the ack level is exclusive
+			minCursor = minCursor.Next()
+		}
+
+		queueState, ok := shardInfo.QueueStates[queueCategoryID]
+		if !ok || minCursor.CompareTo(ConvertFromPersistenceTaskKey(queueState.ExclusiveReaderHighWatermark)) > 0 {
+			queueState = &persistencespb.QueueState{
+				ExclusiveReaderHighWatermark: ConvertToPersistenceTaskKey(minCursor),
+				ReaderStates:                 make(map[int64]*persistencespb.QueueReaderState),
+			}
+			shardInfo.QueueStates[queueCategoryID] = queueState
+		}
+	}
+	return shardInfo
+}
+
+func loadShardInfoCompatibilityCheckWithReplication(
+	allClusterInfo map[string]cluster.ClusterInformation,
+	shardInfo *persistencespb.ShardInfo,
+) *persistencespb.ShardInfo {
+	shardInfo = trimShardInfo(allClusterInfo, shardInfo)
+	if shardInfo.QueueAckLevels == nil {
+		return shardInfo
+	}
+	queueAckLevel, ok := shardInfo.QueueAckLevels[tasks.CategoryIDReplication]
+	if !ok {
+		return shardInfo
+	}
+
+	for clusterName, ackLevel := range queueAckLevel.ClusterAckLevel {
+		minCursor := convertPersistenceAckLevelToTaskKey(tasks.CategoryReplication.Type(), ackLevel).Next()
+		readerID := ReplicationReaderIDFromClusterShardID(
+			allClusterInfo[clusterName].InitialFailoverVersion,
+			shardInfo.ShardId,
+		)
+
+		queueStates, ok := shardInfo.QueueStates[tasks.CategoryIDReplication]
+		if !ok {
+			queueStates = &persistencespb.QueueState{
+				ExclusiveReaderHighWatermark: nil,
+				ReaderStates:                 map[int64]*persistencespb.QueueReaderState{},
+			}
+			shardInfo.QueueStates[tasks.CategoryIDReplication] = queueStates
+		}
+		readerState, ok := queueStates.ReaderStates[readerID]
+		if !ok || minCursor.CompareTo(ConvertFromPersistenceTaskKey(readerState.Scopes[0].Range.InclusiveMin)) > 0 {
+			queueStates.ReaderStates[readerID] = &persistencespb.QueueReaderState{
+				Scopes: []*persistencespb.QueueSliceScope{{
+					Range: &persistencespb.QueueSliceRange{
+						InclusiveMin: ConvertToPersistenceTaskKey(minCursor),
+						ExclusiveMax: ConvertToPersistenceTaskKey(
+							convertPersistenceAckLevelToTaskKey(
+								tasks.CategoryReplication.Type(),
+								math.MaxInt64,
+							),
+						),
+					},
+					Predicate: &persistencespb.Predicate{
+						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+					},
+				}},
+			}
+		}
+	}
+	return shardInfo
+}
+
+func storeShardInfoCompatibilityCheck(
+	clusterMetadata cluster.Metadata,
+	shardInfo *persistencespb.ShardInfo,
+) *persistencespb.ShardInfo {
+	// TODO this section maintains the forward / backward compatibility
+	//  should be removed once the migration is done
+	//  also see ShardInfoFromBlob
+	allClusterInfo := clusterMetadata.GetAllClusterInfo()
+	shardInfo = storeShardInfoCompatibilityCheckWithoutReplication(shardInfo)
+	shardInfo = storeShardInfoCompatibilityCheckWithReplication(allClusterInfo, shardInfo)
+	return shardInfo
+}
+
+func storeShardInfoCompatibilityCheckWithoutReplication(
+	shardInfo *persistencespb.ShardInfo,
+) *persistencespb.ShardInfo {
+	for queueCategoryID, queueState := range shardInfo.QueueStates {
+		if queueCategoryID == tasks.CategoryIDReplication {
+			continue
+		}
+
+		queueCategory, ok := tasks.GetCategoryByID(queueCategoryID)
+		if !ok {
+			panic(fmt.Sprintf("unable to find queue category by queye category ID: %v", queueCategoryID))
+		}
+
+		// for compatability, update ack level and cluster ack level as well
+		// so after rollback or disabling the feature, we won't load too many tombstones
+		minAckLevel := ConvertFromPersistenceTaskKey(queueState.ExclusiveReaderHighWatermark)
+		for _, readerState := range queueState.ReaderStates {
+			if len(readerState.Scopes) != 0 {
+				minAckLevel = tasks.MinKey(
+					minAckLevel,
+					ConvertFromPersistenceTaskKey(readerState.Scopes[0].Range.InclusiveMin),
+				)
+			}
+		}
+
+		if queueCategory.Type() == tasks.CategoryTypeImmediate && minAckLevel.TaskID > 0 {
+			// for immediate task type, the ack level is inclusive
+			// for scheduled task type, the ack level is exclusive
+			minAckLevel = minAckLevel.Prev()
+		}
+		persistenceAckLevel := convertTaskKeyToPersistenceAckLevel(queueCategory.Type(), minAckLevel)
+
+		shardInfo.QueueAckLevels[queueCategoryID] = &persistencespb.QueueAckLevel{
+			AckLevel:        persistenceAckLevel,
+			ClusterAckLevel: make(map[string]int64),
+		}
+	}
+	return shardInfo
+}
+
+func storeShardInfoCompatibilityCheckWithReplication(
+	allClusterInfo map[string]cluster.ClusterInformation,
+	shardInfo *persistencespb.ShardInfo,
+) *persistencespb.ShardInfo {
+	shardInfo = trimShardInfo(allClusterInfo, shardInfo)
+	if shardInfo.QueueStates == nil {
+		return shardInfo
+	}
+	queueStates, ok := shardInfo.QueueStates[tasks.CategoryIDReplication]
+	if !ok {
+		return shardInfo
+	}
+
+	for readerID, readerState := range queueStates.ReaderStates {
+		clusterID, _ := ReplicationReaderIDToClusterShardID(readerID)
+		clusterName, _, _ := ClusterNameInfoFromClusterID(allClusterInfo, clusterID)
+		queueAckLevel, ok := shardInfo.QueueAckLevels[tasks.CategoryIDReplication]
+		if !ok {
+			queueAckLevel = &persistencespb.QueueAckLevel{
+				AckLevel:        0,
+				ClusterAckLevel: make(map[string]int64),
+			}
+			shardInfo.QueueAckLevels[tasks.CategoryIDReplication] = queueAckLevel
+		}
+		readerAckLevel := convertTaskKeyToPersistenceAckLevel(
+			tasks.CategoryReplication.Type(),
+			ConvertFromPersistenceTaskKey(readerState.Scopes[0].Range.InclusiveMin).Prev(),
+		)
+		if ackLevel, ok := queueAckLevel.ClusterAckLevel[clusterName]; !ok {
+			queueAckLevel.ClusterAckLevel[clusterName] = readerAckLevel
+		} else if ackLevel > readerAckLevel {
+			queueAckLevel.ClusterAckLevel[clusterName] = readerAckLevel
+		}
+	}
+	return shardInfo
+}
+
+func trimShardInfo(
+	allClusterInfo map[string]cluster.ClusterInformation,
+	shardInfo *persistencespb.ShardInfo,
+) *persistencespb.ShardInfo {
+	// clean up replication info if cluster is disabled || missing
+	if shardInfo.QueueAckLevels != nil && shardInfo.QueueAckLevels[tasks.CategoryIDReplication] != nil {
+		for clusterName := range shardInfo.QueueAckLevels[tasks.CategoryIDReplication].ClusterAckLevel {
+			clusterInfo, ok := allClusterInfo[clusterName]
+			if !ok || !clusterInfo.Enabled {
+				delete(shardInfo.QueueAckLevels[tasks.CategoryIDReplication].ClusterAckLevel, clusterName)
+			}
+		}
+	}
+
+	if shardInfo.QueueStates != nil && shardInfo.QueueStates[tasks.CategoryIDReplication] != nil {
+		for readerID := range shardInfo.QueueStates[tasks.CategoryIDReplication].ReaderStates {
+			clusterID, _ := ReplicationReaderIDToClusterShardID(readerID)
+			_, clusterInfo, found := ClusterNameInfoFromClusterID(allClusterInfo, clusterID)
+			if !found || !clusterInfo.Enabled {
+				delete(shardInfo.QueueStates[tasks.CategoryIDReplication].ReaderStates, readerID)
+			}
+		}
+	}
+	return shardInfo
+}
+
+// ReplicationReaderIDFromClusterShardID convert from cluster ID & shard ID to reader ID
+// NOTE: cluster metadata guarantee
+//  1. initial failover version <= int32 max
+//  2. failover increment <= int32 max
+//  3. initial failover version == cluster ID
+func ReplicationReaderIDFromClusterShardID(
+	clusterID int64,
+	shardID int32,
+) int64 {
+	return clusterID<<32 + int64(shardID)
+}
+
+// ReplicationReaderIDToClusterShardID convert from reader ID to cluster ID & shard ID
+// NOTE: see ReplicationReaderIDFromClusterShardID
+func ReplicationReaderIDToClusterShardID(
+	readerID int64,
+) (int64, int32) {
+	return readerID >> 32, int32(readerID & 0xffffffff)
+}
+
+func ClusterNameInfoFromClusterID(
+	allClusterInfo map[string]cluster.ClusterInformation,
+	clusterID int64,
+) (string, cluster.ClusterInformation, bool) {
+	for name, info := range allClusterInfo {
+		if info.InitialFailoverVersion == clusterID {
+			return name, info, true
+		}
+	}
+	return "", cluster.ClusterInformation{}, false
+}

--- a/service/history/shard/compatibility.go
+++ b/service/history/shard/compatibility.go
@@ -250,26 +250,6 @@ func trimShardInfo(
 	return shardInfo
 }
 
-// ReplicationReaderIDFromClusterShardID convert from cluster ID & shard ID to reader ID
-// NOTE: cluster metadata guarantee
-//  1. initial failover version <= int32 max
-//  2. failover increment <= int32 max
-//  3. initial failover version == cluster ID
-func ReplicationReaderIDFromClusterShardID(
-	clusterID int64,
-	shardID int32,
-) int64 {
-	return clusterID<<32 + int64(shardID)
-}
-
-// ReplicationReaderIDToClusterShardID convert from reader ID to cluster ID & shard ID
-// NOTE: see ReplicationReaderIDFromClusterShardID
-func ReplicationReaderIDToClusterShardID(
-	readerID int64,
-) (int64, int32) {
-	return readerID >> 32, int32(readerID & 0xffffffff)
-}
-
 func ClusterNameInfoFromClusterID(
 	allClusterInfo map[string]cluster.ClusterInformation,
 	clusterID int64,

--- a/service/history/shard/compatibility_test.go
+++ b/service/history/shard/compatibility_test.go
@@ -1,0 +1,641 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	enumspb "go.temporal.io/api/enums/v1"
+
+	enumsspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	compatibilitySuite struct {
+		suite.Suite
+		*require.Assertions
+	}
+)
+
+func TestCompatibilitySuite(t *testing.T) {
+	s := &compatibilitySuite{}
+	suite.Run(t, s)
+}
+
+func (s *compatibilitySuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+}
+
+func (s *compatibilitySuite) TestLoadShardInfoCompatibilityCheckWithoutReplication_OnlyQueueAckLevel() {
+	transferAckTaskID := rand.Int63()
+	timerAckTime := rand.Int63()
+	persistenceShardInfo := &persistencespb.ShardInfo{
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{
+			tasks.CategoryIDTransfer: {
+				AckLevel:        transferAckTaskID,
+				ClusterAckLevel: map[string]int64{},
+			},
+			tasks.CategoryIDTimer: {
+				AckLevel:        timerAckTime,
+				ClusterAckLevel: map[string]int64{},
+			},
+		},
+		QueueStates: make(map[int32]*persistencespb.QueueState),
+	}
+
+	expectedMemShardInfo := &persistencespb.ShardInfo{
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDTransfer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+					TaskId:   transferAckTaskID + 1,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+			tasks.CategoryIDTimer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, timerAckTime)),
+					TaskId:   0,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+		},
+	}
+	actualMemShardInfo := loadShardInfoCompatibilityCheckWithoutReplication(copyShardInfo(persistenceShardInfo))
+	actualMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{}
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestLoadShardInfoCompatibilityCheckWithoutReplication_OnlyQueueState() {
+	transferAckTaskID := rand.Int63()
+	timerAckTime := rand.Int63()
+
+	persistenceShardInfo := &persistencespb.ShardInfo{
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDTransfer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+					TaskId:   transferAckTaskID + 1,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+			tasks.CategoryIDTimer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, timerAckTime)),
+					TaskId:   0,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+		},
+	}
+
+	expectedMemShardInfo := copyShardInfo(persistenceShardInfo)
+	actualMemShardInfo := loadShardInfoCompatibilityCheckWithoutReplication(copyShardInfo(persistenceShardInfo))
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestLoadShardInfoCompatibilityCheckWithoutReplication_Both() {
+	ackLevelTransferAckTaskID := rand.Int63()
+	ackLevelTimerAckTime := rand.Int63()
+	queueStateTransferAckTaskID := rand.Int63()
+	queueStateTimerAckTime := rand.Int63()
+
+	persistenceShardInfo := &persistencespb.ShardInfo{
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{
+			tasks.CategoryIDTransfer: {
+				AckLevel:        ackLevelTransferAckTaskID,
+				ClusterAckLevel: map[string]int64{},
+			},
+			tasks.CategoryIDTimer: {
+				AckLevel:        ackLevelTimerAckTime,
+				ClusterAckLevel: map[string]int64{},
+			},
+		},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDTransfer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+					TaskId:   queueStateTransferAckTaskID + 1,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+			tasks.CategoryIDTimer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, queueStateTimerAckTime)),
+					TaskId:   0,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+		},
+	}
+
+	expectedMemShardInfo := &persistencespb.ShardInfo{
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDTransfer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+					TaskId:   s.MaxInt64(ackLevelTransferAckTaskID, queueStateTransferAckTaskID) + 1,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+			tasks.CategoryIDTimer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, s.MaxInt64(ackLevelTimerAckTime, queueStateTimerAckTime))),
+					TaskId:   0,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+		},
+	}
+	actualMemShardInfo := loadShardInfoCompatibilityCheckWithoutReplication(copyShardInfo(persistenceShardInfo))
+	actualMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{}
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestStoreShardInfoCompatibilityCheckWithoutReplication_NoOverride() {
+	transferAckTaskID := rand.Int63()
+	timerAckTime := rand.Int63()
+
+	memShardInfo := &persistencespb.ShardInfo{
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDTransfer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+					TaskId:   transferAckTaskID + 1,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+			tasks.CategoryIDTimer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, timerAckTime)),
+					TaskId:   0,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{},
+			},
+		},
+	}
+
+	expectedMemShardInfo := copyShardInfo(memShardInfo)
+	expectedMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{
+		tasks.CategoryIDTransfer: {
+			AckLevel:        transferAckTaskID,
+			ClusterAckLevel: map[string]int64{},
+		},
+		tasks.CategoryIDTimer: {
+			AckLevel:        timerAckTime,
+			ClusterAckLevel: map[string]int64{},
+		},
+	}
+	actualMemShardInfo := storeShardInfoCompatibilityCheckWithoutReplication(copyShardInfo(memShardInfo))
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestStoreShardInfoCompatibilityCheckWithoutReplication_Override() {
+	transferAckTaskID := rand.Int63()
+	timerAckTime := rand.Int63()
+
+	memShardInfo := &persistencespb.ShardInfo{
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDTransfer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+					TaskId:   transferAckTaskID + 1 + rand.Int63n(100),
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{
+					0: {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   transferAckTaskID + 1,
+								},
+								ExclusiveMax: nil, // not used
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+				},
+			},
+			tasks.CategoryIDTimer: {
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(time.Unix(0, timerAckTime+rand.Int63n(100))),
+					TaskId:   0,
+				},
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{
+					0: {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, timerAckTime)),
+									TaskId:   0,
+								},
+								ExclusiveMax: nil, // not used
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	expectedMemShardInfo := copyShardInfo(memShardInfo)
+	expectedMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{
+		tasks.CategoryIDTransfer: {
+			AckLevel:        transferAckTaskID,
+			ClusterAckLevel: map[string]int64{},
+		},
+		tasks.CategoryIDTimer: {
+			AckLevel:        timerAckTime,
+			ClusterAckLevel: map[string]int64{},
+		},
+	}
+	actualMemShardInfo := storeShardInfoCompatibilityCheckWithoutReplication(copyShardInfo(memShardInfo))
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestLoadShardInfoCompatibilityCheckWithReplication_OnlyQueueAckLevel() {
+	allClusterInfo := cluster.TestAllClusterInfo
+	shardID := rand.Int31()
+	replicationAckTaskID := rand.Int63()
+	persistenceShardInfo := &persistencespb.ShardInfo{
+		ShardId: shardID,
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{
+			tasks.CategoryIDReplication: {
+				AckLevel: 0,
+				ClusterAckLevel: map[string]int64{
+					cluster.TestAlternativeClusterName: replicationAckTaskID,
+				},
+			},
+		},
+		QueueStates: make(map[int32]*persistencespb.QueueState),
+	}
+
+	expectedMemShardInfo := &persistencespb.ShardInfo{
+		ShardId:        shardID,
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDReplication: {
+				ExclusiveReaderHighWatermark: nil,
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{
+					ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, shardID): {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   replicationAckTaskID + 1,
+								},
+								ExclusiveMax: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   math.MaxInt64,
+								},
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+	actualMemShardInfo := loadShardInfoCompatibilityCheckWithReplication(allClusterInfo, copyShardInfo(persistenceShardInfo))
+	actualMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{}
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestLoadShardInfoCompatibilityCheckWithReplication_OnlyQueueState() {
+	allClusterInfo := cluster.TestAllClusterInfo
+	shardID := rand.Int31()
+	replicationAckTaskID := rand.Int63()
+	persistenceShardInfo := &persistencespb.ShardInfo{
+		ShardId:        shardID,
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDReplication: {
+				ExclusiveReaderHighWatermark: nil,
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{
+					ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, shardID): {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   replicationAckTaskID + 1,
+								},
+								ExclusiveMax: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   math.MaxInt64,
+								},
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	expectedMemShardInfo := copyShardInfo(persistenceShardInfo)
+	actualMemShardInfo := loadShardInfoCompatibilityCheckWithReplication(allClusterInfo, copyShardInfo(persistenceShardInfo))
+	actualMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{}
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestLoadShardInfoCompatibilityCheckWithReplication_Both() {
+	allClusterInfo := cluster.TestAllClusterInfo
+	shardID := rand.Int31()
+	ackLevelReplicationAckTaskID := rand.Int63()
+	queueStateReplicationAckTaskID := rand.Int63()
+	persistenceShardInfo := &persistencespb.ShardInfo{
+		ShardId: shardID,
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{
+			tasks.CategoryIDReplication: {
+				AckLevel: 0,
+				ClusterAckLevel: map[string]int64{
+					cluster.TestAlternativeClusterName: ackLevelReplicationAckTaskID,
+				},
+			},
+		},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDReplication: {
+				ExclusiveReaderHighWatermark: nil,
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{
+					ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, shardID): {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   queueStateReplicationAckTaskID + 1,
+								},
+								ExclusiveMax: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   math.MaxInt64,
+								},
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	expectedMemShardInfo := &persistencespb.ShardInfo{
+		ShardId:        shardID,
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDReplication: {
+				ExclusiveReaderHighWatermark: nil,
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{
+					ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, shardID): {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   s.MaxInt64(ackLevelReplicationAckTaskID, queueStateReplicationAckTaskID) + 1,
+								},
+								ExclusiveMax: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   math.MaxInt64,
+								},
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+	actualMemShardInfo := loadShardInfoCompatibilityCheckWithReplication(allClusterInfo, copyShardInfo(persistenceShardInfo))
+	actualMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{}
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestStoreShardInfoCompatibilityCheckWithReplication_NoOverride() {
+	allClusterInfo := cluster.TestAllClusterInfo
+	shardID := rand.Int31()
+	replicationAckTaskID := rand.Int63()
+	memShardInfo := &persistencespb.ShardInfo{
+		ShardId:        shardID,
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDReplication: {
+				ExclusiveReaderHighWatermark: nil,
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{
+					ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, shardID): {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   replicationAckTaskID + 1,
+								},
+								ExclusiveMax: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   math.MaxInt64,
+								},
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	expectedMemShardInfo := copyShardInfo(memShardInfo)
+	expectedMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{
+		tasks.CategoryIDReplication: {
+			AckLevel: 0,
+			ClusterAckLevel: map[string]int64{
+				cluster.TestAlternativeClusterName: replicationAckTaskID,
+			},
+		},
+	}
+	actualMemShardInfo := storeShardInfoCompatibilityCheckWithReplication(allClusterInfo, copyShardInfo(memShardInfo))
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestStoreShardInfoCompatibilityCheckWithReplication_Override() {
+	allClusterInfo := cluster.TestAllClusterInfo
+	shardID := rand.Int31()
+	replicationAckTaskID := rand.Int63()
+	memShardInfo := &persistencespb.ShardInfo{
+		ShardId:        shardID,
+		QueueAckLevels: map[int32]*persistencespb.QueueAckLevel{},
+		QueueStates: map[int32]*persistencespb.QueueState{
+			tasks.CategoryIDReplication: {
+				ExclusiveReaderHighWatermark: nil,
+				ReaderStates: map[int64]*persistencespb.QueueReaderState{
+					ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, shardID): {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   replicationAckTaskID + 1,
+								},
+								ExclusiveMax: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   math.MaxInt64,
+								},
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+					ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, shardID+1): {
+						Scopes: []*persistencespb.QueueSliceScope{{
+							Range: &persistencespb.QueueSliceRange{
+								InclusiveMin: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   replicationAckTaskID + 1 + rand.Int63n(100),
+								},
+								ExclusiveMax: &persistencespb.TaskKey{
+									FireTime: timestamp.TimePtr(time.Unix(0, 0)),
+									TaskId:   math.MaxInt64,
+								},
+							},
+							Predicate: &persistencespb.Predicate{
+								PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+								Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+							},
+						}},
+					},
+				},
+			},
+		},
+	}
+
+	expectedMemShardInfo := copyShardInfo(memShardInfo)
+	expectedMemShardInfo.QueueAckLevels = map[int32]*persistencespb.QueueAckLevel{
+		tasks.CategoryIDReplication: {
+			AckLevel: 0,
+			ClusterAckLevel: map[string]int64{
+				cluster.TestAlternativeClusterName: replicationAckTaskID,
+			},
+		},
+	}
+	actualMemShardInfo := storeShardInfoCompatibilityCheckWithReplication(allClusterInfo, copyShardInfo(memShardInfo))
+	s.EqualShardInfo(expectedMemShardInfo, actualMemShardInfo)
+}
+
+func (s *compatibilitySuite) TestReplicationReaderIDConversion() {
+	expectedClusterID := int64(rand.Int31())
+	expectedShardID := rand.Int31()
+
+	actualClusterID, actualShardID := ReplicationReaderIDToClusterShardID(
+		ReplicationReaderIDFromClusterShardID(expectedClusterID, expectedShardID),
+	)
+	s.Equal(expectedClusterID, actualClusterID)
+	s.Equal(expectedShardID, actualShardID)
+}
+
+func (s *compatibilitySuite) TestReplicationReaderIDConversion_1() {
+	expectedClusterID := int64(1)
+	expectedShardID := int32(1)
+
+	actualClusterID, actualShardID := ReplicationReaderIDToClusterShardID(
+		ReplicationReaderIDFromClusterShardID(expectedClusterID, expectedShardID),
+	)
+	s.Equal(expectedClusterID, actualClusterID)
+	s.Equal(expectedShardID, actualShardID)
+}
+
+func (s *compatibilitySuite) TestReplicationReaderIDConversion_Int32Max() {
+	expectedClusterID := int64(math.MaxInt32)
+	expectedShardID := int32(math.MaxInt32)
+
+	actualClusterID, actualShardID := ReplicationReaderIDToClusterShardID(
+		ReplicationReaderIDFromClusterShardID(expectedClusterID, expectedShardID),
+	)
+	s.Equal(expectedClusterID, actualClusterID)
+	s.Equal(expectedShardID, actualShardID)
+}
+
+func (s *compatibilitySuite) EqualShardInfo(
+	expected *persistencespb.ShardInfo,
+	actual *persistencespb.ShardInfo,
+) {
+	// this helper function exists to deal with time comparison issue
+
+	serializer := serialization.NewSerializer()
+	expectedBlob, err := serializer.ShardInfoToBlob(expected, enumspb.ENCODING_TYPE_PROTO3)
+	s.NoError(err)
+	expected, err = serializer.ShardInfoFromBlob(expectedBlob)
+	s.NoError(err)
+
+	actualBlob, err := serializer.ShardInfoToBlob(actual, enumspb.ENCODING_TYPE_PROTO3)
+	s.NoError(err)
+	actual, err = serializer.ShardInfoFromBlob(actualBlob)
+	s.NoError(err)
+
+	s.Equal(expected, actual)
+}
+
+func (s *compatibilitySuite) MaxInt64(
+	this int64,
+	that int64,
+) int64 {
+	if this < that {
+		return that
+	}
+	return this
+}

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -77,12 +77,9 @@ type (
 
 		GetImmediateQueueExclusiveHighReadWatermark() tasks.Key
 		UpdateScheduledQueueExclusiveHighReadWatermark() (tasks.Key, error)
-		GetQueueAckLevel(category tasks.Category) tasks.Key
-		UpdateQueueAckLevel(category tasks.Category, ackLevel tasks.Key) error
-		GetQueueClusterAckLevel(category tasks.Category, cluster string) tasks.Key
-		UpdateQueueClusterAckLevel(category tasks.Category, cluster string, ackLevel tasks.Key) error
 		GetQueueState(category tasks.Category) (*persistencespb.QueueState, bool)
 		SetQueueState(category tasks.Category, state *persistencespb.QueueState) error
+		UpdateReplicationQueueReaderState(readerID int64, readerState *persistencespb.QueueReaderState) error
 
 		GetReplicatorDLQAckLevel(sourceCluster string) int64
 		UpdateReplicatorDLQAckLevel(sourCluster string, ackLevel int64) error

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -328,106 +328,6 @@ func (s *ContextImpl) UpdateScheduledQueueExclusiveHighReadWatermark() (tasks.Ke
 	return tasks.NewKey(s.scheduledTaskMaxReadLevel, 0), nil
 }
 
-// NOTE: the ack level returned is inclusive for immediate task category (acked),
-// but exclusive for scheduled task category (not acked).
-func (s *ContextImpl) GetQueueAckLevel(category tasks.Category) tasks.Key {
-	s.rLock()
-	defer s.rUnlock()
-
-	return s.getQueueAckLevelLocked(category)
-}
-
-func (s *ContextImpl) getQueueAckLevelLocked(category tasks.Category) tasks.Key {
-	if queueAckLevel, ok := s.shardInfo.QueueAckLevels[category.ID()]; ok && queueAckLevel.AckLevel != 0 {
-		return convertPersistenceAckLevelToTaskKey(category.Type(), queueAckLevel.AckLevel)
-	}
-
-	return tasks.NewKey(tasks.DefaultFireTime, 0)
-}
-
-func (s *ContextImpl) UpdateQueueAckLevel(
-	category tasks.Category,
-	ackLevel tasks.Key,
-) error {
-	s.wLock()
-	defer s.wUnlock()
-
-	// the ack level is already the min ack level across all types of
-	// queue processors: active, passive, failover
-
-	categoryID := category.ID()
-	if _, ok := s.shardInfo.QueueAckLevels[categoryID]; !ok {
-		s.shardInfo.QueueAckLevels[categoryID] = &persistencespb.QueueAckLevel{
-			ClusterAckLevel: make(map[string]int64),
-		}
-	}
-	persistenceAckLevel := convertTaskKeyToPersistenceAckLevel(category.Type(), ackLevel)
-	s.shardInfo.QueueAckLevels[categoryID].AckLevel = persistenceAckLevel
-
-	// if cluster ack level is less than the overall ack level, update cluster ack level
-	// as well to prevent loading too many tombstones if the cluster ack level is used later
-	// this may happen when adding back a removed cluster or rolling back the change for using
-	// single queue in timer/transfer queue processor
-	clusterAckLevel := s.shardInfo.QueueAckLevels[categoryID].ClusterAckLevel
-	for clusterName, persistenceClusterAckLevel := range clusterAckLevel {
-		if persistenceClusterAckLevel < persistenceAckLevel {
-			clusterAckLevel[clusterName] = persistenceAckLevel
-		}
-	}
-
-	// when this method is called, it means multi-cursor is disabled.
-	// clear processor state field, so that next time multi-cursor is enabled,
-	// it won't start from an very old state
-	delete(s.shardInfo.QueueStates, categoryID)
-
-	s.shardInfo.StolenSinceRenew = 0
-	return s.updateShardInfoLocked()
-}
-
-func (s *ContextImpl) GetQueueClusterAckLevel(
-	category tasks.Category,
-	cluster string,
-) tasks.Key {
-	s.rLock()
-	defer s.rUnlock()
-
-	return s.getQueueClusterAckLevelLocked(category, cluster)
-}
-
-func (s *ContextImpl) getQueueClusterAckLevelLocked(
-	category tasks.Category,
-	cluster string,
-) tasks.Key {
-	if queueAckLevel, ok := s.shardInfo.QueueAckLevels[category.ID()]; ok {
-		if ackLevel, ok := queueAckLevel.ClusterAckLevel[cluster]; ok {
-			return convertPersistenceAckLevelToTaskKey(category.Type(), ackLevel)
-		}
-	}
-
-	// otherwise, default to existing ack level, which belongs to local cluster
-	// this can happen if you add more clusters or a new category
-	return s.getQueueAckLevelLocked(category)
-}
-
-func (s *ContextImpl) UpdateQueueClusterAckLevel(
-	category tasks.Category,
-	cluster string,
-	ackLevel tasks.Key,
-) error {
-	s.wLock()
-	defer s.wUnlock()
-
-	if _, ok := s.shardInfo.QueueAckLevels[category.ID()]; !ok {
-		s.shardInfo.QueueAckLevels[category.ID()] = &persistencespb.QueueAckLevel{
-			ClusterAckLevel: make(map[string]int64),
-		}
-	}
-	s.shardInfo.QueueAckLevels[category.ID()].ClusterAckLevel[cluster] = convertTaskKeyToPersistenceAckLevel(category.Type(), ackLevel)
-
-	s.shardInfo.StolenSinceRenew = 0
-	return s.updateShardInfoLocked()
-}
-
 func (s *ContextImpl) GetQueueState(
 	category tasks.Category,
 ) (*persistencespb.QueueState, bool) {
@@ -435,6 +335,12 @@ func (s *ContextImpl) GetQueueState(
 	defer s.rUnlock()
 
 	queueState, ok := s.shardInfo.QueueStates[category.ID()]
+	if !ok {
+		return nil, false
+	}
+	// need to make a deep copy, in case UpdateReplicationQueueReaderState does a partial update
+	blob, _ := serialization.QueueStateToBlob(queueState)
+	queueState, _ = serialization.QueueStateFromBlob(blob.Data, blob.EncodingType.String())
 	return queueState, ok
 }
 
@@ -448,36 +354,27 @@ func (s *ContextImpl) SetQueueState(
 	categoryID := category.ID()
 	s.shardInfo.QueueStates[categoryID] = state
 
-	// for compatability, update ack level and cluster ack level as well
-	// so after rollback or disabling the feature, we won't load too many tombstones
-	minAckLevel := convertFromPersistenceTaskKey(state.ExclusiveReaderHighWatermark)
-	for _, readerState := range state.ReaderStates {
-		if len(readerState.Scopes) != 0 {
-			minAckLevel = tasks.MinKey(
-				minAckLevel,
-				convertFromPersistenceTaskKey(readerState.Scopes[0].Range.InclusiveMin),
-			)
+	s.shardInfo.StolenSinceRenew = 0
+	return s.updateShardInfoLocked()
+}
+
+func (s *ContextImpl) UpdateReplicationQueueReaderState(
+	readerID int64,
+	readerState *persistencespb.QueueReaderState,
+) error {
+	s.wLock()
+	defer s.wUnlock()
+
+	categoryID := tasks.CategoryReplication.ID()
+	queueState, ok := s.shardInfo.QueueStates[categoryID]
+	if !ok {
+		queueState = &persistencespb.QueueState{
+			ExclusiveReaderHighWatermark: nil,
+			ReaderStates:                 make(map[int64]*persistencespb.QueueReaderState),
 		}
+		s.shardInfo.QueueStates[categoryID] = queueState
 	}
-
-	if category.Type() == tasks.CategoryTypeImmediate && minAckLevel.TaskID > 0 {
-		// for immediate task type, the ack level is inclusive
-		// for scheduled task type, the ack level is exclusive
-		minAckLevel = minAckLevel.Prev()
-	}
-	persistenceAckLevel := convertTaskKeyToPersistenceAckLevel(category.Type(), minAckLevel)
-
-	if _, ok := s.shardInfo.QueueAckLevels[categoryID]; !ok {
-		s.shardInfo.QueueAckLevels[categoryID] = &persistencespb.QueueAckLevel{
-			ClusterAckLevel: make(map[string]int64),
-		}
-	}
-	s.shardInfo.QueueAckLevels[categoryID].AckLevel = persistenceAckLevel
-
-	clusterAckLevel := s.shardInfo.QueueAckLevels[categoryID].ClusterAckLevel
-	for clusterName := range clusterAckLevel {
-		clusterAckLevel[clusterName] = persistenceAckLevel
-	}
+	queueState.ReaderStates[readerID] = readerState
 
 	s.shardInfo.StolenSinceRenew = 0
 	return s.updateShardInfoLocked()
@@ -1173,7 +1070,7 @@ func (s *ContextImpl) updateRangeIfNeededLocked() error {
 }
 
 func (s *ContextImpl) renewRangeLocked(isStealing bool) error {
-	updatedShardInfo := copyShardInfo(s.shardInfo)
+	updatedShardInfo := storeShardInfoCompatibilityCheck(s.clusterMetadata, copyShardInfo(s.shardInfo))
 	updatedShardInfo.RangeId++
 	if isStealing {
 		updatedShardInfo.StolenSinceRenew++
@@ -1229,8 +1126,7 @@ func (s *ContextImpl) updateShardInfoLocked() error {
 	if s.lastUpdated.Add(s.config.ShardUpdateMinInterval()).After(now) {
 		return nil
 	}
-	updatedShardInfo := copyShardInfo(s.shardInfo)
-	s.emitShardInfoMetricsLogsLocked()
+	updatedShardInfo := storeShardInfoCompatibilityCheck(s.clusterMetadata, copyShardInfo(s.shardInfo))
 
 	ctx, cancel := s.newIOContext()
 	defer cancel()
@@ -1246,63 +1142,64 @@ func (s *ContextImpl) updateShardInfoLocked() error {
 	return nil
 }
 
-func (s *ContextImpl) emitShardInfoMetricsLogsLocked() {
-	handler := s.GetMetricsHandler().WithTags(metrics.OperationTag(metrics.ShardInfoScope))
-	logWarnLagExceeded := false
-
-	for categoryID := range s.shardInfo.QueueAckLevels {
-		category, ok := tasks.GetCategoryByID(categoryID)
-		if !ok {
-			continue
-		}
-
-		switch category.Type() {
-		case tasks.CategoryTypeImmediate:
-			lag := s.immediateTaskExclusiveMaxReadLevel - s.getQueueAckLevelLocked(category).TaskID - 1
-			if lag > logWarnImmediateTaskLag {
-				logWarnLagExceeded = true
-			}
-			handler.Histogram(
-				metrics.ShardInfoImmediateQueueLagHistogram.GetMetricName(),
-				metrics.ShardInfoImmediateQueueLagHistogram.GetMetricUnit(),
-			).Record(lag, metrics.TaskCategoryTag(category.Name()))
-		case tasks.CategoryTypeScheduled:
-			lag := s.scheduledTaskMaxReadLevel.Sub(s.getQueueAckLevelLocked(category).FireTime)
-			if lag > logWarnScheduledTaskLag {
-				logWarnLagExceeded = true
-			}
-			handler.Timer(
-				metrics.ShardInfoScheduledQueueLagTimer.GetMetricName(),
-			).Record(lag, metrics.TaskCategoryTag(category.Name()))
-		default:
-			s.contextTaggedLogger.Error("Unknown task category type", tag.NewStringTag("task-category", category.Type().String()))
-		}
-	}
-
-	if logWarnLagExceeded && s.config.EmitShardLagLog() {
-		ackLevelTags := make([]tag.Tag, 0, len(s.shardInfo.QueueAckLevels))
-		for categoryID, ackLevel := range s.shardInfo.QueueAckLevels {
-			category, ok := tasks.GetCategoryByID(categoryID)
-			if !ok {
-				continue
-			}
-			ackLevelTags = append(ackLevelTags, tag.ShardQueueAcks(category.Name(), ackLevel))
-		}
-		s.contextTaggedLogger.Warn("Shard ack levels lag exceeds warn threshold.", ackLevelTags...)
-	}
-
-	// Following metrics are double-emitted for backward compatibility so that old dashboard/alert won't break
-	// TODO: remove in 1.21 release
-	replicationLag := s.immediateTaskExclusiveMaxReadLevel - s.getQueueAckLevelLocked(tasks.CategoryReplication).TaskID - 1
-	transferLag := s.immediateTaskExclusiveMaxReadLevel - s.getQueueAckLevelLocked(tasks.CategoryTransfer).TaskID - 1
-	visibilityLag := s.immediateTaskExclusiveMaxReadLevel - s.getQueueAckLevelLocked(tasks.CategoryVisibility).TaskID - 1
-	timerLag := s.timeSource.Now().Sub(s.getQueueAckLevelLocked(tasks.CategoryTimer).FireTime)
-
-	handler.Histogram(metrics.ShardInfoReplicationLagHistogram.GetMetricName(), metrics.ShardInfoReplicationLagHistogram.GetMetricUnit()).Record(replicationLag)
-	handler.Histogram(metrics.ShardInfoTransferLagHistogram.GetMetricName(), metrics.ShardInfoTransferLagHistogram.GetMetricUnit()).Record(transferLag)
-	handler.Histogram(metrics.ShardInfoVisibilityLagHistogram.GetMetricName(), metrics.ShardInfoVisibilityLagHistogram.GetMetricUnit()).Record(visibilityLag)
-	handler.Timer(metrics.ShardInfoTimerLagTimer.GetMetricName()).Record(timerLag)
-}
+//
+//func (s *ContextImpl) emitShardInfoMetricsLogsLocked() {
+//	handler := s.GetMetricsHandler().WithTags(metrics.OperationTag(metrics.ShardInfoScope))
+//	logWarnLagExceeded := false
+//
+//	for categoryID := range s.shardInfo.QueueAckLevels {
+//		category, ok := tasks.GetCategoryByID(categoryID)
+//		if !ok {
+//			continue
+//		}
+//
+//		switch category.Type() {
+//		case tasks.CategoryTypeImmediate:
+//			lag := s.immediateTaskExclusiveMaxReadLevel - s.getQueueAckLevelLocked(category).TaskID - 1
+//			if lag > logWarnImmediateTaskLag {
+//				logWarnLagExceeded = true
+//			}
+//			handler.Histogram(
+//				metrics.ShardInfoImmediateQueueLagHistogram.GetMetricName(),
+//				metrics.ShardInfoImmediateQueueLagHistogram.GetMetricUnit(),
+//			).Record(lag, metrics.TaskCategoryTag(category.Name()))
+//		case tasks.CategoryTypeScheduled:
+//			lag := s.scheduledTaskMaxReadLevel.Sub(s.getQueueAckLevelLocked(category).FireTime)
+//			if lag > logWarnScheduledTaskLag {
+//				logWarnLagExceeded = true
+//			}
+//			handler.Timer(
+//				metrics.ShardInfoScheduledQueueLagTimer.GetMetricName(),
+//			).Record(lag, metrics.TaskCategoryTag(category.Name()))
+//		default:
+//			s.contextTaggedLogger.Error("Unknown task category type", tag.NewStringTag("task-category", category.Type().String()))
+//		}
+//	}
+//
+//	if logWarnLagExceeded && s.config.EmitShardLagLog() {
+//		ackLevelTags := make([]tag.Tag, 0, len(s.shardInfo.QueueAckLevels))
+//		for categoryID, ackLevel := range s.shardInfo.QueueAckLevels {
+//			category, ok := tasks.GetCategoryByID(categoryID)
+//			if !ok {
+//				continue
+//			}
+//			ackLevelTags = append(ackLevelTags, tag.ShardQueueAcks(category.Name(), ackLevel))
+//		}
+//		s.contextTaggedLogger.Warn("Shard ack levels lag exceeds warn threshold.", ackLevelTags...)
+//	}
+//
+//	// Following metrics are double-emitted for backward compatibility so that old dashboard/alert won't break
+//	// TODO: remove in 1.21 release
+//	replicationLag := s.immediateTaskExclusiveMaxReadLevel - s.getQueueAckLevelLocked(tasks.CategoryReplication).TaskID - 1
+//	transferLag := s.immediateTaskExclusiveMaxReadLevel - s.getQueueAckLevelLocked(tasks.CategoryTransfer).TaskID - 1
+//	visibilityLag := s.immediateTaskExclusiveMaxReadLevel - s.getQueueAckLevelLocked(tasks.CategoryVisibility).TaskID - 1
+//	timerLag := s.timeSource.Now().Sub(s.getQueueAckLevelLocked(tasks.CategoryTimer).FireTime)
+//
+//	handler.Histogram(metrics.ShardInfoReplicationLagHistogram.GetMetricName(), metrics.ShardInfoReplicationLagHistogram.GetMetricUnit()).Record(replicationLag)
+//	handler.Histogram(metrics.ShardInfoTransferLagHistogram.GetMetricName(), metrics.ShardInfoTransferLagHistogram.GetMetricUnit()).Record(transferLag)
+//	handler.Histogram(metrics.ShardInfoVisibilityLagHistogram.GetMetricName(), metrics.ShardInfoVisibilityLagHistogram.GetMetricUnit()).Record(visibilityLag)
+//	handler.Timer(metrics.ShardInfoTimerLagTimer.GetMetricName()).Record(timerLag)
+//}
 
 func (s *ContextImpl) allocateTaskIDAndTimestampLocked(
 	namespaceEntry *namespace.Namespace,
@@ -1754,13 +1651,9 @@ func (s *ContextImpl) loadShardMetadata(ownershipChanged *bool) error {
 		s.contextTaggedLogger.Error("Failed to load shard", tag.Error(err))
 		return err
 	}
-	shardInfo := resp.ShardInfo
-
-	// shardInfo is a fresh value, so we don't really need to copy, but
-	// copyShardInfo also ensures that all maps are non-nil
-	updatedShardInfo := copyShardInfo(shardInfo)
-	*ownershipChanged = shardInfo.Owner != s.owner
-	updatedShardInfo.Owner = s.owner
+	*ownershipChanged = resp.ShardInfo.Owner != s.owner
+	shardInfo := loadShardInfoCompatibilityCheck(s.clusterMetadata, copyShardInfo(resp.ShardInfo))
+	shardInfo.Owner = s.owner
 
 	// initialize the cluster current time to be the same as ack level
 	remoteClusterInfos := make(map[string]*remoteClusterInfo)
@@ -1773,25 +1666,6 @@ func (s *ContextImpl) loadShardMetadata(ownershipChanged *bool) error {
 		}
 
 		maxReadTime := tasks.DefaultFireTime
-		for categoryID, queueAckLevels := range shardInfo.QueueAckLevels {
-			category, ok := taskCategories[categoryID]
-			if !ok || category.Type() != tasks.CategoryTypeScheduled {
-				continue
-			}
-
-			if queueAckLevels.AckLevel != 0 {
-				currentTime := timestamp.UnixOrZeroTime(queueAckLevels.AckLevel)
-				maxReadTime = util.MaxTime(maxReadTime, currentTime)
-			}
-
-			if queueAckLevels.ClusterAckLevel != nil {
-				if ackLevel, ok := queueAckLevels.ClusterAckLevel[clusterName]; ok {
-					currentTime := timestamp.UnixOrZeroTime(ackLevel)
-					maxReadTime = util.MaxTime(maxReadTime, currentTime)
-				}
-			}
-		}
-
 		for categoryID, queueState := range shardInfo.QueueStates {
 			category, ok := taskCategories[categoryID]
 			if !ok || category.Type() != tasks.CategoryTypeScheduled {
@@ -1819,7 +1693,7 @@ func (s *ContextImpl) loadShardMetadata(ownershipChanged *bool) error {
 	s.wLock()
 	defer s.wUnlock()
 
-	s.shardInfo = updatedShardInfo
+	s.shardInfo = shardInfo
 	s.remoteClusterInfos = remoteClusterInfos
 	s.scheduledTaskMaxReadLevel = scheduledTaskMaxReadLevel
 
@@ -2059,6 +1933,13 @@ func copyShardInfo(shardInfo *persistencespb.ShardInfo) *persistencespb.ShardInf
 			ClusterAckLevel: maps.Clone(ackLevels.ClusterAckLevel),
 		}
 	}
+	// need to ser/de to make a deep copy of queue state
+	queueStates := make(map[int32]*persistencespb.QueueState, len(shardInfo.QueueStates))
+	for k, v := range shardInfo.QueueStates {
+		blob, _ := serialization.QueueStateToBlob(v)
+		queueState, _ := serialization.QueueStateFromBlob(blob.Data, blob.EncodingType.String())
+		queueStates[k] = queueState
+	}
 
 	return &persistencespb.ShardInfo{
 		ShardId:                      shardInfo.ShardId,
@@ -2068,8 +1949,8 @@ func copyShardInfo(shardInfo *persistencespb.ShardInfo) *persistencespb.ShardInf
 		NamespaceNotificationVersion: shardInfo.NamespaceNotificationVersion,
 		ReplicationDlqAckLevel:       maps.Clone(shardInfo.ReplicationDlqAckLevel),
 		UpdateTime:                   shardInfo.UpdateTime,
-		QueueAckLevels:               queueAckLevels,
-		QueueStates:                  shardInfo.QueueStates,
+		QueueAckLevels:               maps.Clone(queueAckLevels),
+		QueueStates:                  queueStates,
 	}
 }
 
@@ -2196,11 +2077,20 @@ func convertTaskKeyToPersistenceAckLevel(
 	return taskKey.FireTime.UnixNano()
 }
 
-func convertFromPersistenceTaskKey(
+func ConvertFromPersistenceTaskKey(
 	key *persistencespb.TaskKey,
 ) tasks.Key {
 	return tasks.NewKey(
 		timestamp.TimeValue(key.FireTime),
 		key.TaskId,
 	)
+}
+
+func ConvertToPersistenceTaskKey(
+	key tasks.Key,
+) *persistencespb.TaskKey {
+	return &persistencespb.TaskKey{
+		FireTime: timestamp.TimePtr(key.FireTime),
+		TaskId:   key.TaskID,
+	}
 }

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1949,7 +1949,7 @@ func copyShardInfo(shardInfo *persistencespb.ShardInfo) *persistencespb.ShardInf
 		NamespaceNotificationVersion: shardInfo.NamespaceNotificationVersion,
 		ReplicationDlqAckLevel:       maps.Clone(shardInfo.ReplicationDlqAckLevel),
 		UpdateTime:                   shardInfo.UpdateTime,
-		QueueAckLevels:               maps.Clone(queueAckLevels),
+		QueueAckLevels:               queueAckLevels,
 		QueueStates:                  queueStates,
 	}
 }

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1127,10 +1127,15 @@ func (s *ContextImpl) updateShardInfoLocked() error {
 		return nil
 	}
 	updatedShardInfo := storeShardInfoCompatibilityCheck(s.clusterMetadata, copyShardInfo(s.shardInfo))
+	// since linter is against any logging control ¯\_(ツ)_/¯, e.g.
+	//  "flag-parameter: parameter 'verboseLogging' seems to be a control flag, avoid control coupling (revive)"
+	var logger log.Logger = log.NewNoopLogger()
+	if s.config.EmitShardLagLog() {
+		logger = s.contextTaggedLogger
+	}
 	emitShardInfoMetricsLogsLocked(
 		s.GetMetricsHandler().WithTags(metrics.OperationTag(metrics.ShardInfoScope)),
-		s.contextTaggedLogger,
-		s.config.EmitShardLagLog(),
+		logger,
 		updatedShardInfo.QueueStates,
 		s.immediateTaskExclusiveMaxReadLevel,
 		s.scheduledTaskMaxReadLevel,

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -448,34 +448,6 @@ func (mr *MockContextMockRecorder) GetPayloadSerializer() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayloadSerializer", reflect.TypeOf((*MockContext)(nil).GetPayloadSerializer))
 }
 
-// GetQueueAckLevel mocks base method.
-func (m *MockContext) GetQueueAckLevel(category tasks.Category) tasks.Key {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetQueueAckLevel", category)
-	ret0, _ := ret[0].(tasks.Key)
-	return ret0
-}
-
-// GetQueueAckLevel indicates an expected call of GetQueueAckLevel.
-func (mr *MockContextMockRecorder) GetQueueAckLevel(category interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueueAckLevel", reflect.TypeOf((*MockContext)(nil).GetQueueAckLevel), category)
-}
-
-// GetQueueClusterAckLevel mocks base method.
-func (m *MockContext) GetQueueClusterAckLevel(category tasks.Category, cluster string) tasks.Key {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetQueueClusterAckLevel", category, cluster)
-	ret0, _ := ret[0].(tasks.Key)
-	return ret0
-}
-
-// GetQueueClusterAckLevel indicates an expected call of GetQueueClusterAckLevel.
-func (mr *MockContextMockRecorder) GetQueueClusterAckLevel(category, cluster interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueueClusterAckLevel", reflect.TypeOf((*MockContext)(nil).GetQueueClusterAckLevel), category, cluster)
-}
-
 // GetQueueState mocks base method.
 func (m *MockContext) GetQueueState(category tasks.Category) (*v13.QueueState, bool) {
 	m.ctrl.T.Helper()
@@ -715,34 +687,6 @@ func (mr *MockContextMockRecorder) UpdateNamespaceNotificationVersion(namespaceN
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNamespaceNotificationVersion", reflect.TypeOf((*MockContext)(nil).UpdateNamespaceNotificationVersion), namespaceNotificationVersion)
 }
 
-// UpdateQueueAckLevel mocks base method.
-func (m *MockContext) UpdateQueueAckLevel(category tasks.Category, ackLevel tasks.Key) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateQueueAckLevel", category, ackLevel)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateQueueAckLevel indicates an expected call of UpdateQueueAckLevel.
-func (mr *MockContextMockRecorder) UpdateQueueAckLevel(category, ackLevel interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQueueAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateQueueAckLevel), category, ackLevel)
-}
-
-// UpdateQueueClusterAckLevel mocks base method.
-func (m *MockContext) UpdateQueueClusterAckLevel(category tasks.Category, cluster string, ackLevel tasks.Key) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateQueueClusterAckLevel", category, cluster, ackLevel)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// UpdateQueueClusterAckLevel indicates an expected call of UpdateQueueClusterAckLevel.
-func (mr *MockContextMockRecorder) UpdateQueueClusterAckLevel(category, cluster, ackLevel interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateQueueClusterAckLevel", reflect.TypeOf((*MockContext)(nil).UpdateQueueClusterAckLevel), category, cluster, ackLevel)
-}
-
 // UpdateRemoteClusterInfo mocks base method.
 func (m *MockContext) UpdateRemoteClusterInfo(cluster string, ackTaskID int64, ackTimestamp time.Time) {
 	m.ctrl.T.Helper()
@@ -753,6 +697,20 @@ func (m *MockContext) UpdateRemoteClusterInfo(cluster string, ackTaskID int64, a
 func (mr *MockContextMockRecorder) UpdateRemoteClusterInfo(cluster, ackTaskID, ackTimestamp interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteClusterInfo", reflect.TypeOf((*MockContext)(nil).UpdateRemoteClusterInfo), cluster, ackTaskID, ackTimestamp)
+}
+
+// UpdateReplicationQueueReaderState mocks base method.
+func (m *MockContext) UpdateReplicationQueueReaderState(readerID int64, readerState *v13.QueueReaderState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateReplicationQueueReaderState", readerID, readerState)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateReplicationQueueReaderState indicates an expected call of UpdateReplicationQueueReaderState.
+func (mr *MockContextMockRecorder) UpdateReplicationQueueReaderState(readerID, readerState interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateReplicationQueueReaderState", reflect.TypeOf((*MockContext)(nil).UpdateReplicationQueueReaderState), readerID, readerState)
 }
 
 // UpdateReplicatorDLQAckLevel mocks base method.

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -80,6 +80,7 @@ func NewTestContext(
 	if shardInfo.QueueStates == nil {
 		shardInfo.QueueStates = make(map[int32]*persistencespb.QueueState)
 	}
+	shardInfo = loadShardInfoCompatibilityCheckWithoutReplication(shardInfo)
 	shard := &ContextImpl{
 		shardID:             shardInfo.GetShardId(),
 		owner:               shardInfo.GetOwner(),

--- a/service/history/shard/context_util.go
+++ b/service/history/shard/context_util.go
@@ -38,7 +38,6 @@ import (
 func emitShardInfoMetricsLogsLocked(
 	metricsHandler metrics.Handler,
 	logger log.Logger,
-	verboseLogging bool,
 	queueStates map[int32]*persistencespb.QueueState,
 	immediateTaskExclusiveMaxReadLevel int64,
 	scheduledTaskMaxReadLevel time.Time,
@@ -57,7 +56,7 @@ Loop:
 				continue Loop
 			}
 			lag := immediateTaskExclusiveMaxReadLevel - minTaskKey.TaskID
-			if lag > logWarnImmediateTaskLag && verboseLogging {
+			if lag > logWarnImmediateTaskLag {
 				logger.Warn(
 					"Shard queue lag exceeds warn threshold.",
 					tag.ShardQueueAcks(category.Name(), minTaskKey.TaskID),
@@ -74,7 +73,7 @@ Loop:
 				continue Loop
 			}
 			lag := scheduledTaskMaxReadLevel.Sub(minTaskKey.FireTime)
-			if lag > logWarnScheduledTaskLag && verboseLogging {
+			if lag > logWarnScheduledTaskLag {
 				logger.Warn(
 					"Shard queue lag exceeds warn threshold.",
 					tag.ShardQueueAcks(category.Name(), minTaskKey.FireTime),

--- a/service/history/shard/context_util.go
+++ b/service/history/shard/context_util.go
@@ -1,0 +1,165 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"time"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+func emitShardInfoMetricsLogsLocked(
+	metricsHandler metrics.Handler,
+	logger log.Logger,
+	emitLog bool,
+	queueStates map[int32]*persistencespb.QueueState,
+	immediateTaskExclusiveMaxReadLevel int64,
+	scheduledTaskMaxReadLevel time.Time,
+) {
+Loop:
+	for categoryID, queueState := range queueStates {
+		category, ok := tasks.GetCategoryByID(categoryID)
+		if !ok {
+			continue Loop
+		}
+
+		switch category.Type() {
+		case tasks.CategoryTypeImmediate:
+			minTaskKey := getMinTaskKey(queueState)
+			if minTaskKey == nil {
+				continue Loop
+			}
+			lag := immediateTaskExclusiveMaxReadLevel - minTaskKey.TaskID
+			if lag > logWarnImmediateTaskLag && emitLog {
+				logger.Warn(
+					"Shard queue lag exceeds warn threshold.",
+					tag.ShardQueueAcks(category.Name(), minTaskKey.TaskID),
+				)
+			}
+			metricsHandler.Histogram(
+				metrics.ShardInfoImmediateQueueLagHistogram.GetMetricName(),
+				metrics.ShardInfoImmediateQueueLagHistogram.GetMetricUnit(),
+			).Record(lag, metrics.TaskCategoryTag(category.Name()))
+
+		case tasks.CategoryTypeScheduled:
+			minTaskKey := getMinTaskKey(queueState)
+			if minTaskKey == nil {
+				continue Loop
+			}
+			lag := scheduledTaskMaxReadLevel.Sub(minTaskKey.FireTime)
+			if lag > logWarnScheduledTaskLag && emitLog {
+				logger.Warn(
+					"Shard queue lag exceeds warn threshold.",
+					tag.ShardQueueAcks(category.Name(), minTaskKey.FireTime),
+				)
+			}
+			metricsHandler.Timer(
+				metrics.ShardInfoScheduledQueueLagTimer.GetMetricName(),
+			).Record(lag, metrics.TaskCategoryTag(category.Name()))
+		default:
+			logger.Error("Unknown task category type", tag.NewStringTag("task-category", category.Type().String()))
+		}
+	}
+}
+
+func convertPersistenceAckLevelToTaskKey(
+	categoryType tasks.CategoryType,
+	ackLevel int64,
+) tasks.Key {
+	if categoryType == tasks.CategoryTypeImmediate {
+		return tasks.NewImmediateKey(ackLevel)
+	}
+	return tasks.NewKey(timestamp.UnixOrZeroTime(ackLevel), 0)
+}
+
+func convertTaskKeyToPersistenceAckLevel(
+	categoryType tasks.CategoryType,
+	taskKey tasks.Key,
+) int64 {
+	if categoryType == tasks.CategoryTypeImmediate {
+		return taskKey.TaskID
+	}
+	return taskKey.FireTime.UnixNano()
+}
+
+func ConvertFromPersistenceTaskKey(
+	key *persistencespb.TaskKey,
+) tasks.Key {
+	return tasks.NewKey(
+		timestamp.TimeValue(key.FireTime),
+		key.TaskId,
+	)
+}
+
+func ConvertToPersistenceTaskKey(
+	key tasks.Key,
+) *persistencespb.TaskKey {
+	return &persistencespb.TaskKey{
+		FireTime: timestamp.TimePtr(key.FireTime),
+		TaskId:   key.TaskID,
+	}
+}
+
+// ReplicationReaderIDFromClusterShardID convert from cluster ID & shard ID to reader ID
+// NOTE: cluster metadata guarantee
+//  1. initial failover version <= int32 max
+//  2. failover increment <= int32 max
+//  3. initial failover version == cluster ID
+func ReplicationReaderIDFromClusterShardID(
+	clusterID int64,
+	shardID int32,
+) int64 {
+	return clusterID<<32 + int64(shardID)
+}
+
+// ReplicationReaderIDToClusterShardID convert from reader ID to cluster ID & shard ID
+// NOTE: see ReplicationReaderIDFromClusterShardID
+func ReplicationReaderIDToClusterShardID(
+	readerID int64,
+) (int64, int32) {
+	return readerID >> 32, int32(readerID & 0xffffffff)
+}
+
+func getMinTaskKey(
+	queueState *persistencespb.QueueState,
+) *tasks.Key {
+	var minTaskKey *tasks.Key
+	if queueState.ExclusiveReaderHighWatermark != nil {
+		taskKey := ConvertFromPersistenceTaskKey(queueState.ExclusiveReaderHighWatermark)
+		minTaskKey = &taskKey
+	}
+	for _, readerState := range queueState.ReaderStates {
+		taskKey := ConvertFromPersistenceTaskKey(readerState.Scopes[0].Range.InclusiveMin)
+		if minTaskKey == nil || taskKey.CompareTo(*minTaskKey) < 0 {
+			minTaskKey = &taskKey
+		}
+	}
+	return minTaskKey
+}

--- a/service/history/shard/context_util_test.go
+++ b/service/history/shard/context_util_test.go
@@ -1,0 +1,63 @@
+package shard
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type (
+	contextUtilSuite struct {
+		suite.Suite
+		*require.Assertions
+	}
+)
+
+func TestContextUtilSuite(t *testing.T) {
+	s := &contextUtilSuite{}
+	suite.Run(t, s)
+}
+
+func (s *contextUtilSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *contextUtilSuite) TeardownTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *contextUtilSuite) TestReplicationReaderIDConversion() {
+	expectedClusterID := int64(rand.Int31())
+	expectedShardID := rand.Int31()
+
+	actualClusterID, actualShardID := ReplicationReaderIDToClusterShardID(
+		ReplicationReaderIDFromClusterShardID(expectedClusterID, expectedShardID),
+	)
+	s.Equal(expectedClusterID, actualClusterID)
+	s.Equal(expectedShardID, actualShardID)
+}
+
+func (s *contextUtilSuite) TestReplicationReaderIDConversion_1() {
+	expectedClusterID := int64(1)
+	expectedShardID := int32(1)
+
+	actualClusterID, actualShardID := ReplicationReaderIDToClusterShardID(
+		ReplicationReaderIDFromClusterShardID(expectedClusterID, expectedShardID),
+	)
+	s.Equal(expectedClusterID, actualClusterID)
+	s.Equal(expectedShardID, actualShardID)
+}
+
+func (s *contextUtilSuite) TestReplicationReaderIDConversion_Int32Max() {
+	expectedClusterID := int64(math.MaxInt32)
+	expectedShardID := int32(math.MaxInt32)
+
+	actualClusterID, actualShardID := ReplicationReaderIDToClusterShardID(
+		ReplicationReaderIDFromClusterShardID(expectedClusterID, expectedShardID),
+	)
+	s.Equal(expectedClusterID, actualClusterID)
+	s.Equal(expectedShardID, actualShardID)
+}

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -29,7 +29,6 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
-	reflect "reflect"
 	"strconv"
 	"strings"
 	"sync"
@@ -39,7 +38,6 @@ import (
 
 	"go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"golang.org/x/exp/maps"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -968,10 +966,7 @@ func (s *controllerSuite) queueStates() map[int32]*persistencespb.QueueState {
 				},
 				1: nil,
 			},
-			ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
-				FireTime: &tasks.DefaultFireTime,
-				TaskId:   3000,
-			},
+			ExclusiveReaderHighWatermark: nil,
 		},
 	}
 }
@@ -1011,14 +1006,13 @@ func (m updateShardRequestMatcher) Matches(x interface{}) bool {
 		return false
 	}
 
+	// only compare the essential vars,
+	// other vars like queue state / queue ack level should not be test in this util
 	return m.PreviousRangeID == req.PreviousRangeID &&
 		m.ShardInfo.ShardId == req.ShardInfo.ShardId &&
 		strings.Contains(req.ShardInfo.Owner, m.ShardInfo.Owner) &&
 		m.ShardInfo.RangeId == req.ShardInfo.RangeId &&
-		m.ShardInfo.StolenSinceRenew == req.ShardInfo.StolenSinceRenew &&
-		maps.Equal(m.ShardInfo.ReplicationDlqAckLevel, req.ShardInfo.ReplicationDlqAckLevel) &&
-		reflect.DeepEqual(m.ShardInfo.QueueAckLevels, req.ShardInfo.QueueAckLevels) &&
-		reflect.DeepEqual(m.ShardInfo.QueueStates, req.ShardInfo.QueueStates)
+		m.ShardInfo.StolenSinceRenew == req.ShardInfo.StolenSinceRenew
 }
 
 func (m updateShardRequestMatcher) String() string {

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -2507,7 +2507,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 		Name                    string
 		EnsureCloseBeforeDelete bool
 		CloseTransferTaskIdSet  bool
-		MultiCursorQueue        bool
 		CloseTaskIsAcked        bool
 		ShouldDelete            bool
 	}{
@@ -2523,26 +2522,9 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 			ShouldDelete:            true,
 		},
 		{
-			Name:                    "single cursor queue unacked",
-			EnsureCloseBeforeDelete: true,
-			CloseTransferTaskIdSet:  true,
-			MultiCursorQueue:        false,
-			CloseTaskIsAcked:        false,
-			ShouldDelete:            false,
-		},
-		{
-			Name:                    "single cursor queue acked",
-			EnsureCloseBeforeDelete: true,
-			CloseTransferTaskIdSet:  true,
-			MultiCursorQueue:        false,
-			CloseTaskIsAcked:        true,
-			ShouldDelete:            true,
-		},
-		{
 			Name:                    "multicursor queue unacked",
 			EnsureCloseBeforeDelete: true,
 			CloseTransferTaskIdSet:  true,
-			MultiCursorQueue:        true,
 			CloseTaskIsAcked:        false,
 			ShouldDelete:            false,
 		},
@@ -2550,7 +2532,6 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 			Name:                    "multicursor queue acked",
 			EnsureCloseBeforeDelete: true,
 			CloseTransferTaskIdSet:  true,
-			MultiCursorQueue:        true,
 			CloseTaskIsAcked:        true,
 			ShouldDelete:            true,
 		},
@@ -2599,30 +2580,20 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 			mockNamespaceRegistry := namespace.NewMockRegistry(ctrl)
 			mockNamespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(namespaceEntry, nil)
 			mockShard.EXPECT().GetNamespaceRegistry().Return(mockNamespaceRegistry)
-			if c.MultiCursorQueue {
-				var highWatermarkTaskId int64
-				if c.CloseTaskIsAcked {
-					highWatermarkTaskId = closeTransferTaskId + 1
-				} else {
-					highWatermarkTaskId = closeTransferTaskId
-				}
-				mockShard.EXPECT().GetQueueState(tasks.CategoryTransfer).Return(&persistencespb.QueueState{
-					ReaderStates: nil,
-					ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
-						FireTime: timestamp.TimePtr(tasks.DefaultFireTime),
-						TaskId:   highWatermarkTaskId,
-					},
-				}, true).AnyTimes()
+
+			var highWatermarkTaskId int64
+			if c.CloseTaskIsAcked {
+				highWatermarkTaskId = closeTransferTaskId + 1
 			} else {
-				var ackLevel int64
-				if c.CloseTaskIsAcked {
-					ackLevel = closeTransferTaskId
-				} else {
-					ackLevel = closeTransferTaskId - 1
-				}
-				mockShard.EXPECT().GetQueueState(tasks.CategoryTransfer).Return(nil, false).AnyTimes()
-				mockShard.EXPECT().GetQueueAckLevel(tasks.CategoryTransfer).Return(tasks.NewImmediateKey(ackLevel)).AnyTimes()
+				highWatermarkTaskId = closeTransferTaskId
 			}
+			mockShard.EXPECT().GetQueueState(tasks.CategoryTransfer).Return(&persistencespb.QueueState{
+				ReaderStates: nil,
+				ExclusiveReaderHighWatermark: &persistencespb.TaskKey{
+					FireTime: timestamp.TimePtr(tasks.DefaultFireTime),
+					TaskId:   highWatermarkTaskId,
+				},
+			}, true).AnyTimes()
 
 			mockWorkflowDeleteManager := deletemanager.NewMockDeleteManager(ctrl)
 			if c.ShouldDelete {

--- a/service/history/transferQueueTaskExecutorBase.go
+++ b/service/history/transferQueueTaskExecutorBase.go
@@ -323,8 +323,7 @@ func (t *transferQueueTaskExecutorBase) isCloseExecutionTaskPending(ms workflow.
 	// check if close execution transfer task is completed
 	transferQueueState, ok := t.shard.GetQueueState(tasks.CategoryTransfer)
 	if !ok {
-		transferQueueAckLevel := t.shard.GetQueueAckLevel(tasks.CategoryTransfer).TaskID
-		return closeTransferTaskId > transferQueueAckLevel
+		return true
 	}
 	fakeCloseTransferTask := &tasks.CloseExecutionTask{
 		WorkflowKey: weCtx.GetWorkflowKey(),

--- a/service/history/visibilityQueueTaskExecutor.go
+++ b/service/history/visibilityQueueTaskExecutor.go
@@ -503,9 +503,7 @@ func (t *visibilityQueueTaskExecutor) isCloseExecutionVisibilityTaskPending(task
 	// check if close execution visibility task is completed
 	visibilityQueueState, ok := t.shard.GetQueueState(tasks.CategoryVisibility)
 	if !ok {
-		// !ok means multi-cursor is not available, so we have to revert to using acks
-		visibilityQueueAckLevel := t.shard.GetQueueAckLevel(tasks.CategoryVisibility).TaskID
-		return CloseExecutionVisibilityTaskID > visibilityQueueAckLevel
+		return true
 	}
 	queryTask := &tasks.CloseExecutionVisibilityTask{
 		WorkflowKey: definition.NewWorkflowKey(task.GetNamespaceID(), task.GetWorkflowID(), task.GetRunID()),

--- a/service/history/visibilityQueueTaskExecutor_test.go
+++ b/service/history/visibilityQueueTaskExecutor_test.go
@@ -498,28 +498,6 @@ func (s *visibilityQueueTaskExecutorSuite) TestProcessorDeleteExecution() {
 		})
 		s.Assert().NoError(err)
 	})
-	s.Run("SingleCursorQueue", func() {
-		const ackLevel int64 = 5
-		s.mockShard.Resource.ShardMgr.EXPECT().UpdateShard(gomock.Any(), gomock.Any())
-		s.NoError(s.mockShard.UpdateQueueAckLevel(tasks.CategoryVisibility,
-			tasks.NewImmediateKey(ackLevel),
-		))
-		s.Run("NotAcked", func() {
-			err := s.execute(&tasks.DeleteExecutionVisibilityTask{
-				WorkflowKey:                    workflowKey,
-				CloseExecutionVisibilityTaskID: ackLevel + 1,
-			})
-			s.ErrorIs(err, consts.ErrDependencyTaskNotCompleted)
-		})
-		s.Run("Acked", func() {
-			s.mockVisibilityMgr.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any())
-			err := s.execute(&tasks.DeleteExecutionVisibilityTask{
-				WorkflowKey:                    workflowKey,
-				CloseExecutionVisibilityTaskID: ackLevel - 1,
-			})
-			s.NoError(err)
-		})
-	})
 	s.Run("MultiCursorQueue", func() {
 		const highWatermark int64 = 5
 		s.NoError(s.mockShard.SetQueueState(tasks.CategoryVisibility, &persistencespb.QueueState{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Mostly deprecate queue ack level in favor of queue state
* Additional compatibility logic for forward / backward compatibility
* Use queue state for replication acks
* Allow replication streams between clusters with different shard count

<!-- Tell your future self why have you made these changes -->
**Why?**
N/A

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A