### PR TITLE
Extract new queues.DLQWriter type

### DIFF
--- a/service/history/queue_factory_base.go
+++ b/service/history/queue_factory_base.go
@@ -27,6 +27,7 @@ package history
 import (
 	"context"
 
+	"go.temporal.io/server/common/persistence"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common/clock"
@@ -91,9 +92,13 @@ type (
 )
 
 var QueueModule = fx.Options(
-	fx.Provide(QueueSchedulerRateLimiterProvider),
-	fx.Provide(NewExecutableDLQWrapper),
 	fx.Provide(
+		QueueSchedulerRateLimiterProvider,
+		func(tqm persistence.HistoryTaskQueueManager) queues.QueueWriter {
+			return tqm
+		},
+		queues.NewDLQWriter,
+		NewExecutableDLQWrapper,
 		fx.Annotated{
 			Group:  QueueFactoryFxGroup,
 			Target: NewTransferQueueFactory,

--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -1,0 +1,87 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	// DLQWriter can be used to write tasks to the DLQ.
+	DLQWriter struct {
+		dlqWriter QueueWriter
+	}
+	// QueueWriter is a subset of persistence.HistoryTaskQueueManager.
+	QueueWriter interface {
+		CreateQueue(
+			ctx context.Context,
+			request *persistence.CreateQueueRequest,
+		) (*persistence.CreateQueueResponse, error)
+		EnqueueTask(
+			ctx context.Context,
+			request *persistence.EnqueueTaskRequest,
+		) (*persistence.EnqueueTaskResponse, error)
+	}
+)
+
+// NewDLQWriter returns a DLQ which will write to the given QueueWriter.
+func NewDLQWriter(w QueueWriter) *DLQWriter {
+	return &DLQWriter{
+		dlqWriter: w,
+	}
+}
+
+// WriteTaskToDLQ writes a task to the DLQ, creating the underlying queue if it doesn't already exist.
+func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetCluster string, task tasks.Task) error {
+	queueKey := persistence.QueueKey{
+		QueueType:     persistence.QueueTypeHistoryDLQ,
+		Category:      task.GetCategory(),
+		SourceCluster: sourceCluster,
+		TargetCluster: targetCluster,
+	}
+	_, err := q.dlqWriter.CreateQueue(ctx, &persistence.CreateQueueRequest{
+		QueueKey: queueKey,
+	})
+	if err != nil {
+		if !errors.Is(err, persistence.ErrQueueAlreadyExists) {
+			return fmt.Errorf("%w: %v", ErrCreateDLQ, err)
+		}
+	}
+	_, err = q.dlqWriter.EnqueueTask(ctx, &persistence.EnqueueTaskRequest{
+		QueueType:     queueKey.QueueType,
+		SourceCluster: queueKey.SourceCluster,
+		TargetCluster: queueKey.TargetCluster,
+		Task:          task,
+	})
+	if err != nil {
+		return fmt.Errorf("%w: %v", ErrSendTaskToDLQ, err)
+	}
+	return nil
+}

--- a/service/history/queues/executable_dlq_observer_test.go
+++ b/service/history/queues/executable_dlq_observer_test.go
@@ -111,7 +111,7 @@ func TestExecutableDLQObserver(t *testing.T) {
 	}
 	timeSource := clock.NewEventTimeSource()
 
-	dlq := &queuestest.FakeDLQ{}
+	dlq := &queuestest.FakeQueueWriter{}
 	logger := &testLogger{}
 	metricsHandler := metricstest.NewCaptureHandler()
 	capture := metricsHandler.StartCapture()
@@ -213,7 +213,7 @@ func TestExecutableDLQObserver_GetNamespaceByIDErr(t *testing.T) {
 	}
 	timeSource := clock.NewEventTimeSource()
 
-	dlq := &queuestest.FakeDLQ{}
+	dlq := &queuestest.FakeQueueWriter{}
 	logger := &testLogger{}
 	metricsHandler := metricstest.NewCaptureHandler()
 	capture := metricsHandler.StartCapture()

--- a/service/history/queues/queuestest/executable_dlq_test_suite.go
+++ b/service/history/queues/queuestest/executable_dlq_test_suite.go
@@ -75,7 +75,8 @@ func TestExecutable(t *testing.T, tqm persistence.HistoryTaskQueueManager) {
 			clusterName := "test-cluster-" + t.Name()
 
 			var executable queues.Executable = NewFakeExecutable(task, tc.err)
-			executable = queues.NewExecutableDLQ(executable, tqm, clock.NewEventTimeSource(), clusterName)
+			dlqWriter := queues.NewDLQWriter(tqm)
+			executable = queues.NewExecutableDLQ(executable, dlqWriter, clock.NewEventTimeSource(), clusterName)
 			err := executable.Execute()
 			assert.ErrorContains(t, err, tc.err.Error())
 			if tc.shouldDLQ {

--- a/service/history/queues/queuestest/fake_queue_writer.go
+++ b/service/history/queues/queuestest/fake_queue_writer.go
@@ -31,25 +31,24 @@ import (
 	"go.temporal.io/server/service/history/queues"
 )
 
-// FakeDLQ is a DLQ which records the requests it receives and returns the given error upon DLQ.EnqueueTask.
-type FakeDLQ struct {
-	// Requests to write to the DLQ
-	Requests       []*persistence.EnqueueTaskRequest
-	EnqueueTaskErr error
-	CreateQueueErr error
+// FakeQueueWriter is a [queues.QueueWriter] which records the requests it receives and returns the provided errors.
+type FakeQueueWriter struct {
+	EnqueueTaskRequests []*persistence.EnqueueTaskRequest
+	EnqueueTaskErr      error
+	CreateQueueErr      error
 }
 
-var _ queues.DLQ = (*FakeDLQ)(nil)
+var _ queues.QueueWriter = (*FakeQueueWriter)(nil)
 
-func (d *FakeDLQ) EnqueueTask(
+func (d *FakeQueueWriter) EnqueueTask(
 	_ context.Context,
 	request *persistence.EnqueueTaskRequest,
 ) (*persistence.EnqueueTaskResponse, error) {
-	d.Requests = append(d.Requests, request)
+	d.EnqueueTaskRequests = append(d.EnqueueTaskRequests, request)
 	return nil, d.EnqueueTaskErr
 }
 
-func (d *FakeDLQ) CreateQueue(
+func (d *FakeQueueWriter) CreateQueue(
 	context.Context,
 	*persistence.CreateQueueRequest,
 ) (*persistence.CreateQueueResponse, error) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I extracted a `DLQWriter` from our `ExecutableDLQ` type in the `queues` package.

<!-- Tell your future self why have you made these changes -->
**Why?**
For the replication DLQ, we don't want `ExecutableDLQ` because replication tasks track their state in a different way, and so they have an explicit `MarkPoisonPill` method. The `ExecutableDLQ` currently does 2 things:

1. Track whether this executable failed with a terminal error
2. If it did, try sending the task to the DLQ whenever we execute again

So, for replication tasks, I only need the second part. I went ahead and extracted that to its own type as some preparatory refactoring for the replication DLQ change.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This is already fully tested by `executable_dlq_test.go`.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
