### PR TITLE
Update main branch in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,9 +70,7 @@ ALL_SRC         := $(shell find . -name "*.go")
 ALL_SRC         += go.mod
 ALL_SCRIPTS     := $(shell find . -name "*.sh")
 
-MAIN_BRANCH	   = master
-MERGE_BASE     ?= $(shell git merge-base $(MAIN_BRANCH) HEAD)
-MODIFIED_FILES := $(shell git diff --name-status $(MERGE_BASE) -- | cut -f2)
+MAIN_BRANCH    := main
 
 TEST_DIRS       := $(sort $(dir $(filter %_test.go,$(ALL_SRC))))
 FUNCTIONAL_TEST_ROOT          := ./tests
@@ -234,6 +232,8 @@ copyright:
 	@printf $(COLOR) "Fix license header..."
 	@go run ./cmd/tools/copyright/licensegen.go
 
+goimports: MERGE_BASE ?= $(shell git merge-base $(MAIN_BRANCH) HEAD)
+goimports: MODIFIED_FILES := $(shell git diff --name-status $(MERGE_BASE) -- | cut -f2)
 goimports:
 	@printf $(COLOR) "Run goimports for modified files..."
 	@printf "Merge base: $(MERGE_BASE)\n"


### PR DESCRIPTION
**What changed?**
- Update `MAIN_BRANCH` to `main`. This is used by `goimports` and `lint` targets.
- Move `MERGE_BASE` and `MODIFIED_FILES` to target-specific variables on `goimports`, which is the only target that uses them. This saves two useless `git` invocations per run.

**Why?**
Keep Makefile up to date, optimize common operations.

**How did you test it?**
manually