### PR TITLE
Unload task queue manager on user data update failure

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -1129,6 +1129,12 @@ func (e *matchingEngineImpl) UpdateTaskQueueUserData(ctx context.Context, reques
 		BuildIdsAdded:   request.BuildIdsAdded,
 		BuildIdsRemoved: request.BuildIdsRemoved,
 	})
+
+	var conditionFailedError *persistence.ConditionFailedError
+	if errors.As(err, &conditionFailedError) {
+		err = serviceerror.NewFailedPrecondition(conditionFailedError.Msg)
+	}
+
 	return &matchingservice.UpdateTaskQueueUserDataResponse{}, err
 }
 

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -488,10 +488,10 @@ func (c *taskQueueManagerImpl) UpdateUserData(ctx context.Context, options UserD
 		return serviceerror.NewFailedPrecondition("Task queue user data operations are disabled")
 	}
 	newData, shouldReplicate, err := c.db.UpdateUserData(ctx, updateFn, options.KnownVersion, options.TaskQueueLimitPerBuildId)
+	c.signalIfFatal(err)
 	if err != nil {
 		return err
 	}
-	c.signalIfFatal(err)
 	if !shouldReplicate {
 		return nil
 	}
@@ -802,7 +802,7 @@ func (c *taskQueueManagerImpl) fetchUserData(ctx context.Context) error {
 			c.db.setUserDataForNonOwningPartition(res.GetUserData())
 		}
 		if firstCall {
-			c.userDataInitialFetch.Set(struct{}{}, err)
+			c.userDataInitialFetch.Set(struct{}{}, nil)
 			firstCall = false
 		}
 		return nil


### PR DESCRIPTION
Fixes an issue where failing to update task queue user data due to a failed persistence condition (concurrent update) did not cause task queue manager to unload.

Needed to convert the error over gRPC since the update is routed to the matching node that owns all namespace updates.

Also explicitly set `nil` in the user data update routine to express that we do not resolve futures with an error.