### PR TITLE
Prevent scavenger from removing build ids that were recently default for a set

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -197,6 +197,9 @@ const (
 	ReachabilityQueryBuildIdLimit = "limit.reachabilityQueryBuildIds"
 	// TaskQueuesPerBuildIdLimit limits the number of task queue names that can be mapped to a single build id.
 	TaskQueuesPerBuildIdLimit = "limit.taskQueuesPerBuildId"
+	// RemovableBuildIdDurationSinceDefault is the minimum duration since a build id was last default in its containing
+	// set for it to be considered for removal, used by the build id scavenger.
+	RemovableBuildIdDurationSinceDefault = "worker.removableBuildIdDurationSinceDefault"
 
 	// keys for frontend
 

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -89,6 +89,10 @@ type (
 		ExecutionScannerWorkerCount dynamicconfig.IntPropertyFn
 		// ExecutionScannerHistoryEventIdValidator indicates if the execution scavenger to validate history event id.
 		ExecutionScannerHistoryEventIdValidator dynamicconfig.BoolPropertyFn
+
+		// RemovableBuildIdDurationSinceDefault is the minimum duration since a build id was last default in its
+		// containing set for it to be considered for removal.
+		RemovableBuildIdDurationSinceDefault dynamicconfig.DurationPropertyFn
 	}
 
 	// scannerContext is the context object that gets
@@ -204,6 +208,7 @@ func (s *Scanner) Start() error {
 			s.context.namespaceRegistry,
 			s.context.matchingClient,
 			s.context.currentClusterName,
+			s.context.cfg.RemovableBuildIdDurationSinceDefault,
 		)
 
 		work := s.context.sdkClientFactory.NewWorker(s.context.sdkClientFactory.GetSystemClient(), build_ids.BuildIdScavengerTaskQueueName, workerOpts)

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -320,6 +320,10 @@ func NewConfig(
 				dynamicconfig.ExecutionScannerHistoryEventIdValidator,
 				true,
 			),
+			RemovableBuildIdDurationSinceDefault: dc.GetDurationProperty(
+				dynamicconfig.RemovableBuildIdDurationSinceDefault,
+				time.Hour,
+			),
 		},
 		EnableBatcher:      dc.GetBoolProperty(dynamicconfig.EnableBatcher, true),
 		BatcherRPS:         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BatcherRPS, batcher.DefaultRPS),

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -98,6 +98,8 @@ func (s *advancedVisibilitySuite) SetupSuite() {
 		dynamicconfig.ReachabilityTaskQueueScanLimit:             2,
 		dynamicconfig.ReachabilityQueryBuildIdLimit:              1,
 		dynamicconfig.BuildIdScavengerEnabled:                    true,
+		// Allow the scavenger to remove any build id regardless of when it was last default for a set.
+		dynamicconfig.RemovableBuildIdDurationSinceDefault: time.Microsecond,
 	}
 
 	switch TestFlags.PersistenceDriver {

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -81,6 +81,8 @@ func (s *userDataReplicationTestSuite) SetupSuite() {
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:                               true,
 		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs:                           true,
 		dynamicconfig.BuildIdScavengerEnabled:                                              true,
+		// Ensure the scavenger can immediately delete build ids that are not in use.
+		dynamicconfig.RemovableBuildIdDurationSinceDefault: time.Microsecond,
 	}
 	s.setupSuite([]string{"task_queue_repl_active", "task_queue_repl_standby"})
 }


### PR DESCRIPTION
Part 3 of the last minute refactoring of versioning data timestamps (see #4524 and #4526).

With this change, the scavenger uses the build id `became_default_timestamp` to determine whether it should be considered for removal.

From the documentation in code:

```
// If a build id was still default recently, there may be:
// 1. workers with that identifier processing tasks
// 2. workflows with that identifier that have yet to be indexed in visibility
// The scavenger should allow enough time to pass before cleaning these build ids.
```

Note that this is stacked on top of #4526 and only the last commit should be reviewed.