### PR TITLE
Add versioned tag to loaded task queue gauge

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -40,6 +40,7 @@ const (
 	visibilityTypeTagName      = "visibility_type"
 	ErrorTypeTagName           = "error_type"
 	httpStatusTagName          = "http_status"
+	versionedTagName           = "versioned"
 	resourceExhaustedTag       = "resource_exhausted_cause"
 	standardVisibilityTagValue = "standard_visibility"
 	advancedVisibilityTagValue = "advanced_visibility"

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -250,6 +250,11 @@ func VisibilityTypeTag(value string) Tag {
 	return &tagImpl{key: visibilityTypeTagName, value: value}
 }
 
+// VersionedTag represents whether a loaded task queue manager represents a specific version set.
+func VersionedTag(versioned bool) Tag {
+	return &tagImpl{key: versionedTagName, value: strconv.FormatBool(versioned)}
+}
+
 func ServiceErrorTypeTag(err error) Tag {
 	return &tagImpl{key: ErrorTypeTagName, value: strings.TrimPrefix(fmt.Sprintf(getType, err), errorPrefix)}
 }

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -95,6 +95,7 @@ type (
 		namespaceID namespace.ID
 		taskType    enumspb.TaskQueueType
 		kind        enumspb.TaskQueueKind
+		versioned   bool
 	}
 
 	pollMetadata struct {
@@ -123,6 +124,7 @@ type (
 		metricsHandler       metrics.Handler
 		taskQueuesLock       sync.RWMutex // locks mutation of taskQueues
 		taskQueues           map[taskQueueID]taskQueueManager
+		taskQueueCountLock   sync.Mutex
 		taskQueueCount       map[taskQueueCounterKey]int // per-namespace task queue counter
 		config               *Config
 		lockableQueryTaskMap lockableQueryTaskMap
@@ -271,25 +273,22 @@ func (e *matchingEngineImpl) getTaskQueueManager(
 
 		// If it gets here, write lock and check again in case a task queue is created between the two locks
 		e.taskQueuesLock.Lock()
-		if tqm, ok = e.taskQueues[*taskQueue]; !ok {
+		tqm, ok = e.taskQueues[*taskQueue]
+		if !ok {
 			var err error
 			tqm, err = newTaskQueueManager(e, taskQueue, stickyInfo, e.config, e.clusterMeta)
 			if err != nil {
 				e.taskQueuesLock.Unlock()
 				return nil, err
 			}
-			tqm.Start()
 			e.taskQueues[*taskQueue] = tqm
-			countKey := taskQueueCounterKey{
-				namespaceID: taskQueue.namespaceID,
-				taskType:    taskQueue.taskType,
-				kind:        stickyInfo.kind,
-			}
-			e.taskQueueCount[countKey]++
-			taskQueueCount := e.taskQueueCount[countKey]
-			e.updateTaskQueueGauge(countKey, taskQueueCount)
 		}
 		e.taskQueuesLock.Unlock()
+
+		if !ok {
+			tqm.Start()
+			e.updateTaskQueueGauge(tqm, 1)
+		}
 	}
 
 	if err := tqm.WaitUntilInitialized(ctx); err != nil {
@@ -1249,16 +1248,26 @@ func (e *matchingEngineImpl) unloadTaskQueue(unloadTQM taskQueueManager) {
 		return
 	}
 	delete(e.taskQueues, *queueID)
-	countKey := taskQueueCounterKey{namespaceID: queueID.namespaceID, taskType: queueID.taskType, kind: foundTQM.TaskQueueKind()}
-	e.taskQueueCount[countKey]--
-	taskQueueCount := e.taskQueueCount[countKey]
 	e.taskQueuesLock.Unlock()
-
-	e.updateTaskQueueGauge(countKey, taskQueueCount)
+	// This may call unloadTaskQueue again but that's okay, the next call will not find it.
 	foundTQM.Stop()
+	e.updateTaskQueueGauge(foundTQM, -1)
 }
 
-func (e *matchingEngineImpl) updateTaskQueueGauge(countKey taskQueueCounterKey, taskQueueCount int) {
+func (e *matchingEngineImpl) updateTaskQueueGauge(tqm taskQueueManager, delta int) {
+	id := tqm.QueueID()
+	countKey := taskQueueCounterKey{
+		namespaceID: id.namespaceID,
+		taskType:    id.taskType,
+		kind:        tqm.TaskQueueKind(),
+		versioned:   id.VersionSet() != "",
+	}
+
+	e.taskQueueCountLock.Lock()
+	e.taskQueueCount[countKey] += delta
+	newCount := e.taskQueueCount[countKey]
+	e.taskQueueCountLock.Unlock()
+
 	nsEntry, err := e.namespaceRegistry.GetNamespaceByID(countKey.namespaceID)
 	ns := namespace.Name("unknown")
 	if err == nil {
@@ -1266,10 +1275,11 @@ func (e *matchingEngineImpl) updateTaskQueueGauge(countKey taskQueueCounterKey, 
 	}
 
 	e.metricsHandler.Gauge(metrics.LoadedTaskQueueGauge.GetMetricName()).Record(
-		float64(taskQueueCount),
+		float64(newCount),
 		metrics.NamespaceTag(ns.String()),
 		metrics.TaskTypeTag(countKey.taskType.String()),
 		metrics.QueueTypeTag(countKey.kind.String()),
+		metrics.VersionedTag(countKey.versioned),
 	)
 }
 


### PR DESCRIPTION
**What changed?**
- Refactor loaded task queue gauge
- Call `tqm.Start()` and manage loaded task queue gauge outside of task queue map lock
- Add `versioned` tag representing whether a loaded tqm is for a specific version set

**Why?**
- Less contention on lock
- Get more data about how much feature is used

**How did you test it?**
Existing tests can validate the refactoring, the metric is just a metric

**Potential risks**
For a versioned tqm, this counts it once as "unversioned" and once per version set as "versioned". That corresponds closely to the current implementation, but is a little unintuitive and could be misinterpreted.

If we change the implementation to do something like count a a versioned tqm once as "versioned" and not count version sets independently at all, then the meaning of the metric would change.
