### PR TITLE
Add a Clock option to our LRU cache

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -26,6 +26,8 @@ package cache
 
 import (
 	"time"
+
+	"github.com/jonboulle/clockwork"
 )
 
 // A Cache is a generalized interface to a cache.  See cache.LRU for a specific
@@ -66,6 +68,9 @@ type Options struct {
 
 	// Pin prevents in-use objects from getting evicted.
 	Pin bool
+
+	// Clock is an optional clock to use for time-skipping and testing. If this is nil, a real clock will be used.
+	Clock clockwork.Clock
 }
 
 // SimpleOptions provides options that can be used to configure SimpleCache


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a Clock to our LRU cache, and I modified our tests to use that instead of time.Sleep.

<!-- Tell your future self why have you made these changes -->
**Why?**
To make our tests faster, and to support time-skipping in the future

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
A flaky test here would probably make it hang forever. If someone uses clock.Sleep instead of clock.Advance in the future, that can happen.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
