### PR TITLE
Disable confusing-naming linter and tune unhandled-error

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -31,6 +31,8 @@ linters-settings:
         disabled: true
       - name: bool-literal-in-expr
         disabled: true
+      - name: confusing-naming
+        disabled: true
       - name: empty-lines
         disabled: true
       - name: error-naming
@@ -86,6 +88,7 @@ linters-settings:
       - name: unhandled-error
         arguments:
           - "fmt.Printf"
+          - "fmt.Println"
 issues:
   # Exclude cyclomatic and cognitive complexity rules for functional tests in the `tests` root directory.
   exclude-rules:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I disabled the `confusing-naming` linter, and I made the `unhandled-error` linter ignore calls to `fmt.Println`.

<!-- Tell your future self why have you made these changes -->
**Why?**
I disabled the `confusing-naming` linter because it's very common to have an exported method that calls an unexported method of the same name as a helper, and I don't find it confusing at all. I made the `unhandled-error` linter ignore calls to `fmt.Println` because you're kind of SoL in that case any way--what are you going to do if you can't even print?

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I have a branch that violated these two rules, and then I ran `make lint` and saw the errors go away.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
