### PR TITLE
Handle nil HistoryURI during visibility archival

### DIFF
--- a/service/history/archival/archiver.go
+++ b/service/history/archival/archiver.go
@@ -247,6 +247,11 @@ func (a *archiver) archiveVisibility(ctx context.Context, request *Request, logg
 		return err
 	}
 
+	var historyArchivalUri string
+	if request.HistoryURI != nil {
+		historyArchivalUri = request.HistoryURI.String()
+	}
+
 	return visibilityArchiver.Archive(ctx, request.VisibilityURI, &archiverspb.VisibilityRecord{
 		NamespaceId:        request.NamespaceID,
 		Namespace:          request.Namespace,
@@ -260,7 +265,7 @@ func (a *archiver) archiveVisibility(ctx context.Context, request *Request, logg
 		HistoryLength:      request.HistoryLength,
 		Memo:               request.Memo,
 		SearchAttributes:   searchAttributes,
-		HistoryArchivalUri: request.HistoryURI.String(),
+		HistoryArchivalUri: historyArchivalUri,
 	})
 }
 

--- a/service/history/archival/archiver_test.go
+++ b/service/history/archival/archiver_test.go
@@ -60,6 +60,7 @@ func TestArchiver(t *testing.T) {
 		SearchAttributesErr  error
 		NameTypeMap          searchattribute.NameTypeMap
 		NameTypeMapErr       error
+		NilHistoryUri        bool
 
 		ExpectArchiveHistory    bool
 		ExpectArchiveVisibility bool
@@ -95,6 +96,13 @@ func TestArchiver(t *testing.T) {
 		{
 			Name:    "Visibility archival succeeds",
 			Targets: []Target{TargetVisibility},
+
+			ExpectArchiveVisibility: true,
+		},
+		{
+			Name:          "Visibility archival succeeds with nil HistoryURI",
+			Targets:       []Target{TargetVisibility},
+			NilHistoryUri: true,
 
 			ExpectArchiveVisibility: true,
 		},
@@ -181,7 +189,11 @@ func TestArchiver(t *testing.T) {
 			sdkClientFactory := sdk.NewMockClientFactory(controller)
 			sdkClientFactory.EXPECT().GetSystemClient().Return(sdkClient).AnyTimes()
 
-			historyURI, err := carchiver.NewURI("test:///history/archival")
+			var historyURI carchiver.URI
+			var err error
+			if !c.NilHistoryUri {
+				historyURI, err = carchiver.NewURI("test:///history/archival")
+			}
 			require.NoError(t, err)
 
 			if c.ExpectArchiveHistory {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Handle cases of `nil` `HistoryArchivalURI` when performing visibility archival

See https://github.com/temporalio/temporal/issues/4879 for details

<!-- Tell your future self why have you made these changes -->
This PR is a suggested fix for https://github.com/temporalio/temporal/issues/4879
We are not fully familiar with the codebase so it's ok to close and make a better fix (or point us in the right direction; we are happy to make the patch)


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added a test that sets the URI to nil during visibility archival. It panics before the change and passes after


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
The risk is lower than before this fix. This is not, however, a comprehensive check on when similar panics can occur


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
This error has resulted in a P0 incident for us but it is also somewhat unlikely given it has not happened in such a long time. This _may_ bring down cloud clusters as well in theory.
