### PR TITLE
Make ringpop.monitor depend on our service listener

### DIFF
--- a/common/config/fx.go
+++ b/common/config/fx.go
@@ -25,6 +25,8 @@
 package config
 
 import (
+	"errors"
+
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common/primitives"
@@ -38,6 +40,8 @@ var Module = fx.Provide(
 	provideMembershipConfig,
 	provideServicePortMap,
 )
+
+var errInvalidListener = errors.New("listener is not a TCP listener")
 
 func provideRPCConfig(cfg *Config, svcName primitives.ServiceName) *RPC {
 	c := cfg.Services[string(svcName)].RPC

--- a/common/membership/ringpop/fx.go
+++ b/common/membership/ringpop/fx.go
@@ -25,6 +25,8 @@
 package ringpop
 
 import (
+	"net"
+
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common/membership"
@@ -33,7 +35,7 @@ import (
 // Module provides membership objects given the types in factoryParams.
 var Module = fx.Provide(
 	provideFactory,
-	provideMembership,
+	provideMonitor,
 	provideHostInfoProvider,
 )
 
@@ -46,7 +48,9 @@ func provideFactory(lc fx.Lifecycle, params factoryParams) (*factory, error) {
 	return f, nil
 }
 
-func provideMembership(lc fx.Lifecycle, f *factory) membership.Monitor {
+// provideMonitor provides a membership monitor that is started and stopped. We depend on a listener object because
+// we don't want to broadcast our own address to the ringpop cluster until we are ready to accept connections.
+func provideMonitor(lc fx.Lifecycle, f *factory, _ net.Listener) membership.Monitor {
 	m := f.getMonitor()
 	lc.Append(fx.StartStopHook(m.Start, m.Stop))
 	return m

--- a/common/resource/fx.go
+++ b/common/resource/fx.go
@@ -27,7 +27,6 @@ package resource
 import (
 	"crypto/tls"
 	"fmt"
-	"net"
 	"os"
 	"time"
 
@@ -111,7 +110,7 @@ var Module = fx.Options(
 	fx.Provide(ClientFactoryProvider),
 	fx.Provide(ClientBeanProvider),
 	fx.Provide(FrontendClientProvider),
-	fx.Provide(GrpcListenerProvider),
+	fx.Provide(rpc.StartServiceListener),
 	fx.Provide(RuntimeMetricsReporterProvider),
 	metrics.RuntimeMetricsReporterLifetimeHooksModule,
 	fx.Provide(HistoryClientProvider),
@@ -147,10 +146,6 @@ func ThrottledLoggerProvider(
 		logger,
 		quotas.RateFn(fn),
 	)
-}
-
-func GrpcListenerProvider(factory common.RPCFactory) net.Listener {
-	return factory.GetGRPCListener()
 }
 
 func HostNameProvider() (HostName, error) {

--- a/common/rpc/test/rpc_common_test.go
+++ b/common/rpc/test/rpc_common_test.go
@@ -32,6 +32,7 @@ import (
 	"strings"
 
 	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/common/primitives"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/examples/helloworld/helloworld"
@@ -99,7 +100,8 @@ func startHelloWorldServer(s *suite.Suite, factory *TestFactory) (*grpc.Server, 
 	greeter := &HelloServer{}
 	helloworld.RegisterGreeterServer(server, greeter)
 
-	listener := factory.GetGRPCListener()
+	listener, err := rpc.StartServiceListener(rpcTestCfgDefault, log.NewTestLogger(), primitives.FrontendService)
+	s.NoError(err)
 
 	port := strings.Split(listener.Addr().String(), ":")[1]
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
^

<!-- Tell your future self why have you made these changes -->
**Why?**
I made this change so that we don't broadcast the history service's address to Ringpop until we're actually listening on that port.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I wrote a unit test for our `StartServiceListener` function. I also verified the order of operations by adding a log statement:

<img width="1358" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/7e86eeab-36eb-4e28-bea8-dd6bd8c95eb9">


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Not sure. Perhaps this makes the fx graph less flexible?

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No