### PR TITLE
Refactor the Update type to a state machine

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1358,8 +1358,9 @@ var (
 	CommandTypeUpsertWorkflowSearchAttributesCounter  = NewCounterDef("upsert_workflow_search_attributes_command")
 	CommandTypeModifyWorkflowPropertiesCounter        = NewCounterDef("modify_workflow_properties_command")
 	CommandTypeChildWorkflowCounter                   = NewCounterDef("child_workflow_command")
+	MessageTypeRequestWorkflowExecutionUpdateCounter  = NewCounterDef("request_workflow_update_message")
 	MessageTypeAcceptWorkflowExecutionUpdateCounter   = NewCounterDef("accept_workflow_update_message")
-	MessageTypeCompleteWorkflowExecutionUpdateCounter = NewCounterDef("complete_workflow_update_message")
+	MessageTypeRespondWorkflowExecutionUpdateCounter  = NewCounterDef("respond_workflow_update_message")
 	MessageTypeRejectWorkflowExecutionUpdateCounter   = NewCounterDef("reject_workflow_update_message")
 
 	ActivityEagerExecutionCounter = NewCounterDef("activity_eager_execution")

--- a/internal/effect/buffer.go
+++ b/internal/effect/buffer.go
@@ -1,0 +1,69 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package effect
+
+import "context"
+
+// Buffer holds a set of effect and rollback functions that can be invoked as a
+// batch with a defined order. Once either Apply or Cancel is called, all
+// buffered effects are cleared. This type is not threadsafe. The zero-value of
+// a Buffer is a valid state.
+type Buffer struct {
+	effects []func(context.Context)
+	cancels []func(context.Context)
+}
+
+// OnAfterCommit adds the provided effect function to set of such functions to
+// be invoked when Buffer.Apply is called.
+func (b *Buffer) OnAfterCommit(effect func(context.Context)) {
+	b.effects = append(b.effects, effect)
+}
+
+// OnAfterRollback adds the provided effect function to set of such functions to
+// be invoked when Buffer.Cancel is called.
+func (b *Buffer) OnAfterRollback(effect func(context.Context)) {
+	b.cancels = append(b.cancels, effect)
+}
+
+// Apply invokes the buffered effect functions in the order that they were added
+// to this Buffer.
+func (b *Buffer) Apply(ctx context.Context) {
+	for _, effect := range b.effects {
+		effect(ctx)
+	}
+	b.effects = nil
+	b.cancels = nil
+}
+
+// Cancel invokes the buffered rollback functions in the reverse of the order
+// that they were added to this Buffer.
+func (b *Buffer) Cancel(ctx context.Context) {
+	b.effects = nil
+	for i := len(b.cancels) - 1; i >= 0; i-- {
+		b.cancels[i](ctx)
+	}
+	b.cancels = nil
+	b.effects = nil
+}

--- a/internal/effect/buffer_test.go
+++ b/internal/effect/buffer_test.go
@@ -1,0 +1,93 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package effect_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/internal/effect"
+)
+
+func TestBufferApplyOrder(t *testing.T) {
+	var buf effect.Buffer
+	state := make([]int, 0, 3)
+
+	buf.OnAfterCommit(func(context.Context) { state = append(state, 0) })
+	buf.OnAfterCommit(func(context.Context) { state = append(state, 1) })
+	buf.OnAfterCommit(func(context.Context) { state = append(state, 2) })
+
+	buf.Apply(context.TODO())
+
+	require.ElementsMatch(t, []int{0, 1, 2}, state)
+}
+
+func TestBufferRollbackOrder(t *testing.T) {
+	var buf effect.Buffer
+	state := make([]int, 0, 3)
+
+	buf.OnAfterRollback(func(context.Context) { state = append(state, 0) })
+	buf.OnAfterRollback(func(context.Context) { state = append(state, 1) })
+	buf.OnAfterRollback(func(context.Context) { state = append(state, 2) })
+
+	buf.Cancel(context.TODO())
+
+	require.ElementsMatch(t, []int{2, 1, 0}, state)
+}
+
+func TestBufferCancelAfterApply(t *testing.T) {
+	var buf effect.Buffer
+	var commit, rollback int
+	buf.OnAfterCommit(func(context.Context) { commit++ })
+	buf.OnAfterRollback(func(context.Context) { rollback++ })
+
+	buf.Apply(context.TODO())
+	buf.Cancel(context.TODO())
+	buf.Apply(context.TODO())
+	buf.Cancel(context.TODO())
+	buf.Apply(context.TODO())
+	buf.Cancel(context.TODO())
+
+	require.Equal(t, commit, 1)
+	require.Equal(t, rollback, 0)
+}
+
+func TestBufferApplyAfterCancel(t *testing.T) {
+	var buf effect.Buffer
+	var commit, rollback int
+	buf.OnAfterCommit(func(context.Context) { commit++ })
+	buf.OnAfterRollback(func(context.Context) { rollback++ })
+
+	buf.Cancel(context.TODO())
+	buf.Apply(context.TODO())
+	buf.Apply(context.TODO())
+	buf.Cancel(context.TODO())
+	buf.Apply(context.TODO())
+	buf.Cancel(context.TODO())
+
+	require.Equal(t, commit, 0)
+	require.Equal(t, rollback, 1)
+}

--- a/internal/effect/controller.go
+++ b/internal/effect/controller.go
@@ -1,0 +1,32 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package effect
+
+import "context"
+
+type Controller interface {
+	OnAfterCommit(func(context.Context))
+	OnAfterRollback(func(context.Context))
+}

--- a/internal/effect/immediate.go
+++ b/internal/effect/immediate.go
@@ -1,0 +1,37 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package effect
+
+import "context"
+
+type immediate struct{ context.Context }
+
+// Immediate returns an effects.Set that executes effects immdiately upon
+// insertion. Useful in contexts where you don't actually want to delay effect
+// application and in tests.
+func Immediate(ctx context.Context) Controller { return immediate{ctx} }
+
+func (i immediate) OnAfterCommit(effect func(context.Context)) { effect(i) }
+func (i immediate) OnAfterRollback(func(context.Context))      {}

--- a/internal/effect/immediate_test.go
+++ b/internal/effect/immediate_test.go
@@ -1,0 +1,43 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package effect_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/internal/effect"
+)
+
+func TestImmediate(t *testing.T) {
+	var i int
+	immediate := effect.Immediate(context.TODO())
+	immediate.OnAfterCommit(func(context.Context) { i = 1 })
+	require.Equal(t, i, 1, "commit func should have run")
+
+	immediate.OnAfterRollback(func(context.Context) { i = 2 })
+	require.Equal(t, i, 1, "rollback func should not run")
+}

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -79,7 +79,7 @@ func Invoke(
 
 	updateID := req.GetRequest().GetRequest().GetMeta().GetUpdateId()
 	updateReg := weCtx.GetUpdateRegistry(ctx)
-	upd, newlyCreated, err := updateReg.FindOrCreate(ctx, updateID)
+	upd, alreadyExisted, err := updateReg.FindOrCreate(ctx, updateID)
 	if err != nil {
 		return nil, err
 	}
@@ -90,7 +90,7 @@ func Invoke(
 	// If WT is scheduled, but not started, updates will be attached to it, when WT is started.
 	// If WT has already started, new speculative WT will be created when started WT completes.
 	// If update is duplicate, then WT for this update was already created.
-	createNewWorkflowTask := !ms.HasPendingWorkflowTask() && newlyCreated
+	createNewWorkflowTask := !ms.HasPendingWorkflowTask() && !alreadyExisted
 
 	if createNewWorkflowTask {
 		// This will try not to add an event but will create speculative WT in mutable state.

--- a/service/history/api/workflow_context.go
+++ b/service/history/api/workflow_context.go
@@ -25,6 +25,8 @@
 package api
 
 import (
+	"context"
+
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/workflow"
@@ -39,7 +41,7 @@ type WorkflowContext interface {
 
 	GetNamespaceEntry() *namespace.Namespace
 	GetWorkflowKey() definition.WorkflowKey
-	GetUpdateRegistry() update.Registry
+	GetUpdateRegistry(context.Context) update.Registry
 }
 
 type WorkflowContextImpl struct {
@@ -99,6 +101,6 @@ func (w *WorkflowContextImpl) GetWorkflowKey() definition.WorkflowKey {
 	return w.context.GetWorkflowKey()
 }
 
-func (w *WorkflowContextImpl) GetUpdateRegistry() update.Registry {
-	return w.context.UpdateRegistry()
+func (w *WorkflowContextImpl) GetUpdateRegistry(ctx context.Context) update.Registry {
+	return w.context.UpdateRegistry(ctx)
 }

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -35,7 +35,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
-	updatepb "go.temporal.io/api/update/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/backoff"
@@ -543,84 +542,6 @@ func (v *commandAttrValidator) validateSignalExternalWorkflowExecutionAttributes
 		return failedCause, serviceerror.NewInvalidArgument("SignalName is not set on command.")
 	}
 
-	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
-}
-
-// TODO (alex-update): Move this to messageValidator
-func (v *commandAttrValidator) validateWorkflowExecutionUpdateAcceptanceMessage(
-	_ namespace.ID,
-	protocolInstanceID string,
-	updAcceptance *updatepb.Acceptance,
-) (enumspb.WorkflowTaskFailedCause, error) {
-	const failedCause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE
-
-	if updAcceptance == nil {
-		return failedCause, serviceerror.NewInvalidArgument("Message body of type update.Acceptance is not set.")
-	}
-	if updAcceptance.GetAcceptedRequest() == nil {
-		return failedCause, serviceerror.NewInvalidArgument("accepted_request is not set on update.Acceptance message body.")
-	}
-	if updAcceptance.GetAcceptedRequest().GetMeta() == nil {
-		return failedCause, serviceerror.NewInvalidArgument("meta is not set on accepted_request of message body.")
-	}
-	if updAcceptance.GetAcceptedRequest().GetMeta().GetUpdateId() == "" {
-		return failedCause, serviceerror.NewInvalidArgument("update_id is not set on accepted_request of message body.")
-	}
-	if updAcceptance.GetAcceptedRequest().GetMeta().GetUpdateId() != protocolInstanceID {
-		return failedCause, serviceerror.NewInvalidArgument("update_id of accepted_request of message body is not equal to protocol_instance_id of the message.")
-	}
-
-	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
-}
-
-// TODO (alex-update): Move this to messageValidator.
-func (v *commandAttrValidator) validateWorkflowExecutionUpdateResponseMessage(
-	_ namespace.ID,
-	protocolInstanceID string,
-	updResponse *updatepb.Response,
-) (enumspb.WorkflowTaskFailedCause, error) {
-
-	const failedCause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE
-
-	if updResponse == nil {
-		return failedCause, serviceerror.NewInvalidArgument("Message body of type update.Response is not set.")
-	}
-	if updResponse.GetMeta() == nil {
-		return failedCause, serviceerror.NewInvalidArgument("meta is not set on message body of update.Response type.")
-	}
-	if updResponse.GetMeta().GetUpdateId() == "" {
-		return failedCause, serviceerror.NewInvalidArgument("update_id is not set on message body of update.Response type.")
-	}
-	if updResponse.GetMeta().GetUpdateId() != protocolInstanceID {
-		return failedCause, serviceerror.NewInvalidArgument("update_id of message body of update.Response type is not equal to protocol_instance_id of the message.")
-	}
-
-	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
-}
-
-// TODO (alex-update): Move this to messageValidator.
-func (v *commandAttrValidator) validateWorkflowExecutionUpdateRejectionMessage(
-	_ namespace.ID,
-	protocolInstanceID string,
-	updRejection *updatepb.Rejection,
-) (enumspb.WorkflowTaskFailedCause, error) {
-	const failedCause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE
-
-	if updRejection == nil {
-		return failedCause, serviceerror.NewInvalidArgument("Message body of type update.Rejection is not set.")
-	}
-	if updRejection.GetRejectedRequest() == nil {
-		return failedCause, serviceerror.NewInvalidArgument("rejected_request is not set on update.Rejection message body.")
-	}
-	if updRejection.GetRejectedRequest().GetMeta() == nil {
-		return failedCause, serviceerror.NewInvalidArgument("meta is not set on rejected_request of message body.")
-	}
-	if updRejection.GetRejectedRequest().GetMeta().GetUpdateId() == "" {
-		return failedCause, serviceerror.NewInvalidArgument("update_id is not set on rejected_request of message body.")
-	}
-	if updRejection.GetRejectedRequest().GetMeta().GetUpdateId() != protocolInstanceID {
-		return failedCause, serviceerror.NewInvalidArgument("update_id of rejected_request of message body is not equal to protocol_instance_id of the message.")
-	}
 	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
 }
 

--- a/service/history/queues/memory_scheduled_queue_test.go
+++ b/service/history/queues/memory_scheduled_queue_test.go
@@ -160,7 +160,7 @@ func (s *memoryScheduledQueueSuite) Test_1KRandomTasks() {
 	}
 
 	// To ensure all timers have fired.
-	s.Eventually(func() bool { return calls.Load() == 0 }, time.Second, 100*time.Millisecond)
+	s.Eventually(func() bool { return calls.Load() == 0 }, 10*time.Second, 100*time.Millisecond)
 }
 
 func (s *memoryScheduledQueueSuite) newSpeculativeWorkflowTaskTimeoutTestExecutable(

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"time"
 
+	"go.opentelemetry.io/otel/trace"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
@@ -138,7 +139,7 @@ type (
 			ctx context.Context,
 		) error
 		// TODO (alex-update): move this from workflow context.
-		UpdateRegistry() update.Registry
+		UpdateRegistry(ctx context.Context) update.Registry
 	}
 )
 
@@ -848,9 +849,14 @@ func (c *ContextImpl) ReapplyEvents(
 	return err
 }
 
-func (c *ContextImpl) UpdateRegistry() update.Registry {
+func (c *ContextImpl) UpdateRegistry(ctx context.Context) update.Registry {
 	if c.updateRegistry == nil {
-		c.updateRegistry = update.NewRegistry(c.MutableState)
+		c.updateRegistry = update.NewRegistry(
+			c.MutableState,
+			update.WithLogger(c.logger),
+			update.WithMetrics(c.metricsHandler),
+			update.WithTracerProvider(trace.SpanFromContext(ctx).TracerProvider()),
+		)
 	}
 	return c.updateRegistry
 }

--- a/service/history/workflow/context_mock.go
+++ b/service/history/workflow/context_mock.go
@@ -247,17 +247,17 @@ func (mr *MockContextMockRecorder) Unlock(lockPriority interface{}) *gomock.Call
 }
 
 // UpdateRegistry mocks base method.
-func (m *MockContext) UpdateRegistry() update.Registry {
+func (m *MockContext) UpdateRegistry(ctx context.Context) update.Registry {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateRegistry")
+	ret := m.ctrl.Call(m, "UpdateRegistry", ctx)
 	ret0, _ := ret[0].(update.Registry)
 	return ret0
 }
 
 // UpdateRegistry indicates an expected call of UpdateRegistry.
-func (mr *MockContextMockRecorder) UpdateRegistry() *gomock.Call {
+func (mr *MockContextMockRecorder) UpdateRegistry(ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRegistry", reflect.TypeOf((*MockContext)(nil).UpdateRegistry))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRegistry", reflect.TypeOf((*MockContext)(nil).UpdateRegistry), ctx)
 }
 
 // UpdateWorkflowExecutionAsActive mocks base method.

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -157,7 +157,7 @@ type (
 		DeleteWorkflowTask()
 		DeleteSignalRequested(requestID string)
 		FlushBufferedEvents()
-		GetAcceptedWorkflowExecutionUpdateIDs(context.Context) ([]string, error)
+		GetAcceptedWorkflowExecutionUpdateIDs(context.Context) []string
 		GetWorkflowKey() definition.WorkflowKey
 		GetActivityByActivityID(string) (*persistencespb.ActivityInfo, bool)
 		GetActivityInfo(int64) (*persistencespb.ActivityInfo, bool)
@@ -200,6 +200,7 @@ type (
 		GetQueryRegistry() QueryRegistry
 		GetBaseWorkflowInfo() *workflowspb.BaseExecutionInfo
 		GetUpdateOutcome(ctx context.Context, updateID string) (*updatepb.Outcome, error)
+		GetUpdateInfo(ctx context.Context, updateID string) (*persistencespb.UpdateInfo, bool)
 		IsTransientWorkflowTask() bool
 		ClearTransientWorkflowTask() error
 		HasBufferedEvents() bool

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -3276,14 +3276,19 @@ func (ms *MutableStateImpl) AddWorkflowExecutionUpdateCompletedEvent(updResp *up
 
 func (ms *MutableStateImpl) GetAcceptedWorkflowExecutionUpdateIDs(
 	ctx context.Context,
-) ([]string, error) {
+) []string {
 	out := make([]string, 0)
 	for id, updateInfo := range ms.updateInfos {
 		if updateInfo.GetAcceptancePointer() != nil {
 			out = append(out, id)
 		}
 	}
-	return out, nil
+	return out
+}
+
+func (ms *MutableStateImpl) GetUpdateInfo(ctx context.Context, updateID string) (*persistencespb.UpdateInfo, bool) {
+	info, ok := ms.updateInfos[updateID]
+	return info, ok
 }
 
 func (ms *MutableStateImpl) ReplicateWorkflowExecutionUpdateCompletedEvent(

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -860,8 +860,7 @@ func (s *mutableStateSuite) TestUpdateInfos() {
 	s.Require().Error(err)
 	s.Require().IsType((*serviceerror.NotFound)(nil), err)
 
-	incompletes, err := s.mutableState.GetAcceptedWorkflowExecutionUpdateIDs(context.TODO())
-	s.Require().NoError(err)
+	incompletes := s.mutableState.GetAcceptedWorkflowExecutionUpdateIDs(context.TODO())
 	s.Require().Len(incompletes, 2)
 }
 

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -985,12 +985,11 @@ func (mr *MockMutableStateMockRecorder) GenerateMigrationTasks() *gomock.Call {
 }
 
 // GetAcceptedWorkflowExecutionUpdateIDs mocks base method.
-func (m *MockMutableState) GetAcceptedWorkflowExecutionUpdateIDs(arg0 context.Context) ([]string, error) {
+func (m *MockMutableState) GetAcceptedWorkflowExecutionUpdateIDs(arg0 context.Context) []string {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAcceptedWorkflowExecutionUpdateIDs", arg0)
 	ret0, _ := ret[0].([]string)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	return ret0
 }
 
 // GetAcceptedWorkflowExecutionUpdateIDs indicates an expected call of GetAcceptedWorkflowExecutionUpdateIDs.
@@ -1521,6 +1520,21 @@ func (m *MockMutableState) GetUpdateCondition() (int64, int64) {
 func (mr *MockMutableStateMockRecorder) GetUpdateCondition() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateCondition", reflect.TypeOf((*MockMutableState)(nil).GetUpdateCondition))
+}
+
+// GetUpdateInfo mocks base method.
+func (m *MockMutableState) GetUpdateInfo(ctx context.Context, updateID string) (*v112.UpdateInfo, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUpdateInfo", ctx, updateID)
+	ret0, _ := ret[0].(*v112.UpdateInfo)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetUpdateInfo indicates an expected call of GetUpdateInfo.
+func (mr *MockMutableStateMockRecorder) GetUpdateInfo(ctx, updateID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUpdateInfo", reflect.TypeOf((*MockMutableState)(nil).GetUpdateInfo), ctx, updateID)
 }
 
 // GetUpdateOutcome mocks base method.

--- a/service/history/workflow/update/export_test.go
+++ b/service/history/workflow/update/export_test.go
@@ -1,0 +1,34 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+var (
+	// while we *could* write the unit test code to walk an Update through a
+	// series of message deliveries to get to the right state, it's much faster
+	// just to instantiate directly into the desired state.
+
+	NewAccepted  = newAccepted
+	NewCompleted = newCompleted
+)

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -60,7 +60,7 @@ type (
 		// sent messages to a worker.
 		HasOutgoing() bool
 
-		// Len observes the number of updates in tis Registry.
+		// Len observes the number of updates in this Registry.
 		Len() int
 	}
 

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -48,9 +48,9 @@ type (
 		// new update it is absent.
 		Find(ctx context.Context, protocolInstanceID string) (*Update, bool)
 
-		// CreateOutgoingMessages polls each registered Update for outbound
+		// ReadOutoundMessages polls each registered Update for outbound
 		// messages and returns them.
-		CreateOutgoingMessages(startedEventID int64) ([]*protocolpb.Message, error)
+		ReadOutgoingMessages(startedEventID int64) ([]*protocolpb.Message, error)
 
 		// HasIncomplete returns true if the registry has Updates that have not
 		// yet completed or are not at least provisionally complete.
@@ -168,14 +168,14 @@ func (r *RegistryImpl) HasOutgoing() bool {
 	return false
 }
 
-func (r *RegistryImpl) CreateOutgoingMessages(
+func (r *RegistryImpl) ReadOutgoingMessages(
 	startedEventID int64,
 ) ([]*protocolpb.Message, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	var out []*protocolpb.Message
 	for _, upd := range r.updates {
-		upd.PollOutboundMessages(&out)
+		upd.ReadOutgoingMessages(&out)
 	}
 
 	// TODO (alex-update): currently sequencing_id is simply pointing to the

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -38,9 +38,10 @@ import (
 
 type (
 	Registry interface {
-		// FindOrCrate finds an existing Update or creates a new one. The second
-		// return value (bool) indicates whether the Update returned is newly
-		// created (true) for an existing update (false).
+		// FindOrCreate finds an existing Update or creates a new one. The second
+		// return value (bool) indicates whether the Update returned already
+		// existed and was found (true) or was not found and has been newly
+		// created (false)
 		FindOrCreate(ctx context.Context, protocolInstanceID string) (*Update, bool, error)
 
 		// Find finds an existing update in this Registry but does not create a
@@ -132,11 +133,11 @@ func (r *RegistryImpl) FindOrCreate(ctx context.Context, id string) (*Update, bo
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if upd, ok := r.findLocked(ctx, id); ok {
-		return upd, false, nil
+		return upd, true, nil
 	}
 	upd := New(id, r.remover(id), withInstrumentation(&r.instrumentation))
 	r.updates[id] = upd
-	return upd, true, nil
+	return upd, false, nil
 }
 
 func (r *RegistryImpl) Find(ctx context.Context, id string) (*Update, bool) {

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -64,9 +64,9 @@ type (
 		Len() int
 	}
 
-	// RegistryStore represents the update package's requirements for writing
+	// UpdateStore represents the update package's requirements for writing
 	// events and restoring ephemeral state from an event index.
-	RegistryStore interface {
+	UpdateStore interface {
 		GetAcceptedWorkflowExecutionUpdateIDs(context.Context) []string
 		GetUpdateInfo(ctx context.Context, updateID string) (*persistencespb.UpdateInfo, bool)
 		GetUpdateOutcome(ctx context.Context, updateID string) (*updatepb.Outcome, error)
@@ -75,7 +75,7 @@ type (
 	RegistryImpl struct {
 		mu              sync.RWMutex
 		updates         map[string]*Update
-		store           RegistryStore
+		store           UpdateStore
 		instrumentation instrumentation
 	}
 
@@ -112,7 +112,7 @@ func WithTracerProvider(t trace.TracerProvider) regOpt {
 
 var _ Registry = (*RegistryImpl)(nil)
 
-func NewRegistry(store RegistryStore, opts ...regOpt) *RegistryImpl {
+func NewRegistry(store UpdateStore, opts ...regOpt) *RegistryImpl {
 	r := &RegistryImpl{
 		updates:         make(map[string]*Update),
 		store:           store,

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -193,8 +193,8 @@ func (r *RegistryImpl) CreateOutgoingMessages(
 }
 
 func (r *RegistryImpl) Len() int {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	return len(r.updates)
 }
 

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -26,229 +26,202 @@ package update
 
 import (
 	"context"
-	"fmt"
 	"sync"
 
-	"github.com/gogo/protobuf/types"
-	historypb "go.temporal.io/api/history/v1"
+	"go.opentelemetry.io/otel/trace"
 	protocolpb "go.temporal.io/api/protocol/v1"
-	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 )
 
 type (
 	Registry interface {
-		Add(request *updatepb.Request) (*Update, Duplicate, RemoveFunc)
+		// FindOrCrate finds an existing Update or creates a new one. The second
+		// return value (bool) indicates whether the Update returned is newly
+		// created (true) for an existing update (false).
+		FindOrCreate(ctx context.Context, protocolInstanceID string) (*Update, bool, error)
 
+		// Find finds an existing update in this Registry but does not create a
+		// new update it is absent.
+		Find(ctx context.Context, protocolInstanceID string) (*Update, bool)
+
+		// CreateOutgoingMessages polls each registered Update for outbound
+		// messages and returns them.
 		CreateOutgoingMessages(startedEventID int64) ([]*protocolpb.Message, error)
 
-		HasPending(filterMessages []*protocolpb.Message) bool
-		ValidateIncomingMessages(messages []*protocolpb.Message) error
-		ProcessIncomingMessages(messages []*protocolpb.Message) error
+		// HasIncomplete returns true if the registry has Updates that have not
+		// yet completed or are not at least provisionally complete.
+		HasIncomplete() bool
+
+		// HasOutgoing returns true if the registry has any Updates that want to
+		// sent messages to a worker.
+		HasOutgoing() bool
+
+		// Len observes the number of updates in tis Registry.
+		Len() int
 	}
 
-	Duplicate bool
-
-	RemoveFunc func()
-
-	// Storage represents the update package's requirements for writing
+	// RegistryStore represents the update package's requirements for writing
 	// events and restoring ephemeral state from an event index.
-	Storage interface {
-		// AddWorkflowExecutionUpdateAcceptedEvent writes an update accepted
-		// event.
-		AddWorkflowExecutionUpdateAcceptedEvent(updateID string, accpt *updatepb.Acceptance) (*historypb.HistoryEvent, error)
-
-		// AddWorkflowExecutionUpdateCompletedEvent writes an update completed
-		// event.
-		AddWorkflowExecutionUpdateCompletedEvent(resp *updatepb.Response) (*historypb.HistoryEvent, error)
-
-		// GetAcceptedWorkflowExecutionUpdateIDs reads from durable state the
-		// set of update IDs that are known to be in the accepted state.
-		GetAcceptedWorkflowExecutionUpdateIDs(ctx context.Context) ([]string, error)
+	RegistryStore interface {
+		GetAcceptedWorkflowExecutionUpdateIDs(context.Context) []string
+		GetUpdateInfo(ctx context.Context, updateID string) (*persistencespb.UpdateInfo, bool)
+		GetUpdateOutcome(ctx context.Context, updateID string) (*updatepb.Outcome, error)
 	}
 
 	RegistryImpl struct {
-		sync.RWMutex
-		updates map[string]*Update
-		store   Storage
+		mu              sync.RWMutex
+		updates         map[string]*Update
+		store           RegistryStore
+		instrumentation instrumentation
 	}
+
+	regOpt func(*RegistryImpl)
 )
+
+//revive:disable:unexported-return I *want* it to be unexported
+
+// WithLogger sets the log.Logger to be used by an UpdateRegistry and its
+// Updates.
+func WithLogger(l log.Logger) regOpt {
+	return func(r *RegistryImpl) {
+		r.instrumentation.log = l
+	}
+}
+
+// WithMetrics sets the metrics.Handler to be used by an UpdateRegistry and its
+// Updates.
+func WithMetrics(m metrics.Handler) regOpt {
+	return func(r *RegistryImpl) {
+		r.instrumentation.metrics = m
+	}
+}
+
+// WithTracerProvider sets the trace.TracerProvider (and by extension the
+// trace.Tracer) to be used by an UpdateRegistry and its Updates.
+func WithTracerProvider(t trace.TracerProvider) regOpt {
+	return func(r *RegistryImpl) {
+		r.instrumentation.tracer = t.Tracer(libraryName)
+	}
+}
+
+//revive:enable:unexported-return
 
 var _ Registry = (*RegistryImpl)(nil)
 
-func NewRegistry(store Storage) *RegistryImpl {
-	return &RegistryImpl{
-		updates: make(map[string]*Update),
-		store:   store,
+func NewRegistry(store RegistryStore, opts ...regOpt) *RegistryImpl {
+	r := &RegistryImpl{
+		updates:         make(map[string]*Update),
+		store:           store,
+		instrumentation: noopInstrumentation,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	// need to eager load here so that HasIncomplete is correct.
+	for _, id := range store.GetAcceptedWorkflowExecutionUpdateIDs(context.Background()) {
+		r.updates[id] = newAccepted(id, r.remover(id), withInstrumentation(&r.instrumentation))
+	}
+	return r
 }
 
-func (r *RegistryImpl) Add(request *updatepb.Request) (*Update, Duplicate, RemoveFunc) {
-	r.Lock()
-	defer r.Unlock()
-	protocolInstanceID := request.GetMeta().GetUpdateId()
-	upd, ok := r.updates[protocolInstanceID]
-	if ok {
-		return upd, true, nil
+func (r *RegistryImpl) FindOrCreate(ctx context.Context, id string) (*Update, bool, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if upd, ok := r.findLocked(ctx, id); ok {
+		return upd, false, nil
 	}
-	upd = newUpdate(request, protocolInstanceID)
-	r.updates[upd.protocolInstanceID] = upd
-	return upd, false, func() { r.remove(protocolInstanceID) }
+	upd := New(id, r.remover(id), withInstrumentation(&r.instrumentation))
+	r.updates[id] = upd
+	return upd, true, nil
 }
 
-func (r *RegistryImpl) HasPending(filterMessages []*protocolpb.Message) bool {
-	// Filter out updates which will be accepted or rejected by current workflow task messages.
-	// These updates have Pending state in the registry but in fact, they are already accepted or rejected by worker
-	// and shouldn't be counted as Pending.
-	notPendingUpdates := make(map[string]struct{})
-	for _, message := range filterMessages {
-		if types.Is(message.GetBody(), (*updatepb.Acceptance)(nil)) {
-			notPendingUpdates[message.GetProtocolInstanceId()] = struct{}{}
-		} else if types.Is(message.GetBody(), (*updatepb.Rejection)(nil)) {
-			notPendingUpdates[message.GetProtocolInstanceId()] = struct{}{}
-		}
-	}
+func (r *RegistryImpl) Find(ctx context.Context, id string) (*Update, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.findLocked(ctx, id)
+}
 
-	r.RLock()
-	defer r.RUnlock()
-
-	for _, update := range r.updates {
-		if _, notPending := notPendingUpdates[update.protocolInstanceID]; !notPending && update.state == statePending {
+func (r *RegistryImpl) HasIncomplete() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	for _, upd := range r.updates {
+		if !upd.completedOrProvisionallyCompleted() {
 			return true
 		}
 	}
 	return false
 }
 
-func (r *RegistryImpl) CreateOutgoingMessages(startedEventID int64) ([]*protocolpb.Message, error) {
-	r.RLock()
-	defer r.RUnlock()
-	numPendingUpd := 0
+func (r *RegistryImpl) HasOutgoing() bool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
 	for _, upd := range r.updates {
-		if upd.state == statePending {
-			numPendingUpd++
+		if upd.hasOutgoingMessage() {
+			return true
 		}
 	}
-	if numPendingUpd == 0 {
-		return nil, nil
+	return false
+}
+
+func (r *RegistryImpl) CreateOutgoingMessages(
+	startedEventID int64,
+) ([]*protocolpb.Message, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	var out []*protocolpb.Message
+	for _, upd := range r.updates {
+		upd.PollOutboundMessages(&out)
 	}
 
-	// TODO (alex-update): currently sequencing_id is simply pointing to the event before WorkflowTaskStartedEvent.
-	//  SDKs are supposed to respect this and process messages (specifically, updates) after event with that ID.
-	//  In the future, sequencing_id could point to some specific event (specifically, signal) after which the update should be processed.
-	//  Currently, it is not possible due to buffered events reordering on server and events reordering in some SDKs.
+	// TODO (alex-update): currently sequencing_id is simply pointing to the
+	// event before WorkflowTaskStartedEvent.  SDKs are supposed to respect this
+	// and process messages (specifically, updates) after event with that ID.
+	// In the future, sequencing_id could point to some specific event
+	// (specifically, signal) after which the update should be processed.
+	// Currently, it is not possible due to buffered events reordering on server
+	// and events reordering in some SDKs.
 	sequencingEventID := startedEventID - 1
-
-	updMessages := make([]*protocolpb.Message, 0, numPendingUpd)
-	for _, upd := range r.updates {
-		if upd.state == statePending {
-			messageBody, err := types.MarshalAny(upd.request)
-			if err != nil {
-				return nil, err
-			}
-			updMessages = append(updMessages, &protocolpb.Message{
-				Id:                 upd.messageID,
-				ProtocolInstanceId: upd.protocolInstanceID,
-				SequencingId: &protocolpb.Message_EventId{
-					EventId: sequencingEventID,
-				},
-				Body: messageBody,
-			})
-		}
+	for _, msg := range out {
+		msg.SequencingId = &protocolpb.Message_EventId{EventId: sequencingEventID}
 	}
-	return updMessages, nil
+	return out, nil
 }
 
-func (r *RegistryImpl) ValidateIncomingMessages(messages []*protocolpb.Message) error {
-	r.RLock()
-	defer r.RUnlock()
-
-	// Valid message sequences:
-	//  pending -> reject
-	//  pending -> accept
-	//  accept -> complete
-
-	// make a shallow copy of updates for validation so that it does not alter the state which will be used
-	// by a retry of failed workflow task
-	updates := make(map[string]*Update, len(r.updates))
-	for k, v := range r.updates {
-		updates[k] = &Update{
-			state:              v.state,
-			request:            v.request,
-			messageID:          v.messageID,
-			protocolInstanceID: v.protocolInstanceID,
-			outcome:            nil, // we don't need it for validation
-		}
-	}
-
-	_, err := processIncomingMessages(updates, messages)
-	return err
+func (r *RegistryImpl) Len() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.updates)
 }
 
-func (r *RegistryImpl) ProcessIncomingMessages(messages []*protocolpb.Message) error {
-	r.Lock()
-	defer r.Unlock()
-
-	closedUpdates, err := processIncomingMessages(r.updates, messages)
-	if err != nil {
-		return err
+func (r *RegistryImpl) remover(id string) func() {
+	return func() {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		delete(r.updates, id)
 	}
-
-	// notify result to caller
-	for _, upd := range closedUpdates {
-		upd.notify()
-	}
-	return nil
 }
 
-//nolint:revive // cognitive complexity
-func processIncomingMessages(updates map[string]*Update, messages []*protocolpb.Message) ([]*Update, error) {
-	var closedUpdates []*Update
-	for _, message := range messages {
-		instanceId := message.GetProtocolInstanceId()
-		upd, ok := updates[instanceId]
-		if !ok {
-			return nil, serviceerror.NewNotFound(fmt.Sprintf("BadUpdateWorkflowExecutionMessage: update %s not found", instanceId))
-		}
+func (r *RegistryImpl) findLocked(ctx context.Context, id string) (*Update, bool) {
+	upd, ok := r.updates[id]
+	if ok {
+		return upd, true
+	}
 
-		if message.GetBody() == nil {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("BadUpdateWorkflowExecutionMessage: message %s has empty body", instanceId))
-		}
+	// update not found in ephemeral state, but could have already completed so
+	// check in registry storage
 
-		if types.Is(message.GetBody(), (*updatepb.Acceptance)(nil)) {
-			if upd.state != statePending {
-				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("BadUpdateWorkflowExecutionMessage: failed to accept update %s, current state: %s", instanceId, upd.state))
-			}
-			upd.accept()
-		} else if types.Is(message.GetBody(), (*updatepb.Response)(nil)) {
-			if upd.state != stateAccepted {
-				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("BadUpdateWorkflowExecutionMessage: failed to complete update %s, current state: %s", instanceId, upd.state))
-			}
-			var response updatepb.Response
-			if err := types.UnmarshalAny(message.GetBody(), &response); err != nil {
-				return nil, err
-			}
-			upd.complete(response.GetOutcome())
-			closedUpdates = append(closedUpdates, upd)
-		} else if types.Is(message.GetBody(), (*updatepb.Rejection)(nil)) {
-			if upd.state != statePending {
-				return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("BadUpdateWorkflowExecutionMessage: failed to reject update %s, current state: %s", instanceId, upd.state))
-			}
-			var rejection updatepb.Rejection
-			if err := types.UnmarshalAny(message.GetBody(), &rejection); err != nil {
-				return nil, err
-			}
-			upd.reject(rejection.GetFailure())
-			closedUpdates = append(closedUpdates, upd)
-		} else {
-			return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("unknown message type: %s", message.GetBody().GetTypeUrl()))
+	if info, ok := r.store.GetUpdateInfo(ctx, id); ok {
+		if info.GetCompletedPointer() != nil {
+			// Completed, create the Update object but do not add to registry. this
+			// should not happen often.
+			return newCompleted(id, func(ctx context.Context) (*updatepb.Outcome, error) {
+				return r.store.GetUpdateOutcome(ctx, id)
+			}, withInstrumentation(&r.instrumentation)), true
 		}
 	}
-	return closedUpdates, nil
-}
-
-func (r *RegistryImpl) remove(id string) {
-	r.Lock()
-	defer r.Unlock()
-	delete(r.updates, id)
+	return nil, false
 }

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -252,7 +252,7 @@ func TestMessageGathering(t *testing.T) {
 	require.NoError(t, err)
 	wftStartedEventID := int64(123)
 
-	msgs, err := reg.CreateOutgoingMessages(wftStartedEventID)
+	msgs, err := reg.ReadOutgoingMessages(wftStartedEventID)
 	require.NoError(t, err)
 	require.Empty(t, msgs)
 
@@ -264,7 +264,7 @@ func TestMessageGathering(t *testing.T) {
 	}, evStore)
 	require.NoError(t, err)
 
-	msgs, err = reg.CreateOutgoingMessages(wftStartedEventID)
+	msgs, err = reg.ReadOutgoingMessages(wftStartedEventID)
 	require.NoError(t, err)
 	require.Len(t, msgs, 1)
 
@@ -274,7 +274,7 @@ func TestMessageGathering(t *testing.T) {
 	}, evStore)
 	require.NoError(t, err)
 
-	msgs, err = reg.CreateOutgoingMessages(wftStartedEventID)
+	msgs, err = reg.ReadOutgoingMessages(wftStartedEventID)
 	require.NoError(t, err)
 	require.Len(t, msgs, 2)
 

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -39,27 +39,27 @@ import (
 	"go.temporal.io/server/service/history/workflow/update"
 )
 
-type mockRegStore struct {
-	update.RegistryStore
+type mockUpdateStore struct {
+	update.UpdateStore
 	GetAcceptedWorkflowExecutionUpdateIDsFunc func(context.Context) []string
 	GetUpdateInfoFunc                         func(context.Context, string) (*persistencespb.UpdateInfo, bool)
 	GetUpdateOutcomeFunc                      func(context.Context, string) (*updatepb.Outcome, error)
 }
 
-func (m mockRegStore) GetAcceptedWorkflowExecutionUpdateIDs(
+func (m mockUpdateStore) GetAcceptedWorkflowExecutionUpdateIDs(
 	ctx context.Context,
 ) []string {
 	return m.GetAcceptedWorkflowExecutionUpdateIDsFunc(ctx)
 }
 
-func (m mockRegStore) GetUpdateInfo(
+func (m mockUpdateStore) GetUpdateInfo(
 	ctx context.Context,
 	updateID string,
 ) (*persistencespb.UpdateInfo, bool) {
 	return m.GetUpdateInfoFunc(ctx, updateID)
 }
 
-func (m mockRegStore) GetUpdateOutcome(
+func (m mockUpdateStore) GetUpdateOutcome(
 	ctx context.Context,
 	updateID string,
 ) (*updatepb.Outcome, error) {
@@ -69,7 +69,7 @@ func (m mockRegStore) GetUpdateOutcome(
 func TestFind(t *testing.T) {
 	t.Parallel()
 	updateID := t.Name() + "-update-id"
-	store := mockRegStore{
+	store := mockUpdateStore{
 		GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
 			return nil
 		},
@@ -96,7 +96,7 @@ func TestHasOutgoing(t *testing.T) {
 	t.Parallel()
 	var (
 		updateID = t.Name() + "-update-id"
-		store    = mockRegStore{
+		store    = mockUpdateStore{
 			GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
 				return nil
 			},
@@ -143,7 +143,7 @@ func TestFindOrCreate(t *testing.T) {
 			},
 		}
 		// make a store with 1 accepted and 1 completed update
-		store = mockRegStore{
+		store = mockUpdateStore{
 			GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
 				return []string{acceptedUpdateID}
 			},
@@ -204,7 +204,7 @@ func TestUpdateRemovalFromRegistry(t *testing.T) {
 	t.Parallel()
 	var (
 		storedAcceptedUpdateID = t.Name() + "-accepted-update-id"
-		regStore               = mockRegStore{
+		regStore               = mockUpdateStore{
 			GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
 				return []string{storedAcceptedUpdateID}
 			},
@@ -234,7 +234,7 @@ func TestUpdateRemovalFromRegistry(t *testing.T) {
 func TestMessageGathering(t *testing.T) {
 	t.Parallel()
 	var (
-		regStore = mockRegStore{
+		regStore = mockUpdateStore{
 			GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
 				return nil
 			},

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -84,9 +84,9 @@ func TestFind(t *testing.T) {
 	_, ok := reg.Find(context.TODO(), updateID)
 	require.False(t, ok)
 
-	_, created, err := reg.FindOrCreate(context.TODO(), updateID)
+	_, found, err := reg.FindOrCreate(context.TODO(), updateID)
 	require.NoError(t, err)
-	require.True(t, created)
+	require.False(t, found)
 
 	_, ok = reg.Find(context.TODO(), updateID)
 	require.True(t, ok)
@@ -171,18 +171,18 @@ func TestFindOrCreate(t *testing.T) {
 
 	t.Run("new update", func(t *testing.T) {
 		updateID := "a completely new update ID"
-		_, created, err := reg.FindOrCreate(context.TODO(), updateID)
+		_, found, err := reg.FindOrCreate(context.TODO(), updateID)
 		require.NoError(t, err)
-		require.True(t, created)
+		require.False(t, found)
 
-		_, created, err = reg.FindOrCreate(context.TODO(), updateID)
+		_, found, err = reg.FindOrCreate(context.TODO(), updateID)
 		require.NoError(t, err)
-		require.False(t, created, "second lookup for same updateID should not create new")
+		require.True(t, found, "second lookup for same updateID should find previous")
 	})
 	t.Run("find stored completed", func(t *testing.T) {
-		upd, created, err := reg.FindOrCreate(context.TODO(), completedUpdateID)
+		upd, found, err := reg.FindOrCreate(context.TODO(), completedUpdateID)
 		require.NoError(t, err)
-		require.False(t, created)
+		require.True(t, found)
 		acptOutcome, err := upd.WaitAccepted(context.TODO())
 		require.NoError(t, err, "completed update should also be accepted")
 		require.Equal(t, completedOutcome, acptOutcome, "completed update should have an outcome")
@@ -191,9 +191,9 @@ func TestFindOrCreate(t *testing.T) {
 		require.Equal(t, completedOutcome, got, "completed update should have an outcome")
 	})
 	t.Run("find stored accepted", func(t *testing.T) {
-		upd, created, err := reg.FindOrCreate(context.TODO(), acceptedUpdateID)
+		upd, found, err := reg.FindOrCreate(context.TODO(), acceptedUpdateID)
 		require.NoError(t, err)
-		require.False(t, created)
+		require.True(t, found)
 		acptOutcome, err := upd.WaitAccepted(context.TODO())
 		require.NoError(t, err)
 		require.Nil(t, acptOutcome)
@@ -212,9 +212,9 @@ func TestUpdateRemovalFromRegistry(t *testing.T) {
 		reg = update.NewRegistry(regStore)
 	)
 
-	upd, created, err := reg.FindOrCreate(context.TODO(), storedAcceptedUpdateID)
+	upd, found, err := reg.FindOrCreate(context.TODO(), storedAcceptedUpdateID)
 	require.NoError(t, err)
-	require.False(t, created)
+	require.True(t, found)
 
 	var effects effect.Buffer
 	evStore := mockEventStore{Controller: &effects}

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package update
+package update_test
 
 import (
 	"context"
@@ -30,216 +30,262 @@ import (
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
-	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	historypb "go.temporal.io/api/history/v1"
-	protocolpb "go.temporal.io/api/protocol/v1"
+	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
+	historyspb "go.temporal.io/server/api/history/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/internal/effect"
+	"go.temporal.io/server/service/history/workflow/update"
 )
 
-type (
-	updateSuite struct {
-		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
-		// not merely log an error
-		*require.Assertions
-		suite.Suite
-	}
-
-	mockStore struct {
-		Storage
-		AddWorkflowExecutionUpdateAcceptedEventFunc  func(string, *updatepb.Acceptance) (*historypb.HistoryEvent, error)
-		AddWorkflowExecutionUpdateCompletedEventFunc func(*updatepb.Response) (*historypb.HistoryEvent, error)
-		GetAcceptedWorkflowExecutionUpdateIDsFunc    func(context.Context) ([]string, error)
-	}
-)
-
-func (m mockStore) AddWorkflowExecutionUpdateAcceptedEvent(
-	updateID string,
-	accpt *updatepb.Acceptance,
-) (*historypb.HistoryEvent, error) {
-	return m.AddWorkflowExecutionUpdateAcceptedEventFunc(updateID, accpt)
+type mockRegStore struct {
+	update.RegistryStore
+	GetAcceptedWorkflowExecutionUpdateIDsFunc func(context.Context) []string
+	GetUpdateInfoFunc                         func(context.Context, string) (*persistencespb.UpdateInfo, bool)
+	GetUpdateOutcomeFunc                      func(context.Context, string) (*updatepb.Outcome, error)
 }
 
-func (m mockStore) AddWorkflowExecutionUpdateCompletedEvent(
-	resp *updatepb.Response,
-) (*historypb.HistoryEvent, error) {
-	return m.AddWorkflowExecutionUpdateCompletedEventFunc(resp)
-}
-
-func (m mockStore) GetAcceptedWorkflowExecutionUpdateIDs(
+func (m mockRegStore) GetAcceptedWorkflowExecutionUpdateIDs(
 	ctx context.Context,
-) ([]string, error) {
+) []string {
 	return m.GetAcceptedWorkflowExecutionUpdateIDsFunc(ctx)
 }
 
-func (s *updateSuite) SetupSuite() {
-	s.Assertions = require.New(s.T())
+func (m mockRegStore) GetUpdateInfo(
+	ctx context.Context,
+	updateID string,
+) (*persistencespb.UpdateInfo, bool) {
+	return m.GetUpdateInfoFunc(ctx, updateID)
 }
 
-func TestUpdateSuite(t *testing.T) {
-	suite.Run(t, new(updateSuite))
+func (m mockRegStore) GetUpdateOutcome(
+	ctx context.Context,
+	updateID string,
+) (*updatepb.Outcome, error) {
+	return m.GetUpdateOutcomeFunc(ctx, updateID)
 }
 
-func (s *updateSuite) TestValidateMessages() {
-
-	reg := NewRegistry(mockStore{})
-	upd1, _, _ := reg.Add(&updatepb.Request{Meta: &updatepb.Meta{UpdateId: "update-1"}})
-
-	testCases := []struct {
-		Name     string
-		Error    string
-		Messages []*protocolpb.Message
-	}{
-		{
-			Name:  "update id not found",
-			Error: "not found",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: "bogus-update-id",
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Acceptance{}),
-				},
-			},
+func TestFind(t *testing.T) {
+	t.Parallel()
+	updateID := t.Name() + "-update-id"
+	store := mockRegStore{
+		GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
+			return nil
 		},
-		{
-			Name:  "unknown message type",
-			Error: "unknown message type",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.WaitPolicy{}),
-				},
-			},
-		},
-		{
-			Name:  "duplicate acceptance",
-			Error: "BadUpdateWorkflowExecutionMessage: failed to accept update update-1, current state: accepted",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Acceptance{}),
-				},
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Acceptance{}),
-				},
-			},
-		},
-		{
-			Name:  "complete without accept",
-			Error: "BadUpdateWorkflowExecutionMessage: failed to complete update update-1, current state: pending",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Response{}),
-				},
-			},
-		},
-		{
-			Name:  "reject after accept",
-			Error: "BadUpdateWorkflowExecutionMessage: failed to reject update update-1, current state: accepted",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Acceptance{}),
-				},
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Rejection{}),
-				},
-			},
-		},
-		{
-			Name:  "complete after reject",
-			Error: "BadUpdateWorkflowExecutionMessage: failed to complete update update-1, current state: rejected",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Rejection{}),
-				},
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Response{}),
-				},
-			},
-		},
-
-		{
-			Name: "accept only",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Acceptance{}),
-				},
-			},
-		},
-		{
-			Name: "reject only",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Rejection{}),
-				},
-			},
-		},
-
-		{
-			Name: "accept and complete",
-			Messages: []*protocolpb.Message{
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Acceptance{}),
-				},
-				{
-					Id:                 uuid.New(),
-					ProtocolInstanceId: upd1.protocolInstanceID,
-					SequencingId:       nil,
-					Body:               marshalAny(s, &updatepb.Response{}),
-				},
-			},
+		GetUpdateInfoFunc: func(
+			ctx context.Context,
+			updateID string,
+		) (*persistencespb.UpdateInfo, bool) {
+			return nil, false
 		},
 	}
+	reg := update.NewRegistry(store)
+	_, ok := reg.Find(context.TODO(), updateID)
+	require.False(t, ok)
 
-	for _, tc := range testCases {
-		s.T().Run(tc.Name, func(t *testing.T) {
-			err := reg.ValidateIncomingMessages(tc.Messages)
-			if len(tc.Error) > 0 {
-				s.Error(err)
-				s.Contains(err.Error(), tc.Error)
-			} else {
-				s.NoError(err)
-			}
-		})
+	_, created, err := reg.FindOrCreate(context.TODO(), updateID)
+	require.NoError(t, err)
+	require.True(t, created)
+
+	_, ok = reg.Find(context.TODO(), updateID)
+	require.True(t, ok)
+}
+
+func TestHasOutgoing(t *testing.T) {
+	t.Parallel()
+	var (
+		updateID = t.Name() + "-update-id"
+		store    = mockRegStore{
+			GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
+				return nil
+			},
+			GetUpdateInfoFunc: func(
+				ctx context.Context,
+				updateID string,
+			) (*persistencespb.UpdateInfo, bool) {
+				return nil, false
+			},
+		}
+		reg = update.NewRegistry(store)
+	)
+
+	upd, _, err := reg.FindOrCreate(context.TODO(), updateID)
+	require.NoError(t, err)
+	require.False(t, reg.HasOutgoing())
+
+	evStore := mockEventStore{Controller: effect.Immediate(context.TODO())}
+	req := updatepb.Request{
+		Meta:  &updatepb.Meta{UpdateId: updateID},
+		Input: &updatepb.Input{Name: "not_empty"},
+	}
+	require.NoError(t, upd.OnMessage(context.TODO(), &req, evStore))
+	require.True(t, reg.HasOutgoing())
+}
+
+func TestFindOrCreate(t *testing.T) {
+	t.Parallel()
+	var (
+		acceptedUpdateID  = t.Name() + "-accepted-update-id"
+		completedUpdateID = t.Name() + "-completed-update-id"
+		completedOutcome  = successOutcome(t, "success!")
+
+		storeData = map[string]*persistencespb.UpdateInfo{
+			acceptedUpdateID: &persistencespb.UpdateInfo{
+				Value: &persistencespb.UpdateInfo_AcceptancePointer{
+					AcceptancePointer: &historyspb.HistoryEventPointer{EventId: 120},
+				},
+			},
+			completedUpdateID: &persistencespb.UpdateInfo{
+				Value: &persistencespb.UpdateInfo_CompletedPointer{
+					CompletedPointer: &historyspb.HistoryEventPointer{EventId: 123},
+				},
+			},
+		}
+		// make a store with 1 accepted and 1 completed update
+		store = mockRegStore{
+			GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
+				return []string{acceptedUpdateID}
+			},
+			GetUpdateInfoFunc: func(
+				ctx context.Context,
+				updateID string,
+			) (*persistencespb.UpdateInfo, bool) {
+				ui, ok := storeData[updateID]
+				return ui, ok
+			},
+			GetUpdateOutcomeFunc: func(
+				ctx context.Context,
+				updateID string,
+			) (*updatepb.Outcome, error) {
+				if updateID == completedUpdateID {
+					return completedOutcome, nil
+				}
+				return nil, serviceerror.NewNotFound("not found")
+			},
+		}
+		reg = update.NewRegistry(store)
+	)
+
+	require.True(t, reg.HasIncomplete())
+
+	t.Run("new update", func(t *testing.T) {
+		updateID := "a completely new update ID"
+		_, created, err := reg.FindOrCreate(context.TODO(), updateID)
+		require.NoError(t, err)
+		require.True(t, created)
+
+		_, created, err = reg.FindOrCreate(context.TODO(), updateID)
+		require.NoError(t, err)
+		require.False(t, created, "second lookup for same updateID should not create new")
+	})
+	t.Run("find stored completed", func(t *testing.T) {
+		upd, created, err := reg.FindOrCreate(context.TODO(), completedUpdateID)
+		require.NoError(t, err)
+		require.False(t, created)
+		acptOutcome, err := upd.WaitAccepted(context.TODO())
+		require.NoError(t, err, "completed update should also be accepted")
+		require.Equal(t, completedOutcome, acptOutcome, "completed update should have an outcome")
+		got, err := upd.WaitOutcome(context.TODO())
+		require.NoError(t, err, "completed update should have an outcome")
+		require.Equal(t, completedOutcome, got, "completed update should have an outcome")
+	})
+	t.Run("find stored accepted", func(t *testing.T) {
+		upd, created, err := reg.FindOrCreate(context.TODO(), acceptedUpdateID)
+		require.NoError(t, err)
+		require.False(t, created)
+		acptOutcome, err := upd.WaitAccepted(context.TODO())
+		require.NoError(t, err)
+		require.Nil(t, acptOutcome)
+	})
+}
+
+func TestUpdateRemovalFromRegistry(t *testing.T) {
+	t.Parallel()
+	var (
+		storedAcceptedUpdateID = t.Name() + "-accepted-update-id"
+		regStore               = mockRegStore{
+			GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
+				return []string{storedAcceptedUpdateID}
+			},
+		}
+		reg = update.NewRegistry(regStore)
+	)
+
+	upd, created, err := reg.FindOrCreate(context.TODO(), storedAcceptedUpdateID)
+	require.NoError(t, err)
+	require.False(t, created)
+
+	var effects effect.Buffer
+	evStore := mockEventStore{Controller: &effects}
+	meta := updatepb.Meta{UpdateId: storedAcceptedUpdateID}
+	outcome := successOutcome(t, "success!")
+	require.True(t, reg.HasIncomplete(), "accepted update counts as incomplete")
+
+	err = upd.OnMessage(context.TODO(), &updatepb.Response{Meta: &meta, Outcome: outcome}, evStore)
+
+	require.NoError(t, err)
+	require.False(t, reg.HasIncomplete(), "updates should be ProvisionallyCompleted")
+	require.Equal(t, 1, reg.Len(), "update should still be present in map")
+	effects.Apply(context.TODO())
+	require.Equal(t, 0, reg.Len(), "update should have been removed")
+}
+
+func TestMessageGathering(t *testing.T) {
+	t.Parallel()
+	var (
+		regStore = mockRegStore{
+			GetAcceptedWorkflowExecutionUpdateIDsFunc: func(context.Context) []string {
+				return nil
+			},
+			GetUpdateInfoFunc: func(context.Context, string) (*persistencespb.UpdateInfo, bool) {
+				return nil, false
+			},
+		}
+		reg = update.NewRegistry(regStore)
+	)
+
+	updateID1, updateID2 := t.Name()+"-update-id-1", t.Name()+"-update-id-2"
+	upd1, _, err := reg.FindOrCreate(context.TODO(), updateID1)
+	require.NoError(t, err)
+	upd2, _, err := reg.FindOrCreate(context.TODO(), updateID2)
+	require.NoError(t, err)
+	wftStartedEventID := int64(123)
+
+	msgs, err := reg.CreateOutgoingMessages(wftStartedEventID)
+	require.NoError(t, err)
+	require.Empty(t, msgs)
+
+	evStore := mockEventStore{Controller: effect.Immediate(context.TODO())}
+
+	err = upd1.OnMessage(context.TODO(), &updatepb.Request{
+		Meta:  &updatepb.Meta{UpdateId: updateID1},
+		Input: &updatepb.Input{Name: t.Name() + "-update-func"},
+	}, evStore)
+	require.NoError(t, err)
+
+	msgs, err = reg.CreateOutgoingMessages(wftStartedEventID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+
+	err = upd2.OnMessage(context.TODO(), &updatepb.Request{
+		Meta:  &updatepb.Meta{UpdateId: updateID2},
+		Input: &updatepb.Input{Name: t.Name() + "-update-func"},
+	}, evStore)
+	require.NoError(t, err)
+
+	msgs, err = reg.CreateOutgoingMessages(wftStartedEventID)
+	require.NoError(t, err)
+	require.Len(t, msgs, 2)
+
+	for _, msg := range msgs {
+		require.Equal(t, wftStartedEventID-1, msg.GetEventId())
 	}
 }
 
-func marshalAny(s *updateSuite, pb proto.Message) *types.Any {
-	s.T().Helper()
+func mustMarshalAny(t *testing.T, pb proto.Message) *types.Any {
+	t.Helper()
 	a, err := types.MarshalAny(pb)
-	s.NoError(err)
+	require.NoError(t, err)
 	return a
 }

--- a/service/history/workflow/update/state.go
+++ b/service/history/workflow/update/state.go
@@ -1,0 +1,81 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+import "sync/atomic"
+
+type state int32
+
+const (
+	stateAdmitted state = iota
+	stateProvisionallyRequested
+	stateRequested
+	stateProvisionallyAccepted
+	stateAccepted
+	stateProvisionallyCompleted
+	stateCompleted
+)
+
+func (s state) String() string {
+	switch s {
+	case stateAdmitted:
+		return "Admitted"
+	case stateProvisionallyRequested:
+		return "ProvisionallyRequested"
+	case stateRequested:
+		return "Requested"
+	case stateProvisionallyAccepted:
+		return "ProvisionallyAccepted"
+	case stateAccepted:
+		return "Accepted"
+	case stateProvisionallyCompleted:
+		return "ProvisionallyCompleted"
+	case stateCompleted:
+		return "Completed"
+	}
+	return "unrecognized state"
+}
+
+func (s *state) Is(other state) bool {
+	return state(atomic.LoadInt32((*int32)(s))) == other
+}
+
+func (s *state) Set(other state) {
+	atomic.StoreInt32((*int32)(s), int32(other))
+}
+
+func (s *state) Load() state {
+	return state(atomic.LoadInt32((*int32)(s)))
+}
+
+func (s *state) IsOneOf(ss ...state) bool {
+	actual := s.Load()
+	for _, s := range ss {
+		if s == actual {
+			return true
+		}
+	}
+	return false
+}

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -26,85 +26,392 @@ package update
 
 import (
 	"context"
+	"sync/atomic"
 
-	"github.com/pborman/uuid"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
 	failurepb "go.temporal.io/api/failure/v1"
+	historypb "go.temporal.io/api/history/v1"
+	protocolpb "go.temporal.io/api/protocol/v1"
 	updatepb "go.temporal.io/api/update/v1"
 
 	"go.temporal.io/server/common/future"
+	"go.temporal.io/server/internal/effect"
 )
 
 type (
+	// EventStore is the interface that an Update needs to read and write events
+	// and to be notified when buffered writes have been flushed. It is the
+	// expectation of this code that writes to EventStore will return before the
+	// data has been made durable. Callbacks attached to the EventStore via
+	// OnAfterCommit and OnAfterRollback *must* be called after the EventStore
+	// state is successfully written or is discarded.
+	EventStore interface {
+		effect.Controller
+
+		// AddWorkflowExecutionUpdateAcceptedEvent writes an update accepted
+		// event. The data may not be durable when this function returns.
+		AddWorkflowExecutionUpdateAcceptedEvent(
+			updateID string,
+			accpt *updatepb.Acceptance,
+		) (*historypb.HistoryEvent, error)
+
+		// AddWorkflowExecutionUpdateCompletedEvent writes an update completed
+		// event. The data may not be durable when this function returns.
+		AddWorkflowExecutionUpdateCompletedEvent(
+			resp *updatepb.Response,
+		) (*historypb.HistoryEvent, error)
+	}
+
+	// Update is a state machine for the update protocol. It reads and writes
+	// messages from the go.temporal.io/api/update/v1 package. The update state
+	// machine is straightforward except in that it provides "provisional"
+	// in-between states where the update has received a message that has
+	// updated its internal state but those updates have not been made visible
+	// to clients yet (e.g. accepted or outcome futures have not been set yet).
+	// The effects are bound to the EventStore's effect.Set and will be
+	// triggered withen those effects are applied.
 	Update struct {
-		state                 state
-		request               *updatepb.Request
-		afterBufferedEventNum int
-		messageID             string
-		protocolInstanceID    string
-		outcome               *future.FutureImpl[*updatepb.Outcome]
-		pendingOutcome        *updatepb.Outcome
+		// accessed only while holding workflow lock
+		id              string
+		request         *protocolpb.Message // nil when not in stateAdmitted
+		onComplete      func()
+		instrumentation *instrumentation
+
+		// these fields might be accessed while not holding the workflow lock
+		state    state
+		accepted future.Future[*failurepb.Failure]
+		outcome  future.Future[*updatepb.Outcome]
 	}
 
 	state int32
+
+	updateOpt func(*Update)
 )
 
 const (
-	statePending state = iota
+	stateAdmitted state = iota
+	stateProvisionallyRequested
+	stateRequested
+	stateProvisionallyAccepted
 	stateAccepted
-	stateRejected
+	stateProvisionallyCompleted
 	stateCompleted
 )
 
-func (s state) String() string {
-	switch s {
-	case statePending:
-		return "pending"
-	case stateAccepted:
-		return "accepted"
-	case stateRejected:
-		return "rejected"
-	case stateCompleted:
-		return "completed"
-	default:
-		return "unknown"
+// New creates a new Update instance with the provided ID that will call the
+// onComplete callback when it completes.
+func New(id string, onComplete func(), opts ...updateOpt) *Update {
+	upd := &Update{
+		id:              id,
+		state:           stateAdmitted,
+		onComplete:      onComplete,
+		instrumentation: &noopInstrumentation,
+		accepted:        future.NewFuture[*failurepb.Failure](),
+		outcome:         future.NewFuture[*updatepb.Outcome](),
+	}
+	for _, opt := range opts {
+		opt(upd)
+	}
+	return upd
+}
+
+func withInstrumentation(i *instrumentation) updateOpt {
+	return func(u *Update) {
+		u.instrumentation = i
 	}
 }
 
-func newUpdate(request *updatepb.Request, protocolInstanceID string) *Update {
-	return &Update{
-		state:              statePending,
-		request:            request,
-		messageID:          uuid.New(),
-		protocolInstanceID: protocolInstanceID,
-		outcome:            future.NewFuture[*updatepb.Outcome](),
+func newAccepted(id string, onComplete func(), opts ...updateOpt) *Update {
+	upd := &Update{
+		id:              id,
+		state:           stateAccepted,
+		onComplete:      onComplete,
+		instrumentation: &noopInstrumentation,
+		accepted:        future.NewReadyFuture[*failurepb.Failure](nil, nil),
+		outcome:         future.NewFuture[*updatepb.Outcome](),
 	}
+	for _, opt := range opts {
+		opt(upd)
+	}
+	return upd
 }
 
+func newCompleted(
+	id string,
+	fetchOutcome func(ctx context.Context) (*updatepb.Outcome, error),
+	opts ...updateOpt,
+) *Update {
+	upd := &Update{
+		id:              id,
+		state:           stateCompleted,
+		instrumentation: &noopInstrumentation,
+		accepted:        future.NewReadyFuture[*failurepb.Failure](nil, nil),
+		outcome:         lazyOutcome(fetchOutcome),
+	}
+	for _, opt := range opts {
+		opt(upd)
+	}
+	return upd
+}
+
+// WaitOutcome observes this Update's completion, returning the Outcome when it
+// is available. This call will block until the Outcome is known or the provided
+// context.Context expires.
 func (u *Update) WaitOutcome(ctx context.Context) (*updatepb.Outcome, error) {
 	return u.outcome.Get(ctx)
 }
 
-func (u *Update) accept() {
-	u.state = stateAccepted
+// WaitAccepted blocks on the acceptance of this update, returning nil if has
+// been accepted but not yet completed or the overall Outcome if the update has
+// been completed (including completed by rejection). This call will block until
+// the acceptance occurs or the provided context.Context expires.
+func (u *Update) WaitAccepted(ctx context.Context) (*updatepb.Outcome, error) {
+	if u.outcome.Ready() {
+		// being complete implies being accepted, return the completed outcome
+		// here because we can.
+		return u.outcome.Get(ctx)
+	}
+	if _, err := u.accepted.Get(ctx); err != nil {
+		return nil, err
+	}
+	return nil, nil
 }
 
-func (u *Update) complete(o *updatepb.Outcome) {
-	u.state = stateCompleted
-	u.pendingOutcome = o
-}
-
-func (u *Update) reject(f *failurepb.Failure) {
-	u.state = stateRejected
-	u.pendingOutcome = &updatepb.Outcome{
-		Value: &updatepb.Outcome_Failure{
-			Failure: f,
-		},
+// OnMessage delivers a message to the Update state machine. The proto.Message
+// parameter is expected to be one of *updatepb.Request, *updatepb.Response,
+// *updatepb.Rejection, *updatepb.Acceptance, or a *protocolpb.Message whose
+// Body field contains an instance from the same list. Writes to the EventStore
+// occur synchronously but externally observable effects on this Update (e.g.
+// emmitting an Outcome or an Accepted) are registered with the EventStore to be
+// applied after the durable updates are committed. If the EventStore rolls
+// back its effects, this state machine does the same.
+func (u *Update) OnMessage(
+	ctx context.Context,
+	msg proto.Message,
+	eventStore EventStore,
+) error {
+	if msg == nil {
+		return invalidArgf("Update %q received nil message", u.id)
+	}
+	if protocolMsg, ok := msg.(*protocolpb.Message); ok {
+		var dynbody types.DynamicAny
+		if err := types.UnmarshalAny(protocolMsg.Body, &dynbody); err != nil {
+			return err
+		}
+		msg = dynbody.Message
+	}
+	switch body := msg.(type) {
+	case *updatepb.Request:
+		return u.onRequestMsg(ctx, body, eventStore)
+	case *updatepb.Acceptance:
+		return u.onAcceptanceMsg(ctx, body, eventStore)
+	case *updatepb.Rejection:
+		return u.onRejectionMsg(ctx, body, eventStore)
+	case *updatepb.Response:
+		return u.onResponseMsg(ctx, body, eventStore)
+	default:
+		return invalidArgf("Message type %T not supported", body)
 	}
 }
 
-func (u *Update) notify() {
-	if u.pendingOutcome != nil {
-		u.outcome.Set(u.pendingOutcome, nil)
-		u.pendingOutcome = nil
+// PollOutboundMessages loads any oubound messages from this Update state
+// machine into the output slice provided.
+func (u *Update) PollOutboundMessages(out *[]*protocolpb.Message) {
+	if !u.state.Is(stateRequested) {
+		// Update only sends messages to the workflow when it is in
+		// stateRequested
+		return
 	}
+	*out = append(*out, u.request)
+}
+
+// onRequestMsg works if the Update is in any state but if the state is anything
+// other than stateAdmitted then it just early returns a nil error. This
+// effectively gives us update request deduplication by update ID. If the Update
+// is in stateAdmitted then it builds a protocolpb.Message that will be sent on
+// ensuing calls to PollOutboundMessages until the update is accepted.
+func (u *Update) onRequestMsg(
+	ctx context.Context,
+	req *updatepb.Request,
+	eventStore EventStore,
+) error {
+	if !u.state.Is(stateAdmitted) {
+		return nil
+	}
+	if err := validateRequestMsg(u.id, req); err != nil {
+		return err
+	}
+	u.instrumentation.CountRequestMsg()
+	body, err := types.MarshalAny(req)
+	if err != nil {
+		return invalidArgf("could not marshal request: %v", err)
+	}
+	u.request = &protocolpb.Message{
+		ProtocolInstanceId: u.id,
+		Id:                 u.id + "/request",
+		Body:               body,
+	}
+	u.setState(stateProvisionallyRequested)
+	eventStore.OnAfterCommit(func(context.Context) { u.setState(stateRequested) })
+	eventStore.OnAfterRollback(func(context.Context) { u.setState(stateAdmitted) })
+	return nil
+}
+
+// onAcceptanceMsg expects the Update to be in stateRequested and returns an
+// error if it finds otherwise. An event is written to the provided EventStore
+// and on commit the accepted future is completed and the Update transitions to
+// stateAccepted.
+func (u *Update) onAcceptanceMsg(
+	ctx context.Context,
+	acpt *updatepb.Acceptance,
+	eventStore EventStore,
+) error {
+	if err := u.checkState(acpt, stateRequested); err != nil {
+		return err
+	}
+	if err := validateAcceptanceMsg(u.id, acpt); err != nil {
+		return err
+	}
+	u.instrumentation.CountAcceptanceMsg()
+	if _, err := eventStore.AddWorkflowExecutionUpdateAcceptedEvent(u.id, acpt); err != nil {
+		return err
+	}
+	u.setState(stateProvisionallyAccepted)
+	eventStore.OnAfterCommit(func(context.Context) {
+		u.request = nil
+		u.setState(stateAccepted)
+		u.accepted.(*future.FutureImpl[*failurepb.Failure]).Set(nil, nil)
+	})
+	eventStore.OnAfterRollback(func(context.Context) { u.setState(stateRequested) })
+	return nil
+}
+
+// onRejectionMsg expectes the Update stae to be in stateRequested and returns
+// an error if it finds otherwise. On commit of buffered effects the state
+// machine transitions to stateCompleted and the accepted and outcome futures
+// are both completed with the failurepb.Failure value from the
+// updatepb.Rejection input message.
+func (u *Update) onRejectionMsg(
+	ctx context.Context,
+	rej *updatepb.Rejection,
+	eventStore EventStore,
+) error {
+	if err := u.checkState(rej, stateRequested); err != nil {
+		return err
+	}
+	if err := validateRejectionMsg(u.id, rej); err != nil {
+		return err
+	}
+	u.instrumentation.CountRejectionMsg()
+	u.setState(stateProvisionallyCompleted)
+	eventStore.OnAfterCommit(func(context.Context) {
+		u.request = nil
+		u.setState(stateCompleted)
+		outcome := updatepb.Outcome{
+			Value: &updatepb.Outcome_Failure{Failure: rej.Failure},
+		}
+		u.accepted.(*future.FutureImpl[*failurepb.Failure]).Set(rej.Failure, nil)
+		u.outcome.(*future.FutureImpl[*updatepb.Outcome]).Set(&outcome, nil)
+		u.onComplete()
+	})
+	eventStore.OnAfterRollback(func(context.Context) { u.setState(stateRequested) })
+	return nil
+}
+
+// onResponseMsg expectes the Update to be in either stateProvisionallyAccepted
+// or stateAccepted and returns an error if it finds otherwise. On commit of
+// buffered effects the state machine will transtion to stateCompleted and the
+// outcome future is completed with the updatepb.Outcome from the
+// updatepb.Response input message.
+func (u *Update) onResponseMsg(
+	ctx context.Context,
+	res *updatepb.Response,
+	eventStore EventStore,
+) error {
+	if err := u.checkState(res, stateProvisionallyAccepted, stateAccepted); err != nil {
+		return err
+	}
+	if err := validateResponseMsg(u.id, res); err != nil {
+		return err
+	}
+	if _, err := eventStore.AddWorkflowExecutionUpdateCompletedEvent(res); err != nil {
+		return err
+	}
+	u.instrumentation.CountResponseMsg()
+	prevState := u.setState(stateProvisionallyCompleted)
+	eventStore.OnAfterCommit(func(context.Context) {
+		u.setState(stateCompleted)
+		u.outcome.(*future.FutureImpl[*updatepb.Outcome]).Set(res.GetOutcome(), nil)
+		u.onComplete()
+	})
+	eventStore.OnAfterRollback(func(context.Context) { u.setState(prevState) })
+	return nil
+}
+
+func (u *Update) completedOrProvisionallyCompleted() bool {
+	return u.state.IsOneOf(stateCompleted, stateProvisionallyCompleted)
+}
+
+func (u *Update) hasOutgoingMessage() bool {
+	return u.state.Is(stateRequested)
+}
+
+func (u *Update) checkState(msg proto.Message, allowedStates ...state) error {
+	if u.state.IsOneOf(allowedStates...) {
+		return nil
+	}
+	return invalidArgf("invalid state transition attempted: "+
+		"received %T message while in state %q", msg, u.state)
+}
+
+// setState assigns the current state to a new value returning the original
+// value.
+func (u *Update) setState(newState state) state {
+	currState := u.state.Load()
+	u.instrumentation.StateChange(u.id, currState, newState)
+	u.state.Set(newState)
+	return currState
+}
+
+func (s state) String() string {
+	switch s {
+	case stateAdmitted:
+		return "Admitted"
+	case stateProvisionallyRequested:
+		return "ProvisionallyRequested"
+	case stateRequested:
+		return "Requested"
+	case stateProvisionallyAccepted:
+		return "ProvisionallyAccepted"
+	case stateAccepted:
+		return "Accepted"
+	case stateProvisionallyCompleted:
+		return "ProvisionallyCompleted"
+	case stateCompleted:
+		return "Completed"
+	}
+	return "unrecognized state"
+}
+
+func (s *state) Is(other state) bool {
+	return state(atomic.LoadInt32((*int32)(s))) == other
+}
+
+func (s *state) Set(other state) {
+	atomic.StoreInt32((*int32)(s), int32(other))
+}
+
+func (s *state) Load() state {
+	return state(atomic.LoadInt32((*int32)(s)))
+}
+
+func (s *state) IsOneOf(ss ...state) bool {
+	actual := s.Load()
+	for _, s := range ss {
+		if s == actual {
+			return true
+		}
+	}
+	return false
 }

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -202,9 +202,9 @@ func (u *Update) OnMessage(
 	}
 }
 
-// PollOutboundMessages loads any oubound messages from this Update state
+// ReadOutgoingMessages loads any oubound messages from this Update state
 // machine into the output slice provided.
-func (u *Update) PollOutboundMessages(out *[]*protocolpb.Message) {
+func (u *Update) ReadOutgoingMessages(out *[]*protocolpb.Message) {
 	if !u.state.Is(stateRequested) {
 		// Update only sends messages to the workflow when it is in
 		// stateRequested
@@ -217,7 +217,7 @@ func (u *Update) PollOutboundMessages(out *[]*protocolpb.Message) {
 // other than stateAdmitted then it just early returns a nil error. This
 // effectively gives us update request deduplication by update ID. If the Update
 // is in stateAdmitted then it builds a protocolpb.Message that will be sent on
-// ensuing calls to PollOutboundMessages until the update is accepted.
+// ensuing calls to PollOutgoingMessages until the update is accepted.
 func (u *Update) onRequestMsg(
 	ctx context.Context,
 	req *updatepb.Request,

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -315,20 +315,20 @@ func TestMessageOutput(t *testing.T) {
 
 	t.Run("before request received", func(t *testing.T) {
 		msgs := make([]*protocolpb.Message, 0)
-		upd.PollOutboundMessages(&msgs)
+		upd.ReadOutgoingMessages(&msgs)
 		require.Empty(t, msgs)
 	})
 	t.Run("requested", func(t *testing.T) {
 		require.NoError(t, upd.OnMessage(context.TODO(), &req, store))
 		effects.Apply(context.TODO())
 		msgs := make([]*protocolpb.Message, 0)
-		upd.PollOutboundMessages(&msgs)
+		upd.ReadOutgoingMessages(&msgs)
 		require.Len(t, msgs, 1)
 	})
 	t.Run("after requested", func(t *testing.T) {
 		upd := update.NewAccepted(updateID, ignoreCompletion)
 		msgs := make([]*protocolpb.Message, 0)
-		upd.PollOutboundMessages(&msgs)
+		upd.ReadOutgoingMessages(&msgs)
 		require.Empty(t, msgs)
 	})
 }
@@ -399,7 +399,7 @@ func TestDuplicateRequestNoError(t *testing.T) {
 		"a second request message should be ignored, not cause an error")
 
 	msgs := make([]*protocolpb.Message, 0)
-	upd.PollOutboundMessages(&msgs)
+	upd.ReadOutgoingMessages(&msgs)
 	require.Empty(t, msgs)
 }
 

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -1,0 +1,526 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/require"
+	failurepb "go.temporal.io/api/failure/v1"
+	historypb "go.temporal.io/api/history/v1"
+	protocolpb "go.temporal.io/api/protocol/v1"
+	"go.temporal.io/api/serviceerror"
+	updatepb "go.temporal.io/api/update/v1"
+	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/internal/effect"
+	"go.temporal.io/server/service/history/workflow/update"
+)
+
+func successOutcome(t *testing.T, s string) *updatepb.Outcome {
+	return &updatepb.Outcome{
+		Value: &updatepb.Outcome_Success{
+			Success: payloads.EncodeString(t.Name() + s),
+		},
+	}
+}
+
+func ignoreCompletion() {}
+
+var eventStoreUnused update.EventStore
+
+type mockEventStore struct {
+	effect.Controller
+	AddWorkflowExecutionUpdateAcceptedEventFunc func(
+		updateID string,
+		acpt *updatepb.Acceptance,
+	) (*historypb.HistoryEvent, error)
+
+	AddWorkflowExecutionUpdateCompletedEventFunc func(
+		resp *updatepb.Response,
+	) (*historypb.HistoryEvent, error)
+}
+
+func (m mockEventStore) AddWorkflowExecutionUpdateAcceptedEvent(
+	updateID string,
+	acpt *updatepb.Acceptance,
+) (*historypb.HistoryEvent, error) {
+	if m.AddWorkflowExecutionUpdateAcceptedEventFunc != nil {
+		return m.AddWorkflowExecutionUpdateAcceptedEventFunc(updateID, acpt)
+	}
+	return nil, nil
+}
+
+func (m mockEventStore) AddWorkflowExecutionUpdateCompletedEvent(
+	resp *updatepb.Response,
+) (*historypb.HistoryEvent, error) {
+	if m.AddWorkflowExecutionUpdateCompletedEventFunc != nil {
+		return m.AddWorkflowExecutionUpdateCompletedEventFunc(resp)
+	}
+	return nil, nil
+}
+
+func TestNilMessage(t *testing.T) {
+	t.Parallel()
+	upd := update.New(t.Name()+"update-id", ignoreCompletion)
+	err := upd.OnMessage(context.TODO(), nil, mockEventStore{})
+	var invalidArg *serviceerror.InvalidArgument
+	require.ErrorAs(t, err, &invalidArg)
+}
+
+func TestUnsupportedMessageType(t *testing.T) {
+	t.Parallel()
+	upd := update.New(t.Name()+"update-id", ignoreCompletion)
+	notAMessageType := historypb.HistoryEvent{}
+	err := upd.OnMessage(context.TODO(), &notAMessageType, mockEventStore{})
+	var invalidArg *serviceerror.InvalidArgument
+	require.ErrorAs(t, err, &invalidArg)
+}
+
+func TestRequestAcceptComplete(t *testing.T) {
+	// this is the most common happy path - an update is created, requested,
+	// accepted, and finally completed
+	t.Parallel()
+	var (
+		completed  = false
+		effects    = effect.Buffer{}
+		invalidArg *serviceerror.InvalidArgument
+		meta       = updatepb.Meta{UpdateId: t.Name() + "-update-id"}
+		req        = updatepb.Request{Meta: &meta, Input: &updatepb.Input{Name: t.Name()}}
+		acpt       = updatepb.Acceptance{AcceptedRequest: &req, AcceptedRequestMessageId: "x"}
+		resp       = updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")}
+
+		completedEventData updatepb.Response
+		acceptedEventData  = struct {
+			updateID string
+			acpt     updatepb.Acceptance
+		}{}
+		store = mockEventStore{
+			Controller: &effects,
+			AddWorkflowExecutionUpdateAcceptedEventFunc: func(
+				updateID string,
+				acpt *updatepb.Acceptance,
+			) (*historypb.HistoryEvent, error) {
+				acceptedEventData.updateID = updateID
+				acceptedEventData.acpt = *acpt
+				return nil, nil
+			},
+			AddWorkflowExecutionUpdateCompletedEventFunc: func(
+				res *updatepb.Response,
+			) (*historypb.HistoryEvent, error) {
+				completedEventData = *res
+				return nil, nil
+			},
+		}
+		upd = update.New(meta.UpdateId, func() { completed = true })
+	)
+
+	t.Run("request", func(t *testing.T) {
+		err := upd.OnMessage(context.TODO(), &acpt, store)
+		require.ErrorAs(t, err, &invalidArg,
+			"expected InvalidArgument from %T while in Admitted state", &acpt)
+
+		err = upd.OnMessage(context.TODO(), &resp, store)
+		require.ErrorAsf(t, err, &invalidArg,
+			"expected InvalidArgument from %T while in Admitted state", &resp)
+
+		err = upd.OnMessage(context.TODO(), &req, store)
+		require.NoError(t, err)
+		require.False(t, completed)
+
+		err = upd.OnMessage(context.TODO(), &acpt, store)
+		require.ErrorAsf(t, err, &invalidArg,
+			"expected InvalidArgument from %T while in ProvisionallyRequested state", &resp)
+
+		effects.Apply(context.TODO())
+		t.Log("update state should now be Requested")
+	})
+
+	t.Run("accept", func(t *testing.T) {
+		err := upd.OnMessage(context.TODO(), &acpt, store)
+		require.NoError(t, err)
+		require.False(t, completed)
+
+		err = upd.OnMessage(context.TODO(), &acpt, store)
+		require.ErrorAsf(t, err, &invalidArg,
+			"expected InvalidArgument from %T in while ProvisionallyAccepted state", &resp)
+		require.False(t, completed)
+
+		ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		defer cncl()
+		_, err = upd.WaitAccepted(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded,
+			"update acceptance should not be observable until effects are applied")
+
+		effects.Apply(context.TODO())
+		t.Log("update state should now be Accepted")
+
+		outcome, err := upd.WaitAccepted(context.TODO())
+		require.NoError(t, err)
+		require.Nil(t, outcome,
+			"update is accepted but not completed so outcome should be nil")
+	})
+
+	t.Run("respond", func(t *testing.T) {
+		err := upd.OnMessage(context.TODO(), &resp, store)
+		require.NoError(t, err)
+		require.False(t, completed)
+
+		ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		defer cncl()
+		_, err = upd.WaitOutcome(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded,
+			"update outcome should not be observable until effects are applied")
+
+		effects.Apply(context.TODO())
+		t.Log("update state should now be Completed")
+
+		gotOutcome, err := upd.WaitOutcome(context.TODO())
+		require.NoError(t, err)
+		require.Equal(t, resp.Outcome, gotOutcome)
+		require.True(t, completed)
+	})
+
+	require.Equal(t, meta.UpdateId, acceptedEventData.updateID)
+	require.Equal(t, acpt, acceptedEventData.acpt)
+	require.Equal(t, resp, completedEventData)
+}
+
+func TestRequestReject(t *testing.T) {
+	t.Parallel()
+	var (
+		completed = false
+		effects   = effect.Buffer{}
+		store     = mockEventStore{Controller: &effects}
+		updateID  = t.Name() + "-update-id"
+		upd       = update.New(updateID, func() { completed = true })
+		req       = updatepb.Request{
+			Meta:  &updatepb.Meta{UpdateId: updateID},
+			Input: &updatepb.Input{Name: t.Name()},
+		}
+	)
+
+	t.Run("request", func(t *testing.T) {
+		err := upd.OnMessage(context.TODO(), &req, store)
+		require.NoError(t, err)
+		require.False(t, completed)
+		effects.Apply(context.TODO())
+		t.Log("update state should now be Requested")
+	})
+
+	t.Run("reject", func(t *testing.T) {
+		rej := updatepb.Rejection{
+			RejectedRequest: &req,
+			Failure:         &failurepb.Failure{Message: "An intentional failure"},
+		}
+		err := upd.OnMessage(context.TODO(), &rej, store)
+		require.NoError(t, err)
+		require.False(t, completed)
+
+		{
+			ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+			defer cncl()
+			_, err := upd.WaitAccepted(ctx)
+			require.ErrorIs(t, err, context.DeadlineExceeded,
+				"update acceptance failure should not be observable until effects are applied")
+		}
+		{
+			ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+			defer cncl()
+			_, err := upd.WaitOutcome(ctx)
+			require.ErrorIs(t, err, context.DeadlineExceeded,
+				"update acceptance failure should not be observable until effects are applied")
+		}
+
+		effects.Apply(context.TODO())
+		t.Log("update state should now be Completed")
+
+		acptOutcome, err := upd.WaitAccepted(context.TODO())
+		require.NoError(t, err)
+		require.Equal(t, rej.Failure, acptOutcome.GetFailure())
+
+		outcome, err := upd.WaitOutcome(context.TODO())
+		require.NoError(t, err)
+		require.Equal(t, rej.Failure, outcome.GetFailure())
+
+		require.True(t, completed)
+	})
+}
+
+func TestWithProtocolMessage(t *testing.T) {
+	t.Parallel()
+	var (
+		store    = mockEventStore{Controller: &effect.Buffer{}}
+		updateID = t.Name() + "-update-id"
+		upd      = update.New(updateID, ignoreCompletion)
+		req      = updatepb.Request{
+			Meta:  &updatepb.Meta{UpdateId: updateID},
+			Input: &updatepb.Input{Name: t.Name()},
+		}
+	)
+
+	t.Run("good message", func(t *testing.T) {
+		protocolMsg := &protocolpb.Message{Body: mustMarshalAny(t, &req)}
+		err := upd.OnMessage(context.TODO(), protocolMsg, store)
+		require.NoError(t, err)
+	})
+	t.Run("junk message", func(t *testing.T) {
+		protocolMsg := &protocolpb.Message{
+			Body: &types.Any{
+				TypeUrl: "nonsense",
+				Value:   []byte("even more nonsense"),
+			},
+		}
+		err := upd.OnMessage(context.TODO(), protocolMsg, store)
+		require.Error(t, err)
+	})
+}
+
+func TestMessageOutput(t *testing.T) {
+	t.Parallel()
+	var (
+		effects  effect.Buffer
+		store    = mockEventStore{Controller: &effects}
+		updateID = t.Name() + "-update-id"
+		upd      = update.New(updateID, ignoreCompletion)
+		req      = updatepb.Request{
+			Meta:  &updatepb.Meta{UpdateId: updateID},
+			Input: &updatepb.Input{Name: t.Name()},
+		}
+	)
+
+	t.Run("before request received", func(t *testing.T) {
+		msgs := make([]*protocolpb.Message, 0)
+		upd.PollOutboundMessages(&msgs)
+		require.Empty(t, msgs)
+	})
+	t.Run("requested", func(t *testing.T) {
+		require.NoError(t, upd.OnMessage(context.TODO(), &req, store))
+		effects.Apply(context.TODO())
+		msgs := make([]*protocolpb.Message, 0)
+		upd.PollOutboundMessages(&msgs)
+		require.Len(t, msgs, 1)
+	})
+	t.Run("after requested", func(t *testing.T) {
+		upd := update.NewAccepted(updateID, ignoreCompletion)
+		msgs := make([]*protocolpb.Message, 0)
+		upd.PollOutboundMessages(&msgs)
+		require.Empty(t, msgs)
+	})
+}
+
+func TestRejectAfterAcceptFails(t *testing.T) {
+	t.Parallel()
+	updateID := t.Name() + "-update-id"
+	upd := update.NewAccepted(updateID, ignoreCompletion)
+	err := upd.OnMessage(context.TODO(), &updatepb.Rejection{}, eventStoreUnused)
+	var invalidArg *serviceerror.InvalidArgument
+	require.ErrorAs(t, err, &invalidArg)
+	require.ErrorContains(t, err, "state")
+}
+
+func TestAcceptanceAndResponseInSameMessageBatch(t *testing.T) {
+	// it is possible for the acceptance message and the completion message to
+	// be part of the same message batch and thus they will be delivered without
+	// an intermediate call to apply pending effects
+	t.Parallel()
+	var (
+		completed = false
+		effects   = effect.Buffer{}
+		store     = mockEventStore{Controller: &effects}
+		meta      = updatepb.Meta{UpdateId: t.Name() + "-update-id"}
+		req       = updatepb.Request{Meta: &meta, Input: &updatepb.Input{Name: t.Name()}}
+		acpt      = updatepb.Acceptance{AcceptedRequest: &req, AcceptedRequestMessageId: "x"}
+		resp      = updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")}
+		upd       = update.New(meta.UpdateId, func() { completed = true })
+	)
+
+	require.NoError(t, upd.OnMessage(context.TODO(), &req, store))
+	effects.Apply(context.TODO())
+
+	require.NoError(t, upd.OnMessage(context.TODO(), &acpt, store))
+	// no call to effects.Apply between these messages
+	require.NoError(t, upd.OnMessage(context.TODO(), &resp, store))
+	require.False(t, completed)
+	effects.Apply(context.TODO())
+	require.True(t, completed)
+}
+
+func TestCompletedLazyOutcomeRead(t *testing.T) {
+	t.Parallel()
+	updateID := t.Name() + "-update-id"
+	outcome := successOutcome(t, "success!")
+	fetched := false
+	upd := update.NewCompleted(updateID, func(context.Context) (*updatepb.Outcome, error) {
+		fetched = true
+		return outcome, nil
+	})
+	require.False(t, fetched)
+	acceptedOutcome, err := upd.WaitAccepted(context.TODO())
+	require.NoError(t, err)
+	require.Equal(t, outcome, acceptedOutcome)
+
+	got, err := upd.WaitOutcome(context.TODO())
+	require.True(t, fetched)
+	require.NoError(t, err)
+	require.Equal(t, outcome, got)
+}
+
+func TestDuplicateRequestNoError(t *testing.T) {
+	t.Parallel()
+	updateID := t.Name() + "-update-id"
+	upd := update.NewAccepted(updateID, ignoreCompletion)
+	err := upd.OnMessage(context.TODO(), &updatepb.Request{}, eventStoreUnused)
+	require.NoError(t, err,
+		"a second request message should be ignored, not cause an error")
+
+	msgs := make([]*protocolpb.Message, 0)
+	upd.PollOutboundMessages(&msgs)
+	require.Empty(t, msgs)
+}
+
+func TestMessageValidation(t *testing.T) {
+	t.Parallel()
+	var invalidArg *serviceerror.InvalidArgument
+	updateID := t.Name() + "-update-id"
+	t.Run("invalid request msg", func(t *testing.T) {
+		upd := update.New("", ignoreCompletion)
+		err := upd.OnMessage(context.TODO(), &updatepb.Request{}, eventStoreUnused)
+		require.ErrorAs(t, err, &invalidArg)
+		require.ErrorContains(t, err, "invalid")
+	})
+	t.Run("invalid acceptance msg", func(t *testing.T) {
+		upd := update.New(updateID, ignoreCompletion)
+		store := mockEventStore{Controller: effect.Immediate(context.TODO())}
+		validReq := updatepb.Request{
+			Meta:  &updatepb.Meta{UpdateId: updateID},
+			Input: &updatepb.Input{Name: "not empty"},
+		}
+		err := upd.OnMessage(context.TODO(), &validReq, store)
+		require.NoError(t, err)
+		err = upd.OnMessage(context.TODO(), &updatepb.Acceptance{}, store)
+		require.ErrorAs(t, err, &invalidArg)
+		require.ErrorContains(t, err, "invalid")
+	})
+	t.Run("invalid rejection msg", func(t *testing.T) {
+		upd := update.New(updateID, ignoreCompletion)
+		store := mockEventStore{Controller: effect.Immediate(context.TODO())}
+		validReq := updatepb.Request{
+			Meta:  &updatepb.Meta{UpdateId: updateID},
+			Input: &updatepb.Input{Name: "not empty"},
+		}
+		err := upd.OnMessage(context.TODO(), &validReq, store)
+		require.NoError(t, err)
+		err = upd.OnMessage(context.TODO(), &updatepb.Rejection{}, store)
+		require.ErrorAs(t, err, &invalidArg)
+		require.ErrorContains(t, err, "invalid")
+	})
+	t.Run("invalid response msg", func(t *testing.T) {
+		upd := update.NewAccepted("", ignoreCompletion)
+		err := upd.OnMessage(context.TODO(), &updatepb.Response{}, eventStoreUnused)
+		require.ErrorAs(t, err, &invalidArg)
+		require.ErrorContains(t, err, "invalid")
+	})
+}
+
+func TestDoubleRollback(t *testing.T) {
+	// Test that an Update that receives both an Acceptance and a Response in
+	// the same message batch but is then rolled back ends up in the proper
+	// state.
+	t.Parallel()
+	var (
+		completed = false
+		effects   = effect.Buffer{}
+		store     = mockEventStore{Controller: &effects}
+		reqMsgID  = t.Name() + "-req-msg-id"
+		meta      = updatepb.Meta{UpdateId: t.Name() + "-update-id"}
+		req       = updatepb.Request{Meta: &meta, Input: &updatepb.Input{Name: t.Name()}}
+		acpt      = updatepb.Acceptance{AcceptedRequest: &req, AcceptedRequestMessageId: reqMsgID}
+		resp      = updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")}
+	)
+
+	upd := update.New(meta.UpdateId, func() { completed = true })
+	require.NoError(t, upd.OnMessage(context.TODO(), &req, store))
+	effects.Apply(context.TODO())
+
+	require.NoError(t, upd.OnMessage(context.TODO(), &acpt, store))
+	require.NoError(t, upd.OnMessage(context.TODO(), &resp, store))
+	require.False(t, completed)
+
+	// pretend MutalbeState write to DB fails - unwind effects
+	effects.Cancel(context.TODO())
+
+	t.Run("not accepted", func(t *testing.T) {
+		ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		defer cncl()
+		_, err := upd.WaitAccepted(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+	t.Run("not completed", func(t *testing.T) {
+		ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		defer cncl()
+		_, err := upd.WaitOutcome(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+	})
+	t.Run("back to requested state", func(t *testing.T) {
+		err := upd.OnMessage(context.TODO(), &acpt, store)
+		require.NoError(t, err, "update should be back in Requested state")
+	})
+}
+
+func TestRollbackCompletion(t *testing.T) {
+	t.Parallel()
+	var (
+		completed = false
+		effects   = effect.Buffer{}
+		store     = mockEventStore{Controller: &effects}
+		updateID  = t.Name() + "-update-id"
+		upd       = update.NewAccepted(updateID, func() { completed = true })
+		resp      = updatepb.Response{
+			Meta:    &updatepb.Meta{UpdateId: updateID},
+			Outcome: successOutcome(t, "success!"),
+		}
+	)
+
+	require.NoError(t, upd.OnMessage(context.TODO(), &resp, store))
+	require.False(t, completed)
+
+	// pretend MutalbeState write to DB fails - unwind effects
+	effects.Cancel(context.TODO())
+
+	t.Run("not completed", func(t *testing.T) {
+		ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		defer cncl()
+		_, err := upd.WaitOutcome(ctx)
+		require.ErrorIs(t, err, context.DeadlineExceeded)
+		require.False(t, completed)
+	})
+	t.Run("back to accepted state", func(t *testing.T) {
+		err := upd.OnMessage(context.TODO(), &resp, store)
+		require.NoError(t, err, "update should be back in Accepted state")
+	})
+}

--- a/service/history/workflow/update/util.go
+++ b/service/history/workflow/update/util.go
@@ -1,0 +1,103 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+import (
+	"context"
+	"fmt"
+
+	"go.opentelemetry.io/otel/trace"
+	"go.temporal.io/api/serviceerror"
+	updatepb "go.temporal.io/api/update/v1"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+)
+
+const libraryName = "go.temporal.io/service/history/workflow/update"
+
+type (
+	// lazyOutcome adapts a func to the future.Future[*updatepb.Outcome] interface
+	lazyOutcome func(context.Context) (*updatepb.Outcome, error)
+
+	instrumentation struct {
+		log     log.Logger
+		metrics metrics.Handler
+		tracer  trace.Tracer
+	}
+)
+
+var (
+	noopInstrumentation = instrumentation{
+		log:     log.NewNoopLogger(),
+		metrics: metrics.NoopMetricsHandler,
+		tracer:  trace.NewNoopTracerProvider().Tracer(libraryName),
+	}
+)
+
+func (lo lazyOutcome) Get(ctx context.Context) (*updatepb.Outcome, error) {
+	return lo(ctx)
+}
+
+func (lazyOutcome) Ready() bool {
+	return true
+}
+
+func invalidArgf(tmpl string, args ...any) error {
+	return serviceerror.NewInvalidArgument(fmt.Sprintf(tmpl, args...))
+}
+
+// CountRequestMessage adds 1 to the update request message counter
+func (i *instrumentation) CountRequestMsg() {
+	i.countMessage(metrics.MessageTypeRequestWorkflowExecutionUpdateCounter.GetMetricName())
+}
+
+// CountAcceptanceMessage adds 1 to the update acceptance message counter
+func (i *instrumentation) CountAcceptanceMsg() {
+	i.countMessage(metrics.MessageTypeAcceptWorkflowExecutionUpdateCounter.GetMetricName())
+}
+
+// CountRejectionmessage counter adds 1 to the update rejection message counter
+func (i *instrumentation) CountRejectionMsg() {
+	i.countMessage(metrics.MessageTypeRejectWorkflowExecutionUpdateCounter.GetMetricName())
+}
+
+// CountResponsemessage counter adds 1 to the update response message counter
+func (i *instrumentation) CountResponseMsg() {
+	i.countMessage(metrics.MessageTypeRespondWorkflowExecutionUpdateCounter.GetMetricName())
+}
+
+func (i *instrumentation) countMessage(ctrName string) {
+	i.metrics.Counter(ctrName).Record(1)
+}
+
+// StateChange records instrumentation info about an Update state change
+func (i *instrumentation) StateChange(updateID string, from, to state) {
+	i.log.Debug("update state change",
+		tag.NewStringTag("update-id", updateID),
+		tag.NewStringTag("from-state", from.String()),
+		tag.NewStringTag("to-state", to.String()),
+	)
+}

--- a/service/history/workflow/update/validation.go
+++ b/service/history/workflow/update/validation.go
@@ -1,0 +1,125 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+import (
+	"github.com/gogo/protobuf/proto"
+	updatepb "go.temporal.io/api/update/v1"
+)
+
+func notZero[T comparable](v T, label string, msg proto.Message) func() error {
+	return func() error {
+		var zero T
+		if v == zero {
+			return invalidArgf("invalid %T: %v is not set", msg, label)
+		}
+		return nil
+	}
+}
+
+func eq[T comparable](
+	left T,
+	leftLbl string,
+	right T,
+	rightLbl string,
+	msg proto.Message,
+) func() error {
+	return func() error {
+		if left != right {
+			return invalidArgf("invalid %T: %v != %v", msg, leftLbl, rightLbl)
+		}
+		return nil
+	}
+}
+
+func validate(vs ...func() error) error {
+	for _, v := range vs {
+		if err := v(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRequestMsg(updateID string, msg *updatepb.Request) error {
+	return validateRequestMsgPrefix(updateID, "", msg)
+}
+
+func validateRequestMsgPrefix(
+	updateID string,
+	prefix string,
+	msg *updatepb.Request,
+) error {
+	return validate(
+		notZero(msg, prefix+"body", msg),
+		notZero(msg.GetMeta(), prefix+"meta", msg),
+		notZero(msg.GetMeta().GetUpdateId(), prefix+"meta.update_id", msg),
+		eq(msg.GetMeta().GetUpdateId(), prefix+"meta.update_id", updateID, updateID, msg),
+		notZero(msg.GetInput(), prefix+"input", msg),
+		notZero(msg.GetInput().GetName(), prefix+"input.name", msg),
+	)
+}
+
+func validateAcceptanceMsg(updateID string, msg *updatepb.Acceptance) error {
+	return validate(
+		notZero(msg, "body", msg),
+		func() error {
+			return validateRequestMsgPrefix(updateID, "accepted_request.", msg.GetAcceptedRequest())
+		},
+		notZero(msg.GetAcceptedRequestMessageId(), "accepted_request_message_id", msg),
+	)
+}
+
+func validateResponseMsg(updateID string, msg *updatepb.Response) error {
+	return validate(
+		notZero(msg, "body", msg),
+		notZero(msg.GetMeta(), "meta", msg),
+		notZero(msg.GetMeta().GetUpdateId(), "meta.update_id", msg),
+		eq(msg.GetMeta().GetUpdateId(), "meta.update_id", updateID, updateID, msg),
+		notZero(msg.GetOutcome(), "outcome", msg),
+	)
+}
+
+// ValidateWorkflowExecutionUpdateRejectionMessage validates the presence of
+// expected fields on updatepb.Rejection messages.
+func validateRejectionMsg(updateID string, msg *updatepb.Rejection) error {
+	return validate(
+		notZero(msg, "body", msg),
+		notZero(msg.GetRejectedRequest(), "rejected_request", msg),
+		notZero(msg.GetRejectedRequest().GetMeta(), "rejected_request.meta", msg),
+		notZero(
+			msg.GetRejectedRequest().GetMeta().GetUpdateId(),
+			"rejected_request.meta.update_id",
+			msg,
+		),
+		eq(
+			msg.RejectedRequest.GetMeta().GetUpdateId(),
+			"rejected_request.meta.update_id",
+			updateID,
+			updateID,
+			msg,
+		),
+	)
+}

--- a/service/history/workflow/update/version.go
+++ b/service/history/workflow/update/version.go
@@ -1,0 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+const ProtocolV1 = "temporal.api.update.v1"

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -38,6 +38,7 @@ import (
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/internal/effect"
 	"go.temporal.io/server/service/history/consts"
 )
 
@@ -185,4 +186,16 @@ func FindAutoResetPoint(
 		}
 	}
 	return "", nil
+}
+
+func WithEffects(effects effect.Controller, ms MutableState) MutableStateWithEffects {
+	return MutableStateWithEffects{
+		MutableState: ms,
+		Controller:   effects,
+	}
+}
+
+type MutableStateWithEffects struct {
+	MutableState
+	effect.Controller
 }

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -27,6 +27,7 @@ package history
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/gogo/protobuf/types"
@@ -37,8 +38,8 @@ import (
 	failurepb "go.temporal.io/api/failure/v1"
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
-	updatepb "go.temporal.io/api/update/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/internal/effect"
 	"go.temporal.io/server/service/history/workflow/update"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -75,7 +76,9 @@ type (
 		newMutableState                 workflow.MutableState
 		stopProcessing                  bool // should stop processing any more commands
 		mutableState                    workflow.MutableState
+		effects                         effect.Controller
 		initiatedChildExecutionsInBatch map[string]struct{} // Set of initiated child executions in the workflow task
+		updateRegistry                  update.Registry
 
 		// validation
 		attrValidator                  *commandAttrValidator
@@ -114,6 +117,8 @@ func newWorkflowTaskHandler(
 	identity string,
 	workflowTaskCompletedID int64,
 	mutableState workflow.MutableState,
+	updateRegistry update.Registry,
+	effects effect.Controller,
 	attrValidator *commandAttrValidator,
 	sizeLimitChecker *workflowSizeChecker,
 	logger log.Logger,
@@ -123,7 +128,6 @@ func newWorkflowTaskHandler(
 	shard shard.Context,
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	hasBufferedEvents bool,
-	hasPendingUpdates bool,
 ) *workflowTaskHandlerImpl {
 
 	return &workflowTaskHandlerImpl{
@@ -132,13 +136,14 @@ func newWorkflowTaskHandler(
 
 		// internal state
 		hasBufferedEvents:               hasBufferedEvents,
-		hasPendingUpdates:               hasPendingUpdates,
 		workflowTaskFailedCause:         nil,
 		activityNotStartedCancelled:     false,
 		newMutableState:                 nil,
 		stopProcessing:                  false,
 		mutableState:                    mutableState,
+		effects:                         effects,
 		initiatedChildExecutionsInBatch: make(map[string]struct{}),
+		updateRegistry:                  updateRegistry,
 
 		// validation
 		attrValidator:                  attrValidator,
@@ -249,7 +254,6 @@ func (handler *workflowTaskHandlerImpl) handleCommand(ctx context.Context, comma
 func (handler *workflowTaskHandlerImpl) handleMessages(
 	ctx context.Context,
 	messages []*protocolpb.Message,
-	updateRegistry update.Registry,
 ) error {
 	if !handler.mutableState.IsWorkflowExecutionRunning() {
 		// Workflow might get completed within the same WT after processing corresponding command.
@@ -260,12 +264,8 @@ func (handler *workflowTaskHandlerImpl) handleMessages(
 		return nil
 	}
 
-	if err := updateRegistry.ValidateIncomingMessages(messages); err != nil {
-		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE, err)
-	}
-
 	for _, message := range messages {
-		err := handler.handleMessage(ctx, message)
+		err := handler.handleMessage(ctx, message, handler.updateRegistry)
 		if err != nil || handler.stopProcessing {
 			return err
 		}
@@ -274,29 +274,45 @@ func (handler *workflowTaskHandlerImpl) handleMessages(
 	return nil
 }
 
-func (handler *workflowTaskHandlerImpl) handleMessage(ctx context.Context, message *protocolpb.Message) error {
+func (handler *workflowTaskHandlerImpl) handleMessage(
+	ctx context.Context,
+	message *protocolpb.Message,
+	updateRegistry update.Registry,
+) error {
+	bodyTypeName, err := types.AnyMessageName(message.GetBody())
+	if err != nil {
+		return serviceerror.NewInvalidArgument(err.Error())
+	}
+	if err := handler.sizeLimitChecker.checkIfPayloadSizeExceedsLimit(
+		// TODO (alex-update): Should use MessageTypeTag here but then it needs to be another metric name too.
+		metrics.CommandTypeTag(bodyTypeName),
+		message.Body.Size(),
+		fmt.Sprintf("Message type %v exceeds size limit.", bodyTypeName),
+	); err != nil {
+		return handler.failWorkflow(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE, err)
+	}
 
-	if types.Is(message.GetBody(), (*updatepb.Acceptance)(nil)) {
-		var acceptance updatepb.Acceptance
-		err := types.UnmarshalAny(message.GetBody(), &acceptance)
-		if err != nil {
-			return err
+	protocolTypeName := "__unknown"
+	if lastDot := strings.LastIndex(bodyTypeName, "."); lastDot > -1 {
+		protocolTypeName = bodyTypeName[0:lastDot]
+	}
+
+	switch protocolTypeName {
+	case update.ProtocolV1:
+		upd, ok := updateRegistry.Find(ctx, message.ProtocolInstanceId)
+		if !ok {
+			return handler.failWorkflowTask(
+				enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
+				serviceerror.NewNotFound(fmt.Sprintf("update %q not found", message.ProtocolInstanceId)))
 		}
-		return handler.handleMessageAcceptWorkflowExecutionUpdate(ctx, message.GetProtocolInstanceId(), &acceptance)
-	} else if types.Is(message.GetBody(), (*updatepb.Response)(nil)) {
-		var response updatepb.Response
-		err := types.UnmarshalAny(message.GetBody(), &response)
-		if err != nil {
-			return err
+		if err := upd.OnMessage(ctx, message, workflow.WithEffects(handler.effects, handler.mutableState)); err != nil {
+			return handler.failWorkflowTaskOnInvalidArgument(
+				enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE, err)
 		}
-		return handler.handleMessageCompleteWorkflowExecutionUpdate(ctx, message.GetProtocolInstanceId(), &response)
-	} else if types.Is(message.GetBody(), (*updatepb.Rejection)(nil)) {
-		var rejection updatepb.Rejection
-		err := types.UnmarshalAny(message.GetBody(), &rejection)
-		if err != nil {
-			return err
-		}
-		return handler.handleMessageRejectWorkflowExecutionUpdate(ctx, message.GetProtocolInstanceId(), &rejection)
+	default:
+		return handler.failWorkflowTask(
+			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
+			serviceerror.NewInvalidArgument(fmt.Sprintf("unsupported protocol type %q", protocolTypeName)))
 	}
 
 	return nil
@@ -1172,126 +1188,6 @@ func (handler *workflowTaskHandlerImpl) handleCommandModifyWorkflowProperties(
 		handler.workflowTaskCompletedID, attr,
 	)
 	return err
-}
-
-func (handler *workflowTaskHandlerImpl) handleMessageAcceptWorkflowExecutionUpdate(
-	_ context.Context,
-	protocolInstanceID string,
-	updAcceptance *updatepb.Acceptance,
-) error {
-
-	handler.metricsHandler.Counter(metrics.MessageTypeAcceptWorkflowExecutionUpdateCounter.GetMetricName()).Record(1)
-
-	executionInfo := handler.mutableState.GetExecutionInfo()
-	nsID := namespace.ID(executionInfo.GetNamespaceId())
-
-	if err := handler.sizeLimitChecker.checkIfPayloadSizeExceedsLimit(
-		// TODO (alex-update): Should use MessageTypeTag here but then it needs to be another metric name too.
-		metrics.CommandTypeTag("MessageAcceptUpdate"),
-		updAcceptance.Size(),
-		"Message body of type update.Acceptance exceeds size limit.",
-	); err != nil {
-		return handler.failWorkflow(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE, err)
-	}
-
-	if err := handler.validateCommandAttr(
-		func() (enumspb.WorkflowTaskFailedCause, error) {
-			return handler.attrValidator.validateWorkflowExecutionUpdateAcceptanceMessage(
-				nsID,
-				protocolInstanceID,
-				updAcceptance,
-			)
-		},
-	); err != nil || handler.stopProcessing {
-		return err
-	}
-
-	_, err := handler.mutableState.AddWorkflowExecutionUpdateAcceptedEvent(protocolInstanceID, updAcceptance)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (handler *workflowTaskHandlerImpl) handleMessageCompleteWorkflowExecutionUpdate(
-	_ context.Context,
-	protocolInstanceID string,
-	updResponse *updatepb.Response,
-) error {
-
-	handler.metricsHandler.Counter(metrics.MessageTypeCompleteWorkflowExecutionUpdateCounter.GetMetricName()).Record(1)
-
-	executionInfo := handler.mutableState.GetExecutionInfo()
-	nsID := namespace.ID(executionInfo.GetNamespaceId())
-
-	if err := handler.sizeLimitChecker.checkIfPayloadSizeExceedsLimit(
-		// TODO (alex-update): Should use MessageTypeTag here, but then it needs to be another metric name too.
-		metrics.CommandTypeTag("MessageCompleteUpdate"),
-		updResponse.Size(),
-		"Message body of type update.Response exceeds size limit.",
-	); err != nil {
-		return handler.failWorkflow(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE, err)
-	}
-
-	if err := handler.validateCommandAttr(
-		func() (enumspb.WorkflowTaskFailedCause, error) {
-			return handler.attrValidator.validateWorkflowExecutionUpdateResponseMessage(
-				nsID,
-				protocolInstanceID,
-				updResponse,
-			)
-		},
-	); err != nil || handler.stopProcessing {
-		return err
-	}
-
-	_, err := handler.mutableState.AddWorkflowExecutionUpdateCompletedEvent(updResponse)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (handler *workflowTaskHandlerImpl) handleMessageRejectWorkflowExecutionUpdate(
-	_ context.Context,
-	protocolInstanceID string,
-	updRejection *updatepb.Rejection,
-) error {
-
-	handler.metricsHandler.Counter(metrics.MessageTypeRejectWorkflowExecutionUpdateCounter.GetMetricName()).Record(1)
-
-	executionInfo := handler.mutableState.GetExecutionInfo()
-	nsID := namespace.ID(executionInfo.GetNamespaceId())
-
-	if err := handler.sizeLimitChecker.checkIfPayloadSizeExceedsLimit(
-		// TODO (alex-update): Should use MessageTypeTag here but then it needs to be another metric name too.
-		metrics.CommandTypeTag("MessageRejectUpdate"),
-		updRejection.Size(),
-		"Message body of type update.Rejection exceeds size limit.",
-	); err != nil {
-		return handler.failWorkflow(enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE, err)
-	}
-
-	if err := handler.validateCommandAttr(
-		func() (enumspb.WorkflowTaskFailedCause, error) {
-			return handler.attrValidator.validateWorkflowExecutionUpdateRejectionMessage(
-				nsID,
-				protocolInstanceID,
-				updRejection,
-			)
-		},
-	); err != nil || handler.stopProcessing {
-		return err
-	}
-
-	err := handler.mutableState.RejectWorkflowExecutionUpdate(protocolInstanceID, updRejection)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func payloadsMapSize(fields map[string]*commonpb.Payload) int {

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -851,7 +851,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) createRecordWorkflowTaskStarted
 		}
 	}
 
-	response.Messages, err = updateRegistry.CreateOutgoingMessages(workflowTask.StartedEventID)
+	response.Messages, err = updateRegistry.ReadOutgoingMessages(workflowTask.StartedEventID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -51,6 +51,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
 	serviceerrors "go.temporal.io/server/common/serviceerror"
+	"go.temporal.io/server/internal/effect"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
@@ -212,7 +213,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 			if workflowTask.StartedEventID != common.EmptyEventID {
 				// If workflow task is started as part of the current request scope then return a positive response
 				if workflowTask.RequestID == requestID {
-					resp, err = handler.createRecordWorkflowTaskStartedResponse(mutableState, workflowContext.GetContext().UpdateRegistry(), workflowTask, req.PollRequest.GetIdentity())
+					resp, err = handler.createRecordWorkflowTaskStartedResponse(mutableState, workflowContext.GetUpdateRegistry(ctx), workflowTask, req.PollRequest.GetIdentity())
 					if err != nil {
 						return nil, err
 					}
@@ -267,7 +268,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 				metrics.TaskQueueTypeTag(enumspb.TASK_QUEUE_TYPE_WORKFLOW),
 			)
 
-			resp, err = handler.createRecordWorkflowTaskStartedResponse(mutableState, workflowContext.GetContext().UpdateRegistry(), workflowTask, req.PollRequest.GetIdentity())
+			resp, err = handler.createRecordWorkflowTaskStartedResponse(mutableState, workflowContext.GetUpdateRegistry(ctx), workflowTask, req.PollRequest.GetIdentity())
 			if err != nil {
 				return nil, err
 			}
@@ -352,7 +353,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	ctx context.Context,
 	req *historyservice.RespondWorkflowTaskCompletedRequest,
 ) (_ *historyservice.RespondWorkflowTaskCompletedResponse, retError error) {
-
 	namespaceEntry, err := api.GetActiveNamespace(handler.shard, namespace.ID(req.GetNamespaceId()))
 	if err != nil {
 		return nil, err
@@ -388,6 +388,14 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		return nil, err
 	}
 	defer func() { workflowContext.GetReleaseFn()(retError) }()
+
+	var effects effect.Buffer
+	defer func() {
+		if retError != nil {
+			effects.Cancel(ctx)
+		}
+		effects.Apply(ctx)
+	}()
 
 	weContext := workflowContext.GetContext()
 	ms := workflowContext.GetMutableState()
@@ -468,8 +476,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		activityNotStartedCancelled bool
 		newMutableState             workflow.MutableState
 	)
-	// hasPendingUpdates indicates if there are more pending updates (excluding those which are accepted/rejected by this workflow task).
-	hasPendingUpdates := weContext.UpdateRegistry().HasPending(request.GetMessages())
 	// hasBufferedEvents indicates if there are any buffered events which should generate a new workflow task
 	hasBufferedEvents := ms.HasBufferedEvents()
 	if err := namespaceEntry.VerifyBinaryChecksum(request.GetBinaryChecksum()); err != nil {
@@ -507,6 +513,8 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			request.GetIdentity(),
 			completedEvent.GetEventId(), // If completedEvent is nil, then GetEventId() returns 0 and this value shouldn't be used in workflowTaskHandler.
 			ms,
+			weContext.UpdateRegistry(ctx),
+			&effects,
 			handler.commandAttrValidator,
 			workflowSizeChecker,
 			handler.logger,
@@ -516,7 +524,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			handler.shard,
 			handler.searchAttributesMapperProvider,
 			hasBufferedEvents,
-			hasPendingUpdates,
 		)
 
 		if responseMutations, err = workflowTaskHandler.handleCommands(
@@ -526,11 +533,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			return nil, err
 		}
 
-		if err = workflowTaskHandler.handleMessages(
-			ctx,
-			request.Messages,
-			weContext.UpdateRegistry(),
-		); err != nil {
+		if err = workflowTaskHandler.handleMessages(ctx, request.Messages); err != nil {
 			return nil, err
 		}
 
@@ -549,6 +552,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 
 	wtFailedShouldCreateNewTask := false
 	if wtFailedCause != nil {
+		effects.Cancel(ctx)
 		handler.metricsHandler.Counter(metrics.FailedWorkflowTasksCounter.GetMetricName()).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))
@@ -591,7 +595,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	newWorkflowTaskType := enumsspb.WORKFLOW_TASK_TYPE_UNSPECIFIED
 	if ms.IsWorkflowExecutionRunning() && (wtFailedShouldCreateNewTask || bufferedEventShouldCreateNewTask || request.GetForceCreateNewWorkflowTask() || activityNotStartedCancelled) {
 		newWorkflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_NORMAL
-	} else if ms.IsWorkflowExecutionRunning() && hasPendingUpdates {
+	} else if ms.IsWorkflowExecutionRunning() && weContext.UpdateRegistry(ctx).HasOutgoing() {
 		newWorkflowTaskType = enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE
 	}
 
@@ -664,6 +668,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	}
 
 	if updateErr != nil {
+		effects.Cancel(ctx)
 		if persistence.IsConflictErr(updateErr) {
 			handler.metricsHandler.Counter(metrics.ConcurrencyUpdateFailureCounter.GetMetricName()).Record(
 				1,
@@ -718,12 +723,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		}
 	}
 
-	// Send update results to gRPC API callers.
-	err = weContext.UpdateRegistry().ProcessIncomingMessages(req.GetCompleteRequest().GetMessages())
-	if err != nil {
-		return nil, err
-	}
-
 	handler.handleBufferedQueries(ms, req.GetCompleteRequest().GetQueryResults(), newWorkflowTask != nil, namespaceEntry, workflowTaskHeartbeating)
 
 	if workflowTaskHeartbeatTimeout {
@@ -737,7 +736,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 
 	resp := &historyservice.RespondWorkflowTaskCompletedResponse{}
 	if request.GetReturnNewWorkflowTask() && newWorkflowTask != nil {
-		resp.StartedResponse, err = handler.createRecordWorkflowTaskStartedResponse(ms, weContext.UpdateRegistry(), newWorkflowTask, request.GetIdentity())
+		resp.StartedResponse, err = handler.createRecordWorkflowTaskStartedResponse(ms, weContext.UpdateRegistry(ctx), newWorkflowTask, request.GetIdentity())
 		if err != nil {
 			return nil, err
 		}

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -391,6 +391,13 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 
 	var effects effect.Buffer
 	defer func() {
+		// code in this file and workflowTaskHandler is inconsistent in the way
+		// errors are returned - some functions which appear to return error
+		// actually return nil in all cases and instead set a member variable
+		// that should be observed by other collaborating code (e.g.
+		// workflowtaskHandler.workflowTaskFailedCause). That made me paranoid
+		// about the way this function exits so while we have this defer here
+		// there is _also_ code to call effects.Cancel at key points.
 		if retError != nil {
 			effects.Cancel(ctx)
 		}

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -2296,5 +2296,7 @@ func (s *integrationSuite) TestUpdateWorkflow_TimeoutSpeculativeWorkflowTask() {
   9 WorkflowTaskScheduled
  10 WorkflowTaskStarted
  11 WorkflowTaskCompleted
- 12 WorkflowExecutionCompleted`, events)
+ 12 WorkflowExecutionUpdateAccepted
+ 13 WorkflowExecutionUpdateCompleted
+ 14 WorkflowExecutionCompleted`, events)
 }

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	commandpb "go.temporal.io/api/command/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -297,7 +298,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ValidateMessages() {
 		},
 		{
 			Name:                     "complete-without-accept",
-			RespondWorkflowTaskError: "current state: pending",
+			RespondWorkflowTaskError: "invalid state transition attempted",
 			MessageFn: func(reqMsg *protocolpb.Message) []*protocolpb.Message {
 				updRequest := unmarshalAny[*updatepb.Request](s, reqMsg.GetBody())
 				return []*protocolpb.Message{
@@ -319,7 +320,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ValidateMessages() {
 		},
 		{
 			Name:                     "accept-twice",
-			RespondWorkflowTaskError: "current state: accepted",
+			RespondWorkflowTaskError: "invalid state transition attempted",
 			MessageFn: func(reqMsg *protocolpb.Message) []*protocolpb.Message {
 				updRequest := unmarshalAny[*updatepb.Request](s, reqMsg.GetBody())
 				return []*protocolpb.Message{
@@ -436,10 +437,10 @@ func (s *integrationSuite) TestUpdateWorkflow_ValidateMessages() {
 			_, _, err = poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 5, false, nil)
 			if len(tc.RespondWorkflowTaskError) > 0 {
 				// respond workflow task should return error
-				s.Error(err, "RespondWorkflowTaskCompleted should return an error contains`%v`", tc.RespondWorkflowTaskError)
-				s.Contains(err.Error(), tc.RespondWorkflowTaskError)
+				require.Error(t, err, "RespondWorkflowTaskCompleted should return an error contains`%v`", tc.RespondWorkflowTaskError)
+				require.Contains(t, err.Error(), tc.RespondWorkflowTaskError)
 			} else {
-				s.NoError(err)
+				require.NoError(t, err)
 			}
 
 		})
@@ -1819,8 +1820,10 @@ func (s *integrationSuite) TestUpdateWorkflow_FailWorkflowTask() {
 			// Returning error will cause the poller to fail WT.
 			return nil, errors.New("malformed request")
 		case 4:
-			// 3rd attempt doesn't have any updates attached to it because UpdateWorkflowExecution call has timed out.
-			s.Empty(task.Messages)
+			// 3rd attempt UpdateWorkflowExecution call has timed out but the
+			// update is still running
+			updRequestMsg := task.Messages[0]
+			s.EqualValues(9, updRequestMsg.GetEventId())
 			wtHandlerCalls++ // because it won't be called for case 4 but counter should be in sync.
 			// Fail WT one more time. This is transient WT and shouldn't appear in the history.
 			// Returning error will cause the poller to fail WT.


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**

- Write update.Update as a protocol state machine that encapsulates all message processing, validation, event writing, and metric emission related to an update.
- Make explicit the set of "Provisional" state transitions wherein the Update has recieved and reacted to a protocol message but cannot make externally observable changes like returning update outcomes to RPC callers until it knows that changes have been written to stable storage.
- The effect package is introduced as a utility to buffer and later apply or cancel a set of effects.
- With more responsibility in the Update type, UpdateRegistry is simplified.
- UpdateRegistry can restore its state (mainly in-flight Accepted updates) from MutableState.
- Update message validation is moved into the update package.
- UpdateRegistry differentiates between having incomplete updates (which prevents a workflow from closing) and having messages to send (which may trigger the creation of a new workflow task)
- Removed a chunk of processing from workflowTaskHandler that is now encapsulated in the Update state machine, allowing task handling to be more decoupled from update protocol semantics.


<!-- Tell your future self why have you made these changes -->
**Why?**
This is a step in the direction of being able to process messages one at a time rather than in a batch. Individual message processing will be required to respect protocols (like update) that need message processing that is ordered with respect to other commands. Additionally we lay the groundwork for async updates and outcome polling.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Lots of new unit tests for the update package
- Corrections to functional tests as needed (/tests/ directory here)
- Sync update tests in the features repo

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
I'm not thrilled about the size of this PR but there were a number of things that could not be teased apart. Changes external to the update package were minimized

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no.
