### PR TITLE
Correct spelling: updat_id -> update_id

### DIFF
--- a/schema/mysql/v57/temporal/versioned/v1.10/update_info_maps_table.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.10/update_info_maps_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE update_info_maps (
   namespace_id BINARY(16) NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BINARY(16) NOT NULL,
-  updat_id VARCHAR(255) NOT NULL,
+  update_id VARCHAR(255) NOT NULL,
 --
   data MEDIUMBLOB NOT NULL,
   data_encoding VARCHAR(16),

--- a/schema/mysql/v57/version.go
+++ b/schema/mysql/v57/version.go
@@ -27,7 +27,7 @@ package v57
 // NOTE: whenever there is a new database schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "1.9"
+const Version = "1.10"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "1.1"

--- a/schema/mysql/v8/temporal/versioned/v1.10/update_info_maps_table.sql
+++ b/schema/mysql/v8/temporal/versioned/v1.10/update_info_maps_table.sql
@@ -4,7 +4,7 @@ CREATE TABLE update_info_maps (
   namespace_id BINARY(16) NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BINARY(16) NOT NULL,
-  updat_id VARCHAR(255) NOT NULL,
+  update_id VARCHAR(255) NOT NULL,
 --
   data MEDIUMBLOB NOT NULL,
   data_encoding VARCHAR(16),

--- a/schema/mysql/v8/version.go
+++ b/schema/mysql/v8/version.go
@@ -27,7 +27,7 @@ package v8
 // NOTE: whenever there is a new database schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "1.9"
+const Version = "1.10"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "1.3"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Correct spelling of column name updat_id -> update_id

<!-- Tell your future self why have you made these changes -->
**Why?**
That's not how you spell it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran `make install-schema-mysql` and `desc update_info_maps` to verify column name
FYI this these two lines are the only to instances of the string "updat_id" in the server repo.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
We haven't released the server with this bug so I _think_ it's ok to modify the versioned sql in place. If not I can create v1.10.1

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No