### PR TITLE
Fix wrong format specifier in client_gen

### DIFF
--- a/client/matching/client_gen.go
+++ b/client/matching/client_gen.go
@@ -103,7 +103,7 @@ func (c *clientImpl) GetBuildIdTaskQueueMapping(
 	opts ...grpc.CallOption,
 ) (*matchingservice.GetBuildIdTaskQueueMappingResponse, error) {
 
-	client, err := c.getClientForTaskqueue(request.GetNamespaceId(), &taskqueuepb.TaskQueue{Name: fmt.Sprintf("not-applicable-%s", rand.Int())}, enumspb.TASK_QUEUE_TYPE_UNSPECIFIED)
+	client, err := c.getClientForTaskqueue(request.GetNamespaceId(), &taskqueuepb.TaskQueue{Name: fmt.Sprintf("not-applicable-%d", rand.Int())}, enumspb.TASK_QUEUE_TYPE_UNSPECIFIED)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/tools/rpcwrappers/main.go
+++ b/cmd/tools/rpcwrappers/main.go
@@ -187,7 +187,7 @@ func makeGetMatchingClient(reqType reflect.Type) string {
 	switch t.Name() {
 	case "GetBuildIdTaskQueueMappingRequest":
 		// Pick a random node for this request, it's not associated with a specific task queue.
-		tqPath = "&taskqueuepb.TaskQueue{Name: fmt.Sprintf(\"not-applicable-%s\", rand.Int())}"
+		tqPath = "&taskqueuepb.TaskQueue{Name: fmt.Sprintf(\"not-applicable-%d\", rand.Int())}"
 		tqtPath = "enumspb.TASK_QUEUE_TYPE_UNSPECIFIED"
 		return fmt.Sprintf("client, err := c.getClientForTaskqueue(%s, %s, %s)", nsIDPath, tqPath, tqtPath)
 	case "UpdateTaskQueueUserDataRequest",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
^

<!-- Tell your future self why have you made these changes -->
**Why?**
Was getting errors for this: 
![image](https://github.com/temporalio/temporal/assets/5942963/f8d775ef-86e6-4827-8e49-dcc3cffab246)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Reran same test that triggered them `go test ./client/...`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
