### PR TITLE
Add an ExecutableDLQ to write history tasks to the DLQ

### DIFF
--- a/common/clock/context.go
+++ b/common/clock/context.go
@@ -1,0 +1,95 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package clock
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+type ctxWithDeadline struct {
+	context.Context
+	deadline time.Time
+	timer    Timer
+	once     sync.Once
+	done     chan struct{}
+	err      error
+}
+
+func (ctx *ctxWithDeadline) Deadline() (deadline time.Time, ok bool) {
+	return ctx.deadline, true
+}
+
+func (ctx *ctxWithDeadline) Done() <-chan struct{} {
+	return ctx.done
+}
+
+func (ctx *ctxWithDeadline) Err() error {
+	select {
+	case <-ctx.done:
+		return ctx.err
+	default:
+		return nil
+	}
+}
+
+func (ctx *ctxWithDeadline) deadlineExceeded() {
+	ctx.once.Do(func() {
+		ctx.err = context.DeadlineExceeded
+		close(ctx.done)
+	})
+}
+
+func (ctx *ctxWithDeadline) cancel() {
+	ctx.once.Do(func() {
+		ctx.timer.Stop()
+		ctx.err = context.Canceled
+		close(ctx.done)
+	})
+}
+
+func ContextWithDeadline(
+	ctx context.Context,
+	deadline time.Time,
+	timeSource TimeSource,
+) (context.Context, context.CancelFunc) {
+	ctxd := &ctxWithDeadline{
+		Context:  ctx,
+		deadline: deadline,
+		done:     make(chan struct{}),
+	}
+	timer := timeSource.AfterFunc(deadline.Sub(timeSource.Now()), ctxd.deadlineExceeded)
+	ctxd.timer = timer
+	return ctxd, ctxd.cancel
+}
+
+func ContextWithTimeout(
+	ctx context.Context,
+	timeout time.Duration,
+	timeSource TimeSource,
+) (context.Context, context.CancelFunc) {
+	return ContextWithDeadline(ctx, timeSource.Now().Add(timeout), timeSource)
+}

--- a/common/clock/context_test.go
+++ b/common/clock/context_test.go
@@ -1,0 +1,80 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package clock_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/server/common/clock"
+)
+
+func TestContextWithTimeout_Canceled(t *testing.T) {
+	t.Parallel()
+
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(time.Unix(0, 0))
+	ctx := context.Background()
+	ctx, cancel := clock.ContextWithTimeout(ctx, time.Second, timeSource)
+	deadline, ok := ctx.Deadline()
+	assert.True(t, ok)
+	assert.Equal(t, time.Unix(1, 0), deadline)
+	cancel()
+	select {
+	case <-ctx.Done():
+		assert.ErrorIs(t, ctx.Err(), context.Canceled)
+	default:
+		t.Fatal("expected context to be canceled")
+	}
+}
+
+func TestContextWithTimeout_Fire(t *testing.T) {
+	t.Parallel()
+
+	timeSource := clock.NewEventTimeSource()
+	timeSource.Update(time.Unix(0, 0))
+	ctx := context.Background()
+	ctx, cancel := clock.ContextWithTimeout(ctx, time.Second, timeSource)
+	deadline, ok := ctx.Deadline()
+	assert.True(t, ok)
+	assert.Equal(t, time.Unix(1, 0), deadline)
+	timeSource.Advance(time.Second - time.Millisecond)
+	select {
+	case <-ctx.Done():
+		t.Fatal("expected context to not be canceled")
+	default:
+		assert.NoError(t, ctx.Err())
+	}
+	timeSource.Advance(time.Millisecond)
+	select {
+	case <-ctx.Done():
+		assert.ErrorIs(t, ctx.Err(), context.DeadlineExceeded)
+	default:
+		t.Fatal("expected context to be canceled")
+	}
+	cancel() // should be a no-op
+}

--- a/common/persistence/tests/cassandra_test.go
+++ b/common/persistence/tests/cassandra_test.go
@@ -233,6 +233,12 @@ func TestCassandraQueuePersistence(t *testing.T) {
 }
 
 func TestCassandraQueueV2Persistence(t *testing.T) {
+	// This test function is split up into two parts:
+	// 1. Test the generic queue functionality, which is independent of the database choice (Cassandra here).
+	//   This is done by calling the generic RunQueueV2TestSuite function.
+	// 2. Test the Cassandra-specific implementation of the queue. For example, things like queue message ID conflicts
+	//   can only happen in Cassandra due to its lack of transactions, so we need to test those here.
+
 	t.Parallel()
 
 	cluster := persistencetests.NewTestClusterForCassandra(&persistencetests.TestBaseOptions{}, log.NewNoopLogger())
@@ -243,6 +249,10 @@ func TestCassandraQueueV2Persistence(t *testing.T) {
 		t.Parallel()
 		RunQueueV2TestSuite(t, cassandra.NewQueueV2Store(cluster.GetSession()))
 	})
+	runCassandraSpecificQueueV2Tests(t, cluster)
+}
+
+func runCassandraSpecificQueueV2Tests(t *testing.T, cluster *cassandra.TestCluster) {
 	t.Run("QueueMessageIDConflict", func(t *testing.T) {
 		t.Parallel()
 		testCassandraQueueV2ErrQueueMessageConflict(t, cluster)

--- a/common/persistence/tests/history_task_queue_manager_test_suite.go
+++ b/common/persistence/tests/history_task_queue_manager_test_suite.go
@@ -40,6 +40,7 @@ import (
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/api/getdlqtasks/getdlqtaskstest"
+	"go.temporal.io/server/service/history/queues/queuestest"
 	"go.temporal.io/server/service/history/tasks"
 )
 
@@ -62,6 +63,10 @@ func RunHistoryTaskQueueManagerTestSuite(t *testing.T, queue persistence.QueueV2
 	t.Run("ClientTest", func(t *testing.T) {
 		t.Parallel()
 		historytest.TestClientGetDLQTasks(t, historyTaskQueueManager)
+	})
+	t.Run("ExecutableTest", func(t *testing.T) {
+		t.Parallel()
+		queuestest.TestExecutable(t, historyTaskQueueManager)
 	})
 }
 

--- a/service/history/queues/executable_dlq.go
+++ b/service/history/queues/executable_dlq.go
@@ -1,0 +1,114 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+)
+
+type (
+	// ExecutableDLQ is an Executable decorator that will enqueue the task to a DLQ if the underlying Executable fails.
+	// The first call to Execute for which the underlying Executable returns a terminal error will return an
+	// ErrTerminalTaskFailure error and change the behavior of this task to just try to send itself to the DLQ.
+	// Specifically, all subsequent calls to Execute will attempt to send the task to the DLQ. If this fails, the error
+	// will be returned (with the expectation that clients will retry). If it succeeds, no error will be returned and
+	// the task can be acked. When the executable is in the failed state, all calls to HandleErr will just return the
+	// error passed in.
+	// TODO: wrap all executables with this
+	// TODO: add metrics and logging to this
+	ExecutableDLQ struct {
+		Executable
+		dlq        DLQ
+		timeSource clock.TimeSource
+		// dlqCause is the original error which caused this task to be sent to the DLQ. It is only set once.
+		dlqCause    error
+		clusterName string
+	}
+
+	// DLQ is a dead letter queue that can be used to enqueue tasks that fail to be processed.
+	DLQ interface {
+		EnqueueTask(
+			ctx context.Context,
+			request *persistence.EnqueueTaskRequest,
+		) (*persistence.EnqueueTaskResponse, error)
+	}
+)
+
+const (
+	sendToDLQTimeout = 3 * time.Second
+)
+
+var (
+	_                      Executable = new(ExecutableDLQ)
+	ErrTerminalTaskFailure            = errors.New("original task failed and this task is now to send the original to the DLQ")
+	ErrSendTaskToDLQ                  = errors.New("failed to send task to DLQ")
+)
+
+// NewExecutableDLQ wraps an Executable to ensure that it is sent to the DLQ if it fails terminally.
+func NewExecutableDLQ(executable Executable, dlq DLQ, timeSource clock.TimeSource, clusterName string) *ExecutableDLQ {
+	return &ExecutableDLQ{
+		Executable:  executable,
+		dlq:         dlq,
+		timeSource:  timeSource,
+		clusterName: clusterName,
+	}
+}
+
+// Execute is not thread-safe.
+func (d *ExecutableDLQ) Execute() error {
+	if d.dlqCause == nil {
+		// This task has not experienced a terminal failure yet, so we should execute it.
+		err := d.Executable.Execute()
+		// TODO: expand on the errors that should be considered terminal
+		if !errors.As(err, new(*serialization.DeserializationError)) &&
+			!errors.As(err, new(*serialization.UnknownEncodingTypeError)) {
+			return err
+		}
+		d.dlqCause = err
+		return fmt.Errorf("%w: %v", ErrTerminalTaskFailure, err)
+	}
+	// This task experienced a terminal failure, so we should try to send it to the DLQ.
+	ctx := headers.SetCallerInfo(context.Background(), headers.SystemPreemptableCallerInfo)
+	ctx, cancel := clock.ContextWithTimeout(ctx, sendToDLQTimeout, d.timeSource)
+	defer cancel()
+	_, err := d.dlq.EnqueueTask(ctx, &persistence.EnqueueTaskRequest{
+		QueueType:     persistence.QueueTypeHistoryDLQ,
+		SourceCluster: d.clusterName,
+		TargetCluster: d.clusterName,
+		Task:          d.GetTask(),
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrSendTaskToDLQ, err)
+	}
+	return nil
+}

--- a/service/history/queues/executable_dlq_test.go
+++ b/service/history/queues/executable_dlq_test.go
@@ -1,0 +1,184 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/queues/queuestest"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	// testDLQ is a DLQ which records the requests it receives and returns the given error upon DLQ.EnqueueTask.
+	testDLQ struct {
+		// requests to write to the DLQ
+		requests []*persistence.EnqueueTaskRequest
+		// err to return on EnqueueTask
+		err error
+	}
+	// fakeTask is needed to compare tasks.Task values by identity
+	fakeTask struct {
+		tasks.Task
+	}
+)
+
+var (
+	// testTask is an arbitrary task that we use to verify that the correct task is enqueued to the DLQ
+	testTask tasks.Task = fakeTask{}
+)
+
+func (d *testDLQ) EnqueueTask(
+	_ context.Context,
+	request *persistence.EnqueueTaskRequest,
+) (*persistence.EnqueueTaskResponse, error) {
+	d.requests = append(d.requests, request)
+	return nil, d.err
+}
+
+func TestDLQExecutable_TerminalErrors(t *testing.T) {
+	// Verify that if Executable.Execute returns a terminal error, the task is sent to the DLQ
+
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		err  error
+	}{
+		{
+			name: "Deserialization Error",
+			err:  new(serialization.DeserializationError),
+		},
+		{
+			name: "Unknown Encoding Type Error",
+			err:  new(serialization.UnknownEncodingTypeError),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			dlq := &testDLQ{}
+			executable := newExecutable(tc.err)
+
+			dlqExecutable := newExecutableDLQ(executable, dlq)
+			err := dlqExecutable.Execute()
+			assert.ErrorIs(t, err, queues.ErrTerminalTaskFailure)
+			assert.ErrorContains(t, err, tc.err.Error())
+
+			err = dlqExecutable.Execute()
+			assert.Equal(t, 1, executable.GetCalls())
+			assert.NoError(t, err)
+
+			require.Len(t, dlq.requests, 1)
+			assert.Equal(t, &persistence.EnqueueTaskRequest{
+				QueueType:     persistence.QueueTypeHistoryDLQ,
+				SourceCluster: "test-cluster-name",
+				TargetCluster: "test-cluster-name",
+				Task:          testTask,
+			}, dlq.requests[0])
+		})
+	}
+}
+
+func TestDLQExecutable_NilError(t *testing.T) {
+	// Verify that successful calls to Execute do not send the task to the DLQ
+
+	t.Parallel()
+	dlq := &testDLQ{}
+	executable := newExecutable(nil)
+	dlqExecutable := newExecutableDLQ(executable, dlq)
+	err := dlqExecutable.Execute()
+	assert.NoError(t, err)
+	assert.Empty(t, dlq.requests, "Nil error should not be sent to DLQ")
+}
+
+func TestDLQExecutable_RandomErr(t *testing.T) {
+	// Verify that non-terminal errors are not sent to the DLQ
+
+	t.Parallel()
+
+	originalErr := errors.New("some non-terminal error")
+	dlq := &testDLQ{}
+	executable := newExecutable(originalErr)
+	dlqExecutable := newExecutableDLQ(executable, dlq)
+	for i := 0; i < 2; i++ {
+		// simulate the client retrying the task
+		err := dlqExecutable.Execute()
+		assert.ErrorIs(t, err, originalErr)
+	}
+	assert.Empty(t, dlq.requests, "Non-terminal error should not be sent to DLQ")
+}
+
+func TestDLQExecutable_DLQErr(t *testing.T) {
+	// Verify that if the DLQ returns an error, we return ErrSendTaskToDLQ
+
+	t.Parallel()
+
+	dlqErr := errors.New("error writing task to queue")
+	originalErr := new(serialization.DeserializationError)
+	dlq := &testDLQ{err: dlqErr}
+	executable := newExecutable(originalErr)
+	dlqExecutable := newExecutableDLQ(executable, dlq)
+
+	err := dlqExecutable.Execute()
+	assert.ErrorIs(t, err, queues.ErrTerminalTaskFailure, "First call to Execute for a terminal error should return"+
+		" ErrTerminalTaskFailure")
+	assert.ErrorContains(t, err, originalErr.Error())
+
+	for i := 0; i < 2; i++ {
+		err := dlqExecutable.Execute()
+		assert.ErrorIs(t, err, queues.ErrSendTaskToDLQ)
+		assert.ErrorContains(t, err, dlqErr.Error(), "Subsequent calls to Execute should return"+
+			" ErrSendTaskToDLQ if the DLQ is still returning an error")
+	}
+
+	require.Len(t, dlq.requests, 2, "The DLQ should have received two requests: one for each call"+
+		" to Execute after the first")
+	for _, r := range dlq.requests {
+		assert.Equal(t, &persistence.EnqueueTaskRequest{
+			QueueType:     persistence.QueueTypeHistoryDLQ,
+			SourceCluster: "test-cluster-name",
+			TargetCluster: "test-cluster-name",
+			Task:          testTask,
+		}, r, "The queue should have received a request to enqueue the failing task")
+	}
+}
+
+func newExecutableDLQ(executable *queuestest.FakeExecutable, dlq *testDLQ) *queues.ExecutableDLQ {
+	return queues.NewExecutableDLQ(executable, dlq, clock.NewEventTimeSource(), "test-cluster-name")
+}
+
+func newExecutable(err error) *queuestest.FakeExecutable {
+	return queuestest.NewFakeExecutable(testTask, err)
+}

--- a/service/history/queues/queuestest/executable_dlq_test_suite.go
+++ b/service/history/queues/queuestest/executable_dlq_test_suite.go
@@ -1,0 +1,106 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queuestest
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+var errRetryable = errors.New("retryable error")
+
+// TestExecutable is a library test function which tests the behavior of queues.ExecutableDLQ against a real database.
+func TestExecutable(t *testing.T, tqm persistence.HistoryTaskQueueManager) {
+	for _, tc := range []struct {
+		name      string
+		err       error
+		shouldDLQ bool
+	}{
+		{
+			name:      "Deserialization Error",
+			err:       new(serialization.DeserializationError),
+			shouldDLQ: true,
+		},
+		{
+			name:      "Unknown Encoding Type Error",
+			err:       new(serialization.UnknownEncodingTypeError),
+			shouldDLQ: true,
+		},
+		{
+			name:      "Retryable Error",
+			err:       errRetryable,
+			shouldDLQ: false,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+
+			task := &tasks.WorkflowTask{}
+			clusterName := "test-cluster-" + t.Name()
+
+			var executable queues.Executable = NewFakeExecutable(task, tc.err)
+			executable = queues.NewExecutableDLQ(executable, tqm, clock.NewEventTimeSource(), clusterName)
+			err := executable.Execute()
+			assert.ErrorContains(t, err, tc.err.Error())
+			if tc.shouldDLQ {
+				assert.ErrorIs(t, err, queues.ErrTerminalTaskFailure)
+				err = executable.Execute()
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorIs(t, err, tc.err)
+			}
+			response, err := tqm.ReadTasks(ctx, &persistence.ReadTasksRequest{
+				QueueKey: persistence.QueueKey{
+					QueueType:     persistence.QueueTypeHistoryDLQ,
+					Category:      tasks.CategoryTransfer,
+					SourceCluster: clusterName,
+					TargetCluster: clusterName,
+				},
+				PageSize:      2, // make it 2 even though we want just 1 to verify that there's no extra tasks
+				NextPageToken: nil,
+			})
+			require.NoError(t, err)
+			if tc.shouldDLQ {
+				if assert.Len(t, response.Tasks, 1) {
+					assert.Equal(t, task, response.Tasks[0].Task)
+				}
+			} else {
+				assert.Empty(t, response.Tasks)
+			}
+		})
+	}
+}

--- a/service/history/queues/queuestest/fake_executable.go
+++ b/service/history/queues/queuestest/fake_executable.go
@@ -1,0 +1,56 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queuestest
+
+import (
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+// FakeExecutable is a fake queues.Executable that returns the given task and error upon GetTask and Execute,
+// respectively, and it also records the number of calls.
+type FakeExecutable struct {
+	queues.Executable
+	err   error
+	task  tasks.Task
+	calls int
+}
+
+func NewFakeExecutable(task tasks.Task, err error) *FakeExecutable {
+	return &FakeExecutable{task: task, err: err}
+}
+
+func (e *FakeExecutable) Execute() error {
+	e.calls++
+	return e.err
+}
+
+func (e *FakeExecutable) GetTask() tasks.Task {
+	return e.task
+}
+
+func (e *FakeExecutable) GetCalls() int {
+	return e.calls
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added an ExecutableDLQ struct which wraps Executables in such a way that terminal errors result in the task eventually being written to the database. It works by modifying the behavior of the executable after the first terminal error is encountered. When this happens, the Execute method is modified to instead attempt to write the task to the DLQ. We do this instead of writing to the DLQ inline so that we can reuse the upstream retry logic.

A follow-up PR will actually wrap our executables with this class; for now, the behavior in production isn't changed at all.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is part of the write-path for the DLQ project. I made this a wrapper instead of putting it inline in the ExecutableImpl to keep things modular and reduce bloat.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
There's 100% test coverage for the new code.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It's not used anywhere in prod yet. There is some risk to bypassing the underlying Execute method. We no longer have the same telemetry and what-not.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.