### PR TITLE
Fix mutable state get event error handling

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -380,6 +380,12 @@ func IsInternalError(err error) bool {
 	return errors.As(err, &internalErr)
 }
 
+// IsNotFoundError checks if the error is a not found error.
+func IsNotFoundError(err error) bool {
+	var notFoundErr *serviceerror.NotFound
+	return errors.As(err, &notFoundErr)
+}
+
 // WorkflowIDToHistoryShard is used to map namespaceID-workflowID pair to a shardID.
 func WorkflowIDToHistoryShard(
 	namespaceID string,

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -785,10 +785,13 @@ func (ms *MutableStateImpl) GetActivityScheduledEvent(
 		currentBranchToken,
 	)
 	if err != nil {
-		// do not return the original error
-		// since original error can be of type entity not exists
-		// which can cause task processing side to fail silently
-		return nil, ErrMissingActivityScheduledEvent
+		if common.IsNotFoundError(err) {
+			// do not return the original error
+			// since original error of type NotFound
+			// can cause task processing side to fail silently
+			return nil, ErrMissingActivityScheduledEvent
+		}
+		return nil, err
 	}
 	return event, nil
 }
@@ -865,10 +868,13 @@ func (ms *MutableStateImpl) GetChildExecutionInitiatedEvent(
 		currentBranchToken,
 	)
 	if err != nil {
-		// do not return the original error
-		// since original error can be of type entity not exists
-		// which can cause task processing side to fail silently
-		return nil, ErrMissingChildWorkflowInitiatedEvent
+		if common.IsNotFoundError(err) {
+			// do not return the original error
+			// since original error of type NotFound
+			// can cause task processing side to fail silently
+			return nil, ErrMissingChildWorkflowInitiatedEvent
+		}
+		return nil, err
 	}
 	return event, nil
 }
@@ -908,10 +914,13 @@ func (ms *MutableStateImpl) GetRequesteCancelExternalInitiatedEvent(
 		currentBranchToken,
 	)
 	if err != nil {
-		// do not return the original error
-		// since original error can be of type entity not exists
-		// which can cause task processing side to fail silently
-		return nil, ErrMissingRequestCancelInfo
+		if common.IsNotFoundError(err) {
+			// do not return the original error
+			// since original error of type NotFound
+			// can cause task processing side to fail silently
+			return nil, ErrMissingRequestCancelInfo
+		}
+		return nil, err
 	}
 	return event, nil
 }
@@ -982,10 +991,13 @@ func (ms *MutableStateImpl) GetSignalExternalInitiatedEvent(
 		currentBranchToken,
 	)
 	if err != nil {
-		// do not return the original error
-		// since original error can be of type entity not exists
-		// which can cause task processing side to fail silently
-		return nil, ErrMissingSignalInitiatedEvent
+		if common.IsNotFoundError(err) {
+			// do not return the original error
+			// since original error of type NotFound
+			// can cause task processing side to fail silently
+			return nil, ErrMissingSignalInitiatedEvent
+		}
+		return nil, err
 	}
 	return event, nil
 }
@@ -1020,10 +1032,13 @@ func (ms *MutableStateImpl) GetCompletionEvent(
 		currentBranchToken,
 	)
 	if err != nil {
-		// do not return the original error
-		// since original error can be of type entity not exists
-		// which can cause task processing side to fail silently
-		return nil, ErrMissingWorkflowCompletionEvent
+		if common.IsNotFoundError(err) {
+			// do not return the original error
+			// since original error of type NotFound
+			// can cause task processing side to fail silently
+			return nil, ErrMissingWorkflowCompletionEvent
+		}
+		return nil, err
 	}
 	return event, nil
 }
@@ -1070,10 +1085,13 @@ func (ms *MutableStateImpl) GetStartEvent(
 		currentBranchToken,
 	)
 	if err != nil {
-		// do not return the original error
-		// since original error can be of type entity not exists
-		// which can cause task processing side to fail silently
-		return nil, ErrMissingWorkflowStartEvent
+		if common.IsNotFoundError(err) {
+			// do not return the original error
+			// since original error of type NotFound
+			// can cause task processing side to fail silently
+			return nil, ErrMissingWorkflowStartEvent
+		}
+		return nil, err
 	}
 	return event, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Only return ErrMissingXXX internal error when getEvent method failed with NotFound error to prevent task processing logic from silently drop the task/error. In all other cases, return the original error.

<!-- Tell your future self why have you made these changes -->
**Why?**
- If ErrMissingXXX is returned regardless of the actual error of getEvent, caller has no idea what's the actual issue. The error may due to resource exhausted, in which case caller should backoff more before retrying (for task processing a different error metric will be emitted). It can due to timeout, in which case the getEvent operation is retryable, but ErrMissingXXX is an internal error which means the operation is not retryable.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
