### PR TITLE
Use task queue base name for dynamic config

### DIFF
--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -166,7 +166,7 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 }
 
 func newTaskQueueConfig(id *taskQueueID, config *Config, namespace namespace.Name) *taskQueueConfig {
-	taskQueueName := id.FullName()
+	taskQueueName := id.BaseNameString()
 	taskType := id.taskType
 
 	return &taskQueueConfig{


### PR DESCRIPTION
**What changed?**
Looking up task-queue-specific dynamic config should use the base name

**Why?**
Fix bug

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
