### PR TITLE
Handle XDC replication task retry error / not found error correctly

### DIFF
--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -151,11 +151,12 @@ func (e *ExecutableActivityStateTask) HandleErr(err error) error {
 		ctx, cancel := newTaskContext(namespaceName)
 		defer cancel()
 
-		if resendErr := e.Resend(
+		if doContinue, resendErr := e.Resend(
 			ctx,
 			e.ExecutableTask.SourceClusterName(),
 			retryErr,
-		); resendErr != nil {
+			ResendAttempt,
+		); resendErr != nil || !doContinue {
 			return err
 		}
 		return e.Execute()

--- a/service/history/replication/executable_activity_state_task_test.go
+++ b/service/history/replication/executable_activity_state_task_test.go
@@ -249,7 +249,7 @@ func (s *executableActivityStateTaskSuite) TestHandleErr_Resend_Success() {
 		rand.Int63(),
 		rand.Int63(),
 	)
-	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err).Return(nil)
+	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err, ResendAttempt).Return(true, nil)
 
 	s.NoError(s.task.HandleErr(err))
 }
@@ -268,7 +268,7 @@ func (s *executableActivityStateTaskSuite) TestHandleErr_Resend_Error() {
 		rand.Int63(),
 		rand.Int63(),
 	)
-	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err).Return(errors.New("OwO"))
+	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err, ResendAttempt).Return(false, errors.New("OwO"))
 
 	s.Equal(err, s.task.HandleErr(err))
 }

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -32,6 +32,7 @@ import (
 	"go.temporal.io/api/common/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -165,11 +166,12 @@ func (e *ExecutableHistoryTask) HandleErr(err error) error {
 		ctx, cancel := newTaskContext(namespaceName)
 		defer cancel()
 
-		if resendErr := e.Resend(
+		if doContinue, resendErr := e.Resend(
 			ctx,
 			e.ExecutableTask.SourceClusterName(),
 			retryErr,
-		); resendErr != nil {
+			ResendAttempt,
+		); resendErr != nil || !doContinue {
 			return err
 		}
 		return e.Execute()

--- a/service/history/replication/executable_history_task_test.go
+++ b/service/history/replication/executable_history_task_test.go
@@ -37,6 +37,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/definition"
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
@@ -249,7 +250,7 @@ func (s *executableHistoryTaskSuite) TestHandleErr_Resend_Success() {
 		rand.Int63(),
 		rand.Int63(),
 	)
-	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err).Return(nil)
+	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err, ResendAttempt).Return(true, nil)
 
 	s.NoError(s.task.HandleErr(err))
 }
@@ -268,7 +269,7 @@ func (s *executableHistoryTaskSuite) TestHandleErr_Resend_Error() {
 		rand.Int63(),
 		rand.Int63(),
 	)
-	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err).Return(errors.New("OwO"))
+	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err, ResendAttempt).Return(false, errors.New("OwO"))
 
 	s.Equal(err, s.task.HandleErr(err))
 }

--- a/service/history/replication/executable_task_mock.go
+++ b/service/history/replication/executable_task_mock.go
@@ -182,17 +182,18 @@ func (mr *MockExecutableTaskMockRecorder) Reschedule() *gomock.Call {
 }
 
 // Resend mocks base method.
-func (m *MockExecutableTask) Resend(ctx context.Context, remoteCluster string, retryErr *serviceerror.RetryReplication) error {
+func (m *MockExecutableTask) Resend(ctx context.Context, remoteCluster string, retryErr *serviceerror.RetryReplication, remainingAttempt int) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Resend", ctx, remoteCluster, retryErr)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret := m.ctrl.Call(m, "Resend", ctx, remoteCluster, retryErr, remainingAttempt)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Resend indicates an expected call of Resend.
-func (mr *MockExecutableTaskMockRecorder) Resend(ctx, remoteCluster, retryErr interface{}) *gomock.Call {
+func (mr *MockExecutableTaskMockRecorder) Resend(ctx, remoteCluster, retryErr, remainingAttempt interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resend", reflect.TypeOf((*MockExecutableTask)(nil).Resend), ctx, remoteCluster, retryErr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Resend", reflect.TypeOf((*MockExecutableTask)(nil).Resend), ctx, remoteCluster, retryErr, remainingAttempt)
 }
 
 // RetryPolicy mocks base method.

--- a/service/history/replication/executable_task_test.go
+++ b/service/history/replication/executable_task_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/serviceerror"
+
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/tests"
@@ -282,7 +283,7 @@ func (s *executableTaskSuite) TestResend_Success() {
 		resendErr.EndEventVersion,
 	).Return(nil)
 
-	err := s.task.Resend(context.Background(), remoteCluster, resendErr)
+	err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
 	s.NoError(err)
 }
 
@@ -326,7 +327,7 @@ func (s *executableTaskSuite) TestResend_NotFound() {
 		ClosedWorkflowOnly: false,
 	}).Return(&historyservice.DeleteWorkflowExecutionResponse{}, nil)
 
-	err := s.task.Resend(context.Background(), remoteCluster, resendErr)
+	err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
 	s.NoError(err)
 }
 
@@ -354,7 +355,7 @@ func (s *executableTaskSuite) TestResend_Error() {
 		resendErr.EndEventVersion,
 	).Return(serviceerror.NewUnavailable(""))
 
-	err := s.task.Resend(context.Background(), remoteCluster, resendErr)
+	err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
 	s.Error(err)
 }
 

--- a/service/history/replication/executable_task_test.go
+++ b/service/history/replication/executable_task_test.go
@@ -283,8 +283,9 @@ func (s *executableTaskSuite) TestResend_Success() {
 		resendErr.EndEventVersion,
 	).Return(nil)
 
-	err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
+	doContinue, err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
 	s.NoError(err)
+	s.True(doContinue)
 }
 
 func (s *executableTaskSuite) TestResend_NotFound() {
@@ -327,8 +328,124 @@ func (s *executableTaskSuite) TestResend_NotFound() {
 		ClosedWorkflowOnly: false,
 	}).Return(&historyservice.DeleteWorkflowExecutionResponse{}, nil)
 
-	err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
+	doContinue, err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
 	s.NoError(err)
+	s.False(doContinue)
+}
+
+func (s *executableTaskSuite) TestResend_ResendError_Success() {
+	remoteCluster := cluster.TestAlternativeClusterName
+	resendErr := &serviceerrors.RetryReplication{
+		NamespaceId:       uuid.NewString(),
+		WorkflowId:        uuid.NewString(),
+		RunId:             uuid.NewString(),
+		StartEventId:      rand.Int63(),
+		StartEventVersion: rand.Int63(),
+		EndEventId:        rand.Int63(),
+		EndEventVersion:   rand.Int63(),
+	}
+
+	anotherResendErr := &serviceerrors.RetryReplication{
+		NamespaceId:       resendErr.NamespaceId,
+		WorkflowId:        resendErr.WorkflowId,
+		RunId:             resendErr.RunId,
+		StartEventId:      rand.Int63(),
+		StartEventVersion: rand.Int63(),
+		EndEventId:        rand.Int63(),
+		EndEventVersion:   rand.Int63(),
+	}
+
+	gomock.InOrder(
+		s.ndcHistoryResender.EXPECT().SendSingleWorkflowHistory(
+			gomock.Any(),
+			remoteCluster,
+			namespace.ID(resendErr.NamespaceId),
+			resendErr.WorkflowId,
+			resendErr.RunId,
+			resendErr.StartEventId,
+			resendErr.StartEventVersion,
+			resendErr.EndEventId,
+			resendErr.EndEventVersion,
+		).Return(anotherResendErr),
+		s.ndcHistoryResender.EXPECT().SendSingleWorkflowHistory(
+			gomock.Any(),
+			remoteCluster,
+			namespace.ID(anotherResendErr.NamespaceId),
+			anotherResendErr.WorkflowId,
+			anotherResendErr.RunId,
+			anotherResendErr.StartEventId,
+			anotherResendErr.StartEventVersion,
+			anotherResendErr.EndEventId,
+			anotherResendErr.EndEventVersion,
+		).Return(nil),
+		s.ndcHistoryResender.EXPECT().SendSingleWorkflowHistory(
+			gomock.Any(),
+			remoteCluster,
+			namespace.ID(resendErr.NamespaceId),
+			resendErr.WorkflowId,
+			resendErr.RunId,
+			resendErr.StartEventId,
+			resendErr.StartEventVersion,
+			resendErr.EndEventId,
+			resendErr.EndEventVersion,
+		).Return(nil),
+	)
+
+	doContinue, err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
+	s.NoError(err)
+	s.True(doContinue)
+}
+
+func (s *executableTaskSuite) TestResend_ResendError_Error() {
+	remoteCluster := cluster.TestAlternativeClusterName
+	resendErr := &serviceerrors.RetryReplication{
+		NamespaceId:       uuid.NewString(),
+		WorkflowId:        uuid.NewString(),
+		RunId:             uuid.NewString(),
+		StartEventId:      rand.Int63(),
+		StartEventVersion: rand.Int63(),
+		EndEventId:        rand.Int63(),
+		EndEventVersion:   rand.Int63(),
+	}
+
+	anotherResendErr := &serviceerrors.RetryReplication{
+		NamespaceId:       resendErr.NamespaceId,
+		WorkflowId:        resendErr.WorkflowId,
+		RunId:             resendErr.RunId,
+		StartEventId:      rand.Int63(),
+		StartEventVersion: rand.Int63(),
+		EndEventId:        rand.Int63(),
+		EndEventVersion:   rand.Int63(),
+	}
+
+	gomock.InOrder(
+		s.ndcHistoryResender.EXPECT().SendSingleWorkflowHistory(
+			gomock.Any(),
+			remoteCluster,
+			namespace.ID(resendErr.NamespaceId),
+			resendErr.WorkflowId,
+			resendErr.RunId,
+			resendErr.StartEventId,
+			resendErr.StartEventVersion,
+			resendErr.EndEventId,
+			resendErr.EndEventVersion,
+		).Return(anotherResendErr),
+		s.ndcHistoryResender.EXPECT().SendSingleWorkflowHistory(
+			gomock.Any(),
+			remoteCluster,
+			namespace.ID(anotherResendErr.NamespaceId),
+			anotherResendErr.WorkflowId,
+			anotherResendErr.RunId,
+			anotherResendErr.StartEventId,
+			anotherResendErr.StartEventVersion,
+			anotherResendErr.EndEventId,
+			anotherResendErr.EndEventVersion,
+		).Return(&serviceerrors.RetryReplication{}),
+	)
+
+	doContinue, err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
+	s.Error(err)
+	s.False(doContinue)
 }
 
 func (s *executableTaskSuite) TestResend_Error() {
@@ -355,8 +472,9 @@ func (s *executableTaskSuite) TestResend_Error() {
 		resendErr.EndEventVersion,
 	).Return(serviceerror.NewUnavailable(""))
 
-	err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
+	doContinue, err := s.task.Resend(context.Background(), remoteCluster, resendErr, ResendAttempt)
 	s.Error(err)
+	s.False(doContinue)
 }
 
 func (s *executableTaskSuite) TestGetNamespaceInfo_Process() {

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -144,11 +144,12 @@ func (e *ExecutableWorkflowStateTask) HandleErr(err error) error {
 		ctx, cancel := newTaskContext(namespaceName)
 		defer cancel()
 
-		if resendErr := e.Resend(
+		if doContinue, resendErr := e.Resend(
 			ctx,
 			e.ExecutableTask.SourceClusterName(),
 			retryErr,
-		); resendErr != nil {
+			ResendAttempt,
+		); resendErr != nil || !doContinue {
 			return err
 		}
 		return e.Execute()

--- a/service/history/replication/executable_workflow_state_task_test.go
+++ b/service/history/replication/executable_workflow_state_task_test.go
@@ -209,7 +209,7 @@ func (s *executableWorkflowStateTaskSuite) TestHandleErr_Resend_Success() {
 		rand.Int63(),
 		rand.Int63(),
 	)
-	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err).Return(nil)
+	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err, ResendAttempt).Return(true, nil)
 	engine.EXPECT().ReplicateWorkflowState(gomock.Any(), gomock.Any()).Return(nil)
 	s.NoError(s.task.HandleErr(err))
 }
@@ -228,7 +228,7 @@ func (s *executableWorkflowStateTaskSuite) TestHandleErr_Resend_Error() {
 		rand.Int63(),
 		rand.Int63(),
 	)
-	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err).Return(errors.New("OwO"))
+	s.executableTask.EXPECT().Resend(gomock.Any(), s.sourceClusterName, err, ResendAttempt).Return(false, errors.New("OwO"))
 
 	s.Equal(err, s.task.HandleErr(err))
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Handle XDC replication task retry error / not found error correctly
  * When encountered not found, delete workflow abort replication task
  * When encountered another retry error, retry one more time

<!-- Tell your future self why have you made these changes -->
**Why?**
Properly handle reset workflow & deleted workflow case

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
UT

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A