### PR TITLE
Add a pluggable ExecutableWrapper to our queue factories

### DIFF
--- a/service/history/archival_queue_factory.go
+++ b/service/history/archival_queue_factory.go
@@ -160,13 +160,22 @@ func (f *archivalQueueFactory) newScheduledQueue(shard shard.Context, executor q
 		metricsHandler,
 	)
 
+	factory := f.NewExecutableFactory(
+		executor,
+		rescheduler,
+		f.ExecutableWrapper,
+		shard.GetClusterMetadata(),
+		shard.GetNamespaceRegistry(),
+		logger,
+		metricsHandler,
+		shard.GetTimeSource(),
+	)
 	return queues.NewScheduledQueue(
 		shard,
 		tasks.CategoryArchival,
 		f.HostScheduler,
 		rescheduler,
-		f.HostPriorityAssigner,
-		executor,
+		factory,
 		&queues.Options{
 			ReaderOptions: queues.ReaderOptions{
 				BatchSize:            f.Config.ArchivalTaskBatchSize,

--- a/service/history/queues/executable_factory.go
+++ b/service/history/queues/executable_factory.go
@@ -1,0 +1,117 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues
+
+import (
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	// ExecutableFactory and the related interfaces here are needed to make it possible to extend the functionality of
+	// task processing without changing its core logic. This is similar to ExecutorWrapper.
+	ExecutableFactory interface {
+		NewExecutable(task tasks.Task, readerID int64) Executable
+	}
+	// ExecutableFactoryFn is a convenience type to avoid having to create a struct that implements ExecutableFactory.
+	ExecutableFactoryFn func(readerID int64, t tasks.Task) Executable
+	ExecutableWrapper   interface {
+		Wrap(e Executable) Executable
+	}
+
+	executableFactoryImpl struct {
+		executor          Executor
+		scheduler         Scheduler
+		rescheduler       Rescheduler
+		priorityAssigner  PriorityAssigner
+		timeSource        clock.TimeSource
+		namespaceRegistry namespace.Registry
+		clusterMetadata   cluster.Metadata
+		logger            log.Logger
+		metricsHandler    metrics.Handler
+	}
+	executableFactoryWrapper struct {
+		factory ExecutableFactory
+		wrapper ExecutableWrapper
+	}
+)
+
+func (f ExecutableFactoryFn) NewExecutable(task tasks.Task, readerID int64) Executable {
+	return f(readerID, task)
+}
+
+func NewExecutableFactory(
+	executor Executor,
+	scheduler Scheduler,
+	rescheduler Rescheduler,
+	priorityAssigner PriorityAssigner,
+	timeSource clock.TimeSource,
+	namespaceRegistry namespace.Registry,
+	clusterMetadata cluster.Metadata,
+	logger log.Logger,
+	metricsHandler metrics.Handler,
+) *executableFactoryImpl {
+	return &executableFactoryImpl{
+		executor:          executor,
+		scheduler:         scheduler,
+		rescheduler:       rescheduler,
+		priorityAssigner:  priorityAssigner,
+		timeSource:        timeSource,
+		namespaceRegistry: namespaceRegistry,
+		clusterMetadata:   clusterMetadata,
+		logger:            logger,
+		metricsHandler:    metricsHandler,
+	}
+}
+
+// NewExecutableFactoryWrapper returns a new ExecutableFactory that wraps the executable created by the factory with the
+// given wrapper.
+func NewExecutableFactoryWrapper(factory ExecutableFactory, wrapper ExecutableWrapper) executableFactoryWrapper {
+	return executableFactoryWrapper{factory: factory, wrapper: wrapper}
+}
+
+func (f *executableFactoryImpl) NewExecutable(task tasks.Task, readerID int64) Executable {
+	return NewExecutable(
+		readerID,
+		task,
+		f.executor,
+		f.scheduler,
+		f.rescheduler,
+		f.priorityAssigner,
+		f.timeSource,
+		f.namespaceRegistry,
+		f.clusterMetadata,
+		f.logger,
+		f.metricsHandler,
+	)
+}
+
+func (f executableFactoryWrapper) NewExecutable(task tasks.Task, readerID int64) Executable {
+	return f.wrapper.Wrap(f.factory.NewExecutable(task, readerID))
+}

--- a/service/history/queues/executable_factory_test.go
+++ b/service/history/queues/executable_factory_test.go
@@ -1,0 +1,67 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	testWrapper       struct{}
+	wrappedExecutable struct {
+		queues.Executable
+	}
+)
+
+func TestNewExecutableFactoryWrapper(t *testing.T) {
+	t.Parallel()
+
+	wrapper := testWrapper{}
+	factory := queues.NewExecutableFactory(
+		nil,
+		nil,
+		nil,
+		queues.NewNoopPriorityAssigner(),
+		clock.NewEventTimeSource(),
+		nil,
+		nil,
+		log.NewNoopLogger(),
+		nil,
+	)
+	wrappedFactory := queues.NewExecutableFactoryWrapper(factory, wrapper)
+	executable := wrappedFactory.NewExecutable(&tasks.WorkflowTask{}, 0)
+	_, ok := executable.(wrappedExecutable)
+	assert.True(t, ok, "expected executable to be wrapped")
+}
+
+func (t testWrapper) Wrap(e queues.Executable) queues.Executable {
+	return wrappedExecutable{e}
+}

--- a/service/history/queues/queue_base_test.go
+++ b/service/history/queues/queue_base_test.go
@@ -127,20 +127,7 @@ func (s *queueBaseSuite) TestNewProcessBase_NoPreviousState() {
 		s.config,
 	)
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTransfer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
+	base := s.newQueueBase(mockShard, tasks.CategoryTransfer, nil)
 
 	s.Len(base.readerGroup.Readers(), 0)
 	s.Equal(int64(1), base.nonReadableScope.Range.InclusiveMin.TaskID)
@@ -212,21 +199,7 @@ func (s *queueBaseSuite) TestNewProcessBase_WithPreviousState_RestoreSucceed() {
 	)
 	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTransfer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
-
+	base := s.newQueueBase(mockShard, tasks.CategoryTransfer, nil)
 	readerScopes := make(map[int64][]Scope)
 	for id, reader := range base.readerGroup.Readers() {
 		readerScopes[id] = reader.Scopes()
@@ -287,21 +260,7 @@ func (s *queueBaseSuite) TestNewProcessBase_WithPreviousState_RestoreFailed() {
 	)
 	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(errors.New("some random error")).Times(2)
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTransfer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
-
+	base := s.newQueueBase(mockShard, tasks.CategoryTransfer, nil)
 	s.Empty(base.readerGroup.Readers())
 	s.Equal(
 		NewScope(
@@ -343,21 +302,7 @@ func (s *queueBaseSuite) TestStartStop() {
 	}).Times(1)
 	s.mockRescheduler.EXPECT().Len().Return(0).AnyTimes()
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTransfer,
-		paginationFnProvider,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
-
+	base := s.newQueueBase(mockShard, tasks.CategoryTransfer, paginationFnProvider)
 	s.mockRescheduler.EXPECT().Start().Times(1)
 	base.Start()
 	base.processNewRange()
@@ -394,20 +339,7 @@ func (s *queueBaseSuite) TestProcessNewRange() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTimer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
+	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	s.True(base.nonReadableScope.Range.Equals(NewRange(tasks.MinimumKey, tasks.MaximumKey)))
 
 	base.processNewRange()
@@ -453,20 +385,7 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks_PerformRangeCompletion(
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(len(readerIDs))
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTimer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
+	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
 
 	s.True(scopeMinKey.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
@@ -537,20 +456,7 @@ func (s *queueBaseSuite) TestCheckPoint_WithPendingTasks_SkipRangeCompletion() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(len(readerScopes))
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTimer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
+	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
 
 	s.True(scopeMinKey.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
@@ -596,20 +502,7 @@ func (s *queueBaseSuite) TestCheckPoint_NoPendingTasks() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTimer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
+	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
 
 	s.True(exclusiveReaderHighWatermark.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
@@ -685,20 +578,7 @@ func (s *queueBaseSuite) TestCheckPoint_MoveSlices() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTimer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
+	base := s.newQueueBase(mockShard, tasks.CategoryTimer, nil)
 	base.checkpointTimer = time.NewTimer(s.options.CheckpointInterval())
 	s.True(scopes[0].Range.InclusiveMin.CompareTo(base.exclusiveDeletionHighWatermark) == 0)
 
@@ -756,21 +636,7 @@ func (s *queueBaseSuite) TestUpdateReaderProgress() {
 	mockShard.Resource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	mockShard.Resource.ExecutionMgr.EXPECT().RegisterHistoryTaskReader(gomock.Any(), gomock.Any()).Return(nil).Times(2)
 
-	base := newQueueBase(
-		mockShard,
-		tasks.CategoryTransfer,
-		nil,
-		s.mockScheduler,
-		s.mockRescheduler,
-		NewNoopPriorityAssigner(),
-		nil,
-		s.options,
-		s.rateLimiter,
-		NoopReaderCompletionFn,
-		s.logger,
-		s.metricsHandler,
-	)
-
+	base := s.newQueueBase(mockShard, tasks.CategoryTransfer, nil)
 	readerProgress := make(map[int64]tasks.Key)
 	mockShard.Resource.ExecutionMgr.EXPECT().UpdateHistoryTaskReaderProgress(gomock.Any(), gomock.Any()).Do(
 		func(_ context.Context, request *persistence.UpdateHistoryTaskReaderProgressRequest) {
@@ -806,4 +672,35 @@ func (s *queueBaseSuite) QueueStateEqual(
 	s.NoError(err)
 
 	s.Equal(this, that)
+}
+
+func (s *queueBaseSuite) newQueueBase(
+	mockShard *shard.ContextTest,
+	category tasks.Category,
+	paginationFnProvider PaginationFnProvider,
+) *queueBase {
+	factory := NewExecutableFactory(
+		nil,
+		s.mockScheduler,
+		s.mockRescheduler,
+		NewNoopPriorityAssigner(),
+		mockShard.GetTimeSource(),
+		mockShard.GetNamespaceRegistry(),
+		mockShard.GetClusterMetadata(),
+		s.logger,
+		s.metricsHandler,
+	)
+	return newQueueBase(
+		mockShard,
+		category,
+		paginationFnProvider,
+		s.mockScheduler,
+		s.mockRescheduler,
+		factory,
+		s.options,
+		s.rateLimiter,
+		NoopReaderCompletionFn,
+		s.logger,
+		s.metricsHandler,
+	)
 }

--- a/service/history/queues/queue_immediate.go
+++ b/service/history/queues/queue_immediate.go
@@ -55,12 +55,11 @@ func NewImmediateQueue(
 	category tasks.Category,
 	scheduler Scheduler,
 	rescheduler Rescheduler,
-	priorityAssigner PriorityAssigner,
-	executor Executor,
 	options *Options,
 	hostRateLimiter quotas.RequestRateLimiter,
 	logger log.Logger,
 	metricsHandler metrics.Handler,
+	factory ExecutableFactory,
 ) *immediateQueue {
 	paginationFnProvider := func(readerID int64, r Range) collection.PaginationFn[tasks.Task] {
 		return func(paginationToken []byte) ([]tasks.Task, []byte, error) {
@@ -93,8 +92,7 @@ func NewImmediateQueue(
 			paginationFnProvider,
 			scheduler,
 			rescheduler,
-			priorityAssigner,
-			executor,
+			factory,
 			options,
 			hostRateLimiter,
 			NoopReaderCompletionFn,

--- a/service/history/queues/queue_scheduled.go
+++ b/service/history/queues/queue_scheduled.go
@@ -70,8 +70,7 @@ func NewScheduledQueue(
 	category tasks.Category,
 	scheduler Scheduler,
 	rescheduler Rescheduler,
-	priorityAssigner PriorityAssigner,
-	executor Executor,
+	executableFactory ExecutableFactory,
 	options *Options,
 	hostRateLimiter quotas.RequestRateLimiter,
 	logger log.Logger,
@@ -87,9 +86,12 @@ func NewScheduledQueue(
 				TaskCategory:        category,
 				ReaderID:            readerID,
 				InclusiveMinTaskKey: tasks.NewKey(r.InclusiveMin.FireTime, 0),
-				ExclusiveMaxTaskKey: tasks.NewKey(r.ExclusiveMax.FireTime.Add(persistence.ScheduledTaskMinPrecision), 0),
-				BatchSize:           options.BatchSize(),
-				NextPageToken:       paginationToken,
+				ExclusiveMaxTaskKey: tasks.NewKey(
+					r.ExclusiveMax.FireTime.Add(persistence.ScheduledTaskMinPrecision),
+					0,
+				),
+				BatchSize:     options.BatchSize(),
+				NextPageToken: paginationToken,
 			}
 
 			resp, err := shard.GetExecutionManager().GetHistoryTasks(ctx, request)
@@ -129,8 +131,7 @@ func NewScheduledQueue(
 			paginationFnProvider,
 			scheduler,
 			rescheduler,
-			priorityAssigner,
-			executor,
+			executableFactory,
 			options,
 			hostRateLimiter,
 			readerCompletionFn,

--- a/service/history/queues/queue_scheduled_test.go
+++ b/service/history/queues/queue_scheduled_test.go
@@ -118,19 +118,29 @@ func (s *scheduledQueueSuite) SetupTest() {
 		metrics.NoopMetricsHandler,
 	)
 
+	var logger log.Logger = log.NewTestLogger()
+	factory := NewExecutableFactory(nil,
+		scheduler,
+		rescheduler,
+		nil,
+		s.mockShard.GetTimeSource(),
+		s.mockShard.GetNamespaceRegistry(),
+		s.mockShard.GetClusterMetadata(),
+		logger,
+		metrics.NoopMetricsHandler,
+	)
 	s.scheduledQueue = NewScheduledQueue(
 		s.mockShard,
 		tasks.CategoryTimer,
 		scheduler,
 		rescheduler,
-		nil,
-		nil,
+		factory,
 		testQueueOptions,
 		NewReaderPriorityRateLimiter(
 			func() float64 { return 10 },
 			1,
 		),
-		log.NewTestLogger(),
+		logger,
 		metrics.NoopMetricsHandler,
 	)
 }

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -173,13 +173,22 @@ func (f *timerQueueFactory) CreateQueue(
 		executor = f.ExecutorWrapper.Wrap(executor)
 	}
 
+	factory := f.NewExecutableFactory(
+		executor,
+		rescheduler,
+		f.ExecutableWrapper,
+		shard.GetClusterMetadata(),
+		shard.GetNamespaceRegistry(),
+		logger,
+		metricsHandler,
+		shard.GetTimeSource(),
+	)
 	return queues.NewScheduledQueue(
 		shard,
 		tasks.CategoryTimer,
 		f.HostScheduler,
 		rescheduler,
-		f.HostPriorityAssigner,
-		executor,
+		factory,
 		&queues.Options{
 			ReaderOptions: queues.ReaderOptions{
 				BatchSize:            f.Config.TimerTaskBatchSize,

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -165,13 +165,21 @@ func (f *transferQueueFactory) CreateQueue(
 		executor = f.ExecutorWrapper.Wrap(executor)
 	}
 
+	factory := f.NewExecutableFactory(
+		executor,
+		rescheduler,
+		f.ExecutableWrapper,
+		shard.GetClusterMetadata(),
+		shard.GetNamespaceRegistry(),
+		logger,
+		metricsHandler,
+		shard.GetTimeSource(),
+	)
 	return queues.NewImmediateQueue(
 		shard,
 		tasks.CategoryTransfer,
 		f.HostScheduler,
 		rescheduler,
-		f.HostPriorityAssigner,
-		executor,
 		&queues.Options{
 			ReaderOptions: queues.ReaderOptions{
 				BatchSize:            f.Config.TransferTaskBatchSize,
@@ -193,5 +201,6 @@ func (f *transferQueueFactory) CreateQueue(
 		f.HostReaderRateLimiter,
 		logger,
 		metricsHandler,
+		factory,
 	)
 }

--- a/service/history/visibility_queue_factory.go
+++ b/service/history/visibility_queue_factory.go
@@ -118,13 +118,21 @@ func (f *visibilityQueueFactory) CreateQueue(
 		executor = f.ExecutorWrapper.Wrap(executor)
 	}
 
+	factory := f.NewExecutableFactory(
+		executor,
+		rescheduler,
+		f.ExecutableWrapper,
+		shard.GetClusterMetadata(),
+		shard.GetNamespaceRegistry(),
+		logger,
+		metricsHandler,
+		shard.GetTimeSource(),
+	)
 	return queues.NewImmediateQueue(
 		shard,
 		tasks.CategoryVisibility,
 		f.HostScheduler,
 		rescheduler,
-		f.HostPriorityAssigner,
-		executor,
 		&queues.Options{
 			ReaderOptions: queues.ReaderOptions{
 				BatchSize:            f.Config.VisibilityTaskBatchSize,
@@ -146,5 +154,6 @@ func (f *visibilityQueueFactory) CreateQueue(
 		f.HostReaderRateLimiter,
 		logger,
 		metricsHandler,
+		factory,
 	)
 }

--- a/temporal/server_test.go
+++ b/temporal/server_test.go
@@ -142,8 +142,13 @@ func (d *errorLogDetector) Stop() {
 }
 
 func (d *errorLogDetector) Warn(msg string, tags ...tag.Tag) {
-	if strings.Contains(msg, "error creating sdk client") {
-		return
+	for _, s := range []string{
+		"error creating sdk client",
+		"Failed to poll for task",
+	} {
+		if strings.Contains(msg, s) {
+			return
+		}
 	}
 
 	d.logUnexpected("Warn", msg, tags)
@@ -195,6 +200,7 @@ func TestErrorLogDetector(t *testing.T) {
 	d.Info("info")
 	d.Warn("error creating sdk client")
 	d.Warn("unexpected warning")
+	d.Warn("Failed to poll for task")
 	d.Error("Unable to process new range")
 	d.Error("Unable to call matching.PollActivityTaskQueue")
 	d.Error("service failures")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added an `ExecutableWrapper` parameter to our queue factory fx graph.

<!-- Tell your future self why have you made these changes -->
**Why?**
This should make it possible to extend the behavior of history task processing. Specifically, I need this to add DLQ functionality to history tasks.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This is mostly dependency plumbing, but there is a unit test for the executable factory wrapper.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
