### PR TITLE
Rename deadlock detector latency metrics

### DIFF
--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -273,7 +273,7 @@ func (m *metadataImpl) GetPingChecks() []common.PingCheck {
 				m.clusterLock.Unlock()
 				return nil
 			},
-			MetricsName: metrics.ClusterMetadataLockLatency.GetMetricName(),
+			MetricsName: metrics.DDClusterMetadataLockLatency.GetMetricName(),
 		},
 		{
 			Name: "cluster metadata callback lock",
@@ -286,7 +286,7 @@ func (m *metadataImpl) GetPingChecks() []common.PingCheck {
 				m.clusterCallbackLock.Unlock()
 				return nil
 			},
-			MetricsName: metrics.ClusterMetadataCallbackLockLatency.GetMetricName(),
+			MetricsName: metrics.DDClusterMetadataCallbackLockLatency.GetMetricName(),
 		},
 	}
 }

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -907,16 +907,18 @@ var (
 	MutableStateDirty                              = NewCounterDef("mutable_state_dirty")
 	MutableStateChecksumMismatch                   = NewCounterDef("mutable_state_checksum_mismatch")
 	MutableStateChecksumInvalidated                = NewCounterDef("mutable_state_checksum_invalidated")
-	ClusterMetadataLockLatency                     = NewTimerDef("cluster_metadata_lock_latency")
-	ClusterMetadataCallbackLockLatency             = NewTimerDef("cluster_metadata_callback_lock_latency")
-	ShardControllerLockLatency                     = NewTimerDef("shard_controller_lock_latency")
-	ShardLockLatency                               = NewTimerDef("shard_lock_latency")
-	NamespaceRegistryLockLatency                   = NewTimerDef("namespace_registry_lock_latency")
 	ClosedWorkflowBufferEventCount                 = NewCounterDef("closed_workflow_buffer_event_counter")
 	InorderBufferedEventsCounter                   = NewCounterDef("inordered_buffered_events")
 	ShardLingerSuccess                             = NewTimerDef("shard_linger_success")
 	ShardLingerTimeouts                            = NewCounterDef("shard_linger_timeouts")
 	DynamicRateLimiterMultiplier                   = NewGaugeDef("dynamic_rate_limit_multiplier")
+
+	// Deadlock detector latency metrics
+	DDClusterMetadataLockLatency         = NewTimerDef("dd_cluster_metadata_lock_latency")
+	DDClusterMetadataCallbackLockLatency = NewTimerDef("dd_cluster_metadata_callback_lock_latency")
+	DDShardControllerLockLatency         = NewTimerDef("dd_shard_controller_lock_latency")
+	DDShardLockLatency                   = NewTimerDef("dd_shard_lock_latency")
+	DDNamespaceRegistryLockLatency       = NewTimerDef("dd_namespace_registry_lock_latency")
 
 	// Matching
 	MatchingClientForwardedCounter            = NewCounterDef("forwarded")

--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -259,7 +259,7 @@ func (r *registry) GetPingChecks() []common.PingCheck {
 				r.cacheLock.Unlock()
 				return nil
 			},
-			MetricsName: metrics.NamespaceRegistryLockLatency.GetMetricName(),
+			MetricsName: metrics.DDNamespaceRegistryLockLatency.GetMetricName(),
 		},
 	}
 }

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -233,7 +233,7 @@ func (s *ContextImpl) GetPingChecks() []common.PingCheck {
 			s.rwLock.Unlock()
 			return nil
 		},
-		MetricsName: metrics.ShardLockLatency.GetMetricName(),
+		MetricsName: metrics.DDShardLockLatency.GetMetricName(),
 	}}
 }
 

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -165,7 +165,7 @@ func (c *ControllerImpl) GetPingChecks() []common.PingCheck {
 			}
 			return out
 		},
-		MetricsName: metrics.ShardControllerLockLatency.GetMetricName(),
+		MetricsName: metrics.DDShardControllerLockLatency.GetMetricName(),
 	}}
 }
 


### PR DESCRIPTION
**What changed?**
Rename go constants and metric names for latency metrics collected by deadlock detector.

**Why?**
There was some confusion between the two "shard lock latency" metrics. The other one is more useful since it's collected on every usage instead of once in a while, and both read and write locks. Renaming the deadlock detector ones makes it more clear where they're coming from.

**How did you test it?**
Just renames.

**Potential risks**
The exported metric names are changing, so anyone using them will have to change. But it's unlikely anyone is using them since they were never documented. We can make a note in release notes.