### PR TITLE
Put user data replication tasks in DLQ

### DIFF
--- a/service/worker/replicator/namespace_replication_message_processor.go
+++ b/service/worker/replicator/namespace_replication_message_processor.go
@@ -68,6 +68,7 @@ func newNamespaceReplicationMessageProcessor(
 	serviceResolver membership.ServiceResolver,
 	namespaceReplicationQueue persistence.NamespaceReplicationQueue,
 	matchingClient matchingservice.MatchingServiceClient,
+	namespaceRegistry namespace.Registry,
 ) *namespaceReplicationMessageProcessor {
 	retryPolicy := backoff.NewExponentialRetryPolicy(taskProcessorErrorRetryWait).
 		WithBackoffCoefficient(taskProcessorErrorRetryBackoffCoefficient).
@@ -89,6 +90,7 @@ func newNamespaceReplicationMessageProcessor(
 		done:                      make(chan struct{}),
 		namespaceReplicationQueue: namespaceReplicationQueue,
 		matchingClient:            matchingClient,
+		namespaceRegistry:         namespaceRegistry,
 	}
 }
 
@@ -109,6 +111,7 @@ type (
 		done                      chan struct{}
 		namespaceReplicationQueue persistence.NamespaceReplicationQueue
 		matchingClient            matchingservice.MatchingServiceClient
+		namespaceRegistry         namespace.Registry
 	}
 )
 
@@ -209,10 +212,14 @@ func (p *namespaceReplicationMessageProcessor) putNamespaceReplicationTaskToDLQ(
 				metrics.NamespaceTag(task.GetNamespaceTaskAttributes().GetInfo().GetName()),
 			)
 	case enumsspb.REPLICATION_TASK_TYPE_TASK_QUEUE_USER_DATA:
+		ns, err := p.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetTaskQueueUserDataAttributes().GetNamespaceId()))
+		if err != nil {
+			return err
+		}
 		p.metricsHandler.Counter(metrics.NamespaceReplicationEnqueueDLQCount.GetMetricName()).
 			Record(1,
 				metrics.ReplicationTaskTypeTag(task.TaskType),
-				metrics.StringTag("namespaceId", task.GetTaskQueueUserDataAttributes().GetNamespaceId()),
+				metrics.NamespaceTag(ns.Name().String()),
 			)
 	default:
 		return serviceerror.NewUnavailable(
@@ -237,16 +244,38 @@ func (p *namespaceReplicationMessageProcessor) handleNamespaceReplicationTask(
 	case enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK:
 		return p.namespaceTaskExecutor.Execute(ctx, task.GetNamespaceTaskAttributes())
 	case enumsspb.REPLICATION_TASK_TYPE_TASK_QUEUE_USER_DATA:
-		attrs := task.GetTaskQueueUserDataAttributes()
-		_, err := p.matchingClient.ApplyTaskQueueUserDataReplicationEvent(ctx, &matchingservice.ApplyTaskQueueUserDataReplicationEventRequest{
-			NamespaceId: attrs.GetNamespaceId(),
-			TaskQueue:   attrs.GetTaskQueueName(),
-			UserData:    attrs.GetUserData(),
-		})
-		return err
+		return p.handleTaskQueueUserDataReplicationTask(ctx, task.GetTaskQueueUserDataAttributes())
 	default:
 		return fmt.Errorf("cannot handle replication task of type %v", task.TaskType)
 	}
+}
+
+func (p *namespaceReplicationMessageProcessor) handleTaskQueueUserDataReplicationTask(
+	ctx context.Context,
+	attrs *replicationspb.TaskQueueUserDataAttributes,
+) error {
+	_, err := p.namespaceRegistry.GetNamespaceByID(namespace.ID(attrs.GetNamespaceId()))
+	switch err.(type) {
+	case nil:
+	case *serviceerror.NamespaceNotFound:
+		// The namespace in the request isn't registered on this cluster, drop the replication task.
+		// This is okay and enables using the cluster-global replication queue to replicate different namespaces to
+		// different sets of clusters.
+		// When this cluster is added to the list of replicated clusters for this namespace on the origin cluster, the
+		// force replication workflow should be triggered to seed the namespace replication queue with all task queue
+		// user data entries for the namespace.
+		return nil
+	default:
+		// return the original err
+		return err
+	}
+
+	_, err = p.matchingClient.ApplyTaskQueueUserDataReplicationEvent(ctx, &matchingservice.ApplyTaskQueueUserDataReplicationEventRequest{
+		NamespaceId: attrs.GetNamespaceId(),
+		TaskQueue:   attrs.GetTaskQueueName(),
+		UserData:    attrs.GetUserData(),
+	})
+	return err
 }
 
 func (p *namespaceReplicationMessageProcessor) Stop() {

--- a/service/worker/replicator/replicator.go
+++ b/service/worker/replicator/replicator.go
@@ -57,6 +57,7 @@ type (
 		namespaceProcessorsLock sync.Mutex
 		namespaceProcessors     map[string]*namespaceReplicationMessageProcessor
 		matchingClient          matchingservice.MatchingServiceClient
+		namespaceRegistry       namespace.Registry
 	}
 
 	// Config contains all the replication config for worker
@@ -75,8 +76,8 @@ func NewReplicator(
 	namespaceReplicationQueue persistence.NamespaceReplicationQueue,
 	namespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor,
 	matchingClient matchingservice.MatchingServiceClient,
+	namespaceRegistry namespace.Registry,
 ) *Replicator {
-
 	return &Replicator{
 		status:                           common.DaemonStatusInitialized,
 		hostInfo:                         hostInfo,
@@ -89,6 +90,7 @@ func NewReplicator(
 		metricsHandler:                   metricsHandler,
 		namespaceReplicationQueue:        namespaceReplicationQueue,
 		matchingClient:                   matchingClient,
+		namespaceRegistry:                namespaceRegistry,
 	}
 }
 
@@ -161,6 +163,7 @@ func (r *Replicator) listenToClusterMetadataChange() {
 						r.serviceResolver,
 						r.namespaceReplicationQueue,
 						r.matchingClient,
+						r.namespaceRegistry,
 					)
 					processor.Start()
 					r.namespaceProcessors[clusterName] = processor

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -522,6 +522,7 @@ func (s *Service) startReplicator() {
 		s.namespaceReplicationQueue,
 		namespaceReplicationTaskExecutor,
 		s.matchingClient,
+		s.namespaceRegistry,
 	)
 	msgReplicator.Start()
 }


### PR DESCRIPTION
**What changed?**

- Handle `REPLICATION_TASK_TYPE_TASK_QUEUE_USER_DATA` in `putNamespaceReplicationTaskToDLQ`.
- Drop user data replication tasks for unknown namespaces.

**Why?**

In case the replication task cannot be applied, put it in the DLQ instead of blocking the namespace replication queue.
Dropping tasks for unknown namespaces seems desirable in cases where different namespaces are replicated to different sets of clusters using the global namespace replication queue.

**How did you test it?**

I have not, there doesn't seem to be any existing tests for this path.
I can add some unit tests if reviewer feels it's worth it.
