### PR TITLE
Allow multiple hosts for elasticsearch

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/client/client_v7.go
+++ b/common/persistence/visibility/store/elasticsearch/client/client_v7.go
@@ -64,8 +64,17 @@ var _ Client = (*clientImpl)(nil)
 
 // newClient create a ES client
 func newClient(cfg *Config, httpClient *http.Client, logger log.Logger) (*clientImpl, error) {
+	var urls []string
+	if len(cfg.URLs) > 0 {
+		urls = make([]string, len(cfg.URLs))
+		for i, u := range cfg.URLs {
+			urls[i] = u.String()
+		}
+	} else {
+		urls = []string{cfg.URL.String()}
+	}
 	options := []elastic.ClientOptionFunc{
-		elastic.SetURL(cfg.URL.String()),
+		elastic.SetURL(urls...),
 		elastic.SetBasicAuth(cfg.Username, cfg.Password),
 		// Disable healthcheck to prevent blocking client creation (and thus Temporal server startup) if the Elasticsearch is down.
 		elastic.SetHealthcheck(false),

--- a/common/persistence/visibility/store/elasticsearch/client/config.go
+++ b/common/persistence/visibility/store/elasticsearch/client/config.go
@@ -42,6 +42,7 @@ type (
 	Config struct {
 		Version                      string                    `yaml:"version"`
 		URL                          url.URL                   `yaml:"url"`
+		URLs                         []url.URL                 `yaml:"urls"`
 		Username                     string                    `yaml:"username"`
 		Password                     string                    `yaml:"password"`
 		Indices                      map[string]string         `yaml:"indices"`


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
New field `hosts` has been added to the Elasticsearch config. Now, it is possible to connect to a multi-node cluster. Possible fix for https://github.com/temporalio/temporal/issues/4890


<!-- Tell your future self why have you made these changes -->
**Why?**
To support Elasticsearch clusters with no load balancer.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Checked in staging env. I'd be happy to add a test, but I did not find where the connection configs are tested


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No, since this is a new field, which will not affect existing Temporal installations.


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No