### PR TITLE
Fix flaky TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError

### DIFF
--- a/service/worker/migration/force_replication_workflow_test.go
+++ b/service/worker/migration/force_replication_workflow_test.go
@@ -344,7 +344,8 @@ func TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError(t *test
 	})
 
 	var errMsg = "mock verify replication tasks error"
-	env.OnActivity(a.GenerateReplicationTasks, mock.Anything, mock.Anything).Return(nil).Times(1)
+	// GenerateReplicationTasks and VerifyReplicationTasks runs in paralle. GenerateReplicationTasks may not start before VerifyReplicationTasks failed.
+	env.OnActivity(a.GenerateReplicationTasks, mock.Anything, mock.Anything).Return(nil).Maybe()
 	env.OnActivity(a.VerifyReplicationTasks, mock.Anything, mock.Anything).Return(
 		temporal.NewNonRetryableApplicationError(errMsg, "", nil),
 	).Times(1)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
```
 go test ./service/worker/migration -run TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError -count 1000 -json | jq -s 'map(select(.Test and .Action == "pass")) | length'
1000
```

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
