### PR TITLE
Add frontend.globalNamespaceCount

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -252,8 +252,20 @@ const (
 	FrontendMaxNamespaceRPSPerInstance = "frontend.namespaceRPS"
 	// FrontendMaxNamespaceBurstPerInstance is workflow namespace burst limit
 	FrontendMaxNamespaceBurstPerInstance = "frontend.namespaceBurst"
-	// FrontendMaxNamespaceCountPerInstance limits concurrent task queue polls per namespace per instance
-	FrontendMaxNamespaceCountPerInstance = "frontend.namespaceCount"
+	// FrontendMaxConcurrentLongRunningRequestsPerInstance limits concurrent long-running requests per-instance,
+	// per-API. Example requests include long-poll requests, and `Query` requests (which need to wait for WFTs). The
+	// limit is applied individually to each API method. This value is ignored if
+	// FrontendGlobalMaxConcurrentLongRunningRequests is greater than zero. Warning: setting this to zero will cause all
+	// long-running requests to fail. The name `frontend.namespaceCount` is kept for backwards compatibility with
+	// existing deployments even though it is a bit of a misnomer. This does not limit the number of namespaces; it is a
+	// per-_namespace_ limit on the _count_ of long-running requests. Requests are only throttled when the limit is
+	// exceeded, not when it is only reached.
+	FrontendMaxConcurrentLongRunningRequestsPerInstance = "frontend.namespaceCount"
+	// FrontendGlobalMaxConcurrentLongRunningRequests limits concurrent long-running requests across all frontend
+	// instances in the cluster, for a given namespace, per-API method. If this is set to 0 (the default), then it is
+	// ignored. The name `frontend.globalNamespaceCount` is kept for consistency with the per-instance limit name,
+	// `frontend.namespaceCount`.
+	FrontendGlobalMaxConcurrentLongRunningRequests = "frontend.globalNamespaceCount"
 	// FrontendMaxNamespaceVisibilityRPSPerInstance is namespace rate limit per second for visibility APIs.
 	// This config is EXPERIMENTAL and may be changed or removed in a later release.
 	FrontendMaxNamespaceVisibilityRPSPerInstance = "frontend.namespaceRPS.visibility"

--- a/service/frontend/configs/quotas.go
+++ b/service/frontend/configs/quotas.go
@@ -39,12 +39,12 @@ const (
 
 var (
 	// ExecutionAPICountLimitOverride determines how many tokens each of these API calls consumes from their
-	// corresponding quota, which is determined by dynamicconfig.FrontendMaxNamespaceCountPerInstance. If the value is
-	// not set, then the method is not considered a long-running request and the number of concurrent requests will not
-	// be throttled. The Poll* methods here are long-running because they block until there is a task available. The
-	// GetWorkflowExecutionHistory method is blocking only if WaitNewEvent is true, otherwise it is not long-running.
-	// The QueryWorkflow and UpdateWorkflowExecution methods are long-running because they both block until a background
-	// WFT is complete.
+	// corresponding quota, which is determined by dynamicconfig.FrontendMaxConcurrentLongRunningRequestsPerInstance. If
+	// the value is not set, then the method is not considered a long-running request and the number of concurrent
+	// requests will not be throttled. The Poll* methods here are long-running because they block until there is a task
+	// available. The GetWorkflowExecutionHistory method is blocking only if WaitNewEvent is true, otherwise it is not
+	// long-running. The QueryWorkflow and UpdateWorkflowExecution methods are long-running because they both block
+	// until a background WFT is complete.
 	ExecutionAPICountLimitOverride = map[string]int{
 		"PollActivityTaskQueue":       1,
 		"PollWorkflowTaskQueue":       1,

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -364,12 +364,15 @@ func NamespaceRateLimitInterceptorProvider(
 func NamespaceCountLimitInterceptorProvider(
 	serviceConfig *Config,
 	namespaceRegistry namespace.Registry,
+	serviceResolver membership.ServiceResolver,
 	logger log.SnTaggedLogger,
 ) *interceptor.ConcurrentRequestLimitInterceptor {
 	return interceptor.NewConcurrentRequestLimitInterceptor(
 		namespaceRegistry,
+		serviceResolver,
 		logger,
-		serviceConfig.MaxNamespaceCountPerInstance,
+		serviceConfig.MaxConcurrentLongRunningRequestsPerInstance,
+		serviceConfig.MaxGlobalConcurrentLongRunningRequests,
 		configs.ExecutionAPICountLimitOverride,
 	)
 }

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -75,7 +75,8 @@ type Config struct {
 	NamespaceReplicationInducingAPIsRPS                          dynamicconfig.IntPropertyFn
 	MaxNamespaceRPSPerInstance                                   dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxNamespaceBurstPerInstance                                 dynamicconfig.IntPropertyFnWithNamespaceFilter
-	MaxNamespaceCountPerInstance                                 dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxConcurrentLongRunningRequestsPerInstance                  dynamicconfig.IntPropertyFnWithNamespaceFilter
+	MaxGlobalConcurrentLongRunningRequests                       dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxNamespaceVisibilityRPSPerInstance                         dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxNamespaceVisibilityBurstPerInstance                       dynamicconfig.IntPropertyFnWithNamespaceFilter
 	MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance   dynamicconfig.IntPropertyFnWithNamespaceFilter
@@ -212,7 +213,8 @@ func NewConfig(
 
 		MaxNamespaceRPSPerInstance:                                   dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceRPSPerInstance, 2400),
 		MaxNamespaceBurstPerInstance:                                 dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceBurstPerInstance, 4800),
-		MaxNamespaceCountPerInstance:                                 dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceCountPerInstance, 1200),
+		MaxConcurrentLongRunningRequestsPerInstance:                  dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxConcurrentLongRunningRequestsPerInstance, 1200),
+		MaxGlobalConcurrentLongRunningRequests:                       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendGlobalMaxConcurrentLongRunningRequests, 0),
 		MaxNamespaceVisibilityRPSPerInstance:                         dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceVisibilityRPSPerInstance, 10),
 		MaxNamespaceVisibilityBurstPerInstance:                       dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceVisibilityBurstPerInstance, 10),
 		MaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:   dc.GetIntPropertyFilteredByNamespace(dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance, 1),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a new dynamic config flag called `frontend.globalNamespaceCount` which limits the number of concurrent pollers across the cluster.

<!-- Tell your future self why have you made these changes -->
**Why?**
Because the per-instance limit doesn't work well if there are many instances.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added global instance limit tests to the concurrent request limit interceptor.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is disabled by default, so it should have no behavioral impact unless turned on explicitly.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.