### PR TITLE
Fail workflow execution update fast if workflow task constantly fails

### DIFF
--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -32,6 +32,7 @@ import (
 	querypb "go.temporal.io/api/query/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
+
 	"go.temporal.io/server/common/log/tag"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -129,7 +130,7 @@ func Invoke(
 			tag.WorkflowNamespaceID(workflowKey.NamespaceID),
 			tag.WorkflowID(workflowKey.WorkflowID),
 			tag.WorkflowRunID(workflowKey.RunID))
-		return nil, serviceerror.NewWorkflowNotReady("Cannot query workflow due to Workflow Task in failed state.")
+		return nil, serviceerror.NewWorkflowNotReady("Unable to query workflow due to Workflow Task in failed state.")
 	}
 
 	// There are two ways in which queries get dispatched to workflow worker. First, queries can be dispatched on workflow tasks.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fail workflow execution update fast if workflow task constantly fails.

<!-- Tell your future self why have you made these changes -->
**Why?**
If workflow task is constantly failing, the update to that workflow will also fail. Additionally, workflow update can't "fix" workflow state because updates (delivered with messages) are applied after events.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.