### PR TITLE
Event buffer size limit

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -573,12 +573,10 @@ const (
 	ReplicatorProcessorUpdateAckIntervalJitterCoefficient = "history.replicatorProcessorUpdateAckIntervalJitterCoefficient"
 	// ReplicatorProcessorEnablePriorityTaskProcessor indicates whether priority task processor should be used for ReplicatorProcessor
 	ReplicatorProcessorEnablePriorityTaskProcessor = "history.replicatorProcessorEnablePriorityTaskProcessor"
-	// MaximumBufferedEventsBatch is max number of buffer event in mutable state.
-	// This limit is exclusive, so the number of buffered events must be less than this amount.
+	// MaximumBufferedEventsBatch is the maximum permissible number of buffered events for any given mutable state.
 	MaximumBufferedEventsBatch = "history.maximumBufferedEventsBatch"
-	// MaximumBufferedEventsSizeInBytes is the maximum total size of all buffered events for a workflow execution.
-	// The total size is determined by the sum of the size, in bytes, of each HistoryEvent proto.
-	// This limit is inclusive, so the size of the buffered events must be less than or equal to this amount.
+	// MaximumBufferedEventsSizeInBytes is the maximum permissible size of all buffered events for any given mutable
+	// state. The total size is determined by the sum of the size, in bytes, of each HistoryEvent proto.
 	MaximumBufferedEventsSizeInBytes = "history.maximumBufferedEventsSizeInBytes"
 	// MaximumSignalsPerExecution is max number of signals supported by single execution
 	MaximumSignalsPerExecution = "history.maximumSignalsPerExecution"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -573,10 +573,12 @@ const (
 	ReplicatorProcessorUpdateAckIntervalJitterCoefficient = "history.replicatorProcessorUpdateAckIntervalJitterCoefficient"
 	// ReplicatorProcessorEnablePriorityTaskProcessor indicates whether priority task processor should be used for ReplicatorProcessor
 	ReplicatorProcessorEnablePriorityTaskProcessor = "history.replicatorProcessorEnablePriorityTaskProcessor"
-	// MaximumBufferedEventsBatch is max number of buffer event in mutable state
+	// MaximumBufferedEventsBatch is max number of buffer event in mutable state.
+	// This limit is exclusive, so the number of buffered events must be less than this amount.
 	MaximumBufferedEventsBatch = "history.maximumBufferedEventsBatch"
 	// MaximumBufferedEventsSizeInBytes is the maximum total size of all buffered events for a workflow execution.
 	// The total size is determined by the sum of the size, in bytes, of each HistoryEvent proto.
+	// This limit is inclusive, so the size of the buffered events must be less than or equal to this amount.
 	MaximumBufferedEventsSizeInBytes = "history.maximumBufferedEventsSizeInBytes"
 	// MaximumSignalsPerExecution is max number of signals supported by single execution
 	MaximumSignalsPerExecution = "history.maximumSignalsPerExecution"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -575,6 +575,9 @@ const (
 	ReplicatorProcessorEnablePriorityTaskProcessor = "history.replicatorProcessorEnablePriorityTaskProcessor"
 	// MaximumBufferedEventsBatch is max number of buffer event in mutable state
 	MaximumBufferedEventsBatch = "history.maximumBufferedEventsBatch"
+	// MaximumBufferedEventsSizeInBytes is the maximum total size of all buffered events for a workflow execution.
+	// The total size is determined by the sum of the size, in bytes, of each HistoryEvent proto.
+	MaximumBufferedEventsSizeInBytes = "history.maximumBufferedEventsSizeInBytes"
 	// MaximumSignalsPerExecution is max number of signals supported by single execution
 	MaximumSignalsPerExecution = "history.maximumSignalsPerExecution"
 	// ShardUpdateMinInterval is the minimal time interval which the shard info can be updated

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -247,7 +247,7 @@ const (
 	FrontendClientListOpenWorkflowExecutionsScope = "FrontendClientListOpenWorkflowExecutions"
 	// FrontendClientPollActivityTaskQueueScope tracks RPC calls to frontend service
 	FrontendClientPollActivityTaskQueueScope = "FrontendClientPollActivityTaskQueue"
-	//FrontendClientPollWorkflowExecutionUpdateScope tracks RPC calls to frontend service
+	// FrontendClientPollWorkflowExecutionUpdateScope tracks RPC calls to frontend service
 	FrontendClientPollWorkflowExecutionUpdateScope = "FrontendClientPollWorkflowExecutionUpdate"
 	// FrontendClientPollWorkflowTaskQueueScope tracks RPC calls to frontend service
 	FrontendClientPollWorkflowTaskQueueScope = "FrontendClientPollWorkflowTaskQueue"

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -146,8 +146,9 @@ type Config struct {
 	ReplicatorProcessorMaxSkipTaskCount                   dynamicconfig.IntPropertyFn
 
 	// System Limits
-	MaximumBufferedEventsBatch dynamicconfig.IntPropertyFn
-	MaximumSignalsPerExecution dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaximumBufferedEventsBatch       dynamicconfig.IntPropertyFn
+	MaximumBufferedEventsSizeInBytes dynamicconfig.IntPropertyFn
+	MaximumSignalsPerExecution       dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	// ShardUpdateMinInterval the minimal time interval which the shard info can be updated
 	ShardUpdateMinInterval dynamicconfig.DurationPropertyFn
@@ -408,11 +409,12 @@ func NewConfig(
 		ReplicationProcessorSchedulerQueueSize:   dc.GetIntProperty(dynamicconfig.ReplicationProcessorSchedulerQueueSize, 128),
 		ReplicationProcessorSchedulerWorkerCount: dc.GetIntProperty(dynamicconfig.ReplicationProcessorSchedulerWorkerCount, 512),
 
-		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
-		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MaximumSignalsPerExecution, 0),
-		ShardUpdateMinInterval:          dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
-		ShardSyncMinInterval:            dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),
-		ShardSyncTimerJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
+		MaximumBufferedEventsBatch:       dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
+		MaximumBufferedEventsSizeInBytes: dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsSizeInBytes, 1<<20),
+		MaximumSignalsPerExecution:       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MaximumSignalsPerExecution, 0),
+		ShardUpdateMinInterval:           dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
+		ShardSyncMinInterval:             dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),
+		ShardSyncTimerJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
 
 		// history client: client/history/client.go set the client timeout 30s
 		// TODO: Return this value to the client: go.temporal.io/server/issues/294

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -410,7 +410,7 @@ func NewConfig(
 		ReplicationProcessorSchedulerWorkerCount: dc.GetIntProperty(dynamicconfig.ReplicationProcessorSchedulerWorkerCount, 512),
 
 		MaximumBufferedEventsBatch:       dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
-		MaximumBufferedEventsSizeInBytes: dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsSizeInBytes, 1<<20),
+		MaximumBufferedEventsSizeInBytes: dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsSizeInBytes, 2*1024*1024),
 		MaximumSignalsPerExecution:       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MaximumSignalsPerExecution, 0),
 		ShardUpdateMinInterval:           dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
 		ShardSyncMinInterval:             dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),

--- a/service/history/workflow/history_builder.go
+++ b/service/history/workflow/history_builder.go
@@ -1119,8 +1119,16 @@ func (b *HistoryBuilder) HasAnyBufferedEvent(filter BufferedEventFilter) bool {
 	return false
 }
 
-func (b *HistoryBuilder) BufferEventSize() int {
+func (b *HistoryBuilder) NumBufferedEvents() int {
 	return len(b.dbBufferBatch) + len(b.memBufferBatch)
+}
+
+func (b *HistoryBuilder) SizeInBytesOfBufferedEvents() int {
+	size := 0
+	for _, ev := range append(b.dbBufferBatch, b.memBufferBatch...) {
+		size += ev.Size()
+	}
+	return size
 }
 
 func (b *HistoryBuilder) NextEventID() int64 {

--- a/service/history/workflow/history_builder.go
+++ b/service/history/workflow/history_builder.go
@@ -1125,7 +1125,10 @@ func (b *HistoryBuilder) NumBufferedEvents() int {
 
 func (b *HistoryBuilder) SizeInBytesOfBufferedEvents() int {
 	size := 0
-	for _, ev := range append(b.dbBufferBatch, b.memBufferBatch...) {
+	for _, ev := range b.dbBufferBatch {
+		size += ev.Size()
+	}
+	for _, ev := range b.memBufferBatch {
 		size += ev.Size()
 	}
 	return size

--- a/service/history/workflow/history_builder_test.go
+++ b/service/history/workflow/history_builder_test.go
@@ -2315,7 +2315,7 @@ func (s *historyBuilderSuite) TestReorder() {
 	)
 }
 
-func (s *historyBuilderSuite) TestBufferSize() {
+func (s *historyBuilderSuite) TestBufferSize_Memory() {
 	s.Assert().Zero(s.historyBuilder.NumBufferedEvents())
 	s.Assert().Zero(s.historyBuilder.SizeInBytesOfBufferedEvents())
 	s.historyBuilder.AddWorkflowExecutionSignaledEvent(
@@ -2329,6 +2329,26 @@ func (s *historyBuilderSuite) TestBufferSize() {
 	// the size of the proto  is non-deterministic, so just assert that it's non-zero, and it isn't really high
 	s.Assert().Greater(s.historyBuilder.SizeInBytesOfBufferedEvents(), 0)
 	s.Assert().Less(s.historyBuilder.SizeInBytesOfBufferedEvents(), 100)
+	s.flush()
+	s.Assert().Zero(s.historyBuilder.NumBufferedEvents())
+	s.Assert().Zero(s.historyBuilder.SizeInBytesOfBufferedEvents())
+}
+
+func (s *historyBuilderSuite) TestBufferSize_DB() {
+	s.Assert().Zero(s.historyBuilder.NumBufferedEvents())
+	s.Assert().Zero(s.historyBuilder.SizeInBytesOfBufferedEvents())
+	s.historyBuilder.dbBufferBatch = []*historypb.HistoryEvent{{
+		EventType: enumspb.EVENT_TYPE_TIMER_FIRED,
+		EventId:   common.BufferedEventID,
+		TaskId:    common.EmptyEventTaskID,
+	}}
+	s.Assert().Equal(1, s.historyBuilder.NumBufferedEvents())
+	// the size of the proto  is non-deterministic, so just assert that it's non-zero, and it isn't really high
+	s.Assert().Greater(s.historyBuilder.SizeInBytesOfBufferedEvents(), 0)
+	s.Assert().Less(s.historyBuilder.SizeInBytesOfBufferedEvents(), 100)
+	s.flush()
+	s.Assert().Zero(s.historyBuilder.NumBufferedEvents())
+	s.Assert().Zero(s.historyBuilder.SizeInBytesOfBufferedEvents())
 }
 
 func (s *historyBuilderSuite) assertEventIDTaskID(

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4606,7 +4606,7 @@ func (ms *MutableStateImpl) BufferSizeAcceptable() bool {
 		return false
 	}
 
-	if ms.hBuilder.SizeInBytesOfBufferedEvents() >= ms.config.MaximumBufferedEventsSizeInBytes() {
+	if ms.hBuilder.SizeInBytesOfBufferedEvents() > ms.config.MaximumBufferedEventsSizeInBytes() {
 		return false
 	}
 	return true

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4602,7 +4602,7 @@ func (ms *MutableStateImpl) closeTransactionWithPolicyCheck(
 }
 
 func (ms *MutableStateImpl) BufferSizeAcceptable() bool {
-	if ms.hBuilder.NumBufferedEvents() >= ms.config.MaximumBufferedEventsBatch() {
+	if ms.hBuilder.NumBufferedEvents() > ms.config.MaximumBufferedEventsBatch() {
 		return false
 	}
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4601,6 +4601,17 @@ func (ms *MutableStateImpl) closeTransactionWithPolicyCheck(
 	}
 }
 
+func (ms *MutableStateImpl) BufferSizeAcceptable() bool {
+	if ms.hBuilder.NumBufferedEvents() >= ms.config.MaximumBufferedEventsBatch() {
+		return false
+	}
+
+	if ms.hBuilder.SizeInBytesOfBufferedEvents() >= ms.config.MaximumBufferedEventsSizeInBytes() {
+		return false
+	}
+	return true
+}
+
 func (ms *MutableStateImpl) closeTransactionHandleBufferedEventsLimit(
 	transactionPolicy TransactionPolicy,
 ) error {
@@ -4610,7 +4621,7 @@ func (ms *MutableStateImpl) closeTransactionHandleBufferedEventsLimit(
 		return nil
 	}
 
-	if ms.hBuilder.BufferEventSize() < ms.config.MaximumBufferedEventsBatch() {
+	if ms.BufferSizeAcceptable() {
 		return nil
 	}
 

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -152,7 +152,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 	}))
 	err := s.mutableState.ReplicateWorkflowTaskCompletedEvent(newWorkflowTaskCompletedEvent)
 	s.NoError(err)
-	s.Equal(0, s.mutableState.hBuilder.BufferEventSize())
+	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
 }
 
 func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplicated_FailoverWorkflowTaskTimeout() {
@@ -175,7 +175,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 		newWorkflowTask,
 	)
 	s.NoError(err)
-	s.Equal(0, s.mutableState.hBuilder.BufferEventSize())
+	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
 }
 
 func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplicated_FailoverWorkflowTaskFailed() {
@@ -202,7 +202,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 		"", "", "", 0,
 	)
 	s.NoError(err)
-	s.Equal(0, s.mutableState.hBuilder.BufferEventSize())
+	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
 }
 
 func (s *mutableStateSuite) TestChecksum() {
@@ -421,7 +421,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskSchedule_CurrentVersionChan
 	s.NotNil(wt)
 
 	s.Equal(int32(1), s.mutableState.GetExecutionInfo().WorkflowTaskAttempt)
-	s.Equal(0, s.mutableState.hBuilder.BufferEventSize())
+	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
 }
 
 func (s *mutableStateSuite) TestTransientWorkflowTaskStart_CurrentVersionChanged() {
@@ -461,7 +461,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskStart_CurrentVersionChanged
 		"random identity",
 	)
 	s.NoError(err)
-	s.Equal(0, s.mutableState.hBuilder.BufferEventSize())
+	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
 }
 
 func (s *mutableStateSuite) TestSanitizedMutableState() {

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -29,6 +29,7 @@ package workflow_test
 
 import (
 	"fmt"
+	"math"
 	"testing"
 	"time"
 
@@ -59,24 +60,35 @@ func TestMutableStateImpl_ForceFlushBufferedEvents(t *testing.T) {
 
 	for _, tc := range []mutationTestCase{
 		{
-			name:              "signals<maxNumEvents",
-			signals:           1,
-			maxNumEvents:      2,
+			name:              "Number of events acceptable",
 			transactionPolicy: workflow.TransactionPolicyActive,
+			signals:           1,
+			maxEvents:         2,
+			maxSizeInBytes:    math.MaxInt,
 			expectFlush:       false,
 		},
 		{
-			name:              "signals=maxNumEvents",
-			signals:           2,
-			maxNumEvents:      2,
+			name:              "Number of events has reached limit",
 			transactionPolicy: workflow.TransactionPolicyActive,
+			signals:           2,
+			maxEvents:         2,
+			maxSizeInBytes:    math.MaxInt,
 			expectFlush:       true,
 		},
 		{
-			name:              "signals>maxNumEvents",
-			signals:           3,
-			maxNumEvents:      2,
+			name:              "Number of events acceptable but byte size limit exceeded",
 			transactionPolicy: workflow.TransactionPolicyActive,
+			signals:           1,
+			maxEvents:         2,
+			maxSizeInBytes:    0,
+			expectFlush:       true,
+		},
+		{
+			name:              "Number of events limit reached and byte size limit exceeded",
+			transactionPolicy: workflow.TransactionPolicyActive,
+			signals:           2,
+			maxEvents:         2,
+			maxSizeInBytes:    0,
 			expectFlush:       true,
 		},
 	} {
@@ -88,11 +100,12 @@ type mutationTestCase struct {
 	name              string
 	transactionPolicy workflow.TransactionPolicy
 	signals           int
-	maxNumEvents      int
+	maxEvents         int
 	expectFlush       bool
+	maxSizeInBytes    int
 }
 
-func (c mutationTestCase) Run(t *testing.T) {
+func (c *mutationTestCase) Run(t *testing.T) {
 	t.Parallel()
 
 	nsEntry := tests.LocalNamespaceEntry
@@ -118,7 +131,7 @@ func (c mutationTestCase) Run(t *testing.T) {
 	}
 }
 
-func (c mutationTestCase) startWFT(
+func (c *mutationTestCase) startWFT(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 ) *workflow.WorkflowTaskInfo {
@@ -137,7 +150,7 @@ func (c mutationTestCase) startWFT(
 	return wft
 }
 
-func (c mutationTestCase) startWorkflowExecution(
+func (c *mutationTestCase) startWorkflowExecution(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 	nsEntry *namespace.Namespace,
@@ -165,7 +178,7 @@ func (c mutationTestCase) startWorkflowExecution(
 	}
 }
 
-func (c mutationTestCase) addWorkflowExecutionSignaled(t *testing.T, i int, ms *workflow.MutableStateImpl) {
+func (c *mutationTestCase) addWorkflowExecutionSignaled(t *testing.T, i int, ms *workflow.MutableStateImpl) {
 	t.Helper()
 
 	payload := &commonpb.Payloads{}
@@ -184,7 +197,7 @@ func (c mutationTestCase) addWorkflowExecutionSignaled(t *testing.T, i int, ms *
 	}
 }
 
-func (c mutationTestCase) createMutableState(t *testing.T, nsEntry *namespace.Namespace) *workflow.MutableStateImpl {
+func (c *mutationTestCase) createMutableState(t *testing.T, nsEntry *namespace.Namespace) *workflow.MutableStateImpl {
 	t.Helper()
 
 	ctrl := gomock.NewController(t)
@@ -223,16 +236,23 @@ func (c mutationTestCase) createMutableState(t *testing.T, nsEntry *namespace.Na
 	return ms
 }
 
-func (c mutationTestCase) createConfig() *configs.Config {
+func (c *mutationTestCase) createConfig() *configs.Config {
 	cfg := tests.NewDynamicConfig()
-	cfg.MaximumBufferedEventsBatch = func() int {
-		return c.maxNumEvents
-	}
+	cfg.MaximumBufferedEventsBatch = c.getMaxEvents
+	cfg.MaximumBufferedEventsSizeInBytes = c.getMaxSizeInBytes
 
 	return cfg
 }
 
-func (c mutationTestCase) testWFTFailedEvent(
+func (c *mutationTestCase) getMaxEvents() int {
+	return c.maxEvents
+}
+
+func (c *mutationTestCase) getMaxSizeInBytes() int {
+	return c.maxSizeInBytes
+}
+
+func (c *mutationTestCase) testWFTFailedEvent(
 	t *testing.T,
 	wft *workflow.WorkflowTaskInfo,
 	event *history.HistoryEvent,
@@ -256,7 +276,7 @@ func (c mutationTestCase) testWFTFailedEvent(
 	}
 }
 
-func (c mutationTestCase) findWFTEvent(eventType enumspb.EventType, workflowEvents []*persistence.WorkflowEvents) (
+func (c *mutationTestCase) findWFTEvent(eventType enumspb.EventType, workflowEvents []*persistence.WorkflowEvents) (
 	*history.HistoryEvent,
 	bool,
 ) {
@@ -271,7 +291,7 @@ func (c mutationTestCase) findWFTEvent(eventType enumspb.EventType, workflowEven
 	return nil, false
 }
 
-func (c mutationTestCase) testFailure(
+func (c *mutationTestCase) testFailure(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 	wft *workflow.WorkflowTaskInfo,
@@ -310,7 +330,7 @@ func (c mutationTestCase) testFailure(
 	c.testWFTFailedEvent(t, wft, event)
 }
 
-func (c mutationTestCase) testSuccess(
+func (c *mutationTestCase) testSuccess(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 	workflowEvents []*persistence.WorkflowEvents,

--- a/service/history/workflow/workflow_test/mutable_state_impl_test.go
+++ b/service/history/workflow/workflow_test/mutable_state_impl_test.go
@@ -105,7 +105,7 @@ type mutationTestCase struct {
 	maxSizeInBytes    int
 }
 
-func (c *mutationTestCase) Run(t *testing.T) {
+func (c mutationTestCase) Run(t *testing.T) {
 	t.Parallel()
 
 	nsEntry := tests.LocalNamespaceEntry
@@ -131,7 +131,7 @@ func (c *mutationTestCase) Run(t *testing.T) {
 	}
 }
 
-func (c *mutationTestCase) startWFT(
+func (c mutationTestCase) startWFT(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 ) *workflow.WorkflowTaskInfo {
@@ -150,7 +150,7 @@ func (c *mutationTestCase) startWFT(
 	return wft
 }
 
-func (c *mutationTestCase) startWorkflowExecution(
+func (c mutationTestCase) startWorkflowExecution(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 	nsEntry *namespace.Namespace,
@@ -178,7 +178,7 @@ func (c *mutationTestCase) startWorkflowExecution(
 	}
 }
 
-func (c *mutationTestCase) addWorkflowExecutionSignaled(t *testing.T, i int, ms *workflow.MutableStateImpl) {
+func (c mutationTestCase) addWorkflowExecutionSignaled(t *testing.T, i int, ms *workflow.MutableStateImpl) {
 	t.Helper()
 
 	payload := &commonpb.Payloads{}
@@ -197,7 +197,7 @@ func (c *mutationTestCase) addWorkflowExecutionSignaled(t *testing.T, i int, ms 
 	}
 }
 
-func (c *mutationTestCase) createMutableState(t *testing.T, nsEntry *namespace.Namespace) *workflow.MutableStateImpl {
+func (c mutationTestCase) createMutableState(t *testing.T, nsEntry *namespace.Namespace) *workflow.MutableStateImpl {
 	t.Helper()
 
 	ctrl := gomock.NewController(t)
@@ -236,7 +236,7 @@ func (c *mutationTestCase) createMutableState(t *testing.T, nsEntry *namespace.N
 	return ms
 }
 
-func (c *mutationTestCase) createConfig() *configs.Config {
+func (c mutationTestCase) createConfig() *configs.Config {
 	cfg := tests.NewDynamicConfig()
 	cfg.MaximumBufferedEventsBatch = c.getMaxEvents
 	cfg.MaximumBufferedEventsSizeInBytes = c.getMaxSizeInBytes
@@ -244,15 +244,15 @@ func (c *mutationTestCase) createConfig() *configs.Config {
 	return cfg
 }
 
-func (c *mutationTestCase) getMaxEvents() int {
+func (c mutationTestCase) getMaxEvents() int {
 	return c.maxEvents
 }
 
-func (c *mutationTestCase) getMaxSizeInBytes() int {
+func (c mutationTestCase) getMaxSizeInBytes() int {
 	return c.maxSizeInBytes
 }
 
-func (c *mutationTestCase) testWFTFailedEvent(
+func (c mutationTestCase) testWFTFailedEvent(
 	t *testing.T,
 	wft *workflow.WorkflowTaskInfo,
 	event *history.HistoryEvent,
@@ -276,7 +276,7 @@ func (c *mutationTestCase) testWFTFailedEvent(
 	}
 }
 
-func (c *mutationTestCase) findWFTEvent(eventType enumspb.EventType, workflowEvents []*persistence.WorkflowEvents) (
+func (c mutationTestCase) findWFTEvent(eventType enumspb.EventType, workflowEvents []*persistence.WorkflowEvents) (
 	*history.HistoryEvent,
 	bool,
 ) {
@@ -291,7 +291,7 @@ func (c *mutationTestCase) findWFTEvent(eventType enumspb.EventType, workflowEve
 	return nil, false
 }
 
-func (c *mutationTestCase) testFailure(
+func (c mutationTestCase) testFailure(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 	wft *workflow.WorkflowTaskInfo,
@@ -330,7 +330,7 @@ func (c *mutationTestCase) testFailure(
 	c.testWFTFailedEvent(t, wft, event)
 }
 
-func (c *mutationTestCase) testSuccess(
+func (c mutationTestCase) testSuccess(
 	t *testing.T,
 	ms *workflow.MutableStateImpl,
 	workflowEvents []*persistence.WorkflowEvents,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a limit on the total size of the history events buffer. Here, size means the sum of the number of bytes of each HistoryEvent proto in the batch, as determined by protobuf.

<!-- Tell your future self why have you made these changes -->
**Why?**
Because we don't want to have huge mutable state objects.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added test cases which verify that we force-flush and restart WFTs when this limit is exceeded.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There are risks that this will break users that somehow had huge event buffers, but that behavior would already degrade performance anyway.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
I think we should definitely include a message about this new limit in the patch notes.