### PR TITLE
Apply stricter rate limiting for the RegisterNamespace API

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -218,7 +218,7 @@ const (
 	// FrontendRPS is workflow rate limit per second
 	FrontendRPS = "frontend.rps"
 	// FrontendNamespaceReplicationInducingAPIsRPS limits the per second request rate for namespace replication inducing
-	// APIs (e.g. UpdateNamespace, UpdateWorkerBuildIdCompatibility).
+	// APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility).
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendNamespaceReplicationInducingAPIsRPS = "frontend.rps.namespaceReplicationInducingAPIs"
 	// FrontendMaxNamespaceRPSPerInstance is workflow namespace rate limit per second
@@ -231,14 +231,14 @@ const (
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceVisibilityRPSPerInstance = "frontend.namespaceRPS.visibility"
 	// FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance is a per host/per namespace RPS limit for
-	// namespace replication inducing APIs (e.g. UpdateNamespace, UpdateWorkerBuildIdCompatibility).
+	// namespace replication inducing APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility).
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance = "frontend.namespaceRPS.namespaceReplicationInducingAPIs"
 	// FrontendMaxNamespaceVisibilityBurstPerInstance is namespace burst limit for visibility APIs.
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceVisibilityBurstPerInstance = "frontend.namespaceBurst.visibility"
 	// FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance is a per host/per namespace burst limit for
-	// namespace replication inducing APIs (e.g. UpdateNamespace, UpdateWorkerBuildIdCompatibility).
+	// namespace replication inducing APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility).
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceNamespaceReplicationInducingAPIsBurstPerInstance = "frontend.namespaceBurst.namespaceReplicationInducingAPIs"
 	// FrontendGlobalNamespaceRPS is workflow namespace rate limit per second for the whole cluster.
@@ -254,7 +254,7 @@ const (
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendGlobalNamespaceVisibilityRPS = "frontend.globalNamespaceRPS.visibility"
 	// FrontendGlobalNamespaceNamespaceReplicationInducingAPIsRPS is a cluster global, per namespace RPS limit for
-	// namespace replication inducing APIs (e.g. UpdateNamespace, UpdateWorkerBuildIdCompatibility).
+	// namespace replication inducing APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility).
 	// The limit is evenly distributed among available frontend service instances.
 	// If this is set, it overwrites the per instance limit configured with
 	// "frontend.namespaceRPS.namespaceReplicationInducingAPIs".

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -98,6 +98,7 @@ var (
 	// The replication queue is used to propagate critical failover messages and this mapping prevents flooding the
 	// queue and delaying failover.
 	NamespaceReplicationInducingAPIToPriority = map[string]int{
+		"RegisterNamespace":                0,
 		"UpdateNamespace":                  0,
 		"UpdateWorkerBuildIdCompatibility": 1,
 	}
@@ -109,7 +110,6 @@ var (
 		"GetSystemInfo":       0,
 		"GetSearchAttributes": 0,
 
-		"RegisterNamespace":  0,
 		"DescribeNamespace":  0,
 		"ListNamespaces":     0,
 		"DeprecateNamespace": 0,

--- a/service/frontend/configs/quotas_test.go
+++ b/service/frontend/configs/quotas_test.go
@@ -186,8 +186,9 @@ func (s *quotasSuite) TestVisibilityAPIs() {
 
 func (s *quotasSuite) TestNamespaceReplicationInducingAPIs() {
 	apis := map[string]struct{}{
-		"UpdateWorkerBuildIdCompatibility": {},
+		"RegisterNamespace":                {},
 		"UpdateNamespace":                  {},
+		"UpdateWorkerBuildIdCompatibility": {},
 	}
 
 	var service workflowservice.WorkflowServiceServer
@@ -208,7 +209,6 @@ func (s *quotasSuite) TestOtherAPIs() {
 		"GetSystemInfo":       {},
 		"GetSearchAttributes": {},
 
-		"RegisterNamespace":  {},
 		"DescribeNamespace":  {},
 		"ListNamespaces":     {},
 		"DeprecateNamespace": {},


### PR DESCRIPTION
This was mentioned in the review for #4455 but was not addressed.