### PR TITLE
Refactor fx service Start/Stop

### DIFF
--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -25,7 +25,6 @@
 package frontend
 
 import (
-	"context"
 	"fmt"
 	"net"
 
@@ -599,26 +598,6 @@ func HandlerProvider(
 	return wfHandler
 }
 
-func ServiceLifetimeHooks(
-	lc fx.Lifecycle,
-	svcStoppedCh chan struct{},
-	svc *Service,
-) {
-	lc.Append(
-		fx.Hook{
-			OnStart: func(context.Context) error {
-				go func(svc *Service, svcStoppedCh chan<- struct{}) {
-					// Start is blocked until Stop() is called.
-					svc.Start()
-					close(svcStoppedCh)
-				}(svc, svcStoppedCh)
-
-				return nil
-			},
-			OnStop: func(ctx context.Context) error {
-				svc.Stop()
-				return nil
-			},
-		},
-	)
+func ServiceLifetimeHooks(lc fx.Lifecycle, svc *Service) {
+	lc.Append(fx.StartStopHook(svc.Start, svc.Stop))
 }

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -28,7 +28,7 @@ import (
 	"math/rand"
 	"net"
 	"os"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"go.temporal.io/api/operatorservice/v1"
@@ -274,8 +274,8 @@ func NewConfig(
 
 // Service represents the frontend service
 type Service struct {
-	status int32
-	config *Config
+	serveWg sync.WaitGroup
+	config  *Config
 
 	healthServer      *health.Server
 	handler           Handler
@@ -306,7 +306,6 @@ func NewService(
 	faultInjectionDataStoreFactory *client.FaultInjectionDataStoreFactory,
 ) *Service {
 	return &Service{
-		status:                         common.DaemonStatusInitialized,
 		config:                         serviceConfig,
 		server:                         server,
 		healthServer:                   healthServer,
@@ -324,12 +323,7 @@ func NewService(
 
 // Start starts the service
 func (s *Service) Start() {
-	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
-		return
-	}
-
-	logger := s.logger
-	logger.Info("frontend starting")
+	s.logger.Info("frontend starting")
 
 	healthpb.RegisterHealthServer(s.server, s.healthServer)
 	workflowservice.RegisterWorkflowServiceServer(s.server, s.handler)
@@ -347,21 +341,18 @@ func (s *Service) Start() {
 	s.operatorHandler.Start()
 	s.handler.Start()
 
-	listener := s.grpcListener
-	logger.Info("Starting to serve on frontend listener")
-	if err := s.server.Serve(listener); err != nil {
-		logger.Fatal("Failed to serve on frontend listener", tag.Error(err))
-	}
+	s.serveWg.Add(1)
+	go func() {
+		s.logger.Info("Starting to serve on frontend listener")
+		if err := s.server.Serve(s.grpcListener); err != nil {
+			s.logger.Fatal("Failed to serve on frontend listener", tag.Error(err))
+		}
+		s.serveWg.Done()
+	}()
 }
 
 // Stop stops the service
 func (s *Service) Stop() {
-	logger := s.logger
-
-	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
-		return
-	}
-
 	// initiate graceful shutdown:
 	// 1. Fail rpc health check, this will cause client side load balancer to stop forwarding requests to this node
 	// 2. wait for failure detection time
@@ -372,10 +363,10 @@ func (s *Service) Stop() {
 	requestDrainTime := util.Max(time.Second, s.config.ShutdownDrainDuration())
 	failureDetectionTime := util.Max(0, s.config.ShutdownFailHealthCheckDuration())
 
-	logger.Info("ShutdownHandler: Updating gRPC health status to ShuttingDown")
+	s.logger.Info("ShutdownHandler: Updating gRPC health status to ShuttingDown")
 	s.healthServer.Shutdown()
 
-	logger.Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
+	s.logger.Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
 	time.Sleep(failureDetectionTime)
 
 	s.handler.Stop()
@@ -384,19 +375,20 @@ func (s *Service) Stop() {
 	s.versionChecker.Stop()
 	s.visibilityManager.Close()
 
-	logger.Info("ShutdownHandler: Draining traffic")
+	s.logger.Info("ShutdownHandler: Draining traffic")
 	t := time.AfterFunc(requestDrainTime, func() {
-		logger.Info("ShutdownHandler: Drain time expired, stopping all traffic")
+		s.logger.Info("ShutdownHandler: Drain time expired, stopping all traffic")
 		s.server.Stop()
 	})
 	s.server.GracefulStop()
 	t.Stop()
+	s.serveWg.Wait()
 
 	if s.metricsHandler != nil {
-		s.metricsHandler.Stop(logger)
+		s.metricsHandler.Stop(s.logger)
 	}
 
-	logger.Info("frontend stopped")
+	s.logger.Info("frontend stopped")
 }
 
 func namespaceRPS(

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -25,7 +25,6 @@
 package history
 
 import (
-	"context"
 	"net"
 
 	"go.uber.org/fx"
@@ -289,26 +288,6 @@ func ArchivalClientProvider(
 	)
 }
 
-func ServiceLifetimeHooks(
-	lc fx.Lifecycle,
-	svcStoppedCh chan struct{},
-	svc *Service,
-) {
-	lc.Append(
-		fx.Hook{
-			OnStart: func(context.Context) error {
-				go func(svc *Service, svcStoppedCh chan<- struct{}) {
-					// Start is blocked until Stop() is called.
-					svc.Start()
-					close(svcStoppedCh)
-				}(svc, svcStoppedCh)
-
-				return nil
-			},
-			OnStop: func(ctx context.Context) error {
-				svc.Stop()
-				return nil
-			},
-		},
-	)
+func ServiceLifetimeHooks(lc fx.Lifecycle, svc *Service) {
+	lc.Append(fx.StartStopHook(svc.Start, svc.Stop))
 }

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -27,7 +27,7 @@ package history
 import (
 	"math/rand"
 	"net"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"google.golang.org/grpc"
@@ -35,7 +35,6 @@ import (
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 
 	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
@@ -49,7 +48,7 @@ import (
 // Service represents the history service
 type (
 	Service struct {
-		status            int32
+		serveWg           sync.WaitGroup
 		handler           *Handler
 		visibilityManager manager.VisibilityManager
 		config            *configs.Config
@@ -77,7 +76,6 @@ func NewService(
 	healthServer *health.Server,
 ) *Service {
 	return &Service{
-		status:                         common.DaemonStatusInitialized,
 		server:                         grpc.NewServer(grpcServerOptions...),
 		handler:                        handler,
 		visibilityManager:              visibilityMgr,
@@ -93,12 +91,7 @@ func NewService(
 
 // Start starts the service
 func (s *Service) Start() {
-	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
-		return
-	}
-
-	logger := s.logger
-	logger.Info("history starting")
+	s.logger.Info("history starting")
 
 	s.metricsHandler.Counter(metrics.RestartCount).Record(1)
 	rand.Seed(time.Now().UnixNano())
@@ -109,20 +102,18 @@ func (s *Service) Start() {
 	healthpb.RegisterHealthServer(s.server, s.healthServer)
 	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_SERVING)
 
-	listener := s.grpcListener
-	logger.Info("Starting to serve on history listener")
-	if err := s.server.Serve(listener); err != nil {
-		logger.Fatal("Failed to serve on history listener", tag.Error(err))
-	}
+	s.serveWg.Add(1)
+	go func() {
+		s.logger.Info("Starting to serve on history listener")
+		if err := s.server.Serve(s.grpcListener); err != nil {
+			s.logger.Fatal("Failed to serve on history listener", tag.Error(err))
+		}
+		s.serveWg.Done()
+	}()
 }
 
 // Stop stops the service
 func (s *Service) Stop() {
-	logger := s.logger
-	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
-		return
-	}
-
 	// initiate graceful shutdown :
 	// 1. remove self from the membership ring
 	// 2. wait for other members to discover we are going down
@@ -140,28 +131,29 @@ func (s *Service) Stop() {
 
 	remainingTime := s.config.ShutdownDrainDuration()
 
-	logger.Info("ShutdownHandler: Evicting self from membership ring")
+	s.logger.Info("ShutdownHandler: Evicting self from membership ring")
 	_ = s.membershipMonitor.EvictSelf()
 	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
 
-	logger.Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
+	s.logger.Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
 	remainingTime = s.sleep(gossipPropagationDelay, remainingTime)
 
-	logger.Info("ShutdownHandler: Initiating shardController shutdown")
+	s.logger.Info("ShutdownHandler: Initiating shardController shutdown")
 	s.handler.controller.Stop()
-	logger.Info("ShutdownHandler: Waiting for traffic to drain")
+	s.logger.Info("ShutdownHandler: Waiting for traffic to drain")
 	remainingTime = s.sleep(shardOwnershipTransferDelay, remainingTime)
 
-	logger.Info("ShutdownHandler: No longer taking rpc requests")
+	s.logger.Info("ShutdownHandler: No longer taking rpc requests")
 	_ = s.sleep(gracePeriod, remainingTime)
 
 	// TODO: Change this to GracefulStop when integration tests are refactored.
 	s.server.Stop()
+	s.serveWg.Wait()
 
 	s.handler.Stop()
 	s.visibilityManager.Close()
 
-	logger.Info("history stopped")
+	s.logger.Info("history stopped")
 }
 
 // sleep sleeps for the minimum of desired and available duration

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -25,8 +25,6 @@
 package matching
 
 import (
-	"context"
-
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/api/historyservice/v1"
@@ -204,27 +202,6 @@ func HandlerProvider(
 	)
 }
 
-func ServiceLifetimeHooks(
-	lc fx.Lifecycle,
-	svcStoppedCh chan struct{},
-	svc *Service,
-) {
-	lc.Append(
-		fx.Hook{
-			OnStart: func(context.Context) error {
-				go func(svc *Service, svcStoppedCh chan<- struct{}) {
-					// Start is blocked until Stop() is called.
-					svc.Start()
-					close(svcStoppedCh)
-				}(svc, svcStoppedCh)
-
-				return nil
-			},
-			OnStop: func(ctx context.Context) error {
-				svc.Stop()
-				return nil
-			},
-		},
-	)
-
+func ServiceLifetimeHooks(lc fx.Lifecycle, svc *Service) {
+	lc.Append(fx.StartStopHook(svc.Start, svc.Stop))
 }

--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -25,8 +25,6 @@
 package worker
 
 import (
-	"context"
-
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common/config"
@@ -122,26 +120,6 @@ func VisibilityManagerProvider(
 	)
 }
 
-func ServiceLifetimeHooks(
-	lc fx.Lifecycle,
-	svcStoppedCh chan struct{},
-	svc *Service,
-) {
-	lc.Append(
-		fx.Hook{
-			OnStart: func(context.Context) error {
-				go func(svc *Service, svcStoppedCh chan<- struct{}) {
-					// Start is blocked until Stop() is called.
-					svc.Start()
-					close(svcStoppedCh)
-				}(svc, svcStoppedCh)
-
-				return nil
-			},
-			OnStop: func(ctx context.Context) error {
-				svc.Stop()
-				return nil
-			},
-		},
-	)
+func ServiceLifetimeHooks(lc fx.Lifecycle, svc *Service) {
+	lc.Append(fx.StartStopHook(svc.Start, svc.Stop))
 }

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -27,7 +27,6 @@ package worker
 import (
 	"context"
 	"math/rand"
-	"sync/atomic"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -35,7 +34,6 @@ import (
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	"go.temporal.io/server/client"
-	"go.temporal.io/server/common"
 	carchiver "go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/archiver/provider"
 	"go.temporal.io/server/common/cluster"
@@ -88,8 +86,6 @@ type (
 
 		metricsHandler metrics.Handler
 
-		status           int32
-		stopC            chan struct{}
 		sdkClientFactory sdk.ClientFactory
 		esClient         esclient.Client
 		config           *Config
@@ -158,11 +154,9 @@ func NewService(
 	}
 
 	s := &Service{
-		status:                    common.DaemonStatusInitialized,
 		config:                    serviceConfig,
 		sdkClientFactory:          sdkClientFactory,
 		esClient:                  esClient,
-		stopC:                     make(chan struct{}),
 		logger:                    logger,
 		archivalMetadata:          archivalMetadata,
 		clusterMetadata:           clusterMetadata,
@@ -378,14 +372,6 @@ func NewConfig(
 
 // Start is called to start the service
 func (s *Service) Start() {
-	if !atomic.CompareAndSwapInt32(
-		&s.status,
-		common.DaemonStatusInitialized,
-		common.DaemonStatusStarted,
-	) {
-		return
-	}
-
 	s.logger.Info(
 		"worker starting",
 		tag.ComponentWorker,
@@ -428,21 +414,10 @@ func (s *Service) Start() {
 		tag.ComponentWorker,
 		tag.Address(s.hostInfo.GetAddress()),
 	)
-	<-s.stopC
 }
 
 // Stop is called to stop the service
 func (s *Service) Stop() {
-	if !atomic.CompareAndSwapInt32(
-		&s.status,
-		common.DaemonStatusStarted,
-		common.DaemonStatusStopped,
-	) {
-		return
-	}
-
-	close(s.stopC)
-
 	s.scanner.Stop()
 	s.perNamespaceWorkerManager.Stop()
 	s.workerManager.Stop()

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -87,7 +87,6 @@ type (
 		app         *fx.App
 		serviceName primitives.ServiceName
 		logger      log.Logger
-		stopChan    chan struct{}
 	}
 
 	ServerFx struct {
@@ -316,13 +315,6 @@ func (svc *ServicesMetadata) Stop(ctx context.Context) {
 	if err != nil {
 		svc.logger.Error("Failed to stop service", tag.Service(svc.serviceName), tag.Error(err))
 	}
-
-	// verify "Start" goroutine returned
-	select {
-	case <-svc.stopChan:
-	case <-stopCtx.Done():
-		svc.logger.Error("Timed out waiting for service to stop", tag.Service(svc.serviceName), tag.NewDurationTag("timeout", serviceStopTimeout))
-	}
 }
 
 type (
@@ -354,13 +346,12 @@ type (
 	}
 )
 
-func NewService(app *fx.App, serviceName primitives.ServiceName, logger log.Logger, stopChan chan struct{}) ServicesGroupOut {
+func NewService(app *fx.App, serviceName primitives.ServiceName, logger log.Logger) ServicesGroupOut {
 	return ServicesGroupOut{
 		Services: &ServicesMetadata{
 			app:         app,
 			serviceName: serviceName,
 			logger:      logger,
-			stopChan:    stopChan,
 		},
 	}
 }
@@ -375,10 +366,8 @@ func HistoryServiceProvider(
 		return ServicesGroupOut{}, nil
 	}
 
-	stopChan := make(chan struct{})
 	app := fx.New(
 		fx.Supply(
-			stopChan,
 			params.EsConfig,
 			params.PersistenceConfig,
 			params.ClusterMetadata,
@@ -412,7 +401,7 @@ func HistoryServiceProvider(
 		FxLogAdapter,
 	)
 
-	return NewService(app, serviceName, params.Logger, stopChan), app.Err()
+	return NewService(app, serviceName, params.Logger), app.Err()
 }
 
 func MatchingServiceProvider(
@@ -425,10 +414,8 @@ func MatchingServiceProvider(
 		return ServicesGroupOut{}, nil
 	}
 
-	stopChan := make(chan struct{})
 	app := fx.New(
 		fx.Supply(
-			stopChan,
 			params.EsConfig,
 			params.PersistenceConfig,
 			params.ClusterMetadata,
@@ -459,7 +446,7 @@ func MatchingServiceProvider(
 		FxLogAdapter,
 	)
 
-	return NewService(app, serviceName, params.Logger, stopChan), app.Err()
+	return NewService(app, serviceName, params.Logger), app.Err()
 }
 
 func FrontendServiceProvider(
@@ -483,10 +470,8 @@ func genericFrontendServiceProvider(
 		return ServicesGroupOut{}, nil
 	}
 
-	stopChan := make(chan struct{})
 	app := fx.New(
 		fx.Supply(
-			stopChan,
 			params.EsConfig,
 			params.PersistenceConfig,
 			params.ClusterMetadata,
@@ -536,7 +521,7 @@ func genericFrontendServiceProvider(
 		FxLogAdapter,
 	)
 
-	return NewService(app, serviceName, params.Logger, stopChan), app.Err()
+	return NewService(app, serviceName, params.Logger), app.Err()
 }
 
 func WorkerServiceProvider(
@@ -549,10 +534,8 @@ func WorkerServiceProvider(
 		return ServicesGroupOut{}, nil
 	}
 
-	stopChan := make(chan struct{})
 	app := fx.New(
 		fx.Supply(
-			stopChan,
 			params.EsConfig,
 			params.PersistenceConfig,
 			params.ClusterMetadata,
@@ -583,7 +566,7 @@ func WorkerServiceProvider(
 		FxLogAdapter,
 	)
 
-	return NewService(app, serviceName, params.Logger, stopChan), app.Err()
+	return NewService(app, serviceName, params.Logger), app.Err()
 }
 
 // ApplyClusterMetadataConfigProvider performs a config check against the configured persistence store for cluster metadata.

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -367,14 +367,12 @@ func (c *temporalImpl) startFrontend(hosts map[primitives.ServiceName][]string, 
 		}
 	}
 
-	stoppedCh := make(chan struct{})
 	var frontendService *frontend.Service
 	var clientBean client.Bean
 	var namespaceRegistry namespace.Registry
 	var rpcFactory common.RPCFactory
 	feApp := fx.New(
 		fx.Supply(
-			stoppedCh,
 			persistenceConfig,
 			serviceName,
 		),
@@ -464,13 +462,11 @@ func (c *temporalImpl) startHistory(
 			}
 		}
 
-		stoppedCh := make(chan struct{})
 		var historyService *history.Service
 		var clientBean client.Bean
 		var namespaceRegistry namespace.Registry
 		app := fx.New(
 			fx.Supply(
-				stoppedCh,
 				persistenceConfig,
 				serviceName,
 			),
@@ -562,13 +558,11 @@ func (c *temporalImpl) startMatching(hosts map[primitives.ServiceName][]string, 
 		}
 	}
 
-	stoppedCh := make(chan struct{})
 	var matchingService *matching.Service
 	var clientBean client.Bean
 	var namespaceRegistry namespace.Registry
 	app := fx.New(
 		fx.Supply(
-			stoppedCh,
 			persistenceConfig,
 			serviceName,
 		),
@@ -656,13 +650,11 @@ func (c *temporalImpl) startWorker(hosts map[primitives.ServiceName][]string, st
 		clusterConfigCopy.EnableGlobalNamespace = true
 	}
 
-	stoppedCh := make(chan struct{})
 	var workerService *worker.Service
 	var clientBean client.Bean
 	var namespaceRegistry namespace.Registry
 	app := fx.New(
 		fx.Supply(
-			stoppedCh,
 			persistenceConfig,
 			serviceName,
 		),


### PR DESCRIPTION
**What changed?**
- Change the four main `Service` `Start` methods to no longer block
- But also run synchronously in fx lifecycle (except for the final `Serve` call)
- Use `fx.StartStopHook` to simplify code
- Get rid of `s.status` atomic ops since fx will serialize Start/Stop
- Get rid of `stopChan` as well

**Why?**
Allow more of service start/stop to be serialized by fx lifecycle, to avoid bugs when e.g. Stop is called while Start is still running.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manually and integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
