### PR TITLE
Return NonRetryableApplicationError if Namespace is not found on remote cluster during verify

### DIFF
--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -638,6 +638,9 @@ func (a *activities) verifyReplicationTasks(
 				Reason:            reason,
 			})
 
+		case *serviceerror.NamespaceNotFound:
+			return false, skippedList, temporal.NewNonRetryableApplicationError("remoteClient.DescribeMutableState call failed", "NamespaceNotFound", err)
+
 		default:
 			a.forceReplicationMetricsHandler.WithTags(metrics.NamespaceTag(request.Namespace), metrics.ServiceErrorTypeTag(err)).
 				Counter(metrics.VerifyReplicationTaskFailed.GetMetricName()).Record(1)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
During force replication, namespace should exist on remote (target cluster). If namespace doesn't exist (due to operator error e.g.,), fail VerifyReplicationTasks activity fast. Otherwise, workflow will retry VerifyReplicationTasks activity infinitely. 


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
