### PR TITLE
Add shard.OwnershipScaledRateBurst

### DIFF
--- a/service/history/shard/ownership_scaled_rate_burst.go
+++ b/service/history/shard/ownership_scaled_rate_burst.go
@@ -1,0 +1,151 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+
+	"go.temporal.io/server/common/quotas"
+)
+
+type (
+	// OwnershipScaledRateBurst is a quotas.RateBurst implementation that scales the RPS and burst quotas linearly with
+	// the fraction of the total shards in the cluster owned by this host. The effective Rate and Burst are both
+	// multiplied by (shardCount / totalShards). Note that there is no scaling until the first shard count update is
+	// received.
+	OwnershipScaledRateBurst struct {
+		// rb is the base rate burst that we will scale.
+		rb quotas.RateBurst
+		// shardCount is the number of shards owned by this host.
+		shardCount atomic.Int64
+		// totalShards is the total number of shards in the cluster.
+		totalShards int
+		// subscription is the subscription to the shard counter.
+		subscription ShardCountSubscription
+		// updateAppliedCallback is a callback channel that is sent to when the shard count updates are applied. This is
+		// useful for testing. In production, it should be nil.
+		updateAppliedCallback chan struct{}
+		// wg is a wait group that is used to wait for the shard count subscription goroutine to exit.
+		wg sync.WaitGroup
+	}
+	// ShardCountSubscription is a subscription to a ShardCounter. It provides a channel that receives the
+	// shard count updates and an Unsubscribe method that unsubscribes from the counter.
+	ShardCountSubscription interface {
+		// ShardCount returns a channel that receives shard count updates.
+		ShardCount() <-chan int
+		// Unsubscribe unsubscribes from the shard counter. This closes the ShardCount channel.
+		Unsubscribe()
+	}
+	// ShardCounter is an observable object that emits the current shard count.
+	ShardCounter interface {
+		// Subscribe returns a ShardCountSubscription for receiving shard count updates.
+		Subscribe() ShardCountSubscription
+	}
+)
+
+var (
+	// shardCountNotSet is a sentinel value for the shardCount which indicates that it hasn't been set yet. It's an
+	// int64 because that's the type of the atomic.
+	shardCountNotSet int64 = -1
+
+	ErrNonPositiveTotalNumShards = errors.New("totalNumShards must be greater than 0")
+)
+
+// Rate returns the rate of the base rate limiter multiplied by the shard ownership share.
+func (rb *OwnershipScaledRateBurst) Rate() float64 {
+	return rb.rb.Rate() * rb.scaleFactor()
+}
+
+// Burst returns the burst quota of the base rate limiter multiplied by the shard ownership share, rounded up to the
+// nearest integer. We round up because we don't want to let this drop to zero unless the base burst is zero.
+func (rb *OwnershipScaledRateBurst) Burst() int {
+	return int(math.Ceil(float64(rb.rb.Burst()) * rb.scaleFactor()))
+}
+
+// scaleFactor returns the fraction of the total shards in the cluster owned by this host. It returns 1.0 if there
+// haven't been any shard count updates yet.
+func (rb *OwnershipScaledRateBurst) scaleFactor() float64 {
+	shardCount := rb.shardCount.Load()
+	if shardCount == shardCountNotSet {
+		// If the shard count is not set, then we haven't received the first shard count update yet. In this case, we
+		// return 1.0 so that the base rate/burst quotas are not scaled.
+		return 1.0
+	}
+
+	return float64(shardCount) / float64(rb.totalShards)
+}
+
+// NewOwnershipScaledRateBurst returns a OwnershipScaledRateBurst that scales the rate/burst quotas of the base
+// RateBurst by the fraction of the total shards in the cluster owned by this host. The updateAppliedCallback field is a
+// channel which is sent to in a blocking fashion when the shard count updates are applied. This is useful for testing.
+// In production, you should pass in nil, which will cause the callback to be ignored. If totalNumShards is
+// non-positive, then an error is returned.
+func NewOwnershipScaledRateBurst(
+	rb quotas.RateBurst,
+	shardCounter ShardCounter,
+	totalNumShards int,
+	updateAppliedCallback chan struct{},
+) (*OwnershipScaledRateBurst, error) {
+	if totalNumShards <= 0 {
+		return nil, fmt.Errorf("%w: %d", ErrNonPositiveTotalNumShards, totalNumShards)
+	}
+	subscription := shardCounter.Subscribe()
+	srb := &OwnershipScaledRateBurst{
+		rb:                    rb,
+		totalShards:           totalNumShards,
+		subscription:          subscription,
+		updateAppliedCallback: updateAppliedCallback,
+	}
+	// Initialize the shard count to the shardCountNotSet sentinel value so that we don't try to apply the scale factor
+	// until we receive the first shard count.
+	srb.shardCount.Store(shardCountNotSet)
+	srb.wg.Add(1)
+
+	go srb.startScaling()
+
+	return srb, nil
+}
+
+func (rb *OwnershipScaledRateBurst) startScaling() {
+	defer rb.wg.Done()
+
+	for shardCount := range rb.subscription.ShardCount() {
+		rb.shardCount.Store(int64(shardCount))
+		if rb.updateAppliedCallback != nil {
+			rb.updateAppliedCallback <- struct{}{}
+		}
+	}
+}
+
+// StopScaling unsubscribes from the shard counter and stops scaling the rate and burst quotas. This method blocks until
+// the shard count subscription goroutine exits (which should be almost immediately).
+func (rb *OwnershipScaledRateBurst) StopScaling() {
+	rb.subscription.Unsubscribe()
+	rb.wg.Wait()
+}

--- a/service/history/shard/ownership_scaled_rate_burst_test.go
+++ b/service/history/shard/ownership_scaled_rate_burst_test.go
@@ -1,0 +1,116 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/service/history/shard"
+)
+
+// shardCounter adapts a channel of shard count updates to the ShardCounter interface.
+type shardCounter struct {
+	ch     chan int
+	closed bool
+}
+
+func (s *shardCounter) Subscribe() shard.ShardCountSubscription {
+	return s
+}
+
+func (s *shardCounter) ShardCount() <-chan int {
+	return s.ch
+}
+
+func (s *shardCounter) Unsubscribe() {
+	close(s.ch)
+	s.closed = true
+}
+
+// constantRateBurst is a quotas.RateBurst implementation that returns the same rate and burst every time.
+type constantRateBurst struct {
+	rate  float64
+	burst int
+}
+
+func (rb constantRateBurst) Rate() float64 {
+	return rb.rate
+}
+
+func (rb constantRateBurst) Burst() int {
+	return rb.burst
+}
+
+func newRateBurst(rate float64, burst int) constantRateBurst {
+	return constantRateBurst{rate: rate, burst: burst}
+}
+
+func TestOwnershipScaledRateBurst_NonPositiveTotalNumShards(t *testing.T) {
+	t.Parallel()
+
+	rb := newRateBurst(1, 1)
+	sco := &shardCounter{
+		ch:     make(chan int),
+		closed: false,
+	}
+	totalNumShards := 0
+	_, err := shard.NewOwnershipScaledRateBurst(rb, sco, totalNumShards, nil)
+	assert.ErrorIs(t, err, shard.ErrNonPositiveTotalNumShards)
+}
+
+func TestOwnershipScaledRateBurst(t *testing.T) {
+	t.Parallel()
+
+	rb := newRateBurst(2, 4)
+	sc := &shardCounter{
+		ch:     make(chan int),
+		closed: false,
+	}
+	totalNumShards := 10
+	updateAppliedCallback := make(chan struct{})
+	srb, err := shard.NewOwnershipScaledRateBurst(rb, sc, totalNumShards, updateAppliedCallback)
+	require.NoError(t, err)
+	assert.Equal(t, 2.0, srb.Rate(), "Rate should be equal to the base rate before any shard "+
+		"count updates")
+	assert.Equal(t, 4, srb.Burst(), "Burst should be equal to the base burst before any shard "+
+		"count updates")
+	sc.ch <- 3
+
+	// Wait for the update to be applied. Even though the send above is blocking, we still need to wait for the
+	// rate/burst scaler's goroutine to use it to adjust the scale factor.
+	<-updateAppliedCallback
+
+	// After the update is applied, the scale factor is calculated as 3/10 = 0.3, so the rate and burst should be
+	// multiplied by 0.3. Since the initial rate and burst are 2 and 4, respectively, the final rate and burst should be
+	// 0.6 and 1.2, respectively. However, since the burst is rounded up to the nearest integer, the final burst should
+	// be 2.
+	assert.Equal(t, 0.6, srb.Rate())
+	assert.Equal(t, 2, srb.Burst())
+	assert.False(t, sc.closed, "The shard counter should not be closed until the srb scaler is stopped")
+	srb.StopScaling()
+	assert.True(t, sc.closed, "The shard counter should be closed after the srb scaler is stopped")
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a `shard.OwnershipScaledRateBurst`, which scales the `Rate` and `Burst` functions of a `quotas.RateBurst` object by the percentage of shards owned by the current history host, and a constant scale factor.

<!-- Tell your future self why have you made these changes -->
**Why?**
We will soon be adding some new rate limiters to the history service which need to scale with the workload of the current host.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added 100% test coverage.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None. These are just additions.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.