### PR TITLE
Rename some var names in replication stream logic

### DIFF
--- a/client/history/metadata_test.go
+++ b/client/history/metadata_test.go
@@ -71,63 +71,63 @@ func (s *metadataSuite) TearDownTest() {
 }
 
 func (s *metadataSuite) TestClusterShardMD_Encode_Decode() {
-	sourceClusterShardID := ClusterShardID{
-		ClusterName: uuid.NewString(),
-		ShardID:     rand.Int31(),
+	clientClusterShardID := ClusterShardID{
+		ClusterID: rand.Int31(),
+		ShardID:   rand.Int31(),
 	}
-	targetClusterShardID := ClusterShardID{
-		ClusterName: uuid.NewString(),
-		ShardID:     rand.Int31(),
+	serverClusterShardID := ClusterShardID{
+		ClusterID: rand.Int31(),
+		ShardID:   rand.Int31(),
 	}
 
 	clusterShardMD := EncodeClusterShardMD(
-		sourceClusterShardID,
-		targetClusterShardID,
+		clientClusterShardID,
+		serverClusterShardID,
 	)
-	actualSourceClusterShardID, actualTargetClusterShardID, err := DecodeClusterShardMD(clusterShardMD)
+	actualClientClusterShardID, actualServerClusterShardID, err := DecodeClusterShardMD(clusterShardMD)
 	s.NoError(err)
-	s.Equal(sourceClusterShardID, actualSourceClusterShardID)
-	s.Equal(targetClusterShardID, actualTargetClusterShardID)
+	s.Equal(clientClusterShardID, actualClientClusterShardID)
+	s.Equal(serverClusterShardID, actualServerClusterShardID)
 }
 
 func (s *metadataSuite) TestClusterShardMD_Decode_Error() {
 	clusterShardMD := metadata.Pairs(
-		MetadataKeySourceShardID, strconv.Itoa(int(rand.Int31())),
-		MetadataKeyTargetClusterName, uuid.NewString(),
-		MetadataKeyTargetShardID, strconv.Itoa(int(rand.Int31())),
+		MetadataKeyClientShardID, strconv.Itoa(int(rand.Int31())),
+		MetadataKeyServerClusterID, uuid.NewString(),
+		MetadataKeyServerShardID, strconv.Itoa(int(rand.Int31())),
 	)
 	_, _, err := DecodeClusterShardMD(clusterShardMD)
 	s.Error(err)
 
 	clusterShardMD = metadata.Pairs(
-		MetadataKeySourceClusterName, uuid.NewString(),
-		MetadataKeyTargetClusterName, uuid.NewString(),
-		MetadataKeyTargetShardID, strconv.Itoa(int(rand.Int31())),
+		MetadataKeyClientClusterID, uuid.NewString(),
+		MetadataKeyServerClusterID, uuid.NewString(),
+		MetadataKeyServerShardID, strconv.Itoa(int(rand.Int31())),
 	)
 	_, _, err = DecodeClusterShardMD(clusterShardMD)
 	s.Error(err)
 
 	clusterShardMD = metadata.Pairs(
-		MetadataKeySourceClusterName, uuid.NewString(),
-		MetadataKeySourceShardID, strconv.Itoa(int(rand.Int31())),
-		MetadataKeyTargetShardID, strconv.Itoa(int(rand.Int31())),
+		MetadataKeyClientClusterID, uuid.NewString(),
+		MetadataKeyClientShardID, strconv.Itoa(int(rand.Int31())),
+		MetadataKeyServerShardID, strconv.Itoa(int(rand.Int31())),
 	)
 	_, _, err = DecodeClusterShardMD(clusterShardMD)
 	s.Error(err)
 
 	clusterShardMD = metadata.Pairs(
-		MetadataKeySourceClusterName, uuid.NewString(),
-		MetadataKeySourceShardID, strconv.Itoa(int(rand.Int31())),
-		MetadataKeyTargetClusterName, uuid.NewString(),
+		MetadataKeyClientClusterID, uuid.NewString(),
+		MetadataKeyClientShardID, strconv.Itoa(int(rand.Int31())),
+		MetadataKeyServerClusterID, uuid.NewString(),
 	)
 	_, _, err = DecodeClusterShardMD(clusterShardMD)
 	s.Error(err)
 
 	clusterShardMD = metadata.Pairs(
-		MetadataKeySourceClusterName, uuid.NewString(),
-		MetadataKeySourceShardID, uuid.NewString(),
-		MetadataKeyTargetClusterName, uuid.NewString(),
-		MetadataKeyTargetShardID, uuid.NewString(),
+		MetadataKeyClientClusterID, uuid.NewString(),
+		MetadataKeyClientShardID, uuid.NewString(),
+		MetadataKeyServerClusterID, uuid.NewString(),
+		MetadataKeyServerShardID, uuid.NewString(),
 	)
 	_, _, err = DecodeClusterShardMD(clusterShardMD)
 	s.Error(err)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -1868,22 +1868,22 @@ func (h *Handler) StreamWorkflowReplicationMessages(
 	if !ok {
 		return serviceerror.NewInvalidArgument("missing cluster & shard ID metadata")
 	}
-	sourceClusterShardID, targetClusterShardID, err := history.DecodeClusterShardMD(ctxMetadata)
+	clientClusterShardID, serverClusterShardID, err := history.DecodeClusterShardMD(ctxMetadata)
 	if err != nil {
 		return err
 	}
-	if targetClusterShardID.ClusterName != h.clusterMetadata.GetCurrentClusterName() {
+	if serverClusterShardID.ClusterID != int32(h.clusterMetadata.GetClusterID()) {
 		return serviceerror.NewInvalidArgument(fmt.Sprintf(
 			"wrong cluster: target: %v, current: %v",
-			targetClusterShardID.ClusterName,
-			h.clusterMetadata.GetCurrentClusterName(),
+			serverClusterShardID.ClusterID,
+			h.clusterMetadata.GetClusterID(),
 		))
 	}
-	shardContext, err := h.controller.GetShardByID(targetClusterShardID.ShardID)
+	shardContext, err := h.controller.GetShardByID(serverClusterShardID.ShardID)
 	if err != nil {
 		return err
 	}
-	return replicationapi.StreamReplicationTasks(server, shardContext, sourceClusterShardID, targetClusterShardID)
+	return replicationapi.StreamReplicationTasks(server, shardContext, clientClusterShardID, serverClusterShardID)
 }
 
 // convertError is a helper method to convert ShardOwnershipLostError from persistence layer returned by various

--- a/service/history/replication/stream_receiver_monitor_test.go
+++ b/service/history/replication/stream_receiver_monitor_test.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
-	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -53,8 +52,8 @@ type (
 		controller *gomock.Controller
 		clientBean *client.MockBean
 
-		sourceCluster string
-		targetCluster string
+		clientClusterID int32
+		serverClusterID int32
 
 		streamReceiverMonitor *StreamReceiverMonitorImpl
 	}
@@ -79,8 +78,8 @@ func (s *streamReceiverMonitorSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.clientBean = client.NewMockBean(s.controller)
 
-	s.sourceCluster = uuid.NewString()
-	s.targetCluster = uuid.NewString()
+	s.clientClusterID = rand.Int31()
+	s.serverClusterID = rand.Int31()
 
 	s.streamReceiverMonitor = NewStreamReceiverMonitor(
 		ProcessToolBox{
@@ -108,7 +107,7 @@ func (s *streamReceiverMonitorSuite) SetupTest() {
 	}, nil).AnyTimes()
 	adminClient := adminservicemock.NewMockAdminServiceClient(s.controller)
 	adminClient.EXPECT().StreamWorkflowReplicationMessages(gomock.Any()).Return(streamClient, nil).AnyTimes()
-	s.clientBean.EXPECT().GetRemoteAdminClient(s.targetCluster).Return(adminClient, nil).AnyTimes()
+	s.clientBean.EXPECT().GetRemoteAdminClient(s.serverClusterID).Return(adminClient, nil).AnyTimes()
 }
 
 func (s *streamReceiverMonitorSuite) TearDownTest() {
@@ -116,15 +115,15 @@ func (s *streamReceiverMonitorSuite) TearDownTest() {
 
 	s.streamReceiverMonitor.Lock()
 	defer s.streamReceiverMonitor.Unlock()
-	for targetKey, stream := range s.streamReceiverMonitor.streams {
+	for serverKey, stream := range s.streamReceiverMonitor.streams {
 		stream.Stop()
-		delete(s.streamReceiverMonitor.streams, targetKey)
+		delete(s.streamReceiverMonitor.streams, serverKey)
 	}
 }
 
-func (s *streamReceiverMonitorSuite) TestReconcileToTargetStreams_Add() {
-	sourceKey := NewClusterShardKey(s.sourceCluster, rand.Int31())
-	targetKey := NewClusterShardKey(s.targetCluster, rand.Int31())
+func (s *streamReceiverMonitorSuite) TestDoReconcileStreams_Add() {
+	clientKey := NewClusterShardKey(s.clientClusterID, rand.Int31())
+	serverKey := NewClusterShardKey(s.serverClusterID, rand.Int31())
 
 	s.streamReceiverMonitor.Lock()
 	s.Equal(0, len(s.streamReceiverMonitor.streams))
@@ -132,39 +131,39 @@ func (s *streamReceiverMonitorSuite) TestReconcileToTargetStreams_Add() {
 
 	streamKeys := map[ClusterShardKeyPair]struct{}{
 		ClusterShardKeyPair{
-			Source: sourceKey,
-			Target: targetKey,
+			Client: clientKey,
+			Server: serverKey,
 		}: {},
 	}
-	s.streamReceiverMonitor.reconcileToTargetStreams(streamKeys)
+	s.streamReceiverMonitor.doReconcileStreams(streamKeys)
 
 	s.streamReceiverMonitor.Lock()
 	defer s.streamReceiverMonitor.Unlock()
 	s.Equal(1, len(s.streamReceiverMonitor.streams))
 	stream, ok := s.streamReceiverMonitor.streams[ClusterShardKeyPair{
-		Source: sourceKey,
-		Target: targetKey,
+		Client: clientKey,
+		Server: serverKey,
 	}]
 	s.True(ok)
 	s.True(stream.IsValid())
 }
 
-func (s *streamReceiverMonitorSuite) TestReconcileToTargetStreams_Remove() {
-	sourceKey := NewClusterShardKey(s.sourceCluster, rand.Int31())
-	targetKey := NewClusterShardKey(s.targetCluster, rand.Int31())
-	stream := NewStreamReceiver(s.streamReceiverMonitor.ProcessToolBox, sourceKey, targetKey)
+func (s *streamReceiverMonitorSuite) TestDoReconcileStreams_Remove() {
+	clientKey := NewClusterShardKey(s.clientClusterID, rand.Int31())
+	serverKey := NewClusterShardKey(s.serverClusterID, rand.Int31())
+	stream := NewStreamReceiver(s.streamReceiverMonitor.ProcessToolBox, clientKey, serverKey)
 
 	s.streamReceiverMonitor.Lock()
 	s.Equal(0, len(s.streamReceiverMonitor.streams))
 	stream.Start()
 	s.True(stream.IsValid())
 	s.streamReceiverMonitor.streams[ClusterShardKeyPair{
-		Source: sourceKey,
-		Target: targetKey,
+		Client: clientKey,
+		Server: serverKey,
 	}] = stream
 	s.streamReceiverMonitor.Unlock()
 
-	s.streamReceiverMonitor.reconcileToTargetStreams(map[ClusterShardKeyPair]struct{}{})
+	s.streamReceiverMonitor.doReconcileStreams(map[ClusterShardKeyPair]struct{}{})
 
 	s.streamReceiverMonitor.Lock()
 	defer s.streamReceiverMonitor.Unlock()
@@ -172,10 +171,10 @@ func (s *streamReceiverMonitorSuite) TestReconcileToTargetStreams_Remove() {
 	s.False(stream.IsValid())
 }
 
-func (s *streamReceiverMonitorSuite) TestReconcileToTargetStreams_Reactivate() {
-	sourceKey := NewClusterShardKey(s.sourceCluster, rand.Int31())
-	targetKey := NewClusterShardKey(s.targetCluster, rand.Int31())
-	stream := NewStreamReceiver(s.streamReceiverMonitor.ProcessToolBox, sourceKey, targetKey)
+func (s *streamReceiverMonitorSuite) TestDoReconcileStreams_Reactivate() {
+	clientKey := NewClusterShardKey(s.clientClusterID, rand.Int31())
+	serverKey := NewClusterShardKey(s.serverClusterID, rand.Int31())
+	stream := NewStreamReceiver(s.streamReceiverMonitor.ProcessToolBox, clientKey, serverKey)
 
 	s.streamReceiverMonitor.Lock()
 	s.Equal(0, len(s.streamReceiverMonitor.streams))
@@ -183,15 +182,15 @@ func (s *streamReceiverMonitorSuite) TestReconcileToTargetStreams_Reactivate() {
 	stream.Stop()
 	s.False(stream.IsValid())
 	s.streamReceiverMonitor.streams[ClusterShardKeyPair{
-		Source: sourceKey,
-		Target: targetKey,
+		Client: clientKey,
+		Server: serverKey,
 	}] = stream
 	s.streamReceiverMonitor.Unlock()
 
-	s.streamReceiverMonitor.reconcileToTargetStreams(map[ClusterShardKeyPair]struct{}{
+	s.streamReceiverMonitor.doReconcileStreams(map[ClusterShardKeyPair]struct{}{
 		ClusterShardKeyPair{
-			Source: sourceKey,
-			Target: targetKey,
+			Client: clientKey,
+			Server: serverKey,
 		}: {},
 	})
 
@@ -199,8 +198,8 @@ func (s *streamReceiverMonitorSuite) TestReconcileToTargetStreams_Reactivate() {
 	defer s.streamReceiverMonitor.Unlock()
 	s.Equal(1, len(s.streamReceiverMonitor.streams))
 	stream, ok := s.streamReceiverMonitor.streams[ClusterShardKeyPair{
-		Source: sourceKey,
-		Target: targetKey,
+		Client: clientKey,
+		Server: serverKey,
 	}]
 	s.True(ok)
 	s.True(stream.IsValid())


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Rename source cluster key to client cluster key
* Rename target cluster key to server cluster key

<!-- Tell your future self why have you made these changes -->
**Why?**
Before this PR:
source cluster key means the source of the stream, but this usually means the target of replication data flow;
target cluster key means the target of the stream, but this usually means the source of replication data flow;
the meaning can be misleading

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A