### PR TITLE
Add dynamic config flag to disable worker versioning

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -115,6 +115,8 @@ const (
 	DeadlockInterval = "system.deadlock.Interval"
 	// How many extra goroutines can be created per root.
 	DeadlockMaxWorkersPerRoot = "system.deadlock.MaxWorkersPerRoot"
+	// Enable / disable worker versioning.
+	EnableWorkerVersioning = "system.workerVersioning.enable"
 
 	// keys for size limit
 

--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -117,4 +117,5 @@ var (
 	errBatchOpsMaxWorkflowExecutionCount = serviceerror.NewInvalidArgument("Workflow executions count exceeded.")
 
 	errUpdateWorkflowExecutionAPINotAllowed = serviceerror.NewPermissionDenied("UpdateWorkflowExecution operation is disabled on this namespace.", "")
+	errWorkerVersioningNotAllowed           = serviceerror.NewPermissionDenied("Worker versioning operations is disabled on this namespace.", "")
 )

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -164,6 +164,7 @@ type Config struct {
 	MaxExecutionCountBatchOperation dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	EnableUpdateWorkflowExecution dynamicconfig.BoolPropertyFnWithNamespaceFilter
+	EnableWorkerVersioning        dynamicconfig.BoolPropertyFnWithNamespaceFilter
 }
 
 // NewConfig returns new service config with default values
@@ -238,6 +239,7 @@ func NewConfig(
 		MaxExecutionCountBatchOperation: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxExecutionCountBatchOperationPerNamespace, 1000),
 
 		EnableUpdateWorkflowExecution: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableUpdateWorkflowExecution, false),
+		EnableWorkerVersioning:        dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.EnableWorkerVersioning, false),
 	}
 }
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3699,6 +3699,10 @@ func (wh *WorkflowHandler) UpdateWorkerBuildIdCompatibility(ctx context.Context,
 		return nil, errRequestNotSet
 	}
 
+	if !wh.config.EnableWorkerVersioning(request.Namespace) {
+		return nil, errWorkerVersioningNotAllowed
+	}
+
 	if err := wh.validateBuildIdCompatibilityUpdate(request); err != nil {
 		return nil, err
 	}
@@ -3733,6 +3737,10 @@ func (wh *WorkflowHandler) GetWorkerBuildIdCompatibility(ctx context.Context, re
 
 	if request == nil {
 		return nil, errRequestNotSet
+	}
+
+	if !wh.config.EnableWorkerVersioning(request.Namespace) {
+		return nil, errWorkerVersioningNotAllowed
 	}
 
 	if err := wh.validateTaskQueue(&taskqueuepb.TaskQueue{Name: request.GetTaskQueue(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL}); err != nil {

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -56,6 +56,7 @@ type versioningIntegSuite struct {
 func (s *versioningIntegSuite) SetupSuite() {
 	s.dynamicConfigOverrides = make(map[dynamicconfig.Key]interface{})
 	s.dynamicConfigOverrides[dynamicconfig.MatchingUpdateAckInterval] = 1 * time.Second
+	s.dynamicConfigOverrides[dynamicconfig.EnableWorkerVersioning] = true
 	s.setupSuite("testdata/integration_test_cluster.yaml")
 }
 


### PR DESCRIPTION
The feature is not ready yet and once it is, we'll still need a safe way to roll it out, hence this feature flag.