### PR TITLE
Fix QueryWorkflow forwarding on versioned queue

### DIFF
--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -170,7 +170,7 @@ func (c *clientImpl) PollWorkflowTaskQueue(
 }
 
 func (c *clientImpl) QueryWorkflow(ctx context.Context, request *matchingservice.QueryWorkflowRequest, opts ...grpc.CallOption) (*matchingservice.QueryWorkflowResponse, error) {
-	partition := c.loadBalancer.PickReadPartition(
+	partition := c.loadBalancer.PickWritePartition(
 		namespace.ID(request.GetNamespaceId()),
 		*request.GetTaskQueue(),
 		enumspb.TASK_QUEUE_TYPE_WORKFLOW,

--- a/client/matching/loadbalancer.go
+++ b/client/matching/loadbalancer.go
@@ -85,7 +85,7 @@ func NewLoadBalancer(
 		nReadPartitions:     dc.GetTaskQueuePartitionsProperty(dynamicconfig.MatchingNumTaskqueueReadPartitions),
 		nWritePartitions:    dc.GetTaskQueuePartitionsProperty(dynamicconfig.MatchingNumTaskqueueWritePartitions),
 		forceReadPartition:  dc.GetIntProperty(dynamicconfig.TestMatchingLBForceReadPartition, -1),
-		forceWritePartition: dc.GetIntProperty(dynamicconfig.TestMatchingLBForceReadPartition, -1),
+		forceWritePartition: dc.GetIntProperty(dynamicconfig.TestMatchingLBForceWritePartition, -1),
 	}
 	return lb
 }

--- a/service/matching/forwarder.go
+++ b/service/matching/forwarder.go
@@ -197,8 +197,9 @@ func (fwdr *Forwarder) ForwardQueryTask(
 			Name: target.FullName(),
 			Kind: fwdr.taskQueueKind,
 		},
-		QueryRequest:    task.query.request.QueryRequest,
-		ForwardedSource: fwdr.taskQueueID.FullName(),
+		QueryRequest:     task.query.request.QueryRequest,
+		ForwardedSource:  fwdr.taskQueueID.FullName(),
+		VersionDirective: task.query.request.VersionDirective,
 	})
 
 	return resp, fwdr.handleErr(err)


### PR DESCRIPTION
**What changed?**
- Fix forwarding of query tasks with a version directive.
- Use PickWritePartition for load-balancing query tasks.
- Fix the logic to force specific partitions for testing with forcing forwarding, used by versioning tests.

**Why?**
- The version directive was being omitted when forwarding queries, we need it to match versioned tasks correctly.
- Query tasks are new tasks, not polls, so they're on the "write" side from matching's point of view, even though they read data.
- Make the test test what it's supposed to.

**How did you test it?**
integration tests

**Potential risks**

**Is hotfix candidate?**
