### PR TITLE
Redirect spooled tasks using versioning directive

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -26,6 +26,7 @@ package matching
 
 import (
 	"context"
+	"errors"
 	"math"
 	"sync"
 	"time"
@@ -67,6 +68,11 @@ type TaskMatcher struct {
 const (
 	defaultTaskDispatchRPS    = 100000.0
 	defaultTaskDispatchRPSTTL = time.Minute
+)
+
+var (
+	// Sentinel error to redirect while blocked in matcher.
+	errInterrupted = errors.New("interrupted offer")
 )
 
 // newTaskMatcher returns an task matcher instance. The returned instance can be
@@ -231,7 +237,7 @@ func (tm *TaskMatcher) OfferQuery(ctx context.Context, task *internalTask) (*mat
 // MustOffer blocks until a consumer is found to handle this task
 // Returns error only when context is canceled or the ratelimit is set to zero (allow nothing)
 // The passed in context MUST NOT have a deadline associated with it
-func (tm *TaskMatcher) MustOffer(ctx context.Context, task *internalTask) error {
+func (tm *TaskMatcher) MustOffer(ctx context.Context, task *internalTask, interruptCh chan struct{}) error {
 	if err := tm.rateLimiter.Wait(ctx); err != nil {
 		return err
 	}
@@ -269,6 +275,9 @@ forLoop:
 				case <-ctx.Done():
 					cancel()
 					return ctx.Err()
+				case <-interruptCh:
+					cancel()
+					return errInterrupted
 				}
 				cancel()
 				continue forLoop
@@ -281,6 +290,8 @@ forLoop:
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
+		case <-interruptCh:
+			return errInterrupted
 		}
 	}
 }

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -358,7 +358,7 @@ func (t *MatcherTestSuite) TestMustOfferLocalMatch() {
 	time.Sleep(10 * time.Millisecond)
 	task := newInternalTask(randomTaskInfo(), nil, enumsspb.TASK_SOURCE_HISTORY, "", false)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
-	err := t.matcher.MustOffer(ctx, task)
+	err := t.matcher.MustOffer(ctx, task, nil)
 	cancel()
 	t.NoError(err)
 }
@@ -420,7 +420,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 	// fail the test as the PollWorkflowTaskQueue and the 2nd AddWorkflowTask expectations would then never be met.
 	wg.Wait()
 
-	t.NoError(t.matcher.MustOffer(ctx, task))
+	t.NoError(t.matcher.MustOffer(ctx, task, nil))
 	cancel()
 
 	t.NotNil(req)

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -115,9 +115,9 @@ type (
 		// maxDispatchPerSecond is the max rate at which tasks are allowed to be dispatched
 		// from this task queue to pollers
 		GetTask(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error)
-		// DispatchTask dispatches a task to a poller. When there are no pollers to pick
+		// DispatchSpooledTask dispatches a task to a poller. When there are no pollers to pick
 		// up the task, this method will return error. Task will not be persisted to db
-		DispatchTask(ctx context.Context, task *internalTask) error
+		DispatchSpooledTask(ctx context.Context, task *internalTask, userDataChanged chan struct{}) error
 		// DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,
 		// if dispatched to local poller then nil and nil is returned.
 		DispatchQueryTask(ctx context.Context, taskID string, request *matchingservice.QueryWorkflowRequest) (*matchingservice.QueryWorkflowResponse, error)
@@ -446,14 +446,15 @@ func (c *taskQueueManagerImpl) GetTask(
 	return task, nil
 }
 
-// DispatchTask dispatches a task to a poller. When there are no pollers to pick
+// DispatchSpooledTask dispatches a task to a poller. When there are no pollers to pick
 // up the task or if rate limit is exceeded, this method will return error. Task
 // *will not* be persisted to db
-func (c *taskQueueManagerImpl) DispatchTask(
+func (c *taskQueueManagerImpl) DispatchSpooledTask(
 	ctx context.Context,
 	task *internalTask,
+	userDataChanged chan struct{},
 ) error {
-	return c.matcher.MustOffer(ctx, task)
+	return c.matcher.MustOffer(ctx, task, userDataChanged)
 }
 
 // DispatchQueryTask will dispatch query to local or remote poller. If forwarded then result or error is returned,

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -131,7 +131,7 @@ dispatchLoop:
 					// Don't try to set read level here because it may have been advanced already.
 					break
 				}
-				err := tr.tlMgr.DispatchTask(ctx, task)
+				err := tr.tlMgr.engine.DispatchSpooledTask(ctx, task, tr.tlMgr.taskQueueID)
 				if err == nil {
 					break
 				}


### PR DESCRIPTION
**What changed?**
When tasks come out of the db, pass them through versioning redirection again because versioning data may have changed (default may be different for first wft, or "active" set id may be different). Also, be able to interrupt the head blocking task and re-resolve if versioning data changes.

**Why?**
to make things work

**How did you test it?**
not yet
