### PR TITLE
Custom search attributes validation per store

### DIFF
--- a/common/persistence/visibility/manager/visibility_manager.go
+++ b/common/persistence/visibility/manager/visibility_manager.go
@@ -47,6 +47,7 @@ type (
 		GetStoreNames() []string
 		HasStoreName(stName string) bool
 		GetIndexName() string
+		ValidateCustomSearchAttributes(searchAttributes map[string]any) (map[string]any, error)
 
 		// Write APIs.
 		RecordWorkflowExecutionStarted(ctx context.Context, request *RecordWorkflowExecutionStartedRequest) error

--- a/common/persistence/visibility/manager/visibility_manager_mock.go
+++ b/common/persistence/visibility/manager/visibility_manager_mock.go
@@ -347,3 +347,18 @@ func (mr *MockVisibilityManagerMockRecorder) UpsertWorkflowExecution(ctx, reques
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertWorkflowExecution", reflect.TypeOf((*MockVisibilityManager)(nil).UpsertWorkflowExecution), ctx, request)
 }
+
+// ValidateCustomSearchAttributes mocks base method.
+func (m *MockVisibilityManager) ValidateCustomSearchAttributes(searchAttributes map[string]any) (map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateCustomSearchAttributes", searchAttributes)
+	ret0, _ := ret[0].(map[string]any)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateCustomSearchAttributes indicates an expected call of ValidateCustomSearchAttributes.
+func (mr *MockVisibilityManagerMockRecorder) ValidateCustomSearchAttributes(searchAttributes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCustomSearchAttributes", reflect.TypeOf((*MockVisibilityManager)(nil).ValidateCustomSearchAttributes), searchAttributes)
+}

--- a/common/persistence/visibility/store/errors.go
+++ b/common/persistence/visibility/store/errors.go
@@ -25,10 +25,33 @@
 package store
 
 import (
+	"strings"
+
 	"go.temporal.io/api/serviceerror"
+)
+
+type (
+	VisibilityStoreInvalidValuesError struct {
+		errs []error
+	}
 )
 
 var (
 	// OperationNotSupportedErr is returned when visibility operation in not supported.
 	OperationNotSupportedErr = serviceerror.NewInvalidArgument("Operation not supported. Please use on Elasticsearch")
 )
+
+func (e *VisibilityStoreInvalidValuesError) Error() string {
+	var sb strings.Builder
+	sb.WriteString("Visibility store invalid values errors: ")
+	for _, err := range e.errs {
+		sb.WriteString("[")
+		sb.WriteString(err.Error())
+		sb.WriteString("]")
+	}
+	return sb.String()
+}
+
+func NewVisibilityStoreInvalidValuesError(errs []error) error {
+	return &VisibilityStoreInvalidValuesError{errs: errs}
+}

--- a/common/persistence/visibility/store/standard/cassandra/visibility_store.go
+++ b/common/persistence/visibility/store/standard/cassandra/visibility_store.go
@@ -177,6 +177,12 @@ func (v *visibilityStore) GetIndexName() string {
 	return ""
 }
 
+func (v *visibilityStore) ValidateCustomSearchAttributes(
+	searchAttributes map[string]any,
+) (map[string]any, error) {
+	return searchAttributes, nil
+}
+
 // Close releases the resources held by this object
 func (v *visibilityStore) Close() {
 	v.session.Close()

--- a/common/persistence/visibility/store/standard/sql/visibility_store.go
+++ b/common/persistence/visibility/store/standard/sql/visibility_store.go
@@ -86,6 +86,12 @@ func (s *visibilityStore) GetIndexName() string {
 	return ""
 }
 
+func (s *visibilityStore) ValidateCustomSearchAttributes(
+	searchAttributes map[string]any,
+) (map[string]any, error) {
+	return searchAttributes, nil
+}
+
 func (s *visibilityStore) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *store.InternalRecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/store/standard/visibility_store.go
+++ b/common/persistence/visibility/store/standard/visibility_store.go
@@ -79,6 +79,12 @@ func (s *standardStore) GetIndexName() string {
 	return ""
 }
 
+func (s *standardStore) ValidateCustomSearchAttributes(
+	searchAttributes map[string]any,
+) (map[string]any, error) {
+	return searchAttributes, nil
+}
+
 func (s *standardStore) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *store.InternalRecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/store/visibility_store.go
+++ b/common/persistence/visibility/store/visibility_store.go
@@ -45,6 +45,11 @@ type (
 		GetName() string
 		GetIndexName() string
 
+		// Validate search attributes based on the store constraints. It returns a new map containing
+		// only search attributes with valid values. If there are invalid values, an error of type
+		// VisibilityStoreInvalidValuesError wraps all invalid values errors.
+		ValidateCustomSearchAttributes(searchAttributes map[string]any) (map[string]any, error)
+
 		// Write APIs.
 		RecordWorkflowExecutionStarted(ctx context.Context, request *InternalRecordWorkflowExecutionStartedRequest) error
 		RecordWorkflowExecutionClosed(ctx context.Context, request *InternalRecordWorkflowExecutionClosedRequest) error

--- a/common/persistence/visibility/store/visibility_store_mock.go
+++ b/common/persistence/visibility/store/visibility_store_mock.go
@@ -319,3 +319,18 @@ func (mr *MockVisibilityStoreMockRecorder) UpsertWorkflowExecution(ctx, request 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpsertWorkflowExecution", reflect.TypeOf((*MockVisibilityStore)(nil).UpsertWorkflowExecution), ctx, request)
 }
+
+// ValidateCustomSearchAttributes mocks base method.
+func (m *MockVisibilityStore) ValidateCustomSearchAttributes(searchAttributes map[string]any) (map[string]any, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ValidateCustomSearchAttributes", searchAttributes)
+	ret0, _ := ret[0].(map[string]any)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ValidateCustomSearchAttributes indicates an expected call of ValidateCustomSearchAttributes.
+func (mr *MockVisibilityStoreMockRecorder) ValidateCustomSearchAttributes(searchAttributes interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ValidateCustomSearchAttributes", reflect.TypeOf((*MockVisibilityStore)(nil).ValidateCustomSearchAttributes), searchAttributes)
+}

--- a/common/persistence/visibility/visibility_manager_dual.go
+++ b/common/persistence/visibility/visibility_manager_dual.go
@@ -81,6 +81,22 @@ func (v *visibilityManagerDual) GetIndexName() string {
 	return v.visibilityManager.GetIndexName()
 }
 
+func (v *visibilityManagerDual) ValidateCustomSearchAttributes(
+	searchAttributes map[string]any,
+) (map[string]any, error) {
+	ms, err := v.managerSelector.writeManagers()
+	if err != nil {
+		return nil, err
+	}
+	for _, m := range ms {
+		searchAttributes, err = m.ValidateCustomSearchAttributes(searchAttributes)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return searchAttributes, nil
+}
+
 func (v *visibilityManagerDual) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *manager.RecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/visibility_manager_impl.go
+++ b/common/persistence/visibility/visibility_manager_impl.go
@@ -89,6 +89,12 @@ func (p *visibilityManagerImpl) GetIndexName() string {
 	return p.store.GetIndexName()
 }
 
+func (p *visibilityManagerImpl) ValidateCustomSearchAttributes(
+	searchAttributes map[string]any,
+) (map[string]any, error) {
+	return p.store.ValidateCustomSearchAttributes(searchAttributes)
+}
+
 func (p *visibilityManagerImpl) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *manager.RecordWorkflowExecutionStartedRequest,

--- a/common/persistence/visibility/visibility_manager_rate_limited.go
+++ b/common/persistence/visibility/visibility_manager_rate_limited.go
@@ -81,6 +81,12 @@ func (m *visibilityManagerRateLimited) GetIndexName() string {
 	return m.delegate.GetIndexName()
 }
 
+func (m *visibilityManagerRateLimited) ValidateCustomSearchAttributes(
+	searchAttributes map[string]any,
+) (map[string]any, error) {
+	return m.delegate.ValidateCustomSearchAttributes(searchAttributes)
+}
+
 // Below are write APIs.
 
 func (m *visibilityManagerRateLimited) RecordWorkflowExecutionStarted(

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -82,6 +82,12 @@ func (m *visibilityManagerMetrics) GetIndexName() string {
 	return m.delegate.GetIndexName()
 }
 
+func (m *visibilityManagerMetrics) ValidateCustomSearchAttributes(
+	searchAttributes map[string]any,
+) (map[string]any, error) {
+	return m.delegate.ValidateCustomSearchAttributes(searchAttributes)
+}
+
 func (m *visibilityManagerMetrics) RecordWorkflowExecutionStarted(
 	ctx context.Context,
 	request *manager.RecordWorkflowExecutionStartedRequest,

--- a/common/searchattribute/validator_test.go
+++ b/common/searchattribute/validator_test.go
@@ -27,19 +27,35 @@ package searchattribute
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/payload"
+	"go.temporal.io/server/common/persistence/visibility/manager"
 )
 
 type searchAttributesValidatorSuite struct {
 	suite.Suite
+
+	mockVisibilityManager *manager.MockVisibilityManager
 }
 
 func TestSearchAttributesValidatorSuite(t *testing.T) {
-	s := &searchAttributesValidatorSuite{}
+	ctrl := gomock.NewController(t)
+	s := &searchAttributesValidatorSuite{
+		mockVisibilityManager: manager.NewMockVisibilityManager(ctrl),
+	}
+	s.mockVisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
+	s.mockVisibilityManager.EXPECT().
+		ValidateCustomSearchAttributes(gomock.Any()).
+		DoAndReturn(
+			func(searchAttributes map[string]any) (map[string]any, error) {
+				return searchAttributes, nil
+			},
+		).
+		AnyTimes()
 	suite.Run(t, s)
 }
 
@@ -54,7 +70,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate() {
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit),
-		"",
+		s.mockVisibilityManager,
 		true,
 	)
 
@@ -131,7 +147,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidate_Mapper() {
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit),
-		"",
+		s.mockVisibilityManager,
 		false,
 	)
 
@@ -194,7 +210,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize() {
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit),
-		"",
+		s.mockVisibilityManager,
 		false,
 	)
 
@@ -233,7 +249,7 @@ func (s *searchAttributesValidatorSuite) TestSearchAttributesValidateSize_Mapper
 		dynamicconfig.GetIntPropertyFilteredByNamespace(numOfKeysLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfValueLimit),
 		dynamicconfig.GetIntPropertyFilteredByNamespace(sizeOfTotalLimit),
-		"",
+		s.mockVisibilityManager,
 		false,
 	)
 

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -191,7 +191,7 @@ func NewWorkflowHandler(
 			config.SearchAttributesNumberOfKeysLimit,
 			config.SearchAttributesSizeOfValueLimit,
 			config.SearchAttributesTotalSizeLimit,
-			visibilityMrg.GetIndexName(),
+			visibilityMrg,
 			visibility.AllowListForValidation(visibilityMrg.GetStoreNames()),
 		),
 		archivalMetadata:  archivalMetadata,

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -233,7 +233,7 @@ func NewEngineWithShardContext(
 		config.SearchAttributesNumberOfKeysLimit,
 		config.SearchAttributesSizeOfValueLimit,
 		config.SearchAttributesTotalSizeLimit,
-		persistenceVisibilityMgr.GetIndexName(),
+		persistenceVisibilityMgr,
 		visibility.AllowListForValidation(persistenceVisibilityMgr.GetStoreNames()),
 	)
 

--- a/service/history/workflow_task_handler_callbacks_test.go
+++ b/service/history/workflow_task_handler_callbacks_test.go
@@ -101,6 +101,17 @@ func (s *WorkflowTaskHandlerCallbackSuite) SetupTest() {
 	mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(false, common.EmptyVersion).Return(cluster.TestCurrentClusterName).AnyTimes()
 	mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, tests.Version).Return(cluster.TestCurrentClusterName).AnyTimes()
 
+	mockVisibilityManager := mockShard.Resource.VisibilityManager
+	mockVisibilityManager.EXPECT().GetIndexName().Return("").AnyTimes()
+	mockVisibilityManager.EXPECT().
+		ValidateCustomSearchAttributes(gomock.Any()).
+		DoAndReturn(
+			func(searchAttributes map[string]any) (map[string]any, error) {
+				return searchAttributes, nil
+			},
+		).
+		AnyTimes()
+
 	s.mockEventsCache = mockShard.MockEventsCache
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any()).AnyTimes()
 	s.logger = mockShard.GetLogger()
@@ -124,7 +135,7 @@ func (s *WorkflowTaskHandlerCallbackSuite) SetupTest() {
 			config.SearchAttributesNumberOfKeysLimit,
 			config.SearchAttributesSizeOfValueLimit,
 			config.SearchAttributesTotalSizeLimit,
-			"",
+			mockShard.Resource.VisibilityManager,
 			false,
 		),
 		workflowConsistencyChecker: api.NewWorkflowConsistencyChecker(mockShard, workflowCache),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add custom search attributes validation to `VisibilityStore` interface, and implements ES constraints.

<!-- Tell your future self why have you made these changes -->
**Why?**
Each store can have different constraint that might reject the value when inserting.
Eg: In ES, dates can only be between 1970 and 2262.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
