### PR TITLE
Fix temporal-sql-tool database creation on postgresql when database name contains hyphen

### DIFF
--- a/common/persistence/sql/sqlplugin/postgresql/admin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/admin.go
@@ -64,7 +64,7 @@ const (
 	// NOTE we have to use %v because somehow postgresql doesn't work with ? here
 	// It's a small bug in sqlx library
 	// TODO https://github.com/uber/cadence/issues/2893
-	createDatabaseQuery = "CREATE DATABASE %v"
+	createDatabaseQuery = `CREATE DATABASE "%v"`
 
 	dropDatabaseQuery = "DROP DATABASE IF EXISTS %v"
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added double quotes around database name in the create database query for PostgreSQL. 

<!-- Tell your future self why have you made these changes -->
**Why?**

The issue has been created on temporal-operator project (see: https://github.com/alexandrevilain/temporal-operator/issues/402). 
When we try to use the `temporal-sql-tool` `create` command with a database name containing hyphen(s), even if escaped in command, it throws the following error:  `pq: syntax error at or near \"-\"`. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Before the fix:
```bash
$ go run ./cmd/tools/sql --endpoint="localhost" --port="5432" --user="temporal-aws-dev" --password="$TEMPORAL_DEFAULT_DATASTORE_PASSWORD" --database="temporal-aws-dev" --plugin="postgres" create
2023-08-05T20:44:58.957+0200    ERROR   Unable to create SQL database.  {"error": "pq: syntax error at or near \"-\"", "logging-call-at": "handler.go:94"}
exit status 1
```

After the fix:
```bash
$ go run ./cmd/tools/sql --endpoint="localhost" --port="5432" --user="temporal-aws-dev" --password="$TEMPORAL_DEFAULT_DATASTORE_PASSWORD" --database="temporal-aws-dev" --plugin="postgres" create
$ echo $?
0
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Nothing.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.
