### PR TITLE
Add frontend global RPS limit

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -237,8 +237,10 @@ const (
 	FrontendVisibilityMaxPageSize = "frontend.visibilityMaxPageSize"
 	// FrontendHistoryMaxPageSize is default max size for GetWorkflowExecutionHistory in one page
 	FrontendHistoryMaxPageSize = "frontend.historyMaxPageSize"
-	// FrontendRPS is workflow rate limit per second
+	// FrontendRPS is workflow rate limit per second per-instance
 	FrontendRPS = "frontend.rps"
+	// FrontendGlobalRPS is workflow rate limit per second for the whole cluster
+	FrontendGlobalRPS = "frontend.globalRPS"
 	// FrontendNamespaceReplicationInducingAPIsRPS limits the per second request rate for namespace replication inducing
 	// APIs (e.g. RegisterNamespace, UpdateNamespace, UpdateWorkerBuildIdCompatibility).
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -287,8 +287,11 @@ func TelemetryInterceptorProvider(
 
 func RateLimitInterceptorProvider(
 	serviceConfig *Config,
+	frontendServiceResolver membership.ServiceResolver,
 ) *interceptor.RateLimitInterceptor {
-	rateFn := func() float64 { return float64(serviceConfig.RPS()) }
+	rateFn := func() float64 {
+		return effectiveRPS(frontendServiceResolver, serviceConfig.RPS, serviceConfig.GlobalRPS)
+	}
 	namespaceReplicationInducingRateFn := func() float64 { return float64(serviceConfig.NamespaceReplicationInducingAPIsRPS()) }
 
 	return interceptor.NewRateLimitInterceptor(

--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -1,0 +1,280 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package frontend
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/internal/nettest"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+type testCase struct {
+	// name of the test case
+	name string
+	// t is the test object
+	t *testing.T
+	// globalRPSLimit is the global RPS limit for all frontend hosts
+	globalRPSLimit int
+	// perInstanceRPSLimit is the RPS limit for each frontend host
+	perInstanceRPSLimit int
+	// expectRateLimit is true if the interceptor should return a rate limit error
+	expectRateLimit bool
+	// numRequests is the number of requests to send to the interceptor
+	numRequests int
+	// serviceResolver is used to determine the number of frontend hosts for the global rate limiter
+	serviceResolver membership.ServiceResolver
+	// configure is a function that can be used to override the default test case values
+	configure func(tc *testCase)
+}
+
+func TestRateLimitInterceptorProvider(t *testing.T) {
+	t.Parallel()
+
+	// The burst limit is 2 * the rps limit, so this is 8, which is < the number of requests. The interceptor should
+	// rate limit one of the last two requests because we exceeded the burst limit, and there is no delay between the
+	// last two requests.
+	lowPerInstanceRPSLimit := 4
+	// The burst limit is 2 * the rps limit, so this is 10, which is >= the number of requests. The interceptor should
+	// not rate limit any of the requests because we never exceed the burst limit.
+	highPerInstanceRPSLimit := 5
+	// The number of hosts is 10, so if 4 is too low of an RPS limit per-instance, then 40 is too low of a global RPS
+	// limit.
+	numHosts := 10
+	lowGlobalRPSLimit := lowPerInstanceRPSLimit * numHosts
+	highGlobalRPSLimit := highPerInstanceRPSLimit * numHosts
+
+	testCases := []testCase{
+		{
+			name: "both rate limits hit",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = lowGlobalRPSLimit
+				tc.perInstanceRPSLimit = lowPerInstanceRPSLimit
+				tc.expectRateLimit = true
+			},
+		},
+		{
+			name: "global rate limit hit",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = lowGlobalRPSLimit
+				tc.perInstanceRPSLimit = highPerInstanceRPSLimit
+				tc.expectRateLimit = true
+			},
+		},
+		{
+			name: "per instance rate limit hit but ignored because global rate limit is not hit",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = highGlobalRPSLimit
+				tc.perInstanceRPSLimit = lowPerInstanceRPSLimit
+				tc.expectRateLimit = false
+			},
+		},
+		{
+			name: "neither rate limit hit",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = highGlobalRPSLimit
+				tc.perInstanceRPSLimit = highPerInstanceRPSLimit
+				tc.expectRateLimit = false
+			},
+		},
+		{
+			name: "global rate limit not configured and per instance rate limit not hit",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = 0
+				tc.perInstanceRPSLimit = highPerInstanceRPSLimit
+				tc.expectRateLimit = false
+			},
+		},
+		{
+			name: "global rate limit not configured and per instance rate limit is hit",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = 0
+				tc.perInstanceRPSLimit = lowPerInstanceRPSLimit
+				tc.expectRateLimit = true
+			},
+		},
+		{
+			name: "global rate limit not configured and zero per-instance rate limit",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = 0
+				tc.perInstanceRPSLimit = 0
+				tc.expectRateLimit = true
+			},
+		},
+		{
+			name: "nil service resolver causes global RPS limit to be ignored",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = lowPerInstanceRPSLimit
+				tc.perInstanceRPSLimit = highPerInstanceRPSLimit
+				tc.expectRateLimit = false
+				tc.serviceResolver = nil
+			},
+		},
+		{
+			name: "no hosts returned by service resolver acts as if there was one host",
+			configure: func(tc *testCase) {
+				tc.globalRPSLimit = lowPerInstanceRPSLimit
+				tc.perInstanceRPSLimit = highPerInstanceRPSLimit
+				tc.expectRateLimit = true
+				serviceResolver := membership.NewMockServiceResolver(gomock.NewController(tc.t))
+				serviceResolver.EXPECT().MemberCount().Return(0).AnyTimes()
+				tc.serviceResolver = serviceResolver
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tc.numRequests = 10
+			tc.t = t
+			{
+				// Create a mock service resolver which returns the number of frontend hosts.
+				// This may be overridden by the test case.
+				ctrl := gomock.NewController(t)
+				serviceResolver := membership.NewMockServiceResolver(ctrl)
+				serviceResolver.EXPECT().MemberCount().Return(numHosts).AnyTimes()
+				tc.serviceResolver = serviceResolver
+			}
+			tc.configure(&tc)
+
+			// Create a rate limit interceptor which uses the fake clock, and the per instance and global RPS limits
+			// from the test case.
+			rateLimitInterceptor := RateLimitInterceptorProvider(&Config{
+				RPS: func() int {
+					return tc.perInstanceRPSLimit
+				},
+				GlobalRPS: func() int {
+					return tc.globalRPSLimit
+				},
+				NamespaceReplicationInducingAPIsRPS: func() int {
+					// this is not used in this test
+					return 0
+				},
+			}, tc.serviceResolver)
+
+			// Create a gRPC server for the fake workflow service.
+			svc := &testSvc{}
+			server := grpc.NewServer(grpc.UnaryInterceptor(rateLimitInterceptor.Intercept))
+			workflowservice.RegisterWorkflowServiceServer(server, svc)
+
+			pipe := nettest.NewPipe()
+
+			var wg sync.WaitGroup
+			defer wg.Wait()
+			wg.Add(1)
+
+			listenerDone := make(chan struct{})
+
+			go func() {
+				defer wg.Done()
+
+				// This should return an error because Accept returns an error, but we don't assert anything because we
+				// don't actually care whether this returns an error or not.
+				_ = server.Serve(&testListener{
+					Pipe: pipe,
+					done: listenerDone,
+				})
+			}()
+
+			// Create a gRPC client to the fake workflow service.
+			dialer := grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+				return pipe.Connect(ctx.Done())
+			})
+			transportCredentials := grpc.WithTransportCredentials(insecure.NewCredentials())
+			conn, err := grpc.DialContext(context.Background(), "fake", dialer, transportCredentials)
+			require.NoError(t, err)
+
+			defer func() {
+				assert.NoError(t, conn.Close())
+				// This causes the server to get an error from its call to Accept and stop itself.
+				close(listenerDone)
+			}()
+
+			client := workflowservice.NewWorkflowServiceClient(conn)
+
+			// Generate load by sending a number of requests to the server.
+			for i := 0; i < tc.numRequests; i++ {
+				_, err = client.StartWorkflowExecution(
+					context.Background(),
+					&workflowservice.StartWorkflowExecutionRequest{},
+				)
+				if err != nil {
+					break
+				}
+			}
+
+			// Check if the rate limit is hit.
+			if tc.expectRateLimit {
+				assert.ErrorContains(t, err, "rate limit exceeded")
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+// testSvc is a fake workflow service.
+type testSvc struct {
+	workflowservice.UnimplementedWorkflowServiceServer
+}
+
+// StartWorkflowExecution is a fake implementation of the StartWorkflowExecution gRPC method which does nothing.
+func (t *testSvc) StartWorkflowExecution(
+	context.Context,
+	*workflowservice.StartWorkflowExecutionRequest,
+) (*workflowservice.StartWorkflowExecutionResponse, error) {
+	return &workflowservice.StartWorkflowExecutionResponse{}, nil
+}
+
+// testListener is a fake listener which uses a nettest.Pipe to simulate a network connection.
+type testListener struct {
+	*nettest.Pipe
+	// We cancel calls to Accept using the done channel so that tests don't hang if they're broken.
+	done <-chan struct{}
+}
+
+func (t testListener) Accept() (net.Conn, error) {
+	return t.Pipe.Accept(t.done)
+}
+
+func (t testListener) Close() error {
+	return nil
+}
+
+func (t testListener) Addr() net.Addr {
+	return &net.TCPAddr{}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added an optional rate limit on the total RPS to across all frontend hosts.

<!-- Tell your future self why have you made these changes -->
**Why?**
To make it easier to write rate limits based on database resources, rather than frontend host resources.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added a test which creates a gRPC server for the workflow service with this rate limiter, and then I sent traffic to it. I verified that the different rate limit configurations behave as-expected, and then I looked at the test coverage [here](https://buildkiteartifacts.com/1f9c9f7c-4305-42bc-b1ef-8ce362b961c6/a9393275-f704-4056-af35-70c39e6a54d3/0189288c-1b22-4c5a-9398-f12a57dc7e3f/0189288c-2998-4a77-9911-0727ca40fb85/.coverage/summary.out.html?response-content-type=text%2Fhtml&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQPCP3C7L6VEAMXXS%2F20230706%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20230706T010131Z&X-Amz-Expires=600&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEL7%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIBbV2mO94E84DZ8SvrcyyKzU6urD5t%2BP8%2FDE6kpg2ajCAiEAhDk3DJGaaUAehvSvkfTyndi5dqokK1e7C%2Fmtz6owGmsq8QMINxAAGgwwMzIzNzk3MDUzMDMiDD0xl26q7Qt5FqzE7irOA5qgqgy0ZyveebaHoOcK2cedMdPmmKDB4PDJVXIrGF2XaTF30oM7nxVbvh4mydC0xL%2Fy9l5L3XZSFFm%2FerdUJwdaAYCN4tYIrcelJS8XZgBLuNFCUXnQvRuwqLzt8A961NAK6n%2BCRNdaOUVPSvch0uqjxpmhKlmGVG29GarbUOag4Efcf7FYtcFJeTIXaMwmlK27gXun0rzFrT8a0oDp9D6LyALR3b%2FsYXGqR16bFqdKKJVFrAC0aPpgfIwGbYZjwDz1tq58huP1mUNc%2FIOpXhWotfC8wqWj5mwTpYoX2sLZGGpE9f043NSx47AAxrYN9Ac%2FxOUZXjhCQo0bl5EYFSHwvgFBv4JWNEzvedG4e8T7uKL084wiqJBJhOZdWNefowAVSqMk0xx4HwnQZjv7V%2BaZvXj%2FhRzKKTiDYw32F3KLV5pxZOBGV1Fy2It6%2FQlAReaeyjuEXgt%2B2ktIMte6nSQbEtcVFjdnCCtXvRSKM75wrjYP%2BlKMMJJoYgkmNVUQ5AqWFEu9OzbF%2BC5eSadKIFB%2Bvsk95uireWPJ0vvvNxllanxNAEQ8C4KcO0E4N121d86Imenhqwuvi%2FeR%2BqK8QTCx6QXuq%2F40rhkUPfmddzC00ZelBjqlATPaKzDyC1Fj4sgBij5EtwC%2Buib0ovriB6GszJvrKQhq9JNbEC%2BCaUXV828uoNFzN31SQE7KluPxa0PcM%2BHnX757Wcf6r0eZ4i3CkcxSOUDHgW%2FQkdm9UJSWuYjRXXIdI06rJxX2BRMsay01WkUvwoeVAnXVlbmxuSAlO0ModdCuKIRjsmoIZGH9EAEpnHbmalbh803ZTFRVUQ2SpyuotnisRMBmUQ%3D%3D&X-Amz-SignedHeaders=host&X-Amz-Signature=bba52b85c6c0cf29ea1b9a9cedc68bcbf431cd30ce0db8cbaa75d9da298ea2ed#file475)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there's a bug here, it will probably lead to us not rate limiting requests and overwhelming our backend resources like the database.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes. The community should know about this new knob.