### PR TITLE
Allow GetTaskQueueUserData and matching long polls to use a 5m timeout

### DIFF
--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -45,10 +45,10 @@ import (
 var _ matchingservice.MatchingServiceClient = (*clientImpl)(nil)
 
 const (
-	// DefaultTimeout is the default timeout used to make calls
+	// DefaultTimeout is the max timeout for regular calls
 	DefaultTimeout = time.Minute * debug.TimeoutMultiplier
-	// DefaultLongPollTimeout is the long poll default timeout used to make calls
-	DefaultLongPollTimeout = time.Minute * 2 * debug.TimeoutMultiplier
+	// DefaultLongPollTimeout is the max timeout for long poll calls
+	DefaultLongPollTimeout = time.Minute * 5 * debug.TimeoutMultiplier
 )
 
 type clientImpl struct {

--- a/client/matching/client_gen.go
+++ b/client/matching/client_gen.go
@@ -122,7 +122,7 @@ func (c *clientImpl) GetTaskQueueUserData(
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.createContext(ctx)
+	ctx, cancel := c.createLongPollContext(ctx)
 	defer cancel()
 	return client.GetTaskQueueUserData(ctx, request, opts...)
 }

--- a/cmd/tools/rpcwrappers/main.go
+++ b/cmd/tools/rpcwrappers/main.go
@@ -78,6 +78,7 @@ var (
 		"client.frontend.ListArchivedWorkflowExecutions": true,
 		"client.frontend.PollActivityTaskQueue":          true,
 		"client.frontend.PollWorkflowTaskQueue":          true,
+		"client.matching.GetTaskQueueUserData":           true,
 	}
 	largeTimeoutContext = map[string]bool{
 		"client.admin.GetReplicationMessages": true,
@@ -362,7 +363,7 @@ func (c *clientImpl) {{.Method}}(
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.createContext(ctx)
+	ctx, cancel := c.create{{or .LongPoll ""}}Context(ctx)
 	defer cancel()
 	return client.{{.Method}}(ctx, request, opts...)
 }


### PR DESCRIPTION
**What changed?**
Consider `GetTaskQueueUserData` a long poll for matching client timeout purposes, and raise the max long poll limit at the matching client level to 5m. (Task poll timeouts are still limited by the LongPollExpirationInterval dynamic config.)

**Why?**
Reduce the overhead of user data long polls.

**How did you test it?**
manually

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
