### PR TITLE
Remove unused MetricType concept

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -30,14 +30,10 @@ type (
 	// MetricName is the name of the metric
 	MetricName string
 
-	// MetricType is the type of the metric
-	MetricType int
-
 	MetricUnit string
 
 	// metricDefinition contains the definition for a metric
 	metricDefinition struct {
-		metricType MetricType // metric type
 		metricName MetricName // metric name
 		unit       MetricUnit
 	}
@@ -54,14 +50,6 @@ const (
 	Bytes         = "By"
 )
 
-// MetricTypes which are supported
-const (
-	Counter MetricType = iota
-	Timer
-	Gauge
-	Histogram
-)
-
 // Empty returns true if the metricName is an empty string
 func (mn MetricName) Empty() bool {
 	return mn == ""
@@ -70,10 +58,6 @@ func (mn MetricName) Empty() bool {
 // String returns string representation of this metric name
 func (mn MetricName) String() string {
 	return string(mn)
-}
-
-func (md metricDefinition) GetMetricType() MetricType {
-	return md.metricType
 }
 
 func (md metricDefinition) GetMetricName() string {
@@ -85,21 +69,21 @@ func (md metricDefinition) GetMetricUnit() MetricUnit {
 }
 
 func NewTimerDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Timer, unit: Milliseconds}
+	return metricDefinition{metricName: MetricName(name), unit: Milliseconds}
 }
 
 func NewBytesHistogramDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Bytes}
+	return metricDefinition{metricName: MetricName(name), unit: Bytes}
 }
 
 func NewDimensionlessHistogramDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Histogram, unit: Dimensionless}
+	return metricDefinition{metricName: MetricName(name), unit: Dimensionless}
 }
 
 func NewCounterDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Counter}
+	return metricDefinition{metricName: MetricName(name)}
 }
 
 func NewGaugeDef(name string) metricDefinition {
-	return metricDefinition{metricName: MetricName(name), metricType: Gauge}
+	return metricDefinition{metricName: MetricName(name)}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The `MetricsType` isn't actually used anywhere other than `GetMetricType` which isn't called anywhere.

<!-- Tell your future self why have you made these changes -->
**Why?**
It's confusing that this exists when it doesn't do anything. It's already clear what the type of the metric is when this value is written, and no one is reading it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Looking for references to it and using the CI. I also verified that this doesn't change the help text in the /metrics page, which still contains the metric type:

```
# HELP workflow_context_cleared workflow_context_cleared counter
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
