### PR TITLE
Use search attribute size limit for BuildIds truncation

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -695,8 +695,6 @@ const (
 	DefaultWorkflowRetryPolicy = "history.defaultWorkflowRetryPolicy"
 	// HistoryMaxAutoResetPoints is the key for max number of auto reset points stored in mutableState
 	HistoryMaxAutoResetPoints = "history.historyMaxAutoResetPoints"
-	// HistoryMaxTrackedBuildIds indicates the max number of build IDs to store in the BuildIds search attribute
-	HistoryMaxTrackedBuildIds = "history.maxTrackedBuildIds"
 	// EnableParentClosePolicy whether to  ParentClosePolicy
 	EnableParentClosePolicy = "history.enableParentClosePolicy"
 	// ParentClosePolicyThreshold decides that parent close policy will be processed by sys workers(if enabled) if

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -59,7 +59,6 @@ type Config struct {
 
 	EmitShardLagLog       dynamicconfig.BoolPropertyFn
 	MaxAutoResetPoints    dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxTrackedBuildIds    dynamicconfig.IntPropertyFnWithNamespaceFilter
 	ThrottledLogRPS       dynamicconfig.IntPropertyFn
 	EnableStickyQuery     dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	ShutdownDrainDuration dynamicconfig.DurationPropertyFn
@@ -312,7 +311,6 @@ type Config struct {
 
 const (
 	DefaultHistoryMaxAutoResetPoints = 20
-	DefaultHistoryMaxTrackedBuildIds = 20
 )
 
 // NewConfig returns new service config with default values
@@ -337,7 +335,6 @@ func NewConfig(
 		PersistenceDynamicRateLimitingParams:  dc.GetMapProperty(dynamicconfig.HistoryPersistenceDynamicRateLimitingParams, dynamicconfig.DefaultDynamicRateLimitingParams),
 		ShutdownDrainDuration:                 dc.GetDurationProperty(dynamicconfig.HistoryShutdownDrainDuration, 0*time.Second),
 		MaxAutoResetPoints:                    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryMaxAutoResetPoints, DefaultHistoryMaxAutoResetPoints),
-		MaxTrackedBuildIds:                    dc.GetIntPropertyFilteredByNamespace(dynamicconfig.HistoryMaxTrackedBuildIds, DefaultHistoryMaxTrackedBuildIds),
 		DefaultWorkflowTaskTimeout:            dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.DefaultWorkflowTaskTimeout, common.DefaultWorkflowTaskTimeout),
 		ContinueAsNewMinInterval:              dc.GetDurationPropertyFilteredByNamespace(dynamicconfig.ContinueAsNewMinInterval, time.Second),
 

--- a/service/history/transferQueueActiveTaskExecutor_test.go
+++ b/service/history/transferQueueActiveTaskExecutor_test.go
@@ -125,7 +125,7 @@ type (
 	}
 )
 
-var defaultWorkflowTaskCompletionLimits = workflow.WorkflowTaskCompletionLimits{MaxResetPoints: configs.DefaultHistoryMaxAutoResetPoints, MaxTrackedBuildIds: configs.DefaultHistoryMaxTrackedBuildIds}
+var defaultWorkflowTaskCompletionLimits = workflow.WorkflowTaskCompletionLimits{MaxResetPoints: configs.DefaultHistoryMaxAutoResetPoints, MaxSearchAttributeValueSize: 2048}
 
 func TestTransferQueueActiveTaskExecutorSuite(t *testing.T) {
 	s := new(transferQueueActiveTaskExecutorSuite)

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -101,8 +101,8 @@ type (
 	}
 
 	WorkflowTaskCompletionLimits struct {
-		MaxResetPoints     int
-		MaxTrackedBuildIds int
+		MaxResetPoints              int
+		MaxSearchAttributeValueSize int
 	}
 
 	MutableState interface {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1901,8 +1901,8 @@ func (ms *MutableStateImpl) ReplicateWorkflowExecutionStartedEvent(
 		ms.executionInfo.SearchAttributes = event.SearchAttributes.GetIndexedFields()
 	}
 	if event.SourceVersionStamp.GetUseVersioning() && event.SourceVersionStamp.GetBuildId() != "" {
-		limit := ms.config.MaxTrackedBuildIds(string(ms.namespaceEntry.Name()))
-		if err := ms.addBuildIdWithNoVisibilityTask(worker_versioning.VersionedBuildIdSearchAttribute(event.SourceVersionStamp.BuildId), limit); err != nil {
+		limit := ms.config.SearchAttributesSizeOfValueLimit(string(ms.namespaceEntry.Name()))
+		if err := ms.addBuildIdsWithNoVisibilityTask([]string{worker_versioning.VersionedBuildIdSearchAttribute(event.SourceVersionStamp.BuildId)}, limit); err != nil {
 			return err
 		}
 	}
@@ -2096,27 +2096,18 @@ func (ms *MutableStateImpl) trackBuildIdFromCompletion(
 	eventID int64,
 	limits WorkflowTaskCompletionLimits,
 ) error {
-	buildIds, err := ms.loadBuildIds()
-	if err != nil {
-		return err
-	}
-	anyAdded := false
+	var toAdd []string
 	if !version.GetUseVersioning() {
-		var added bool
-		// Make sure unversioned workflow tasks are easily locatable with just the prefix
-		buildIds, added = ms.addBuildIdToLoadedSearchAttribute(buildIds, worker_versioning.UnversionedSearchAttribute, limits.MaxTrackedBuildIds)
-		anyAdded = anyAdded || added
+		toAdd = append(toAdd, worker_versioning.UnversionedSearchAttribute)
 	}
 	if version.GetBuildId() != "" {
-		var added bool
 		ms.addResetPointFromCompletion(version.GetBuildId(), eventID, limits.MaxResetPoints)
-		buildIds, added = ms.addBuildIdToLoadedSearchAttribute(buildIds, worker_versioning.VersionStampToBuildIdSearchAttribute(version), limits.MaxTrackedBuildIds)
-		anyAdded = anyAdded || added
+		toAdd = append(toAdd, worker_versioning.VersionStampToBuildIdSearchAttribute(version))
 	}
-	if !anyAdded {
+	if len(toAdd) == 0 {
 		return nil
 	}
-	if err := ms.saveBuildIds(buildIds); err != nil {
+	if err := ms.addBuildIdsWithNoVisibilityTask(toAdd, limits.MaxSearchAttributeValueSize); err != nil {
 		return err
 	}
 	return ms.taskGenerator.GenerateUpsertVisibilityTask()
@@ -2143,55 +2134,67 @@ func (ms *MutableStateImpl) loadBuildIds() ([]string, error) {
 	}
 }
 
-// Takes a list of loaded build IDs from a search attribute and added a new build ID to it while respecting provided limits.
-// Returns a potentially modified list and a flag indicating whether it was modified.
-func (ms *MutableStateImpl) addBuildIdToLoadedSearchAttribute(searchAttributeValues []string, searchAttributeValue string, maxTrackedBuildIds int) ([]string, bool) {
-	if maxTrackedBuildIds < 1 {
-		// Can't track this build ID
-		return searchAttributeValues, false
-	}
-	for _, exisitingValue := range searchAttributeValues {
-		if exisitingValue == searchAttributeValue {
-			return searchAttributeValues, false
+// Takes a list of loaded build IDs from a search attribute and adds new build IDs to it. Returns a potentially modified
+// list and a flag indicating whether it was modified.
+func (ms *MutableStateImpl) addBuildIdToLoadedSearchAttribute(existingValues []string, newValues []string) ([]string, bool) {
+	var added []string
+	for _, newValue := range newValues {
+		found := false
+		for _, exisitingValue := range existingValues {
+			if exisitingValue == newValue {
+				found = true
+				break
+			}
+		}
+		if !found {
+			added = append(added, newValue)
 		}
 	}
-	if len(searchAttributeValues) >= maxTrackedBuildIds {
-		hasUnversioned := searchAttributeValues[0] == worker_versioning.UnversionedSearchAttribute
-		searchAttributeValues = searchAttributeValues[len(searchAttributeValues)-maxTrackedBuildIds+1:]
-		// Make sure not to lose the unversioned value, it's required for the reachability API
-		if hasUnversioned {
-			searchAttributeValues[0] = worker_versioning.UnversionedSearchAttribute
-		}
+	if len(added) == 0 {
+		return existingValues, false
 	}
-	return append(searchAttributeValues, searchAttributeValue), true
+	return append(existingValues, added...), true
 }
 
-func (ms *MutableStateImpl) saveBuildIds(buildIds []string) error {
+func (ms *MutableStateImpl) saveBuildIds(buildIds []string, maxSearchAttributeValueSize int) error {
 	searchAttributes := ms.executionInfo.SearchAttributes
 	if searchAttributes == nil {
 		searchAttributes = make(map[string]*commonpb.Payload, 1)
 		ms.executionInfo.SearchAttributes = searchAttributes
 	}
 
-	saPayload, err := searchattribute.EncodeValue(buildIds, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
-	if err != nil {
-		return err
+	hasUnversioned := buildIds[0] == worker_versioning.UnversionedSearchAttribute
+	for {
+		saPayload, err := searchattribute.EncodeValue(buildIds, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
+		if err != nil {
+			return err
+		}
+		if len(buildIds) == 0 || len(saPayload.GetData()) <= maxSearchAttributeValueSize {
+			searchAttributes[searchattribute.BuildIds] = saPayload
+			break
+		}
+		if len(buildIds) == 1 {
+			buildIds = make([]string, 0)
+		} else if hasUnversioned {
+			// Make sure to maintain the unversioned sentinel, it's required for the reachability API
+			buildIds = append(buildIds[:1], buildIds[2:]...)
+		} else {
+			buildIds = buildIds[1:]
+		}
 	}
-	searchAttributes[searchattribute.BuildIds] = saPayload
 	return nil
 }
 
-func (ms *MutableStateImpl) addBuildIdWithNoVisibilityTask(searchAttributeValue string, maxTrackedBuildIds int) error {
-	buildIds, err := ms.loadBuildIds()
+func (ms *MutableStateImpl) addBuildIdsWithNoVisibilityTask(buildIds []string, maxSearchAttributeValueSize int) error {
+	existingBuildIds, err := ms.loadBuildIds()
 	if err != nil {
 		return err
 	}
-	var added bool
-	buildIds, added = ms.addBuildIdToLoadedSearchAttribute(buildIds, searchAttributeValue, maxTrackedBuildIds)
+	modifiedBuildIds, added := ms.addBuildIdToLoadedSearchAttribute(existingBuildIds, buildIds)
 	if !added {
 		return nil
 	}
-	return ms.saveBuildIds(buildIds)
+	return ms.saveBuildIds(modifiedBuildIds, maxSearchAttributeValueSize)
 }
 
 // TODO: we will release the restriction when reset API allow those pending

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -1150,8 +1150,8 @@ func (s *mutableStateSuite) TestTrackBuildIdFromCompletion() {
 		stamp           func(buildId string) *commonpb.WorkerVersionStamp
 	}
 	matrix := []testCase{
-		{name: "versioned", searchAttribute: versionedSearchAttribute, stamp: versioned},
 		{name: "unversioned", searchAttribute: unversionedSearchAttribute, stamp: unversioned},
+		{name: "versioned", searchAttribute: versionedSearchAttribute, stamp: versioned},
 	}
 	for _, c := range matrix {
 		s.T().Run(c.name, func(t *testing.T) {
@@ -1161,29 +1161,29 @@ func (s *mutableStateSuite) TestTrackBuildIdFromCompletion() {
 			s.NoError(err)
 
 			// Max 0
-			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.1"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 0, MaxTrackedBuildIds: 0})
+			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.1"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 0, MaxSearchAttributeValueSize: 0})
 			s.NoError(err)
 			s.Equal([]string{}, s.getBuildIdsFromMutableState())
 			s.Equal([]string{}, s.getResetPointsBinaryChecksumsFromMutableState())
 
-			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.1"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 2, MaxTrackedBuildIds: 2})
+			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.1"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 2, MaxSearchAttributeValueSize: 40})
 			s.NoError(err)
 			s.Equal(c.searchAttribute("0.1"), s.getBuildIdsFromMutableState())
 			s.Equal([]string{"0.1"}, s.getResetPointsBinaryChecksumsFromMutableState())
 
 			// Add the same build ID
-			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.1"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 2, MaxTrackedBuildIds: 2})
+			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.1"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 2, MaxSearchAttributeValueSize: 40})
 			s.NoError(err)
 			s.Equal(c.searchAttribute("0.1"), s.getBuildIdsFromMutableState())
 			s.Equal([]string{"0.1"}, s.getResetPointsBinaryChecksumsFromMutableState())
 
-			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.2"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 2, MaxTrackedBuildIds: 2})
+			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.2"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 2, MaxSearchAttributeValueSize: 40})
 			s.NoError(err)
 			s.Equal(c.searchAttribute("0.1", "0.2"), s.getBuildIdsFromMutableState())
 			s.Equal([]string{"0.1", "0.2"}, s.getResetPointsBinaryChecksumsFromMutableState())
 
 			// Limit applies
-			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.3"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 2, MaxTrackedBuildIds: 2})
+			err = s.mutableState.trackBuildIdFromCompletion(c.stamp("0.3"), 4, WorkflowTaskCompletionLimits{MaxResetPoints: 2, MaxSearchAttributeValueSize: 40})
 			s.NoError(err)
 			s.Equal(c.searchAttribute("0.2", "0.3"), s.getBuildIdsFromMutableState())
 			s.Equal([]string{"0.2", "0.3"}, s.getResetPointsBinaryChecksumsFromMutableState())

--- a/service/history/workflowTaskHandlerCallbacks.go
+++ b/service/history/workflowTaskHandlerCallbacks.go
@@ -420,9 +420,10 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		return nil, serviceerror.NewInvalidArgument("Workflow using versioning must continue to use versioning.")
 	}
 
+	nsName := namespaceEntry.Name().String()
 	limits := workflow.WorkflowTaskCompletionLimits{
-		MaxResetPoints:     handler.config.MaxAutoResetPoints(namespaceEntry.Name().String()),
-		MaxTrackedBuildIds: handler.config.MaxTrackedBuildIds(namespaceEntry.Name().String()),
+		MaxResetPoints:              handler.config.MaxAutoResetPoints(nsName),
+		MaxSearchAttributeValueSize: handler.config.SearchAttributesSizeOfValueLimit(nsName),
 	}
 	// TODO: this metric is inaccurate, it should only be emitted if a new binary checksum (or build ID) is added in this completion.
 	if ms.GetExecutionInfo().AutoResetPoints != nil && limits.MaxResetPoints == len(ms.GetExecutionInfo().AutoResetPoints.Points) {


### PR DESCRIPTION
Build ids can have an arbitrary length of up to 255 bytes and the maximum search attribute size is 2k.
While reducing the _number_ of tracked build ids is possible, the approach taken in this PR is to truncate when exceeding the search attribute size limit and permits storing a lot of shorter build ids or a less longer ones.