### PR TITLE
Spool tasks with "default" versioning directive along with unversioned tasks

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -323,7 +323,7 @@ func (e *matchingEngineImpl) AddWorkflowTask(
 	// We don't need the userDataChanged channel here because:
 	// - if we sync match or sticky worker unavailable, we're done
 	// - if we spool to db, we'll re-resolve when it comes out of the db
-	taskQueue, unversionedTqm, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, addRequest.VersionDirective, stickyInfo)
+	taskQueue, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, addRequest.VersionDirective, stickyInfo)
 	if err != nil {
 		if errors.Is(err, errUserDataDisabled) {
 			// When user data loading is disabled, we intentionally drop tasks for versioned workflows
@@ -362,12 +362,16 @@ func (e *matchingEngineImpl) AddWorkflowTask(
 		VersionDirective: addRequest.VersionDirective,
 	}
 
+	baseTqm, err := e.getTaskQueueManager(ctx, origTaskQueue, stickyInfo, true)
+	if err != nil {
+		return false, err
+	}
 	return tqm.AddTask(ctx, addTaskParams{
-		execution:      addRequest.Execution,
-		taskInfo:       taskInfo,
-		source:         addRequest.GetSource(),
-		forwardedFrom:  addRequest.GetForwardedSource(),
-		unversionedTqm: unversionedTqm,
+		execution:     addRequest.Execution,
+		taskInfo:      taskInfo,
+		source:        addRequest.GetSource(),
+		forwardedFrom: addRequest.GetForwardedSource(),
+		baseTqm:       baseTqm,
 	})
 }
 
@@ -389,7 +393,7 @@ func (e *matchingEngineImpl) AddActivityTask(
 	// We don't need the userDataChanged channel here because:
 	// - if we sync match, we're done
 	// - if we spool to db, we'll re-resolve when it comes out of the db
-	taskQueue, unversionedTqm, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, addRequest.VersionDirective, stickyInfo)
+	taskQueue, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, addRequest.VersionDirective, stickyInfo)
 	if err != nil {
 		if errors.Is(err, errUserDataDisabled) {
 			// When user data loading is disabled, we intentionally drop tasks for versioned workflows
@@ -423,12 +427,17 @@ func (e *matchingEngineImpl) AddActivityTask(
 		VersionDirective: addRequest.VersionDirective,
 	}
 
+	baseTqm, err := e.getTaskQueueManager(ctx, origTaskQueue, stickyInfo, true)
+	if err != nil {
+		return false, err
+	}
+
 	return tlMgr.AddTask(ctx, addTaskParams{
-		execution:      addRequest.Execution,
-		taskInfo:       taskInfo,
-		source:         addRequest.GetSource(),
-		forwardedFrom:  addRequest.GetForwardedSource(),
-		unversionedTqm: unversionedTqm,
+		execution:     addRequest.Execution,
+		taskInfo:      taskInfo,
+		source:        addRequest.GetSource(),
+		forwardedFrom: addRequest.GetForwardedSource(),
+		baseTqm:       baseTqm,
 	})
 }
 
@@ -446,16 +455,15 @@ func (e *matchingEngineImpl) DispatchSpooledTask(
 	unversionedOrigTaskQueue := newTaskQueueIDWithVersionSet(origTaskQueue, "")
 	// Redirect and re-resolve if we're blocked in matcher and user data changes.
 	for {
-		taskQueue, _, userDataChanged, err := e.redirectToVersionedQueueForAdd(
+		taskQueue, userDataChanged, err := e.redirectToVersionedQueueForAdd(
 			ctx, unversionedOrigTaskQueue, directive, stickyInfo)
 		if err != nil {
-			if errors.Is(err, errUserDataDisabled) && directive.GetBuildId() == "" {
-				// Only fail tasks with compatiblity constraints when user data is disabled.
-				// "default" directive tasks become unversioned.
-				err = nil
-			} else {
+			// Return error for tasks with compatiblity constraints when user data is disabled so they can be retried later.
+			// "default" directive tasks become unversioned.
+			if !errors.Is(err, errUserDataDisabled) || directive.GetBuildId() != "" {
 				return err
 			}
+			err = nil
 		}
 		sticky := stickyInfo.kind == enumspb.TASK_QUEUE_KIND_STICKY
 		tqm, err := e.getTaskQueueManager(ctx, taskQueue, stickyInfo, !sticky)
@@ -689,7 +697,7 @@ func (e *matchingEngineImpl) QueryWorkflow(
 
 	// We don't need the userDataChanged channel here because we either do this sync (local or remote)
 	// or fail with a relatively short timeout.
-	taskQueue, _, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, queryRequest.VersionDirective, stickyInfo)
+	taskQueue, _, err := e.redirectToVersionedQueueForAdd(ctx, origTaskQueue, queryRequest.VersionDirective, stickyInfo)
 	if err != nil {
 		if errors.Is(err, errUserDataDisabled) {
 			// Rewrite to nicer error message
@@ -1472,13 +1480,8 @@ func (e *matchingEngineImpl) redirectToVersionedQueueForAdd(
 	taskQueue *taskQueueID,
 	directive *taskqueuespb.TaskVersionDirective,
 	stickyInfo stickyInfo,
-) (*taskQueueID, taskQueueManager, chan struct{}, error) {
+) (*taskQueueID, chan struct{}, error) {
 	var buildId string
-	baseTqm, err := e.getTaskQueueManager(ctx, taskQueue, stickyInfo, true)
-	if err != nil {
-		return nil, nil, nil, err
-	}
-
 	switch dir := directive.GetValue().(type) {
 	case *taskqueuespb.TaskVersionDirective_UseDefault:
 		// leave buildId = "", lookupVersionSetForAdd understands that to mean "default"
@@ -1486,13 +1489,18 @@ func (e *matchingEngineImpl) redirectToVersionedQueueForAdd(
 		buildId = dir.BuildId
 	default:
 		// Unversioned task, leave on unversioned queue.
-		return taskQueue, baseTqm, nil, nil
+		return taskQueue, nil, nil
+	}
+
+	baseTqm, err := e.getTaskQueueManager(ctx, taskQueue, stickyInfo, true)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	// Have to look up versioning data.
 	userData, userDataChanged, err := baseTqm.GetUserData(ctx)
 	if err != nil {
-		return taskQueue, baseTqm, userDataChanged, err
+		return taskQueue, userDataChanged, err
 	}
 	data := userData.GetData().GetVersioningData()
 
@@ -1500,17 +1508,17 @@ func (e *matchingEngineImpl) redirectToVersionedQueueForAdd(
 		// In the sticky case we don't redirect, but we may kick off this worker if there's a
 		// newer one.
 		err := checkVersionForStickyAdd(data, buildId)
-		return taskQueue, baseTqm, userDataChanged, err
+		return taskQueue, userDataChanged, err
 	}
 
 	versionSet, err := lookupVersionSetForAdd(data, buildId)
 	if err == errEmptyVersioningData {
 		// default was requested for an unversioned queue
-		return taskQueue, baseTqm, userDataChanged, nil
+		return taskQueue, userDataChanged, nil
 	} else if err != nil {
-		return nil, baseTqm, nil, err
+		return nil, nil, err
 	}
-	return newTaskQueueIDWithVersionSet(taskQueue, versionSet), baseTqm, userDataChanged, nil
+	return newTaskQueueIDWithVersionSet(taskQueue, versionSet), userDataChanged, nil
 }
 
 func (m *lockableQueryTaskMap) put(key string, value chan *queryResult) {

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -397,6 +397,82 @@ func (s *versioningIntegSuite) dispatchNewWorkflowStartWorkerFirst() {
 	s.Equal("done!", out)
 }
 
+func (s *versioningIntegSuite) TestDisableLoadUserDataDefaultTasksBecomeUnversioned() {
+	dc := s.testCluster.host.dcClient
+	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
+	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueWritePartitions)
+
+	tq := s.randomizeStr(s.T().Name())
+	v0 := s.prefixed("v0")
+
+	// Register a versioned "v0" worker to execute a single workflow task to constrain a workflow on the task queue to a
+	// compatible set.
+	ch := make(chan struct{}, 1)
+	wf1 := func(ctx workflow.Context) (string, error) {
+		close(ch)
+		workflow.GetSignalChannel(ctx, "unblock").Receive(ctx, nil)
+		return "done!", nil
+	}
+
+	w1 := worker.New(s.sdkClient, tq, worker.Options{
+		BuildID:                          v0,
+		UseBuildIDForVersioning:          true,
+		MaxConcurrentWorkflowTaskPollers: numPollers,
+	})
+	w1.RegisterWorkflow(wf1)
+	s.NoError(w1.Start())
+	defer w1.Stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	s.addNewDefaultBuildId(ctx, tq, v0)
+	s.waitForPropagation(ctx, tq, v0)
+
+	// Start the first workflow while the task queue is still considered versioned.
+	// We want to verify that if a spooled task with a "compatible" versioning directive doesn't block a spooled task
+	// with a "default" directive.
+	// This should never happen in practice since we dispatch "default" tasks to the unversioned task queue but the test
+	// verifies this at a functional level.
+	run1, err := s.sdkClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{TaskQueue: tq}, wf1)
+	s.NoError(err)
+
+	// Wait for first WFT and stop the worker
+	<-ch
+	w1.Stop()
+
+	// Generate a second workflow task with a "compatible" directive, it should be spooled in the versioned task queue.
+	s.NoError(s.sdkClient.SignalWorkflow(ctx, run1.GetID(), run1.GetRunID(), "unblock", nil))
+
+	wf2 := func(ctx workflow.Context) (string, error) {
+		return "done!", nil
+	}
+	run2, err := s.sdkClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{TaskQueue: tq}, wf2)
+	s.NoError(err)
+
+	// Wait a bit and allow tasks to be spooled.
+	time.Sleep(time.Second * 3)
+
+	// Disable user data and unload the task queue.
+	dc.OverrideValue(dynamicconfig.MatchingLoadUserData, false)
+	defer dc.RemoveOverride(dynamicconfig.MatchingLoadUserData)
+	s.unloadTaskQueue(ctx, tq)
+
+	// Start an unversioned worker and verify that the second workflow completes.
+	w2 := worker.New(s.sdkClient, tq, worker.Options{
+		MaxConcurrentWorkflowTaskPollers: numPollers,
+	})
+	w2.RegisterWorkflow(wf2)
+	s.NoError(w2.Start())
+	defer w2.Stop()
+
+	var out string
+	s.NoError(run2.Get(ctx, &out))
+	s.Equal("done!", out)
+}
+
 func (s *versioningIntegSuite) TestDispatchUnversionedRemainsUnversioned() {
 	s.testWithMatchingBehavior(s.dispatchUnversionedRemainsUnversioned)
 }


### PR DESCRIPTION
Ensure that tasks with the "default" versioning directive get spooled in the unversioned queue as they not
associated with any version set until their execution is touched by a version specific worker.
"compatible" tasks OTOH are associated with a specific version set and should be stored along with all tasks for
that version set.
The task queue default set is dynamic and applies only at dispatch time. Putting "default" tasks into version set
specific queues could cause them to get stuck behind "compatible" tasks when they should be able to progress
independently.