### PR TITLE
Ignore global rate limit if there are no hosts

### DIFF
--- a/service/frontend/fx_test.go
+++ b/service/frontend/fx_test.go
@@ -142,11 +142,11 @@ func TestRateLimitInterceptorProvider(t *testing.T) {
 			},
 		},
 		{
-			name: "no hosts returned by service resolver acts as if there was one host",
+			name: "no hosts causes global RPS limit to be ignored",
 			configure: func(tc *testCase) {
 				tc.globalRPSLimit = lowPerInstanceRPSLimit
 				tc.perInstanceRPSLimit = highPerInstanceRPSLimit
-				tc.expectRateLimit = true
+				tc.expectRateLimit = false
 				serviceResolver := membership.NewMockServiceResolver(gomock.NewController(tc.t))
 				serviceResolver.EXPECT().MemberCount().Return(0).AnyTimes()
 				tc.serviceResolver = serviceResolver

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -408,26 +408,12 @@ func namespaceRPS(
 
 func effectiveRPS(frontendResolver membership.ServiceResolver, hostRPS func() int, globalRPS func() int) float64 {
 	if gRPS := globalRPS(); gRPS > 0 && frontendResolver != nil {
-		hosts := float64(numFrontendHosts(frontendResolver))
-		return float64(gRPS) / hosts
+		if numHosts := frontendResolver.MemberCount(); numHosts > 0 {
+			return float64(gRPS) / float64(numHosts)
+		}
 	}
 
 	return float64(hostRPS())
-}
-
-func numFrontendHosts(
-	frontendResolver membership.ServiceResolver,
-) int {
-	defaultHosts := 1
-	if frontendResolver == nil {
-		return defaultHosts
-	}
-
-	ringSize := frontendResolver.MemberCount()
-	if ringSize < defaultHosts {
-		return defaultHosts
-	}
-	return ringSize
 }
 
 func (s *Service) GetFaultInjection() *client.FaultInjectionDataStoreFactory {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We have cluster-wide and per-instance limits for some resources. If the cluster-wide limit is set, we compute the effective limit to be `globalLimit/numHosts`. However, we get the `numHosts` variable from the membership service resolver object. In some cases, this may return 0 hosts, and we want to avoid a division-by-zero error, so we interpret this as 1 host. However, this will cause the host to use the entire cluster-wide limit, which could cause us to exceed our desired rate limits. 

<!-- Tell your future self why have you made these changes -->
**Why?**
To avoid us DoS'ing ourselves. I also think this behavior is more intuitive.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
There's already a test case for this. I watched it fail before this change, and then I fixed it.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
