### PR TITLE
Simplify task queue liveness

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -318,10 +318,8 @@ const (
 	MatchingSyncMatchWaitDuration = "matching.syncMatchWaitDuration"
 	// MatchingUpdateAckInterval is the interval for update ack
 	MatchingUpdateAckInterval = "matching.updateAckInterval"
-	// MatchingIdleTaskqueueCheckInterval is the IdleTaskqueueCheckInterval
-	MatchingIdleTaskqueueCheckInterval = "matching.idleTaskqueueCheckInterval"
-	// MaxTaskqueueIdleTime is the max time taskqueue being idle
-	MaxTaskqueueIdleTime = "matching.maxTaskqueueIdleTime"
+	// MatchingMaxTaskQueueIdleTime is the time after which an idle task queue will be unloaded
+	MatchingMaxTaskQueueIdleTime = "matching.maxTaskQueueIdleTime"
 	// MatchingOutstandingTaskAppendsThreshold is the threshold for outstanding task appends
 	MatchingOutstandingTaskAppendsThreshold = "matching.outstandingTaskAppendsThreshold"
 	// MatchingMaxTaskBatchSize is max batch size for task writer

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/iancoleman/strcase v0.2.0
 	github.com/jmoiron/sqlx v1.3.4
-	github.com/jonboulle/clockwork v0.3.0
+	github.com/jonboulle/clockwork v0.4.0
 	github.com/lib/pq v1.10.7
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/olivere/elastic/v7 v7.0.32

--- a/go.sum
+++ b/go.sum
@@ -883,8 +883,8 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
 github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
-github.com/jonboulle/clockwork v0.3.0 h1:9BSCMi8C+0qdApAp4auwX0RkLGUjs956h0EkuQymUhg=
-github.com/jonboulle/clockwork v0.3.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
+github.com/jonboulle/clockwork v0.4.0 h1:p4Cf1aMWXnXAUh8lVfewRBx1zaTSYKrKMF2g3ST4RZ4=
+github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -49,8 +49,7 @@ type (
 		RangeSize                    int64
 		GetTasksBatchSize            dynamicconfig.IntPropertyFnWithTaskQueueInfoFilters
 		UpdateAckInterval            dynamicconfig.DurationPropertyFnWithTaskQueueInfoFilters
-		IdleTaskqueueCheckInterval   dynamicconfig.DurationPropertyFnWithTaskQueueInfoFilters
-		MaxTaskqueueIdleTime         dynamicconfig.DurationPropertyFnWithTaskQueueInfoFilters
+		MaxTaskQueueIdleTime         dynamicconfig.DurationPropertyFnWithTaskQueueInfoFilters
 		NumTaskqueueWritePartitions  dynamicconfig.IntPropertyFnWithTaskQueueInfoFilters
 		NumTaskqueueReadPartitions   dynamicconfig.IntPropertyFnWithTaskQueueInfoFilters
 		ForwarderMaxOutstandingPolls dynamicconfig.IntPropertyFnWithTaskQueueInfoFilters
@@ -90,8 +89,7 @@ type (
 		RangeSize                  int64
 		GetTasksBatchSize          func() int
 		UpdateAckInterval          func() time.Duration
-		IdleTaskqueueCheckInterval func() time.Duration
-		MaxTaskqueueIdleTime       func() time.Duration
+		MaxTaskQueueIdleTime       func() time.Duration
 		MinTaskThrottlingBurstSize func() int
 		MaxTaskDeleteBatchSize     func() int
 		// taskWriter configuration
@@ -132,8 +130,7 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 		RangeSize:                             100000,
 		GetTasksBatchSize:                     dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingGetTasksBatchSize, 1000),
 		UpdateAckInterval:                     dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingUpdateAckInterval, defaultUpdateAckInterval),
-		IdleTaskqueueCheckInterval:            dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingIdleTaskqueueCheckInterval, 5*time.Minute),
-		MaxTaskqueueIdleTime:                  dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MaxTaskqueueIdleTime, 5*time.Minute),
+		MaxTaskQueueIdleTime:                  dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingMaxTaskQueueIdleTime, 5*time.Minute),
 		LongPollExpirationInterval:            dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingLongPollExpirationInterval, time.Minute),
 		MinTaskThrottlingBurstSize:            dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingMinTaskThrottlingBurstSize, 1),
 		MaxTaskDeleteBatchSize:                dc.GetIntPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingMaxTaskDeleteBatchSize, 100),
@@ -167,11 +164,8 @@ func newTaskQueueConfig(id *taskQueueID, config *Config, namespace namespace.Nam
 		UpdateAckInterval: func() time.Duration {
 			return config.UpdateAckInterval(namespace.String(), taskQueueName, taskType)
 		},
-		IdleTaskqueueCheckInterval: func() time.Duration {
-			return config.IdleTaskqueueCheckInterval(namespace.String(), taskQueueName, taskType)
-		},
-		MaxTaskqueueIdleTime: func() time.Duration {
-			return config.MaxTaskqueueIdleTime(namespace.String(), taskQueueName, taskType)
+		MaxTaskQueueIdleTime: func() time.Duration {
+			return config.MaxTaskQueueIdleTime(namespace.String(), taskQueueName, taskType)
 		},
 		MinTaskThrottlingBurstSize: func() int {
 			return config.MinTaskThrottlingBurstSize(namespace.String(), taskQueueName, taskType)

--- a/service/matching/liveness.go
+++ b/service/matching/liveness.go
@@ -25,103 +25,41 @@
 package matching
 
 import (
-	"sync"
 	"sync/atomic"
 	"time"
-
-	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/clock"
 )
 
 type (
 	liveness struct {
-		status     int32
-		timeSource clock.TimeSource
-		ttl        time.Duration
-		// internal shutdown channel
-		shutdownChan chan struct{}
-
-		// broadcast shutdown functions
-		broadcastShutdownFn func()
-
-		sync.Mutex
-		lastEventTime time.Time
+		ttl    func() time.Duration
+		onIdle func()
+		timer  atomic.Value
 	}
 )
 
-var _ common.Daemon = (*liveness)(nil)
-
 func newLiveness(
-	timeSource clock.TimeSource,
-	ttl time.Duration,
-	broadcastShutdownFn func(),
+	ttl func() time.Duration,
+	onIdle func(),
 ) *liveness {
 	return &liveness{
-		status:       common.DaemonStatusInitialized,
-		timeSource:   timeSource,
-		ttl:          ttl,
-		shutdownChan: make(chan struct{}),
-
-		broadcastShutdownFn: broadcastShutdownFn,
-
-		lastEventTime: timeSource.Now(),
+		ttl:    ttl,
+		onIdle: onIdle,
 	}
 }
 
 func (l *liveness) Start() {
-	if !atomic.CompareAndSwapInt32(
-		&l.status,
-		common.DaemonStatusInitialized,
-		common.DaemonStatusStarted,
-	) {
-		return
-	}
-
-	go l.eventLoop()
+	l.timer.Store(time.AfterFunc(l.ttl(), l.onIdle))
 }
 
 func (l *liveness) Stop() {
-	if !atomic.CompareAndSwapInt32(
-		&l.status,
-		common.DaemonStatusStarted,
-		common.DaemonStatusStopped,
-	) {
-		return
-	}
-
-	close(l.shutdownChan)
-	l.broadcastShutdownFn()
-}
-
-func (l *liveness) eventLoop() {
-	ttlTimer := time.NewTicker(l.ttl)
-	defer ttlTimer.Stop()
-
-	for {
-		select {
-		case <-ttlTimer.C:
-			if !l.isAlive() {
-				l.Stop()
-			}
-
-		case <-l.shutdownChan:
-			return
-		}
+	var nilTimer *time.Timer
+	if t, ok := l.timer.Swap(nilTimer).(*time.Timer); ok && t != nil {
+		t.Stop()
 	}
 }
 
-func (l *liveness) isAlive() bool {
-	l.Lock()
-	defer l.Unlock()
-	return l.lastEventTime.Add(l.ttl).After(l.timeSource.Now())
-}
-
-func (l *liveness) markAlive(
-	now time.Time,
-) {
-	l.Lock()
-	defer l.Unlock()
-	if l.lastEventTime.Before(now) {
-		l.lastEventTime = now.UTC()
+func (l *liveness) markAlive() {
+	if t, ok := l.timer.Load().(*time.Timer); ok && t != nil {
+		t.Reset(l.ttl())
 	}
 }

--- a/service/matching/liveness_test.go
+++ b/service/matching/liveness_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestLiveness(t *testing.T) {
+	t.Parallel()
 	var idleCalled atomic.Int32
 	ttl := func() time.Duration { return 2500 * time.Millisecond }
 	clock := clockwork.NewFakeClock()
@@ -60,6 +61,7 @@ func TestLiveness(t *testing.T) {
 }
 
 func TestLivenessStop(t *testing.T) {
+	t.Parallel()
 	var idleCalled atomic.Int32
 	ttl := func() time.Duration { return 1000 * time.Millisecond }
 	clock := clockwork.NewFakeClock()

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -33,6 +33,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	uberatomic "go.uber.org/atomic"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -241,6 +242,7 @@ func newTaskQueueManager(
 	tlMgr.metadataPoller.tqMgr = tlMgr
 
 	tlMgr.liveness = newLiveness(
+		clockwork.NewRealClock(),
 		taskQueueConfig.MaxTaskQueueIdleTime,
 		tlMgr.unloadFromEngine,
 	)

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -414,7 +414,7 @@ func TestCheckIdleTaskQueue(t *testing.T) {
 	defer controller.Finish()
 
 	cfg := NewConfig(dynamicconfig.NewNoopCollection())
-	cfg.IdleTaskqueueCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(2 * time.Second)
+	cfg.MaxTaskQueueIdleTime = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(2 * time.Second)
 	tqCfg := defaultTqmTestOpts(controller)
 	tqCfg.config = cfg
 


### PR DESCRIPTION
**What changed?**
Change implementation of task queue liveness to use a timer instead of a goroutine

**Why?**
Simpler implementation, more accurate idle timeout

**How did you test it?**
unit test

**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
