### PR TITLE
Exit build id scavenger on rate limiter error

### DIFF
--- a/service/worker/scanner/build_ids/scavenger.go
+++ b/service/worker/scanner/build_ids/scavenger.go
@@ -211,12 +211,12 @@ func (a *Activities) processNamespaceEntry(
 				return ctx.Err()
 			}
 			entry := tqResponse.Entries[heartbeat.TaskQueueIdx]
-			err := a.processUserDataEntry(ctx, rateLimiter, *heartbeat, ns, entry)
-			if common.IsContextDeadlineExceededErr(err) {
-				// This is either a real DeadlineExceeded from the context, or the rate limiter
-				// thinks there's not enough time left until the deadline. Either way, we're done.
-				return err
-			} else if err != nil {
+			if err := a.processUserDataEntry(ctx, rateLimiter, *heartbeat, ns, entry); err != nil {
+				if common.IsContextDeadlineExceededErr(err) {
+					// This is either a real DeadlineExceeded from the context, or the rate limiter
+					// thinks there's not enough time left until the deadline. Either way, we're done.
+					return err
+				}
 				// Intentionally don't fail the activity on single entry.
 				a.logger.Error("Failed to update task queue user data",
 					tag.WorkflowNamespace(ns.Name().String()),

--- a/service/worker/scanner/build_ids/scavenger.go
+++ b/service/worker/scanner/build_ids/scavenger.go
@@ -207,17 +207,17 @@ func (a *Activities) processNamespaceEntry(
 			return err
 		}
 		for heartbeat.TaskQueueIdx < len(tqResponse.Entries) {
-			if ctx.Err() != nil {
-				return ctx.Err()
-			}
 			entry := tqResponse.Entries[heartbeat.TaskQueueIdx]
 			if err := a.processUserDataEntry(ctx, rateLimiter, *heartbeat, ns, entry); err != nil {
 				if common.IsContextDeadlineExceededErr(err) {
 					// This is either a real DeadlineExceeded from the context, or the rate limiter
 					// thinks there's not enough time left until the deadline. Either way, we're done.
 					return err
+				} else if ctx.Err() != nil {
+					// Also return on context.Canceled.
+					return ctx.Err()
 				}
-				// Intentionally don't fail the activity on single entry.
+				// Intentionally don't fail the activity on other single entry errors.
 				a.logger.Error("Failed to update task queue user data",
 					tag.WorkflowNamespace(ns.Name().String()),
 					tag.WorkflowTaskQueueName(entry.TaskQueue),


### PR DESCRIPTION
**What changed?**
In the build id scavenger, if `rateLimiter.Wait` returns an error (it would have to wait longer than the context deadline), then exit the activity.

**Why?**
The loop in the calling function only exits if the context deadline is actually exceeded, not if it would be exceeded shortly. So it would try the next task queue, which would hit the same error, etc. It should just exit early instead.

**How did you test it?**
looked at code
