### PR TITLE
Disable revive.unexported-return linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,13 +59,15 @@ linters-settings:
         disabled: true
       - name: unexported-naming
         disabled: true
+      - name: unexported-return
+        disabled: true
+      - name: unused-parameter
+        disabled: true
       - name: unused-receiver
         disabled: true
       - name: use-any
         disabled: true
       - name: var-naming
-        disabled: true
-      - name: unused-parameter
         disabled: true
 
       # Rule tuning

--- a/service/history/workflow/update/export_test.go
+++ b/service/history/workflow/update/export_test.go
@@ -34,8 +34,6 @@ var (
 )
 
 // ObserveCompletion exporses withOnComplete to unit tests
-//
-//revive:disable-next-line:unexported-return for testing
 func ObserveCompletion(b *bool) updateOpt {
 	return withCompletionCallback(func() { *b = true })
 }

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -92,8 +92,6 @@ type (
 	regOpt func(*RegistryImpl)
 )
 
-//revive:disable:unexported-return I *want* it to be unexported
-
 // WithInFlightLimit provides an optional limit to the number of incomplete
 // updates that a Registry instance will allow.
 func WithInFlightLimit(f func() int) regOpt {
@@ -132,8 +130,6 @@ func WithTracerProvider(t trace.TracerProvider) regOpt {
 		r.instrumentation.tracer = t.Tracer(libraryName)
 	}
 }
-
-//revive:enable:unexported-return
 
 var _ Registry = (*RegistryImpl)(nil)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
^

<!-- Tell your future self why have you made these changes -->
**Why?**
Returning an unexported type from an exported method allows clients to use the object's exported methods without the need for authors to introduce another interface. It also allows users to use exported fields of the object, too, which isn't possible with interfaces. It also lets you use the opaque interface pattern for free.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added a test violation and ran the linter with/without this change.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
