### PR TITLE
Don't return workflow task if it is speculative and doesn't have any messages (empty)

### DIFF
--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -860,6 +860,9 @@ func (handler *workflowTaskHandlerCallbacksImpl) createRecordWorkflowTaskStarted
 	if err != nil {
 		return nil, err
 	}
+	if workflowTask.Type == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE && len(response.GetMessages()) == 0 {
+		return nil, serviceerror.NewNotFound("No messages for speculative workflow task.")
+	}
 
 	return response, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Don't return workflow task from `RecordWorkflowTaskStarted` if it is speculative and doesn't have any messages (empty).

<!-- Tell your future self why have you made these changes -->
**Why?**
To save an RPC call to worker and back.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added new unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.