### PR TITLE
Improve batchedTask enqueue efficiency

### DIFF
--- a/service/history/replication/batchable_task.go
+++ b/service/history/replication/batchable_task.go
@@ -95,8 +95,8 @@ func (w *batchedTask) Ack() {
 
 func (w *batchedTask) Execute() error {
 	w.lock.Lock()
-	defer w.lock.Unlock()
 	w.state = batchStateClose
+	w.lock.Unlock()
 	return w.batchedTask.Execute()
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move unlock prior to the execute() finishing.

<!-- Tell your future self why have you made these changes -->
**Why?**
The underlying Execute() func usually involves I/O with DB and take longer time to execute. 
The Lock in the batchedTask is to prevent the batchTask accepting new Task when executing. We have `state` to prevent this happening, so we can unlock() before underlying Execute() and let the AddTask() fail faster.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/a

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/a

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No