### PR TITLE
Make shard ownership more resilient when shard is busy

### DIFF
--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -467,12 +467,21 @@ func (s *ContextImpl) AddTasks(
 	ctx context.Context,
 	request *persistence.AddHistoryTasksRequest,
 ) error {
-	ctx, cancel, err := s.newDetachedContext(ctx)
+	engine, err := s.GetEngine(ctx)
 	if err != nil {
 		return err
 	}
-	defer cancel()
+	err = s.addTasksWithoutNotification(ctx, request)
+	if OperationPossiblySucceeded(err) {
+		engine.NotifyNewTasks(request.Tasks)
+	}
+	return err
+}
 
+func (s *ContextImpl) addTasksWithoutNotification(
+	ctx context.Context,
+	request *persistence.AddHistoryTasksRequest,
+) error {
 	// do not try to get namespace cache within shard lock
 	namespaceID := namespace.ID(request.NamespaceID)
 	namespaceEntry, err := s.GetNamespaceRegistry().GetNamespaceByID(namespaceID)
@@ -480,40 +489,29 @@ func (s *ContextImpl) AddTasks(
 		return err
 	}
 
-	engine, err := s.GetEngine(ctx)
+	s.wLock()
+	defer s.wUnlock()
+
+	// timeout check should be done within the shard lock, in case of shard lock contention
+	ctx, cancel, err := s.newDetachedContext(ctx)
 	if err != nil {
 		return err
 	}
+	defer cancel()
 
-	s.wLock()
 	if err := s.errorByState(); err != nil {
-		s.wUnlock()
 		return err
 	}
 	if err := s.errorByNamespaceStateLocked(namespaceEntry.Name()); err != nil {
-		s.wUnlock()
 		return err
 	}
-	err = s.addTasksLocked(ctx, request, namespaceEntry)
-	s.wUnlock()
-
-	if OperationPossiblySucceeded(err) {
-		engine.NotifyNewTasks(request.Tasks)
-	}
-
-	return err
+	return s.addTasksLocked(ctx, request, namespaceEntry)
 }
 
 func (s *ContextImpl) CreateWorkflowExecution(
 	ctx context.Context,
 	request *persistence.CreateWorkflowExecutionRequest,
 ) (*persistence.CreateWorkflowExecutionResponse, error) {
-	ctx, cancel, err := s.newDetachedContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer cancel()
-
 	// do not try to get namespace cache within shard lock
 	namespaceID := namespace.ID(request.NewWorkflowSnapshot.ExecutionInfo.NamespaceId)
 	workflowID := request.NewWorkflowSnapshot.ExecutionInfo.WorkflowId
@@ -524,6 +522,13 @@ func (s *ContextImpl) CreateWorkflowExecution(
 
 	s.wLock()
 	defer s.wUnlock()
+
+	// timeout check should be done within the shard lock, in case of shard lock contention
+	ctx, cancel, err := s.newDetachedContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 
 	if err := s.errorByState(); err != nil {
 		return nil, err
@@ -557,12 +562,6 @@ func (s *ContextImpl) UpdateWorkflowExecution(
 	ctx context.Context,
 	request *persistence.UpdateWorkflowExecutionRequest,
 ) (*persistence.UpdateWorkflowExecutionResponse, error) {
-	ctx, cancel, err := s.newDetachedContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer cancel()
-
 	// do not try to get namespace cache within shard lock
 	namespaceID := namespace.ID(request.UpdateWorkflowMutation.ExecutionInfo.NamespaceId)
 	workflowID := request.UpdateWorkflowMutation.ExecutionInfo.WorkflowId
@@ -573,6 +572,13 @@ func (s *ContextImpl) UpdateWorkflowExecution(
 
 	s.wLock()
 	defer s.wUnlock()
+
+	// timeout check should be done within the shard lock, in case of shard lock contention
+	ctx, cancel, err := s.newDetachedContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 
 	if err := s.errorByState(); err != nil {
 		return nil, err
@@ -632,12 +638,6 @@ func (s *ContextImpl) ConflictResolveWorkflowExecution(
 	ctx context.Context,
 	request *persistence.ConflictResolveWorkflowExecutionRequest,
 ) (*persistence.ConflictResolveWorkflowExecutionResponse, error) {
-	ctx, cancel, err := s.newDetachedContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer cancel()
-
 	// do not try to get namespace cache within shard lock
 	namespaceID := namespace.ID(request.ResetWorkflowSnapshot.ExecutionInfo.NamespaceId)
 	workflowID := request.ResetWorkflowSnapshot.ExecutionInfo.WorkflowId
@@ -648,6 +648,13 @@ func (s *ContextImpl) ConflictResolveWorkflowExecution(
 
 	s.wLock()
 	defer s.wUnlock()
+
+	// timeout check should be done within the shard lock, in case of shard lock contention
+	ctx, cancel, err := s.newDetachedContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 
 	if err := s.errorByState(); err != nil {
 		return nil, err
@@ -700,12 +707,6 @@ func (s *ContextImpl) SetWorkflowExecution(
 	ctx context.Context,
 	request *persistence.SetWorkflowExecutionRequest,
 ) (*persistence.SetWorkflowExecutionResponse, error) {
-	ctx, cancel, err := s.newDetachedContext(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer cancel()
-
 	// do not try to get namespace cache within shard lock
 	namespaceID := namespace.ID(request.SetWorkflowSnapshot.ExecutionInfo.NamespaceId)
 	workflowID := request.SetWorkflowSnapshot.ExecutionInfo.WorkflowId
@@ -716,6 +717,13 @@ func (s *ContextImpl) SetWorkflowExecution(
 
 	s.wLock()
 	defer s.wUnlock()
+
+	// timeout check should be done within the shard lock, in case of shard lock contention
+	ctx, cancel, err := s.newDetachedContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cancel()
 
 	if err := s.errorByState(); err != nil {
 		return nil, err
@@ -855,12 +863,6 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 	// The history branch won't be accessible (because mutable state is deleted) and special garbage collection workflow will delete it eventually.
 	// Stage 4 shouldn't be done earlier because if this func fails after it, workflow execution will be accessible but won't have history (inconsistent state).
 
-	ctx, cancel, err := s.newDetachedContext(ctx)
-	if err != nil {
-		return err
-	}
-	defer cancel()
-
 	engine, err := s.GetEngine(ctx)
 	if err != nil {
 		return err
@@ -896,6 +898,12 @@ func (s *ContextImpl) DeleteWorkflowExecution(
 		if err = func() error {
 			s.wLock()
 			defer s.wUnlock()
+
+			ctx, cancel, err := s.newDetachedContext(ctx)
+			if err != nil {
+				return err
+			}
+			defer cancel()
 
 			if err := s.errorByState(); err != nil {
 				return err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Do timeout check after shard lock acquired, not before

<!-- Tell your future self why have you made these changes -->
**Why?**
When shard lock contention occurs, caller coroutine can wait a long time before acquiring shard lock, consequent IO operation may not have enough timeout left.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes