### PR TITLE
Update updateRegistry store on mutable state reload

### DIFF
--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -814,7 +814,7 @@ func (c *ContextImpl) UpdateRegistry(ctx context.Context) update.Registry {
 	if c.updateRegistry == nil {
 		nsIDStr := c.MutableState.GetNamespaceEntry().ID().String()
 		c.updateRegistry = update.NewRegistry(
-			c.MutableState,
+			func() update.UpdateStore { return c.MutableState },
 			update.WithLogger(c.logger),
 			update.WithMetrics(c.metricsHandler),
 			update.WithTracerProvider(trace.SpanFromContext(ctx).TracerProvider()),

--- a/service/history/workflowTaskHandler_test.go
+++ b/service/history/workflowTaskHandler_test.go
@@ -83,7 +83,7 @@ func TestCommandProtocolMessage(t *testing.T) {
 		out.conf = map[dynamicconfig.Key]any{}
 		out.ms = workflow.NewMockMutableState(gomock.NewController(t))
 		out.ms.EXPECT().VisitUpdates(gomock.Any()).Times(1)
-		out.updates = update.NewRegistry(out.ms)
+		out.updates = update.NewRegistry(func() update.UpdateStore { return out.ms })
 		var effects effect.Buffer
 		config := configs.NewConfig(
 			dynamicconfig.NewCollection(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Use up to date mutable state in update registry

<!-- Tell your future self why have you made these changes -->
**Why?**
- Lifecycle for updateRegistry is different from mutable state.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested on test cell

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- yes