### PR TITLE
Truncate activity failure in mutable state

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -151,6 +151,11 @@ const (
 	HistoryCountLimitError = "limit.historyCount.error"
 	// HistoryCountLimitWarn is the per workflow execution history event count limit for warning
 	HistoryCountLimitWarn = "limit.historyCount.warn"
+	// MutableStateActivityFailureSizeLimitError is the per activity failure size limit for workflow mutable state.
+	// If exceeded, failure will be truncated before being stored in mutable state.
+	MutableStateActivityFailureSizeLimitError = "limit.mutableStateActivityFailureSize.error"
+	// MutableStateActivityFailureSizeLimitWarn is the per activity failure size warning limit for workflow mutable state
+	MutableStateActivityFailureSizeLimitWarn = "limit.mutableStateActivityFailureSize.warn"
 	// HistoryCountSuggestContinueAsNew is the workflow execution history event count limit to
 	// suggest continue-as-new (in workflow task started event)
 	HistoryCountSuggestContinueAsNew = "limit.historyCount.suggestContinueAsNew"

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -307,6 +307,11 @@ func WorkflowTaskQueueName(taskQueueName string) ZapTag {
 
 // size limit
 
+// BlobSize returns tag for BlobSize
+func BlobSize(blobSize int64) ZapTag {
+	return NewInt64("blob-size", blobSize)
+}
+
 // WorkflowSize returns tag for WorkflowSize
 func WorkflowSize(workflowSize int64) ZapTag {
 	return NewInt64("wf-size", workflowSize)

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -182,20 +182,22 @@ type Config struct {
 	DurableArchivalEnabled    dynamicconfig.BoolPropertyFn
 
 	// Size limit related settings
-	BlobSizeLimitError               dynamicconfig.IntPropertyFnWithNamespaceFilter
-	BlobSizeLimitWarn                dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MemoSizeLimitError               dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MemoSizeLimitWarn                dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistorySizeLimitError            dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistorySizeLimitWarn             dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistorySizeSuggestContinueAsNew  dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryCountLimitError           dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryCountLimitWarn            dynamicconfig.IntPropertyFnWithNamespaceFilter
-	HistoryCountSuggestContinueAsNew dynamicconfig.IntPropertyFnWithNamespaceFilter
-	NumPendingChildExecutionsLimit   dynamicconfig.IntPropertyFnWithNamespaceFilter
-	NumPendingActivitiesLimit        dynamicconfig.IntPropertyFnWithNamespaceFilter
-	NumPendingSignalsLimit           dynamicconfig.IntPropertyFnWithNamespaceFilter
-	NumPendingCancelsRequestLimit    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	BlobSizeLimitError                        dynamicconfig.IntPropertyFnWithNamespaceFilter
+	BlobSizeLimitWarn                         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MemoSizeLimitError                        dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MemoSizeLimitWarn                         dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistorySizeLimitError                     dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistorySizeLimitWarn                      dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistorySizeSuggestContinueAsNew           dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCountLimitError                    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCountLimitWarn                     dynamicconfig.IntPropertyFnWithNamespaceFilter
+	HistoryCountSuggestContinueAsNew          dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MutableStateActivityFailureSizeLimitError dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MutableStateActivityFailureSizeLimitWarn  dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingChildExecutionsLimit            dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingActivitiesLimit                 dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingSignalsLimit                    dynamicconfig.IntPropertyFnWithNamespaceFilter
+	NumPendingCancelsRequestLimit             dynamicconfig.IntPropertyFnWithNamespaceFilter
 
 	// DefaultActivityRetryOptions specifies the out-of-box retry policy if
 	// none is configured on the Activity by the user.
@@ -440,20 +442,22 @@ func NewConfig(
 		ArchiveSignalTimeout:      dc.GetDurationProperty(dynamicconfig.ArchiveSignalTimeout, 300*time.Millisecond),
 		DurableArchivalEnabled:    dc.GetBoolProperty(dynamicconfig.DurableArchivalEnabled, true),
 
-		BlobSizeLimitError:               dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
-		BlobSizeLimitWarn:                dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitWarn, 512*1024),
-		MemoSizeLimitError:               dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitError, 2*1024*1024),
-		MemoSizeLimitWarn:                dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitWarn, 2*1024),
-		NumPendingChildExecutionsLimit:   dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingChildExecutionsLimitError, 2000),
-		NumPendingActivitiesLimit:        dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingActivitiesLimitError, 2000),
-		NumPendingSignalsLimit:           dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingSignalsLimitError, 2000),
-		NumPendingCancelsRequestLimit:    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingCancelRequestsLimitError, 2000),
-		HistorySizeLimitError:            dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitError, 50*1024*1024),
-		HistorySizeLimitWarn:             dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitWarn, 10*1024*1024),
-		HistorySizeSuggestContinueAsNew:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeSuggestContinueAsNew, 4*1024*1024),
-		HistoryCountLimitError:           dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitError, 50*1024),
-		HistoryCountLimitWarn:            dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitWarn, 10*1024),
-		HistoryCountSuggestContinueAsNew: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountSuggestContinueAsNew, 4*1024),
+		BlobSizeLimitError:                        dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
+		BlobSizeLimitWarn:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitWarn, 512*1024),
+		MemoSizeLimitError:                        dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitError, 2*1024*1024),
+		MemoSizeLimitWarn:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MemoSizeLimitWarn, 2*1024),
+		NumPendingChildExecutionsLimit:            dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingChildExecutionsLimitError, 2000),
+		NumPendingActivitiesLimit:                 dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingActivitiesLimitError, 2000),
+		NumPendingSignalsLimit:                    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingSignalsLimitError, 2000),
+		NumPendingCancelsRequestLimit:             dc.GetIntPropertyFilteredByNamespace(dynamicconfig.NumPendingCancelRequestsLimitError, 2000),
+		HistorySizeLimitError:                     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitError, 50*1024*1024),
+		HistorySizeLimitWarn:                      dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeLimitWarn, 10*1024*1024),
+		HistorySizeSuggestContinueAsNew:           dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistorySizeSuggestContinueAsNew, 4*1024*1024),
+		HistoryCountLimitError:                    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitError, 50*1024),
+		HistoryCountLimitWarn:                     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitWarn, 10*1024),
+		HistoryCountSuggestContinueAsNew:          dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountSuggestContinueAsNew, 4*1024),
+		MutableStateActivityFailureSizeLimitError: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateActivityFailureSizeLimitError, 32*1024),
+		MutableStateActivityFailureSizeLimitWarn:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateActivityFailureSizeLimitWarn, 16*1024),
 
 		ThrottledLogRPS:   dc.GetIntProperty(dynamicconfig.HistoryThrottledLogRPS, 4),
 		EnableStickyQuery: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.EnableStickyQuery, true),

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -456,8 +456,8 @@ func NewConfig(
 		HistoryCountLimitError:                    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitError, 50*1024),
 		HistoryCountLimitWarn:                     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountLimitWarn, 10*1024),
 		HistoryCountSuggestContinueAsNew:          dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryCountSuggestContinueAsNew, 4*1024),
-		MutableStateActivityFailureSizeLimitError: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateActivityFailureSizeLimitError, 32*1024),
-		MutableStateActivityFailureSizeLimitWarn:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateActivityFailureSizeLimitWarn, 16*1024),
+		MutableStateActivityFailureSizeLimitError: dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateActivityFailureSizeLimitError, 4*1024),
+		MutableStateActivityFailureSizeLimitWarn:  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.MutableStateActivityFailureSizeLimitWarn, 2*1024),
 
 		ThrottledLogRPS:   dc.GetIntProperty(dynamicconfig.HistoryThrottledLogRPS, 4),
 		EnableStickyQuery: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.EnableStickyQuery, true),

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4012,6 +4012,10 @@ func (ms *MutableStateImpl) truncateRetryableActivityFailure(
 	}
 
 	throttledLogger.Warn("Activity failure size exceeds error limit for mutable state, truncated.")
+
+	// nonRetryable is set to false here as only retryable failures are recorded in mutable state.
+	// also when this method is called, the check for isRetryable is already done, so the value
+	// is only for visibility/debugging purpose.
 	serverFailure := failure.NewServerFailure(common.FailureReasonFailureExceedsLimit, false)
 	serverFailure.Cause = failure.Truncate(activityFailure, sizeLimitError)
 	return serverFailure

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -55,6 +55,7 @@ import (
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/enums"
+	"go.temporal.io/server/common/failure"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
@@ -3972,7 +3973,7 @@ func (ms *MutableStateImpl) RetryActivity(
 	ai.StartedTime = timestamp.TimePtr(time.Time{})
 	ai.TimerTaskStatus = TimerTaskStatusNone
 	ai.RetryLastWorkerIdentity = ai.StartedIdentity
-	ai.RetryLastFailure = failure
+	ai.RetryLastFailure = ms.truncateRetryableActivityFailure(failure)
 
 	if err := ms.taskGenerator.GenerateActivityRetryTasks(
 		ai.ScheduledEventId,
@@ -3983,6 +3984,37 @@ func (ms *MutableStateImpl) RetryActivity(
 	ms.updateActivityInfos[ai.ScheduledEventId] = ai
 	ms.syncActivityTasks[ai.ScheduledEventId] = struct{}{}
 	return enumspb.RETRY_STATE_IN_PROGRESS, nil
+}
+
+func (ms *MutableStateImpl) truncateRetryableActivityFailure(
+	activityFailure *failurepb.Failure,
+) *failurepb.Failure {
+	namespaceName := ms.namespaceEntry.Name().String()
+	failureSize := activityFailure.Size()
+
+	if failureSize <= ms.config.MutableStateActivityFailureSizeLimitWarn(namespaceName) {
+		return activityFailure
+	}
+
+	throttledLogger := log.With(
+		ms.shard.GetThrottledLogger(),
+		tag.WorkflowNamespace(namespaceName),
+		tag.WorkflowID(ms.executionInfo.WorkflowId),
+		tag.WorkflowRunID(ms.executionState.RunId),
+		tag.BlobSize(int64(failureSize)),
+		tag.BlobSizeViolationOperation("RetryActivity"),
+	)
+
+	sizeLimitError := ms.config.MutableStateActivityFailureSizeLimitError(namespaceName)
+	if failureSize <= sizeLimitError {
+		throttledLogger.Warn("Activity failure size exceeds warning limit for mutable state.")
+		return activityFailure
+	}
+
+	throttledLogger.Warn("Activity failure size exceeds error limit for mutable state, truncated.")
+	serverFailure := failure.NewServerFailure(common.FailureReasonFailureExceedsLimit, false)
+	serverFailure.Cause = failure.Truncate(activityFailure, sizeLimitError)
+	return serverFailure
 }
 
 // TODO mutable state should generate corresponding transfer / timer tasks according to


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Truncate activity failure before storing it in mutable state
- Introduced new warn & error limit for mutable state activity failure size
NOTE: this change should not break users (unless user has logic depend on workflow history). Activity failures stored in workflow mutable state is not visible to workflow code and can only be retrieved via describeWorkflowExecution. 

<!-- Tell your future self why have you made these changes -->
**Why?**
- Prevent large mutable state

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.