### PR TITLE
Get rid of tdbg.cFactory global variable

### DIFF
--- a/cmd/tools/tdbg/main.go
+++ b/cmd/tools/tdbg/main.go
@@ -31,6 +31,6 @@ import (
 )
 
 func main() {
-	app := tdbg.NewCliApp()
+	app := tdbg.NewCliApp(tdbg.NewClientFactory())
 	_ = app.Run(os.Args)
 }

--- a/tools/tdbg/app.go
+++ b/tools/tdbg/app.go
@@ -35,13 +35,8 @@ import (
 	"github.com/temporalio/tctl-kit/pkg/color"
 )
 
-// SetFactory is used to set the ClientFactory global
-func SetFactory(factory ClientFactory) {
-	cFactory = factory
-}
-
 // NewCliApp instantiates a new instance of the CLI application.
-func NewCliApp() *cli.App {
+func NewCliApp(clientFactory ClientFactory) *cli.App {
 	app := cli.NewApp()
 	app.Name = "tdbg"
 	app.Usage = "A command-line tool for Temporal server debugging"
@@ -106,13 +101,8 @@ func NewCliApp() *cli.App {
 			Value: string(color.Auto),
 		},
 	}
-	app.Commands = commands
+	app.Commands = getCommands(clientFactory)
 	app.ExitErrHandler = handleError
-
-	// set builder if not customized
-	if cFactory == nil {
-		SetFactory(NewClientFactory())
-	}
 
 	return app
 }

--- a/tools/tdbg/app_test.go
+++ b/tools/tdbg/app_test.go
@@ -22,7 +22,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tdbg
+package tdbg_test
 
 import (
 	"encoding/json"

--- a/tools/tdbg/defs.go
+++ b/tools/tdbg/defs.go
@@ -49,7 +49,3 @@ const (
 
 	showErrorStackEnv = `TEMPORAL_CLI_SHOW_STACKS`
 )
-
-var (
-	cFactory ClientFactory
-)

--- a/tools/tdbg/dlq_commands.go
+++ b/tools/tdbg/dlq_commands.go
@@ -45,11 +45,11 @@ const (
 )
 
 // AdminGetDLQMessages gets DLQ metadata
-func AdminGetDLQMessages(c *cli.Context) (err error) {
+func AdminGetDLQMessages(c *cli.Context, clientFactory ClientFactory) (err error) {
 	ctx, cancel := newContext(c)
 	defer cancel()
 
-	adminClient := cFactory.AdminClient(c)
+	adminClient := clientFactory.AdminClient(c)
 	dlqType := c.String(FlagDLQType)
 	sourceCluster := c.String(FlagCluster)
 	shardID := c.Int(FlagShardID)
@@ -120,7 +120,7 @@ func AdminGetDLQMessages(c *cli.Context) (err error) {
 }
 
 // AdminPurgeDLQMessages deletes messages from DLQ
-func AdminPurgeDLQMessages(c *cli.Context) error {
+func AdminPurgeDLQMessages(c *cli.Context, clientFactory ClientFactory) error {
 	ctx, cancel := newContext(c)
 	defer cancel()
 
@@ -135,7 +135,7 @@ func AdminPurgeDLQMessages(c *cli.Context) error {
 		prompt("Are you sure to purge all DLQ messages without a upper boundary?", c.Bool(FlagYes))
 	}
 
-	adminClient := cFactory.AdminClient(c)
+	adminClient := clientFactory.AdminClient(c)
 	t, err := toQueueType(dlqType)
 	if err != nil {
 		return err
@@ -153,7 +153,7 @@ func AdminPurgeDLQMessages(c *cli.Context) error {
 }
 
 // AdminMergeDLQMessages merges message from DLQ
-func AdminMergeDLQMessages(c *cli.Context) error {
+func AdminMergeDLQMessages(c *cli.Context, clientFactory ClientFactory) error {
 	ctx, cancel := newContext(c)
 	defer cancel()
 
@@ -168,7 +168,7 @@ func AdminMergeDLQMessages(c *cli.Context) error {
 		prompt("Are you sure to merge all DLQ messages without a upper boundary?", c.Bool(FlagYes))
 	}
 
-	adminClient := cFactory.AdminClient(c)
+	adminClient := clientFactory.AdminClient(c)
 
 	t, err := toQueueType(dlqType)
 	if err != nil {

--- a/tools/tdbg/task_queue_commands.go
+++ b/tools/tdbg/task_queue_commands.go
@@ -33,13 +33,13 @@ import (
 )
 
 // AdminListTaskQueueTasks displays task information
-func AdminListTaskQueueTasks(c *cli.Context) error {
+func AdminListTaskQueueTasks(c *cli.Context, clientFactory ClientFactory) error {
 	namespace, err := getRequiredOption(c, FlagNamespace)
 	if err != nil {
 		return err
 	}
 	tqName := c.String(FlagTaskQueue)
-	tlTypeInt, err := stringToEnum(c.String(FlagTaskQueueType), enumspb.TaskQueueType_value)
+	tlTypeInt, err := StringToEnum(c.String(FlagTaskQueueType), enumspb.TaskQueueType_value)
 	if err != nil {
 		return fmt.Errorf("invalid task queue type: %v", err)
 	}
@@ -56,7 +56,7 @@ func AdminListTaskQueueTasks(c *cli.Context) error {
 	workflowID := c.String(FlagWorkflowID)
 	runID := c.String(FlagRunID)
 
-	client := cFactory.AdminClient(c)
+	client := clientFactory.AdminClient(c)
 
 	req := &adminservice.GetTaskQueueTasksRequest{
 		Namespace:     namespace,

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -28,50 +28,52 @@ import (
 	"github.com/urfave/cli/v2"
 )
 
-var commands = []*cli.Command{
-	{
-		Name:        "workflow",
-		Aliases:     []string{"w"},
-		Usage:       "Run admin operation on workflow",
-		Subcommands: newAdminWorkflowCommands(),
-	},
-	{
-		Name:        "shard",
-		Aliases:     []string{"s"},
-		Usage:       "Run admin operation on specific shard",
-		Subcommands: newAdminShardManagementCommands(),
-	},
-	{
-		Name:        "history-host",
-		Aliases:     []string{"h"},
-		Usage:       "Run admin operation on history host",
-		Subcommands: newAdminHistoryHostCommands(),
-	},
-	{
-		Name:        "taskqueue",
-		Aliases:     []string{"tq"},
-		Usage:       "Run admin operation on taskQueue",
-		Subcommands: newAdminTaskQueueCommands(),
-	},
-	{
-		Name:        "membership",
-		Aliases:     []string{"m"},
-		Usage:       "Run admin operation on membership",
-		Subcommands: newAdminMembershipCommands(),
-	},
-	{
-		Name:        "dlq",
-		Usage:       "Run admin operation on DLQ",
-		Subcommands: newAdminDLQCommands(),
-	},
-	{
-		Name:        "decode",
-		Usage:       "Decode payload",
-		Subcommands: newDecodeCommands(),
-	},
+func getCommands(clientFactory ClientFactory) []*cli.Command {
+	return []*cli.Command{
+		{
+			Name:        "workflow",
+			Aliases:     []string{"w"},
+			Usage:       "Run admin operation on workflow",
+			Subcommands: newAdminWorkflowCommands(clientFactory),
+		},
+		{
+			Name:        "shard",
+			Aliases:     []string{"s"},
+			Usage:       "Run admin operation on specific shard",
+			Subcommands: newAdminShardManagementCommands(clientFactory),
+		},
+		{
+			Name:        "history-host",
+			Aliases:     []string{"h"},
+			Usage:       "Run admin operation on history host",
+			Subcommands: newAdminHistoryHostCommands(clientFactory),
+		},
+		{
+			Name:        "taskqueue",
+			Aliases:     []string{"tq"},
+			Usage:       "Run admin operation on taskQueue",
+			Subcommands: newAdminTaskQueueCommands(clientFactory),
+		},
+		{
+			Name:        "membership",
+			Aliases:     []string{"m"},
+			Usage:       "Run admin operation on membership",
+			Subcommands: newAdminMembershipCommands(clientFactory),
+		},
+		{
+			Name:        "dlq",
+			Usage:       "Run admin operation on DLQ",
+			Subcommands: newAdminDLQCommands(clientFactory),
+		},
+		{
+			Name:        "decode",
+			Usage:       "Decode payload",
+			Subcommands: newDecodeCommands(),
+		},
+	}
 }
 
-func newAdminWorkflowCommands() []*cli.Command {
+func newAdminWorkflowCommands(clientFactory ClientFactory) []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:  "import",
@@ -92,7 +94,7 @@ func newAdminWorkflowCommands() []*cli.Command {
 					Usage: "input file",
 				}},
 			Action: func(c *cli.Context) error {
-				return AdminImportWorkflow(c)
+				return AdminImportWorkflow(c, clientFactory)
 			},
 		},
 		{
@@ -131,7 +133,7 @@ func newAdminWorkflowCommands() []*cli.Command {
 					Usage: "output file",
 				}},
 			Action: func(c *cli.Context) error {
-				return AdminShowWorkflow(c)
+				return AdminShowWorkflow(c, clientFactory)
 			},
 		},
 		{
@@ -151,7 +153,7 @@ func newAdminWorkflowCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminDescribeWorkflow(c)
+				return AdminDescribeWorkflow(c, clientFactory)
 			},
 		},
 		{
@@ -171,7 +173,7 @@ func newAdminWorkflowCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminRefreshWorkflowTasks(c)
+				return AdminRefreshWorkflowTasks(c, clientFactory)
 			},
 		},
 		{
@@ -191,7 +193,7 @@ func newAdminWorkflowCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminRebuildMutableState(c)
+				return AdminRebuildMutableState(c, clientFactory)
 			},
 		},
 		{
@@ -211,13 +213,13 @@ func newAdminWorkflowCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminDeleteWorkflow(c)
+				return AdminDeleteWorkflow(c, clientFactory)
 			},
 		},
 	}
 }
 
-func newAdminShardManagementCommands() []*cli.Command {
+func newAdminShardManagementCommands(clientFactory ClientFactory) []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:    "describe",
@@ -230,7 +232,7 @@ func newAdminShardManagementCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminDescribeShard(c)
+				return AdminDescribeShard(c, clientFactory)
 			},
 		},
 		{
@@ -284,7 +286,7 @@ func newAdminShardManagementCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminListShardTasks(c)
+				return AdminListShardTasks(c, clientFactory)
 			},
 		},
 		{
@@ -297,7 +299,7 @@ func newAdminShardManagementCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminShardManagement(c)
+				return AdminShardManagement(c, clientFactory)
 			},
 		},
 		{
@@ -324,13 +326,13 @@ func newAdminShardManagementCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminRemoveTask(c)
+				return AdminRemoveTask(c, clientFactory)
 			},
 		},
 	}
 }
 
-func newAdminMembershipCommands() []*cli.Command {
+func newAdminMembershipCommands(clientFactory ClientFactory) []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:  "list-gossip",
@@ -343,7 +345,7 @@ func newAdminMembershipCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminListGossipMembers(c)
+				return AdminListGossipMembers(c, clientFactory)
 			},
 		},
 		{
@@ -364,13 +366,13 @@ func newAdminMembershipCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminListClusterMembers(c)
+				return AdminListClusterMembers(c, clientFactory)
 			},
 		},
 	}
 }
 
-func newAdminHistoryHostCommands() []*cli.Command {
+func newAdminHistoryHostCommands(clientFactory ClientFactory) []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:    "describe",
@@ -396,7 +398,7 @@ func newAdminHistoryHostCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminDescribeHistoryHost(c)
+				return AdminDescribeHistoryHost(c, clientFactory)
 			},
 		},
 		{
@@ -424,7 +426,7 @@ func newAdminHistoryHostCommands() []*cli.Command {
 	}
 }
 
-func newAdminTaskQueueCommands() []*cli.Command {
+func newAdminTaskQueueCommands(clientFactory ClientFactory) []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:  "list-tasks",
@@ -463,99 +465,71 @@ func newAdminTaskQueueCommands() []*cli.Command {
 				},
 			},
 			Action: func(c *cli.Context) error {
-				return AdminListTaskQueueTasks(c)
+				return AdminListTaskQueueTasks(c, clientFactory)
 			},
 		},
 	}
 }
 
-func newAdminDLQCommands() []*cli.Command {
+func newAdminDLQCommands(clientFactory ClientFactory) []*cli.Command {
 	return []*cli.Command{
 		{
 			Name:    "read",
 			Aliases: []string{"r"},
 			Usage:   "Read DLQ Messages",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:  FlagDLQType,
-					Usage: "Type of DLQ to manage. (Options: namespace, history)",
-				},
-				&cli.StringFlag{
-					Name:  FlagCluster,
-					Usage: "Source cluster",
-				},
-				&cli.IntFlag{
-					Name:  FlagShardID,
-					Usage: "ShardId",
-				},
+			Flags: append(
+				getDLQFlags(),
 				&cli.IntFlag{
 					Name:  FlagMaxMessageCount,
 					Usage: "Max message size to fetch",
-				},
-				&cli.IntFlag{
-					Name:  FlagLastMessageID,
-					Usage: "The upper boundary of the read message",
 				},
 				&cli.StringFlag{
 					Name:  FlagOutputFilename,
 					Usage: "Output file to write to, if not provided output is written to stdout",
 				},
-			},
+			),
 			Action: func(c *cli.Context) error {
-				return AdminGetDLQMessages(c)
+				return AdminGetDLQMessages(c, clientFactory)
 			},
 		},
 		{
 			Name:    "purge",
 			Aliases: []string{"p"},
 			Usage:   "Delete DLQ messages with equal or smaller ids than the provided task id",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:  FlagDLQType,
-					Usage: "Type of DLQ to manage. (Options: namespace, history)",
-				},
-				&cli.StringFlag{
-					Name:  FlagCluster,
-					Usage: "Source cluster",
-				},
-				&cli.IntFlag{
-					Name:  FlagShardID,
-					Usage: "ShardId",
-				},
-				&cli.IntFlag{
-					Name:  FlagLastMessageID,
-					Usage: "The upper boundary of the read message",
-				},
-			},
+			Flags:   getDLQFlags(),
 			Action: func(c *cli.Context) error {
-				return AdminPurgeDLQMessages(c)
+				return AdminPurgeDLQMessages(c, clientFactory)
 			},
 		},
 		{
 			Name:    "merge",
 			Aliases: []string{"m"},
 			Usage:   "Merge DLQ messages with equal or smaller ids than the provided task id",
-			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:  FlagDLQType,
-					Usage: "Type of DLQ to manage. (Options: namespace, history)",
-				},
-				&cli.StringFlag{
-					Name:  FlagCluster,
-					Usage: "Source cluster",
-				},
-				&cli.IntFlag{
-					Name:  FlagShardID,
-					Usage: "ShardId",
-				},
-				&cli.IntFlag{
-					Name:  FlagLastMessageID,
-					Usage: "The upper boundary of the read message",
-				},
-			},
+			Flags:   getDLQFlags(),
 			Action: func(c *cli.Context) error {
-				return AdminMergeDLQMessages(c)
+				return AdminMergeDLQMessages(c, clientFactory)
 			},
+		},
+	}
+}
+
+func getDLQFlags() []cli.Flag {
+	return []cli.Flag{
+		&cli.StringFlag{
+			Name:  FlagDLQType,
+			Usage: "Type of DLQ to manage. (options: namespace, history)",
+		},
+		&cli.StringFlag{
+			Name:  FlagCluster,
+			Usage: "Source cluster",
+		},
+		&cli.IntFlag{
+			Name:  FlagShardID,
+			Usage: "ShardId",
+		},
+		&cli.IntFlag{
+			Name:  FlagLastMessageID,
+			Usage: "The upper boundary of the read message",
 		},
 	}
 }

--- a/tools/tdbg/util.go
+++ b/tools/tdbg/util.go
@@ -199,7 +199,7 @@ func newContextWithTimeout(c *cli.Context, timeout time.Duration) (context.Conte
 	return context.WithTimeout(context.Background(), timeout)
 }
 
-func stringToEnum(search string, candidates map[string]int32) (int32, error) {
+func StringToEnum(search string, candidates map[string]int32) (int32, error) {
 	if search == "" {
 		return 0, nil
 	}
@@ -314,8 +314,8 @@ func showNextPage() bool {
 	return strings.Trim(input, " ") == ""
 }
 
-func getNamespaceID(c *cli.Context, nsName namespace.Name) (namespace.ID, error) {
-	wfClient := cFactory.WorkflowClient(c)
+func getNamespaceID(c *cli.Context, clientFactory ClientFactory, nsName namespace.Name) (namespace.ID, error) {
+	wfClient := clientFactory.WorkflowClient(c)
 
 	ctx, cancel := newContext(c)
 	defer cancel()

--- a/tools/tdbg/util_test.go
+++ b/tools/tdbg/util_test.go
@@ -22,7 +22,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tdbg
+package tdbg_test
+
+import "go.temporal.io/server/tools/tdbg"
 
 func (s *utilSuite) TestStringToEnum_MapCaseInsensitive() {
 	enumValues := map[string]int32{
@@ -32,7 +34,7 @@ func (s *utilSuite) TestStringToEnum_MapCaseInsensitive() {
 		"Replication": 3,
 	}
 
-	result, err := stringToEnum("timeR", enumValues)
+	result, err := tdbg.StringToEnum("timeR", enumValues)
 	s.NoError(err)
 	s.Equal(result, int32(2)) // Timer
 }
@@ -45,7 +47,7 @@ func (s *utilSuite) TestStringToEnum_MapNonExisting() {
 		"Replication": 3,
 	}
 
-	result, err := stringToEnum("Timer2", enumValues)
+	result, err := tdbg.StringToEnum("Timer2", enumValues)
 	s.Error(err)
 	s.Equal(result, int32(0))
 }
@@ -58,7 +60,7 @@ func (s *utilSuite) TestStringToEnum_MapEmptyValue() {
 		"Replication": 3,
 	}
 
-	result, err := stringToEnum("", enumValues)
+	result, err := tdbg.StringToEnum("", enumValues)
 	s.NoError(err)
 	s.Equal(result, int32(0))
 }
@@ -66,7 +68,7 @@ func (s *utilSuite) TestStringToEnum_MapEmptyValue() {
 func (s *utilSuite) TestStringToEnum_MapEmptyEnum() {
 	enumValues := map[string]int32{}
 
-	result, err := stringToEnum("Timer", enumValues)
+	result, err := tdbg.StringToEnum("Timer", enumValues)
 	s.Error(err)
 	s.Equal(result, int32(0))
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I got rid of the `cFactory` global variable in the `tdbg` package in favor of a parameter to the `NewCliApp` method. I also refactored the DLQ client to re-use some of its flag variables to keep the code a bit more DRY.

<!-- Tell your future self why have you made these changes -->
**Why?**
I need to override this variable in a unit test, and I don't want to do it globally because that would mean that the tests can't run in parallel.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
