### PR TITLE
Provide a shard ownership-based rate limit quota scaler from the history/shard package

### DIFF
--- a/service/history/shard/fx.go
+++ b/service/history/shard/fx.go
@@ -25,16 +25,25 @@
 package shard
 
 import (
+	"go.temporal.io/server/service/history/configs"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common"
 )
 
-var Module = fx.Options(
-	fx.Provide(ControllerProvider),
-	fx.Provide(ContextFactoryProvider),
-	fx.Provide(fx.Annotate(
+var Module = fx.Provide(
+	ControllerProvider,
+	func(impl *ControllerImpl) Controller { return impl },
+	func(impl *ControllerImpl, cfg *configs.Config) (*OwnershipBasedQuotaScaler, error) {
+		return NewOwnershipBasedQuotaScaler(
+			impl,
+			int(cfg.NumberOfShards),
+			nil,
+		)
+	},
+	ContextFactoryProvider,
+	fx.Annotate(
 		func(p Controller) common.Pingable { return p },
 		fx.ResultTags(`group:"deadlockDetectorRoots"`),
-	)),
+	),
 )

--- a/service/history/shard/ownership_test.go
+++ b/service/history/shard/ownership_test.go
@@ -79,7 +79,7 @@ func (s *ownershipSuite) newController(contextFactory ContextFactory) *Controlle
 		s.resource.GetMetricsHandler(),
 		s.resource.GetHostInfoProvider(),
 		contextFactory,
-	).(*ControllerImpl)
+	)
 }
 
 func (s *ownershipSuite) TestAcquireViaMembershipUpdate() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added code to the history/shard package which supplies the shard controller to the ownership-based rate limit quota scaler, so that it can be used to get the shard count. Basically, this PR adds the plumbing needed to propagate the shard count from the shard controller to the quota scaler, so that clients can just grab an `OwnershipBasedQuotaScaler` from the fx graph, and then call `scaler.ScaleRateBurst(rb)` without thinking about any other dependencies.

<!-- Tell your future self why have you made these changes -->
**Why?**
So that we can have rate limit quotas in the history service that scale with the approximate workload of the service.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added tests which verify that shard counts are propagated to subscribers whenever acquire shards completes. I also verified that this does not block if the subscriber is not listening.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The changes to ControllerImpl here come with a risk because the shard controller is such an essential part of the history service. 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.