### PR TITLE
Add function to get custom search attributes mapper in namespace registry

### DIFF
--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -144,6 +144,9 @@ type (
 		// State, ReplicationState, ActiveCluster, or isGlobalNamespace config changed.
 		RegisterStateChangeCallback(key any, cb StateChangeCallbackFn)
 		UnregisterStateChangeCallback(key any)
+		// GetCustomSearchAttributesMapper is a temporary solution to be able to get search attributes
+		// with from persistence if forceSearchAttributesCacheRefreshOnRead is true.
+		GetCustomSearchAttributesMapper(name Name) (CustomSearchAttributesMapper, error)
 	}
 
 	registry struct {
@@ -172,6 +175,9 @@ type (
 		// readthroughNotFoundCache stores namespaces that missed the above caches
 		// AND was not found when reading through to the persistence layer
 		readthroughNotFoundCache cache.Cache
+
+		// Temporary solution to force read search attributes from persistence
+		forceSearchAttributesCacheRefreshOnRead dynamicconfig.BoolPropertyFn
 	}
 )
 
@@ -181,6 +187,7 @@ func NewRegistry(
 	persistence Persistence,
 	enableGlobalNamespaces bool,
 	refreshInterval dynamicconfig.DurationPropertyFn,
+	forceSearchAttributesCacheRefreshOnRead dynamicconfig.BoolPropertyFn,
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) Registry {
@@ -196,6 +203,8 @@ func NewRegistry(
 		refreshInterval:          refreshInterval,
 		stateChangeCallbacks:     make(map[any]StateChangeCallbackFn),
 		readthroughNotFoundCache: cache.New(cacheMaxSize, &readthroughNotFoundCacheOpts),
+
+		forceSearchAttributesCacheRefreshOnRead: forceSearchAttributesCacheRefreshOnRead,
 	}
 	return reg
 }
@@ -333,6 +342,24 @@ func (r *registry) GetNamespaceName(
 		return "", err
 	}
 	return ns.Name(), nil
+}
+
+// GetCustomSearchAttributesMapper is a temporary solution to be able to get search attributes
+// with from persistence if forceSearchAttributesCacheRefreshOnRead is true.
+func (r *registry) GetCustomSearchAttributesMapper(name Name) (CustomSearchAttributesMapper, error) {
+	var ns *Namespace
+	var err error
+	if r.forceSearchAttributesCacheRefreshOnRead() {
+		r.readthroughLock.Lock()
+		defer r.readthroughLock.Unlock()
+		ns, err = r.getNamespaceByNamePersistence(name)
+	} else {
+		ns, err = r.GetNamespace(name)
+	}
+	if err != nil {
+		return CustomSearchAttributesMapper{}, err
+	}
+	return ns.CustomSearchAttributesMapper(), nil
 }
 
 func (r *registry) refreshLoop(ctx context.Context) error {

--- a/common/namespace/registry_mock.go
+++ b/common/namespace/registry_mock.go
@@ -181,6 +181,21 @@ func (mr *MockRegistryMockRecorder) GetCacheSize() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCacheSize", reflect.TypeOf((*MockRegistry)(nil).GetCacheSize))
 }
 
+// GetCustomSearchAttributesMapper mocks base method.
+func (m *MockRegistry) GetCustomSearchAttributesMapper(name Name) (CustomSearchAttributesMapper, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCustomSearchAttributesMapper", name)
+	ret0, _ := ret[0].(CustomSearchAttributesMapper)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCustomSearchAttributesMapper indicates an expected call of GetCustomSearchAttributesMapper.
+func (mr *MockRegistryMockRecorder) GetCustomSearchAttributesMapper(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCustomSearchAttributesMapper", reflect.TypeOf((*MockRegistry)(nil).GetCustomSearchAttributesMapper), name)
+}
+
 // GetNamespace mocks base method.
 func (m *MockRegistry) GetNamespace(name Name) (*Namespace, error) {
 	m.ctrl.T.Helper()

--- a/common/namespace/registry_test.go
+++ b/common/namespace/registry_test.go
@@ -74,6 +74,7 @@ func (s *registrySuite) SetupTest() {
 		s.regPersistence,
 		true,
 		dynamicconfig.GetDurationPropertyFn(time.Second),
+		dynamicconfig.GetBoolPropertyFn(false),
 		metrics.NoopMetricsHandler,
 		log.NewTestLogger())
 }

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -210,6 +210,7 @@ func NamespaceRegistryProvider(
 		metadataManager,
 		clusterMetadata.IsGlobalNamespaceEnabled(),
 		dynamicCollection.GetDurationProperty(dynamicconfig.NamespaceCacheRefreshInterval, 10*time.Second),
+		dynamicCollection.GetBoolProperty(dynamicconfig.ForceSearchAttributesCacheRefreshOnRead, false),
 		metricsHandler,
 		logger,
 	)

--- a/common/searchattribute/mapper.go
+++ b/common/searchattribute/mapper.go
@@ -124,11 +124,10 @@ func (m *mapperProviderImpl) GetMapper(nsName namespace.Name) (Mapper, error) {
 	if !m.enableMapperFromNamespace {
 		return &noopMapper{}, nil
 	}
-	ns, err := m.namespaceRegistry.GetNamespace(nsName)
+	saMapper, err := m.namespaceRegistry.GetCustomSearchAttributesMapper(nsName)
 	if err != nil {
 		return nil, err
 	}
-	saMapper := ns.CustomSearchAttributesMapper()
 	// if there's an error, it returns an empty object, which is expected here
 	emptyStringNameTypeMap, _ := m.searchAttributesProvider.GetSearchAttributes("", false)
 	return &backCompMapper_v1_20{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added function to get custom search attributes mapper in namespace registry capable of bypassing the cache if the dynamic config `system.forceSearchAttributesCacheRefreshOnRead` is set to true.

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/temporalio/temporal/issues/4017
The purpose of the dynamic config is to be able to immediately use the search attributes after being created. However, due to how they work differently when using SQL databases, this flag was a no-op in this case, only working when using Elasticsearch as visibility store.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started Temporal Server with MySQL, created search attributes, and immediately after started an workflow using the newly created search attributes. Before, it was always failing due to the namespace registry refresh interval. Now, if I set the dynamic config to `true`, it works.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.