### PR TITLE
Fix misc. context value propagation issues

### DIFF
--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -149,7 +149,7 @@ func (h *historyArchiver) Archive(
 
 	var historyBatches []*historypb.History
 	for historyIterator.HasNext() {
-		historyBlob, err := historyIterator.Next()
+		historyBlob, err := historyIterator.Next(ctx)
 		if err != nil {
 			if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 				// workflow history no longer exists, may due to duplicated archival signal

--- a/common/archiver/filestore/historyArchiver_test.go
+++ b/common/archiver/filestore/historyArchiver_test.go
@@ -169,7 +169,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_ErrorOnReadHistory() {
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, errors.New("some random error")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, errors.New("some random error")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -192,7 +192,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_TimeoutWhenReadingHistory() {
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -232,7 +232,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -255,7 +255,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_NonRetryableErrorOption() {
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, errors.New("some random error")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, errors.New("some random error")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -295,9 +295,9 @@ func (s *historyArchiverSuite) TestArchive_Skip() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewNotFound("workflow not found")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, serviceerror.NewNotFound("workflow not found")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -351,7 +351,7 @@ func (s *historyArchiverSuite) TestArchive_Success() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(false),
 	)
 
@@ -534,7 +534,7 @@ func (s *historyArchiverSuite) TestArchiveAndGet() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(false),
 	)
 

--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -150,7 +150,7 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 
 	for historyIterator.HasNext() {
 		part := progress.CurrentPageNumber
-		historyBlob, err := historyIterator.Next()
+		historyBlob, err := historyIterator.Next(ctx)
 		if err != nil {
 			if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 				// workflow history no longer exists, may due to duplicated archival signal

--- a/common/archiver/gcloud/historyArchiver_test.go
+++ b/common/archiver/gcloud/historyArchiver_test.go
@@ -192,7 +192,7 @@ func (h *historyArchiverSuite) TestArchive_Fail_ErrorOnReadHistory() {
 	historyIterator := archiver.NewMockHistoryIterator(h.controller)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, errors.New("some random error")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, errors.New("some random error")),
 	)
 
 	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)
@@ -218,7 +218,7 @@ func (h *historyArchiverSuite) TestArchive_Fail_TimeoutWhenReadingHistory() {
 	historyIterator := archiver.NewMockHistoryIterator(h.controller)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "")),
 	)
 
 	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)
@@ -260,7 +260,7 @@ func (h *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 	)
 
 	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)
@@ -286,7 +286,7 @@ func (h *historyArchiverSuite) TestArchive_Fail_NonRetryableErrorOption() {
 	historyIterator := archiver.NewMockHistoryIterator(h.controller)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, errors.New("upload non-retryable error")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, errors.New("upload non-retryable error")),
 	)
 
 	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)
@@ -330,9 +330,9 @@ func (h *historyArchiverSuite) TestArchive_Skip() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewNotFound("workflow not found")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, serviceerror.NewNotFound("workflow not found")),
 	)
 
 	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)
@@ -391,7 +391,7 @@ func (h *historyArchiverSuite) TestArchive_Success() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(false),
 	)
 

--- a/common/archiver/historyIterator_mock.go
+++ b/common/archiver/historyIterator_mock.go
@@ -29,6 +29,7 @@
 package archiver
 
 import (
+	context "context"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -88,18 +89,18 @@ func (mr *MockHistoryIteratorMockRecorder) HasNext() *gomock.Call {
 }
 
 // Next mocks base method.
-func (m *MockHistoryIterator) Next() (*archiver.HistoryBlob, error) {
+func (m *MockHistoryIterator) Next(arg0 context.Context) (*archiver.HistoryBlob, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Next")
+	ret := m.ctrl.Call(m, "Next", arg0)
 	ret0, _ := ret[0].(*archiver.HistoryBlob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Next indicates an expected call of Next.
-func (mr *MockHistoryIteratorMockRecorder) Next() *gomock.Call {
+func (mr *MockHistoryIteratorMockRecorder) Next(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*MockHistoryIterator)(nil).Next))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Next", reflect.TypeOf((*MockHistoryIterator)(nil).Next), arg0)
 }
 
 // MockSizeEstimator is a mock of SizeEstimator interface.

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -162,7 +162,7 @@ func (h *historyArchiver) Archive(
 		historyIterator = loadHistoryIterator(ctx, request, h.container.ExecutionManager, featureCatalog, &progress)
 	}
 	for historyIterator.HasNext() {
-		historyBlob, err := historyIterator.Next()
+		historyBlob, err := historyIterator.Next(ctx)
 		if err != nil {
 			if _, isNotFound := err.(*serviceerror.NotFound); isNotFound {
 				// workflow history no longer exists, may due to duplicated archival signal

--- a/common/archiver/s3store/historyArchiver_test.go
+++ b/common/archiver/s3store/historyArchiver_test.go
@@ -300,7 +300,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_ErrorOnReadHistory() {
 	historyIterator := archiver.NewMockHistoryIterator(s.controller)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, errors.New("some random error")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, errors.New("some random error")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -321,7 +321,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_TimeoutWhenReadingHistory() {
 	historyIterator := archiver.NewMockHistoryIterator(s.controller)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_RPS_LIMIT, "")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -359,7 +359,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -380,7 +380,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_NonRetryableErrorOption() {
 	historyIterator := archiver.NewMockHistoryIterator(s.controller)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, errors.New("some random error")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, errors.New("some random error")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -418,9 +418,9 @@ func (s *historyArchiverSuite) TestArchive_Skip() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(nil, serviceerror.NewNotFound("workflow not found")),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(nil, serviceerror.NewNotFound("workflow not found")),
 	)
 
 	historyArchiver := s.newTestHistoryArchiver(historyIterator)
@@ -477,7 +477,7 @@ func (s *historyArchiverSuite) TestArchive_Success() {
 	}
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(historyBlob, nil),
 		historyIterator.EXPECT().HasNext().Return(false),
 	)
 
@@ -653,9 +653,9 @@ func (s *historyArchiverSuite) TestArchiveAndGet() {
 	historyIterator := archiver.NewMockHistoryIterator(s.controller)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(s.historyBatchesV100[0], nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(s.historyBatchesV100[0], nil),
 		historyIterator.EXPECT().HasNext().Return(true),
-		historyIterator.EXPECT().Next().Return(s.historyBatchesV100[1], nil),
+		historyIterator.EXPECT().Next(gomock.Any()).Return(s.historyBatchesV100[1], nil),
 		historyIterator.EXPECT().HasNext().Return(false),
 	)
 

--- a/common/rpc/context.go
+++ b/common/rpc/context.go
@@ -55,9 +55,10 @@ func CopyContextValues(dst context.Context, src context.Context) context.Context
 	}
 }
 
-// NewContextWithTimeout creates context with timeout.
-func NewContextWithTimeout(timeout time.Duration) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), timeout)
+// ResetContextTimeout creates new context with specified timeout and copies values from source Context.
+func ResetContextTimeout(ctx context.Context, newTimeout time.Duration) (context.Context, context.CancelFunc) {
+	newContext, cancel := context.WithTimeout(context.Background(), newTimeout)
+	return CopyContextValues(newContext, ctx), cancel
 }
 
 // NewContextWithTimeoutAndVersionHeaders creates context with timeout and version headers.

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -78,6 +78,7 @@ import (
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/sdk"
 	"go.temporal.io/server/common/searchattribute"
@@ -4673,12 +4674,16 @@ func (wh *WorkflowHandler) cancelOutstandingPoll(ctx context.Context, namespaceI
 	}
 	// Our rpc stack does not propagates context cancellation to the other service.  Lets make an explicit
 	// call to matching to notify this poller is gone to prevent any tasks being dispatched to zombie pollers.
-	_, err := wh.matchingClient.CancelOutstandingPoll(context.Background(), &matchingservice.CancelOutstandingPollRequest{
-		NamespaceId:   namespaceID.String(),
-		TaskQueueType: taskQueueType,
-		TaskQueue:     taskQueue,
-		PollerId:      pollerID,
-	})
+	// TODO: specify a reasonable timeout for CancelOutstandingPoll.
+	_, err := wh.matchingClient.CancelOutstandingPoll(
+		rpc.CopyContextValues(context.TODO(), ctx),
+		&matchingservice.CancelOutstandingPollRequest{
+			NamespaceId:   namespaceID.String(),
+			TaskQueueType: taskQueueType,
+			TaskQueue:     taskQueue,
+			PollerId:      pollerID,
+		},
+	)
 	// We can not do much if this call fails.  Just log the error and move on.
 	if err != nil {
 		wh.logger.Warn("Failed to cancel outstanding poller.",

--- a/service/history/deletemanager/delete_manager.go
+++ b/service/history/deletemanager/delete_manager.go
@@ -320,7 +320,7 @@ func (m *DeleteManagerImpl) archiveWorkflowIfEnabled(
 	// and it might not have access to typeMap (i.e. type needs to be embedded).
 	searchattribute.ApplyTypeMap(req.ArchiveRequest.SearchAttributes, saTypeMap)
 
-	ctx, cancel := context.WithTimeout(context.Background(), m.config.TimerProcessorArchivalTimeLimit())
+	ctx, cancel := context.WithTimeout(ctx, m.config.TimerProcessorArchivalTimeLimit())
 	defer cancel()
 	resp, err := m.archivalClient.Archive(ctx, req)
 	if err != nil {

--- a/service/history/ndc/state_rebuilder.go
+++ b/service/history/ndc/state_rebuilder.go
@@ -149,6 +149,7 @@ func (r *StateRebuilderImpl) Rebuild(
 		}
 
 		if err := r.applyEvents(
+			ctx,
 			targetWorkflowIdentifier,
 			stateBuilder,
 			history.History.Events,
@@ -221,6 +222,7 @@ func (r *StateRebuilderImpl) initializeBuilders(
 }
 
 func (r *StateRebuilderImpl) applyEvents(
+	ctx context.Context,
 	workflowKey definition.WorkflowKey,
 	stateBuilder workflow.MutableStateRebuilder,
 	events []*historypb.HistoryEvent,
@@ -228,7 +230,7 @@ func (r *StateRebuilderImpl) applyEvents(
 ) error {
 
 	_, err := stateBuilder.ApplyEvents(
-		context.Background(),
+		ctx,
 		namespace.ID(workflowKey.NamespaceID),
 		requestID,
 		commonpb.WorkflowExecution{

--- a/service/history/ndc/state_rebuilder_test.go
+++ b/service/history/ndc/state_rebuilder_test.go
@@ -151,7 +151,7 @@ func (s *stateRebuilderSuite) TestApplyEvents() {
 
 	mockStateBuilder := workflow.NewMockMutableStateRebuilder(s.controller)
 	mockStateBuilder.EXPECT().ApplyEvents(
-		context.Background(),
+		gomock.Any(),
 		s.namespaceID,
 		requestID,
 		commonpb.WorkflowExecution{
@@ -162,7 +162,7 @@ func (s *stateRebuilderSuite) TestApplyEvents() {
 		[]*historypb.HistoryEvent(nil),
 	).Return(nil, nil)
 
-	err := s.nDCStateRebuilder.applyEvents(workflowKey, mockStateBuilder, events, requestID)
+	err := s.nDCStateRebuilder.applyEvents(context.Background(), workflowKey, mockStateBuilder, events, requestID)
 	s.NoError(err)
 }
 

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -370,6 +370,7 @@ func (r *transactionMgrImpl) backfillWorkflowEventsReapply(
 	// case 2
 	//  find the current & active workflow to reapply
 	if err := targetWorkflow.GetContext().ReapplyEvents(
+		ctx,
 		targetWorkflowEventsSlice,
 	); err != nil {
 		return 0, workflow.TransactionPolicyActive, err

--- a/service/history/ndc/transaction_manager_new_workflow.go
+++ b/service/history/ndc/transaction_manager_new_workflow.go
@@ -228,6 +228,7 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) createAsZombie(
 	}
 
 	if err := targetWorkflow.GetContext().ReapplyEvents(
+		ctx,
 		targetWorkflowEventsSeq,
 	); err != nil {
 		return err

--- a/service/history/ndc/transaction_manager_new_workflow_test.go
+++ b/service/history/ndc/transaction_manager_new_workflow_test.go
@@ -415,7 +415,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_CreateAsZ
 		targetWorkflowSnapshot,
 		targetWorkflowEventsSeq,
 	).Return(nil)
-	targetContext.EXPECT().ReapplyEvents(targetWorkflowEventsSeq).Return(nil)
+	targetContext.EXPECT().ReapplyEvents(gomock.Any(), targetWorkflowEventsSeq).Return(nil)
 
 	err := s.createMgr.dispatchForNewWorkflow(ctx, now, targetWorkflow)
 	s.NoError(err)
@@ -484,7 +484,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_CreateAsZ
 		targetWorkflowSnapshot,
 		targetWorkflowEventsSeq,
 	).Return(nil)
-	targetContext.EXPECT().ReapplyEvents(targetWorkflowEventsSeq).Return(nil)
+	targetContext.EXPECT().ReapplyEvents(gomock.Any(), targetWorkflowEventsSeq).Return(nil)
 
 	err := s.createMgr.dispatchForNewWorkflow(ctx, now, targetWorkflow)
 	s.NoError(err)
@@ -553,7 +553,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_CreateAsZ
 		targetWorkflowSnapshot,
 		targetWorkflowEventsSeq,
 	).Return(&persistence.WorkflowConditionFailedError{})
-	targetContext.EXPECT().ReapplyEvents(targetWorkflowEventsSeq).Return(nil)
+	targetContext.EXPECT().ReapplyEvents(gomock.Any(), targetWorkflowEventsSeq).Return(nil)
 
 	err := s.createMgr.dispatchForNewWorkflow(ctx, now, targetWorkflow)
 	s.NoError(err)
@@ -622,7 +622,7 @@ func (s *transactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_CreateAsZ
 		targetWorkflowSnapshot,
 		targetWorkflowEventsSeq,
 	).Return(&persistence.WorkflowConditionFailedError{})
-	targetContext.EXPECT().ReapplyEvents(targetWorkflowEventsSeq).Return(nil)
+	targetContext.EXPECT().ReapplyEvents(gomock.Any(), targetWorkflowEventsSeq).Return(nil)
 
 	err := s.createMgr.dispatchForNewWorkflow(ctx, now, targetWorkflow)
 	s.NoError(err)

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -354,7 +354,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_Open(
 	mutableState.EXPECT().IsCurrentWorkflowGuaranteed().Return(true).AnyTimes()
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetNamespaceEntry().Return(s.namespaceEntry).AnyTimes()
-	weContext.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents})
+	weContext.EXPECT().ReapplyEvents(gomock.Any(), []*persistence.WorkflowEvents{workflowEvents})
 	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
@@ -403,7 +403,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_Close
 		NamespaceID: namespaceID.String(),
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil)
-	weContext.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents})
+	weContext.EXPECT().ReapplyEvents(gomock.Any(), []*persistence.WorkflowEvents{workflowEvents})
 	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
@@ -460,7 +460,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active() {
 		NamespaceID: namespaceID.String(),
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil)
-	weContext.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents})
+	weContext.EXPECT().ReapplyEvents(gomock.Any(), []*persistence.WorkflowEvents{workflowEvents})
 	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeBypassCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),
@@ -516,7 +516,7 @@ func (s *transactionMgrSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passive() 
 		NamespaceID: namespaceID.String(),
 		WorkflowID:  workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil)
-	weContext.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents})
+	weContext.EXPECT().ReapplyEvents(gomock.Any(), []*persistence.WorkflowEvents{workflowEvents})
 	weContext.EXPECT().PersistWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil)
 	weContext.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), persistence.UpdateWorkflowModeBypassCurrent, nil, nil, workflow.TransactionPolicyPassive, (*workflow.TransactionPolicy)(nil),

--- a/service/history/transferQueueActiveTaskExecutor.go
+++ b/service/history/transferQueueActiveTaskExecutor.go
@@ -52,6 +52,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/common/sdk"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/service/history/configs"
@@ -998,6 +999,7 @@ func (t *transferQueueActiveTaskExecutor) processResetWorkflow(
 	// NOTE: reset need to go through history which may take a longer time,
 	// so it's using its own timeout
 	return t.resetWorkflow(
+		ctx,
 		task,
 		reason,
 		resetPoint,
@@ -1363,6 +1365,7 @@ func (t *transferQueueActiveTaskExecutor) startWorkflow(
 }
 
 func (t *transferQueueActiveTaskExecutor) resetWorkflow(
+	ctx context.Context,
 	task *tasks.ResetWorkflowTask,
 	reason string,
 	resetPoint *workflowpb.ResetPointInfo,
@@ -1371,8 +1374,10 @@ func (t *transferQueueActiveTaskExecutor) resetWorkflow(
 	currentMutableState workflow.MutableState,
 	logger log.Logger,
 ) error {
-	var err error
-	ctx, cancel := context.WithTimeout(context.Background(), taskHistoryOpTimeout)
+	// the actual reset operation needs to read history and may not be able to completed within
+	// the original context timeout.
+	// create a new context with a longer timeout, but retain all existing context values.
+	resetWorkflowCtx, cancel := rpc.ResetContextTimeout(ctx, taskHistoryOpTimeout)
 	defer cancel()
 
 	namespaceID := namespace.ID(task.NamespaceID)
@@ -1394,7 +1399,7 @@ func (t *transferQueueActiveTaskExecutor) resetWorkflow(
 	baseNextEventID := baseMutableState.GetNextEventID()
 
 	err = t.workflowResetter.ResetWorkflow(
-		ctx,
+		resetWorkflowCtx,
 		namespaceID,
 		workflowID,
 		baseRunID,
@@ -1405,7 +1410,7 @@ func (t *transferQueueActiveTaskExecutor) resetWorkflow(
 		resetRunID,
 		uuid.New(),
 		ndc.NewWorkflow(
-			ctx,
+			resetWorkflowCtx,
 			t.registry,
 			t.shard.GetClusterMetadata(),
 			currentContext,

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -49,7 +49,6 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/rpc"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
@@ -83,6 +82,7 @@ type (
 		SetHistorySize(size int64)
 
 		ReapplyEvents(
+			ctx context.Context,
 			eventBatches []*persistence.WorkflowEvents,
 		) error
 
@@ -436,6 +436,7 @@ func (c *ContextImpl) ConflictResolveWorkflowExecution(
 	}
 
 	if err := c.conflictResolveEventReapply(
+		ctx,
 		conflictResolveMode,
 		resetWorkflowEventsSeq,
 		newWorkflowEventsSeq,
@@ -606,6 +607,7 @@ func (c *ContextImpl) UpdateWorkflowExecutionWithNew(
 	}
 
 	if err := c.updateWorkflowExecutionEventReapply(
+		ctx,
 		updateMode,
 		currentWorkflowEventsSeq,
 		newWorkflowEventsSeq,
@@ -723,6 +725,7 @@ func (c *ContextImpl) mergeContinueAsNewReplicationTasks(
 }
 
 func (c *ContextImpl) updateWorkflowExecutionEventReapply(
+	ctx context.Context,
 	updateMode persistence.UpdateWorkflowMode,
 	eventBatch1 []*persistence.WorkflowEvents,
 	eventBatch2 []*persistence.WorkflowEvents,
@@ -735,10 +738,11 @@ func (c *ContextImpl) updateWorkflowExecutionEventReapply(
 	var eventBatches []*persistence.WorkflowEvents
 	eventBatches = append(eventBatches, eventBatch1...)
 	eventBatches = append(eventBatches, eventBatch2...)
-	return c.ReapplyEvents(eventBatches)
+	return c.ReapplyEvents(ctx, eventBatches)
 }
 
 func (c *ContextImpl) conflictResolveEventReapply(
+	ctx context.Context,
 	conflictResolveMode persistence.ConflictResolveWorkflowMode,
 	eventBatch1 []*persistence.WorkflowEvents,
 	eventBatch2 []*persistence.WorkflowEvents,
@@ -751,10 +755,11 @@ func (c *ContextImpl) conflictResolveEventReapply(
 	var eventBatches []*persistence.WorkflowEvents
 	eventBatches = append(eventBatches, eventBatch1...)
 	eventBatches = append(eventBatches, eventBatch2...)
-	return c.ReapplyEvents(eventBatches)
+	return c.ReapplyEvents(ctx, eventBatches)
 }
 
 func (c *ContextImpl) ReapplyEvents(
+	ctx context.Context,
 	eventBatches []*persistence.WorkflowEvents,
 ) error {
 
@@ -800,10 +805,6 @@ func (c *ContextImpl) ReapplyEvents(
 		return err
 	}
 
-	// TODO: should we pass in a context instead of using the default one?
-	ctx, cancel := context.WithTimeout(context.Background(), defaultRemoteCallTimeout)
-	defer cancel()
-
 	activeCluster := namespaceEntry.ActiveClusterName()
 	if activeCluster == c.shard.GetClusterMetadata().GetCurrentClusterName() {
 		engine, err := c.shard.GetEngine(ctx)
@@ -828,17 +829,17 @@ func (c *ContextImpl) ReapplyEvents(
 	// The active cluster of the namespace is differ from the current cluster
 	// Use frontend client to route this request to the active cluster
 	// Reapplication only happens in active cluster
-	sourceCluster, err := c.shard.GetRemoteAdminClient(activeCluster)
+	sourceAdminClient, err := c.shard.GetRemoteAdminClient(activeCluster)
 	if err != nil {
 		return err
 	}
-	if sourceCluster == nil {
+	if sourceAdminClient == nil {
+		// TODO: will this ever happen?
 		return serviceerror.NewInternal(fmt.Sprintf("cannot find cluster config %v to do reapply", activeCluster))
 	}
-	ctx2, cancel2 := rpc.NewContextWithTimeoutAndVersionHeaders(defaultRemoteCallTimeout)
-	defer cancel2()
-	_, err = sourceCluster.ReapplyEvents(
-		ctx2,
+
+	_, err = sourceAdminClient.ReapplyEvents(
+		ctx,
 		&adminservice.ReapplyEventsRequest{
 			NamespaceId:       namespaceEntry.ID().String(),
 			WorkflowExecution: execution,

--- a/service/history/workflow/context_mock.go
+++ b/service/history/workflow/context_mock.go
@@ -195,17 +195,17 @@ func (mr *MockContextMockRecorder) PersistWorkflowEvents(ctx interface{}, workfl
 }
 
 // ReapplyEvents mocks base method.
-func (m *MockContext) ReapplyEvents(eventBatches []*persistence.WorkflowEvents) error {
+func (m *MockContext) ReapplyEvents(ctx context.Context, eventBatches []*persistence.WorkflowEvents) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReapplyEvents", eventBatches)
+	ret := m.ctrl.Call(m, "ReapplyEvents", ctx, eventBatches)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReapplyEvents indicates an expected call of ReapplyEvents.
-func (mr *MockContextMockRecorder) ReapplyEvents(eventBatches interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) ReapplyEvents(ctx, eventBatches interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockContext)(nil).ReapplyEvents), eventBatches)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockContext)(nil).ReapplyEvents), ctx, eventBatches)
 }
 
 // SetHistorySize mocks base method.

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -172,7 +172,7 @@ type (
 		GetNamespaceEntry() *namespace.Namespace
 		GetStartEvent(context.Context) (*historypb.HistoryEvent, error)
 		GetSignalExternalInitiatedEvent(context.Context, int64) (*historypb.HistoryEvent, error)
-		GetFirstRunID() (string, error)
+		GetFirstRunID(ctx context.Context) (string, error)
 		GetCurrentBranchToken() ([]byte, error)
 		GetCurrentVersion() int64
 		GetExecutionInfo() *persistencespb.WorkflowExecutionInfo

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1013,7 +1013,9 @@ func (ms *MutableStateImpl) GetStartEvent(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) GetFirstRunID() (string, error) {
+func (ms *MutableStateImpl) GetFirstRunID(
+	ctx context.Context,
+) (string, error) {
 	firstRunID := ms.executionInfo.FirstExecutionRunId
 	// This is needed for backwards compatibility.  Workflow execution create with Temporal release v0.28.0 or earlier
 	// does not have FirstExecutionRunID stored as part of mutable state.  If this is not set then load it from
@@ -1021,7 +1023,7 @@ func (ms *MutableStateImpl) GetFirstRunID() (string, error) {
 	if len(firstRunID) != 0 {
 		return firstRunID, nil
 	}
-	currentStartEvent, err := ms.GetStartEvent(context.TODO())
+	currentStartEvent, err := ms.GetStartEvent(ctx)
 	if err != nil {
 		return "", err
 	}
@@ -3395,7 +3397,7 @@ func (ms *MutableStateImpl) AddContinueAsNewEvent(
 		command,
 	)
 
-	firstRunID, err := ms.GetFirstRunID()
+	firstRunID, err := ms.GetFirstRunID(ctx)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -1177,18 +1177,18 @@ func (mr *MockMutableStateMockRecorder) GetExecutionState() *gomock.Call {
 }
 
 // GetFirstRunID mocks base method.
-func (m *MockMutableState) GetFirstRunID() (string, error) {
+func (m *MockMutableState) GetFirstRunID(ctx context.Context) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetFirstRunID")
+	ret := m.ctrl.Call(m, "GetFirstRunID", ctx)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetFirstRunID indicates an expected call of GetFirstRunID.
-func (mr *MockMutableStateMockRecorder) GetFirstRunID() *gomock.Call {
+func (mr *MockMutableStateMockRecorder) GetFirstRunID(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstRunID", reflect.TypeOf((*MockMutableState)(nil).GetFirstRunID))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFirstRunID", reflect.TypeOf((*MockMutableState)(nil).GetFirstRunID), ctx)
 }
 
 // GetLastFirstEventIDTxnID mocks base method.

--- a/service/history/workflow/retry.go
+++ b/service/history/workflow/retry.go
@@ -186,7 +186,7 @@ func SetupNewWorkflowForRetryOrCron(
 		RunId:      newRunID,
 	}
 
-	firstRunID, err := previousMutableState.GetFirstRunID()
+	firstRunID, err := previousMutableState.GetFirstRunID(ctx)
 	if err != nil {
 		return err
 	}

--- a/service/worker/archiver/client.go
+++ b/service/worker/archiver/client.go
@@ -292,7 +292,7 @@ func (c *client) sendArchiveSignal(ctx context.Context, request *ArchiveRequest,
 		WorkflowTaskTimeout:      workflowTaskTimeout,
 		WorkflowIDReusePolicy:    enumspb.WORKFLOW_ID_REUSE_POLICY_ALLOW_DUPLICATE,
 	}
-	signalCtx, cancel := context.WithTimeout(context.Background(), c.signalTimeout())
+	signalCtx, cancel := context.WithTimeout(ctx, c.signalTimeout())
 	defer cancel()
 
 	sdkClient := c.sdkClientFactory.GetSystemClient()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix context propagation in misc places

<!-- Tell your future self why have you made these changes -->
**Why?**
- Resolved some context.TODO()
- Make sure caller related information is available in context so persistence layer can do proper priority rate limiting.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Less timeout for some operations like events reapply

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- could be