### PR TITLE
Improve otel gauge memory usage

### DIFF
--- a/common/metrics/otel_metrics_handler.go
+++ b/common/metrics/otel_metrics_handler.go
@@ -81,7 +81,7 @@ func NewOtelMetricsHandler(
 	}
 	return &otelMetricsHandler{
 		l:            l,
-		set:          *attribute.EmptySet(),
+		set:          makeInitialSet(cfg.Tags),
 		provider:     o,
 		tagConverter: makeTagConverter(configExcludeTags(cfg)),
 		catalog:      c,
@@ -201,6 +201,17 @@ func (omp *otelMetricsHandler) makeSet(tags []Tag) attribute.Set {
 	}
 	for _, t := range tags {
 		attrs = append(attrs, omp.tagConverter(t))
+	}
+	return attribute.NewSet(attrs...)
+}
+
+func makeInitialSet(tags map[string]string) attribute.Set {
+	if len(tags) == 0 {
+		return *attribute.EmptySet()
+	}
+	var attrs []attribute.KeyValue
+	for k, v := range tags {
+		attrs = append(attrs, attribute.String(k, v))
 	}
 	return attribute.NewSet(attrs...)
 }


### PR DESCRIPTION
**What changed?**
- Register new callbacks for otel gauge only once instead of at each record. (We need callbacks because otel doesn't have a synchronous gauge yet, but it should happen soon and then we can get rid of this.)
- A few small optimizations to `attribute.Set` handling.

**Why?**
The current code seems to be leaking memory and causing other problems.

**How did you test it?**
Tested on local machine with frequent scrapes for a couple hours, saw no slowdown. Also diffed scrape before/after change.