### PR TITLE
Measure backlog after completing current task

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -1327,7 +1327,7 @@ func (e *matchingEngineImpl) createPollWorkflowTaskQueueResponse(
 	if task.query != nil {
 		response.Query = task.query.request.QueryRequest.Query
 	}
-	response.BacklogCountHint = task.backlogCountHint
+	response.BacklogCountHint = task.backlogCountHint()
 	return response
 }
 

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -1327,7 +1327,9 @@ func (e *matchingEngineImpl) createPollWorkflowTaskQueueResponse(
 	if task.query != nil {
 		response.Query = task.query.request.QueryRequest.Query
 	}
-	response.BacklogCountHint = task.backlogCountHint()
+	if task.backlogCountHint != nil {
+		response.BacklogCountHint = task.backlogCountHint()
+	}
 	return response
 }
 

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -399,7 +399,7 @@ func (s *matchingEngineSuite) TestPollWorkflowTaskQueues() {
 		StartedEventId:         common.EmptyEventID,
 		Attempt:                1,
 		NextEventId:            common.EmptyEventID,
-		BacklogCountHint:       1,
+		BacklogCountHint:       0,
 		StickyExecutionEnabled: true,
 		Query:                  nil,
 		TransientWorkflowTask:  nil,

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -61,7 +61,7 @@ type (
 		source           enumsspb.TaskSource
 		forwardedFrom    string     // name of the child partition this task is forwarded from (empty if not forwarded)
 		responseC        chan error // non-nil only where there is a caller waiting for response (sync-match)
-		backlogCountHint int64
+		backlogCountHint func() int64
 	}
 )
 

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -479,7 +479,7 @@ func (c *taskQueueManagerImpl) GetTask(
 	}
 
 	task.namespace = c.namespace
-	task.backlogCountHint = c.taskAckManager.getBacklogCountHint()
+	task.backlogCountHint = c.taskAckManager.getBacklogCountHint
 	return task, nil
 }
 


### PR DESCRIPTION
**What changed?**
PollWorkflowTaskQueue returns a hint for the backlog on the task queue polled, which is measured (approximately) as tasks in the taskReader buffer or pending return to a poller. When matching a task that came from the db, the task itself would be counted in the backlog, since the backlog was recorded at match time, instead of after marking the task acked.

This measures the backlog after marking the task acked.

**Why?**
SDKs always poll on the sticky queue if there is a backlog, so they could incorrectly poll on the sticky queue when there are no tasks there and neglect the normal queue, causing a delay of up to the long poll interval.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manually for now

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
