### PR TITLE
Always persist guessed set id on unknown build id

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -849,8 +849,6 @@ func (e *matchingEngineImpl) UpdateWorkerBuildIdCompatibility(
 		updateOptions.TaskQueueLimitPerBuildId = e.config.TaskQueueLimitPerBuildId()
 	case *matchingservice.UpdateWorkerBuildIdCompatibilityRequest_RemoveBuildIds_:
 		updateOptions.KnownVersion = req.GetRemoveBuildIds().GetKnownUserDataVersion()
-	default:
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("invalid operation: %v", req.GetOperation()))
 	}
 
 	err = tqMgr.UpdateUserData(ctx, updateOptions, func(data *persistencespb.TaskQueueUserData) (*persistencespb.TaskQueueUserData, bool, error) {


### PR DESCRIPTION
**What changed?**
- In PersistUnknownBuildId, if the build id is already present but the guessed set id is not a set id of that set, add it to the set (previously it would leave the data unchanged).
- Get rid of the first unknown operation check in UpdateWorkerBuildIdCompatibility (unknown operations will error out in the mutation function anyway).

**Why?**
- The goal of PersistUnknownBuildId is to record that we spooled a task using a guessed set id. In the propagation lag case, PersistUnknownBuildId would see that a build id is present and not modify the data. If the build id was not the first one in its set, then we'd lose that guessed set id.
- We only need to check for unknown operations once, instead of updating the options switch with each new operation, we can just update the main switch in the mutation function.

**How did you test it?**
unit tests
