### PR TITLE
Run no-op claim mapper even without auth info

### DIFF
--- a/common/authorization/claim_mapper.go
+++ b/common/authorization/claim_mapper.go
@@ -57,6 +57,13 @@ type ClaimMapper interface {
 
 // @@@SNIPEND
 
+// Normally, GetClaims will never be called without either an auth token or TLS metadata set in
+// AuthInfo. However, if you want your ClaimMapper to be called in all cases, you can implement
+// this additional interface and return false.
+type ClaimMapperWithAuthInfoRequired interface {
+	AuthInfoRequired() bool
+}
+
 // No-op claim mapper that gives system level admin permission to everybody
 type noopClaimMapper struct{}
 
@@ -70,8 +77,9 @@ func (*noopClaimMapper) GetClaims(_ *AuthInfo) (*Claims, error) {
 	return &Claims{System: RoleAdmin}, nil
 }
 
-// tag this implementation to always run even without auth info
-func (*noopClaimMapper) AuthInfoNotRequired() {
+// This implementation can run even without auth info.
+func (*noopClaimMapper) AuthInfoRequired() bool {
+	return false
 }
 
 func GetClaimMapperFromConfig(config *config.Authorization, logger log.Logger) (ClaimMapper, error) {

--- a/common/authorization/claim_mapper.go
+++ b/common/authorization/claim_mapper.go
@@ -68,6 +68,7 @@ type ClaimMapperWithAuthInfoRequired interface {
 type noopClaimMapper struct{}
 
 var _ ClaimMapper = (*noopClaimMapper)(nil)
+var _ ClaimMapperWithAuthInfoRequired = (*noopClaimMapper)(nil)
 
 func NewNoopClaimMapper() ClaimMapper {
 	return &noopClaimMapper{}

--- a/common/authorization/claim_mapper.go
+++ b/common/authorization/claim_mapper.go
@@ -70,6 +70,10 @@ func (*noopClaimMapper) GetClaims(_ *AuthInfo) (*Claims, error) {
 	return &Claims{System: RoleAdmin}, nil
 }
 
+// tag this implementation to always run even without auth info
+func (*noopClaimMapper) AuthInfoNotRequired() {
+}
+
 func GetClaimMapperFromConfig(config *config.Authorization, logger log.Logger) (ClaimMapper, error) {
 
 	switch strings.ToLower(config.ClaimMapper) {

--- a/common/authorization/claim_mapper_mock.go
+++ b/common/authorization/claim_mapper_mock.go
@@ -71,3 +71,40 @@ func (mr *MockClaimMapperMockRecorder) GetClaims(authInfo interface{}) *gomock.C
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClaims", reflect.TypeOf((*MockClaimMapper)(nil).GetClaims), authInfo)
 }
+
+// MockClaimMapperWithAuthInfoRequired is a mock of ClaimMapperWithAuthInfoRequired interface.
+type MockClaimMapperWithAuthInfoRequired struct {
+	ctrl     *gomock.Controller
+	recorder *MockClaimMapperWithAuthInfoRequiredMockRecorder
+}
+
+// MockClaimMapperWithAuthInfoRequiredMockRecorder is the mock recorder for MockClaimMapperWithAuthInfoRequired.
+type MockClaimMapperWithAuthInfoRequiredMockRecorder struct {
+	mock *MockClaimMapperWithAuthInfoRequired
+}
+
+// NewMockClaimMapperWithAuthInfoRequired creates a new mock instance.
+func NewMockClaimMapperWithAuthInfoRequired(ctrl *gomock.Controller) *MockClaimMapperWithAuthInfoRequired {
+	mock := &MockClaimMapperWithAuthInfoRequired{ctrl: ctrl}
+	mock.recorder = &MockClaimMapperWithAuthInfoRequiredMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockClaimMapperWithAuthInfoRequired) EXPECT() *MockClaimMapperWithAuthInfoRequiredMockRecorder {
+	return m.recorder
+}
+
+// AuthInfoRequired mocks base method.
+func (m *MockClaimMapperWithAuthInfoRequired) AuthInfoRequired() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AuthInfoRequired")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// AuthInfoRequired indicates an expected call of AuthInfoRequired.
+func (mr *MockClaimMapperWithAuthInfoRequiredMockRecorder) AuthInfoRequired() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AuthInfoRequired", reflect.TypeOf((*MockClaimMapperWithAuthInfoRequired)(nil).AuthInfoRequired))
+}

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -89,10 +89,13 @@ func (a *interceptor) Interceptor(
 			tlsSubject = &clientCert.Subject
 		}
 
-		_, authInfoNotRequired := a.claimMapper.(interface{ AuthInfoNotRequired() })
+		authInfoRequired := true
+		if cm, ok := a.claimMapper.(ClaimMapperWithAuthInfoRequired); ok {
+			authInfoRequired = cm.AuthInfoRequired()
+		}
 
 		// Add auth info to context only if there's some auth info
-		if tlsSubject != nil || len(authHeaders) > 0 || authInfoNotRequired {
+		if tlsSubject != nil || len(authHeaders) > 0 || !authInfoRequired {
 			var authHeader string
 			var authExtraHeader string
 			var audience string

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -89,8 +89,10 @@ func (a *interceptor) Interceptor(
 			tlsSubject = &clientCert.Subject
 		}
 
+		_, authInfoNotRequired := a.claimMapper.(interface{ AuthInfoNotRequired() })
+
 		// Add auth info to context only if there's some auth info
-		if tlsSubject != nil || len(authHeaders) > 0 {
+		if tlsSubject != nil || len(authHeaders) > 0 || authInfoNotRequired {
 			var authHeader string
 			var authExtraHeader string
 			var audience string


### PR DESCRIPTION
**What changed?**
The no-op claim mapper doesn't require auth info (TLS or authorization header) and should be invoked all the time.

**Why?**
To be able to use internal-frontend without TLS.

**How did you test it?**
unit test

**Potential risks**

**Is hotfix candidate?**
