### PR TITLE
Bugfix: backfill replication queue state read ID calculation

### DIFF
--- a/common/cluster/metadata_test_config.go
+++ b/common/cluster/metadata_test_config.go
@@ -50,7 +50,7 @@ var (
 			Enabled:                true,
 			InitialFailoverVersion: TestCurrentClusterInitialFailoverVersion,
 			RPCAddress:             TestCurrentClusterFrontendAddress,
-			ShardCount:             4,
+			ShardCount:             8,
 		},
 		TestAlternativeClusterName: {
 			Enabled:                true,

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -176,7 +176,11 @@ func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Cleanup() {
 	s.mockShard.EXPECT().GetQueueState(tasks.CategoryReplication).Return(&persistencespb.QueueState{
 		ExclusiveReaderHighWatermark: nil,
 		ReaderStates: map[int64]*persistencespb.QueueReaderState{
-			shard.ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, s.shardID): {
+			shard.ReplicationReaderIDFromClusterShardID(cluster.TestAlternativeClusterInitialFailoverVersion, common.MapShardID(
+				cluster.TestAllClusterInfo[cluster.TestCurrentClusterName].ShardCount,
+				cluster.TestAllClusterInfo[cluster.TestAlternativeClusterName].ShardCount,
+				s.shardID,
+			)[0]): {
 				Scopes: []*persistencespb.QueueSliceScope{{
 					Range: &persistencespb.QueueSliceRange{
 						InclusiveMin: shard.ConvertToPersistenceTaskKey(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* When clusters have different shard count, logic should use mapping util for shard ID calculation e.g. local 8 shards, remote 4 shards; for local shard ID 5, corresponding remote shard ID is 1, not 5

<!-- Tell your future self why have you made these changes -->
**Why?**
Bugfix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
UT

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No, not released