### PR TITLE
defer shard.Unlock()

### DIFF
--- a/common/locks/id_mutex.go
+++ b/common/locks/id_mutex.go
@@ -108,6 +108,7 @@ func (idMutex *idMutexImpl) UnlockID(identifier interface{}) {
 	shard := idMutex.shards[idMutex.getShardIndex(identifier)]
 
 	shard.Lock()
+	defer shard.Unlock()
 	mutexInfo, ok := shard.mutexInfos[identifier]
 	if !ok {
 		panic("cannot find workflow lock")
@@ -118,7 +119,6 @@ func (idMutex *idMutexImpl) UnlockID(identifier interface{}) {
 	} else {
 		mutexInfo.waitCount--
 	}
-	shard.Unlock()
 }
 
 func (idMutex *idMutexImpl) getShardIndex(key interface{}) uint32 {


### PR DESCRIPTION
**What changed?**
Add a missing deferred unlocking of a shard so we don't panic without unlocking it.

**Why?**
Resolving a legitimate find from a static analysis tool.

**How did you test it?**
Ran existing tests with make test.

**Potential risks**
If there was some reason the panic is handled while expecting this shard to not have been unlocked, this would now violate that expectation.

**Is hotfix candidate?**
No

**N.B.**
#4658 also had this fix, but there was an issue with also using the master branch in my fork.