### PR TITLE
Ensure workflow key is fully specified

### DIFF
--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -117,6 +117,10 @@ func Invoke(
 			return consts.ErrWorkflowCompleted
 		}
 
+		// wfKey built from request may have blank RunID so assign a fully
+		// populated version
+		wfKey = ms.GetWorkflowKey()
+
 		if req.GetRequest().GetFirstExecutionRunId() != "" && ms.GetExecutionInfo().GetFirstExecutionRunId() != req.GetRequest().GetFirstExecutionRunId() {
 			return consts.ErrWorkflowExecutionNotFound
 		}


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
As commented, a WorkflowKey built from request input may have a blank RunID so we overwrite the one built from the request with the fully specified value pulled (by value) from MutableState.

<!-- Tell your future self why have you made these changes -->
**Why?**
Causes cache misses and rebuilds on the worker side

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Found via feature tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
low

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no