### PR TITLE
Fix adding multiple search attributes of same type at once

### DIFF
--- a/common/searchattribute/test_provider.go
+++ b/common/searchattribute/test_provider.go
@@ -53,13 +53,27 @@ var (
 			"CustomBoolField":     enumspb.INDEXED_VALUE_TYPE_BOOL,
 
 			"Int01":         enumspb.INDEXED_VALUE_TYPE_INT,
+			"Int02":         enumspb.INDEXED_VALUE_TYPE_INT,
+			"Int03":         enumspb.INDEXED_VALUE_TYPE_INT,
 			"Text01":        enumspb.INDEXED_VALUE_TYPE_TEXT,
 			"Keyword01":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"Keyword02":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"Keyword03":     enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 			"Datetime01":    enumspb.INDEXED_VALUE_TYPE_DATETIME,
 			"Double01":      enumspb.INDEXED_VALUE_TYPE_DOUBLE,
 			"Bool01":        enumspb.INDEXED_VALUE_TYPE_BOOL,
 			"KeywordList01": enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 		},
+	}
+
+	TestAliases = map[string]string{
+		"Int01":         "CustomIntField",
+		"Text01":        "CustomTextField",
+		"Keyword01":     "CustomKeywordField",
+		"Datetime01":    "CustomDatetimeField",
+		"Double01":      "CustomDoubleField",
+		"Bool01":        "CustomBoolField",
+		"KeywordList01": "CustomKeywordListField",
 	}
 )
 

--- a/service/frontend/operator_handler_test.go
+++ b/service/frontend/operator_handler_test.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -36,8 +37,10 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
+	namespacepb "go.temporal.io/api/namespace/v1"
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
 	"google.golang.org/grpc/health"
 
 	"go.temporal.io/server/api/adminservice/v1"
@@ -50,7 +53,13 @@ import (
 	"go.temporal.io/server/common/resourcetest"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/common/testing/mocksdk"
+	"go.temporal.io/server/service/worker/addsearchattributes"
 	"go.temporal.io/server/service/worker/deletenamespace"
+)
+
+var (
+	testNamespace = "test-namespace"
+	testIndexName = "test-index-name"
 )
 
 type (
@@ -165,7 +174,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes_EmptyIndexName() {
 	}
 }
 
-func (s *operatorHandlerSuite) Test_AddSearchAttributes_NonEmptyIndexName() {
+func (s *operatorHandlerSuite) Test_AddSearchAttributes_Elasticsearch() {
 	handler := s.handler
 	ctx := context.Background()
 
@@ -176,7 +185,7 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes_NonEmptyIndexName() {
 	}
 	testCases := []test{
 		{
-			Name: "reserved key (ES configured)",
+			Name: "reserved key",
 			Request: &operatorservice.AddSearchAttributesRequest{
 				SearchAttributes: map[string]enumspb.IndexedValueType{
 					"WorkflowId": enumspb.INDEXED_VALUE_TYPE_TEXT,
@@ -185,9 +194,19 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes_NonEmptyIndexName() {
 			Expected: &serviceerror.InvalidArgument{Message: "Search attribute WorkflowId is reserved by system."},
 		},
 		{
-			Name: "key already whitelisted (ES configured)",
+			Name: "key already whitelisted",
 			Request: &operatorservice.AddSearchAttributesRequest{
 				SearchAttributes: map[string]enumspb.IndexedValueType{
+					"CustomTextField": enumspb.INDEXED_VALUE_TYPE_TEXT,
+				},
+			},
+			Expected: &serviceerror.AlreadyExists{Message: "Search attribute CustomTextField already exists."},
+		},
+		{
+			Name: "mix new key and key already whitelisted",
+			Request: &operatorservice.AddSearchAttributesRequest{
+				SearchAttributes: map[string]enumspb.IndexedValueType{
+					"CustomAttr":      enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 					"CustomTextField": enumspb.INDEXED_VALUE_TYPE_TEXT,
 				},
 			},
@@ -197,8 +216,8 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes_NonEmptyIndexName() {
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
 	s.mockResource.VisibilityManager.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(true).AnyTimes()
-	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return(testIndexName).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(testIndexName, true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
 	for _, testCase := range testCases {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.AddSearchAttributes(ctx, testCase.Request)
@@ -239,12 +258,160 @@ func (s *operatorHandlerSuite) Test_AddSearchAttributes_NonEmptyIndexName() {
 
 	// Success case.
 	mockRun.EXPECT().Get(gomock.Any(), nil).Return(nil)
-	mockSdkClient.EXPECT().ExecuteWorkflow(gomock.Any(), gomock.Any(), "temporal-sys-add-search-attributes-workflow", gomock.Any()).Return(mockRun, nil)
+	mockSdkClient.EXPECT().ExecuteWorkflow(
+		gomock.Any(),
+		gomock.Any(),
+		"temporal-sys-add-search-attributes-workflow",
+		addsearchattributes.WorkflowParams{
+			CustomAttributesToAdd: map[string]enumspb.IndexedValueType{
+				"CustomAttr1": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				"CustomAttr2": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			},
+			IndexName:        testIndexName,
+			SkipSchemaUpdate: false,
+		},
+	).Return(mockRun, nil)
 
 	resp, err = handler.AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
 		SearchAttributes: map[string]enumspb.IndexedValueType{
-			"CustomAttr": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"CustomAttr1": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"CustomAttr2": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		},
+	})
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
+func (s *operatorHandlerSuite) Test_AddSearchAttributes_SQL() {
+	handler := s.handler
+	ctx := context.Background()
+
+	s.mockResource.VisibilityManager.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(false).AnyTimes()
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return(testIndexName).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().
+		GetSearchAttributes(testIndexName, true).
+		Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.ClientFactory.EXPECT().
+		NewLocalFrontendClientWithTimeout(gomock.Any(), gomock.Any()).
+		Return(nil, s.mockResource.GetFrontendClient(), nil).
+		AnyTimes()
+	s.mockResource.FrontendClient.EXPECT().
+		DescribeNamespace(gomock.Any(), &workflowservice.DescribeNamespaceRequest{Namespace: testNamespace}).
+		Return(
+			&workflowservice.DescribeNamespaceResponse{
+				Config: &namespacepb.NamespaceConfig{CustomSearchAttributeAliases: searchattribute.TestAliases},
+			},
+			nil,
+		).
+		AnyTimes()
+
+	type test struct {
+		Name     string
+		Request  *operatorservice.AddSearchAttributesRequest
+		Expected error
+	}
+	testCases := []test{
+		{
+			Name: "reserved key",
+			Request: &operatorservice.AddSearchAttributesRequest{
+				SearchAttributes: map[string]enumspb.IndexedValueType{
+					"WorkflowId": enumspb.INDEXED_VALUE_TYPE_TEXT,
+				},
+				Namespace: testNamespace,
+			},
+			Expected: &serviceerror.InvalidArgument{Message: "Search attribute WorkflowId is reserved by system."},
+		},
+		{
+			Name: "key already whitelisted",
+			Request: &operatorservice.AddSearchAttributesRequest{
+				SearchAttributes: map[string]enumspb.IndexedValueType{
+					"CustomTextField": enumspb.INDEXED_VALUE_TYPE_TEXT,
+				},
+				Namespace: testNamespace,
+			},
+			Expected: &serviceerror.AlreadyExists{Message: "Search attribute CustomTextField already exists."},
+		},
+		{
+			Name: "mix new key and key already whitelisted",
+			Request: &operatorservice.AddSearchAttributesRequest{
+				SearchAttributes: map[string]enumspb.IndexedValueType{
+					"CustomAttr":      enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+					"CustomTextField": enumspb.INDEXED_VALUE_TYPE_TEXT,
+				},
+				Namespace: testNamespace,
+			},
+			Expected: &serviceerror.AlreadyExists{Message: "Search attribute CustomTextField already exists."},
+		},
+		{
+			Name: "too many search attributes",
+			Request: &operatorservice.AddSearchAttributesRequest{
+				SearchAttributes: map[string]enumspb.IndexedValueType{
+					"CustomAttr1": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+					"CustomAttr2": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+					"CustomAttr3": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+				},
+				Namespace: testNamespace,
+			},
+			Expected: &serviceerror.InvalidArgument{Message: "Unable to create search attributes: cannot have more than 3 search attribute of type Keyword."},
+		},
+	}
+
+	for _, testCase := range testCases {
+		s.T().Run(testCase.Name, func(t *testing.T) {
+			resp, err := handler.AddSearchAttributes(ctx, testCase.Request)
+			s.Equal(testCase.Expected, err)
+			s.Nil(resp)
+		})
+	}
+
+	s.mockResource.FrontendClient.EXPECT().
+		UpdateNamespace(gomock.Any(), gomock.Any()).
+		Return(nil, errCustomSearchAttributeFieldAlreadyAllocated)
+	resp, err := handler.AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
+		SearchAttributes: map[string]enumspb.IndexedValueType{
+			"CustomAttr1": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"CustomAttr2": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"CustomAttr3": enumspb.INDEXED_VALUE_TYPE_INT,
+		},
+		Namespace: testNamespace,
+	})
+	s.Equal(errRaceConditionAddingSearchAttributes, err)
+	s.Nil(resp)
+
+	s.mockResource.FrontendClient.EXPECT().
+		UpdateNamespace(
+			gomock.Any(),
+			newUpdateNamespaceRequestMatcher(
+				func(request *workflowservice.UpdateNamespaceRequest) bool {
+					if len(request.Config.CustomSearchAttributeAliases) != 3 {
+						return false
+					}
+					cnt := 0
+					for field, alias := range request.Config.CustomSearchAttributeAliases {
+						if alias == "CustomAttr1" || alias == "CustomAttr2" {
+							if !strings.HasPrefix(field, "Keyword") {
+								return false
+							}
+							cnt++
+						} else if alias == "CustomAttr3" {
+							if !strings.HasPrefix(field, "Int") {
+								return false
+							}
+							cnt++
+						}
+					}
+					return cnt == 3
+				},
+			),
+		).
+		Return(&workflowservice.UpdateNamespaceResponse{}, nil)
+	resp, err = handler.AddSearchAttributes(ctx, &operatorservice.AddSearchAttributesRequest{
+		SearchAttributes: map[string]enumspb.IndexedValueType{
+			"CustomAttr1": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"CustomAttr2": enumspb.INDEXED_VALUE_TYPE_KEYWORD,
+			"CustomAttr3": enumspb.INDEXED_VALUE_TYPE_INT,
+		},
+		Namespace: testNamespace,
 	})
 	s.NoError(err)
 	s.NotNil(resp)
@@ -270,20 +437,58 @@ func (s *operatorHandlerSuite) Test_ListSearchAttributes_EmptyIndexName() {
 	s.NotNil(resp)
 }
 
-func (s *operatorHandlerSuite) Test_ListSearchAttributes_NonEmptyIndexName() {
+func (s *operatorHandlerSuite) Test_ListSearchAttributes_Elasticsearch() {
 	handler := s.handler
 	ctx := context.Background()
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
 	s.mockResource.VisibilityManager.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(true)
-	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
-	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), "random-index-name").Return(map[string]string{"col": "type"}, nil)
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil)
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return(testIndexName).AnyTimes()
+	s.mockResource.ESClient.EXPECT().GetMapping(gomock.Any(), testIndexName).Return(map[string]string{"col": "type"}, nil)
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(testIndexName, true).Return(searchattribute.TestNameTypeMap, nil)
 	resp, err := handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
 	s.NoError(err)
 	s.NotNil(resp)
 
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.NameTypeMap{}, errors.New("random error"))
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(testIndexName, true).Return(searchattribute.NameTypeMap{}, errors.New("random error"))
+	resp, err = handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
+	s.Error(err)
+	s.Nil(resp)
+}
+
+func (s *operatorHandlerSuite) Test_ListSearchAttributes_SQL() {
+	handler := s.handler
+	ctx := context.Background()
+
+	s.mockResource.VisibilityManager.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(false)
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return(testIndexName).AnyTimes()
+	s.mockResource.ClientFactory.EXPECT().
+		NewLocalFrontendClientWithTimeout(gomock.Any(), gomock.Any()).
+		Return(nil, s.mockResource.GetFrontendClient(), nil).
+		AnyTimes()
+	s.mockResource.FrontendClient.EXPECT().
+		DescribeNamespace(gomock.Any(), &workflowservice.DescribeNamespaceRequest{Namespace: testNamespace}).
+		Return(
+			&workflowservice.DescribeNamespaceResponse{
+				Config: &namespacepb.NamespaceConfig{CustomSearchAttributeAliases: searchattribute.TestAliases},
+			},
+			nil,
+		).
+		AnyTimes()
+
+	s.mockResource.SearchAttributesProvider.EXPECT().
+		GetSearchAttributes(testIndexName, true).
+		Return(searchattribute.TestNameTypeMap, nil)
+	resp, err := handler.ListSearchAttributes(
+		ctx,
+		&operatorservice.ListSearchAttributesRequest{Namespace: testNamespace},
+	)
+	s.NoError(err)
+	s.NotNil(resp)
+
+	s.mockResource.SearchAttributesProvider.EXPECT().
+		GetSearchAttributes(testIndexName, true).
+		Return(searchattribute.NameTypeMap{}, errors.New("random error"))
 	resp, err = handler.ListSearchAttributes(ctx, &operatorservice.ListSearchAttributesRequest{})
 	s.Error(err)
 	s.Nil(resp)
@@ -353,7 +558,7 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_EmptyIndexName() {
 	}
 }
 
-func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_NonEmptyIndexName() {
+func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_Elasticsearch() {
 	handler := s.handler
 	ctx := context.Background()
 
@@ -385,8 +590,8 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_NonEmptyIndexName() {
 
 	// Configure Elasticsearch: add advanced visibility store config with index name.
 	s.mockResource.VisibilityManager.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(true).AnyTimes()
-	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return("random-index-name").AnyTimes()
-	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes("random-index-name", true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return(testIndexName).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().GetSearchAttributes(testIndexName, true).Return(searchattribute.TestNameTypeMap, nil).AnyTimes()
 	for _, testCase := range testCases {
 		s.T().Run(testCase.Name, func(t *testing.T) {
 			resp, err := handler.RemoveSearchAttributes(ctx, testCase.Request)
@@ -396,13 +601,100 @@ func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_NonEmptyIndexName() {
 	}
 
 	// Success case.
-	s.mockResource.SearchAttributesManager.EXPECT().SaveSearchAttributes(gomock.Any(), "random-index-name", gomock.Any()).Return(nil)
+	s.mockResource.SearchAttributesManager.EXPECT().SaveSearchAttributes(gomock.Any(), testIndexName, gomock.Any()).Return(nil)
 
 	resp, err := handler.RemoveSearchAttributes(ctx, &operatorservice.RemoveSearchAttributesRequest{
 		SearchAttributes: []string{
 			"CustomKeywordField",
 		},
 	})
+	s.NoError(err)
+	s.NotNil(resp)
+}
+
+func (s *operatorHandlerSuite) Test_RemoveSearchAttributes_SQL() {
+	handler := s.handler
+	ctx := context.Background()
+
+	s.mockResource.VisibilityManager.EXPECT().HasStoreName(elasticsearch.PersistenceName).Return(false).AnyTimes()
+	s.mockResource.VisibilityManager.EXPECT().GetIndexName().Return(testIndexName).AnyTimes()
+	s.mockResource.SearchAttributesProvider.EXPECT().
+		GetSearchAttributes(testIndexName, true).
+		Return(searchattribute.TestNameTypeMap, nil).
+		AnyTimes()
+	s.mockResource.ClientFactory.EXPECT().
+		NewLocalFrontendClientWithTimeout(gomock.Any(), gomock.Any()).
+		Return(nil, s.mockResource.GetFrontendClient(), nil).
+		AnyTimes()
+	s.mockResource.FrontendClient.EXPECT().
+		DescribeNamespace(gomock.Any(), &workflowservice.DescribeNamespaceRequest{Namespace: testNamespace}).
+		Return(
+			&workflowservice.DescribeNamespaceResponse{
+				Config: &namespacepb.NamespaceConfig{CustomSearchAttributeAliases: searchattribute.TestAliases},
+			},
+			nil,
+		).
+		AnyTimes()
+
+	type test struct {
+		Name     string
+		Request  *operatorservice.RemoveSearchAttributesRequest
+		Expected error
+	}
+	testCases := []test{
+		{
+			Name: "reserved search attribute",
+			Request: &operatorservice.RemoveSearchAttributesRequest{
+				SearchAttributes: []string{
+					"WorkflowId",
+				},
+				Namespace: testNamespace,
+			},
+			Expected: &serviceerror.InvalidArgument{Message: "Unable to remove non-custom search attributes: WorkflowId."},
+		},
+		{
+			Name: "search attribute doesn't exist",
+			Request: &operatorservice.RemoveSearchAttributesRequest{
+				SearchAttributes: []string{
+					"CustomKeywordField",
+					"ProductId",
+				},
+				Namespace: testNamespace,
+			},
+			Expected: &serviceerror.NotFound{Message: "Search attribute ProductId doesn't exist."},
+		},
+	}
+
+	for _, testCase := range testCases {
+		s.T().Run(testCase.Name, func(t *testing.T) {
+			resp, err := handler.RemoveSearchAttributes(ctx, testCase.Request)
+			s.Equal(testCase.Expected, err)
+			s.Nil(resp)
+		})
+	}
+
+	s.mockResource.FrontendClient.EXPECT().
+		UpdateNamespace(
+			gomock.Any(),
+			&workflowservice.UpdateNamespaceRequest{
+				Namespace: testNamespace,
+				Config: &namespacepb.NamespaceConfig{
+					CustomSearchAttributeAliases: map[string]string{
+						"Keyword01": "",
+					},
+				},
+			},
+		).
+		Return(&workflowservice.UpdateNamespaceResponse{}, nil)
+	resp, err := handler.RemoveSearchAttributes(
+		ctx,
+		&operatorservice.RemoveSearchAttributesRequest{
+			SearchAttributes: []string{
+				"CustomKeywordField",
+			},
+			Namespace: testNamespace,
+		},
+	)
 	s.NoError(err)
 	s.NotNil(resp)
 }
@@ -865,4 +1157,26 @@ func (s *operatorHandlerSuite) Test_AddOrUpdateRemoteCluster_SaveClusterMetadata
 	_, err := s.handler.AddOrUpdateRemoteCluster(context.Background(), &operatorservice.AddOrUpdateRemoteClusterRequest{FrontendAddress: rpcAddress})
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
+}
+
+type updateNamespaceRequestMatcher struct {
+	f func(request *workflowservice.UpdateNamespaceRequest) bool
+}
+
+func newUpdateNamespaceRequestMatcher(f func(request *workflowservice.UpdateNamespaceRequest) bool) gomock.Matcher {
+	return &updateNamespaceRequestMatcher{
+		f: f,
+	}
+}
+
+func (m *updateNamespaceRequestMatcher) Matches(x interface{}) bool {
+	request, ok := x.(*workflowservice.UpdateNamespaceRequest)
+	if !ok {
+		return false
+	}
+	return m.f(request)
+}
+
+func (m *updateNamespaceRequestMatcher) String() string {
+	return "UpdateNamespaceRequest match condition"
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix adding multiple search attributes of same type at once.
Synched `AdminHandler`'s code to add search attributes.
Added unit tests to operator handler.

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/temporalio/temporal/issues/4160

When adding multiple search attributes of same type, it's missing a check to not use new mappings when trying to map a new search attribute. Eg: initially it maps `Key1` to `Field1` and then `Key2` to `Field1` again because it didn't check that `Field1` is unavailable after `Key1` was mapped.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added multiple search attributes with same type using Temporal CLI and `tctl`.
Added unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.