### PR TITLE
Handle namespace not found in history scan

### DIFF
--- a/service/worker/scanner/history/scavenger.go
+++ b/service/worker/scanner/history/scavenger.go
@@ -278,7 +278,7 @@ func (s *Scavenger) handleTask(
 			return s.cleanUpWorkflowPastRetention(ctx, ms.GetDatabaseMutableState())
 		}
 		return nil
-	case *serviceerror.NotFound:
+	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		// case handled below
 	default:
 		s.logger.Error("encounter error when describing the mutable state", getTaskLoggingTags(err, task)...)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Handle namespace not found in history scan

<!-- Tell your future self why have you made these changes -->
**Why?**
There is race condition:
1. Orphan history in history table.
2. The namespace is deleted.

When the history scanner hit a namespace is deleted, currently it just failed. The correct behavior is to ignore the namespace not found error and delete orphan history as the namespace is deleted.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
