### PR TITLE
Continue replication verification by skipping workflow which should be or soon to be deleted

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1573,14 +1573,15 @@ var (
 	ScheduleTerminateWorkflowErrors                   = NewCounterDef("schedule_terminate_workflow_errors")
 
 	// Force replication
-	EncounterZombieWorkflowCount      = NewCounterDef("encounter_zombie_workflow_count")
-	EncounterNotFoundWorkflowCount    = NewCounterDef("encounter_not_found_workflow_count")
-	GenerateReplicationTasksLatency   = NewTimerDef("generate_replication_tasks_latency")
-	VerifyReplicationTaskSuccess      = NewCounterDef("verify_replication_task_success")
-	VerifyReplicationTaskNotFound     = NewCounterDef("verify_replication_task_not_found")
-	VerifyReplicationTaskFailed       = NewCounterDef("verify_replication_task_failed")
-	VerifyReplicationTasksLatency     = NewTimerDef("verify_replication_tasks_latency")
-	VerifyDescribeMutableStateLatency = NewTimerDef("verify_describe_mutable_state_latency")
+	EncounterZombieWorkflowCount           = NewCounterDef("encounter_zombie_workflow_count")
+	EncounterNotFoundWorkflowCount         = NewCounterDef("encounter_not_found_workflow_count")
+	EncounterCloseToRetentionWorkflowCount = NewCounterDef("encounter_close_to_retention_workflow_count")
+	GenerateReplicationTasksLatency        = NewTimerDef("generate_replication_tasks_latency")
+	VerifyReplicationTaskSuccess           = NewCounterDef("verify_replication_task_success")
+	VerifyReplicationTaskNotFound          = NewCounterDef("verify_replication_task_not_found")
+	VerifyReplicationTaskFailed            = NewCounterDef("verify_replication_task_failed")
+	VerifyReplicationTasksLatency          = NewTimerDef("verify_replication_tasks_latency")
+	VerifyDescribeMutableStateLatency      = NewTimerDef("verify_describe_mutable_state_latency")
 
 	// Replication
 	NamespaceReplicationTaskAckLevelGauge = NewGaugeDef("namespace_replication_task_ack_level")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Source and target cluster handles workflow retention separately. For a workflow which is abort to be deleted,
it may be already deleted on target cluster but still exist on source, which cause verification delay.
We skip workflow of which retention time is close to current time to continue the verification.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
