### PR TITLE
Fix SQLite FTS query expression with dashes

### DIFF
--- a/common/persistence/visibility/store/sql/query_converter_sqlite.go
+++ b/common/persistence/visibility/store/sql/query_converter_sqlite.go
@@ -108,7 +108,7 @@ func (c *sqliteQueryConverter) convertKeywordListComparisonExpr(
 				sqlparser.String(expr.Right),
 			)
 		}
-		ftsQuery = fmt.Sprintf(`%s:"%s"`, saColNameExpr.dbColName.Name, valueExpr.Val)
+		ftsQuery = buildFtsQueryString(saColNameExpr.dbColName.Name, valueExpr.Val)
 
 	case sqlparser.InStr, sqlparser.NotInStr:
 		valTupleExpr, isValTuple := expr.Right.(sqlparser.ValTuple)
@@ -123,10 +123,7 @@ func (c *sqliteQueryConverter) convertKeywordListComparisonExpr(
 		if err != nil {
 			return nil, err
 		}
-		for i := range values {
-			values[i] = fmt.Sprintf(`"%s"`, values[i])
-		}
-		ftsQuery = fmt.Sprintf("%s:(%s)", saColNameExpr.dbColName.Name, strings.Join(values, " OR "))
+		ftsQuery = buildFtsQueryString(saColNameExpr.dbColName.Name, values...)
 
 	default:
 		// this should never happen since isSupportedKeywordListOperator should already fail
@@ -201,7 +198,6 @@ func (c *sqliteQueryConverter) convertTextComparisonExpr(
 			sqlparser.String(expr.Right),
 		)
 	}
-	ftsQuery := fmt.Sprintf("%s:(%s)", saColNameExpr.dbColName.Name, strings.Join(tokens, " OR "))
 
 	var oper string
 	switch expr.Operator {
@@ -219,6 +215,7 @@ func (c *sqliteQueryConverter) convertTextComparisonExpr(
 		)
 	}
 
+	ftsQuery := buildFtsQueryString(saColNameExpr.dbColName.Name, tokens...)
 	newExpr := sqlparser.ComparisonExpr{
 		Operator: oper,
 		Left:     newColName("rowid"),
@@ -348,4 +345,9 @@ func (c *sqliteQueryConverter) buildCountStmt(
 		strings.Join(whereClauses, " AND "),
 		groupByClause,
 	), queryArgs
+}
+
+func buildFtsQueryString(colname string, values ...string) string {
+	// FTS query format: 'colname : ("token1" OR "token2" OR ...)'
+	return fmt.Sprintf(`%s : ("%s")`, colname, strings.Join(values, `" OR "`))
 }

--- a/common/persistence/visibility/store/sql/query_converter_sqlite_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_sqlite_test.go
@@ -73,25 +73,25 @@ func (s *sqliteQueryConverterSuite) TestConvertKeywordListComparisonExpr() {
 		{
 			name:   "valid equal expression",
 			input:  "AliasForKeywordList01 = 'foo'",
-			output: "rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01:\"foo\"')",
+			output: `rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo")')`,
 			err:    nil,
 		},
 		{
 			name:   "valid not equal expression",
 			input:  "AliasForKeywordList01 != 'foo'",
-			output: "rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01:\"foo\"')",
+			output: `rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo")')`,
 			err:    nil,
 		},
 		{
 			name:   "valid in expression",
 			input:  "AliasForKeywordList01 in ('foo', 'bar')",
-			output: "rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01:(\"foo\" OR \"bar\")')",
+			output: `rowid in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo" OR "bar")')`,
 			err:    nil,
 		},
 		{
 			name:   "valid not in expression",
 			input:  "AliasForKeywordList01 not in ('foo', 'bar')",
-			output: "rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01:(\"foo\" OR \"bar\")')",
+			output: `rowid not in (select rowid from executions_visibility_fts_keyword_list where executions_visibility_fts_keyword_list = 'KeywordList01 : ("foo" OR "bar")')`,
 			err:    nil,
 		},
 	}
@@ -130,13 +130,13 @@ func (s *sqliteQueryConverterSuite) TestConvertTextComparisonExpr() {
 		{
 			name:   "valid equal expression",
 			input:  "AliasForText01 = 'foo bar'",
-			output: "rowid in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01:(foo OR bar)')",
+			output: `rowid in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
 			err:    nil,
 		},
 		{
 			name:   "valid not equal expression",
 			input:  "AliasForText01 != 'foo bar'",
-			output: "rowid not in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01:(foo OR bar)')",
+			output: `rowid not in (select rowid from executions_visibility_fts_text where executions_visibility_fts_text = 'Text01 : ("foo" OR "bar")')`,
 			err:    nil,
 		},
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix SQLite FTS query expression builder when token contain dashes.

<!-- Tell your future self why have you made these changes -->
**Why?**
Dash (-) is a special char in the FTS expression, so the token need to be quoted to be escaped.
https://github.com/temporalio/temporal/issues/4729

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Followed the repro instructions in the issue above, and it doesn't repro anymore, ie., no errors are thrown.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.