### PR TITLE
Improve scheduler workflow unit test

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -96,6 +96,8 @@ const (
 	rateLimitedErrorType = "RateLimited"
 
 	nextTimeCacheV1Size = 10
+
+	impossibleHistorySize = 1e6 // just for testing, no real history can be this long
 )
 
 type (
@@ -252,7 +254,7 @@ func (s *scheduler) run() error {
 	iters := s.tweakables.IterationsBeforeContinueAsNew
 	for {
 		// TODO: use the real GetContinueAsNewSuggested
-		suggestContinueAsNew := iters <= 0 || workflow.GetInfo(s.ctx).GetCurrentHistoryLength() >= 1e6
+		suggestContinueAsNew := iters <= 0 || workflow.GetInfo(s.ctx).GetCurrentHistoryLength() >= impossibleHistorySize
 		if suggestContinueAsNew && s.pendingUpdate == nil && s.pendingPatch == nil {
 			break
 		}

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -254,8 +254,8 @@ func (s *scheduler) run() error {
 	iters := s.tweakables.IterationsBeforeContinueAsNew
 	for {
 		// TODO: use the real GetContinueAsNewSuggested
-		suggestContinueAsNew := iters <= 0 || workflow.GetInfo(s.ctx).GetCurrentHistoryLength() >= impossibleHistorySize
-		if suggestContinueAsNew && s.pendingUpdate == nil && s.pendingPatch == nil {
+		continueAsNewSuggested := iters <= 0 || workflow.GetInfo(s.ctx).GetCurrentHistoryLength() >= impossibleHistorySize
+		if continueAsNewSuggested && s.pendingUpdate == nil && s.pendingPatch == nil {
 			break
 		}
 		iters--

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -251,9 +251,9 @@ func (s *scheduler) run() error {
 
 	iters := s.tweakables.IterationsBeforeContinueAsNew
 	for {
-		// TODO: use the real GetSuggestContinueAsNew
-		suggestContinueAsNew := workflow.GetInfo(s.ctx).GetCurrentHistoryLength() >= 1e6
-		if (iters == 0 || suggestContinueAsNew) && s.pendingUpdate == nil && s.pendingPatch == nil {
+		// TODO: use the real GetContinueAsNewSuggested
+		suggestContinueAsNew := iters <= 0 || workflow.GetInfo(s.ctx).GetCurrentHistoryLength() >= 1e6
+		if suggestContinueAsNew && s.pendingUpdate == nil && s.pendingPatch == nil {
 			break
 		}
 		iters--

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -191,7 +191,12 @@ type workflowRun struct {
 	result     enumspb.WorkflowExecutionStatus
 }
 
-func (s *workflowSuite) setupMocksForWorkflows(runs []workflowRun, started map[string]time.Time) {
+type runAcrossContinueState struct {
+	started  map[string]time.Time
+	finished bool
+}
+
+func (s *workflowSuite) setupMocksForWorkflows(runs []workflowRun, state *runAcrossContinueState) {
 	for _, run := range runs {
 		run := run // capture fresh value
 		// set up start
@@ -200,10 +205,10 @@ func (s *workflowSuite) setupMocksForWorkflows(runs []workflowRun, started map[s
 		})
 		s.env.OnActivity(new(activities).StartWorkflow, mock.Anything, matchStart).Times(0).Maybe().Return(
 			func(_ context.Context, req *schedspb.StartWorkflowRequest) (*schedspb.StartWorkflowResponse, error) {
-				if _, ok := started[req.Request.WorkflowId]; ok {
+				if _, ok := state.started[req.Request.WorkflowId]; ok {
 					s.Failf("multiple starts for %s", req.Request.WorkflowId)
 				}
-				started[req.Request.WorkflowId] = s.now()
+				state.started[req.Request.WorkflowId] = s.now()
 				return &schedspb.StartWorkflowResponse{
 					RunId:         uuid.NewString(),
 					RealStartTime: timestamp.TimePtr(time.Now()),
@@ -233,13 +238,20 @@ func (s *workflowSuite) setupMocksForWorkflows(runs []workflowRun, started map[s
 }
 
 type delayedCallback struct {
-	at time.Time
-	f  func()
+	at         time.Time
+	f          func()
+	finishTest bool
 }
 
-func (s *workflowSuite) setupDelayedCallbacks(start time.Time, cbs []delayedCallback) {
+func (s *workflowSuite) setupDelayedCallbacks(start time.Time, cbs []delayedCallback, state *runAcrossContinueState) {
 	for _, cb := range cbs {
 		if delay := cb.at.Sub(start); delay > 0 {
+			if cb.finishTest {
+				cb.f = func() {
+					s.env.SetCurrentHistoryLength(1e6) // signals workflow loop to exit
+					state.finished = true              // signals this loop to exit
+				}
+			}
 			s.env.RegisterDelayedCallback(cb.f, delay)
 		}
 	}
@@ -249,7 +261,6 @@ func (s *workflowSuite) runAcrossContinue(
 	runs []workflowRun,
 	cbs []delayedCallback,
 	sched *schedpb.Schedule,
-	maxIterations int,
 ) {
 	// fill this in so callers don't need to
 	sched.Action = s.defaultAction("myid")
@@ -267,21 +278,21 @@ func (s *workflowSuite) runAcrossContinue(
 				ConflictToken: InitialConflictToken,
 			},
 		}
-		iterations := maxIterations
-		gotRuns := make(map[string]time.Time)
+		currentTweakablePolicies.IterationsBeforeContinueAsNew = every
+		state := runAcrossContinueState{
+			started: make(map[string]time.Time),
+		}
 		for {
 			s.env = s.NewTestWorkflowEnvironment()
 			s.env.SetStartTime(startTime)
 
-			s.setupMocksForWorkflows(runs, gotRuns)
-			s.setupDelayedCallbacks(startTime, cbs)
+			s.setupMocksForWorkflows(runs, &state)
+			s.setupDelayedCallbacks(startTime, cbs, &state)
 
-			currentTweakablePolicies.IterationsBeforeContinueAsNew = min(iterations, every)
-
-			s.T().Logf("starting workflow for %d iterations out of %d remaining, %d total, start time %s",
-				currentTweakablePolicies.IterationsBeforeContinueAsNew, iterations, maxIterations, startTime)
+			s.T().Logf("starting workflow with CAN every %d iterations, start time %s",
+				currentTweakablePolicies.IterationsBeforeContinueAsNew, startTime)
 			s.env.ExecuteWorkflow(SchedulerWorkflow, startArgs)
-			s.T().Logf("finished workflow, time is now %s", s.now())
+			s.T().Logf("finished workflow, time is now %s, finished is %v", s.now(), state.finished)
 
 			s.True(s.env.IsWorkflowCompleted())
 			result := s.env.GetWorkflowError()
@@ -290,8 +301,7 @@ func (s *workflowSuite) runAcrossContinue(
 
 			s.env.AssertExpectations(s.T())
 
-			iterations -= currentTweakablePolicies.IterationsBeforeContinueAsNew
-			if iterations == 0 {
+			if state.finished {
 				break
 			}
 
@@ -300,9 +310,9 @@ func (s *workflowSuite) runAcrossContinue(
 			s.NoError(payloads.Decode(canErr.Input, &startArgs))
 		}
 		// check starts that we actually got
-		s.Require().Equal(len(runs), len(gotRuns))
+		s.Require().Equal(len(runs), len(state.started))
 		for _, run := range runs {
-			s.Truef(run.start.Equal(gotRuns[run.id]), "%v != %v", run.start, gotRuns[run.id])
+			s.Truef(run.start.Equal(state.started[run.id]), "%v != %v", run.start, state.started[run.id])
 		}
 	}
 }
@@ -512,6 +522,10 @@ func (s *workflowSuite) TestOverlapSkip() {
 					s.Equal([]string{"myid-2022-06-01T00:15:00Z"}, s.runningWorkflows())
 				},
 			},
+			{
+				at:         time.Date(2022, 6, 1, 0, 18, 0, 0, time.UTC),
+				finishTest: true,
+			},
 		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
@@ -523,7 +537,6 @@ func (s *workflowSuite) TestOverlapSkip() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
 			},
 		},
-		4,
 	)
 }
 
@@ -556,19 +569,22 @@ func (s *workflowSuite) TestOverlapBufferOne() {
 				at: time.Date(2022, 6, 1, 0, 6, 0, 0, time.UTC),
 				f:  func() { s.Equal([]string{"myid-2022-06-01T00:05:00Z"}, s.runningWorkflows()) },
 			},
-			{at: time.Date(2022, 6, 1, 0, 11, 0, 0, time.UTC),
+			{
+				at: time.Date(2022, 6, 1, 0, 11, 0, 0, time.UTC),
 				f: func() {
 					s.Equal(int64(1), s.describe().Info.BufferSize)
 					s.Equal(int64(0), s.describe().Info.OverlapSkipped)
 				},
 			},
-			{at: time.Date(2022, 6, 1, 0, 16, 0, 0, time.UTC),
+			{
+				at: time.Date(2022, 6, 1, 0, 16, 0, 0, time.UTC),
 				f: func() {
 					s.Equal(int64(1), s.describe().Info.BufferSize)
 					s.Equal(int64(1), s.describe().Info.OverlapSkipped)
 				},
 			},
-			{at: time.Date(2022, 6, 1, 0, 26, 0, 0, time.UTC),
+			{
+				at: time.Date(2022, 6, 1, 0, 26, 0, 0, time.UTC),
 				f: func() {
 					s.Equal(int64(1), s.describe().Info.BufferSize)
 					s.Equal(int64(3), s.describe().Info.OverlapSkipped)
@@ -578,11 +594,16 @@ func (s *workflowSuite) TestOverlapBufferOne() {
 				at: time.Date(2022, 6, 1, 0, 31, 0, 0, time.UTC),
 				f:  func() { s.Equal([]string{"myid-2022-06-01T00:30:00Z"}, s.runningWorkflows()) },
 			},
-			{at: time.Date(2022, 6, 1, 0, 32, 0, 0, time.UTC),
+			{
+				at: time.Date(2022, 6, 1, 0, 32, 0, 0, time.UTC),
 				f: func() {
 					s.Equal(int64(0), s.describe().Info.BufferSize)
 					s.Equal(int64(3), s.describe().Info.OverlapSkipped)
 				},
+			},
+			{
+				at:         time.Date(2022, 6, 1, 0, 34, 59, 0, time.UTC),
+				finishTest: true,
 			},
 		},
 		&schedpb.Schedule{
@@ -595,7 +616,6 @@ func (s *workflowSuite) TestOverlapBufferOne() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ONE,
 			},
 		},
-		8,
 	)
 }
 
@@ -646,6 +666,10 @@ func (s *workflowSuite) TestOverlapBufferAll() {
 				at: time.Date(2022, 6, 1, 0, 22, 30, 0, time.UTC),
 				f:  func() { s.Equal([]string{"myid-2022-06-01T00:20:00Z"}, s.runningWorkflows()) },
 			},
+			{
+				at:         time.Date(2022, 6, 1, 0, 29, 30, 0, time.UTC),
+				finishTest: true,
+			},
 		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
@@ -657,7 +681,6 @@ func (s *workflowSuite) TestOverlapBufferAll() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
 			},
 		},
-		9,
 	)
 }
 
@@ -721,6 +744,10 @@ func (s *workflowSuite) TestBufferLimit() {
 					s.Equal(int64(1), s.describe().Info.BufferDropped)
 				},
 			},
+			{
+				at:         time.Date(2022, 6, 1, 0, 29, 30, 0, time.UTC),
+				finishTest: true,
+			},
 		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
@@ -732,7 +759,6 @@ func (s *workflowSuite) TestBufferLimit() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
 			},
 		},
-		8,
 	)
 }
 
@@ -863,7 +889,12 @@ func (s *workflowSuite) TestOverlapAllowAll() {
 				result: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
 			},
 		},
-		nil,
+		[]delayedCallback{
+			{
+				at:         time.Date(2022, 6, 1, 0, 24, 30, 0, time.UTC),
+				finishTest: true,
+			},
+		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
 				Interval: []*schedpb.IntervalSpec{{
@@ -874,7 +905,6 @@ func (s *workflowSuite) TestOverlapAllowAll() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 			},
 		},
-		5,
 	)
 }
 
@@ -1130,6 +1160,10 @@ func (s *workflowSuite) TestTriggerImmediate() {
 					})
 				},
 			},
+			{
+				at:         time.Date(2022, 6, 1, 0, 54, 0, 0, time.UTC),
+				finishTest: true,
+			},
 		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
@@ -1141,7 +1175,6 @@ func (s *workflowSuite) TestTriggerImmediate() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
 			},
 		},
-		4,
 	)
 }
 
@@ -1193,6 +1226,10 @@ func (s *workflowSuite) TestBackfill() {
 					})
 				},
 			},
+			{
+				at:         time.Date(2022, 7, 31, 19, 6, 0, 0, time.UTC),
+				finishTest: true,
+			},
 		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
@@ -1206,7 +1243,6 @@ func (s *workflowSuite) TestBackfill() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
 			},
 		},
-		6,
 	)
 }
 
@@ -1266,6 +1302,10 @@ func (s *workflowSuite) TestPause() {
 					s.Equal("go ahead", desc.Schedule.State.Notes)
 				},
 			},
+			{
+				at:         time.Date(2022, 6, 1, 0, 28, 8, 0, time.UTC),
+				finishTest: true,
+			},
 		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
@@ -1277,7 +1317,6 @@ func (s *workflowSuite) TestPause() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_ALLOW_ALL,
 			},
 		},
-		12,
 	)
 }
 
@@ -1350,6 +1389,10 @@ func (s *workflowSuite) TestUpdate() {
 					})
 				},
 			},
+			{
+				at:         time.Date(2022, 6, 1, 0, 19, 30, 0, time.UTC),
+				finishTest: true,
+			},
 		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
@@ -1361,7 +1404,6 @@ func (s *workflowSuite) TestUpdate() {
 				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
 			},
 		},
-		10,
 	)
 }
 
@@ -1403,6 +1445,10 @@ func (s *workflowSuite) TestUpdateNotRetroactive() {
 					})
 				},
 			},
+			{
+				at:         time.Date(2022, 6, 1, 1, 7, 55, 0, time.UTC),
+				finishTest: true,
+			},
 		},
 		&schedpb.Schedule{
 			Spec: &schedpb.ScheduleSpec{
@@ -1411,7 +1457,6 @@ func (s *workflowSuite) TestUpdateNotRetroactive() {
 				}},
 			},
 		},
-		5,
 	)
 }
 
@@ -1493,16 +1538,15 @@ func (s *workflowSuite) TestLotsOfIterations() {
 			result: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
 		}
 	}
+	testEnd := runs[len(runs)-1].end.Add(time.Second)
 
 	delayedCallbacks := make([]delayedCallback, backfillIterations)
 
-	expected := runIterations
 	// schedule some callbacks to spray backfills among scheduled runs
 	// each call back adds random number of backfills in [10, 20) range
 	for i := range delayedCallbacks {
 
 		maxRuns := rand.Intn(10) + 10
-		expected += maxRuns
 		// a point in time to send the callback request
 		offset := i * runIterations / backfillIterations
 		callbackTime := time.Date(2022, 6, 1, offset, 2, 0, 0, time.UTC)
@@ -1534,6 +1578,11 @@ func (s *workflowSuite) TestLotsOfIterations() {
 		}
 	}
 
+	delayedCallbacks = append(delayedCallbacks, delayedCallback{
+		at:         testEnd,
+		finishTest: true,
+	})
+
 	s.runAcrossContinue(
 		runs,
 		delayedCallbacks,
@@ -1545,7 +1594,6 @@ func (s *workflowSuite) TestLotsOfIterations() {
 				},
 			},
 		},
-		expected+1,
 	)
 }
 

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -248,8 +248,8 @@ func (s *workflowSuite) setupDelayedCallbacks(start time.Time, cbs []delayedCall
 		if delay := cb.at.Sub(start); delay > 0 {
 			if cb.finishTest {
 				cb.f = func() {
-					s.env.SetCurrentHistoryLength(1e6) // signals workflow loop to exit
-					state.finished = true              // signals this loop to exit
+					s.env.SetCurrentHistoryLength(impossibleHistorySize) // signals workflow loop to exit
+					state.finished = true                                // signals test to exit
 				}
 			}
 			s.env.RegisterDelayedCallback(cb.f, delay)


### PR DESCRIPTION
**What changed?**
The end of each test is signaled by time instead of iteration count, which was really confusing.

**Why?**
Easier to write and maintain tests.
They now stop at exactly the right time and avoid spurious calls that would trigger panics.

**How did you test it?**
is tests