### PR TITLE
Support prometheus prefix and tags in docker config template

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -279,6 +279,16 @@ global:
             prefix: "temporal"
     {{- else if .Env.PROMETHEUS_ENDPOINT }}
     metrics:
+        {{- if .Env.PROMETHEUS_PREFIX }}
+        prefix: {{ .Env.PROMETHEUS_PREFIX }}
+        {{- end }}
+        {{- if and (.Env.PROMETHEUS_TAGS_KEY1) (.Env.PROMETHEUS_TAGS_VALUE1) }}
+        tags:
+          {{ .Env.PROMETHEUS_TAGS_KEY1 }}: {{ .Env.PROMETHEUS_TAGS_VALUE1 }}
+          {{- if and .Env.PROMETHEUS_TAGS_KEY2 .Env.PROMETHEUS_TAGS_VALUE2 }}
+          {{ .Env.PROMETHEUS_TAGS_KEY2 }}: {{ .Env.PROMETHEUS_TAGS_VALUE2 }}
+          {{- end }}
+        {{- end}}
         prometheus:
             timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
             listenAddress: "{{ .Env.PROMETHEUS_ENDPOINT }}"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->

Added an option to set Prometheus prefix and tags (two at the moment) in the docker config template using environment variables.
It won't affect current users as it keeps the current behaviour which is having no Prometheus prefix and tags defined in this template.

**Why?**

There's no way to set Prometheus prefix and tags when using the default docker config template.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Local build, and tested.

**Potential risks**

No.

**Is hotfix candidate?**

No.