### PR TITLE
Increase shutdown timeout to 5 minutes

### DIFF
--- a/temporal/server.go
+++ b/temporal/server.go
@@ -33,7 +33,7 @@ import (
 const (
 	mismatchLogMessage  = "Supplied configuration key/value mismatches persisted cluster metadata. Continuing with the persisted value as this value cannot be changed once initialized."
 	serviceStartTimeout = time.Duration(15) * time.Second
-	serviceStopTimeout  = time.Duration(60) * time.Second
+	serviceStopTimeout  = time.Duration(5) * time.Minute
 )
 
 type (


### PR DESCRIPTION
**What changed?**
Previously there were two 60s timeouts when shutting down (one for fx and another separately waiting for the grpc services to stop). Now there's one 5 minute timeout.

**Why?**
We might want to set drain durations longer than one or two minutes. Fixes #4192.

**How did you test it?**
Manually for now

**Potential risks**


**Is hotfix candidate?**
