### PR TITLE
Improve retry util

### DIFF
--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -113,62 +113,6 @@ func NewConcurrentRetrier(retryPolicy RetryPolicy) *ConcurrentRetrier {
 	return &ConcurrentRetrier{retrier: retrier}
 }
 
-// Retry function can be used to wrap any call with retry logic using the passed
-// in policy. A `nil` IsRetryable predicate will retry all errors. There is a
-// context-aware version of this function: RetryContext.
-// Deprecated: Use ThrottleRetry
-func Retry(operation Operation, policy RetryPolicy, isRetryable IsRetryable) error {
-	ctxOp := func(context.Context) error { return operation() }
-	return RetryContext(context.Background(), ctxOp, policy, isRetryable)
-}
-
-// RetryContext is a context-aware version of Retry. Context
-// timeout/cancellation errors are never retried, regardless of IsRetryable.
-// Deprecated: use ThrottleRetryContext,
-func RetryContext(
-	ctx context.Context,
-	operation OperationCtx,
-	policy RetryPolicy,
-	isRetryable IsRetryable,
-) error {
-	var err error
-	var next time.Duration
-
-	if isRetryable == nil {
-		isRetryable = func(error) bool { return true }
-	}
-
-	r := NewRetrier(policy, SystemClock)
-	for ctx.Err() == nil {
-		if err = operation(ctx); err == nil {
-			return nil
-		}
-
-		if next = r.NextBackOff(); next == done {
-			return err
-		}
-
-		// stop retrying if context has expired or the error
-		// is not retryable (err is known to be non-nil here)
-		if err == ctx.Err() || !isRetryable(err) {
-			return err
-		}
-
-		t := time.NewTimer(next)
-		select {
-		case <-t.C:
-		case <-ctx.Done():
-			t.Stop()
-		}
-	}
-	// always return the last error we got from operation, even if it is not useful
-	// this retry utility does not have enough information to do any filtering/mapping
-	if err != nil {
-		return err
-	}
-	return ctx.Err()
-}
-
 // ThrottleRetry is a resource aware version of Retry.
 // Resource exhausted error will be retried using a different throttle retry policy, instead of the specified one.
 func ThrottleRetry(operation Operation, policy RetryPolicy, isRetryable IsRetryable) error {
@@ -193,6 +137,8 @@ func ThrottleRetryContext(
 		isRetryable = func(error) bool { return true }
 	}
 
+	deadline, hasDeadline := ctx.Deadline()
+
 	r := NewRetrier(policy, SystemClock)
 	t := NewRetrier(throttleRetryPolicy, SystemClock)
 	for ctx.Err() == nil {
@@ -210,6 +156,10 @@ func ThrottleRetryContext(
 
 		if _, ok := err.(*serviceerror.ResourceExhausted); ok {
 			next = util.Max(next, t.NextBackOff())
+		}
+
+		if hasDeadline && SystemClock.Now().Add(next).After(deadline) {
+			break
 		}
 
 		timer := time.NewTimer(next)

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -68,7 +68,7 @@ func (s *RetrySuite) TestRetrySuccess() {
 		WithMaximumInterval(5 * time.Millisecond).
 		WithMaximumAttempts(10)
 
-	err := Retry(op, policy, nil)
+	err := ThrottleRetry(op, policy, nil)
 	s.NoError(err)
 	s.Equal(5, i)
 }
@@ -89,7 +89,7 @@ func (s *RetrySuite) TestRetryFailed() {
 		WithMaximumInterval(5 * time.Millisecond).
 		WithMaximumAttempts(5)
 
-	err := Retry(op, policy, nil)
+	err := ThrottleRetry(op, policy, nil)
 	s.Error(err)
 }
 
@@ -117,7 +117,7 @@ func (s *RetrySuite) TestIsRetryableSuccess() {
 		WithMaximumInterval(5 * time.Millisecond).
 		WithMaximumAttempts(10)
 
-	err := Retry(op, policy, isRetryable)
+	err := ThrottleRetry(op, policy, isRetryable)
 	s.NoError(err, "Retry count: %v", i)
 	s.Equal(5, i)
 }
@@ -139,7 +139,7 @@ func (s *RetrySuite) TestIsRetryableFailure() {
 		WithMaximumInterval(5 * time.Millisecond).
 		WithMaximumAttempts(10)
 
-	err := Retry(op, policy, IgnoreErrors([]error{&theErr}))
+	err := ThrottleRetry(op, policy, IgnoreErrors([]error{&theErr}))
 	s.Error(err)
 	s.Equal(1, i)
 }
@@ -192,7 +192,7 @@ func (s *RetrySuite) TestConcurrentRetrier() {
 func (s *RetrySuite) TestRetryContextCancel() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	err := RetryContext(ctx, func(ctx context.Context) error { return ctx.Err() },
+	err := ThrottleRetryContext(ctx, func(ctx context.Context) error { return ctx.Err() },
 		NewExponentialRetryPolicy(1*time.Millisecond), retryEverything)
 	s.ErrorIs(err, context.Canceled)
 }
@@ -202,12 +202,12 @@ func (s *RetrySuite) TestRetryContextTimeout() {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 	start := time.Now()
-	err := RetryContext(ctx, func(ctx context.Context) error { return &someError{} },
+	err := ThrottleRetryContext(ctx, func(ctx context.Context) error { return &someError{} },
 		NewExponentialRetryPolicy(1*time.Second), retryEverything)
 	elapsed := time.Since(start)
 	s.ErrorIs(err, &someError{})
-	s.GreaterOrEqual(elapsed, timeout,
-		"Call to retry should take at least as long as the context timeout")
+	s.Less(elapsed, timeout,
+		"Call to retry should return early if backoff exceeds context timeout")
 }
 
 func (s *RetrySuite) TestContextErrorFromSomeOtherContext() {
@@ -215,7 +215,7 @@ func (s *RetrySuite) TestContextErrorFromSomeOtherContext() {
 	// actually from the context.Context passed to RetryContext
 	script := []error{context.Canceled, context.DeadlineExceeded, nil}
 	invocation := -1
-	err := RetryContext(context.Background(),
+	err := ThrottleRetryContext(context.Background(),
 		func(ctx context.Context) error {
 			invocation++
 			return script[invocation]


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Return early if now + retry backoff period exceeds context deadline

<!-- Tell your future self why have you made these changes -->
**Why?**
- There's no reason to just wait until timeout happens
- Currently when timeout happens, caller (in other service/pod/host) with just get a context deadline exceeded error, instead it should get the error from last attempt.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
