### PR TITLE
Rewrite some workflow history size calculation

### DIFF
--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -35,6 +35,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
@@ -76,7 +77,6 @@ type (
 
 		mutableState              workflow.MutableState
 		searchAttributesValidator *searchattribute.Validator
-		executionStats            *persistencespb.ExecutionStats
 		metricsHandler            metrics.Handler
 		logger                    log.Logger
 	}
@@ -106,7 +106,6 @@ func newWorkflowSizeChecker(
 	limits workflowSizeLimits,
 	mutableState workflow.MutableState,
 	searchAttributesValidator *searchattribute.Validator,
-	executionStats *persistencespb.ExecutionStats,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) *workflowSizeChecker {
@@ -114,7 +113,6 @@ func newWorkflowSizeChecker(
 		workflowSizeLimits:        limits,
 		mutableState:              mutableState,
 		searchAttributesValidator: searchAttributesValidator,
-		executionStats:            executionStats,
 		metricsHandler:            metricsHandler,
 		logger:                    logger,
 	}

--- a/service/history/commandChecker_test.go
+++ b/service/history/commandChecker_test.go
@@ -895,7 +895,7 @@ func TestWorkflowSizeChecker_NumChildWorkflows(t *testing.T) {
 				numPendingActivitiesLimit:      c.PendingActivitiesLimit,
 				numPendingCancelsRequestLimit:  c.PendingCancelRequestsLimit,
 				numPendingSignalsLimit:         c.PendingSignalsLimit,
-			}, mutableState, nil, nil, metricsHandler, logger)
+			}, mutableState, nil, metricsHandler, logger)
 
 			err := checker.checkIfNumChildWorkflowsExceedsLimit()
 			if len(c.ExpectedChildExecutionsErrorMsg) > 0 {

--- a/service/history/ndc/conflict_resolver.go
+++ b/service/history/ndc/conflict_resolver.go
@@ -180,10 +180,10 @@ func (r *ConflictResolverImpl) rebuild(
 		return nil, err
 	}
 	rebuildMutableState.GetExecutionInfo().VersionHistories = versionHistories
+	rebuildMutableState.AddHistorySize(rebuiltHistorySize)
 	// set the update condition from original mutable state
 	rebuildMutableState.SetUpdateCondition(r.mutableState.GetUpdateCondition())
 
 	r.context.Clear()
-	r.context.SetHistorySize(rebuiltHistorySize)
 	return rebuildMutableState, nil
 }

--- a/service/history/ndc/conflict_resolver.go
+++ b/service/history/ndc/conflict_resolver.go
@@ -144,8 +144,9 @@ func (r *ConflictResolverImpl) rebuild(
 		executionInfo.WorkflowId,
 		executionState.RunId,
 	)
+	historySize := r.mutableState.GetHistorySize()
 
-	rebuildMutableState, rebuiltHistorySize, err := r.stateRebuilder.Rebuild(
+	rebuildMutableState, _, err := r.stateRebuilder.Rebuild(
 		ctx,
 		timestamp.TimeValue(executionInfo.StartTime),
 		workflowKey,
@@ -180,7 +181,7 @@ func (r *ConflictResolverImpl) rebuild(
 		return nil, err
 	}
 	rebuildMutableState.GetExecutionInfo().VersionHistories = versionHistories
-	rebuildMutableState.AddHistorySize(rebuiltHistorySize)
+	rebuildMutableState.AddHistorySize(historySize)
 	// set the update condition from original mutable state
 	rebuildMutableState.SetUpdateCondition(r.mutableState.GetUpdateCondition())
 

--- a/service/history/ndc/conflict_resolver_test.go
+++ b/service/history/ndc/conflict_resolver_test.go
@@ -26,6 +26,7 @@ package ndc
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -139,6 +140,7 @@ func (s *conflictResolverSuite) TestRebuild() {
 	s.mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: s.runID,
 	}).AnyTimes()
+	s.mockMutableState.EXPECT().GetHistorySize().Return(historySize).AnyTimes()
 
 	workflowKey := definition.NewWorkflowKey(
 		s.namespaceID,
@@ -169,7 +171,7 @@ func (s *conflictResolverSuite) TestRebuild() {
 		workflowKey,
 		branchToken1,
 		requestID,
-	).Return(mockRebuildMutableState, historySize, nil)
+	).Return(mockRebuildMutableState, rand.Int63(), nil)
 
 	s.mockContext.EXPECT().Clear()
 	rebuiltMutableState, err := s.nDCConflictResolver.rebuild(ctx, 1, requestID)
@@ -236,6 +238,7 @@ func (s *conflictResolverSuite) TestPrepareMutableState_Rebuild() {
 	s.mockMutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: s.runID,
 	}).AnyTimes()
+	s.mockMutableState.EXPECT().GetHistorySize().Return(historySize).AnyTimes()
 
 	workflowKey := definition.NewWorkflowKey(
 		s.namespaceID,
@@ -266,7 +269,7 @@ func (s *conflictResolverSuite) TestPrepareMutableState_Rebuild() {
 		workflowKey,
 		branchToken1,
 		gomock.Any(),
-	).Return(mockRebuildMutableState, historySize, nil)
+	).Return(mockRebuildMutableState, rand.Int63(), nil)
 
 	s.mockContext.EXPECT().Clear()
 	rebuiltMutableState, isRebuilt, err := s.nDCConflictResolver.prepareMutableState(ctx, 1, incomingVersion)

--- a/service/history/ndc/conflict_resolver_test.go
+++ b/service/history/ndc/conflict_resolver_test.go
@@ -155,7 +155,8 @@ func (s *conflictResolverSuite) TestRebuild() {
 				),
 			),
 		},
-	).Times(2)
+	).AnyTimes()
+	mockRebuildMutableState.EXPECT().AddHistorySize(historySize)
 	mockRebuildMutableState.EXPECT().SetUpdateCondition(updateCondition, dbVersion)
 
 	s.mockStateBuilder.EXPECT().Rebuild(
@@ -171,7 +172,6 @@ func (s *conflictResolverSuite) TestRebuild() {
 	).Return(mockRebuildMutableState, historySize, nil)
 
 	s.mockContext.EXPECT().Clear()
-	s.mockContext.EXPECT().SetHistorySize(historySize)
 	rebuiltMutableState, err := s.nDCConflictResolver.rebuild(ctx, 1, requestID)
 	s.NoError(err)
 	s.NotNil(rebuiltMutableState)
@@ -252,7 +252,8 @@ func (s *conflictResolverSuite) TestPrepareMutableState_Rebuild() {
 				),
 			),
 		},
-	).Times(2)
+	).AnyTimes()
+	mockRebuildMutableState.EXPECT().AddHistorySize(historySize)
 	mockRebuildMutableState.EXPECT().SetUpdateCondition(updateCondition, dbVersion)
 
 	s.mockStateBuilder.EXPECT().Rebuild(
@@ -268,7 +269,6 @@ func (s *conflictResolverSuite) TestPrepareMutableState_Rebuild() {
 	).Return(mockRebuildMutableState, historySize, nil)
 
 	s.mockContext.EXPECT().Clear()
-	s.mockContext.EXPECT().SetHistorySize(historySize)
 	rebuiltMutableState, isRebuilt, err := s.nDCConflictResolver.prepareMutableState(ctx, 1, incomingVersion)
 	s.NoError(err)
 	s.NotNil(rebuiltMutableState)

--- a/service/history/ndc/resetter.go
+++ b/service/history/ndc/resetter.go
@@ -154,9 +154,9 @@ func (r *resetterImpl) resetWorkflow(
 	if err != nil {
 		return nil, err
 	}
+	rebuildMutableState.AddHistorySize(rebuiltHistorySize)
 
 	r.newContext.Clear()
-	r.newContext.SetHistorySize(rebuiltHistorySize)
 	return rebuildMutableState, nil
 }
 

--- a/service/history/ndc/resetter_test.go
+++ b/service/history/ndc/resetter_test.go
@@ -185,6 +185,7 @@ func (s *resetterSuite) TestResetWorkflow_NoError() {
 		newBranchToken,
 		gomock.Any(),
 	).Return(s.mockRebuiltMutableState, rebuiltHistorySize, nil)
+	s.mockRebuiltMutableState.EXPECT().AddHistorySize(rebuiltHistorySize)
 
 	shardID := s.mockShard.GetShardID()
 	s.mockExecManager.EXPECT().ForkHistoryBranch(gomock.Any(), &persistence.ForkHistoryBranchRequest{
@@ -205,7 +206,6 @@ func (s *resetterSuite) TestResetWorkflow_NoError() {
 	)
 	s.NoError(err)
 	s.Equal(s.mockRebuiltMutableState, rebuiltMutableState)
-	s.Equal(s.newContext.GetHistorySize(), rebuiltHistorySize)
 	s.True(mockBaseWorkflowReleaseFnCalled)
 }
 

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -247,13 +247,15 @@ func (r *transactionMgrImpl) backfillWorkflow(
 		}
 	}()
 
-	if _, err := targetWorkflow.GetContext().PersistWorkflowEvents(
+	sizeSiff, err := targetWorkflow.GetContext().PersistWorkflowEvents(
 		ctx,
 		targetWorkflowEventsSlice...,
-	); err != nil {
+	)
+	if err != nil {
 		return err
 	}
 
+	targetWorkflow.GetMutableState().AddHistorySize(sizeSiff)
 	updateMode, transactionPolicy, err := r.backfillWorkflowEventsReapply(
 		ctx,
 		targetWorkflow,

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -26,6 +26,7 @@ package ndc
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -153,6 +154,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Open()
 	workflowEvents := &persistence.WorkflowEvents{
 		Events: []*historypb.HistoryEvent{{EventId: 1}},
 	}
+	historySize := rand.Int63()
 
 	targetWorkflow.EXPECT().GetContext().Return(weContext).AnyTimes()
 	targetWorkflow.EXPECT().GetMutableState().Return(mutableState).AnyTimes()
@@ -167,7 +169,8 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Open()
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetNamespaceEntry().Return(s.namespaceEntry).AnyTimes()
 	mutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{RunId: runID})
-	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
+	mutableState.EXPECT().AddHistorySize(historySize)
+	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(historySize, nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, workflow.TransactionPolicyActive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)
@@ -189,6 +192,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Closed
 		{EventId: lastWorkflowTaskStartedEventID, Version: lastWorkflowTaskStartedVersion},
 	})
 	histories := versionhistory.NewVersionHistories(versionHistory)
+	histroySize := rand.Int63()
 
 	releaseCalled := false
 
@@ -219,6 +223,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Closed
 	}).AnyTimes()
 	mutableState.EXPECT().GetNextEventID().Return(nextEventID).AnyTimes()
 	mutableState.EXPECT().GetLastWorkflowTaskStartedEventID().Return(lastWorkflowTaskStartedEventID)
+	mutableState.EXPECT().AddHistorySize(histroySize)
 
 	s.mockWorkflowResetter.EXPECT().ResetWorkflow(
 		ctx,
@@ -243,7 +248,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Closed
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil)
 
-	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
+	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(histroySize, nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeBypassCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)
@@ -275,6 +280,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Closed_ResetF
 	var releaseFn wcache.ReleaseCacheFunc = func(error) { releaseCalled = true }
 
 	workflowEvents := &persistence.WorkflowEvents{}
+	historySize := rand.Int63()
 
 	targetWorkflow.EXPECT().GetContext().Return(weContext).AnyTimes()
 	targetWorkflow.EXPECT().GetMutableState().Return(mutableState).AnyTimes()
@@ -296,6 +302,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Closed_ResetF
 	}).AnyTimes()
 	mutableState.EXPECT().GetNextEventID().Return(nextEventID).AnyTimes()
 	mutableState.EXPECT().GetLastWorkflowTaskStartedEventID().Return(lastWorkflowTaskStartedEventID)
+	mutableState.EXPECT().AddHistorySize(historySize)
 
 	s.mockWorkflowResetter.EXPECT().ResetWorkflow(
 		ctx,
@@ -320,7 +327,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Closed_ResetF
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil)
 
-	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
+	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(historySize, nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)
@@ -343,6 +350,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_Open(
 	workflowEvents := &persistence.WorkflowEvents{
 		Events: []*historypb.HistoryEvent{{EventId: 1}},
 	}
+	historySize := rand.Int63()
 
 	targetWorkflow.EXPECT().GetContext().Return(weContext).AnyTimes()
 	targetWorkflow.EXPECT().GetMutableState().Return(mutableState).AnyTimes()
@@ -354,8 +362,9 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_Open(
 	mutableState.EXPECT().IsCurrentWorkflowGuaranteed().Return(true).AnyTimes()
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetNamespaceEntry().Return(s.namespaceEntry).AnyTimes()
+	mutableState.EXPECT().AddHistorySize(historySize)
 	weContext.EXPECT().ReapplyEvents(gomock.Any(), []*persistence.WorkflowEvents{workflowEvents})
-	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
+	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(historySize, nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)
@@ -379,6 +388,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_Close
 	var releaseFn wcache.ReleaseCacheFunc = func(error) { releaseCalled = true }
 
 	workflowEvents := &persistence.WorkflowEvents{}
+	historySize := rand.Int63()
 
 	targetWorkflow.EXPECT().GetContext().Return(weContext).AnyTimes()
 	targetWorkflow.EXPECT().GetMutableState().Return(mutableState).AnyTimes()
@@ -397,6 +407,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_Close
 	mutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: runID,
 	}).AnyTimes()
+	mutableState.EXPECT().AddHistorySize(historySize)
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), &persistence.GetCurrentExecutionRequest{
 		ShardID:     s.mockShard.GetShardID(),
@@ -404,7 +415,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_Close
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil)
 	weContext.EXPECT().ReapplyEvents(gomock.Any(), []*persistence.WorkflowEvents{workflowEvents})
-	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
+	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(historySize, nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)
@@ -436,6 +447,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active() {
 		NamespaceID: namespaceID.String(),
 		WorkflowID:  workflowID,
 	}
+	historySize := rand.Int63()
 
 	targetWorkflow.EXPECT().GetContext().Return(weContext).AnyTimes()
 	targetWorkflow.EXPECT().GetMutableState().Return(mutableState).AnyTimes()
@@ -454,6 +466,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active() {
 	mutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: runID,
 	}).AnyTimes()
+	mutableState.EXPECT().AddHistorySize(historySize)
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), &persistence.GetCurrentExecutionRequest{
 		ShardID:     s.mockShard.GetShardID(),
@@ -461,7 +474,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active() {
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil)
 	weContext.EXPECT().ReapplyEvents(gomock.Any(), []*persistence.WorkflowEvents{workflowEvents})
-	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
+	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(historySize, nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeBypassCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)
@@ -492,6 +505,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passive() 
 		NamespaceID: namespaceID.String(),
 		WorkflowID:  workflowID,
 	}
+	historySize := rand.Int63()
 
 	targetWorkflow.EXPECT().GetContext().Return(weContext).AnyTimes()
 	targetWorkflow.EXPECT().GetMutableState().Return(mutableState).AnyTimes()
@@ -510,6 +524,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passive() 
 	mutableState.EXPECT().GetExecutionState().Return(&persistencespb.WorkflowExecutionState{
 		RunId: runID,
 	}).AnyTimes()
+	mutableState.EXPECT().AddHistorySize(historySize)
 
 	s.mockExecutionMgr.EXPECT().GetCurrentExecution(gomock.Any(), &persistence.GetCurrentExecutionRequest{
 		ShardID:     s.mockShard.GetShardID(),
@@ -517,7 +532,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passive() 
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil)
 	weContext.EXPECT().ReapplyEvents(gomock.Any(), []*persistence.WorkflowEvents{workflowEvents})
-	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
+	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(historySize, nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeBypassCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
 	).Return(nil)

--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -36,7 +36,6 @@ import (
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 
-	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/collection"
@@ -152,9 +151,6 @@ func (r *workflowResetterImpl) ResetWorkflow(
 		)
 		if err != nil {
 			return err
-		}
-		currentWorkflowMutation.ExecutionInfo.ExecutionStats = &persistencespb.ExecutionStats{
-			HistorySize: currentWorkflow.GetContext().GetHistorySize(),
 		}
 
 		reapplyEventsFn = func(ctx context.Context, resetMutableState workflow.MutableState) error {
@@ -350,12 +346,9 @@ func (r *workflowResetterImpl) persistToDB(
 	if err != nil {
 		return err
 	}
-	resetWorkflowSnapshot.ExecutionInfo.ExecutionStats = &persistencespb.ExecutionStats{
-		HistorySize: resetWorkflow.GetContext().GetHistorySize(),
-	}
 
 	if currentWorkflowMutation != nil {
-		if currentWorkflowSizeDiff, resetWorkflowSizeDiff, err := r.transaction.UpdateWorkflowExecution(
+		if _, _, err := r.transaction.UpdateWorkflowExecution(
 			ctx,
 			persistence.UpdateWorkflowModeUpdateCurrent,
 			currentWorkflow.GetMutableState().GetCurrentVersion(),
@@ -366,9 +359,6 @@ func (r *workflowResetterImpl) persistToDB(
 			resetWorkflowEventsSeq,
 		); err != nil {
 			return err
-		} else {
-			currentWorkflow.GetContext().SetHistorySize(currentWorkflow.GetContext().GetHistorySize() + currentWorkflowSizeDiff)
-			resetWorkflow.GetContext().SetHistorySize(resetWorkflow.GetContext().GetHistorySize() + resetWorkflowSizeDiff)
 		}
 		return nil
 	}
@@ -452,8 +442,7 @@ func (r *workflowResetterImpl) replayResetWorkflow(
 		baseRebuildLastEventID,
 		baseRebuildLastEventVersion,
 	)
-
-	resetContext.SetHistorySize(resetHistorySize)
+	resetMutableState.AddHistorySize(resetHistorySize)
 	return NewWorkflow(
 		ctx,
 		r.namespaceRegistry,

--- a/service/history/workflow/context_mock.go
+++ b/service/history/workflow/context_mock.go
@@ -102,20 +102,6 @@ func (mr *MockContextMockRecorder) CreateWorkflowExecution(ctx, createMode, prev
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockContext)(nil).CreateWorkflowExecution), ctx, createMode, prevRunID, prevLastWriteVersion, newMutableState, newWorkflow, newWorkflowEvents)
 }
 
-// GetHistorySize mocks base method.
-func (m *MockContext) GetHistorySize() int64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetHistorySize")
-	ret0, _ := ret[0].(int64)
-	return ret0
-}
-
-// GetHistorySize indicates an expected call of GetHistorySize.
-func (mr *MockContextMockRecorder) GetHistorySize() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistorySize", reflect.TypeOf((*MockContext)(nil).GetHistorySize))
-}
-
 // GetWorkflowKey mocks base method.
 func (m *MockContext) GetWorkflowKey() definition.WorkflowKey {
 	m.ctrl.T.Helper()
@@ -206,18 +192,6 @@ func (m *MockContext) ReapplyEvents(ctx context.Context, eventBatches []*persist
 func (mr *MockContextMockRecorder) ReapplyEvents(ctx, eventBatches interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockContext)(nil).ReapplyEvents), ctx, eventBatches)
-}
-
-// SetHistorySize mocks base method.
-func (m *MockContext) SetHistorySize(size int64) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "SetHistorySize", size)
-}
-
-// SetHistorySize indicates an expected call of SetHistorySize.
-func (mr *MockContextMockRecorder) SetHistorySize(size interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetHistorySize", reflect.TypeOf((*MockContext)(nil).SetHistorySize), size)
 }
 
 // SetWorkflowExecution mocks base method.

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -281,6 +281,9 @@ type (
 		UpdateCurrentVersion(version int64, forceUpdate bool) error
 		UpdateWorkflowStateStatus(state enumsspb.WorkflowExecutionState, status enumspb.WorkflowExecutionStatus) error
 
+		GetHistorySize() int64
+		AddHistorySize(size int64)
+
 		AddTasks(tasks ...tasks.Task)
 		PopTasks() map[tasks.Category][]tasks.Task
 		SetUpdateCondition(int64, int64)

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4043,6 +4043,14 @@ func (ms *MutableStateImpl) truncateRetryableActivityFailure(
 	return serverFailure
 }
 
+func (ms *MutableStateImpl) GetHistorySize() int64 {
+	return ms.executionInfo.ExecutionStats.HistorySize
+}
+
+func (ms *MutableStateImpl) AddHistorySize(size int64) {
+	ms.executionInfo.ExecutionStats.HistorySize += size
+}
+
 // TODO mutable state should generate corresponding transfer / timer tasks according to
 //  updates accumulated, while currently all transfer / timer tasks are managed manually
 

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -366,6 +366,18 @@ func (mr *MockMutableStateMockRecorder) AddFirstWorkflowTaskScheduled(parentCloc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddFirstWorkflowTaskScheduled", reflect.TypeOf((*MockMutableState)(nil).AddFirstWorkflowTaskScheduled), parentClock, event, bypassTaskGeneration)
 }
 
+// AddHistorySize mocks base method.
+func (m *MockMutableState) AddHistorySize(size int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddHistorySize", size)
+}
+
+// AddHistorySize indicates an expected call of AddHistorySize.
+func (mr *MockMutableStateMockRecorder) AddHistorySize(size interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddHistorySize", reflect.TypeOf((*MockMutableState)(nil).AddHistorySize), size)
+}
+
 // AddRecordMarkerEvent mocks base method.
 func (m *MockMutableState) AddRecordMarkerEvent(arg0 int64, arg1 *v1.RecordMarkerCommandAttributes) (*v13.HistoryEvent, error) {
 	m.ctrl.T.Helper()
@@ -1217,6 +1229,20 @@ func (m *MockMutableState) GetFirstRunID(ctx context.Context) (string, error) {
 func (mr *MockMutableStateMockRecorder) GetFirstRunID(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstRunID", reflect.TypeOf((*MockMutableState)(nil).GetFirstRunID), ctx)
+}
+
+// GetHistorySize mocks base method.
+func (m *MockMutableState) GetHistorySize() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHistorySize")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetHistorySize indicates an expected call of GetHistorySize.
+func (mr *MockMutableStateMockRecorder) GetHistorySize() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistorySize", reflect.TypeOf((*MockMutableState)(nil).GetHistorySize))
 }
 
 // GetLastFirstEventIDTxnID mocks base method.

--- a/service/history/workflowRebuilder.go
+++ b/service/history/workflowRebuilder.go
@@ -32,7 +32,6 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 
-	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence/versionhistory"
@@ -107,7 +106,7 @@ func (r *workflowRebuilderImpl) rebuild(
 	branchToken := currentVersionHistory.BranchToken
 	stateTransitionCount := mutableState.GetExecutionInfo().StateTransitionCount
 
-	rebuildMutableState, rebuildHistorySize, err := r.replayResetWorkflow(
+	rebuildMutableState, err := r.replayResetWorkflow(
 		ctx,
 		workflowKey,
 		branchToken,
@@ -118,7 +117,7 @@ func (r *workflowRebuilderImpl) rebuild(
 	if err != nil {
 		return err
 	}
-	return r.persistToDB(ctx, rebuildMutableState, rebuildHistorySize)
+	return r.persistToDB(ctx, rebuildMutableState)
 }
 
 func (r *workflowRebuilderImpl) replayResetWorkflow(
@@ -128,7 +127,7 @@ func (r *workflowRebuilderImpl) replayResetWorkflow(
 	stateTransitionCount int64,
 	dbRecordVersion int64,
 	requestID string,
-) (workflow.MutableState, int64, error) {
+) (workflow.MutableState, error) {
 
 	rebuildMutableState, rebuildHistorySize, err := ndc.NewStateRebuilder(r.shard, r.logger).Rebuild(
 		ctx,
@@ -142,20 +141,20 @@ func (r *workflowRebuilderImpl) replayResetWorkflow(
 		requestID,
 	)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	// note: this is an admin API, for operator to recover a corrupted mutable state, so state transition count
 	// should remain the same, the -= 1 exists here since later CloseTransactionAsSnapshot will += 1 to state transition count
 	rebuildMutableState.GetExecutionInfo().StateTransitionCount = stateTransitionCount - 1
+	rebuildMutableState.AddHistorySize(rebuildHistorySize)
 	rebuildMutableState.SetUpdateCondition(rebuildMutableState.GetNextEventID(), dbRecordVersion)
-	return rebuildMutableState, rebuildHistorySize, nil
+	return rebuildMutableState, nil
 }
 
 func (r *workflowRebuilderImpl) persistToDB(
 	ctx context.Context,
 	mutableState workflow.MutableState,
-	historySize int64,
 ) error {
 	resetWorkflowSnapshot, resetWorkflowEventsSeq, err := mutableState.CloseTransactionAsSnapshot(
 		workflow.TransactionPolicyPassive,
@@ -167,9 +166,6 @@ func (r *workflowRebuilderImpl) persistToDB(
 		return serviceerror.NewInternal("workflowRebuilder encountered new events when rebuilding mutable state")
 	}
 
-	resetWorkflowSnapshot.ExecutionInfo.ExecutionStats = &persistencespb.ExecutionStats{
-		HistorySize: historySize,
-	}
 	return r.transaction.SetWorkflowExecution(
 		ctx,
 		resetWorkflowSnapshot,

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -410,11 +410,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	weContext := workflowContext.GetContext()
 	ms := workflowContext.GetMutableState()
 
-	executionStats, err := weContext.LoadExecutionStats(ctx)
-	if err != nil {
-		return nil, err
-	}
-
 	currentWorkflowTask := ms.GetWorkflowTaskByID(token.GetScheduledEventId())
 	// TODO (alex-update): call mutableState.SetSpeculativeWorkflowTaskStartedEventID(mutableState) here to set StartEventID.
 	if !ms.IsWorkflowExecutionRunning() || currentWorkflowTask == nil || currentWorkflowTask.Attempt != token.Attempt ||
@@ -508,7 +503,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			},
 			ms,
 			handler.searchAttributesValidator,
-			executionStats,
 			handler.metricsHandler.WithTags(
 				metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope),
 				metrics.NamespaceTag(namespace.String()),

--- a/service/history/workflowTaskHandler_test.go
+++ b/service/history/workflowTaskHandler_test.go
@@ -38,6 +38,7 @@ import (
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -110,7 +111,6 @@ func TestCommandProtocolMessage(t *testing.T) {
 				workflowSizeLimits{blobSizeLimitError: blobSizeLimit},
 				out.ms,
 				nil, //searchAttributesValidator
-				&persistencespb.ExecutionStats{},
 				metricsHandler,
 				logger,
 			),

--- a/tests/ndc/ndc_integration_test.go
+++ b/tests/ndc/ndc_integration_test.go
@@ -27,7 +27,6 @@ package ndc
 import (
 	"context"
 	"flag"
-	"fmt"
 	"os"
 	"sync/atomic"
 	"testing"
@@ -94,7 +93,6 @@ type (
 )
 
 func TestNDCIntegrationTestSuite(t *testing.T) {
-
 	flag.Parse()
 	suite.Run(t, new(nDCIntegrationTestSuite))
 }
@@ -215,12 +213,14 @@ func (s *nDCIntegrationTestSuite) TestSingleBranch() {
 	workflowType := "event-generator-workflow-type"
 	taskqueue := "event-generator-taskQueue"
 
-	// active has initial version 0
+	// active has initial version 1
 	historyClient := s.active.GetHistoryClient()
 
-	versions := []int64{0, 102, 2, 202, 302, 402, 602, 502, 802, 1002, 902, 702, 1102}
+	versions := []int64{3, 13, 2, 202, 302, 402, 602, 502, 802, 1002, 902, 702, 1102}
 	for _, version := range versions {
 		runID := uuid.New()
+		historySize := int64(0)
+
 		var historyBatch []*historypb.History
 		s.generator = test.InitializeHistoryEventGenerator(s.namespace, s.namespaceID, version)
 
@@ -230,6 +230,7 @@ func (s *nDCIntegrationTestSuite) TestSingleBranch() {
 			for _, event := range events {
 				historyEvents.Events = append(historyEvents.Events, event.GetData().(*historypb.HistoryEvent))
 			}
+			historySize += s.sizeOfHistoryEvents(historyEvents.Events)
 			historyBatch = append(historyBatch, historyEvents)
 		}
 
@@ -243,57 +244,9 @@ func (s *nDCIntegrationTestSuite) TestSingleBranch() {
 			historyBatch,
 			historyClient,
 		)
-
-		err := s.verifyEventHistory(workflowID, runID, historyBatch)
-		s.Require().NoError(err)
+		s.verifyEventHistorySize(workflowID, runID, historySize)
+		s.verifyEventHistory(workflowID, runID, historyBatch)
 	}
-}
-
-func (s *nDCIntegrationTestSuite) verifyEventHistory(
-	workflowID string,
-	runID string,
-	historyBatch []*historypb.History,
-) error {
-	// get replicated history events from passive side
-	passiveClient := s.active.GetFrontendClient()
-	replicatedHistory, err := passiveClient.GetWorkflowExecutionHistory(
-		tests.NewContext(),
-		&workflowservice.GetWorkflowExecutionHistoryRequest{
-			Namespace: s.namespace.String(),
-			Execution: &commonpb.WorkflowExecution{
-				WorkflowId: workflowID,
-				RunId:      runID,
-			},
-			MaximumPageSize:        1000,
-			NextPageToken:          nil,
-			WaitNewEvent:           false,
-			HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
-		},
-	)
-
-	if err != nil {
-		return fmt.Errorf("failed to get history event from passive side: %v", err)
-	}
-
-	// compare origin events with replicated events
-	batchIndex := 0
-	batch := historyBatch[batchIndex].Events
-	eventIndex := 0
-	for _, event := range replicatedHistory.GetHistory().GetEvents() {
-		if eventIndex >= len(batch) {
-			batchIndex++
-			batch = historyBatch[batchIndex].Events
-			eventIndex = 0
-		}
-		originEvent := batch[eventIndex]
-		eventIndex++
-		if enumspb.EventType(originEvent.GetEventType()) != event.GetEventType() {
-			return fmt.Errorf("the replicated event (%v) and the origin event (%v) are not the same",
-				originEvent.GetEventType().String(), event.GetEventType().String())
-		}
-	}
-
-	return nil
 }
 
 func (s *nDCIntegrationTestSuite) TestMultipleBranches() {
@@ -304,12 +257,13 @@ func (s *nDCIntegrationTestSuite) TestMultipleBranches() {
 	workflowType := "event-generator-workflow-type"
 	taskqueue := "event-generator-taskQueue"
 
-	// active has initial version 0
+	// active has initial version 1
 	historyClient := s.active.GetHistoryClient()
 
 	versions := []int64{102, 2, 202}
 	for _, version := range versions {
 		runID := uuid.New()
+		historySize := int64(0)
 
 		var baseBranch []*historypb.History
 		baseGenerator := test.InitializeHistoryEventGenerator(s.namespace, s.namespaceID, version)
@@ -321,6 +275,7 @@ func (s *nDCIntegrationTestSuite) TestMultipleBranches() {
 			for _, event := range events {
 				historyEvents.Events = append(historyEvents.Events, event.GetData().(*historypb.HistoryEvent))
 			}
+			historySize += s.sizeOfHistoryEvents(historyEvents.Events)
 			baseBranch = append(baseBranch, historyEvents)
 		}
 		baseVersionHistory := s.eventBatchesToVersionHistory(nil, baseBranch)
@@ -334,6 +289,7 @@ func (s *nDCIntegrationTestSuite) TestMultipleBranches() {
 			for _, event := range events {
 				historyEvents.Events = append(historyEvents.Events, event.GetData().(*historypb.HistoryEvent))
 			}
+			historySize += s.sizeOfHistoryEvents(historyEvents.Events)
 			branch1 = append(branch1, historyEvents)
 		}
 		branchVersionHistory1 = s.eventBatchesToVersionHistory(branchVersionHistory1, branch1)
@@ -348,6 +304,7 @@ func (s *nDCIntegrationTestSuite) TestMultipleBranches() {
 			for _, event := range events {
 				historyEvents.Events = append(historyEvents.Events, event.GetData().(*historypb.HistoryEvent))
 			}
+			historySize += s.sizeOfHistoryEvents(historyEvents.Events)
 			branch2 = append(branch2, historyEvents)
 		}
 		branchVersionHistory2 = s.eventBatchesToVersionHistory(branchVersionHistory2, branch2)
@@ -379,6 +336,7 @@ func (s *nDCIntegrationTestSuite) TestMultipleBranches() {
 			branch2,
 			historyClient,
 		)
+		s.verifyEventHistorySize(workflowID, runID, historySize)
 	}
 }
 
@@ -388,7 +346,7 @@ func (s *nDCIntegrationTestSuite) TestEmptyVersionAndNonEmptyVersion() {
 	workflowType := "event-generator-workflow-type"
 	taskqueue := "event-generator-taskQueue"
 
-	// active has initial version 0
+	// active has initial version 1
 	historyClient := s.active.GetHistoryClient()
 
 	runID := uuid.New()
@@ -422,6 +380,8 @@ func (s *nDCIntegrationTestSuite) TestEmptyVersionAndNonEmptyVersion() {
 	}
 	branchVersionHistory1 = s.eventBatchesToVersionHistory(branchVersionHistory1, branch1)
 
+	// TODO ?
+
 	s.applyEvents(
 		workflowID,
 		runID,
@@ -447,12 +407,13 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranches() {
 	s.setupRemoteFrontendClients()
 	workflowID := "ndc-handcrafted-multiple-branches-test" + uuid.New()
 	runID := uuid.New()
+	historySize := int64(0)
 
 	workflowType := "event-generator-workflow-type"
 	taskqueue := "event-generator-taskQueue"
 	identity := "worker-identity"
 
-	// active has initial version 0
+	// active has initial version 1
 	historyClient := s.active.GetHistoryClient()
 
 	eventsBatch1 := []*historypb.History{
@@ -730,6 +691,15 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranches() {
 			},
 		}},
 	}
+	for _, eventBatch := range eventsBatch1 {
+		historySize += s.sizeOfHistoryEvents(eventBatch.Events)
+	}
+	for _, eventBatch := range eventsBatch2 {
+		historySize += s.sizeOfHistoryEvents(eventBatch.Events)
+	}
+	for _, eventBatch := range eventsBatch3 {
+		historySize += s.sizeOfHistoryEvents(eventBatch.Events)
+	}
 
 	versionHistory1 := s.eventBatchesToVersionHistory(nil, eventsBatch1)
 
@@ -772,6 +742,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranches() {
 		eventsBatch2,
 		historyClient,
 	)
+	s.verifyEventHistorySize(workflowID, runID, historySize)
 }
 
 func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieContinueAsNew() {
@@ -779,12 +750,13 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieConti
 	s.setupRemoteFrontendClients()
 	workflowID := "ndc-handcrafted-multiple-branches-with-continue-as-new-test" + uuid.New()
 	runID := uuid.New()
+	historySize := int64(0)
 
 	workflowType := "event-generator-workflow-type"
 	taskqueue := "event-generator-taskQueue"
 	identity := "worker-identity"
 
-	// active has initial version 0
+	// active has initial version 1
 	historyClient := s.active.GetHistoryClient()
 
 	eventsBatch1 := []*historypb.History{
@@ -1019,6 +991,15 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieConti
 			},
 		}},
 	}
+	for _, eventBatch := range eventsBatch1 {
+		historySize += s.sizeOfHistoryEvents(eventBatch.Events)
+	}
+	for _, eventBatch := range eventsBatch2 {
+		historySize += s.sizeOfHistoryEvents(eventBatch.Events)
+	}
+	for _, eventBatch := range eventsBatch3 {
+		historySize += s.sizeOfHistoryEvents(eventBatch.Events)
+	}
 
 	versionHistory1 := s.eventBatchesToVersionHistory(nil, eventsBatch1)
 
@@ -1061,6 +1042,7 @@ func (s *nDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieConti
 		eventsBatch3,
 		historyClient,
 	)
+	s.verifyEventHistorySize(workflowID, runID, historySize)
 }
 
 func (s *nDCIntegrationTestSuite) TestEventsReapply_ZombieWorkflow() {
@@ -1070,11 +1052,12 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_ZombieWorkflow() {
 	workflowType := "event-generator-workflow-type"
 	taskqueue := "event-generator-taskQueue"
 
-	// active has initial version 0
+	// active has initial version 1
 	historyClient := s.active.GetHistoryClient()
 
 	version := int64(102)
 	runID := uuid.New()
+	historySize := int64(0)
 	historyBatch := []*historypb.History{}
 	s.generator = test.InitializeHistoryEventGenerator(s.namespace, s.namespaceID, version)
 
@@ -1084,6 +1067,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_ZombieWorkflow() {
 		for _, event := range events {
 			historyEvents.Events = append(historyEvents.Events, event.GetData().(*historypb.HistoryEvent))
 		}
+		historySize += s.sizeOfHistoryEvents(historyEvents.Events)
 		historyBatch = append(historyBatch, historyEvents)
 	}
 
@@ -1097,13 +1081,15 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_ZombieWorkflow() {
 		historyBatch,
 		historyClient,
 	)
+	s.verifyEventHistorySize(workflowID, runID, historySize)
 
 	version = int64(2)
 	runID = uuid.New()
+	historySize = int64(0)
 	historyBatch = []*historypb.History{}
 	s.generator = test.InitializeHistoryEventGenerator(s.namespace, s.namespaceID, version)
 
-	// verify two batches of zombie workflow are call reapply API
+	// verify two batches of zombie workflow call reapply API
 	reapplyCount := 0
 	for i := 0; i < 2 && s.generator.HasNextVertex(); i++ {
 		events := s.generator.GetNextVertices()
@@ -1119,6 +1105,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_ZombieWorkflow() {
 		if reapply {
 			reapplyCount += 1
 		}
+		historySize += s.sizeOfHistoryEvents(historyEvents.Events)
 		historyBatch = append(historyBatch, historyEvents)
 	}
 	s.mockAdminClient["standby"].(*adminservicemock.MockAdminServiceClient).EXPECT().ReapplyEvents(
@@ -1139,12 +1126,14 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_ZombieWorkflow() {
 		historyBatch,
 		historyClient,
 	)
+	s.verifyEventHistorySize(workflowID, runID, historySize)
 }
 
 func (s *nDCIntegrationTestSuite) TestEventsReapply_UpdateNonCurrentBranch() {
 
 	workflowID := "ndc-single-branch-test" + uuid.New()
 	runID := uuid.New()
+	historySize := int64(0)
 	workflowType := "event-generator-workflow-type"
 	taskqueue := "event-generator-taskQueue"
 	version := int64(102)
@@ -1172,6 +1161,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_UpdateNonCurrentBranch() {
 				isWorkflowFinished = true
 			}
 		}
+		historySize += s.sizeOfHistoryEvents(historyEvents.Events)
 		baseBranch = append(baseBranch, historyEvents)
 	}
 	if isWorkflowFinished {
@@ -1191,6 +1181,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_UpdateNonCurrentBranch() {
 		baseBranch,
 		historyClient,
 	)
+	s.verifyEventHistorySize(workflowID, runID, historySize)
 
 	newGenerator := s.generator.DeepCopy()
 	var newBranch []*historypb.History
@@ -1204,6 +1195,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_UpdateNonCurrentBranch() {
 			taskID = history.GetTaskId()
 			historyEvents.Events = append(historyEvents.Events, history)
 		}
+		historySize += s.sizeOfHistoryEvents(historyEvents.Events)
 		newBranch = append(newBranch, historyEvents)
 	}
 	newVersionHistory = s.eventBatchesToVersionHistory(newVersionHistory, newBranch)
@@ -1216,6 +1208,7 @@ func (s *nDCIntegrationTestSuite) TestEventsReapply_UpdateNonCurrentBranch() {
 		newBranch,
 		historyClient,
 	)
+	s.verifyEventHistorySize(workflowID, runID, historySize)
 
 	s.mockAdminClient["standby"].(*adminservicemock.MockAdminServiceClient).EXPECT().ReapplyEvents(gomock.Any(), gomock.Any()).Return(&adminservice.ReapplyEventsResponse{}, nil)
 	// Handcraft a stale signal event
@@ -1939,7 +1932,75 @@ func (s *nDCIntegrationTestSuite) eventBatchesToVersionHistory(
 	return versionHistory
 }
 
+func (s *nDCIntegrationTestSuite) verifyEventHistorySize(
+	workflowID string,
+	runID string,
+	historySize int64,
+) {
+	// get replicated history events from passive side
+	passiveClient := s.active.GetFrontendClient()
+	describeWorkflow, err := passiveClient.DescribeWorkflowExecution(
+		tests.NewContext(),
+		&workflowservice.DescribeWorkflowExecutionRequest{
+			Namespace: s.namespace.String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+				RunId:      runID,
+			},
+		},
+	)
+	s.NoError(err)
+	s.Equal(describeWorkflow.WorkflowExecutionInfo.HistorySizeBytes, historySize)
+}
+
+func (s *nDCIntegrationTestSuite) verifyEventHistory(
+	workflowID string,
+	runID string,
+	historyBatch []*historypb.History,
+) {
+	// get replicated history events from passive side
+	passiveClient := s.active.GetFrontendClient()
+	replicatedHistory, err := passiveClient.GetWorkflowExecutionHistory(
+		tests.NewContext(),
+		&workflowservice.GetWorkflowExecutionHistoryRequest{
+			Namespace: s.namespace.String(),
+			Execution: &commonpb.WorkflowExecution{
+				WorkflowId: workflowID,
+				RunId:      runID,
+			},
+			MaximumPageSize:        1000,
+			NextPageToken:          nil,
+			WaitNewEvent:           false,
+			HistoryEventFilterType: enumspb.HISTORY_EVENT_FILTER_TYPE_ALL_EVENT,
+		},
+	)
+	s.NoError(err)
+
+	// compare origin events with replicated events
+	batchIndex := 0
+	batch := historyBatch[batchIndex].Events
+	eventIndex := 0
+	for _, event := range replicatedHistory.GetHistory().GetEvents() {
+		if eventIndex >= len(batch) {
+			batchIndex++
+			batch = historyBatch[batchIndex].Events
+			eventIndex = 0
+		}
+		originEvent := batch[eventIndex]
+		eventIndex++
+		s.Equal(originEvent.GetEventType(), event.GetEventType())
+	}
+}
+
 func (s *nDCIntegrationTestSuite) setupRemoteFrontendClients() {
 	s.mockAdminClient["standby"].(*adminservicemock.MockAdminServiceClient).EXPECT().ReapplyEvents(gomock.Any(), gomock.Any()).Return(&adminservice.ReapplyEventsResponse{}, nil).AnyTimes()
 	s.mockAdminClient["other"].(*adminservicemock.MockAdminServiceClient).EXPECT().ReapplyEvents(gomock.Any(), gomock.Any()).Return(&adminservice.ReapplyEventsResponse{}, nil).AnyTimes()
+}
+
+func (s *nDCIntegrationTestSuite) sizeOfHistoryEvents(
+	events []*historypb.HistoryEvent,
+) int64 {
+	blob, err := serialization.NewSerializer().SerializeEvents(events, enumspb.ENCODING_TYPE_PROTO3)
+	s.NoError(err)
+	return int64(len(blob.Data))
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Use implicit contract, instead of multiple round trip updating history size in 2 different places
  * Persistence layer will keep tract of history size & update history size

<!-- Tell your future self why have you made these changes -->
**Why?**
N/A

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
more tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A