### PR TITLE
Change schedules default catchup window to 1 year

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -159,7 +159,7 @@ var (
 	// the workflow so that we can change them without breaking existing executions or having
 	// to use versioning.
 	currentTweakablePolicies = tweakablePolicies{
-		DefaultCatchupWindow:              60 * time.Second,
+		DefaultCatchupWindow:              365 * 24 * time.Hour,
 		MinCatchupWindow:                  10 * time.Second,
 		CanceledTerminatedCountAsFailures: false,
 		AlwaysAppendTimestamp:             true,

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -251,7 +251,7 @@ func (s *scheduleIntegrationSuite) TestBasics() {
 	checkSpec(describeResp.Schedule.Spec)
 
 	s.Equal(enumspb.SCHEDULE_OVERLAP_POLICY_SKIP, describeResp.Schedule.Policies.OverlapPolicy) // set to default value
-	s.EqualValues(60, describeResp.Schedule.Policies.CatchupWindow.Seconds())                   // set to default value
+	s.EqualValues(365*24*3600, describeResp.Schedule.Policies.CatchupWindow.Seconds())          // set to default value
 
 	s.Equal(schSAValue.Data, describeResp.SearchAttributes.IndexedFields[csa].Data)
 	s.Equal(schMemo.Data, describeResp.Memo.Fields["schedmemo1"].Data)


### PR DESCRIPTION
**What changed?**
Change default catchup window to 1 year (will only affect newly created schedules)

**Why?**
Better match user expectations: we shouldn't skip runs for short slowness/unavailability, other parts of temporal always attempt to catch up

**How did you test it?**

**Potential risks**

**Is hotfix candidate?**
