### PR TITLE
Reduce the heartbeat size of VerifyReplicationTasks activity

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1574,6 +1574,7 @@ var (
 
 	// Force replication
 	EncounterZombieWorkflowCount      = NewCounterDef("encounter_zombie_workflow_count")
+	EncounterNotFoundWorkflowCount    = NewCounterDef("encounter_not_found_workflow_count")
 	GenerateReplicationTasksLatency   = NewTimerDef("generate_replication_tasks_latency")
 	VerifyReplicationTaskSuccess      = NewCounterDef("verify_replication_task_success")
 	VerifyReplicationTaskNotFound     = NewCounterDef("verify_replication_task_not_found")

--- a/service/worker/migration/activities_test.go
+++ b/service/worker/migration/activities_test.go
@@ -204,7 +204,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_Success() {
 	r, err := env.ExecuteActivity(s.a.VerifyReplicationTasks, &request)
 	s.NoError(err)
 	var response verifyReplicationTasksResponse
-	r.Get(&response)
+	s.NoError(r.Get(&response))
 	s.Empty(response.SkippedWorkflowExecutions)
 
 	s.Greater(len(iceptor.replicationRecordedHeartbeats), 0)
@@ -269,7 +269,7 @@ func (s *activitiesSuite) TestVerifyReplicationTasks_SkipWorkflowExecution() {
 			s.Equal(len(request.Executions), lastHeartBeat.NextIndex)
 
 			var response verifyReplicationTasksResponse
-			r.Get(&response)
+			s.NoError(r.Get(&response))
 			s.Equal(request.Executions[0], response.SkippedWorkflowExecutions[0].WorkflowExecution)
 			s.Equal(t.expectedReason, response.SkippedWorkflowExecutions[0].Reason)
 		} else {

--- a/service/worker/migration/force_replication_workflow.go
+++ b/service/worker/migration/force_replication_workflow.go
@@ -110,6 +110,10 @@ type (
 		Executions            []commonpb.WorkflowExecution
 	}
 
+	verifyReplicationTasksResponse struct {
+		SkippedWorkflowExecutions []SkippedWorkflowExecution
+	}
+
 	metadataRequest struct {
 		Namespace string
 	}

--- a/service/worker/migration/force_replication_workflow.go
+++ b/service/worker/migration/force_replication_workflow.go
@@ -112,6 +112,7 @@ type (
 
 	verifyReplicationTasksResponse struct {
 		SkippedWorkflowExecutions []SkippedWorkflowExecution
+		SkippedWorkflowCount      int
 	}
 
 	metadataRequest struct {

--- a/service/worker/migration/force_replication_workflow_test.go
+++ b/service/worker/migration/force_replication_workflow_test.go
@@ -85,7 +85,7 @@ func TestForceReplicationWorkflow(t *testing.T) {
 	}).Times(totalPageCount)
 
 	env.OnActivity(a.GenerateReplicationTasks, mock.Anything, mock.Anything).Return(nil).Times(totalPageCount)
-	env.OnActivity(a.VerifyReplicationTasks, mock.Anything, mock.Anything).Return(nil).Times(totalPageCount)
+	env.OnActivity(a.VerifyReplicationTasks, mock.Anything, mock.Anything).Return(verifyReplicationTasksResponse{}, nil).Times(totalPageCount)
 
 	env.RegisterWorkflow(ForceTaskQueueUserDataReplicationWorkflow)
 	env.OnActivity(a.SeedReplicationQueueWithUserDataEntries, mock.Anything, mock.Anything).Return(nil).Times(1)
@@ -152,7 +152,7 @@ func TestForceReplicationWorkflow_ContinueAsNew(t *testing.T) {
 	}).Times(maxPageCountPerExecution)
 
 	env.OnActivity(a.GenerateReplicationTasks, mock.Anything, mock.Anything).Return(nil).Times(maxPageCountPerExecution)
-	env.OnActivity(a.VerifyReplicationTasks, mock.Anything, mock.Anything).Return(nil).Times(maxPageCountPerExecution)
+	env.OnActivity(a.VerifyReplicationTasks, mock.Anything, mock.Anything).Return(verifyReplicationTasksResponse{}, nil).Times(maxPageCountPerExecution)
 
 	env.RegisterWorkflow(ForceTaskQueueUserDataReplicationWorkflow)
 	env.OnActivity(a.SeedReplicationQueueWithUserDataEntries, mock.Anything, mock.Anything).Return(nil)
@@ -347,6 +347,7 @@ func TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError(t *test
 	// GenerateReplicationTasks and VerifyReplicationTasks runs in paralle. GenerateReplicationTasks may not start before VerifyReplicationTasks failed.
 	env.OnActivity(a.GenerateReplicationTasks, mock.Anything, mock.Anything).Return(nil).Maybe()
 	env.OnActivity(a.VerifyReplicationTasks, mock.Anything, mock.Anything).Return(
+		verifyReplicationTasksResponse{},
 		temporal.NewNonRetryableApplicationError(errMsg, "", nil),
 	).Times(1)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Reducing heart beat size (current payload size is 26K for 1000 executions). 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests + cluster tests 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
