### PR TITLE
Simplify DescribeSchedule

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2644,76 +2644,50 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 	}
 
 	// then query to get current state from the workflow itself
-	// TODO: turn the refresh path into a synchronous update so we don't have to retry in a loop
-	sentRefresh := make(map[commonpb.WorkflowExecution]struct{})
-	// limit how many signals we send, separate from the retry policy (which is used to retry
-	// the query if the signal was not received or processed yet)
-	signalsLeft := 1
+	req := &historyservice.QueryWorkflowRequest{
+		NamespaceId: namespaceID.String(),
+		Request: &workflowservice.QueryWorkflowRequest{
+			Namespace: request.Namespace,
+			Execution: execution,
+			Query:     &querypb.WorkflowQuery{QueryType: scheduler.QueryNameDescribe},
+		},
+	}
+	res, err := wh.historyClient.QueryWorkflow(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
 	var queryResponse schedspb.DescribeResponse
+	err = payloads.Decode(res.GetResponse().GetQueryResult(), &queryResponse)
+	if err != nil {
+		return nil, err
+	}
 
-	op := func(ctx context.Context) error {
-		req := &historyservice.QueryWorkflowRequest{
+	// Search attributes in the Action are already in external ("aliased") form. Do not alias them here.
+
+	// for all running workflows started by the schedule, we should check that they're still running
+	origLen := len(queryResponse.Info.RunningWorkflows)
+	queryResponse.Info.RunningWorkflows = util.FilterSlice(queryResponse.Info.RunningWorkflows, func(ex *commonpb.WorkflowExecution) bool {
+		// we'll usually have just zero or one of these so we can just do them sequentially
+		msResponse, err := wh.historyClient.GetMutableState(ctx, &historyservice.GetMutableStateRequest{
 			NamespaceId: namespaceID.String(),
-			Request: &workflowservice.QueryWorkflowRequest{
-				Namespace: request.Namespace,
-				Execution: execution,
-				Query:     &querypb.WorkflowQuery{QueryType: scheduler.QueryNameDescribe},
-			},
-		}
-		res, err := wh.historyClient.QueryWorkflow(ctx, req)
+			// Note: do not send runid here so that we always get the latest one
+			Execution: &commonpb.WorkflowExecution{WorkflowId: ex.WorkflowId},
+		})
 		if err != nil {
-			return err
+			// if it's not found, it's certainly not running, so return false. if we got
+			// another error, we don't know the state so assume it's still running.
+			return !common.IsNotFoundError(err)
 		}
+		// return true if it is still running and is part of the chain the schedule started
+		return msResponse.WorkflowStatus == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING &&
+			msResponse.FirstExecutionRunId == ex.RunId
+	})
 
-		queryResponse.Reset()
-		err = payloads.Decode(res.GetResponse().GetQueryResult(), &queryResponse)
-		if err != nil {
-			return err
-		}
-
-		// Search attributes in the Action are already in external ("aliased") form. Do not alias them here.
-
-		// for all running workflows started by the schedule, we should check that they're
-		// still running, and if not, poke the schedule to refresh
-		needRefresh := false
-		for _, ex := range queryResponse.GetInfo().GetRunningWorkflows() {
-			if _, ok := sentRefresh[*ex]; ok {
-				// we asked the schedule to refresh this one because it wasn't running, but
-				// it's still reporting it as running
-				return errWaitForRefresh
-			}
-
-			// we'll usually have just zero or one of these so we can just do them sequentially
-			if msResponse, err := wh.historyClient.GetMutableState(ctx, &historyservice.GetMutableStateRequest{
-				NamespaceId: namespaceID.String(),
-				// Note: do not send runid here so that we always get the latest one
-				Execution: &commonpb.WorkflowExecution{WorkflowId: ex.WorkflowId},
-			}); err != nil {
-				switch err.(type) {
-				case *serviceerror.NotFound:
-					// if it doesn't exist (past retention period?) it's certainly not running
-					needRefresh = true
-					sentRefresh[*ex] = struct{}{}
-				default:
-					return err
-				}
-			} else if msResponse.WorkflowStatus != enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING ||
-				msResponse.FirstExecutionRunId != ex.RunId {
-				// there is no running execution of this workflow id, or there is a running
-				// execution, but it's not part of the chain that we started.
-				// either way, the workflow that we started is not running.
-				needRefresh = true
-				sentRefresh[*ex] = struct{}{}
-			}
-		}
-
-		if !needRefresh || signalsLeft == 0 {
-			return nil
-		}
-		signalsLeft--
-
-		// poke to refresh
-		_, err = wh.historyClient.SignalWorkflowExecution(ctx, &historyservice.SignalWorkflowExecutionRequest{
+	if len(queryResponse.Info.RunningWorkflows) < origLen {
+		// we noticed some "running workflows" aren't running anymore. poke the workflow to
+		// refresh, but don't wait for the state to change. ignore errors.
+		go wh.historyClient.SignalWorkflowExecution(ctx, &historyservice.SignalWorkflowExecutionRequest{
 			NamespaceId: namespaceID.String(),
 			SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
 				Namespace:         request.Namespace,
@@ -2723,29 +2697,6 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 				RequestId:         uuid.New(),
 			},
 		})
-		if err != nil {
-			return err
-		}
-
-		return errWaitForRefresh
-	}
-
-	// wait up to 4 seconds or rpc deadline minus 1 second, but at least 1 second
-	expiration := 4 * time.Second
-	if deadline, ok := ctx.Deadline(); ok {
-		remaining := time.Until(deadline) - 1*time.Second
-		expiration = util.Min(expiration, remaining)
-	}
-	expiration = util.Max(expiration, 1*time.Second)
-	policy := backoff.NewExponentialRetryPolicy(200 * time.Millisecond).
-		WithExpirationInterval(expiration)
-	isWaitErr := func(e error) bool { return e == errWaitForRefresh }
-
-	err = backoff.ThrottleRetryContext(ctx, op, policy, isWaitErr)
-	// if we still got errWaitForRefresh that means we used up our retries, just return
-	// whatever we have
-	if err != nil && err != errWaitForRefresh {
-		return nil, err
 	}
 
 	token := make([]byte, 8)

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2689,7 +2689,7 @@ func (wh *WorkflowHandler) DescribeSchedule(ctx context.Context, request *workfl
 		// refresh, but don't wait for the state to change. ignore errors.
 		go func() {
 			disconnectedCtx := headers.SetCallerInfo(context.Background(), headers.NewBackgroundCallerInfo(request.Namespace))
-			wh.historyClient.SignalWorkflowExecution(disconnectedCtx, &historyservice.SignalWorkflowExecutionRequest{
+			_, _ = wh.historyClient.SignalWorkflowExecution(disconnectedCtx, &historyservice.SignalWorkflowExecutionRequest{
 				NamespaceId: namespaceID.String(),
 				SignalRequest: &workflowservice.SignalWorkflowExecutionRequest{
 					Namespace:         request.Namespace,

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -650,9 +650,11 @@ func (s *scheduleIntegrationSuite) TestRefresh() {
 	s.NoError(err)
 	s.EqualValues(0, len(describeResp.Info.RunningWorkflows))
 
-	// scheduler has done some stuff
-	events3 := s.getHistory(s.namespace, &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
-	s.Greater(len(events3), len(events2))
+	// check scheduler has gotten the refresh and done some stuff. signal is sent without waiting so we need to wait.
+	s.Eventually(func() bool {
+		events3 := s.getHistory(s.namespace, &commonpb.WorkflowExecution{WorkflowId: scheduler.WorkflowIDPrefix + sid})
+		return len(events3) > len(events2)
+	}, 5*time.Second, 100*time.Millisecond)
 
 	// cleanup
 	_, err = s.engine.DeleteSchedule(NewContext(), &workflowservice.DeleteScheduleRequest{


### PR DESCRIPTION
**What changed?**
DescribeSchedule now does just one workflow query. It still sends a refresh signal if it filters out closed workflows, but it doesn't wait to observe a state change after the signal.

**Why?**
This extra work (repeated query to observe state change after signal) was not really useful since we can just filter out the closed workflows directly, and it made the call more expensive than it needs to be.

**How did you test it?**
existing integration tests
