### PR TITLE
Add BuildIds predefined search attribute

### DIFF
--- a/common/searchattribute/defs.go
+++ b/common/searchattribute/defs.go
@@ -46,6 +46,7 @@ const (
 	StateTransitionCount  = "StateTransitionCount"
 	TemporalChangeVersion = "TemporalChangeVersion"
 	BinaryChecksums       = "BinaryChecksums"
+	BuildIds              = "BuildIds"
 	BatcherNamespace      = "BatcherNamespace"
 	BatcherUser           = "BatcherUser"
 	HistorySizeBytes      = "HistorySizeBytes"
@@ -88,6 +89,7 @@ var (
 	predefined = map[string]enumspb.IndexedValueType{
 		TemporalChangeVersion:      enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 		BinaryChecksums:            enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
+		BuildIds:                   enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST,
 		BatcherNamespace:           enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		BatcherUser:                enumspb.INDEXED_VALUE_TYPE_KEYWORD,
 		TemporalScheduledStartTime: enumspb.INDEXED_VALUE_TYPE_DATETIME,


### PR DESCRIPTION
**What changed?**
Add BuildIds predefined search attribute to 1.20.x

**Why?**
In a rollback scenario, after upgrading to 1.21 and then back to 1.20, the new predefined search attribute BuildIds wouldn't be understood by the older version and would block visibility tasks. Adding this to the type map will make it able to process workflows with the search attribute.

**How did you test it?**
manual rollback (cassandra+es, mysql, postgres)

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
