### PR TITLE
No shard lock on I/O: task request tracker

### DIFF
--- a/service/history/shard/task_request_tracker.go
+++ b/service/history/shard/task_request_tracker.go
@@ -1,0 +1,171 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"sync"
+
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	taskRequestCompletionFn func(error)
+
+	taskRequestTracker struct {
+		sync.Mutex
+
+		// using priority queue to track the min pending task key
+		// might be an overkill since the max length of the nested map
+		// is equal to shardIO concurrency limit which should be small
+		pendingTaskKeys      map[tasks.Category]map[tasks.Key]struct{}
+		inflightRequestCount int
+
+		waitChannels []chan<- struct{}
+	}
+)
+
+func newTaskRequestTracker() *taskRequestTracker {
+	outstandingTaskKeys := make(map[tasks.Category]map[tasks.Key]struct{})
+	for _, category := range tasks.GetCategories() {
+		outstandingTaskKeys[category] = make(map[tasks.Key]struct{})
+	}
+	return &taskRequestTracker{
+		pendingTaskKeys: outstandingTaskKeys,
+		waitChannels:    make([]chan<- struct{}, 0),
+	}
+}
+
+func (t *taskRequestTracker) track(
+	taskMaps ...map[tasks.Category][]tasks.Task,
+) taskRequestCompletionFn {
+	t.Lock()
+	defer t.Unlock()
+
+	t.inflightRequestCount++
+
+	minKeyByCategory := make(map[tasks.Category]tasks.Key)
+	for _, taskMap := range taskMaps {
+		for category, tasksPerCategory := range taskMap {
+			minKey := tasks.MaximumKey
+			for _, task := range tasksPerCategory {
+				if task.GetKey().CompareTo(minKey) < 0 {
+					minKey = task.GetKey()
+				}
+			}
+			if minKey.CompareTo(tasks.MaximumKey) == 0 {
+				continue
+			}
+
+			if _, ok := minKeyByCategory[category]; !ok {
+				minKeyByCategory[category] = minKey
+			} else {
+				minKeyByCategory[category] = tasks.MinKey(minKeyByCategory[category], minKey)
+			}
+		}
+	}
+	for category, minKey := range minKeyByCategory {
+		t.pendingTaskKeys[category][minKey] = struct{}{}
+	}
+
+	return func(writeErr error) {
+		t.Lock()
+		defer t.Unlock()
+
+		// Task key is not pending only when we get a definitive result from persistence.
+		// This result can be either a success or a error that guarantees the task with that key
+		// will not be persisted.
+		if writeErr == nil || !OperationPossiblySucceeded(writeErr) {
+			// we can only remove the task from the pending task list if we are sure it was inserted
+			// or the insertion is guaranteed to have failed
+			for category, minKey := range minKeyByCategory {
+				delete(t.pendingTaskKeys[category], minKey)
+			}
+		}
+
+		// While task key might still be pending, the request is completed and no longer inflight
+		t.inflightRequestCount--
+		if t.inflightRequestCount == 0 {
+			t.closeWaitChannelsLocked()
+		}
+	}
+}
+
+func (t *taskRequestTracker) minTaskKey(
+	category tasks.Category,
+) (tasks.Key, bool) {
+	t.Lock()
+	defer t.Unlock()
+
+	pendingTasksForCategory := t.pendingTaskKeys[category]
+	if len(pendingTasksForCategory) == 0 {
+		return tasks.MinimumKey, false
+	}
+
+	minKey := tasks.MaximumKey
+	for taskKey := range pendingTasksForCategory {
+		if taskKey.CompareTo(minKey) < 0 {
+			minKey = taskKey
+		}
+	}
+
+	return minKey, true
+}
+
+// drain method blocks until all inflight requests are completed
+// This method should be called before updating shard rangeID,
+// otherwise inflight request can fails as those requests are conditioned on
+// the current rangeID
+func (t *taskRequestTracker) drain() {
+	t.Lock()
+
+	if t.inflightRequestCount == 0 {
+		t.Unlock()
+		return
+	}
+
+	waitCh := make(chan struct{})
+	t.waitChannels = append(t.waitChannels, waitCh)
+	t.Unlock()
+
+	<-waitCh
+}
+
+func (t *taskRequestTracker) clear() {
+	t.Lock()
+	defer t.Unlock()
+
+	for category := range t.pendingTaskKeys {
+		t.pendingTaskKeys[category] = make(map[tasks.Key]struct{})
+	}
+	t.inflightRequestCount = 0
+	t.closeWaitChannelsLocked()
+}
+
+func (t *taskRequestTracker) closeWaitChannelsLocked() {
+	for _, waitCh := range t.waitChannels {
+		close(waitCh)
+	}
+	t.waitChannels = nil
+}

--- a/service/history/shard/task_request_tracker.go
+++ b/service/history/shard/task_request_tracker.go
@@ -53,18 +53,12 @@ func newTaskRequestTracker() *taskRequestTracker {
 	}
 	return &taskRequestTracker{
 		pendingTaskKeys: outstandingTaskKeys,
-		waitChannels:    make([]chan<- struct{}, 0),
 	}
 }
 
 func (t *taskRequestTracker) track(
 	taskMaps ...map[tasks.Category][]tasks.Task,
 ) taskRequestCompletionFn {
-	t.Lock()
-	defer t.Unlock()
-
-	t.inflightRequestCount++
-
 	minKeyByCategory := make(map[tasks.Category]tasks.Key)
 	for _, taskMap := range taskMaps {
 		for category, tasksPerCategory := range taskMap {
@@ -85,6 +79,12 @@ func (t *taskRequestTracker) track(
 			}
 		}
 	}
+
+	t.Lock()
+	defer t.Unlock()
+
+	t.inflightRequestCount++
+
 	for category, minKey := range minKeyByCategory {
 		t.pendingTaskKeys[category][minKey] = struct{}{}
 	}

--- a/service/history/shard/task_request_tracker_test.go
+++ b/service/history/shard/task_request_tracker_test.go
@@ -1,0 +1,204 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/api/serviceerror"
+
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+)
+
+type (
+	taskRequestTrackerSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		tracker *taskRequestTracker
+	}
+)
+
+func TestTaskRequestTrackerSuite(t *testing.T) {
+	s := &taskRequestTrackerSuite{}
+	suite.Run(t, s)
+}
+
+func (s *taskRequestTrackerSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.tracker = newTaskRequestTracker()
+}
+
+func (s *taskRequestTrackerSuite) TestTrackAndMinTaskKey() {
+	now := time.Now()
+
+	_ = s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(123),
+			tasks.NewImmediateKey(125),
+		},
+		tasks.CategoryTimer: {
+			tasks.NewKey(now, 124),
+			tasks.NewKey(now.Add(time.Minute), 122),
+		},
+	}))
+	s.assertMinTaskKey(tasks.CategoryTransfer, tasks.NewImmediateKey(123))
+	s.assertMinTaskKey(tasks.CategoryTimer, tasks.NewKey(now, 124))
+
+	_ = s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(130),
+		},
+		tasks.CategoryTimer: {
+			tasks.NewKey(now.Add(-time.Minute), 131),
+		},
+	}))
+	s.assertMinTaskKey(tasks.CategoryTransfer, tasks.NewImmediateKey(123))
+	s.assertMinTaskKey(tasks.CategoryTimer, tasks.NewKey(now.Add(-time.Minute), 131))
+
+	_, ok := s.tracker.minTaskKey(tasks.CategoryVisibility)
+	s.False(ok)
+}
+
+func (s *taskRequestTrackerSuite) TestRequestCompletion() {
+	completionFunc1 := s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(123),
+			tasks.NewImmediateKey(125),
+		},
+	}))
+	completionFunc2 := s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(122),
+		},
+	}))
+	completionFunc3 := s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(127),
+		},
+	}))
+	s.assertMinTaskKey(tasks.CategoryTransfer, tasks.NewImmediateKey(122))
+
+	completionFunc2(nil)
+	s.assertMinTaskKey(tasks.CategoryTransfer, tasks.NewImmediateKey(123))
+
+	completionFunc3(serviceerror.NewNotFound("not found error guarantees task is not inserted"))
+	s.assertMinTaskKey(tasks.CategoryTransfer, tasks.NewImmediateKey(123))
+
+	completionFunc1(errors.New("random error means task may still be inserted in the future"))
+	s.assertMinTaskKey(tasks.CategoryTransfer, tasks.NewImmediateKey(123))
+
+	s.tracker.drain()
+}
+
+func (s *taskRequestTrackerSuite) TestDrain() {
+	// drain should not block if there is no inflight request
+	s.tracker.drain()
+
+	completionFunc1 := s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(123),
+		},
+	}))
+	completionFunc2 := s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(122),
+		},
+	}))
+	completionFunc3 := s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(127),
+		},
+	}))
+
+	for _, completionFn := range []taskRequestCompletionFn{
+		completionFunc1,
+		completionFunc2,
+		completionFunc3,
+	} {
+		go func(completionFn taskRequestCompletionFn) {
+			completionFn(nil)
+		}(completionFn)
+	}
+
+	s.tracker.drain()
+}
+
+func (s *taskRequestTrackerSuite) TestClear() {
+	_ = s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(123),
+			tasks.NewImmediateKey(125),
+		},
+	}))
+	completionFn := s.tracker.track(s.convertKeysToTasks(map[tasks.Category][]tasks.Key{
+		tasks.CategoryTransfer: {
+			tasks.NewImmediateKey(122),
+		},
+	}))
+	completionFn(errors.New("some random error"))
+	s.assertMinTaskKey(tasks.CategoryTransfer, tasks.NewImmediateKey(122))
+
+	s.tracker.clear()
+	_, ok := s.tracker.minTaskKey(tasks.CategoryTransfer)
+	s.False(ok)
+	s.tracker.drain()
+}
+
+func (s *taskRequestTrackerSuite) assertMinTaskKey(
+	category tasks.Category,
+	expectedKey tasks.Key,
+) {
+	actualKey, ok := s.tracker.minTaskKey(category)
+	s.True(ok)
+	s.Zero(expectedKey.CompareTo(actualKey))
+}
+
+func (s *taskRequestTrackerSuite) convertKeysToTasks(
+	keysByCategory map[tasks.Category][]tasks.Key,
+) map[tasks.Category][]tasks.Task {
+	tasksByCategory := make(map[tasks.Category][]tasks.Task)
+	for category, keys := range keysByCategory {
+		tasksByCategory[category] = make([]tasks.Task, 0, len(keys))
+		for _, key := range keys {
+			fakeTask := tasks.NewFakeTask(
+				tests.WorkflowKey,
+				category,
+				time.Time{},
+			)
+			fakeTask.SetTaskID(key.TaskID)
+			fakeTask.SetVisibilityTime(key.FireTime)
+			tasksByCategory[category] = append(tasksByCategory[category], fakeTask)
+		}
+	}
+
+	return tasksByCategory
+}

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -33,6 +33,7 @@ import (
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
@@ -58,6 +59,7 @@ var (
 	MissedNamespaceID                        = namespace.ID("missed-namespace-id")
 	WorkflowID                               = "mock-workflow-id"
 	RunID                                    = "0d00698f-08e1-4d36-a3e2-3bf109f5d2d6"
+	WorkflowKey                              = definition.NewWorkflowKey(NamespaceID.String(), WorkflowID, RunID)
 
 	LocalNamespaceEntry = namespace.NewLocalNamespaceForTest(
 		&persistencespb.NamespaceInfo{Id: NamespaceID.String(), Name: Namespace.String()},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add task request tracker for shard context

<!-- Tell your future self why have you made these changes -->
**Why?**
- Pull out logic related to tracking pending task keys and inflight persistence requests. Needed for later work for releasing shard lock on shard I/O. For the full change check: https://github.com/temporalio/temporal/tree/remove-shard-lock-v2/service/history/shard

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test & tested in test cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A, not wired up yet

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
