### PR TITLE
Add missing reset type params

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3759,6 +3759,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 	var identity string
 	var operationType string
 	var signalParams batcher.SignalParams
+	var resetParams batcher.ResetParams
 	switch op := request.Operation.(type) {
 	case *workflowservice.StartBatchOperationRequest_TerminationOperation:
 		identity = op.TerminationOperation.GetIdentity()
@@ -3777,6 +3778,8 @@ func (wh *WorkflowHandler) StartBatchOperation(
 	case *workflowservice.StartBatchOperationRequest_ResetOperation:
 		identity = op.ResetOperation.GetIdentity()
 		operationType = batcher.BatchTypeReset
+		resetParams.ResetType = op.ResetOperation.GetResetType()
+		resetParams.ResetReapplyType = op.ResetOperation.GetResetReapplyType()
 	default:
 		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("The operation type %T is not supported", op))
 	}
@@ -3791,7 +3794,7 @@ func (wh *WorkflowHandler) StartBatchOperation(
 		CancelParams:    batcher.CancelParams{},
 		SignalParams:    signalParams,
 		DeleteParams:    batcher.DeleteParams{},
-		ResetParams:     batcher.ResetParams{},
+		ResetParams:     resetParams,
 	}
 	inputPayload, err := sdk.PreferProtoDataConverter.ToPayloads(input)
 	if err != nil {

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2290,6 +2290,68 @@ func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Signal
 	s.NoError(err)
 }
 
+func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_Reset() {
+	testNamespace := namespace.Name("test-namespace")
+	namespaceID := namespace.ID(uuid.New())
+	executions := []*commonpb.WorkflowExecution{
+		{
+			WorkflowId: uuid.New(),
+			RunId:      uuid.New(),
+		},
+	}
+	reason := "reason"
+	identity := "identity"
+	config := s.newConfig()
+	wh := s.getWorkflowHandler(config)
+	params := &batcher.BatchParams{
+		Namespace:  testNamespace.String(),
+		Executions: executions,
+		Reason:     reason,
+		BatchType:  batcher.BatchTypeReset,
+		ResetParams: batcher.ResetParams{
+			ResetType:        enumspb.RESET_TYPE_LAST_WORKFLOW_TASK,
+			ResetReapplyType: enumspb.RESET_REAPPLY_TYPE_NONE,
+		},
+	}
+	inputPayload, err := payloads.Encode(params)
+	s.NoError(err)
+	s.mockNamespaceCache.EXPECT().GetNamespaceID(gomock.Any()).Return(namespaceID, nil).AnyTimes()
+	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(
+			_ context.Context,
+			request *historyservice.StartWorkflowExecutionRequest,
+			_ ...grpc.CallOption,
+		) (*historyservice.StartWorkflowExecutionResponse, error) {
+			s.Equal(namespaceID.String(), request.NamespaceId)
+			s.Equal(batcher.BatchWFTypeName, request.StartRequest.WorkflowType.Name)
+			s.Equal(primitives.PerNSWorkerTaskQueue, request.StartRequest.TaskQueue.Name)
+			s.Equal(enumspb.WORKFLOW_ID_REUSE_POLICY_REJECT_DUPLICATE, request.StartRequest.WorkflowIdReusePolicy)
+			s.Equal(identity, request.StartRequest.Identity)
+			s.Equal(payload.EncodeString(batcher.BatchTypeReset), request.StartRequest.Memo.Fields[batcher.BatchOperationTypeMemo])
+			s.Equal(payload.EncodeString(reason), request.StartRequest.Memo.Fields[batcher.BatchReasonMemo])
+			s.Equal(payload.EncodeString(identity), request.StartRequest.SearchAttributes.IndexedFields[searchattribute.BatcherUser])
+			s.Equal(inputPayload, request.StartRequest.Input)
+			return &historyservice.StartWorkflowExecutionResponse{}, nil
+		},
+	)
+	s.mockVisibilityMgr.EXPECT().CountWorkflowExecutions(gomock.Any(), gomock.Any()).Return(&manager.CountWorkflowExecutionsResponse{Count: 0}, nil)
+	request := &workflowservice.StartBatchOperationRequest{
+		Namespace: testNamespace.String(),
+		JobId:     uuid.New(),
+		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
+			ResetOperation: &batchpb.BatchOperationReset{
+				ResetType:        enumspb.RESET_TYPE_LAST_WORKFLOW_TASK,
+				ResetReapplyType: enumspb.RESET_REAPPLY_TYPE_NONE,
+				Identity:         identity,
+			},
+		},
+		Reason:     reason,
+		Executions: executions,
+	}
+
+	_, err = wh.StartBatchOperation(context.Background(), request)
+	s.NoError(err)
+}
 func (s *workflowHandlerSuite) TestStartBatchOperation_WorkflowExecutions_TooMany() {
 	testNamespace := namespace.Name("test-namespace")
 	namespaceID := namespace.ID(uuid.New())

--- a/tests/client_integration_test.go
+++ b/tests/client_integration_test.go
@@ -1574,10 +1574,11 @@ func (s *clientIntegrationSuite) TestBatchSignal() {
 func (s *clientIntegrationSuite) TestBatchReset() {
 
 	var count int32
+
 	activityFn := func(ctx context.Context) (int32, error) {
 		val := atomic.LoadInt32(&count)
 		if val == 0 {
-			return 0, fmt.Errorf("some random error")
+			return 0, temporal.NewApplicationError("some random error", "", false, nil)
 		}
 		return val, nil
 	}
@@ -1616,8 +1617,7 @@ func (s *clientIntegrationSuite) TestBatchReset() {
 		Namespace: s.namespace,
 		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
 			ResetOperation: &batch.BatchOperationReset{
-				ResetType:        enumspb.RESET_TYPE_FIRST_WORKFLOW_TASK,
-				ResetReapplyType: enumspb.RESET_REAPPLY_TYPE_NONE,
+				ResetType: enumspb.RESET_TYPE_FIRST_WORKFLOW_TASK,
 			},
 		},
 		Executions: []*commonpb.WorkflowExecution{

--- a/tests/client_integration_test.go
+++ b/tests/client_integration_test.go
@@ -34,6 +34,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1568,4 +1569,76 @@ func (s *clientIntegrationSuite) TestBatchSignal() {
 	s.NoError(err)
 
 	s.Equal(input1, returnedData)
+}
+
+func (s *clientIntegrationSuite) TestBatchReset() {
+
+	var count int32
+	activityFn := func(ctx context.Context) (int32, error) {
+		val := atomic.LoadInt32(&count)
+		if val == 0 {
+			return 0, fmt.Errorf("some random error")
+		}
+		return val, nil
+	}
+	workflowFn := func(ctx workflow.Context) (int, error) {
+		ao := workflow.ActivityOptions{
+			ScheduleToStartTimeout: 20 * time.Second,
+			StartToCloseTimeout:    40 * time.Second,
+		}
+		ctx = workflow.WithActivityOptions(ctx, ao)
+
+		var result int
+		err := workflow.ExecuteActivity(ctx, activityFn).Get(ctx, &result)
+		if err != nil {
+			return 0, err
+		}
+		return result, nil
+	}
+	s.worker.RegisterWorkflow(workflowFn)
+	s.worker.RegisterActivity(activityFn)
+
+	workflowRun, err := s.sdkClient.ExecuteWorkflow(context.Background(), sdkclient.StartWorkflowOptions{
+		ID:                       uuid.New(),
+		TaskQueue:                s.taskQueue,
+		WorkflowExecutionTimeout: 10 * time.Second,
+	}, workflowFn)
+	s.NoError(err)
+
+	// make sure it failed the first time
+	var result int
+	err = workflowRun.Get(context.Background(), &result)
+	s.Error(err)
+
+	atomic.AddInt32(&count, 1)
+
+	_, err = s.sdkClient.WorkflowService().StartBatchOperation(context.Background(), &workflowservice.StartBatchOperationRequest{
+		Namespace: s.namespace,
+		Operation: &workflowservice.StartBatchOperationRequest_ResetOperation{
+			ResetOperation: &batch.BatchOperationReset{
+				ResetType:        enumspb.RESET_TYPE_FIRST_WORKFLOW_TASK,
+				ResetReapplyType: enumspb.RESET_REAPPLY_TYPE_NONE,
+			},
+		},
+		Executions: []*commonpb.WorkflowExecution{
+			{
+				WorkflowId: workflowRun.GetID(),
+				RunId:      workflowRun.GetRunID(),
+			},
+		},
+		JobId:  uuid.New(),
+		Reason: "test",
+	})
+	s.NoError(err)
+
+	// wait for signal to be processed
+	time.Sleep(5 * time.Second)
+
+	// get the latest run
+	workflowRun = s.sdkClient.GetWorkflow(context.Background(), workflowRun.GetID(), "")
+
+	err = workflowRun.Get(context.Background(), &result)
+	s.NoError(err)
+
+	s.Equal(1, result)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
pass reset type params from `StartBatchOperationRequest` to
`StartBatchOperation`.


<!-- Tell your future self why have you made these changes -->
**Why?**
This is a bug, reset params should be passed further down the call stack.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added Unit and integration tests.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
