### PR TITLE
Fix GenerateMigrationTasks behavior

### DIFF
--- a/service/history/api/replication/generate_task.go
+++ b/service/history/api/replication/generate_task.go
@@ -66,7 +66,7 @@ func GenerateTask(
 	defer func() { wfContext.GetReleaseFn()(retError) }()
 
 	mutableState := wfContext.GetMutableState()
-	task, stateTransitionCount, err := mutableState.GenerateMigrationTasks()
+	replicationTasks, stateTransitionCount, err := mutableState.GenerateMigrationTasks()
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +78,7 @@ func GenerateTask(
 		WorkflowID:  request.Execution.WorkflowId,
 		RunID:       request.Execution.RunId,
 		Tasks: map[tasks.Category][]tasks.Task{
-			tasks.CategoryReplication: {task},
+			tasks.CategoryReplication: replicationTasks,
 		},
 	})
 	if err != nil {

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -307,7 +307,7 @@ type (
 		StartTransaction(entry *namespace.Namespace) (bool, error)
 		CloseTransactionAsMutation(transactionPolicy TransactionPolicy) (*persistence.WorkflowMutation, []*persistence.WorkflowEvents, error)
 		CloseTransactionAsSnapshot(transactionPolicy TransactionPolicy) (*persistence.WorkflowSnapshot, []*persistence.WorkflowEvents, error)
-		GenerateMigrationTasks() (tasks.Task, int64, error)
+		GenerateMigrationTasks() ([]tasks.Task, int64, error)
 
 		// ContinueAsNewMinBackoff calculate minimal backoff for next ContinueAsNew run.
 		// Input backoffDuration is current backoff for next run.

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4606,7 +4606,7 @@ func (ms *MutableStateImpl) UpdateDuplicatedResource(
 	ms.appliedEvents[id] = struct{}{}
 }
 
-func (ms *MutableStateImpl) GenerateMigrationTasks() (tasks.Task, int64, error) {
+func (ms *MutableStateImpl) GenerateMigrationTasks() ([]tasks.Task, int64, error) {
 	return ms.taskGenerator.GenerateMigrationTasks()
 }
 

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -985,10 +985,10 @@ func (mr *MockMutableStateMockRecorder) FlushBufferedEvents() *gomock.Call {
 }
 
 // GenerateMigrationTasks mocks base method.
-func (m *MockMutableState) GenerateMigrationTasks() (tasks.Task, int64, error) {
+func (m *MockMutableState) GenerateMigrationTasks() ([]tasks.Task, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateMigrationTasks")
-	ret0, _ := ret[0].(tasks.Task)
+	ret0, _ := ret[0].([]tasks.Task)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -96,7 +96,7 @@ type (
 		GenerateHistoryReplicationTasks(
 			events []*historypb.HistoryEvent,
 		) error
-		GenerateMigrationTasks() (tasks.Task, int64, error)
+		GenerateMigrationTasks() ([]tasks.Task, int64, error)
 	}
 
 	TaskGeneratorImpl struct {
@@ -604,7 +604,7 @@ func (r *TaskGeneratorImpl) GenerateHistoryReplicationTasks(
 	return nil
 }
 
-func (r *TaskGeneratorImpl) GenerateMigrationTasks() (tasks.Task, int64, error) {
+func (r *TaskGeneratorImpl) GenerateMigrationTasks() ([]tasks.Task, int64, error) {
 	executionInfo := r.mutableState.GetExecutionInfo()
 	versionHistory, err := versionhistory.GetCurrentVersionHistory(executionInfo.GetVersionHistories())
 	if err != nil {
@@ -615,21 +615,37 @@ func (r *TaskGeneratorImpl) GenerateMigrationTasks() (tasks.Task, int64, error) 
 		return nil, 0, err
 	}
 
+	workflowKey := r.mutableState.GetWorkflowKey()
+
 	if r.mutableState.GetExecutionState().State == enumsspb.WORKFLOW_EXECUTION_STATE_COMPLETED {
-		return &tasks.SyncWorkflowStateTask{
+		return []tasks.Task{&tasks.SyncWorkflowStateTask{
 			// TaskID, VisibilityTimestamp is set by shard
-			WorkflowKey: r.mutableState.GetWorkflowKey(),
+			WorkflowKey: workflowKey,
 			Version:     lastItem.GetVersion(),
-		}, 1, nil
-	} else {
-		return &tasks.HistoryReplicationTask{
-			// TaskID, VisibilityTimestamp is set by shard
-			WorkflowKey:  r.mutableState.GetWorkflowKey(),
-			FirstEventID: executionInfo.LastFirstEventId,
-			NextEventID:  lastItem.GetEventId() + 1,
-			Version:      lastItem.GetVersion(),
-		}, executionInfo.StateTransitionCount, nil
+		}}, 1, nil
 	}
+
+	now := time.Now().UTC()
+	replicationTasks := make([]tasks.Task, 0, len(r.mutableState.GetPendingActivityInfos())+1)
+	replicationTasks = append(replicationTasks, &tasks.HistoryReplicationTask{
+		// TaskID, VisibilityTimestamp is set by shard
+		WorkflowKey:  workflowKey,
+		FirstEventID: executionInfo.LastFirstEventId,
+		NextEventID:  lastItem.GetEventId() + 1,
+		Version:      lastItem.GetVersion(),
+	})
+	activityIDs := make(map[int64]struct{}, len(r.mutableState.GetPendingActivityInfos()))
+	for activityID := range r.mutableState.GetPendingActivityInfos() {
+		activityIDs[activityID] = struct{}{}
+	}
+	replicationTasks = append(replicationTasks, convertSyncActivityInfos(
+		now,
+		workflowKey,
+		r.mutableState.GetPendingActivityInfos(),
+		activityIDs,
+	)...)
+	return replicationTasks, executionInfo.StateTransitionCount, nil
+
 }
 
 func (r *TaskGeneratorImpl) getTimerSequence() TimerSequence {

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -174,10 +174,10 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateHistoryReplicationTasks(events 
 }
 
 // GenerateMigrationTasks mocks base method.
-func (m *MockTaskGenerator) GenerateMigrationTasks() (tasks.Task, int64, error) {
+func (m *MockTaskGenerator) GenerateMigrationTasks() ([]tasks.Task, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateMigrationTasks")
-	ret0, _ := ret[0].(tasks.Task)
+	ret0, _ := ret[0].([]tasks.Task)
 	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* GenerateMigrationTasks API should also propagate pending activity info

<!-- Tell your future self why have you made these changes -->
**Why?**
For namespace migration, history events as well as (updated) activity info both should be replicated

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
N/A