### PR TITLE
Handful of minor changes to the update package

### DIFF
--- a/service/history/api/pollupdate/api_test.go
+++ b/service/history/api/pollupdate/api_test.go
@@ -141,7 +141,7 @@ func TestPollOutcome(t *testing.T) {
 	})
 	t.Run("future timeout", func(t *testing.T) {
 		reg.FindFunc = func(ctx context.Context, updateID string) (*update.Update, bool) {
-			return update.New(updateID, func() {}), true
+			return update.New(updateID), true
 		}
 		ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
 		defer cncl()
@@ -149,7 +149,7 @@ func TestPollOutcome(t *testing.T) {
 		require.Error(t, err)
 	})
 	t.Run("get an outcome", func(t *testing.T) {
-		upd := update.New(updateID, func() {})
+		upd := update.New(updateID)
 		reg.FindFunc = func(ctx context.Context, updateID string) (*update.Update, bool) {
 			return upd, true
 		}

--- a/service/history/workflow/update/export_test.go
+++ b/service/history/workflow/update/export_test.go
@@ -32,3 +32,8 @@ var (
 	NewAccepted  = newAccepted
 	NewCompleted = newCompleted
 )
+
+// ObserveCompletion exporses withOnComplete to unit tests
+func ObserveCompletion(b *bool) updateOpt {
+	return withCompletionCallback(func() { *b = true })
+}

--- a/service/history/workflow/update/export_test.go
+++ b/service/history/workflow/update/export_test.go
@@ -34,6 +34,8 @@ var (
 )
 
 // ObserveCompletion exporses withOnComplete to unit tests
+//
+//revive:disable-next-line:unexported-return for testing
 func ObserveCompletion(b *bool) updateOpt {
 	return withCompletionCallback(func() { *b = true })
 }

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -42,6 +42,8 @@ import (
 )
 
 type (
+	// Registry maintains a set of updates that have been admitted to run
+	// against a workflow execution.
 	Registry interface {
 		// FindOrCreate finds an existing Update or creates a new one. The second
 		// return value (bool) indicates whether the Update returned already
@@ -50,7 +52,7 @@ type (
 		FindOrCreate(ctx context.Context, protocolInstanceID string) (*Update, bool, error)
 
 		// Find finds an existing update in this Registry but does not create a
-		// new update it is absent.
+		// new update if no update is found.
 		Find(ctx context.Context, protocolInstanceID string) (*Update, bool)
 
 		// ReadOutoundMessages polls each registered Update for outbound
@@ -66,7 +68,7 @@ type (
 		// sent messages to a worker.
 		HasOutgoing() bool
 
-		// Len observes the number of updates in this Registry.
+		// Len observes the number of incomplete updates in this Registry.
 		Len() int
 	}
 
@@ -91,6 +93,8 @@ type (
 
 //revive:disable:unexported-return I *want* it to be unexported
 
+// WithInFlightLimit provides an optional limit to the number of incomplete
+// updates that a Registry instance will allow.
 func WithInFlightLimit(f func() int) regOpt {
 	return func(r *RegistryImpl) {
 		r.maxInFlight = f

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -219,12 +219,14 @@ func (r *RegistryImpl) Len() int {
 	return len(r.updates)
 }
 
-func (r *RegistryImpl) remover(id string) func() {
-	return func() {
-		r.mu.Lock()
-		defer r.mu.Unlock()
-		delete(r.updates, id)
-	}
+func (r *RegistryImpl) remover(id string) updateOpt {
+	return withCompletionCallback(
+		func() {
+			r.mu.Lock()
+			defer r.mu.Unlock()
+			delete(r.updates, id)
+		},
+	)
 }
 
 func (r *RegistryImpl) admit(context.Context) error {

--- a/service/history/workflow/update/state.go
+++ b/service/history/workflow/update/state.go
@@ -24,8 +24,6 @@
 
 package update
 
-import "sync/atomic"
-
 type (
 	state    uint32
 	stateSet uint32
@@ -61,15 +59,6 @@ func (s state) String() string {
 	return "unrecognized state"
 }
 
-func (s *state) Is(other state) bool {
-	return state(atomic.LoadUint32((*uint32)(s))) == other
-}
-
-func (s *state) Set(other state) state {
-	return state(atomic.SwapUint32((*uint32)(s), uint32(other)))
-}
-
-func (s *state) Matches(mask stateSet) bool {
-	actual := atomic.LoadUint32((*uint32)(s))
-	return actual&uint32(mask) == actual
+func (s state) Matches(mask stateSet) bool {
+	return uint32(s)&uint32(mask) == uint32(s)
 }

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -218,7 +218,7 @@ func (u *Update) OnMessage(
 // ReadOutgoingMessages loads any oubound messages from this Update state
 // machine into the output slice provided.
 func (u *Update) ReadOutgoingMessages(out *[]*protocolpb.Message) {
-	if u.state != (stateRequested) {
+	if u.state != stateRequested {
 		// Update only sends messages to the workflow when it is in
 		// stateRequested
 		return

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -66,10 +66,10 @@ type (
 	// messages from the go.temporal.io/api/update/v1 package. The update state
 	// machine is straightforward except in that it provides "provisional"
 	// in-between states where the update has received a message that has
-	// updated its internal state but those updates have not been made visible
+	// modified its internal state but those changes have not been made visible
 	// to clients yet (e.g. accepted or outcome futures have not been set yet).
-	// The effects are bound to the EventStore's effect.Set and will be
-	// triggered withen those effects are applied.
+	// The observable changes are bound to the EventStore's effect.Controller
+	// and will be triggered when those effects are applied.
 	Update struct {
 		// accessed only while holding workflow lock
 		id              string
@@ -280,7 +280,7 @@ func (u *Update) onAcceptanceMsg(
 	return nil
 }
 
-// onRejectionMsg expectes the Update stae to be in stateRequested and returns
+// onRejectionMsg expectes the Update state to be stateRequested and returns
 // an error if it finds otherwise. On commit of buffered effects the state
 // machine transitions to stateCompleted and the accepted and outcome futures
 // are both completed with the failurepb.Failure value from the
@@ -312,7 +312,7 @@ func (u *Update) onRejectionMsg(
 	return nil
 }
 
-// onResponseMsg expectes the Update to be in either stateProvisionallyAccepted
+// onResponseMsg expects the Update to be in either stateProvisionallyAccepted
 // or stateAccepted and returns an error if it finds otherwise. On commit of
 // buffered effects the state machine will transtion to stateCompleted and the
 // outcome future is completed with the updatepb.Outcome from the

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -172,7 +172,7 @@ func TestRequestAcceptComplete(t *testing.T) {
 		require.False(t, completed)
 
 		ctx, cncl := context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cncl()
+		t.Cleanup(cncl)
 		_, err = upd.WaitAccepted(ctx)
 		require.ErrorIs(t, err, context.DeadlineExceeded,
 			"update acceptance should not be observable until effects are applied")
@@ -192,7 +192,7 @@ func TestRequestAcceptComplete(t *testing.T) {
 		require.False(t, completed)
 
 		ctx, cncl := context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cncl()
+		t.Cleanup(cncl)
 		_, err = upd.WaitOutcome(ctx)
 		require.ErrorIs(t, err, context.DeadlineExceeded,
 			"update outcome should not be observable until effects are applied")
@@ -245,14 +245,14 @@ func TestRequestReject(t *testing.T) {
 
 		{
 			ctx, cncl := context.WithTimeout(ctx, 5*time.Millisecond)
-			defer cncl()
+			t.Cleanup(cncl)
 			_, err := upd.WaitAccepted(ctx)
 			require.ErrorIs(t, err, context.DeadlineExceeded,
 				"update acceptance failure should not be observable until effects are applied")
 		}
 		{
 			ctx, cncl := context.WithTimeout(ctx, 5*time.Millisecond)
-			defer cncl()
+			t.Cleanup(cncl)
 			_, err := upd.WaitOutcome(ctx)
 			require.ErrorIs(t, err, context.DeadlineExceeded,
 				"update acceptance failure should not be observable until effects are applied")
@@ -471,13 +471,13 @@ func TestDoubleRollback(t *testing.T) {
 
 	t.Run("not accepted", func(t *testing.T) {
 		ctx, cncl := context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cncl()
+		t.Cleanup(cncl)
 		_, err := upd.WaitAccepted(ctx)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
 	t.Run("not completed", func(t *testing.T) {
 		ctx, cncl := context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cncl()
+		t.Cleanup(cncl)
 		_, err := upd.WaitOutcome(ctx)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 	})
@@ -510,7 +510,7 @@ func TestRollbackCompletion(t *testing.T) {
 
 	t.Run("not completed", func(t *testing.T) {
 		ctx, cncl := context.WithTimeout(ctx, 5*time.Millisecond)
-		defer cncl()
+		t.Cleanup(cncl)
 		_, err := upd.WaitOutcome(ctx)
 		require.ErrorIs(t, err, context.DeadlineExceeded)
 		require.False(t, completed)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- comments and spelling
- make Update onComplete callback optional and unexported
- improve unit test context cancellation cleanup
- remove atomic read/write for update.state type

<!-- Tell your future self why have you made these changes -->
**Why?**
I had made state reads and writes threadsafe back when it was observed from multiple threads but that has evolved to no longer be the case.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No behavioral changes so current unit tests suffice

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
low

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No