### PR TITLE
Allow plain int seconds for duration in dynamic config

### DIFF
--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -538,6 +538,9 @@ func convertDuration(val any) (time.Duration, error) {
 	switch v := val.(type) {
 	case time.Duration:
 		return v, nil
+	case int:
+		// treat plain int as seconds
+		return time.Duration(v) * time.Second, nil
 	case string:
 		d, err := timestamp.ParseDurationDefaultDays(v)
 		if err != nil {

--- a/common/dynamicconfig/collection.go
+++ b/common/dynamicconfig/collection.go
@@ -542,7 +542,7 @@ func convertDuration(val any) (time.Duration, error) {
 		// treat plain int as seconds
 		return time.Duration(v) * time.Second, nil
 	case string:
-		d, err := timestamp.ParseDurationDefaultDays(v)
+		d, err := timestamp.ParseDurationDefaultSeconds(v)
 		if err != nil {
 			return 0, fmt.Errorf("failed to parse duration: %v", err)
 		}

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -142,6 +142,8 @@ func (s *collectionSuite) TestGetDurationProperty() {
 	s.Equal(time.Second, value())
 	s.client[testGetDurationPropertyKey] = time.Minute
 	s.Equal(time.Minute, value())
+	s.client[testGetDurationPropertyKey] = 33
+	s.Equal(33*time.Second, value())
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByNamespace() {

--- a/common/dynamicconfig/collection_test.go
+++ b/common/dynamicconfig/collection_test.go
@@ -144,6 +144,8 @@ func (s *collectionSuite) TestGetDurationProperty() {
 	s.Equal(time.Minute, value())
 	s.client[testGetDurationPropertyKey] = 33
 	s.Equal(33*time.Second, value())
+	s.client[testGetDurationPropertyKey] = "33"
+	s.Equal(33*time.Second, value())
 }
 
 func (s *collectionSuite) TestGetDurationPropertyFilteredByNamespace() {

--- a/common/dynamicconfig/config/testConfig.yaml
+++ b/common/dynamicconfig/config/testConfig.yaml
@@ -24,6 +24,9 @@ testGetDurationPropertyKey:
 - value: 2
   constraints:
     namespace: samples-namespace
+- value: true
+  constraints:
+    namespace: broken-namespace
 testGetFloat64PropertyKey:
 - value: 12
   constraints: {}

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -216,8 +216,13 @@ func (s *fileBasedClientSuite) TestGetDurationValue() {
 	s.Equal(time.Minute, v)
 }
 
-func (s *fileBasedClientSuite) TestGetDurationValue_NotStringRepresentation() {
+func (s *fileBasedClientSuite) TestGetDurationValue_DefaultSeconds() {
 	v := s.collection.GetDurationPropertyFilteredByNamespace(testGetDurationPropertyKey, time.Second)("samples-namespace")
+	s.Equal(2*time.Second, v)
+}
+
+func (s *fileBasedClientSuite) TestGetDurationValue_NotStringRepresentation() {
+	v := s.collection.GetDurationPropertyFilteredByNamespace(testGetDurationPropertyKey, time.Second)("broken-namespace")
 	s.Equal(time.Second, v)
 }
 

--- a/common/primitives/timestamp/parseDuration.go
+++ b/common/primitives/timestamp/parseDuration.go
@@ -57,3 +57,13 @@ func ParseDurationDefaultDays(s string) (time.Duration, error) {
 	}
 	return ParseDuration(s)
 }
+
+// ParseDurationDefaultSeconds is like time.ParseDuration, but supports unit "d"
+// for days (always interpreted as exactly 24 hours), and also supports
+// unit-less numbers, which are interpreted as seconds.
+func ParseDurationDefaultSeconds(s string) (time.Duration, error) {
+	if reUnitless.MatchString(s) {
+		s += "s"
+	}
+	return ParseDuration(s)
+}

--- a/common/primitives/timestamp/parseDuration_test.go
+++ b/common/primitives/timestamp/parseDuration_test.go
@@ -84,3 +84,21 @@ func (s *ParseDurationSuite) TestParseDurationDefaultDays() {
 		}
 	}
 }
+
+func (s *ParseDurationSuite) TestParseDurationDefaultSeconds() {
+	for _, c := range []struct {
+		input    string
+		expected time.Duration // -1 means error
+	}{
+		{"3m30s", 3*time.Minute + 30*time.Second},
+		{"7", 7 * time.Second},
+		{"", -1}, // error
+	} {
+		got, err := ParseDurationDefaultSeconds(c.input)
+		if c.expected == -1 {
+			s.Error(err)
+		} else {
+			s.Equal(c.expected, got)
+		}
+	}
+}


### PR DESCRIPTION
**What changed?**
If dynamic config is expecting a duration and gets a plain integer, interpret it as seconds instead of falling back to the default. For consistency, interpret strings that have a unit-less integer as seconds also.

**Why?**
Less surprising behavior for users. It's easy to leave out the "s" by accident when configuring a duration.

**How did you test it?**
Unit tests and manual test.

**Potential risks**
Could change the behavior of currently-broken dynamic config files.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
