### PR TITLE
Remove common.Daemon interface

### DIFF
--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -55,7 +55,6 @@ const (
 
 type (
 	Metadata interface {
-		common.Daemon
 		common.Pingable
 
 		// IsGlobalNamespaceEnabled whether the global namespace is enabled,
@@ -81,6 +80,8 @@ type (
 		GetFailoverVersionIncrement() int64
 		RegisterMetadataChangeCallback(callbackId any, cb CallbackFn)
 		UnRegisterMetadataChangeCallback(callbackId any)
+		Start()
+		Stop()
 	}
 
 	CallbackFn func(oldClusterMetadata map[string]*ClusterInformation, newClusterMetadata map[string]*ClusterInformation)

--- a/common/daemon.go
+++ b/common/daemon.go
@@ -34,12 +34,3 @@ const (
 	// DaemonStatusStopped coroutine pool stopped
 	DaemonStatusStopped int32 = 2
 )
-
-type (
-	// Daemon is the base interfaces implemented by
-	// background tasks within Temporal
-	Daemon interface {
-		Start()
-		Stop()
-	}
-)

--- a/common/flusher/flusher.go
+++ b/common/flusher/flusher.go
@@ -25,7 +25,6 @@
 package flusher
 
 import (
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/future"
 )
 
@@ -35,7 +34,6 @@ type (
 	}
 
 	Flusher[T any] interface {
-		common.Daemon
 		Buffer(item T) future.Future[struct{}]
 		Flush()
 	}

--- a/common/membership/ringpop/ringpop.go
+++ b/common/membership/ringpop/ringpop.go
@@ -45,7 +45,7 @@ const (
 )
 
 type (
-	// service is a wrapper around ringpop.Ringpop that implements common.Daemon
+	// service is a wrapper around ringpop.Ringpop
 	service struct {
 		status int32
 		*ringpop.Ringpop

--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -133,7 +133,6 @@ type (
 
 	// Registry provides access to Namespace objects by name or by ID.
 	Registry interface {
-		common.Daemon
 		common.Pingable
 		GetNamespace(name Name) (*Namespace, error)
 		GetNamespaceByID(id ID) (*Namespace, error)
@@ -148,6 +147,8 @@ type (
 		// GetCustomSearchAttributesMapper is a temporary solution to be able to get search attributes
 		// with from persistence if forceSearchAttributesCacheRefreshOnRead is true.
 		GetCustomSearchAttributesMapper(name Name) (CustomSearchAttributesMapper, error)
+		Start()
+		Stop()
 	}
 
 	registry struct {

--- a/common/persistence/health_signal_aggregator.go
+++ b/common/persistence/health_signal_aggregator.go
@@ -43,10 +43,11 @@ const (
 
 type (
 	HealthSignalAggregator interface {
-		common.Daemon
 		Record(callerSegment int32, namespace string, latency time.Duration, err error)
 		AverageLatency() float64
 		ErrorRatio() float64
+		Start()
+		Stop()
 	}
 
 	HealthSignalAggregatorImpl struct {

--- a/common/persistence/namespaceReplicationQueue.go
+++ b/common/persistence/namespaceReplicationQueue.go
@@ -104,7 +104,6 @@ type (
 
 	// NamespaceReplicationQueue is used to publish and list namespace replication tasks
 	NamespaceReplicationQueue interface {
-		common.Daemon
 		Publish(ctx context.Context, task *replicationspb.ReplicationTask) error
 		GetReplicationMessages(
 			ctx context.Context,
@@ -127,6 +126,8 @@ type (
 
 		RangeDeleteMessagesFromDLQ(ctx context.Context, firstMessageID int64, lastMessageID int64) error
 		DeleteMessageFromDLQ(ctx context.Context, messageID int64) error
+		Start()
+		Stop()
 	}
 )
 

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -54,10 +54,10 @@ import (
 type (
 	// Processor is interface for Elasticsearch bulk processor
 	Processor interface {
-		common.Daemon
-
 		// Add request to bulk processor.
 		Add(request *client.BulkableRequest, visibilityTaskKey string) *future.FutureImpl[bool]
+		Start()
+		Stop()
 	}
 
 	// processorImpl implements Processor, it's an agent of elastic.BulkProcessor

--- a/common/tasks/scheduler.go
+++ b/common/tasks/scheduler.go
@@ -24,16 +24,12 @@
 
 package tasks
 
-import (
-	"go.temporal.io/server/common"
-)
-
 type (
 	// Scheduler is the generic interface for scheduling & processing tasks
 	Scheduler[T Task] interface {
-		common.Daemon
-
 		Submit(task T)
 		TrySubmit(task T) bool
+		Start()
+		Stop()
 	}
 )

--- a/internal/goro/group.go
+++ b/internal/goro/group.go
@@ -32,10 +32,10 @@ import (
 // Group manages a set of long-running goroutines. Goroutines are spawned
 // individually with Group.Go and after that interrupted and waited-on as a
 // single unit. The expected use-case for this type is as a member field of a
-// `common.Daemon` (or similar) type that spawns one or more goroutines in
-// its Start() function and then stops those same goroutines in its Stop()
-// function. The zero-value of this type is valid. A Group must not be copied
-// after first use.
+// background process type that spawns one or more goroutines in its Start()
+// function and then stops those same goroutines in its Stop() function.
+// The zero-value of this type is valid. A Group must not be copied after
+// first use.
 type Group struct {
 	initOnce sync.Once
 	ctx      context.Context

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -607,7 +607,7 @@ func ServiceLifetimeHooks(
 	lc.Append(
 		fx.Hook{
 			OnStart: func(context.Context) error {
-				go func(svc common.Daemon, svcStoppedCh chan<- struct{}) {
+				go func(svc *Service, svcStoppedCh chan<- struct{}) {
 					// Start is blocked until Stop() is called.
 					svc.Start()
 					close(svcStoppedCh)

--- a/service/frontend/interface.go
+++ b/service/frontend/interface.go
@@ -29,8 +29,6 @@ package frontend
 import (
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
-
-	"go.temporal.io/server/common"
 )
 
 const (
@@ -43,14 +41,13 @@ type (
 	// Handler is interface wrapping frontend workflow handler
 	Handler interface {
 		workflowservice.WorkflowServiceServer
-		common.Daemon
-
 		GetConfig() *Config
+		Start()
+		Stop()
 	}
 
 	// OperatorHandler is interface wrapping frontend workflow handler
 	OperatorHandler interface {
 		operatorservice.OperatorServiceServer
-		common.Daemon
 	}
 )

--- a/service/frontend/interface_mock.go
+++ b/service/frontend/interface_mock.go
@@ -1080,27 +1080,3 @@ func (mr *MockOperatorHandlerMockRecorder) RemoveSearchAttributes(arg0, arg1 int
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSearchAttributes", reflect.TypeOf((*MockOperatorHandler)(nil).RemoveSearchAttributes), arg0, arg1)
 }
-
-// Start mocks base method.
-func (m *MockOperatorHandler) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start.
-func (mr *MockOperatorHandlerMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockOperatorHandler)(nil).Start))
-}
-
-// Stop mocks base method.
-func (m *MockOperatorHandler) Stop() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Stop")
-}
-
-// Stop indicates an expected call of Stop.
-func (mr *MockOperatorHandlerMockRecorder) Stop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockOperatorHandler)(nil).Stop))
-}

--- a/service/history/events/notifier.go
+++ b/service/history/events/notifier.go
@@ -48,10 +48,11 @@ const (
 
 type (
 	Notifier interface {
-		common.Daemon
 		NotifyNewHistoryEvent(event *Notification)
 		WatchHistoryEvent(identifier definition.WorkflowKey) (string, chan *Notification, error)
 		UnwatchHistoryEvent(identifier definition.WorkflowKey, subscriberID string) error
+		Start()
+		Stop()
 	}
 
 	Notification struct {

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -297,7 +297,7 @@ func ServiceLifetimeHooks(
 	lc.Append(
 		fx.Hook{
 			OnStart: func(context.Context) error {
-				go func(svc common.Daemon, svcStoppedCh chan<- struct{}) {
+				go func(svc *Service, svcStoppedCh chan<- struct{}) {
 					// Start is blocked until Stop() is called.
 					svc.Start()
 					close(svcStoppedCh)

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -109,7 +109,7 @@ type (
 		replicationAckMgr          replication.AckManager
 		nDCReplicator              ndc.HistoryReplicator
 		nDCActivityReplicator      ndc.ActivityReplicator
-		replicationProcessorMgr    common.Daemon
+		replicationProcessorMgr    replication.TaskProcessor
 		eventNotifier              events.Notifier
 		tokenSerializer            common.TaskTokenSerializer
 		metricsHandler             metrics.Handler

--- a/service/history/queueFactoryBase.go
+++ b/service/history/queueFactoryBase.go
@@ -29,7 +29,6 @@ import (
 
 	"go.uber.org/fx"
 
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -49,7 +48,8 @@ const QueueFactoryFxGroup = "queueFactory"
 
 type (
 	QueueFactory interface {
-		common.Daemon
+		Start()
+		Stop()
 
 		// TODO:
 		// 1. Remove the cache parameter after workflow cache become a host level component

--- a/service/history/queues/queue.go
+++ b/service/history/queues/queue.go
@@ -25,7 +25,6 @@
 package queues
 
 import (
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/service/history/tasks"
 )
 
@@ -33,9 +32,10 @@ import (
 
 type (
 	Queue interface {
-		common.Daemon
 		Category() tasks.Category
 		NotifyNewTasks(tasks []tasks.Task)
 		FailoverNamespace(namespaceID string)
+		Start()
+		Stop()
 	}
 )

--- a/service/history/queues/reader.go
+++ b/service/history/queues/reader.go
@@ -49,8 +49,6 @@ var (
 
 type (
 	Reader interface {
-		common.Daemon
-
 		Scopes() []Scope
 
 		WalkSlices(SliceIterator)
@@ -63,6 +61,8 @@ type (
 
 		Notify()
 		Pause(time.Duration)
+		Start()
+		Stop()
 	}
 
 	ReaderOptions struct {

--- a/service/history/queues/rescheduler.go
+++ b/service/history/queues/rescheduler.go
@@ -53,8 +53,6 @@ type (
 	// Rescheduler buffers task executables that are failed to process and
 	// resubmit them to the task scheduler when the Reschedule method is called.
 	Rescheduler interface {
-		common.Daemon
-
 		// Add task executable to the rescheduler.
 		Add(task Executable, rescheduleTime time.Time)
 
@@ -65,6 +63,8 @@ type (
 
 		// Len returns the total number of task executables waiting to be rescheduled.
 		Len() int
+		Start()
+		Stop()
 	}
 
 	rescheduledExecuable struct {

--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -27,7 +27,6 @@
 package queues
 
 import (
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -54,13 +53,13 @@ type (
 	// be called on all executables that have been successfully submited.
 	// Reschedule() will only be called after the Scheduler has been stopped
 	Scheduler interface {
-		common.Daemon
-
 		Submit(Executable)
 		TrySubmit(Executable) bool
 
 		TaskChannelKeyFn() TaskChannelKeyFn
 		ChannelWeightFn() ChannelWeightFn
+		Start()
+		Stop()
 	}
 
 	TaskChannelKey struct {

--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -44,9 +44,9 @@ import (
 
 type (
 	StreamReceiver interface {
-		common.Daemon
 		IsValid() bool
 		Key() ClusterShardKeyPair
+		Stop()
 	}
 	StreamReceiverImpl struct {
 		ProcessToolBox

--- a/service/history/replication/stream_receiver_mock.go
+++ b/service/history/replication/stream_receiver_mock.go
@@ -85,18 +85,6 @@ func (mr *MockStreamReceiverMockRecorder) Key() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Key", reflect.TypeOf((*MockStreamReceiver)(nil).Key))
 }
 
-// Start mocks base method.
-func (m *MockStreamReceiver) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start.
-func (mr *MockStreamReceiverMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockStreamReceiver)(nil).Start))
-}
-
 // Stop mocks base method.
 func (m *MockStreamReceiver) Stop() {
 	m.ctrl.T.Helper()

--- a/service/history/replication/stream_receiver_monitor.go
+++ b/service/history/replication/stream_receiver_monitor.go
@@ -41,8 +41,9 @@ const (
 
 type (
 	StreamReceiverMonitor interface {
-		common.Daemon
 		RegisterInboundStream(streamSender StreamSender)
+		Start()
+		Stop()
 	}
 	StreamReceiverMonitorImpl struct {
 		ProcessToolBox

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -61,9 +61,9 @@ type (
 		Convert(task tasks.Task) (*replicationspb.ReplicationTask, error)
 	}
 	StreamSender interface {
-		common.Daemon
 		IsValid() bool
 		Key() ClusterShardKeyPair
+		Stop()
 	}
 	StreamSenderImpl struct {
 		server        historyservice.HistoryService_StreamWorkflowReplicationMessagesServer

--- a/service/history/replication/stream_sender_mock.go
+++ b/service/history/replication/stream_sender_mock.go
@@ -125,18 +125,6 @@ func (mr *MockStreamSenderMockRecorder) Key() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Key", reflect.TypeOf((*MockStreamSender)(nil).Key))
 }
 
-// Start mocks base method.
-func (m *MockStreamSender) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start.
-func (mr *MockStreamSenderMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockStreamSender)(nil).Start))
-}
-
 // Stop mocks base method.
 func (m *MockStreamSender) Stop() {
 	m.ctrl.T.Helper()

--- a/service/history/replication/task_fetcher.go
+++ b/service/history/replication/task_fetcher.go
@@ -56,18 +56,17 @@ const (
 type (
 	// TaskFetcherFactory is a group of fetchers, one per source DC.
 	TaskFetcherFactory interface {
-		common.Daemon
-
 		GetOrCreateFetcher(clusterName string) taskFetcher
+		Start()
+		Stop()
 	}
 
 	// taskFetcher is responsible for fetching replication messages from remote DC.
 	taskFetcher interface {
-		common.Daemon
-
 		getSourceCluster() string
 		getRequestChan() chan<- *replicationTaskRequest
 		getRateLimiter() quotas.RateLimiter
+		Stop()
 	}
 
 	// taskFetcherFactoryImpl is a group of fetchers, one per source DC.

--- a/service/history/replication/task_fetcher_mock.go
+++ b/service/history/replication/task_fetcher_mock.go
@@ -119,18 +119,6 @@ func (m *MocktaskFetcher) EXPECT() *MocktaskFetcherMockRecorder {
 	return m.recorder
 }
 
-// Start mocks base method.
-func (m *MocktaskFetcher) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start.
-func (mr *MocktaskFetcherMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MocktaskFetcher)(nil).Start))
-}
-
 // Stop mocks base method.
 func (m *MocktaskFetcher) Stop() {
 	m.ctrl.T.Helper()

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -69,7 +69,8 @@ var (
 type (
 	// TaskProcessor is the interface for task processor
 	TaskProcessor interface {
-		common.Daemon
+		Start()
+		Stop()
 	}
 
 	// taskProcessorImpl is responsible for processing replication tasks for a shard.

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -80,8 +80,6 @@ type (
 	}
 )
 
-var _ common.Daemon = (*taskProcessorManagerImpl)(nil)
-
 func NewTaskProcessorManager(
 	config *configs.Config,
 	shard shard.Context,

--- a/service/history/shard/controller.go
+++ b/service/history/shard/controller.go
@@ -33,12 +33,13 @@ import (
 
 type (
 	Controller interface {
-		common.Daemon
 		common.Pingable
 
 		GetShardByID(shardID int32) (Context, error)
 		GetShardByNamespaceWorkflow(namespaceID namespace.ID, workflowID string) (Context, error)
 		CloseShardByID(shardID int32)
 		ShardIDs() []int32
+		Start()
+		Stop()
 	}
 )

--- a/service/history/shard/engine.go
+++ b/service/history/shard/engine.go
@@ -35,7 +35,6 @@ import (
 
 	"go.temporal.io/server/api/historyservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/events"
@@ -45,8 +44,6 @@ import (
 type (
 	// Engine represents an interface for managing workflow execution history.
 	Engine interface {
-		common.Daemon
-
 		StartWorkflowExecution(ctx context.Context, request *historyservice.StartWorkflowExecutionRequest) (*historyservice.StartWorkflowExecutionResponse, error)
 		GetMutableState(ctx context.Context, request *historyservice.GetMutableStateRequest) (*historyservice.GetMutableStateResponse, error)
 		PollMutableState(ctx context.Context, request *historyservice.PollMutableStateRequest) (*historyservice.PollMutableStateResponse, error)
@@ -95,6 +92,8 @@ type (
 		AddSpeculativeWorkflowTaskTimeoutTask(task *tasks.WorkflowTaskTimeoutTask)
 
 		ReplicationStream
+		Start()
+		Stop()
 	}
 
 	ReplicationStream interface {

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -212,7 +212,7 @@ func ServiceLifetimeHooks(
 	lc.Append(
 		fx.Hook{
 			OnStart: func(context.Context) error {
-				go func(svc common.Daemon, svcStoppedCh chan<- struct{}) {
+				go func(svc *Service, svcStoppedCh chan<- struct{}) {
 					// Start is blocked until Stop() is called.
 					svc.Start()
 					close(svcStoppedCh)

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -29,7 +29,6 @@ import (
 
 	"go.uber.org/fx"
 
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
@@ -131,7 +130,7 @@ func ServiceLifetimeHooks(
 	lc.Append(
 		fx.Hook{
 			OnStart: func(context.Context) error {
-				go func(svc common.Daemon, svcStoppedCh chan<- struct{}) {
+				go func(svc *Service, svcStoppedCh chan<- struct{}) {
 					// Start is blocked until Stop() is called.
 					svc.Start()
 					close(svcStoppedCh)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the common.Daemon interface.

<!-- Tell your future self why have you made these changes -->
**Why?**
The main reason is that it makes it nearly impossible to figure out where a Start or Stop method of a concrete type is actually called.

Before:
<img width="1254" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/bdbe5d97-0d60-4690-a873-bf9797441284">

After:
<img width="724" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/8bdcb01a-b5e9-4ba7-8f9a-ccbc6bc6a5d9">

Conversely, it makes it harder to find the actual implementation for a method at its callsite.

Before:
<img width="851" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/c651b90b-430c-4a93-951e-21fc26e1f309">


After:
<img width="908" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/2e877c3f-7a63-48b8-a83a-302b93be92f3">


Finally, we actually don't use this abstraction for anything. We don't need to ever view something as an abstract background process--only fx needs to define and consume an abstraction like that. Most of our callsites of Start and Stop already have a more concrete type available. It's a useful abstraction *conceptually*, but, in code, it just makes it impossible to find where things are used or defined.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I verified that it's much easier to find where a Start or Stop method is defined / called.

To write this, I removed the embedded common.Daemon from all interfaces, looked for unresolved-reference errors, and then I added the method to the type of whatever variable was complaining. That way, the methods are present at the most concrete level possible, which will ensure that there are as few choices as possible when finding references or definitions.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Maybe we were doing something weird with reflection for this or there's some other use case I'm unaware of.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.