### PR TITLE
Remove speculative workflow task restoration code

### DIFF
--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -819,55 +819,7 @@ func (m *workflowTaskStateMachine) GetWorkflowTaskByID(scheduledEventID int64) *
 		return workflowTask
 	}
 
-	workflowTask = m.tryRestoreSpeculativeWorkflowTask(scheduledEventID)
-	if workflowTask != nil {
-		return workflowTask
-	}
-
 	return nil
-}
-
-func (m *workflowTaskStateMachine) tryRestoreSpeculativeWorkflowTask(
-	scheduledEventID int64,
-) *WorkflowTaskInfo {
-	// TODO (alex-update): Uncomment this code to support speculative workflow task restoration.
-	/*
-		// ScheduledEventID might be lost (cleared) for speculative workflow task due to shard reload or history service restart.
-		// It is still considered to be valid speculative workflow task if ScheduledEventID from token is equal to the next event ID.
-		if m.ms.executionInfo.WorkflowTaskScheduledEventId == common.EmptyEventID && m.ms.GetNextEventID() == scheduledEventID {
-			workflowTask := &WorkflowTaskInfo{
-				Version:          m.ms.GetCurrentVersion(), // For version check to pass, speculative workflow tasks are not replicated.
-				ScheduledEventID: scheduledEventID,
-				ScheduledTime:    timestamp.TimePtr(m.ms.timeSource.Now().UTC()),
-				Type:             enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE,
-
-				StartedEventID:        common.EmptyEventID,
-				RequestID:             emptyUUID,
-				WorkflowTaskTimeout:   timestamp.DurationFromSeconds(0),
-				StartedTime:           timestamp.UnixOrZeroTimePtr(0),
-				TaskQueue:             nil,
-				OriginalScheduledTime: timestamp.UnixOrZeroTimePtr(0),
-				Attempt:               1,
-			}
-			m.UpdateWorkflowTask(workflowTask)
-			return workflowTask
-		}
-	*/
-	return nil
-}
-
-func (m *workflowTaskStateMachine) setSpeculativeWorkflowTaskStartedEventID(
-	workflowTask *WorkflowTaskInfo,
-) {
-	// TODO (alex-update): Uncomment this code to support speculative workflow task restoration.
-
-	/*
-		// StartedEventID might be lost (cleared) for speculative workflow task due to shard reload or history service restart.
-		if workflowTask != nil && workflowTask.Type == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE && workflowTask.StartedEventID == common.EmptyEventID {
-			workflowTask.StartedEventID = workflowTask.ScheduledEventID + 1
-			m.UpdateWorkflowTask(workflowTask)
-		}
-	*/
 }
 
 func (m *workflowTaskStateMachine) GetTransientWorkflowTaskInfo(

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -321,7 +321,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskFailed(
 
 			scheduledEventID := token.GetScheduledEventId()
 			workflowTask := mutableState.GetWorkflowTaskByID(scheduledEventID)
-			// TODO (alex-update): call mutableState.SetSpeculativeWorkflowTaskStartedEventID(mutableState) here to set StartEventID.
 
 			if workflowTask == nil || workflowTask.Attempt != token.Attempt || workflowTask.StartedEventID == common.EmptyEventID {
 				return nil, serviceerror.NewNotFound("Workflow task not found.")
@@ -411,7 +410,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	ms := workflowContext.GetMutableState()
 
 	currentWorkflowTask := ms.GetWorkflowTaskByID(token.GetScheduledEventId())
-	// TODO (alex-update): call mutableState.SetSpeculativeWorkflowTaskStartedEventID(mutableState) here to set StartEventID.
 	if !ms.IsWorkflowExecutionRunning() || currentWorkflowTask == nil || currentWorkflowTask.Attempt != token.Attempt ||
 		currentWorkflowTask.StartedEventID == common.EmptyEventID {
 		return nil, serviceerror.NewNotFound("Workflow task not found.")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove speculative workflow task restoration code.

<!-- Tell your future self why have you made these changes -->
**Why?**
Code was commented out but final design blocks WT restoration because validation logic depends on the registry which is also lost when shard moves.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.