### PR TITLE
Remove time.Sleep from liveness_test

### DIFF
--- a/service/matching/liveness.go
+++ b/service/matching/liveness.go
@@ -32,42 +32,74 @@ import (
 )
 
 type (
-	liveness struct {
-		clock  clockwork.Clock
+	// liveness is a helper for tracking whether a component is alive or not. It is alive if it is marked alive within
+	// a certain time period, and dead otherwise. It is useful for tracking whether a poller is alive or not.
+	liveness[T simpleTimer] struct {
+		clock  timerFactory[T]
 		ttl    func() time.Duration
 		onIdle func()
 		timer  atomic.Value
 	}
-
-	timerWrapper struct {
+	// timerFactory is a subset of clockwork.Clock that only has the AfterFunc method, which returns a simpleTimer.
+	timerFactory[T simpleTimer] interface {
+		AfterFunc(d time.Duration, f func()) T
+	}
+	// simpleTimer is similar to clockwork.Timer, but the Reset and Stop methods return nothing because we don't care about
+	// those results.
+	simpleTimer interface {
+		Reset(d time.Duration)
+		Stop()
+	}
+	// clockworkClock adapts a clockwork.Clock to the timerFactory interface.
+	clockworkClock struct {
+		clockwork.Clock
+	}
+	// clockworkTimer adapts a clockwork.Timer to the simpleTimer interface.
+	clockworkTimer struct {
 		clockwork.Timer
+	}
+	// monomorphicTimer is a Timer that always has the same concrete type, so that it can be stored in an atomic.Value.
+	monomorphicTimer struct {
+		simpleTimer
 	}
 )
 
-func newLiveness(
-	clock clockwork.Clock,
+func (c clockworkClock) AfterFunc(d time.Duration, f func()) clockworkTimer {
+	return clockworkTimer{c.Clock.AfterFunc(d, f)}
+}
+
+func (t clockworkTimer) Reset(d time.Duration) {
+	t.Timer.Reset(d)
+}
+
+func (t clockworkTimer) Stop() {
+	t.Timer.Stop()
+}
+
+func newLiveness[T simpleTimer](
+	clock timerFactory[T],
 	ttl func() time.Duration,
 	onIdle func(),
-) *liveness {
-	return &liveness{
+) *liveness[T] {
+	return &liveness[T]{
 		clock:  clock,
 		ttl:    ttl,
 		onIdle: onIdle,
 	}
 }
 
-func (l *liveness) Start() {
-	l.timer.Store(timerWrapper{l.clock.AfterFunc(l.ttl(), l.onIdle)})
+func (l *liveness[T]) Start() {
+	l.timer.Store(monomorphicTimer{l.clock.AfterFunc(l.ttl(), l.onIdle)})
 }
 
-func (l *liveness) Stop() {
-	if t, ok := l.timer.Swap(timerWrapper{}).(timerWrapper); ok && t.Timer != nil {
+func (l *liveness[T]) Stop() {
+	if t, ok := l.timer.Swap(monomorphicTimer{}).(monomorphicTimer); ok && t.simpleTimer != nil {
 		t.Stop()
 	}
 }
 
-func (l *liveness) markAlive() {
-	if t, ok := l.timer.Load().(timerWrapper); ok && t.Timer != nil {
+func (l *liveness[T]) markAlive() {
+	if t, ok := l.timer.Load().(monomorphicTimer); ok && t.simpleTimer != nil {
 		t.Reset(l.ttl())
 	}
 }

--- a/service/matching/matchingtest/synchronous_timer_factory.go
+++ b/service/matching/matchingtest/synchronous_timer_factory.go
@@ -1,0 +1,125 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matchingtest
+
+import (
+	"sync"
+	"time"
+)
+
+type (
+	// synchronousTimerFactory keeps a list of timers and fires them synchronously when Advance is called.
+	synchronousTimerFactory struct {
+		sync.Mutex
+		// A list of timers which have been created by this clock and have not yet been fired or stopped.
+		timers []*SynchronousTimer
+	}
+	// SynchronousTimer is a timer with a callback. It holds a reference to the clock that created it, so that it can
+	// be stopped or reset.
+	SynchronousTimer struct {
+		// The remaining time on the timer. This is updated when the timer is reset.
+		remaining time.Duration
+		// The callback to be called when the timer fires.
+		callback func()
+		// A reference to the parent clock which created this timer.
+		clock *synchronousTimerFactory
+		// The index of this timer in the parent clock's list of timers.
+		index int
+		// A timer is orphaned if it has been stopped or fired. This is used to prevent Stop from panicking if it is
+		// called multiple times.
+		orphaned bool
+	}
+)
+
+// NewSynchronousTimerFactory returns a synchronousTimerFactory, which is a fake clock that can be manually advanced.
+// The advantage over clockwork.FakeClock is that its AfterFunc returns a timer which will be fired synchronously after
+// Advance is called.
+func NewSynchronousTimerFactory() *synchronousTimerFactory {
+	return &synchronousTimerFactory{}
+}
+
+// AfterFunc returns a timer which will be fired synchronously after Advance is called. The callback runs while the lock
+// is held, so it should not call any methods on the clock.
+func (c *synchronousTimerFactory) AfterFunc(d time.Duration, f func()) *SynchronousTimer {
+	c.Lock()
+	defer c.Unlock()
+	index := len(c.timers)
+	t := &SynchronousTimer{
+		remaining: d,
+		callback:  f,
+		clock:     c,
+		index:     index,
+	}
+	c.timers = append(c.timers, t)
+
+	return t
+}
+
+// remove removes the timer from the clock. It assumes the lock is already held.
+func (c *synchronousTimerFactory) remove(t *SynchronousTimer) {
+	c.timers[t.index] = c.timers[len(c.timers)-1]
+	c.timers[t.index].index = t.index
+	c.timers = c.timers[:len(c.timers)-1]
+	t.orphaned = true
+}
+
+// Reset resets the timer to the given duration. If the timer was already fired or stopped, this has no effect.
+func (t *SynchronousTimer) Reset(d time.Duration) {
+	t.clock.Lock()
+	defer t.clock.Unlock()
+
+	t.remaining = d
+}
+
+// Stop stops the timer. If the timer was already fired or stopped, this has no effect.
+func (t *SynchronousTimer) Stop() {
+	t.clock.Lock()
+	defer t.clock.Unlock()
+
+	if t.orphaned {
+		return
+	}
+	t.clock.remove(t)
+}
+
+// Advance advances the clock by the given duration. All timers whose duration has elapsed will have their callbacks
+// fired synchronously and removed from the clock.
+func (c *synchronousTimerFactory) Advance(d time.Duration) {
+	c.Lock()
+	defer c.Unlock()
+
+	// Iterate backwards so that we can remove timers while iterating.
+	for i := len(c.timers) - 1; i >= 0; i-- {
+		t := c.timers[i]
+		t.remaining -= d
+
+		if t.remaining > 0 {
+			continue
+		}
+
+		t.callback()
+		c.remove(t)
+	}
+}

--- a/service/matching/task_queue_manager.go
+++ b/service/matching/task_queue_manager.go
@@ -162,7 +162,7 @@ type (
 		db                   *taskQueueDB
 		taskWriter           *taskWriter
 		taskReader           *taskReader // reads tasks from db and async matches it with poller
-		liveness             *liveness
+		liveness             *liveness[clockworkTimer]
 		taskGC               *taskGC
 		taskAckManager       ackManager   // tracks ackLevel for delivered messages
 		matcher              *TaskMatcher // for matching a task producer with a poller
@@ -261,7 +261,7 @@ func newTaskQueueManager(
 	}
 
 	tlMgr.liveness = newLiveness(
-		clockwork.NewRealClock(),
+		timerFactory[clockworkTimer](clockworkClock{clockwork.NewRealClock()}),
 		taskQueueConfig.MaxTaskQueueIdleTime,
 		tlMgr.unloadFromEngine,
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the `time.Sleep` calls from our `liveness_test` by creating a clock whose timers fire synchronously when they are advanced past the fire time. 

<!-- Tell your future self why have you made these changes -->
**Why?**
To speed up tests and remove the implicit race condition in them. This can't be done with just clockwork because the callbacks from its timers are fired in the background: https://github.com/jonboulle/clockwork/blob/8a29bc122650db93cecf642b2a37701ff6ec2332/timer.go#L43

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
There's 100% test coverage for the test clock , and I ran the tests for both the testclock and liveness itself 100K times with `-race`:

```console
$ go test ./service/matching/matchingtest -count 100000 -race
ok      go.temporal.io/server/service/matching/matchingtest     5.994s
$ go test ./service/matching -run ^TestLiveness -count 100000 -race
ok      go.temporal.io/server/service/matching  37.639s
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There is a risk of maintenance burden here--this is a lot more complicated than just running `time.Sleep`. However, I think these synchronous timers will be really useful in other tests as well.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.