### PR TITLE
Use GracefulStop in frontend

### DIFF
--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -292,7 +292,13 @@ func (ti *TelemetryInterceptor) handleError(
 	//	*serviceerror.Unavailable:
 	default:
 		metricsHandler.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
-		ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
+
+		// TODO: do this with a proper type comparison
+		skipLog := err.Error() == "Shutting down"
+
+		if !skipLog {
+			ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
+		}
 	}
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -356,8 +356,8 @@ func (s *Service) Stop() {
 	logger.Info("ShutdownHandler: Draining traffic")
 	time.Sleep(requestDrainTime)
 
-	// TODO: Change this to GracefulStop when integration tests are refactored.
-	s.server.Stop()
+	logger.Info("ShutdownHandler: Stopping gRPC server")
+	s.server.GracefulStop()
 
 	if s.metricsHandler != nil {
 		s.metricsHandler.Stop(logger)

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -312,7 +312,7 @@ func (s *workflowHandlerSuite) TestTransientTaskInjection() {
 		s.Run(tc.name, func() {
 			ctx, cancel := context.WithTimeout(context.TODO(), 1*time.Minute)
 			defer cancel()
-			s.mockMatchingClient.EXPECT().PollWorkflowTaskQueue(ctx, gomock.Any()).Return(
+			s.mockMatchingClient.EXPECT().PollWorkflowTaskQueue(gomock.Any(), gomock.Any()).Return(
 				&matchingservice.PollWorkflowTaskQueueResponse{
 					NextEventId: int64(len(baseEvents) + 1),
 					WorkflowExecution: &commonpb.WorkflowExecution{


### PR DESCRIPTION
**What changed?**
- Use GracefulStop in frontend on shutdown to cleanly allow current rpc calls to finish.
- Because long polls are long and we only wait to wait a little while, cancel them on shutdown. This requires keeping a map of current long polls and some more error logic.

**Why?**
Fixes #4202 

**How did you test it?**
Manually, integration tests

**Potential risks**

**Is hotfix candidate?**
