### PR TITLE
Add test for heartbeat from speculative workflow task

### DIFF
--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -500,7 +500,17 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskStartedEvent(
 	return startedEvent, workflowTask, err
 }
 func (m *workflowTaskStateMachine) skipWorkflowTaskCompletedEvent(workflowTaskType enumsspb.WorkflowTaskType, request *workflowservice.RespondWorkflowTaskCompletedRequest) bool {
-	if workflowTaskType != enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE || len(request.GetCommands()) != 0 {
+	if workflowTaskType != enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE {
+		// Only Speculative WT can skip WorkflowTaskCompletedEvent.
+		return false
+	}
+	if len(request.GetCommands()) != 0 {
+		// If worker returned commands, they will be converted to events, which must follow by WorkflowTaskCompletedEvent.
+		return false
+	}
+	if len(request.GetMessages()) == 0 {
+		// If both commands & messages are empty, then this is heartbeat response.
+		// New WT will be created as Normal and WorkflowTaskCompletedEvent for this WT is also must be written.
 		return false
 	}
 

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -511,6 +511,8 @@ func (m *workflowTaskStateMachine) skipWorkflowTaskCompletedEvent(workflowTaskTy
 	if len(request.GetMessages()) == 0 {
 		// If both commands & messages are empty, then this is heartbeat response.
 		// New WT will be created as Normal and WorkflowTaskCompletedEvent for this WT is also must be written.
+		// In the future, if we decide not to write heartbeat WT to the history, this check should be removed,
+		// and extra logic should be added to create next WT as Speculative. Currently, new heartbeat WT is always created as Normal.
 		return false
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add test for heartbeat from speculative workflow task.

<!-- Tell your future self why have you made these changes -->
**Why?**
When worker sends heartbeat response for speculative WT, it gets converted to normal, all 3 WT events get written into the history and new normal WT is created. This should never happened though because update validation/processor handers shouldn't take more than WT `StartToClose` timeout.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This PR.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.