### PR TITLE
Plumb clockwork.Clock through dependency graph

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -93,3 +93,6 @@ issues:
       text: "(cyclomatic|cognitive)"
       linters:
         - revive
+    - path: _test\.go
+      linters:
+        - goerr113

--- a/common/persistence/client/fx.go
+++ b/common/persistence/client/fx.go
@@ -27,6 +27,7 @@ package client
 import (
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common/cluster"
@@ -65,6 +66,7 @@ type (
 		Logger                             log.Logger
 		HealthSignals                      persistence.HealthSignalAggregator
 		DynamicRateLimitingParams          DynamicRateLimitingParams
+		Clock                              clockwork.Clock
 	}
 
 	FactoryProviderFn func(NewFactoryParams) Factory
@@ -95,9 +97,10 @@ func FactoryProvider(
 				params.HealthSignals,
 				params.DynamicRateLimitingParams,
 				params.Logger,
+				params.Clock,
 			)
 		} else {
-			requestRatelimiter = NewNoopPriorityRateLimiter(params.PersistenceMaxQPS)
+			requestRatelimiter = NewNoopPriorityRateLimiter(params.PersistenceMaxQPS, params.Clock)
 		}
 	}
 

--- a/common/persistence/client/quotas_test.go
+++ b/common/persistence/client/quotas_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/server/common/quotas"
@@ -107,7 +108,12 @@ func (s *quotasSuite) TestPriorityNamespaceRateLimiter_DoesLimit() {
 	var namespaceMaxRPS = func(namespace string) int { return 1 }
 	var hostMaxRPS = func() int { return 1 }
 
-	var limiter = newPriorityNamespaceRateLimiter(namespaceMaxRPS, hostMaxRPS, RequestPriorityFn)
+	var limiter = newPriorityNamespaceRateLimiter(
+		namespaceMaxRPS,
+		hostMaxRPS,
+		RequestPriorityFn,
+		clockwork.NewRealClock(),
+	)
 
 	var request = quotas.NewRequest(
 		"test-api",
@@ -134,7 +140,12 @@ func (s *quotasSuite) TestPerShardNamespaceRateLimiter_DoesLimit() {
 	var perShardNamespaceMaxRPS = func(namespace string) int { return 1 }
 	var hostMaxRPS = func() int { return 1 }
 
-	var limiter = newPerShardPerNamespacePriorityRateLimiter(perShardNamespaceMaxRPS, hostMaxRPS, RequestPriorityFn)
+	var limiter = newPerShardPerNamespacePriorityRateLimiter(
+		perShardNamespaceMaxRPS,
+		hostMaxRPS,
+		RequestPriorityFn,
+		clockwork.NewRealClock(),
+	)
 
 	var request = quotas.NewRequest(
 		"test-api",

--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -120,6 +120,7 @@ func newQueueFactoryBase(params ArchivalQueueFactoryParams, hostScheduler queues
 				archivalQueuePersistenceMaxRPSRatio,
 			),
 			int64(params.Config.QueueMaxReaderCount()),
+			params.Clock,
 		),
 	}
 }

--- a/service/history/archival_queue_factory_test.go
+++ b/service/history/archival_queue_factory_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -76,6 +77,7 @@ func TestArchivalQueueFactory(t *testing.T) {
 			TimeSource:     namespace.NewMockClock(ctrl),
 			MetricsHandler: metricsHandler,
 			Logger:         log.NewNoopLogger(),
+			Clock:          clockwork.NewRealClock(),
 		},
 	})
 	queue := queueFactory.CreateQueue(mockShard, nil)

--- a/service/history/configs/quotas.go
+++ b/service/history/configs/quotas.go
@@ -86,6 +86,7 @@ var (
 
 func NewPriorityRateLimiter(
 	rateFn quotas.RateFn,
+	clock clockwork.Clock,
 ) quotas.RequestRateLimiter {
 	rateLimiters := make(map[int]quotas.RequestRateLimiter)
 	for priority := range APIPrioritiesOrdered {
@@ -96,5 +97,5 @@ func NewPriorityRateLimiter(
 			return priority
 		}
 		return APIPrioritiesOrdered[len(APIPrioritiesOrdered)-1]
-	}, rateLimiters, clockwork.NewRealClock())
+	}, rateLimiters, clock)
 }

--- a/service/history/queueFactoryBase.go
+++ b/service/history/queueFactoryBase.go
@@ -27,11 +27,12 @@ package history
 import (
 	"context"
 
+	"github.com/jonboulle/clockwork"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
-	"go.temporal.io/server/common/clock"
+	cclock "go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -67,10 +68,11 @@ type (
 		NamespaceRegistry    namespace.Registry
 		ClusterMetadata      cluster.Metadata
 		Config               *configs.Config
-		TimeSource           clock.TimeSource
+		TimeSource           cclock.TimeSource
 		MetricsHandler       metrics.Handler
 		Logger               log.SnTaggedLogger
 		SchedulerRateLimiter queues.SchedulerRateLimiter
+		Clock                clockwork.Clock
 	}
 
 	QueueFactoryBase struct {
@@ -154,12 +156,14 @@ func getOptionalQueueFactories(
 
 func QueueSchedulerRateLimiterProvider(
 	config *configs.Config,
+	clock clockwork.Clock,
 ) queues.SchedulerRateLimiter {
 	return queues.NewSchedulerRateLimiter(
 		config.TaskSchedulerNamespaceMaxQPS,
 		config.TaskSchedulerMaxQPS,
 		config.PersistenceNamespaceMaxQPS,
 		config.PersistenceMaxQPS,
+		clock,
 	)
 }
 

--- a/service/history/queue_factory_base_test.go
+++ b/service/history/queue_factory_base_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/fx"
@@ -161,6 +162,7 @@ func getModuleDependencies(controller *gomock.Controller, c *moduleTestCase) fx.
 		fx.Annotate(archivalMetadata, fx.As(new(carchiver.ArchivalMetadata))),
 		fx.Annotate(metrics.NoopMetricsHandler, fx.As(new(metrics.Handler))),
 		fx.Annotate(clusterMetadata, fx.As(new(cluster.Metadata))),
+		fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 	)
 }
 

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/jonboulle/clockwork"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -107,7 +108,11 @@ func (s *queueBaseSuite) SetupTest() {
 
 	s.config = tests.NewDynamicConfig()
 	s.options = testQueueOptions
-	s.rateLimiter = NewReaderPriorityRateLimiter(func() float64 { return 20 }, int64(s.options.MaxReaderCount()))
+	s.rateLimiter = NewReaderPriorityRateLimiter(
+		func() float64 { return 20 },
+		int64(s.options.MaxReaderCount()),
+		clockwork.NewRealClock(),
+	)
 	s.logger = log.NewTestLogger()
 	s.metricsHandler = metrics.NoopMetricsHandler
 }

--- a/service/history/queues/queue_scheduled_test.go
+++ b/service/history/queues/queue_scheduled_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	gomock "github.com/golang/mock/gomock"
+	clockwork "github.com/jonboulle/clockwork"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"golang.org/x/exp/slices"
@@ -94,6 +95,7 @@ func (s *scheduledQueueSuite) SetupTest() {
 			s.mockShard.GetConfig().TaskSchedulerMaxQPS,
 			s.mockShard.GetConfig().PersistenceNamespaceMaxQPS,
 			s.mockShard.GetConfig().PersistenceMaxQPS,
+			clockwork.NewRealClock(),
 		),
 		s.mockShard.GetTimeSource(),
 		log.NewTestLogger(),
@@ -117,6 +119,7 @@ func (s *scheduledQueueSuite) SetupTest() {
 		NewReaderPriorityRateLimiter(
 			func() float64 { return 10 },
 			1,
+			clockwork.NewRealClock(),
 		),
 		log.NewTestLogger(),
 		metrics.NoopMetricsHandler,

--- a/service/history/queues/reader_quotas.go
+++ b/service/history/queues/reader_quotas.go
@@ -39,6 +39,7 @@ const (
 func NewReaderPriorityRateLimiter(
 	rateFn quotas.RateFn,
 	maxReaders int64,
+	clock clockwork.Clock,
 ) quotas.RequestRateLimiter {
 	rateLimiters := make(map[int]quotas.RequestRateLimiter, maxReaders)
 	readerCallerToPriority := make(map[string]int, maxReaders)
@@ -55,7 +56,7 @@ func NewReaderPriorityRateLimiter(
 			return priority
 		}
 		return lowestPriority
-	}, rateLimiters, clockwork.NewRealClock())
+	}, rateLimiters, clock)
 }
 
 func newShardReaderRateLimiter(
@@ -67,6 +68,7 @@ func newShardReaderRateLimiter(
 		NewReaderPriorityRateLimiter(
 			func() float64 { return float64(shardMaxPollRPS()) },
 			maxReaders,
+			clockwork.NewRealClock(),
 		),
 		hostReaderRateLimiter,
 	)

--- a/service/history/queues/reader_test.go
+++ b/service/history/queues/reader_test.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/jonboulle/clockwork"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -504,7 +505,7 @@ func (s *readerSuite) newTestReader(
 		s.mockScheduler,
 		s.mockRescheduler,
 		clock.NewRealTimeSource(),
-		NewReaderPriorityRateLimiter(func() float64 { return 20 }, 1),
+		NewReaderPriorityRateLimiter(func() float64 { return 20 }, 1, clockwork.NewRealClock()),
 		s.monitor,
 		completionFn,
 		s.logger,

--- a/service/history/queues/scheduler_quotas.go
+++ b/service/history/queues/scheduler_quotas.go
@@ -38,6 +38,7 @@ func NewSchedulerRateLimiter(
 	hostMaxQPS dynamicconfig.IntPropertyFn,
 	persistenceNamespaceMaxQPS dynamicconfig.IntPropertyFnWithNamespaceFilter,
 	persistenceHostMaxQPS dynamicconfig.IntPropertyFn,
+	clock clockwork.Clock,
 ) SchedulerRateLimiter {
 	hostRateFn := func() float64 {
 		hostMaxQPS := float64(hostMaxQPS())
@@ -76,7 +77,7 @@ func NewSchedulerRateLimiter(
 		priorityToRateLimiters[int(priority)] = requestRateLimiter
 	}
 
-	return quotas.NewPriorityRateLimiter(requestPriorityFn, priorityToRateLimiters, clockwork.NewRealClock())
+	return quotas.NewPriorityRateLimiter(requestPriorityFn, priorityToRateLimiters, clock)
 }
 
 func newHighPriorityTaskRequestRateLimiter(

--- a/service/history/timerQueueFactory.go
+++ b/service/history/timerQueueFactory.go
@@ -97,6 +97,7 @@ func NewTimerQueueFactory(
 					timerQueuePersistenceMaxRPSRatio,
 				),
 				int64(params.Config.QueueMaxReaderCount()),
+				params.Clock,
 			),
 		},
 	}

--- a/service/history/transferQueueFactory.go
+++ b/service/history/transferQueueFactory.go
@@ -99,6 +99,7 @@ func NewTransferQueueFactory(
 					transferQueuePersistenceMaxRPSRatio,
 				),
 				int64(params.Config.QueueMaxReaderCount()),
+				params.Clock,
 			),
 		},
 	}

--- a/service/history/visibilityQueueFactory.go
+++ b/service/history/visibilityQueueFactory.go
@@ -86,6 +86,7 @@ func NewVisibilityQueueFactory(
 					visibilityQueuePersistenceMaxRPSRatio,
 				),
 				int64(params.Config.QueueMaxReaderCount()),
+				params.Clock,
 			),
 		},
 	}

--- a/service/matching/configs/quotas.go
+++ b/service/matching/configs/quotas.go
@@ -55,6 +55,7 @@ var (
 
 func NewPriorityRateLimiter(
 	rateFn quotas.RateFn,
+	clock clockwork.Clock,
 ) quotas.RequestRateLimiter {
 	rateLimiters := make(map[int]quotas.RequestRateLimiter)
 	for priority := range APIPrioritiesOrdered {
@@ -65,5 +66,5 @@ func NewPriorityRateLimiter(
 			return priority
 		}
 		return APIPrioritiesOrdered[len(APIPrioritiesOrdered)-1]
-	}, rateLimiters, clockwork.NewRealClock())
+	}, rateLimiters, clock)
 }

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -27,6 +27,7 @@ package matching
 import (
 	"context"
 
+	clockwork "github.com/jonboulle/clockwork"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -105,10 +106,12 @@ func ThrottledLoggerRpsFnProvider(serviceConfig *Config) resource.ThrottledLogge
 
 func RateLimitInterceptorProvider(
 	serviceConfig *Config,
+	clock clockwork.Clock,
 ) *interceptor.RateLimitInterceptor {
 	return interceptor.NewRateLimitInterceptor(
-		configs.NewPriorityRateLimiter(func() float64 { return float64(serviceConfig.RPS()) }),
+		configs.NewPriorityRateLimiter(func() float64 { return float64(serviceConfig.RPS()) }, clock),
 		map[string]int{},
+		clock,
 	)
 }
 
@@ -187,6 +190,7 @@ func HandlerProvider(
 	clusterMetadata cluster.Metadata,
 	namespaceReplicationQueue TaskQueueReplicatorNamespaceReplicationQueue,
 	visibilityManager manager.VisibilityManager,
+	clock clockwork.Clock,
 ) *Handler {
 	return NewHandler(
 		config,
@@ -201,6 +205,7 @@ func HandlerProvider(
 		clusterMetadata,
 		namespaceReplicationQueue,
 		visibilityManager,
+		clock,
 	)
 }
 

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -29,6 +29,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -78,6 +79,7 @@ func NewHandler(
 	clusterMetadata cluster.Metadata,
 	namespaceReplicationQueue persistence.NamespaceReplicationQueue,
 	visibilityManager manager.VisibilityManager,
+	clock clockwork.Clock,
 ) *Handler {
 	handler := &Handler{
 		config:          config,
@@ -96,6 +98,7 @@ func NewHandler(
 			clusterMetadata,
 			namespaceReplicationQueue,
 			visibilityManager,
+			clock,
 		),
 		namespaceRegistry: namespaceRegistry,
 	}

--- a/service/matching/taskQueueManager.go
+++ b/service/matching/taskQueueManager.go
@@ -215,6 +215,7 @@ func newTaskQueueManager(
 	stickyInfo stickyInfo,
 	config *Config,
 	clusterMeta cluster.Metadata,
+	clock clockwork.Clock,
 	opts ...taskQueueManagerOpt,
 ) (taskQueueManager, error) {
 	namespaceEntry, err := e.namespaceRegistry.GetNamespaceByID(taskQueue.namespaceID)
@@ -261,7 +262,7 @@ func newTaskQueueManager(
 	}
 
 	tlMgr.liveness = newLiveness(
-		clockwork.NewRealClock(),
+		clock,
 		taskQueueConfig.MaxTaskQueueIdleTime,
 		tlMgr.unloadFromEngine,
 	)

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jonboulle/clockwork"
 	"github.com/pborman/uuid"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -153,7 +154,10 @@ func NewServerFx(topLevelModule fx.Option, opts ...ServerOption) (*ServerFx, err
 	var s ServerFx
 	s.app = fx.New(
 		topLevelModule,
-		fx.Supply(opts),
+		fx.Supply(
+			opts,
+			fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
+		),
 		fx.Populate(&s.startupSynchronizationMode),
 		fx.Populate(&s.logger),
 	)
@@ -384,6 +388,7 @@ func HistoryServiceProvider(
 			params.ClusterMetadata,
 			params.Cfg,
 			serviceName,
+			fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 		),
 		fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return params.DataStoreFactory }),
 		fx.Provide(func() client.FactoryProvider { return params.ClientFactoryProvider }),
@@ -434,6 +439,7 @@ func MatchingServiceProvider(
 			params.ClusterMetadata,
 			params.Cfg,
 			serviceName,
+			fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 		),
 		fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return params.DataStoreFactory }),
 		fx.Provide(func() client.FactoryProvider { return params.ClientFactoryProvider }),
@@ -492,6 +498,7 @@ func genericFrontendServiceProvider(
 			params.ClusterMetadata,
 			params.Cfg,
 			serviceName,
+			fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 		),
 		fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return params.DataStoreFactory }),
 		fx.Provide(func() client.FactoryProvider { return params.ClientFactoryProvider }),
@@ -558,6 +565,7 @@ func WorkerServiceProvider(
 			params.ClusterMetadata,
 			params.Cfg,
 			serviceName,
+			fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 		),
 		fx.Provide(func() persistenceClient.AbstractDataStoreFactory { return params.DataStoreFactory }),
 		fx.Provide(func() client.FactoryProvider { return params.ClientFactoryProvider }),

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -32,6 +32,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/jonboulle/clockwork"
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
 	"golang.org/x/exp/maps"
@@ -377,6 +378,7 @@ func (c *temporalImpl) startFrontend(hosts map[primitives.ServiceName][]string, 
 			stoppedCh,
 			persistenceConfig,
 			serviceName,
+			fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 		),
 		fx.Provide(func() listenHostPort { return listenHostPort(c.FrontendGRPCAddress()) }),
 		fx.Provide(func() config.DCRedirectionPolicy { return config.DCRedirectionPolicy{} }),
@@ -473,6 +475,7 @@ func (c *temporalImpl) startHistory(
 				stoppedCh,
 				persistenceConfig,
 				serviceName,
+				fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 			),
 			fx.Provide(func() metrics.Handler { return metrics.NoopMetricsHandler }),
 			fx.Provide(func() listenHostPort { return listenHostPort(grpcPort) }),
@@ -571,6 +574,7 @@ func (c *temporalImpl) startMatching(hosts map[primitives.ServiceName][]string, 
 			stoppedCh,
 			persistenceConfig,
 			serviceName,
+			fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 		),
 		fx.Provide(func() metrics.Handler { return metrics.NoopMetricsHandler }),
 		fx.Provide(func() listenHostPort { return listenHostPort(c.MatchingGRPCServiceAddress()) }),
@@ -665,6 +669,7 @@ func (c *temporalImpl) startWorker(hosts map[primitives.ServiceName][]string, st
 			stoppedCh,
 			persistenceConfig,
 			serviceName,
+			fx.Annotate(clockwork.NewRealClock(), fx.As(new(clockwork.Clock))),
 		),
 		fx.Provide(func() metrics.Handler { return metrics.NoopMetricsHandler }),
 		fx.Provide(func() listenHostPort { return listenHostPort(c.WorkerGRPCServiceAddress()) }),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a `clockwork.Clock` object in our dependency graph.

<!-- Tell your future self why have you made these changes -->
**Why?**
For now, I just need it to test rate limiters, but I believe this will also make it much easier to improve a lot of other tests we have involving time later.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
CI

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Unclear boundaries between this and the existing TimeSource. How do we know which one to use?

Consolidating all of our clocks into one interface would be great, but there's one issue that makes this difficult to do immediately: the mock clockwork Clock doesn't provide a way to skip to a specific point in time, which the mock TimeSource does. I plan on addressing this in a follow-up PR.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.