### PR TITLE
Add support for ES Scroll for Scan API

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/client/client.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client.go
@@ -52,6 +52,11 @@ type (
 		WaitForYellowStatus(ctx context.Context, index string) (string, error)
 		GetMapping(ctx context.Context, index string) (map[string]string, error)
 
+		OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*elastic.SearchResult, error)
+		Scroll(ctx context.Context, id string, keepAliveInterval string) (*elastic.SearchResult, error)
+		CloseScroll(ctx context.Context, id string) error
+
+		IsPointInTimeSupported(ctx context.Context) bool
 		OpenPointInTime(ctx context.Context, index string, keepAliveInterval string) (string, error)
 		ClosePointInTime(ctx context.Context, id string) (bool, error)
 	}
@@ -79,6 +84,7 @@ type (
 		Sorter   []elastic.Sorter
 
 		SearchAfter []interface{}
+		ScrollID    string
 		PointInTime *elastic.PointInTime
 	}
 )

--- a/common/persistence/visibility/store/elasticsearch/client/client_mock.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_mock.go
@@ -75,6 +75,20 @@ func (mr *MockClientMockRecorder) ClosePointInTime(ctx, id interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePointInTime", reflect.TypeOf((*MockClient)(nil).ClosePointInTime), ctx, id)
 }
 
+// CloseScroll mocks base method.
+func (m *MockClient) CloseScroll(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseScroll", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseScroll indicates an expected call of CloseScroll.
+func (mr *MockClientMockRecorder) CloseScroll(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseScroll", reflect.TypeOf((*MockClient)(nil).CloseScroll), ctx, id)
+}
+
 // Count mocks base method.
 func (m *MockClient) Count(ctx context.Context, index string, query v7.Query) (int64, error) {
 	m.ctrl.T.Helper()
@@ -120,6 +134,20 @@ func (mr *MockClientMockRecorder) GetMapping(ctx, index interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMapping", reflect.TypeOf((*MockClient)(nil).GetMapping), ctx, index)
 }
 
+// IsPointInTimeSupported mocks base method.
+func (m *MockClient) IsPointInTimeSupported(ctx context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPointInTimeSupported", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPointInTimeSupported indicates an expected call of IsPointInTimeSupported.
+func (mr *MockClientMockRecorder) IsPointInTimeSupported(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPointInTimeSupported", reflect.TypeOf((*MockClient)(nil).IsPointInTimeSupported), ctx)
+}
+
 // OpenPointInTime mocks base method.
 func (m *MockClient) OpenPointInTime(ctx context.Context, index, keepAliveInterval string) (string, error) {
 	m.ctrl.T.Helper()
@@ -133,6 +161,21 @@ func (m *MockClient) OpenPointInTime(ctx context.Context, index, keepAliveInterv
 func (mr *MockClientMockRecorder) OpenPointInTime(ctx, index, keepAliveInterval interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPointInTime", reflect.TypeOf((*MockClient)(nil).OpenPointInTime), ctx, index, keepAliveInterval)
+}
+
+// OpenScroll mocks base method.
+func (m *MockClient) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenScroll", ctx, p, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenScroll indicates an expected call of OpenScroll.
+func (mr *MockClientMockRecorder) OpenScroll(ctx, p, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenScroll", reflect.TypeOf((*MockClient)(nil).OpenScroll), ctx, p, keepAliveInterval)
 }
 
 // PutMapping mocks base method.
@@ -163,6 +206,21 @@ func (m *MockClient) RunBulkProcessor(ctx context.Context, p *BulkProcessorParam
 func (mr *MockClientMockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockClient)(nil).RunBulkProcessor), ctx, p)
+}
+
+// Scroll mocks base method.
+func (m *MockClient) Scroll(ctx context.Context, id, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Scroll", ctx, id, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Scroll indicates an expected call of Scroll.
+func (mr *MockClientMockRecorder) Scroll(ctx, id, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockClient)(nil).Scroll), ctx, id, keepAliveInterval)
 }
 
 // Search mocks base method.
@@ -233,6 +291,20 @@ func (mr *MockCLIClientMockRecorder) ClosePointInTime(ctx, id interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClosePointInTime", reflect.TypeOf((*MockCLIClient)(nil).ClosePointInTime), ctx, id)
 }
 
+// CloseScroll mocks base method.
+func (m *MockCLIClient) CloseScroll(ctx context.Context, id string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CloseScroll", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseScroll indicates an expected call of CloseScroll.
+func (mr *MockCLIClientMockRecorder) CloseScroll(ctx, id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseScroll", reflect.TypeOf((*MockCLIClient)(nil).CloseScroll), ctx, id)
+}
+
 // Count mocks base method.
 func (m *MockCLIClient) Count(ctx context.Context, index string, query v7.Query) (int64, error) {
 	m.ctrl.T.Helper()
@@ -292,6 +364,20 @@ func (mr *MockCLIClientMockRecorder) GetMapping(ctx, index interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMapping", reflect.TypeOf((*MockCLIClient)(nil).GetMapping), ctx, index)
 }
 
+// IsPointInTimeSupported mocks base method.
+func (m *MockCLIClient) IsPointInTimeSupported(ctx context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPointInTimeSupported", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsPointInTimeSupported indicates an expected call of IsPointInTimeSupported.
+func (mr *MockCLIClientMockRecorder) IsPointInTimeSupported(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPointInTimeSupported", reflect.TypeOf((*MockCLIClient)(nil).IsPointInTimeSupported), ctx)
+}
+
 // OpenPointInTime mocks base method.
 func (m *MockCLIClient) OpenPointInTime(ctx context.Context, index, keepAliveInterval string) (string, error) {
 	m.ctrl.T.Helper()
@@ -305,6 +391,21 @@ func (m *MockCLIClient) OpenPointInTime(ctx context.Context, index, keepAliveInt
 func (mr *MockCLIClientMockRecorder) OpenPointInTime(ctx, index, keepAliveInterval interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenPointInTime", reflect.TypeOf((*MockCLIClient)(nil).OpenPointInTime), ctx, index, keepAliveInterval)
+}
+
+// OpenScroll mocks base method.
+func (m *MockCLIClient) OpenScroll(ctx context.Context, p *SearchParameters, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OpenScroll", ctx, p, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// OpenScroll indicates an expected call of OpenScroll.
+func (mr *MockCLIClientMockRecorder) OpenScroll(ctx, p, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OpenScroll", reflect.TypeOf((*MockCLIClient)(nil).OpenScroll), ctx, p, keepAliveInterval)
 }
 
 // PutMapping mocks base method.
@@ -335,6 +436,21 @@ func (m *MockCLIClient) RunBulkProcessor(ctx context.Context, p *BulkProcessorPa
 func (mr *MockCLIClientMockRecorder) RunBulkProcessor(ctx, p interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunBulkProcessor", reflect.TypeOf((*MockCLIClient)(nil).RunBulkProcessor), ctx, p)
+}
+
+// Scroll mocks base method.
+func (m *MockCLIClient) Scroll(ctx context.Context, id, keepAliveInterval string) (*v7.SearchResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Scroll", ctx, id, keepAliveInterval)
+	ret0, _ := ret[0].(*v7.SearchResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Scroll indicates an expected call of Scroll.
+func (mr *MockCLIClientMockRecorder) Scroll(ctx, id, keepAliveInterval interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Scroll", reflect.TypeOf((*MockCLIClient)(nil).Scroll), ctx, id, keepAliveInterval)
 }
 
 // Search mocks base method.

--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -30,8 +30,10 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"sync"
 	"time"
 
+	"github.com/blang/semver/v4"
 	"github.com/olivere/elastic/v7"
 	"github.com/olivere/elastic/v7/uritemplates"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -44,7 +46,18 @@ type (
 	clientImpl struct {
 		esClient *elastic.Client
 		url      url.URL
+
+		initIsPointInTimeSupported sync.Once
+		isPointInTimeSupported     bool
 	}
+)
+
+const (
+	pointInTimeSupportedFlavor = "default" // the other flavor is "oss"
+)
+
+var (
+	pointInTimeSupportedIn = semver.MustParseRange(">=7.10.0")
 )
 
 var _ Client = (*clientImpl)(nil)
@@ -136,6 +149,56 @@ func (c *clientImpl) Search(ctx context.Context, p *SearchParameters) (*elastic.
 	}
 
 	return searchService.Do(ctx)
+}
+
+func (c *clientImpl) OpenScroll(
+	ctx context.Context,
+	p *SearchParameters,
+	keepAliveInterval string,
+) (*elastic.SearchResult, error) {
+	scrollService := elastic.NewScrollService(c.esClient).
+		Index(p.Index).
+		Query(p.Query).
+		SortBy(p.Sorter...).
+		KeepAlive(keepAliveInterval)
+	if p.PageSize != 0 {
+		scrollService.Size(p.PageSize)
+	}
+	return scrollService.Do(ctx)
+}
+
+func (c *clientImpl) Scroll(
+	ctx context.Context,
+	id string,
+	keepAliveInterval string,
+) (*elastic.SearchResult, error) {
+	return elastic.NewScrollService(c.esClient).ScrollId(id).KeepAlive(keepAliveInterval).Do(ctx)
+}
+
+func (c *clientImpl) CloseScroll(ctx context.Context, id string) error {
+	return elastic.NewScrollService(c.esClient).ScrollId(id).Clear(ctx)
+}
+
+func (c *clientImpl) IsPointInTimeSupported(ctx context.Context) bool {
+	c.initIsPointInTimeSupported.Do(func() {
+		c.isPointInTimeSupported = c.queryPointInTimeSupported(ctx)
+	})
+	return c.isPointInTimeSupported
+}
+
+func (c *clientImpl) queryPointInTimeSupported(ctx context.Context) bool {
+	result, _, err := c.esClient.Ping(c.url.String()).Do(ctx)
+	if err != nil {
+		return false
+	}
+	if result == nil || result.Version.BuildFlavor != pointInTimeSupportedFlavor {
+		return false
+	}
+	esVersion, err := semver.ParseTolerant(result.Version.Number)
+	if err != nil {
+		return false
+	}
+	return pointInTimeSupportedIn(esVersion)
 }
 
 func (c *clientImpl) OpenPointInTime(ctx context.Context, index string, keepAliveInterval string) (string, error) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add support for ES Scroll for Scan API.

This is a revert of https://github.com/temporalio/temporal/pull/4223 and https://github.com/temporalio/temporal/pull/4249.

<!-- Tell your future self why have you made these changes -->
**Why?**
ES 7.10 hosted in AWS is the OSS flavor, not the default one which includes support for PIT.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Add unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
