### PR TITLE
Avoid making a subscope in tallyMetricsHandler if possible

### DIFF
--- a/common/metrics/tally_metrics_handler.go
+++ b/common/metrics/tally_metrics_handler.go
@@ -78,28 +78,44 @@ func (tmp *tallyMetricsHandler) WithTags(tags ...Tag) Handler {
 // Counter obtains a counter for the given name and MetricOptions.
 func (tmp *tallyMetricsHandler) Counter(counter string) CounterIface {
 	return CounterFunc(func(i int64, t ...Tag) {
-		tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags)).Counter(counter).Inc(i)
+		scope := tmp.scope
+		if len(t) > 0 {
+			scope = tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags))
+		}
+		scope.Counter(counter).Inc(i)
 	})
 }
 
 // Gauge obtains a gauge for the given name and MetricOptions.
 func (tmp *tallyMetricsHandler) Gauge(gauge string) GaugeIface {
 	return GaugeFunc(func(f float64, t ...Tag) {
-		tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags)).Gauge(gauge).Update(f)
+		scope := tmp.scope
+		if len(t) > 0 {
+			scope = tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags))
+		}
+		scope.Gauge(gauge).Update(f)
 	})
 }
 
 // Timer obtains a timer for the given name and MetricOptions.
 func (tmp *tallyMetricsHandler) Timer(timer string) TimerIface {
-	return TimerFunc(func(d time.Duration, tag ...Tag) {
-		tmp.scope.Tagged(tagsToMap(tag, tmp.excludeTags)).Timer(timer).Record(d)
+	return TimerFunc(func(d time.Duration, t ...Tag) {
+		scope := tmp.scope
+		if len(t) > 0 {
+			scope = tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags))
+		}
+		scope.Timer(timer).Record(d)
 	})
 }
 
 // Histogram obtains a histogram for the given name and MetricOptions.
 func (tmp *tallyMetricsHandler) Histogram(histogram string, unit MetricUnit) HistogramIface {
 	return HistogramFunc(func(i int64, t ...Tag) {
-		tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags)).Histogram(histogram, tmp.perUnitBuckets[unit]).RecordValue(float64(i))
+		scope := tmp.scope
+		if len(t) > 0 {
+			scope = tmp.scope.Tagged(tagsToMap(t, tmp.excludeTags))
+		}
+		scope.Histogram(histogram, tmp.perUnitBuckets[unit]).RecordValue(float64(i))
 	})
 }
 


### PR DESCRIPTION
Creating a subscope, even if it is `tmp.Scope.Tagged(nil)`, takes extra time.

Used this script to [benchmark](https://gist.github.com/k24dizzle/f652990a342214c539d348c46e831f41).

Before:
```
go test -benchmem -run=^$ -bench . -benchtime=10s
goos: darwin
goarch: arm64
pkg: test/prom13
BenchmarkCounter-10     67209068               170.4 ns/op            48 B/op          2 allocs/op
PASS
ok      test/prom13     11.812s
```

After:
```
go test -benchmem -run=^$ -bench . -benchtime=10s
goos: darwin
goarch: arm64
pkg: test/prom13
BenchmarkCounter-10     84332931               138.2 ns/op            48 B/op          2 allocs/op
PASS
ok      test/prom13     12.028s
```