### PR TITLE
Functional tests: Set ReturnNewWorkflowTask for task poller always to true

### DIFF
--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -303,7 +303,7 @@ Loop:
 				Identity:                   p.Identity,
 				Commands:                   commands,
 				Messages:                   workerToServerMessages,
-				ReturnNewWorkflowTask:      forceCreateNewWorkflowTask,
+				ReturnNewWorkflowTask:      true,
 				ForceCreateNewWorkflowTask: forceCreateNewWorkflowTask,
 				QueryResults:               getQueryResults(response.GetQueries(), queryResult),
 			})
@@ -321,7 +321,7 @@ Loop:
 					WorkerTaskQueue:        p.StickyTaskQueue,
 					ScheduleToStartTimeout: &p.StickyScheduleToStartTimeout,
 				},
-				ReturnNewWorkflowTask:      forceCreateNewWorkflowTask,
+				ReturnNewWorkflowTask:      true,
 				ForceCreateNewWorkflowTask: forceCreateNewWorkflowTask,
 				QueryResults:               getQueryResults(response.GetQueries(), queryResult),
 			},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Functional tests: Set `ReturnNewWorkflowTask` for task poller always to `true`.

<!-- Tell your future self why have you made these changes -->
**Why?**
All exeisting SDKs have this flag set to true and it's gonna be deprecated in future.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.