### PR TITLE
Add method metadata and use for default authorizer

### DIFF
--- a/common/api/metadata.go
+++ b/common/api/metadata.go
@@ -1,0 +1,166 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import "strings"
+
+type (
+	// Describes the scope of a method (whole cluster or inividual namespace).
+	Scope int32
+
+	// Describes what level of access is needed for a method. Note that this field is
+	// completely advisory. Any authorizer implementation may implement whatever logic it
+	// chooses, including ignoring this field. It is used by the "default" authorizer to check
+	// against roles in claims.
+	Access int32
+
+	MethodMetadata struct {
+		// Describes the scope of a method (whole cluster or inividual namespace).
+		Scope Scope
+		// Describes what level of access is needed for a method (advisory).
+		Access Access
+	}
+)
+
+const (
+	// Represents a missing Scope value.
+	ScopeUnknown Scope = iota
+	// Method affects a single namespace. The request message must contain a string field named "Namespace".
+	ScopeNamespace
+	// Method affects the whole cluster. The request message must _not_ contain any field named "Namespace".
+	ScopeCluster
+)
+
+const (
+	// Represents a missing Access value.
+	AccessUnknown Access = iota
+	// Method is read-only and should be accessible to readers.
+	AccessReadOnly
+	// Method is a normal write method.
+	AccessWrite
+	// Method is an administrative operation.
+	AccessAdmin
+)
+
+const (
+	WorkflowServicePrefix = "/temporal.api.workflowservice.v1.WorkflowService/"
+	OperatorServicePrefix = "/temporal.api.operatorservice.v1.OperatorService/"
+	AdminServicePrefix    = "/temporal.server.api.adminservice.v1.AdminService/"
+)
+
+var (
+	workflowServiceMetadata = map[string]MethodMetadata{
+		"RegisterNamespace":                  MethodMetadata{Scope: ScopeNamespace, Access: AccessAdmin},
+		"DescribeNamespace":                  MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"ListNamespaces":                     MethodMetadata{Scope: ScopeCluster, Access: AccessReadOnly},
+		"UpdateNamespace":                    MethodMetadata{Scope: ScopeNamespace, Access: AccessAdmin},
+		"DeprecateNamespace":                 MethodMetadata{Scope: ScopeNamespace, Access: AccessAdmin},
+		"StartWorkflowExecution":             MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"GetWorkflowExecutionHistory":        MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"GetWorkflowExecutionHistoryReverse": MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"PollWorkflowTaskQueue":              MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RespondWorkflowTaskCompleted":       MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RespondWorkflowTaskFailed":          MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"PollActivityTaskQueue":              MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RecordActivityTaskHeartbeat":        MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RecordActivityTaskHeartbeatById":    MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RespondActivityTaskCompleted":       MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RespondActivityTaskCompletedById":   MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RespondActivityTaskFailed":          MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RespondActivityTaskFailedById":      MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RespondActivityTaskCanceled":        MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RespondActivityTaskCanceledById":    MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"RequestCancelWorkflowExecution":     MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"SignalWorkflowExecution":            MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"SignalWithStartWorkflowExecution":   MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"ResetWorkflowExecution":             MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"TerminateWorkflowExecution":         MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"DeleteWorkflowExecution":            MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"ListOpenWorkflowExecutions":         MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"ListClosedWorkflowExecutions":       MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"ListWorkflowExecutions":             MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"ListArchivedWorkflowExecutions":     MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"ScanWorkflowExecutions":             MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"CountWorkflowExecutions":            MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"GetSearchAttributes":                MethodMetadata{Scope: ScopeCluster, Access: AccessReadOnly},
+		"RespondQueryTaskCompleted":          MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"ResetStickyTaskQueue":               MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"QueryWorkflow":                      MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"DescribeWorkflowExecution":          MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"DescribeTaskQueue":                  MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"GetClusterInfo":                     MethodMetadata{Scope: ScopeCluster, Access: AccessReadOnly},
+		"GetSystemInfo":                      MethodMetadata{Scope: ScopeCluster, Access: AccessReadOnly},
+		"ListTaskQueuePartitions":            MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"CreateSchedule":                     MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"DescribeSchedule":                   MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"UpdateSchedule":                     MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"PatchSchedule":                      MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"ListScheduleMatchingTimes":          MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"DeleteSchedule":                     MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"ListSchedules":                      MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"UpdateWorkerBuildIdCompatibility":   MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"GetWorkerBuildIdCompatibility":      MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"GetWorkerTaskReachability":          MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"UpdateWorkflowExecution":            MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"PollWorkflowExecutionUpdate":        MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"StartBatchOperation":                MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"StopBatchOperation":                 MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"DescribeBatchOperation":             MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"ListBatchOperations":                MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+	}
+	operatorServiceMetadata = map[string]MethodMetadata{
+		"AddSearchAttributes":      MethodMetadata{Scope: ScopeNamespace, Access: AccessAdmin},
+		"RemoveSearchAttributes":   MethodMetadata{Scope: ScopeNamespace, Access: AccessAdmin},
+		"ListSearchAttributes":     MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
+		"DeleteNamespace":          MethodMetadata{Scope: ScopeNamespace, Access: AccessAdmin},
+		"AddOrUpdateRemoteCluster": MethodMetadata{Scope: ScopeCluster, Access: AccessAdmin},
+		"RemoveRemoteCluster":      MethodMetadata{Scope: ScopeCluster, Access: AccessAdmin},
+		"ListClusters":             MethodMetadata{Scope: ScopeCluster, Access: AccessAdmin},
+	}
+)
+
+// GetMethodMetadata gets metadata for a given API method in one of the services exported by
+// frontend (WorkflowService, OperatorService, AdminService).
+func GetMethodMetadata(fullApiName string) MethodMetadata {
+	switch {
+	case strings.HasPrefix(fullApiName, WorkflowServicePrefix):
+		return workflowServiceMetadata[MethodName(fullApiName)]
+	case strings.HasPrefix(fullApiName, OperatorServicePrefix):
+		return operatorServiceMetadata[MethodName(fullApiName)]
+	case strings.HasPrefix(fullApiName, AdminServicePrefix):
+		return MethodMetadata{Scope: ScopeCluster, Access: AccessAdmin}
+	default:
+		return MethodMetadata{Scope: ScopeUnknown, Access: AccessUnknown}
+	}
+}
+
+// BaseName returns just the method name from a fullly qualified name.
+func MethodName(fullApiName string) string {
+	index := strings.LastIndex(fullApiName, "/")
+	if index > -1 {
+		return fullApiName[index+1:]
+	}
+	return fullApiName
+}

--- a/common/api/metadata_test.go
+++ b/common/api/metadata_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/operatorservice/v1"
 	"go.temporal.io/api/workflowservice/v1"
 	"golang.org/x/exp/maps"
@@ -36,14 +37,58 @@ import (
 
 func TestWorkflowServiceMetadata(t *testing.T) {
 	tp := reflect.TypeOf((*workflowservice.WorkflowServiceServer)(nil)).Elem()
-	assert.ElementsMatch(t, getMethodNames(tp), maps.Keys(workflowServiceMetadata),
-		"If you're adding a new method to WorkflowService, please add metadata for it in metadata.go")
+	checkService(t, tp, workflowServiceMetadata)
 }
 
 func TestOperatorServiceMetadata(t *testing.T) {
 	tp := reflect.TypeOf((*operatorservice.OperatorServiceServer)(nil)).Elem()
-	assert.ElementsMatch(t, getMethodNames(tp), maps.Keys(operatorServiceMetadata),
-		"If you're adding a new method to OperatorService, please add metadata for it in metadata.go")
+	checkService(t, tp, operatorServiceMetadata)
+}
+
+func checkService(t *testing.T, tp reflect.Type, m map[string]MethodMetadata) {
+	methods := getMethodNames(tp)
+	require.ElementsMatch(t, methods, maps.Keys(m),
+		"If you're adding a new method to Workflow/OperatorService, please add metadata for it in metadata.go")
+
+	for _, method := range methods {
+		refMethod, ok := tp.MethodByName(method)
+		require.True(t, ok)
+
+		checkNamespace := false
+		hasNamespace := false
+		namespaceIsString := false
+
+		if refMethod.Type.NumIn() >= 2 {
+			// not streaming
+			checkNamespace = true
+			requestType := refMethod.Type.In(1).Elem()
+			var nsField reflect.StructField
+			nsField, hasNamespace = requestType.FieldByName("Namespace")
+			if hasNamespace {
+				namespaceIsString = nsField.Type == reflect.TypeOf("string")
+			}
+		}
+
+		md := m[method]
+		switch md.Scope {
+		case ScopeNamespace:
+			if checkNamespace {
+				assert.Truef(t, namespaceIsString, "%s with ScopeNamespace should have a Namespace field that is a string", method)
+			}
+		case ScopeCluster:
+			if checkNamespace {
+				assert.Falsef(t, hasNamespace, "%s with ScopeCluster should not have a Namespace field", method)
+			}
+		default:
+			t.Error("unknown Scope for", method)
+		}
+
+		switch md.Access {
+		case AccessReadOnly, AccessWrite, AccessAdmin:
+		default:
+			t.Error("unknown Access for", method)
+		}
+	}
 }
 
 func TestGetMethodMetadata(t *testing.T) {

--- a/common/api/metadata_test.go
+++ b/common/api/metadata_test.go
@@ -1,0 +1,70 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	"golang.org/x/exp/maps"
+)
+
+func TestWorkflowServiceMetadata(t *testing.T) {
+	tp := reflect.TypeOf((*workflowservice.WorkflowServiceServer)(nil)).Elem()
+	assert.ElementsMatch(t, getMethodNames(tp), maps.Keys(workflowServiceMetadata),
+		"If you're adding a new method to WorkflowService, please add metadata for it in metadata.go")
+}
+
+func TestOperatorServiceMetadata(t *testing.T) {
+	tp := reflect.TypeOf((*operatorservice.OperatorServiceServer)(nil)).Elem()
+	assert.ElementsMatch(t, getMethodNames(tp), maps.Keys(operatorServiceMetadata),
+		"If you're adding a new method to OperatorService, please add metadata for it in metadata.go")
+}
+
+func TestGetMethodMetadata(t *testing.T) {
+	md := GetMethodMetadata("/temporal.api.workflowservice.v1.WorkflowService/RespondActivityTaskCompleted")
+	assert.Equal(t, ScopeNamespace, md.Scope)
+	assert.Equal(t, AccessWrite, md.Access)
+
+	// all AdminService is cluster/admin
+	md = GetMethodMetadata("/temporal.server.api.adminservice.v1.AdminService/CloseShard")
+	assert.Equal(t, ScopeCluster, md.Scope)
+	assert.Equal(t, AccessAdmin, md.Access)
+
+	md = GetMethodMetadata("/OtherService/Method1")
+	assert.Equal(t, ScopeUnknown, md.Scope)
+	assert.Equal(t, AccessUnknown, md.Access)
+}
+
+func getMethodNames(tp reflect.Type) []string {
+	var out []string
+	for i := 0; i < tp.NumMethod(); i++ {
+		out = append(out, tp.Method(i).Name)
+	}
+	return out
+}

--- a/common/authorization/frontend_api.go
+++ b/common/authorization/frontend_api.go
@@ -24,50 +24,23 @@
 
 package authorization
 
-var readOnlyNamespaceAPI = map[string]struct{}{
-	"DescribeNamespace":                  {},
-	"GetWorkflowExecutionHistory":        {},
-	"GetWorkflowExecutionHistoryReverse": {},
-	"ListOpenWorkflowExecutions":         {},
-	"ListClosedWorkflowExecutions":       {},
-	"ListWorkflowExecutions":             {},
-	"ListArchivedWorkflowExecutions":     {},
-	"ScanWorkflowExecutions":             {},
-	"CountWorkflowExecutions":            {},
-	"QueryWorkflow":                      {},
-	"DescribeWorkflowExecution":          {},
-	"DescribeTaskQueue":                  {},
-	"ListTaskQueuePartitions":            {},
-	"DescribeSchedule":                   {},
-	"ListSchedules":                      {},
-	"ListScheduleMatchingTimes":          {},
-	"DescribeBatchOperation":             {},
-	"ListBatchOperations":                {},
-	"GetWorkerBuildIdCompatibility":      {},
-	"GetWorkerTaskReachability":          {},
-}
+import "go.temporal.io/server/common/api"
 
-var readOnlyGlobalAPI = map[string]struct{}{
-	"ListNamespaces":      {},
-	"GetSearchAttributes": {},
-	"GetClusterInfo":      {},
-	"GetSystemInfo":       {},
-}
-
-// note that these use the fully-qualified name
 var healthCheckAPI = map[string]struct{}{
 	"/grpc.health.v1.Health/Check":                                   {},
 	"/temporal.api.workflowservice.v1.WorkflowService/GetSystemInfo": {},
 }
 
-func IsReadOnlyNamespaceAPI(api string) bool {
-	_, found := readOnlyNamespaceAPI[api]
-	return found
+func IsReadOnlyNamespaceAPI(workflowServiceMethod string) bool {
+	fullApiName := api.WorkflowServicePrefix + workflowServiceMethod
+	metadata := api.GetMethodMetadata(fullApiName)
+	return metadata.Scope == api.ScopeNamespace && metadata.Access == api.AccessReadOnly
 }
 
-func IsReadOnlyGlobalAPI(api string) bool {
-	_, found := readOnlyGlobalAPI[api]
-	return found
+func IsReadOnlyGlobalAPI(workflowServiceMethod string) bool {
+	fullApiName := api.WorkflowServicePrefix + workflowServiceMethod
+	metadata := api.GetMethodMetadata(fullApiName)
+	return metadata.Scope == api.ScopeCluster && metadata.Access == api.AccessReadOnly
 }
 
 func IsHealthCheckAPI(fullApi string) bool {

--- a/common/rpc/interceptor/telemetry_test.go
+++ b/common/rpc/interceptor/telemetry_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 
+	"go.temporal.io/server/common/api"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -48,7 +49,7 @@ func TestEmitActionMetric(t *testing.T) {
 	}{
 		{
 			metrics.FrontendQueryWorkflowScope,
-			frontendPackagePrefix + metrics.FrontendQueryWorkflowScope,
+			api.WorkflowServicePrefix + metrics.FrontendQueryWorkflowScope,
 			true,
 		},
 		{
@@ -58,7 +59,7 @@ func TestEmitActionMetric(t *testing.T) {
 		},
 		{
 			metrics.MatchingClientAddWorkflowTaskScope,
-			frontendPackagePrefix + metrics.FrontendQueryWorkflowScope,
+			api.WorkflowServicePrefix + metrics.FrontendQueryWorkflowScope,
 			false,
 		},
 	}
@@ -88,17 +89,17 @@ func TestOperationOverwrite(t *testing.T) {
 	}{
 		{
 			"DeleteWorkflowExecution",
-			adminServicePrefix + "DeleteWorkflowExecution",
+			api.AdminServicePrefix + "DeleteWorkflowExecution",
 			"AdminDeleteWorkflowExecution",
 		},
 		{
 			"DeleteNamespace",
-			operatorServicePrefix + "DeleteNamespace",
+			api.OperatorServicePrefix + "DeleteNamespace",
 			"OperatorDeleteNamespace",
 		},
 		{
 			metrics.FrontendStartWorkflowExecutionScope,
-			frontendPackagePrefix + metrics.FrontendStartWorkflowExecutionScope,
+			api.WorkflowServicePrefix + metrics.FrontendStartWorkflowExecutionScope,
 			metrics.FrontendStartWorkflowExecutionScope,
 		},
 	}


### PR DESCRIPTION
**What changed?**
- Add method metadata and unit test to check consistency
- Use metadata to implement default authorizer
- All AdminService requires System Admin role (including GetSearchAttributes)

**Why?**
- More consistent treatment of methods in default authorizer (includes service name)
- Avoid changing semantics if namespace field is added
- Allows ListSearchAttributes in OperatorService to namespace reader (fixes #4654 and #4783)

**How did you test it?**
unit tests
