### PR TITLE
 Restore defaultListWorkflowsPageSize back to 1000 (from 100)

### DIFF
--- a/service/worker/migration/force_replication_workflow.go
+++ b/service/worker/migration/force_replication_workflow.go
@@ -133,7 +133,7 @@ const (
 	taskQueueUserDataReplicationDoneSignalType = "task-queue-user-data-replication-done"
 	taskQueueUserDataReplicationVersionMarker  = "replicate-task-queue-user-data"
 
-	defaultListWorkflowsPageSize                   = 100
+	defaultListWorkflowsPageSize                   = 1000
 	defaultPageCountPerExecution                   = 200
 	maxPageCountPerExecution                       = 1000
 	defaultPageSizeForTaskQueueUserDataReplication = 20


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**
GenerateReplicationTasks and VerifyReplicationTasks runs in parallel. VerifyReplicationTasks runs every 2s. Verification is not instantaneous, which means for every batch, Verification can delay at least 5s. Increase batch size, reduce the ration of the delay in batch processing. 
Before the change, RPS for GenerateReplicationTasks + VerifyReplicationTasks is 30 RPS. With the change RPS is 90. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Cluster test. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
Yes. 