### PR TITLE
Refactor fx Start/Stop usage

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -75,6 +75,7 @@ import (
 type (
 	ServicesGroupOut struct {
 		fx.Out
+
 		Services *ServicesMetadata `group:"services"`
 	}
 
@@ -119,13 +120,14 @@ type (
 		AudienceGetter         authorization.JWTAudienceMapper
 
 		// below are things that could be over write by server options or may have default if not supplied by serverOptions.
-		Logger                log.Logger
-		ClientFactoryProvider client.FactoryProvider
-		DynamicConfigClient   dynamicconfig.Client
-		TLSConfigProvider     encryption.TLSConfigProvider
-		EsConfig              *esclient.Config
-		EsClient              esclient.Client
-		MetricsHandler        metrics.Handler
+		Logger                  log.Logger
+		ClientFactoryProvider   client.FactoryProvider
+		DynamicConfigClient     dynamicconfig.Client
+		DynamicConfigCollection *dynamicconfig.Collection
+		TLSConfigProvider       encryption.TLSConfigProvider
+		EsConfig                *esclient.Config
+		EsClient                esclient.Client
+		MetricsHandler          metrics.Handler
 	}
 )
 
@@ -268,13 +270,14 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 		ClaimMapper:            so.claimMapper,
 		AudienceGetter:         so.audienceGetter,
 
-		Logger:                logger,
-		ClientFactoryProvider: clientFactoryProvider,
-		DynamicConfigClient:   dcClient,
-		TLSConfigProvider:     tlsConfigProvider,
-		EsConfig:              esConfig,
-		EsClient:              esClient,
-		MetricsHandler:        metricHandler,
+		Logger:                  logger,
+		ClientFactoryProvider:   clientFactoryProvider,
+		DynamicConfigClient:     dcClient,
+		DynamicConfigCollection: dynamicconfig.NewCollection(dcClient, logger),
+		TLSConfigProvider:       tlsConfigProvider,
+		EsConfig:                esConfig,
+		EsClient:                esClient,
+		MetricsHandler:          metricHandler,
 	}, nil
 }
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -78,7 +78,6 @@ type (
 
 	ServicesGroupOut struct {
 		fx.Out
-
 		Services *ServicesMetadata `group:"services"`
 	}
 
@@ -119,14 +118,13 @@ type (
 		AudienceGetter         authorization.JWTAudienceMapper
 
 		// below are things that could be over write by server options or may have default if not supplied by serverOptions.
-		Logger                  log.Logger
-		ClientFactoryProvider   client.FactoryProvider
-		DynamicConfigClient     dynamicconfig.Client
-		DynamicConfigCollection *dynamicconfig.Collection
-		TLSConfigProvider       encryption.TLSConfigProvider
-		EsConfig                *esclient.Config
-		EsClient                esclient.Client
-		MetricsHandler          metrics.Handler
+		Logger                log.Logger
+		ClientFactoryProvider client.FactoryProvider
+		DynamicConfigClient   dynamicconfig.Client
+		TLSConfigProvider     encryption.TLSConfigProvider
+		EsConfig              *esclient.Config
+		EsClient              esclient.Client
+		MetricsHandler        metrics.Handler
 	}
 )
 
@@ -264,14 +262,13 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 		ClaimMapper:            so.claimMapper,
 		AudienceGetter:         so.audienceGetter,
 
-		Logger:                  logger,
-		ClientFactoryProvider:   clientFactoryProvider,
-		DynamicConfigClient:     dcClient,
-		DynamicConfigCollection: dynamicconfig.NewCollection(dcClient, logger),
-		TLSConfigProvider:       tlsConfigProvider,
-		EsConfig:                esConfig,
-		EsClient:                esClient,
-		MetricsHandler:          metricHandler,
+		Logger:                logger,
+		ClientFactoryProvider: clientFactoryProvider,
+		DynamicConfigClient:   dcClient,
+		TLSConfigProvider:     tlsConfigProvider,
+		EsConfig:              esConfig,
+		EsClient:              esClient,
+		MetricsHandler:        metricHandler,
 	}, nil
 }
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -316,7 +316,7 @@ func (svc *ServicesMetadata) Stop(ctx context.Context) {
 	select {
 	case <-svc.stopChan:
 	case <-stopCtx.Done():
-		logger.Error("Timed out waiting for service to stop", tag.Service(svcName), tag.NewDurationTag("timeout", serviceStopTimeout))
+		svc.logger.Error("Timed out waiting for service to stop", tag.Service(svc.serviceName), tag.NewDurationTag("timeout", serviceStopTimeout))
 	}
 }
 

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -34,7 +34,6 @@ import (
 
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
@@ -51,8 +50,6 @@ type (
 		stoppedCh        chan interface{}
 		logger           log.Logger
 		namespaceLogger  resource.NamespaceLogger
-
-		dcCollection *dynamicconfig.Collection
 
 		persistenceConfig          config.Persistence
 		clusterMetadata            *cluster.Config
@@ -71,7 +68,6 @@ func NewServerFxImpl(
 	logger log.Logger,
 	namespaceLogger resource.NamespaceLogger,
 	stoppedCh chan interface{},
-	dcCollection *dynamicconfig.Collection,
 	servicesGroup ServicesGroupIn,
 	persistenceConfig config.Persistence,
 	clusterMetadata *cluster.Config,
@@ -83,7 +79,6 @@ func NewServerFxImpl(
 		stoppedCh:                  stoppedCh,
 		logger:                     logger,
 		namespaceLogger:            namespaceLogger,
-		dcCollection:               dcCollection,
 		persistenceConfig:          persistenceConfig,
 		clusterMetadata:            clusterMetadata,
 		persistenceFactoryProvider: persistenceFactoryProvider,

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -33,6 +33,7 @@ import (
 
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
@@ -50,6 +51,8 @@ type (
 		logger           log.Logger
 		namespaceLogger  resource.NamespaceLogger
 
+		dcCollection *dynamicconfig.Collection
+
 		persistenceConfig          config.Persistence
 		clusterMetadata            *cluster.Config
 		persistenceFactoryProvider persistenceClient.FactoryProviderFn
@@ -62,6 +65,7 @@ func NewServerFxImpl(
 	logger log.Logger,
 	namespaceLogger resource.NamespaceLogger,
 	stoppedCh chan interface{},
+	dcCollection *dynamicconfig.Collection,
 	servicesGroup ServicesGroupIn,
 	persistenceConfig config.Persistence,
 	clusterMetadata *cluster.Config,
@@ -72,6 +76,7 @@ func NewServerFxImpl(
 		stoppedCh:                  stoppedCh,
 		logger:                     logger,
 		namespaceLogger:            namespaceLogger,
+		dcCollection:               dcCollection,
 		persistenceConfig:          persistenceConfig,
 		clusterMetadata:            clusterMetadata,
 		persistenceFactoryProvider: persistenceFactoryProvider,

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"sync"
 
-	"go.uber.org/fx"
 	"go.uber.org/multierr"
 
 	"go.temporal.io/server/common/cluster"
@@ -57,11 +56,6 @@ type (
 	}
 )
 
-var ServerFxImplModule = fx.Options(
-	fx.Provide(NewServerFxImpl),
-	fx.Provide(func(src *ServerImpl) Server { return src }),
-)
-
 // NewServerFxImpl returns a new instance of server that serves one or many services.
 func NewServerFxImpl(
 	opts *serverOptions,
@@ -75,7 +69,6 @@ func NewServerFxImpl(
 ) *ServerImpl {
 	s := &ServerImpl{
 		so:                         opts,
-		servicesMetadata:           servicesGroup.Services,
 		stoppedCh:                  stoppedCh,
 		logger:                     logger,
 		namespaceLogger:            namespaceLogger,
@@ -83,16 +76,17 @@ func NewServerFxImpl(
 		clusterMetadata:            clusterMetadata,
 		persistenceFactoryProvider: persistenceFactoryProvider,
 	}
+	for _, svcMeta := range servicesGroup.Services {
+		if svcMeta != nil {
+			s.servicesMetadata = append(s.servicesMetadata, svcMeta)
+		}
+	}
 	return s
 }
 
-// Start temporal server.
-// This function should be called only once, Server doesn't support multiple restarts.
-func (s *ServerImpl) Start() error {
+func (s *ServerImpl) Start(ctx context.Context) error {
 	s.logger.Info("Starting server for services", tag.Value(s.so.serviceNames))
 	s.logger.Debug(s.so.config.String())
-
-	ctx := context.TODO()
 
 	if err := initSystemNamespaces(
 		ctx,
@@ -106,29 +100,17 @@ func (s *ServerImpl) Start() error {
 		return fmt.Errorf("unable to initialize system namespace: %w", err)
 	}
 
-	if err := s.startServices(); err != nil {
-		return err
-	}
-
-	if s.so.blockingStart {
-		// If s.so.interruptCh is nil this will wait forever.
-		interruptSignal := <-s.so.interruptCh
-		s.logger.Info("Received interrupt signal, stopping the server.", tag.Value(interruptSignal))
-		return s.Stop()
-	}
-
-	return nil
+	return s.startServices()
 }
 
-// Stop stops the server.
-func (s *ServerImpl) Stop() error {
+func (s *ServerImpl) Stop(ctx context.Context) error {
 	var wg sync.WaitGroup
 	wg.Add(len(s.servicesMetadata))
 	close(s.stoppedCh)
 
 	for _, svcMeta := range s.servicesMetadata {
 		go func(svc *ServicesMetadata) {
-			svc.ServiceStopFn()
+			svc.Stop(ctx)
 			wg.Done()
 		}(svcMeta)
 	}
@@ -150,7 +132,7 @@ func (s *ServerImpl) startServices() error {
 	results := make(chan startServiceResult, len(s.servicesMetadata))
 	for _, svcMeta := range s.servicesMetadata {
 		go func(svcMeta *ServicesMetadata) {
-			err := svcMeta.App.Start(ctx)
+			err := svcMeta.app.Start(ctx)
 			results <- startServiceResult{
 				svc: svcMeta,
 				err: err,
@@ -161,10 +143,10 @@ func (s *ServerImpl) startServices() error {
 }
 
 func (s *ServerImpl) readResults(results chan startServiceResult) (err error) {
-	for i := 0; i < len(s.servicesMetadata); i++ {
+	for range s.servicesMetadata {
 		r := <-results
 		if r.err != nil {
-			err = multierr.Combine(err, fmt.Errorf("failed to start service %v: %w", r.svc.ServiceName, r.err))
+			err = multierr.Combine(err, fmt.Errorf("failed to start service %v: %w", r.svc.serviceName, r.err))
 		}
 	}
 	return

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -79,8 +79,8 @@ func ForServices(names []string) ServerOption {
 // InterruptOn interrupts server on the signal from server. If channel is nil Start() will block forever.
 func InterruptOn(interruptCh <-chan interface{}) ServerOption {
 	return applyFunc(func(s *serverOptions) {
-		s.blockingStart.blockingStart = true
-		s.blockingStart.interruptCh = interruptCh
+		s.startupSynchronizationMode.blockingStart = true
+		s.startupSynchronizationMode.interruptCh = interruptCh
 	})
 }
 

--- a/temporal/server_option.go
+++ b/temporal/server_option.go
@@ -79,8 +79,8 @@ func ForServices(names []string) ServerOption {
 // InterruptOn interrupts server on the signal from server. If channel is nil Start() will block forever.
 func InterruptOn(interruptCh <-chan interface{}) ServerOption {
 	return applyFunc(func(s *serverOptions) {
-		s.blockingStart = true
-		s.interruptCh = interruptCh
+		s.blockingStart.blockingStart = true
+		s.blockingStart.interruptCh = interruptCh
 	})
 }
 

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -45,9 +45,9 @@ import (
 )
 
 type (
-	blockingStartParams struct {
-		interruptCh   <-chan interface{}
+	synchronizationModeParams struct {
 		blockingStart bool
+		interruptCh   <-chan interface{}
 	}
 
 	serverOptions struct {
@@ -58,7 +58,7 @@ type (
 		env       string
 		zone      string
 
-		blockingStart blockingStartParams
+		startupSynchronizationMode synchronizationModeParams
 
 		logger                     log.Logger
 		namespaceLogger            log.Logger

--- a/temporal/server_options.go
+++ b/temporal/server_options.go
@@ -45,6 +45,11 @@ import (
 )
 
 type (
+	blockingStartParams struct {
+		interruptCh   <-chan interface{}
+		blockingStart bool
+	}
+
 	serverOptions struct {
 		serviceNames map[primitives.ServiceName]struct{}
 
@@ -53,8 +58,7 @@ type (
 		env       string
 		zone      string
 
-		interruptCh   <-chan interface{}
-		blockingStart bool
+		blockingStart blockingStartParams
 
 		logger                     log.Logger
 		namespaceLogger            log.Logger


### PR DESCRIPTION
**What changed?**
- Move blocking start outside of fx lifecycle hook
- Propagate outer app Start/Stop context to inner Apps (currently just Background)
- Refactor StopService into proper method
- Other small cleanups

This leaves the shutdown timeout in the inner Apps: if we set a single timeout on the outer one, fx itself might abort shutdown and not give the inner ones time to finish, so I think it's more robust this way.

**Why?**
Simplify and correct usage of fx

**How did you test it?**
Local testing, integration tests

**Potential risks**


**Is hotfix candidate?**
