### PR TITLE
Refresh upsert visibility task only for running workflows

### DIFF
--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -148,7 +148,7 @@ func (r *TaskRefresherImpl) RefreshTasks(
 		return err
 	}
 
-	return r.refreshTasksForWorkflowSearchAttr(taskGenerator)
+	return r.refreshTasksForWorkflowSearchAttr(mutableState, taskGenerator)
 }
 
 func (r *TaskRefresherImpl) refreshTasksForWorkflowStart(
@@ -408,8 +408,11 @@ func (r *TaskRefresherImpl) refreshTasksForSignalExternalWorkflow(
 }
 
 func (r *TaskRefresherImpl) refreshTasksForWorkflowSearchAttr(
+	mutableState MutableState,
 	taskGenerator TaskGenerator,
 ) error {
-
-	return taskGenerator.GenerateUpsertVisibilityTask()
+	if mutableState.GetExecutionState().Status == enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING {
+		return taskGenerator.GenerateUpsertVisibilityTask()
+	}
+	return nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Only refresh upsert visibility task for running workflows.

<!-- Tell your future self why have you made these changes -->
**Why?**
This can cause out of order visibility tasks to be refreshed (CLOSE task followed by UPSERT task).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
