### PR TITLE
Remove unused dynamicconfig.Collection in top level fx container

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -77,7 +77,6 @@ type (
 
 	ServicesGroupOut struct {
 		fx.Out
-
 		Services *ServicesMetadata `group:"services"`
 	}
 
@@ -118,14 +117,13 @@ type (
 		AudienceGetter         authorization.JWTAudienceMapper
 
 		// below are things that could be over write by server options or may have default if not supplied by serverOptions.
-		Logger                  log.Logger
-		ClientFactoryProvider   client.FactoryProvider
-		DynamicConfigClient     dynamicconfig.Client
-		DynamicConfigCollection *dynamicconfig.Collection
-		TLSConfigProvider       encryption.TLSConfigProvider
-		EsConfig                *esclient.Config
-		EsClient                esclient.Client
-		MetricsHandler          metrics.Handler
+		Logger                log.Logger
+		ClientFactoryProvider client.FactoryProvider
+		DynamicConfigClient   dynamicconfig.Client
+		TLSConfigProvider     encryption.TLSConfigProvider
+		EsConfig              *esclient.Config
+		EsClient              esclient.Client
+		MetricsHandler        metrics.Handler
 	}
 )
 
@@ -263,14 +261,13 @@ func ServerOptionsProvider(opts []ServerOption) (serverOptionsProvider, error) {
 		ClaimMapper:            so.claimMapper,
 		AudienceGetter:         so.audienceGetter,
 
-		Logger:                  logger,
-		ClientFactoryProvider:   clientFactoryProvider,
-		DynamicConfigClient:     dcClient,
-		DynamicConfigCollection: dynamicconfig.NewCollection(dcClient, logger),
-		TLSConfigProvider:       tlsConfigProvider,
-		EsConfig:                esConfig,
-		EsClient:                esClient,
-		MetricsHandler:          metricHandler,
+		Logger:                logger,
+		ClientFactoryProvider: clientFactoryProvider,
+		DynamicConfigClient:   dcClient,
+		TLSConfigProvider:     tlsConfigProvider,
+		EsConfig:              esConfig,
+		EsClient:              esClient,
+		MetricsHandler:        metricHandler,
 	}, nil
 }
 

--- a/temporal/server_impl.go
+++ b/temporal/server_impl.go
@@ -34,7 +34,6 @@ import (
 
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	persistenceClient "go.temporal.io/server/common/persistence/client"
@@ -51,8 +50,6 @@ type (
 		stoppedCh        chan interface{}
 		logger           log.Logger
 		namespaceLogger  resource.NamespaceLogger
-
-		dcCollection *dynamicconfig.Collection
 
 		persistenceConfig          config.Persistence
 		clusterMetadata            *cluster.Config
@@ -71,7 +68,6 @@ func NewServerFxImpl(
 	logger log.Logger,
 	namespaceLogger resource.NamespaceLogger,
 	stoppedCh chan interface{},
-	dcCollection *dynamicconfig.Collection,
 	servicesGroup ServicesGroupIn,
 	persistenceConfig config.Persistence,
 	clusterMetadata *cluster.Config,
@@ -83,7 +79,6 @@ func NewServerFxImpl(
 		stoppedCh:                  stoppedCh,
 		logger:                     logger,
 		namespaceLogger:            namespaceLogger,
-		dcCollection:               dcCollection,
 		persistenceConfig:          persistenceConfig,
 		clusterMetadata:            clusterMetadata,
 		persistenceFactoryProvider: persistenceFactoryProvider,


### PR DESCRIPTION
**What changed?**
Remove unused `dynamicconfig.Collection` in top level fx container

<!-- Tell your future self why have you made these changes -->
**Why?**
We only need a `dynamicconfig.Client` at the top level, the individual services each construct a `Collection`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
