### PR TITLE
add stop reason for context

### DIFF
--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -162,7 +162,7 @@ func (c *WorkflowConsistencyCheckerImpl) getWorkflowContextValidatedByClock(
 	}
 	if cmpResult > 0 {
 		shardID := c.shardContext.GetShardID()
-		c.shardContext.Unload()
+		c.shardContext.UnloadForOwnershipLost()
 		return nil, &persistence.ShardOwnershipLostError{
 			ShardID: shardID,
 			Msg:     fmt.Sprintf("Shard: %v consistency check failed, reloading", shardID),

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -118,6 +118,6 @@ type (
 		// If branchToken != nil, then delete history also, otherwise leave history.
 		DeleteWorkflowExecution(ctx context.Context, workflowKey definition.WorkflowKey, branchToken []byte, startTime *time.Time, closeTime *time.Time, closeExecutionVisibilityTaskID int64, stage *tasks.DeleteWorkflowExecutionStage) error
 
-		Unload()
+		UnloadForOwnershipLost()
 	}
 )

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -1371,11 +1371,6 @@ func (s *ContextImpl) UnloadForOwnershipLost() {
 	_ = s.transition(contextRequestStop{reason: stopReasonOwnershipLost})
 }
 
-// requestStop should only be called by the controller.
-func (s *ContextImpl) requestStop() {
-	_ = s.transition(contextRequestStop{reason: stopReasonUnspecified})
-}
-
 // finishStop should only be called by the controller.
 func (s *ContextImpl) finishStop() {
 	// After this returns, engineFuture.Set may not be called anymore, so if we don't get see

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -128,8 +128,9 @@ type (
 		lifecycleCancel context.CancelFunc
 
 		// state is protected by stateLock
-		stateLock sync.Mutex
-		state     contextState
+		stateLock  sync.Mutex
+		state      contextState
+		stopReason stopReason
 
 		// All following fields are protected by rwLock, and only valid if state >= Acquiring:
 		rwLock                             sync.RWMutex
@@ -163,8 +164,15 @@ type (
 	contextRequestAcquire    struct{}
 	contextRequestAcquired   struct{ engine Engine }
 	contextRequestLost       struct{}
-	contextRequestStop       struct{}
+	contextRequestStop       struct{ reason stopReason }
 	contextRequestFinishStop struct{}
+
+	stopReason int
+)
+
+const (
+	stopReasonUnspecified stopReason = iota
+	stopReasonOwnershipLost
 )
 
 var _ Context = (*ContextImpl)(nil)
@@ -1287,7 +1295,7 @@ func (s *ContextImpl) handleReadError(err error) error {
 	case *persistence.ShardOwnershipLostError:
 		// Shard is stolen, trigger shutdown of history engine.
 		// Handling of max read level doesn't matter here.
-		_ = s.transition(contextRequestStop{})
+		_ = s.transition(contextRequestStop{reason: stopReasonOwnershipLost})
 		return err
 
 	default:
@@ -1322,7 +1330,7 @@ func (s *ContextImpl) handleWriteErrorAndUpdateMaxReadLevelLocked(err error, new
 	case *persistence.ShardOwnershipLostError:
 		// Shard is stolen, trigger shutdown of history engine.
 		// Handling of max read level doesn't matter here.
-		_ = s.transition(contextRequestStop{})
+		_ = s.transition(contextRequestStop{reason: stopReasonOwnershipLost})
 		return err
 
 	default:
@@ -1359,8 +1367,13 @@ func (s *ContextImpl) start() {
 	_ = s.transition(contextRequestAcquire{})
 }
 
-func (s *ContextImpl) Unload() {
-	_ = s.transition(contextRequestStop{})
+func (s *ContextImpl) UnloadForOwnershipLost() {
+	_ = s.transition(contextRequestStop{reason: stopReasonOwnershipLost})
+}
+
+// requestStop should only be called by the controller.
+func (s *ContextImpl) requestStop() {
+	_ = s.transition(contextRequestStop{reason: stopReasonUnspecified})
 }
 
 // finishStop should only be called by the controller.
@@ -1384,6 +1397,12 @@ func (s *ContextImpl) IsValid() bool {
 	s.stateLock.Lock()
 	defer s.stateLock.Unlock()
 	return s.state < contextStateStopping
+}
+
+func (s *ContextImpl) stoppedForOwnershipLost() bool {
+	s.stateLock.Lock()
+	defer s.stateLock.Unlock()
+	return s.state >= contextStateStopping && s.stopReason == stopReasonOwnershipLost
 }
 
 func (s *ContextImpl) wLock() {
@@ -1468,8 +1487,9 @@ func (s *ContextImpl) transition(request contextRequest) error {
 		go s.acquireShard()
 	}
 
-	setStateStopping := func() {
+	setStateStopping := func(request contextRequestStop) {
 		s.state = contextStateStopping
+		s.stopReason = request.reason
 		// Cancel lifecycle context as soon as we know we're shutting down
 		s.lifecycleCancel()
 		// This will cause the controller to remove this shard from the map and then call s.finishStop()
@@ -1487,12 +1507,12 @@ func (s *ContextImpl) transition(request contextRequest) error {
 
 	switch s.state {
 	case contextStateInitialized:
-		switch request.(type) {
+		switch request := request.(type) {
 		case contextRequestAcquire:
 			setStateAcquiring()
 			return nil
 		case contextRequestStop:
-			setStateStopping()
+			setStateStopping(request)
 			return nil
 		case contextRequestFinishStop:
 			setStateStopped()
@@ -1525,21 +1545,21 @@ func (s *ContextImpl) transition(request contextRequest) error {
 		case contextRequestLost:
 			return nil // nothing to do, already acquiring
 		case contextRequestStop:
-			setStateStopping()
+			setStateStopping(request)
 			return nil
 		case contextRequestFinishStop:
 			setStateStopped()
 			return nil
 		}
 	case contextStateAcquired:
-		switch request.(type) {
+		switch request := request.(type) {
 		case contextRequestAcquire:
 			return nil // nothing to to do, already acquired
 		case contextRequestLost:
 			setStateAcquiring()
 			return nil
 		case contextRequestStop:
-			setStateStopping()
+			setStateStopping(request)
 			return nil
 		case contextRequestFinishStop:
 			setStateStopped()
@@ -1873,9 +1893,13 @@ func (s *ContextImpl) acquireShard() {
 		// We got an non-retryable error, e.g. ShardOwnershipLostError
 		s.contextTaggedLogger.Error("Couldn't acquire shard", tag.Error(err))
 
+		reason := stopReasonUnspecified
+		if IsShardOwnershipLostError(err) {
+			reason = stopReasonOwnershipLost
+		}
 		// On any error, initiate shutting down the shard. If we already changed state
 		// because we got a ShardOwnershipLostError, this won't do anything.
-		_ = s.transition(contextRequestStop{})
+		_ = s.transition(contextRequestStop{reason: reason})
 	}
 }
 

--- a/service/history/shard/context_mock.go
+++ b/service/history/shard/context_mock.go
@@ -663,16 +663,16 @@ func (mr *MockContextMockRecorder) SetWorkflowExecution(ctx, request interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkflowExecution", reflect.TypeOf((*MockContext)(nil).SetWorkflowExecution), ctx, request)
 }
 
-// Unload mocks base method.
-func (m *MockContext) Unload() {
+// UnloadForOwnershipLost mocks base method.
+func (m *MockContext) UnloadForOwnershipLost() {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Unload")
+	m.ctrl.Call(m, "UnloadForOwnershipLost")
 }
 
-// Unload indicates an expected call of Unload.
-func (mr *MockContextMockRecorder) Unload() *gomock.Call {
+// UnloadForOwnershipLost indicates an expected call of UnloadForOwnershipLost.
+func (mr *MockContextMockRecorder) UnloadForOwnershipLost() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unload", reflect.TypeOf((*MockContext)(nil).Unload))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnloadForOwnershipLost", reflect.TypeOf((*MockContext)(nil).UnloadForOwnershipLost))
 }
 
 // UpdateHandoverNamespace mocks base method.

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -281,10 +281,8 @@ func (c *ControllerImpl) getOrCreateShardContext(shardID int32) (*ContextImpl, e
 			return shard, nil
 		}
 
-		// If the shard was invalid and still in the historyShards map, it should
-		// be because the shardClosedCallback hasn't yet executed its call to
-		// finishStop, so this call to requestStop should be redundant.
-		shard.requestStop()
+		// If the shard was invalid and still in the historyShards map, the
+		// shardClosedCallback call is in-flight, and will call finishStop.
 		delete(c.historyShards, shardID)
 	}
 

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -281,7 +281,10 @@ func (c *ControllerImpl) getOrCreateShardContext(shardID int32) (*ContextImpl, e
 			return shard, nil
 		}
 
-		shard.Unload()
+		// If the shard was invalid and still in the historyShards map, it should
+		// be because the shardClosedCallback hasn't yet executed its call to
+		// finishStop, so this call to requestStop should be redundant.
+		shard.requestStop()
 		delete(c.historyShards, shardID)
 	}
 

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -483,7 +483,7 @@ func (s *controllerSuite) TestShardExplicitUnload() {
 	s.NoError(err)
 	s.Equal(1, len(s.shardController.ShardIDs()))
 
-	shard.Unload()
+	shard.UnloadForOwnershipLost()
 
 	for tries := 0; tries < 100 && len(s.shardController.ShardIDs()) != 0; tries++ {
 		// removal from map happens asynchronously
@@ -529,7 +529,7 @@ func (s *controllerSuite) TestShardExplicitUnloadCancelGetOrCreate() {
 	s.False(shard.engineFuture.Ready())
 
 	start := time.Now()
-	shard.Unload() // this cancels the context so GetOrCreateShard returns immediately
+	shard.UnloadForOwnershipLost() // this cancels the context so GetOrCreateShard returns immediately
 	s.True(<-wasCanceled)
 	s.Less(time.Since(start), 500*time.Millisecond)
 }
@@ -582,7 +582,7 @@ func (s *controllerSuite) TestShardExplicitUnloadCancelAcquire() {
 	s.False(shard.engineFuture.Ready())
 
 	start := time.Now()
-	shard.Unload() // this cancels the context so UpdateShard returns immediately
+	shard.UnloadForOwnershipLost() // this cancels the context so UpdateShard returns immediately
 	s.True(<-wasCanceled)
 	s.Less(time.Since(start), 500*time.Millisecond)
 }
@@ -680,7 +680,7 @@ func (s *controllerSuite) TestShardControllerFuzz() {
 				}
 			case 2:
 				if _, shard := randomLoadedShard(); shard != nil {
-					shard.Unload()
+					shard.UnloadForOwnershipLost()
 				}
 			case 3:
 				if id, _ := randomLoadedShard(); id >= 0 {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When a shard context is stopped, it stores whether or not that was due to a shard ownership lost (SOL) error.

<!-- Tell your future self why have you made these changes -->
**Why?**
Upcoming changes to the shard controller will delay re-acquiring a shard that recently had an SOL error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally & ci, and in a staging environment (with other changes).

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None; this change is only used by tests.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
