### PR TITLE
Change TaskQueueType to WORKFLOW if UNSPECIFIED is provided in DescribeTaskQueue request

### DIFF
--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -767,6 +767,9 @@ func (e *matchingEngineImpl) DescribeTaskQueue(
 ) (*matchingservice.DescribeTaskQueueResponse, error) {
 	namespaceID := namespace.ID(request.GetNamespaceId())
 	taskQueueType := request.DescRequest.GetTaskQueueType()
+	if taskQueueType == enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
+	  taskQueueType = enumspb.TASK_QUEUE_TYPE_WORKFLOW
+	}
 	taskQueueName := request.DescRequest.TaskQueue.GetName()
 	stickyInfo := stickyInfoFromTaskQueue(request.DescRequest.TaskQueue)
 	taskQueue, err := newTaskQueueID(namespaceID, taskQueueName, taskQueueType)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added code to change TaskQueueType to TASK_QUEUE_TYPE_WORKFLOW if TASK_QUEUE_TYPE_UNSPECIFIED is passed to DescribeTaskQueue request.


<!-- Tell your future self why have you made these changes -->
If DescribeTaskQueue called without specifying TaskQueueType, server should use a default type(TASK_QUEUE_TYPE_WORKFLOW).


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Tested locally using tctl taskqueue describe command and ran existing unit tests.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No
