### PR TITLE
Make client code generation safer

### DIFF
--- a/client/history/client.go
+++ b/client/history/client.go
@@ -230,46 +230,6 @@ func (c *clientImpl) GetReplicationStatus(
 	return response, nil
 }
 
-func (c *clientImpl) RecordChildExecutionCompleted(
-	ctx context.Context,
-	request *historyservice.RecordChildExecutionCompletedRequest,
-	opts ...grpc.CallOption,
-) (*historyservice.RecordChildExecutionCompletedResponse, error) {
-	shardID := c.shardIDFromWorkflowID(request.NamespaceId, request.GetParentExecution().GetWorkflowId())
-	var response *historyservice.RecordChildExecutionCompletedResponse
-	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
-		var err error
-		ctx, cancel := c.createContext(ctx)
-		defer cancel()
-		response, err = client.RecordChildExecutionCompleted(ctx, request, opts...)
-		return err
-	}
-	if err := c.executeWithRedirect(ctx, shardID, op); err != nil {
-		return nil, err
-	}
-	return response, nil
-}
-
-func (c *clientImpl) VerifyChildExecutionCompletionRecorded(
-	ctx context.Context,
-	request *historyservice.VerifyChildExecutionCompletionRecordedRequest,
-	opts ...grpc.CallOption,
-) (*historyservice.VerifyChildExecutionCompletionRecordedResponse, error) {
-	shardID := c.shardIDFromWorkflowID(request.NamespaceId, request.GetParentExecution().GetWorkflowId())
-	var response *historyservice.VerifyChildExecutionCompletionRecordedResponse
-	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
-		var err error
-		ctx, cancel := c.createContext(ctx)
-		defer cancel()
-		response, err = client.VerifyChildExecutionCompletionRecorded(ctx, request, opts...)
-		return err
-	}
-	if err := c.executeWithRedirect(ctx, shardID, op); err != nil {
-		return nil, err
-	}
-	return response, nil
-}
-
 func (c *clientImpl) StreamWorkflowReplicationMessages(
 	ctx context.Context,
 	opts ...grpc.CallOption,

--- a/client/history/client_gen.go
+++ b/client/history/client_gen.go
@@ -463,6 +463,26 @@ func (c *clientImpl) RecordActivityTaskStarted(
 	return response, nil
 }
 
+func (c *clientImpl) RecordChildExecutionCompleted(
+	ctx context.Context,
+	request *historyservice.RecordChildExecutionCompletedRequest,
+	opts ...grpc.CallOption,
+) (*historyservice.RecordChildExecutionCompletedResponse, error) {
+	shardID := c.shardIDFromWorkflowID(request.NamespaceId, request.GetParentExecution().GetWorkflowId())
+	var response *historyservice.RecordChildExecutionCompletedResponse
+	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
+		var err error
+		ctx, cancel := c.createContext(ctx)
+		defer cancel()
+		response, err = client.RecordChildExecutionCompleted(ctx, request, opts...)
+		return err
+	}
+	if err := c.executeWithRedirect(ctx, shardID, op); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
 func (c *clientImpl) RecordWorkflowTaskStarted(
 	ctx context.Context,
 	request *historyservice.RecordWorkflowTaskStartedRequest,
@@ -920,6 +940,26 @@ func (c *clientImpl) UpdateWorkflowExecution(
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
 		response, err = client.UpdateWorkflowExecution(ctx, request, opts...)
+		return err
+	}
+	if err := c.executeWithRedirect(ctx, shardID, op); err != nil {
+		return nil, err
+	}
+	return response, nil
+}
+
+func (c *clientImpl) VerifyChildExecutionCompletionRecorded(
+	ctx context.Context,
+	request *historyservice.VerifyChildExecutionCompletionRecordedRequest,
+	opts ...grpc.CallOption,
+) (*historyservice.VerifyChildExecutionCompletionRecordedResponse, error) {
+	shardID := c.shardIDFromWorkflowID(request.NamespaceId, request.GetParentExecution().GetWorkflowId())
+	var response *historyservice.VerifyChildExecutionCompletionRecordedResponse
+	op := func(ctx context.Context, client historyservice.HistoryServiceClient) error {
+		var err error
+		ctx, cancel := c.createContext(ctx)
+		defer cancel()
+		response, err = client.VerifyChildExecutionCompletionRecorded(ctx, request, opts...)
 		return err
 	}
 	if err := c.executeWithRedirect(ctx, shardID, op); err != nil {

--- a/cmd/tools/rpcwrappers/main.go
+++ b/cmd/tools/rpcwrappers/main.go
@@ -48,6 +48,11 @@ type (
 		clientType      reflect.Type
 		clientGenerator func(io.Writer, service)
 	}
+
+	fieldWithPath struct {
+		field *reflect.StructField
+		path  string
+	}
 )
 
 var (
@@ -93,11 +98,9 @@ var (
 		"retryableClient.history.StreamWorkflowReplicationMessages": true,
 
 		// these are non-standard implementations. do not generate.
-		"client.history.DescribeHistoryHost":                    true,
-		"client.history.GetReplicationMessages":                 true,
-		"client.history.GetReplicationStatus":                   true,
-		"client.history.RecordChildExecutionCompleted":          true,
-		"client.history.VerifyChildExecutionCompletionRecorded": true,
+		"client.history.DescribeHistoryHost":    true,
+		"client.history.GetReplicationMessages": true,
+		"client.history.GetReplicationStatus":   true,
 		// these need to pick a partition. too complicated.
 		"client.matching.AddActivityTask":       true,
 		"client.matching.AddWorkflowTask":       true,
@@ -110,6 +113,20 @@ var (
 		"metricsClient.matching.PollActivityTaskQueue": true,
 		"metricsClient.matching.PollWorkflowTaskQueue": true,
 		"metricsClient.matching.QueryWorkflow":         true,
+	}
+	// Fields to ignore when looking for the routing fields in a request object.
+	ignoreField = map[string]bool{
+		// this is the workflow that sent a cancel request
+		"SignalWorkflowExecutionRequest.ExternalWorkflowExecution": true,
+		// this is the workflow that sent a cancel request
+		"RequestCancelWorkflowExecutionRequest.ExternalWorkflowExecution": true,
+		// this is the workflow that sent a terminate
+		"TerminateWorkflowExecutionRequest.ExternalWorkflowExecution": true,
+		// this is the parent for starting a child workflow
+		"StartWorkflowExecutionRequest.ParentExecutionInfo": true,
+		// these get routed to the parent
+		"RecordChildExecutionCompletedRequest.ChildExecution":          true,
+		"VerifyChildExecutionCompletionRecordedRequest.ChildExecution": true,
 	}
 )
 
@@ -126,54 +143,71 @@ func writeTemplatedCode(w io.Writer, service service, text string) {
 	}))
 }
 
-func pathToField(t reflect.Type, name string, path string, maxDepth int) string {
-	p, _ := findNestedField(t, name, path, maxDepth)
-	return p
-}
-
-func findNestedField(t reflect.Type, name string, path string, maxDepth int) (string, *reflect.StructField) {
+func findNestedField(t reflect.Type, name string, path string, maxDepth int) []fieldWithPath {
 	if t.Kind() != reflect.Struct || maxDepth <= 0 {
-		return "", nil
+		return nil
 	}
+	var out []fieldWithPath
 	for i := 0; i < t.NumField(); i++ {
 		f := t.Field(i)
+		if ignoreField[t.Name()+"."+f.Name] {
+			continue
+		}
 		if f.Name == name {
-			return path + ".Get" + name + "()", &f
+			out = append(out, fieldWithPath{field: &f, path: path + ".Get" + name + "()"})
 		}
 		ft := f.Type
 		if ft.Kind() == reflect.Pointer {
-			if path, try := findNestedField(ft.Elem(), name, path+".Get"+f.Name+"()", maxDepth-1); try != nil {
-				return path, try
-			}
+			out = append(out, findNestedField(ft.Elem(), name, path+".Get"+f.Name+"()", maxDepth-1)...)
 		}
 	}
-	return "", nil
+	return out
+}
+
+func findOneNestedField(t reflect.Type, name string, path string, maxDepth int) fieldWithPath {
+	fields := findNestedField(t, name, path, maxDepth)
+	if len(fields) == 0 {
+		panic(fmt.Sprintf("Couldn't find %s in %s", name, t))
+	} else if len(fields) > 1 {
+		panic(fmt.Sprintf("Found more than one %s in %s (%v)", name, t, fields))
+	}
+	return fields[0]
+}
+
+func findZeroOrOneNestedFields(t reflect.Type, name string, path string, maxDepth int) fieldWithPath {
+	fields := findNestedField(t, name, path, maxDepth)
+	if len(fields) == 0 {
+		return fieldWithPath{}
+	} else if len(fields) > 1 {
+		panic(fmt.Sprintf("Found more than one %s in %s (%v)", name, t, fields))
+	}
+	return fields[0]
 }
 
 func makeGetHistoryClient(reqType reflect.Type) string {
 	// this magically figures out how to get a HistoryServiceClient from a request
 	t := reqType.Elem() // we know it's a pointer
-	if path := pathToField(t, "ShardId", "request", 1); path != "" {
-		return fmt.Sprintf("shardID := %s", path)
+	if field := findZeroOrOneNestedFields(t, "ShardId", "request", 1); field.path != "" {
+		return fmt.Sprintf("shardID := %s", field.path)
 	}
-	if path := pathToField(t, "WorkflowId", "request", 4); path != "" {
-		return fmt.Sprintf("shardID := c.shardIDFromWorkflowID(request.NamespaceId, %s)", path)
+	if field := findZeroOrOneNestedFields(t, "WorkflowId", "request", 4); field.path != "" {
+		return fmt.Sprintf("shardID := c.shardIDFromWorkflowID(request.NamespaceId, %s)", field.path)
 	}
-	if path := pathToField(t, "TaskToken", "request", 2); path != "" {
+	if field := findZeroOrOneNestedFields(t, "TaskToken", "request", 2); field.path != "" {
 		return fmt.Sprintf(`taskToken, err := c.tokenSerializer.Deserialize(%s)
 	if err != nil {
 		return nil, err
 	}
 	shardID := c.shardIDFromWorkflowID(request.NamespaceId, taskToken.GetWorkflowId())
-`, path)
+`, field.path)
 	}
 	// slice needs a tiny bit of extra handling for namespace
-	if path := pathToField(t, "TaskInfos", "request", 1); path != "" {
+	if field := findZeroOrOneNestedFields(t, "TaskInfos", "request", 1); field.path != "" {
 		return fmt.Sprintf(`// All workflow IDs are in the same shard per request
 	if len(%s) == 0 {
 		return nil, serviceerror.NewInvalidArgument("missing TaskInfos")
 	}
-	shardID := c.shardIDFromWorkflowID(%s[0].NamespaceId, %s[0].WorkflowId)`, path, path, path)
+	shardID := c.shardIDFromWorkflowID(%s[0].NamespaceId, %s[0].WorkflowId)`, field.path, field.path, field.path)
 	}
 	panic("I don't know how to get a client from a " + t.String())
 }
@@ -182,39 +216,40 @@ func makeGetMatchingClient(reqType reflect.Type) string {
 	// this magically figures out how to get a MatchingServiceClient from a request
 	t := reqType.Elem() // we know it's a pointer
 
-	nsIDPath := pathToField(t, "NamespaceId", "request", 1)
-	tqPath, tqField := findNestedField(t, "TaskQueue", "request", 2)
+	nsID := findOneNestedField(t, "NamespaceId", "request", 1)
+	var tq, tqt fieldWithPath
 
-	var tqtPath string
 	switch t.Name() {
 	case "GetBuildIdTaskQueueMappingRequest":
 		// Pick a random node for this request, it's not associated with a specific task queue.
-		tqPath = "&taskqueuepb.TaskQueue{Name: fmt.Sprintf(\"not-applicable-%d\", rand.Int())}"
-		tqtPath = "enumspb.TASK_QUEUE_TYPE_UNSPECIFIED"
-		return fmt.Sprintf("client, err := c.getClientForTaskqueue(%s, %s, %s)", nsIDPath, tqPath, tqtPath)
+		tq = fieldWithPath{path: "&taskqueuepb.TaskQueue{Name: fmt.Sprintf(\"not-applicable-%d\", rand.Int())}"}
+		tqt = fieldWithPath{path: "enumspb.TASK_QUEUE_TYPE_UNSPECIFIED"}
 	case "UpdateTaskQueueUserDataRequest",
 		"ReplicateTaskQueueUserDataRequest":
 		// Always route these requests to the same matching node by namespace.
-		tqPath = "&taskqueuepb.TaskQueue{Name: \"not-applicable\"}"
-		tqtPath = "enumspb.TASK_QUEUE_TYPE_UNSPECIFIED"
-		return fmt.Sprintf("client, err := c.getClientForTaskqueue(%s, %s, %s)", nsIDPath, tqPath, tqtPath)
+		tq = fieldWithPath{path: "&taskqueuepb.TaskQueue{Name: \"not-applicable\"}"}
+		tqt = fieldWithPath{path: "enumspb.TASK_QUEUE_TYPE_UNSPECIFIED"}
 	case "GetWorkerBuildIdCompatibilityRequest",
 		"UpdateWorkerBuildIdCompatibilityRequest",
 		"RespondQueryTaskCompletedRequest",
 		"ListTaskQueuePartitionsRequest",
 		"ApplyTaskQueueUserDataReplicationEventRequest":
-		tqtPath = "enumspb.TASK_QUEUE_TYPE_WORKFLOW"
+		tq = findOneNestedField(t, "TaskQueue", "request", 2)
+		tqt = fieldWithPath{path: "enumspb.TASK_QUEUE_TYPE_WORKFLOW"}
 	default:
-		tqtPath = pathToField(t, "TaskQueueType", "request", 2)
+		tq = findOneNestedField(t, "TaskQueue", "request", 2)
+		tqt = findOneNestedField(t, "TaskQueueType", "request", 2)
 	}
 
-	if nsIDPath != "" && tqPath != "" && tqField != nil && tqtPath != "" {
-		// Some task queue fields are full messages, some are just strings
-		isTaskQueueMessage := tqField.Type == reflect.TypeOf((*taskqueue.TaskQueue)(nil))
-		if !isTaskQueueMessage {
-			tqPath = fmt.Sprintf("&taskqueuepb.TaskQueue{Name: %s}", tqPath)
+	if nsID.path != "" && tq.path != "" && tqt.path != "" {
+		if tq.field != nil {
+			// Some task queue fields are full messages, some are just strings
+			isTaskQueueMessage := tq.field.Type == reflect.TypeOf((*taskqueue.TaskQueue)(nil))
+			if !isTaskQueueMessage {
+				tq.path = fmt.Sprintf("&taskqueuepb.TaskQueue{Name: %s}", tq.path)
+			}
 		}
-		return fmt.Sprintf("client, err := c.getClientForTaskqueue(%s, %s, %s)", nsIDPath, tqPath, tqtPath)
+		return fmt.Sprintf("client, err := c.getClientForTaskqueue(%s, %s, %s)", nsID.path, tq.path, tqt.path)
 	}
 
 	panic("I don't know how to get a client from a " + t.String())

--- a/cmd/tools/rpcwrappers/main.go
+++ b/cmd/tools/rpcwrappers/main.go
@@ -116,7 +116,7 @@ var (
 	}
 	// Fields to ignore when looking for the routing fields in a request object.
 	ignoreField = map[string]bool{
-		// this is the workflow that sent a cancel request
+		// this is the workflow that sent a signal
 		"SignalWorkflowExecutionRequest.ExternalWorkflowExecution": true,
 		// this is the workflow that sent a cancel request
 		"RequestCancelWorkflowExecutionRequest.ExternalWorkflowExecution": true,


### PR DESCRIPTION
**What changed?**
- Extension of #4708: error if more than one field with the desired name is found.
- Add explicit ignore list to handle known cases.

**Why?**
Prevent future bugs.

**How did you test it?**
Ran and saw no code changes (except for moving some code back into `client_gen.go`) + existing integration tests.
