### PR TITLE
Add worker versioning calls to read-only namespace APIs for authorizer

### DIFF
--- a/common/authorization/frontend_api.go
+++ b/common/authorization/frontend_api.go
@@ -43,6 +43,8 @@ var readOnlyNamespaceAPI = map[string]struct{}{
 	"ListScheduleMatchingTimes":          {},
 	"DescribeBatchOperation":             {},
 	"ListBatchOperations":                {},
+	"GetWorkerBuildIdCompatibility":      {},
+	"GetWorkerTaskReachability":          {},
 }
 
 var readOnlyGlobalAPI = map[string]struct{}{


### PR DESCRIPTION
**What changed?**
Add `GetWorkerBuildIdCompatibility` and `GetWorkerTaskReachability` to the read-only namespace API list.

**Why?**
To make these accessible to read-only clients.
