### PR TITLE
Lock get current execution for API requests

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -509,6 +509,8 @@ const (
 	EnableHostHistoryCache = "history.enableHostHistoryCache"
 	// HistoryCacheShardLevelMaxSize is max size of history shard level cache
 	HistoryCacheShardLevelMaxSize = "history.shardLevelCacheMaxSize"
+	// EnableAPIGetCurrentRunIDLock controls if a lock should be acquired before getting current run ID for API requests
+	EnableAPIGetCurrentRunIDLock = "history.enableAPIGetCurrentRunIDLock"
 	// HistoryStartupMembershipJoinDelay is the duration a history instance waits
 	// before joining membership after starting.
 	HistoryStartupMembershipJoinDelay = "history.startupMembershipJoinDelay"

--- a/service/history/api/activity_util.go
+++ b/service/history/api/activity_util.go
@@ -54,6 +54,7 @@ func SetActivityTaskRunID(
 		ctx,
 		token.NamespaceId,
 		token.WorkflowId,
+		workflow.LockPriorityHigh,
 	)
 	if err != nil {
 		return err

--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -53,6 +53,7 @@ type (
 			ctx context.Context,
 			namespaceID string,
 			workflowID string,
+			lockPriority workflow.LockPriority,
 		) (string, error)
 		GetWorkflowContext(
 			ctx context.Context,
@@ -87,6 +88,7 @@ func (c *WorkflowConsistencyCheckerImpl) GetCurrentRunID(
 	ctx context.Context,
 	namespaceID string,
 	workflowID string,
+	lockPriority workflow.LockPriority,
 ) (string, error) {
 	// to achieve read after write consistency,
 	// logic need to assert shard ownership *at most once* per read API call
@@ -97,6 +99,7 @@ func (c *WorkflowConsistencyCheckerImpl) GetCurrentRunID(
 		&shardOwnershipAsserted,
 		namespaceID,
 		workflowID,
+		lockPriority,
 	)
 	if err != nil {
 		return "", err
@@ -261,6 +264,7 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentWorkflowContext(
 		shardOwnershipAsserted,
 		namespaceID,
 		workflowID,
+		lockPriority,
 	)
 	if err != nil {
 		return nil, err
@@ -284,6 +288,7 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentWorkflowContext(
 		shardOwnershipAsserted,
 		namespaceID,
 		workflowID,
+		lockPriority,
 	)
 	if err != nil {
 		wfContext.GetReleaseFn()(err)
@@ -302,7 +307,20 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentRunID(
 	shardOwnershipAsserted *bool,
 	namespaceID string,
 	workflowID string,
-) (string, error) {
+	lockPriority workflow.LockPriority,
+) (runID string, retErr error) {
+	_, release, err := c.workflowCache.GetOrCreateCurrentWorkflowExecution(
+		ctx,
+		c.shardContext,
+		namespace.ID(namespaceID),
+		workflowID,
+		lockPriority,
+	)
+	if err != nil {
+		return "", err
+	}
+	defer release(retErr)
+
 	resp, err := c.shardContext.GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{

--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -309,17 +309,19 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentRunID(
 	workflowID string,
 	lockPriority workflow.LockPriority,
 ) (runID string, retErr error) {
-	_, release, err := c.workflowCache.GetOrCreateCurrentWorkflowExecution(
-		ctx,
-		c.shardContext,
-		namespace.ID(namespaceID),
-		workflowID,
-		lockPriority,
-	)
-	if err != nil {
-		return "", err
+	if c.shardContext.GetConfig().EnableAPIGetCurrentRunIDLock() {
+		_, release, err := c.workflowCache.GetOrCreateCurrentWorkflowExecution(
+			ctx,
+			c.shardContext,
+			namespace.ID(namespaceID),
+			workflowID,
+			lockPriority,
+		)
+		if err != nil {
+			return "", err
+		}
+		defer release(retErr)
 	}
-	defer release(retErr)
 
 	resp, err := c.shardContext.GetCurrentExecution(
 		ctx,

--- a/service/history/api/consistency_checker_test.go
+++ b/service/history/api/consistency_checker_test.go
@@ -281,7 +281,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Success() {
 		},
 	).Return(&persistence.GetCurrentExecutionResponse{RunID: s.currentRunID}, nil)
 
-	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID)
+	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID, workflow.LockPriorityHigh)
 	s.NoError(err)
 	s.Equal(s.currentRunID, runID)
 }
@@ -300,7 +300,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_Ownership
 	).Return(nil, serviceerror.NewNotFound(""))
 	s.shardContext.EXPECT().AssertOwnership(ctx).Return(nil)
 
-	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID)
+	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID, workflow.LockPriorityHigh)
 	s.IsType(&serviceerror.NotFound{}, err)
 	s.Empty(runID)
 }
@@ -319,7 +319,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_Ownership
 	).Return(nil, serviceerror.NewNotFound(""))
 	s.shardContext.EXPECT().AssertOwnership(ctx).Return(&persistence.ShardOwnershipLostError{})
 
-	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID)
+	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID, workflow.LockPriorityHigh)
 	s.IsType(&persistence.ShardOwnershipLostError{}, err)
 	s.Empty(runID)
 }
@@ -337,7 +337,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Error() {
 		},
 	).Return(nil, serviceerror.NewUnavailable(""))
 
-	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID)
+	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID, workflow.LockPriorityHigh)
 	s.IsType(&serviceerror.Unavailable{}, err)
 	s.Empty(runID)
 }

--- a/service/history/api/consistency_checker_test.go
+++ b/service/history/api/consistency_checker_test.go
@@ -272,6 +272,17 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Success() {
 	ctx := context.Background()
 	shardOwnershipAsserted := false
 
+	wfContext := workflow.NewMockContext(s.controller)
+	released := false
+	releaseFn := func(err error) { released = true }
+
+	s.workflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
+		ctx,
+		s.shardContext,
+		namespace.ID(s.namespaceID),
+		s.workflowID,
+		workflow.LockPriorityHigh,
+	).Return(wfContext, releaseFn, nil)
 	s.shardContext.EXPECT().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{
@@ -284,12 +295,24 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Success() {
 	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID, workflow.LockPriorityHigh)
 	s.NoError(err)
 	s.Equal(s.currentRunID, runID)
+	s.True(released)
 }
 
 func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_OwnershipAsserted() {
 	ctx := context.Background()
 	shardOwnershipAsserted := false
 
+	wfContext := workflow.NewMockContext(s.controller)
+	released := false
+	releaseFn := func(err error) { released = true }
+
+	s.workflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
+		ctx,
+		s.shardContext,
+		namespace.ID(s.namespaceID),
+		s.workflowID,
+		workflow.LockPriorityHigh,
+	).Return(wfContext, releaseFn, nil)
 	s.shardContext.EXPECT().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{
@@ -303,12 +326,24 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_Ownership
 	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID, workflow.LockPriorityHigh)
 	s.IsType(&serviceerror.NotFound{}, err)
 	s.Empty(runID)
+	s.True(released)
 }
 
 func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_OwnershipLost() {
 	ctx := context.Background()
 	shardOwnershipAsserted := false
 
+	wfContext := workflow.NewMockContext(s.controller)
+	released := false
+	releaseFn := func(err error) { released = true }
+
+	s.workflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
+		ctx,
+		s.shardContext,
+		namespace.ID(s.namespaceID),
+		s.workflowID,
+		workflow.LockPriorityHigh,
+	).Return(wfContext, releaseFn, nil)
 	s.shardContext.EXPECT().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{
@@ -322,12 +357,24 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_Ownership
 	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID, workflow.LockPriorityHigh)
 	s.IsType(&persistence.ShardOwnershipLostError{}, err)
 	s.Empty(runID)
+	s.True(released)
 }
 
 func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Error() {
 	ctx := context.Background()
 	shardOwnershipAsserted := false
 
+	wfContext := workflow.NewMockContext(s.controller)
+	released := false
+	releaseFn := func(err error) { released = true }
+
+	s.workflowCache.EXPECT().GetOrCreateCurrentWorkflowExecution(
+		ctx,
+		s.shardContext,
+		namespace.ID(s.namespaceID),
+		s.workflowID,
+		workflow.LockPriorityHigh,
+	).Return(wfContext, releaseFn, nil)
 	s.shardContext.EXPECT().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{
@@ -340,6 +387,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Error() {
 	runID, err := s.checker.getCurrentRunID(ctx, &shardOwnershipAsserted, s.namespaceID, s.workflowID, workflow.LockPriorityHigh)
 	s.IsType(&serviceerror.Unavailable{}, err)
 	s.Empty(runID)
+	s.True(released)
 }
 
 func (s *workflowConsistencyCheckerSuite) TestAssertShardOwnership_FirstTime() {

--- a/service/history/api/consistency_checker_test.go
+++ b/service/history/api/consistency_checker_test.go
@@ -39,7 +39,6 @@ import (
 	historyspb "go.temporal.io/server/api/history/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/definition"
-	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/versionhistory"
@@ -87,7 +86,6 @@ func (s *workflowConsistencyCheckerSuite) SetupTest() {
 	s.shardContext = shard.NewMockContext(s.controller)
 	s.workflowCache = wcache.NewMockCache(s.controller)
 	s.config = tests.NewDynamicConfig()
-	s.config.EnableAPIGetCurrentRunIDLock = dynamicconfig.GetBoolPropertyFn(true)
 
 	s.shardID = rand.Int31()
 	s.namespaceID = uuid.New().String()

--- a/service/history/api/get_workflow_util.go
+++ b/service/history/api/get_workflow_util.go
@@ -64,6 +64,7 @@ func GetOrPollMutableState(
 			ctx,
 			request.NamespaceId,
 			request.Execution.WorkflowId,
+			workflow.LockPriorityHigh,
 		)
 		if err != nil {
 			return nil, err

--- a/service/history/api/queryworkflow/api.go
+++ b/service/history/api/queryworkflow/api.go
@@ -78,6 +78,7 @@ func Invoke(
 			ctx,
 			request.NamespaceId,
 			request.Request.Execution.WorkflowId,
+			workflow.LockPriorityHigh,
 		)
 		if err != nil {
 			return nil, err

--- a/service/history/api/resetworkflow/api.go
+++ b/service/history/api/resetworkflow/api.go
@@ -85,6 +85,7 @@ func Invoke(
 		ctx,
 		namespaceID.String(),
 		request.WorkflowExecution.GetWorkflowId(),
+		workflow.LockPriorityHigh,
 	)
 	if err != nil {
 		return nil, err

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -181,9 +181,11 @@ func (s *Starter) Invoke(
 		return s.generateResponse(creationParams.runID, creationParams.workflowTaskInfo, extractHistoryEvents(creationParams.workflowEventBatches))
 	}
 	var currentWorkflowConditionFailedError *persistence.CurrentWorkflowConditionFailedError
-	if !errors.As(err, &currentWorkflowConditionFailedError) {
+	if !errors.As(err, &currentWorkflowConditionFailedError) ||
+		len(currentWorkflowConditionFailedError.RunID) == 0 {
 		return nil, err
 	}
+
 	// The history and mutable state we generated above should be deleted by a background process.
 	return s.handleConflict(ctx, creationParams, currentWorkflowConditionFailedError)
 }
@@ -346,6 +348,8 @@ func (s *Starter) applyWorkflowIDReusePolicy(
 	}
 	var mutableStateInfo *mutableStateInfo
 	// update prev execution and create new execution in one transaction
+	// we already validated that currentWorkflowConditionFailed.RunID is not empty,
+	// so the following update won't try to lock current execution again.
 	err = api.GetAndUpdateWorkflowWithNew(
 		ctx,
 		nil,

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -74,6 +74,7 @@ type Config struct {
 	HistoryCacheNonUserContextLockTimeout dynamicconfig.DurationPropertyFn
 	EnableHostLevelHistoryCache           dynamicconfig.BoolPropertyFn
 	HistoryShardLevelCacheMaxSize         dynamicconfig.IntPropertyFn
+	EnableAPIGetCurrentRunIDLock          dynamicconfig.BoolPropertyFn
 
 	// EventsCache settings
 	// Change of these configs require shard restart
@@ -362,6 +363,7 @@ func NewConfig(
 		HistoryCacheNonUserContextLockTimeout: dc.GetDurationProperty(dynamicconfig.HistoryCacheNonUserContextLockTimeout, 500*time.Millisecond),
 		EnableHostLevelHistoryCache:           dc.GetBoolProperty(dynamicconfig.EnableHostHistoryCache, false),
 		HistoryShardLevelCacheMaxSize:         dc.GetIntProperty(dynamicconfig.HistoryCacheShardLevelMaxSize, 512),
+		EnableAPIGetCurrentRunIDLock:          dc.GetBoolProperty(dynamicconfig.EnableAPIGetCurrentRunIDLock, false),
 
 		EventsCacheMaxSizeBytes: dc.GetIntProperty(dynamicconfig.EventsCacheMaxSizeBytes, 512*1024), // 512KB
 		EventsCacheTTL:          dc.GetDurationProperty(dynamicconfig.EventsCacheTTL, time.Hour),

--- a/service/history/tests/vars.go
+++ b/service/history/tests/vars.go
@@ -185,5 +185,6 @@ func NewDynamicConfig() *configs.Config {
 	config.EnableActivityEagerExecution = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.EnableEagerWorkflowStart = dynamicconfig.GetBoolPropertyFnFilteredByNamespace(true)
 	config.NamespaceCacheRefreshInterval = dynamicconfig.GetDurationPropertyFn(time.Second)
+	config.EnableAPIGetCurrentRunIDLock = dynamicconfig.GetBoolPropertyFn(true)
 	return config
 }

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -831,6 +831,8 @@ func (c *temporalImpl) overrideHistoryDynamicConfig(client *dcClient) {
 	// For DeleteWorkflowExecution tests
 	client.OverrideValue(dynamicconfig.TransferProcessorUpdateAckInterval, 1*time.Second)
 	client.OverrideValue(dynamicconfig.VisibilityProcessorUpdateAckInterval, 1*time.Second)
+
+	client.OverrideValue(dynamicconfig.EnableAPIGetCurrentRunIDLock, true)
 }
 
 func (c *temporalImpl) newRPCFactory(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Grab current execution lock when consistency checker (used for serving api requests) need to get current runID.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Prevent the case where large # of requests for the same workflowID try to get runID from db at the same time and cause hot shard problem.
- Ideally for requests with no runID, the current workflow lock should be hold for the entire lifetime of the request (or until the concrete record is locked), to prevent the race where current runID get changed after it's retrieved from DB. But that requires much larger change. This PR is just a short term hotfix for the issue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Updated existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Reduced concurrency for requests targeting the same workflowID

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
- Yes.