### PR TITLE
More functional tests for worker versioning

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -877,7 +877,7 @@ func (wh *WorkflowHandler) PollWorkflowTaskQueue(ctx context.Context, request *w
 			return &workflowservice.PollWorkflowTaskQueueResponse{}, nil
 		}
 
-		// For newer build error, return silently.
+		// These errors are expected based on certain client behavior. We should not log them, it'd be too noisy.
 		var newerBuild *serviceerror.NewerBuildExists
 		if errors.As(err, &newerBuild) {
 			return nil, err
@@ -1113,7 +1113,7 @@ func (wh *WorkflowHandler) PollActivityTaskQueue(ctx context.Context, request *w
 			return &workflowservice.PollActivityTaskQueueResponse{}, nil
 		}
 
-		// For newer build error, return silently.
+		// These errors are expected based on certain client behavior. We should not log them, it'd be too noisy.
 		var newerBuild *serviceerror.NewerBuildExists
 		if errors.As(err, &newerBuild) {
 			return nil, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Add more tests and followups from #4375:
- Rename `isVersioned` to `managesSpecificVersionSet`
- Test wtih `UseBuildIDForVersioning: false`
- Test dispatch with activities that fail or timeout (to test retry)
- Test activity with compatible version
- Test child workflow with compatible version
- Test query dispatch

**Why?**
More tests

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
More tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
