### PR TITLE
wait for drain duration before stopping shard controller

### DIFF
--- a/service/history/service.go
+++ b/service/history/service.go
@@ -129,7 +129,7 @@ func (s *Service) Stop() {
 	if delay := s.config.ShutdownDrainDuration(); delay > 0 {
 		s.logger.Info("ShutdownHandler: delaying for shutdown drain",
 			tag.NewDurationTag("shutdownDrainDuration", delay))
-		time.Sleep(s.config.ShutdownDrainDuration())
+		time.Sleep(delay)
 	}
 
 	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -40,7 +40,6 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence/client"
 	"go.temporal.io/server/common/persistence/visibility/manager"
-	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/service/history/configs"
 )
 
@@ -124,37 +123,19 @@ func (s *Service) Start() {
 
 // Stop stops the service
 func (s *Service) Stop() {
-	// initiate graceful shutdown :
-	// 1. remove self from the membership ring
-	// 2. wait for other members to discover we are going down
-	// 3. stop acquiring new shards (periodically or based on other membership changes)
-	// 4. wait for shard ownership to transfer (and inflight requests to drain) while still accepting new requests
-	// 5. Reject all requests arriving at rpc handler to avoid taking on more work except for RespondXXXCompleted and
-	//    RecordXXStarted APIs - for these APIs, most of the work is already one and rejecting at last stage is
-	//    probably not that desirable. If the shard is closed, these requests will fail anyways.
-	// 6. wait for grace period
-	// 7. force stop the whole world and return
-
-	const gossipPropagationDelay = 400 * time.Millisecond
-	const shardOwnershipTransferDelay = 5 * time.Second
-	const gracePeriod = 2 * time.Second
-
-	remainingTime := s.config.ShutdownDrainDuration()
-
 	s.logger.Info("ShutdownHandler: Evicting self from membership ring")
 	_ = s.membershipMonitor.EvictSelf()
-	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
 
-	s.logger.Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
-	remainingTime = s.sleep(gossipPropagationDelay, remainingTime)
+	if delay := s.config.ShutdownDrainDuration(); delay > 0 {
+		s.logger.Info("ShutdownHandler: delaying for shutdown drain",
+			tag.NewDurationTag("shutdownDrainDuration", delay))
+		time.Sleep(s.config.ShutdownDrainDuration())
+	}
+
+	s.healthServer.SetServingStatus(serviceName, healthpb.HealthCheckResponse_NOT_SERVING)
 
 	s.logger.Info("ShutdownHandler: Initiating shardController shutdown")
 	s.handler.controller.Stop()
-	s.logger.Info("ShutdownHandler: Waiting for traffic to drain")
-	remainingTime = s.sleep(shardOwnershipTransferDelay, remainingTime)
-
-	s.logger.Info("ShutdownHandler: No longer taking rpc requests")
-	_ = s.sleep(gracePeriod, remainingTime)
 
 	// TODO: Change this to GracefulStop when integration tests are refactored.
 	s.server.Stop()
@@ -163,16 +144,6 @@ func (s *Service) Stop() {
 	s.visibilityManager.Close()
 
 	s.logger.Info("history stopped")
-}
-
-// sleep sleeps for the minimum of desired and available duration
-// returns the remaining available time duration
-func (s *Service) sleep(desired time.Duration, available time.Duration) time.Duration {
-	d := util.Min(desired, available)
-	if d > 0 {
-		time.Sleep(d)
-	}
-	return available - d
 }
 
 func (s *Service) GetFaultInjection() *client.FaultInjectionDataStoreFactory {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This simplifies the logic inside history service stop, while still using the `ShutdownDrainDuration` config to allow answering requests while shutdown is in progress.

<!-- Tell your future self why have you made these changes -->
**Why?**
With this change, the only pause is immediately after leaving membership, and the duration of that pause is completely configurable. A pause at that point is useful, because it keeps the terminating instance up to respond with shard ownership lost errors to in-flight requests, and history clients will retry those requests quickly. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This was tested in a staging environment.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
ShutdownDrainDuration defaults to zero, so this change only impacts environments which intentionally set that config. For environments that do set it, it was previously gated by the hardcoded values in the code, so it could cause history to stay up longer than previously.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.