### PR TITLE
4590: configure user data fetch retry interval

### DIFF
--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -108,8 +108,9 @@ type (
 		MinTaskThrottlingBurstSize func() int
 		MaxTaskDeleteBatchSize     func() int
 
-		GetUserDataLongPollTimeout dynamicconfig.DurationPropertyFn
-		GetUserDataMinWaitTime     time.Duration
+		GetUserDataLongPollTimeout   dynamicconfig.DurationPropertyFn
+		GetUserDataMinWaitTime       time.Duration
+		GetUserDataRetryBaseInterval time.Duration
 
 		// taskWriter configuration
 		OutstandingTaskAppendsThreshold func() int
@@ -223,8 +224,9 @@ func newTaskQueueConfig(id *taskQueueID, config *Config, namespace namespace.Nam
 		MaxTaskDeleteBatchSize: func() int {
 			return config.MaxTaskDeleteBatchSize(namespace.String(), taskQueueName, taskType)
 		},
-		GetUserDataLongPollTimeout: config.GetUserDataLongPollTimeout,
-		GetUserDataMinWaitTime:     1 * time.Second,
+		GetUserDataLongPollTimeout:   config.GetUserDataLongPollTimeout,
+		GetUserDataMinWaitTime:       1 * time.Second,
+		GetUserDataRetryBaseInterval: 1 * time.Second,
 		OutstandingTaskAppendsThreshold: func() int {
 			return config.OutstandingTaskAppendsThreshold(namespace.String(), taskQueueName, taskType)
 		},

--- a/service/matching/task_queue_manager.go
+++ b/service/matching/task_queue_manager.go
@@ -776,7 +776,7 @@ func (c *taskQueueManagerImpl) userDataFetchSource() (string, error) {
 	return parent.FullName(), nil
 }
 
-func (c *taskQueueManagerImpl) makeBackoff() *backoff.ExponentialRetryPolicy {
+func (c *taskQueueManagerImpl) makeUserDataFetchBackoff() *backoff.ExponentialRetryPolicy {
 	return backoff.NewExponentialRetryPolicy(c.config.GetUserDataRetryBaseInterval).
 		WithMaximumInterval(5 * time.Minute)
 }
@@ -851,7 +851,7 @@ func (c *taskQueueManagerImpl) fetchUserData(ctx context.Context) error {
 
 	for ctx.Err() == nil {
 		start := time.Now()
-		_ = backoff.ThrottleRetryContext(ctx, op, c.makeBackoff(), nil)
+		_ = backoff.ThrottleRetryContext(ctx, op, c.makeUserDataFetchBackoff(), nil)
 		elapsed := time.Since(start)
 
 		// In general we want to start a new call immediately on completion of the previous


### PR DESCRIPTION
**What changed?**
Fixes #4590 
Add configuration of user data fetch retry interval.

**Why?**
Mutating user data fetch's static backoff config in a test led to a data race. It seemed simplest to just make it explicitly configured along with a lot of other similar config numbers/durations.

**How did you test it?**
Replaced the overriding behavior in the unit test with config.

**Potential risks**
Maybe config is serialized/persisted and reused somewhere? (I'm very new to the temporal service.) If so, this could be a breaking change, since new instances could get existing config values and crash. However, I'm assuming that config is immutable and created fresh for a given task queue manager.

**Is hotfix candidate?**
No.