### PR TITLE
Single metric for commands in History Service

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -768,29 +768,45 @@ var (
 		"pending_tasks",
 		WithDescription("A histogram across history shards for the number of in-memory pending history tasks."),
 	)
-	TaskSchedulerThrottled                               = NewCounterDef("task_scheduler_throttled")
-	QueueScheduleLatency                                 = NewTimerDef("queue_latency_schedule") // latency for scheduling 100 tasks in one task channel
-	QueueReaderCountHistogram                            = NewDimensionlessHistogramDef("queue_reader_count")
-	QueueSliceCountHistogram                             = NewDimensionlessHistogramDef("queue_slice_count")
-	QueueActionCounter                                   = NewCounterDef("queue_actions")
-	QueueActionFailures                                  = NewCounterDef("queue_action_errors")
-	ActivityE2ELatency                                   = NewTimerDef("activity_end_to_end_latency")
-	AckLevelUpdateCounter                                = NewCounterDef("ack_level_update")
-	AckLevelUpdateFailedCounter                          = NewCounterDef("ack_level_update_failed")
-	CommandTypeScheduleActivityCounter                   = NewCounterDef("schedule_activity_command")
-	CommandTypeCompleteWorkflowCounter                   = NewCounterDef("complete_workflow_command")
-	CommandTypeFailWorkflowCounter                       = NewCounterDef("fail_workflow_command")
-	CommandTypeCancelWorkflowCounter                     = NewCounterDef("cancel_workflow_command")
-	CommandTypeStartTimerCounter                         = NewCounterDef("start_timer_command")
-	CommandTypeCancelActivityCounter                     = NewCounterDef("cancel_activity_command")
-	CommandTypeCancelTimerCounter                        = NewCounterDef("cancel_timer_command")
-	CommandTypeRecordMarkerCounter                       = NewCounterDef("record_marker_command")
-	CommandTypeCancelExternalWorkflowCounter             = NewCounterDef("cancel_external_workflow_command")
-	CommandTypeContinueAsNewCounter                      = NewCounterDef("continue_as_new_command")
-	CommandTypeSignalExternalWorkflowCounter             = NewCounterDef("signal_external_workflow_command")
-	CommandTypeUpsertWorkflowSearchAttributesCounter     = NewCounterDef("upsert_workflow_search_attributes_command")
-	CommandTypeModifyWorkflowPropertiesCounter           = NewCounterDef("modify_workflow_properties_command")
-	CommandTypeChildWorkflowCounter                      = NewCounterDef("child_workflow_command")
+	TaskSchedulerThrottled      = NewCounterDef("task_scheduler_throttled")
+	QueueScheduleLatency        = NewTimerDef("queue_latency_schedule") // latency for scheduling 100 tasks in one task channel
+	QueueReaderCountHistogram   = NewDimensionlessHistogramDef("queue_reader_count")
+	QueueSliceCountHistogram    = NewDimensionlessHistogramDef("queue_slice_count")
+	QueueActionCounter          = NewCounterDef("queue_actions")
+	QueueActionFailures         = NewCounterDef("queue_action_errors")
+	ActivityE2ELatency          = NewTimerDef("activity_end_to_end_latency")
+	AckLevelUpdateCounter       = NewCounterDef("ack_level_update")
+	AckLevelUpdateFailedCounter = NewCounterDef("ack_level_update_failed")
+	CommandCounter              = NewCounterDef("command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeScheduleActivityCounter = NewCounterDef("schedule_activity_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeCompleteWorkflowCounter = NewCounterDef("complete_workflow_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeFailWorkflowCounter = NewCounterDef("fail_workflow_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeCancelWorkflowCounter = NewCounterDef("cancel_workflow_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeStartTimerCounter = NewCounterDef("start_timer_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeCancelActivityCounter = NewCounterDef("cancel_activity_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeCancelTimerCounter = NewCounterDef("cancel_timer_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeRecordMarkerCounter = NewCounterDef("record_marker_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeCancelExternalWorkflowCounter = NewCounterDef("cancel_external_workflow_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeContinueAsNewCounter = NewCounterDef("continue_as_new_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeSignalExternalWorkflowCounter = NewCounterDef("signal_external_workflow_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeUpsertWorkflowSearchAttributesCounter = NewCounterDef("upsert_workflow_search_attributes_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeModifyWorkflowPropertiesCounter = NewCounterDef("modify_workflow_properties_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
+	CommandTypeChildWorkflowCounter = NewCounterDef("child_workflow_command")
+	// Deprecated: replaced by CommandCounter and will be removed in a future release
 	CommandTypeProtocolMessage                           = NewCounterDef("protocol_message_command")
 	MessageTypeRequestWorkflowExecutionUpdateCounter     = NewCounterDef("request_workflow_update_message")
 	MessageTypeAcceptWorkflowExecutionUpdateCounter      = NewCounterDef("accept_workflow_update_message")

--- a/service/history/workflow_task_handler.go
+++ b/service/history/workflow_task_handler.go
@@ -129,7 +129,6 @@ func newWorkflowTaskHandler(
 	searchAttributesMapperProvider searchattribute.MapperProvider,
 	hasBufferedEvents bool,
 ) *workflowTaskHandlerImpl {
-
 	return &workflowTaskHandlerImpl{
 		identity:                identity,
 		workflowTaskCompletedID: workflowTaskCompletedID,
@@ -152,10 +151,13 @@ func newWorkflowTaskHandler(
 
 		logger:            logger,
 		namespaceRegistry: namespaceRegistry,
-		metricsHandler:    metricsHandler.WithTags(metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope)),
-		config:            config,
-		shard:             shard,
-		tokenSerializer:   common.NewProtoTaskTokenSerializer(),
+		metricsHandler: metricsHandler.WithTags(
+			metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope),
+			metrics.NamespaceTag(mutableState.GetNamespaceEntry().Name().String()),
+		),
+		config:          config,
+		shard:           shard,
+		tokenSerializer: common.NewProtoTaskTokenSerializer(),
 	}
 }
 
@@ -216,10 +218,8 @@ func (handler *workflowTaskHandlerImpl) handleCommand(
 	msgs *collection.IndexedTakeList[string, *protocolpb.Message],
 ) (*handleCommandResponse, error) {
 
-	handler.metricsHandler.Counter(metrics.CommandCounter.GetMetricName()).Record(
-		1,
-		metrics.NamespaceTag(handler.mutableState.GetExecutionInfo().NamespaceId),
-		metrics.CommandTypeTag(command.GetCommandType().String()))
+	handler.metricsHandler.Counter(metrics.CommandCounter.GetMetricName()).
+		Record(1, metrics.CommandTypeTag(command.GetCommandType().String()))
 
 	switch command.GetCommandType() {
 	case enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK:

--- a/service/history/workflow_task_handler.go
+++ b/service/history/workflow_task_handler.go
@@ -215,6 +215,12 @@ func (handler *workflowTaskHandlerImpl) handleCommand(
 	command *commandpb.Command,
 	msgs *collection.IndexedTakeList[string, *protocolpb.Message],
 ) (*handleCommandResponse, error) {
+
+	handler.metricsHandler.Counter(metrics.CommandCounter.GetMetricName()).Record(
+		1,
+		metrics.NamespaceTag(handler.mutableState.GetExecutionInfo().NamespaceId),
+		metrics.CommandTypeTag(command.GetCommandType().String()))
+
 	switch command.GetCommandType() {
 	case enumspb.COMMAND_TYPE_SCHEDULE_ACTIVITY_TASK:
 		return handler.handleCommandScheduleActivity(ctx, command.GetScheduleActivityTaskCommandAttributes())

--- a/service/history/workflow_task_handler_test.go
+++ b/service/history/workflow_task_handler_test.go
@@ -38,6 +38,7 @@ import (
 	protocolpb "go.temporal.io/api/protocol/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
+	"go.temporal.io/server/service/history/tests"
 
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/collection"
@@ -83,6 +84,7 @@ func TestCommandProtocolMessage(t *testing.T) {
 		out.conf = map[dynamicconfig.Key]any{}
 		out.ms = workflow.NewMockMutableState(gomock.NewController(t))
 		out.ms.EXPECT().VisitUpdates(gomock.Any()).Times(1)
+		out.ms.EXPECT().GetNamespaceEntry().Return(tests.LocalNamespaceEntry).Times(1)
 		out.updates = update.NewRegistry(func() update.Store { return out.ms })
 		var effects effect.Buffer
 		config := configs.NewConfig(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

(1) Added new single metric to track _all_ commands coming into the History Service.
(2) Marked previous per-command-metrics as deprecated (will be removed in future release).
(3) Added namespace tag to metric.  

<!-- Tell your future self why have you made these changes -->
**Why?**

Fixes https://github.com/temporalio/temporal/issues/4628

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Used the debugger to inspect during a test:

![Screenshot 2023-10-17 at 4 38 25 PM](https://github.com/temporalio/temporal/assets/159852/0eb09b1a-27e3-4189-969e-c613fba4c67b)

Is there a better way?

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No