### PR TITLE
Send versioned tasks to dlq when user data disabled

### DIFF
--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -384,7 +384,12 @@ func (db *taskQueueDB) loadUserData(ctx context.Context) error {
 func (db *taskQueueDB) setUserDataState(userDataState userDataState) {
 	db.Lock()
 	defer db.Unlock()
-	db.userDataState = userDataState
+
+	if userDataState != db.userDataState {
+		db.userDataState = userDataState
+		close(db.userDataChanged)
+		db.userDataChanged = make(chan struct{})
+	}
 }
 
 // UpdateUserData allows callers to update user data (such as worker build IDs) for this task queue. The pointer passed

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -47,6 +47,10 @@ const (
 	initialRangeID     = 1 // Id of the first range of a new task queue
 	stickyTaskQueueTTL = 24 * time.Hour
 
+	// "Version set id" for the dlq for versioned tasks. This won't match any real version set
+	// since those are based on hashes of build ids.
+	dlqVersionSet = "dlq"
+
 	// userDataEnabled is the default state: user data is enabled.
 	userDataEnabled userDataState = iota
 	// userDataDisabled means user data is disabled due to the LoadUserData dynamic config
@@ -119,6 +123,12 @@ func newTaskQueueDB(
 		userDataChanged: make(chan struct{}),
 		matchingClient:  matchingClient,
 	}
+}
+
+func (db *taskQueueDB) Close() {
+	db.Lock()
+	defer db.Unlock()
+	close(db.userDataChanged)
 }
 
 // RangeID returns the current persistence view of rangeID
@@ -329,7 +339,9 @@ func (db *taskQueueDB) getUserDataLocked() (*persistencespb.VersionedTaskQueueUs
 	case userDataEnabled:
 		return db.userData, db.userDataChanged, nil
 	case userDataDisabled:
-		return nil, nil, errUserDataDisabled
+		// return userDataChanged even with an error here so that a blocking wait can be
+		// interrupted when user data is enabled again.
+		return nil, db.userDataChanged, errUserDataDisabled
 	case userDataSpecificVersion:
 		return nil, nil, errNoUserDataOnVersionedTQM
 	default:
@@ -369,10 +381,10 @@ func (db *taskQueueDB) loadUserData(ctx context.Context) error {
 	return nil
 }
 
-func (db *taskQueueDB) setUserDataState(setUserDataState userDataState) {
+func (db *taskQueueDB) setUserDataState(userDataState userDataState) {
 	db.Lock()
 	defer db.Unlock()
-	db.userDataState = setUserDataState
+	db.userDataState = userDataState
 }
 
 // UpdateUserData allows callers to update user data (such as worker build IDs) for this task queue. The pointer passed

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -685,11 +685,10 @@ func (e *matchingEngineImpl) QueryWorkflow(
 	// We don't need the userDataChanged channel here because we either do this sync (local or remote)
 	// or fail with a relatively short timeout.
 	taskQueue, _, err := baseTqm.RedirectToVersionedQueueForAdd(ctx, queryRequest.VersionDirective)
-	if err == nil && taskQueue.VersionSet() == dlqVersionSet {
-		err = serviceerror.NewFailedPrecondition("Operations on versioned workflows are disabled")
-	}
 	if err != nil {
 		return nil, err
+	} else if taskQueue.VersionSet() == dlqVersionSet {
+		return nil, serviceerror.NewFailedPrecondition("Operations on versioned workflows are disabled")
 	}
 
 	sticky := stickyInfo.kind == enumspb.TASK_QUEUE_KIND_STICKY

--- a/service/matching/task_queue_manager.go
+++ b/service/matching/task_queue_manager.go
@@ -54,6 +54,7 @@ import (
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
+	serviceerrors "go.temporal.io/server/common/serviceerror"
 	"go.temporal.io/server/common/tqname"
 	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/internal/goro"
@@ -350,6 +351,7 @@ func (c *taskQueueManagerImpl) Stop() {
 	c.taskWriter.Stop()
 	c.taskReader.Stop()
 	c.goroGroup.Cancel()
+	c.db.Close()
 	c.logger.Info("", tag.LifeCycleStopped)
 	c.taggedMetricsHandler.Counter(metrics.TaskQueueStoppedCounter.GetMetricName()).Record(1)
 	// This may call Stop again, but the status check above makes that a no-op.
@@ -415,6 +417,12 @@ func (c *taskQueueManagerImpl) AddTask(
 	if params.forwardedFrom == "" {
 		// request sent by history service
 		c.liveness.markAlive()
+	}
+
+	if c.taskQueueID.VersionSet() == dlqVersionSet {
+		// If this is the versioned task dlq, skip straight to spooling the task since we can't
+		// have any pollers.
+		return false, c.SpoolTask(params)
 	}
 
 	// TODO: make this work for versioned queues too
@@ -799,9 +807,17 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Contex
 	// Have to look up versioning data.
 	userData, userDataChanged, err := c.GetUserData()
 	if err != nil {
-		if errors.Is(err, errUserDataDisabled) && buildId == "" {
+		if errors.Is(err, errUserDataDisabled) {
 			// When user data disabled, send "default" tasks to unversioned queue.
-			return c.taskQueueID, userDataChanged, nil
+			if buildId == "" {
+				return c.taskQueueID, userDataChanged, nil
+			}
+			// Send versioned sticky back to regular queue so they can go in the dlq.
+			if c.kind == enumspb.TASK_QUEUE_KIND_STICKY {
+				return nil, nil, serviceerrors.NewStickyWorkerUnavailable()
+			}
+			// Send versioned tasks to dlq.
+			return newTaskQueueIDWithVersionSet(c.taskQueueID, dlqVersionSet), userDataChanged, nil
 		}
 		return nil, nil, err
 	}

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
 	taskqueuepb "go.temporal.io/api/taskqueue/v1"
@@ -48,6 +49,7 @@ import (
 	"go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
 
+	"go.temporal.io/server/api/adminservice/v1"
 	"go.temporal.io/server/api/matchingservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/dynamicconfig"
@@ -1648,6 +1650,158 @@ func (s *versioningIntegSuite) TestDisableUserData_QueryFails() {
 	s.Equal(int32(0), runs.Load())
 }
 
+func (s *versioningIntegSuite) TestDisableUserData_DLQ() {
+	// force one partition so we can unload easily
+	dc := s.testCluster.host.dcClient
+	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
+	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueWritePartitions)
+
+	tq := s.randomizeStr(s.T().Name())
+	v1 := s.prefixed("v1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	started := make(chan struct{}, 1)
+
+	wf1 := func(ctx workflow.Context) (string, error) {
+		started <- struct{}{}
+		workflow.GetSignalChannel(ctx, "wait").Receive(ctx, nil)
+		return "done!", nil
+	}
+
+	s.addNewDefaultBuildId(ctx, tq, v1)
+	s.waitForPropagation(ctx, tq, v1)
+
+	w1 := worker.New(s.sdkClient, tq, worker.Options{
+		BuildID:                          v1,
+		UseBuildIDForVersioning:          true,
+		MaxConcurrentWorkflowTaskPollers: numPollers,
+	})
+	w1.RegisterWorkflowWithOptions(wf1, workflow.RegisterOptions{Name: "wf"})
+	s.NoError(w1.Start())
+	defer w1.Stop()
+
+	run, err := s.sdkClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		TaskQueue:           tq,
+		WorkflowTaskTimeout: 1 * time.Minute, // don't let this interfere
+	}, "wf")
+	s.NoError(err)
+	s.waitForChan(ctx, started)
+	time.Sleep(100 * time.Millisecond) // wait for worker to respond
+
+	// disable user data and unload so it picks it up
+	dc.OverrideValue(dynamicconfig.MatchingLoadUserData, false)
+	defer dc.RemoveOverride(dynamicconfig.MatchingLoadUserData)
+	s.unloadTaskQueue(ctx, tq)
+	s.unloadTaskQueue(ctx, s.getStickyQueueName(ctx, run.GetID()))
+
+	// unblock the workflow. the sticky task will get kicked back to the regular queue and then
+	// get redirected to the dlq.
+	s.NoError(s.sdkClient.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "wait", nil))
+
+	// workflow is blocked for > 2s
+	waitCtx, waitCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer waitCancel()
+	s.Error(run.Get(waitCtx, nil))
+
+	// enable user data. task can be dispatched from dlq immediately since dlq is still loaded.
+	dc.OverrideValue(dynamicconfig.MatchingLoadUserData, true)
+	s.unloadTaskQueue(ctx, tq)
+
+	// workflow can finish
+	var out string
+	s.NoError(run.Get(ctx, &out))
+	s.Equal("done!", out)
+}
+
+func (s *versioningIntegSuite) TestDisableUserData_DLQ_WithUnload() {
+	// force one partition so we can unload easily
+	dc := s.testCluster.host.dcClient
+	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
+	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
+	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueWritePartitions)
+
+	tq := s.randomizeStr(s.T().Name())
+	v1 := s.prefixed("v1")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	started := make(chan struct{}, 1)
+
+	wf1 := func(ctx workflow.Context) (string, error) {
+		started <- struct{}{}
+		workflow.GetSignalChannel(ctx, "wait").Receive(ctx, nil)
+		return "done!", nil
+	}
+
+	s.addNewDefaultBuildId(ctx, tq, v1)
+	s.waitForPropagation(ctx, tq, v1)
+
+	w1 := worker.New(s.sdkClient, tq, worker.Options{
+		BuildID:                          v1,
+		UseBuildIDForVersioning:          true,
+		MaxConcurrentWorkflowTaskPollers: numPollers,
+	})
+	w1.RegisterWorkflowWithOptions(wf1, workflow.RegisterOptions{Name: "wf"})
+	s.NoError(w1.Start())
+	defer w1.Stop()
+
+	run, err := s.sdkClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		TaskQueue:           tq,
+		WorkflowTaskTimeout: 1 * time.Minute, // don't let this interfere
+	}, "wf")
+	s.NoError(err)
+	s.waitForChan(ctx, started)
+	time.Sleep(100 * time.Millisecond) // wait for worker to respond
+
+	// disable user data and unload so it picks it up
+	dc.OverrideValue(dynamicconfig.MatchingLoadUserData, false)
+	defer dc.RemoveOverride(dynamicconfig.MatchingLoadUserData)
+	s.unloadTaskQueue(ctx, tq)
+	s.unloadTaskQueue(ctx, s.getStickyQueueName(ctx, run.GetID()))
+
+	// unblock the workflow. the sticky task will get kicked back to the regular queue and then
+	// get redirected to the dlq.
+	s.NoError(s.sdkClient.SignalWorkflow(ctx, run.GetID(), run.GetRunID(), "wait", nil))
+
+	// workflow is blocked for > 2s
+	waitCtx, waitCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer waitCancel()
+	s.Error(run.Get(waitCtx, nil))
+
+	// force unload dlq to test what would happen if it idled out
+	dlqName, err := tqname.Parse(tq)
+	s.NoError(err)
+	dlqName = dlqName.WithVersionSet("dlq")
+	s.unloadTaskQueue(ctx, dlqName.FullName())
+
+	// enable user data
+	dc.OverrideValue(dynamicconfig.MatchingLoadUserData, true)
+	s.unloadTaskQueue(ctx, tq)
+
+	// workflow is still stuck because dlq is unloaded
+	waitCtx, waitCancel = context.WithTimeout(ctx, 2*time.Second)
+	defer waitCancel()
+	s.Error(run.Get(waitCtx, nil))
+
+	// force dlq to get loaded
+	_, _ = s.engine.DescribeTaskQueue(ctx, &workflowservice.DescribeTaskQueueRequest{
+		Namespace:     s.namespace,
+		TaskQueue:     &taskqueuepb.TaskQueue{Name: dlqName.FullName(), Kind: enumspb.TASK_QUEUE_KIND_NORMAL},
+		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
+	})
+
+	// now workflow can finish
+	var out string
+	s.NoError(run.Get(ctx, &out))
+	s.Equal("done!", out)
+}
+
 func (s *versioningIntegSuite) TestDescribeTaskQueue() {
 	// force one partition since DescribeTaskQueue only goes to the root
 	dc := s.testCluster.host.dcClient
@@ -1892,6 +2046,15 @@ func (s *versioningIntegSuite) unloadTaskQueue(ctx context.Context, tq string) {
 		TaskQueueType: enumspb.TASK_QUEUE_TYPE_WORKFLOW,
 	})
 	s.Require().NoError(err)
+}
+
+func (s *versioningIntegSuite) getStickyQueueName(ctx context.Context, id string) string {
+	ms, err := s.adminClient.DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
+		Namespace: s.namespace,
+		Execution: &commonpb.WorkflowExecution{WorkflowId: id},
+	})
+	s.NoError(err)
+	return ms.DatabaseMutableState.ExecutionInfo.StickyTaskQueue
 }
 
 func containsBuildId(data *persistencespb.VersioningData, buildId string) bool {


### PR DESCRIPTION
**What changed?**
Instead of dropping versioned tasks when user data (and thus versioning) is disabled, send them to a "dlq" where they can be recovered later.

**Why?**
Simplify recovery from a situation where user data was turned off while versioned workflows were running. Note that the "dlq" will not be automatically loaded, so if the switch was disabled for > 5 minutes and then enabled, it's possible that the dlq taskQueueManager could be unloaded and the tasks would not be dispatched. To handle this, the dlq task queues can be manually loaded with any rpc, e.g. `DescribeTaskQueue`. This is still a semi-manual procedure, but better than refreshing workflow tasks, since it's easier to determine which task queues may be affected compared to workflows.

**How did you test it?**
modified unit tests + new integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
