### PR TITLE
Add support for help text in metric definitions

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -40,6 +40,7 @@ type (
 		metricType MetricType // metric type
 		metricName MetricName // metric name
 		unit       MetricUnit
+		opts       []Option
 	}
 
 	// ServiceIdx is an index that uniquely identifies the service
@@ -84,22 +85,26 @@ func (md metricDefinition) GetMetricUnit() MetricUnit {
 	return md.unit
 }
 
-func NewTimerDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Timer, unit: Milliseconds}
+func (md metricDefinition) GetOptions() []Option {
+	return md.opts
 }
 
-func NewBytesHistogramDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Bytes}
+func NewTimerDef(name string, opts ...Option) metricDefinition {
+	return metricDefinition{metricName: MetricName(name), metricType: Timer, unit: Milliseconds, opts: opts}
 }
 
-func NewDimensionlessHistogramDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Dimensionless}
+func NewBytesHistogramDef(name string, opts ...Option) metricDefinition {
+	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Bytes, opts: opts}
 }
 
-func NewCounterDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Counter}
+func NewDimensionlessHistogramDef(name string, opts ...Option) metricDefinition {
+	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Dimensionless, opts: opts}
 }
 
-func NewGaugeDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Gauge}
+func NewCounterDef(name string, opts ...Option) metricDefinition {
+	return metricDefinition{metricName: MetricName(name), metricType: Counter, opts: opts}
+}
+
+func NewGaugeDef(name string, opts ...Option) metricDefinition {
+	return metricDefinition{metricName: MetricName(name), metricType: Gauge, opts: opts}
 }

--- a/common/metrics/help_text.go
+++ b/common/metrics/help_text.go
@@ -1,0 +1,41 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+// WithHelpText returns a HelpTextOption that sets the help text of a metric.
+// Metrics handlers are not required to use this option.
+func WithHelpText(helpText string) HelpTextOption {
+	return HelpTextOption{helpText: helpText}
+}
+
+// HelpTextOption stores the help text provided to the option.
+type HelpTextOption struct {
+	helpText string
+}
+
+// apply sets the params.optionalHelpText field.
+func (h HelpTextOption) apply(p *params) {
+	p.optionalHelpText = &h.helpText
+}

--- a/common/metrics/help_text.go
+++ b/common/metrics/help_text.go
@@ -27,15 +27,13 @@ package metrics
 // WithHelpText returns a HelpTextOption that sets the help text of a metric.
 // Metrics handlers are not required to use this option.
 func WithHelpText(helpText string) HelpTextOption {
-	return HelpTextOption{helpText: helpText}
+	return HelpTextOption(helpText)
 }
 
 // HelpTextOption stores the help text provided to the option.
-type HelpTextOption struct {
-	helpText string
-}
+type HelpTextOption string
 
 // apply sets the params.optionalHelpText field.
 func (h HelpTextOption) apply(p *params) {
-	p.optionalHelpText = &h.helpText
+	p.optionalHelpText = (*string)(&h)
 }

--- a/common/metrics/help_text.go
+++ b/common/metrics/help_text.go
@@ -24,8 +24,8 @@
 
 package metrics
 
-// WithHelpText returns a HelpTextOption that sets the help text of a metric.
-// Metrics handlers are not required to use this option.
+// WithHelpText returns a HelpTextOption that sets the help text (description) of a metric.
+// Metrics handlers are not required to do anything with this option.
 func WithHelpText(helpText string) HelpTextOption {
 	return HelpTextOption(helpText)
 }

--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -42,17 +42,17 @@ type (
 		// Tags are merged with registered Tags from the source MetricsHandler
 		WithTags(...Tag) Handler
 
-		// Counter obtains a counter for the given name and MetricOptions.
-		Counter(string) CounterIface
+		// Counter obtains a counter for the given name and Option list.
+		Counter(string, ...Option) CounterIface
 
-		// Gauge obtains a gauge for the given name and MetricOptions.
-		Gauge(string) GaugeIface
+		// Gauge obtains a gauge for the given name and Option list.
+		Gauge(string, ...Option) GaugeIface
 
-		// Timer obtains a timer for the given name and MetricOptions.
-		Timer(string) TimerIface
+		// Timer obtains a timer for the given name and Option list.
+		Timer(string, ...Option) TimerIface
 
-		// Histogram obtains a histogram for the given name and MetricOptions.
-		Histogram(string, MetricUnit) HistogramIface
+		// Histogram obtains a histogram for the given name, unit, and Option list.
+		Histogram(string, MetricUnit, ...Option) HistogramIface
 
 		Stop(log.Logger)
 	}

--- a/common/metrics/metrics_mock.go
+++ b/common/metrics/metrics_mock.go
@@ -60,45 +60,60 @@ func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 }
 
 // Counter mocks base method.
-func (m *MockHandler) Counter(arg0 string) CounterIface {
+func (m *MockHandler) Counter(arg0 string, arg1 ...Option) CounterIface {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Counter", arg0)
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Counter", varargs...)
 	ret0, _ := ret[0].(CounterIface)
 	return ret0
 }
 
 // Counter indicates an expected call of Counter.
-func (mr *MockHandlerMockRecorder) Counter(arg0 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) Counter(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Counter", reflect.TypeOf((*MockHandler)(nil).Counter), arg0)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Counter", reflect.TypeOf((*MockHandler)(nil).Counter), varargs...)
 }
 
 // Gauge mocks base method.
-func (m *MockHandler) Gauge(arg0 string) GaugeIface {
+func (m *MockHandler) Gauge(arg0 string, arg1 ...Option) GaugeIface {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Gauge", arg0)
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Gauge", varargs...)
 	ret0, _ := ret[0].(GaugeIface)
 	return ret0
 }
 
 // Gauge indicates an expected call of Gauge.
-func (mr *MockHandlerMockRecorder) Gauge(arg0 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) Gauge(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gauge", reflect.TypeOf((*MockHandler)(nil).Gauge), arg0)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gauge", reflect.TypeOf((*MockHandler)(nil).Gauge), varargs...)
 }
 
 // Histogram mocks base method.
-func (m *MockHandler) Histogram(arg0 string, arg1 MetricUnit) HistogramIface {
+func (m *MockHandler) Histogram(arg0 string, arg1 MetricUnit, arg2 ...Option) HistogramIface {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Histogram", arg0, arg1)
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Histogram", varargs...)
 	ret0, _ := ret[0].(HistogramIface)
 	return ret0
 }
 
 // Histogram indicates an expected call of Histogram.
-func (mr *MockHandlerMockRecorder) Histogram(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) Histogram(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Histogram", reflect.TypeOf((*MockHandler)(nil).Histogram), arg0, arg1)
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Histogram", reflect.TypeOf((*MockHandler)(nil).Histogram), varargs...)
 }
 
 // Stop mocks base method.
@@ -114,17 +129,22 @@ func (mr *MockHandlerMockRecorder) Stop(arg0 interface{}) *gomock.Call {
 }
 
 // Timer mocks base method.
-func (m *MockHandler) Timer(arg0 string) TimerIface {
+func (m *MockHandler) Timer(arg0 string, arg1 ...Option) TimerIface {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Timer", arg0)
+	varargs := []interface{}{arg0}
+	for _, a := range arg1 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Timer", varargs...)
 	ret0, _ := ret[0].(TimerIface)
 	return ret0
 }
 
 // Timer indicates an expected call of Timer.
-func (mr *MockHandlerMockRecorder) Timer(arg0 interface{}) *gomock.Call {
+func (mr *MockHandlerMockRecorder) Timer(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Timer", reflect.TypeOf((*MockHandler)(nil).Timer), arg0)
+	varargs := append([]interface{}{arg0}, arg1...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Timer", reflect.TypeOf((*MockHandler)(nil).Timer), varargs...)
 }
 
 // WithTags mocks base method.

--- a/common/metrics/noop_impl.go
+++ b/common/metrics/noop_impl.go
@@ -47,22 +47,22 @@ func (n *noopMetricsHandler) WithTags(...Tag) Handler {
 }
 
 // Counter obtains a counter for the given name and MetricOptions.
-func (*noopMetricsHandler) Counter(string) CounterIface {
+func (*noopMetricsHandler) Counter(string, ...Option) CounterIface {
 	return NoopCounterMetricFunc
 }
 
 // Gauge obtains a gauge for the given name and MetricOptions.
-func (*noopMetricsHandler) Gauge(string) GaugeIface {
+func (*noopMetricsHandler) Gauge(string, ...Option) GaugeIface {
 	return NoopGaugeMetricFunc
 }
 
 // Timer obtains a timer for the given name and MetricOptions.
-func (*noopMetricsHandler) Timer(string) TimerIface {
+func (*noopMetricsHandler) Timer(string, ...Option) TimerIface {
 	return NoopTimerMetricFunc
 }
 
 // Histogram obtains a histogram for the given name and MetricOptions.
-func (*noopMetricsHandler) Histogram(string, MetricUnit) HistogramIface {
+func (*noopMetricsHandler) Histogram(string, MetricUnit, ...Option) HistogramIface {
 	return NoopHistogramMetricFunc
 }
 

--- a/common/metrics/option.go
+++ b/common/metrics/option.go
@@ -1,0 +1,53 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+type (
+	// Option adds information to a metric definition.
+	// Consumers of Option values may do nothing with them,
+	// i.e. they may be specific to the metrics handler implementation.
+	Option interface {
+		apply(p *params)
+	}
+
+	// params are the set of parameters that can be provided to functions which return a new metric.
+	params struct {
+		// optionalHelpText is the name of the help text that will be set in the help tag.
+		// If this is nil, no help text will be added.
+		optionalHelpText *string
+	}
+)
+
+// buildParams takes a set of options and constructs the params used to define a metric.
+func buildParams(opts []Option) params {
+	p := params{
+		optionalHelpText: nil,
+	}
+	for _, opt := range opts {
+		opt.apply(&p)
+	}
+
+	return p
+}

--- a/common/metrics/otel_metrics_handler_test.go
+++ b/common/metrics/otel_metrics_handler_test.go
@@ -144,6 +144,7 @@ func TestMeter(t *testing.T) {
 				Temporality: metricdata.CumulativeTemporality,
 				IsMonotonic: true,
 			},
+			Description: "hits-tagged-excluded-help",
 		},
 		{
 			Name: "latency",
@@ -171,6 +172,7 @@ func TestMeter(t *testing.T) {
 					},
 				},
 			},
+			Description: "temp-help",
 		},
 		{
 			Name: "transmission",
@@ -186,7 +188,8 @@ func TestMeter(t *testing.T) {
 				},
 				Temporality: metricdata.CumulativeTemporality,
 			},
-			Unit: unit.Bytes,
+			Unit:        unit.Bytes,
+			Description: "transmission-help",
 		},
 	}
 	if diff := cmp.Diff(want, got.ScopeMetrics[0].Metrics,
@@ -211,12 +214,12 @@ func TestMeter(t *testing.T) {
 
 func recordMetrics(mp Handler) {
 	hitsCounter := mp.Counter("hits")
-	gauge := mp.Gauge("temp")
+	gauge := mp.Gauge("temp", WithHelpText("temp-help"))
 
 	timer := mp.Timer("latency")
-	histogram := mp.Histogram("transmission", Bytes)
+	histogram := mp.Histogram("transmission", Bytes, WithHelpText("transmission-help"))
 	hitsTaggedCounter := mp.Counter("hits-tagged")
-	hitsTaggedExcludedCounter := mp.Counter("hits-tagged-excluded")
+	hitsTaggedExcludedCounter := mp.Counter("hits-tagged-excluded", WithHelpText("hits-tagged-excluded-help"))
 
 	hitsCounter.Record(8)
 	gauge.Record(100, StringTag("location", "Mare Imbrium"))

--- a/common/metrics/tally_metrics_handler.go
+++ b/common/metrics/tally_metrics_handler.go
@@ -75,29 +75,29 @@ func (tmp *tallyMetricsHandler) WithTags(tags ...Tag) Handler {
 	}
 }
 
-// Counter obtains a counter for the given name and MetricOptions.
-func (tmp *tallyMetricsHandler) Counter(counter string) CounterIface {
+// Counter obtains a counter for the given name. The Option list is ignored.
+func (tmp *tallyMetricsHandler) Counter(counter string, _ ...Option) CounterIface {
 	return CounterFunc(func(i int64, t ...Tag) {
 		tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags)).Counter(counter).Inc(i)
 	})
 }
 
-// Gauge obtains a gauge for the given name and MetricOptions.
-func (tmp *tallyMetricsHandler) Gauge(gauge string) GaugeIface {
+// Gauge obtains a gauge for the given name. The Option list is ignored.
+func (tmp *tallyMetricsHandler) Gauge(gauge string, option ...Option) GaugeIface {
 	return GaugeFunc(func(f float64, t ...Tag) {
 		tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags)).Gauge(gauge).Update(f)
 	})
 }
 
-// Timer obtains a timer for the given name and MetricOptions.
-func (tmp *tallyMetricsHandler) Timer(timer string) TimerIface {
+// Timer obtains a timer for the given name. The Option list is ignored.
+func (tmp *tallyMetricsHandler) Timer(timer string, _ ...Option) TimerIface {
 	return TimerFunc(func(d time.Duration, tag ...Tag) {
 		tmp.scope.Tagged(tagsToMap(tag, tmp.excludeTags)).Timer(timer).Record(d)
 	})
 }
 
 // Histogram obtains a histogram for the given name and MetricOptions.
-func (tmp *tallyMetricsHandler) Histogram(histogram string, unit MetricUnit) HistogramIface {
+func (tmp *tallyMetricsHandler) Histogram(histogram string, unit MetricUnit, _ ...Option) HistogramIface {
 	return HistogramFunc(func(i int64, t ...Tag) {
 		tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags)).Histogram(histogram, tmp.perUnitBuckets[unit]).RecordValue(float64(i))
 	})

--- a/service/history/shard/context_util.go
+++ b/service/history/shard/context_util.go
@@ -79,10 +79,9 @@ Loop:
 					tag.ShardQueueAcks(category.Name(), minTaskKey.FireTime),
 				)
 			}
-			metricsHandler.Timer(metrics.ShardInfoScheduledQueueLagTimer.GetMetricName()).Record(
-				lag,
-				metrics.TaskCategoryTag(category.Name()),
-			)
+			metricsHandler.Timer(
+				metrics.ShardInfoScheduledQueueLagTimer.GetMetricName(),
+			).Record(lag, metrics.TaskCategoryTag(category.Name()))
 		default:
 			logger.Error("Unknown task category type", tag.NewStringTag("task-category", category.Type().String()))
 		}

--- a/service/history/shard/context_util.go
+++ b/service/history/shard/context_util.go
@@ -79,9 +79,10 @@ Loop:
 					tag.ShardQueueAcks(category.Name(), minTaskKey.FireTime),
 				)
 			}
-			metricsHandler.Timer(
-				metrics.ShardInfoScheduledQueueLagTimer.GetMetricName(),
-			).Record(lag, metrics.TaskCategoryTag(category.Name()))
+			metricsHandler.Timer(metrics.ShardInfoScheduledQueueLagTimer.GetMetricName()).Record(
+				lag,
+				metrics.TaskCategoryTag(category.Name()),
+			)
 		default:
 			logger.Error("Unknown task category type", tag.NewStringTag("task-category", category.Type().String()))
 		}

--- a/service/worker/archiver/replay_metrics_client.go
+++ b/service/worker/archiver/replay_metrics_client.go
@@ -55,28 +55,28 @@ func (r *replayMetricsClient) WithTags(tags ...metrics.Tag) metrics.Handler {
 	return NewReplayMetricsClient(r.metricsHandler.WithTags(tags...), r.ctx)
 }
 
-func (r *replayMetricsClient) Counter(s string) metrics.CounterIface {
+func (r *replayMetricsClient) Counter(s string, _ ...metrics.Option) metrics.CounterIface {
 	if workflow.IsReplaying(r.ctx) {
 		return metrics.CounterFunc(func(i int64, t ...metrics.Tag) {})
 	}
 	return r.metricsHandler.Counter(s)
 }
 
-func (r *replayMetricsClient) Gauge(s string) metrics.GaugeIface {
+func (r *replayMetricsClient) Gauge(s string, _ ...metrics.Option) metrics.GaugeIface {
 	if workflow.IsReplaying(r.ctx) {
 		return metrics.GaugeFunc(func(i float64, t ...metrics.Tag) {})
 	}
 	return r.metricsHandler.Gauge(s)
 }
 
-func (r *replayMetricsClient) Timer(s string) metrics.TimerIface {
+func (r *replayMetricsClient) Timer(s string, option ...metrics.Option) metrics.TimerIface {
 	if workflow.IsReplaying(r.ctx) {
 		return metrics.TimerFunc(func(ti time.Duration, t ...metrics.Tag) {})
 	}
 	return r.metricsHandler.Timer(s)
 }
 
-func (r *replayMetricsClient) Histogram(s string, unit metrics.MetricUnit) metrics.HistogramIface {
+func (r *replayMetricsClient) Histogram(s string, unit metrics.MetricUnit, option ...metrics.Option) metrics.HistogramIface {
 	if workflow.IsReplaying(r.ctx) {
 		return metrics.HistogramFunc(func(i int64, t ...metrics.Tag) {})
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now have support for adding help text to metrics defined using our open telemetry metrics handler.

<!-- Tell your future self why have you made these changes -->
**Why?**
To document our metrics better.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added test cases which verified that the description field in the metrics produced contained the provided help text.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There is a potential panic in `buildOtelOptions`, but it is an unexported function, and all callsites require that the return type be implemented by `instrument.Option`, so they will not panic. 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.