### PR TITLE
No shard lock on I/O: task key generator

### DIFF
--- a/service/history/shard/task_key_generator.go
+++ b/service/history/shard/task_key_generator.go
@@ -1,0 +1,207 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/util"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+const (
+	taskIDUninitialized = -1
+)
+
+type (
+	renewRangeIDFn func() error
+
+	taskKeyGenerator struct {
+		nextTaskID         int64
+		exclusiveMaxTaskID int64
+
+		taskMinScheduledTime time.Time
+
+		rangeSizeBits uint
+		timeSource    clock.TimeSource
+		logger        log.Logger
+
+		renewRangeIDFn renewRangeIDFn
+	}
+)
+
+func newTaskKeyGenerator(
+	rangeSizeBits uint,
+	timeSource clock.TimeSource,
+	logger log.Logger,
+	renewRangeIDFn renewRangeIDFn,
+) *taskKeyGenerator {
+	return &taskKeyGenerator{
+		nextTaskID:         taskIDUninitialized,
+		exclusiveMaxTaskID: taskIDUninitialized,
+		rangeSizeBits:      rangeSizeBits,
+		timeSource:         timeSource,
+		logger:             logger,
+		renewRangeIDFn:     renewRangeIDFn,
+	}
+}
+
+func (a *taskKeyGenerator) setTaskKeys(
+	taskMaps ...map[tasks.Category][]tasks.Task,
+) error {
+	now := a.timeSource.Now()
+	// TODO: Truncation here is just to make sure task scheduled time has the same precision as the old logic.
+	// Remove this truncation once we validate the rest of the code can worker correctly with higher precision.
+	a.setTaskMinScheduledTime(now.Truncate(persistence.ScheduledTaskMinPrecision))
+
+	for _, taskMap := range taskMaps {
+		for category, tasksByCategory := range taskMap {
+			isScheduledTask := category.Type() == tasks.CategoryTypeScheduled
+			for _, task := range tasksByCategory {
+				id, err := a.generateTaskID()
+				if err != nil {
+					return err
+				}
+				task.SetTaskID(id)
+
+				taskScheduledTime := now
+				if isScheduledTask {
+					// Persistence might loss precision when saving to DB.
+					// Make the task scheduled time to have the same precision as DB here,
+					// so that if the comparsion in the next step passes, it's guaranteed
+					// the task can be retrieved from DB by queue processor.
+					taskScheduledTime = task.GetVisibilityTime().
+						Add(persistence.ScheduledTaskMinPrecision).
+						Truncate(persistence.ScheduledTaskMinPrecision)
+
+					if taskScheduledTime.Before(a.taskMinScheduledTime) {
+						a.logger.Debug("New timer generated is less than min scheduled time",
+							tag.WorkflowNamespaceID(task.GetNamespaceID()),
+							tag.WorkflowID(task.GetWorkflowID()),
+							tag.WorkflowRunID(task.GetRunID()),
+							tag.Timestamp(taskScheduledTime),
+							tag.CursorTimestamp(a.taskMinScheduledTime),
+							tag.ValueShardAllocateTimerBeforeRead,
+						)
+						// Theoritically we don't need to add the extra 1ms.
+						// Guess it's just to be extra safe here.
+						taskScheduledTime = a.taskMinScheduledTime.Add(persistence.ScheduledTaskMinPrecision)
+					}
+				}
+				task.SetVisibilityTime(taskScheduledTime)
+
+				a.logger.Debug("Assigning new task key",
+					tag.WorkflowNamespaceID(task.GetNamespaceID()),
+					tag.WorkflowID(task.GetWorkflowID()),
+					tag.WorkflowRunID(task.GetRunID()),
+					tag.TaskType(task.GetType()),
+					tag.TaskID(id),
+					tag.Timestamp(task.GetVisibilityTime()),
+					tag.CursorTimestamp(a.taskMinScheduledTime),
+				)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (a *taskKeyGenerator) peekTaskKey(
+	category tasks.Category,
+) tasks.Key {
+	switch category.Type() {
+	case tasks.CategoryTypeImmediate:
+		return tasks.NewImmediateKey(a.nextTaskID)
+	case tasks.CategoryTypeScheduled:
+		return tasks.NewKey(
+			a.taskMinScheduledTime,
+			a.nextTaskID,
+		)
+	default:
+		panic(fmt.Sprintf("Unknown category type: %v", category.Type()))
+	}
+}
+
+func (a *taskKeyGenerator) generateTaskKey(
+	category tasks.Category,
+) (tasks.Key, error) {
+	id, err := a.generateTaskID()
+	if err != nil {
+		return tasks.Key{}, err
+	}
+
+	switch category.Type() {
+	case tasks.CategoryTypeImmediate:
+		return tasks.NewImmediateKey(id), nil
+	case tasks.CategoryTypeScheduled:
+		return tasks.NewKey(
+			a.taskMinScheduledTime,
+			id,
+		), nil
+	default:
+		panic(fmt.Sprintf("Unknown category type: %v", category.Type()))
+	}
+}
+
+func (a *taskKeyGenerator) setRangeID(rangeID int64) {
+	a.nextTaskID = rangeID << a.rangeSizeBits
+	a.exclusiveMaxTaskID = (rangeID + 1) << a.rangeSizeBits
+
+	a.logger.Info("Task key range updated",
+		tag.Number(a.nextTaskID),
+		tag.NextNumber(a.exclusiveMaxTaskID),
+	)
+}
+
+func (a *taskKeyGenerator) setTaskMinScheduledTime(
+	taskMinScheduledTime time.Time,
+) {
+	a.taskMinScheduledTime = util.MaxTime(a.taskMinScheduledTime, taskMinScheduledTime)
+}
+
+func (a *taskKeyGenerator) generateTaskID() (int64, error) {
+	if a.nextTaskID == taskIDUninitialized {
+		a.logger.Panic("Range id is not initialized before generating task id")
+	}
+
+	if a.nextTaskID == a.exclusiveMaxTaskID {
+		if err := a.renewRangeIDFn(); err != nil {
+			return taskIDUninitialized, err
+		}
+
+		if a.nextTaskID == a.exclusiveMaxTaskID {
+			a.logger.Panic("Renew rangeID succeeded, but rangeID in task key allocator is not updated.")
+		}
+	}
+
+	taskID := a.nextTaskID
+	a.nextTaskID++
+	return taskID, nil
+}

--- a/service/history/shard/task_key_generator_test.go
+++ b/service/history/shard/task_key_generator_test.go
@@ -1,0 +1,194 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+)
+
+type (
+	taskKeyGeneratorSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		rangeID int64
+
+		rangeSizeBits  uint
+		mockTimeSource *clock.EventTimeSource
+
+		generator *taskKeyGenerator
+	}
+)
+
+func TestTaskKeyGeneratorSuite(t *testing.T) {
+	s := &taskKeyGeneratorSuite{}
+	suite.Run(t, s)
+}
+
+func (s *taskKeyGeneratorSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.rangeID = 1
+	s.rangeSizeBits = 3 // 2 << 3 = 8 tasks per range
+	s.mockTimeSource = clock.NewEventTimeSource()
+	s.generator = newTaskKeyGenerator(
+		s.rangeSizeBits,
+		s.mockTimeSource,
+		log.NewTestLogger(),
+		func() error {
+			s.rangeID++
+			s.generator.setRangeID(s.rangeID)
+			return nil
+		},
+	)
+	s.generator.setRangeID(s.rangeID)
+	s.generator.setTaskMinScheduledTime(time.Now().Add(-time.Second))
+}
+
+func (s *taskKeyGeneratorSuite) TestSetTaskKeys_ImmediateTasks() {
+	now := time.Now()
+	s.mockTimeSource.Update(now)
+
+	numTask := 5
+	transferTasks := make([]tasks.Task, 0, numTask)
+	for i := 0; i < numTask; i++ {
+		transferTasks = append(
+			transferTasks,
+			tasks.NewFakeTask(
+				tests.WorkflowKey,
+				tasks.CategoryTransfer,
+				// use some random initial timestamp for the task
+				now.Add(time.Duration(time.Second*time.Duration(rand.Int63n(100)-50))),
+			),
+		)
+	}
+
+	err := s.generator.setTaskKeys(map[tasks.Category][]tasks.Task{
+		tasks.CategoryTransfer: transferTasks,
+	})
+	s.NoError(err)
+
+	expectedTaskID := int64(s.rangeID << int64(s.rangeSizeBits))
+	for _, transferTask := range transferTasks {
+		actualKey := transferTask.GetKey()
+		expectedKey := tasks.NewImmediateKey(expectedTaskID)
+		s.Zero(expectedKey.CompareTo(actualKey))
+		s.Equal(now, transferTask.GetVisibilityTime())
+
+		expectedTaskID++
+	}
+}
+
+func (s *taskKeyGeneratorSuite) TestSetTaskKeys_ScheduledTasks() {
+	now := time.Now().Truncate(persistence.ScheduledTaskMinPrecision)
+	s.mockTimeSource.Update(now)
+
+	timerTasks := []tasks.Task{
+		tasks.NewFakeTask(tests.WorkflowKey, tasks.CategoryTimer, now.Add(-time.Minute)),
+		tasks.NewFakeTask(tests.WorkflowKey, tasks.CategoryTimer, now.Add(time.Minute)),
+	}
+	initialTaskID := int64(s.rangeID << int64(s.rangeSizeBits))
+	expectedKeys := []tasks.Key{
+		tasks.NewKey(now.Add(persistence.ScheduledTaskMinPrecision), initialTaskID),
+		tasks.NewKey(now.Add(time.Minute).Add(persistence.ScheduledTaskMinPrecision), initialTaskID+1),
+	}
+
+	err := s.generator.setTaskKeys(map[tasks.Category][]tasks.Task{
+		tasks.CategoryTimer: timerTasks,
+	})
+	s.NoError(err)
+
+	for i, timerTask := range timerTasks {
+		actualKey := timerTask.GetKey()
+		expectedKey := expectedKeys[i]
+		s.Zero(expectedKey.CompareTo(actualKey))
+	}
+}
+
+func (s *taskKeyGeneratorSuite) TestSetTaskKeys_RenewRange() {
+	now := time.Now()
+	s.mockTimeSource.Update(now)
+
+	initialRangeID := s.rangeID
+
+	numTask := 10
+	s.True(numTask > (1 << s.rangeSizeBits))
+
+	transferTasks := make([]tasks.Task, 0, numTask)
+	for i := 0; i < numTask; i++ {
+		transferTasks = append(
+			transferTasks,
+			tasks.NewFakeTask(tests.WorkflowKey, tasks.CategoryTransfer, now),
+		)
+	}
+
+	err := s.generator.setTaskKeys(map[tasks.Category][]tasks.Task{
+		tasks.CategoryTransfer: transferTasks,
+	})
+	s.NoError(err)
+
+	expectedTaskID := int64(initialRangeID << int64(s.rangeSizeBits))
+	for _, transferTask := range transferTasks {
+		actualKey := transferTask.GetKey()
+		expectedKey := tasks.NewImmediateKey(expectedTaskID)
+		s.Zero(expectedKey.CompareTo(actualKey))
+		s.Equal(now, transferTask.GetVisibilityTime())
+
+		expectedTaskID++
+	}
+	s.Equal(initialRangeID+1, s.rangeID)
+}
+
+func (s *taskKeyGeneratorSuite) TestPeekAndGenerateTaskKey() {
+	nextTaskID := s.rangeID << int64(s.rangeSizeBits)
+	nextKey := s.generator.peekTaskKey(tasks.CategoryTransfer)
+	s.Zero(tasks.NewImmediateKey(nextTaskID).CompareTo(nextKey))
+
+	generatedKey, err := s.generator.generateTaskKey(tasks.CategoryTransfer)
+	s.NoError(err)
+	s.Zero(nextKey.CompareTo(generatedKey))
+
+	nextTaskID++
+	now := time.Now().Truncate(persistence.ScheduledTaskMinPrecision)
+	s.mockTimeSource.Update(now)
+	s.generator.setTaskMinScheduledTime(now)
+	nextKey = s.generator.peekTaskKey(tasks.CategoryTimer)
+	s.Zero(tasks.NewKey(now, nextTaskID).CompareTo(nextKey))
+
+	generatedKey, err = s.generator.generateTaskKey(tasks.CategoryTimer)
+	s.NoError(err)
+	s.Zero(nextKey.CompareTo(generatedKey))
+}

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -33,6 +33,7 @@ import (
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
@@ -58,6 +59,7 @@ var (
 	MissedNamespaceID                        = namespace.ID("missed-namespace-id")
 	WorkflowID                               = "mock-workflow-id"
 	RunID                                    = "0d00698f-08e1-4d36-a3e2-3bf109f5d2d6"
+	WorkflowKey                              = definition.NewWorkflowKey(NamespaceID.String(), WorkflowID, RunID)
 
 	LocalNamespaceEntry = namespace.NewLocalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Id: NamespaceID.String(), Name: Namespace.String()},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add task key generator for shard context

<!-- Tell your future self why have you made these changes -->
**Why?**
- Pull out logic related to task key generation/allocation to a component. Needed for later work for releasing shard lock on shard I/O. For the full change check: https://github.com/temporalio/temporal/tree/remove-shard-lock-v2/service/history/shard

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test & tested in test cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A, not wired up yet

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
