### PR TITLE
Replace tctl with cli in CONTRIBUTING.md and Makefile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ and then run the server:
 make start
 ```
 
-Now you can create default namespace with `tctl`:
+Now you can create default namespace with Temporal CLI:
 ```bash
 temporal operator namespace create default
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,10 +12,10 @@ This doc is for contributors to Temporal Server (hopefully that's you!)
 * [Protocol buffers compiler](https://github.com/protocolbuffers/protobuf/) (only if you are going to change `proto` files):
   - Install on macOS with `brew install protobuf`.
   - Download all other versions from [protoc release page](https://github.com/protocolbuffers/protobuf/releases).
-* [Temporal CLI tctl](https://github.com/temporalio/tctl)
-  - Homebrew `brew install tctl`
-  - Go install `make update-tctl`
-  - Or download it from here https://github.com/temporalio/tctl
+* [Temporal CLI](https://github.com/temporalio/cli)
+  - Homebrew `brew install temporal`
+  - Go install `make update-cli`
+  - Or download it from here https://github.com/temporalio/cli
 
 
 ### Runtime (server and tests) prerequisites
@@ -116,7 +116,7 @@ make start
 
 Now you can create default namespace with `tctl`:
 ```bash
-tctl --namespace default namespace register
+temporal operator namespace create default
 ```
 and run samples from [Go](https://github.com/temporalio/samples-go) and [Java](https://github.com/temporalio/samples-java) samples repos. Also, you can access web UI at `localhost:8080`.
 

--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,10 @@ update-tctl:
 	@printf $(COLOR) "Install/update tctl..."
 	@go install github.com/temporalio/tctl/cmd/tctl@latest
 
+update-cli:
+	@printf $(COLOR) "Install/update cli..."
+	curl -sSf https://temporal.download/cli.sh | sh
+
 update-ui:
 	@printf $(COLOR) "Install/update temporal ui-server..."
 	@go install github.com/temporalio/ui-server/cmd/server@latest


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**
Replace tctl with cli in CONTRIBUTING.md
Create update-cli Make target

<!-- Tell your future self why have you made these changes -->
**Why?**
We're deprecating tctl in v1.22

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
tested the update-cli make target

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Nothing

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No