### PR TITLE
[UNTESTED] Fix handling of batch signal input payloads

### DIFF
--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -244,7 +244,16 @@ func startTaskProcessor(
 			case BatchTypeSignal:
 				err = processTask(ctx, limiter, task,
 					func(workflowID, runID string) error {
-						return sdkClient.SignalWorkflow(ctx, workflowID, runID, batchParams.SignalParams.SignalName, batchParams.SignalParams.Input)
+						_, err := frontendClient.SignalWorkflowExecution(ctx, &workflowservice.SignalWorkflowExecutionRequest{
+							Namespace: batchParams.Namespace,
+							WorkflowExecution: &commonpb.WorkflowExecution{
+								WorkflowId: workflowID,
+								RunId:      runID,
+							},
+							SignalName: batchParams.SignalParams.SignalName,
+							Input:      batchParams.SignalParams.Input,
+						})
+						return err
 					})
 			case BatchTypeDelete:
 				err = processTask(ctx, limiter, task,


### PR DESCRIPTION
### What changed?

In the Batch operation Workflow's activities, use the raw gRPC call `SignalWorkflowExecution` instead of the high level equivalent `SignalWorkflow`.

### Why?

The signal's input payloads are never decoded by the server (ie. they are still in protobuf `Payload` format). Passing these payloads to the high level client will cause them to be double-encoded, resulting in incorrect input being sent to the Workflow.

### Tests and more

- This has NOT been tested yet.
- This could be included in a patch release
- Fix #4373