### PR TITLE
defaultJWTClaimMapper treat namespace as case sensitive

### DIFF
--- a/common/authorization/default_jwt_claim_mapper.go
+++ b/common/authorization/default_jwt_claim_mapper.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/golang-jwt/jwt/v4"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/primitives"
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
@@ -40,7 +41,7 @@ const (
 	defaultPermissionsClaimName = "permissions"
 	authorizationBearer         = "bearer"
 	headerSubject               = "sub"
-	permissionScopeSystem       = "system"
+	permissionScopeSystem       = primitives.SystemLocalNamespace
 	permissionRead              = "read"
 	permissionWrite             = "write"
 	permissionWorker            = "worker"
@@ -110,8 +111,8 @@ func (a *defaultJWTClaimMapper) extractPermissions(permissions []interface{}, cl
 			a.logger.Warn(fmt.Sprintf("ignoring permission in unexpected format: %v", permission))
 			continue
 		}
-		namespace := strings.ToLower(parts[0])
-		if strings.EqualFold(namespace, permissionScopeSystem) {
+		namespace := parts[0]
+		if namespace == permissionScopeSystem {
 			claims.System |= permissionToRole(parts[1])
 		} else {
 			if claims.Namespaces == nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change defaultJWTClaimMapper treat namespace as case sensitive.
Change system namespace from `system` to `temporal-system` and make it case sensitive.

<!-- Tell your future self why have you made these changes -->
**Why?**
Namespace in temporal is case sensitive.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If the JWT generator produce token using case insensitive namespace name, that will not work with this change.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No