### PR TITLE
Schedule a new workflow task after force flush buffer events

### DIFF
--- a/service/history/ndc/branch_manager.go
+++ b/service/history/ndc/branch_manager.go
@@ -190,6 +190,7 @@ func (r *BranchMgrImpl) flushBufferedEvents(
 	if err := targetWorkflow.FlushBufferedEvents(); err != nil {
 		return nil, 0, err
 	}
+
 	// the workflow must be updated as active, to send out replication tasks
 	if err := targetWorkflow.context.UpdateWorkflowExecutionAsActive(
 		ctx,

--- a/service/history/ndc/branch_manager_test.go
+++ b/service/history/ndc/branch_manager_test.go
@@ -35,6 +35,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 
+	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
@@ -254,6 +255,10 @@ func (s *branchMgrSuite) TestFlushBufferedEvents() {
 		"",
 		int64(0),
 	).Return(&historypb.HistoryEvent{}, nil)
+	s.mockMutableState.EXPECT().AddWorkflowTaskScheduledEvent(
+		false,
+		enumsspb.WORKFLOW_TASK_TYPE_NORMAL,
+	).Return(&workflow.WorkflowTaskInfo{}, nil)
 	s.mockMutableState.EXPECT().FlushBufferedEvents()
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, lastWriteVersion).Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()

--- a/service/history/ndc/workflow.go
+++ b/service/history/ndc/workflow.go
@@ -222,6 +222,12 @@ func (r *WorkflowImpl) FlushBufferedEvents() error {
 	}
 
 	_, err = r.failWorkflowTask(lastWriteVersion)
+	if _, err := r.mutableState.AddWorkflowTaskScheduledEvent(
+		false,
+		enumsspb.WORKFLOW_TASK_TYPE_NORMAL,
+	); err != nil {
+		return err
+	}
 	return err
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Schedule a new workflow task after force flush buffer events

<!-- Tell your future self why have you made these changes -->
**Why?**
[#cadence/5006](https://github.com/uber/cadence/issues/5006)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A