### PR TITLE
Handle batch reset in DescribeBatchOperation

### DIFF
--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -3542,8 +3542,11 @@ func (wh *WorkflowHandler) DescribeBatchOperation(
 		operationType = enumspb.BATCH_OPERATION_TYPE_TERMINATE
 	case batcher.BatchTypeDelete:
 		operationType = enumspb.BATCH_OPERATION_TYPE_DELETE
+	case batcher.BatchTypeReset:
+		operationType = enumspb.BATCH_OPERATION_TYPE_RESET
 	default:
-		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("The operation type %s is not supported", operationTypeString))
+		operationType = enumspb.BATCH_OPERATION_TYPE_UNSPECIFIED
+		wh.throttledLogger.Warn("Unknown batch operation type", tag.NewStringTag("batch-operation-type", operationTypeString))
 	}
 
 	batchOperationResp := &workflowservice.DescribeBatchOperationResponse{

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -2167,7 +2167,7 @@ func (s *workflowHandlerSuite) TestDescribeBatchOperation_CompletedStatus() {
 						ExecutionTime: now,
 						Memo: &commonpb.Memo{
 							Fields: map[string]*commonpb.Payload{
-								batcher.BatchOperationTypeMemo: payload.EncodeString(batcher.BatchTypeTerminate),
+								batcher.BatchOperationTypeMemo: payload.EncodeString(batcher.BatchTypeReset),
 							},
 						},
 						SearchAttributes: nil,


### PR DESCRIPTION
**What changed?**
- Handle batch reset operation type so DescribeBatchOperation doesn't fail on reset
- Made DescribeBatchOperation not fail on future unknown types, just log a warning.

**Why?**
Fixes #4939.
There's no need to fail DescribeBatchOperation just because it can't map the string back into an enum.

**How did you test it?**
Modified one of the unit tests to use that batch type (also tested with an unknown string and saw the log message)

**Potential risks**


**Is hotfix candidate?**
