### PR TITLE
support delaying shard close for membership change

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -501,6 +501,16 @@ const (
 	AcquireShardInterval = "history.acquireShardInterval"
 	// AcquireShardConcurrency is number of goroutines that can be used to acquire shards in the shard controller.
 	AcquireShardConcurrency = "history.acquireShardConcurrency"
+	// ShardLingerEnabled configures if the shard controller will temporarily
+	// delay closing shards after a membership update, awaiting a shard
+	// ownership lost error from persistence. Not recommended with persistence
+	// layers that are missing AssertShardOwnership support.
+	ShardLingerEnabled = "history.shardLingerEnabled"
+	// ShardLingerOwnershipCheckQPS is the frequency to perform shard ownership
+	// checks while a shard is lingering.
+	ShardLingerOwnershipCheckQPS = "history.shardLingerOwnershipCheckQPS"
+	// ShardLingerTimeLimit is the upper bound on how long a shard can linger.
+	ShardLingerTimeLimit = "history.shardLingerTimeLimit"
 	// StandbyClusterDelay is the artificial delay added to standby cluster's view of active cluster's time
 	StandbyClusterDelay = "history.standbyClusterDelay"
 	// StandbyTaskMissingEventsResendDelay is the amount of time standby cluster's will wait (if events are missing)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1426,6 +1426,8 @@ var (
 	NamespaceRegistryLockLatency                   = NewTimerDef("namespace_registry_lock_latency")
 	ClosedWorkflowBufferEventCount                 = NewCounterDef("closed_workflow_buffer_event_counter")
 	InorderBufferedEventsCounter                   = NewCounterDef("inordered_buffered_events")
+	ShardLingerSuccess                             = NewTimerDef("shard_linger_success")
+	ShardLingerTimeouts                            = NewCounterDef("shard_linger_timeouts")
 
 	// Matching
 	MatchingClientForwardedCounter            = NewCounterDef("forwarded")

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -79,9 +79,12 @@ type Config struct {
 	EventsCacheTTL              dynamicconfig.DurationPropertyFn
 
 	// ShardController settings
-	RangeSizeBits           uint
-	AcquireShardInterval    dynamicconfig.DurationPropertyFn
-	AcquireShardConcurrency dynamicconfig.IntPropertyFn
+	RangeSizeBits                uint
+	AcquireShardInterval         dynamicconfig.DurationPropertyFn
+	AcquireShardConcurrency      dynamicconfig.IntPropertyFn
+	ShardLingerEnabled           dynamicconfig.BoolPropertyFn
+	ShardLingerOwnershipCheckQPS dynamicconfig.IntPropertyFn
+	ShardLingerTimeLimit         dynamicconfig.DurationPropertyFn
 
 	// the artificial delay added to standby cluster's view of active cluster's time
 	StandbyClusterDelay                  dynamicconfig.DurationPropertyFn
@@ -362,6 +365,9 @@ func NewConfig(
 		RangeSizeBits:                        20, // 20 bits for sequencer, 2^20 sequence number for any range
 		AcquireShardInterval:                 dc.GetDurationProperty(dynamicconfig.AcquireShardInterval, time.Minute),
 		AcquireShardConcurrency:              dc.GetIntProperty(dynamicconfig.AcquireShardConcurrency, 10),
+		ShardLingerEnabled:                   dc.GetBoolProperty(dynamicconfig.ShardLingerEnabled, false),
+		ShardLingerOwnershipCheckQPS:         dc.GetIntProperty(dynamicconfig.ShardLingerOwnershipCheckQPS, 4),
+		ShardLingerTimeLimit:                 dc.GetDurationProperty(dynamicconfig.ShardLingerTimeLimit, 3*time.Second),
 		StandbyClusterDelay:                  dc.GetDurationProperty(dynamicconfig.StandbyClusterDelay, 5*time.Minute),
 		StandbyTaskMissingEventsResendDelay:  dc.GetDurationPropertyFilteredByTaskType(dynamicconfig.StandbyTaskMissingEventsResendDelay, 10*time.Minute),
 		StandbyTaskMissingEventsDiscardDelay: dc.GetDurationPropertyFilteredByTaskType(dynamicconfig.StandbyTaskMissingEventsDiscardDelay, 15*time.Minute),

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -34,6 +34,7 @@ import (
 
 	"go.temporal.io/api/serviceerror"
 	"golang.org/x/sync/semaphore"
+	"golang.org/x/time/rate"
 
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/headers"
@@ -203,7 +204,7 @@ func (c *ControllerImpl) ShardIDs() []int32 {
 	return ids
 }
 
-func (c *ControllerImpl) shardClosedCallback(shard ControllableContext) {
+func (c *ControllerImpl) shardRemoveAndStop(shard ControllableContext) {
 	startTime := time.Now().UTC()
 	defer func() {
 		c.taggedMetricsHandler.Timer(metrics.RemoveEngineForShardLatency.GetMetricName()).Record(time.Since(startTime))
@@ -256,7 +257,7 @@ func (c *ControllerImpl) getOrCreateShardContext(shardID int32) (Context, error)
 		return nil, fmt.Errorf("ControllerImpl for host '%v' shutting down", hostInfo.Identity())
 	}
 
-	shard, err := c.contextFactory.CreateContext(shardID, c.shardClosedCallback)
+	shard, err := c.contextFactory.CreateContext(shardID, c.shardRemoveAndStop)
 	if err != nil {
 		return nil, err
 	}
@@ -291,6 +292,52 @@ func (c *ControllerImpl) removeShardLocked(shardID int32, expected ControllableC
 	return current
 }
 
+// shardLingerThenClose delays closing the shard for a small amount of time,
+// while watching for the shard to become invalid due to receiving a shard
+// ownership lost error. It calls AssertOwnership to probe for lost ownership,
+// but any concurrent request may also see the error, which will mark the shard
+// as invalid.
+func (c *ControllerImpl) shardLingerThenClose(ctx context.Context, shardID int32) {
+	c.RLock()
+	shard, ok := c.historyShards[shardID]
+	c.RUnlock()
+	if !ok {
+		return
+	}
+
+	startTime := time.Now()
+	timeout := util.Min(c.config.ShardLingerTimeLimit(), shardIOTimeout)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	qps := c.config.ShardLingerOwnershipCheckQPS()
+	// The limiter must be configured with burst>=1. With burst=1,
+	// the first call to Wait() won't be delayed.
+	limiter := rate.NewLimiter(rate.Limit(qps), 1)
+
+	for {
+		if !shard.IsValid() {
+			c.taggedMetricsHandler.Timer(metrics.ShardLingerSuccess.GetMetricName()).Record(time.Since(startTime))
+			break
+		}
+
+		if err := limiter.Wait(ctx); err != nil {
+			c.contextTaggedLogger.Info("shardLinger: wait timed out",
+				tag.ShardID(shardID),
+				tag.NewDurationTag("duration", time.Now().Sub(startTime)),
+			)
+			c.taggedMetricsHandler.Counter(metrics.ShardLingerTimeouts.GetMetricName()).Record(1)
+			break
+		}
+
+		// If this AssertOwnership or any other request on the shard receives
+		// a shard ownership lost error, the shard will be marked as invalid.
+		_ = shard.AssertOwnership(ctx)
+	}
+
+	c.shardRemoveAndStop(shard)
+}
+
 func (c *ControllerImpl) acquireShards(ctx context.Context) {
 	c.taggedMetricsHandler.Counter(metrics.AcquireShardsCounter.GetMetricName()).Record(1)
 	startTime := time.Now().UTC()
@@ -304,7 +351,11 @@ func (c *ControllerImpl) acquireShards(ctx context.Context) {
 		if err := c.ownership.verifyOwnership(shardID); err != nil {
 			if IsShardOwnershipLostError(err) {
 				// current host is not owner of shard, unload it if it is already loaded.
-				c.CloseShardByID(shardID)
+				if c.config.ShardLingerEnabled() {
+					c.shardLingerThenClose(ctx, shardID)
+				} else {
+					c.CloseShardByID(shardID)
+				}
 			}
 			return
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This adds support to the shard controller to delay closing a shard due to membership changes, until either a shard ownership lost error, or up to a max delay time, intended to be a few seconds. This is the server side dual of https://github.com/temporalio/temporal/pull/4652 .

<!-- Tell your future self why have you made these changes -->
**Why?**
The intent is to allow an existing shard owner to keep processing requests until the new shard owner has acquired the shard. In testing, this has reduced latencies requests experience during shard transitions, like history service upgrades and restarts.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests, and has been tested in a staging environment.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The behavior is off by default.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
