### PR TITLE
Fix race condition for task latency calculation

### DIFF
--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -423,11 +423,12 @@ func (e *executableImpl) Nack(err error) {
 
 	if !submitted {
 		backoffDuration := e.backoffDuration(err, e.Attempt())
-		e.rescheduler.Add(e, e.timeSource.Now().Add(backoffDuration))
 		if !errors.Is(err, consts.ErrResourceExhaustedBusyWorkflow) &&
 			!errors.Is(err, consts.ErrResourceExhaustedAPSLimit) {
 			e.inMemoryNoUserLatency += backoffDuration
 		}
+
+		e.rescheduler.Add(e, e.timeSource.Now().Add(backoffDuration))
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix race condition in task in memory nouser latency calculation
- Once task is resubmitted or rescheduled, its internal state should not be accessed or updated. `common/tasks.Task` part of the Executable implementation is not designed to be thread safe.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Bug fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Updated unit test to catch the case

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- no. the bug only impact latency metric calculation in error case.