### PR TITLE
Fix metrics double emission in admin and operator handler

### DIFF
--- a/client/admin/metric_client.go
+++ b/client/admin/metric_client.go
@@ -97,7 +97,7 @@ func (c *metricClient) StreamWorkflowReplicationMessages(
 	opts ...grpc.CallOption,
 ) (_ adminservice.AdminService_StreamWorkflowReplicationMessagesClient, retError error) {
 
-	metricsHandler, startTime := c.startMetricsRecording(ctx, metrics.AdminStreamWorkflowReplicationMessagesScope)
+	metricsHandler, startTime := c.startMetricsRecording(ctx, metrics.AdminClientStreamWorkflowReplicationMessagesScope)
 	defer func() {
 		c.finishMetricsRecording(metricsHandler, startTime, retError)
 	}()

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -131,79 +131,8 @@ const (
 	AdminClientGetTaskQueueTasksScope = "AdminClientGetTaskQueueTasks"
 	// AdminClientDeleteWorkflowExecutionScope tracks RPC calls to admin service
 	AdminClientDeleteWorkflowExecutionScope = "AdminClientDeleteWorkflowExecution"
-
-	// AdminDescribeHistoryHostScope is the metric scope for admin.AdminDescribeHistoryHost
-	AdminDescribeHistoryHostScope = "AdminDescribeHistoryHost"
-	// AdminAddSearchAttributesScope is the metric scope for admin.AdminAddSearchAttributes
-	AdminAddSearchAttributesScope = "AdminAddSearchAttributes"
-	// AdminRemoveSearchAttributesScope is the metric scope for admin.AdminRemoveSearchAttributes
-	AdminRemoveSearchAttributesScope = "AdminRemoveSearchAttributes"
-	// AdminGetSearchAttributesScope is the metric scope for admin.AdminGetSearchAttributes
-	AdminGetSearchAttributesScope = "AdminGetSearchAttributes"
-	// AdminRebuildMutableStateScope is the metric scope for admin.AdminRebuildMutableState
-	AdminRebuildMutableStateScope = "AdminRebuildMutableState"
-	// AdminDescribeMutableStateScope is the metric scope for admin.AdminDescribeMutableState
-	AdminDescribeMutableStateScope = "AdminDescribeMutableState"
-	// AdminGetWorkflowExecutionRawHistoryV2Scope is the metric scope for admin.GetWorkflowExecutionRawHistoryScope
-	AdminGetWorkflowExecutionRawHistoryV2Scope = "AdminGetWorkflowExecutionRawHistoryV2"
-	// AdminGetReplicationMessagesScope is the metric scope for admin.GetReplicationMessages
-	AdminGetReplicationMessagesScope = "AdminGetReplicationMessages"
-	// AdminGetNamespaceReplicationMessagesScope is the metric scope for admin.GetNamespaceReplicationMessages
-	AdminGetNamespaceReplicationMessagesScope = "AdminGetNamespaceReplicationMessages"
-	// AdminGetDLQReplicationMessagesScope is the metric scope for admin.GetDLQReplicationMessages
-	AdminGetDLQReplicationMessagesScope = "AdminGetDLQReplicationMessages"
-	// AdminReapplyEventsScope is the metric scope for admin.ReapplyEvents
-	AdminReapplyEventsScope = "AdminReapplyEvents"
-	// AdminRefreshWorkflowTasksScope is the metric scope for admin.RefreshWorkflowTasks
-	AdminRefreshWorkflowTasksScope = "AdminRefreshWorkflowTasks"
-	// AdminResendReplicationTasksScope is the metric scope for admin.ResendReplicationTasks
-	AdminResendReplicationTasksScope = "AdminResendReplicationTasks"
-	// AdminGetTaskQueueTasksScope is the metric scope for admin.GetTaskQueueTasks
-	AdminGetTaskQueueTasksScope = "AdminGetTaskQueueTasks"
-	// AdminRemoveTaskScope is the metric scope for admin.AdminRemoveTask
-	AdminRemoveTaskScope = "AdminRemoveTask"
-	// AdminCloseShardScope is the metric scope for admin.AdminCloseShard
-	AdminCloseShardScope = "AdminCloseShard"
-	// AdminGetShardScope is the metric scope for admin.AdminGetShard
-	AdminGetShardScope = "AdminGetShard"
-	// AdminListHistoryTasksScope is the metric scope for admin.ListHistoryTasks
-	AdminListHistoryTasksScope = "AdminListHistoryTasks"
-	// AdminGetDLQMessagesScope is the metric scope for admin.AdminGetDLQMessages
-	AdminGetDLQMessagesScope = "AdminGetDLQMessages"
-	// AdminPurgeDLQMessagesScope is the metric scope for admin.AdminPurgeDLQMessages
-	AdminPurgeDLQMessagesScope = "AdminPurgeDLQMessages"
-	// AdminMergeDLQMessagesScope is the metric scope for admin.AdminMergeDLQMessages
-	AdminMergeDLQMessagesScope = "AdminMergeDLQMessages"
-	// AdminListClusterMembersScope is the metric scope for admin.AdminListClusterMembers
-	AdminListClusterMembersScope = "AdminListClusterMembers"
-	// AdminDescribeClusterScope is the metric scope for admin.AdminDescribeCluster
-	AdminDescribeClusterScope = "AdminDescribeCluster"
-	// AdminListClustersScope is the metric scope for admin.AdminListClusters
-	AdminListClustersScope = "AdminListClusters"
-	// AdminAddOrUpdateRemoteClusterScope is the metric scope for admin.AdminAddOrUpdateRemoteCluster
-	AdminAddOrUpdateRemoteClusterScope = "AdminAddOrUpdateRemoteCluster"
-	// AdminRemoveRemoteClusterScope is the metric scope for admin.AdminRemoveRemoteCluster
-	AdminRemoveRemoteClusterScope = "AdminRemoveRemoteCluster"
-	// AdminDeleteWorkflowExecutionScope is the metric scope for admin.AdminDeleteWorkflowExecution
-	AdminDeleteWorkflowExecutionScope = "AdminDeleteWorkflowExecution"
-	// AdminStreamWorkflowReplicationMessagesScope is the metric scope for admin.AdminStreamReplicationMessages
-	AdminStreamWorkflowReplicationMessagesScope = "AdminStreamWorkflowReplicationMessages"
-
-	// OperatorAddSearchAttributesScope is the metric scope for operator.AddSearchAttributes
-	OperatorAddSearchAttributesScope
-	// OperatorRemoveSearchAttributesScope is the metric scope for operator.RemoveSearchAttributes
-	OperatorRemoveSearchAttributesScope = "OperatorRemoveSearchAttributes"
-	// OperatorListSearchAttributesScope is the metric scope for operator.ListSearchAttributes
-	OperatorListSearchAttributesScope = "OperatorListSearchAttributes"
-	OperatorDeleteNamespaceScope      = "OperatorDeleteNamespace"
-	// OperatorAddOrUpdateRemoteClusterScope is the metric scope for operator.AddOrUpdateRemoteCluster
-	OperatorAddOrUpdateRemoteClusterScope = "OperatorAddOrUpdateRemoteCluster"
-	// OperatorRemoveRemoteClusterScope is the metric scope for operator.RemoveRemoteCluster
-	OperatorRemoveRemoteClusterScope = "OperatorRemoveRemoteCluster"
-	// OperatorListClustersScope is the metric scope for operator.OperatorListClusters
-	OperatorListClustersScope = "OperatorListClusters"
-	// OperatorDeleteWorkflowExecutionScope is the metric scope for operator.DeleteWorkflowExecution
-	OperatorDeleteWorkflowExecutionScope = "OperatorDeleteWorkflowExecution"
+	// AdminClientStreamWorkflowReplicationMessagesScope tracks RPC calls to admin service
+	AdminClientStreamWorkflowReplicationMessagesScope = "AdminClientStreamWorkflowReplicationMessages"
 )
 
 // Frontend Client Operations
@@ -707,6 +636,14 @@ const (
 
 // Frontend Scope
 const (
+	// AdminGetWorkflowExecutionRawHistoryV2Scope is the metric scope for admin.GetWorkflowExecutionRawHistoryScope
+	AdminGetWorkflowExecutionRawHistoryV2Scope = "AdminGetWorkflowExecutionRawHistoryV2"
+
+	// OperatorAddSearchAttributesScope is the metric scope for operator.AddSearchAttributes
+	OperatorAddSearchAttributesScope = "OperatorAddSearchAttributes"
+	// OperatorDeleteNamespaceScope is the metric scope for operator.OperatorDeleteNamespace
+	OperatorDeleteNamespaceScope = "OperatorDeleteNamespace"
+
 	// FrontendStartWorkflowExecutionScope is the metric scope for frontend.StartWorkflowExecution
 	FrontendStartWorkflowExecutionScope = "StartWorkflowExecution"
 	// FrontendPollWorkflowTaskQueueScope is the metric scope for frontend.PollWorkflowTaskQueue

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -888,11 +888,6 @@ func (adh *AdminHandler) DescribeHistoryHost(ctx context.Context, request *admin
 func (adh *AdminHandler) GetWorkflowExecutionRawHistoryV2(ctx context.Context, request *adminservice.GetWorkflowExecutionRawHistoryV2Request) (_ *adminservice.GetWorkflowExecutionRawHistoryV2Response, retError error) {
 	defer log.CapturePanic(adh.logger, &retError)
 
-	taggedMetricsHandler, startTime := adh.startRequestProfile(metrics.AdminGetWorkflowExecutionRawHistoryV2Scope)
-	defer func() {
-		taggedMetricsHandler.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime))
-	}()
-
 	if err := adh.validateGetWorkflowExecutionRawHistoryV2Request(
 		request,
 	); err != nil {
@@ -903,7 +898,6 @@ func (adh *AdminHandler) GetWorkflowExecutionRawHistoryV2(ctx context.Context, r
 	if err != nil {
 		return nil, err
 	}
-	taggedMetricsHandler = taggedMetricsHandler.WithTags(metrics.NamespaceTag(ns.Name().String()))
 
 	execution := request.Execution
 	var pageToken *tokenspb.RawHistoryContinuation
@@ -990,12 +984,11 @@ func (adh *AdminHandler) GetWorkflowExecutionRawHistoryV2(ctx context.Context, r
 
 	pageToken.PersistenceToken = rawHistoryResponse.NextPageToken
 	size := rawHistoryResponse.Size
-	// N.B. - Dual emit is required here so that we can see aggregate timer stats across all
-	// namespaces along with the individual namespaces stats
 	adh.metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(
 		int64(size),
-		metrics.OperationTag(metrics.AdminGetWorkflowExecutionRawHistoryV2Scope))
-	taggedMetricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(size))
+		metrics.NamespaceTag(ns.Name().String()),
+		metrics.OperationTag(metrics.AdminGetWorkflowExecutionRawHistoryV2Scope),
+	)
 
 	result := &adminservice.GetWorkflowExecutionRawHistoryV2Response{
 		HistoryBatches: rawHistoryResponse.HistoryEventBlobs,
@@ -1914,13 +1907,6 @@ func (adh *AdminHandler) setRequestDefaultValueAndGetTargetVersionHistory(
 	}
 
 	return targetBranch, nil
-}
-
-// startRequestProfile initiates recording of request metrics
-func (adh *AdminHandler) startRequestProfile(operation string) (metrics.Handler, time.Time) {
-	metricsScope := adh.metricsHandler.WithTags(metrics.OperationTag(operation))
-	metricsScope.Counter(metrics.ServiceRequests.GetMetricName()).Record(1)
-	return metricsScope, time.Now().UTC()
 }
 
 func (adh *AdminHandler) getWorkflowCompletionEvent(

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"fmt"
 	"sync/atomic"
-	"time"
 
 	"golang.org/x/exp/maps"
 	"google.golang.org/grpc/health"
@@ -159,9 +158,6 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(
 ) (_ *operatorservice.AddSearchAttributesResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
 
-	scope, startTime := h.startRequestProfile(metrics.OperatorAddSearchAttributesScope)
-	defer func() { scope.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime)) }()
-
 	// validate request
 	if request == nil {
 		return nil, errRequestNotSet
@@ -192,6 +188,7 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(
 	// `skip-schema-update` is set. This is for backward compatibility using
 	// standard visibility.
 	if h.visibilityMgr.HasStoreName(elasticsearch.PersistenceName) || indexName == "" {
+		scope := h.metricsHandler.WithTags(metrics.OperationTag(metrics.OperatorAddSearchAttributesScope))
 		err = h.addSearchAttributesElasticsearch(ctx, request, indexName, currentSearchAttributes)
 		if err != nil {
 			if _, isWorkflowErr := err.(*serviceerror.SystemWorkflow); isWorkflowErr {
@@ -548,9 +545,6 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 ) (_ *operatorservice.DeleteNamespaceResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
 
-	scope, startTime := h.startRequestProfile(metrics.OperatorDeleteNamespaceScope)
-	defer func() { scope.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime)) }()
-
 	// validate request
 	if request == nil {
 		return nil, errRequestNotSet
@@ -586,6 +580,8 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf(errUnableToStartWorkflowMessage, deletenamespace.WorkflowName, err))
 	}
 
+	scope := h.metricsHandler.WithTags(metrics.OperationTag(metrics.OperatorDeleteNamespaceScope))
+
 	// Wait for workflow to complete.
 	var wfResult deletenamespace.DeleteNamespaceWorkflowResult
 	err = run.Get(ctx, &wfResult)
@@ -607,8 +603,6 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 	request *operatorservice.AddOrUpdateRemoteClusterRequest,
 ) (_ *operatorservice.AddOrUpdateRemoteClusterResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
-	scope, startTime := h.startRequestProfile(metrics.OperatorAddOrUpdateRemoteClusterScope)
-	defer func() { scope.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime)) }()
 
 	adminClient := h.clientFactory.NewRemoteAdminClientWithTimeout(
 		request.GetFrontendAddress(),
@@ -619,7 +613,6 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 	// Fetch cluster metadata from remote cluster
 	resp, err := adminClient.DescribeCluster(ctx, &adminservice.DescribeClusterRequest{})
 	if err != nil {
-		scope.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf(
 			errUnableConnectRemoteClusterMessage,
 			request.GetFrontendAddress(),
@@ -629,7 +622,6 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 
 	err = h.validateRemoteClusterMetadata(resp)
 	if err != nil {
-		scope.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
 		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errInvalidRemoteClusterInfo, err))
 	}
 
@@ -644,7 +636,6 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 	case *serviceerror.NotFound:
 		updateRequestVersion = 0
 	default:
-		scope.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
 		return nil, serviceerror.NewInternal(fmt.Sprintf(errUnableToStoreClusterInfo, err))
 	}
 
@@ -662,11 +653,9 @@ func (h *OperatorHandlerImpl) AddOrUpdateRemoteCluster(
 		Version: updateRequestVersion,
 	})
 	if err != nil {
-		scope.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
 		return nil, serviceerror.NewInternal(fmt.Sprintf(errUnableToStoreClusterInfo, err))
 	}
 	if !applied {
-		scope.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
 		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf(errUnableToStoreClusterInfo, err))
 	}
 	return &operatorservice.AddOrUpdateRemoteClusterResponse{}, nil
@@ -677,8 +666,6 @@ func (h *OperatorHandlerImpl) RemoveRemoteCluster(
 	request *operatorservice.RemoveRemoteClusterRequest,
 ) (_ *operatorservice.RemoveRemoteClusterResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
-	scope, startTime := h.startRequestProfile(metrics.OperatorRemoveRemoteClusterScope)
-	defer func() { scope.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime)) }()
 
 	var isClusterNameExist bool
 	for clusterName := range h.clusterMetadata.GetAllClusterInfo() {
@@ -695,7 +682,6 @@ func (h *OperatorHandlerImpl) RemoveRemoteCluster(
 		ctx,
 		&persistence.DeleteClusterMetadataRequest{ClusterName: request.GetClusterName()},
 	); err != nil {
-		scope.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
 		return nil, serviceerror.NewInternal(fmt.Sprintf(errUnableToDeleteClusterInfo, err))
 	}
 	return &operatorservice.RemoveRemoteClusterResponse{}, nil
@@ -706,8 +692,6 @@ func (h *OperatorHandlerImpl) ListClusters(
 	request *operatorservice.ListClustersRequest,
 ) (_ *operatorservice.ListClustersResponse, retError error) {
 	defer log.CapturePanic(h.logger, &retError)
-	scope, startTime := h.startRequestProfile(metrics.OperatorListClustersScope)
-	defer func() { scope.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime)) }()
 
 	if request == nil {
 		return nil, errRequestNotSet
@@ -721,7 +705,6 @@ func (h *OperatorHandlerImpl) ListClusters(
 		NextPageToken: request.GetNextPageToken(),
 	})
 	if err != nil {
-		scope.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
 		return nil, err
 	}
 
@@ -776,11 +759,4 @@ func (h *OperatorHandlerImpl) validateRemoteClusterMetadata(metadata *adminservi
 		}
 	}
 	return nil
-}
-
-// startRequestProfile initiates recording of request metrics
-func (h *OperatorHandlerImpl) startRequestProfile(operation string) (metrics.Handler, time.Time) {
-	metricsScope := h.metricsHandler.WithTags(metrics.OperationTag(operation))
-	metricsScope.Counter(metrics.ServiceRequests.GetMetricName()).Record(1)
-	return metricsScope, time.Now().UTC()
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- service_request, latency, and errors metrics are already emitted by [telemetry interceptor](https://github.com/temporalio/temporal/blob/master/common/rpc/interceptor/telemetry.go#L148). Remove additional emits in api handler.
- Remove history size double emission since the metric is a histogram and supports aggregation. The existing code will actually cause one metrics name to have different set of tags.
- Remove unused metric scope definition.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Fix metrics double emission in admin and operator handler

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Lose metrics for some admin and operator apis.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.