### PR TITLE
Make rate multi min and max dynamic

### DIFF
--- a/common/dynamicconfig/shared_constants.go
+++ b/common/dynamicconfig/shared_constants.go
@@ -68,6 +68,12 @@ const (
 	// dynamicRateLimitIncreaseStepSizeKey the amount the rate limit multiplier is increased when the system is healthy. should be between 0 and 1
 	dynamicRateLimitIncreaseStepSizeKey     = "rateIncreaseStepSize"
 	dynamicRateLimitIncreaseStepSizeDefault = 0.1
+	// dynamicRateLimitMultiMinKey is the minimum the rate limit multiplier can be reduced to
+	dynamicRateLimitMultiMinKey     = "rateMultiMin"
+	dynamicRateLimitMultiMinDefault = 0.5
+	// dynamicRateLimitMultiMaxKey is the maximum the rate limit multiplier can be increased to
+	dynamicRateLimitMultiMaxKey     = "rateMultiMax"
+	dynamicRateLimitMultiMaxDefault = 1.0
 )
 
 var DefaultDynamicRateLimitingParams = map[string]interface{}{
@@ -77,4 +83,6 @@ var DefaultDynamicRateLimitingParams = map[string]interface{}{
 	dynamicRateLimitErrorThresholdKey:   dynamicRateLimitErrorThresholdDefault,
 	dynamicRateLimitBackoffStepSizeKey:  dynamicRateLimitBackoffStepSizeDefault,
 	dynamicRateLimitIncreaseStepSizeKey: dynamicRateLimitIncreaseStepSizeDefault,
+	dynamicRateLimitMultiMinKey:         dynamicRateLimitMultiMinDefault,
+	dynamicRateLimitMultiMaxKey:         dynamicRateLimitMultiMaxDefault,
 }

--- a/common/dynamicconfig/shared_constants.go
+++ b/common/dynamicconfig/shared_constants.go
@@ -70,7 +70,7 @@ const (
 	dynamicRateLimitIncreaseStepSizeDefault = 0.1
 	// dynamicRateLimitMultiMinKey is the minimum the rate limit multiplier can be reduced to
 	dynamicRateLimitMultiMinKey     = "rateMultiMin"
-	dynamicRateLimitMultiMinDefault = 0.5
+	dynamicRateLimitMultiMinDefault = 0.8
 	// dynamicRateLimitMultiMaxKey is the maximum the rate limit multiplier can be increased to
 	dynamicRateLimitMultiMaxKey     = "rateMultiMax"
 	dynamicRateLimitMultiMaxDefault = 1.0

--- a/common/persistence/client/health_request_rate_limiter.go
+++ b/common/persistence/client/health_request_rate_limiter.go
@@ -39,15 +39,14 @@ import (
 )
 
 const (
-	DefaultRefreshInterval   = 10 * time.Second
-	DefaultRateBurstRatio    = 1.0
-	DefaultMinRateMultiplier = 0.1
-	DefaultMaxRateMultiplier = 1.0
+	DefaultRefreshInterval       = 10 * time.Second
+	DefaultRateBurstRatio        = 1.0
+	DefaultInitialRateMultiplier = 1.0
 )
 
 type (
 	HealthRequestRateLimiterImpl struct {
-		enabled    *atomic.Bool
+		enabled    atomic.Bool
 		params     DynamicRateLimitingParams  // dynamic config map
 		curOptions dynamicRateLimitingOptions // current dynamic config values (updated on refresh)
 
@@ -59,8 +58,6 @@ type (
 		rateFn           quotas.RateFn
 		rateToBurstRatio float64
 
-		minRateMultiplier float64
-		maxRateMultiplier float64
 		curRateMultiplier float64
 
 		logger log.Logger
@@ -80,6 +77,9 @@ type (
 		// when the system is healthy and current rate < max rate, the current rate multiplier will be
 		// increased by this amount
 		RateIncreaseStepSize float64
+
+		RateMultiMax float64
+		RateMultiMin float64
 	}
 )
 
@@ -92,16 +92,14 @@ func NewHealthRequestRateLimiterImpl(
 	logger log.Logger,
 ) *HealthRequestRateLimiterImpl {
 	limiter := &HealthRequestRateLimiterImpl{
-		enabled:           &atomic.Bool{},
+		enabled:           atomic.Bool{},
 		rateLimiter:       quotas.NewRateLimiter(rateFn(), int(DefaultRateBurstRatio*rateFn())),
 		healthSignals:     healthSignals,
 		rateFn:            rateFn,
 		params:            params,
 		refreshTimer:      time.NewTicker(DefaultRefreshInterval),
 		rateToBurstRatio:  DefaultRateBurstRatio,
-		minRateMultiplier: DefaultMinRateMultiplier,
-		maxRateMultiplier: DefaultMaxRateMultiplier,
-		curRateMultiplier: DefaultMaxRateMultiplier,
+		curRateMultiplier: DefaultInitialRateMultiplier,
 		logger:            logger,
 	}
 	limiter.refreshDynamicParams()
@@ -149,13 +147,13 @@ func (rl *HealthRequestRateLimiterImpl) maybeRefresh() {
 func (rl *HealthRequestRateLimiterImpl) refreshRate() {
 	if rl.latencyThresholdExceeded() || rl.errorThresholdExceeded() {
 		// limit exceeded, do backoff
-		rl.curRateMultiplier = math.Max(rl.minRateMultiplier, rl.curRateMultiplier-rl.curOptions.RateBackoffStepSize)
+		rl.curRateMultiplier = math.Max(rl.curOptions.RateMultiMin, rl.curRateMultiplier-rl.curOptions.RateBackoffStepSize)
 		rl.rateLimiter.SetRPS(rl.curRateMultiplier * rl.rateFn())
 		rl.rateLimiter.SetBurst(int(rl.rateToBurstRatio * rl.rateFn()))
 		rl.logger.Info("Health threshold exceeded, reducing rate limit.", tag.NewFloat64("newMulti", rl.curRateMultiplier), tag.NewFloat64("newRate", rl.rateLimiter.Rate()), tag.NewFloat64("latencyAvg", rl.healthSignals.AverageLatency()), tag.NewFloat64("errorRatio", rl.healthSignals.ErrorRatio()))
-	} else if rl.curRateMultiplier < rl.maxRateMultiplier {
+	} else if rl.curRateMultiplier < rl.curOptions.RateMultiMax {
 		// already doing backoff and under thresholds, increase limit
-		rl.curRateMultiplier = math.Min(rl.maxRateMultiplier, rl.curRateMultiplier+rl.curOptions.RateIncreaseStepSize)
+		rl.curRateMultiplier = math.Min(rl.curOptions.RateMultiMax, rl.curRateMultiplier+rl.curOptions.RateIncreaseStepSize)
 		rl.rateLimiter.SetRPS(rl.curRateMultiplier * rl.rateFn())
 		rl.rateLimiter.SetBurst(int(rl.rateToBurstRatio * rl.rateFn()))
 		rl.logger.Info("System healthy, increasing rate limit.", tag.NewFloat64("newMulti", rl.curRateMultiplier), tag.NewFloat64("newRate", rl.rateLimiter.Rate()), tag.NewFloat64("latencyAvg", rl.healthSignals.AverageLatency()), tag.NewFloat64("errorRatio", rl.healthSignals.ErrorRatio()))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Made dynamic rate limiting options for minimum and maximum rate multipliers into dynamic config options
Increased default minimum rate multiplier from 0.1 to 0.5

<!-- Tell your future self why have you made these changes -->
**Why?**
For easier control over dynamic rate limiting behavior
If reducing the rate limit below 50% does not improve system health, reducing it further is unlikely to help either

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No