### PR TITLE
Refactor TaskPoller.PollAndProcessWorkflowTask

### DIFF
--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -155,7 +155,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.True(err == nil || err == errNoTasks)
 
 	err = poller.PollAndProcessActivityTask(false)
@@ -164,7 +164,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(we.RunId))
 
 	s.False(workflowComplete)
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 	s.Equal(1, activityExecutedCount)
@@ -338,7 +338,7 @@ func (s *integrationSuite) TestActivityRetry() {
 		})
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	err = poller.PollAndProcessActivityTask(false)
@@ -486,7 +486,7 @@ func (s *integrationSuite) TestActivityRetry_Infinite() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	for i := 0; i <= activityExecutedLimit; i++ {
@@ -587,7 +587,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.True(err == nil || err == errNoTasks)
 
 	err = poller.PollAndProcessActivityTask(false)
@@ -598,7 +598,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(we.RunId))
 
 	s.False(workflowComplete)
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -712,7 +712,7 @@ func (s *integrationSuite) TestTryActivityCancellationFromWorkflow() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.True(err == nil || err == errNoTasks, err)
 
 	cancelCh := make(chan struct{})
@@ -733,7 +733,7 @@ func (s *integrationSuite) TestTryActivityCancellationFromWorkflow() {
 
 		scheduleActivity = false
 		requestCancellation = true
-		_, err2 := poller.PollAndProcessWorkflowTask(false, false)
+		_, err2 := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.NoError(err2)
 		close(cancelCh)
 	}()
@@ -841,7 +841,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.True(err == nil || err == errNoTasks)
 
 	// Send signal so that worker can send an activity cancel
@@ -862,12 +862,12 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 	// Process signal in workflow and send request cancellation
 	scheduleActivity = false
 	requestCancellation = true
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	scheduleActivity = false
 	requestCancellation = false
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.True(err == nil || err == errNoTasks)
 }
 

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -155,7 +155,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.True(err == nil || err == errNoTasks)
 
 	err = poller.PollAndProcessActivityTask(false)
@@ -164,7 +164,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(we.RunId))
 
 	s.False(workflowComplete)
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 	s.Equal(1, activityExecutedCount)
@@ -338,7 +338,7 @@ func (s *integrationSuite) TestActivityRetry() {
 		})
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	err = poller.PollAndProcessActivityTask(false)
@@ -376,7 +376,7 @@ func (s *integrationSuite) TestActivityRetry() {
 		s.False(workflowComplete)
 
 		s.Logger.Info("Processing workflow task:", tag.Counter(i))
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
+		_, err := poller.PollAndProcessWorkflowTask(WithRetries(1))
 		if err != nil {
 			s.printWorkflowHistory(s.namespace, &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -486,7 +486,7 @@ func (s *integrationSuite) TestActivityRetry_Infinite() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	for i := 0; i <= activityExecutedLimit; i++ {
@@ -494,7 +494,7 @@ func (s *integrationSuite) TestActivityRetry_Infinite() {
 		s.NoError(err)
 	}
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
+	_, err = poller.PollAndProcessWorkflowTask(WithRetries(1))
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -587,7 +587,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.True(err == nil || err == errNoTasks)
 
 	err = poller.PollAndProcessActivityTask(false)
@@ -598,7 +598,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(we.RunId))
 
 	s.False(workflowComplete)
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -712,7 +712,7 @@ func (s *integrationSuite) TestTryActivityCancellationFromWorkflow() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.True(err == nil || err == errNoTasks, err)
 
 	cancelCh := make(chan struct{})
@@ -733,7 +733,7 @@ func (s *integrationSuite) TestTryActivityCancellationFromWorkflow() {
 
 		scheduleActivity = false
 		requestCancellation = true
-		_, err2 := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err2 := poller.PollAndProcessWorkflowTask()
 		s.NoError(err2)
 		close(cancelCh)
 	}()
@@ -841,7 +841,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.True(err == nil || err == errNoTasks)
 
 	// Send signal so that worker can send an activity cancel
@@ -862,12 +862,12 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 	// Process signal in workflow and send request cancellation
 	scheduleActivity = false
 	requestCancellation = true
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	scheduleActivity = false
 	requestCancellation = false
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.True(err == nil || err == errNoTasks)
 }
 

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -376,7 +376,7 @@ func (s *integrationSuite) TestActivityRetry() {
 		s.False(workflowComplete)
 
 		s.Logger.Info("Processing workflow task:", tag.Counter(i))
-		_, err := poller.PollAndProcessWorkflowTaskWithoutRetry(false, false)
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
 		if err != nil {
 			s.printWorkflowHistory(s.namespace, &commonpb.WorkflowExecution{
 				WorkflowId: id,
@@ -494,7 +494,7 @@ func (s *integrationSuite) TestActivityRetry_Infinite() {
 		s.NoError(err)
 	}
 
-	_, err = poller.PollAndProcessWorkflowTaskWithoutRetry(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
 	s.NoError(err)
 	s.True(workflowComplete)
 }

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -308,7 +308,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_SearchAttribute() {
 	res, err := poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)
@@ -1365,7 +1365,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	res, err := poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)
@@ -1413,7 +1413,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)
@@ -1435,7 +1435,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)
@@ -1526,7 +1526,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)
@@ -1660,7 +1660,7 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	res, err := poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)
@@ -1708,7 +1708,7 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)
@@ -1754,7 +1754,7 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -1906,7 +1906,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 	if s.isElasticsearchEnabled {

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -305,16 +305,14 @@ func (s *advancedVisibilitySuite) TestListWorkflow_SearchAttribute() {
 		Logger:              s.Logger,
 		T:                   s.T(),
 	}
-	_, newTask, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask := res.NewTask
 	s.NotNil(newTask)
 	s.NotNil(newTask.WorkflowTask)
 
@@ -1364,16 +1362,14 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	}
 
 	// process 1st workflow task and assert workflow task is handled correctly.
-	_, newTask, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask := res.NewTask
 	s.NotNil(newTask)
 	s.NotNil(newTask.WorkflowTask)
 	s.Equal(int64(3), newTask.WorkflowTask.GetPreviousStartedEventId())
@@ -1414,16 +1410,14 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	s.True(verified)
 
 	// process 2nd workflow task and assert workflow task is handled correctly.
-	_, newTask, err = poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask = res.NewTask
 	s.NotNil(newTask)
 	s.NotNil(newTask.WorkflowTask)
 	s.Equal(4, len(newTask.WorkflowTask.History.Events))
@@ -1438,16 +1432,14 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	s.testListResultForUpsertSearchAttributes(listRequest)
 
 	// process 3rd workflow task and assert workflow task is handled correctly.
-	_, newTask, err = poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask = res.NewTask
 	s.NotNil(newTask)
 	s.NotNil(newTask.WorkflowTask)
 	s.Equal(4, len(newTask.WorkflowTask.History.Events))
@@ -1531,16 +1523,14 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	}
 
 	// process close workflow task and assert search attributes is correct after workflow is closed
-	_, newTask, err = poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask = res.NewTask
 	s.NotNil(newTask)
 	s.Nil(newTask.WorkflowTask)
 
@@ -1667,16 +1657,14 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	}
 
 	// process 1st workflow task and assert workflow task is handled correctly.
-	_, newTask, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask := res.NewTask
 	s.NotNil(newTask)
 	s.NotNil(newTask.WorkflowTask)
 	s.Equal(int64(3), newTask.WorkflowTask.GetPreviousStartedEventId())
@@ -1717,16 +1705,14 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	s.True(verified)
 
 	// process 2nd workflow task and assert workflow task is handled correctly.
-	_, newTask, err = poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask = res.NewTask
 	s.NotNil(newTask)
 	s.NotNil(newTask.WorkflowTask)
 	s.Equal(4, len(newTask.WorkflowTask.History.Events))
@@ -1765,16 +1751,14 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	s.True(verified)
 
 	// process close workflow task and assert workflow task is handled correctly.
-	_, newTask, err = poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask = res.NewTask
 	s.NotNil(newTask)
 	s.Nil(newTask.WorkflowTask)
 

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -305,7 +305,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_SearchAttribute() {
 		Logger:              s.Logger,
 		T:                   s.T(),
 	}
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err := poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -1362,7 +1362,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	}
 
 	// process 1st workflow task and assert workflow task is handled correctly.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err := poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -1410,7 +1410,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	s.True(verified)
 
 	// process 2nd workflow task and assert workflow task is handled correctly.
-	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -1432,7 +1432,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	s.testListResultForUpsertSearchAttributes(listRequest)
 
 	// process 3rd workflow task and assert workflow task is handled correctly.
-	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -1523,7 +1523,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	}
 
 	// process close workflow task and assert search attributes is correct after workflow is closed
-	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -1657,7 +1657,7 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	}
 
 	// process 1st workflow task and assert workflow task is handled correctly.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err := poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -1705,7 +1705,7 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	s.True(verified)
 
 	// process 2nd workflow task and assert workflow task is handled correctly.
-	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -1751,7 +1751,7 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	s.True(verified)
 
 	// process close workflow task and assert workflow task is handled correctly.
-	res, err = poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err = poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -1890,7 +1890,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 	if s.isElasticsearchEnabled {

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -423,7 +423,7 @@ func (s *archivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceI
 	}
 	for run := 0; run < numRuns; run++ {
 		for i := 0; i < numActivities; i++ {
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+			_, err := poller.PollAndProcessWorkflowTask()
 			s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 			s.NoError(err)
 			if i%2 == 0 {
@@ -435,7 +435,7 @@ func (s *archivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceI
 			s.NoError(err)
 		}
 
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 		s.NoError(err)
 	}
 

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -423,7 +423,7 @@ func (s *archivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceI
 	}
 	for run := 0; run < numRuns; run++ {
 		for i := 0; i < numActivities; i++ {
-			_, err := poller.PollAndProcessWorkflowTask(false, false)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 			s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 			s.NoError(err)
 			if i%2 == 0 {
@@ -435,7 +435,7 @@ func (s *archivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceI
 			s.NoError(err)
 		}
 
-		_, err = poller.PollAndProcessWorkflowTask(true, false)
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 		s.NoError(err)
 	}
 

--- a/tests/cancel_workflow_test.go
+++ b/tests/cancel_workflow_test.go
@@ -119,7 +119,7 @@ func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
 	})
 	s.NoError(err)
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -257,19 +257,19 @@ func (s *integrationSuite) TestRequestCancelWorkflowCommandExecution_TargetRunni
 	}
 
 	// Cancel the foreign workflow with this workflow task request.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(cancellationSent)
 
 	// Finish execution
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Accept cancellation.
-	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = foreignPoller.PollAndProcessWorkflowTask()
 	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
@@ -389,19 +389,19 @@ func (s *integrationSuite) TestRequestCancelWorkflowCommandExecution_TargetFinis
 	}
 
 	// Complete target workflow
-	_, err := foreignPoller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := foreignPoller.PollAndProcessWorkflowTask()
 	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Cancel the target workflow with this workflow task request.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(cancellationSent)
 
 	// Finish execution
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
@@ -474,14 +474,14 @@ func (s *integrationSuite) TestRequestCancelWorkflowCommandExecution_TargetNotFo
 	}
 
 	// Cancel the target workflow with this workflow task request.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(cancellationSent)
 
 	// Finish execution
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
@@ -622,7 +622,7 @@ func (s *integrationSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
 	}
 
 	s.Logger.Info("Process first workflow task which starts and request cancels child workflow")
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 	s.Equal("BadRequestCancelExternalWorkflowExecutionAttributes: Start and RequestCancel for child workflow is not allowed in same workflow task.", err.Error())
@@ -632,7 +632,7 @@ func (s *integrationSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
 	})
 
 	s.Logger.Info("Process second workflow task which observes child workflow is cancelled and completes")
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	s.printWorkflowHistory(s.namespace, &commonpb.WorkflowExecution{

--- a/tests/cancel_workflow_test.go
+++ b/tests/cancel_workflow_test.go
@@ -119,7 +119,7 @@ func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
 	})
 	s.NoError(err)
 
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -257,19 +257,19 @@ func (s *integrationSuite) TestRequestCancelWorkflowCommandExecution_TargetRunni
 	}
 
 	// Cancel the foreign workflow with this workflow task request.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(cancellationSent)
 
 	// Finish execution
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Accept cancellation.
-	_, err = foreignPoller.PollAndProcessWorkflowTask(false, false)
+	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
@@ -389,19 +389,19 @@ func (s *integrationSuite) TestRequestCancelWorkflowCommandExecution_TargetFinis
 	}
 
 	// Complete target workflow
-	_, err := foreignPoller.PollAndProcessWorkflowTask(false, false)
+	_, err := foreignPoller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Cancel the target workflow with this workflow task request.
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(cancellationSent)
 
 	// Finish execution
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
@@ -474,14 +474,14 @@ func (s *integrationSuite) TestRequestCancelWorkflowCommandExecution_TargetNotFo
 	}
 
 	// Cancel the target workflow with this workflow task request.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	s.True(cancellationSent)
 
 	// Finish execution
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
@@ -622,7 +622,7 @@ func (s *integrationSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
 	}
 
 	s.Logger.Info("Process first workflow task which starts and request cancels child workflow")
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 	s.Equal("BadRequestCancelExternalWorkflowExecutionAttributes: Start and RequestCancel for child workflow is not allowed in same workflow task.", err.Error())
@@ -632,7 +632,7 @@ func (s *integrationSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
 	})
 
 	s.Logger.Info("Process second workflow task which observes child workflow is cancelled and completes")
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	s.printWorkflowHistory(s.namespace, &commonpb.WorkflowExecution{

--- a/tests/child_workflow_test.go
+++ b/tests/child_workflow_test.go
@@ -195,17 +195,17 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	}
 
 	// Make first workflow task to start child execution
-	_, err := pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err := pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event and Process Child Execution and complete it
-	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerChild.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(startedEvent)
@@ -226,7 +226,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	s.Equal(200*time.Second, timestamp.DurationValue(childStartedEvent.GetWorkflowExecutionStartedEventAttributes().GetWorkflowRunTimeout()))
 
 	// Process ChildExecution completed event and complete parent execution
-	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(completedEvent)
@@ -355,20 +355,20 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 	}
 
 	// Make first workflow task to start child execution
-	_, err := pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err := pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event
-	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(seenChildStarted)
 
 	// Run through three executions of the child workflow
 	for i := 0; i < 3; i++ {
-		_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
+		_, err = pollerChild.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err), tag.Counter(i))
 		s.NoError(err)
 	}
@@ -383,7 +383,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 	s.Nil(terminateErr)
 
 	// Process ChildExecution terminated event and complete parent execution
-	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(terminatedEvent)
@@ -563,37 +563,37 @@ func (s *integrationSuite) TestRetryChildWorkflowExecution() {
 	}
 
 	// Make first workflow task to start child execution
-	_, err := pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err := pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event
-	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(startedEvent)
 
 	// Process Child Execution #1
-	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerChild.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.False(childComplete)
 
 	// Process Child Execution #2
-	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerChild.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.False(childComplete)
 
 	// Process Child Execution #3
-	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerChild.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childComplete)
 
 	// Parent should see child complete
-	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -728,34 +728,34 @@ func (s *integrationSuite) TestRetryFailChildWorkflowExecution() {
 	}
 
 	// Make first workflow task to start child execution
-	_, err := pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err := pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event
-	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(startedEvent)
 
 	// Process Child Execution #1
-	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerChild.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Process Child Execution #2
-	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerChild.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Process Child Execution #3
-	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerChild.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Parent should see child complete
-	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
+	_, err = pollerParent.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/child_workflow_test.go
+++ b/tests/child_workflow_test.go
@@ -195,17 +195,17 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	}
 
 	// Make first workflow task to start child execution
-	_, err := pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err := pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event and Process Child Execution and complete it
-	_, err = pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = pollerChild.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(startedEvent)
@@ -226,7 +226,7 @@ func (s *integrationSuite) TestChildWorkflowExecution() {
 	s.Equal(200*time.Second, timestamp.DurationValue(childStartedEvent.GetWorkflowExecutionStartedEventAttributes().GetWorkflowRunTimeout()))
 
 	// Process ChildExecution completed event and complete parent execution
-	_, err = pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(completedEvent)
@@ -355,20 +355,20 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 	}
 
 	// Make first workflow task to start child execution
-	_, err := pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err := pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event
-	_, err = pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(seenChildStarted)
 
 	// Run through three executions of the child workflow
 	for i := 0; i < 3; i++ {
-		_, err = pollerChild.PollAndProcessWorkflowTask(false, false)
+		_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err), tag.Counter(i))
 		s.NoError(err)
 	}
@@ -383,7 +383,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 	s.Nil(terminateErr)
 
 	// Process ChildExecution terminated event and complete parent execution
-	_, err = pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(terminatedEvent)
@@ -563,37 +563,37 @@ func (s *integrationSuite) TestRetryChildWorkflowExecution() {
 	}
 
 	// Make first workflow task to start child execution
-	_, err := pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err := pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event
-	_, err = pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(startedEvent)
 
 	// Process Child Execution #1
-	_, err = pollerChild.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.False(childComplete)
 
 	// Process Child Execution #2
-	_, err = pollerChild.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.False(childComplete)
 
 	// Process Child Execution #3
-	_, err = pollerChild.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childComplete)
 
 	// Parent should see child complete
-	_, err = pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -728,34 +728,34 @@ func (s *integrationSuite) TestRetryFailChildWorkflowExecution() {
 	}
 
 	// Make first workflow task to start child execution
-	_, err := pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err := pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(childExecutionStarted)
 
 	// Process ChildExecution Started event
-	_, err = pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(startedEvent)
 
 	// Process Child Execution #1
-	_, err = pollerChild.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Process Child Execution #2
-	_, err = pollerChild.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Process Child Execution #3
-	_, err = pollerChild.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerChild.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Parent should see child complete
-	_, err = pollerParent.PollAndProcessWorkflowTask(false, false)
+	_, err = pollerParent.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -139,13 +139,13 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 	}
 
 	for i := 0; i < 10; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 	s.Equal(previousRunID, lastRunStartedEvent.GetWorkflowExecutionStartedEventAttributes().GetContinuedExecutionRunId())
@@ -224,7 +224,7 @@ func (s *integrationSuite) TestContinueAsNewRun_Timeout() {
 	}
 
 	// process the workflow task and continue as new
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -325,7 +325,7 @@ func (s *integrationSuite) TestWorkflowContinueAsNew_TaskID() {
 	}
 
 	minTaskID := int64(0)
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events := s.getHistory(s.namespace, executions[0])
 	s.True(len(events) != 0)
@@ -334,7 +334,7 @@ func (s *integrationSuite) TestWorkflowContinueAsNew_TaskID() {
 		minTaskID = event.GetTaskId()
 	}
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events = s.getHistory(s.namespace, executions[1])
 	s.True(len(events) != 0)
@@ -505,7 +505,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	}
 
 	// Make first command to start child execution
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(definition.childExecutionStarted)
@@ -513,7 +513,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	// Process ChildExecution Started event and all generations of child executions
 	for i := 0; i < 11; i++ {
 		s.Logger.Info("workflow task", tag.Counter(i))
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err = poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -522,13 +522,13 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	s.NotNil(definition.startedEvent)
 
 	// Process Child Execution final workflow task to complete it
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(definition.childComplete)
 
 	// Process ChildExecution completed event and complete parent execution
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(definition.completedEvent)
@@ -588,7 +588,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 	}
 
 	// Make first command to start child execution
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(definition.childExecutionStarted)
@@ -596,7 +596,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 	// Process ChildExecution Started event and all generations of child executions
 	for i := 0; i < 11; i++ {
 		s.Logger.Info("workflow task", tag.Counter(i))
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err = poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -139,13 +139,13 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 	}
 
 	for i := 0; i < 10; i++ {
-		_, err := poller.PollAndProcessWorkflowTask(false, false)
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 	s.Equal(previousRunID, lastRunStartedEvent.GetWorkflowExecutionStartedEventAttributes().GetContinuedExecutionRunId())
@@ -224,7 +224,7 @@ func (s *integrationSuite) TestContinueAsNewRun_Timeout() {
 	}
 
 	// process the workflow task and continue as new
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -325,7 +325,7 @@ func (s *integrationSuite) TestWorkflowContinueAsNew_TaskID() {
 	}
 
 	minTaskID := int64(0)
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events := s.getHistory(s.namespace, executions[0])
 	s.True(len(events) != 0)
@@ -334,7 +334,7 @@ func (s *integrationSuite) TestWorkflowContinueAsNew_TaskID() {
 		minTaskID = event.GetTaskId()
 	}
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events = s.getHistory(s.namespace, executions[1])
 	s.True(len(events) != 0)
@@ -505,7 +505,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	}
 
 	// Make first command to start child execution
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(definition.childExecutionStarted)
@@ -513,7 +513,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	// Process ChildExecution Started event and all generations of child executions
 	for i := 0; i < 11; i++ {
 		s.Logger.Info("workflow task", tag.Counter(i))
-		_, err = poller.PollAndProcessWorkflowTask(false, false)
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -522,13 +522,13 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	s.NotNil(definition.startedEvent)
 
 	// Process Child Execution final workflow task to complete it
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(definition.childComplete)
 
 	// Process ChildExecution completed event and complete parent execution
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(definition.completedEvent)
@@ -588,7 +588,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 	}
 
 	// Make first command to start child execution
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(definition.childExecutionStarted)
@@ -596,7 +596,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 	// Process ChildExecution Started event and all generations of child executions
 	for i := 0; i < 11; i++ {
 		s.Logger.Info("workflow task", tag.Counter(i))
-		_, err = poller.PollAndProcessWorkflowTask(false, false)
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}

--- a/tests/cron_test.go
+++ b/tests/cron_test.go
@@ -122,11 +122,11 @@ func (s *integrationSuite) TestCronWorkflow_Failed_Infinite() {
 	}
 
 	s.Logger.Info("Process first cron run which fails")
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	s.Logger.Info("Process first cron run which completes")
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	s.True(seeRetry)
@@ -256,7 +256,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	executionInfo := resp.GetExecutions()[0]
 	s.Equal(targetBackoffDuration, executionInfo.GetExecutionTime().Sub(timestamp.TimeValue(executionInfo.GetStartTime())))
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	// Make sure the cron workflow start running at a proper time, in this case 3 seconds after the
@@ -265,10 +265,10 @@ func (s *integrationSuite) TestCronWorkflow() {
 	s.True(backoffDuration > targetBackoffDuration)
 	s.True(backoffDuration < targetBackoffDuration+backoffDurationTolerance)
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	s.Equal(3, len(executions))

--- a/tests/cron_test.go
+++ b/tests/cron_test.go
@@ -122,11 +122,11 @@ func (s *integrationSuite) TestCronWorkflow_Failed_Infinite() {
 	}
 
 	s.Logger.Info("Process first cron run which fails")
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	s.Logger.Info("Process first cron run which completes")
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	s.True(seeRetry)
@@ -256,7 +256,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	executionInfo := resp.GetExecutions()[0]
 	s.Equal(targetBackoffDuration, executionInfo.GetExecutionTime().Sub(timestamp.TimeValue(executionInfo.GetStartTime())))
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	// Make sure the cron workflow start running at a proper time, in this case 3 seconds after the
@@ -265,10 +265,10 @@ func (s *integrationSuite) TestCronWorkflow() {
 	s.True(backoffDuration > targetBackoffDuration)
 	s.True(backoffDuration < targetBackoffDuration+backoffDurationTolerance)
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	s.Equal(3, len(executions))

--- a/tests/describe_test.go
+++ b/tests/describe_test.go
@@ -134,7 +134,7 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 	}
 
 	// first workflow task to schedule new activity
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -156,7 +156,7 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 	s.Equal(0, len(dweResponse.PendingActivities))
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 
@@ -262,7 +262,7 @@ func (s *integrationSuite) TestDescribeTaskQueue() {
 	pollerInfos = testDescribeTaskQueue(s.namespace, &taskqueuepb.TaskQueue{Name: tl}, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Empty(pollerInfos)
 
-	_, errWorkflowTask := poller.PollAndProcessWorkflowTask(false, false)
+	_, errWorkflowTask := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(errWorkflowTask)
 	pollerInfos = testDescribeTaskQueue(s.namespace, &taskqueuepb.TaskQueue{Name: tl}, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	s.Empty(pollerInfos)

--- a/tests/describe_test.go
+++ b/tests/describe_test.go
@@ -134,7 +134,7 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 	}
 
 	// first workflow task to schedule new activity
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -156,7 +156,7 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 	s.Equal(0, len(dweResponse.PendingActivities))
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 
@@ -262,7 +262,7 @@ func (s *integrationSuite) TestDescribeTaskQueue() {
 	pollerInfos = testDescribeTaskQueue(s.namespace, &taskqueuepb.TaskQueue{Name: tl}, enumspb.TASK_QUEUE_TYPE_WORKFLOW)
 	s.Empty(pollerInfos)
 
-	_, errWorkflowTask := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, errWorkflowTask := poller.PollAndProcessWorkflowTask()
 	s.NoError(errWorkflowTask)
 	pollerInfos = testDescribeTaskQueue(s.namespace, &taskqueuepb.TaskQueue{Name: tl}, enumspb.TASK_QUEUE_TYPE_ACTIVITY)
 	s.Empty(pollerInfos)

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -194,7 +194,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 	// here do a long pull and check # of events and time elapsed
 	// Make first command to schedule activity, this should affect the long poll above
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTask(false, false)
+		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask1))
 	})
 	start = time.Now().UTC()
@@ -210,7 +210,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errActivity))
 	})
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTask(false, false)
+		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask2))
 	})
 	for token != nil {
@@ -361,7 +361,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 	// here do a long pull and check # of events and time elapsed
 	// Make first command to schedule activity, this should affect the long poll above
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTask(false, false)
+		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask1))
 	})
 	start = time.Now().UTC()
@@ -377,7 +377,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errActivity))
 	})
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTask(false, false)
+		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask2))
 	})
 	for token != nil {
@@ -552,7 +552,7 @@ func (s *rawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 	// here do a long pull and check # of events and time elapsed
 	// Make first command to schedule activity, this should affect the long poll above
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTask(false, false)
+		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask1))
 	})
 	start = time.Now().UTC()
@@ -569,7 +569,7 @@ func (s *rawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errActivity))
 	})
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTask(false, false)
+		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask2))
 	})
 	for token != nil {

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -194,7 +194,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 	// here do a long pull and check # of events and time elapsed
 	// Make first command to schedule activity, this should affect the long poll above
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask1))
 	})
 	start = time.Now().UTC()
@@ -210,7 +210,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errActivity))
 	})
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask2))
 	})
 	for token != nil {
@@ -361,7 +361,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 	// here do a long pull and check # of events and time elapsed
 	// Make first command to schedule activity, this should affect the long poll above
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask1))
 	})
 	start = time.Now().UTC()
@@ -377,7 +377,7 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errActivity))
 	})
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask2))
 	})
 	for token != nil {
@@ -552,7 +552,7 @@ func (s *rawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 	// here do a long pull and check # of events and time elapsed
 	// Make first command to schedule activity, this should affect the long poll above
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, errWorkflowTask1 := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask1))
 	})
 	start = time.Now().UTC()
@@ -569,7 +569,7 @@ func (s *rawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errActivity))
 	})
 	time.AfterFunc(time.Second*8, func() {
-		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, errWorkflowTask2 := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(errWorkflowTask2))
 	})
 	for token != nil {

--- a/tests/relay_task_test.go
+++ b/tests/relay_task_test.go
@@ -98,7 +98,7 @@ func (s *integrationSuite) TestRelayWorkflowTaskTimeout() {
 
 	// First workflow task complete with a marker command, and request to relay workflow task (immediately return a new workflow task)
 	res, err := poller.PollAndProcessWorkflowTask(
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(3),
 		WithForceNewWorkflowTask)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
@@ -123,7 +123,7 @@ func (s *integrationSuite) TestRelayWorkflowTaskTimeout() {
 	s.True(workflowTaskTimeout)
 
 	// Now complete workflow
-	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(2))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithExpectedAttemptCount(2))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/relay_task_test.go
+++ b/tests/relay_task_test.go
@@ -97,17 +97,13 @@ func (s *integrationSuite) TestRelayWorkflowTaskTimeout() {
 	}
 
 	// First workflow task complete with a marker command, and request to relay workflow task (immediately return a new workflow task)
-	_, newTask, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		false,
-		false,
-		0,
-		3,
-		true,
-		nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+		WithAttemptCount(0),
+		WithRetries(3),
+		WithForceNewWorkflowTask)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
+	newTask := res.NewTask
 	s.NotNil(newTask)
 	s.NotNil(newTask.WorkflowTask)
 

--- a/tests/relay_task_test.go
+++ b/tests/relay_task_test.go
@@ -127,7 +127,7 @@ func (s *integrationSuite) TestRelayWorkflowTaskTimeout() {
 	s.True(workflowTaskTimeout)
 
 	// Now complete workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, false, 2)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(2))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/relay_task_test.go
+++ b/tests/relay_task_test.go
@@ -97,7 +97,7 @@ func (s *integrationSuite) TestRelayWorkflowTaskTimeout() {
 	}
 
 	// First workflow task complete with a marker command, and request to relay workflow task (immediately return a new workflow task)
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err := poller.PollAndProcessWorkflowTask(
 		WithAttemptCount(0),
 		WithRetries(3),
 		WithForceNewWorkflowTask)
@@ -123,7 +123,7 @@ func (s *integrationSuite) TestRelayWorkflowTaskTimeout() {
 	s.True(workflowTaskTimeout)
 
 	// Now complete workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(2))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(2))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -146,7 +146,7 @@ func (s *integrationSuite) TestResetWorkflow() {
 	}
 
 	// Process first workflow task to schedule activities
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -156,7 +156,7 @@ func (s *integrationSuite) TestResetWorkflow() {
 	s.NoError(err)
 
 	// Process second workflow task which checks activity completion
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("Poll and process second workflow task", tag.Error(err))
 	s.NoError(err)
 
@@ -193,7 +193,7 @@ func (s *integrationSuite) TestResetWorkflow() {
 	s.Logger.Info("Poll and process third activity", tag.Error(err))
 	s.NoError(err)
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("Poll and process final workflow task", tag.Error(err))
 	s.NoError(err)
 
@@ -296,7 +296,7 @@ func (s *integrationSuite) testResetWorkflowReapply(
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -305,7 +305,7 @@ func (s *integrationSuite) testResetWorkflowReapply(
 		_, err = s.engine.SignalWorkflowExecution(NewContext(), signalRequest)
 		s.NoError(err)
 
-		_, err = poller.PollAndProcessWorkflowTask(true, false)
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -463,11 +463,11 @@ func (s *integrationSuite) testResetWorkflowReapplyBuffer(
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.Error(err) // due to workflow termination (reset)
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -590,7 +590,7 @@ func (s *integrationSuite) testResetWorkflowRangeScheduleToStart(
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -614,7 +614,7 @@ func (s *integrationSuite) testResetWorkflowRangeScheduleToStart(
 	})
 	s.NoError(err)
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -146,7 +146,7 @@ func (s *integrationSuite) TestResetWorkflow() {
 	}
 
 	// Process first workflow task to schedule activities
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -156,7 +156,7 @@ func (s *integrationSuite) TestResetWorkflow() {
 	s.NoError(err)
 
 	// Process second workflow task which checks activity completion
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("Poll and process second workflow task", tag.Error(err))
 	s.NoError(err)
 
@@ -193,7 +193,7 @@ func (s *integrationSuite) TestResetWorkflow() {
 	s.Logger.Info("Poll and process third activity", tag.Error(err))
 	s.NoError(err)
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("Poll and process final workflow task", tag.Error(err))
 	s.NoError(err)
 
@@ -296,7 +296,7 @@ func (s *integrationSuite) testResetWorkflowReapply(
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -305,7 +305,7 @@ func (s *integrationSuite) testResetWorkflowReapply(
 		_, err = s.engine.SignalWorkflowExecution(NewContext(), signalRequest)
 		s.NoError(err)
 
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -463,11 +463,11 @@ func (s *integrationSuite) testResetWorkflowReapplyBuffer(
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.Error(err) // due to workflow termination (reset)
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -590,7 +590,7 @@ func (s *integrationSuite) testResetWorkflowRangeScheduleToStart(
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -614,7 +614,7 @@ func (s *integrationSuite) testResetWorkflowRangeScheduleToStart(
 	})
 	s.NoError(err)
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)

--- a/tests/signal_workflow_test.go
+++ b/tests/signal_workflow_test.go
@@ -160,7 +160,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	}
 
 	// Make first command to schedule activity
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -181,7 +181,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	s.NoError(err)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -207,7 +207,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	s.NoError(err)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -338,7 +338,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	}
 
 	// Make first command to schedule activity
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -361,7 +361,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	s.NoError(err)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -377,7 +377,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	s.NoError(err)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -542,11 +542,11 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand() {
 	}
 
 	// Start both current and foreign workflows to make some progress.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = foreignPoller.PollAndProcessWorkflowTask()
 	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -555,7 +555,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand() {
 	s.NoError(err)
 
 	// Signal the foreign workflow with this command.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -595,7 +595,7 @@ CheckHistoryLoopForSignalSent:
 	s.True(signalSent)
 
 	// Process signal in workflow for foreign workflow
-	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = foreignPoller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -678,7 +678,7 @@ func (s *integrationSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated() {
 	}
 
 	// Make first command to schedule activity
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowTaskDelay > time.Second*2)
@@ -740,7 +740,7 @@ func (s *integrationSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 	}
 
 	// process start task
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -773,7 +773,7 @@ func (s *integrationSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 	s.NoError(err)
 
 	// process signal and complete workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -876,11 +876,11 @@ func (s *integrationSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.Error(err)
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
@@ -1037,11 +1037,11 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 	}
 
 	// Start both current and foreign workflows to make some progress.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = foreignPoller.PollAndProcessWorkflowTask()
 	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1050,7 +1050,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 	s.NoError(err)
 
 	// Signal the foreign workflow with this command.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1089,7 +1089,7 @@ CheckHistoryLoopForSignalSent:
 	s.True(signalSent)
 
 	// Process signal in workflow for foreign workflow
-	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = foreignPoller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1183,12 +1183,12 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand_UnKnownTarget() {
 	}
 
 	// Start workflows to make some progress.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Signal the foreign workflow with this command.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1308,12 +1308,12 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand_SignalSelf() {
 	}
 
 	// Start workflows to make some progress.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Signal the foreign workflow with this command.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1463,7 +1463,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	}
 
 	// Make first command to schedule activity
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1491,7 +1491,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	s.Equal(we.GetRunId(), resp.GetRunId())
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1527,7 +1527,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	newWorkflowStarted = true
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1552,7 +1552,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	newWorkflowStarted = true
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1696,10 +1696,10 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	}
 
 	// Start workflows, make some progress and complete workflow
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -1854,7 +1854,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_StartDelay() {
 		T:                   s.T(),
 	}
 
-	_, pollErr := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, pollErr := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(pollErr)
 	s.GreaterOrEqual(delayEndTime.Sub(reqStartTime), startDelay)
 	s.NotNil(signalEvent)
@@ -1927,7 +1927,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
 	}
 
 	// process start task
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	signalName := "my signal"
@@ -1966,7 +1966,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
 	s.NoError(err)
 
 	// process signal and complete workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/signal_workflow_test.go
+++ b/tests/signal_workflow_test.go
@@ -160,7 +160,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	}
 
 	// Make first command to schedule activity
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -181,7 +181,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	s.NoError(err)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -207,7 +207,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	s.NoError(err)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -338,7 +338,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	}
 
 	// Make first command to schedule activity
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -361,7 +361,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	s.NoError(err)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -377,7 +377,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	s.NoError(err)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -542,11 +542,11 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand() {
 	}
 
 	// Start both current and foreign workflows to make some progress.
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = foreignPoller.PollAndProcessWorkflowTask(false, false)
+	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -555,7 +555,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand() {
 	s.NoError(err)
 
 	// Signal the foreign workflow with this command.
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -595,7 +595,7 @@ CheckHistoryLoopForSignalSent:
 	s.True(signalSent)
 
 	// Process signal in workflow for foreign workflow
-	_, err = foreignPoller.PollAndProcessWorkflowTask(true, false)
+	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -678,7 +678,7 @@ func (s *integrationSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated() {
 	}
 
 	// Make first command to schedule activity
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowTaskDelay > time.Second*2)
@@ -740,7 +740,7 @@ func (s *integrationSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 	}
 
 	// process start task
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -773,7 +773,7 @@ func (s *integrationSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 	s.NoError(err)
 
 	// process signal and complete workflow
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -876,11 +876,11 @@ func (s *integrationSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.Error(err)
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 }
@@ -1037,11 +1037,11 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 	}
 
 	// Start both current and foreign workflows to make some progress.
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
-	_, err = foreignPoller.PollAndProcessWorkflowTask(false, false)
+	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("foreign PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1050,7 +1050,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 	s.NoError(err)
 
 	// Signal the foreign workflow with this command.
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1089,7 +1089,7 @@ CheckHistoryLoopForSignalSent:
 	s.True(signalSent)
 
 	// Process signal in workflow for foreign workflow
-	_, err = foreignPoller.PollAndProcessWorkflowTask(true, false)
+	_, err = foreignPoller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1183,12 +1183,12 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand_UnKnownTarget() {
 	}
 
 	// Start workflows to make some progress.
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Signal the foreign workflow with this command.
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1308,12 +1308,12 @@ func (s *integrationSuite) TestSignalExternalWorkflowCommand_SignalSelf() {
 	}
 
 	// Start workflows to make some progress.
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Signal the foreign workflow with this command.
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1463,7 +1463,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	}
 
 	// Make first command to schedule activity
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1491,7 +1491,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	s.Equal(we.GetRunId(), resp.GetRunId())
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1527,7 +1527,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	newWorkflowStarted = true
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1552,7 +1552,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	newWorkflowStarted = true
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1696,10 +1696,10 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	}
 
 	// Start workflows, make some progress and complete workflow
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -1854,7 +1854,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_StartDelay() {
 		T:                   s.T(),
 	}
 
-	_, pollErr := poller.PollAndProcessWorkflowTask(true, false)
+	_, pollErr := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(pollErr)
 	s.GreaterOrEqual(delayEndTime.Sub(reqStartTime), startDelay)
 	s.NotNil(signalEvent)
@@ -1927,7 +1927,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
 	}
 
 	// process start task
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	signalName := "my signal"
@@ -1966,7 +1966,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
 	s.NoError(err)
 
 	// process signal and complete workflow
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/sizelimit_test.go
+++ b/tests/sizelimit_test.go
@@ -165,7 +165,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedByHistoryCountLim
 
 		// Poll workflow task only if it is running
 		if dwResp.WorkflowExecutionInfo.Status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
-			_, err := poller.PollAndProcessWorkflowTask(false, false)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 			s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 			s.NoError(err)
 
@@ -304,7 +304,7 @@ func (s *sizeLimitIntegrationSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 	s.NoError(err)
 
 	go func() {
-		_, err = poller.PollAndProcessWorkflowTask(false, false)
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	}()
 
@@ -431,7 +431,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 
 	// Poll workflow task only if it is running
 	if dwResp.WorkflowExecutionInfo.Status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
-		_, err := poller.PollAndProcessWorkflowTask(false, false)
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 
 		// Workflow should be force terminated at this point

--- a/tests/sizelimit_test.go
+++ b/tests/sizelimit_test.go
@@ -165,7 +165,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedByHistoryCountLim
 
 		// Poll workflow task only if it is running
 		if dwResp.WorkflowExecutionInfo.Status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+			_, err := poller.PollAndProcessWorkflowTask()
 			s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 			s.NoError(err)
 
@@ -304,7 +304,7 @@ func (s *sizeLimitIntegrationSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 	s.NoError(err)
 
 	go func() {
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err = poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	}()
 
@@ -431,7 +431,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 
 	// Poll workflow task only if it is running
 	if dwResp.WorkflowExecutionInfo.Status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 
 		// Workflow should be force terminated at this point

--- a/tests/stickytq_test.go
+++ b/tests/stickytq_test.go
@@ -131,7 +131,7 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientWorkflowTask() {
 		StickyScheduleToStartTimeout: stickyScheduleToStartTimeout,
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithAttempt(false, false, false, true, 1)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -162,7 +162,7 @@ WaitForStickyTimeoutLoop:
 	s.True(stickyTimeout, "Workflow task not timed out")
 
 	for i := 1; i <= 3; i++ {
-		_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, true, int32(i))
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -178,7 +178,7 @@ WaitForStickyTimeoutLoop:
 	s.NoError(err)
 
 	for i := 1; i <= 2; i++ {
-		_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, true, int32(i))
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -194,7 +194,7 @@ WaitForStickyTimeoutLoop:
 	s.True(workflowTaskFailed)
 
 	// Complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, true, 3)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(3))
 	s.NoError(err)
 
 	// Assert for single workflow task failed and workflow completion
@@ -291,7 +291,7 @@ func (s *integrationSuite) TestStickyTaskqueueResetThenTimeout() {
 		StickyScheduleToStartTimeout: stickyScheduleToStartTimeout,
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithAttempt(false, false, false, true, 1)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -329,7 +329,7 @@ WaitForStickyTimeoutLoop:
 	s.True(stickyTimeout, "Workflow task not timed out")
 
 	for i := 1; i <= 3; i++ {
-		_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, true, int32(i))
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -345,7 +345,7 @@ WaitForStickyTimeoutLoop:
 	s.NoError(err)
 
 	for i := 1; i <= 2; i++ {
-		_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, true, int32(i))
+		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -361,7 +361,7 @@ WaitForStickyTimeoutLoop:
 	s.True(workflowTaskFailed)
 
 	// Complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, true, 3)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(3))
 	s.NoError(err)
 
 	// Assert for single workflow task failed and workflow completion

--- a/tests/stickytq_test.go
+++ b/tests/stickytq_test.go
@@ -131,7 +131,7 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientWorkflowTask() {
 		StickyScheduleToStartTimeout: stickyScheduleToStartTimeout,
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
+	_, err := poller.PollAndProcessWorkflowTask(WithRespondSticky)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -162,7 +162,7 @@ WaitForStickyTimeoutLoop:
 	s.True(stickyTimeout, "Workflow task not timed out")
 
 	for i := 1; i <= 3; i++ {
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -178,7 +178,7 @@ WaitForStickyTimeoutLoop:
 	s.NoError(err)
 
 	for i := 1; i <= 2; i++ {
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -194,7 +194,7 @@ WaitForStickyTimeoutLoop:
 	s.True(workflowTaskFailed)
 
 	// Complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(3))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(3))
 	s.NoError(err)
 
 	// Assert for single workflow task failed and workflow completion
@@ -291,7 +291,7 @@ func (s *integrationSuite) TestStickyTaskqueueResetThenTimeout() {
 		StickyScheduleToStartTimeout: stickyScheduleToStartTimeout,
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
+	_, err := poller.PollAndProcessWorkflowTask(WithRespondSticky)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -329,7 +329,7 @@ WaitForStickyTimeoutLoop:
 	s.True(stickyTimeout, "Workflow task not timed out")
 
 	for i := 1; i <= 3; i++ {
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -345,7 +345,7 @@ WaitForStickyTimeoutLoop:
 	s.NoError(err)
 
 	for i := 1; i <= 2; i++ {
-		_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -361,7 +361,7 @@ WaitForStickyTimeoutLoop:
 	s.True(workflowTaskFailed)
 
 	// Complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithRespondSticky, WithAttemptCount(3))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(3))
 	s.NoError(err)
 
 	// Assert for single workflow task failed and workflow completion

--- a/tests/stickytq_test.go
+++ b/tests/stickytq_test.go
@@ -162,7 +162,7 @@ WaitForStickyTimeoutLoop:
 	s.True(stickyTimeout, "Workflow task not timed out")
 
 	for i := 1; i <= 3; i++ {
-		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithExpectedAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -178,7 +178,7 @@ WaitForStickyTimeoutLoop:
 	s.NoError(err)
 
 	for i := 1; i <= 2; i++ {
-		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithExpectedAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -194,7 +194,7 @@ WaitForStickyTimeoutLoop:
 	s.True(workflowTaskFailed)
 
 	// Complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(3))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithExpectedAttemptCount(3))
 	s.NoError(err)
 
 	// Assert for single workflow task failed and workflow completion
@@ -329,7 +329,7 @@ WaitForStickyTimeoutLoop:
 	s.True(stickyTimeout, "Workflow task not timed out")
 
 	for i := 1; i <= 3; i++ {
-		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithExpectedAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -345,7 +345,7 @@ WaitForStickyTimeoutLoop:
 	s.NoError(err)
 
 	for i := 1; i <= 2; i++ {
-		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(i))
+		_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithExpectedAttemptCount(i))
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 	}
@@ -361,7 +361,7 @@ WaitForStickyTimeoutLoop:
 	s.True(workflowTaskFailed)
 
 	// Complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithAttemptCount(3))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithRespondSticky, WithExpectedAttemptCount(3))
 	s.NoError(err)
 
 	// Assert for single workflow task failed and workflow completion

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -81,7 +81,7 @@ type (
 		DropTask             bool
 		PollSticky           bool
 		RespondSticky        bool
-		AttemptCount         int
+		ExpectedAttemptCount int
 		Retries              int
 		ForceNewWorkflowTask bool
 		QueryResult          *querypb.WorkflowQueryResult
@@ -104,7 +104,7 @@ var (
 		DropTask:             false,
 		PollSticky:           false,
 		RespondSticky:        false,
-		AttemptCount:         1,
+		ExpectedAttemptCount: 1,
 		Retries:              5,
 		ForceNewWorkflowTask: false,
 		QueryResult:          nil,
@@ -116,8 +116,8 @@ func WithNoDumpCommands(o *PollAndProcessWorkflowTaskOptions) { o.DumpCommands =
 func WithDropTask(o *PollAndProcessWorkflowTaskOptions)       { o.DropTask = true }
 func WithPollSticky(o *PollAndProcessWorkflowTaskOptions)     { o.PollSticky = true }
 func WithRespondSticky(o *PollAndProcessWorkflowTaskOptions)  { o.RespondSticky = true }
-func WithAttemptCount(c int) PollAndProcessWorkflowTaskOptionFunc {
-	return func(o *PollAndProcessWorkflowTaskOptions) { o.AttemptCount = c }
+func WithExpectedAttemptCount(c int) PollAndProcessWorkflowTaskOptionFunc {
+	return func(o *PollAndProcessWorkflowTaskOptions) { o.ExpectedAttemptCount = c }
 }
 func WithRetries(c int) PollAndProcessWorkflowTaskOptionFunc {
 	return func(o *PollAndProcessWorkflowTaskOptions) { o.Retries = c }
@@ -265,8 +265,8 @@ Loop:
 				lastWorkflowTaskScheduleEvent = e
 			}
 		}
-		if lastWorkflowTaskScheduleEvent != nil && opts.AttemptCount > 1 {
-			require.Equal(p.T, opts.AttemptCount, lastWorkflowTaskScheduleEvent.GetWorkflowTaskScheduledEventAttributes().GetAttempt())
+		if lastWorkflowTaskScheduleEvent != nil && opts.ExpectedAttemptCount > 1 {
+			require.Equal(p.T, opts.ExpectedAttemptCount, lastWorkflowTaskScheduleEvent.GetWorkflowTaskScheduledEventAttributes().GetAttempt())
 		}
 
 		commands, err := p.WorkflowTaskHandler(response.WorkflowExecution, response.WorkflowType, response.PreviousStartedEventId, response.StartedEventId, response.History)

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -111,38 +111,20 @@ var (
 	}
 )
 
-func WithDumpHistory(o *WorkflowTaskPollOptions) {
-	o.DumpHistory = true
-}
-func WithNoDumpCommands(o *WorkflowTaskPollOptions) {
-	o.DumpCommands = false
-}
-func WithDropTask(o *WorkflowTaskPollOptions) {
-	o.DropTask = true
-}
-func WithPollSticky(o *WorkflowTaskPollOptions) {
-	o.PollSticky = true
-}
-func WithRespondSticky(o *WorkflowTaskPollOptions) {
-	o.RespondSticky = true
-}
+func WithDumpHistory(o *WorkflowTaskPollOptions)    { o.DumpHistory = true }
+func WithNoDumpCommands(o *WorkflowTaskPollOptions) { o.DumpCommands = false }
+func WithDropTask(o *WorkflowTaskPollOptions)       { o.DropTask = true }
+func WithPollSticky(o *WorkflowTaskPollOptions)     { o.PollSticky = true }
+func WithRespondSticky(o *WorkflowTaskPollOptions)  { o.RespondSticky = true }
 func WithAttemptCount(c int) WorkflowTaskPollOptionFunc {
-	return func(o *WorkflowTaskPollOptions) {
-		o.AttemptCount = c
-	}
+	return func(o *WorkflowTaskPollOptions) { o.AttemptCount = c }
 }
 func WithRetries(c int) WorkflowTaskPollOptionFunc {
-	return func(o *WorkflowTaskPollOptions) {
-		o.Retries = c
-	}
+	return func(o *WorkflowTaskPollOptions) { o.Retries = c }
 }
-func WithForceNewWorkflowTask(o *WorkflowTaskPollOptions) {
-	o.ForceNewWorkflowTask = true
-}
+func WithForceNewWorkflowTask(o *WorkflowTaskPollOptions) { o.ForceNewWorkflowTask = true }
 func WithQueryResult(r *querypb.WorkflowQueryResult) WorkflowTaskPollOptionFunc {
-	return func(o *WorkflowTaskPollOptions) {
-		o.QueryResult = r
-	}
+	return func(o *WorkflowTaskPollOptions) { o.QueryResult = r }
 }
 
 func (p *TaskPoller) PollAndProcessWorkflowTask(funcs ...WorkflowTaskPollOptionFunc) (res WorkflowTaskPollResponse, err error) {

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -145,46 +145,6 @@ func WithQueryResult(r *querypb.WorkflowQueryResult) WorkflowTaskPollOptionFunc 
 	}
 }
 
-// PollAndProcessWorkflowTaskWithAttempt for workflow tasks
-func (p *TaskPoller) PollAndProcessWorkflowTaskWithAttempt(
-	dumpHistory bool,
-	dropTask bool,
-	pollStickyTaskQueue bool,
-	respondStickyTaskQueue bool,
-	workflowTaskAttempt int32,
-) (isQueryTask bool, err error) {
-
-	return p.PollAndProcessWorkflowTaskWithAttemptAndRetry(
-		dumpHistory,
-		dropTask,
-		pollStickyTaskQueue,
-		respondStickyTaskQueue,
-		workflowTaskAttempt,
-		5)
-}
-
-// PollAndProcessWorkflowTaskWithAttemptAndRetry for workflow tasks
-func (p *TaskPoller) PollAndProcessWorkflowTaskWithAttemptAndRetry(
-	dumpHistory bool,
-	dropTask bool,
-	pollStickyTaskQueue bool,
-	respondStickyTaskQueue bool,
-	workflowTaskAttempt int32,
-	retryCount int,
-) (isQueryTask bool, err error) {
-
-	isQueryTask, _, err = p.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		dumpHistory,
-		dropTask,
-		pollStickyTaskQueue,
-		respondStickyTaskQueue,
-		workflowTaskAttempt,
-		retryCount,
-		false,
-		nil)
-	return isQueryTask, err
-}
-
 func (p *TaskPoller) PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
 	dumpHistory bool,
 	dropTask bool,

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -145,29 +145,6 @@ func WithQueryResult(r *querypb.WorkflowQueryResult) WorkflowTaskPollOptionFunc 
 	}
 }
 
-func (p *TaskPoller) PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-	dumpHistory bool,
-	dropTask bool,
-	pollStickyTaskQueue bool,
-	respondStickyTaskQueue bool,
-	workflowTaskAttempt int32,
-	retryCount int,
-	forceCreateNewWorkflowTask bool,
-	queryResult *querypb.WorkflowQueryResult,
-) (isQueryTask bool, newTask *workflowservice.RespondWorkflowTaskCompletedResponse, err error) {
-	res, err := p.PollAndProcessWorkflowTaskGeneric(&WorkflowTaskPollOptions{
-		DumpHistory:          dumpHistory,
-		DropTask:             dropTask,
-		PollSticky:           pollStickyTaskQueue,
-		RespondSticky:        respondStickyTaskQueue,
-		AttemptCount:         int(workflowTaskAttempt),
-		Retries:              retryCount,
-		ForceNewWorkflowTask: forceCreateNewWorkflowTask,
-		QueryResult:          queryResult,
-	})
-	return res.IsQueryTask, res.NewTask, err
-}
-
 func (p *TaskPoller) PollAndProcessWorkflowTaskWithOptions(funcs ...WorkflowTaskPollOptionFunc) (res WorkflowTaskPollResponse, err error) {
 	opts := defaultWorkflowTaskPollOptions
 	for _, f := range funcs {

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -266,7 +266,7 @@ Loop:
 			}
 		}
 		if lastWorkflowTaskScheduleEvent != nil && opts.ExpectedAttemptCount > 1 {
-			require.Equal(p.T, opts.ExpectedAttemptCount, lastWorkflowTaskScheduleEvent.GetWorkflowTaskScheduledEventAttributes().GetAttempt())
+			require.Equal(p.T, opts.ExpectedAttemptCount, int(lastWorkflowTaskScheduleEvent.GetWorkflowTaskScheduledEventAttributes().GetAttempt()))
 		}
 
 		commands, err := p.WorkflowTaskHandler(response.WorkflowExecution, response.WorkflowType, response.PreviousStartedEventId, response.StartedEventId, response.History)

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -98,7 +98,7 @@ type (
 var (
 	errNoTasks = errors.New("no tasks")
 
-	defaultWorkflowTaskPollOptions = PollAndProcessWorkflowTaskOptions{
+	defaultPollAndProcessWorkflowTaskOptions = PollAndProcessWorkflowTaskOptions{
 		DumpHistory:          false,
 		DumpCommands:         true,
 		DropTask:             false,
@@ -128,14 +128,14 @@ func WithQueryResult(r *querypb.WorkflowQueryResult) PollAndProcessWorkflowTaskO
 }
 
 func (p *TaskPoller) PollAndProcessWorkflowTask(funcs ...PollAndProcessWorkflowTaskOptionFunc) (res PollAndProcessWorkflowTaskResponse, err error) {
-	opts := defaultWorkflowTaskPollOptions
+	opts := defaultPollAndProcessWorkflowTaskOptions
 	for _, f := range funcs {
 		f(&opts)
 	}
-	return p.PollAndProcessWorkflowTaskGeneric(&opts)
+	return p.PollAndProcessWorkflowTaskWithOptions(&opts)
 }
 
-func (p *TaskPoller) PollAndProcessWorkflowTaskGeneric(opts *PollAndProcessWorkflowTaskOptions) (res PollAndProcessWorkflowTaskResponse, err error) {
+func (p *TaskPoller) PollAndProcessWorkflowTaskWithOptions(opts *PollAndProcessWorkflowTaskOptions) (res PollAndProcessWorkflowTaskResponse, err error) {
 Loop:
 	for attempt := 1; attempt <= opts.Retries; attempt++ {
 

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -82,7 +82,7 @@ type (
 		PollSticky           bool
 		RespondSticky        bool
 		AttemptCount         int
-		RetryCount           int
+		Retries              int
 		ForceNewWorkflowTask bool
 		QueryResult          *querypb.WorkflowQueryResult
 	}
@@ -105,7 +105,7 @@ var (
 		PollSticky:           false,
 		RespondSticky:        false,
 		AttemptCount:         1,
-		RetryCount:           5,
+		Retries:              5,
 		ForceNewWorkflowTask: false,
 		QueryResult:          nil,
 	}
@@ -131,9 +131,9 @@ func WithAttemptCount(c int) WorkflowTaskPollOptionFunc {
 		o.AttemptCount = c
 	}
 }
-func WithRetryCount(c int) WorkflowTaskPollOptionFunc {
+func WithRetries(c int) WorkflowTaskPollOptionFunc {
 	return func(o *WorkflowTaskPollOptions) {
-		o.RetryCount = c
+		o.Retries = c
 	}
 }
 func WithForceNewWorkflowTask(o *WorkflowTaskPollOptions) {
@@ -143,16 +143,6 @@ func WithQueryResult(r *querypb.WorkflowQueryResult) WorkflowTaskPollOptionFunc 
 	return func(o *WorkflowTaskPollOptions) {
 		o.QueryResult = r
 	}
-}
-
-// PollAndProcessWorkflowTask for workflow tasks
-func (p *TaskPoller) PollAndProcessWorkflowTask(dumpHistory bool, dropTask bool) (isQueryTask bool, err error) {
-	return p.PollAndProcessWorkflowTaskWithAttempt(dumpHistory, dropTask, false, false, 1)
-}
-
-// PollAndProcessWorkflowTaskWithoutRetry for workflow tasks
-func (p *TaskPoller) PollAndProcessWorkflowTaskWithoutRetry(dumpHistory bool, dropTask bool) (isQueryTask bool, err error) {
-	return p.PollAndProcessWorkflowTaskWithAttemptAndRetry(dumpHistory, dropTask, false, false, 1, 1)
 }
 
 // PollAndProcessWorkflowTaskWithAttempt for workflow tasks
@@ -211,7 +201,7 @@ func (p *TaskPoller) PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWor
 		PollSticky:           pollStickyTaskQueue,
 		RespondSticky:        respondStickyTaskQueue,
 		AttemptCount:         int(workflowTaskAttempt),
-		RetryCount:           retryCount,
+		Retries:              retryCount,
 		ForceNewWorkflowTask: forceCreateNewWorkflowTask,
 		QueryResult:          queryResult,
 	})
@@ -229,7 +219,7 @@ func (p *TaskPoller) PollAndProcessWorkflowTaskWithOptions(funcs ...WorkflowTask
 // PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask for workflow tasks
 func (p *TaskPoller) PollAndProcessWorkflowTaskGeneric(opts *WorkflowTaskPollOptions) (res WorkflowTaskPollResponse, err error) {
 Loop:
-	for attempt := 1; attempt <= opts.RetryCount; attempt++ {
+	for attempt := 1; attempt <= opts.Retries; attempt++ {
 
 		taskQueue := p.TaskQueue
 		if opts.PollSticky {

--- a/tests/taskpoller.go
+++ b/tests/taskpoller.go
@@ -145,7 +145,7 @@ func WithQueryResult(r *querypb.WorkflowQueryResult) WorkflowTaskPollOptionFunc 
 	}
 }
 
-func (p *TaskPoller) PollAndProcessWorkflowTaskWithOptions(funcs ...WorkflowTaskPollOptionFunc) (res WorkflowTaskPollResponse, err error) {
+func (p *TaskPoller) PollAndProcessWorkflowTask(funcs ...WorkflowTaskPollOptionFunc) (res WorkflowTaskPollResponse, err error) {
 	opts := defaultWorkflowTaskPollOptions
 	for _, f := range funcs {
 		f(&opts)
@@ -153,7 +153,6 @@ func (p *TaskPoller) PollAndProcessWorkflowTaskWithOptions(funcs ...WorkflowTask
 	return p.PollAndProcessWorkflowTaskGeneric(&opts)
 }
 
-// PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask for workflow tasks
 func (p *TaskPoller) PollAndProcessWorkflowTaskGeneric(opts *WorkflowTaskPollOptions) (res WorkflowTaskPollResponse, err error) {
 Loop:
 	for attempt := 1; attempt <= opts.Retries; attempt++ {

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -111,7 +111,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskTimeout() {
 	}
 
 	// First workflow task immediately fails and schedules a transient workflow task
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -120,7 +120,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskTimeout() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// Drop workflow task to cause a workflow task timeout
-	_, err = poller.PollAndProcessWorkflowTask(true, true)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithDropTask)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -260,7 +260,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	}
 
 	// stage 1
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -268,7 +268,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// stage 2
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -276,7 +276,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// stage 3: this one fails with a panic
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -285,7 +285,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.testCluster.host.dcClient.OverrideValue(dynamicconfig.HistorySizeSuggestContinueAsNew, 8*1024*1024)
 
 	// stage 4
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -293,12 +293,12 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// drop workflow task to cause a workflow task timeout
-	_, err = poller.PollAndProcessWorkflowTask(true, true)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithDropTask)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// stage 5
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -403,7 +403,7 @@ func (s *integrationSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents()
 
 	// fist workflow task, this try to do a continue as new but there is a buffered event,
 	// so it will fail and create a new workflow task
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -260,7 +260,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	}
 
 	// stage 1
-	_, err := poller.PollAndProcessWorkflowTask()
+	_, err := poller.PollAndProcessWorkflowTask(WithNoDumpCommands)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -268,7 +268,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// stage 2
-	_, err = poller.PollAndProcessWorkflowTask()
+	_, err = poller.PollAndProcessWorkflowTask(WithNoDumpCommands)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -276,7 +276,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// stage 3: this one fails with a panic
-	_, err = poller.PollAndProcessWorkflowTask()
+	_, err = poller.PollAndProcessWorkflowTask(WithNoDumpCommands)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -285,7 +285,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.testCluster.host.dcClient.OverrideValue(dynamicconfig.HistorySizeSuggestContinueAsNew, 8*1024*1024)
 
 	// stage 4
-	_, err = poller.PollAndProcessWorkflowTask()
+	_, err = poller.PollAndProcessWorkflowTask(WithNoDumpCommands)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -293,12 +293,12 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// drop workflow task to cause a workflow task timeout
-	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithDropTask)
+	_, err = poller.PollAndProcessWorkflowTask(WithDropTask, WithNoDumpCommands)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// stage 5
-	_, err = poller.PollAndProcessWorkflowTask()
+	_, err = poller.PollAndProcessWorkflowTask(WithNoDumpCommands)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -125,7 +125,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskTimeout() {
 	s.NoError(err)
 
 	// Now process signal and complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(2))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithExpectedAttemptCount(2))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -411,7 +411,7 @@ func (s *integrationSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents()
 
 	// second workflow task, which will complete the workflow
 	// this expect the workflow task to have attempt == 1
-	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(1))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithExpectedAttemptCount(1))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -111,7 +111,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskTimeout() {
 	}
 
 	// First workflow task immediately fails and schedules a transient workflow task
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -120,12 +120,12 @@ func (s *integrationSuite) TestTransientWorkflowTaskTimeout() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// Drop workflow task to cause a workflow task timeout
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithDropTask)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithDropTask)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// Now process signal and complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(2))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(2))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -260,7 +260,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	}
 
 	// stage 1
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -268,7 +268,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// stage 2
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -276,7 +276,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// stage 3: this one fails with a panic
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -285,7 +285,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.testCluster.host.dcClient.OverrideValue(dynamicconfig.HistorySizeSuggestContinueAsNew, 8*1024*1024)
 
 	// stage 4
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -293,12 +293,12 @@ func (s *integrationSuite) TestTransientWorkflowTaskHistorySize() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// drop workflow task to cause a workflow task timeout
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithDropTask)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithDropTask)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
 	// stage 5
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -403,7 +403,7 @@ func (s *integrationSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents()
 
 	// fist workflow task, this try to do a continue as new but there is a buffered event,
 	// so it will fail and create a new workflow task
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
@@ -411,7 +411,7 @@ func (s *integrationSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents()
 
 	// second workflow task, which will complete the workflow
 	// this expect the workflow task to have attempt == 1
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(1))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(1))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -125,7 +125,7 @@ func (s *integrationSuite) TestTransientWorkflowTaskTimeout() {
 	s.NoError(err)
 
 	// Now process signal and complete workflow execution
-	_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, false, 2)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(2))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -411,7 +411,7 @@ func (s *integrationSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents()
 
 	// second workflow task, which will complete the workflow
 	// this expect the workflow task to have attempt == 1
-	_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, false, 1)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(1))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -282,8 +282,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_AcceptC
 			}()
 
 			// Process update in workflow.
-			_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
+			updateResp := res.NewTask
 			updateResult := <-updateResultCh
 			s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
 			s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -430,8 +431,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalWorkflowTask_AcceptComple
 			}()
 
 			// Process update in workflow.
-			_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
+			updateResp := res.NewTask
 			updateResult := <-updateResultCh
 			s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
 			s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -559,8 +561,9 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_A
 			}()
 
 			// Process update in workflow.
-			_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
+			updateResp := res.NewTask
 
 			updateResult := <-updateResultCh
 			s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
@@ -700,8 +703,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_Accept
 			}()
 
 			// Process update in workflow. It will be attached to existing WT.
-			_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
+			updateResp := res.NewTask
 
 			updateResult := <-updateResultCh
 			s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
@@ -814,8 +818,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowT
 	}
 
 	// Drain first WT which starts 1st update.
-	_, wt1Resp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, false, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
 	s.NoError(err)
+	wt1Resp := res.NewTask
 
 	// Reject update in 2nd WT.
 	wt2Resp, err := poller.HandlePartialWorkflowTask(wt1Resp.GetWorkflowTask(), true)
@@ -932,8 +937,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalFromStartedWorkflowTask_R
 	}
 
 	// Drain first WT which starts 1st update.
-	_, wt1Resp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, false, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
 	s.NoError(err)
+	wt1Resp := res.NewTask
 
 	// Reject update in 2nd WT.
 	wt2Resp, err := poller.HandlePartialWorkflowTask(wt1Resp.GetWorkflowTask(), true)
@@ -1418,8 +1424,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_A
 			}()
 
 			// Process update in workflow task (it is sticky).
-			_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, true, false, 1, 1, true, nil)
+			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithPollSticky, WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
+			updateResp := res.NewTask
 			updateResult := <-updateResultCh
 			s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
 			s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -1547,8 +1554,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_A
 	}()
 
 	// Process update in workflow task from non-sticky task queue.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
 	s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -1649,8 +1657,9 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_R
 	}()
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	s.Equal(tv.String("update rejected", "1"), updateResult.GetOutcome().GetFailure().GetMessage())
 	s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -1758,8 +1767,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject(
 	}()
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	s.Equal(tv.String("update rejected", "1"), updateResult.GetOutcome().GetFailure().GetMessage())
 	s.EqualValues(3, updateResp.ResetHistoryEventId)
@@ -1875,8 +1885,9 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
 	}()
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	s.Equal(tv.String("update rejected", "1"), updateResult.GetOutcome().GetFailure().GetMessage())
 	s.EqualValues(0, updateResp.ResetHistoryEventId, "no reset of event ID should happened after update rejection if it was delivered with normal workflow task")
@@ -2021,8 +2032,9 @@ func (s *integrationSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1s
 	}()
 
 	// Poll for WT2 which 2nd update. Accept update2.
-	_, updateAcceptResp2, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateAcceptResp2 := res.NewTask
 	s.NotNil(updateAcceptResp2)
 	s.EqualValues(0, updateAcceptResp2.ResetHistoryEventId)
 
@@ -2182,8 +2194,9 @@ func (s *integrationSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() 
 	}()
 
 	// Poll for WT2 which 2nd update. Reject update2.
-	_, updateRejectResp2, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateRejectResp2 := res.NewTask
 	s.NotNil(updateRejectResp2)
 	s.EqualValues(0, updateRejectResp2.ResetHistoryEventId, "no reset of event ID should happened after update rejection if it was delivered with normal workflow task")
 
@@ -2488,8 +2501,9 @@ func (s *integrationSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowT
 	}()
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	s.Equal(tv.String("update rejected", "1"), updateResult.GetOutcome().GetFailure().GetMessage())
 	s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -2607,8 +2621,9 @@ func (s *integrationSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflo
 	s.NoError(err)
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	s.Equal(tv.String("update rejected", "1"), updateResult.GetOutcome().GetFailure().GetMessage())
 	s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -2745,14 +2760,15 @@ func (s *integrationSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWork
 	}()
 
 	// Try to process update in workflow, but it takes more than WT timeout. So, WT times out.
-	_, _, err = poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, false, nil)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
 	s.Error(err)
 	s.Equal("Workflow task not found.", err.Error())
 
 	// New normal WT was created on server after speculative WT has timed out.
 	// It will accept and complete update first and workflow itself with the same WT.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, false, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
 	s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -2862,8 +2878,9 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeW
 	time.Sleep(poller.StickyScheduleToStartTimeout + 100*time.Millisecond)
 
 	// Try to process update in workflow, poll from normal task queue.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	s.NotNil(updateResp)
 
 	// Complete workflow.
@@ -2982,11 +2999,10 @@ func (s *integrationSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Ter
 	go updateWorkflowFn()
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, false, nil)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
 	s.Error(err)
 	s.IsType(err, (*serviceerror.NotFound)(nil))
 	s.ErrorContains(err, "Workflow task not found.")
-	s.Nil(updateResp)
 	<-updateResultCh
 
 	s.Equal(2, wtHandlerCalls)
@@ -3324,8 +3340,9 @@ func (s *integrationSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat(
 	}()
 
 	// Heartbeat from workflow.
-	_, heartbeatResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	heartbeatResp := res.NewTask
 
 	// Reject update from workflow.
 	updateResp, err := poller.HandlePartialWorkflowTask(heartbeatResp.GetWorkflowTask(), true)
@@ -3596,11 +3613,10 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskL
 	go updateWorkflowFn()
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, false, nil)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
 	s.Error(err)
 	s.IsType(&serviceerror.NotFound{}, err)
 	s.ErrorContains(err, "Workflow task not found")
-	s.Nil(updateResp)
 
 	<-updateResultCh
 
@@ -3835,8 +3851,9 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_D
 	}()
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	updateResult2 := <-updateResultCh2
 	s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
@@ -3956,8 +3973,9 @@ func (s *integrationSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Ded
 	}()
 
 	// Process update in workflow.
-	_, updateResp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	updateResp := res.NewTask
 	updateResult := <-updateResultCh
 	s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
 	s.EqualValues(0, updateResp.ResetHistoryEventId)
@@ -4200,8 +4218,9 @@ func (s *integrationSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Close
 	}
 
 	// First WT will schedule activity and create a new WT.
-	_, wt1Resp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	wt1Resp := res.NewTask
 
 	// Drain 2nd WT (which is force created as requested) to make all events seen by SDK so following update can be speculative.
 	_, err = poller.HandlePartialWorkflowTask(wt1Resp.GetWorkflowTask(), false)
@@ -4373,8 +4392,9 @@ func (s *integrationSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Close
 	}
 
 	// First WT will schedule activity and create a new WT.
-	_, wt1Resp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	wt1Resp := res.NewTask
 
 	// Drain 2nd WT (which is force created as requested) to make all events seem by SDK so following update can be speculative.
 	_, err = poller.HandlePartialWorkflowTask(wt1Resp.GetWorkflowTask(), false)
@@ -4550,8 +4570,9 @@ func (s *integrationSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Clear
 	}
 
 	// First WT will schedule activity and create a new WT.
-	_, wt1Resp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	wt1Resp := res.NewTask
 
 	// Drain 2nd WT (which is force created as requested) to make all events seen by SDK so following update can be speculative.
 	_, err = poller.HandlePartialWorkflowTask(wt1Resp.GetWorkflowTask(), false)
@@ -4767,8 +4788,9 @@ func (s *integrationSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_SameS
 	}
 
 	// First WT will schedule activity and create a new WT.
-	_, wt1Resp, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(false, false, false, false, 1, 1, true, nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
+	wt1Resp := res.NewTask
 
 	// Drain 2nd WT (which is force created as requested) to make all events seen by SDK so following update can be speculative.
 	_, err = poller.HandlePartialWorkflowTask(wt1Resp.GetWorkflowTask(), false)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -273,7 +273,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_AcceptC
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTask(true, false)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 			s.NoError(err)
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -421,7 +421,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalWorkflowTask_AcceptComple
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTask(true, false)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 			s.NoError(err)
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -687,7 +687,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_Accept
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTask(false, false)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 			s.NoError(err)
 
 			// Send signal to schedule new WT.
@@ -1304,7 +1304,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 			go updateWorkflowFn(tc.RespondWorkflowTaskError != "")
 
 			// Process update in workflow.
-			_, err := poller.PollAndProcessWorkflowTask(false, false)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 			if tc.RespondWorkflowTaskError != "" {
 				require.Error(s.T(), err, "RespondWorkflowTaskCompleted should return an error contains `%v`", tc.RespondWorkflowTaskError)
 				require.Contains(s.T(), err.Error(), tc.RespondWorkflowTaskError)
@@ -1749,7 +1749,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject(
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -1866,7 +1866,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -2011,7 +2011,7 @@ func (s *integrationSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1s
 	}()
 
 	// Accept update1 in normal WT1.
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	// Send 2nd update and create speculative WT2.
@@ -2172,7 +2172,7 @@ func (s *integrationSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() 
 	}()
 
 	// Accept update1 in WT1.
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	// Send 2nd update and create speculative WT2.
@@ -2338,7 +2338,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -2364,13 +2364,13 @@ func (s *integrationSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 	go updateWorkflowFn()
 
 	// Try to accept update in workflow: get malformed response.
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Error(err)
 	s.Contains(err.Error(), "not found")
 	// New normal (but transient) WT will be created but not returned.
 
 	// Try to accept update in workflow 2nd time: get error. Poller will fail WT.
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
 	s.NoError(err)
 
@@ -2379,12 +2379,12 @@ func (s *integrationSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 	<-updateResultCh
 
 	// Try to accept update in workflow 3rd time: get error. Poller will fail WT.
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
 	s.NoError(err)
 
 	// Complete workflow.
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	s.Equal(5, wtHandlerCalls)
@@ -2479,7 +2479,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowT
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -2592,7 +2592,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflo
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -2736,7 +2736,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWork
 	}
 
 	// Drain first WT.
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -2955,7 +2955,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Ter
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -3054,7 +3054,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_T
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -3194,7 +3194,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate()
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTask(true, false)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 			s.NoError(err)
 
 			updateResultCh := make(chan struct{})
@@ -3226,7 +3226,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate()
 			}(tc.UpdateErrMsg)
 
 			// Complete workflow.
-			_, err = poller.PollAndProcessWorkflowTask(false, false)
+			_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 			s.NoError(err)
 			<-updateResultCh
 
@@ -3315,7 +3315,7 @@ func (s *integrationSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat(
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -3421,7 +3421,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTas
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -3470,7 +3470,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTas
 	s.NoError(err)
 
 	// Complete workflow.
-	completeWorkflowResp, err := poller.PollAndProcessWorkflowTask(false, false)
+	completeWorkflowResp, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	s.NotNil(completeWorkflowResp)
 
@@ -3568,7 +3568,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskL
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -3609,7 +3609,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskL
 	s.NoError(err)
 
 	// Complete workflow.
-	completeWorkflowResp, err := poller.PollAndProcessWorkflowTask(false, false)
+	completeWorkflowResp, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	s.NotNil(completeWorkflowResp)
 
@@ -3721,7 +3721,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_
 	go updateWorkflowFn()
 
 	// Process update in workflow. Update won't be found on server due to shard reload and server will fail WT.
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err, "workflow task failure must be an InvalidArgument error")
 	s.ErrorContains(err, fmt.Sprintf("update %q not found", tv.UpdateID("1")))
@@ -3729,7 +3729,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_
 	<-updateResultCh
 
 	// Complete workflow.
-	completeWorkflowResp, err := poller.PollAndProcessWorkflowTask(false, false)
+	completeWorkflowResp, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	s.NotNil(completeWorkflowResp)
 
@@ -3820,7 +3820,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_D
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -3947,7 +3947,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Ded
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -4072,7 +4072,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_D
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTask(true, false)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 			s.NoError(err)
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -4081,7 +4081,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_D
 			}()
 
 			// Process update in workflow.
-			_, err = poller.PollAndProcessWorkflowTask(false, false)
+			_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 			s.NoError(err)
 			updateResult := <-updateResultCh
 			s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
@@ -4119,7 +4119,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_D
 			s.NoError(err)
 
 			// Complete workflow.
-			completeWorkflowResp, err := poller.PollAndProcessWorkflowTask(false, false)
+			completeWorkflowResp, err := poller.PollAndProcessWorkflowTaskWithOptions()
 			s.NoError(err)
 			s.NotNil(completeWorkflowResp)
 

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -1531,7 +1531,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_A
 	}
 
 	// Drain existing WT from regular task queue, but respond with sticky enabled response to enable stick task queue.
-	_, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetry(false, false, false, true, 1, 1)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky, WithRetries(1))
 	s.NoError(err)
 
 	s.Logger.Info("Sleep 10 seconds to make sure stickyPollerUnavailableWindow time has passed.")
@@ -2850,7 +2850,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeW
 	}
 
 	// Drain first WT and respond with sticky enabled response to enable sticky task queue.
-	_, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetry(false, false, false, true, 1, 1)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky, WithRetries(1))
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -1408,7 +1408,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_A
 			}
 
 			// Drain existing first WT from regular task queue, but respond with sticky queue enabled response, next WT will go to sticky queue.
-			_, err := poller.PollAndProcessWorkflowTaskWithAttempt(false, false, false, true, 1)
+			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
 			s.NoError(err)
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -273,7 +273,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_AcceptC
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+			_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 			s.NoError(err)
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -282,7 +282,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_AcceptC
 			}()
 
 			// Process update in workflow.
-			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+			res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
 			updateResp := res.NewTask
 			updateResult := <-updateResultCh
@@ -422,7 +422,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalWorkflowTask_AcceptComple
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+			_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 			s.NoError(err)
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -431,7 +431,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalWorkflowTask_AcceptComple
 			}()
 
 			// Process update in workflow.
-			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+			res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
 			updateResp := res.NewTask
 			updateResult := <-updateResultCh
@@ -561,7 +561,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_A
 			}()
 
 			// Process update in workflow.
-			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+			res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
 			updateResp := res.NewTask
 
@@ -690,7 +690,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_Accept
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+			_, err := poller.PollAndProcessWorkflowTask()
 			s.NoError(err)
 
 			// Send signal to schedule new WT.
@@ -703,7 +703,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_Accept
 			}()
 
 			// Process update in workflow. It will be attached to existing WT.
-			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+			res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
 			updateResp := res.NewTask
 
@@ -818,7 +818,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowT
 	}
 
 	// Drain first WT which starts 1st update.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1))
 	s.NoError(err)
 	wt1Resp := res.NewTask
 
@@ -937,7 +937,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalFromStartedWorkflowTask_R
 	}
 
 	// Drain first WT which starts 1st update.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1))
 	s.NoError(err)
 	wt1Resp := res.NewTask
 
@@ -1310,7 +1310,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 			go updateWorkflowFn(tc.RespondWorkflowTaskError != "")
 
 			// Process update in workflow.
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+			_, err := poller.PollAndProcessWorkflowTask()
 			if tc.RespondWorkflowTaskError != "" {
 				require.Error(s.T(), err, "RespondWorkflowTaskCompleted should return an error contains `%v`", tc.RespondWorkflowTaskError)
 				require.Contains(s.T(), err.Error(), tc.RespondWorkflowTaskError)
@@ -1414,7 +1414,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_A
 			}
 
 			// Drain existing first WT from regular task queue, but respond with sticky queue enabled response, next WT will go to sticky queue.
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
+			_, err := poller.PollAndProcessWorkflowTask(WithRespondSticky)
 			s.NoError(err)
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -1424,7 +1424,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_A
 			}()
 
 			// Process update in workflow task (it is sticky).
-			res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithPollSticky, WithRetries(1), WithForceNewWorkflowTask)
+			res, err := poller.PollAndProcessWorkflowTask(WithPollSticky, WithRetries(1), WithForceNewWorkflowTask)
 			s.NoError(err)
 			updateResp := res.NewTask
 			updateResult := <-updateResultCh
@@ -1538,7 +1538,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_A
 	}
 
 	// Drain existing WT from regular task queue, but respond with sticky enabled response to enable stick task queue.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky, WithRetries(1))
+	_, err := poller.PollAndProcessWorkflowTask(WithRespondSticky, WithRetries(1))
 	s.NoError(err)
 
 	s.Logger.Info("Sleep 10 seconds to make sure stickyPollerUnavailableWindow time has passed.")
@@ -1554,7 +1554,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_A
 	}()
 
 	// Process update in workflow task from non-sticky task queue.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -1657,7 +1657,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_R
 	}()
 
 	// Process update in workflow.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -1758,7 +1758,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject(
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -1767,7 +1767,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject(
 	}()
 
 	// Process update in workflow.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -1876,7 +1876,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -1885,7 +1885,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
 	}()
 
 	// Process update in workflow.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -2022,7 +2022,7 @@ func (s *integrationSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1s
 	}()
 
 	// Accept update1 in normal WT1.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	// Send 2nd update and create speculative WT2.
@@ -2032,7 +2032,7 @@ func (s *integrationSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1s
 	}()
 
 	// Poll for WT2 which 2nd update. Accept update2.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateAcceptResp2 := res.NewTask
 	s.NotNil(updateAcceptResp2)
@@ -2184,7 +2184,7 @@ func (s *integrationSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() 
 	}()
 
 	// Accept update1 in WT1.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	// Send 2nd update and create speculative WT2.
@@ -2194,7 +2194,7 @@ func (s *integrationSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() 
 	}()
 
 	// Poll for WT2 which 2nd update. Reject update2.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateRejectResp2 := res.NewTask
 	s.NotNil(updateRejectResp2)
@@ -2351,7 +2351,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -2377,13 +2377,13 @@ func (s *integrationSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 	go updateWorkflowFn()
 
 	// Try to accept update in workflow: get malformed response.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Error(err)
 	s.Contains(err.Error(), "not found")
 	// New normal (but transient) WT will be created but not returned.
 
 	// Try to accept update in workflow 2nd time: get error. Poller will fail WT.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
 	s.NoError(err)
 
@@ -2392,12 +2392,12 @@ func (s *integrationSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 	<-updateResultCh
 
 	// Try to accept update in workflow 3rd time: get error. Poller will fail WT.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	// The error is from RespondWorkflowTaskFailed, which should go w/o error.
 	s.NoError(err)
 
 	// Complete workflow.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	s.Equal(5, wtHandlerCalls)
@@ -2492,7 +2492,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowT
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -2501,7 +2501,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowT
 	}()
 
 	// Process update in workflow.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -2606,7 +2606,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflo
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -2621,7 +2621,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflo
 	s.NoError(err)
 
 	// Process update in workflow.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -2751,7 +2751,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWork
 	}
 
 	// Drain first WT.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -2760,13 +2760,13 @@ func (s *integrationSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWork
 	}()
 
 	// Try to process update in workflow, but it takes more than WT timeout. So, WT times out.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
+	_, err = poller.PollAndProcessWorkflowTask(WithRetries(1))
 	s.Error(err)
 	s.Equal("Workflow task not found.", err.Error())
 
 	// New normal WT was created on server after speculative WT has timed out.
 	// It will accept and complete update first and workflow itself with the same WT.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1))
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -2866,7 +2866,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeW
 	}
 
 	// Drain first WT and respond with sticky enabled response to enable sticky task queue.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky, WithRetries(1))
+	_, err := poller.PollAndProcessWorkflowTask(WithRespondSticky, WithRetries(1))
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -2878,7 +2878,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeW
 	time.Sleep(poller.StickyScheduleToStartTimeout + 100*time.Millisecond)
 
 	// Try to process update in workflow, poll from normal task queue.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	s.NotNil(updateResp)
@@ -2972,7 +2972,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Ter
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -2999,7 +2999,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Ter
 	go updateWorkflowFn()
 
 	// Process update in workflow.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
+	_, err = poller.PollAndProcessWorkflowTask(WithRetries(1))
 	s.Error(err)
 	s.IsType(err, (*serviceerror.NotFound)(nil))
 	s.ErrorContains(err, "Workflow task not found.")
@@ -3070,7 +3070,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_T
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -3210,7 +3210,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate()
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+			_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 			s.NoError(err)
 
 			updateResultCh := make(chan struct{})
@@ -3242,7 +3242,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate()
 			}(tc.UpdateErrMsg)
 
 			// Complete workflow.
-			_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+			_, err = poller.PollAndProcessWorkflowTask()
 			s.NoError(err)
 			<-updateResultCh
 
@@ -3331,7 +3331,7 @@ func (s *integrationSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat(
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -3340,7 +3340,7 @@ func (s *integrationSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat(
 	}()
 
 	// Heartbeat from workflow.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	heartbeatResp := res.NewTask
 
@@ -3438,7 +3438,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTas
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -3487,7 +3487,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTas
 	s.NoError(err)
 
 	// Complete workflow.
-	completeWorkflowResp, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	completeWorkflowResp, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	s.NotNil(completeWorkflowResp)
 
@@ -3585,7 +3585,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskL
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan struct{})
@@ -3613,7 +3613,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskL
 	go updateWorkflowFn()
 
 	// Process update in workflow.
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1))
+	_, err = poller.PollAndProcessWorkflowTask(WithRetries(1))
 	s.Error(err)
 	s.IsType(&serviceerror.NotFound{}, err)
 	s.ErrorContains(err, "Workflow task not found")
@@ -3625,7 +3625,7 @@ func (s *integrationSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskL
 	s.NoError(err)
 
 	// Complete workflow.
-	completeWorkflowResp, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	completeWorkflowResp, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	s.NotNil(completeWorkflowResp)
 
@@ -3737,7 +3737,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_
 	go updateWorkflowFn()
 
 	// Process update in workflow. Update won't be found on server due to shard reload and server will fail WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err, "workflow task failure must be an InvalidArgument error")
 	s.ErrorContains(err, fmt.Sprintf("update %q not found", tv.UpdateID("1")))
@@ -3745,7 +3745,7 @@ func (s *integrationSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_
 	<-updateResultCh
 
 	// Complete workflow.
-	completeWorkflowResp, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	completeWorkflowResp, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	s.NotNil(completeWorkflowResp)
 
@@ -3836,7 +3836,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_D
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -3851,7 +3851,7 @@ func (s *integrationSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_D
 	}()
 
 	// Process update in workflow.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -3964,7 +3964,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Ded
 	}
 
 	// Drain first WT.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 
 	updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -3973,7 +3973,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Ded
 	}()
 
 	// Process update in workflow.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	updateResp := res.NewTask
 	updateResult := <-updateResultCh
@@ -4090,7 +4090,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_D
 			}
 
 			// Drain first WT.
-			_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+			_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 			s.NoError(err)
 
 			updateResultCh := make(chan *workflowservice.UpdateWorkflowExecutionResponse)
@@ -4099,7 +4099,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_D
 			}()
 
 			// Process update in workflow.
-			_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+			_, err = poller.PollAndProcessWorkflowTask()
 			s.NoError(err)
 			updateResult := <-updateResultCh
 			s.EqualValues(tv.String("success-result", "1"), decodeString(s, updateResult.GetOutcome().GetSuccess()))
@@ -4137,7 +4137,7 @@ func (s *integrationSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_D
 			s.NoError(err)
 
 			// Complete workflow.
-			completeWorkflowResp, err := poller.PollAndProcessWorkflowTaskWithOptions()
+			completeWorkflowResp, err := poller.PollAndProcessWorkflowTask()
 			s.NoError(err)
 			s.NotNil(completeWorkflowResp)
 
@@ -4218,7 +4218,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Close
 	}
 
 	// First WT will schedule activity and create a new WT.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	wt1Resp := res.NewTask
 
@@ -4392,7 +4392,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Close
 	}
 
 	// First WT will schedule activity and create a new WT.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	wt1Resp := res.NewTask
 
@@ -4570,7 +4570,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_Clear
 	}
 
 	// First WT will schedule activity and create a new WT.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	wt1Resp := res.NewTask
 
@@ -4788,7 +4788,7 @@ func (s *integrationSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_SameS
 	}
 
 	// First WT will schedule activity and create a new WT.
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(WithRetries(1), WithForceNewWorkflowTask)
+	res, err := poller.PollAndProcessWorkflowTask(WithRetries(1), WithForceNewWorkflowTask)
 	s.NoError(err)
 	wt1Resp := res.NewTask
 

--- a/tests/user_timers_test.go
+++ b/tests/user_timers_test.go
@@ -107,13 +107,13 @@ func (s *integrationSuite) TestUserTimers_Sequential() {
 	}
 
 	for i := 0; i < 4; i++ {
-		_, err := poller.PollAndProcessWorkflowTask(false, false)
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask: completed")
 		s.NoError(err)
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -179,7 +179,7 @@ func (s *integrationSuite) TestUserTimers_CapDuration() {
 	}
 
 	// poll workflow task to schedule the timer
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 

--- a/tests/user_timers_test.go
+++ b/tests/user_timers_test.go
@@ -107,13 +107,13 @@ func (s *integrationSuite) TestUserTimers_Sequential() {
 	}
 
 	for i := 0; i < 4; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask: completed")
 		s.NoError(err)
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -179,7 +179,7 @@ func (s *integrationSuite) TestUserTimers_CapDuration() {
 	}
 
 	// poll workflow task to schedule the timer
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 

--- a/tests/workflow_buffered_events_test.go
+++ b/tests/workflow_buffered_events_test.go
@@ -127,14 +127,14 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 	}
 
 	// first workflow task to send 101 signals, the last signal will force fail workflow task and flush buffered events.
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NotNil(err)
 	s.IsType(&serviceerror.NotFound{}, err)
 	s.Equal("Workflow task not found.", err.Error())
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -230,7 +230,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 	}
 
 	// first workflow task, which sends signal and the signal event should be buffered to append after first workflow task closed
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -250,7 +250,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 	s.Equal(histResp.History.Events[5].GetEventType(), enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(signalEvent)

--- a/tests/workflow_buffered_events_test.go
+++ b/tests/workflow_buffered_events_test.go
@@ -360,7 +360,7 @@ func (s *integrationSuite) TestBufferedEventsOutOfOrder() {
 	// first workflow task, which will schedule an activity and add marker
 	res, err := poller.PollAndProcessWorkflowTask(
 		WithDumpHistory,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.Logger.Info("pollAndProcessWorkflowTask", tag.Error(err))

--- a/tests/workflow_buffered_events_test.go
+++ b/tests/workflow_buffered_events_test.go
@@ -358,16 +358,13 @@ func (s *integrationSuite) TestBufferedEventsOutOfOrder() {
 	}
 
 	// first workflow task, which will schedule an activity and add marker
-	_, task, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		true,
-		false,
-		false,
-		false,
-		0,
-		1,
-		true,
-		nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+		WithDumpHistory,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.Logger.Info("pollAndProcessWorkflowTask", tag.Error(err))
+	task := res.NewTask
 	s.NoError(err)
 
 	// This will cause activity start and complete to be buffered

--- a/tests/workflow_buffered_events_test.go
+++ b/tests/workflow_buffered_events_test.go
@@ -127,14 +127,14 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 	}
 
 	// first workflow task to send 101 signals, the last signal will force fail workflow task and flush buffered events.
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NotNil(err)
 	s.IsType(&serviceerror.NotFound{}, err)
 	s.Equal("Workflow task not found.", err.Error())
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -230,7 +230,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 	}
 
 	// first workflow task, which sends signal and the signal event should be buffered to append after first workflow task closed
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -250,7 +250,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 	s.Equal(histResp.History.Events[5].GetEventType(), enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED)
 
 	// Process signal in workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.NotNil(signalEvent)
@@ -358,7 +358,7 @@ func (s *integrationSuite) TestBufferedEventsOutOfOrder() {
 	}
 
 	// first workflow task, which will schedule an activity and add marker
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err := poller.PollAndProcessWorkflowTask(
 		WithDumpHistory,
 		WithAttemptCount(0),
 		WithRetries(1),

--- a/tests/workflow_delete_execution_test.go
+++ b/tests/workflow_delete_execution_test.go
@@ -92,7 +92,7 @@ func (s *integrationSuite) Test_DeleteWorkflowExecution_Competed() {
 	}
 
 	for range wes {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err := poller.PollAndProcessWorkflowTask()
 		s.NoError(err)
 	}
 

--- a/tests/workflow_delete_execution_test.go
+++ b/tests/workflow_delete_execution_test.go
@@ -92,7 +92,7 @@ func (s *integrationSuite) Test_DeleteWorkflowExecution_Competed() {
 	}
 
 	for range wes {
-		_, err := poller.PollAndProcessWorkflowTask(false, false)
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.NoError(err)
 	}
 

--- a/tests/workflow_failures_test.go
+++ b/tests/workflow_failures_test.go
@@ -245,7 +245,7 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 	}
 
 	// Make first workflow task to schedule activity
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -264,7 +264,7 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// process signal
-	_, err = poller.PollAndProcessWorkflowTask(true, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.Equal(1, signalCount)
@@ -372,7 +372,7 @@ func (s *integrationSuite) TestRespondWorkflowTaskCompleted_ReturnsErrorIfInvali
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 	s.Equal("BadRecordMarkerAttributes: MarkerName is not set on command.", err.Error())

--- a/tests/workflow_failures_test.go
+++ b/tests/workflow_failures_test.go
@@ -256,7 +256,7 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 
 	// fail workflow task 5 times
 	for i := 1; i <= 5; i++ {
-		_, err := poller.PollAndProcessWorkflowTask(WithAttemptCount(i))
+		_, err := poller.PollAndProcessWorkflowTask(WithExpectedAttemptCount(i))
 		s.NoError(err)
 	}
 
@@ -275,26 +275,26 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 
 	// fail workflow task 2 more times
 	for i := 1; i <= 2; i++ {
-		_, err := poller.PollAndProcessWorkflowTask(WithAttemptCount(i))
+		_, err := poller.PollAndProcessWorkflowTask(WithExpectedAttemptCount(i))
 		s.NoError(err)
 	}
 	s.Equal(3, signalCount)
 
 	// now send a signal during failed workflow task
 	sendSignal = true
-	_, err = poller.PollAndProcessWorkflowTask(WithAttemptCount(3))
+	_, err = poller.PollAndProcessWorkflowTask(WithExpectedAttemptCount(3))
 	s.NoError(err)
 	s.Equal(4, signalCount)
 
 	// fail workflow task 1 more times
 	for i := 1; i <= 2; i++ {
-		_, err := poller.PollAndProcessWorkflowTask(WithAttemptCount(i))
+		_, err := poller.PollAndProcessWorkflowTask(WithExpectedAttemptCount(i))
 		s.NoError(err)
 	}
 	s.Equal(12, signalCount)
 
 	// Make complete workflow workflow task
-	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(3))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithExpectedAttemptCount(3))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)

--- a/tests/workflow_failures_test.go
+++ b/tests/workflow_failures_test.go
@@ -256,7 +256,7 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 
 	// fail workflow task 5 times
 	for i := 1; i <= 5; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithAttempt(false, false, false, false, int32(i))
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(i))
 		s.NoError(err)
 	}
 
@@ -275,26 +275,26 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 
 	// fail workflow task 2 more times
 	for i := 1; i <= 2; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithAttempt(false, false, false, false, int32(i))
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(i))
 		s.NoError(err)
 	}
 	s.Equal(3, signalCount)
 
 	// now send a signal during failed workflow task
 	sendSignal = true
-	_, err = poller.PollAndProcessWorkflowTaskWithAttempt(false, false, false, false, 3)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(3))
 	s.NoError(err)
 	s.Equal(4, signalCount)
 
 	// fail workflow task 1 more times
 	for i := 1; i <= 2; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithAttempt(false, false, false, false, int32(i))
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(i))
 		s.NoError(err)
 	}
 	s.Equal(12, signalCount)
 
 	// Make complete workflow workflow task
-	_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, false, 3)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(3))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)

--- a/tests/workflow_failures_test.go
+++ b/tests/workflow_failures_test.go
@@ -245,7 +245,7 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 	}
 
 	// Make first workflow task to schedule activity
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -256,7 +256,7 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 
 	// fail workflow task 5 times
 	for i := 1; i <= 5; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(i))
+		_, err := poller.PollAndProcessWorkflowTask(WithAttemptCount(i))
 		s.NoError(err)
 	}
 
@@ -264,7 +264,7 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 	s.NoError(err, "failed to send signal to execution")
 
 	// process signal
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.Equal(1, signalCount)
@@ -275,26 +275,26 @@ func (s *integrationSuite) TestWorkflowTaskFailed() {
 
 	// fail workflow task 2 more times
 	for i := 1; i <= 2; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(i))
+		_, err := poller.PollAndProcessWorkflowTask(WithAttemptCount(i))
 		s.NoError(err)
 	}
 	s.Equal(3, signalCount)
 
 	// now send a signal during failed workflow task
 	sendSignal = true
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(3))
+	_, err = poller.PollAndProcessWorkflowTask(WithAttemptCount(3))
 	s.NoError(err)
 	s.Equal(4, signalCount)
 
 	// fail workflow task 1 more times
 	for i := 1; i <= 2; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(i))
+		_, err := poller.PollAndProcessWorkflowTask(WithAttemptCount(i))
 		s.NoError(err)
 	}
 	s.Equal(12, signalCount)
 
 	// Make complete workflow workflow task
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(3))
+	_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(3))
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -372,7 +372,7 @@ func (s *integrationSuite) TestRespondWorkflowTaskCompleted_ReturnsErrorIfInvali
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Error(err)
 	s.IsType(&serviceerror.InvalidArgument{}, err)
 	s.Equal("BadRecordMarkerAttributes: MarkerName is not set on command.", err.Error())

--- a/tests/workflow_memo_test.go
+++ b/tests/workflow_memo_test.go
@@ -183,7 +183,7 @@ func (s *integrationSuite) startWithMemoHelper(startFn startFunc, id string, tas
 	s.Equal(memo, descResp.WorkflowExecutionInfo.Memo)
 
 	// make progress of workflow
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/workflow_memo_test.go
+++ b/tests/workflow_memo_test.go
@@ -183,7 +183,7 @@ func (s *integrationSuite) startWithMemoHelper(startFn startFunc, id string, tas
 	s.Equal(memo, descResp.WorkflowExecutionInfo.Memo)
 
 	// make progress of workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -525,7 +525,7 @@ func (s *integrationSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 	res, err := poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
-		WithAttemptCount(0),
+		WithExpectedAttemptCount(0),
 		WithRetries(1),
 		WithForceNewWorkflowTask)
 	s.NoError(err)
@@ -629,7 +629,7 @@ func (s *integrationSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 		if dropWorkflowTask {
 			_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithDropTask)
 		} else {
-			_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(2))
+			_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithExpectedAttemptCount(2))
 		}
 		if err != nil {
 			historyResponse, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -198,7 +198,7 @@ func (s *integrationSuite) TestStartWorkflowExecutionWithDelay() {
 		T:                   s.T(),
 	}
 
-	_, pollErr := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, pollErr := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(pollErr)
 	s.GreaterOrEqual(delayEndTime.Sub(reqStartTime), startDelay)
 
@@ -286,7 +286,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -448,7 +448,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 	}
 
 	for i := 0; i < 10; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err := poller.PollAndProcessWorkflowTask()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 		if i%2 == 0 {
@@ -461,7 +461,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -522,7 +522,7 @@ func (s *integrationSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 		T:                   s.T(),
 	}
 
-	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+	res, err := poller.PollAndProcessWorkflowTask(
 		WithPollSticky,
 		WithRespondSticky,
 		WithAttemptCount(0),
@@ -627,9 +627,9 @@ func (s *integrationSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 		s.Logger.Info("Calling Workflow Task", tag.Counter(i))
 		var err error
 		if dropWorkflowTask {
-			_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithDropTask)
+			_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithDropTask)
 		} else {
-			_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(2))
+			_, err = poller.PollAndProcessWorkflowTask(WithDumpHistory, WithAttemptCount(2))
 		}
 		if err != nil {
 			historyResponse, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
@@ -654,7 +654,7 @@ func (s *integrationSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(we.RunId))
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
+	_, err := poller.PollAndProcessWorkflowTask(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -736,7 +736,7 @@ func (s *integrationSuite) TestWorkflowRetry() {
 	}
 
 	for i := 1; i <= maximumAttempts; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err := poller.PollAndProcessWorkflowTask()
 		s.NoError(err)
 		events := s.getHistory(s.namespace, executions[i-1])
 		if i == maximumAttempts {
@@ -882,19 +882,19 @@ func (s *integrationSuite) TestWorkflowRetryFailures() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events := s.getHistory(s.namespace, executions[0])
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())
 	s.Equal(int32(1), events[0].GetWorkflowExecutionStartedEventAttributes().GetAttempt())
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events = s.getHistory(s.namespace, executions[1])
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())
 	s.Equal(int32(2), events[0].GetWorkflowExecutionStartedEventAttributes().GetAttempt())
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events = s.getHistory(s.namespace, executions[2])
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())
@@ -937,7 +937,7 @@ func (s *integrationSuite) TestWorkflowRetryFailures() {
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events = s.getHistory(s.namespace, executions[0])
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -522,16 +522,14 @@ func (s *integrationSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 		T:                   s.T(),
 	}
 
-	_, newTask, err := poller.PollAndProcessWorkflowTaskWithAttemptAndRetryAndForceNewWorkflowTask(
-		false,
-		false,
-		true,
-		true,
-		0,
-		1,
-		true,
-		nil)
+	res, err := poller.PollAndProcessWorkflowTaskWithOptions(
+		WithPollSticky,
+		WithRespondSticky,
+		WithAttemptCount(0),
+		WithRetries(1),
+		WithForceNewWorkflowTask)
 	s.NoError(err)
+	newTask := res.NewTask
 	s.NotNil(newTask)
 	s.NotNil(newTask.WorkflowTask)
 

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -631,7 +631,7 @@ func (s *integrationSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 		if dropWorkflowTask {
 			_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithDropTask)
 		} else {
-			_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, false, 2)
+			_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithAttemptCount(2))
 		}
 		if err != nil {
 			historyResponse, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -198,7 +198,7 @@ func (s *integrationSuite) TestStartWorkflowExecutionWithDelay() {
 		T:                   s.T(),
 	}
 
-	_, pollErr := poller.PollAndProcessWorkflowTask(true, false)
+	_, pollErr := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(pollErr)
 	s.GreaterOrEqual(delayEndTime.Sub(reqStartTime), startDelay)
 
@@ -286,7 +286,7 @@ func (s *integrationSuite) TestTerminateWorkflow() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -448,7 +448,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 	}
 
 	for i := 0; i < 10; i++ {
-		_, err := poller.PollAndProcessWorkflowTask(false, false)
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err)
 		if i%2 == 0 {
@@ -461,7 +461,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -629,7 +629,7 @@ func (s *integrationSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 		s.Logger.Info("Calling Workflow Task", tag.Counter(i))
 		var err error
 		if dropWorkflowTask {
-			_, err = poller.PollAndProcessWorkflowTask(true, true)
+			_, err = poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory, WithDropTask)
 		} else {
 			_, err = poller.PollAndProcessWorkflowTaskWithAttempt(true, false, false, false, 2)
 		}
@@ -656,7 +656,7 @@ func (s *integrationSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(we.RunId))
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessWorkflowTask(true, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions(WithDumpHistory)
 	s.NoError(err)
 	s.True(workflowComplete)
 }
@@ -738,7 +738,7 @@ func (s *integrationSuite) TestWorkflowRetry() {
 	}
 
 	for i := 1; i <= maximumAttempts; i++ {
-		_, err := poller.PollAndProcessWorkflowTask(false, false)
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.NoError(err)
 		events := s.getHistory(s.namespace, executions[i-1])
 		if i == maximumAttempts {
@@ -884,19 +884,19 @@ func (s *integrationSuite) TestWorkflowRetryFailures() {
 		T:                   s.T(),
 	}
 
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events := s.getHistory(s.namespace, executions[0])
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())
 	s.Equal(int32(1), events[0].GetWorkflowExecutionStartedEventAttributes().GetAttempt())
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events = s.getHistory(s.namespace, executions[1])
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())
 	s.Equal(int32(2), events[0].GetWorkflowExecutionStartedEventAttributes().GetAttempt())
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events = s.getHistory(s.namespace, executions[2])
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())
@@ -939,7 +939,7 @@ func (s *integrationSuite) TestWorkflowRetryFailures() {
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events = s.getHistory(s.namespace, executions[0])
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())

--- a/tests/workflow_timer_test.go
+++ b/tests/workflow_timer_test.go
@@ -134,20 +134,20 @@ func (s *integrationSuite) TestCancelTimer() {
 	}
 
 	// schedule the timer
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
 	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 
 	// receive the signal & cancel the timer
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
 	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 	// complete the workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
@@ -266,20 +266,20 @@ func (s *integrationSuite) TestCancelTimer_CancelFiredAndBuffered() {
 	}
 
 	// schedule the timer
-	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err := poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
 	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 
 	// receive the signal & cancel the timer
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
 	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 	// complete the workflow
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 

--- a/tests/workflow_timer_test.go
+++ b/tests/workflow_timer_test.go
@@ -134,20 +134,20 @@ func (s *integrationSuite) TestCancelTimer() {
 	}
 
 	// schedule the timer
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
 	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 
 	// receive the signal & cancel the timer
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
 	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 	// complete the workflow
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
@@ -266,20 +266,20 @@ func (s *integrationSuite) TestCancelTimer_CancelFiredAndBuffered() {
 	}
 
 	// schedule the timer
-	_, err := poller.PollAndProcessWorkflowTask(false, false)
+	_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
 	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 
 	// receive the signal & cancel the timer
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 
 	s.Nil(s.sendSignal(s.namespace, workflowExecution, "random signal name", payloads.EncodeString("random signal payload"), identity))
 	// complete the workflow
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.Logger.Info("PollAndProcessWorkflowTask: completed")
 	s.NoError(err)
 

--- a/tests/workflow_visibility_test.go
+++ b/tests/workflow_visibility_test.go
@@ -87,7 +87,7 @@ func (s *integrationSuite) TestVisibility() {
 		T:                   s.T(),
 	}
 
-	_, err1 := poller.PollAndProcessWorkflowTask(false, false)
+	_, err1 := poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err1)
 
 	// wait until the start workflow is done

--- a/tests/workflow_visibility_test.go
+++ b/tests/workflow_visibility_test.go
@@ -87,7 +87,7 @@ func (s *integrationSuite) TestVisibility() {
 		T:                   s.T(),
 	}
 
-	_, err1 := poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err1 := poller.PollAndProcessWorkflowTask()
 	s.NoError(err1)
 
 	// wait until the start workflow is done

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -302,7 +302,7 @@ func (s *advVisCrossDCTestSuite) TestSearchAttributes() {
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -302,7 +302,7 @@ func (s *advVisCrossDCTestSuite) TestSearchAttributes() {
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 

--- a/tests/xdc/integration_failover_test.go
+++ b/tests/xdc/integration_failover_test.go
@@ -555,7 +555,7 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 		T:                            s.T(),
 	}
 
-	_, err = poller1.PollAndProcessWorkflowTaskWithAttemptAndRetry(false, false, false, true, 1, 5)
+	_, err = poller1.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(firstCommandMade)
@@ -577,7 +577,7 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTaskWithAttemptAndRetry(false, false, false, true, 1, 5)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(secondCommandMade)

--- a/tests/xdc/integration_failover_test.go
+++ b/tests/xdc/integration_failover_test.go
@@ -1792,7 +1792,7 @@ func (s *integrationClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	// for failover transient workflow task, it is guaranteed that the transient workflow task
 	// after the failover has attempt 1
 	// for details see ReplicateTransientWorkflowTaskScheduled
-	_, err = poller2.PollAndProcessWorkflowTask(tests.WithAttemptCount(1))
+	_, err = poller2.PollAndProcessWorkflowTask(tests.WithExpectedAttemptCount(1))
 	s.NoError(err)
 	s.True(workflowFinished)
 }

--- a/tests/xdc/integration_failover_test.go
+++ b/tests/xdc/integration_failover_test.go
@@ -1792,7 +1792,7 @@ func (s *integrationClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	// for failover transient workflow task, it is guaranteed that the transient workflow task
 	// after the failover has attempt 1
 	// for details see ReplicateTransientWorkflowTaskScheduled
-	_, err = poller2.PollAndProcessWorkflowTaskWithAttempt(false, false, false, false, 1)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(1))
 	s.NoError(err)
 	s.True(workflowFinished)
 }

--- a/tests/xdc/integration_failover_test.go
+++ b/tests/xdc/integration_failover_test.go
@@ -301,7 +301,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	}
 
 	// make some progress in cluster 1
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -329,7 +329,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller.PollAndProcessWorkflowTaskWithOptions()
+		isQueryTask, errInner := poller.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
@@ -351,7 +351,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller2.PollAndProcessWorkflowTaskWithOptions()
+		isQueryTask, errInner := poller2.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
@@ -394,7 +394,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller.PollAndProcessWorkflowTaskWithOptions()
+		isQueryTask, errInner := poller.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
@@ -413,7 +413,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller2.PollAndProcessWorkflowTaskWithOptions()
+		isQueryTask, errInner := poller2.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
@@ -433,7 +433,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	s.NoError(err)
 
 	s.False(workflowComplete)
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask 2", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -555,7 +555,7 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 		T:                            s.T(),
 	}
 
-	_, err = poller1.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
+	_, err = poller1.PollAndProcessWorkflowTask(WithRespondSticky)
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(firstCommandMade)
@@ -577,7 +577,7 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions(WithRespondSticky)
+	_, err = poller2.PollAndProcessWorkflowTask(WithRespondSticky)
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(secondCommandMade)
@@ -596,7 +596,7 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 
 	s.failover(namespace, s.clusterNames[0], int64(11), client2)
 
-	_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller1.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowCompleted)
@@ -690,7 +690,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 	}
 
 	// Complete the workflow in cluster 1
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.Equal(1, workflowCompleteTimes)
@@ -719,7 +719,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 	s.NotNil(we.GetRunId())
 	s.logger.Info("StartWorkflowExecution in cluster 2: ", tag.WorkflowRunID(we.GetRunId()))
 
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask 2", tag.Error(err))
 	s.NoError(err)
 	s.Equal(2, workflowCompleteTimes)
@@ -822,7 +822,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 	}
 
 	// make some progress in cluster 1
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1001,7 +1001,7 @@ func (s *integrationClustersTestSuite) TestResetWorkflowFailover() {
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1027,7 +1027,7 @@ func (s *integrationClustersTestSuite) TestResetWorkflowFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -1156,7 +1156,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 
 	// make some progress in cluster 1 and did some continueAsNew
 	for i := 0; i < 3; i++ {
-		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
+		_, err := poller.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
@@ -1165,13 +1165,13 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 
 	// finish the rest in cluster 2
 	for i := 0; i < 2; i++ {
-		_, err := poller2.PollAndProcessWorkflowTaskWithOptions()
+		_, err := poller2.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
 	s.False(workflowComplete)
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	s.True(workflowComplete)
 	s.Equal(previousRunID, lastRunStartedEvent.GetWorkflowExecutionStartedEventAttributes().GetContinuedExecutionRunId())
@@ -1269,7 +1269,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 	}
 
 	// Process start event in cluster 1
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	s.False(eventSignaled)
 
@@ -1304,7 +1304,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Process signal in cluster 1
 	s.False(eventSignaled)
-	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(eventSignaled)
@@ -1361,7 +1361,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Process signal in cluster 2
 	eventSignaled = false
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.logger.Info("PollAndProcessWorkflowTask 2", tag.Error(err))
 	s.NoError(err)
 	s.True(eventSignaled)
@@ -1516,7 +1516,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 	}
 
 	for i := 0; i < 2; i++ {
-		_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
+		_, err = poller1.PollAndProcessWorkflowTask()
 		if err != nil {
 			timerCreated = false
 			continue
@@ -1531,7 +1531,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 
 	for i := 1; i < 20; i++ {
 		if !workflowCompleted {
-			_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+			_, err = poller2.PollAndProcessWorkflowTask()
 			s.NoError(err)
 			time.Sleep(time.Second)
 		}
@@ -1615,7 +1615,7 @@ func (s *integrationClustersTestSuite) TestForceWorkflowTaskClose_WithClusterRec
 	}
 
 	// this will fail the workflow task
-	_, err = poller1.PollAndProcessWorkflowTaskWithOptions(WithDropTask)
+	_, err = poller1.PollAndProcessWorkflowTask(WithDropTask)
 	s.NoError(err)
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
@@ -1784,7 +1784,7 @@ func (s *integrationClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	}
 
 	// this will fail the workflow task
-	_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller1.PollAndProcessWorkflowTask()
 	s.NoError(err)
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
@@ -1792,7 +1792,7 @@ func (s *integrationClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	// for failover transient workflow task, it is guaranteed that the transient workflow task
 	// after the failover has attempt 1
 	// for details see ReplicateTransientWorkflowTaskScheduled
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions(WithAttemptCount(1))
+	_, err = poller2.PollAndProcessWorkflowTask(WithAttemptCount(1))
 	s.NoError(err)
 	s.True(workflowFinished)
 }
@@ -1871,7 +1871,7 @@ func (s *integrationClustersTestSuite) TestCronWorkflowStartAndFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	s.True(wfCompleted)
 	events := s.getHistory(client2, namespace, executions[0])
@@ -1969,7 +1969,7 @@ func (s *integrationClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 		T:                   s.T(),
 	}
 
-	_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller1.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	s.Equal(1, wfCompletionCount)
 	events := s.getHistory(client1, namespace, executions[0])
@@ -1978,7 +1978,7 @@ func (s *integrationClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	s.Equal(2, wfCompletionCount)
 	events = s.getHistory(client2, namespace, executions[1])
@@ -2073,7 +2073,7 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryStartAndFailover() {
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
 	// First attempt
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events := s.getHistory(client2, namespace, executions[0])
 	s.Equal(int64(1), events[0].GetVersion())
@@ -2082,7 +2082,7 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryStartAndFailover() {
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())
 
 	// second attempt
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events = s.getHistory(client2, namespace, executions[1])
 	s.Equal(int64(2), events[0].GetVersion())
@@ -2177,7 +2177,7 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 		T:                   s.T(),
 	}
 
-	_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller1.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events := s.getHistory(client1, namespace, executions[0])
 	s.Equal(int64(1), events[0].GetVersion())
@@ -2187,7 +2187,7 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
+	_, err = poller2.PollAndProcessWorkflowTask()
 	s.NoError(err)
 	events = s.getHistory(client2, namespace, executions[1])
 	s.Equal(int64(1), events[0].GetVersion())

--- a/tests/xdc/integration_failover_test.go
+++ b/tests/xdc/integration_failover_test.go
@@ -329,10 +329,10 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller.PollAndProcessWorkflowTask()
+		res, errInner := poller.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
-		if isQueryTask {
+		if res.IsQueryTask {
 			break
 		}
 	}
@@ -351,10 +351,10 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller2.PollAndProcessWorkflowTask()
+		res, errInner := poller2.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
-		if isQueryTask {
+		if res.IsQueryTask {
 			break
 		}
 	}
@@ -394,10 +394,10 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller.PollAndProcessWorkflowTask()
+		res, errInner := poller.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(errInner)
-		if isQueryTask {
+		if res.IsQueryTask {
 			break
 		}
 	}
@@ -413,10 +413,10 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller2.PollAndProcessWorkflowTask()
+		res, errInner := poller2.PollAndProcessWorkflowTask()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(errInner)
-		if isQueryTask {
+		if res.IsQueryTask {
 			break
 		}
 	}
@@ -555,7 +555,7 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 		T:                            s.T(),
 	}
 
-	_, err = poller1.PollAndProcessWorkflowTask(WithRespondSticky)
+	_, err = poller1.PollAndProcessWorkflowTask(tests.WithRespondSticky)
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(firstCommandMade)
@@ -577,7 +577,7 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTask(WithRespondSticky)
+	_, err = poller2.PollAndProcessWorkflowTask(tests.WithRespondSticky)
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(secondCommandMade)
@@ -1615,7 +1615,7 @@ func (s *integrationClustersTestSuite) TestForceWorkflowTaskClose_WithClusterRec
 	}
 
 	// this will fail the workflow task
-	_, err = poller1.PollAndProcessWorkflowTask(WithDropTask)
+	_, err = poller1.PollAndProcessWorkflowTask(tests.WithDropTask)
 	s.NoError(err)
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
@@ -1792,7 +1792,7 @@ func (s *integrationClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	// for failover transient workflow task, it is guaranteed that the transient workflow task
 	// after the failover has attempt 1
 	// for details see ReplicateTransientWorkflowTaskScheduled
-	_, err = poller2.PollAndProcessWorkflowTask(WithAttemptCount(1))
+	_, err = poller2.PollAndProcessWorkflowTask(tests.WithAttemptCount(1))
 	s.NoError(err)
 	s.True(workflowFinished)
 }

--- a/tests/xdc/integration_failover_test.go
+++ b/tests/xdc/integration_failover_test.go
@@ -301,7 +301,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	}
 
 	// make some progress in cluster 1
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -329,7 +329,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller.PollAndProcessWorkflowTask(false, false)
+		isQueryTask, errInner := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
@@ -351,7 +351,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller2.PollAndProcessWorkflowTask(false, false)
+		isQueryTask, errInner := poller2.PollAndProcessWorkflowTaskWithOptions()
 		s.logger.Info("PollAndProcessQueryTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
@@ -394,7 +394,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller.PollAndProcessWorkflowTask(false, false)
+		isQueryTask, errInner := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
@@ -413,7 +413,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	// process that query task, which should respond via RespondQueryTaskCompleted
 	for {
 		// loop until process the query task
-		isQueryTask, errInner := poller2.PollAndProcessWorkflowTask(false, false)
+		isQueryTask, errInner := poller2.PollAndProcessWorkflowTaskWithOptions()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(errInner)
 		if isQueryTask {
@@ -433,7 +433,7 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 	s.NoError(err)
 
 	s.False(workflowComplete)
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask 2", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -596,7 +596,7 @@ func (s *integrationClustersTestSuite) TestStickyWorkflowTaskFailover() {
 
 	s.failover(namespace, s.clusterNames[0], int64(11), client2)
 
-	_, err = poller1.PollAndProcessWorkflowTask(false, false)
+	_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowCompleted)
@@ -690,7 +690,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 	}
 
 	// Complete the workflow in cluster 1
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.Equal(1, workflowCompleteTimes)
@@ -719,7 +719,7 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 	s.NotNil(we.GetRunId())
 	s.logger.Info("StartWorkflowExecution in cluster 2: ", tag.WorkflowRunID(we.GetRunId()))
 
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask 2", tag.Error(err))
 	s.NoError(err)
 	s.Equal(2, workflowCompleteTimes)
@@ -822,7 +822,7 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 	}
 
 	// make some progress in cluster 1
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1001,7 +1001,7 @@ func (s *integrationClustersTestSuite) TestResetWorkflowFailover() {
 		T:                   s.T(),
 	}
 
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 
@@ -1027,7 +1027,7 @@ func (s *integrationClustersTestSuite) TestResetWorkflowFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(workflowComplete)
@@ -1156,7 +1156,7 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 
 	// make some progress in cluster 1 and did some continueAsNew
 	for i := 0; i < 3; i++ {
-		_, err := poller.PollAndProcessWorkflowTask(false, false)
+		_, err := poller.PollAndProcessWorkflowTaskWithOptions()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
@@ -1165,13 +1165,13 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 
 	// finish the rest in cluster 2
 	for i := 0; i < 2; i++ {
-		_, err := poller2.PollAndProcessWorkflowTask(false, false)
+		_, err := poller2.PollAndProcessWorkflowTaskWithOptions()
 		s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 		s.NoError(err, strconv.Itoa(i))
 	}
 
 	s.False(workflowComplete)
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	s.True(workflowComplete)
 	s.Equal(previousRunID, lastRunStartedEvent.GetWorkflowExecutionStartedEventAttributes().GetContinuedExecutionRunId())
@@ -1269,7 +1269,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 	}
 
 	// Process start event in cluster 1
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	s.False(eventSignaled)
 
@@ -1304,7 +1304,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Process signal in cluster 1
 	s.False(eventSignaled)
-	_, err = poller.PollAndProcessWorkflowTask(false, false)
+	_, err = poller.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
 	s.NoError(err)
 	s.True(eventSignaled)
@@ -1361,7 +1361,7 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Process signal in cluster 2
 	eventSignaled = false
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.logger.Info("PollAndProcessWorkflowTask 2", tag.Error(err))
 	s.NoError(err)
 	s.True(eventSignaled)
@@ -1516,7 +1516,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 	}
 
 	for i := 0; i < 2; i++ {
-		_, err = poller1.PollAndProcessWorkflowTask(false, false)
+		_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
 		if err != nil {
 			timerCreated = false
 			continue
@@ -1531,7 +1531,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 
 	for i := 1; i < 20; i++ {
 		if !workflowCompleted {
-			_, err = poller2.PollAndProcessWorkflowTask(false, false)
+			_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 			s.NoError(err)
 			time.Sleep(time.Second)
 		}
@@ -1615,7 +1615,7 @@ func (s *integrationClustersTestSuite) TestForceWorkflowTaskClose_WithClusterRec
 	}
 
 	// this will fail the workflow task
-	_, err = poller1.PollAndProcessWorkflowTask(false, true)
+	_, err = poller1.PollAndProcessWorkflowTaskWithOptions(WithDropTask)
 	s.NoError(err)
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
@@ -1784,7 +1784,7 @@ func (s *integrationClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	}
 
 	// this will fail the workflow task
-	_, err = poller1.PollAndProcessWorkflowTask(false, false)
+	_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
@@ -1871,7 +1871,7 @@ func (s *integrationClustersTestSuite) TestCronWorkflowStartAndFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	s.True(wfCompleted)
 	events := s.getHistory(client2, namespace, executions[0])
@@ -1969,7 +1969,7 @@ func (s *integrationClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 		T:                   s.T(),
 	}
 
-	_, err = poller1.PollAndProcessWorkflowTask(false, false)
+	_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	s.Equal(1, wfCompletionCount)
 	events := s.getHistory(client1, namespace, executions[0])
@@ -1978,7 +1978,7 @@ func (s *integrationClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	s.Equal(2, wfCompletionCount)
 	events = s.getHistory(client2, namespace, executions[1])
@@ -2073,7 +2073,7 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryStartAndFailover() {
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
 	// First attempt
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events := s.getHistory(client2, namespace, executions[0])
 	s.Equal(int64(1), events[0].GetVersion())
@@ -2082,7 +2082,7 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryStartAndFailover() {
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED, events[len(events)-1].GetEventType())
 
 	// second attempt
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events = s.getHistory(client2, namespace, executions[1])
 	s.Equal(int64(2), events[0].GetVersion())
@@ -2177,7 +2177,7 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 		T:                   s.T(),
 	}
 
-	_, err = poller1.PollAndProcessWorkflowTask(false, false)
+	_, err = poller1.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events := s.getHistory(client1, namespace, executions[0])
 	s.Equal(int64(1), events[0].GetVersion())
@@ -2187,7 +2187,7 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 
 	s.failover(namespace, s.clusterNames[1], int64(2), client1)
 
-	_, err = poller2.PollAndProcessWorkflowTask(false, false)
+	_, err = poller2.PollAndProcessWorkflowTaskWithOptions()
 	s.NoError(err)
 	events = s.getHistory(client2, namespace, executions[1])
 	s.Equal(int64(1), events[0].GetVersion())


### PR DESCRIPTION
**What changed?**
- Refactored PollAndProcessWorkflowTask and all variations to use an options pattern.
- Added WithNoDumpCommands to disable printing commands.

**Why?**
- The stack of variations was getting annoying.
- And I wanted to add WithNoDumpCommands to make TestTransientWorkflowTaskHistorySize less flaky.

**How did you test it?**
is tests
