### PR TITLE
Remove variable token concept from rate limiters

### DIFF
--- a/common/persistence/client/health_request_rate_limiter.go
+++ b/common/persistence/client/health_request_rate_limiter.go
@@ -113,7 +113,7 @@ func (rl *HealthRequestRateLimiterImpl) Allow(now time.Time, request quotas.Requ
 	if !rl.enabled.Load() {
 		return true
 	}
-	return rl.rateLimiter.AllowN(now, request.Token)
+	return rl.rateLimiter.AllowN(now, 1)
 }
 
 func (rl *HealthRequestRateLimiterImpl) Reserve(now time.Time, request quotas.Request) quotas.Reservation {
@@ -121,7 +121,7 @@ func (rl *HealthRequestRateLimiterImpl) Reserve(now time.Time, request quotas.Re
 	if !rl.enabled.Load() {
 		return quotas.NoopReservation
 	}
-	return rl.rateLimiter.ReserveN(now, request.Token)
+	return rl.rateLimiter.ReserveN(now, 1)
 }
 
 func (rl *HealthRequestRateLimiterImpl) Wait(ctx context.Context, request quotas.Request) error {
@@ -129,7 +129,7 @@ func (rl *HealthRequestRateLimiterImpl) Wait(ctx context.Context, request quotas
 	if !rl.enabled.Load() {
 		return nil
 	}
-	return rl.rateLimiter.WaitN(ctx, request.Token)
+	return rl.rateLimiter.WaitN(ctx, 1)
 }
 
 func (rl *HealthRequestRateLimiterImpl) maybeRefresh() {

--- a/common/persistence/client/quotas_test.go
+++ b/common/persistence/client/quotas_test.go
@@ -109,14 +109,7 @@ func (s *quotasSuite) TestPriorityNamespaceRateLimiter_DoesLimit() {
 
 	var limiter = newPriorityNamespaceRateLimiter(namespaceMaxRPS, hostMaxRPS, RequestPriorityFn)
 
-	var request = quotas.NewRequest(
-		"test-api",
-		1,
-		"test-namespace",
-		"api",
-		-1,
-		"frontend",
-	)
+	var request = quotas.NewRequest("test-api", "test-namespace", "api", -1, "frontend")
 
 	requestTime := time.Now()
 	wasLimited := false
@@ -136,14 +129,7 @@ func (s *quotasSuite) TestPerShardNamespaceRateLimiter_DoesLimit() {
 
 	var limiter = newPerShardPerNamespacePriorityRateLimiter(perShardNamespaceMaxRPS, hostMaxRPS, RequestPriorityFn)
 
-	var request = quotas.NewRequest(
-		"test-api",
-		1,
-		"test-namespace",
-		"api",
-		1,
-		"frontend",
-	)
+	var request = quotas.NewRequest("test-api", "test-namespace", "api", 1, "frontend")
 
 	requestTime := time.Now()
 	wasLimited := false

--- a/common/persistence/persistence_rate_limited_clients.go
+++ b/common/persistence/persistence_rate_limited_clients.go
@@ -38,8 +38,7 @@ import (
 )
 
 const (
-	RateLimitDefaultToken = 1
-	CallerSegmentMissing  = -1
+	CallerSegmentMissing = -1
 )
 
 var (
@@ -1057,14 +1056,7 @@ func allow(
 	rateLimiter quotas.RequestRateLimiter,
 ) bool {
 	callerInfo := headers.GetCallerInfo(ctx)
-	return rateLimiter.Allow(time.Now().UTC(), quotas.NewRequest(
-		api,
-		RateLimitDefaultToken,
-		callerInfo.CallerName,
-		callerInfo.CallerType,
-		shardID,
-		callerInfo.CallOrigin,
-	))
+	return rateLimiter.Allow(time.Now().UTC(), quotas.NewRequest(api, callerInfo.CallerName, callerInfo.CallerType, shardID, callerInfo.CallOrigin))
 }
 
 // TODO: change the value returned so it can also be used by

--- a/common/quotas/multi_rate_limiter_impl.go
+++ b/common/quotas/multi_rate_limiter_impl.go
@@ -131,7 +131,7 @@ func (rl *MultiRateLimiterImpl) WaitN(ctx context.Context, numToken int) error {
 	now := time.Now().UTC()
 	reservation := rl.ReserveN(now, numToken)
 	if !reservation.OK() {
-		return fmt.Errorf("rate: Wait(n=%d) would exceed context deadline", numToken)
+		return fmt.Errorf("%w: %d tokens", errWouldExceedContextDeadline, numToken)
 	}
 
 	delay := reservation.DelayFrom(now)
@@ -144,7 +144,7 @@ func (rl *MultiRateLimiterImpl) WaitN(ctx context.Context, numToken int) error {
 	}
 	if waitLimit < delay {
 		reservation.CancelAt(now)
-		return fmt.Errorf("rate: Wait(n=%d) would exceed context deadline", numToken)
+		return fmt.Errorf("%w: %d tokens", errWouldExceedContextDeadline, numToken)
 	}
 
 	t := time.NewTimer(delay)

--- a/common/quotas/priority_rate_limiter_impl.go
+++ b/common/quotas/priority_rate_limiter_impl.go
@@ -26,7 +26,6 @@ package quotas
 
 import (
 	"context"
-	"fmt"
 	"sort"
 	"time"
 )
@@ -123,7 +122,7 @@ func (p *PriorityRateLimiterImpl) Wait(
 	now := time.Now().UTC()
 	reservation := p.Reserve(now, request)
 	if !reservation.OK() {
-		return fmt.Errorf("rate: Wait(n=%d) would exceed context deadline", request.Token)
+		return errWouldExceedContextDeadline
 	}
 
 	delay := reservation.DelayFrom(now)
@@ -136,7 +135,7 @@ func (p *PriorityRateLimiterImpl) Wait(
 	}
 	if waitLimit < delay {
 		reservation.CancelAt(now)
-		return fmt.Errorf("rate: Wait(n=%d) would exceed context deadline", request.Token)
+		return errWouldExceedContextDeadline
 	}
 
 	t := time.NewTimer(delay)

--- a/common/quotas/priority_rate_limiter_impl_test.go
+++ b/common/quotas/priority_rate_limiter_impl_test.go
@@ -95,15 +95,13 @@ func (s *priorityStageRateLimiterSuite) TearDownTest() {
 
 func (s *priorityStageRateLimiterSuite) TestAllow_HighPriority_Allow() {
 	now := time.Now()
-	token := 1
 	req := Request{
 		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
-	s.highPriorityRateLimiter.EXPECT().AllowN(now, token).Return(true)
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(now, token).Return(s.lowPriorityReservation)
+	s.highPriorityRateLimiter.EXPECT().AllowN(now, 1).Return(true)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(now, 1).Return(s.lowPriorityReservation)
 
 	allow := s.rateLimiter.Allow(now, req)
 	s.True(allow)
@@ -111,14 +109,12 @@ func (s *priorityStageRateLimiterSuite) TestAllow_HighPriority_Allow() {
 
 func (s *priorityStageRateLimiterSuite) TestAllow_HighPriority_Disallow() {
 	now := time.Now()
-	token := 1
 	req := Request{
 		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
-	s.highPriorityRateLimiter.EXPECT().AllowN(now, token).Return(false)
+	s.highPriorityRateLimiter.EXPECT().AllowN(now, 1).Return(false)
 
 	allow := s.rateLimiter.Allow(now, req)
 	s.False(allow)
@@ -126,14 +122,12 @@ func (s *priorityStageRateLimiterSuite) TestAllow_HighPriority_Disallow() {
 
 func (s *priorityStageRateLimiterSuite) TestAllow_LowPriority_Allow() {
 	now := time.Now()
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
-	s.lowPriorityRateLimiter.EXPECT().AllowN(now, token).Return(true)
+	s.lowPriorityRateLimiter.EXPECT().AllowN(now, 1).Return(true)
 
 	allow := s.rateLimiter.Allow(now, req)
 	s.True(allow)
@@ -141,14 +135,12 @@ func (s *priorityStageRateLimiterSuite) TestAllow_LowPriority_Allow() {
 
 func (s *priorityStageRateLimiterSuite) TestAllow_LowPriority_Disallow() {
 	now := time.Now()
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
-	s.lowPriorityRateLimiter.EXPECT().AllowN(now, token).Return(false)
+	s.lowPriorityRateLimiter.EXPECT().AllowN(now, 1).Return(false)
 
 	allow := s.rateLimiter.Allow(now, req)
 	s.False(allow)
@@ -156,16 +148,14 @@ func (s *priorityStageRateLimiterSuite) TestAllow_LowPriority_Disallow() {
 
 func (s *priorityStageRateLimiterSuite) TestReserve_HighPriority_OK() {
 	now := time.Now()
-	token := 1
 	req := Request{
 		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
 	s.highPriorityReservation.EXPECT().OK().Return(true)
-	s.highPriorityRateLimiter.EXPECT().ReserveN(now, token).Return(s.highPriorityReservation)
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(now, token).Return(s.lowPriorityReservation)
+	s.highPriorityRateLimiter.EXPECT().ReserveN(now, 1).Return(s.highPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(now, 1).Return(s.lowPriorityReservation)
 
 	reservation := s.rateLimiter.Reserve(now, req)
 	s.Equal(NewPriorityReservation(
@@ -176,15 +166,13 @@ func (s *priorityStageRateLimiterSuite) TestReserve_HighPriority_OK() {
 
 func (s *priorityStageRateLimiterSuite) TestReserve_HighPriority_NotOK() {
 	now := time.Now()
-	token := 1
 	req := Request{
 		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
 	s.highPriorityReservation.EXPECT().OK().Return(false)
-	s.highPriorityRateLimiter.EXPECT().ReserveN(now, token).Return(s.highPriorityReservation)
+	s.highPriorityRateLimiter.EXPECT().ReserveN(now, 1).Return(s.highPriorityReservation)
 
 	reservation := s.rateLimiter.Reserve(now, req)
 	s.Equal(s.highPriorityReservation, reservation)
@@ -192,15 +180,13 @@ func (s *priorityStageRateLimiterSuite) TestReserve_HighPriority_NotOK() {
 
 func (s *priorityStageRateLimiterSuite) TestReserve_LowPriority_OK() {
 	now := time.Now()
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
 	s.lowPriorityReservation.EXPECT().OK().Return(true)
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(now, token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(now, 1).Return(s.lowPriorityReservation)
 
 	reservation := s.rateLimiter.Reserve(now, req)
 	s.Equal(NewPriorityReservation(
@@ -211,15 +197,13 @@ func (s *priorityStageRateLimiterSuite) TestReserve_LowPriority_OK() {
 
 func (s *priorityStageRateLimiterSuite) TestReserve_LowPriority_NotOK() {
 	now := time.Now()
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
 	s.lowPriorityReservation.EXPECT().OK().Return(false)
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(now, token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(now, 1).Return(s.lowPriorityReservation)
 
 	reservation := s.rateLimiter.Reserve(now, req)
 	s.Equal(s.lowPriorityReservation, reservation)
@@ -228,10 +212,8 @@ func (s *priorityStageRateLimiterSuite) TestReserve_LowPriority_NotOK() {
 func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_AlreadyExpired() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	token := 1
 	req := Request{
 		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -242,10 +224,8 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_AlreadyExpired() {
 func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_AlreadyExpired() {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -256,10 +236,7 @@ func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_AlreadyExpired() {
 func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExpiration_Error() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	token := 1
 	req := Request{
-		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -269,9 +246,9 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExp
 	s.lowPriorityReservation.EXPECT().CancelAt(gomock.Any())
 
 	s.highPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.highPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.highPriorityReservation)
+	s.highPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.highPriorityReservation)
 	s.lowPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.lowPriorityReservation)
 
 	err := s.rateLimiter.Wait(ctx, req)
 	s.Error(err)
@@ -280,10 +257,8 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExp
 func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpiration_Error() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -292,7 +267,7 @@ func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpi
 	s.lowPriorityReservation.EXPECT().CancelAt(gomock.Any())
 
 	s.lowPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.lowPriorityReservation)
 
 	err := s.rateLimiter.Wait(ctx, req)
 	s.Error(err)
@@ -300,10 +275,8 @@ func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpi
 
 func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExpiration_Cancelled() {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
-	token := 1
 	req := Request{
 		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -318,9 +291,9 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExp
 	s.lowPriorityReservation.EXPECT().CancelAt(gomock.Any())
 
 	s.highPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.highPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.highPriorityReservation)
+	s.highPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.highPriorityReservation)
 	s.lowPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.lowPriorityReservation)
 
 	err := s.rateLimiter.Wait(ctx, req)
 	s.Error(err)
@@ -328,10 +301,8 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExp
 
 func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpiration_Cancelled() {
 	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Second)
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -345,7 +316,7 @@ func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpi
 	s.lowPriorityReservation.EXPECT().CancelAt(gomock.Any())
 
 	s.lowPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.lowPriorityReservation)
 
 	err := s.rateLimiter.Wait(ctx, req)
 	s.Error(err)
@@ -354,10 +325,8 @@ func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpi
 func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExpiration_NoError() {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
-	token := 1
 	req := Request{
 		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -365,9 +334,9 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExp
 	s.highPriorityReservation.EXPECT().DelayFrom(gomock.Any()).Return(highPriorityReservationDelay)
 
 	s.highPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.highPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.highPriorityReservation)
+	s.highPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.highPriorityReservation)
 	s.lowPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.lowPriorityReservation)
 
 	err := s.rateLimiter.Wait(ctx, req)
 	s.NoError(err)
@@ -376,10 +345,8 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithExp
 func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpiration_NoError() {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -387,7 +354,7 @@ func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpi
 	s.lowPriorityReservation.EXPECT().DelayFrom(gomock.Any()).Return(lowPriorityReservationDelay)
 
 	s.lowPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.lowPriorityReservation)
 
 	err := s.rateLimiter.Wait(ctx, req)
 	s.NoError(err)
@@ -395,10 +362,8 @@ func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithExpi
 
 func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_WithoutExpiration() {
 	ctx := context.Background()
-	token := 1
 	req := Request{
 		API:    s.highPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -406,9 +371,9 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_Without
 	s.highPriorityReservation.EXPECT().DelayFrom(gomock.Any()).Return(highPriorityReservationDelay)
 
 	s.highPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.highPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.highPriorityReservation)
+	s.highPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.highPriorityReservation)
 	s.lowPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.lowPriorityReservation)
 
 	err := s.rateLimiter.Wait(ctx, req)
 	s.NoError(err)
@@ -416,10 +381,8 @@ func (s *priorityStageRateLimiterSuite) TestWait_HighPriority_NotExpired_Without
 
 func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithoutExpiration() {
 	ctx := context.Background()
-	token := 1
 	req := Request{
 		API:    s.lowPriorityAPIName,
-		Token:  token,
 		Caller: "",
 	}
 
@@ -427,7 +390,7 @@ func (s *priorityStageRateLimiterSuite) TestWait_LowPriority_NotExpired_WithoutE
 	s.lowPriorityReservation.EXPECT().DelayFrom(gomock.Any()).Return(lowPriorityReservationDelay)
 
 	s.lowPriorityReservation.EXPECT().OK().Return(true).AnyTimes()
-	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), token).Return(s.lowPriorityReservation)
+	s.lowPriorityRateLimiter.EXPECT().ReserveN(gomock.Any(), 1).Return(s.lowPriorityReservation)
 
 	err := s.rateLimiter.Wait(ctx, req)
 	s.NoError(err)

--- a/common/quotas/request.go
+++ b/common/quotas/request.go
@@ -27,7 +27,6 @@ package quotas
 type (
 	Request struct {
 		API           string
-		Token         int
 		Caller        string
 		CallerType    string
 		CallerSegment int32
@@ -37,7 +36,6 @@ type (
 
 func NewRequest(
 	api string,
-	token int,
 	caller string,
 	callerType string,
 	callerSegment int32,
@@ -45,7 +43,6 @@ func NewRequest(
 ) Request {
 	return Request{
 		API:           api,
-		Token:         token,
 		Caller:        caller,
 		CallerType:    callerType,
 		CallerSegment: callerSegment,

--- a/common/quotas/request_rate_limiter_adapter_impl.go
+++ b/common/quotas/request_rate_limiter_adapter_impl.go
@@ -49,19 +49,19 @@ func (r *RequestRateLimiterAdapterImpl) Allow(
 	now time.Time,
 	request Request,
 ) bool {
-	return r.rateLimiter.AllowN(now, request.Token)
+	return r.rateLimiter.AllowN(now, 1)
 }
 
 func (r *RequestRateLimiterAdapterImpl) Reserve(
 	now time.Time,
 	request Request,
 ) Reservation {
-	return r.rateLimiter.ReserveN(now, request.Token)
+	return r.rateLimiter.ReserveN(now, 1)
 }
 
 func (r *RequestRateLimiterAdapterImpl) Wait(
 	ctx context.Context,
 	request Request,
 ) error {
-	return r.rateLimiter.WaitN(ctx, request.Token)
+	return r.rateLimiter.WaitN(ctx, 1)
 }

--- a/common/tasks/benchmark_test.go
+++ b/common/tasks/benchmark_test.go
@@ -65,7 +65,7 @@ func BenchmarkInterleavedWeightedRoundRobinScheduler_Sequential(b *testing.B) {
 		InterleavedWeightedRoundRobinSchedulerOptions[*noopTask, int]{
 			TaskChannelKeyFn:            func(nt *noopTask) int { return rand.Intn(4) },
 			ChannelWeightFn:             func(key int) int { return channelKeyToWeight[key] },
-			ChannelQuotaRequestFn:       func(key int) quotas.Request { return quotas.NewRequest("", 1, "", "", 0, "") },
+			ChannelQuotaRequestFn:       func(key int) quotas.Request { return quotas.NewRequest("", "", "", 0, "") },
 			TaskChannelMetricTagsFn:     func(key int) []metrics.Tag { return nil },
 			EnableRateLimiter:           dynamicconfig.GetBoolPropertyFn(true),
 			EnableRateLimiterShadowMode: dynamicconfig.GetBoolPropertyFn(false),
@@ -98,7 +98,7 @@ func BenchmarkInterleavedWeightedRoundRobinScheduler_Parallel(b *testing.B) {
 		InterleavedWeightedRoundRobinSchedulerOptions[*noopTask, int]{
 			TaskChannelKeyFn:            func(nt *noopTask) int { return rand.Intn(4) },
 			ChannelWeightFn:             func(key int) int { return channelKeyToWeight[key] },
-			ChannelQuotaRequestFn:       func(key int) quotas.Request { return quotas.NewRequest("", 1, "", "", 0, "") },
+			ChannelQuotaRequestFn:       func(key int) quotas.Request { return quotas.NewRequest("", "", "", 0, "") },
 			TaskChannelMetricTagsFn:     func(key int) []metrics.Tag { return nil },
 			EnableRateLimiter:           dynamicconfig.GetBoolPropertyFn(true),
 			EnableRateLimiterShadowMode: dynamicconfig.GetBoolPropertyFn(false),

--- a/common/tasks/interleaved_weighted_round_robin_test.go
+++ b/common/tasks/interleaved_weighted_round_robin_test.go
@@ -94,7 +94,7 @@ func (s *interleavedWeightedRoundRobinSchedulerSuite) SetupTest() {
 			TaskChannelKeyFn:            func(task *testTask) int { return task.channelKey },
 			ChannelWeightFn:             func(key int) int { return s.channelKeyToWeight[key] },
 			ChannelWeightUpdateCh:       s.channelWeightUpdateCh,
-			ChannelQuotaRequestFn:       func(key int) quotas.Request { return quotas.NewRequest("", 1, "", "", 0, "") },
+			ChannelQuotaRequestFn:       func(key int) quotas.Request { return quotas.NewRequest("", "", "", 0, "") },
 			TaskChannelMetricTagsFn:     func(key int) []metrics.Tag { return nil },
 			EnableRateLimiter:           dynamicconfig.GetBoolPropertyFn(true),
 			EnableRateLimiterShadowMode: dynamicconfig.GetBoolPropertyFn(false),

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -301,7 +301,6 @@ func RateLimitInterceptorProvider(
 			quotas.NewDefaultIncomingRateLimiter(namespaceReplicationInducingRateFn),
 			quotas.NewDefaultIncomingRateLimiter(rateFn),
 		),
-		map[string]int{},
 	)
 }
 
@@ -362,7 +361,7 @@ func NamespaceRateLimitInterceptorProvider(
 			)
 		},
 	)
-	return interceptor.NewNamespaceRateLimitInterceptor(namespaceRegistry, namespaceRateLimiter, map[string]int{})
+	return interceptor.NewNamespaceRateLimitInterceptor(namespaceRegistry, namespaceRateLimiter)
 }
 
 func NamespaceCountLimitInterceptorProvider(

--- a/service/history/fx.go
+++ b/service/history/fx.go
@@ -197,10 +197,7 @@ func TelemetryInterceptorProvider(
 func RateLimitInterceptorProvider(
 	serviceConfig *configs.Config,
 ) *interceptor.RateLimitInterceptor {
-	return interceptor.NewRateLimitInterceptor(
-		configs.NewPriorityRateLimiter(func() float64 { return float64(serviceConfig.RPS()) }),
-		map[string]int{},
-	)
+	return interceptor.NewRateLimitInterceptor(configs.NewPriorityRateLimiter(func() float64 { return float64(serviceConfig.RPS()) }))
 }
 
 func ESProcessorConfigProvider(

--- a/service/history/queues/reader_quotas.go
+++ b/service/history/queues/reader_quotas.go
@@ -31,10 +31,6 @@ import (
 	"go.temporal.io/server/common/quotas"
 )
 
-const (
-	readerRequestToken = 1
-)
-
 func NewReaderPriorityRateLimiter(
 	rateFn quotas.RateFn,
 	maxReaders int64,
@@ -81,12 +77,5 @@ func newReaderRequest(
 	// api, caller type, caller segment, and call initiation (origin)
 	// are the same for all the readers, and not related to
 	// priority so leaving those fields empty.
-	return quotas.NewRequest(
-		"",
-		readerRequestToken,
-		strconv.FormatInt(readerID, 10),
-		"",
-		0,
-		"",
-	)
+	return quotas.NewRequest("", strconv.FormatInt(readerID, 10), "", 0, "")
 }

--- a/service/history/queues/scheduler.go
+++ b/service/history/queues/scheduler.go
@@ -43,8 +43,6 @@ const (
 	// weighted round robin scheduler and the actual
 	// worker pool (fifo processor).
 	prioritySchedulerProcessorQueueSize = 10
-
-	taskSchedulerToken = 1
 )
 
 type (
@@ -142,7 +140,7 @@ func NewNamespacePriorityScheduler(
 		if err != nil {
 			namespaceName = namespace.EmptyName
 		}
-		return quotas.NewRequest("", taskSchedulerToken, namespaceName.String(), tasks.PriorityName[key.Priority], 0, "")
+		return quotas.NewRequest("", namespaceName.String(), tasks.PriorityName[key.Priority], 0, "")
 	}
 	taskChannelMetricsTagsFn := func(key TaskChannelKey) []metrics.Tag {
 		namespaceName, _ := namespaceRegistry.GetNamespaceName(namespace.ID(key.NamespaceID))
@@ -210,7 +208,7 @@ func NewPriorityScheduler(
 		return weight[key.Priority]
 	}
 	channelQuotaRequestFn := func(key TaskChannelKey) quotas.Request {
-		return quotas.NewRequest("", taskSchedulerToken, "", tasks.PriorityName[key.Priority], 0, "")
+		return quotas.NewRequest("", "", tasks.PriorityName[key.Priority], 0, "")
 	}
 	taskChannelMetricsTagsFn := func(key TaskChannelKey) []metrics.Tag {
 		return []metrics.Tag{

--- a/service/matching/fx.go
+++ b/service/matching/fx.go
@@ -106,7 +106,6 @@ func RateLimitInterceptorProvider(
 ) *interceptor.RateLimitInterceptor {
 	return interceptor.NewRateLimitInterceptor(
 		configs.NewPriorityRateLimiter(func() float64 { return float64(serviceConfig.RPS()) }),
-		map[string]int{},
 	)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I removed the variable token parameter and token map from a bunch of our rate limiter code.

<!-- Tell your future self why have you made these changes -->
**Why?**
It was always set to 1, so the code wasn't necessary. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
