### PR TITLE
Copy build id to binary checksum when present

### DIFF
--- a/service/frontend/errors.go
+++ b/service/frontend/errors.go
@@ -81,6 +81,7 @@ var (
 	errCronAndStartDelaySet                               = serviceerror.NewInvalidArgument("CronSchedule and WorkflowStartDelay may not be used together.")
 	errInvalidWorkflowStartDelaySeconds                   = serviceerror.NewInvalidArgument("An invalid WorkflowStartDelaySeconds is set on request.")
 	errRaceConditionAddingSearchAttributes                = serviceerror.NewUnavailable("Generated search attributes mapping unavailble.")
+	errUseVersioningWithoutBuildID                        = serviceerror.NewInvalidArgument("WorkerVersionStamp must be present if UseVersioning is true.")
 
 	errUpdateMetaNotSet       = serviceerror.NewInvalidArgument("Update meta is not set on request.")
 	errUpdateInputNotSet      = serviceerror.NewInvalidArgument("Update input is not set on request.")

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -884,6 +884,14 @@ func (wh *WorkflowHandler) PollWorkflowTaskQueue(ctx context.Context, request *w
 	}
 	namespaceID := namespaceEntry.ID()
 
+	// Copy WorkerVersionCapabilities.BuildId to BinaryChecksum if BinaryChecksum is missing (small
+	// optimization to save space in the poll request).
+	if request.WorkerVersionCapabilities != nil {
+		if len(request.WorkerVersionCapabilities.BuildId) > 0 && len(request.BinaryChecksum) == 0 {
+			request.BinaryChecksum = request.WorkerVersionCapabilities.BuildId
+		}
+	}
+
 	wh.logger.Debug("Poll workflow task queue.", tag.WorkflowNamespace(namespaceEntry.Name().String()), tag.WorkflowNamespaceID(namespaceID.String()))
 	if err := wh.checkBadBinary(namespaceEntry, request.GetBinaryChecksum()); err != nil {
 		return nil, err

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -532,13 +532,19 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskCompletedEvent(
 		m.ms.hBuilder.FlushAndCreateNewBatch()
 		workflowTask.StartedEventID = startedEvent.GetEventId()
 	}
+
 	// Now write the completed event
+	versionStamp := request.WorkerVersionStamp
+	if !request.UseVersioning {
+		versionStamp = nil
+	}
+	// TODO: omit BinaryChecksum if version stamp is present and matches BinaryChecksum
 	event := m.ms.hBuilder.AddWorkflowTaskCompletedEvent(
 		workflowTask.ScheduledEventID,
 		workflowTask.StartedEventID,
 		request.Identity,
 		request.BinaryChecksum,
-		request.WorkerVersionStamp,
+		versionStamp,
 		request.SdkMetadata,
 		request.MeteringMetadata,
 	)

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -405,6 +405,13 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		return nil, serviceerror.NewNotFound("Workflow task not found.")
 	}
 
+	// It's an error if the workflow has used versioning in the past but this task has no versioning info.
+	if ms.GetWorkerVersionStamp() != nil {
+		if !request.UseVersioning || len(request.WorkerVersionStamp.GetBuildId()) == 0 {
+			return nil, serviceerror.NewInvalidArgument("Workflow using versioning must continue to use versioning.")
+		}
+	}
+
 	maxResetPoints := handler.config.MaxAutoResetPoints(namespaceEntry.Name().String())
 	if ms.GetExecutionInfo().AutoResetPoints != nil && maxResetPoints == len(ms.GetExecutionInfo().AutoResetPoints.Points) {
 		handler.metricsHandler.Counter(metrics.AutoResetPointsLimitExceededCounter.GetMetricName()).Record(

--- a/service/matching/version_sets.go
+++ b/service/matching/version_sets.go
@@ -25,13 +25,11 @@
 package matching
 
 import (
-	"encoding/binary"
 	"fmt"
 
 	"crypto/sha256"
 	"encoding/base64"
 
-	"github.com/dgryski/go-farm"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
@@ -57,21 +55,6 @@ func ToBuildIdOrderingResponse(data *persistence.VersioningData, maxSets int) *w
 		versionSets[i] = &taskqueue.CompatibleVersionSet{BuildIds: buildIds}
 	}
 	return &workflowservice.GetWorkerBuildIdCompatibilityResponse{MajorVersionSets: versionSets}
-}
-
-// HashVersioningData returns a farm.Fingerprint64 hash of the versioning data as bytes. If the data is nonexistent or
-// invalid, returns nil.
-func HashVersioningData(data *persistence.VersioningData) []byte {
-	if data == nil || data.GetVersionSets() == nil {
-		return nil
-	}
-	asBytes, err := data.Marshal()
-	if err != nil {
-		return nil
-	}
-	b := make([]byte, 8)
-	binary.LittleEndian.PutUint64(b, farm.Fingerprint64(asBytes))
-	return b
 }
 
 func checkLimits(g *persistence.VersioningData, maxSets, maxBuildIDs int) error {


### PR DESCRIPTION
**What changed?**
- Copy build id to binary checksum when present
- Respect `use_versioning` for RespondWFTCompleted
- Enforce continuing to provide build id
- Remove some unused code

**Why?**
Implement more of the feature

**How did you test it?**
Will be tested with overall feature tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
