### PR TITLE
Dependency-inject a clock into PriorityRateLimiterImpl

### DIFF
--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -27,6 +27,7 @@ package configs
 import (
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/quotas"
 )
@@ -203,7 +204,7 @@ func NewExecutionPriorityRateLimiter(
 			return priority
 		}
 		return ExecutionAPIPrioritiesOrdered[len(ExecutionAPIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	}, rateLimiters, clockwork.NewRealClock())
 }
 
 func NewVisibilityPriorityRateLimiter(
@@ -218,7 +219,7 @@ func NewVisibilityPriorityRateLimiter(
 			return priority
 		}
 		return VisibilityAPIPrioritiesOrdered[len(VisibilityAPIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	}, rateLimiters, clockwork.NewRealClock())
 }
 
 func NewNamespaceReplicationInducingAPIPriorityRateLimiter(
@@ -233,7 +234,7 @@ func NewNamespaceReplicationInducingAPIPriorityRateLimiter(
 			return priority
 		}
 		return NamespaceReplicationInducingAPIPrioritiesOrdered[len(NamespaceReplicationInducingAPIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	}, rateLimiters, clockwork.NewRealClock())
 }
 
 func NewOtherAPIPriorityRateLimiter(
@@ -248,5 +249,5 @@ func NewOtherAPIPriorityRateLimiter(
 			return priority
 		}
 		return OtherAPIPrioritiesOrdered[len(OtherAPIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	}, rateLimiters, clockwork.NewRealClock())
 }

--- a/service/history/configs/quotas.go
+++ b/service/history/configs/quotas.go
@@ -25,6 +25,7 @@
 package configs
 
 import (
+	"github.com/jonboulle/clockwork"
 	"go.temporal.io/server/common/quotas"
 )
 
@@ -95,5 +96,5 @@ func NewPriorityRateLimiter(
 			return priority
 		}
 		return APIPrioritiesOrdered[len(APIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	}, rateLimiters, clockwork.NewRealClock())
 }

--- a/service/history/queues/reader_quotas.go
+++ b/service/history/queues/reader_quotas.go
@@ -27,6 +27,7 @@ package queues
 import (
 	"strconv"
 
+	"github.com/jonboulle/clockwork"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/quotas"
 )
@@ -49,15 +50,12 @@ func NewReaderPriorityRateLimiter(
 	}
 	lowestPriority := int(DefaultReaderId + maxReaders - 1)
 
-	return quotas.NewPriorityRateLimiter(
-		func(req quotas.Request) int {
-			if priority, ok := readerCallerToPriority[req.Caller]; ok {
-				return priority
-			}
-			return lowestPriority
-		},
-		rateLimiters,
-	)
+	return quotas.NewPriorityRateLimiter(func(req quotas.Request) int {
+		if priority, ok := readerCallerToPriority[req.Caller]; ok {
+			return priority
+		}
+		return lowestPriority
+	}, rateLimiters, clockwork.NewRealClock())
 }
 
 func newShardReaderRateLimiter(

--- a/service/history/queues/scheduler_quotas.go
+++ b/service/history/queues/scheduler_quotas.go
@@ -25,6 +25,7 @@
 package queues
 
 import (
+	"github.com/jonboulle/clockwork"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/quotas"
 	"go.temporal.io/server/common/tasks"
@@ -75,10 +76,7 @@ func NewSchedulerRateLimiter(
 		priorityToRateLimiters[int(priority)] = requestRateLimiter
 	}
 
-	return quotas.NewPriorityRateLimiter(
-		requestPriorityFn,
-		priorityToRateLimiters,
-	)
+	return quotas.NewPriorityRateLimiter(requestPriorityFn, priorityToRateLimiters, clockwork.NewRealClock())
 }
 
 func newHighPriorityTaskRequestRateLimiter(

--- a/service/matching/configs/quotas.go
+++ b/service/matching/configs/quotas.go
@@ -25,6 +25,7 @@
 package configs
 
 import (
+	"github.com/jonboulle/clockwork"
 	"go.temporal.io/server/common/quotas"
 )
 
@@ -64,5 +65,5 @@ func NewPriorityRateLimiter(
 			return priority
 		}
 		return APIPrioritiesOrdered[len(APIPrioritiesOrdered)-1]
-	}, rateLimiters)
+	}, rateLimiters, clockwork.NewRealClock())
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a `clockwork.Clock` to our `PriorityRateLimiterImpl`, and I modified the code to use that clock instead of the standard `time` library functions.

<!-- Tell your future self why have you made these changes -->
**Why?**
I will soon be making a change to our rate limiters to do both per-instance and per-cluster rate limiting for some methods, and I want this test to use a fake clock instead of a real one to make writing the tests better, so this is preparatory refactoring.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I verified there's no test coverage regression. I also ran it 1k times locally with `-race`:
```
 ➜ go test -count 1000 -race -run TestPriorityStageRateLimiterSuite ./common/quotas
ok      go.temporal.io/server/common/quotas     4.030s
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This could make it harder to write tests since you have to think about when to call `BlockUntil` instead of more intuitive concepts like just sleeping in the background whenever and then doing something. It's also inconsistent with the other files here, but we have to start somewhere. Another downside is that we have to call `clockwork.NewRealClock()` everywhere since there's no clock propagation upstream (this is similar to having to write `context.TODO()`), but the alternative would mean a much larger refactor.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.