### PR TITLE
Fix: failWorkflowTask returns wrong nextEventBatchID when failing speculative workflow tasks

### DIFF
--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -89,18 +89,19 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		controller              *gomock.Controller
-		mockShard               *shard.ContextTest
-		mockTxProcessor         *queues.MockQueue
-		mockTimerProcessor      *queues.MockQueue
-		mockVisibilityProcessor *queues.MockQueue
-		mockArchivalProcessor   *queues.MockQueue
-		mockNamespaceCache      *namespace.MockRegistry
-		mockMatchingClient      *matchingservicemock.MockMatchingServiceClient
-		mockHistoryClient       *historyservicemock.MockHistoryServiceClient
-		mockClusterMetadata     *cluster.MockMetadata
-		mockEventsReapplier     *ndc.MockEventsReapplier
-		mockWorkflowResetter    *ndc.MockWorkflowResetter
+		controller               *gomock.Controller
+		mockShard                *shard.ContextTest
+		mockTxProcessor          *queues.MockQueue
+		mockTimerProcessor       *queues.MockQueue
+		mockVisibilityProcessor  *queues.MockQueue
+		mockArchivalProcessor    *queues.MockQueue
+		mockMemoryScheduledQueue *queues.MockQueue
+		mockNamespaceCache       *namespace.MockRegistry
+		mockMatchingClient       *matchingservicemock.MockMatchingServiceClient
+		mockHistoryClient        *historyservicemock.MockHistoryServiceClient
+		mockClusterMetadata      *cluster.MockMetadata
+		mockEventsReapplier      *ndc.MockEventsReapplier
+		mockWorkflowResetter     *ndc.MockWorkflowResetter
 
 		workflowCache     wcache.Cache
 		mockHistoryEngine *historyEngineImpl
@@ -134,14 +135,18 @@ func (s *engineSuite) SetupTest() {
 	s.mockTimerProcessor = queues.NewMockQueue(s.controller)
 	s.mockVisibilityProcessor = queues.NewMockQueue(s.controller)
 	s.mockArchivalProcessor = queues.NewMockQueue(s.controller)
+	s.mockMemoryScheduledQueue = queues.NewMockQueue(s.controller)
 	s.mockTxProcessor.EXPECT().Category().Return(tasks.CategoryTransfer).AnyTimes()
 	s.mockTimerProcessor.EXPECT().Category().Return(tasks.CategoryTimer).AnyTimes()
 	s.mockVisibilityProcessor.EXPECT().Category().Return(tasks.CategoryVisibility).AnyTimes()
 	s.mockArchivalProcessor.EXPECT().Category().Return(tasks.CategoryArchival).AnyTimes()
+	s.mockMemoryScheduledQueue.EXPECT().Category().Return(tasks.CategoryMemoryTimer).AnyTimes()
 	s.mockTxProcessor.EXPECT().NotifyNewTasks(gomock.Any()).AnyTimes()
 	s.mockTimerProcessor.EXPECT().NotifyNewTasks(gomock.Any()).AnyTimes()
 	s.mockVisibilityProcessor.EXPECT().NotifyNewTasks(gomock.Any()).AnyTimes()
 	s.mockArchivalProcessor.EXPECT().NotifyNewTasks(gomock.Any()).AnyTimes()
+	s.mockMemoryScheduledQueue.EXPECT().NotifyNewTasks(gomock.Any()).AnyTimes()
+
 	s.config = tests.NewDynamicConfig()
 	s.mockShard = shard.NewTestContext(
 		s.controller,
@@ -200,10 +205,11 @@ func (s *engineSuite) SetupTest() {
 		eventNotifier:      eventNotifier,
 		config:             s.config,
 		queueProcessors: map[tasks.Category]queues.Queue{
-			s.mockTxProcessor.Category():         s.mockTxProcessor,
-			s.mockTimerProcessor.Category():      s.mockTimerProcessor,
-			s.mockVisibilityProcessor.Category(): s.mockVisibilityProcessor,
-			s.mockArchivalProcessor.Category():   s.mockArchivalProcessor,
+			s.mockTxProcessor.Category():          s.mockTxProcessor,
+			s.mockTimerProcessor.Category():       s.mockTimerProcessor,
+			s.mockVisibilityProcessor.Category():  s.mockVisibilityProcessor,
+			s.mockArchivalProcessor.Category():    s.mockArchivalProcessor,
+			s.mockMemoryScheduledQueue.Category(): s.mockMemoryScheduledQueue,
 		},
 		eventsReapplier:            s.mockEventsReapplier,
 		workflowResetter:           s.mockWorkflowResetter,

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -977,7 +977,6 @@ func failWorkflowTask(
 	if err != nil {
 		return nil, common.EmptyEventID, err
 	}
-	nextEventBatchId := mutableState.GetNextEventID()
 	if _, err = mutableState.AddWorkflowTaskFailedEvent(
 		workflowTask,
 		wtFailedCause.failedCause,
@@ -987,9 +986,10 @@ func failWorkflowTask(
 		"",
 		"",
 		0); err != nil {
-		return nil, nextEventBatchId, err
+		return nil, common.EmptyEventID, err
 	}
 
+	nextEventBatchId := mutableState.GetNextEventID() - 1
 	// Return new mutable state back to the caller for further updates
 	return mutableState, nextEventBatchId, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix: `failWorkflowTask` returns wrong `nextEventBatchID` when failing speculative WT.

<!-- Tell your future self why have you made these changes -->
**Why?**
If current WT is speculative, fail will add 3 events, not 1. `nextEventBatchID` needs to be moved accordingly.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.