### PR TITLE
Remove durable archival flag

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -662,8 +662,6 @@ const (
 	ArchivalProcessorArchiveDelay = "history.archivalProcessorArchiveDelay"
 	// ArchivalBackendMaxRPS is the maximum rate of requests per second to the archival backend
 	ArchivalBackendMaxRPS = "history.archivalBackendMaxRPS"
-	// DurableArchivalEnabled is the flag to enable durable archival
-	DurableArchivalEnabled = "history.durableArchivalEnabled"
 
 	// WorkflowExecutionMaxInFlightUpdates is the max number of updates that can be in-flight (admitted but not yet completed) for any given workflow execution.
 	WorkflowExecutionMaxInFlightUpdates = "history.maxInFlightUpdates"

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -181,7 +181,6 @@ type Config struct {
 	NumArchiveSystemWorkflows dynamicconfig.IntPropertyFn
 	ArchiveRequestRPS         dynamicconfig.IntPropertyFn
 	ArchiveSignalTimeout      dynamicconfig.DurationPropertyFn
-	DurableArchivalEnabled    dynamicconfig.BoolPropertyFn
 
 	// Size limit related settings
 	BlobSizeLimitError                        dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -445,7 +444,6 @@ func NewConfig(
 		NumArchiveSystemWorkflows: dc.GetIntProperty(dynamicconfig.NumArchiveSystemWorkflows, 1000),
 		ArchiveRequestRPS:         dc.GetIntProperty(dynamicconfig.ArchiveRequestRPS, 300), // should be much smaller than frontend RPS
 		ArchiveSignalTimeout:      dc.GetDurationProperty(dynamicconfig.ArchiveSignalTimeout, 300*time.Millisecond),
-		DurableArchivalEnabled:    dc.GetBoolProperty(dynamicconfig.DurableArchivalEnabled, true),
 
 		BlobSizeLimitError:                        dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
 		BlobSizeLimitWarn:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.BlobSizeLimitWarn, 512*1024),

--- a/service/history/tasks/archive_execution_task.go
+++ b/service/history/tasks/archive_execution_task.go
@@ -35,7 +35,7 @@ var _ Task = (*ArchiveExecutionTask)(nil)
 
 type (
 	// ArchiveExecutionTask is the task which archives both the history and visibility of a workflow execution and then
-	// produces a retention timer task to delete the data. See "Durable Archival" for more info.
+	// produces a retention timer task to delete the data.
 	ArchiveExecutionTask struct {
 		definition.WorkflowKey
 		VisibilityTimestamp time.Time

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -185,6 +185,5 @@ func NewDynamicConfig() *configs.Config {
 	config.EnableActivityEagerExecution = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.EnableEagerWorkflowStart = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)
-	config.DurableArchivalEnabled = dynamicconfig.GetBoolPropertyFn(true)
 	return config
 }

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -208,8 +208,8 @@ func (r *TaskGeneratorImpl) GenerateWorkflowCloseTasks(
 			// archiveTime is the time when the archival queue recognizes the ArchiveExecutionTask as ready-to-process
 			archiveTime := closeEvent.GetEventTime().Add(delay)
 
-			// We can skip visibility archival in the close execution task if we are using the durable archival flow.
-			// The visibility archival will be handled by the archival queue.
+			// This flag is only untrue for old server versions which were using the archival workflow instead of the
+			// archival queue.
 			closeExecutionTask.CanSkipVisibilityArchival = true
 			task := &tasks.ArchiveExecutionTask{
 				// TaskID is set by the shard
@@ -670,9 +670,6 @@ func (r *TaskGeneratorImpl) getTargetNamespaceID(
 // itself is also enabled.
 // For both history and visibility, we check that archival is enabled for both the cluster and the namespace.
 func (r *TaskGeneratorImpl) archivalQueueEnabled() bool {
-	if !r.config.DurableArchivalEnabled() {
-		return false
-	}
 	namespaceEntry := r.mutableState.GetNamespaceEntry()
 	return r.archivalMetadata.GetHistoryConfig().ClusterConfiguredForArchival() &&
 		namespaceEntry.HistoryArchivalState().State == enumspb.ARCHIVAL_STATE_ENABLED ||

--- a/service/history/workflow/task_generator_test.go
+++ b/service/history/workflow/task_generator_test.go
@@ -76,7 +76,6 @@ type testConfig struct {
 }
 
 type testParams struct {
-	DurableArchivalEnabled               bool
 	DeleteAfterClose                     bool
 	CloseEventTime                       time.Time
 	Retention                            time.Duration
@@ -96,17 +95,8 @@ type testParams struct {
 func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 	for _, c := range []testConfig{
 		{
-			Name: "delete after retention",
-			ConfigFn: func(p *testParams) {
-				p.ExpectCloseExecutionVisibilityTask = true
-				p.ExpectDeleteHistoryEventTask = true
-			},
-		},
-		{
 			Name: "use archival queue",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
-
 				p.ExpectCloseExecutionVisibilityTask = true
 				p.ExpectArchiveExecutionTask = true
 			},
@@ -114,14 +104,12 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 		{
 			Name: "delete after close ignores durable execution flag",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
 				p.DeleteAfterClose = true
 			},
 		},
 		{
 			Name: "delay is zero",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
 				p.CloseEventTime = time.Unix(0, 0)
 				p.Retention = 24 * time.Hour
 				p.ArchivalProcessorArchiveDelay = 0
@@ -134,7 +122,6 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 		{
 			Name: "delay exceeds retention",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
 				p.CloseEventTime = time.Unix(0, 0)
 				p.Retention = 24 * time.Hour
 				p.ArchivalProcessorArchiveDelay = 48*time.Hour + time.Second
@@ -147,7 +134,6 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 		{
 			Name: "delay is less than retention",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
 				p.CloseEventTime = time.Unix(0, 0)
 				p.Retention = 24 * time.Hour
 				p.ArchivalProcessorArchiveDelay = 12 * time.Hour
@@ -160,7 +146,6 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 		{
 			Name: "history archival disabled",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
 				p.HistoryArchivalEnabledInCluster = false
 				p.HistoryArchivalEnabledInNamespace = false
 
@@ -171,7 +156,6 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 		{
 			Name: "visibility archival disabled",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
 				p.VisibilityArchivalEnabledForCluster = false
 				p.VisibilityArchivalEnabledInNamespace = false
 
@@ -182,7 +166,6 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 		{
 			Name: "archival disabled in cluster",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
 				p.HistoryArchivalEnabledInCluster = false
 				p.VisibilityArchivalEnabledForCluster = false
 
@@ -194,7 +177,6 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 		{
 			Name: "archival disabled in namespace",
 			ConfigFn: func(p *testParams) {
-				p.DurableArchivalEnabled = true
 				p.HistoryArchivalEnabledInNamespace = false
 				p.VisibilityArchivalEnabledInNamespace = false
 
@@ -210,7 +192,6 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockLogger := log.NewMockLogger(ctrl)
 			p := testParams{
-				DurableArchivalEnabled:               false,
 				DeleteAfterClose:                     false,
 				CloseEventTime:                       now,
 				Retention:                            time.Hour * 24 * 7,
@@ -270,9 +251,6 @@ func TestTaskGeneratorImpl_GenerateWorkflowCloseTasks(t *testing.T) {
 			mutableState.EXPECT().GetCurrentBranchToken().Return(nil, nil).AnyTimes()
 			retentionTimerDelay := time.Second
 			cfg := &configs.Config{
-				DurableArchivalEnabled: func() bool {
-					return p.DurableArchivalEnabled
-				},
 				RetentionTimerJitterDuration: func() time.Duration {
 					return retentionTimerDelay
 				},

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -82,30 +82,12 @@ func (s *archivalSuite) SetupTest() {
 
 func TestArchivalSuite(t *testing.T) {
 	flag.Parse()
-	for _, c := range []struct {
-		Name                     string
-		DurableArchivalIsEnabled bool
-	}{
-		{
-			Name:                     "DurableArchivalIsDisabled",
-			DurableArchivalIsEnabled: false,
-		},
-		{
-			Name:                     "DurableArchivalIsEnabled",
-			DurableArchivalIsEnabled: true,
-		},
-	} {
-		c := c
-		t.Run(c.Name, func(t *testing.T) {
-			s := new(archivalSuite)
-			s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
-				dynamicconfig.RetentionTimerJitterDuration:  time.Second,
-				dynamicconfig.ArchivalProcessorArchiveDelay: time.Duration(0),
-				dynamicconfig.DurableArchivalEnabled:        c.DurableArchivalIsEnabled,
-			}
-			suite.Run(t, s)
-		})
+	s := new(archivalSuite)
+	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
+		dynamicconfig.RetentionTimerJitterDuration:  time.Second,
+		dynamicconfig.ArchivalProcessorArchiveDelay: time.Duration(0),
 	}
+	suite.Run(t, s)
 }
 
 func (s *archivalSuite) TestArchival_TimerQueueProcessor() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the durable archival flag which switches between the archival workflow and the archival queue.

<!-- Tell your future self why have you made these changes -->
**Why?**
Because we just use the archival queue unconditionally now, and the old code path is something like 5K lines, so being able to delete it will slim us down a lot.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Durable archival was [released in February](https://github.com/temporalio/temporal/releases/tag/v1.20.0) as part of 1.20.0. There was one bug that caused schedules-based workflows to not be archived, but that was fixed. Other than that, there have been no issues, and so I think it's been long enough, and it's been battle-tested enough that we can now remove its predecessor.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there's a bug in the archival queue, we won't have a way to switch back to the archival workflow any more. 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.