### PR TITLE
Skip final task queue update if lost ownership

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -215,7 +215,7 @@ func (e *matchingEngineImpl) Stop() {
 	}
 
 	for _, l := range e.getTaskQueues(math.MaxInt32) {
-		l.Stop(false)
+		l.Stop()
 	}
 }
 
@@ -1117,7 +1117,7 @@ func (e *matchingEngineImpl) ForceUnloadTaskQueue(
 	if tqm == nil {
 		return &matchingservice.ForceUnloadTaskQueueResponse{WasLoaded: false}, nil
 	}
-	e.unloadTaskQueue(tqm, false)
+	e.unloadTaskQueue(tqm)
 	return &matchingservice.ForceUnloadTaskQueueResponse{WasLoaded: true}, nil
 }
 
@@ -1252,7 +1252,7 @@ func (e *matchingEngineImpl) getTask(
 	return tqm.GetTask(ctx, pollMetadata)
 }
 
-func (e *matchingEngineImpl) unloadTaskQueue(unloadTQM taskQueueManager, lostOwnership bool) {
+func (e *matchingEngineImpl) unloadTaskQueue(unloadTQM taskQueueManager) {
 	queueID := unloadTQM.QueueID()
 	e.taskQueuesLock.Lock()
 	foundTQM, ok := e.taskQueues[*queueID]
@@ -1267,7 +1267,7 @@ func (e *matchingEngineImpl) unloadTaskQueue(unloadTQM taskQueueManager, lostOwn
 	e.taskQueuesLock.Unlock()
 
 	e.updateTaskQueueGauge(countKey, taskQueueCount)
-	foundTQM.Stop(lostOwnership)
+	foundTQM.Stop()
 }
 
 func (e *matchingEngineImpl) updateTaskQueueGauge(countKey taskQueueCounterKey, taskQueueCount int) {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -215,7 +215,7 @@ func (e *matchingEngineImpl) Stop() {
 	}
 
 	for _, l := range e.getTaskQueues(math.MaxInt32) {
-		l.Stop()
+		l.Stop(false)
 	}
 }
 
@@ -1117,7 +1117,7 @@ func (e *matchingEngineImpl) ForceUnloadTaskQueue(
 	if tqm == nil {
 		return &matchingservice.ForceUnloadTaskQueueResponse{WasLoaded: false}, nil
 	}
-	e.unloadTaskQueue(tqm)
+	e.unloadTaskQueue(tqm, false)
 	return &matchingservice.ForceUnloadTaskQueueResponse{WasLoaded: true}, nil
 }
 
@@ -1252,7 +1252,7 @@ func (e *matchingEngineImpl) getTask(
 	return tqm.GetTask(ctx, pollMetadata)
 }
 
-func (e *matchingEngineImpl) unloadTaskQueue(unloadTQM taskQueueManager) {
+func (e *matchingEngineImpl) unloadTaskQueue(unloadTQM taskQueueManager, lostOwnership bool) {
 	queueID := unloadTQM.QueueID()
 	e.taskQueuesLock.Lock()
 	foundTQM, ok := e.taskQueues[*queueID]
@@ -1267,7 +1267,7 @@ func (e *matchingEngineImpl) unloadTaskQueue(unloadTQM taskQueueManager) {
 	e.taskQueuesLock.Unlock()
 
 	e.updateTaskQueueGauge(countKey, taskQueueCount)
-	foundTQM.Stop()
+	foundTQM.Stop(lostOwnership)
 }
 
 func (e *matchingEngineImpl) updateTaskQueueGauge(countKey taskQueueCounterKey, taskQueueCount int) {

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -2406,6 +2406,7 @@ type testTaskQueueManager struct {
 	createTaskCount  int
 	getTasksCount    int
 	getUserDataCount int
+	updateCount      int
 	tasks            *treemap.Map
 	userData         *persistencespb.VersionedTaskQueueUserData
 }
@@ -2470,6 +2471,7 @@ func (m *testTaskManager) UpdateTaskQueue(
 	tlm := m.getTaskQueueManager(newTestTaskQueueID(namespace.ID(tli.GetNamespaceId()), tli.Name, tli.TaskType))
 	tlm.Lock()
 	defer tlm.Unlock()
+	tlm.updateCount++
 
 	if tlm.rangeID != request.PrevRangeID {
 		return nil, &persistence.ConditionFailedError{
@@ -2668,6 +2670,14 @@ func (m *testTaskManager) getGetUserDataCount(taskQueue *taskQueueID) int {
 	tlm.Lock()
 	defer tlm.Unlock()
 	return tlm.getUserDataCount
+}
+
+// getUpdateCount returns how many times UpdateTaskQueue was called
+func (m *testTaskManager) getUpdateCount(taskQueue *taskQueueID) int {
+	tlm := m.getTaskQueueManager(taskQueue)
+	tlm.Lock()
+	defer tlm.Unlock()
+	return tlm.updateCount
 }
 
 func (m *testTaskManager) String() string {

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -302,7 +302,7 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 	s.Require().NoError(err)
 
 	// try to unload a different tqm instance with the same taskqueue ID
-	s.matchingEngine.unloadTaskQueue(tqm2, false)
+	s.matchingEngine.unloadTaskQueue(tqm2)
 
 	got, err := s.matchingEngine.getTaskQueueManager(
 		context.Background(), queueID, normalStickyInfo, true)
@@ -311,7 +311,7 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 		"Unload call with non-matching taskQueueManager should not cause unload")
 
 	// this time unload the right tqm
-	s.matchingEngine.unloadTaskQueue(tqm, false)
+	s.matchingEngine.unloadTaskQueue(tqm)
 
 	got, err = s.matchingEngine.getTaskQueueManager(
 		context.Background(), queueID, normalStickyInfo, true)
@@ -1706,7 +1706,7 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 
 	// stop all goroutines that read / write tasks in the background
 	// remainder of this test works with the in-memory buffer
-	tlMgr.Stop(false)
+	tlMgr.Stop()
 
 	// setReadLevel should NEVER be called without updating ackManager.outstandingTasks
 	// This is only for unit test purpose
@@ -1809,7 +1809,7 @@ func (s *matchingEngineSuite) TestTaskQueueManager_CyclingBehavior() {
 		tlMgr.Start()
 		// tlMgr.taskWriter startup is async so give it time to complete
 		time.Sleep(100 * time.Millisecond)
-		tlMgr.Stop(false)
+		tlMgr.Stop()
 
 		getTasksCount := s.taskManager.getGetTasksCount(tlID) - prevGetTasksCount
 		s.LessOrEqual(getTasksCount, 1)

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -302,7 +302,7 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 	s.Require().NoError(err)
 
 	// try to unload a different tqm instance with the same taskqueue ID
-	s.matchingEngine.unloadTaskQueue(tqm2)
+	s.matchingEngine.unloadTaskQueue(tqm2, false)
 
 	got, err := s.matchingEngine.getTaskQueueManager(
 		context.Background(), queueID, normalStickyInfo, true)
@@ -311,7 +311,7 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 		"Unload call with non-matching taskQueueManager should not cause unload")
 
 	// this time unload the right tqm
-	s.matchingEngine.unloadTaskQueue(tqm)
+	s.matchingEngine.unloadTaskQueue(tqm, false)
 
 	got, err = s.matchingEngine.getTaskQueueManager(
 		context.Background(), queueID, normalStickyInfo, true)
@@ -1706,7 +1706,7 @@ func (s *matchingEngineSuite) TestTaskQueueManagerGetTaskBatch() {
 
 	// stop all goroutines that read / write tasks in the background
 	// remainder of this test works with the in-memory buffer
-	tlMgr.Stop()
+	tlMgr.Stop(false)
 
 	// setReadLevel should NEVER be called without updating ackManager.outstandingTasks
 	// This is only for unit test purpose
@@ -1809,7 +1809,7 @@ func (s *matchingEngineSuite) TestTaskQueueManager_CyclingBehavior() {
 		tlMgr.Start()
 		// tlMgr.taskWriter startup is async so give it time to complete
 		time.Sleep(100 * time.Millisecond)
-		tlMgr.Stop()
+		tlMgr.Stop(false)
 
 		getTasksCount := s.taskManager.getGetTasksCount(tlID) - prevGetTasksCount
 		s.LessOrEqual(getTasksCount, 1)

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -278,7 +278,7 @@ func TestSyncMatchLeasingUnavailable(t *testing.T) {
 			return taskQueueState{}, errors.New(t.Name())
 		}))
 	tqm.Start()
-	defer tqm.Stop(false)
+	defer tqm.Stop()
 	poller, _ := runOneShotPoller(context.Background(), tqm)
 	defer poller.Cancel()
 
@@ -299,7 +299,7 @@ func TestForeignPartitionOwnerCausesUnload(t *testing.T) {
 			return taskQueueState{rangeID: 1}, leaseErr
 		}))
 	tqm.Start()
-	defer tqm.Stop(false)
+	defer tqm.Stop()
 
 	// TQM started succesfully with an ID block of size 1. Perform one send
 	// without a poller to consume the one task ID from the reserved block.
@@ -337,7 +337,7 @@ func TestReaderSignaling(t *testing.T) {
 	tqm.taskReader.notifyC = readerNotifications
 
 	tqm.Start()
-	defer tqm.Stop(false)
+	defer tqm.Stop()
 
 	// shut down the taskReader so it doesn't steal notifications from us
 	tqm.taskReader.gorogrp.Cancel()
@@ -514,7 +514,7 @@ func TestCheckIdleTaskQueue(t *testing.T) {
 	require.Equal(t, 1, len(tlm.GetAllPollerInfo()))
 	time.Sleep(1 * time.Second)
 	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
-	tlm.Stop(false)
+	tlm.Stop()
 	require.Equal(t, common.DaemonStatusStopped, atomic.LoadInt32(&tlm.status))
 
 	// Active adding task
@@ -524,7 +524,7 @@ func TestCheckIdleTaskQueue(t *testing.T) {
 	tlm.taskReader.Signal()
 	time.Sleep(1 * time.Second)
 	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
-	tlm.Stop(false)
+	tlm.Stop()
 	require.Equal(t, common.DaemonStatusStopped, atomic.LoadInt32(&tlm.status))
 }
 
@@ -652,7 +652,7 @@ func TestTQMLoadsUserDataFromPersistenceOnInit(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop(false)
+	tq.Stop()
 }
 
 func TestTQMLoadsUserDataFromPersistenceOnInitOnlyOnceWhenNoData(t *testing.T) {
@@ -686,7 +686,7 @@ func TestTQMLoadsUserDataFromPersistenceOnInitOnlyOnceWhenNoData(t *testing.T) {
 
 	require.Equal(t, 1, tm.getGetUserDataCount(tqId))
 
-	tq.Stop(false)
+	tq.Stop()
 }
 
 func TestTQMFetchesUserDataFromOnInit(t *testing.T) {
@@ -724,7 +724,7 @@ func TestTQMFetchesUserDataFromOnInit(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop(false)
+	tq.Stop()
 }
 
 func TestTQMFetchesUserDataAndFetchesAgain(t *testing.T) {
@@ -793,7 +793,7 @@ func TestTQMFetchesUserDataAndFetchesAgain(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data2, userData)
-	tq.Stop(false)
+	tq.Stop()
 }
 
 func TestTQMFetchesUserDataFailsAndTriesAgain(t *testing.T) {
@@ -846,7 +846,7 @@ func TestTQMFetchesUserDataFailsAndTriesAgain(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop(false)
+	tq.Stop()
 }
 
 func TestTQMFetchesUserDataUpTree(t *testing.T) {
@@ -885,7 +885,7 @@ func TestTQMFetchesUserDataUpTree(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop(false)
+	tq.Stop()
 }
 
 func TestTQMFetchesUserDataActivityToWorkflow(t *testing.T) {
@@ -924,7 +924,7 @@ func TestTQMFetchesUserDataActivityToWorkflow(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop(false)
+	tq.Stop()
 }
 
 func TestTQMFetchesUserDataStickyToNormal(t *testing.T) {
@@ -983,7 +983,7 @@ func TestTQMFetchesUserDataStickyToNormal(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop(false)
+	tq.Stop()
 }
 
 func TestUpdateOnNonRootFails(t *testing.T) {

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -579,7 +579,6 @@ func TestTQMDoesFinalUpdateOnIdleUnload(t *testing.T) {
 	t.Parallel()
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	cfg := NewConfig(dynamicconfig.NewNoopCollection(), false, false)
 	cfg.MaxTaskQueueIdleTime = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(1 * time.Second)
@@ -599,7 +598,6 @@ func TestTQMDoesNotDoFinalUpdateOnOwnershipLost(t *testing.T) {
 	t.Parallel()
 
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	cfg := NewConfig(dynamicconfig.NewNoopCollection(), false, false)
 	cfg.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(2 * time.Second)

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -575,6 +575,54 @@ func TestAddTaskStandby(t *testing.T) {
 	require.False(t, syncMatch)
 }
 
+func TestTQMDoesFinalUpdateOnIdleUnload(t *testing.T) {
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	cfg := NewConfig(dynamicconfig.NewNoopCollection(), false, false)
+	cfg.MaxTaskQueueIdleTime = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(1 * time.Second)
+	tqCfg := defaultTqmTestOpts(controller)
+	tqCfg.config = cfg
+
+	tqm := mustCreateTestTaskQueueManagerWithConfig(t, controller, tqCfg)
+	tm := tqm.engine.taskManager.(*testTaskManager)
+
+	tqm.Start()
+	time.Sleep(2 * time.Second) // will unload due to idleness
+	require.Equal(t, 1, tm.getUpdateCount(tqCfg.tqId))
+}
+
+func TestTQMDoesNotDoFinalUpdateOnOwnershipLost(t *testing.T) {
+	// TODO: use mocks instead of testTaskManager so we can do synchronization better instead of sleeps
+	t.Parallel()
+
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	cfg := NewConfig(dynamicconfig.NewNoopCollection(), false, false)
+	cfg.UpdateAckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskQueueInfo(2 * time.Second)
+	tqCfg := defaultTqmTestOpts(controller)
+	tqCfg.config = cfg
+
+	tqm := mustCreateTestTaskQueueManagerWithConfig(t, controller, tqCfg)
+	tm := tqm.engine.taskManager.(*testTaskManager)
+
+	tqm.Start()
+	time.Sleep(1 * time.Second)
+
+	// simulate ownership lost
+	ttm := tm.getTaskQueueManager(tqCfg.tqId)
+	ttm.Lock()
+	ttm.rangeID++
+	ttm.Unlock()
+
+	time.Sleep(2 * time.Second) // will attempt to update and fail and not try again
+
+	require.Equal(t, 1, tm.getUpdateCount(tqCfg.tqId))
+}
+
 func TestTQMLoadsUserDataFromPersistenceOnInit(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()

--- a/service/matching/taskQueueManager_test.go
+++ b/service/matching/taskQueueManager_test.go
@@ -278,7 +278,7 @@ func TestSyncMatchLeasingUnavailable(t *testing.T) {
 			return taskQueueState{}, errors.New(t.Name())
 		}))
 	tqm.Start()
-	defer tqm.Stop()
+	defer tqm.Stop(false)
 	poller, _ := runOneShotPoller(context.Background(), tqm)
 	defer poller.Cancel()
 
@@ -299,7 +299,7 @@ func TestForeignPartitionOwnerCausesUnload(t *testing.T) {
 			return taskQueueState{rangeID: 1}, leaseErr
 		}))
 	tqm.Start()
-	defer tqm.Stop()
+	defer tqm.Stop(false)
 
 	// TQM started succesfully with an ID block of size 1. Perform one send
 	// without a poller to consume the one task ID from the reserved block.
@@ -337,7 +337,7 @@ func TestReaderSignaling(t *testing.T) {
 	tqm.taskReader.notifyC = readerNotifications
 
 	tqm.Start()
-	defer tqm.Stop()
+	defer tqm.Stop(false)
 
 	// shut down the taskReader so it doesn't steal notifications from us
 	tqm.taskReader.gorogrp.Cancel()
@@ -514,7 +514,7 @@ func TestCheckIdleTaskQueue(t *testing.T) {
 	require.Equal(t, 1, len(tlm.GetAllPollerInfo()))
 	time.Sleep(1 * time.Second)
 	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
-	tlm.Stop()
+	tlm.Stop(false)
 	require.Equal(t, common.DaemonStatusStopped, atomic.LoadInt32(&tlm.status))
 
 	// Active adding task
@@ -524,7 +524,7 @@ func TestCheckIdleTaskQueue(t *testing.T) {
 	tlm.taskReader.Signal()
 	time.Sleep(1 * time.Second)
 	require.Equal(t, common.DaemonStatusStarted, atomic.LoadInt32(&tlm.status))
-	tlm.Stop()
+	tlm.Stop(false)
 	require.Equal(t, common.DaemonStatusStopped, atomic.LoadInt32(&tlm.status))
 }
 
@@ -604,7 +604,7 @@ func TestTQMLoadsUserDataFromPersistenceOnInit(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop()
+	tq.Stop(false)
 }
 
 func TestTQMLoadsUserDataFromPersistenceOnInitOnlyOnceWhenNoData(t *testing.T) {
@@ -638,7 +638,7 @@ func TestTQMLoadsUserDataFromPersistenceOnInitOnlyOnceWhenNoData(t *testing.T) {
 
 	require.Equal(t, 1, tm.getGetUserDataCount(tqId))
 
-	tq.Stop()
+	tq.Stop(false)
 }
 
 func TestTQMFetchesUserDataFromOnInit(t *testing.T) {
@@ -676,7 +676,7 @@ func TestTQMFetchesUserDataFromOnInit(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop()
+	tq.Stop(false)
 }
 
 func TestTQMFetchesUserDataAndFetchesAgain(t *testing.T) {
@@ -745,7 +745,7 @@ func TestTQMFetchesUserDataAndFetchesAgain(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data2, userData)
-	tq.Stop()
+	tq.Stop(false)
 }
 
 func TestTQMFetchesUserDataFailsAndTriesAgain(t *testing.T) {
@@ -798,7 +798,7 @@ func TestTQMFetchesUserDataFailsAndTriesAgain(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop()
+	tq.Stop(false)
 }
 
 func TestTQMFetchesUserDataUpTree(t *testing.T) {
@@ -837,7 +837,7 @@ func TestTQMFetchesUserDataUpTree(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop()
+	tq.Stop(false)
 }
 
 func TestTQMFetchesUserDataActivityToWorkflow(t *testing.T) {
@@ -876,7 +876,7 @@ func TestTQMFetchesUserDataActivityToWorkflow(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop()
+	tq.Stop(false)
 }
 
 func TestTQMFetchesUserDataStickyToNormal(t *testing.T) {
@@ -935,7 +935,7 @@ func TestTQMFetchesUserDataStickyToNormal(t *testing.T) {
 	userData, _, err := tq.GetUserData(ctx)
 	require.NoError(t, err)
 	require.Equal(t, data1, userData)
-	tq.Stop()
+	tq.Stop(false)
 }
 
 func TestUpdateOnNonRootFails(t *testing.T) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
taskQueueManager tries to persist its state (ack level) one final time on unload. This is useless if it lost ownership since we know the write will fail. We can tell the difference and make it skip the call if it lost ownership.
Also don't log if it fails since we're unloading anyway.

<!-- Tell your future self why have you made these changes -->
**Why?**
Avoid useless persistence calls.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing tests, new unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
