### PR TITLE
Take acceptedEventID write out of commit callback

### DIFF
--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -575,7 +575,8 @@ func TestAcceptEventIDInCompletedEvent(t *testing.T) {
 	t.Parallel()
 	var (
 		ctx      = context.Background()
-		store    = mockEventStore{Controller: effect.Immediate(ctx)}
+		effects  = effect.Buffer{}
+		store    = mockEventStore{Controller: &effects}
 		updateID = t.Name() + "-update-id"
 		upd      = update.New(updateID)
 		req      = updatepb.Request{
@@ -611,7 +612,9 @@ func TestAcceptEventIDInCompletedEvent(t *testing.T) {
 	}
 
 	require.NoError(t, upd.OnMessage(ctx, &req, store))
+	effects.Apply(ctx)
 	require.NoError(t, upd.OnMessage(ctx, &acpt, store))
 	require.NoError(t, upd.OnMessage(ctx, &resp, store))
+	effects.Apply(ctx)
 	require.Equal(t, wantAcceptedEventID, gotAcceptedEventID)
 }


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**
Take acceptedEventID write out of commit callback

<!-- Tell your future self why have you made these changes -->
**Why?**
This value needs to be visible to the update completion message handler even in the case when the acceptance and completion come in the same message batch (i.e. workflow task).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test changed to create the scenario in question

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Low

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No