### PR TITLE
Handle ProtocolMessageCommands in WFT completion

### DIFF
--- a/common/collection/indexedtakelist.go
+++ b/common/collection/indexedtakelist.go
@@ -1,0 +1,86 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package collection
+
+import "math/big"
+
+// IndexedTakeList holds a set of values that can only be observed by being
+// removed from the set. It is possible for this set to contain duplicate values
+// as long as each value maps to a distinct index.
+type (
+	IndexedTakeList[K comparable, V any] struct {
+		values  []kv[K, V]
+		removed big.Int
+	}
+
+	kv[K comparable, V any] struct {
+		key   K
+		value V
+	}
+)
+
+// NewIndexedTakeList constructs a new IndexedTakeSet by applying the provided
+// indexer to each of the provided values.
+func NewIndexedTakeList[K comparable, V any](
+	values []V,
+	indexer func(V) K,
+) *IndexedTakeList[K, V] {
+	ret := &IndexedTakeList[K, V]{
+		values: make([]kv[K, V], 0, len(values)),
+	}
+	for _, v := range values {
+		ret.values = append(ret.values, kv[K, V]{key: indexer(v), value: v})
+	}
+	return ret
+}
+
+// Take finds a value in this set by its index and removes it, returning the
+// value.
+func (itl *IndexedTakeList[K, V]) Take(key K) (V, bool) {
+	var zero V
+	for i, kv := range itl.values {
+		if kv.key != key {
+			continue
+		}
+		if itl.removed.Bit(i) != 0 {
+			return zero, false
+		}
+		itl.removed.SetBit(&itl.removed, i, 1)
+		return kv.value, true
+	}
+	return zero, false
+}
+
+// TakeRemaining removes all remaining values from this set and returns them.
+func (itl *IndexedTakeList[K, V]) TakeRemaining() []V {
+	out := make([]V, 0, len(itl.values))
+	for i, kv := range itl.values {
+		if itl.removed.Bit(i) == 0 {
+			out = append(out, kv.value)
+		}
+	}
+	itl.values = nil
+	return out
+}

--- a/common/collection/indexedtakelist_test.go
+++ b/common/collection/indexedtakelist_test.go
@@ -22,8 +22,50 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package update
+package collection_test
 
-import "go.temporal.io/server/internal/protocol"
+import (
+	"testing"
 
-const ProtocolV1 = protocol.Type("temporal.api.update.v1")
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/collection"
+)
+
+func TestIndexedTakeList(t *testing.T) {
+	t.Parallel()
+
+	type Value struct{ ID int }
+	values := []Value{{ID: 0}, {ID: 1}, {ID: 2}, {ID: 3}, {ID: 4}}
+	indexer := func(v Value) int { return v.ID }
+
+	list := collection.NewIndexedTakeList(values, indexer)
+
+	t.Run("take absent", func(t *testing.T) {
+		_, ok := list.Take(999)
+		require.False(t, ok)
+	})
+
+	t.Run("take present", func(t *testing.T) {
+		v, ok := list.Take(3)
+		require.True(t, ok)
+		require.Equal(t, 3, v.ID)
+	})
+
+	t.Run("take taken", func(t *testing.T) {
+		_, ok := list.Take(3)
+		require.False(t, ok)
+	})
+
+	t.Run("take remaining", func(t *testing.T) {
+		allowed := []int{0, 1, 2, 4}
+		remaining := list.TakeRemaining()
+		require.Len(t, remaining, len(allowed))
+		for _, v := range remaining {
+			require.Contains(t, allowed, v.ID)
+		}
+	})
+
+	t.Run("now empty", func(t *testing.T) {
+		require.Empty(t, list.TakeRemaining())
+	})
+}

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1358,6 +1358,7 @@ var (
 	CommandTypeUpsertWorkflowSearchAttributesCounter  = NewCounterDef("upsert_workflow_search_attributes_command")
 	CommandTypeModifyWorkflowPropertiesCounter        = NewCounterDef("modify_workflow_properties_command")
 	CommandTypeChildWorkflowCounter                   = NewCounterDef("child_workflow_command")
+	CommandTypeProtocolMessage                        = NewCounterDef("protocol_message_command")
 	MessageTypeRequestWorkflowExecutionUpdateCounter  = NewCounterDef("request_workflow_update_message")
 	MessageTypeAcceptWorkflowExecutionUpdateCounter   = NewCounterDef("accept_workflow_update_message")
 	MessageTypeRespondWorkflowExecutionUpdateCounter  = NewCounterDef("respond_workflow_update_message")

--- a/internal/protocol/naming.go
+++ b/internal/protocol/naming.go
@@ -1,0 +1,90 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protocol
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/gogo/protobuf/types"
+	protocolpb "go.temporal.io/api/protocol/v1"
+)
+
+type (
+	// Type is a protocol type of which there may be many instances like the
+	// update protocol or the query protocol.
+	Type string
+
+	// MessageType is the type of a message within a protocol.
+	MessageType string
+)
+
+const (
+	MessageTypeUnknown = MessageType("__message_type_unknown")
+	TypeUnknown        = Type("__protocol_type_unknown")
+)
+
+// String transforms a MessageType into a string
+func (mt MessageType) String() string {
+	return string(mt)
+}
+
+// String tranforms a Type into a string
+func (pt Type) String() string {
+	return string(pt)
+}
+
+// Identify is a function that given a protocol message gives the specific
+// message type of the body and the type of the protocol to which this message
+// belongs.
+func Identify(msg *protocolpb.Message) (Type, MessageType, error) {
+	if msg == nil {
+		return TypeUnknown, MessageTypeUnknown, errors.New("nil message")
+	}
+	if msg.Body == nil {
+		return TypeUnknown, MessageTypeUnknown, errors.New("nil message body")
+	}
+	bodyTypeName, err := types.AnyMessageName(msg.Body)
+	if err != nil {
+		return TypeUnknown, MessageTypeUnknown, err
+	}
+	msgType := MessageType(bodyTypeName)
+
+	lastDot := strings.LastIndex(bodyTypeName, ".")
+	if lastDot < 0 {
+		err := fmt.Errorf("could not read protocol type from %q", bodyTypeName)
+		return TypeUnknown, msgType, err
+	}
+	return Type(bodyTypeName[0:lastDot]), msgType, nil
+}
+
+// IdentifyOrUnknown wraps Identify to return TypeUnknown and/or
+// MessageTypeUnknown in the case where either one cannot be determined due to
+// an error.
+func IdentifyOrUnknown(msg *protocolpb.Message) (Type, MessageType) {
+	pt, mt, _ := Identify(msg)
+	return pt, mt
+}

--- a/internal/protocol/naming_test.go
+++ b/internal/protocol/naming_test.go
@@ -1,0 +1,77 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package protocol_test
+
+import (
+	"testing"
+
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/require"
+	protocolpb "go.temporal.io/api/protocol/v1"
+	"go.temporal.io/server/internal/protocol"
+)
+
+func TestNilSafety(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil message", func(t *testing.T) {
+		pt, mt := protocol.IdentifyOrUnknown(nil)
+		require.Equal(t, protocol.TypeUnknown, pt)
+		require.Equal(t, protocol.MessageTypeUnknown, mt)
+	})
+
+	t.Run("nil message body", func(t *testing.T) {
+		pt, mt := protocol.IdentifyOrUnknown(&protocolpb.Message{})
+		require.Equal(t, protocol.TypeUnknown, pt)
+		require.Equal(t, protocol.MessageTypeUnknown, mt)
+	})
+}
+
+func TestWithValidMessage(t *testing.T) {
+	t.Parallel()
+
+	body, err := types.MarshalAny(&types.Empty{})
+	require.NoError(t, err)
+
+	msg := protocolpb.Message{Body: body}
+
+	pt, mt := protocol.IdentifyOrUnknown(&msg)
+
+	require.Equal(t, "google.protobuf", pt.String())
+	require.Equal(t, "google.protobuf.Empty", mt.String())
+}
+
+func TestWithInvalidBody(t *testing.T) {
+	t.Parallel()
+
+	body, err := types.MarshalAny(&types.Empty{})
+	require.NoError(t, err)
+
+	msg := protocolpb.Message{Body: body}
+	msg.Body.TypeUrl = "this isn't valid"
+
+	_, _, err = protocol.Identify(&msg)
+	require.Error(t, err)
+}

--- a/service/history/commandChecker.go
+++ b/service/history/commandChecker.go
@@ -271,6 +271,24 @@ func (c *workflowSizeChecker) checkIfSearchAttributesSizeExceedsLimit(
 	return err
 }
 
+func (v *commandAttrValidator) validateProtocolMessageAttributes(
+	namespaceID namespace.ID,
+	attributes *commandpb.ProtocolMessageCommandAttributes,
+	runTimeout time.Duration,
+) (enumspb.WorkflowTaskFailedCause, error) {
+	const failedCause = enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE
+
+	if attributes == nil {
+		return failedCause, serviceerror.NewInvalidArgument("ProtocolMessageCommandAttributes is not set on command.")
+	}
+
+	if attributes.MessageId == "" {
+		return failedCause, serviceerror.NewInvalidArgument("MessageID is not set on command.")
+	}
+
+	return enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNSPECIFIED, nil
+}
+
 func (v *commandAttrValidator) validateActivityScheduleAttributes(
 	namespaceID namespace.ID,
 	attributes *commandpb.ScheduleActivityTaskCommandAttributes,

--- a/service/history/workflowTaskHandler_test.go
+++ b/service/history/workflowTaskHandler_test.go
@@ -1,0 +1,316 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	commandpb "go.temporal.io/api/command/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	protocolpb "go.temporal.io/api/protocol/v1"
+	"go.temporal.io/api/serviceerror"
+	updatepb "go.temporal.io/api/update/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/collection"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/internal/effect"
+	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/workflow"
+	"go.temporal.io/server/service/history/workflow/update"
+)
+
+func TestCommandProtocolMessage(t *testing.T) {
+	t.Parallel()
+
+	type testconf struct {
+		ms      *workflow.MockMutableState
+		updates update.Registry
+		handler *workflowTaskHandlerImpl
+		conf    map[dynamicconfig.Key]any
+	}
+
+	const defaultBlobSizeLimit = 1 * 1024 * 1024
+
+	msgCommand := func(msgID string) *commandpb.Command {
+		return &commandpb.Command{
+			CommandType: enumspb.COMMAND_TYPE_PROTOCOL_MESSAGE,
+			Attributes: &commandpb.Command_ProtocolMessageCommandAttributes{
+				ProtocolMessageCommandAttributes: &commandpb.ProtocolMessageCommandAttributes{
+					MessageId: msgID,
+				},
+			},
+		}
+	}
+
+	setup := func(t *testing.T, out *testconf, blobSizeLimit int) {
+		shardCtx := shard.NewMockContext(gomock.NewController(t))
+		logger := log.NewNoopLogger()
+		metricsHandler := metrics.NoopMetricsHandler
+		out.conf = map[dynamicconfig.Key]any{}
+		out.ms = workflow.NewMockMutableState(gomock.NewController(t))
+		out.ms.EXPECT().GetAcceptedWorkflowExecutionUpdateIDs(gomock.Any()).Times(1).Return(nil)
+		out.updates = update.NewRegistry(out.ms)
+		var effects effect.Buffer
+		config := configs.NewConfig(
+			dynamicconfig.NewCollection(
+				dynamicconfig.StaticClient(out.conf), logger), 1, false, false)
+		mockMeta := persistence.NewMockMetadataManager(gomock.NewController(t))
+		nsReg := namespace.NewRegistry(
+			mockMeta,
+			true,
+			func() time.Duration { return 1 * time.Hour },
+			metricsHandler,
+			logger,
+		)
+		out.handler = newWorkflowTaskHandler( // 😲
+			t.Name(), //identity
+			123,      // workflowTaskCompletedID
+			out.ms,
+			out.updates,
+			&effects,
+			newCommandAttrValidator(
+				nsReg,
+				config,
+				nil, // searchAttributesValidator
+			),
+			newWorkflowSizeChecker(
+				workflowSizeLimits{blobSizeLimitError: blobSizeLimit},
+				out.ms,
+				nil, //searchAttributesValidator
+				&persistencespb.ExecutionStats{},
+				metricsHandler,
+				logger,
+			),
+			logger,
+			nsReg,
+			metricsHandler,
+			config,
+			shardCtx,
+			nil, // searchattribute.MapperProvider
+			false,
+		)
+	}
+
+	emptyMessageSet := collection.NewIndexedTakeSet[string, *protocolpb.Message](nil, nil)
+
+	t.Run("missing message ID", func(t *testing.T) {
+		var tc testconf
+		setup(t, &tc, defaultBlobSizeLimit)
+		var (
+			command = msgCommand("") // blank is invalid
+		)
+
+		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
+
+		_, err := tc.handler.handleCommand(context.Background(), command, newMsgList())
+		require.NoError(t, err)
+		require.NotNil(t, tc.handler.workflowTaskFailedCause)
+		require.Equal(t,
+			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
+			tc.handler.workflowTaskFailedCause.failedCause)
+	})
+
+	t.Run("message not found", func(t *testing.T) {
+		var tc testconf
+		setup(t, &tc, defaultBlobSizeLimit)
+		var (
+			command = msgCommand("valid_but_not_found_msg_id")
+		)
+
+		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
+
+		_, err := tc.handler.handleCommand(context.Background(), command, newMsgList())
+		require.NoError(t, err)
+		require.NotNil(t, tc.handler.workflowTaskFailedCause)
+		require.Equal(t,
+			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
+			tc.handler.workflowTaskFailedCause.failedCause)
+	})
+
+	t.Run("message too large", func(t *testing.T) {
+		var tc testconf
+		t.Log("setting max blob size to zero")
+		setup(t, &tc, 0)
+		var (
+			msgID   = t.Name() + "-message-id"
+			command = msgCommand(msgID) // blank is invalid
+			msg     = &protocolpb.Message{
+				Id:                 msgID,
+				ProtocolInstanceId: "does_not_matter",
+				Body:               mustMarshalAny(t, &types.Empty{}),
+			}
+		)
+
+		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
+		tc.ms.EXPECT().GetExecutionState().AnyTimes().Return(&persistencespb.WorkflowExecutionState{})
+
+		_, err := tc.handler.handleCommand(context.Background(), command, newMsgList(msg))
+		require.NoError(t, err)
+		require.NotNil(t, tc.handler.workflowTaskFailedCause)
+		require.Equal(t,
+			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
+			tc.handler.workflowTaskFailedCause.failedCause)
+		require.ErrorContains(t, tc.handler.workflowTaskFailedCause.causeErr, "exceeds size limit")
+	})
+
+	t.Run("message for unsupported protocol", func(t *testing.T) {
+		var tc testconf
+		setup(t, &tc, defaultBlobSizeLimit)
+		var (
+			msgID   = t.Name() + "-message-id"
+			command = msgCommand(msgID) // blank is invalid
+			msg     = &protocolpb.Message{
+				Id:                 msgID,
+				ProtocolInstanceId: "does_not_matter",
+				Body:               mustMarshalAny(t, &types.Empty{}),
+			}
+		)
+
+		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
+		tc.ms.EXPECT().GetExecutionState().AnyTimes().Return(&persistencespb.WorkflowExecutionState{})
+
+		_, err := tc.handler.handleCommand(context.Background(), command, newMsgList(msg))
+		require.NoError(t, err)
+		require.NotNil(t, tc.handler.workflowTaskFailedCause)
+		require.Equal(t,
+			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
+			tc.handler.workflowTaskFailedCause.failedCause)
+		var invalidArg *serviceerror.InvalidArgument
+		require.ErrorAs(t, tc.handler.workflowTaskFailedCause.causeErr, &invalidArg)
+		require.ErrorContains(t, tc.handler.workflowTaskFailedCause.causeErr, "protocol type")
+	})
+
+	t.Run("update not found", func(t *testing.T) {
+		var tc testconf
+		setup(t, &tc, defaultBlobSizeLimit)
+		var (
+			msgID   = t.Name() + "-message-id"
+			command = msgCommand(msgID) // blank is invalid
+			msg     = &protocolpb.Message{
+				Id:                 msgID,
+				ProtocolInstanceId: "will not be found",
+				Body:               mustMarshalAny(t, &updatepb.Acceptance{}),
+			}
+		)
+
+		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
+		tc.ms.EXPECT().GetExecutionState().AnyTimes().Return(&persistencespb.WorkflowExecutionState{})
+		tc.ms.EXPECT().GetUpdateInfo(gomock.Any(), msg.ProtocolInstanceId).Return(nil, false)
+
+		_, err := tc.handler.handleCommand(context.Background(), command, newMsgList(msg))
+		require.NoError(t, err)
+		require.NotNil(t, tc.handler.workflowTaskFailedCause)
+		require.Equal(t,
+			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
+			tc.handler.workflowTaskFailedCause.failedCause)
+		var notfound *serviceerror.NotFound
+		require.ErrorAs(t, tc.handler.workflowTaskFailedCause.causeErr, &notfound)
+	})
+
+	t.Run("deliver message failure", func(t *testing.T) {
+		var tc testconf
+		setup(t, &tc, defaultBlobSizeLimit)
+		var (
+			updateID = t.Name() + "-update-id"
+			msgID    = t.Name() + "-message-id"
+			command  = msgCommand(msgID) // blank is invalid
+			msg      = &protocolpb.Message{
+				Id:                 msgID,
+				ProtocolInstanceId: updateID,
+				Body:               mustMarshalAny(t, &updatepb.Acceptance{}),
+			}
+		)
+		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
+		tc.ms.EXPECT().GetExecutionState().AnyTimes().Return(&persistencespb.WorkflowExecutionState{})
+		tc.ms.EXPECT().GetUpdateInfo(gomock.Any(), updateID).Return(nil, false)
+
+		t.Log("create the expected protocol instance")
+		_, _, err := tc.updates.FindOrCreate(context.Background(), updateID)
+		require.NoError(t, err)
+
+		t.Log("delivering an acceptance message to an update in the admitted state should cause a protocol error")
+		_, err = tc.handler.handleCommand(context.Background(), command, newMsgList(msg))
+		require.NoError(t, err)
+		require.NotNil(t, tc.handler.workflowTaskFailedCause)
+		require.Equal(t,
+			enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE,
+			tc.handler.workflowTaskFailedCause.failedCause)
+		var gotErr *serviceerror.InvalidArgument
+		require.ErrorAs(t, tc.handler.workflowTaskFailedCause.causeErr, &gotErr)
+	})
+
+	t.Run("deliver message success", func(t *testing.T) {
+		var tc testconf
+		setup(t, &tc, defaultBlobSizeLimit)
+		var (
+			updateID = t.Name() + "-update-id"
+			msgID    = t.Name() + "-message-id"
+			command  = msgCommand(msgID) // blank is invalid
+			msg      = &protocolpb.Message{
+				Id:                 msgID,
+				ProtocolInstanceId: updateID,
+				Body: mustMarshalAny(t, &updatepb.Request{
+					Meta:  &updatepb.Meta{UpdateId: updateID},
+					Input: &updatepb.Input{Name: "not_empty"},
+				}),
+			}
+			msgs = newMsgList(msg)
+		)
+		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
+		tc.ms.EXPECT().GetExecutionState().AnyTimes().Return(&persistencespb.WorkflowExecutionState{})
+		tc.ms.EXPECT().GetUpdateInfo(gomock.Any(), updateID).Return(nil, false)
+
+		t.Log("create the expected protocol instance")
+		_, _, err := tc.updates.FindOrCreate(context.Background(), updateID)
+		require.NoError(t, err)
+
+		_, err = tc.handler.handleCommand(context.Background(), command, msgs)
+		require.NoError(t, err,
+			"delivering a request message to an update in the admitted state should succeed")
+		require.Nil(t, tc.handler.workflowTaskFailedCause)
+	})
+}
+
+func newMsgList(msgs ...*protocolpb.Message) *collection.IndexedTakeList[string, *protocolpb.Message] {
+	return collection.NewIndexedTakeList(msgs, func(msg *protocolpb.Message) string { return msg.Id })
+}
+
+func mustMarshalAny(t *testing.T, pb proto.Message) *types.Any {
+	t.Helper()
+	a, err := types.MarshalAny(pb)
+	require.NoError(t, err)
+	return a
+}

--- a/service/history/workflowTaskHandler_test.go
+++ b/service/history/workflowTaskHandler_test.go
@@ -124,8 +124,6 @@ func TestCommandProtocolMessage(t *testing.T) {
 		)
 	}
 
-	emptyMessageSet := collection.NewIndexedTakeSet[string, *protocolpb.Message](nil, nil)
-
 	t.Run("missing message ID", func(t *testing.T) {
 		var tc testconf
 		setup(t, &tc, defaultBlobSizeLimit)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Handle ProtocolMessageCommands in WFT completion

<!-- Tell your future self why have you made these changes -->
**Why?**
ProtocolMessageCommands are references to messages in the same WFT and serve as a way to sequence command and message processing.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit tests here

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Moderate - changes to command processing.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No