### PR TITLE
Allow configurating history cache non-user context lock timeout

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -483,6 +483,9 @@ const (
 	HistoryCacheMaxSize = "history.cacheMaxSize"
 	// HistoryCacheTTL is TTL of history cache
 	HistoryCacheTTL = "history.cacheTTL"
+	// HistoryCacheNonUserContextLockTimeout controls how long non-user call (callerType != API or Operator)
+	// will wait on workflow lock acquisition. Requires service restart to take effect.
+	HistoryCacheNonUserContextLockTimeout = "history.cacheNonUserContextLockTimeout"
 	// HistoryStartupMembershipJoinDelay is the duration a history instance waits
 	// before joining membership after starting.
 	HistoryStartupMembershipJoinDelay = "history.startupMembershipJoinDelay"

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -67,9 +67,10 @@ type Config struct {
 
 	// HistoryCache settings
 	// Change of these configs require shard restart
-	HistoryCacheInitialSize dynamicconfig.IntPropertyFn
-	HistoryCacheMaxSize     dynamicconfig.IntPropertyFn
-	HistoryCacheTTL         dynamicconfig.DurationPropertyFn
+	HistoryCacheInitialSize               dynamicconfig.IntPropertyFn
+	HistoryCacheMaxSize                   dynamicconfig.IntPropertyFn
+	HistoryCacheTTL                       dynamicconfig.DurationPropertyFn
+	HistoryCacheNonUserContextLockTimeout dynamicconfig.DurationPropertyFn
 
 	// EventsCache settings
 	// Change of these configs require shard restart
@@ -348,13 +349,16 @@ func NewConfig(
 		VisibilityDisableOrderByClause:    dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.VisibilityDisableOrderByClause, true),
 		VisibilityEnableManualPagination:  dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.VisibilityEnableManualPagination, true),
 
-		EmitShardLagLog:                      dc.GetBoolProperty(dynamicconfig.EmitShardLagLog, false),
-		HistoryCacheInitialSize:              dc.GetIntProperty(dynamicconfig.HistoryCacheInitialSize, 128),
-		HistoryCacheMaxSize:                  dc.GetIntProperty(dynamicconfig.HistoryCacheMaxSize, 512),
-		HistoryCacheTTL:                      dc.GetDurationProperty(dynamicconfig.HistoryCacheTTL, time.Hour),
-		EventsCacheInitialSize:               dc.GetIntProperty(dynamicconfig.EventsCacheInitialSize, 128*1024), // 128KB
-		EventsCacheMaxSize:                   dc.GetIntProperty(dynamicconfig.EventsCacheMaxSize, 512*1024),     // 512KB
-		EventsCacheTTL:                       dc.GetDurationProperty(dynamicconfig.EventsCacheTTL, time.Hour),
+		EmitShardLagLog:                       dc.GetBoolProperty(dynamicconfig.EmitShardLagLog, false),
+		HistoryCacheInitialSize:               dc.GetIntProperty(dynamicconfig.HistoryCacheInitialSize, 128),
+		HistoryCacheMaxSize:                   dc.GetIntProperty(dynamicconfig.HistoryCacheMaxSize, 512),
+		HistoryCacheTTL:                       dc.GetDurationProperty(dynamicconfig.HistoryCacheTTL, time.Hour),
+		HistoryCacheNonUserContextLockTimeout: dc.GetDurationProperty(dynamicconfig.HistoryCacheNonUserContextLockTimeout, 500*time.Millisecond),
+
+		EventsCacheInitialSize: dc.GetIntProperty(dynamicconfig.EventsCacheInitialSize, 128*1024), // 128KB
+		EventsCacheMaxSize:     dc.GetIntProperty(dynamicconfig.EventsCacheMaxSize, 512*1024),     // 512KB
+		EventsCacheTTL:         dc.GetDurationProperty(dynamicconfig.EventsCacheTTL, time.Hour),
+
 		RangeSizeBits:                        20, // 20 bits for sequencer, 2^20 sequence number for any range
 		AcquireShardInterval:                 dc.GetDurationProperty(dynamicconfig.AcquireShardInterval, time.Minute),
 		AcquireShardConcurrency:              dc.GetIntProperty(dynamicconfig.AcquireShardConcurrency, 10),

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -44,7 +44,6 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
-	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/workflow"
@@ -78,7 +77,8 @@ type (
 		shard          shard.Context
 		logger         log.Logger
 		metricsHandler metrics.Handler
-		config         *configs.Config
+
+		nonUserContextLockTimeout time.Duration
 	}
 
 	NewCacheFn func(shard shard.Context) Cache
@@ -87,10 +87,12 @@ type (
 var NoopReleaseFn ReleaseCacheFunc = func(err error) {}
 
 const (
-	cacheNotReleased            int32 = 0
-	cacheReleased               int32 = 1
-	workflowLockTimeoutTailTime       = 500 * time.Millisecond
-	nonApiContextLockTimeout          = 500 * time.Millisecond
+	cacheNotReleased int32 = 0
+	cacheReleased    int32 = 1
+)
+
+const (
+	workflowLockTimeoutTailTime = 500 * time.Millisecond
 )
 
 func NewCache(shard shard.Context) Cache {
@@ -101,11 +103,11 @@ func NewCache(shard shard.Context) Cache {
 	opts.Pin = true
 
 	return &CacheImpl{
-		Cache:          cache.New(config.HistoryCacheMaxSize(), opts),
-		shard:          shard,
-		logger:         log.With(shard.GetLogger(), tag.ComponentHistoryCache),
-		metricsHandler: shard.GetMetricsHandler().WithTags(metrics.CacheTypeTag(metrics.MutableStateCacheTypeTagValue)),
-		config:         config,
+		Cache:                     cache.New(config.HistoryCacheMaxSize(), opts),
+		shard:                     shard,
+		logger:                    log.With(shard.GetLogger(), tag.ComponentHistoryCache),
+		metricsHandler:            shard.GetMetricsHandler().WithTags(metrics.CacheTypeTag(metrics.MutableStateCacheTypeTagValue)),
+		nonUserContextLockTimeout: config.HistoryCacheNonUserContextLockTimeout(),
 	}
 }
 
@@ -220,7 +222,7 @@ func (c *CacheImpl) lockWorkflowExecution(ctx context.Context,
 	if deadline, ok := ctx.Deadline(); ok {
 		var cancel context.CancelFunc
 		if headers.GetCallerInfo(ctx).CallerType != headers.CallerTypeAPI {
-			newDeadline := time.Now().Add(nonApiContextLockTimeout)
+			newDeadline := time.Now().Add(c.nonUserContextLockTimeout)
 			if newDeadline.Before(deadline) {
 				ctx, cancel = context.WithDeadline(ctx, newDeadline)
 				defer cancel()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Allow configurating history cache non-user context lock timeout

<!-- Tell your future self why have you made these changes -->
**Why?**
- Background task used to wait 1s on workflow lock. In 1.21 release we changed this to 500ms and effectively increased the penalty on workflows that schedules multiple activities or childworkflows at once.
- 500ms should be enough but just in case this change causes any negative effect in production, make it configurable so that we don't need to rollback. 
- Since most likely we don't need to change this value, to prevent accessing dynamic config too much in hot code path, changes to this config requires a service restart (actually shard load) to take effect.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- yes