### PR TITLE
Mark QueryWorkflow as read-only in api metadata

### DIFF
--- a/common/api/metadata.go
+++ b/common/api/metadata.go
@@ -107,7 +107,7 @@ var (
 		"GetSearchAttributes":                MethodMetadata{Scope: ScopeCluster, Access: AccessReadOnly},
 		"RespondQueryTaskCompleted":          MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
 		"ResetStickyTaskQueue":               MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
-		"QueryWorkflow":                      MethodMetadata{Scope: ScopeNamespace, Access: AccessWrite},
+		"QueryWorkflow":                      MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
 		"DescribeWorkflowExecution":          MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
 		"DescribeTaskQueue":                  MethodMetadata{Scope: ScopeNamespace, Access: AccessReadOnly},
 		"GetClusterInfo":                     MethodMetadata{Scope: ScopeCluster, Access: AccessReadOnly},


### PR DESCRIPTION
**What changed?**
QueryWorkflow was marked as needing write access but it should be read-only.

**Why?**
QueryWorkflow doesn't change any workflow state.
