### PR TITLE
Reuse cached RemoteAdminClient in VerifyReplicationTasks

### DIFF
--- a/service/worker/migration/fx.go
+++ b/service/worker/migration/fx.go
@@ -53,6 +53,7 @@ type (
 		HistoryClient             resource.HistoryClient
 		FrontendClient            workflowservice.WorkflowServiceClient
 		ClientFactory             serverClient.Factory
+		ClientBean                serverClient.Bean
 		NamespaceReplicationQueue persistence.NamespaceReplicationQueue
 		TaskManager               persistence.TaskManager
 		Logger                    log.Logger
@@ -104,6 +105,7 @@ func (wc *replicationWorkerComponent) activities() *activities {
 		historyClient:                  wc.HistoryClient,
 		frontendClient:                 wc.FrontendClient,
 		clientFactory:                  wc.ClientFactory,
+		clientBean:                     wc.ClientBean,
 		namespaceReplicationQueue:      wc.NamespaceReplicationQueue,
 		taskManager:                    wc.TaskManager,
 		logger:                         wc.Logger,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Current code create a new AdminClient for every VerifyReplicationTasks activity invocation. Since there is no way to close a connection, it caused a leak. This change uses cached version for creating AdminClient.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests + local cluster tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
