### PR TITLE
fix: create btree_gin extension only if not exists

### DIFF
--- a/schema/postgresql/v12/visibility/schema.sql
+++ b/schema/postgresql/v12/visibility/schema.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION btree_gin;
+CREATE EXTENSION IF NOT EXISTS btree_gin;
 
 -- convert_ts converts a timestamp in RFC3339 to UTC timestamp without time zone.
 CREATE FUNCTION convert_ts(s VARCHAR) RETURNS TIMESTAMP AS $$

--- a/schema/postgresql/v12/visibility/versioned/v1.2/advanced_visibility.sql
+++ b/schema/postgresql/v12/visibility/versioned/v1.2/advanced_visibility.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION btree_gin;
+CREATE EXTENSION IF NOT EXISTS btree_gin;
 
 -- convert_ts converts a timestamp in RFC3339 to UTC timestamp without time zone.
 CREATE FUNCTION convert_ts(s VARCHAR) RETURNS TIMESTAMP AS $$


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Create btree_gin extension only if not exists

<!-- Tell your future self why have you made these changes -->
**Why?**
```go
ERROR   Unable to update SQL schema.    {"error": "error executing statement:pq: permission denied to create extension \"btree_gin\"", "logging-call-at": "handler.go:78"}
```
When using managed databases, it is not possible to create databases or extensions like that.
If the extension already exists, an error is thrown as well.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This change seems completely safe. Not a legal advice 😉

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This change seems completely safe. Not a legal advice 😉

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
