### PR TITLE
Multiply per-ns worker task slots by multiplicity

### DIFF
--- a/common/telemetry/config.go
+++ b/common/telemetry/config.go
@@ -39,6 +39,8 @@ import (
 	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials/insecure"
 	"gopkg.in/yaml.v3"
+
+	"go.temporal.io/server/common/util"
 )
 
 const (
@@ -184,16 +186,16 @@ func (g *grpcconn) Dial(ctx context.Context) (*grpc.ClientConn, error) {
 
 func (g *grpcconn) dialOpts() []grpc.DialOption {
 	out := []grpc.DialOption{
-		grpc.WithReadBufferSize(coalesce(g.ReadBufferSize, defaultReadBufferSize)),
-		grpc.WithWriteBufferSize(coalesce(g.WriteBufferSize, defaultWriteBufferSize)),
+		grpc.WithReadBufferSize(util.Coalesce(g.ReadBufferSize, defaultReadBufferSize)),
+		grpc.WithWriteBufferSize(util.Coalesce(g.WriteBufferSize, defaultWriteBufferSize)),
 		grpc.WithUserAgent(g.UserAgent),
 		grpc.WithConnectParams(grpc.ConnectParams{
-			MinConnectTimeout: coalesce(g.ConnectParams.MinConnectTimeout, defaultMinConnectTimeout),
+			MinConnectTimeout: util.Coalesce(g.ConnectParams.MinConnectTimeout, defaultMinConnectTimeout),
 			Backoff: backoff.Config{
-				BaseDelay:  coalesce(g.ConnectParams.Backoff.BaseDelay, backoff.DefaultConfig.BaseDelay),
-				MaxDelay:   coalesce(g.ConnectParams.Backoff.MaxDelay, backoff.DefaultConfig.MaxDelay),
-				Jitter:     coalesce(g.ConnectParams.Backoff.Jitter, backoff.DefaultConfig.Jitter),
-				Multiplier: coalesce(g.ConnectParams.Backoff.Multiplier, backoff.DefaultConfig.Multiplier),
+				BaseDelay:  util.Coalesce(g.ConnectParams.Backoff.BaseDelay, backoff.DefaultConfig.BaseDelay),
+				MaxDelay:   util.Coalesce(g.ConnectParams.Backoff.MaxDelay, backoff.DefaultConfig.MaxDelay),
+				Jitter:     util.Coalesce(g.ConnectParams.Backoff.Jitter, backoff.DefaultConfig.Jitter),
+				Multiplier: util.Coalesce(g.ConnectParams.Backoff.Multiplier, backoff.DefaultConfig.Multiplier),
 			},
 		}),
 	}
@@ -260,13 +262,13 @@ func (ec *exportConfig) buildOtlpGrpcMetricExporter(
 	opts := []otlpmetricgrpc.Option{
 		otlpmetricgrpc.WithEndpoint(cfg.Connection.Endpoint),
 		otlpmetricgrpc.WithHeaders(cfg.Headers),
-		otlpmetricgrpc.WithTimeout(coalesce(cfg.Timeout, 10*time.Second)),
+		otlpmetricgrpc.WithTimeout(util.Coalesce(cfg.Timeout, 10*time.Second)),
 		otlpmetricgrpc.WithDialOption(dopts...),
 		otlpmetricgrpc.WithRetry(otlpmetricgrpc.RetryConfig{
-			Enabled:         coalesce(cfg.Retry.Enabled, retryDefaultEnabled),
-			InitialInterval: coalesce(cfg.Retry.InitialInterval, retryDefaultInitialInterval),
-			MaxInterval:     coalesce(cfg.Retry.MaxInterval, retryDefaultMaxInterval),
-			MaxElapsedTime:  coalesce(cfg.Retry.MaxElapsedTime, retryDefaultMaxElapsedTime),
+			Enabled:         util.Coalesce(cfg.Retry.Enabled, retryDefaultEnabled),
+			InitialInterval: util.Coalesce(cfg.Retry.InitialInterval, retryDefaultInitialInterval),
+			MaxInterval:     util.Coalesce(cfg.Retry.MaxInterval, retryDefaultMaxInterval),
+			MaxElapsedTime:  util.Coalesce(cfg.Retry.MaxElapsedTime, retryDefaultMaxElapsedTime),
 		}),
 	}
 
@@ -295,13 +297,13 @@ func (ec *exportConfig) buildOtlpGrpcSpanExporter(
 	opts := []otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(cfg.Connection.Endpoint),
 		otlptracegrpc.WithHeaders(cfg.Headers),
-		otlptracegrpc.WithTimeout(coalesce(cfg.Timeout, 10*time.Second)),
+		otlptracegrpc.WithTimeout(util.Coalesce(cfg.Timeout, 10*time.Second)),
 		otlptracegrpc.WithDialOption(cfg.Connection.dialOpts()...),
 		otlptracegrpc.WithRetry(otlptracegrpc.RetryConfig{
-			Enabled:         coalesce(cfg.Retry.Enabled, retryDefaultEnabled),
-			InitialInterval: coalesce(cfg.Retry.InitialInterval, retryDefaultInitialInterval),
-			MaxInterval:     coalesce(cfg.Retry.MaxInterval, retryDefaultMaxInterval),
-			MaxElapsedTime:  coalesce(cfg.Retry.MaxElapsedTime, retryDefaultMaxElapsedTime),
+			Enabled:         util.Coalesce(cfg.Retry.Enabled, retryDefaultEnabled),
+			InitialInterval: util.Coalesce(cfg.Retry.InitialInterval, retryDefaultInitialInterval),
+			MaxInterval:     util.Coalesce(cfg.Retry.MaxInterval, retryDefaultMaxInterval),
+			MaxElapsedTime:  util.Coalesce(cfg.Retry.MaxElapsedTime, retryDefaultMaxElapsedTime),
 		}),
 	}
 
@@ -414,14 +416,4 @@ func (e *exporter) UnmarshalYAML(n *yaml.Node) error {
 		)
 	}
 	return obj.Spec.Decode(e.Spec)
-}
-
-func coalesce[T comparable](vals ...T) T {
-	var zero T
-	for _, v := range vals {
-		if v != zero {
-			return v
-		}
-	}
-	return zero
 }

--- a/common/util/util.go
+++ b/common/util/util.go
@@ -152,3 +152,15 @@ func ReduceSlice[T any, A any](in []T, initializer A, reducer func(A, T) A) A {
 	}
 	return acc
 }
+
+// Coalesce returns the first non-zero value of its arguments, or the zero value for the type
+// if all are zero.
+func Coalesce[T comparable](vals ...T) T {
+	var zero T
+	for _, v := range vals {
+		if v != zero {
+			return v
+		}
+	}
+	return zero
+}

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -458,9 +458,9 @@ func (w *perNamespaceWorker) startWorker(
 	sdkoptions.WorkerActivitiesPerSecond = dcOptions.WorkerActivitiesPerSecond
 	sdkoptions.MaxConcurrentLocalActivityExecutionSize = util.Coalesce(dcOptions.MaxConcurrentLocalActivityExecutionSize, 1000)
 	sdkoptions.WorkerLocalActivitiesPerSecond = dcOptions.WorkerLocalActivitiesPerSecond
-	sdkoptions.MaxConcurrentActivityTaskPollers = util.Coalesce(dcOptions.MaxConcurrentActivityTaskPollers, 2)
+	sdkoptions.MaxConcurrentActivityTaskPollers = util.Max(util.Coalesce(dcOptions.MaxConcurrentActivityTaskPollers, 2), 2)
 	sdkoptions.MaxConcurrentWorkflowTaskExecutionSize = util.Coalesce(dcOptions.MaxConcurrentWorkflowTaskExecutionSize, 1000)
-	sdkoptions.MaxConcurrentWorkflowTaskPollers = util.Coalesce(dcOptions.MaxConcurrentWorkflowTaskPollers, 2)
+	sdkoptions.MaxConcurrentWorkflowTaskPollers = util.Max(util.Coalesce(dcOptions.MaxConcurrentWorkflowTaskPollers, 2), 2)
 	sdkoptions.StickyScheduleToStartTimeout = dcOptions.StickyScheduleToStartTimeoutDuration
 
 	sdkoptions.BackgroundActivityContext = headers.SetCallerInfo(context.Background(), headers.NewBackgroundCallerInfo(ns.Name().String()))

--- a/service/worker/pernamespaceworker.go
+++ b/service/worker/pernamespaceworker.go
@@ -452,14 +452,15 @@ func (w *perNamespaceWorker) startWorker(
 
 	var sdkoptions sdkworker.Options
 
-	// copy from dynamic config
-	sdkoptions.MaxConcurrentActivityExecutionSize = dcOptions.MaxConcurrentActivityExecutionSize
+	// copy from dynamic config. apply explicit defaults for some instead of using the sdk
+	// defaults so that we can multiply below.
+	sdkoptions.MaxConcurrentActivityExecutionSize = util.Coalesce(dcOptions.MaxConcurrentActivityExecutionSize, 1000)
 	sdkoptions.WorkerActivitiesPerSecond = dcOptions.WorkerActivitiesPerSecond
-	sdkoptions.MaxConcurrentLocalActivityExecutionSize = dcOptions.MaxConcurrentLocalActivityExecutionSize
+	sdkoptions.MaxConcurrentLocalActivityExecutionSize = util.Coalesce(dcOptions.MaxConcurrentLocalActivityExecutionSize, 1000)
 	sdkoptions.WorkerLocalActivitiesPerSecond = dcOptions.WorkerLocalActivitiesPerSecond
-	sdkoptions.MaxConcurrentActivityTaskPollers = util.Max(2, dcOptions.MaxConcurrentActivityTaskPollers)
-	sdkoptions.MaxConcurrentWorkflowTaskExecutionSize = dcOptions.MaxConcurrentWorkflowTaskExecutionSize
-	sdkoptions.MaxConcurrentWorkflowTaskPollers = util.Max(2, dcOptions.MaxConcurrentWorkflowTaskPollers)
+	sdkoptions.MaxConcurrentActivityTaskPollers = util.Coalesce(dcOptions.MaxConcurrentActivityTaskPollers, 2)
+	sdkoptions.MaxConcurrentWorkflowTaskExecutionSize = util.Coalesce(dcOptions.MaxConcurrentWorkflowTaskExecutionSize, 1000)
+	sdkoptions.MaxConcurrentWorkflowTaskPollers = util.Coalesce(dcOptions.MaxConcurrentWorkflowTaskPollers, 2)
 	sdkoptions.StickyScheduleToStartTimeout = dcOptions.StickyScheduleToStartTimeoutDuration
 
 	sdkoptions.BackgroundActivityContext = headers.SetCallerInfo(context.Background(), headers.NewBackgroundCallerInfo(ns.Name().String()))
@@ -467,6 +468,9 @@ func (w *perNamespaceWorker) startWorker(
 	// increase these if we're supposed to run with more multiplicity
 	sdkoptions.MaxConcurrentWorkflowTaskPollers *= multiplicity
 	sdkoptions.MaxConcurrentActivityTaskPollers *= multiplicity
+	sdkoptions.MaxConcurrentLocalActivityExecutionSize *= multiplicity
+	sdkoptions.MaxConcurrentWorkflowTaskExecutionSize *= multiplicity
+	sdkoptions.MaxConcurrentActivityExecutionSize *= multiplicity
 	sdkoptions.OnFatalError = w.onFatalError
 
 	// this should not block because the client already has server capabilities

--- a/service/worker/pernamespaceworker_test.go
+++ b/service/worker/pernamespaceworker_test.go
@@ -212,6 +212,9 @@ func (s *perNsWorkerManagerSuite) TestMultiplicity() {
 	s.cfactory.EXPECT().NewWorker(matchStrict{cli1}, primitives.PerNSWorkerTaskQueue, gomock.Any()).Do(func(_, _ any, options sdkworker.Options) {
 		s.Equal(4, options.MaxConcurrentWorkflowTaskPollers)
 		s.Equal(4, options.MaxConcurrentActivityTaskPollers)
+		s.Equal(2000, options.MaxConcurrentWorkflowTaskExecutionSize)
+		s.Equal(2000, options.MaxConcurrentLocalActivityExecutionSize)
+		s.Equal(2000, options.MaxConcurrentActivityExecutionSize)
 	}).Return(wkr1)
 	s.cmp1.EXPECT().Register(wkr1, ns, workercommon.RegistrationDetails{TotalWorkers: 3, Multiplicity: 2})
 	wkr1.EXPECT().Start()


### PR DESCRIPTION
**What changed?**
Multiply these fields of SDK worker options by per-namespace worker multiplicity also:
- `MaxConcurrentLocalActivityExecutionSize`
- `MaxConcurrentWorkflowTaskExecutionSize`
- `MaxConcurrentActivityExecutionSize`

(Poller counts were already multiplied)

**Why?**
For bursty schedule workloads that get rate limited, LA or WFT task slots may fill up and slow down processing. These fields can already be adjusted independently, but using multiplicity as a single knob makes tuning easier and more intuitive.

**How did you test it?**
unit test