### PR TITLE
move ringpop start call to service start

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -58,12 +58,17 @@ type (
 	// Monitor provides membership information for all temporal services.
 	// It can be used to query which member host of a service is responsible for serving a given key.
 	Monitor interface {
+		// Start causes this service to join the membership ring. Services
+		// should not call Start until they are ready to receive requests from
+		// other cluster members.
+		Start()
 		// EvictSelf evicts this member from the membership ring. After this method is
 		// called, other members will discover that this node is no longer part of the
 		// ring. This primitive is useful to carry out graceful host shutdown during deployments.
 		EvictSelf() error
+		// GetResolver returns the service resolver for a service in the cluster.
 		GetResolver(service primitives.ServiceName) (ServiceResolver, error)
-		// GetReachableMembers returns addresses of all members of the ring
+		// GetReachableMembers returns addresses of all members of the ring.
 		GetReachableMembers() ([]string, error)
 		// WaitUntilInitialized blocks until initialization is completed and returns the result
 		// of initialization. The current implementation does log.Fatal if it can't initialize,

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -103,6 +103,18 @@ func (mr *MockMonitorMockRecorder) GetResolver(service interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolver", reflect.TypeOf((*MockMonitor)(nil).GetResolver), service)
 }
 
+// Start mocks base method.
+func (m *MockMonitor) Start() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start")
+}
+
+// Start indicates an expected call of Start.
+func (mr *MockMonitorMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockMonitor)(nil).Start))
+}
+
 // WaitUntilInitialized mocks base method.
 func (m *MockMonitor) WaitUntilInitialized(arg0 context.Context) error {
 	m.ctrl.T.Helper()

--- a/common/membership/ringpop/fx.go
+++ b/common/membership/ringpop/fx.go
@@ -48,7 +48,7 @@ func provideFactory(lc fx.Lifecycle, params factoryParams) (*factory, error) {
 
 func provideMembership(lc fx.Lifecycle, f *factory) membership.Monitor {
 	m := f.getMonitor()
-	lc.Append(fx.StartStopHook(m.Start, m.Stop))
+	lc.Append(fx.StopHook(m.Stop))
 	return m
 }
 

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -112,6 +112,7 @@ func NewServiceProvider(
 	grpcListener net.Listener,
 	metricsHandler metrics.Handler,
 	faultInjectionDataStoreFactory *persistenceClient.FaultInjectionDataStoreFactory,
+	membershipMonitor membership.Monitor,
 ) *Service {
 	return NewService(
 		serviceConfig,
@@ -126,6 +127,7 @@ func NewServiceProvider(
 		grpcListener,
 		metricsHandler,
 		faultInjectionDataStoreFactory,
+		membershipMonitor,
 	)
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -350,15 +350,12 @@ func (s *Service) Start() {
 	s.operatorHandler.Start()
 	s.handler.Start()
 
-	go func() {
-		logger.Info("Starting to serve on frontend listener")
-		if err := s.server.Serve(s.grpcListener); err != nil {
-			logger.Fatal("Failed to serve on frontend listener", tag.Error(err))
-		}
-	}()
+	go s.membershipMonitor.Start()
 
-	s.membershipMonitor.Start()
-	logger.Info("frontend started")
+	logger.Info("Starting to serve on frontend listener")
+	if err := s.server.Serve(s.grpcListener); err != nil {
+		logger.Fatal("Failed to serve on frontend listener", tag.Error(err))
+	}
 }
 
 // Stop stops the service

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -109,11 +109,15 @@ func (s *Service) Start() {
 	healthpb.RegisterHealthServer(s.server, s.healthServer)
 	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
 
-	listener := s.grpcListener
-	logger.Info("Starting to serve on history listener")
-	if err := s.server.Serve(listener); err != nil {
-		logger.Fatal("Failed to serve on history listener", tag.Error(err))
-	}
+	go func() {
+		logger.Info("Starting to serve on history listener")
+		if err := s.server.Serve(s.grpcListener); err != nil {
+			logger.Fatal("Failed to serve on history listener", tag.Error(err))
+		}
+	}()
+
+	s.membershipMonitor.Start()
+	logger.Info("history started")
 }
 
 // Stop stops the service

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -117,16 +117,15 @@ func (c *ControllerImpl) Start() {
 	c.contextTaggedLogger = log.With(c.logger, tag.ComponentShardController, tag.Address(hostIdentity))
 	c.throttledLogger = log.With(c.throttledLogger, tag.ComponentShardController, tag.Address(hostIdentity))
 
-	c.acquireShards()
-	c.shutdownWG.Add(1)
-	go c.shardManagementPump()
-
 	if err := c.historyServiceResolver.AddListener(
 		shardControllerMembershipUpdateListenerName,
 		c.membershipUpdateCh,
 	); err != nil {
 		c.contextTaggedLogger.Error("Error adding listener", tag.Error(err))
 	}
+
+	c.shutdownWG.Add(1)
+	go c.shardManagementPump()
 
 	c.contextTaggedLogger.Info("", tag.LifeCycleStarted)
 }

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -336,6 +336,8 @@ func (s *controllerSuite) TestHistoryEngineClosed() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestSingleDCClusterInfo).AnyTimes()
 	s.shardController.Start()
+	s.shardController.acquireShards()
+
 	var workerWG sync.WaitGroup
 	for w := 0; w < 10; w++ {
 		workerWG.Add(1)
@@ -435,6 +437,7 @@ func (s *controllerSuite) TestShardControllerClosed() {
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestSingleDCClusterInfo).AnyTimes()
 	s.shardController.Start()
+	s.shardController.acquireShards()
 
 	var workerWG sync.WaitGroup
 	for w := 0; w < 10; w++ {
@@ -691,6 +694,7 @@ func (s *controllerSuite) TestShardControllerFuzz() {
 	}
 
 	s.shardController.Start()
+	s.shardController.acquireShards()
 
 	var workers goro.Group
 	for i := 0; i < 10; i++ {

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -108,10 +108,15 @@ func (s *Service) Start() {
 	healthpb.RegisterHealthServer(s.server, s.healthServer)
 	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
 
-	s.logger.Info("Starting to serve on matching listener")
-	if err := s.server.Serve(s.grpcListener); err != nil {
-		s.logger.Fatal("Failed to serve on matching listener", tag.Error(err))
-	}
+	go func() {
+		s.logger.Info("Starting to serve on matching listener")
+		if err := s.server.Serve(s.grpcListener); err != nil {
+			s.logger.Fatal("Failed to serve on matching listener", tag.Error(err))
+		}
+	}()
+
+	s.membershipMonitor.Start()
+	s.logger.Info("matching started")
 }
 
 // Stop stops the service

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -108,15 +108,12 @@ func (s *Service) Start() {
 	healthpb.RegisterHealthServer(s.server, s.healthServer)
 	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
 
-	go func() {
-		s.logger.Info("Starting to serve on matching listener")
-		if err := s.server.Serve(s.grpcListener); err != nil {
-			s.logger.Fatal("Failed to serve on matching listener", tag.Error(err))
-		}
-	}()
+	go s.membershipMonitor.Start()
 
-	s.membershipMonitor.Start()
-	s.logger.Info("matching started")
+	s.logger.Info("Starting to serve on matching listener")
+	if err := s.server.Serve(s.grpcListener); err != nil {
+		s.logger.Fatal("Failed to serve on matching listener", tag.Error(err))
+	}
 }
 
 // Stop stops the service

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -72,6 +72,7 @@ type (
 		clientBean             client.Bean
 		clusterMetadataManager persistence.ClusterMetadataManager
 		metadataManager        persistence.MetadataManager
+		membershipMonitor      membership.Monitor
 		hostInfo               membership.HostInfo
 		executionManager       persistence.ExecutionManager
 		taskManager            persistence.TaskManager
@@ -172,6 +173,7 @@ func NewService(
 		executionManager:          executionManager,
 		persistenceBean:           persistenceBean,
 		workerServiceResolver:     workerServiceResolver,
+		membershipMonitor:         membershipMonitor,
 		hostInfo:                  hostInfoProvider.HostInfo(),
 		archiverProvider:          archiverProvider,
 		namespaceReplicationQueue: namespaceReplicationQueue,
@@ -399,6 +401,8 @@ func (s *Service) Start() {
 	// The service is now started up
 	// seed the random generator once for this service
 	rand.Seed(time.Now().UnixNano())
+
+	s.membershipMonitor.Start()
 
 	s.ensureSystemNamespaceExists(context.TODO())
 	s.startScanner()

--- a/tests/simple_monitor.go
+++ b/tests/simple_monitor.go
@@ -32,23 +32,27 @@ import (
 )
 
 type simpleMonitor struct {
-	resolvers map[primitives.ServiceName]membership.ServiceResolver
+	hosts     map[primitives.ServiceName][]string
+	resolvers map[primitives.ServiceName]*simpleResolver
 }
 
 // NewSimpleMonitor returns a simple monitor interface
 func newSimpleMonitor(hosts map[primitives.ServiceName][]string) *simpleMonitor {
-	resolvers := make(map[primitives.ServiceName]membership.ServiceResolver, len(hosts))
+	resolvers := make(map[primitives.ServiceName]*simpleResolver, len(hosts))
 	for service, hostList := range hosts {
 		resolvers[service] = newSimpleResolver(service, hostList)
 	}
 
-	return &simpleMonitor{resolvers}
+	return &simpleMonitor{
+		hosts:     hosts,
+		resolvers: resolvers,
+	}
 }
 
 func (s *simpleMonitor) Start() {
-}
-
-func (s *simpleMonitor) Stop() {
+	for service, r := range s.resolvers {
+		r.start(s.hosts[service])
+	}
 }
 
 func (s *simpleMonitor) EvictSelf() error {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This moves the membership monitor Start call from a fx lifecycle hook to each individual service's start method.

Note: this is on top of https://github.com/temporalio/temporal/pull/4506 , which is needed so that services can still get the hostinfo (server address) to use when they, eg, initialize their service tagged loggers.

<!-- Tell your future self why have you made these changes -->
**Why?**
In short, because a service instance shouldn't join ringpop, and hence begin to have requests forwarded to it, until it is ready to receive them. In internal testing, focusing on the impact of history service restarts/upgrades, we've seen requests suffer unnecessary delay because they were forwarded to a new history pod before it began accepting on its announced service address.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This has been tested in a staging environment, and for each service (listener, matching, history, worker), scaling up & down pod counts, including to/from zero.

~~Note that with this change, the history service currently generates errors at startup as it attempts lookups during its fx start sequence (inside controller_impl.go), but it will acquire shards as expected. I'll address the error logs in a quick followup PR.~~ (I addressed this in this PR.)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there's a condition that we haven't seen in testing that causes services to lookup ringpop information during fx start time, they'll see errors in places that haven't before. That could manifest as services failing to start up, or failing to take on work as quickly as they had.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.