### PR TITLE
Add a clocked rate limiter

### DIFF
--- a/common/persistence/client/health_request_rate_limiter.go
+++ b/common/persistence/client/health_request_rate_limiter.go
@@ -150,13 +150,13 @@ func (rl *HealthRequestRateLimiterImpl) refreshRate() {
 	if rl.latencyThresholdExceeded() || rl.errorThresholdExceeded() {
 		// limit exceeded, do backoff
 		rl.curRateMultiplier = math.Max(rl.minRateMultiplier, rl.curRateMultiplier-rl.curOptions.RateBackoffStepSize)
-		rl.rateLimiter.SetRate(rl.curRateMultiplier * rl.rateFn())
+		rl.rateLimiter.SetRPS(rl.curRateMultiplier * rl.rateFn())
 		rl.rateLimiter.SetBurst(int(rl.rateToBurstRatio * rl.rateFn()))
 		rl.logger.Info("Health threshold exceeded, reducing rate limit.", tag.NewFloat64("newMulti", rl.curRateMultiplier), tag.NewFloat64("newRate", rl.rateLimiter.Rate()), tag.NewFloat64("latencyAvg", rl.healthSignals.AverageLatency()), tag.NewFloat64("errorRatio", rl.healthSignals.ErrorRatio()))
 	} else if rl.curRateMultiplier < rl.maxRateMultiplier {
 		// already doing backoff and under thresholds, increase limit
 		rl.curRateMultiplier = math.Min(rl.maxRateMultiplier, rl.curRateMultiplier+rl.curOptions.RateIncreaseStepSize)
-		rl.rateLimiter.SetRate(rl.curRateMultiplier * rl.rateFn())
+		rl.rateLimiter.SetRPS(rl.curRateMultiplier * rl.rateFn())
 		rl.rateLimiter.SetBurst(int(rl.rateToBurstRatio * rl.rateFn()))
 		rl.logger.Info("System healthy, increasing rate limit.", tag.NewFloat64("newMulti", rl.curRateMultiplier), tag.NewFloat64("newRate", rl.rateLimiter.Rate()), tag.NewFloat64("latencyAvg", rl.healthSignals.AverageLatency()), tag.NewFloat64("errorRatio", rl.healthSignals.ErrorRatio()))
 	}

--- a/common/quotas/clocked_rate_limiter.go
+++ b/common/quotas/clocked_rate_limiter.go
@@ -1,0 +1,154 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package quotas
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/time/rate"
+)
+
+// ClockedRateLimiter wraps a rate.Limiter with a clockwork.Clock. It is used to ensure that the rate limiter respects
+// the time determined by the clock.
+type ClockedRateLimiter struct {
+	rateLimiter *rate.Limiter
+	clock       clockwork.Clock
+}
+
+var (
+	ErrRateLimiterWaitInterrupted                       = errors.New("rate limiter wait interrupted")
+	ErrRateLimiterReservationCannotBeMade               = errors.New("rate limiter reservation cannot be made due to insufficient quota")
+	ErrRateLimiterReservationWouldExceedContextDeadline = errors.New("rate limiter reservation would exceed context deadline")
+)
+
+func NewClockedRateLimiter(rateLimiter *rate.Limiter, clock clockwork.Clock) ClockedRateLimiter {
+	return ClockedRateLimiter{
+		rateLimiter: rateLimiter,
+		clock:       clock,
+	}
+}
+
+func (l ClockedRateLimiter) Allow() bool {
+	return l.AllowN(l.clock.Now(), 1)
+}
+
+func (l ClockedRateLimiter) AllowN(now time.Time, token int) bool {
+	return l.rateLimiter.AllowN(now, token)
+}
+
+// ClockedReservation wraps a rate.Reservation with a clockwork.Clock. It is used to ensure that the reservation
+// respects the time determined by the clock.
+type ClockedReservation struct {
+	reservation *rate.Reservation
+	clock       clockwork.Clock
+}
+
+func (r ClockedReservation) OK() bool {
+	return r.reservation.OK()
+}
+
+func (r ClockedReservation) Delay() time.Duration {
+	return r.DelayFrom(r.clock.Now())
+}
+
+func (r ClockedReservation) DelayFrom(t time.Time) time.Duration {
+	return r.reservation.DelayFrom(t)
+}
+
+func (r ClockedReservation) Cancel() {
+	r.CancelAt(r.clock.Now())
+}
+
+func (r ClockedReservation) CancelAt(t time.Time) {
+	r.reservation.CancelAt(t)
+}
+
+func (l ClockedRateLimiter) Reserve() ClockedReservation {
+	return l.ReserveN(l.clock.Now(), 1)
+}
+
+func (l ClockedRateLimiter) ReserveN(now time.Time, token int) ClockedReservation {
+	reservation := l.rateLimiter.ReserveN(now, token)
+	return ClockedReservation{reservation, l.clock}
+}
+
+func (l ClockedRateLimiter) Wait(ctx context.Context) error {
+	return l.WaitN(ctx, 1)
+}
+
+// WaitN is the only method that is different from rate.Limiter. We need to fully reimplement this method because
+// the original method uses time.Now(), and does not allow us to pass in a time.Time. Fortunately, it can be built on
+// top of ReserveN. However, there are some optimizations that we can make.
+func (l ClockedRateLimiter) WaitN(ctx context.Context, token int) error {
+	reservation := ClockedReservation{l.rateLimiter.ReserveN(l.clock.Now(), token), l.clock}
+	if !reservation.OK() {
+		return fmt.Errorf(
+			"%w: reservation would delay for %v",
+			ErrRateLimiterReservationCannotBeMade,
+			reservation.Delay(),
+		)
+	}
+
+	waitDuration := reservation.Delay()
+
+	// Optimization: if the waitDuration is 0, we don't need to start a timer.
+	if waitDuration <= 0 {
+		return nil
+	}
+
+	// Optimization: if the waitDuration is longer than the context deadline, we can immediately return an error.
+	if deadline, ok := ctx.Deadline(); ok {
+		if l.clock.Now().Add(waitDuration).After(deadline) {
+			reservation.Cancel()
+			return fmt.Errorf(
+				"%w: reservation would delay for %v",
+				ErrRateLimiterReservationWouldExceedContextDeadline,
+				reservation.Delay(),
+			)
+		}
+	}
+
+	timer := l.clock.NewTimer(waitDuration)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		reservation.Cancel()
+		return fmt.Errorf("%w: %v", ErrRateLimiterWaitInterrupted, ctx.Err())
+	case <-timer.Chan():
+		return nil
+	}
+}
+
+func (l ClockedRateLimiter) SetLimitAt(t time.Time, newLimit rate.Limit) {
+	l.rateLimiter.SetLimitAt(t, newLimit)
+}
+
+func (l ClockedRateLimiter) SetBurstAt(t time.Time, newBurst int) {
+	l.rateLimiter.SetBurstAt(t, newBurst)
+}

--- a/common/quotas/clocked_rate_limiter_test.go
+++ b/common/quotas/clocked_rate_limiter_test.go
@@ -1,0 +1,156 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package quotas_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/jonboulle/clockwork"
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/server/common/quotas"
+	"golang.org/x/time/rate"
+)
+
+func TestClockedRateLimiter_Allow_NoQuota(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewRealClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(0, 0), clock)
+	assert.False(t, rl.Allow())
+}
+
+func TestClockedRateLimiter_Allow_OneBurst(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(0, 1), clock)
+	assert.True(t, rl.Allow())
+	assert.False(t, rl.Allow())
+}
+
+func TestClockedRateLimiter_Allow_RPS_TooHigh(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(1, 1), clock)
+	assert.True(t, rl.Allow())
+	clock.Advance(999 * time.Millisecond)
+	assert.False(t, rl.Allow())
+}
+
+func TestClockedRateLimiter_Allow_RPS_Ok(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(1, 1), clock)
+	assert.True(t, rl.Allow())
+	clock.Advance(time.Second)
+	assert.True(t, rl.Allow())
+}
+
+func TestClockedRateLimiter_AllowN_Ok(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(0, 10), clock)
+	assert.True(t, rl.AllowN(clock.Now(), 10))
+}
+
+func TestClockedRateLimiter_AllowN_NotOk(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(0, 10), clock)
+	assert.False(t, rl.AllowN(clock.Now(), 11))
+}
+
+func TestClockedRateLimiter_Wait_NoBurst(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(1, 0), clock)
+	ctx := context.Background()
+	assert.ErrorIs(t, rl.Wait(ctx), quotas.ErrRateLimiterReservationCannotBeMade)
+}
+
+func TestClockedRateLimiter_Wait_Ok(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(1, 1), clock)
+	ctx := context.Background()
+	assert.NoError(t, rl.Wait(ctx))
+
+	go func() {
+		clock.BlockUntil(1)
+		clock.Advance(time.Second)
+	}()
+	assert.NoError(t, rl.Wait(ctx))
+}
+
+func TestClockedRateLimiter_Wait_Canceled(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(1, 1), clock)
+	ctx := context.Background()
+
+	ctx, cancel := context.WithCancel(ctx)
+	assert.NoError(t, rl.Wait(ctx))
+
+	go func() {
+		clock.BlockUntil(1)
+		clock.Advance(time.Millisecond * 999)
+		clock.BlockUntil(1)
+		cancel()
+	}()
+	assert.ErrorIs(t, rl.Wait(ctx), quotas.ErrRateLimiterWaitInterrupted)
+}
+
+func TestClockedRateLimiter_Reserve(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(1, 1), clock)
+	rl.Allow()
+	reservation := rl.Reserve()
+	assert.Equal(t, time.Second, reservation.DelayFrom(clock.Now()))
+}
+
+func TestClockedRateLimiter_Wait_DeadlineWouldExceed(t *testing.T) {
+	t.Parallel()
+
+	clock := clockwork.NewFakeClock()
+	rl := quotas.NewClockedRateLimiter(rate.NewLimiter(1, 1), clock)
+	rl.Allow()
+
+	ctx := context.Background()
+
+	ctx, cancel := context.WithDeadline(ctx, clock.Now().Add(500*time.Millisecond))
+	t.Cleanup(cancel)
+	assert.ErrorIs(t, rl.Wait(ctx), quotas.ErrRateLimiterReservationWouldExceedContextDeadline)
+}

--- a/common/quotas/dynamic.go
+++ b/common/quotas/dynamic.go
@@ -53,7 +53,7 @@ type (
 	}
 
 	MutableRateBurst interface {
-		SetRate(rate float64)
+		SetRPS(rps float64)
 		SetBurst(burst int)
 		RateBurst
 	}
@@ -120,7 +120,7 @@ func NewMutableRateBurst(
 	}
 }
 
-func (d *MutableRateBurstImpl) SetRate(rate float64) {
+func (d *MutableRateBurstImpl) SetRPS(rate float64) {
 	d.rate.Store(rate)
 }
 

--- a/common/quotas/rate_limiter_impl_test.go
+++ b/common/quotas/rate_limiter_impl_test.go
@@ -63,7 +63,7 @@ func (s *rateLimiterSuite) TestSetRate_Same() {
 	rateLimiter := NewRateLimiter(testRate, testBurst)
 
 	rateLimiterBefore := rateLimiter.ClockedRateLimiter
-	rateLimiter.SetRate(testRate)
+	rateLimiter.SetRPS(testRate)
 	rateLimiterAfter := rateLimiter.ClockedRateLimiter
 	s.Equal(testRate, rateLimiter.Rate())
 	s.Equal(testBurst, rateLimiter.Burst())
@@ -74,7 +74,7 @@ func (s *rateLimiterSuite) TestSetRate_Diff() {
 	rateLimiter := NewRateLimiter(testRate, testBurst)
 
 	newRate := testRate * 2
-	rateLimiter.SetRate(newRate)
+	rateLimiter.SetRPS(newRate)
 	s.Equal(newRate, rateLimiter.Rate())
 	s.Equal(testBurst, rateLimiter.Burst())
 }

--- a/common/quotas/rate_limiter_impl_test.go
+++ b/common/quotas/rate_limiter_impl_test.go
@@ -62,9 +62,9 @@ func (s *rateLimiterSuite) TearDownTest() {
 func (s *rateLimiterSuite) TestSetRate_Same() {
 	rateLimiter := NewRateLimiter(testRate, testBurst)
 
-	rateLimiterBefore := rateLimiter.goRateLimiter
+	rateLimiterBefore := rateLimiter.ClockedRateLimiter
 	rateLimiter.SetRate(testRate)
-	rateLimiterAfter := rateLimiter.goRateLimiter
+	rateLimiterAfter := rateLimiter.ClockedRateLimiter
 	s.Equal(testRate, rateLimiter.Rate())
 	s.Equal(testBurst, rateLimiter.Burst())
 	s.Equal(rateLimiterBefore, rateLimiterAfter)
@@ -82,9 +82,9 @@ func (s *rateLimiterSuite) TestSetRate_Diff() {
 func (s *rateLimiterSuite) TestSetBurst_Same() {
 	rateLimiter := NewRateLimiter(testRate, testBurst)
 
-	rateLimiterBefore := rateLimiter.goRateLimiter
+	rateLimiterBefore := rateLimiter.ClockedRateLimiter
 	rateLimiter.SetBurst(testBurst)
-	rateLimiterAfter := rateLimiter.goRateLimiter
+	rateLimiterAfter := rateLimiter.ClockedRateLimiter
 	s.Equal(testRate, rateLimiter.Rate())
 	s.Equal(testBurst, rateLimiter.Burst())
 	s.Equal(rateLimiterBefore, rateLimiterAfter)
@@ -102,9 +102,9 @@ func (s *rateLimiterSuite) TestSetBurst_Diff() {
 func (s *rateLimiterSuite) TestSetRateBurst_Same() {
 	rateLimiter := NewRateLimiter(testRate, testBurst)
 
-	rateLimiterBefore := rateLimiter.goRateLimiter
+	rateLimiterBefore := rateLimiter.ClockedRateLimiter
 	rateLimiter.SetRateBurst(rateLimiter.Rate(), rateLimiter.Burst())
-	rateLimiterAfter := rateLimiter.goRateLimiter
+	rateLimiterAfter := rateLimiter.ClockedRateLimiter
 	s.Equal(testRate, rateLimiter.Rate())
 	s.Equal(testBurst, rateLimiter.Burst())
 	s.Equal(rateLimiterBefore, rateLimiterAfter)

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -309,25 +309,25 @@ func (tm *TaskMatcher) PollForQuery(ctx context.Context, pollMetadata *pollMetad
 }
 
 // UpdateRatelimit updates the task dispatch rate
-func (tm *TaskMatcher) UpdateRatelimit(rps *float64) {
-	if rps == nil {
+func (tm *TaskMatcher) UpdateRatelimit(rpsPtr *float64) {
+	if rpsPtr == nil {
 		return
 	}
 
-	rate := *rps
+	rps := *rpsPtr
 	nPartitions := float64(tm.numPartitions())
 	if nPartitions > 0 {
 		// divide the rate equally across all partitions
-		rate = rate / nPartitions
+		rps = rps / nPartitions
 	}
-	burst := int(math.Ceil(rate))
+	burst := int(math.Ceil(rps))
 
 	minTaskThrottlingBurstSize := tm.config.MinTaskThrottlingBurstSize()
 	if burst < minTaskThrottlingBurstSize {
 		burst = minTaskThrottlingBurstSize
 	}
 
-	tm.dynamicRateBurst.SetRate(rate)
+	tm.dynamicRateBurst.SetRPS(rps)
 	tm.dynamicRateBurst.SetBurst(burst)
 	tm.forceRefreshRateOnce.Do(func() {
 		// Dynamic rate limiter only refresh its rate every 1m. Before that initial 1m interval, it uses default rate

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -3061,9 +3061,9 @@ type (
 	}
 )
 
-func (d *dynamicRateBurstWrapper) SetRate(rate float64) {
-	d.MutableRateBurst.SetRate(rate)
-	d.RateLimiterImpl.SetRate(rate)
+func (d *dynamicRateBurstWrapper) SetRPS(rps float64) {
+	d.MutableRateBurst.SetRPS(rps)
+	d.RateLimiterImpl.SetRPS(rps)
 }
 
 func (d *dynamicRateBurstWrapper) SetBurst(burst int) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Our RateLimiterImpl now uses a ClockedRateLimiter instead of a raw go rate limiter which does not accept a clock.

<!-- Tell your future self why have you made these changes -->
**Why?**
To make unit testing / time skipping easier in the future, and to add some test coverage.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added a bunch of unit tests for the ClockedRateLimiter.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
1. If I missed something, we could be using system time instead of the clock, and it would make downstream issues harder to debug
2. If there's a bug here, we could end up with a fauly rate limiter which prevents any requests from going through
3. The tests aren't exactly trivial, so it could introduce a maintenance burden

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No