### PR TITLE
buildkite: allow parallel builds on one machine

### DIFF
--- a/develop/buildkite/docker-compose-es8.yml
+++ b/develop/buildkite/docker-compose-es8.yml
@@ -74,5 +74,5 @@ services:
 
 networks:
   services-network:
-    name: services-network
+    name: net-${BUILDKITE_JOB_ID}
     driver: bridge

--- a/develop/buildkite/docker-compose-os2.yml
+++ b/develop/buildkite/docker-compose-os2.yml
@@ -46,5 +46,5 @@ services:
 
 networks:
   services-network:
-    name: services-network
+    name: net-${BUILDKITE_JOB_ID}
     driver: bridge

--- a/develop/buildkite/docker-compose.yml
+++ b/develop/buildkite/docker-compose.yml
@@ -385,5 +385,5 @@ services:
 
 networks:
   services-network:
-    name: services-network
+    name: net-${BUILDKITE_JOB_ID}
     driver: bridge


### PR DESCRIPTION
**What changed?**
Set the "network name" for docker-compose in buildkite to include the job id.

**Why?**
If multiple jobs are run on the same machine, this runs them in separate networks and prevents docker-compose from getting conflicts on the network name.

**How did you test it?**
Ran multiple buildkite agents on one machine