### PR TITLE
Allow customizing authorization header names

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -563,6 +563,10 @@ type (
 		Authorizer string `yaml:"authorizer"`
 		// Empty string for noopClaimMapper or "default" for defaultJWTClaimMapper
 		ClaimMapper string `yaml:"claimMapper"`
+		// Name of main auth header to pass to ClaimMapper (as `AuthToken`). Defaults to `authorization`.
+		AuthHeaderName string `yaml:"authHeaderName"`
+		// Name of extra auth header to pass to ClaimMapper (as `ExtraData`). Defaults to `authorization-extras`.
+		AuthExtraHeaderName string `yaml:"authExtraHeaderName"`
 	}
 
 	// @@@SNIPSTART temporal-common-service-config-jwtkeyprovider

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -143,6 +143,7 @@ type GrpcServerOptions struct {
 
 func GrpcServerOptionsProvider(
 	logger log.Logger,
+	cfg *config.Config,
 	serviceConfig *Config,
 	serviceName primitives.ServiceName,
 	rpcFactory common.RPCFactory,
@@ -202,6 +203,8 @@ func GrpcServerOptionsProvider(
 			metricsHandler,
 			logger,
 			audienceGetter,
+			cfg.Global.Authorization.AuthHeaderName,
+			cfg.Global.Authorization.AuthExtraHeaderName,
 		),
 		namespaceValidatorInterceptor.StateValidationIntercept,
 		namespaceCountLimiterInterceptor.Intercept,


### PR DESCRIPTION
**What changed?**
Add static config options for changing the header names passed to the ClaimMapper. The ClaimMapper interface does not change.

(Note that as before, if the main header is not present, the ClaimMapper will not be called, even if the extra header is present. This can be overridden by implementing `AuthInfoRequired` on the ClaimMapper.)

**Why?**
Fixes #3362

**How did you test it?**
New unit test
