### PR TITLE
Update slices.SortFunc for Go 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,7 @@ require (
 	go.uber.org/fx v1.20.0
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
-	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
+	golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb
 	golang.org/x/oauth2 v0.9.0
 	golang.org/x/sync v0.3.0
 	golang.org/x/time v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -1365,8 +1365,8 @@ golang.org/x/exp v0.0.0-20200119233911-0405dc783f0a/go.mod h1:2RIsYlXP63K8oxa1u0
 golang.org/x/exp v0.0.0-20200207192155-f17229e696bd/go.mod h1:J/WKrq2StrnmMY6+EHIKF9dgMWnmCNThgcyBT1FY9mM=
 golang.org/x/exp v0.0.0-20200224162631-6cc2880d07d6/go.mod h1:3jZMyOhIsHpP37uCMkUooju7aAi5cS1Q23tOzKc+0MU=
 golang.org/x/exp v0.0.0-20220827204233-334a2380cb91/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
-golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb h1:mIKbk8weKhSeLH2GmUTrvx8CjkyJmnU1wFmg59CUjFA=
+golang.org/x/exp v0.0.0-20230811145659-89c5cff77bcb/go.mod h1:FXUEEKJgO7OQYeo8N01OfiKP8RXMtf6e8aTskBGqWdc=
 golang.org/x/image v0.0.0-20180708004352-c73c2afc3b81/go.mod h1:ux5Hcp/YLpHSI86hEcLt0YII63i6oz57MZXIpbrjZUs=
 golang.org/x/image v0.0.0-20190227222117-0694c2d4d067/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.0.0-20190802002840-cff245a6509b/go.mod h1:FeLwcggjj3mMvU+oOTbSwawSJRM1uh48EjtB4UJZlP0=

--- a/service/history/queues/action_pending_task_count.go
+++ b/service/history/queues/action_pending_task_count.go
@@ -126,10 +126,11 @@ func (a *actionQueuePendingTask) gatherStatistics(
 		})
 	}
 	for _, sliceList := range a.slicesPerNamespace {
-		slices.SortFunc(sliceList, func(this, that Slice) bool {
+		slices.SortFunc(sliceList, func(this, that Slice) int {
 			thisMin := this.Scope().Range.InclusiveMin
 			thatMin := that.Scope().Range.InclusiveMin
-			return thisMin.CompareTo(thatMin) > 0
+			// sort in largest to smallest order
+			return thatMin.CompareTo(thisMin)
 		})
 	}
 }

--- a/service/history/queues/action_slice_count.go
+++ b/service/history/queues/action_slice_count.go
@@ -203,8 +203,8 @@ func (a *actionSliceCount) pickCompactCandidates(
 	candidates []compactCandidate,
 	numSliceToCompact int,
 ) map[Slice]struct{} {
-	slices.SortFunc(candidates, func(this, that compactCandidate) bool {
-		return this.distance.CompareTo(that.distance) < 0
+	slices.SortFunc(candidates, func(this, that compactCandidate) int {
+		return this.distance.CompareTo(that.distance)
 	})
 
 	sliceToCompact := make(map[Slice]struct{}, numSliceToCompact)

--- a/service/history/queues/queue_scheduled_test.go
+++ b/service/history/queues/queue_scheduled_test.go
@@ -143,8 +143,8 @@ func (s *scheduledQueueSuite) TestPaginationFnProvider() {
 		tasks.NewKey(r.InclusiveMin.FireTime.Add(time.Microsecond*10), rand.Int63()),
 		tasks.NewKey(r.InclusiveMin.FireTime.Add(time.Second), rand.Int63()),
 	}
-	slices.SortFunc(testTaskKeys, func(k1, k2 tasks.Key) bool {
-		return k1.CompareTo(k2) < 0
+	slices.SortFunc(testTaskKeys, func(k1, k2 tasks.Key) int {
+		return k1.CompareTo(k2)
 	})
 	shouldHaveNextPage := true
 	if testTaskKeys[len(testTaskKeys)-1].CompareTo(r.ExclusiveMax) >= 0 {

--- a/service/history/queues/slice_test.go
+++ b/service/history/queues/slice_test.go
@@ -337,8 +337,8 @@ func (s *sliceSuite) TestShrinkScope_ShrinkRange() {
 	slice.iterators = s.randomIteratorsInRange(r, rand.Intn(2), nil)
 
 	executables := s.randomExecutablesInRange(r, 5)
-	slices.SortFunc(executables, func(a, b Executable) bool {
-		return a.GetKey().CompareTo(b.GetKey()) < 0
+	slices.SortFunc(executables, func(a, b Executable) int {
+		return a.GetKey().CompareTo(b.GetKey())
 	})
 
 	firstPendingIdx := len(executables)
@@ -386,8 +386,8 @@ func (s *sliceSuite) TestShrinkScope_ShrinkPredicate() {
 	slice.iterators = []Iterator{} // manually set iterators to be empty to trigger predicate update
 
 	executables := s.randomExecutablesInRange(r, 100)
-	slices.SortFunc(executables, func(a, b Executable) bool {
-		return a.GetKey().CompareTo(b.GetKey()) < 0
+	slices.SortFunc(executables, func(a, b Executable) int {
+		return a.GetKey().CompareTo(b.GetKey())
 	})
 
 	pendingNamespaceID := []string{uuid.New(), uuid.New()}
@@ -442,8 +442,8 @@ func (s *sliceSuite) TestSelectTasks_NoError() {
 				mockTasks = append(mockTasks, mockTask)
 			}
 
-			slices.SortFunc(mockTasks, func(a, b tasks.Task) bool {
-				return a.GetKey().CompareTo(b.GetKey()) < 0
+			slices.SortFunc(mockTasks, func(a, b tasks.Task) int {
+				return a.GetKey().CompareTo(b.GetKey())
 			})
 
 			return mockTasks, nil, nil
@@ -491,8 +491,8 @@ func (s *sliceSuite) TestSelectTasks_Error_NoLoadedTasks() {
 				mockTasks = append(mockTasks, mockTask)
 			}
 
-			slices.SortFunc(mockTasks, func(a, b tasks.Task) bool {
-				return a.GetKey().CompareTo(b.GetKey()) < 0
+			slices.SortFunc(mockTasks, func(a, b tasks.Task) int {
+				return a.GetKey().CompareTo(b.GetKey())
 			})
 
 			return mockTasks, nil, nil
@@ -534,8 +534,8 @@ func (s *sliceSuite) TestSelectTasks_Error_WithLoadedTasks() {
 				mockTasks = append(mockTasks, mockTask)
 			}
 
-			slices.SortFunc(mockTasks, func(a, b tasks.Task) bool {
-				return a.GetKey().CompareTo(b.GetKey()) < 0
+			slices.SortFunc(mockTasks, func(a, b tasks.Task) int {
+				return a.GetKey().CompareTo(b.GetKey())
 			})
 
 			return mockTasks, []byte{1, 2, 3}, nil

--- a/service/history/queues/test_util.go
+++ b/service/history/queues/test_util.go
@@ -98,8 +98,8 @@ func NewRandomOrderedRangesInRange(
 		ranges = append(ranges[1:], left, right)
 	}
 
-	slices.SortFunc(ranges, func(a, b Range) bool {
-		return a.InclusiveMin.CompareTo(b.InclusiveMin) < 0
+	slices.SortFunc(ranges, func(a, b Range) int {
+		return a.InclusiveMin.CompareTo(b.InclusiveMin)
 	})
 
 	return ranges


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

The golang.org/x/exp module was updated to use the same function signature as Go 1.21's upcoming slices.SortFunc function. This changed the return value from a bool (less than) to an int (compare to). Update Temporal to the latest version and fix the uses.

For more details about this change, see the following issue and commit:

- https://github.com/golang/go/issues/61374
- https://cs.opensource.google/go/x/exp/+/302865e7556b4ae5de27248ce625d443ef4ad3ed


<!-- Tell your future self why have you made these changes -->
**Why?**

I am attempting to build code in a repository that imports Temporal and has updated to the latest version of this third-party library.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I only ran the unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

It is possible that I have accidentally reversed the sort order in some cases, but otherwise this should be low risk.


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No
