### PR TITLE
Exclude history APIs from persistence health signals

### DIFF
--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -905,7 +905,6 @@ func (p *executionPersistenceClient) ReadHistoryBranch(
 	startTime := time.Now().UTC()
 	defer func() {
 		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
 		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchScope, caller, latency, retErr)
 	}()
 	return p.persistence.ReadHistoryBranch(ctx, request)
@@ -919,7 +918,6 @@ func (p *executionPersistenceClient) ReadHistoryBranchReverse(
 	startTime := time.Now().UTC()
 	defer func() {
 		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
 		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchReverseScope, caller, latency, retErr)
 	}()
 	return p.persistence.ReadHistoryBranchReverse(ctx, request)
@@ -934,7 +932,6 @@ func (p *executionPersistenceClient) ReadHistoryBranchByBatch(
 	startTime := time.Now().UTC()
 	defer func() {
 		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
 		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchScope, caller, latency, retErr)
 	}()
 	return p.persistence.ReadHistoryBranchByBatch(ctx, request)
@@ -949,7 +946,6 @@ func (p *executionPersistenceClient) ReadRawHistoryBranch(
 	startTime := time.Now().UTC()
 	defer func() {
 		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
 		p.recordRequestMetrics(metrics.PersistenceReadRawHistoryBranchScope, caller, latency, retErr)
 	}()
 	return p.persistence.ReadRawHistoryBranch(ctx, request)
@@ -964,7 +960,6 @@ func (p *executionPersistenceClient) ForkHistoryBranch(
 	startTime := time.Now().UTC()
 	defer func() {
 		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
 		p.recordRequestMetrics(metrics.PersistenceForkHistoryBranchScope, caller, latency, retErr)
 	}()
 	return p.persistence.ForkHistoryBranch(ctx, request)
@@ -979,7 +974,6 @@ func (p *executionPersistenceClient) DeleteHistoryBranch(
 	startTime := time.Now().UTC()
 	defer func() {
 		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
 		p.recordRequestMetrics(metrics.PersistenceDeleteHistoryBranchScope, caller, latency, retErr)
 	}()
 	return p.persistence.DeleteHistoryBranch(ctx, request)

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -185,9 +185,8 @@ func (p *shardPersistenceClient) UpdateShard(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardInfo.GetShardId(), caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceUpdateShardScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardInfo.GetShardId(), caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceUpdateShardScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.UpdateShard(ctx, request)
 }
@@ -199,9 +198,8 @@ func (p *shardPersistenceClient) AssertShardOwnership(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceAssertShardOwnershipScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceAssertShardOwnershipScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.AssertShardOwnership(ctx, request)
 }
@@ -225,9 +223,8 @@ func (p *executionPersistenceClient) CreateWorkflowExecution(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceCreateWorkflowExecutionScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceCreateWorkflowExecutionScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.CreateWorkflowExecution(ctx, request)
 }
@@ -239,9 +236,8 @@ func (p *executionPersistenceClient) GetWorkflowExecution(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetWorkflowExecutionScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetWorkflowExecutionScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetWorkflowExecution(ctx, request)
 }
@@ -253,9 +249,8 @@ func (p *executionPersistenceClient) SetWorkflowExecution(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceSetWorkflowExecutionScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceSetWorkflowExecutionScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.SetWorkflowExecution(ctx, request)
 }
@@ -267,9 +262,8 @@ func (p *executionPersistenceClient) UpdateWorkflowExecution(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceUpdateWorkflowExecutionScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceUpdateWorkflowExecutionScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.UpdateWorkflowExecution(ctx, request)
 }
@@ -281,9 +275,8 @@ func (p *executionPersistenceClient) ConflictResolveWorkflowExecution(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceConflictResolveWorkflowExecutionScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceConflictResolveWorkflowExecutionScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ConflictResolveWorkflowExecution(ctx, request)
 }
@@ -295,9 +288,8 @@ func (p *executionPersistenceClient) DeleteWorkflowExecution(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteWorkflowExecutionScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteWorkflowExecutionScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteWorkflowExecution(ctx, request)
 }
@@ -309,9 +301,8 @@ func (p *executionPersistenceClient) DeleteCurrentWorkflowExecution(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteCurrentWorkflowExecution(ctx, request)
 }
@@ -323,9 +314,8 @@ func (p *executionPersistenceClient) GetCurrentExecution(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetCurrentExecutionScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetCurrentExecutionScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetCurrentExecution(ctx, request)
 }
@@ -337,9 +327,8 @@ func (p *executionPersistenceClient) ListConcreteExecutions(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceListConcreteExecutionsScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceListConcreteExecutionsScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ListConcreteExecutions(ctx, request)
 }
@@ -378,9 +367,8 @@ func (p *executionPersistenceClient) AddHistoryTasks(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceAddTasksScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceAddTasksScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.AddHistoryTasks(ctx, request)
 }
@@ -408,9 +396,8 @@ func (p *executionPersistenceClient) GetHistoryTasks(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(operation, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(operation, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetHistoryTasks(ctx, request)
 }
@@ -438,9 +425,8 @@ func (p *executionPersistenceClient) CompleteHistoryTask(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(operation, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(operation, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.CompleteHistoryTask(ctx, request)
 }
@@ -468,9 +454,8 @@ func (p *executionPersistenceClient) RangeCompleteHistoryTasks(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(operation, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(operation, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.RangeCompleteHistoryTasks(ctx, request)
 }
@@ -482,9 +467,8 @@ func (p *executionPersistenceClient) PutReplicationTaskToDLQ(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistencePutReplicationTaskToDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistencePutReplicationTaskToDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.PutReplicationTaskToDLQ(ctx, request)
 }
@@ -496,9 +480,8 @@ func (p *executionPersistenceClient) GetReplicationTasksFromDLQ(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetReplicationTasksFromDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetReplicationTasksFromDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetReplicationTasksFromDLQ(ctx, request)
 }
@@ -510,9 +493,8 @@ func (p *executionPersistenceClient) DeleteReplicationTaskFromDLQ(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteReplicationTaskFromDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteReplicationTaskFromDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteReplicationTaskFromDLQ(ctx, request)
 }
@@ -524,9 +506,8 @@ func (p *executionPersistenceClient) RangeDeleteReplicationTaskFromDLQ(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceRangeDeleteReplicationTaskFromDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.RangeDeleteReplicationTaskFromDLQ(ctx, request)
 }
@@ -538,9 +519,8 @@ func (p *executionPersistenceClient) IsReplicationDLQEmpty(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(request.ShardID, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetReplicationTasksFromDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(request.ShardID, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetReplicationTasksFromDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.IsReplicationDLQEmpty(ctx, request)
 }
@@ -560,9 +540,8 @@ func (p *taskPersistenceClient) CreateTasks(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceCreateTasksScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceCreateTasksScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.CreateTasks(ctx, request)
 }
@@ -574,9 +553,8 @@ func (p *taskPersistenceClient) GetTasks(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetTasksScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetTasksScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetTasks(ctx, request)
 }
@@ -588,9 +566,8 @@ func (p *taskPersistenceClient) CompleteTask(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceCompleteTaskScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceCompleteTaskScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.CompleteTask(ctx, request)
 }
@@ -602,9 +579,8 @@ func (p *taskPersistenceClient) CompleteTasksLessThan(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceCompleteTasksLessThanScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceCompleteTasksLessThanScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.CompleteTasksLessThan(ctx, request)
 }
@@ -616,9 +592,8 @@ func (p *taskPersistenceClient) CreateTaskQueue(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceCreateTaskQueueScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceCreateTaskQueueScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.CreateTaskQueue(ctx, request)
 }
@@ -630,9 +605,8 @@ func (p *taskPersistenceClient) UpdateTaskQueue(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceUpdateTaskQueueScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceUpdateTaskQueueScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.UpdateTaskQueue(ctx, request)
 }
@@ -644,9 +618,8 @@ func (p *taskPersistenceClient) GetTaskQueue(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetTaskQueueScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetTaskQueueScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetTaskQueue(ctx, request)
 }
@@ -658,9 +631,8 @@ func (p *taskPersistenceClient) ListTaskQueue(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceListTaskQueueScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceListTaskQueueScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ListTaskQueue(ctx, request)
 }
@@ -672,9 +644,8 @@ func (p *taskPersistenceClient) DeleteTaskQueue(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteTaskQueueScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteTaskQueueScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteTaskQueue(ctx, request)
 }
@@ -686,9 +657,8 @@ func (p *taskPersistenceClient) GetTaskQueueUserData(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetTaskQueueUserDataScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetTaskQueueUserDataScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetTaskQueueUserData(ctx, request)
 }
@@ -700,9 +670,8 @@ func (p *taskPersistenceClient) UpdateTaskQueueUserData(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceUpdateTaskQueueUserDataScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceUpdateTaskQueueUserDataScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.UpdateTaskQueueUserData(ctx, request)
 }
@@ -714,9 +683,8 @@ func (p *taskPersistenceClient) ListTaskQueueUserDataEntries(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceListTaskQueueUserDataEntriesScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceListTaskQueueUserDataEntriesScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ListTaskQueueUserDataEntries(ctx, request)
 }
@@ -725,9 +693,8 @@ func (p *taskPersistenceClient) GetTaskQueuesByBuildId(ctx context.Context, requ
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetTaskQueuesByBuildIdScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetTaskQueuesByBuildIdScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetTaskQueuesByBuildId(ctx, request)
 }
@@ -736,9 +703,8 @@ func (p *taskPersistenceClient) CountTaskQueuesByBuildId(ctx context.Context, re
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceCountTaskQueuesByBuildIdScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceCountTaskQueuesByBuildIdScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.CountTaskQueuesByBuildId(ctx, request)
 }
@@ -758,9 +724,8 @@ func (p *metadataPersistenceClient) CreateNamespace(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceCreateNamespaceScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceCreateNamespaceScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.CreateNamespace(ctx, request)
 }
@@ -772,9 +737,8 @@ func (p *metadataPersistenceClient) GetNamespace(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetNamespaceScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetNamespaceScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetNamespace(ctx, request)
 }
@@ -786,9 +750,8 @@ func (p *metadataPersistenceClient) UpdateNamespace(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceUpdateNamespaceScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceUpdateNamespaceScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.UpdateNamespace(ctx, request)
 }
@@ -800,9 +763,8 @@ func (p *metadataPersistenceClient) RenameNamespace(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceRenameNamespaceScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceRenameNamespaceScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.RenameNamespace(ctx, request)
 }
@@ -814,9 +776,8 @@ func (p *metadataPersistenceClient) DeleteNamespace(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteNamespaceScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteNamespaceScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteNamespace(ctx, request)
 }
@@ -828,9 +789,8 @@ func (p *metadataPersistenceClient) DeleteNamespaceByName(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteNamespaceByNameScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteNamespaceByNameScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteNamespaceByName(ctx, request)
 }
@@ -842,9 +802,8 @@ func (p *metadataPersistenceClient) ListNamespaces(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceListNamespacesScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceListNamespacesScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ListNamespaces(ctx, request)
 }
@@ -855,9 +814,8 @@ func (p *metadataPersistenceClient) GetMetadata(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetMetadataScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetMetadataScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetMetadata(ctx)
 }
@@ -874,9 +832,8 @@ func (p *executionPersistenceClient) AppendHistoryNodes(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceAppendHistoryNodesScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceAppendHistoryNodesScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.AppendHistoryNodes(ctx, request)
 }
@@ -889,9 +846,8 @@ func (p *executionPersistenceClient) AppendRawHistoryNodes(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceAppendRawHistoryNodesScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceAppendRawHistoryNodesScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.AppendRawHistoryNodes(ctx, request)
 }
@@ -904,8 +860,7 @@ func (p *executionPersistenceClient) ReadHistoryBranch(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchScope, caller, latency, retErr)
+		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ReadHistoryBranch(ctx, request)
 }
@@ -917,8 +872,7 @@ func (p *executionPersistenceClient) ReadHistoryBranchReverse(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchReverseScope, caller, latency, retErr)
+		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchReverseScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ReadHistoryBranchReverse(ctx, request)
 }
@@ -931,8 +885,7 @@ func (p *executionPersistenceClient) ReadHistoryBranchByBatch(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchScope, caller, latency, retErr)
+		p.recordRequestMetrics(metrics.PersistenceReadHistoryBranchScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ReadHistoryBranchByBatch(ctx, request)
 }
@@ -945,8 +898,7 @@ func (p *executionPersistenceClient) ReadRawHistoryBranch(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.recordRequestMetrics(metrics.PersistenceReadRawHistoryBranchScope, caller, latency, retErr)
+		p.recordRequestMetrics(metrics.PersistenceReadRawHistoryBranchScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ReadRawHistoryBranch(ctx, request)
 }
@@ -959,8 +911,7 @@ func (p *executionPersistenceClient) ForkHistoryBranch(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.recordRequestMetrics(metrics.PersistenceForkHistoryBranchScope, caller, latency, retErr)
+		p.recordRequestMetrics(metrics.PersistenceForkHistoryBranchScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ForkHistoryBranch(ctx, request)
 }
@@ -973,8 +924,7 @@ func (p *executionPersistenceClient) DeleteHistoryBranch(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.recordRequestMetrics(metrics.PersistenceDeleteHistoryBranchScope, caller, latency, retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteHistoryBranchScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteHistoryBranch(ctx, request)
 }
@@ -987,9 +937,8 @@ func (p *executionPersistenceClient) TrimHistoryBranch(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceTrimHistoryBranchScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceTrimHistoryBranchScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.TrimHistoryBranch(ctx, request)
 }
@@ -1001,9 +950,8 @@ func (p *executionPersistenceClient) GetAllHistoryTreeBranches(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetAllHistoryTreeBranchesScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetAllHistoryTreeBranchesScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetAllHistoryTreeBranches(ctx, request)
 }
@@ -1016,9 +964,8 @@ func (p *executionPersistenceClient) GetHistoryTree(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetHistoryTreeScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetHistoryTreeScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetHistoryTree(ctx, request)
 }
@@ -1037,9 +984,8 @@ func (p *queuePersistenceClient) EnqueueMessage(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceEnqueueMessageScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceEnqueueMessageScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.EnqueueMessage(ctx, blob)
 }
@@ -1052,9 +998,8 @@ func (p *queuePersistenceClient) ReadMessages(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceReadQueueMessagesScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceReadQueueMessagesScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ReadMessages(ctx, lastMessageID, maxCount)
 }
@@ -1066,9 +1011,8 @@ func (p *queuePersistenceClient) UpdateAckLevel(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceUpdateAckLevelScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceUpdateAckLevelScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.UpdateAckLevel(ctx, metadata)
 }
@@ -1079,9 +1023,8 @@ func (p *queuePersistenceClient) GetAckLevels(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetAckLevelScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetAckLevelScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetAckLevels(ctx)
 }
@@ -1093,9 +1036,8 @@ func (p *queuePersistenceClient) DeleteMessagesBefore(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteMessagesBeforeScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteMessagesBeforeScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteMessagesBefore(ctx, messageID)
 }
@@ -1107,9 +1049,8 @@ func (p *queuePersistenceClient) EnqueueMessageToDLQ(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceEnqueueMessageToDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceEnqueueMessageToDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.EnqueueMessageToDLQ(ctx, blob)
 }
@@ -1124,9 +1065,8 @@ func (p *queuePersistenceClient) ReadMessagesFromDLQ(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceReadMessagesFromDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceReadMessagesFromDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ReadMessagesFromDLQ(ctx, firstMessageID, lastMessageID, pageSize, pageToken)
 }
@@ -1138,9 +1078,8 @@ func (p *queuePersistenceClient) DeleteMessageFromDLQ(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteMessageFromDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteMessageFromDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteMessageFromDLQ(ctx, messageID)
 }
@@ -1153,9 +1092,8 @@ func (p *queuePersistenceClient) RangeDeleteMessagesFromDLQ(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceRangeDeleteMessagesFromDLQScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceRangeDeleteMessagesFromDLQScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.RangeDeleteMessagesFromDLQ(ctx, firstMessageID, lastMessageID)
 }
@@ -1167,9 +1105,8 @@ func (p *queuePersistenceClient) UpdateDLQAckLevel(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceUpdateDLQAckLevelScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceUpdateDLQAckLevelScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.UpdateDLQAckLevel(ctx, metadata)
 }
@@ -1180,9 +1117,8 @@ func (p *queuePersistenceClient) GetDLQAckLevels(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetDLQAckLevelScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetDLQAckLevelScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetDLQAckLevels(ctx)
 }
@@ -1202,9 +1138,8 @@ func (p *clusterMetadataPersistenceClient) ListClusterMetadata(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceListClusterMetadataScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceListClusterMetadataScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.ListClusterMetadata(ctx, request)
 }
@@ -1215,9 +1150,8 @@ func (p *clusterMetadataPersistenceClient) GetCurrentClusterMetadata(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetCurrentClusterMetadataScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetCurrentClusterMetadataScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetCurrentClusterMetadata(ctx)
 }
@@ -1229,9 +1163,8 @@ func (p *clusterMetadataPersistenceClient) GetClusterMetadata(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetClusterMetadataScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetClusterMetadataScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetClusterMetadata(ctx, request)
 }
@@ -1243,9 +1176,8 @@ func (p *clusterMetadataPersistenceClient) SaveClusterMetadata(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceSaveClusterMetadataScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceSaveClusterMetadataScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.SaveClusterMetadata(ctx, request)
 }
@@ -1257,9 +1189,8 @@ func (p *clusterMetadataPersistenceClient) DeleteClusterMetadata(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceDeleteClusterMetadataScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceDeleteClusterMetadataScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.DeleteClusterMetadata(ctx, request)
 }
@@ -1275,9 +1206,8 @@ func (p *clusterMetadataPersistenceClient) GetClusterMembers(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceGetClusterMembersScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceGetClusterMembersScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.GetClusterMembers(ctx, request)
 }
@@ -1289,9 +1219,8 @@ func (p *clusterMetadataPersistenceClient) UpsertClusterMembership(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceUpsertClusterMembershipScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceUpsertClusterMembershipScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.UpsertClusterMembership(ctx, request)
 }
@@ -1303,9 +1232,8 @@ func (p *clusterMetadataPersistenceClient) PruneClusterMembership(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistencePruneClusterMembershipScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistencePruneClusterMembershipScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.PruneClusterMembership(ctx, request)
 }
@@ -1317,9 +1245,8 @@ func (p *metadataPersistenceClient) InitializeSystemNamespaces(
 	caller := headers.GetCallerInfo(ctx).CallerName
 	startTime := time.Now().UTC()
 	defer func() {
-		latency := time.Since(startTime)
-		p.healthSignals.Record(CallerSegmentMissing, caller, latency, retErr)
-		p.recordRequestMetrics(metrics.PersistenceInitializeSystemNamespaceScope, caller, latency, retErr)
+		p.healthSignals.Record(CallerSegmentMissing, caller, time.Since(startTime), retErr)
+		p.recordRequestMetrics(metrics.PersistenceInitializeSystemNamespaceScope, caller, time.Since(startTime), retErr)
 	}()
 	return p.persistence.InitializeSystemNamespaces(ctx, currentClusterName)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* excluding history APIs that go to s3 from persistence health signals
* including time to record/aggregate health signals in persistence metrics

<!-- Tell your future self why have you made these changes -->
**Why?**
So that issues with s3 do not slow down the whole system

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No