### PR TITLE
Refactor task queue user data loading

### DIFF
--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -755,6 +755,10 @@ func (c *taskQueueManagerImpl) fetchUserData(ctx context.Context) error {
 		// root workflow partition "owns" user data, read it from db
 		err := c.db.loadUserData(ctx)
 		c.userDataInitialFetch.Set(struct{}{}, err)
+		if err != nil {
+			// We can't recover from here without starting over, so unload the whole task queue
+			c.unloadFromEngine()
+		}
 		return err
 	}
 

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -309,7 +309,7 @@ func (c *taskQueueManagerImpl) Start() {
 	c.liveness.Start()
 	c.taskWriter.Start()
 	c.taskReader.Start()
-	c.goroGroup.Go(c.fetchUserDataLoop)
+	c.goroGroup.Go(c.fetchUserData)
 	c.logger.Info("", tag.LifeCycleStarted)
 	c.taggedMetricsHandler.Counter(metrics.TaskQueueStartedCounter.GetMetricName()).Record(1)
 }
@@ -738,7 +738,7 @@ func (c *taskQueueManagerImpl) userDataFetchSource() (string, error) {
 	return parent.FullName(), nil
 }
 
-func (c *taskQueueManagerImpl) fetchUserDataLoop(ctx context.Context) error {
+func (c *taskQueueManagerImpl) fetchUserData(ctx context.Context) error {
 	ctx = c.callerInfoContext(ctx)
 
 	if !c.config.LoadUserData() {

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -1623,9 +1623,11 @@ func (s *versioningIntegSuite) TestDescribeWorkflowExecution() {
 	s.waitForChan(ctx, started1)
 
 	// describe and check build id
-	resp, err := s.sdkClient.DescribeWorkflowExecution(ctx, run.GetID(), "")
-	s.NoError(err)
-	s.Equal(v1, resp.WorkflowExecutionInfo.MostRecentWorkerVersionStamp.BuildId)
+	s.Eventually(func() bool {
+		resp, err := s.sdkClient.DescribeWorkflowExecution(ctx, run.GetID(), "")
+		s.NoError(err)
+		return v1 == resp.GetWorkflowExecutionInfo().GetMostRecentWorkerVersionStamp().GetBuildId()
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// now register v11 as newer compatible with v1
 	s.addCompatibleBuildId(ctx, tq, v11, v1, false)
@@ -1649,9 +1651,11 @@ func (s *versioningIntegSuite) TestDescribeWorkflowExecution() {
 	s.NoError(s.sdkClient.SignalWorkflow(ctx, run.GetID(), "", "wait", nil))
 	s.waitForChan(ctx, started11)
 
-	resp, err = s.sdkClient.DescribeWorkflowExecution(ctx, run.GetID(), "")
-	s.NoError(err)
-	s.Equal(v11, resp.WorkflowExecutionInfo.MostRecentWorkerVersionStamp.BuildId)
+	s.Eventually(func() bool {
+		resp, err := s.sdkClient.DescribeWorkflowExecution(ctx, run.GetID(), "")
+		s.NoError(err)
+		return v11 == resp.GetWorkflowExecutionInfo().GetMostRecentWorkerVersionStamp().GetBuildId()
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// unblock. it should complete
 	s.NoError(s.sdkClient.SignalWorkflow(ctx, run.GetID(), "", "wait", nil))


### PR DESCRIPTION
**What changed?**
- Load user data from db only once on init
- Consolidate setting user data future in one function

**Why?**
- Root partition with no user data should only read it once
- Simplify code

**How did you test it?**
Manually + new unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
