### PR TITLE
Verify WFTs with large event buffers fail

### DIFF
--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -39,6 +39,7 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/server/api/enums/v1"
+	historyspb "go.temporal.io/server/api/history/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
@@ -164,11 +165,6 @@ func (c mutationTestCase) startWorkflowExecution(
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	_, _, err = ms.CloseTransactionAsMutation(c.transactionPolicy)
-	if err != nil {
-		t.Fatal(err)
-	}
 }
 
 func (c mutationTestCase) addWorkflowExecutionSignaled(t *testing.T, i int, ms *workflow.MutableStateImpl) {
@@ -221,6 +217,10 @@ func (c mutationTestCase) createMutableState(t *testing.T, nsEntry *namespace.Na
 		startTime,
 	)
 	ms.GetExecutionInfo().NamespaceId = nsEntry.ID().String()
+	// must start with a non-empty version history so that we have something to compare against when writing
+	ms.GetExecutionInfo().VersionHistories.Histories[0].Items = []*historyspb.VersionHistoryItem{
+		{Version: 0, EventId: 1},
+	}
 
 	return ms
 }

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -63,21 +63,21 @@ func TestMutableStateImpl_ForceFlushBufferedEvents(t *testing.T) {
 			signals:           1,
 			maxNumEvents:      2,
 			transactionPolicy: workflow.TransactionPolicyActive,
-			expectFailure:     false,
+			expectFlush:       false,
 		},
 		{
 			name:              "signals=maxNumEvents",
 			signals:           2,
 			maxNumEvents:      2,
 			transactionPolicy: workflow.TransactionPolicyActive,
-			expectFailure:     true,
+			expectFlush:       true,
 		},
 		{
 			name:              "signals>maxNumEvents",
 			signals:           3,
 			maxNumEvents:      2,
 			transactionPolicy: workflow.TransactionPolicyActive,
-			expectFailure:     true,
+			expectFlush:       true,
 		},
 	} {
 		t.Run(tc.name, tc.Run)
@@ -89,7 +89,7 @@ type mutationTestCase struct {
 	transactionPolicy workflow.TransactionPolicy
 	signals           int
 	maxNumEvents      int
-	expectFailure     bool
+	expectFlush       bool
 }
 
 func (c mutationTestCase) Run(t *testing.T) {
@@ -106,14 +106,12 @@ func (c mutationTestCase) Run(t *testing.T) {
 		c.addWorkflowExecutionSignaled(t, i, ms)
 	}
 
-	mu, workflowEvents, err := ms.CloseTransactionAsMutation(c.transactionPolicy)
+	_, workflowEvents, err := ms.CloseTransactionAsMutation(c.transactionPolicy)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	_ = mu
-
-	if c.expectFailure {
+	if c.expectFlush {
 		c.testFailure(t, ms, wft, workflowEvents)
 	} else {
 		c.testSuccess(t, ms, workflowEvents)

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -109,6 +109,7 @@ func (c mutationTestCase) Run(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	_ = mu
 
 	if c.expectFailure {
@@ -122,6 +123,8 @@ func (c mutationTestCase) startWFT(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 ) *workflow.WorkflowTaskInfo {
+	t.Helper()
+
 	wft, err := ms.AddWorkflowTaskScheduledEvent(false, enums.WORKFLOW_TASK_TYPE_NORMAL)
 	if err != nil {
 		t.Fatal(err)
@@ -131,10 +134,15 @@ func (c mutationTestCase) startWFT(
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	return wft
 }
 
-func (c mutationTestCase) startWorkflowExecution(t *testing.T, ms *workflow.MutableStateImpl, nsEntry *namespace.Namespace) {
+func (c mutationTestCase) startWorkflowExecution(
+	t *testing.T,
+	ms *workflow.MutableStateImpl,
+	nsEntry *namespace.Namespace,
+) {
 	t.Helper()
 
 	_, err := ms.AddWorkflowExecutionStartedEvent(
@@ -284,6 +292,7 @@ func (c mutationTestCase) testFailure(
 	}
 
 	flushedSignals := 0
+
 	for _, batch := range workflowEvents {
 		for _, ev := range batch.Events {
 			if ev.EventType == enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED {
@@ -291,6 +300,7 @@ func (c mutationTestCase) testFailure(
 			}
 		}
 	}
+
 	if flushedSignals != c.signals {
 		t.Errorf(
 			"Expected number of flushed signals, %d, to equal the number of signals in this WFT, %d",

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -1,0 +1,320 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package workflow_test contains tests for the workflow package. There are also tests in the workflow package itself,
+// but test packages force you to only test exported methods.
+// See https://github.com/maratori/testpackage#motivation for more on the rationale used here.
+package workflow_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/history/v1"
+	taskqueuepb "go.temporal.io/api/taskqueue/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/enums/v1"
+	"go.temporal.io/server/api/historyservice/v1"
+	persistence2 "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/events"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tests"
+	"go.temporal.io/server/service/history/workflow"
+)
+
+func TestMutableStateImpl_CloseTransactionAsMutation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []mutationTestCase{
+		{
+			name:              "numEvents<maxNumEvents",
+			numEvents:         1,
+			maxNumEvents:      2,
+			transactionPolicy: workflow.TransactionPolicyActive,
+			expectFailure:     false,
+		},
+		{
+			name:              "numEvents=maxNumEvents",
+			numEvents:         2,
+			maxNumEvents:      2,
+			transactionPolicy: workflow.TransactionPolicyActive,
+			expectFailure:     true,
+		},
+		{
+			name:              "numEvents>maxNumEvents",
+			numEvents:         3,
+			maxNumEvents:      2,
+			transactionPolicy: workflow.TransactionPolicyActive,
+			expectFailure:     true,
+		},
+	} {
+		t.Run(tc.name, tc.Run)
+	}
+}
+
+type mutationTestCase struct {
+	name              string
+	transactionPolicy workflow.TransactionPolicy
+	numEvents         int
+	maxNumEvents      int
+	expectFailure     bool
+}
+
+func (c mutationTestCase) Run(t *testing.T) {
+	t.Parallel()
+
+	nsEntry := tests.LocalNamespaceEntry
+	ms := c.createMutableState(t, nsEntry)
+
+	_, err := ms.AddWorkflowExecutionStartedEvent(
+		commonpb.WorkflowExecution{
+			WorkflowId: "694B31C3-1FDC-4C9E-87BC-747D539BF0CD",
+			RunId:      "3E1836B8-8692-440D-9495-45D9EABDED6B",
+		},
+		&historyservice.StartWorkflowExecutionRequest{
+			Attempt:     1,
+			NamespaceId: nsEntry.ID().String(),
+			StartRequest: &workflowservice.StartWorkflowExecutionRequest{
+				WorkflowType:        &commonpb.WorkflowType{Name: "workflow-type"},
+				TaskQueue:           &taskqueuepb.TaskQueue{Name: "task-queue-name"},
+				WorkflowRunTimeout:  timestamp.DurationPtr(200 * time.Second),
+				WorkflowTaskTimeout: timestamp.DurationPtr(1 * time.Second),
+			},
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.completeOneWFT(t, ms)
+
+	wft, err := ms.AddWorkflowTaskScheduledEvent(false, enums.WORKFLOW_TASK_TYPE_NORMAL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, wft, err = ms.AddWorkflowTaskStartedEvent(wft.ScheduledEventID, wft.RequestID, wft.TaskQueue, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < c.numEvents; i++ {
+		c.addWorkflowExecutionSignaled(t, i, ms)
+	}
+
+	_, workflowEvents, err := ms.CloseTransactionAsMutation(c.transactionPolicy)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if c.expectFailure {
+		c.testFailure(t, ms, wft, workflowEvents)
+	} else {
+		c.testSuccess(t, ms, workflowEvents)
+	}
+}
+
+func (c mutationTestCase) addWorkflowExecutionSignaled(t *testing.T, i int, ms *workflow.MutableStateImpl) {
+	t.Helper()
+
+	payload := &commonpb.Payloads{}
+	identity := fmt.Sprintf("%d", i)
+	header := &commonpb.Header{}
+
+	_, err := ms.AddWorkflowExecutionSignaled(
+		"signal-name",
+		payload,
+		identity,
+		header,
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (c mutationTestCase) createMutableState(t *testing.T, nsEntry *namespace.Namespace) *workflow.MutableStateImpl {
+	t.Helper()
+
+	ctrl := gomock.NewController(t)
+	cfg := c.createConfig()
+	shardContext := shard.NewTestContext(ctrl, &persistence2.ShardInfo{}, cfg)
+
+	nsRegistry := shardContext.Resource.NamespaceCache
+	nsRegistry.EXPECT().GetNamespaceByID(nsEntry.ID()).Return(nsEntry, nil).AnyTimes()
+
+	clusterMetadata := shardContext.Resource.ClusterMetadata
+	clusterMetadata.EXPECT().ClusterNameForFailoverVersion(nsEntry.IsGlobalNamespace(),
+		nsEntry.FailoverVersion()).Return(cluster.TestCurrentClusterName).AnyTimes()
+	clusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+
+	executionManager := shardContext.Resource.ExecutionMgr
+	executionManager.EXPECT().GetHistoryBranchUtil().Return(&persistence.HistoryBranchUtilImpl{}).AnyTimes()
+
+	startTime := time.Time{}
+	logger := log.NewNoopLogger()
+	eventsCache := events.NewMockCache(ctrl)
+	eventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
+
+	ms := workflow.NewMutableState(
+		shardContext,
+		eventsCache,
+		logger,
+		nsEntry,
+		startTime,
+	)
+	ms.GetExecutionInfo().NamespaceId = nsEntry.ID().String()
+
+	return ms
+}
+
+func (c mutationTestCase) createConfig() *configs.Config {
+	cfg := tests.NewDynamicConfig()
+	cfg.MaximumBufferedEventsBatch = func() int {
+		return c.maxNumEvents
+	}
+
+	return cfg
+}
+
+func (c mutationTestCase) completeOneWFT(t *testing.T, ms *workflow.MutableStateImpl) {
+	t.Helper()
+
+	wft, err := ms.AddWorkflowTaskScheduledEvent(false, enums.WORKFLOW_TASK_TYPE_NORMAL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, wft, err = ms.AddWorkflowTaskStartedEvent(
+		wft.ScheduledEventID,
+		wft.RequestID,
+		wft.TaskQueue,
+		"identity",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = ms.AddWorkflowTaskCompletedEvent(
+		wft,
+		&workflowservice.RespondWorkflowTaskCompletedRequest{},
+		1,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err = ms.CloseTransactionAsMutation(c.transactionPolicy)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func (c mutationTestCase) testWFTFailedEvent(
+	t *testing.T,
+	wft *workflow.WorkflowTaskInfo,
+	event *history.HistoryEvent,
+) {
+	t.Helper()
+
+	attr := event.GetWorkflowTaskFailedEventAttributes()
+	if attr == nil {
+		t.Fatal("WFT-failed event has nil attributes")
+	}
+
+	if attr.ScheduledEventId != wft.ScheduledEventID || attr.StartedEventId != wft.StartedEventID {
+		t.Errorf("WFT-failed event, %#v, does not target our WFT, %#v", event, wft)
+	}
+
+	if attr.Cause != enumspb.WORKFLOW_TASK_FAILED_CAUSE_FORCE_CLOSE_COMMAND {
+		t.Errorf(
+			"WFT should fail because it was force closed, but the failure cause is %q instead",
+			attr.Cause.String(),
+		)
+	}
+}
+
+func (c mutationTestCase) findWFTEvent(eventType enumspb.EventType, workflowEvents []*persistence.WorkflowEvents) (
+	*history.HistoryEvent,
+	bool,
+) {
+	for _, batch := range workflowEvents {
+		for _, ev := range batch.Events {
+			if ev.EventType == eventType {
+				return ev, true
+			}
+		}
+	}
+
+	return nil, false
+}
+
+func (c mutationTestCase) testFailure(
+	t *testing.T,
+	ms *workflow.MutableStateImpl,
+	wft *workflow.WorkflowTaskInfo,
+	workflowEvents []*persistence.WorkflowEvents,
+) {
+	t.Helper()
+
+	wftAttempt := ms.GetExecutionInfo().GetWorkflowTaskAttempt()
+	if wftAttempt != 2 {
+		t.Errorf("Expected WFT attempt number to be 2 if the WFT failed, but was %d", wftAttempt)
+	}
+
+	event, ok := c.findWFTEvent(enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED, workflowEvents)
+	if !ok {
+		t.Fatal("Failed to find WFT-failed event in history")
+	}
+
+	c.testWFTFailedEvent(t, wft, event)
+}
+
+func (c mutationTestCase) testSuccess(
+	t *testing.T,
+	ms *workflow.MutableStateImpl,
+	workflowEvents []*persistence.WorkflowEvents,
+) {
+	t.Helper()
+
+	_, ok := c.findWFTEvent(enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED, workflowEvents)
+	if ok {
+		t.Fatalf("Expected to not find a WFT-failed event in %#v", workflowEvents)
+	}
+
+	wftAttempt := ms.GetExecutionInfo().GetWorkflowTaskAttempt()
+	if wftAttempt != 1 {
+		t.Errorf("Expected WFT attempt number to be unchanged if the WFT succeeded, but is now %d", wftAttempt)
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a unit test which verifies that we fail WFTs with event buffers that are too large.

<!-- Tell your future self why have you made these changes -->
**Why?**
To make it easier to add the event buffer byte size check to the CloseTransactionAsMutation.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I verify that the WFT attempt was incremented and the WFT-failed event in the history exists and looks correct.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Just a test.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No 