### PR TITLE
Prevent workflow close when updates are undelivered

### DIFF
--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -104,6 +104,7 @@ func TestFind(t *testing.T) {
 	_, found, err := reg.FindOrCreate(ctx, updateID)
 	require.NoError(t, err)
 	require.False(t, found)
+	require.True(t, reg.HasUndeliveredUpdates())
 
 	_, ok = reg.Find(ctx, updateID)
 	require.True(t, ok)
@@ -194,7 +195,7 @@ func TestFindOrCreate(t *testing.T) {
 		reg = update.NewRegistry(store)
 	)
 
-	require.True(t, reg.HasIncomplete())
+	require.False(t, reg.HasUndeliveredUpdates())
 
 	t.Run("new update", func(t *testing.T) {
 		updateID := "a completely new update ID"
@@ -252,7 +253,7 @@ func TestUpdateRemovalFromRegistry(t *testing.T) {
 	evStore := mockEventStore{Controller: &effects}
 	meta := updatepb.Meta{UpdateId: storedAcceptedUpdateID}
 	outcome := successOutcome(t, "success!")
-	require.True(t, reg.HasIncomplete(), "accepted update counts as incomplete")
+	require.False(t, reg.HasUndeliveredUpdates(), "accepted is not undelivered")
 
 	err = upd.OnMessage(
 		ctx,
@@ -261,7 +262,7 @@ func TestUpdateRemovalFromRegistry(t *testing.T) {
 	)
 
 	require.NoError(t, err)
-	require.False(t, reg.HasIncomplete(), "updates should be ProvisionallyCompleted")
+	require.False(t, reg.HasUndeliveredUpdates(), "updates should be ProvisionallyCompleted")
 	require.Equal(t, 1, reg.Len(), "update should still be present in map")
 	effects.Apply(ctx)
 	require.Equal(t, 0, reg.Len(), "update should have been removed")

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -342,8 +342,9 @@ func (u *Update) onResponseMsg(
 	return nil
 }
 
-func (u *Update) completedOrProvisionallyCompleted() bool {
-	return u.state.Matches(stateSet(stateCompleted | stateProvisionallyCompleted))
+func (u *Update) hasBeenSeenByWorkflowExecution() bool {
+	const unseen = stateAdmitted | stateProvisionallyRequested | stateRequested
+	return !u.state.Matches(stateSet(unseen))
 }
 
 func (u *Update) hasOutgoingMessage() bool {

--- a/service/history/workflowTaskHandler.go
+++ b/service/history/workflowTaskHandler.go
@@ -70,7 +70,6 @@ type (
 
 		// internal state
 		hasBufferedEvents               bool
-		hasPendingUpdates               bool
 		workflowTaskFailedCause         *workflowTaskFailedCause
 		activityNotStartedCancelled     bool
 		newMutableState                 workflow.MutableState
@@ -553,7 +552,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCompleteWorkflow(
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
 
-	if handler.hasPendingUpdates {
+	if handler.updateRegistry.HasUndeliveredUpdates() {
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_UPDATE, nil)
 	}
 
@@ -615,7 +614,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandFailWorkflow(
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
 
-	if handler.hasPendingUpdates {
+	if handler.updateRegistry.HasUndeliveredUpdates() {
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_UPDATE, nil)
 	}
 
@@ -721,7 +720,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCancelWorkflow(
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
 
-	if handler.hasPendingUpdates {
+	if handler.updateRegistry.HasUndeliveredUpdates() {
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_UPDATE, nil)
 	}
 
@@ -828,7 +827,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
 	}
 
-	if handler.hasPendingUpdates {
+	if handler.updateRegistry.HasUndeliveredUpdates() {
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_UPDATE, nil)
 	}
 

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -1885,7 +1885,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FailWorkflowTask() {
 	s.NoError(err)
 
 	// Wait for UpdateWorkflowExecution to timeout.
-	// This will also remove update from registry and next WT won't have any updates attached to it.
+	// This does NOT remove update from registry
 	<-updateResultCh
 
 	// Try to accept update in workflow 3rd time: get error. Poller will fail WT.
@@ -1895,7 +1895,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FailWorkflowTask() {
 
 	// Complete workflow.
 	_, err = poller.PollAndProcessWorkflowTask(false, false)
-	s.NoError(err)
+	s.Errorf(err, "update was never successfully accepted so it prevents completion")
 
 	s.Equal(5, wtHandlerCalls)
 	s.Equal(5, msgHandlerCalls)
@@ -1909,11 +1909,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FailWorkflowTask() {
   5 ActivityTaskScheduled
   6 WorkflowTaskScheduled
   7 WorkflowTaskStarted
-  8 WorkflowTaskFailed
-  9 WorkflowTaskScheduled
- 10 WorkflowTaskStarted
- 11 WorkflowTaskCompleted
- 12 WorkflowExecutionCompleted`, events)
+  8 WorkflowTaskFailed`, events)
 }
 
 func (s *integrationSuite) TestUpdateWorkflow_ConvertSpeculativeWorkflowTaskToNormal_BecauseOfBufferedSignal() {

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -1895,7 +1895,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FailWorkflowTask() {
 
 	// Complete workflow.
 	_, err = poller.PollAndProcessWorkflowTask(false, false)
-	s.Errorf(err, "update was never successfully accepted so it prevents completion")
+	s.Error(err, "update was never successfully accepted so it prevents completion")
 
 	s.Equal(5, wtHandlerCalls)
 	s.Equal(5, msgHandlerCalls)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Prevent a workflow from closing if there are workflow updates that have been admitted into the registry but which have not yet been seen by the workflow execution. Previous behavior was to prevent workflow close for any _incomplete_ updates.


<!-- Tell your future self why have you made these changes -->
**Why?**
Consensus that this is the desired behavior. If a workflow execution has seen the update, it has also had the opportunity to prevent itself from completing. If the workflow has not taken action to prevent completion when it had the chance then the server should assume that was intentional.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit and functional tests changed to expect new behavior

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
low

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no