### PR TITLE
Bugfix: do not leak gRPC stream

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -238,7 +238,6 @@ type Config struct {
 	ReplicationEnableDLQMetrics                          dynamicconfig.BoolPropertyFn
 
 	ReplicationStreamSyncStatusDuration      dynamicconfig.DurationPropertyFn
-	ReplicationStreamMinReconnectDuration    dynamicconfig.DurationPropertyFn
 	ReplicationProcessorSchedulerQueueSize   dynamicconfig.IntPropertyFn
 	ReplicationProcessorSchedulerWorkerCount dynamicconfig.IntPropertyFn
 
@@ -417,7 +416,6 @@ func NewConfig(
 		ReplicationEnableDLQMetrics:                           dc.GetBoolProperty(dynamicconfig.ReplicationEnableDLQMetrics, true),
 
 		ReplicationStreamSyncStatusDuration:      dc.GetDurationProperty(dynamicconfig.ReplicationStreamSyncStatusDuration, 1*time.Second),
-		ReplicationStreamMinReconnectDuration:    dc.GetDurationProperty(dynamicconfig.ReplicationStreamMinReconnectDuration, 4*time.Second),
 		ReplicationProcessorSchedulerQueueSize:   dc.GetIntProperty(dynamicconfig.ReplicationProcessorSchedulerQueueSize, 128),
 		ReplicationProcessorSchedulerWorkerCount: dc.GetIntProperty(dynamicconfig.ReplicationProcessorSchedulerWorkerCount, 512),
 

--- a/service/history/replication/bi_direction_stream.go
+++ b/service/history/replication/bi_direction_stream.go
@@ -63,6 +63,7 @@ type (
 		Send(Req) error
 		Recv() (<-chan StreamResp[Resp], error)
 		Close()
+		IsValid() bool
 	}
 	StreamResp[Resp any] struct {
 		Resp Resp
@@ -133,6 +134,12 @@ func (s *BiDirectionStreamImpl[Req, Resp]) Close() {
 	defer s.Unlock()
 
 	s.closeLocked()
+}
+
+func (s *BiDirectionStreamImpl[Req, Resp]) IsValid() bool {
+	s.Lock()
+	defer s.Unlock()
+	return s.status != streamStatusClosed
 }
 
 func (s *BiDirectionStreamImpl[Req, Resp]) closeLocked() {

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -61,6 +61,7 @@ type (
 	mockStream struct {
 		requests []*adminservice.StreamWorkflowReplicationMessagesRequest
 		respChan chan StreamResp[*adminservice.StreamWorkflowReplicationMessagesResponse]
+		closed   bool
 	}
 	mockScheduler struct {
 		tasks []TrackableExecutableTask
@@ -212,7 +213,13 @@ func (s *mockStream) Recv() (<-chan StreamResp[*adminservice.StreamWorkflowRepli
 	return s.respChan, nil
 }
 
-func (s *mockStream) Close() {}
+func (s *mockStream) Close() {
+	s.closed = true
+}
+
+func (s *mockStream) IsValid() bool {
+	return !s.closed
+}
 
 func (s *mockScheduler) Submit(task TrackableExecutableTask) {
 	s.tasks = append(s.tasks, task)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Do not recreate gRPC stream if error occurs, instead, rely on periodical health check to re-create stream

<!-- Tell your future self why have you made these changes -->
**Why?**
Do not recreate gRPC stream since this will lead to resource leak

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A