### PR TITLE
Fix flaky versioning integration test

### DIFF
--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -399,6 +399,7 @@ func (s *versioningIntegSuite) dispatchNewWorkflowStartWorkerFirst() {
 }
 
 func (s *versioningIntegSuite) TestDisableUserData_DefaultTasksBecomeUnversioned() {
+	// force one partition so that we can unload the task queue
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
 	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
@@ -1481,13 +1482,11 @@ func (s *versioningIntegSuite) TestDisableUserData() {
 	// First insert some data (we'll try to read it below)
 	s.addNewDefaultBuildId(ctx, tq, v1)
 
-	// unload so that we reload and pick up LoadUserData dynamic config
-	s.unloadTaskQueue(ctx, tq)
-
 	dc := s.testCluster.host.dcClient
 	defer dc.RemoveOverride(dynamicconfig.MatchingLoadUserData)
 	dc.OverrideValue(dynamicconfig.MatchingLoadUserData, false)
 
+	// unload so that we reload and pick up LoadUserData dynamic config
 	s.unloadTaskQueue(ctx, tq)
 
 	// Verify update fails


### PR DESCRIPTION
**What changed?**
- Fix flaky `TestDisableUserData_QueryTimesOut` (it should actually fail with `FailedPrecondition`)
- Other small test cleanups

**Why?**
Fixes #4640

**How did you test it?**
is tests

Also tried a variation where the test workflow sleeps instead of completing. In that case the query ran on the sticky queue so it needed more sleep or to reset sticky to pass. I don't think we need to keep both variation though.
