### PR TITLE
Extract ServiceProviderParamsCommon.GetCommonServiceOptions

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -89,7 +89,7 @@ linters-settings:
           - 25
       - name: cyclomatic
         arguments:
-          - 18
+          - 25
       - name: function-result-limit
         arguments:
           - 5

--- a/common/persistence/visibility/store/sql/query_converter_sqlite.go
+++ b/common/persistence/visibility/store/sql/query_converter_sqlite.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/xwb1989/sqlparser"
+
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence/sql/sqlplugin"
 	"go.temporal.io/server/common/persistence/visibility/store/query"
@@ -75,7 +76,6 @@ func (c *sqliteQueryConverter) getCoalesceCloseTimeExpr() sqlparser.Expr {
 	)
 }
 
-//nolint:revive // cyclomatic complexity 17 (> 15)
 func (c *sqliteQueryConverter) convertKeywordListComparisonExpr(
 	expr *sqlparser.ComparisonExpr,
 ) (sqlparser.Expr, error) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. There's a lot of duplicated code in `temporal/fx.go` where we convert the dependencies in `ServiceProviderParamsCommon` into `fx.Option`s. I simply extracted a method for this so that the duplication is avoided. 
2. I also increased the cyclomatic complexity threshold in our linter because it was complaining about the `ServerOptionsProvider` function, which is not complex in my opinion, just a little long.

<!-- Tell your future self why have you made these changes -->
**Why?**
We probably had the duplication originally because `fx.Decorate` didn't exist, so the customization that the frontend service does would've been impossible.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
There's the existing `server_test.go`, which verifies that the `fx` graph builds and runs. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
