### PR TITLE
Add an error log detection test to the server

### DIFF
--- a/temporal/server_test.go
+++ b/temporal/server_test.go
@@ -26,27 +26,107 @@ package temporal
 
 import (
 	"path"
+	"strings"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"time"
 
 	"go.temporal.io/server/common/config"
-	// need to import this package to register the sqlite plugin
-	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/sqlite" // needed to register the sqlite plugin
 	"go.temporal.io/server/tests/testutils"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-// TestNewServer verifies that NewServer doesn't cause any fx errors
+// TestNewServer verifies that NewServer doesn't cause any fx errors, and that there are no unexpected error logs after
+// running for a few seconds.
 func TestNewServer(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	cfg := loadConfig(t)
+	logger := newErrorLogDetector(t, ctrl)
+
+	server, err := NewServer(
+		WithConfig(cfg),
+		WithLogger(logger),
+	)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, server.Stop())
+	})
+	require.NoError(t, server.Start())
+	time.Sleep(10 * time.Second)
+}
+
+func loadConfig(t *testing.T) *config.Config {
+	cfg := loadSQLiteConfig(t)
+	setTestPorts(cfg)
+
+	return cfg
+}
+
+// loadSQLiteConfig loads the config for the sqlite persistence store. We use sqlite because it doesn't require any
+// external dependencies, so it's easy to run this test in isolation.
+func loadSQLiteConfig(t *testing.T) *config.Config {
 	configDir := path.Join(testutils.GetRepoRootDirectory(), "config")
 	cfg, err := config.LoadConfig("development-sqlite", configDir, "")
 	require.NoError(t, err)
+
 	cfg.DynamicConfigClient.Filepath = path.Join(configDir, "dynamicconfig", "development-sql.yaml")
-	_, err = NewServer(
-		ForServices(DefaultServices),
-		WithConfig(cfg),
-	)
-	assert.NoError(t, err)
-	// TODO: add tests for Server.Run(), etc.
+
+	return cfg
+}
+
+// setTestPorts sets the ports of all services to something different from the default ports, so that we can run the
+// tests in parallel.
+func setTestPorts(cfg *config.Config) {
+	port := 10000
+
+	for k, v := range cfg.Services {
+		rpc := v.RPC
+		rpc.GRPCPort = port
+		port++
+		rpc.MembershipPort = port
+		port++
+		v.RPC = rpc
+		cfg.Services[k] = v
+	}
+}
+
+// newErrorLogDetector returns a logger that fails the test if it logs any errors or warnings, except for the ones that
+// are expected. Ideally, there are no "expected" errors or warnings, but we still want this test to avoid introducing
+// any new ones while we are working on removing the existing ones.
+func newErrorLogDetector(t *testing.T, ctrl *gomock.Controller) *log.MockLogger {
+	logger := log.NewMockLogger(ctrl)
+	logger.EXPECT().Debug(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Info(gomock.Any(), gomock.Any()).AnyTimes()
+	logger.EXPECT().Warn(gomock.Any(), gomock.Any()).AnyTimes().Do(func(msg string, tags ...tag.Tag) {
+		if strings.Contains(msg, "error creating sdk client") {
+			return
+		}
+
+		if strings.Contains(msg, "poll for task") {
+			return
+		}
+
+		if strings.Contains(msg, "error in prometheus") {
+			return
+		}
+
+		t.Errorf("unexpected warning: %v", msg)
+	})
+	logger.EXPECT().Error(gomock.Any(), gomock.Any()).AnyTimes().Do(func(msg string, tags ...tag.Tag) {
+		if strings.Contains(msg, "looking up host for shardID") {
+			return
+		}
+
+		t.Errorf("unexpected error: %v", msg)
+	})
+
+	return logger
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a test which verifies that the server can run for 10 seconds without logging any new errors or warnings.

<!-- Tell your future self why have you made these changes -->
**Why?**
There have been several times where we've introduced regressions which are visible within a few seconds of starting the server. Ideally, we have a better test for this than just running the server for 10 seconds, but it's been several months since we've needed this test, and I haven't thought of anything else.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
A recent regression is fixed in the commit here titled "Log fxevent.Run". I made an example branch just containing this new test which still has that regression, and you should be able to see this test fail there: https://buildkite.com/temporal/temporal-public/builds/10576

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There may be some existing error/warning logs that I didn't put in the `EXPECT()` blocks here, so this may introduce flakiness into our server. It might also slow down our test suite since this test is guaranteed to run for 10 seconds.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.