### PR TITLE
Update API and SDK to latest master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -44,8 +44,8 @@ require (
 	go.opentelemetry.io/otel/metric v0.36.0
 	go.opentelemetry.io/otel/sdk v1.13.0
 	go.opentelemetry.io/otel/sdk/metric v0.36.0
-	go.temporal.io/api v1.19.1-0.20230524162623-0e1dbb54f8e4
-	go.temporal.io/sdk v1.22.2-0.20230524182847-c4cf774f0cc9
+	go.temporal.io/api v1.19.1-0.20230525230013-9405e60150d6
+	go.temporal.io/sdk v1.22.3-0.20230525220126-76377c79cbf8
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.10.0
 	go.uber.org/automaxprocs v1.5.2
@@ -130,7 +130,7 @@ require (
 	golang.org/x/tools v0.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 // indirect
+	google.golang.org/genproto v0.0.0-20230525154841-bd750badd5c6 // indirect
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	lukechampine.com/uint128 v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1122,10 +1122,11 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.opentelemetry.io/proto/otlp v0.15.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
 go.opentelemetry.io/proto/otlp v0.19.0 h1:IVN6GR+mhC4s5yfcTbmzHYODqvWAp3ZedA2SJPI1Nnw=
 go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI405h3+duxN4U=
-go.temporal.io/api v1.19.1-0.20230524162623-0e1dbb54f8e4 h1:jPO/S2h2StE9OTvXVj7lKIQ5NA7KBHhoU+EOcMQZniE=
-go.temporal.io/api v1.19.1-0.20230524162623-0e1dbb54f8e4/go.mod h1:HHNMo8QTfbYTTAbJ758tBhUNY0Bm/Mxp1EQeEjZhrFQ=
-go.temporal.io/sdk v1.22.2-0.20230524182847-c4cf774f0cc9 h1:Dx6tdmzGvh+a08Y+I/HW4gu3Jjau+UGg/jf5ClCHhAk=
-go.temporal.io/sdk v1.22.2-0.20230524182847-c4cf774f0cc9/go.mod h1:mvVIfK8OIAd7uvpA++q87MVH6q8EQJpGhJqMQr/pWQw=
+go.temporal.io/api v1.19.1-0.20230525203837-c5e9155968d8/go.mod h1:xlsUEakkN2vU2/WV7e5NqMG4N93nfuNfvbXdaXUpU8w=
+go.temporal.io/api v1.19.1-0.20230525230013-9405e60150d6 h1:Le/iDq0TtQ/lD4QLig4vp0KCUrkyyE1vMScwN0V6Uh8=
+go.temporal.io/api v1.19.1-0.20230525230013-9405e60150d6/go.mod h1:xlsUEakkN2vU2/WV7e5NqMG4N93nfuNfvbXdaXUpU8w=
+go.temporal.io/sdk v1.22.3-0.20230525220126-76377c79cbf8 h1:SspH9panUyoNEulnN7pUf1hkoMUy50sDOjISHXjy5mc=
+go.temporal.io/sdk v1.22.3-0.20230525220126-76377c79cbf8/go.mod h1:817x1iY44Jdt3WrchR7FEsr/vlteIgEPxAL+V1IKj60=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=
 go.temporal.io/version v0.3.0/go.mod h1:UA9S8/1LaKYae6TyD9NaPMJTZb911JcbqghI2CBSP78=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
@@ -1734,8 +1735,8 @@ google.golang.org/genproto v0.0.0-20230320184635-7606e756e683/go.mod h1:NWraEVix
 google.golang.org/genproto v0.0.0-20230323212658-478b75c54725/go.mod h1:UUQDJDOlWu4KYeJZffbWgBkS1YFobzKbLVfK69pe0Ak=
 google.golang.org/genproto v0.0.0-20230330154414-c0448cd141ea/go.mod h1:UUQDJDOlWu4KYeJZffbWgBkS1YFobzKbLVfK69pe0Ak=
 google.golang.org/genproto v0.0.0-20230331144136-dcfb400f0633/go.mod h1:UUQDJDOlWu4KYeJZffbWgBkS1YFobzKbLVfK69pe0Ak=
-google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 h1:KpwkzHKEF7B9Zxg18WzOa7djJ+Ha5DzthMyZYQfEn2A=
-google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1/go.mod h1:nKE/iIaLqn2bQwXBg8f1g2Ylh6r5MN5CmZvuzZCgsCU=
+google.golang.org/genproto v0.0.0-20230525154841-bd750badd5c6 h1:62QuyPXKEkZpjZesyj5K5jABl6MnSnWl+vNuT5oz90E=
+google.golang.org/genproto v0.0.0-20230525154841-bd750badd5c6/go.mod h1:nKE/iIaLqn2bQwXBg8f1g2Ylh6r5MN5CmZvuzZCgsCU=
 google.golang.org/grpc v1.12.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -1981,12 +1981,12 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorke
 			workflow.GetSignalChannel(ctx, "continue").Receive(ctx, nil)
 
 			// Start compatible child
-			c1Ctx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{WorkflowID: childId1, TaskQueue: taskQueue, VersioningIntent: worker.CompatibleVersion})
+			c1Ctx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{WorkflowID: childId1, TaskQueue: taskQueue, VersioningIntent: temporal.VersioningIntentCompatible})
 			if err := workflow.ExecuteChildWorkflow(c1Ctx, "doesnt-exist").GetChildWorkflowExecution().Get(ctx, nil); err != nil {
 				return err
 			}
-			// Start latest child
-			c2Ctx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{WorkflowID: childId2, TaskQueue: taskQueue, VersioningIntent: worker.UseDefaultVersion})
+			// Start default child
+			c2Ctx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{WorkflowID: childId2, TaskQueue: taskQueue, VersioningIntent: temporal.VersioningIntentDefault})
 			if err := workflow.ExecuteChildWorkflow(c2Ctx, "doesnt-exist").GetChildWorkflowExecution().Get(ctx, nil); err != nil {
 				return err
 			}
@@ -1997,12 +1997,9 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorke
 			startedCh <- info.WorkflowExecution.RunID
 		}
 		workflow.GetSignalChannel(ctx, "continue").Receive(ctx, nil)
-		// TODO: shouldn't be WithChildOptions
-		useLatestCtx := workflow.WithChildOptions(ctx, workflow.ChildWorkflowOptions{
-			VersioningIntent: worker.UseDefaultVersion,
-		})
+		useDefault := workflow.WithWorkflowVersioningIntent(ctx, temporal.VersioningIntentDefault)
 		// Finally continue-as-new to latest
-		return workflow.NewContinueAsNewError(useLatestCtx, "doesnt-exist")
+		return workflow.NewContinueAsNewError(useDefault, "doesnt-exist")
 	}
 
 	// Declare v1


### PR DESCRIPTION
We'll need to upgrade once more after sdk-go is released.

Just want to upgrade the code to use the latest defintions.