### PR TITLE
silence verbose `proto` target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ FUNCTIONAL_TEST_COVERPKG := -coverpkg="$(MODULE_ROOT)/client/...,$(MODULE_ROOT)/
 
 # Only prints output if the exit code is non-zero
 define silent_exec
-    @output=$$( $(1) 2>&1); \
+    @output=`$(1) 2>&1`; \
     status=$$?; \
     if [ $$status -ne 0 ]; then \
         echo "$$output"; \

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ FUNCTIONAL_TEST_COVERPKG := -coverpkg="$(MODULE_ROOT)/client/...,$(MODULE_ROOT)/
 
 # Only prints output if the exit code is non-zero
 define silent_exec
-    @output=`$(1) 2>&1`; \
+    @output=$$($(1) 2>&1); \
     status=$$?; \
     if [ $$status -ne 0 ]; then \
         echo "$$output"; \

--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,16 @@ SQL_PASSWORD ?= temporal
 INTEGRATION_TEST_COVERPKG := -coverpkg="$(MODULE_ROOT)/common/persistence/...,$(MODULE_ROOT)/tools/..."
 FUNCTIONAL_TEST_COVERPKG := -coverpkg="$(MODULE_ROOT)/client/...,$(MODULE_ROOT)/common/...,$(MODULE_ROOT)/service/...,$(MODULE_ROOT)/temporal/...,$(MODULE_ROOT)/tools/..."
 
+# Only prints output if the exit code is non-zero
+define silent_exec
+    @output=$$( $(1) 2>&1); \
+    status=$$?; \
+    if [ $$status -ne 0 ]; then \
+        echo "$$output"; \
+    fi; \
+    exit $$status
+endef
+
 ##### Tools #####
 update-goimports:
 	@printf $(COLOR) "Install/update goimports..."
@@ -166,15 +176,15 @@ install-proto-submodule:
 
 protoc: $(PROTO_OUT)
 	@printf $(COLOR) "Build proto files..."
-# Run protoc separately for each directory because of different package names.
+	@# Run protoc separately for each directory because of different package names.
 	$(foreach PROTO_DIR,$(PROTO_DIRS),\
-		protoc --fatal_warnings $(PROTO_IMPORTS) \
+		@protoc --fatal_warnings $(PROTO_IMPORTS) \
 		 	--gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:$(PROTO_OUT) \
 			$(PROTO_DIR)*.proto \
 	$(NEWLINE))
 
 fix-proto-path:
-	mv -f $(PROTO_OUT)/temporal/server/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
+	@mv -f $(PROTO_OUT)/temporal/server/api/* $(PROTO_OUT) && rm -rf $(PROTO_OUT)/temporal
 
 # All gRPC generated service files pathes relative to PROTO_OUT.
 PROTO_GRPC_SERVICES = $(patsubst $(PROTO_OUT)/%,%,$(shell find $(PROTO_OUT) -name "service.pb.go"))
@@ -184,7 +194,7 @@ mock_file_name = $(call service_name,$(1))mock/$(subst $(call service_name,$(1))
 proto-mocks: $(PROTO_OUT)
 	@printf $(COLOR) "Generate proto mocks..."
 	$(foreach PROTO_GRPC_SERVICE,$(PROTO_GRPC_SERVICES),\
-		cd $(PROTO_OUT) && \
+		@cd $(PROTO_OUT) && \
 		mockgen -copyright_file ../LICENSE -package $(call service_name,$(PROTO_GRPC_SERVICE))mock -source $(PROTO_GRPC_SERVICE) -destination $(call mock_file_name,$(PROTO_GRPC_SERVICE)) \
 	$(NEWLINE))
 
@@ -251,7 +261,7 @@ lint:
 
 api-linter:
 	@printf $(COLOR) "Run api-linter..."
-	@api-linter --set-exit-status $(PROTO_IMPORTS) --config=$(PROTO_ROOT)/api-linter.yaml $(PROTO_FILES)
+	$(call silent_exec, api-linter --set-exit-status $(PROTO_IMPORTS) --config=$(PROTO_ROOT)/api-linter.yaml $(PROTO_FILES))
 
 buf-lint:
 	@printf $(COLOR) "Run buf linter..."


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

The make target `proto` is quieter now when it succeeds (like most of our other Makefile targets).

### After

```
$ make proto
Run buf linter...
Run api-linter...
Build proto files...
Run goimports for proto files...
Generate proto mocks...
Update license headers for proto files...
```

### Before

```
$ make proto
Install proto submodule...
git submodule update --init proto/api
Run buf linter...
Run api-linter...
- file_path: temporal/server/api/token/v1/message.proto
  problems: []
- file_path: temporal/server/api/metrics/v1/message.proto
  problems: []
- file_path: temporal/server/api/taskqueue/v1/message.proto
  problems: []
- file_path: temporal/server/api/cluster/v1/message.proto
  problems: []
- file_path: temporal/server/api/schedule/v1/message.proto
  problems: []
- file_path: temporal/server/api/update/v1/message.proto
  problems: []
- file_path: temporal/server/api/matchingservice/v1/service.proto
  problems: []
- file_path: temporal/server/api/matchingservice/v1/request_response.proto
  problems: []
- file_path: temporal/server/api/enums/v1/workflow_task_type.proto
  problems: []
- file_path: temporal/server/api/enums/v1/task.proto
  problems: []
- file_path: temporal/server/api/enums/v1/cluster.proto
  problems: []
- file_path: temporal/server/api/enums/v1/predicate.proto
  problems: []
- file_path: temporal/server/api/enums/v1/replication.proto
  problems: []
- file_path: temporal/server/api/enums/v1/workflow.proto
  problems: []
- file_path: temporal/server/api/enums/v1/common.proto
  problems: []
- file_path: temporal/server/api/archiver/v1/message.proto
  problems: []
- file_path: temporal/server/api/namespace/v1/message.proto
  problems: []
- file_path: temporal/server/api/cli/v1/message.proto
  problems: []
- file_path: temporal/server/api/historyservice/v1/service.proto
  problems: []
- file_path: temporal/server/api/historyservice/v1/request_response.proto
  problems: []
- file_path: temporal/server/api/workflow/v1/message.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/task_queues.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/predicates.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/cluster_metadata.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/tasks.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/executions.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/history_tree.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/namespaces.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/queue_metadata.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/queues.proto
  problems: []
- file_path: temporal/server/api/persistence/v1/workflow_mutable_state.proto
  problems: []
- file_path: temporal/server/api/history/v1/message.proto
  problems: []
- file_path: temporal/server/api/replication/v1/message.proto
  problems: []
- file_path: temporal/server/api/checksum/v1/message.proto
  problems: []
- file_path: temporal/server/api/errordetails/v1/message.proto
  problems: []
- file_path: temporal/server/api/clock/v1/message.proto
  problems: []
- file_path: temporal/server/api/adminservice/v1/service.proto
  problems: []
- file_path: temporal/server/api/adminservice/v1/request_response.proto
  problems: []
Build proto files...
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/adminservice/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/archiver/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/checksum/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/cli/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/clock/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/cluster/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/enums/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/errordetails/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/history/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/historyservice/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/matchingservice/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/metrics/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/namespace/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/persistence/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/replication/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/schedule/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/taskqueue/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/token/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/update/v1/*.proto
protoc --fatal_warnings -I=proto/internal -I=proto/api -I=../golang/1.21.0/packages/pkg/mod/github.com/temporalio/gogo-protobuf@v1.22.1/protobuf --gogoslick_out=Mgoogle/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,Mgoogle/protobuf/duration.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/wrappers.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/timestamp.proto=github.com/gogo/protobuf/types,Mgoogle/protobuf/empty.proto=github.com/gogo/protobuf/types,plugins=grpc,paths=source_relative:api ./proto/internal/temporal/server/api/workflow/v1/*.proto
mv -f api/temporal/server/api/* api && rm -rf api/temporal
Run goimports for proto files...
Generate proto mocks...
cd api && mockgen -copyright_file ../LICENSE -package matchingservicemock -source matchingservice/v1/service.pb.go -destination matchingservicemock/v1/service.pb.mock.go 
cd api && mockgen -copyright_file ../LICENSE -package historyservicemock -source historyservice/v1/service.pb.go -destination historyservicemock/v1/service.pb.mock.go 
cd api && mockgen -copyright_file ../LICENSE -package adminservicemock -source adminservice/v1/service.pb.go -destination adminservicemock/v1/service.pb.mock.go 
Update license headers for proto files...
```

<!-- Tell your future self why have you made these changes -->
**Why?**

Success output shouldn't be verbose; error output should be.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- [x] happy case (no errors)
- [x] linter errors: errors are still printed and target fails

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Targets silently breaking?

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No