### PR TITLE
Add lazy deserialization on history replication task

### DIFF
--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -26,7 +26,6 @@ package replication
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	historypb "go.temporal.io/api/history/v1"
@@ -57,8 +56,6 @@ type (
 		versionHistoryItems []*historyspb.VersionHistoryItem
 		events              []*historypb.HistoryEvent
 		newRunEvents        []*historypb.HistoryEvent
-		canBatch            bool // indicate if current task want to be batched with other task
-		batchLock           sync.Mutex
 	}
 )
 
@@ -92,7 +89,6 @@ func NewExecutableHistoryTask(
 		events:              events,
 		// new run events does not need version history since there is no prior events
 		newRunEvents: newRunEvents,
-		canBatch:     true,
 	}
 }
 

--- a/service/history/replication/executable_history_task_test.go
+++ b/service/history/replication/executable_history_task_test.go
@@ -116,14 +116,14 @@ func (s *executableHistoryTaskSuite) SetupTest() {
 		EventId: firstEventID,
 		Version: version,
 	}}, enumspb.ENCODING_TYPE_PROTO3)
-	e, _ := serialization.NewSerializer().DeserializeEvents(eventsBlob)
-	s.events = e
+	s.events, _ = serialization.NewSerializer().DeserializeEvents(eventsBlob)
+
 	newEventsBlob, _ := serialization.NewSerializer().SerializeEvents([]*historypb.HistoryEvent{{
 		EventId: 1,
 		Version: version,
 	}}, enumspb.ENCODING_TYPE_PROTO3)
-	ne, _ := serialization.NewSerializer().DeserializeEvents(newEventsBlob)
-	s.newRunEvents = ne
+	s.newRunEvents, _ = serialization.NewSerializer().DeserializeEvents(newEventsBlob)
+
 	s.replicationTask = &replicationspb.HistoryTaskAttributes{
 		NamespaceId:       uuid.NewString(),
 		WorkflowId:        uuid.NewString(),
@@ -178,7 +178,8 @@ func (s *executableHistoryTaskSuite) TestExecute_Process() {
 		s.task.WorkflowID,
 	).Return(shardContext, nil).AnyTimes()
 	shardContext.EXPECT().GetEngine(gomock.Any()).Return(engine, nil).AnyTimes()
-	engine.EXPECT().ReplicateHistoryEvents(gomock.Any(),
+	engine.EXPECT().ReplicateHistoryEvents(
+		gomock.Any(),
 		definition.NewWorkflowKey(s.task.NamespaceID, s.task.WorkflowID, s.task.RunID),
 		s.task.baseExecutionInfo,
 		s.task.versionHistoryItems,
@@ -229,7 +230,8 @@ func (s *executableHistoryTaskSuite) TestHandleErr_Resend_Success() {
 		s.task.WorkflowID,
 	).Return(shardContext, nil).AnyTimes()
 	shardContext.EXPECT().GetEngine(gomock.Any()).Return(engine, nil).AnyTimes()
-	engine.EXPECT().ReplicateHistoryEvents(gomock.Any(),
+	engine.EXPECT().ReplicateHistoryEvents(
+		gomock.Any(),
 		definition.NewWorkflowKey(s.task.NamespaceID, s.task.WorkflowID, s.task.RunID),
 		s.task.baseExecutionInfo,
 		s.task.versionHistoryItems,

--- a/service/history/replication/executable_task_converter.go
+++ b/service/history/replication/executable_task_converter.go
@@ -28,8 +28,11 @@ import (
 	"fmt"
 	"time"
 
+	historypb "go.temporal.io/api/history/v1"
+	"go.temporal.io/api/serviceerror"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 )
 
@@ -70,7 +73,11 @@ func (e *executableTaskConverterImpl) Convert(
 			metrics.ToClusterIDTag(clientShardKey.ClusterID),
 			metrics.OperationTag(TaskOperationTag(replicationTask)),
 		)
-		tasks[index] = e.convertOne(taskClusterName, replicationTask)
+		task, err := e.convertOne(taskClusterName, replicationTask)
+		if err != nil {
+			continue
+		}
+		tasks[index] = task
 	}
 	return tasks
 }
@@ -78,7 +85,7 @@ func (e *executableTaskConverterImpl) Convert(
 func (e *executableTaskConverterImpl) convertOne(
 	taskClusterName string,
 	replicationTask *replicationspb.ReplicationTask,
-) TrackableExecutableTask {
+) (TrackableExecutableTask, error) {
 	var taskCreationTime time.Time
 	if replicationTask.VisibilityTime != nil {
 		taskCreationTime = *replicationTask.VisibilityTime
@@ -93,14 +100,14 @@ func (e *executableTaskConverterImpl) convertOne(
 			replicationTask.SourceTaskId,
 			taskCreationTime,
 			taskClusterName,
-		)
+		), nil
 	case enumsspb.REPLICATION_TASK_TYPE_HISTORY_METADATA_TASK: // TODO to be deprecated
 		return NewExecutableNoopTask(
 			e.processToolBox,
 			replicationTask.SourceTaskId,
 			taskCreationTime,
 			taskClusterName,
-		)
+		), nil
 	case enumsspb.REPLICATION_TASK_TYPE_SYNC_ACTIVITY_TASK:
 		return NewExecutableActivityStateTask(
 			e.processToolBox,
@@ -108,7 +115,7 @@ func (e *executableTaskConverterImpl) convertOne(
 			taskCreationTime,
 			replicationTask.GetSyncActivityTaskAttributes(),
 			taskClusterName,
-		)
+		), nil
 	case enumsspb.REPLICATION_TASK_TYPE_SYNC_WORKFLOW_STATE_TASK:
 		return NewExecutableWorkflowStateTask(
 			e.processToolBox,
@@ -116,15 +123,30 @@ func (e *executableTaskConverterImpl) convertOne(
 			taskCreationTime,
 			replicationTask.GetSyncWorkflowStateTaskAttributes(),
 			taskClusterName,
-		)
+		), nil
 	case enumsspb.REPLICATION_TASK_TYPE_HISTORY_V2_TASK:
+		events, newRunEvents, err := e.deserializeHistoryEvents(replicationTask.SourceTaskId, replicationTask.GetHistoryTaskAttributes())
+		if err == nil {
+			return nil, err
+		}
+		if len(events) == 0 {
+			e.processToolBox.Logger.Error("unable to create history replication task, no events",
+				tag.WorkflowNamespaceID(replicationTask.GetHistoryTaskAttributes().GetNamespaceId()),
+				tag.WorkflowID(replicationTask.GetHistoryTaskAttributes().GetWorkflowId()),
+				tag.WorkflowRunID(replicationTask.GetHistoryTaskAttributes().GetRunId()),
+				tag.TaskID(replicationTask.SourceTaskId),
+			)
+			return nil, serviceerror.NewInvalidArgument("unable to create replication task, no events")
+		}
 		return NewExecutableHistoryTask(
 			e.processToolBox,
 			replicationTask.SourceTaskId,
 			taskCreationTime,
 			replicationTask.GetHistoryTaskAttributes(),
+			events,
+			newRunEvents,
 			taskClusterName,
-		)
+		), nil
 	default:
 		e.processToolBox.Logger.Error(fmt.Sprintf("unknown replication task: %v", replicationTask))
 		return NewExecutableUnknownTask(
@@ -132,6 +154,33 @@ func (e *executableTaskConverterImpl) convertOne(
 			replicationTask.SourceTaskId,
 			taskCreationTime,
 			replicationTask,
-		)
+		), nil
 	}
+}
+
+func (e *executableTaskConverterImpl) deserializeHistoryEvents(sourceTaskId int64, task *replicationspb.HistoryTaskAttributes) ([]*historypb.HistoryEvent, []*historypb.HistoryEvent, error) {
+	events, err := e.processToolBox.EventSerializer.DeserializeEvents(task.GetEvents())
+	if err != nil {
+		e.processToolBox.Logger.Error("unable to deserialize history events",
+			tag.WorkflowNamespaceID(task.NamespaceId),
+			tag.WorkflowID(task.WorkflowId),
+			tag.WorkflowRunID(task.RunId),
+			tag.TaskID(sourceTaskId),
+			tag.Error(err),
+		)
+		return nil, nil, err
+	}
+
+	newRunEvents, err := e.processToolBox.EventSerializer.DeserializeEvents(task.GetNewRunEvents())
+	if err != nil {
+		e.processToolBox.Logger.Error("unable to deserialize new run history events",
+			tag.WorkflowNamespaceID(task.GetNamespaceId()),
+			tag.WorkflowID(task.GetWorkflowId()),
+			tag.WorkflowRunID(task.GetRunId()),
+			tag.TaskID(sourceTaskId),
+			tag.Error(err),
+		)
+		return nil, nil, err
+	}
+	return events, newRunEvents, nil
 }

--- a/service/history/replication/executable_task_tool_box.go
+++ b/service/history/replication/executable_task_tool_box.go
@@ -25,6 +25,7 @@
 package replication
 
 import (
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/client"
@@ -52,5 +53,6 @@ type (
 		TaskScheduler           ctasks.Scheduler[TrackableExecutableTask]
 		MetricsHandler          metrics.Handler
 		Logger                  log.Logger
+		EventSerializer         serialization.Serializer
 	}
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add lazy deserialization on history replication task

<!-- Tell your future self why have you made these changes -->
**Why?**
Batching functionality requires inspecting events details. So advancing the deserialization to task creation time to reduce back and force in des/ser

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
replication stack will not work

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no