### PR TITLE
Fix task attempt reset

### DIFF
--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -212,10 +212,9 @@ func (e *executableImpl) Execute() (retErr error) {
 	e.taggedMetricsHandler = e.metricsHandler.WithTags(metricsTags...)
 
 	if isActive != e.lastActiveness {
-		// namespace did a failover, reset task attempt
-		e.Lock()
-		e.attempt = 0
-		e.Unlock()
+		// namespace did a failover,
+		// reset task attempt since the execution logic used will change
+		e.resetAttempt()
 	}
 	e.lastActiveness = isActive
 
@@ -533,6 +532,13 @@ func (e *executableImpl) updatePriority() {
 	if e.priority > e.lowestPriority {
 		e.lowestPriority = e.priority
 	}
+}
+
+func (e *executableImpl) resetAttempt() {
+	e.Lock()
+	defer e.Unlock()
+
+	e.attempt = 1
 }
 
 func (e *executableImpl) estimateTaskMetricTag() []metrics.Tag {

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -149,6 +149,30 @@ func (s *executableSuite) TestExecute_CallerInfo() {
 	s.NoError(executable.Execute())
 }
 
+func (s *executableSuite) TestExecuteHandleErr_ResetAttempt() {
+	executable := s.newTestExecutable()
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).DoAndReturn(
+		func(ctx context.Context, _ Executable) ([]metrics.Tag, bool, error) {
+			s.Equal(headers.CallerTypeBackground, headers.GetCallerInfo(ctx).CallerType)
+			return nil, true, errors.New("some random error")
+		},
+	)
+	err := executable.Execute()
+	s.Error(err)
+	executable.HandleErr(err)
+	s.Equal(2, executable.Attempt())
+
+	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).DoAndReturn(
+		func(ctx context.Context, _ Executable) ([]metrics.Tag, bool, error) {
+			s.Equal(headers.CallerTypeBackground, headers.GetCallerInfo(ctx).CallerType)
+			// isActive changed to false, should reset attempt
+			return nil, false, nil
+		},
+	)
+	s.NoError(executable.Execute())
+	s.Equal(1, executable.Attempt())
+}
+
 func (s *executableSuite) TestExecuteHandleErr_Corrupted() {
 	executable := s.newTestExecutable()
 

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -154,7 +154,7 @@ func (s *executableSuite) TestExecuteHandleErr_ResetAttempt() {
 	s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Return(nil, true, errors.New("some random error"))
 	err := executable.Execute()
 	s.Error(err)
-	executable.HandleErr(err)
+	s.Error(executable.HandleErr(err))
 	s.Equal(2, executable.Attempt())
 
 	// isActive changed to false, should reset attempt


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
-  Reset task attempt to 1 instead of 0

<!-- Tell your future self why have you made these changes -->
**Why?**
- Attempt count should always start from 1, which is more natural.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- added new unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
yes