### PR TITLE
Fail query fast if workflow task attempt greater or equals 3

### DIFF
--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -296,6 +296,7 @@ func (ti *TelemetryInterceptor) handleError(
 	// we emit service_error_with_type metrics, no need to emit specific metric for these known error types.
 	case *serviceerror.AlreadyExists,
 		*serviceerror.CancellationAlreadyRequested,
+		*serviceerror.FailedPrecondition,
 		*serviceerror.NamespaceInvalidState,
 		*serviceerror.NamespaceNotActive,
 		*serviceerror.NamespaceNotFound,

--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -32,6 +32,7 @@ import (
 	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/log/tag"
 
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
@@ -46,6 +47,9 @@ import (
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
 )
+
+// Fail query fast if workflow task keeps failing (attempt >= 3).
+const failQueryWorkflowTaskAttemptCount = 3
 
 func Invoke(
 	ctx context.Context,
@@ -116,9 +120,14 @@ func Invoke(
 		return nil, consts.ErrWorkflowTaskNotScheduled
 	}
 
-	if mutableState.IsTransientWorkflowTask() {
+	if mutableState.GetExecutionInfo().WorkflowTaskAttempt >= failQueryWorkflowTaskAttemptCount {
 		// while workflow task is failing, the query to that workflow will also fail. Failing fast here to prevent wasting
 		// resources to load history for a query that will fail.
+		shard.GetLogger().Info("Fail query fast due to WorkflowTask in failed state.",
+			tag.WorkflowNamespace(request.Request.Namespace),
+			tag.WorkflowNamespaceID(workflowKey.NamespaceID),
+			tag.WorkflowID(workflowKey.WorkflowID),
+			tag.WorkflowRunID(workflowKey.RunID))
 		return nil, serviceerror.NewFailedPrecondition("Cannot query workflow due to Workflow Task in failed state.")
 	}
 

--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -128,7 +128,7 @@ func Invoke(
 			tag.WorkflowNamespaceID(workflowKey.NamespaceID),
 			tag.WorkflowID(workflowKey.WorkflowID),
 			tag.WorkflowRunID(workflowKey.RunID))
-		return nil, serviceerror.NewFailedPrecondition("Cannot query workflow due to Workflow Task in failed state.")
+		return nil, serviceerror.NewWorkflowNotReady("Cannot query workflow due to Workflow Task in failed state.")
 	}
 
 	// There are two ways in which queries get dispatched to workflow worker. First, queries can be dispatched on workflow tasks.

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -296,6 +296,6 @@ func (s *clientIntegrationSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
 	time.Sleep(time.Second * 3) // 1st_attempt, 0_delay, 2nd_attempt, 1s_delay, 3rd_attempt
 	_, err = s.sdkClient.QueryWorkflow(ctx, id, "", "test")
 	s.Error(err)
-	s.IsType(&serviceerror.FailedPrecondition{}, err)
+	s.IsType(&serviceerror.WorkflowNotReady{}, err)
 
 }

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -294,7 +294,6 @@ func (s *clientIntegrationSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
 
 	// wait for workflow task to fail 3 times
 	time.Sleep(time.Second * 3) // 1st_attempt, 0_delay, 2nd_attempt, 1s_delay, 3rd_attempt
-	s.printWorkflowHistory(s.namespace, &commonpb.WorkflowExecution{WorkflowId: workflowRun.GetID()})
 	_, err = s.sdkClient.QueryWorkflow(ctx, id, "", "test")
 	s.Error(err)
 	s.IsType(&serviceerror.FailedPrecondition{}, err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fail query fast if workflow task attempt count >= 3.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is to avoid fail query on transient error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No