### PR TITLE
Emit metrics when gocql session refresh fails

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1078,7 +1078,7 @@ var (
 	VisibilityPersistenceFailures          = NewCounterDef("visibility_persistence_errors")
 	VisibilityPersistenceResourceExhausted = NewCounterDef("visibility_persistence_resource_exhausted")
 	VisibilityPersistenceLatency           = NewTimerDef("visibility_persistence_latency")
-	CassandraInitSessionLatency			   = NewTimerDef("cassandra_init_session_latency")
+	CassandraInitSessionLatency            = NewTimerDef("cassandra_init_session_latency")
 	CassandraSessionRefreshFailures        = NewCounterDef("cassandra_session_refresh_failures")
 )
 

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1078,6 +1078,7 @@ var (
 	VisibilityPersistenceFailures          = NewCounterDef("visibility_persistence_errors")
 	VisibilityPersistenceResourceExhausted = NewCounterDef("visibility_persistence_resource_exhausted")
 	VisibilityPersistenceLatency           = NewTimerDef("visibility_persistence_latency")
+	CassandraSessionRefreshFailures        = NewCounterDef("cassandra_session_refresh_failures")
 )
 
 // DEPRECATED: remove interim metric names for tracking fraction of FE->History calls during migration

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1078,6 +1078,7 @@ var (
 	VisibilityPersistenceFailures          = NewCounterDef("visibility_persistence_errors")
 	VisibilityPersistenceResourceExhausted = NewCounterDef("visibility_persistence_resource_exhausted")
 	VisibilityPersistenceLatency           = NewTimerDef("visibility_persistence_latency")
+	CassandraInitSessionLatency			   = NewTimerDef("cassandra_init_session_latency")
 	CassandraSessionRefreshFailures        = NewCounterDef("cassandra_session_refresh_failures")
 )
 

--- a/common/persistence/cassandra/factory.go
+++ b/common/persistence/cassandra/factory.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	p "go.temporal.io/server/common/persistence"
 	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
@@ -55,12 +56,14 @@ func NewFactory(
 	r resolver.ServiceResolver,
 	clusterName string,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) *Factory {
 	session, err := commongocql.NewSession(
 		func() (*gocql.ClusterConfig, error) {
 			return commongocql.NewCassandraCluster(cfg, r)
 		},
 		logger,
+		metricsHandler,
 	)
 	if err != nil {
 		logger.Fatal("unable to initialize cassandra session", tag.Error(err))

--- a/common/persistence/cassandra/test.go
+++ b/common/persistence/cassandra/test.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	p "go.temporal.io/server/common/persistence"
 	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
@@ -154,6 +155,7 @@ func (s *TestCluster) CreateSession(
 			)
 		},
 		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
 	)
 	if err != nil {
 		s.logger.Fatal("CreateSession", tag.Error(err))

--- a/common/persistence/cassandra/version_checker.go
+++ b/common/persistence/cassandra/version_checker.go
@@ -28,6 +28,7 @@ import (
 	"github.com/gocql/gocql"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/persistence/schema"
 	"go.temporal.io/server/common/resolver"
@@ -87,6 +88,7 @@ func CheckCompatibleVersion(
 			return commongocql.NewCassandraCluster(cfg, r)
 		},
 		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
 	)
 	if err != nil {
 		return err

--- a/common/persistence/client/store.go
+++ b/common/persistence/client/store.go
@@ -79,7 +79,7 @@ func DataStoreFactoryProvider(
 	defaultCfg := config.DataStores[config.DefaultStore]
 	switch {
 	case defaultCfg.Cassandra != nil:
-		dataStoreFactory = cassandra.NewFactory(*defaultCfg.Cassandra, r, string(clusterName), logger)
+		dataStoreFactory = cassandra.NewFactory(*defaultCfg.Cassandra, r, string(clusterName), logger, metricsHandler)
 	case defaultCfg.SQL != nil:
 		dataStoreFactory = sql.NewFactory(*defaultCfg.SQL, r, string(clusterName), logger)
 	case defaultCfg.CustomDataStoreConfig != nil:

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
@@ -1,0 +1,70 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package gocql
+
+import (
+	"errors"
+	"github.com/gocql/gocql"
+	"github.com/golang/mock/gomock"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"testing"
+	"time"
+)
+
+func TestSessionEmitsMetricOnRefreshError(t *testing.T) {
+	controller := gomock.NewController(t)
+	metricsHandler := metrics.NewMockHandler(controller)
+	s := session{
+		status: common.DaemonStatusStarted,
+		newClusterConfigFunc: func() (*gocql.ClusterConfig, error) {
+			return nil, errors.New("mock error for failing cluster creation")
+		},
+		logger:         log.NewNoopLogger(),
+		metricsHandler: metricsHandler,
+	}
+
+	metricsHandler.EXPECT().WithTags(metrics.FailureTag(refreshErrorTagValue)).Return(metricsHandler)
+	metricsHandler.EXPECT().Counter(metrics.CassandraSessionRefreshFailures.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+
+	s.refresh()
+}
+
+func TestSessionEmitsMetricOnRefreshThrottle(t *testing.T) {
+	controller := gomock.NewController(t)
+	metricsHandler := metrics.NewMockHandler(controller)
+	s := session{
+		status:          common.DaemonStatusStarted,
+		logger:          log.NewNoopLogger(),
+		metricsHandler:  metricsHandler,
+		sessionInitTime: time.Now().UTC(),
+	}
+
+	metricsHandler.EXPECT().WithTags(metrics.FailureTag(refreshThrottleTagValue)).Return(metricsHandler)
+	metricsHandler.EXPECT().Counter(metrics.CassandraSessionRefreshFailures.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+
+	s.refresh()
+}

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
@@ -26,13 +26,14 @@ package gocql
 
 import (
 	"errors"
+	"testing"
+	"time"
+
 	"github.com/gocql/gocql"
 	"github.com/golang/mock/gomock"
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
-	"testing"
-	"time"
 )
 
 func TestSessionEmitsMetricOnRefreshError(t *testing.T) {

--- a/common/persistence/tests/cassandra_test_util.go
+++ b/common/persistence/tests/cassandra_test_util.go
@@ -40,6 +40,7 @@ import (
 
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/cassandra"
 	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
@@ -85,6 +86,7 @@ func setUpCassandraTest(t *testing.T) (CassandraTestData, func()) {
 		resolver.NewNoopResolver(),
 		testCassandraClusterName,
 		testData.Logger,
+		metrics.NoopMetricsHandler,
 	)
 
 	tearDown := func() {
@@ -105,6 +107,7 @@ func SetUpCassandraDatabase(cfg *config.Cassandra, logger log.Logger) {
 			return commongocql.NewCassandraCluster(adminCfg, resolver.NewNoopResolver())
 		},
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))
@@ -133,6 +136,7 @@ func ApplySchemaUpdate(cfg *config.Cassandra, schemaFile string, logger log.Logg
 			return commongocql.NewCassandraCluster(*cfg, resolver.NewNoopResolver())
 		},
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	if err != nil {
 		panic(err)
@@ -167,6 +171,7 @@ func TearDownCassandraKeyspace(cfg *config.Cassandra) {
 			return commongocql.NewCassandraCluster(adminCfg, resolver.NewNoopResolver())
 		},
 		log.NewNoopLogger(),
+		metrics.NoopMetricsHandler,
 	)
 	if err != nil {
 		panic(fmt.Sprintf("unable to create Cassandra session: %v", err))

--- a/common/persistence/visibility/factory.go
+++ b/common/persistence/visibility/factory.go
@@ -245,10 +245,10 @@ func newVisibilityStoreFromDataStoreConfig(
 				logger,
 			)
 		default:
-			visStore, err = newStandardVisibilityStore(dsConfig, persistenceResolver, logger)
+			visStore, err = newStandardVisibilityStore(dsConfig, persistenceResolver, logger, metricsHandler)
 		}
 	} else if dsConfig.Cassandra != nil {
-		visStore, err = newStandardVisibilityStore(dsConfig, persistenceResolver, logger)
+		visStore, err = newStandardVisibilityStore(dsConfig, persistenceResolver, logger, metricsHandler)
 	} else if dsConfig.Elasticsearch != nil {
 		visStore = newElasticsearchVisibilityStore(
 			dsConfig.Elasticsearch.GetVisibilityIndex(),
@@ -269,6 +269,7 @@ func newStandardVisibilityStore(
 	dsConfig config.DataStore,
 	persistenceResolver resolver.ServiceResolver,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) (store.VisibilityStore, error) {
 	var (
 		visStore store.VisibilityStore
@@ -279,6 +280,7 @@ func newStandardVisibilityStore(
 			*dsConfig.Cassandra,
 			persistenceResolver,
 			logger,
+			metricsHandler,
 		)
 	} else if dsConfig.SQL != nil {
 		visStore, err = standardSql.NewSQLVisibilityStore(

--- a/common/persistence/visibility/store/standard/cassandra/visibility_store.go
+++ b/common/persistence/visibility/store/standard/cassandra/visibility_store.go
@@ -34,6 +34,7 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
 	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/persistence/visibility/manager"
@@ -150,12 +151,14 @@ func NewVisibilityStore(
 	cfg config.Cassandra,
 	r resolver.ServiceResolver,
 	logger log.Logger,
+	metricsHandler metrics.Handler,
 ) (*visibilityStore, error) {
 	session, err := commongocql.NewSession(
 		func() (*gocql.ClusterConfig, error) {
 			return commongocql.NewCassandraCluster(cfg, r)
 		},
 		logger,
+		metricsHandler,
 	)
 	if err != nil {
 		logger.Fatal("unable to initialize cassandra session", tag.Error(err))

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -2329,7 +2329,7 @@ func (wh *WorkflowHandler) DescribeTaskQueue(ctx context.Context, request *workf
 	if err := wh.validateTaskQueue(request.TaskQueue, namespaceName); err != nil {
 		return nil, err
 	}
-	
+
 	if request.TaskQueueType == enumspb.TASK_QUEUE_TYPE_UNSPECIFIED {
 		request.TaskQueueType = enumspb.TASK_QUEUE_TYPE_WORKFLOW
 	}

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -34,6 +34,7 @@ import (
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
 	commongocql "go.temporal.io/server/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"go.temporal.io/server/common/resolver"
 	"go.temporal.io/server/tools/common/schema"
@@ -114,6 +115,7 @@ func newCQLClient(cfg *CQLClientConfig, logger log.Logger) (*cqlClient, error) {
 			return commongocql.NewCassandraCluster(*cassandraConfig, resolver.NewNoopResolver())
 		},
 		logger,
+		metrics.NoopMetricsHandler,
 	)
 	if err != nil {
 		logger.Error("Connection validation failed.", tag.Error(err))


### PR DESCRIPTION
What changed?
passing metrics handler all the way down to gocql Session and emit metric when refresh fails


Why?
So we can put alert on this metric and catch downstream Cassandra issues

How did you test it?
unit-test

Potential risks
None

Is hotfix candidate?
No