### PR TITLE
use a factory to create shard contexts

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -34,6 +34,7 @@ import (
 	clockspb "go.temporal.io/server/api/clock/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/archiver"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/cluster"
@@ -119,5 +120,14 @@ type (
 		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime *time.Time, closeTime *time.Time, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error
 
 		UnloadForOwnershipLost()
+	}
+
+	// A ControllableContext is a Context plus other methods needed by
+	// the Controller.
+	ControllableContext interface {
+		Context
+
+		common.Pingable
+		FinishStop()
 	}
 )

--- a/service/history/shard/context_factory.go
+++ b/service/history/shard/context_factory.go
@@ -1,0 +1,116 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"go.uber.org/fx"
+
+	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/client"
+	"go.temporal.io/server/common/archiver"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/service/history/configs"
+)
+
+type (
+	CloseCallback func(ControllableContext)
+
+	ContextFactory interface {
+		CreateContext(shardID int32, closeCallback CloseCallback) (ControllableContext, error)
+	}
+
+	ContextFactoryParams struct {
+		fx.In
+
+		ArchivalMetadata            archiver.ArchivalMetadata
+		ClientBean                  client.Bean
+		ClusterMetadata             cluster.Metadata
+		Config                      *configs.Config
+		EngineFactory               EngineFactory
+		HistoryClient               historyservice.HistoryServiceClient
+		HistoryServiceResolver      membership.ServiceResolver
+		HostInfoProvider            membership.HostInfoProvider
+		Logger                      log.Logger
+		MetricsHandler              metrics.Handler
+		NamespaceRegistry           namespace.Registry
+		PayloadSerializer           serialization.Serializer
+		PersistenceExecutionManager persistence.ExecutionManager
+		PersistenceShardManager     persistence.ShardManager
+		SaMapperProvider            searchattribute.MapperProvider
+		SaProvider                  searchattribute.Provider
+		ThrottledLogger             log.ThrottledLogger
+		TimeSource                  clock.TimeSource
+	}
+
+	contextFactoryImpl struct {
+		*ContextFactoryParams
+	}
+)
+
+func ContextFactoryProvider(params ContextFactoryParams) ContextFactory {
+	return &contextFactoryImpl{
+		ContextFactoryParams: &params,
+	}
+}
+
+func (c *contextFactoryImpl) CreateContext(
+	shardID int32,
+	closeCallback CloseCallback,
+) (ControllableContext, error) {
+	shard, err := newContext(
+		shardID,
+		c.EngineFactory,
+		c.Config,
+		closeCallback,
+		c.Logger,
+		c.ThrottledLogger,
+		c.PersistenceExecutionManager,
+		c.PersistenceShardManager,
+		c.ClientBean,
+		c.HistoryClient,
+		c.MetricsHandler,
+		c.PayloadSerializer,
+		c.TimeSource,
+		c.NamespaceRegistry,
+		c.SaProvider,
+		c.SaMapperProvider,
+		c.ClusterMetadata,
+		c.ArchivalMetadata,
+		c.HostInfoProvider,
+	)
+	if err != nil {
+		return nil, err
+	}
+	shard.start()
+	return shard, nil
+}

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -39,6 +39,7 @@ import (
 	v11 "go.temporal.io/server/api/clock/v1"
 	v12 "go.temporal.io/server/api/historyservice/v1"
 	v13 "go.temporal.io/server/api/persistence/v1"
+	common "go.temporal.io/server/common"
 	archiver "go.temporal.io/server/common/archiver"
 	clock "go.temporal.io/server/common/clock"
 	cluster "go.temporal.io/server/common/cluster"
@@ -769,4 +770,747 @@ func (m *MockContext) UpdateWorkflowExecution(ctx context.Context, request *pers
 func (mr *MockContextMockRecorder) UpdateWorkflowExecution(ctx, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecution", reflect.TypeOf((*MockContext)(nil).UpdateWorkflowExecution), ctx, request)
+}
+
+// MockControllableContext is a mock of ControllableContext interface.
+type MockControllableContext struct {
+	ctrl     *gomock.Controller
+	recorder *MockControllableContextMockRecorder
+}
+
+// MockControllableContextMockRecorder is the mock recorder for MockControllableContext.
+type MockControllableContextMockRecorder struct {
+	mock *MockControllableContext
+}
+
+// NewMockControllableContext creates a new mock instance.
+func NewMockControllableContext(ctrl *gomock.Controller) *MockControllableContext {
+	mock := &MockControllableContext{ctrl: ctrl}
+	mock.recorder = &MockControllableContextMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockControllableContext) EXPECT() *MockControllableContextMockRecorder {
+	return m.recorder
+}
+
+// AddSpeculativeWorkflowTaskTimeoutTask mocks base method.
+func (m *MockControllableContext) AddSpeculativeWorkflowTaskTimeoutTask(task *tasks.WorkflowTaskTimeoutTask) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddSpeculativeWorkflowTaskTimeoutTask", task)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddSpeculativeWorkflowTaskTimeoutTask indicates an expected call of AddSpeculativeWorkflowTaskTimeoutTask.
+func (mr *MockControllableContextMockRecorder) AddSpeculativeWorkflowTaskTimeoutTask(task interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddSpeculativeWorkflowTaskTimeoutTask", reflect.TypeOf((*MockControllableContext)(nil).AddSpeculativeWorkflowTaskTimeoutTask), task)
+}
+
+// AddTasks mocks base method.
+func (m *MockControllableContext) AddTasks(ctx context.Context, request *persistence.AddHistoryTasksRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTasks", ctx, request)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddTasks indicates an expected call of AddTasks.
+func (mr *MockControllableContextMockRecorder) AddTasks(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTasks", reflect.TypeOf((*MockControllableContext)(nil).AddTasks), ctx, request)
+}
+
+// AppendHistoryEvents mocks base method.
+func (m *MockControllableContext) AppendHistoryEvents(ctx context.Context, request *persistence.AppendHistoryNodesRequest, namespaceID namespace.ID, execution v1.WorkflowExecution) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AppendHistoryEvents", ctx, request, namespaceID, execution)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AppendHistoryEvents indicates an expected call of AppendHistoryEvents.
+func (mr *MockControllableContextMockRecorder) AppendHistoryEvents(ctx, request, namespaceID, execution interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendHistoryEvents", reflect.TypeOf((*MockControllableContext)(nil).AppendHistoryEvents), ctx, request, namespaceID, execution)
+}
+
+// AssertOwnership mocks base method.
+func (m *MockControllableContext) AssertOwnership(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssertOwnership", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AssertOwnership indicates an expected call of AssertOwnership.
+func (mr *MockControllableContextMockRecorder) AssertOwnership(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssertOwnership", reflect.TypeOf((*MockControllableContext)(nil).AssertOwnership), ctx)
+}
+
+// ConflictResolveWorkflowExecution mocks base method.
+func (m *MockControllableContext) ConflictResolveWorkflowExecution(ctx context.Context, request *persistence.ConflictResolveWorkflowExecutionRequest) (*persistence.ConflictResolveWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ConflictResolveWorkflowExecution", ctx, request)
+	ret0, _ := ret[0].(*persistence.ConflictResolveWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ConflictResolveWorkflowExecution indicates an expected call of ConflictResolveWorkflowExecution.
+func (mr *MockControllableContextMockRecorder) ConflictResolveWorkflowExecution(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ConflictResolveWorkflowExecution", reflect.TypeOf((*MockControllableContext)(nil).ConflictResolveWorkflowExecution), ctx, request)
+}
+
+// CreateWorkflowExecution mocks base method.
+func (m *MockControllableContext) CreateWorkflowExecution(ctx context.Context, request *persistence.CreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateWorkflowExecution", ctx, request)
+	ret0, _ := ret[0].(*persistence.CreateWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateWorkflowExecution indicates an expected call of CreateWorkflowExecution.
+func (mr *MockControllableContextMockRecorder) CreateWorkflowExecution(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockControllableContext)(nil).CreateWorkflowExecution), ctx, request)
+}
+
+// CurrentVectorClock mocks base method.
+func (m *MockControllableContext) CurrentVectorClock() *v11.VectorClock {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CurrentVectorClock")
+	ret0, _ := ret[0].(*v11.VectorClock)
+	return ret0
+}
+
+// CurrentVectorClock indicates an expected call of CurrentVectorClock.
+func (mr *MockControllableContextMockRecorder) CurrentVectorClock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentVectorClock", reflect.TypeOf((*MockControllableContext)(nil).CurrentVectorClock))
+}
+
+// DeleteWorkflowExecution mocks base method.
+func (m *MockControllableContext) DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime, closeTime *time.Time, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteWorkflowExecution", ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteWorkflowExecution indicates an expected call of DeleteWorkflowExecution.
+func (mr *MockControllableContextMockRecorder) DeleteWorkflowExecution(ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteWorkflowExecution", reflect.TypeOf((*MockControllableContext)(nil).DeleteWorkflowExecution), ctx, workflowKey, branchToken, startTime, closeTime, closeExecutionVisibilityTaskID, stage)
+}
+
+// FinishStop mocks base method.
+func (m *MockControllableContext) FinishStop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "FinishStop")
+}
+
+// FinishStop indicates an expected call of FinishStop.
+func (mr *MockControllableContextMockRecorder) FinishStop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FinishStop", reflect.TypeOf((*MockControllableContext)(nil).FinishStop))
+}
+
+// GenerateTaskID mocks base method.
+func (m *MockControllableContext) GenerateTaskID() (int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateTaskID")
+	ret0, _ := ret[0].(int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateTaskID indicates an expected call of GenerateTaskID.
+func (mr *MockControllableContextMockRecorder) GenerateTaskID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTaskID", reflect.TypeOf((*MockControllableContext)(nil).GenerateTaskID))
+}
+
+// GenerateTaskIDs mocks base method.
+func (m *MockControllableContext) GenerateTaskIDs(number int) ([]int64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateTaskIDs", number)
+	ret0, _ := ret[0].([]int64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GenerateTaskIDs indicates an expected call of GenerateTaskIDs.
+func (mr *MockControllableContextMockRecorder) GenerateTaskIDs(number interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateTaskIDs", reflect.TypeOf((*MockControllableContext)(nil).GenerateTaskIDs), number)
+}
+
+// GetArchivalMetadata mocks base method.
+func (m *MockControllableContext) GetArchivalMetadata() archiver.ArchivalMetadata {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetArchivalMetadata")
+	ret0, _ := ret[0].(archiver.ArchivalMetadata)
+	return ret0
+}
+
+// GetArchivalMetadata indicates an expected call of GetArchivalMetadata.
+func (mr *MockControllableContextMockRecorder) GetArchivalMetadata() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetArchivalMetadata", reflect.TypeOf((*MockControllableContext)(nil).GetArchivalMetadata))
+}
+
+// GetClusterMetadata mocks base method.
+func (m *MockControllableContext) GetClusterMetadata() cluster.Metadata {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetClusterMetadata")
+	ret0, _ := ret[0].(cluster.Metadata)
+	return ret0
+}
+
+// GetClusterMetadata indicates an expected call of GetClusterMetadata.
+func (mr *MockControllableContextMockRecorder) GetClusterMetadata() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetClusterMetadata", reflect.TypeOf((*MockControllableContext)(nil).GetClusterMetadata))
+}
+
+// GetConfig mocks base method.
+func (m *MockControllableContext) GetConfig() *configs.Config {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetConfig")
+	ret0, _ := ret[0].(*configs.Config)
+	return ret0
+}
+
+// GetConfig indicates an expected call of GetConfig.
+func (mr *MockControllableContextMockRecorder) GetConfig() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockControllableContext)(nil).GetConfig))
+}
+
+// GetCurrentExecution mocks base method.
+func (m *MockControllableContext) GetCurrentExecution(ctx context.Context, request *persistence.GetCurrentExecutionRequest) (*persistence.GetCurrentExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentExecution", ctx, request)
+	ret0, _ := ret[0].(*persistence.GetCurrentExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCurrentExecution indicates an expected call of GetCurrentExecution.
+func (mr *MockControllableContextMockRecorder) GetCurrentExecution(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentExecution", reflect.TypeOf((*MockControllableContext)(nil).GetCurrentExecution), ctx, request)
+}
+
+// GetCurrentTime mocks base method.
+func (m *MockControllableContext) GetCurrentTime(cluster string) time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCurrentTime", cluster)
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// GetCurrentTime indicates an expected call of GetCurrentTime.
+func (mr *MockControllableContextMockRecorder) GetCurrentTime(cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentTime", reflect.TypeOf((*MockControllableContext)(nil).GetCurrentTime), cluster)
+}
+
+// GetEngine mocks base method.
+func (m *MockControllableContext) GetEngine(ctx context.Context) (Engine, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEngine", ctx)
+	ret0, _ := ret[0].(Engine)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEngine indicates an expected call of GetEngine.
+func (mr *MockControllableContextMockRecorder) GetEngine(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEngine", reflect.TypeOf((*MockControllableContext)(nil).GetEngine), ctx)
+}
+
+// GetEventsCache mocks base method.
+func (m *MockControllableContext) GetEventsCache() events.Cache {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEventsCache")
+	ret0, _ := ret[0].(events.Cache)
+	return ret0
+}
+
+// GetEventsCache indicates an expected call of GetEventsCache.
+func (mr *MockControllableContextMockRecorder) GetEventsCache() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEventsCache", reflect.TypeOf((*MockControllableContext)(nil).GetEventsCache))
+}
+
+// GetExecutionManager mocks base method.
+func (m *MockControllableContext) GetExecutionManager() persistence.ExecutionManager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetExecutionManager")
+	ret0, _ := ret[0].(persistence.ExecutionManager)
+	return ret0
+}
+
+// GetExecutionManager indicates an expected call of GetExecutionManager.
+func (mr *MockControllableContextMockRecorder) GetExecutionManager() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetExecutionManager", reflect.TypeOf((*MockControllableContext)(nil).GetExecutionManager))
+}
+
+// GetHistoryClient mocks base method.
+func (m *MockControllableContext) GetHistoryClient() v12.HistoryServiceClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetHistoryClient")
+	ret0, _ := ret[0].(v12.HistoryServiceClient)
+	return ret0
+}
+
+// GetHistoryClient indicates an expected call of GetHistoryClient.
+func (mr *MockControllableContextMockRecorder) GetHistoryClient() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHistoryClient", reflect.TypeOf((*MockControllableContext)(nil).GetHistoryClient))
+}
+
+// GetImmediateQueueExclusiveHighReadWatermark mocks base method.
+func (m *MockControllableContext) GetImmediateQueueExclusiveHighReadWatermark() tasks.Key {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetImmediateQueueExclusiveHighReadWatermark")
+	ret0, _ := ret[0].(tasks.Key)
+	return ret0
+}
+
+// GetImmediateQueueExclusiveHighReadWatermark indicates an expected call of GetImmediateQueueExclusiveHighReadWatermark.
+func (mr *MockControllableContextMockRecorder) GetImmediateQueueExclusiveHighReadWatermark() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetImmediateQueueExclusiveHighReadWatermark", reflect.TypeOf((*MockControllableContext)(nil).GetImmediateQueueExclusiveHighReadWatermark))
+}
+
+// GetLogger mocks base method.
+func (m *MockControllableContext) GetLogger() log.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetLogger")
+	ret0, _ := ret[0].(log.Logger)
+	return ret0
+}
+
+// GetLogger indicates an expected call of GetLogger.
+func (mr *MockControllableContextMockRecorder) GetLogger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogger", reflect.TypeOf((*MockControllableContext)(nil).GetLogger))
+}
+
+// GetMetricsHandler mocks base method.
+func (m *MockControllableContext) GetMetricsHandler() metrics.Handler {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMetricsHandler")
+	ret0, _ := ret[0].(metrics.Handler)
+	return ret0
+}
+
+// GetMetricsHandler indicates an expected call of GetMetricsHandler.
+func (mr *MockControllableContextMockRecorder) GetMetricsHandler() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetricsHandler", reflect.TypeOf((*MockControllableContext)(nil).GetMetricsHandler))
+}
+
+// GetNamespaceRegistry mocks base method.
+func (m *MockControllableContext) GetNamespaceRegistry() namespace.Registry {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespaceRegistry")
+	ret0, _ := ret[0].(namespace.Registry)
+	return ret0
+}
+
+// GetNamespaceRegistry indicates an expected call of GetNamespaceRegistry.
+func (mr *MockControllableContextMockRecorder) GetNamespaceRegistry() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceRegistry", reflect.TypeOf((*MockControllableContext)(nil).GetNamespaceRegistry))
+}
+
+// GetOwner mocks base method.
+func (m *MockControllableContext) GetOwner() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOwner")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetOwner indicates an expected call of GetOwner.
+func (mr *MockControllableContextMockRecorder) GetOwner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOwner", reflect.TypeOf((*MockControllableContext)(nil).GetOwner))
+}
+
+// GetPayloadSerializer mocks base method.
+func (m *MockControllableContext) GetPayloadSerializer() serialization.Serializer {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPayloadSerializer")
+	ret0, _ := ret[0].(serialization.Serializer)
+	return ret0
+}
+
+// GetPayloadSerializer indicates an expected call of GetPayloadSerializer.
+func (mr *MockControllableContextMockRecorder) GetPayloadSerializer() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPayloadSerializer", reflect.TypeOf((*MockControllableContext)(nil).GetPayloadSerializer))
+}
+
+// GetPingChecks mocks base method.
+func (m *MockControllableContext) GetPingChecks() []common.PingCheck {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPingChecks")
+	ret0, _ := ret[0].([]common.PingCheck)
+	return ret0
+}
+
+// GetPingChecks indicates an expected call of GetPingChecks.
+func (mr *MockControllableContextMockRecorder) GetPingChecks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPingChecks", reflect.TypeOf((*MockControllableContext)(nil).GetPingChecks))
+}
+
+// GetQueueState mocks base method.
+func (m *MockControllableContext) GetQueueState(category tasks.Category) (*v13.QueueState, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetQueueState", category)
+	ret0, _ := ret[0].(*v13.QueueState)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// GetQueueState indicates an expected call of GetQueueState.
+func (mr *MockControllableContextMockRecorder) GetQueueState(category interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetQueueState", reflect.TypeOf((*MockControllableContext)(nil).GetQueueState), category)
+}
+
+// GetRangeID mocks base method.
+func (m *MockControllableContext) GetRangeID() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRangeID")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetRangeID indicates an expected call of GetRangeID.
+func (mr *MockControllableContextMockRecorder) GetRangeID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeID", reflect.TypeOf((*MockControllableContext)(nil).GetRangeID))
+}
+
+// GetRemoteAdminClient mocks base method.
+func (m *MockControllableContext) GetRemoteAdminClient(arg0 string) (v10.AdminServiceClient, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRemoteAdminClient", arg0)
+	ret0, _ := ret[0].(v10.AdminServiceClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRemoteAdminClient indicates an expected call of GetRemoteAdminClient.
+func (mr *MockControllableContextMockRecorder) GetRemoteAdminClient(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteAdminClient", reflect.TypeOf((*MockControllableContext)(nil).GetRemoteAdminClient), arg0)
+}
+
+// GetReplicationStatus mocks base method.
+func (m *MockControllableContext) GetReplicationStatus(cluster []string) (map[string]*v12.ShardReplicationStatusPerCluster, map[string]*v12.HandoverNamespaceInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReplicationStatus", cluster)
+	ret0, _ := ret[0].(map[string]*v12.ShardReplicationStatusPerCluster)
+	ret1, _ := ret[1].(map[string]*v12.HandoverNamespaceInfo)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetReplicationStatus indicates an expected call of GetReplicationStatus.
+func (mr *MockControllableContextMockRecorder) GetReplicationStatus(cluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicationStatus", reflect.TypeOf((*MockControllableContext)(nil).GetReplicationStatus), cluster)
+}
+
+// GetReplicatorDLQAckLevel mocks base method.
+func (m *MockControllableContext) GetReplicatorDLQAckLevel(sourceCluster string) int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReplicatorDLQAckLevel", sourceCluster)
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetReplicatorDLQAckLevel indicates an expected call of GetReplicatorDLQAckLevel.
+func (mr *MockControllableContextMockRecorder) GetReplicatorDLQAckLevel(sourceCluster interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReplicatorDLQAckLevel", reflect.TypeOf((*MockControllableContext)(nil).GetReplicatorDLQAckLevel), sourceCluster)
+}
+
+// GetSearchAttributesMapperProvider mocks base method.
+func (m *MockControllableContext) GetSearchAttributesMapperProvider() searchattribute.MapperProvider {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSearchAttributesMapperProvider")
+	ret0, _ := ret[0].(searchattribute.MapperProvider)
+	return ret0
+}
+
+// GetSearchAttributesMapperProvider indicates an expected call of GetSearchAttributesMapperProvider.
+func (mr *MockControllableContextMockRecorder) GetSearchAttributesMapperProvider() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSearchAttributesMapperProvider", reflect.TypeOf((*MockControllableContext)(nil).GetSearchAttributesMapperProvider))
+}
+
+// GetSearchAttributesProvider mocks base method.
+func (m *MockControllableContext) GetSearchAttributesProvider() searchattribute.Provider {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetSearchAttributesProvider")
+	ret0, _ := ret[0].(searchattribute.Provider)
+	return ret0
+}
+
+// GetSearchAttributesProvider indicates an expected call of GetSearchAttributesProvider.
+func (mr *MockControllableContextMockRecorder) GetSearchAttributesProvider() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetSearchAttributesProvider", reflect.TypeOf((*MockControllableContext)(nil).GetSearchAttributesProvider))
+}
+
+// GetShardID mocks base method.
+func (m *MockControllableContext) GetShardID() int32 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetShardID")
+	ret0, _ := ret[0].(int32)
+	return ret0
+}
+
+// GetShardID indicates an expected call of GetShardID.
+func (mr *MockControllableContextMockRecorder) GetShardID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardID", reflect.TypeOf((*MockControllableContext)(nil).GetShardID))
+}
+
+// GetThrottledLogger mocks base method.
+func (m *MockControllableContext) GetThrottledLogger() log.Logger {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetThrottledLogger")
+	ret0, _ := ret[0].(log.Logger)
+	return ret0
+}
+
+// GetThrottledLogger indicates an expected call of GetThrottledLogger.
+func (mr *MockControllableContextMockRecorder) GetThrottledLogger() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetThrottledLogger", reflect.TypeOf((*MockControllableContext)(nil).GetThrottledLogger))
+}
+
+// GetTimeSource mocks base method.
+func (m *MockControllableContext) GetTimeSource() clock.TimeSource {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTimeSource")
+	ret0, _ := ret[0].(clock.TimeSource)
+	return ret0
+}
+
+// GetTimeSource indicates an expected call of GetTimeSource.
+func (mr *MockControllableContextMockRecorder) GetTimeSource() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTimeSource", reflect.TypeOf((*MockControllableContext)(nil).GetTimeSource))
+}
+
+// GetWorkflowExecution mocks base method.
+func (m *MockControllableContext) GetWorkflowExecution(ctx context.Context, request *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowExecution", ctx, request)
+	ret0, _ := ret[0].(*persistence.GetWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWorkflowExecution indicates an expected call of GetWorkflowExecution.
+func (mr *MockControllableContextMockRecorder) GetWorkflowExecution(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowExecution", reflect.TypeOf((*MockControllableContext)(nil).GetWorkflowExecution), ctx, request)
+}
+
+// IsValid mocks base method.
+func (m *MockControllableContext) IsValid() bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsValid")
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsValid indicates an expected call of IsValid.
+func (mr *MockControllableContextMockRecorder) IsValid() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsValid", reflect.TypeOf((*MockControllableContext)(nil).IsValid))
+}
+
+// NewVectorClock mocks base method.
+func (m *MockControllableContext) NewVectorClock() (*v11.VectorClock, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewVectorClock")
+	ret0, _ := ret[0].(*v11.VectorClock)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// NewVectorClock indicates an expected call of NewVectorClock.
+func (mr *MockControllableContextMockRecorder) NewVectorClock() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewVectorClock", reflect.TypeOf((*MockControllableContext)(nil).NewVectorClock))
+}
+
+// SetCurrentTime mocks base method.
+func (m *MockControllableContext) SetCurrentTime(cluster string, currentTime time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetCurrentTime", cluster, currentTime)
+}
+
+// SetCurrentTime indicates an expected call of SetCurrentTime.
+func (mr *MockControllableContextMockRecorder) SetCurrentTime(cluster, currentTime interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetCurrentTime", reflect.TypeOf((*MockControllableContext)(nil).SetCurrentTime), cluster, currentTime)
+}
+
+// SetQueueState mocks base method.
+func (m *MockControllableContext) SetQueueState(category tasks.Category, state *v13.QueueState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetQueueState", category, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SetQueueState indicates an expected call of SetQueueState.
+func (mr *MockControllableContextMockRecorder) SetQueueState(category, state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetQueueState", reflect.TypeOf((*MockControllableContext)(nil).SetQueueState), category, state)
+}
+
+// SetWorkflowExecution mocks base method.
+func (m *MockControllableContext) SetWorkflowExecution(ctx context.Context, request *persistence.SetWorkflowExecutionRequest) (*persistence.SetWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetWorkflowExecution", ctx, request)
+	ret0, _ := ret[0].(*persistence.SetWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetWorkflowExecution indicates an expected call of SetWorkflowExecution.
+func (mr *MockControllableContextMockRecorder) SetWorkflowExecution(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkflowExecution", reflect.TypeOf((*MockControllableContext)(nil).SetWorkflowExecution), ctx, request)
+}
+
+// UnloadForOwnershipLost mocks base method.
+func (m *MockControllableContext) UnloadForOwnershipLost() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UnloadForOwnershipLost")
+}
+
+// UnloadForOwnershipLost indicates an expected call of UnloadForOwnershipLost.
+func (mr *MockControllableContextMockRecorder) UnloadForOwnershipLost() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnloadForOwnershipLost", reflect.TypeOf((*MockControllableContext)(nil).UnloadForOwnershipLost))
+}
+
+// UpdateHandoverNamespace mocks base method.
+func (m *MockControllableContext) UpdateHandoverNamespace(ns *namespace.Namespace, deletedFromDb bool) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateHandoverNamespace", ns, deletedFromDb)
+}
+
+// UpdateHandoverNamespace indicates an expected call of UpdateHandoverNamespace.
+func (mr *MockControllableContextMockRecorder) UpdateHandoverNamespace(ns, deletedFromDb interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHandoverNamespace", reflect.TypeOf((*MockControllableContext)(nil).UpdateHandoverNamespace), ns, deletedFromDb)
+}
+
+// UpdateRemoteClusterInfo mocks base method.
+func (m *MockControllableContext) UpdateRemoteClusterInfo(cluster string, ackTaskID int64, ackTimestamp time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateRemoteClusterInfo", cluster, ackTaskID, ackTimestamp)
+}
+
+// UpdateRemoteClusterInfo indicates an expected call of UpdateRemoteClusterInfo.
+func (mr *MockControllableContextMockRecorder) UpdateRemoteClusterInfo(cluster, ackTaskID, ackTimestamp interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteClusterInfo", reflect.TypeOf((*MockControllableContext)(nil).UpdateRemoteClusterInfo), cluster, ackTaskID, ackTimestamp)
+}
+
+// UpdateRemoteReaderInfo mocks base method.
+func (m *MockControllableContext) UpdateRemoteReaderInfo(readerID, ackTaskID int64, ackTimestamp time.Time) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRemoteReaderInfo", readerID, ackTaskID, ackTimestamp)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateRemoteReaderInfo indicates an expected call of UpdateRemoteReaderInfo.
+func (mr *MockControllableContextMockRecorder) UpdateRemoteReaderInfo(readerID, ackTaskID, ackTimestamp interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRemoteReaderInfo", reflect.TypeOf((*MockControllableContext)(nil).UpdateRemoteReaderInfo), readerID, ackTaskID, ackTimestamp)
+}
+
+// UpdateReplicationQueueReaderState mocks base method.
+func (m *MockControllableContext) UpdateReplicationQueueReaderState(readerID int64, readerState *v13.QueueReaderState) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateReplicationQueueReaderState", readerID, readerState)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateReplicationQueueReaderState indicates an expected call of UpdateReplicationQueueReaderState.
+func (mr *MockControllableContextMockRecorder) UpdateReplicationQueueReaderState(readerID, readerState interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateReplicationQueueReaderState", reflect.TypeOf((*MockControllableContext)(nil).UpdateReplicationQueueReaderState), readerID, readerState)
+}
+
+// UpdateReplicatorDLQAckLevel mocks base method.
+func (m *MockControllableContext) UpdateReplicatorDLQAckLevel(sourCluster string, ackLevel int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateReplicatorDLQAckLevel", sourCluster, ackLevel)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateReplicatorDLQAckLevel indicates an expected call of UpdateReplicatorDLQAckLevel.
+func (mr *MockControllableContextMockRecorder) UpdateReplicatorDLQAckLevel(sourCluster, ackLevel interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateReplicatorDLQAckLevel", reflect.TypeOf((*MockControllableContext)(nil).UpdateReplicatorDLQAckLevel), sourCluster, ackLevel)
+}
+
+// UpdateScheduledQueueExclusiveHighReadWatermark mocks base method.
+func (m *MockControllableContext) UpdateScheduledQueueExclusiveHighReadWatermark() (tasks.Key, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateScheduledQueueExclusiveHighReadWatermark")
+	ret0, _ := ret[0].(tasks.Key)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateScheduledQueueExclusiveHighReadWatermark indicates an expected call of UpdateScheduledQueueExclusiveHighReadWatermark.
+func (mr *MockControllableContextMockRecorder) UpdateScheduledQueueExclusiveHighReadWatermark() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateScheduledQueueExclusiveHighReadWatermark", reflect.TypeOf((*MockControllableContext)(nil).UpdateScheduledQueueExclusiveHighReadWatermark))
+}
+
+// UpdateWorkflowExecution mocks base method.
+func (m *MockControllableContext) UpdateWorkflowExecution(ctx context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateWorkflowExecution", ctx, request)
+	ret0, _ := ret[0].(*persistence.UpdateWorkflowExecutionResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateWorkflowExecution indicates an expected call of UpdateWorkflowExecution.
+func (mr *MockControllableContextMockRecorder) UpdateWorkflowExecution(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecution", reflect.TypeOf((*MockControllableContext)(nil).UpdateWorkflowExecution), ctx, request)
 }

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -729,7 +729,7 @@ func (s *contextSuite) TestShardStopReasonCloseShard() {
 	s.mockShard.state = contextStateAcquired
 	s.mockHistoryEngine.EXPECT().Stop().Times(1)
 
-	s.mockShard.finishStop()
+	s.mockShard.FinishStop()
 
 	s.False(s.mockShard.IsValid())
 	s.False(s.mockShard.stoppedForOwnershipLost())

--- a/service/history/shard/context_testutil.go
+++ b/service/history/shard/context_testutil.go
@@ -135,9 +135,9 @@ func (s *ContextTest) SetHistoryClientForTesting(client historyservice.HistorySe
 	s.historyClient = client
 }
 
-// StopForTest calls private method finishStop(). In general only the controller
+// StopForTest calls FinishStop(). In general only the controller
 // should call that, but integration tests need to do it also to clean up any
 // background acquireShard goroutines that may exist.
 func (s *ContextTest) StopForTest() {
-	s.finishStop()
+	s.FinishStop()
 }

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -36,22 +36,20 @@ import (
 	"testing"
 	"time"
 
-	"go.temporal.io/server/api/enums/v1"
-	persistencespb "go.temporal.io/server/api/persistence/v1"
-	"go.temporal.io/server/common/primitives"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/convert"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/membership"
-	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/resourcetest"
 	"go.temporal.io/server/internal/goro"
@@ -88,33 +86,35 @@ func NewTestController(
 	resource *resourcetest.Test,
 	hostInfoProvider *membership.MockHostInfoProvider,
 ) *ControllerImpl {
-	return &ControllerImpl{
-		config:                      config,
-		logger:                      resource.GetLogger(),
-		throttledLogger:             resource.GetThrottledLogger(),
-		contextTaggedLogger:         log.With(resource.GetLogger(), tag.ComponentShardController, tag.Address(resource.GetHostInfo().Identity())),
-		persistenceExecutionManager: resource.GetExecutionManager(),
-		persistenceShardManager:     resource.GetShardManager(),
-		clientBean:                  resource.GetClientBean(),
-		historyClient:               resource.GetHistoryClient(),
-		historyServiceResolver:      resource.GetHistoryServiceResolver(),
-		metricsHandler:              resource.GetMetricsHandler(),
-		payloadSerializer:           resource.GetPayloadSerializer(),
-		timeSource:                  resource.GetTimeSource(),
-		namespaceRegistry:           resource.GetNamespaceRegistry(),
-		saProvider:                  resource.GetSearchAttributesProvider(),
-		saMapperProvider:            resource.GetSearchAttributesMapperProvider(),
-		clusterMetadata:             resource.GetClusterMetadata(),
-		archivalMetadata:            resource.GetArchivalMetadata(),
-		hostInfoProvider:            hostInfoProvider,
+	contextFactory := ContextFactoryProvider(ContextFactoryParams{
+		ArchivalMetadata:            resource.GetArchivalMetadata(),
+		ClientBean:                  resource.GetClientBean(),
+		ClusterMetadata:             resource.GetClusterMetadata(),
+		Config:                      config,
+		EngineFactory:               engineFactory,
+		HistoryClient:               resource.GetHistoryClient(),
+		HistoryServiceResolver:      resource.GetHistoryServiceResolver(),
+		HostInfoProvider:            hostInfoProvider,
+		Logger:                      resource.GetLogger(),
+		MetricsHandler:              resource.GetMetricsHandler(),
+		NamespaceRegistry:           resource.GetNamespaceRegistry(),
+		PayloadSerializer:           resource.GetPayloadSerializer(),
+		PersistenceExecutionManager: resource.GetExecutionManager(),
+		PersistenceShardManager:     resource.GetShardManager(),
+		SaMapperProvider:            resource.GetSearchAttributesMapperProvider(),
+		SaProvider:                  resource.GetSearchAttributesProvider(),
+		ThrottledLogger:             resource.GetThrottledLogger(),
+		TimeSource:                  resource.GetTimeSource(),
+	})
 
-		status:               common.DaemonStatusInitialized,
-		membershipUpdateCh:   make(chan *membership.ChangedEvent, 10),
-		engineFactory:        engineFactory,
-		shutdownCh:           make(chan struct{}),
-		taggedMetricsHandler: resource.GetMetricsHandler().WithTags(metrics.OperationTag(metrics.HistoryShardControllerScope)),
-		historyShards:        make(map[int32]*ContextImpl),
-	}
+	return ControllerProvider(
+		config,
+		resource.GetLogger(),
+		resource.GetHistoryServiceResolver(),
+		resource.GetMetricsHandler(),
+		resource.GetHostInfoProvider(),
+		contextFactory,
+	).(*ControllerImpl)
 }
 
 func TestShardControllerSuite(t *testing.T) {
@@ -528,7 +528,7 @@ func (s *controllerSuite) TestShardExplicitUnloadCancelGetOrCreate() {
 
 	<-ready
 	// now shard is blocked on GetOrCreateShard
-	s.False(shard.engineFuture.Ready())
+	s.False(shard.(*ContextImpl).engineFuture.Ready())
 
 	start := time.Now()
 	shard.UnloadForOwnershipLost() // this cancels the context so GetOrCreateShard returns immediately
@@ -583,7 +583,7 @@ func (s *controllerSuite) TestShardExplicitUnloadCancelAcquire() {
 
 	<-ready
 	// now shard is blocked on UpdateShard
-	s.False(shard.engineFuture.Ready())
+	s.False(shard.(*ContextImpl).engineFuture.Ready())
 
 	start := time.Now()
 	shard.UnloadForOwnershipLost() // this cancels the context so UpdateShard returns immediately

--- a/service/history/shard/fx.go
+++ b/service/history/shard/fx.go
@@ -25,80 +25,16 @@
 package shard
 
 import (
-	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/fx"
 
-	"go.temporal.io/server/api/historyservice/v1"
-	"go.temporal.io/server/client"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/archiver"
-	"go.temporal.io/server/common/clock"
-	"go.temporal.io/server/common/cluster"
-	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/membership"
-	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/common/persistence/serialization"
-	"go.temporal.io/server/common/searchattribute"
-	"go.temporal.io/server/service/history/configs"
-	"go.temporal.io/server/service/history/consts"
 )
 
 var Module = fx.Options(
 	fx.Provide(ControllerProvider),
+	fx.Provide(ContextFactoryProvider),
 	fx.Provide(fx.Annotate(
 		func(p Controller) common.Pingable { return p },
 		fx.ResultTags(`group:"deadlockDetectorRoots"`),
 	)),
 )
-
-func ControllerProvider(
-	config *configs.Config,
-	logger log.Logger,
-	throttledLogger log.ThrottledLogger,
-	persistenceExecutionManager persistence.ExecutionManager,
-	persistenceShardManager persistence.ShardManager,
-	clientBean client.Bean,
-	historyClient historyservice.HistoryServiceClient,
-	historyServiceResolver membership.ServiceResolver,
-	metricsHandler metrics.Handler,
-	payloadSerializer serialization.Serializer,
-	timeSource clock.TimeSource,
-	namespaceRegistry namespace.Registry,
-	saProvider searchattribute.Provider,
-	saMapperProvider searchattribute.MapperProvider,
-	clusterMetadata cluster.Metadata,
-	archivalMetadata archiver.ArchivalMetadata,
-	hostInfoProvider membership.HostInfoProvider,
-	engineFactory EngineFactory,
-	tracerProvider trace.TracerProvider,
-) Controller {
-	return &ControllerImpl{
-		status:                      common.DaemonStatusInitialized,
-		membershipUpdateCh:          make(chan *membership.ChangedEvent, 10),
-		historyShards:               make(map[int32]*ContextImpl),
-		shutdownCh:                  make(chan struct{}),
-		logger:                      logger,
-		contextTaggedLogger:         logger,          // will add tags in Start
-		throttledLogger:             throttledLogger, // will add tags in Start
-		config:                      config,
-		persistenceExecutionManager: persistenceExecutionManager,
-		persistenceShardManager:     persistenceShardManager,
-		clientBean:                  clientBean,
-		historyClient:               historyClient,
-		historyServiceResolver:      historyServiceResolver,
-		metricsHandler:              metricsHandler,
-		taggedMetricsHandler:        metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryShardControllerScope)),
-		payloadSerializer:           payloadSerializer,
-		timeSource:                  timeSource,
-		namespaceRegistry:           namespaceRegistry,
-		saProvider:                  saProvider,
-		saMapperProvider:            saMapperProvider,
-		clusterMetadata:             clusterMetadata,
-		archivalMetadata:            archivalMetadata,
-		hostInfoProvider:            hostInfoProvider,
-		engineFactory:               engineFactory,
-		tracer:                      tracerProvider.Tracer(consts.LibraryName),
-	}
-}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Edit: I moved this from "draft" to real PR.

This adds a shard context factory, which returns a `ControllableContext` that is the existing context interface plus the Pingable & FinishStop methods that the controller needs (but api request handling doesn't). The shard controller uses that to create contexts, instead of calling `newContext` directly.

This does not update the shard controller tests. The tests in controller_test.go should eventually change to test behavior at the new interface boundary, and some of the existing tests ought to be moved, likely to context's tests. 

<!-- Tell your future self why have you made these changes -->
**Why?**
It simplifies the shard controller, and removes the duplicate logic used to create a controller between the provider and `NewTestController`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit & CI.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
