### PR TITLE
Allow adding history tasks for different workflows in one batch

### DIFF
--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -199,10 +199,6 @@ type (
 		ShardID int32
 		RangeID int64
 
-		NamespaceID string
-		WorkflowID  string
-		RunID       string
-
 		Tasks map[tasks.Category][]tasks.Task
 	}
 

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -752,10 +752,6 @@ func (m *executionManagerImpl) AddHistoryTasks(
 		ShardID: input.ShardID,
 		RangeID: input.RangeID,
 
-		NamespaceID: input.NamespaceID,
-		WorkflowID:  input.WorkflowID,
-		RunID:       input.RunID,
-
 		Tasks: tasks,
 	})
 }

--- a/common/persistence/tests/execution_mutable_state_task.go
+++ b/common/persistence/tests/execution_mutable_state_task.go
@@ -503,11 +503,8 @@ func (s *ExecutionMutableStateTaskSuite) TestGetTimerTasksOrdered() {
 	}
 
 	err := s.ExecutionManager.AddHistoryTasks(s.Ctx, &p.AddHistoryTasksRequest{
-		ShardID:     s.ShardID,
-		RangeID:     s.RangeID,
-		NamespaceID: s.WorkflowKey.NamespaceID,
-		WorkflowID:  s.WorkflowKey.WorkflowID,
-		RunID:       s.WorkflowKey.RunID,
+		ShardID: s.ShardID,
+		RangeID: s.RangeID,
 		Tasks: map[tasks.Category][]tasks.Task{
 			tasks.CategoryTimer: timerTasks,
 		},
@@ -545,11 +542,8 @@ func (s *ExecutionMutableStateTaskSuite) TestGetScheduledTasksOrdered() {
 	scheduledTasks[1].SetTaskID(50)
 
 	err := s.ExecutionManager.AddHistoryTasks(s.Ctx, &p.AddHistoryTasksRequest{
-		ShardID:     s.ShardID,
-		RangeID:     s.RangeID,
-		NamespaceID: s.WorkflowKey.NamespaceID,
-		WorkflowID:  s.WorkflowKey.WorkflowID,
-		RunID:       s.WorkflowKey.RunID,
+		ShardID: s.ShardID,
+		RangeID: s.RangeID,
 		Tasks: map[tasks.Category][]tasks.Task{
 			fakeScheduledTaskCategory: scheduledTasks,
 		},
@@ -604,11 +598,8 @@ func (s *ExecutionMutableStateTaskSuite) AddRandomTasks(
 	}
 
 	err := s.ExecutionManager.AddHistoryTasks(s.Ctx, &p.AddHistoryTasksRequest{
-		ShardID:     s.ShardID,
-		RangeID:     s.RangeID,
-		NamespaceID: s.WorkflowKey.NamespaceID,
-		WorkflowID:  s.WorkflowKey.WorkflowID,
-		RunID:       s.WorkflowKey.RunID,
+		ShardID: s.ShardID,
+		RangeID: s.RangeID,
 		Tasks: map[tasks.Category][]tasks.Task{
 			category: randomTasks,
 		},

--- a/common/util.go
+++ b/common/util.go
@@ -389,6 +389,12 @@ func IsNotFoundError(err error) bool {
 	return errors.As(err, &notFoundErr)
 }
 
+// IsNotFoundError checks if the error is a namespace not found error.
+func IsNamespaceNotFoundError(err error) bool {
+	var namespaceNotFoundErr *serviceerror.NamespaceNotFound
+	return errors.As(err, &namespaceNotFoundErr)
+}
+
 // WorkflowIDToHistoryShard is used to map namespaceID-workflowID pair to a shardID.
 func WorkflowIDToHistoryShard(
 	namespaceID string,

--- a/service/history/api/refreshworkflow/api.go
+++ b/service/history/api/refreshworkflow/api.go
@@ -74,9 +74,6 @@ func Invoke(
 	return shard.AddTasks(ctx, &persistence.AddHistoryTasksRequest{
 		ShardID: shard.GetShardID(),
 		// RangeID is set by shard
-		NamespaceID: workflowKey.NamespaceID,
-		WorkflowID:  workflowKey.WorkflowID,
-		RunID:       workflowKey.RunID,
-		Tasks:       mutableState.PopTasks(),
+		Tasks: mutableState.PopTasks(),
 	})
 }

--- a/service/history/api/replication/generate_task.go
+++ b/service/history/api/replication/generate_task.go
@@ -74,9 +74,6 @@ func GenerateTask(
 	err = shard.AddTasks(ctx, &persistence.AddHistoryTasksRequest{
 		ShardID: shard.GetShardID(),
 		// RangeID is set by shard
-		NamespaceID: string(namespaceID),
-		WorkflowID:  request.Execution.WorkflowId,
-		RunID:       request.Execution.RunId,
 		Tasks: map[tasks.Category][]tasks.Task{
 			tasks.CategoryReplication: {task},
 		},

--- a/service/history/archival_queue_task_executor.go
+++ b/service/history/archival_queue_task_executor.go
@@ -256,11 +256,8 @@ func (e *archivalQueueTaskExecutor) addDeletionTask(
 		return err
 	}
 	err = e.shardContext.AddTasks(ctx, &persistence.AddHistoryTasksRequest{
-		ShardID:     e.shardContext.GetShardID(),
-		NamespaceID: task.GetNamespaceID(),
-		WorkflowID:  task.WorkflowID,
-		RunID:       task.RunID,
-		Tasks:       mutableState.PopTasks(),
+		ShardID: e.shardContext.GetShardID(),
+		Tasks:   mutableState.PopTasks(),
 	})
 	return err
 }

--- a/service/history/archival_queue_task_executor_test.go
+++ b/service/history/archival_queue_task_executor_test.go
@@ -443,11 +443,8 @@ func TestArchivalQueueTaskExecutor(t *testing.T) {
 						}
 						mutableState.EXPECT().PopTasks().Return(popTasks)
 						shardContext.EXPECT().AddTasks(gomock.Any(), &cpersistence.AddHistoryTasksRequest{
-							ShardID:     shardID,
-							NamespaceID: tests.NamespaceID.String(),
-							WorkflowID:  task.WorkflowID,
-							RunID:       task.RunID,
-							Tasks:       popTasks,
+							ShardID: shardID,
+							Tasks:   popTasks,
 						})
 					})
 				}

--- a/service/history/deletemanager/delete_manager.go
+++ b/service/history/deletemanager/delete_manager.go
@@ -135,9 +135,6 @@ func (m *DeleteManagerImpl) AddDeleteWorkflowExecutionTask(
 	return m.shard.AddTasks(ctx, &persistence.AddHistoryTasksRequest{
 		ShardID: m.shard.GetShardID(),
 		// RangeID is set by shard
-		NamespaceID: nsID.String(),
-		WorkflowID:  we.GetWorkflowId(),
-		RunID:       we.GetRunId(),
 		Tasks: map[tasks.Category][]tasks.Task{
 			tasks.CategoryTransfer: {deleteTask},
 		},

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -162,11 +162,8 @@ func (s *contextSuite) TestOverwriteScheduledTaskTimestamp() {
 		err = s.mockShard.AddTasks(
 			context.Background(),
 			&persistence.AddHistoryTasksRequest{
-				ShardID:     s.mockShard.GetShardID(),
-				NamespaceID: workflowKey.NamespaceID,
-				WorkflowID:  workflowKey.WorkflowID,
-				RunID:       workflowKey.RunID,
-				Tasks:       testTasks,
+				ShardID: s.mockShard.GetShardID(),
+				Tasks:   testTasks,
 			},
 		)
 		s.NoError(err)
@@ -185,12 +182,8 @@ func (s *contextSuite) TestAddTasks_Success() {
 	}
 
 	addTasksRequest := &persistence.AddHistoryTasksRequest{
-		ShardID:     s.mockShard.GetShardID(),
-		NamespaceID: tests.NamespaceID.String(),
-		WorkflowID:  tests.WorkflowID,
-		RunID:       tests.RunID,
-
-		Tasks: testTasks,
+		ShardID: s.mockShard.GetShardID(),
+		Tasks:   testTasks,
 	}
 
 	s.mockExecutionManager.EXPECT().AddHistoryTasks(gomock.Any(), addTasksRequest).Return(nil)

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -174,11 +174,24 @@ func (s *contextSuite) TestOverwriteScheduledTaskTimestamp() {
 }
 
 func (s *contextSuite) TestAddTasks_Success() {
+	workflowKey := definition.NewWorkflowKey(
+		tests.NamespaceID.String(),
+		tests.WorkflowID,
+		tests.RunID,
+	)
 	testTasks := map[tasks.Category][]tasks.Task{
-		tasks.CategoryTransfer:    {&tasks.ActivityTask{}},           // Just for testing purpose. In the real code ActivityTask can't be passed to shardContext.AddTasks.
-		tasks.CategoryTimer:       {&tasks.ActivityRetryTimerTask{}}, // Just for testing purpose. In the real code ActivityRetryTimerTask can't be passed to shardContext.AddTasks.
-		tasks.CategoryReplication: {&tasks.HistoryReplicationTask{}}, // Just for testing purpose. In the real code HistoryReplicationTask can't be passed to shardContext.AddTasks.
-		tasks.CategoryVisibility:  {&tasks.DeleteExecutionVisibilityTask{}},
+		tasks.CategoryTransfer: {&tasks.ActivityTask{
+			WorkflowKey: workflowKey,
+		}}, // Just for testing purpose. In the real code ActivityTask can't be passed to shardContext.AddTasks.
+		tasks.CategoryTimer: {&tasks.ActivityRetryTimerTask{
+			WorkflowKey: workflowKey,
+		}}, // Just for testing purpose. In the real code ActivityRetryTimerTask can't be passed to shardContext.AddTasks.
+		tasks.CategoryReplication: {&tasks.HistoryReplicationTask{
+			WorkflowKey: workflowKey,
+		}}, // Just for testing purpose. In the real code HistoryReplicationTask can't be passed to shardContext.AddTasks.
+		tasks.CategoryVisibility: {&tasks.DeleteExecutionVisibilityTask{
+			WorkflowKey: workflowKey,
+		}},
 	}
 
 	addTasksRequest := &persistence.AddHistoryTasksRequest{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Allow adding history tasks for different workflows in one batch.
- Remove workflow key params from add tasks request.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Merging DLQ will need to add tasks from different workflows/namespaces in batch.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- No.