### PR TITLE
Check only running workflows for build id removal

### DIFF
--- a/common/worker_versioning/worker_versioning.go
+++ b/common/worker_versioning/worker_versioning.go
@@ -83,10 +83,13 @@ func FindBuildId(versionSets []*taskqueuepb.CompatibleVersionSet, buildId string
 	return setIndex, indexInSet
 }
 
-func WorkflowsExistForBuildId(ctx context.Context, visibilityManager manager.VisibilityManager, ns *namespace.Namespace, taskQueue, buildId string) (bool, error) {
+func BuildIdHasRunningWorkflows(ctx context.Context, visibilityManager manager.VisibilityManager, ns *namespace.Namespace, taskQueue, buildId string) (bool, error) {
 	escapedTaskQueue := sqlparser.String(sqlparser.NewStrVal([]byte(taskQueue)))
 	escapedBuildId := sqlparser.String(sqlparser.NewStrVal([]byte(VersionedBuildIdSearchAttribute(buildId))))
-	query := fmt.Sprintf("%s = %s AND %s = %s", searchattribute.TaskQueue, escapedTaskQueue, searchattribute.BuildIds, escapedBuildId)
+	query := fmt.Sprintf("%s = %s AND %s = %s AND %s = 'Running'",
+		searchattribute.TaskQueue, escapedTaskQueue,
+		searchattribute.BuildIds, escapedBuildId,
+		searchattribute.ExecutionStatus)
 
 	response, err := visibilityManager.CountWorkflowExecutions(ctx, &manager.CountWorkflowExecutionsRequest{
 		NamespaceID: ns.ID(),

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -40,3 +40,5 @@ frontend.workerVersioningDataAPIs:
   - value: true
 frontend.workerVersioningWorkflowAPIs:
   - value: true
+worker.buildIdScavengerEnabled:
+  - value: true

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -30,16 +30,18 @@
 #    constraints: {}
 #system.enableParentClosePolicyWorker:
 #  - value: true
-system.enableEagerWorkflowStart:
-  - value: true
 limit.maxIDLength:
   - value: 255
     constraints: {}
-frontend.workerVersioningDataAPIs:
-  - value: true
-frontend.workerVersioningWorkflowAPIs:
+system.enableEagerWorkflowStart:
   - value: true
 frontend.enableUpdateWorkflowExecution:
   - value: true
 frontend.enableUpdateWorkflowExecutionAsyncAccepted:
+  - value: true
+frontend.workerVersioningDataAPIs:
+  - value: true
+frontend.workerVersioningWorkflowAPIs:
+  - value: true
+worker.buildIdScavengerEnabled:
   - value: true

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -1051,11 +1051,11 @@ func (e *matchingEngineImpl) ApplyTaskQueueUserDataReplicationEvent(
 		for _, buildId := range buildIdsRemoved {
 			// We accept that the user data is locked for updates while running these visibility queries.
 			// Nothing else is _supposed_ to update it on follower (standby) clusters.
-			exists, err := worker_versioning.WorkflowsExistForBuildId(ctx, e.visibilityManager, ns, req.TaskQueue, buildId)
+			hasRunningWorkflows, err := worker_versioning.BuildIdHasRunningWorkflows(ctx, e.visibilityManager, ns, req.TaskQueue, buildId)
 			if err != nil {
 				return nil, false, err
 			}
-			if exists {
+			if hasRunningWorkflows {
 				buildIdsToRevive = append(buildIdsToRevive, buildId)
 			}
 		}

--- a/service/worker/scanner/build_ids/scavenger.go
+++ b/service/worker/scanner/build_ids/scavenger.go
@@ -288,12 +288,12 @@ func (a *Activities) findBuildIdsToRemove(
 			if err := rateLimiter.Wait(ctx); err != nil {
 				return buildIdsToRemove, err
 			}
-			exists, err := worker_versioning.WorkflowsExistForBuildId(ctx, a.visibilityManager, ns, entry.TaskQueue, buildId.Id)
+			hasRunningWorkflows, err := worker_versioning.BuildIdHasRunningWorkflows(ctx, a.visibilityManager, ns, entry.TaskQueue, buildId.Id)
 			if err != nil {
 				return buildIdsToRemove, err
 			}
 			a.recordHeartbeat(ctx, heartbeat)
-			if !exists {
+			if !hasRunningWorkflows {
 				a.logger.Info("Found build id to remove",
 					tag.WorkflowNamespace(ns.Name().String()),
 					tag.WorkflowTaskQueueName(entry.TaskQueue),


### PR DESCRIPTION
**What changed?**

The build id scavenger now checks if a build id has running workflows when it considers it for removal, not existing workflows.

**Why?**

While running on a live cluster I realized that build ids aren't being removed by the scavenger even though they haven't been used in over an hour.

**How did you test it?**

Added integration test