### PR TITLE
emit history service panic metric for all requests

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1223,6 +1223,7 @@ var (
 	)
 	ServicePendingRequests                   = NewGaugeDef("service_pending_requests")
 	ServiceFailures                          = NewCounterDef("service_errors")
+	ServicePanic                             = NewCounterDef("service_panics")
 	ServiceErrorWithType                     = NewCounterDef("service_error_with_type")
 	ServiceLatency                           = NewTimerDef("service_latency")
 	ServiceLatencyNoUserLatency              = NewTimerDef("service_latency_nouserlatency")

--- a/common/metrics/panic.go
+++ b/common/metrics/panic.go
@@ -26,6 +26,7 @@
 package metrics
 
 import (
+	"errors"
 	"fmt"
 	"runtime/debug"
 
@@ -39,9 +40,15 @@ import (
 // We have to use pointer is because in golang: "recover return nil if was not called directly by a deferred function."
 // And we have to set the returned error otherwise our handler will return nil as error which is incorrect
 func CapturePanic(logger log.Logger, metricHandler Handler, retError *error) {
+	//revive:disable-next-line:defer
 	if panicObj := recover(); panicObj != nil {
-		err, ok := panicObj.(error)
-		if !ok {
+		var err error
+		switch t := panicObj.(type) {
+		case string:
+			err = errors.New(t)
+		case error:
+			err = t
+		default:
 			err = fmt.Errorf("panic: %v", panicObj)
 		}
 

--- a/common/metrics/panic.go
+++ b/common/metrics/panic.go
@@ -1,0 +1,55 @@
+// The MIT License
+
+//
+// Copyright (c) 2023 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+)
+
+// CapturePanic is used to capture panic, it will emit the service panic metric, log the panic and also return the error through pointer.
+// If the panic value is not error then a default error is returned
+// We have to use pointer is because in golang: "recover return nil if was not called directly by a deferred function."
+// And we have to set the returned error otherwise our handler will return nil as error which is incorrect
+func CapturePanic(logger log.Logger, metricHandler Handler, retError *error) {
+	if panicObj := recover(); panicObj != nil {
+		err, ok := panicObj.(error)
+		if !ok {
+			err = fmt.Errorf("panic: %v", panicObj)
+		}
+
+		st := string(debug.Stack())
+
+		logger.Error("Panic is captured", tag.SysStackTrace(st), tag.Error(err))
+
+		metricHandler.Counter(ServicePanic.GetMetricName()).Record(1)
+		*retError = serviceerror.NewInternal(err.Error())
+	}
+}

--- a/common/metrics/panic.go
+++ b/common/metrics/panic.go
@@ -26,7 +26,6 @@
 package metrics
 
 import (
-	"errors"
 	"fmt"
 	"runtime/debug"
 
@@ -42,14 +41,9 @@ import (
 func CapturePanic(logger log.Logger, metricHandler Handler, retError *error) {
 	//revive:disable-next-line:defer
 	if panicObj := recover(); panicObj != nil {
-		var err error
-		switch t := panicObj.(type) {
-		case string:
-			err = errors.New(t)
-		case error:
-			err = t
-		default:
-			err = fmt.Errorf("panic: %v", panicObj)
+		err, ok := panicObj.(error)
+		if !ok {
+			err = serviceerror.NewInternal(fmt.Sprintf("panic: %v", panicObj))
 		}
 
 		st := string(debug.Stack())

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -190,7 +190,7 @@ func (h *Handler) isStopped() bool {
 
 // RecordActivityTaskHeartbeat - Record Activity Task Heart beat.
 func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *historyservice.RecordActivityTaskHeartbeatRequest) (_ *historyservice.RecordActivityTaskHeartbeatResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -229,7 +229,7 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context, request *hist
 
 // RecordActivityTaskStarted - Record Activity Task started.
 func (h *Handler) RecordActivityTaskStarted(ctx context.Context, request *historyservice.RecordActivityTaskStartedRequest) (_ *historyservice.RecordActivityTaskStartedResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -261,7 +261,7 @@ func (h *Handler) RecordActivityTaskStarted(ctx context.Context, request *histor
 
 // RecordWorkflowTaskStarted - Record Workflow Task started.
 func (h *Handler) RecordWorkflowTaskStarted(ctx context.Context, request *historyservice.RecordWorkflowTaskStartedRequest) (_ *historyservice.RecordWorkflowTaskStartedResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -303,7 +303,7 @@ func (h *Handler) RecordWorkflowTaskStarted(ctx context.Context, request *histor
 
 // RespondActivityTaskCompleted - records completion of an activity task
 func (h *Handler) RespondActivityTaskCompleted(ctx context.Context, request *historyservice.RespondActivityTaskCompletedRequest) (_ *historyservice.RespondActivityTaskCompletedResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -342,7 +342,7 @@ func (h *Handler) RespondActivityTaskCompleted(ctx context.Context, request *his
 
 // RespondActivityTaskFailed - records failure of an activity task
 func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *historyservice.RespondActivityTaskFailedRequest) (_ *historyservice.RespondActivityTaskFailedResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -381,7 +381,7 @@ func (h *Handler) RespondActivityTaskFailed(ctx context.Context, request *histor
 
 // RespondActivityTaskCanceled - records failure of an activity task
 func (h *Handler) RespondActivityTaskCanceled(ctx context.Context, request *historyservice.RespondActivityTaskCanceledRequest) (_ *historyservice.RespondActivityTaskCanceledResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -420,7 +420,7 @@ func (h *Handler) RespondActivityTaskCanceled(ctx context.Context, request *hist
 
 // RespondWorkflowTaskCompleted - records completion of a workflow task
 func (h *Handler) RespondWorkflowTaskCompleted(ctx context.Context, request *historyservice.RespondWorkflowTaskCompletedRequest) (_ *historyservice.RespondWorkflowTaskCompletedResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -465,7 +465,7 @@ func (h *Handler) RespondWorkflowTaskCompleted(ctx context.Context, request *his
 
 // RespondWorkflowTaskFailed - failed response to workflow task
 func (h *Handler) RespondWorkflowTaskFailed(ctx context.Context, request *historyservice.RespondWorkflowTaskFailedRequest) (_ *historyservice.RespondWorkflowTaskFailedResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -510,7 +510,7 @@ func (h *Handler) RespondWorkflowTaskFailed(ctx context.Context, request *histor
 
 // StartWorkflowExecution - creates a new workflow execution
 func (h *Handler) StartWorkflowExecution(ctx context.Context, request *historyservice.StartWorkflowExecutionRequest) (_ *historyservice.StartWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	namespaceID := namespace.ID(request.GetNamespaceId())
@@ -545,7 +545,7 @@ func (h *Handler) StartWorkflowExecution(ctx context.Context, request *historyse
 
 // DescribeHistoryHost returns information about the internal states of a history host
 func (h *Handler) DescribeHistoryHost(_ context.Context, _ *historyservice.DescribeHistoryHostRequest) (_ *historyservice.DescribeHistoryHostResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	itemsInCacheByIDCount, itemsInCacheByNameCount := h.namespaceRegistry.GetCacheSize()
@@ -603,14 +603,14 @@ func (h *Handler) RemoveTask(ctx context.Context, request *historyservice.Remove
 
 // CloseShard closes a shard hosted by this instance
 func (h *Handler) CloseShard(_ context.Context, request *historyservice.CloseShardRequest) (_ *historyservice.CloseShardResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.controller.CloseShardByID(request.GetShardId())
 	return &historyservice.CloseShardResponse{}, nil
 }
 
 // GetShard gets a shard hosted by this instance
 func (h *Handler) GetShard(ctx context.Context, request *historyservice.GetShardRequest) (_ *historyservice.GetShardResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	resp, err := h.persistenceShardManager.GetOrCreateShard(ctx, &persistence.GetOrCreateShardRequest{
 		ShardID: request.ShardId,
 	})
@@ -622,7 +622,7 @@ func (h *Handler) GetShard(ctx context.Context, request *historyservice.GetShard
 
 // RebuildMutableState attempts to rebuild mutable state according to persisted history events
 func (h *Handler) RebuildMutableState(ctx context.Context, request *historyservice.RebuildMutableStateRequest) (_ *historyservice.RebuildMutableStateResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -656,7 +656,7 @@ func (h *Handler) RebuildMutableState(ctx context.Context, request *historyservi
 
 // DescribeMutableState - returns the internal analysis of workflow execution state
 func (h *Handler) DescribeMutableState(ctx context.Context, request *historyservice.DescribeMutableStateRequest) (_ *historyservice.DescribeMutableStateResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -688,7 +688,7 @@ func (h *Handler) DescribeMutableState(ctx context.Context, request *historyserv
 
 // GetMutableState - returns the id of the next event in the execution's history
 func (h *Handler) GetMutableState(ctx context.Context, request *historyservice.GetMutableStateRequest) (_ *historyservice.GetMutableStateResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -720,7 +720,7 @@ func (h *Handler) GetMutableState(ctx context.Context, request *historyservice.G
 
 // PollMutableState - returns the id of the next event in the execution's history
 func (h *Handler) PollMutableState(ctx context.Context, request *historyservice.PollMutableStateRequest) (_ *historyservice.PollMutableStateResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -752,7 +752,7 @@ func (h *Handler) PollMutableState(ctx context.Context, request *historyservice.
 
 // DescribeWorkflowExecution returns information about the specified workflow execution.
 func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *historyservice.DescribeWorkflowExecutionRequest) (_ *historyservice.DescribeWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -784,7 +784,7 @@ func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *histor
 
 // RequestCancelWorkflowExecution - requests cancellation of a workflow
 func (h *Handler) RequestCancelWorkflowExecution(ctx context.Context, request *historyservice.RequestCancelWorkflowExecutionRequest) (_ *historyservice.RequestCancelWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -824,7 +824,7 @@ func (h *Handler) RequestCancelWorkflowExecution(ctx context.Context, request *h
 // SignalWorkflowExecution is used to send a signal event to running workflow execution.  This results in
 // WorkflowExecutionSignaled event recorded in the history and a workflow task being created for the execution.
 func (h *Handler) SignalWorkflowExecution(ctx context.Context, request *historyservice.SignalWorkflowExecutionRequest) (_ *historyservice.SignalWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -861,7 +861,7 @@ func (h *Handler) SignalWorkflowExecution(ctx context.Context, request *historys
 // If workflow is not running or not found, this results in WorkflowExecutionStarted and WorkflowExecutionSignaled
 // event recorded in history, and a workflow task being created for the execution
 func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context, request *historyservice.SignalWithStartWorkflowExecutionRequest) (_ *historyservice.SignalWithStartWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -918,7 +918,7 @@ func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context, request 
 // RemoveSignalMutableState is used to remove a signal request ID that was previously recorded.  This is currently
 // used to clean execution info when signal workflow task finished.
 func (h *Handler) RemoveSignalMutableState(ctx context.Context, request *historyservice.RemoveSignalMutableStateRequest) (_ *historyservice.RemoveSignalMutableStateResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -952,7 +952,7 @@ func (h *Handler) RemoveSignalMutableState(ctx context.Context, request *history
 // TerminateWorkflowExecution terminates an existing workflow execution by recording WorkflowExecutionTerminated event
 // in the history and immediately terminating the execution instance.
 func (h *Handler) TerminateWorkflowExecution(ctx context.Context, request *historyservice.TerminateWorkflowExecutionRequest) (_ *historyservice.TerminateWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -984,7 +984,7 @@ func (h *Handler) TerminateWorkflowExecution(ctx context.Context, request *histo
 }
 
 func (h *Handler) DeleteWorkflowExecution(ctx context.Context, request *historyservice.DeleteWorkflowExecutionRequest) (_ *historyservice.DeleteWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1017,7 +1017,7 @@ func (h *Handler) DeleteWorkflowExecution(ctx context.Context, request *historys
 // ResetWorkflowExecution reset an existing workflow execution
 // in the history and immediately terminating the execution instance.
 func (h *Handler) ResetWorkflowExecution(ctx context.Context, request *historyservice.ResetWorkflowExecutionRequest) (_ *historyservice.ResetWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1050,7 +1050,7 @@ func (h *Handler) ResetWorkflowExecution(ctx context.Context, request *historyse
 
 // QueryWorkflow queries a workflow.
 func (h *Handler) QueryWorkflow(ctx context.Context, request *historyservice.QueryWorkflowRequest) (_ *historyservice.QueryWorkflowResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1085,7 +1085,7 @@ func (h *Handler) QueryWorkflow(ctx context.Context, request *historyservice.Que
 // child execution without creating the workflow task and then calls this API after updating the mutable state of
 // parent execution.
 func (h *Handler) ScheduleWorkflowTask(ctx context.Context, request *historyservice.ScheduleWorkflowTaskRequest) (_ *historyservice.ScheduleWorkflowTaskResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1124,7 +1124,7 @@ func (h *Handler) VerifyFirstWorkflowTaskScheduled(
 	ctx context.Context,
 	request *historyservice.VerifyFirstWorkflowTaskScheduledRequest,
 ) (_ *historyservice.VerifyFirstWorkflowTaskScheduledResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1162,7 +1162,7 @@ func (h *Handler) VerifyFirstWorkflowTaskScheduled(
 // RecordChildExecutionCompleted is used for reporting the completion of child workflow execution to parent.
 // This is mainly called by transfer queue processor during the processing of DeleteExecution task.
 func (h *Handler) RecordChildExecutionCompleted(ctx context.Context, request *historyservice.RecordChildExecutionCompletedRequest) (_ *historyservice.RecordChildExecutionCompletedResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1201,7 +1201,7 @@ func (h *Handler) VerifyChildExecutionCompletionRecorded(
 	ctx context.Context,
 	request *historyservice.VerifyChildExecutionCompletionRecordedRequest,
 ) (_ *historyservice.VerifyChildExecutionCompletionRecordedResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1240,7 +1240,7 @@ func (h *Handler) VerifyChildExecutionCompletionRecorded(
 // 2. StickyScheduleToStartTimeout
 func (h *Handler) ResetStickyTaskQueue(ctx context.Context, request *historyservice.ResetStickyTaskQueueRequest) (_ *historyservice.ResetStickyTaskQueueResponse, retError error) {
 
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1272,7 +1272,7 @@ func (h *Handler) ResetStickyTaskQueue(ctx context.Context, request *historyserv
 
 // ReplicateEventsV2 is called by processor to replicate history events for passive namespaces
 func (h *Handler) ReplicateEventsV2(ctx context.Context, request *historyservice.ReplicateEventsV2Request) (_ *historyservice.ReplicateEventsV2Response, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1312,7 +1312,7 @@ func (h *Handler) ReplicateWorkflowState(
 	ctx context.Context,
 	request *historyservice.ReplicateWorkflowStateRequest,
 ) (_ *historyservice.ReplicateWorkflowStateResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1341,7 +1341,7 @@ func (h *Handler) ReplicateWorkflowState(
 
 // SyncShardStatus is called by processor to sync history shard information from another cluster
 func (h *Handler) SyncShardStatus(ctx context.Context, request *historyservice.SyncShardStatusRequest) (_ *historyservice.SyncShardStatusResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1379,7 +1379,7 @@ func (h *Handler) SyncShardStatus(ctx context.Context, request *historyservice.S
 
 // SyncActivity is called by processor to sync activity
 func (h *Handler) SyncActivity(ctx context.Context, request *historyservice.SyncActivityRequest) (_ *historyservice.SyncActivityResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1423,7 +1423,7 @@ func (h *Handler) SyncActivity(ctx context.Context, request *historyservice.Sync
 
 // GetReplicationMessages is called by remote peers to get replicated messages for cross DC replication
 func (h *Handler) GetReplicationMessages(ctx context.Context, request *historyservice.GetReplicationMessagesRequest) (_ *historyservice.GetReplicationMessagesResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1484,7 +1484,7 @@ func (h *Handler) GetReplicationMessages(ctx context.Context, request *historyse
 
 // GetDLQReplicationMessages is called by remote peers to get replicated messages for DLQ merging
 func (h *Handler) GetDLQReplicationMessages(ctx context.Context, request *historyservice.GetDLQReplicationMessagesRequest) (_ *historyservice.GetDLQReplicationMessagesResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1561,7 +1561,7 @@ func (h *Handler) GetDLQReplicationMessages(ctx context.Context, request *histor
 
 // ReapplyEvents applies stale events to the current workflow and the current run
 func (h *Handler) ReapplyEvents(ctx context.Context, request *historyservice.ReapplyEventsRequest) (_ *historyservice.ReapplyEventsResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1602,7 +1602,7 @@ func (h *Handler) ReapplyEvents(ctx context.Context, request *historyservice.Rea
 }
 
 func (h *Handler) GetDLQMessages(ctx context.Context, request *historyservice.GetDLQMessagesRequest) (_ *historyservice.GetDLQMessagesResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1628,7 +1628,7 @@ func (h *Handler) GetDLQMessages(ctx context.Context, request *historyservice.Ge
 }
 
 func (h *Handler) PurgeDLQMessages(ctx context.Context, request *historyservice.PurgeDLQMessagesRequest) (_ *historyservice.PurgeDLQMessagesResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1652,7 +1652,7 @@ func (h *Handler) PurgeDLQMessages(ctx context.Context, request *historyservice.
 }
 
 func (h *Handler) MergeDLQMessages(ctx context.Context, request *historyservice.MergeDLQMessagesRequest) (_ *historyservice.MergeDLQMessagesResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1678,7 +1678,7 @@ func (h *Handler) MergeDLQMessages(ctx context.Context, request *historyservice.
 }
 
 func (h *Handler) RefreshWorkflowTasks(ctx context.Context, request *historyservice.RefreshWorkflowTasksRequest) (_ *historyservice.RefreshWorkflowTasksResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1718,7 +1718,7 @@ func (h *Handler) GenerateLastHistoryReplicationTasks(
 	ctx context.Context,
 	request *historyservice.GenerateLastHistoryReplicationTasksRequest,
 ) (_ *historyservice.GenerateLastHistoryReplicationTasksResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1750,7 +1750,7 @@ func (h *Handler) GetReplicationStatus(
 	ctx context.Context,
 	request *historyservice.GetReplicationStatusRequest,
 ) (_ *historyservice.GetReplicationStatusResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1784,7 +1784,7 @@ func (h *Handler) DeleteWorkflowVisibilityRecord(
 	ctx context.Context,
 	request *historyservice.DeleteWorkflowVisibilityRecordRequest,
 ) (_ *historyservice.DeleteWorkflowVisibilityRecordResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1830,7 +1830,7 @@ func (h *Handler) UpdateWorkflowExecution(
 	ctx context.Context,
 	request *historyservice.UpdateWorkflowExecutionRequest,
 ) (_ *historyservice.UpdateWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {
@@ -1883,7 +1883,7 @@ func (h *Handler) PollWorkflowExecutionUpdate(
 func (h *Handler) StreamWorkflowReplicationMessages(
 	server historyservice.HistoryService_StreamWorkflowReplicationMessagesServer,
 ) (retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer metrics.CapturePanic(h.logger, h.metricsHandler, &retError)
 	h.startWG.Wait()
 
 	if h.isStopped() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Emit panic metric if history service handler experience a panic


<!-- Tell your future self why have you made these changes -->
I want to emit metrics when handler experience panic so that I can create a dedicate alert.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
this change should not change current behavior, only emit the new metric


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
