### PR TITLE
Propagate Signal request IDs to new mutable state on reset

### DIFF
--- a/service/history/ndc/workflow_resetter.go
+++ b/service/history/ndc/workflow_resetter.go
@@ -217,6 +217,7 @@ func (r *workflowResetterImpl) ResetWorkflow(
 		resetReapplyType,
 		reapplyEventsFn,
 		additionalReapplyEvents,
+		currentMutableState.CloneToProto().SignalRequestedIds,
 	); err != nil {
 		return err
 	}
@@ -314,6 +315,7 @@ func (r *workflowResetterImpl) reapplyEventsToResetWorkflow(
 	resetReapplyType enumspb.ResetReapplyType,
 	reapplyEventsApplier workflowResetReapplyEventsFn,
 	additionalReapplyEvents []*historypb.HistoryEvent,
+	currentMutableStateSignalRequestedIds []string,
 ) error {
 	switch resetReapplyType {
 	case enumspb.RESET_REAPPLY_TYPE_SIGNAL:
@@ -322,6 +324,9 @@ func (r *workflowResetterImpl) reapplyEventsToResetWorkflow(
 			resetMutableState,
 		); err != nil {
 			return err
+		}
+		for _, requestId := range currentMutableStateSignalRequestedIds {
+			resetMutableState.AddSignalRequested(requestId)
 		}
 	case enumspb.RESET_REAPPLY_TYPE_NONE:
 		// noop


### PR DESCRIPTION
Draft PR **Not Ready For Review** Fixes #4028

**What changed?**
- On reset, copy Signal request IDs from previous MS to MS for new branch.


**Why?**
- Fixes #4028: When Signal events are preserved on reset, corresponding request IDs should be also. 


**How did you test it?**
- Changed server code to set a fake Signal `RequestId` in the `SignalWorkflowExecution` handler.
- Started a workflow, signaled it, reset, and ran `tctl admin wf desc`
- Confirmed Request IDs not present prior to this change and present with this change.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No