### PR TITLE
Add more errors to targeted fault injector

### DIFF
--- a/tests/testdata/acquire_shard_deadline_exceeded_error.yaml
+++ b/tests/testdata/acquire_shard_deadline_exceeded_error.yaml
@@ -13,4 +13,4 @@ faultinjection:
         methods:
           UpdateShard:
             errors:
-              DeadlineExceededError: 1.0 # 100% of the time, return a deadline exceeded error
+              DeadlineExceeded: 1.0 # 100% of the time, return a deadline exceeded error

--- a/tests/testdata/acquire_shard_eventual_success.yaml
+++ b/tests/testdata/acquire_shard_eventual_success.yaml
@@ -14,4 +14,4 @@ faultinjection:
           UpdateShard:
             seed: 43  # deterministically generate a deadline exceeded error followed by a success
             errors:
-              DeadlineExceededError: 0.5 # 50% of the time, return a deadline exceeded error
+              DeadlineExceeded: 0.5 # 50% of the time, return a deadline exceeded error

--- a/tests/testdata/acquire_shard_ownership_lost_error.yaml
+++ b/tests/testdata/acquire_shard_ownership_lost_error.yaml
@@ -13,4 +13,4 @@ faultinjection:
         methods:
           UpdateShard:
             errors:
-              ShardOwnershipLostError: 1.0  # 100% of the time, return a ShardOwnershipLostError
+              ShardOwnershipLost: 1.0  # 100% of the time, return a persistence.ShardOwnershipLost.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
 - Added `ResourceExhausted` and `Unavailable` errors to target fault injector error factory.
 - Small renames.

<!-- Tell your future self why have you made these changes -->
**Why?**
To support more fault testing scenarios such as persistence rate limiting.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.