### PR TITLE
Turn ErrWorkflowClosing into a retryable error

### DIFF
--- a/service/history/consts/const.go
+++ b/service/history/consts/const.go
@@ -69,8 +69,8 @@ var (
 	ErrDeserializingToken = serviceerror.NewInvalidArgument("error deserializing task token")
 	// ErrSignalsLimitExceeded is the error indicating limit reached for maximum number of signal events
 	ErrSignalsLimitExceeded = serviceerror.NewInvalidArgument("exceeded workflow execution limit for signal events")
-	// ErrWorkflowClosing is the error indicating requests to workflow got rejected due to workflow is closing
-	ErrWorkflowClosing = serviceerror.NewWorkflowNotReady("workflow operation rejected because workflow is closing")
+	// ErrWorkflowClosing is the error indicating requests to workflow can not be applied as workflow is closing
+	ErrWorkflowClosing = serviceerror.NewResourceExhausted(enumspb.RESOURCE_EXHAUSTED_CAUSE_BUSY_WORKFLOW, "workflow operation can not be applied because workflow is closing")
 	// ErrEventsAterWorkflowFinish is the error indicating server error trying to write events after workflow finish event
 	ErrEventsAterWorkflowFinish = serviceerror.NewInternal("error validating last event being workflow finish event")
 	// ErrQueryEnteredInvalidState is error indicating query entered invalid state


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Turn ErrWorkflowClosing into a retryable error: resource exhausted with workflow busy cause.
- The error means workflow is about to close so the operation can not be applied at this time. But the operation will be able to be applied if workflow continues as new or get rejected if workflow completes. and by retrying, hopefully customer won't see the error (depending how fast they process their workflow task). 

<!-- Tell your future self why have you made these changes -->
**Why?**
- so that user doesn't have to retry on their end in most cases.
- resource exhausted error also won't be retried by service handler.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing functional test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
