### PR TITLE
Remove unneeded FlushAndCreateNewBatch call from AddWorkflowTaskScheduleToStartTimeoutEvent

### DIFF
--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -256,7 +256,6 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskScheduleToStartTimeoutEvent(
 			timestamp.TimeValue(workflowTask.ScheduledTime).UTC(),
 		)
 		workflowTask.ScheduledEventID = scheduledEvent.GetEventId()
-		m.ms.hBuilder.FlushAndCreateNewBatch()
 	}
 
 	event := m.ms.hBuilder.AddWorkflowTaskTimedOutEvent(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove unneeded `FlushAndCreateNewBatch` call from `AddWorkflowTaskScheduleToStartTimeoutEvent`.

<!-- Tell your future self why have you made these changes -->
**Why?**
`AddWorkflowTaskScheduleToStartTimeoutEvent` is called `executeWorkflowTaskTimeoutTask` where it follows by `updateWorkflowExecution` which always will create a new batch.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.