### PR TITLE
🧹 remove calls to `rand.Seed`

### DIFF
--- a/client/history/metadata_test.go
+++ b/client/history/metadata_test.go
@@ -28,7 +28,6 @@ import (
 	"math/rand"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
@@ -52,11 +51,9 @@ func TestMetadataSuite(t *testing.T) {
 }
 
 func (s *metadataSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *metadataSuite) TearDownSuite() {
-
 }
 
 func (s *metadataSuite) SetupTest() {

--- a/common/locks/condition_variable_test.go
+++ b/common/locks/condition_variable_test.go
@@ -28,7 +28,6 @@ import (
 	"math/rand"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -51,11 +50,9 @@ func TestConditionVariableSuite(t *testing.T) {
 
 func (s *conditionVariableSuite) SetupSuite() {
 	s.Assertions = require.New(s.T())
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *conditionVariableSuite) TearDownSuite() {
-
 }
 
 func (s *conditionVariableSuite) SetupTest() {

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -416,10 +416,8 @@ func randString(length int) string {
 // GenerateRandomDBName helper
 // Format: MMDDHHMMSS_abc
 func GenerateRandomDBName(n int) string {
-	now := time.Now().UTC()
-	rand.Seed(now.UnixNano())
 	var prefix strings.Builder
-	prefix.WriteString(now.Format("0102150405"))
+	prefix.WriteString(time.Now().UTC().Format("0102150405"))
 	prefix.WriteRune('_')
 	prefix.WriteString(randString(n))
 	return prefix.String()

--- a/common/persistence/tests/execution_mutable_state.go
+++ b/common/persistence/tests/execution_mutable_state.go
@@ -93,11 +93,9 @@ func NewExecutionMutableStateSuite(
 }
 
 func (s *ExecutionMutableStateSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *ExecutionMutableStateSuite) TearDownSuite() {
-
 }
 
 func (s *ExecutionMutableStateSuite) SetupTest() {

--- a/common/persistence/tests/shard.go
+++ b/common/persistence/tests/shard.go
@@ -71,11 +71,9 @@ func NewShardSuite(
 }
 
 func (s *ShardSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *ShardSuite) TearDownSuite() {
-
 }
 
 func (s *ShardSuite) SetupTest() {

--- a/common/persistence/tests/task_queue.go
+++ b/common/persistence/tests/task_queue.go
@@ -78,11 +78,9 @@ func NewTaskQueueSuite(
 }
 
 func (s *TaskQueueSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *TaskQueueSuite) TearDownSuite() {
-
 }
 
 func (s *TaskQueueSuite) SetupTest() {

--- a/common/persistence/tests/task_queue_task.go
+++ b/common/persistence/tests/task_queue_task.go
@@ -80,11 +80,9 @@ func NewTaskQueueTaskSuite(
 }
 
 func (s *TaskQueueTaskSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *TaskQueueTaskSuite) TearDownSuite() {
-
 }
 
 func (s *TaskQueueTaskSuite) SetupTest() {

--- a/common/shuffle/shuffle.go
+++ b/common/shuffle/shuffle.go
@@ -26,12 +26,7 @@ package shuffle
 
 import (
 	"math/rand"
-	"time"
 )
-
-func init() {
-	rand.Seed(time.Now().UTC().UnixNano())
-}
 
 func String(str string) string {
 	return string(Bytes([]byte(str)))

--- a/common/util.go
+++ b/common/util.go
@@ -496,7 +496,6 @@ func IsValidContext(ctx context.Context) error {
 
 // GenerateRandomString is used for generate test string
 func GenerateRandomString(n int) string {
-	rand.Seed(time.Now().UnixNano())
 	letterRunes := []rune("random")
 	b := make([]rune, n)
 	for i := range b {

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -353,7 +353,6 @@ func (s *Service) Start() {
 
 	// must start resource first
 	s.metricsHandler.Counter(metrics.RestartCount).Record(1)
-	rand.Seed(time.Now().UnixNano())
 
 	s.versionChecker.Start()
 	s.adminHandler.Start()

--- a/service/history/api/consistency_checker_test.go
+++ b/service/history/api/consistency_checker_test.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
@@ -72,7 +71,6 @@ func TestWorkflowConsistencyCheckerSuite(t *testing.T) {
 }
 
 func (s *workflowConsistencyCheckerSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *workflowConsistencyCheckerSuite) TearDownSuite() {

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
@@ -26,9 +26,7 @@ package signalwithstartworkflow
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/brianvoe/gofakeit/v6"
 	"github.com/golang/mock/gomock"
@@ -73,7 +71,6 @@ func TestSignalWithStartWorkflowSuite(t *testing.T) {
 }
 
 func (s *signalWithStartWorkflowSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *signalWithStartWorkflowSuite) TearDownSuite() {

--- a/service/history/api/signalworkflow/api_test.go
+++ b/service/history/api/signalworkflow/api_test.go
@@ -26,9 +26,7 @@ package signalworkflow
 
 import (
 	"context"
-	"math/rand"
 	"testing"
-	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
 
@@ -75,7 +73,6 @@ func TestSignalWorkflowSuite(t *testing.T) {
 }
 
 func (s *signalWorkflowSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *signalWorkflowSuite) TearDownSuite() {

--- a/service/history/queues/iterator_test.go
+++ b/service/history/queues/iterator_test.go
@@ -26,7 +26,6 @@ package queues
 
 import (
 	"fmt"
-	"math/rand"
 	"testing"
 	"time"
 
@@ -37,10 +36,6 @@ import (
 	"go.temporal.io/server/common/collection"
 	"go.temporal.io/server/service/history/tasks"
 )
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
 
 type (
 	iteratorSuite struct {

--- a/service/history/replication/stream_sender_test.go
+++ b/service/history/replication/stream_sender_test.go
@@ -73,11 +73,9 @@ func TestStreamSenderSuite(t *testing.T) {
 }
 
 func (s *streamSenderSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *streamSenderSuite) TearDownSuite() {
-
 }
 
 func (s *streamSenderSuite) SetupTest() {

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -28,7 +28,6 @@ import (
 	"math"
 	"math/rand"
 	"testing"
-	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
@@ -82,11 +81,9 @@ func TestTaskProcessorManagerSuite(t *testing.T) {
 }
 
 func (s *taskProcessorManagerSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *taskProcessorManagerSuite) TearDownSuite() {
-
 }
 
 func (s *taskProcessorManagerSuite) SetupTest() {

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -93,11 +93,9 @@ func TestTaskProcessorSuite(t *testing.T) {
 }
 
 func (s *taskProcessorSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *taskProcessorSuite) TearDownSuite() {
-
 }
 
 func (s *taskProcessorSuite) SetupTest() {

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -25,7 +25,6 @@
 package history
 
 import (
-	"math/rand"
 	"net"
 	"time"
 
@@ -91,7 +90,6 @@ func (s *Service) Start() {
 	s.logger.Info("history starting")
 
 	s.metricsHandler.Counter(metrics.RestartCount).Record(1)
-	rand.Seed(time.Now().UnixNano())
 
 	s.handler.Start()
 

--- a/service/history/tasks/key_test.go
+++ b/service/history/tasks/key_test.go
@@ -35,10 +35,6 @@ import (
 	"github.com/stretchr/testify/suite"
 )
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
-
 type (
 	taskKeySuite struct {
 		suite.Suite

--- a/service/history/workflow/history_builder_test.go
+++ b/service/history/workflow/history_builder_test.go
@@ -133,11 +133,9 @@ func TestHistoryBuilderSuite(t *testing.T) {
 }
 
 func (s *historyBuilderSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *historyBuilderSuite) TearDownSuite() {
-
 }
 
 func (s *historyBuilderSuite) SetupTest() {

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -92,11 +92,9 @@ func TestStateBuilderSuite(t *testing.T) {
 }
 
 func (s *stateBuilderSuite) SetupSuite() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func (s *stateBuilderSuite) TearDownSuite() {
-
 }
 
 func (s *stateBuilderSuite) SetupTest() {

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -25,7 +25,6 @@
 package matching
 
 import (
-	"math/rand"
 	"net"
 	"time"
 
@@ -92,7 +91,6 @@ func (s *Service) Start() {
 
 	// must start base service first
 	s.metricsHandler.Counter(metrics.RestartCount).Record(1)
-	rand.Seed(time.Now().UnixNano())
 
 	s.handler.Start()
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -26,7 +26,6 @@ package worker
 
 import (
 	"context"
-	"math/rand"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -347,10 +346,6 @@ func (s *Service) Start() {
 
 	s.clusterMetadata.Start()
 	s.namespaceRegistry.Start()
-
-	// The service is now started up
-	// seed the random generator once for this service
-	rand.Seed(time.Now().UnixNano())
 
 	s.membershipMonitor.Start()
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Removed all calls to `rand.Seed` with a _random_ initialization value.

<!-- Tell your future self why have you made these changes -->
**Why?**

Less code is better.

[From the docs](https://pkg.go.dev/math/rand#Seed):

> If Seed is not called, the generator is seeded randomly at program startup.

> Prior to Go 1.20, the generator was seeded like Seed(1) at program startup. [...]

> Deprecated: **As of Go 1.20 there is no reason to call Seed with a random value**. [...]

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

According to the docs, this is a no-op change in terms of behaviour.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No.