### PR TITLE
Move getTaskQueueManager call into redirect methods

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -433,6 +433,10 @@ func (e *matchingEngineImpl) DispatchSpooledTask(
 	unversionedOrigTaskQueue := newTaskQueueIDWithVersionSet(origTaskQueue, "")
 	// Redirect and re-resolve if we're blocked in matcher and user data changes.
 	for {
+		// If normal queue: always load the base tqm to get versioning data.
+		// If sticky queue: sticky is not versioned, so if we got here (by taskReader calling this),
+		// the queue is already loaded.
+		// So we can always use true here.
 		baseTqm, err := e.getTaskQueueManager(ctx, unversionedOrigTaskQueue, stickyInfo, true)
 		if err != nil {
 			return err

--- a/service/matching/task_queue_manager.go
+++ b/service/matching/task_queue_manager.go
@@ -830,6 +830,8 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Contex
 			}
 			// Send versioned tasks to dlq.
 			newId := newTaskQueueIDWithVersionSet(c.taskQueueID, dlqVersionSet)
+			// If we're called by QueryWorkflow, then we technically don't need to load the dlq
+			// tqm here. But it's not a big deal if we do.
 			tqm, err := c.engine.getTaskQueueManager(ctx, newId, c.stickyInfo, true)
 			if err != nil {
 				return nil, nil, err

--- a/service/matching/task_queue_manager.go
+++ b/service/matching/task_queue_manager.go
@@ -148,8 +148,8 @@ type (
 		QueueID() *taskQueueID
 		TaskQueueKind() enumspb.TaskQueueKind
 		LongPollExpirationInterval() time.Duration
-		RedirectToVersionedQueueForAdd(context.Context, *taskqueuespb.TaskVersionDirective) (*taskQueueID, chan struct{}, error)
-		RedirectToVersionedQueueForPoll(*commonpb.WorkerVersionCapabilities) (*taskQueueID, error)
+		RedirectToVersionedQueueForAdd(context.Context, *taskqueuespb.TaskVersionDirective) (taskQueueManager, chan struct{}, error)
+		RedirectToVersionedQueueForPoll(context.Context, *commonpb.WorkerVersionCapabilities) (taskQueueManager, error)
 	}
 
 	// Single task queue in memory state
@@ -765,11 +765,11 @@ func (c *taskQueueManagerImpl) LongPollExpirationInterval() time.Duration {
 	return c.config.LongPollExpirationInterval()
 }
 
-func (c *taskQueueManagerImpl) RedirectToVersionedQueueForPoll(caps *commonpb.WorkerVersionCapabilities) (*taskQueueID, error) {
+func (c *taskQueueManagerImpl) RedirectToVersionedQueueForPoll(ctx context.Context, caps *commonpb.WorkerVersionCapabilities) (taskQueueManager, error) {
 	if !caps.GetUseVersioning() {
 		// Either this task queue is versioned, or there are still some workflows running on
 		// the "unversioned" set.
-		return c.taskQueueID, nil
+		return c, nil
 	}
 	// We don't need the userDataChanged channel here because polls have a timeout and the
 	// client will retry, so if we're blocked on the wrong matcher it'll just take one poll
@@ -789,7 +789,7 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForPoll(caps *commonpb.Wo
 		if unknownBuild {
 			c.recordUnknownBuildPoll(caps.BuildId)
 		}
-		return c.taskQueueID, nil
+		return c, nil
 	}
 
 	versionSet, unknownBuild, err := lookupVersionSetForPoll(data, caps)
@@ -799,10 +799,12 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForPoll(caps *commonpb.Wo
 	if unknownBuild {
 		c.recordUnknownBuildPoll(caps.BuildId)
 	}
-	return newTaskQueueIDWithVersionSet(c.taskQueueID, versionSet), nil
+
+	newId := newTaskQueueIDWithVersionSet(c.taskQueueID, versionSet)
+	return c.engine.getTaskQueueManager(ctx, newId, c.stickyInfo, true)
 }
 
-func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Context, directive *taskqueuespb.TaskVersionDirective) (*taskQueueID, chan struct{}, error) {
+func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Context, directive *taskqueuespb.TaskVersionDirective) (taskQueueManager, chan struct{}, error) {
 	var buildId string
 	switch dir := directive.GetValue().(type) {
 	case *taskqueuespb.TaskVersionDirective_UseDefault:
@@ -811,7 +813,7 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Contex
 		buildId = dir.BuildId
 	default:
 		// Unversioned task, leave on unversioned queue.
-		return c.taskQueueID, nil, nil
+		return c, nil, nil
 	}
 
 	// Have to look up versioning data.
@@ -820,14 +822,19 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Contex
 		if errors.Is(err, errUserDataDisabled) {
 			// When user data disabled, send "default" tasks to unversioned queue.
 			if buildId == "" {
-				return c.taskQueueID, userDataChanged, nil
+				return c, userDataChanged, nil
 			}
 			// Send versioned sticky back to regular queue so they can go in the dlq.
 			if c.kind == enumspb.TASK_QUEUE_KIND_STICKY {
 				return nil, nil, serviceerrors.NewStickyWorkerUnavailable()
 			}
 			// Send versioned tasks to dlq.
-			return newTaskQueueIDWithVersionSet(c.taskQueueID, dlqVersionSet), userDataChanged, nil
+			newId := newTaskQueueIDWithVersionSet(c.taskQueueID, dlqVersionSet)
+			tqm, err := c.engine.getTaskQueueManager(ctx, newId, c.stickyInfo, true)
+			if err != nil {
+				return nil, nil, err
+			}
+			return tqm, userDataChanged, nil
 		}
 		return nil, nil, err
 	}
@@ -844,13 +851,13 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Contex
 			// Don't bother persisting the unknown build id in this case: sticky tasks have a
 			// short timeout, so it doesn't matter if they get lost.
 		}
-		return c.taskQueueID, userDataChanged, nil
+		return c, userDataChanged, nil
 	}
 
 	versionSet, unknownBuild, err := lookupVersionSetForAdd(data, buildId)
 	if err == errEmptyVersioningData { // nolint:goerr113
 		// default was requested for an unversioned queue
-		return c.taskQueueID, userDataChanged, nil
+		return c, userDataChanged, nil
 	} else if err != nil {
 		return nil, nil, err
 	}
@@ -868,7 +875,13 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Contex
 			return nil, nil, err
 		}
 	}
-	return newTaskQueueIDWithVersionSet(c.taskQueueID, versionSet), userDataChanged, nil
+
+	newId := newTaskQueueIDWithVersionSet(c.taskQueueID, versionSet)
+	tqm, err := c.engine.getTaskQueueManager(ctx, newId, c.stickyInfo, true)
+	if err != nil {
+		return nil, nil, err
+	}
+	return tqm, userDataChanged, nil
 }
 
 func (c *taskQueueManagerImpl) recordUnknownBuildPoll(buildId string) {


### PR DESCRIPTION
**What changed?**
Make `RedirectToVersionedQueueFor{Add,Poll}` return a tqm directly. This is just refactoring, almost no behavior changes (in one specific case, query with user data disabled, it may do an extra task queue load).

**Why?**
Refactoring in advance of future work.

**How did you test it?**
Existing tests
