### PR TITLE
Reduce frontend handler retry max attempts

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -69,7 +69,7 @@ const (
 
 	frontendHandlerRetryInitialInterval = 200 * time.Millisecond
 	frontendHandlerRetryMaxInterval     = time.Second
-	frontendHandlerRetryMaxAttempts     = 5
+	frontendHandlerRetryMaxAttempts     = 2
 
 	historyHandlerRetryInitialInterval = 50 * time.Millisecond
 	historyHandlerRetryMaxAttempts     = 2


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Reduce frontend handler retry max attempts to 2

<!-- Tell your future self why have you made these changes -->
**Why?**
- https://github.com/temporalio/temporal/issues/4733
- 5 is too much since other layer will retry as well. e.g. persistence will retry 2 times, so it used to be 5*2 (and due to the max attempts bug 6*3)
- This value for frontend is currently higher than other handler because there's no frontend client retry layer, but actually our sdk will still perform retry which acts like the frontend client. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
