### PR TITLE
Rename imports to match convention

### DIFF
--- a/api/matchingservice/v1/service.pb.go
+++ b/api/matchingservice/v1/service.pb.go
@@ -144,9 +144,9 @@ type MatchingServiceClient interface {
 	GetWorkerBuildIdCompatibility(ctx context.Context, in *GetWorkerBuildIdCompatibilityRequest, opts ...grpc.CallOption) (*GetWorkerBuildIdCompatibilityResponse, error)
 	// Tell a task queue that the associated user data has changed.
 	InvalidateTaskQueueUserData(ctx context.Context, in *InvalidateTaskQueueUserDataRequest, opts ...grpc.CallOption) (*InvalidateTaskQueueUserDataResponse, error)
-	// Fetch user data for a task queue, this request should always be routed to the node holding the task queue's root partition.
+	// Fetch user data for a task queue, this request should always be routed to the node holding the root partition of the workflow task queue.
 	GetTaskQueueUserData(ctx context.Context, in *GetTaskQueueUserDataRequest, opts ...grpc.CallOption) (*GetTaskQueueUserDataResponse, error)
-	// Apply a user data replication event
+	// Apply a user data replication event.
 	ApplyTaskQueueUserDataReplicationEvent(ctx context.Context, in *ApplyTaskQueueUserDataReplicationEventRequest, opts ...grpc.CallOption) (*ApplyTaskQueueUserDataReplicationEventResponse, error)
 }
 
@@ -323,9 +323,9 @@ type MatchingServiceServer interface {
 	GetWorkerBuildIdCompatibility(context.Context, *GetWorkerBuildIdCompatibilityRequest) (*GetWorkerBuildIdCompatibilityResponse, error)
 	// Tell a task queue that the associated user data has changed.
 	InvalidateTaskQueueUserData(context.Context, *InvalidateTaskQueueUserDataRequest) (*InvalidateTaskQueueUserDataResponse, error)
-	// Fetch user data for a task queue, this request should always be routed to the node holding the task queue's root partition.
+	// Fetch user data for a task queue, this request should always be routed to the node holding the root partition of the workflow task queue.
 	GetTaskQueueUserData(context.Context, *GetTaskQueueUserDataRequest) (*GetTaskQueueUserDataResponse, error)
-	// Apply a user data replication event
+	// Apply a user data replication event.
 	ApplyTaskQueueUserDataReplicationEvent(context.Context, *ApplyTaskQueueUserDataReplicationEventRequest) (*ApplyTaskQueueUserDataReplicationEventResponse, error)
 }
 

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -30,7 +30,7 @@ import (
 	"strings"
 
 	enumspb "go.temporal.io/api/enums/v1"
-	serverenumbspb "go.temporal.io/server/api/enums/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
 
 	"go.temporal.io/server/common/primitives"
 )
@@ -295,6 +295,6 @@ func ReasonTag(value ReasonString) Tag {
 }
 
 // ReplicationTaskTypeTag returns a new replication task type tag.
-func ReplicationTaskTypeTag(value serverenumbspb.ReplicationTaskType) Tag {
+func ReplicationTaskTypeTag(value enumsspb.ReplicationTaskType) Tag {
 	return &tagImpl{key: replicationTaskType, value: value.String()}
 }

--- a/proto/internal/temporal/server/api/matchingservice/v1/service.proto
+++ b/proto/internal/temporal/server/api/matchingservice/v1/service.proto
@@ -87,10 +87,10 @@ service MatchingService {
     rpc GetWorkerBuildIdCompatibility (GetWorkerBuildIdCompatibilityRequest) returns (GetWorkerBuildIdCompatibilityResponse) {}
     // Tell a task queue that the associated user data has changed.
     rpc InvalidateTaskQueueUserData (InvalidateTaskQueueUserDataRequest) returns (InvalidateTaskQueueUserDataResponse) {}
-    // Fetch user data for a task queue, this request should always be routed to the node holding the task queue's root partition.
+    // Fetch user data for a task queue, this request should always be routed to the node holding the root partition of the workflow task queue.
     rpc GetTaskQueueUserData (GetTaskQueueUserDataRequest) returns (GetTaskQueueUserDataResponse) {}
 
-    // Apply a user data replication event
+    // Apply a user data replication event.
     rpc ApplyTaskQueueUserDataReplicationEvent (ApplyTaskQueueUserDataReplicationEventRequest) returns
     (ApplyTaskQueueUserDataReplicationEventResponse) {}
 }

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -43,7 +43,7 @@ import (
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
-	repication "go.temporal.io/server/api/replication/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
 	"go.temporal.io/server/common/clock"
@@ -490,10 +490,10 @@ func (c *taskQueueManagerImpl) UpdateUserData(ctx context.Context, replicate boo
 		return err
 	}
 	if replicate && c.namespaceReplicationQueue != nil {
-		err = c.namespaceReplicationQueue.Publish(ctx, &repication.ReplicationTask{
+		err = c.namespaceReplicationQueue.Publish(ctx, &replicationspb.ReplicationTask{
 			TaskType: enumsspb.REPLICATION_TASK_TYPE_TASK_QUEUE_USER_DATA,
-			Attributes: &repication.ReplicationTask_TaskQueueUserDataAttributes{
-				TaskQueueUserDataAttributes: &repication.TaskQueueUserDataAttributes{
+			Attributes: &replicationspb.ReplicationTask_TaskQueueUserDataAttributes{
+				TaskQueueUserDataAttributes: &replicationspb.TaskQueueUserDataAttributes{
 					NamespaceId:   c.taskQueueID.namespaceID.String(),
 					TaskQueueName: c.taskQueueID.BaseNameString(),
 					UserData:      newData.GetData(),

--- a/service/matching/version_sets.go
+++ b/service/matching/version_sets.go
@@ -206,13 +206,13 @@ func updateImpl(timestamp hlc.Clock, existingData *persistencespb.VersioningData
 			// Make the request idempotent
 			return existingData, nil
 		}
-		// We're gonna have to copy here too to avoid mutating the original
+		// We're gonna have to copy here to to avoid mutating the original
 		numBuildIDs := len(existingData.GetVersionSets()[targetSetIdx].BuildIds)
-		buildIDSCopy := make([]*persistencespb.BuildID, numBuildIDs)
-		copy(buildIDSCopy, existingData.VersionSets[targetSetIdx].BuildIds)
+		buildIDsCopy := make([]*persistencespb.BuildID, numBuildIDs)
+		copy(buildIDsCopy, existingData.VersionSets[targetSetIdx].BuildIds)
 		modifiedData.VersionSets[targetSetIdx] = &persistencespb.CompatibleVersionSet{
 			SetIds:   existingData.VersionSets[targetSetIdx].SetIds,
-			BuildIds: buildIDSCopy,
+			BuildIds: buildIDsCopy,
 		}
 		makeVersionInSetDefault(&modifiedData, targetSetIdx, versionInSetIdx, &timestamp)
 	}

--- a/service/matching/version_sets_test.go
+++ b/service/matching/version_sets_test.go
@@ -33,34 +33,34 @@ import (
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
-	clockpb "go.temporal.io/server/api/clock/v1"
-	persistencepb "go.temporal.io/server/api/persistence/v1"
+	clockspb "go.temporal.io/server/api/clock/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	commonclock "go.temporal.io/server/common/clock"
 	hlc "go.temporal.io/server/common/clock/hybrid_logical_clock"
 )
 
-func mkNewSet(id string, clock clockpb.HybridLogicalClock) *persistencepb.CompatibleVersionSet {
-	return &persistencepb.CompatibleVersionSet{
+func mkNewSet(id string, clock clockspb.HybridLogicalClock) *persistencespb.CompatibleVersionSet {
+	return &persistencespb.CompatibleVersionSet{
 		SetIds:                 []string{hashBuildID(id)},
-		BuildIds:               []*persistencepb.BuildID{{Id: id, State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
+		BuildIds:               []*persistencespb.BuildID{{Id: id, State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
 		DefaultUpdateTimestamp: &clock,
 	}
 }
 
-func mkInitialData(numSets int, clock clockpb.HybridLogicalClock) *persistencepb.VersioningData {
-	sets := make([]*persistencepb.CompatibleVersionSet, numSets)
+func mkInitialData(numSets int, clock clockspb.HybridLogicalClock) *persistencespb.VersioningData {
+	sets := make([]*persistencespb.CompatibleVersionSet, numSets)
 	for i := 0; i < numSets; i++ {
 		sets[i] = mkNewSet(fmt.Sprintf("%v", i), clock)
 	}
-	return &persistencepb.VersioningData{
+	return &persistencespb.VersioningData{
 		VersionSets:            sets,
 		DefaultUpdateTimestamp: &clock,
 	}
 }
 
-func mkUserData(numSets int) *persistencepb.TaskQueueUserData {
+func mkUserData(numSets int) *persistencespb.TaskQueueUserData {
 	clock := hlc.Zero(1)
-	return &persistencepb.TaskQueueUserData{
+	return &persistencespb.TaskQueueUserData{
 		Clock:          &clock,
 		VersioningData: mkInitialData(numSets, clock),
 	}
@@ -109,22 +109,22 @@ func TestNewDefaultUpdate(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, mkInitialData(2, clock), initialData)
 
-	expected := &persistencepb.VersioningData{
+	expected := &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &nextClock,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds:                 []string{hashBuildID("0")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
 				DefaultUpdateTimestamp: &clock,
 			},
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
 				DefaultUpdateTimestamp: &clock,
 			},
 			{
 				SetIds:                 []string{hashBuildID("2")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "2", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "2", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock}},
 				DefaultUpdateTimestamp: &nextClock,
 			},
 		},
@@ -145,12 +145,12 @@ func TestNewDefaultSetUpdateOfEmptyData(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, mkInitialData(0, clock), initialData)
 
-	expected := &persistencepb.VersioningData{
+	expected := &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &nextClock,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock}},
 				DefaultUpdateTimestamp: &nextClock,
 			},
 		},
@@ -168,19 +168,19 @@ func TestNewDefaultSetUpdateCompatWithCurDefault(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, mkInitialData(2, clock), initialData)
 
-	expected := &persistencepb.VersioningData{
+	expected := &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &nextClock,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds:                 []string{hashBuildID("0")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
 				DefaultUpdateTimestamp: &clock,
 			},
 			{
 				SetIds: []string{hashBuildID("1")},
-				BuildIds: []*persistencepb.BuildID{
-					{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock},
-					{Id: "1.1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock},
+				BuildIds: []*persistencespb.BuildID{
+					{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock},
+					{Id: "1.1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock},
 				},
 				DefaultUpdateTimestamp: &nextClock,
 			},
@@ -199,19 +199,19 @@ func TestNewDefaultSetUpdateCompatWithNonDefaultSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, mkInitialData(2, clock), initialData)
 
-	expected := &persistencepb.VersioningData{
+	expected := &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &nextClock,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
 				DefaultUpdateTimestamp: &clock,
 			},
 			{
 				SetIds: []string{hashBuildID("0")},
-				BuildIds: []*persistencepb.BuildID{
-					{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock},
-					{Id: "0.1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock},
+				BuildIds: []*persistencespb.BuildID{
+					{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock},
+					{Id: "0.1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock},
 				},
 				DefaultUpdateTimestamp: &nextClock,
 			},
@@ -230,20 +230,20 @@ func TestNewCompatibleWithVerInOlderSet(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, mkInitialData(2, clock), initialData)
 
-	expected := &persistencepb.VersioningData{
+	expected := &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &clock,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds: []string{hashBuildID("0")},
-				BuildIds: []*persistencepb.BuildID{
-					{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock},
-					{Id: "0.1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock},
+				BuildIds: []*persistencespb.BuildID{
+					{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock},
+					{Id: "0.1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &nextClock},
 				},
 				DefaultUpdateTimestamp: &nextClock,
 			},
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock}},
 				DefaultUpdateTimestamp: &clock,
 			},
 		},
@@ -268,21 +268,21 @@ func TestNewCompatibleWithNonDefaultSetUpdate(t *testing.T) {
 	data, err = UpdateVersionSets(clock2, data, req, 0, 0)
 	assert.NoError(t, err)
 
-	expected := &persistencepb.VersioningData{
+	expected := &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &clock0,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds: []string{hashBuildID("0")},
-				BuildIds: []*persistencepb.BuildID{
-					{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
-					{Id: "0.1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock1},
-					{Id: "0.2", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock2},
+				BuildIds: []*persistencespb.BuildID{
+					{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
+					{Id: "0.1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock1},
+					{Id: "0.2", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock2},
 				},
 				DefaultUpdateTimestamp: &clock2,
 			},
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
 				DefaultUpdateTimestamp: &clock0,
 			},
 		},
@@ -295,22 +295,22 @@ func TestNewCompatibleWithNonDefaultSetUpdate(t *testing.T) {
 	data, err = UpdateVersionSets(clock3, data, req, 0, 0)
 	assert.NoError(t, err)
 
-	expected = &persistencepb.VersioningData{
+	expected = &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &clock0,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds: []string{hashBuildID("0")},
-				BuildIds: []*persistencepb.BuildID{
-					{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
-					{Id: "0.1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock1},
-					{Id: "0.2", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock2},
-					{Id: "0.3", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock3},
+				BuildIds: []*persistencespb.BuildID{
+					{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
+					{Id: "0.1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock1},
+					{Id: "0.2", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock2},
+					{Id: "0.3", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock3},
 				},
 				DefaultUpdateTimestamp: &clock3,
 			},
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
 				DefaultUpdateTimestamp: &clock0,
 			},
 		},
@@ -339,24 +339,24 @@ func TestMakeExistingSetDefault(t *testing.T) {
 	data, err := UpdateVersionSets(clock1, data, req, 0, 0)
 	assert.NoError(t, err)
 
-	expected := &persistencepb.VersioningData{
+	expected := &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &clock1,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds: []string{hashBuildID("0")},
-				BuildIds: []*persistencepb.BuildID{
-					{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
+				BuildIds: []*persistencespb.BuildID{
+					{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
 				},
 				DefaultUpdateTimestamp: &clock0,
 			},
 			{
 				SetIds:                 []string{hashBuildID("2")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "2", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "2", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
 				DefaultUpdateTimestamp: &clock0,
 			},
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
 				DefaultUpdateTimestamp: &clock0,
 			},
 		},
@@ -370,24 +370,24 @@ func TestMakeExistingSetDefault(t *testing.T) {
 	data, err = UpdateVersionSets(clock2, data, req, 0, 0)
 	assert.NoError(t, err)
 
-	expected = &persistencepb.VersioningData{
+	expected = &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &clock2,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds:                 []string{hashBuildID("2")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "2", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "2", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
 				DefaultUpdateTimestamp: &clock0,
 			},
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
 				DefaultUpdateTimestamp: &clock0,
 			},
 			{
 				SetIds: []string{hashBuildID("0")},
-				BuildIds: []*persistencepb.BuildID{
-					{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
-					{Id: "0.1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock2},
+				BuildIds: []*persistencespb.BuildID{
+					{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
+					{Id: "0.1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock2},
 				},
 				DefaultUpdateTimestamp: &clock2,
 			},
@@ -449,21 +449,21 @@ func TestPromoteWithinVersion(t *testing.T) {
 	data, err = UpdateVersionSets(clock3, data, req, 0, 0)
 	assert.NoError(t, err)
 
-	expected := &persistencepb.VersioningData{
+	expected := &persistencespb.VersioningData{
 		DefaultUpdateTimestamp: &clock0,
-		VersionSets: []*persistencepb.CompatibleVersionSet{
+		VersionSets: []*persistencespb.CompatibleVersionSet{
 			{
 				SetIds: []string{hashBuildID("0")},
-				BuildIds: []*persistencepb.BuildID{
-					{Id: "0", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
-					{Id: "0.2", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock2},
-					{Id: "0.1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock1},
+				BuildIds: []*persistencespb.BuildID{
+					{Id: "0", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0},
+					{Id: "0.2", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock2},
+					{Id: "0.1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock1},
 				},
 				DefaultUpdateTimestamp: &clock3,
 			},
 			{
 				SetIds:                 []string{hashBuildID("1")},
-				BuildIds:               []*persistencepb.BuildID{{Id: "1", State: persistencepb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
+				BuildIds:               []*persistencespb.BuildID{{Id: "1", State: persistencespb.STATE_ACTIVE, StateUpdateTimestamp: &clock0}},
 				DefaultUpdateTimestamp: &clock0,
 			},
 		},

--- a/service/worker/replicator/namespace_replication_message_processor.go
+++ b/service/worker/replicator/namespace_replication_message_processor.go
@@ -33,7 +33,7 @@ import (
 	"go.temporal.io/api/serviceerror"
 
 	"go.temporal.io/server/api/adminservice/v1"
-	"go.temporal.io/server/api/enums/v1"
+	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common"
@@ -225,9 +225,9 @@ func (p *namespaceReplicationMessageProcessor) handleNamespaceReplicationTask(
 	}()
 
 	switch task.TaskType {
-	case enums.REPLICATION_TASK_TYPE_NAMESPACE_TASK:
+	case enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK:
 		return p.namespaceTaskExecutor.Execute(ctx, task.GetNamespaceTaskAttributes())
-	case enums.REPLICATION_TASK_TYPE_TASK_QUEUE_USER_DATA:
+	case enumsspb.REPLICATION_TASK_TYPE_TASK_QUEUE_USER_DATA:
 		attrs := task.GetTaskQueueUserDataAttributes()
 		_, err := p.matchingClient.ApplyTaskQueueUserDataReplicationEvent(ctx, &matchingservice.ApplyTaskQueueUserDataReplicationEventRequest{
 			NamespaceId: attrs.GetNamespaceId(),


### PR DESCRIPTION
**What changed?**
Rename imports: public protobuf packages end in `pb`, server protobuf packages end in `spb` (s for server)

**Why?**
consistency

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
