### PR TITLE
Return NonRetryableApplicationError if input is invalid in ForceReplicationWorkflow and NamespaceHandoverWorkflow

### DIFF
--- a/service/worker/migration/force_replication_workflow.go
+++ b/service/worker/migration/force_replication_workflow.go
@@ -25,7 +25,6 @@
 package migration
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -251,7 +250,7 @@ func ForceTaskQueueUserDataReplicationWorkflow(ctx workflow.Context, params Task
 
 func validateAndSetForceReplicationParams(params *ForceReplicationParams) error {
 	if len(params.Namespace) == 0 {
-		return errors.New("InvalidArgument: Namespace is required")
+		return temporal.NewNonRetryableApplicationError("InvalidArgument: Namespace is required", "InvalidArgument", nil)
 	}
 	if params.ConcurrentActivityCount <= 0 {
 		params.ConcurrentActivityCount = 1

--- a/service/worker/migration/handover_workflow.go
+++ b/service/worker/migration/handover_workflow.go
@@ -25,7 +25,6 @@
 package migration
 
 import (
-	"errors"
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
@@ -220,10 +219,10 @@ func NamespaceHandoverWorkflow(ctx workflow.Context, params NamespaceHandoverPar
 
 func validateAndSetNamespaceHandoverParams(params *NamespaceHandoverParams) error {
 	if len(params.Namespace) == 0 {
-		return errors.New("InvalidArgument: Namespace is required")
+		return temporal.NewNonRetryableApplicationError("InvalidArgument: Namespace is required", "InvalidArgument", nil)
 	}
 	if len(params.RemoteCluster) == 0 {
-		return errors.New("InvalidArgument: RemoteCluster is required")
+		return temporal.NewNonRetryableApplicationError("InvalidArgument: RemoteCluster is required", "InvalidArgument", nil)
 	}
 	if params.AllowedLaggingSeconds <= minimumAllowedLaggingSeconds {
 		params.AllowedLaggingSeconds = minimumAllowedLaggingSeconds


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**
Avoid client retry when input is invalid.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
