### PR TITLE
Refactor visibility metrics tag

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -27,23 +27,21 @@ package metrics
 
 // Common tags for all services
 const (
-	OperationTagName           = "operation"
-	ServiceRoleTagName         = "service_role"
-	CacheTypeTagName           = "cache_type"
-	FailureTagName             = "failure"
-	TaskCategoryTagName        = "task_category"
-	TaskTypeTagName            = "task_type"
-	TaskPriorityTagName        = "task_priority"
-	QueueReaderIDTagName       = "queue_reader_id"
-	QueueActionTagName         = "queue_action"
-	QueueTypeTagName           = "queue_type"
-	visibilityTypeTagName      = "visibility_type"
-	ErrorTypeTagName           = "error_type"
-	httpStatusTagName          = "http_status"
-	versionedTagName           = "versioned"
-	resourceExhaustedTag       = "resource_exhausted_cause"
-	standardVisibilityTagValue = "standard_visibility"
-	advancedVisibilityTagValue = "advanced_visibility"
+	OperationTagName            = "operation"
+	ServiceRoleTagName          = "service_role"
+	CacheTypeTagName            = "cache_type"
+	FailureTagName              = "failure"
+	TaskCategoryTagName         = "task_category"
+	TaskTypeTagName             = "task_type"
+	TaskPriorityTagName         = "task_priority"
+	QueueReaderIDTagName        = "queue_reader_id"
+	QueueActionTagName          = "queue_action"
+	QueueTypeTagName            = "queue_type"
+	visibilityPluginNameTagName = "visibility_plugin_name"
+	ErrorTypeTagName            = "error_type"
+	httpStatusTagName           = "http_status"
+	versionedTagName            = "versioned"
+	resourceExhaustedTag        = "resource_exhausted_cause"
 )
 
 // This package should hold all the metrics and tags for temporal

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -243,11 +243,11 @@ func QueueTypeTag(value string) Tag {
 	return &tagImpl{key: QueueTypeTagName, value: value}
 }
 
-func VisibilityTypeTag(value string) Tag {
+func VisibilityPluginNameTag(value string) Tag {
 	if value == "" {
 		value = unknownValue
 	}
-	return &tagImpl{key: visibilityTypeTagName, value: value}
+	return &tagImpl{key: visibilityPluginNameTagName, value: value}
 }
 
 // VersionedTag represents whether a loaded task queue manager represents a specific version set.
@@ -257,19 +257,6 @@ func VersionedTag(versioned bool) Tag {
 
 func ServiceErrorTypeTag(err error) Tag {
 	return &tagImpl{key: ErrorTypeTagName, value: strings.TrimPrefix(fmt.Sprintf(getType, err), errorPrefix)}
-}
-
-var (
-	standardVisibilityTypeTag = VisibilityTypeTag(standardVisibilityTagValue)
-	advancedVisibilityTypeTag = VisibilityTypeTag(advancedVisibilityTagValue)
-)
-
-func StandardVisibilityTypeTag() Tag {
-	return standardVisibilityTypeTag
-}
-
-func AdvancedVisibilityTypeTag() Tag {
-	return advancedVisibilityTypeTag
 }
 
 // HttpStatusTag returns a new httpStatusTag.

--- a/common/persistence/visibility/visibility_manager_test.go
+++ b/common/persistence/visibility/visibility_manager_test.go
@@ -42,6 +42,7 @@ import (
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/sql/sqlplugin/mysql"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/persistence/visibility/store"
 )
@@ -75,6 +76,8 @@ func (s *VisibilityManagerSuite) SetupTest() {
 
 	s.controller = gomock.NewController(s.T())
 	s.visibilityStore = store.NewMockVisibilityStore(s.controller)
+	s.visibilityStore.EXPECT().GetName().Return(mysql.PluginNameV8).AnyTimes()
+	s.visibilityStore.EXPECT().GetIndexName().Return("test-index-name").AnyTimes()
 	s.metricsHandler = metrics.NewMockHandler(s.controller)
 	s.visibilityManager = newVisibilityManager(
 		s.visibilityStore,
@@ -82,7 +85,7 @@ func (s *VisibilityManagerSuite) SetupTest() {
 		dynamicconfig.GetIntPropertyFn(1),
 		dynamicconfig.GetFloatPropertyFn(0.2),
 		s.metricsHandler,
-		metrics.StandardVisibilityTypeTag(),
+		metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		log.NewNoopLogger())
 }
 
@@ -104,7 +107,7 @@ func (s *VisibilityManagerSuite) TestRecordWorkflowExecutionStarted() {
 	s.metricsHandler.EXPECT().
 		WithTags(
 			metrics.OperationTag(metrics.VisibilityPersistenceRecordWorkflowExecutionStartedScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	s.NoError(s.visibilityManager.RecordWorkflowExecutionStarted(context.Background(), request))
@@ -130,7 +133,7 @@ func (s *VisibilityManagerSuite) TestRecordWorkflowExecutionClosed() {
 	s.metricsHandler.EXPECT().
 		WithTags(metrics.OperationTag(
 			metrics.VisibilityPersistenceRecordWorkflowExecutionClosedScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	s.NoError(s.visibilityManager.RecordWorkflowExecutionClosed(context.Background(), request))
@@ -149,7 +152,7 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutions() {
 	s.metricsHandler.EXPECT().
 		WithTags(metrics.OperationTag(
 			metrics.VisibilityPersistenceListOpenWorkflowExecutionsScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	_, err := s.visibilityManager.ListOpenWorkflowExecutions(context.Background(), request)
@@ -170,7 +173,7 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutions() {
 	s.metricsHandler.EXPECT().
 		WithTags(metrics.OperationTag(
 			metrics.VisibilityPersistenceListClosedWorkflowExecutionsScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	_, err := s.visibilityManager.ListClosedWorkflowExecutions(context.Background(), request)
@@ -194,7 +197,7 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutionsByType() {
 	s.metricsHandler.EXPECT().
 		WithTags(metrics.OperationTag(
 			metrics.VisibilityPersistenceListOpenWorkflowExecutionsByTypeScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	_, err := s.visibilityManager.ListOpenWorkflowExecutionsByType(context.Background(), request)
@@ -218,7 +221,7 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByType() {
 	s.metricsHandler.EXPECT().
 		WithTags(metrics.OperationTag(
 			metrics.VisibilityPersistenceListClosedWorkflowExecutionsByTypeScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByType(context.Background(), request)
@@ -242,7 +245,7 @@ func (s *VisibilityManagerSuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 	s.metricsHandler.EXPECT().
 		WithTags(metrics.OperationTag(
 			metrics.VisibilityPersistenceListOpenWorkflowExecutionsByWorkflowIDScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	_, err := s.visibilityManager.ListOpenWorkflowExecutionsByWorkflowID(context.Background(), request)
@@ -266,7 +269,7 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByWorkflowID() 
 	s.metricsHandler.EXPECT().
 		WithTags(metrics.OperationTag(
 			metrics.VisibilityPersistenceListClosedWorkflowExecutionsByWorkflowIDScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByWorkflowID(context.Background(), request)
@@ -290,7 +293,7 @@ func (s *VisibilityManagerSuite) TestListClosedWorkflowExecutionsByStatus() {
 	s.metricsHandler.EXPECT().
 		WithTags(
 			metrics.OperationTag(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByStatusScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	_, err := s.visibilityManager.ListClosedWorkflowExecutionsByStatus(context.Background(), request)
@@ -316,7 +319,7 @@ func (s *VisibilityManagerSuite) TestGetWorkflowExecution() {
 	s.metricsHandler.EXPECT().
 		WithTags(
 			metrics.OperationTag(metrics.VisibilityPersistenceGetWorkflowExecutionScope),
-			metrics.StandardVisibilityTypeTag(),
+			metrics.VisibilityPluginNameTag(s.visibilityStore.GetName()),
 		).
 		Return(metrics.NoopMetricsHandler).Times(2)
 	_, err := s.visibilityManager.GetWorkflowExecution(context.Background(), request)

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -41,24 +41,25 @@ import (
 var _ manager.VisibilityManager = (*visibilityManagerMetrics)(nil)
 
 type visibilityManagerMetrics struct {
-	metricHandler            metrics.Handler
-	logger                   log.Logger
-	delegate                 manager.VisibilityManager
-	visibilityTypeMetricsTag metrics.Tag
+	metricHandler metrics.Handler
+	logger        log.Logger
+	delegate      manager.VisibilityManager
+
+	visibilityPluginNameMetricsTag metrics.Tag
 }
 
 func NewVisibilityManagerMetrics(
 	delegate manager.VisibilityManager,
 	metricHandler metrics.Handler,
 	logger log.Logger,
-	visibilityTypeMetricsTag metrics.Tag,
+	visibilityPluginNameMetricsTag metrics.Tag,
 ) *visibilityManagerMetrics {
 	return &visibilityManagerMetrics{
 		metricHandler: metricHandler,
 		logger:        logger,
 		delegate:      delegate,
 
-		visibilityTypeMetricsTag: visibilityTypeMetricsTag,
+		visibilityPluginNameMetricsTag: visibilityPluginNameMetricsTag,
 	}
 }
 
@@ -239,7 +240,7 @@ func (m *visibilityManagerMetrics) GetWorkflowExecution(
 }
 
 func (m *visibilityManagerMetrics) tagScope(operation string) (metrics.Handler, time.Time) {
-	taggedHandler := m.metricHandler.WithTags(metrics.OperationTag(operation), m.visibilityTypeMetricsTag)
+	taggedHandler := m.metricHandler.WithTags(metrics.OperationTag(operation), m.visibilityPluginNameMetricsTag)
 	taggedHandler.Counter(metrics.VisibilityPersistenceRequests.GetMetricName()).Record(1)
 	return taggedHandler, time.Now().UTC()
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change `visibilityTypeTag` to `visibilityPluginNameTag` as it provides more useful information.
`visibilityTypeTag` only tells if it's standard or advanced, and it's broken at this moment.
`visibilityPluginNameTag` will tell what's the visibility store it's using.

<!-- Tell your future self why have you made these changes -->
**Why?**
Provide more useful information about the visibility store.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.