### PR TITLE
Clean up some matching errors

### DIFF
--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -297,13 +297,13 @@ forLoop:
 
 // Poll blocks until a task is found or context deadline is exceeded
 // On success, the returned task could be a query task or a regular task
-// Returns ErrNoTasks when context deadline is exceeded
+// Returns errNoTasks when context deadline is exceeded
 func (tm *TaskMatcher) Poll(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
 	return tm.poll(ctx, pollMetadata, false)
 }
 
 // PollForQuery blocks until a *query* task is found or context deadline is exceeded
-// Returns ErrNoTasks when context deadline is exceeded
+// Returns errNoTasks when context deadline is exceeded
 func (tm *TaskMatcher) PollForQuery(ctx context.Context, pollMetadata *pollMetadata) (*internalTask, error) {
 	return tm.poll(ctx, pollMetadata, true)
 }
@@ -363,7 +363,7 @@ func (tm *TaskMatcher) poll(ctx context.Context, pollMetadata *pollMetadata, que
 	select {
 	case <-ctx.Done():
 		tm.metricsHandler.Counter(metrics.PollTimeoutPerTaskQueueCounter.GetMetricName()).Record(1)
-		return nil, ErrNoTasks
+		return nil, errNoTasks
 	default:
 	}
 
@@ -386,7 +386,7 @@ func (tm *TaskMatcher) poll(ctx context.Context, pollMetadata *pollMetadata, que
 	select {
 	case <-ctx.Done():
 		tm.metricsHandler.Counter(metrics.PollTimeoutPerTaskQueueCounter.GetMetricName()).Record(1)
-		return nil, ErrNoTasks
+		return nil, errNoTasks
 	case task := <-taskC:
 		if task.responseC != nil {
 			tm.metricsHandler.Counter(metrics.PollSuccessWithSyncPerTaskQueueCounter.GetMetricName()).Record(1)
@@ -409,7 +409,7 @@ func (tm *TaskMatcher) poll(ctx context.Context, pollMetadata *pollMetadata, que
 	select {
 	case <-ctx.Done():
 		tm.metricsHandler.Counter(metrics.PollTimeoutPerTaskQueueCounter.GetMetricName()).Record(1)
-		return nil, ErrNoTasks
+		return nil, errNoTasks
 	case task := <-taskC:
 		if task.responseC != nil {
 			tm.metricsHandler.Counter(metrics.PollSuccessWithSyncPerTaskQueueCounter.GetMetricName()).Record(1)

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -151,9 +151,7 @@ var (
 	// EmptyPollActivityTaskQueueResponse is the response when there are no activity tasks to hand out
 	emptyPollActivityTaskQueueResponse = &matchingservice.PollActivityTaskQueueResponse{}
 
-	// ErrNoTasks is exported temporarily for integration test
-	ErrNoTasks    = errors.New("no tasks")
-	errPumpClosed = errors.New("task queue pump closed its channel")
+	errNoTasks = errors.New("no tasks")
 
 	pollerIDKey pollerIDCtxKey = "pollerID"
 	identityKey identityCtxKey = "identity"
@@ -494,8 +492,7 @@ pollLoop:
 		}
 		task, err := e.getTask(pollerCtx, taskQueue, stickyInfo, pollMetadata)
 		if err != nil {
-			// TODO: Is empty poll the best reply for errPumpClosed?
-			if err == ErrNoTasks || err == errPumpClosed {
+			if err == errNoTasks {
 				return emptyPollWorkflowTaskQueueResponse, nil
 			}
 			return nil, err
@@ -613,8 +610,7 @@ pollLoop:
 		}
 		task, err := e.getTask(pollerCtx, taskQueue, stickyInfo, pollMetadata)
 		if err != nil {
-			// TODO: Is empty poll the best reply for errPumpClosed?
-			if err == ErrNoTasks || err == errPumpClosed {
+			if err == errNoTasks {
 				return emptyPollActivityTaskQueueResponse, nil
 			}
 			return nil, err

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -52,7 +52,6 @@ import (
 	"go.temporal.io/server/common/payload"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/service/matching"
 )
 
 func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
@@ -157,10 +156,10 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 	}
 
 	_, err := poller.PollAndProcessWorkflowTask(false, false)
-	s.True(err == nil || err == matching.ErrNoTasks)
+	s.True(err == nil || err == errNoTasks)
 
 	err = poller.PollAndProcessActivityTask(false)
-	s.True(err == nil || err == matching.ErrNoTasks)
+	s.True(err == nil || err == errNoTasks)
 
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(we.RunId))
 
@@ -343,7 +342,7 @@ func (s *integrationSuite) TestActivityRetry() {
 	s.NoError(err)
 
 	err = poller.PollAndProcessActivityTask(false)
-	s.True(err == nil || err == matching.ErrNoTasks, err)
+	s.True(err == nil || err == errNoTasks, err)
 
 	descResp, err := describeWorkflowExecution()
 	s.NoError(err)
@@ -358,7 +357,7 @@ func (s *integrationSuite) TestActivityRetry() {
 	}
 
 	err = poller2.PollAndProcessActivityTask(false)
-	s.True(err == nil || err == matching.ErrNoTasks, err)
+	s.True(err == nil || err == errNoTasks, err)
 
 	descResp, err = describeWorkflowExecution()
 	s.NoError(err)
@@ -589,7 +588,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 	}
 
 	_, err := poller.PollAndProcessWorkflowTask(false, false)
-	s.True(err == nil || err == matching.ErrNoTasks)
+	s.True(err == nil || err == errNoTasks)
 
 	err = poller.PollAndProcessActivityTask(false)
 	// Not s.ErrorIs() because error goes through RPC.
@@ -714,7 +713,7 @@ func (s *integrationSuite) TestTryActivityCancellationFromWorkflow() {
 	}
 
 	_, err := poller.PollAndProcessWorkflowTask(false, false)
-	s.True(err == nil || err == matching.ErrNoTasks, err)
+	s.True(err == nil || err == errNoTasks, err)
 
 	cancelCh := make(chan struct{})
 	go func() {
@@ -741,7 +740,7 @@ func (s *integrationSuite) TestTryActivityCancellationFromWorkflow() {
 
 	s.Logger.Info("Start activity.")
 	err = poller.PollAndProcessActivityTask(false)
-	s.True(err == nil || err == matching.ErrNoTasks, err)
+	s.True(err == nil || err == errNoTasks, err)
 
 	s.Logger.Info("Waiting for cancel to complete.", tag.WorkflowRunID(we.RunId))
 	<-cancelCh
@@ -843,7 +842,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 	}
 
 	_, err := poller.PollAndProcessWorkflowTask(false, false)
-	s.True(err == nil || err == matching.ErrNoTasks)
+	s.True(err == nil || err == errNoTasks)
 
 	// Send signal so that worker can send an activity cancel
 	signalName := "my signal"
@@ -869,7 +868,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 	scheduleActivity = false
 	requestCancellation = false
 	_, err = poller.PollAndProcessWorkflowTask(false, false)
-	s.True(err == nil || err == matching.ErrNoTasks)
+	s.True(err == nil || err == errNoTasks)
 }
 
 func (s *clientIntegrationSuite) TestActivityHeartbeatDetailsDuringRetry() {

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -47,7 +47,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/service/history/consts"
-	"go.temporal.io/server/service/matching"
 )
 
 type (
@@ -75,6 +74,10 @@ type (
 		Logger                       log.Logger
 		T                            *testing.T
 	}
+)
+
+var (
+	errNoTasks = errors.New("no tasks")
 )
 
 // PollAndProcessWorkflowTask for workflow tasks
@@ -330,7 +333,7 @@ Loop:
 		return false, newTask, err
 	}
 
-	return false, nil, matching.ErrNoTasks
+	return false, nil, errNoTasks
 }
 
 // HandlePartialWorkflowTask for workflow task
@@ -474,7 +477,7 @@ retry:
 		return err
 	}
 
-	return matching.ErrNoTasks
+	return errNoTasks
 }
 
 // PollAndProcessActivityTaskWithID is similar to PollAndProcessActivityTask but using RespondActivityTask...ByID
@@ -550,7 +553,7 @@ retry:
 		return err
 	}
 
-	return matching.ErrNoTasks
+	return errNoTasks
 }
 
 func getQueryResults(queries map[string]*querypb.WorkflowQuery, queryResult *querypb.WorkflowQueryResult) map[string]*querypb.WorkflowQueryResult {

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -48,7 +48,6 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/payloads"
 	"go.temporal.io/server/common/primitives/timestamp"
-	"go.temporal.io/server/service/matching"
 )
 
 func (s *integrationSuite) TestStartWorkflowExecution() {
@@ -646,11 +645,11 @@ func (s *integrationSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 			history := historyResponse.History
 			common.PrettyPrint(history.Events)
 		}
-		s.True(err == nil || err == matching.ErrNoTasks, "%v", err)
+		s.True(err == nil || err == errNoTasks, err)
 		if !dropWorkflowTask {
 			s.Logger.Info("Calling PollAndProcessActivityTask", tag.Counter(i))
 			err = poller.PollAndProcessActivityTask(i%4 == 0)
-			s.True(err == nil || err == matching.ErrNoTasks)
+			s.True(err == nil || err == errNoTasks)
 		}
 	}
 


### PR DESCRIPTION
**What changed?**
- Make `errNoTasks` private
- Remove unused `errPumpClosed`
- Give test framework taskpoller its own error

**Why?**
There's no reason these errors should be linked

**How did you test it?**
Ran integration tests
