### PR TITLE
Deprecate cluster information config

### DIFF
--- a/common/cluster/metadata_test.go
+++ b/common/cluster/metadata_test.go
@@ -99,7 +99,7 @@ func (s *metadataSuite) SetupTest() {
 		s.failoverVersionIncrement,
 		s.clusterName,
 		s.clusterName,
-		clusterInfo,
+		DBRecord{clusterInfo},
 		s.mockClusterMetadataStore,
 		dynamicconfig.GetDurationPropertyFn(time.Second),
 		log.NewNoopLogger(),

--- a/common/cluster/metadata_test_config.go
+++ b/common/cluster/metadata_test_config.go
@@ -73,7 +73,7 @@ var (
 )
 
 // NewTestClusterMetadataConfig return an cluster metadata config
-func NewTestClusterMetadataConfig(enableGlobalNamespace bool, isMasterCluster bool) *Config {
+func NewTestClusterMetadataConfig(enableGlobalNamespace bool, isMasterCluster bool) (*Config, map[string]ClusterInformation) {
 	masterClusterName := TestCurrentClusterName
 	if !isMasterCluster {
 		masterClusterName = TestAlternativeClusterName
@@ -85,8 +85,7 @@ func NewTestClusterMetadataConfig(enableGlobalNamespace bool, isMasterCluster bo
 			FailoverVersionIncrement: TestFailoverVersionIncrement,
 			MasterClusterName:        masterClusterName,
 			CurrentClusterName:       TestCurrentClusterName,
-			ClusterInformation:       TestAllClusterInfo,
-		}
+		}, TestAllClusterInfo
 	}
 
 	return &Config{
@@ -94,6 +93,5 @@ func NewTestClusterMetadataConfig(enableGlobalNamespace bool, isMasterCluster bo
 		FailoverVersionIncrement: TestFailoverVersionIncrement,
 		MasterClusterName:        TestCurrentClusterName,
 		CurrentClusterName:       TestCurrentClusterName,
-		ClusterInformation:       TestSingleDCClusterInfo,
-	}
+	}, TestSingleDCClusterInfo
 }

--- a/common/cluster/metadata_test_config.go
+++ b/common/cluster/metadata_test_config.go
@@ -29,16 +29,22 @@ const (
 	TestCurrentClusterInitialFailoverVersion = int64(1)
 	// TestAlternativeClusterInitialFailoverVersion is initial failover version for alternative cluster
 	TestAlternativeClusterInitialFailoverVersion = int64(2)
+	// TestOptionalClusterInitialFailoverVersion is initial failover version for optional cluster
+	TestOptionalClusterInitialFailoverVersion = int64(3)
 	// TestFailoverVersionIncrement is failover version increment used for test
 	TestFailoverVersionIncrement = int64(10)
 	// TestCurrentClusterName is current cluster used for test
 	TestCurrentClusterName = "active"
 	// TestAlternativeClusterName is alternative cluster used for test
 	TestAlternativeClusterName = "standby"
+	// TestOptionalClusterName is an optional cluster used for test
+	TestOptionalClusterName = "other"
 	// TestCurrentClusterFrontendAddress is the ip port address of current cluster
 	TestCurrentClusterFrontendAddress = "127.0.0.1:7134"
 	// TestAlternativeClusterFrontendAddress is the ip port address of alternative cluster
 	TestAlternativeClusterFrontendAddress = "127.0.0.1:8134"
+	// TestOptionalClusterFrontendAddress is the ip port address of optional cluster
+	TestOptionalClusterFrontendAddress = "127.0.0.1:9134"
 )
 
 var (
@@ -56,6 +62,12 @@ var (
 			Enabled:                true,
 			InitialFailoverVersion: TestAlternativeClusterInitialFailoverVersion,
 			RPCAddress:             TestAlternativeClusterFrontendAddress,
+			ShardCount:             4,
+		},
+		TestOptionalClusterName: {
+			Enabled:                true,
+			InitialFailoverVersion: TestOptionalClusterInitialFailoverVersion,
+			RPCAddress:             TestOptionalClusterFrontendAddress,
 			ShardCount:             4,
 		},
 	}

--- a/common/persistence/cluster_metadata_store.go
+++ b/common/persistence/cluster_metadata_store.go
@@ -27,6 +27,7 @@ package persistence
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -236,11 +237,13 @@ func immutableFieldsChanged(old persistencespb.ClusterMetadata, cur persistences
 		(old.ClusterId != "" && old.ClusterId != cur.ClusterId) ||
 		(old.HistoryShardCount != 0 && old.HistoryShardCount != cur.HistoryShardCount) ||
 		(old.IsGlobalNamespaceEnabled && !cur.IsGlobalNamespaceEnabled) {
+		fmt.Println("XXXXXXXXX", old.ClusterId, cur.ClusterId)
 		return true
 	}
 	if old.IsGlobalNamespaceEnabled {
 		if (old.FailoverVersionIncrement != 0 && old.FailoverVersionIncrement != cur.FailoverVersionIncrement) ||
 			(old.InitialFailoverVersion != 0 && old.InitialFailoverVersion != cur.InitialFailoverVersion) {
+			fmt.Println("YYYYYYYYY")
 			return true
 		}
 	}

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -185,10 +185,9 @@ func NewTestBaseForCluster(testCluster PersistenceTestCluster, logger log.Logger
 }
 
 // Setup sets up the test base, must be called as part of SetupSuite
-func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
+func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config, clusterInfo map[string]cluster.ClusterInformation) {
 	var err error
 	shardID := int32(10)
-	var clusterInfo map[string]cluster.ClusterInformation
 	if clusterMetadataConfig == nil {
 		clusterMetadataConfig, clusterInfo = cluster.NewTestClusterMetadataConfig(false, false)
 	}

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -33,6 +33,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common"
@@ -187,8 +188,9 @@ func NewTestBaseForCluster(testCluster PersistenceTestCluster, logger log.Logger
 func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	var err error
 	shardID := int32(10)
+	var clusterInfo map[string]cluster.ClusterInformation
 	if clusterMetadataConfig == nil {
-		clusterMetadataConfig = cluster.NewTestClusterMetadataConfig(false, false)
+		clusterMetadataConfig, clusterInfo = cluster.NewTestClusterMetadataConfig(false, false)
 	}
 	if s.PersistenceHealthSignals == nil {
 		s.PersistenceHealthSignals = persistence.NoopHealthSignalAggregator
@@ -215,7 +217,7 @@ func (s *TestBase) Setup(clusterMetadataConfig *cluster.Config) {
 	s.ClusterMetadataManager, err = factory.NewClusterMetadataManager()
 	s.fatalOnError("NewClusterMetadataManager", err)
 
-	s.ClusterMetadata = cluster.NewMetadataFromConfig(clusterMetadataConfig, s.ClusterMetadataManager, dynamicconfig.NewNoopCollection(), s.Logger)
+	s.ClusterMetadata = cluster.NewMetadataFromConfig(clusterMetadataConfig, cluster.DBRecord{clusterInfo}, s.ClusterMetadataManager, dynamicconfig.NewNoopCollection(), s.Logger)
 	s.SearchAttributesManager = searchattribute.NewManager(clock.NewRealTimeSource(), s.ClusterMetadataManager, dynamicconfig.GetBoolPropertyFn(true))
 
 	s.MetadataManager, err = factory.NewMetadataManager()

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -28,6 +28,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
 	persistencetests "go.temporal.io/server/common/persistence/persistence-tests"
 	"go.temporal.io/server/common/persistence/serialization"
 	_ "go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
@@ -148,27 +149,27 @@ func TestCassandraVisibilityPersistence(t *testing.T) {
 func TestCassandraHistoryV2Persistence(t *testing.T) {
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestCassandraMetadataPersistenceV2(t *testing.T) {
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestCassandraQueuePersistence(t *testing.T) {
 	s := new(persistencetests.QueuePersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestCassandraClusterMetadataPersistence(t *testing.T) {
 	s := new(persistencetests.ClusterMetadataManagerSuite)
 	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }

--- a/common/persistence/tests/mysql_test.go
+++ b/common/persistence/tests/mysql_test.go
@@ -164,56 +164,56 @@ func TestMySQL8VisibilityPersistenceSuite(t *testing.T) {
 func TestMySQLHistoryV2PersistenceSuite(t *testing.T) {
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetMySQLTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestMySQLMetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetMySQLTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestMySQLQueuePersistence(t *testing.T) {
 	s := new(persistencetests.QueuePersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetMySQLTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestMySQLClusterMetadataPersistence(t *testing.T) {
 	s := new(persistencetests.ClusterMetadataManagerSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetMySQLTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestMySQL8HistoryV2PersistenceSuite(t *testing.T) {
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetMySQL8TestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestMySQL8MetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetMySQL8TestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestMySQL8QueuePersistence(t *testing.T) {
 	s := new(persistencetests.QueuePersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetMySQL8TestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestMySQL8ClusterMetadataPersistence(t *testing.T) {
 	s := new(persistencetests.ClusterMetadataManagerSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetMySQL8TestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 

--- a/common/persistence/tests/postgresql_test.go
+++ b/common/persistence/tests/postgresql_test.go
@@ -160,21 +160,21 @@ func TestPostgreSQL12VisibilityPersistenceSuite(t *testing.T) {
 func TestPostgreSQLHistoryV2PersistenceSuite(t *testing.T) {
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQLTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestPostgreSQLMetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQLTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestPostgreSQLClusterMetadataPersistence(t *testing.T) {
 	s := new(persistencetests.ClusterMetadataManagerSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQLTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
@@ -199,21 +199,21 @@ FAIL: TestPostgreSQLQueuePersistence/TestNamespaceReplicationQueue (0.26s)
 func TestPostgreSQL12HistoryV2PersistenceSuite(t *testing.T) {
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQL12TestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestPostgreSQL12MetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQL12TestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestPostgreSQL12ClusterMetadataPersistence(t *testing.T) {
 	s := new(persistencetests.ClusterMetadataManagerSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetPostgreSQL12TestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 

--- a/common/persistence/tests/sqlite_test.go
+++ b/common/persistence/tests/sqlite_test.go
@@ -389,56 +389,56 @@ func TestSQLiteVisibilityPersistenceSuite(t *testing.T) {
 func TestSQLiteHistoryV2PersistenceSuite(t *testing.T) {
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetSQLiteMemoryTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestSQLiteMetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetSQLiteMemoryTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestSQLiteClusterMetadataPersistence(t *testing.T) {
 	s := new(persistencetests.ClusterMetadataManagerSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetSQLiteMemoryTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestSQLiteQueuePersistence(t *testing.T) {
 	s := new(persistencetests.QueuePersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetSQLiteMemoryTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestSQLiteFileHistoryV2PersistenceSuite(t *testing.T) {
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetSQLiteFileTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestSQLiteFileMetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetSQLiteFileTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestSQLiteFileClusterMetadataPersistence(t *testing.T) {
 	s := new(persistencetests.ClusterMetadataManagerSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetSQLiteFileTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 
 func TestSQLiteFileQueuePersistence(t *testing.T) {
 	s := new(persistencetests.QueuePersistenceSuite)
 	s.TestBase = persistencetests.NewTestBaseWithSQL(persistencetests.GetSQLiteFileTestClusterOption())
-	s.TestBase.Setup(nil)
+	s.TestBase.Setup(nil, nil)
 	suite.Run(t, s)
 }
 

--- a/config/development-cass-archival.yaml
+++ b/config/development-cass-archival.yaml
@@ -59,12 +59,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-cass-es.yaml
+++ b/config/development-cass-es.yaml
@@ -66,12 +66,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-cass-s3.yaml
+++ b/config/development-cass-s3.yaml
@@ -57,12 +57,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-cass.yaml
+++ b/config/development-cass.yaml
@@ -83,12 +83,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-cluster-a.yaml
+++ b/config/development-cluster-a.yaml
@@ -66,24 +66,10 @@ clusterMetadata:
   failoverVersionIncrement: 100
   masterClusterName: "cluster-a"
   currentClusterName: "cluster-a"
-  clusterInformation:
-    cluster-a:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 # Use tctl --ad 127.0.0.1:7233 adm cl upsert-remote-cluster --frontend_address "localhost:8233"
-#    cluster-b:
-#      enabled: true
-#      initialFailoverVersion: 2
-#      rpcName: "frontend"
-#      rpcAddress: "localhost:8233"
 # Use tctl --ad 127.0.0.1:7233 adm cl upsert-remote-cluster --frontend_address "localhost:9233"
-#    cluster-c:
-#      enabled: false
-#      initialFailoverVersion: 3
-#      rpcName: "frontend"
-#      rpcAddress: "localhost:9233"
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/config/development-cluster-b.yaml
+++ b/config/development-cluster-b.yaml
@@ -66,29 +66,10 @@ clusterMetadata:
   failoverVersionIncrement: 100
   masterClusterName: "cluster-a"
   currentClusterName: "cluster-b"
-  clusterInformation:
-    cluster-a:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
-    cluster-b:
-      enabled: true
-      initialFailoverVersion: 2
-      rpcName: "frontend"
-      rpcAddress: "localhost:8233"
+  initialFailoverVersion: 2
+  replicationAddress: "localhost:8233"
 # Use tctl --ad 127.0.0.1:8233 adm cl upsert-remote-cluster --frontend_address "localhost:7233"
-#    active:
-#      enabled: true
-#      initialFailoverVersion: 1
-#      rpcName: "frontend"
-#      rpcAddress: "localhost:7233"
 # Use tctl --ad 127.0.0.1:8233 adm cl upsert-remote-cluster --frontend_address "localhost:9233"
-#    other:
-#      enabled: false
-#      initialFailoverVersion: 3
-#      rpcName: "frontend"
-#      rpcAddress: "localhost:9233"
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/config/development-cluster-c.yaml
+++ b/config/development-cluster-c.yaml
@@ -66,29 +66,10 @@ clusterMetadata:
   failoverVersionIncrement: 100
   masterClusterName: "cluster-a"
   currentClusterName: "cluster-c"
-  clusterInformation:
-    cluster-a:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
-    cluster-c:
-      enabled: true
-      initialFailoverVersion: 3
-      rpcName: "frontend"
-      rpcAddress: "localhost:9233"
+  initialFailoverVersion: 3
+  replicationAddress: "localhost:9233"
 # Use tctl --ad 127.0.0.1:9233 adm cl upsert-remote-cluster --frontend_address "localhost:7233"
-#    active:
-#      enabled: true
-#      initialFailoverVersion: 1
-#      rpcName: "frontend"
-#      rpcAddress: "localhost:7233"
 # Use tctl --ad 127.0.0.1:9233 adm cl upsert-remote-cluster --frontend_address "localhost:8233"
-#    standby:
-#      enabled: true
-#      initialFailoverVersion: 2
-#      rpcName: "frontend"
-#      rpcAddress: "localhost:8233"
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/config/development-mysql-es.yaml
+++ b/config/development-mysql-es.yaml
@@ -72,12 +72,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-mysql.yaml
+++ b/config/development-mysql.yaml
@@ -74,12 +74,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-mysql8.yaml
+++ b/config/development-mysql8.yaml
@@ -74,12 +74,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-postgres-es.yaml
+++ b/config/development-postgres-es.yaml
@@ -74,12 +74,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-postgres.yaml
+++ b/config/development-postgres.yaml
@@ -74,12 +74,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-postgres12.yaml
+++ b/config/development-postgres12.yaml
@@ -74,12 +74,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-sqlite-file.yaml
+++ b/config/development-sqlite-file.yaml
@@ -98,12 +98,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development-sqlite.yaml
+++ b/config/development-sqlite.yaml
@@ -94,12 +94,8 @@ clusterMetadata:
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 1
-      rpcName: "frontend"
-      rpcAddress: "localhost:7233"
+  initialFailoverVersion: 1
+  replicationAddress: "localhost:7233"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -196,6 +196,26 @@ func (s *taskProcessorManagerSuite) TestCleanupReplicationTask_Cleanup() {
 					},
 				}},
 			},
+			shard.ReplicationReaderIDFromClusterShardID(cluster.TestOptionalClusterInitialFailoverVersion, common.MapShardID(
+				cluster.TestAllClusterInfo[cluster.TestCurrentClusterName].ShardCount,
+				cluster.TestAllClusterInfo[cluster.TestOptionalClusterName].ShardCount,
+				s.shardID,
+			)[0]): {
+				Scopes: []*persistencespb.QueueSliceScope{{
+					Range: &persistencespb.QueueSliceRange{
+						InclusiveMin: shard.ConvertToPersistenceTaskKey(
+							tasks.NewImmediateKey(ackedTaskID + 1),
+						),
+						ExclusiveMax: shard.ConvertToPersistenceTaskKey(
+							tasks.NewImmediateKey(math.MaxInt64),
+						),
+					},
+					Predicate: &persistencespb.Predicate{
+						PredicateType: enumsspb.PREDICATE_TYPE_UNIVERSAL,
+						Attributes:    &persistencespb.Predicate_UniversalPredicateAttributes{},
+					},
+				}},
+			},
 		},
 	}, true)
 	s.taskProcessorManager.minTxAckedTaskID = ackedTaskID - 1

--- a/temporal/fx_test.go
+++ b/temporal/fx_test.go
@@ -50,8 +50,8 @@ func TestInitCurrentClusterMetadataRecord(t *testing.T) {
 		func(_ context.Context, request *persistence.SaveClusterMetadataRequest) (bool, error) {
 			require.Equal(t, cfg.ClusterMetadata.EnableGlobalNamespace, request.IsGlobalNamespaceEnabled)
 			require.Equal(t, cfg.ClusterMetadata.CurrentClusterName, request.ClusterName)
-			require.Equal(t, cfg.ClusterMetadata.ClusterInformation[cfg.ClusterMetadata.CurrentClusterName].RPCAddress, request.ClusterAddress)
-			require.Equal(t, cfg.ClusterMetadata.ClusterInformation[cfg.ClusterMetadata.CurrentClusterName].InitialFailoverVersion, request.InitialFailoverVersion)
+			require.Equal(t, cfg.ClusterMetadata.ReplicationAddress, request.ClusterAddress)
+			require.Equal(t, cfg.ClusterMetadata.InitialFailoverVersion, request.InitialFailoverVersion)
 			require.Equal(t, cfg.Persistence.NumHistoryShards, request.HistoryShardCount)
 			require.Equal(t, cfg.ClusterMetadata.FailoverVersionIncrement, request.FailoverVersionIncrement)
 			require.Equal(t, int64(0), request.Version)
@@ -79,8 +79,8 @@ func TestUpdateCurrentClusterMetadataRecord(t *testing.T) {
 		func(_ context.Context, request *persistence.SaveClusterMetadataRequest) (bool, error) {
 			require.Equal(t, cfg.ClusterMetadata.EnableGlobalNamespace, request.IsGlobalNamespaceEnabled)
 			require.Equal(t, "", request.ClusterName)
-			require.Equal(t, cfg.ClusterMetadata.ClusterInformation[cfg.ClusterMetadata.CurrentClusterName].RPCAddress, request.ClusterAddress)
-			require.Equal(t, cfg.ClusterMetadata.ClusterInformation[cfg.ClusterMetadata.CurrentClusterName].InitialFailoverVersion, request.InitialFailoverVersion)
+			require.Equal(t, cfg.ClusterMetadata.ReplicationAddress, request.ClusterAddress)
+			require.Equal(t, cfg.ClusterMetadata.InitialFailoverVersion, request.InitialFailoverVersion)
 			require.Equal(t, int32(0), request.HistoryShardCount)
 			require.Equal(t, cfg.ClusterMetadata.FailoverVersionIncrement, request.FailoverVersionIncrement)
 			require.Equal(t, int64(1), request.Version)

--- a/tests/ndc/ndc_integration_test.go
+++ b/tests/ndc/ndc_integration_test.go
@@ -153,7 +153,7 @@ func (s *nDCIntegrationTestSuite) SetupSuite() {
 
 	s.registerNamespace()
 
-	s.version = clusterConfigs[1].ClusterMetadata.ClusterInformation[clusterConfigs[1].ClusterMetadata.CurrentClusterName].InitialFailoverVersion
+	s.version = clusterConfigs[1].ClusterMetadata.InitialFailoverVersion
 	s.versionIncrement = clusterConfigs[0].ClusterMetadata.FailoverVersionIncrement
 	s.generator = test.InitializeHistoryEventGenerator(s.namespace, s.namespaceID, s.version)
 }

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -101,6 +101,7 @@ type (
 		dcClient                         *dcClient
 		logger                           log.Logger
 		clusterMetadataConfig            *cluster.Config
+		clusterInfo                      map[string]cluster.ClusterInformation
 		persistenceConfig                config.Persistence
 		metadataMgr                      persistence.MetadataManager
 		clusterMetadataMgr               persistence.ClusterMetadataManager
@@ -137,6 +138,7 @@ type (
 	// TemporalParams contains everything needed to bootstrap Temporal
 	TemporalParams struct {
 		ClusterMetadataConfig            *cluster.Config
+		ClusterInfo                      map[string]cluster.ClusterInformation
 		PersistenceConfig                config.Persistence
 		MetadataMgr                      persistence.MetadataManager
 		ClusterMetadataManager           persistence.ClusterMetadataManager
@@ -171,6 +173,7 @@ func newTemporal(params *TemporalParams) *temporalImpl {
 	impl := &temporalImpl{
 		logger:                           params.Logger,
 		clusterMetadataConfig:            params.ClusterMetadataConfig,
+		clusterInfo:                      params.ClusterInfo,
 		persistenceConfig:                params.PersistenceConfig,
 		metadataMgr:                      params.MetadataMgr,
 		clusterMetadataMgr:               params.ClusterMetadataManager,
@@ -387,6 +390,7 @@ func (c *temporalImpl) startFrontend(hosts map[primitives.ServiceName][]string, 
 			return newSimpleHostInfoProvider(serviceName, hosts)
 		}),
 		fx.Provide(func() *cluster.Config { return c.clusterMetadataConfig }),
+		fx.Provide(func() cluster.DBRecord { return cluster.DBRecord{Record: c.clusterInfo} }),
 		fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 		fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
 		fx.Provide(sdkClientFactoryProvider),
@@ -481,6 +485,7 @@ func (c *temporalImpl) startHistory(
 				return newSimpleHostInfoProvider(serviceName, hosts)
 			}),
 			fx.Provide(func() *cluster.Config { return c.clusterMetadataConfig }),
+			fx.Provide(func() cluster.DBRecord { return cluster.DBRecord{Record: c.clusterInfo} }),
 			fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 			fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
 			fx.Provide(sdkClientFactoryProvider),
@@ -576,6 +581,7 @@ func (c *temporalImpl) startMatching(hosts map[primitives.ServiceName][]string, 
 			return newSimpleHostInfoProvider(serviceName, hosts)
 		}),
 		fx.Provide(func() *cluster.Config { return c.clusterMetadataConfig }),
+		fx.Provide(func() cluster.DBRecord { return cluster.DBRecord{Record: c.clusterInfo} }),
 		fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 		fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
 		fx.Provide(func() client.FactoryProvider { return client.NewFactoryProvider() }),
@@ -670,6 +676,7 @@ func (c *temporalImpl) startWorker(hosts map[primitives.ServiceName][]string, st
 			return newSimpleHostInfoProvider(serviceName, hosts)
 		}),
 		fx.Provide(func() *cluster.Config { return &clusterConfigCopy }),
+		fx.Provide(func() cluster.DBRecord { return cluster.DBRecord{Record: c.clusterInfo} }),
 		fx.Provide(func() carchiver.ArchivalMetadata { return c.archiverMetadata }),
 		fx.Provide(func() provider.ArchiverProvider { return c.archiverProvider }),
 		fx.Provide(sdkClientFactoryProvider),

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -34,7 +34,6 @@ import (
 
 	"go.uber.org/fx"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/maps"
 	"google.golang.org/grpc"
 
 	"go.temporal.io/api/operatorservice/v1"
@@ -644,7 +643,8 @@ func (c *temporalImpl) startWorker(hosts map[primitives.ServiceName][]string, st
 		FailoverVersionIncrement: c.clusterMetadataConfig.FailoverVersionIncrement,
 		MasterClusterName:        c.clusterMetadataConfig.MasterClusterName,
 		CurrentClusterName:       c.clusterMetadataConfig.CurrentClusterName,
-		ClusterInformation:       maps.Clone(c.clusterMetadataConfig.ClusterInformation),
+		InitialFailoverVersion:   c.clusterMetadataConfig.InitialFailoverVersion,
+		ReplicationAddress:       c.clusterMetadataConfig.ReplicationAddress,
 	}
 	if c.workerConfig.EnableReplicator {
 		clusterConfigCopy.EnableGlobalNamespace = true

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -158,7 +158,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	}
 
 	testBase := persistencetests.NewTestBase(&options.Persistence)
-	testBase.Setup(clusterMetadataConfig)
+	testBase.Setup(clusterMetadataConfig, clusterInfo)
 	archiverBase := newArchiverBase(options.EnableArchival, logger)
 
 	pConfig := testBase.DefaultTestCluster.Config()
@@ -224,6 +224,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 
 	temporalParams := &TemporalParams{
 		ClusterMetadataConfig:            clusterMetadataConfig,
+		ClusterInfo:                      clusterInfo,
 		PersistenceConfig:                pConfig,
 		MetadataMgr:                      testBase.MetadataManager,
 		ClusterMetadataManager:           testBase.ClusterMetadataManager,

--- a/tests/testdata/ndc_integration_test_clusters.yaml
+++ b/tests/testdata/ndc_integration_test_clusters.yaml
@@ -5,22 +5,8 @@
     failoverVersionIncrement: 10
     masterClusterName: "active"
     currentClusterName: "active"
-    clusterInformation:
-      active:
-        enabled: true
-        initialFailoverVersion: 1
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:7134"
-      standby:
-        enabled: true
-        initialFailoverVersion: 2
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:8134"
-      other:
-        enabled: true
-        initialFailoverVersion: 3
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:9134"
+    initialFailoverVersion: 1
+    replicationAddress: "127.0.0.1:7134"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -36,22 +22,8 @@
     failoverVersionIncrement: 10
     masterClusterName: "active"
     currentClusterName: "standby"
-    clusterInformation:
-      active:
-        enabled: true
-        initialFailoverVersion: 1
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:7134"
-      standby:
-        enabled: true
-        initialFailoverVersion: 2
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:8134"
-      other:
-        enabled: true
-        initialFailoverVersion: 3
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:9134"
+    initialFailoverVersion: 2
+    replicationAddress: "127.0.0.1:8134"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -67,22 +39,8 @@
     failoverVersionIncrement: 10
     masterClusterName: "active"
     currentClusterName: "other"
-    clusterInformation:
-      active:
-        enabled: true
-        initialFailoverVersion: 1
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:7134"
-      standby:
-        enabled: true
-        initialFailoverVersion: 2
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:8134"
-      other:
-        enabled: true
-        initialFailoverVersion: 3
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:9134"
+    initialFailoverVersion: 3
+    replicationAddress: "127.0.0.1:9134"
   enablearchival: false
   workerconfig:
     enablearchiver: false

--- a/tests/testdata/xdc_integration_adv_vis_clusters.yaml
+++ b/tests/testdata/xdc_integration_adv_vis_clusters.yaml
@@ -3,14 +3,10 @@
   clustermetadata:
     enableGlobalNamespace: true
     failoverVersionIncrement: 10
-    masterClusterName: "active-adv-vis"
-    currentClusterName: "active-adv-vis"
-    clusterInformation:
-      active-adv-vis:
-        enabled: true
-        initialFailoverVersion: 1
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:9134"
+    masterClusterName: "active"
+    currentClusterName: "active"
+    initialFailoverVersion: 1
+    replicationAddress: "127.0.0.1:7134"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -25,14 +21,10 @@
   clustermetadata:
     enableGlobalNamespace: true
     failoverVersionIncrement: 10
-    masterClusterName: "standby-adv-vis"
-    currentClusterName: "standby-adv-vis"
-    clusterInformation:
-      standby-adv-vis:
-        enabled: true
-        initialFailoverVersion: 2
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:10134"
+    masterClusterName: "standby"
+    currentClusterName: "standby"
+    initialFailoverVersion: 2
+    replicationAddress: "127.0.0.1:8134"
   enablearchival: false
   workerconfig:
     enablearchiver: false

--- a/tests/testdata/xdc_integration_adv_vis_es_clusters.yaml
+++ b/tests/testdata/xdc_integration_adv_vis_es_clusters.yaml
@@ -3,14 +3,10 @@
   clustermetadata:
     enableGlobalNamespace: true
     failoverVersionIncrement: 10
-    masterClusterName: "active-adv-vis"
-    currentClusterName: "active-adv-vis"
-    clusterInformation:
-      active-adv-vis:
-        enabled: true
-        initialFailoverVersion: 1
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:9134"
+    masterClusterName: "active"
+    currentClusterName: "active"
+    initialFailoverVersion: 1
+    replicationAddress: "127.0.0.1:7134"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -32,14 +28,10 @@
   clustermetadata:
     enableGlobalNamespace: true
     failoverVersionIncrement: 10
-    masterClusterName: "standby-adv-vis"
-    currentClusterName: "standby-adv-vis"
-    clusterInformation:
-      standby-adv-vis:
-        enabled: true
-        initialFailoverVersion: 2
-        rpcName: "frontend"
-        rpcAddress: "127.0.0.1:10134"
+    masterClusterName: "standby"
+    currentClusterName: "standby"
+    initialFailoverVersion: 2
+    replicationAddress: "127.0.0.1:8134"
   enablearchival: false
   workerconfig:
     enablearchiver: false

--- a/tests/testdata/xdc_integration_test_clusters.yaml
+++ b/tests/testdata/xdc_integration_test_clusters.yaml
@@ -1,6 +1,10 @@
 - clustermetadata:
     enableGlobalNamespace: true
     failoverVersionIncrement: 10
+    masterClusterName: "active"
+    currentClusterName: "active"
+    initialFailoverVersion: 1
+    replicationAddress: "127.0.0.1:7134"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -12,6 +16,10 @@
 - clustermetadata:
     enableGlobalNamespace: true
     failoverVersionIncrement: 10
+    masterClusterName: "standby"
+    currentClusterName: "standby"
+    initialFailoverVersion: 2
+    replicationAddress: "127.0.0.1:8134"
   enablearchival: false
   workerconfig:
     enablearchiver: false

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -48,7 +48,6 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"gopkg.in/yaml.v3"
 
-	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -132,21 +131,21 @@ func (s *advVisCrossDCTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 	s.cluster2 = c
 
-	cluster1Address := clusterConfigs[0].ClusterMetadata.ReplicationAddress
-	cluster2Address := clusterConfigs[1].ClusterMetadata.ReplicationAddress
-	_, err = s.cluster1.GetAdminClient().AddOrUpdateRemoteCluster(tests.NewContext(), &adminservice.AddOrUpdateRemoteClusterRequest{
-		FrontendAddress:               cluster2Address,
-		EnableRemoteClusterConnection: true,
-	})
-	s.Require().NoError(err)
-
-	_, err = s.cluster2.GetAdminClient().AddOrUpdateRemoteCluster(tests.NewContext(), &adminservice.AddOrUpdateRemoteClusterRequest{
-		FrontendAddress:               cluster1Address,
-		EnableRemoteClusterConnection: true,
-	})
-	s.Require().NoError(err)
+	//cluster1Address := clusterConfigs[0].ClusterMetadata.ReplicationAddress
+	//cluster2Address := clusterConfigs[1].ClusterMetadata.ReplicationAddress
+	//_, err = s.cluster1.GetAdminClient().AddOrUpdateRemoteCluster(tests.NewContext(), &adminservice.AddOrUpdateRemoteClusterRequest{
+	//	FrontendAddress:               cluster2Address,
+	//	EnableRemoteClusterConnection: true,
+	//})
+	//s.Require().NoError(err)
+	//
+	//_, err = s.cluster2.GetAdminClient().AddOrUpdateRemoteCluster(tests.NewContext(), &adminservice.AddOrUpdateRemoteClusterRequest{
+	//	FrontendAddress:               cluster1Address,
+	//	EnableRemoteClusterConnection: true,
+	//})
+	//s.Require().NoError(err)
 	// Wait for cluster metadata to refresh new added clusters
-	time.Sleep(time.Millisecond * 200)
+	time.Sleep(time.Second * 20)
 
 	s.testSearchAttributeKey = "CustomTextField"
 	s.testSearchAttributeVal = "test value"

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -132,8 +132,8 @@ func (s *advVisCrossDCTestSuite) SetupSuite() {
 	s.Require().NoError(err)
 	s.cluster2 = c
 
-	cluster1Address := clusterConfigs[0].ClusterMetadata.ClusterInformation[clusterConfigs[0].ClusterMetadata.CurrentClusterName].RPCAddress
-	cluster2Address := clusterConfigs[1].ClusterMetadata.ClusterInformation[clusterConfigs[1].ClusterMetadata.CurrentClusterName].RPCAddress
+	cluster1Address := clusterConfigs[0].ClusterMetadata.ReplicationAddress
+	cluster2Address := clusterConfigs[1].ClusterMetadata.ReplicationAddress
 	_, err = s.cluster1.GetAdminClient().AddOrUpdateRemoteCluster(tests.NewContext(), &adminservice.AddOrUpdateRemoteClusterRequest{
 		FrontendAddress:               cluster2Address,
 		EnableRemoteClusterConnection: true,

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -85,7 +85,7 @@ func TestAdvVisCrossDCTestSuite(t *testing.T) {
 }
 
 var (
-	clusterNameAdvVis              = []string{"active-adv-vis", "standby-adv-vis"}
+	clusterNameAdvVis              = []string{"active", "standby"}
 	clusterReplicationConfigAdvVis = []*replicationpb.ClusterReplicationConfig{
 		{
 			ClusterName: clusterNameAdvVis[0],

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -38,7 +38,6 @@ import (
 	replicationpb "go.temporal.io/api/replication/v1"
 	"gopkg.in/yaml.v3"
 
-	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -74,7 +73,9 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string) {
 	s.clusterNames = clusterNames
 	s.logger = log.NewTestLogger()
 	if s.dynamicConfigOverrides == nil {
-		s.dynamicConfigOverrides = make(map[dynamicconfig.Key]interface{})
+		s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
+			dynamicconfig.ClusterMetadataRefreshInterval: time.Second,
+		}
 	}
 
 	fileName := "../testdata/xdc_integration_test_clusters.yaml"
@@ -106,25 +107,25 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string) {
 	s.Require().NoError(err)
 	s.cluster2 = c
 
-	cluster1Address := clusterConfigs[0].ClusterMetadata.ReplicationAddress
-	cluster2Address := clusterConfigs[1].ClusterMetadata.ReplicationAddress
-	_, err = s.cluster1.GetAdminClient().AddOrUpdateRemoteCluster(
-		tests.NewContext(),
-		&adminservice.AddOrUpdateRemoteClusterRequest{
-			FrontendAddress:               cluster2Address,
-			EnableRemoteClusterConnection: true,
-		})
-	s.Require().NoError(err)
-
-	_, err = s.cluster2.GetAdminClient().AddOrUpdateRemoteCluster(
-		tests.NewContext(),
-		&adminservice.AddOrUpdateRemoteClusterRequest{
-			FrontendAddress:               cluster1Address,
-			EnableRemoteClusterConnection: true,
-		})
-	s.Require().NoError(err)
+	//cluster1Address := clusterConfigs[0].ClusterMetadata.ReplicationAddress
+	//cluster2Address := clusterConfigs[1].ClusterMetadata.ReplicationAddress
+	//_, err = s.cluster1.GetAdminClient().AddOrUpdateRemoteCluster(
+	//	tests.NewContext(),
+	//	&adminservice.AddOrUpdateRemoteClusterRequest{
+	//		FrontendAddress:               cluster2Address,
+	//		EnableRemoteClusterConnection: true,
+	//	})
+	//s.Require().NoError(err)
+	//
+	//_, err = s.cluster2.GetAdminClient().AddOrUpdateRemoteCluster(
+	//	tests.NewContext(),
+	//	&adminservice.AddOrUpdateRemoteClusterRequest{
+	//		FrontendAddress:               cluster1Address,
+	//		EnableRemoteClusterConnection: true,
+	//	})
+	//s.Require().NoError(err)
 	// Wait for cluster metadata to refresh new added clusters
-	time.Sleep(time.Millisecond * 200)
+	//time.Sleep(time.Millisecond * 200)
 }
 
 func (s *xdcBaseSuite) tearDownSuite() {

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -125,7 +125,7 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string) {
 	//	})
 	//s.Require().NoError(err)
 	// Wait for cluster metadata to refresh new added clusters
-	//time.Sleep(time.Millisecond * 200)
+	time.Sleep(time.Second * 20)
 }
 
 func (s *xdcBaseSuite) tearDownSuite() {

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -39,7 +39,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"go.temporal.io/server/api/adminservice/v1"
-	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
@@ -95,12 +94,8 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string) {
 		clusterConfigs[i].ClusterMetadata.MasterClusterName = s.clusterNames[i]
 		clusterConfigs[i].ClusterMetadata.CurrentClusterName = s.clusterNames[i]
 		clusterConfigs[i].Persistence.DBName = "integration_" + s.clusterNames[i]
-		clusterConfigs[i].ClusterMetadata.ClusterInformation = make(map[string]cluster.ClusterInformation)
-		clusterConfigs[i].ClusterMetadata.ClusterInformation[s.clusterNames[i]] = cluster.ClusterInformation{
-			Enabled:                true,
-			InitialFailoverVersion: int64(i + 1),
-			RPCAddress:             fmt.Sprintf("127.0.0.1:%d134", 7+i),
-		}
+		clusterConfigs[i].ClusterMetadata.InitialFailoverVersion = int64(i + 1)
+		clusterConfigs[i].ClusterMetadata.ReplicationAddress = fmt.Sprintf("127.0.0.1:%d134", 7+i)
 	}
 
 	c, err := tests.NewCluster(clusterConfigs[0], log.With(s.logger, tag.ClusterName(s.clusterNames[0])))
@@ -111,8 +106,8 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string) {
 	s.Require().NoError(err)
 	s.cluster2 = c
 
-	cluster1Address := clusterConfigs[0].ClusterMetadata.ClusterInformation[clusterConfigs[0].ClusterMetadata.CurrentClusterName].RPCAddress
-	cluster2Address := clusterConfigs[1].ClusterMetadata.ClusterInformation[clusterConfigs[1].ClusterMetadata.CurrentClusterName].RPCAddress
+	cluster1Address := clusterConfigs[0].ClusterMetadata.ReplicationAddress
+	cluster2Address := clusterConfigs[1].ClusterMetadata.ReplicationAddress
 	_, err = s.cluster1.GetAdminClient().AddOrUpdateRemoteCluster(
 		tests.NewContext(),
 		&adminservice.AddOrUpdateRemoteClusterRequest{

--- a/tests/xdc/integration_failover_test.go
+++ b/tests/xdc/integration_failover_test.go
@@ -80,7 +80,7 @@ func TestIntegrationClustersTestSuite(t *testing.T) {
 }
 
 func (s *integrationClustersTestSuite) SetupSuite() {
-	s.setupSuite([]string{"integ_active", "integ_standby"})
+	s.setupSuite([]string{"active", "standby"})
 }
 
 func (s *integrationClustersTestSuite) SetupTest() {

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -41,12 +41,14 @@ import (
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
+
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	sw "go.temporal.io/server/service/worker"
 	"go.temporal.io/server/service/worker/migration"
 	"go.temporal.io/server/service/worker/scanner/build_ids"
 
 	commonpb "go.temporal.io/api/common/v1"
+
 	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
@@ -84,7 +86,7 @@ func (s *userDataReplicationTestSuite) SetupSuite() {
 		// Ensure the scavenger can immediately delete build ids that are not in use.
 		dynamicconfig.RemovableBuildIdDurationSinceDefault: time.Microsecond,
 	}
-	s.setupSuite([]string{"task_queue_repl_active", "task_queue_repl_standby"})
+	s.setupSuite([]string{"active", "standby"})
 }
 
 func (s *userDataReplicationTestSuite) SetupTest() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Deprecate cluster information config

<!-- Tell your future self why have you made these changes -->
**Why?**
Remote cluster connects are created via API. Static config is only for local cluster. There is no need to have a map for the information.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
1. Updated unit tests.
2. Manual test:

2.1 Start a brand new server with the new static config [TODO]

2.2 Upgrade test: 
2.2.1 Upgrade the server from a legacy config with new static config. [TODO]
2.2.2 Upgrade the server from a legacy config without new static config. [TODO]

2.3 Downgrade test:
2.3.1 Follow 2.2.2, then rollback to previous server version with legacy config. [TODO]

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.