### PR TITLE
Refactor matching operations when user data disabled

### DIFF
--- a/common/dynamicconfig/static_properties.go
+++ b/common/dynamicconfig/static_properties.go
@@ -62,6 +62,11 @@ func GetBoolPropertyFnFilteredByNamespace(value bool) func(namespace string) boo
 	return func(namespace string) bool { return value }
 }
 
+// GetBoolPropertyFnFilteredByTaskQueueInfo returns value as BoolPropertyFnWithTaskQueueInfoFilters
+func GetBoolPropertyFnFilteredByTaskQueueInfo(value bool) func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) bool {
+	return func(namespace string, taskQueue string, taskType enumspb.TaskQueueType) bool { return value }
+}
+
 // GetDurationPropertyFnFilteredByNamespace returns value as DurationPropertyFnFilteredByNamespace
 func GetDurationPropertyFnFilteredByNamespace(value time.Duration) func(namespace string) time.Duration {
 	return func(namespace string) time.Duration { return value }

--- a/common/util.go
+++ b/common/util.go
@@ -174,6 +174,14 @@ func AwaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
 	}
 }
 
+// InterruptibleSleep is like time.Sleep but can be interrupted by a context.
+func InterruptibleSleep(ctx context.Context, timeout time.Duration) {
+	select {
+	case <-time.After(timeout):
+	case <-ctx.Done():
+	}
+}
+
 // CreatePersistenceClientRetryPolicy creates a retry policy for calls to persistence
 func CreatePersistenceClientRetryPolicy() backoff.RetryPolicy {
 	return backoff.NewExponentialRetryPolicy(persistenceClientRetryInitialInterval).

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -74,6 +74,8 @@ var (
 	// This is an internal error when requesting user data on a TQM created for a specific
 	// version set. This indicates a bug in the server since nothing should be using this data.
 	errNoUserDataOnVersionedTQM = serviceerror.NewInternal("should not get user data on versioned tqm")
+
+	errUserDataDisabled = serviceerror.NewFailedPrecondition("Task queue user data operations are disabled")
 )
 
 // newTaskQueueDB returns an instance of an object that represents

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -320,18 +320,16 @@ func (e *matchingEngineImpl) AddWorkflowTask(
 		return false, err
 	}
 
-	shouldDrop, err := e.shouldDropTask(origTaskQueue, addRequest.VersionDirective)
-	if err != nil {
-		return false, err
-	} else if shouldDrop {
-		return true, nil
-	}
-
 	// We don't need the userDataChanged channel here because:
 	// - if we sync match or sticky worker unavailable, we're done
 	// - if we spool to db, we'll re-resolve when it comes out of the db
 	taskQueue, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, addRequest.VersionDirective, stickyInfo)
 	if err != nil {
+		if err == errUserDataDisabled {
+			// When user data loading is disabled, we intentionally drop tasks for versioned workflows
+			// to avoid breaking versioning semantics and dispatching tasks to the wrong workers.
+			err = nil
+		}
 		return false, err
 	}
 
@@ -387,18 +385,16 @@ func (e *matchingEngineImpl) AddActivityTask(
 		return false, err
 	}
 
-	shouldDrop, err := e.shouldDropTask(origTaskQueue, addRequest.VersionDirective)
-	if err != nil {
-		return false, err
-	} else if shouldDrop {
-		return true, nil
-	}
-
 	// We don't need the userDataChanged channel here because:
 	// - if we sync match, we're done
 	// - if we spool to db, we'll re-resolve when it comes out of the db
 	taskQueue, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, addRequest.VersionDirective, stickyInfo)
 	if err != nil {
+		if err == errUserDataDisabled {
+			// When user data loading is disabled, we intentionally drop tasks for versioned workflows
+			// to avoid breaking versioning semantics and dispatching tasks to the wrong workers.
+			err = nil
+		}
 		return false, err
 	}
 
@@ -448,12 +444,6 @@ func (e *matchingEngineImpl) DispatchSpooledTask(
 	unversionedOrigTaskQueue := newTaskQueueIDWithVersionSet(origTaskQueue, "")
 	// Redirect and re-resolve if we're blocked in matcher and user data changes.
 	for {
-		shouldDrop, err := e.shouldDropTask(unversionedOrigTaskQueue, directive)
-		if err != nil {
-			return err
-		} else if shouldDrop {
-			return nil
-		}
 		taskQueue, userDataChanged, err := e.redirectToVersionedQueueForAdd(
 			ctx, unversionedOrigTaskQueue, directive, stickyInfo)
 		if err != nil {
@@ -689,16 +679,14 @@ func (e *matchingEngineImpl) QueryWorkflow(
 		return nil, err
 	}
 
-	shouldDrop, err := e.shouldDropTask(origTaskQueue, queryRequest.VersionDirective)
-	if err != nil {
-		return nil, err
-	} else if shouldDrop {
-		return nil, serviceerror.NewFailedPrecondition("Operations on versioned workflows are disabled")
-	}
 	// We don't need the userDataChanged channel here because we either do this sync (local or remote)
 	// or fail with a relatively short timeout.
 	taskQueue, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, queryRequest.VersionDirective, stickyInfo)
 	if err != nil {
+		if err == errUserDataDisabled {
+			// Rewrite to nicer error message
+			err = serviceerror.NewFailedPrecondition("Operations on versioned workflows are disabled")
+		}
 		return nil, err
 	}
 
@@ -1216,6 +1204,10 @@ func (e *matchingEngineImpl) getTask(
 		stickyInfo,
 	)
 	if err != nil {
+		if err == errUserDataDisabled {
+			// Rewrite to nicer error message
+			err = serviceerror.NewFailedPrecondition("Operations on versioned workflows are disabled")
+		}
 		return nil, err
 	}
 	tqm, err := e.getTaskQueueManager(ctx, taskQueue, stickyInfo, true)
@@ -1465,26 +1457,6 @@ func (e *matchingEngineImpl) redirectToVersionedQueueForPoll(
 		return nil, err
 	}
 	return newTaskQueueIDWithVersionSet(taskQueue, versionSet), nil
-}
-
-// When user data loading is disabled, we intentionally drop tasks for versioned workflows to avoid breaking versioning
-// semantics and dispatching tasks to the wrong workers.
-func (e *matchingEngineImpl) shouldDropTask(taskQueue *taskQueueID, directive *taskqueuespb.TaskVersionDirective) (bool, error) {
-	isVersioned := false
-	switch directive.GetValue().(type) {
-	case *taskqueuespb.TaskVersionDirective_UseDefault,
-		*taskqueuespb.TaskVersionDirective_BuildId:
-		isVersioned = true
-	}
-	if !isVersioned {
-		return false, nil
-	}
-	namespaceEntry, err := e.namespaceRegistry.GetNamespaceByID(taskQueue.namespaceID)
-	if err != nil {
-		return false, err
-	}
-	shouldDrop := !e.config.LoadUserData(namespaceEntry.Name().String(), taskQueue.BaseNameString(), taskQueue.taskType)
-	return shouldDrop, nil
 }
 
 func (e *matchingEngineImpl) redirectToVersionedQueueForAdd(

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -1483,6 +1483,11 @@ func (e *matchingEngineImpl) redirectToVersionedQueueForAdd(
 	}
 	userData, userDataChanged, err := baseTqm.GetUserData(ctx)
 	if err != nil {
+		if err == errUserDataDisabled && buildId == "" {
+			// Special case when user data disabled: we can send new workflows to the unversioned
+			// queue so they can potentially make progress.
+			return taskQueue, nil, nil
+		}
 		return nil, nil, err
 	}
 	data := userData.GetData().GetVersioningData()

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -2254,7 +2254,7 @@ func (s *matchingEngineSuite) TestAddWorkflowTask_ForVersionedWorkflows_Silently
 		Name: "test",
 		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 	}
-	s.matchingEngine.config.LoadUserData = func(string, string, enumspb.TaskQueueType) bool { return false }
+	s.matchingEngine.config.LoadUserData = dynamicconfig.GetBoolPropertyFnFilteredByTaskQueueInfo(false)
 
 	_, err := s.matchingEngine.AddWorkflowTask(context.Background(), &matchingservice.AddWorkflowTaskRequest{
 		NamespaceId: namespaceId,
@@ -2278,7 +2278,7 @@ func (s *matchingEngineSuite) TestAddActivityTask_ForVersionedWorkflows_Silently
 		Name: "test",
 		Kind: enumspb.TASK_QUEUE_KIND_NORMAL,
 	}
-	s.matchingEngine.config.LoadUserData = func(string, string, enumspb.TaskQueueType) bool { return false }
+	s.matchingEngine.config.LoadUserData = dynamicconfig.GetBoolPropertyFnFilteredByTaskQueueInfo(false)
 
 	_, err := s.matchingEngine.AddActivityTask(context.Background(), &matchingservice.AddActivityTaskRequest{
 		NamespaceId: namespaceId,
@@ -2293,27 +2293,6 @@ func (s *matchingEngineSuite) TestAddActivityTask_ForVersionedWorkflows_Silently
 			Value: &taskqueue.TaskVersionDirective_UseDefault{UseDefault: &types.Empty{}},
 		},
 	})
-	s.Require().NoError(err)
-}
-
-func (s *matchingEngineSuite) TestDispatchSpooledTask_ForVersionedWorkflows_SilentlyDroppedWhenDisablingLoadingUserData() {
-	namespaceId := namespace.ID(uuid.New())
-	tqId, err := newTaskQueueID(namespaceId, "foo", enumspb.TASK_QUEUE_TYPE_ACTIVITY)
-	s.Require().NoError(err)
-	s.matchingEngine.config.LoadUserData = func(string, string, enumspb.TaskQueueType) bool { return false }
-
-	err = s.matchingEngine.DispatchSpooledTask(context.Background(), &internalTask{
-		event: &genericTaskInfo{
-			&persistencespb.AllocatedTaskInfo{
-				Data: &persistencespb.TaskInfo{
-					VersionDirective: &taskqueue.TaskVersionDirective{
-						Value: &taskqueue.TaskVersionDirective_UseDefault{UseDefault: &types.Empty{}},
-					},
-				},
-			},
-			func(ati *persistencespb.AllocatedTaskInfo, err error) {},
-		},
-	}, tqId, stickyInfo{})
 	s.Require().NoError(err)
 }
 

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -477,7 +477,7 @@ func (c *taskQueueManagerImpl) GetUserData(ctx context.Context) (*persistencespb
 		return nil, nil, errNoUserDataOnVersionedTQM
 	}
 	if !c.config.LoadUserData() {
-		return nil, nil, nil
+		return nil, nil, errUserDataDisabled
 	}
 	return c.db.GetUserData(ctx)
 }
@@ -485,7 +485,7 @@ func (c *taskQueueManagerImpl) GetUserData(ctx context.Context) (*persistencespb
 // UpdateUserData updates user data for this task queue and replicates across clusters if necessary.
 func (c *taskQueueManagerImpl) UpdateUserData(ctx context.Context, options UserDataUpdateOptions, updateFn UserDataUpdateFunc) error {
 	if !c.config.LoadUserData() {
-		return serviceerror.NewFailedPrecondition("Task queue user data operations are disabled")
+		return errUserDataDisabled
 	}
 	newData, shouldReplicate, err := c.db.UpdateUserData(ctx, updateFn, options.KnownVersion, options.TaskQueueLimitPerBuildId)
 	if err != nil {

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -1424,12 +1424,11 @@ func (s *versioningIntegSuite) TestDisableLoadUserData() {
 	s.unloadTaskQueue(ctx, tq)
 
 	// Verify read returns empty
-	res, err := s.engine.GetWorkerBuildIdCompatibility(ctx, &workflowservice.GetWorkerBuildIdCompatibilityRequest{
+	_, err = s.engine.GetWorkerBuildIdCompatibility(ctx, &workflowservice.GetWorkerBuildIdCompatibilityRequest{
 		Namespace: s.namespace,
 		TaskQueue: tq,
 	})
-	s.Require().NoError(err)
-	s.Require().Equal(0, len(res.GetMajorVersionSets()))
+	s.Require().ErrorAs(err, &failedPreconditionError)
 }
 
 func (s *versioningIntegSuite) TestWorkflowGetsStuckWhenDisablingLoadingUserData() {


### PR DESCRIPTION
**What changed?**
- Use error from GetUserData for "drop task" decisions
- New workflows ("use default") can start on the unversioned queue when user data is disabled
- Buffered versioned tasks are not dropped, they're retried indefinitely
- Dispatch buffered tasks loop exits sooner on context canceled
- GetWorkerBuildIdCompatibility, etc. return error when user data disabled

<!-- Tell your future self why have you made these changes -->
**Why?**
- Consolidate logic, easier to understand
- Allow workflow to start when user data disabled
- Preserve tasks when possible
- Return error instead of misleading data

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing + new tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
