### PR TITLE
Add a history replication DLQ test

### DIFF
--- a/service/worker/fx.go
+++ b/service/worker/fx.go
@@ -27,11 +27,14 @@ package worker
 import (
 	"go.uber.org/fx"
 
+	"go.temporal.io/server/common/cluster"
 	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/membership"
 	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/visibility"
 	"go.temporal.io/server/common/persistence/visibility/manager"
 	esclient "go.temporal.io/server/common/persistence/visibility/store/elasticsearch/client"
@@ -67,6 +70,17 @@ var Module = fx.Options(
 	fx.Provide(PersistenceRateLimitingParamsProvider),
 	service.PersistenceLazyLoadedServiceResolverModule,
 	fx.Provide(ServiceResolverProvider),
+	fx.Provide(func(
+		clusterMetadata cluster.Metadata,
+		metadataManager persistence.MetadataManager,
+		logger log.Logger,
+	) namespace.ReplicationTaskExecutor {
+		return namespace.NewReplicationTaskExecutor(
+			clusterMetadata.GetCurrentClusterName(),
+			metadataManager,
+			logger,
+		)
+	}),
 	fx.Provide(NewService),
 	fx.Provide(fx.Annotate(NewWorkerManager, fx.ParamTags(workercommon.WorkerComponentTag))),
 	fx.Provide(NewPerNamespaceWorkerManager),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -84,10 +84,11 @@ type (
 		esClient         esclient.Client
 		config           *Config
 
-		workerManager             *workerManager
-		perNamespaceWorkerManager *perNamespaceWorkerManager
-		scanner                   *scanner.Scanner
-		matchingClient            matchingservice.MatchingServiceClient
+		workerManager                    *workerManager
+		perNamespaceWorkerManager        *perNamespaceWorkerManager
+		scanner                          *scanner.Scanner
+		matchingClient                   matchingservice.MatchingServiceClient
+		namespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor
 	}
 
 	// Config contains all the service config for worker
@@ -140,6 +141,7 @@ func NewService(
 	perNamespaceWorkerManager *perNamespaceWorkerManager,
 	visibilityManager manager.VisibilityManager,
 	matchingClient resource.MatchingClient,
+	namespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor,
 ) (*Service, error) {
 	workerServiceResolver, err := membershipMonitor.GetResolver(primitives.WorkerService)
 	if err != nil {
@@ -167,9 +169,10 @@ func NewService(
 		historyClient:             historyClient,
 		visibilityManager:         visibilityManager,
 
-		workerManager:             workerManager,
-		perNamespaceWorkerManager: perNamespaceWorkerManager,
-		matchingClient:            matchingClient,
+		workerManager:                    workerManager,
+		perNamespaceWorkerManager:        perNamespaceWorkerManager,
+		matchingClient:                   matchingClient,
+		namespaceReplicationTaskExecutor: namespaceReplicationTaskExecutor,
 	}
 	if err := s.initScanner(); err != nil {
 		return nil, err
@@ -460,11 +463,6 @@ func (s *Service) startScanner() {
 }
 
 func (s *Service) startReplicator() {
-	namespaceReplicationTaskExecutor := namespace.NewReplicationTaskExecutor(
-		s.clusterMetadata.GetCurrentClusterName(),
-		s.metadataManager,
-		s.logger,
-	)
 	msgReplicator := replicator.NewReplicator(
 		s.clusterMetadata,
 		s.clientBean,
@@ -473,7 +471,7 @@ func (s *Service) startReplicator() {
 		s.hostInfo,
 		s.workerServiceResolver,
 		s.namespaceReplicationQueue,
-		namespaceReplicationTaskExecutor,
+		s.namespaceReplicationTaskExecutor,
 		s.matchingClient,
 		s.namespaceRegistry,
 	)

--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -179,7 +179,7 @@ func (s *dlqSuite) TestTDBG() {
 				"dlq",
 				"--" + tdbg.FlagDLQVersion, "v2",
 				"read",
-				"--" + tdbg.FlagDLQType, strconv.Itoa(int(tasks.CategoryTransfer.ID())),
+				"--" + tdbg.FlagDLQType, strconv.Itoa(tasks.CategoryTransfer.ID()),
 				"--" + tdbg.FlagCluster, sourceCluster,
 				"--" + tdbg.FlagPageSize, "1",
 				"--" + tdbg.FlagMaxMessageCount, tc.maxMessageCount,

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -71,7 +71,8 @@ func (s *xdcBaseSuite) clusterReplicationConfig() []*replicationpb.ClusterReplic
 	return config
 }
 
-func (s *xdcBaseSuite) setupSuite(clusterNames []string) {
+func (s *xdcBaseSuite) setupSuite(clusterNames []string, opts ...tests.Option) {
+	params := tests.ApplyTestClusterParams(opts)
 	s.clusterNames = clusterNames
 	s.logger = log.NewTestLogger()
 	if s.dynamicConfigOverrides == nil {
@@ -101,6 +102,7 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string) {
 			InitialFailoverVersion: int64(i + 1),
 			RPCAddress:             fmt.Sprintf("127.0.0.1:%d134", 7+i),
 		}
+		clusterConfigs[i].ServiceFxOptions = params.ServiceOptions
 	}
 
 	c, err := tests.NewCluster(clusterConfigs[0], log.With(s.logger, tag.ClusterName(s.clusterNames[0])))

--- a/tests/xdc/history_replication_dlq_test.go
+++ b/tests/xdc/history_replication_dlq_test.go
@@ -1,0 +1,466 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package xdc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/suite"
+	"github.com/urfave/cli/v2"
+	"go.temporal.io/api/serviceerror"
+	"go.temporal.io/api/workflowservice/v1"
+	sdkclient "go.temporal.io/sdk/client"
+	sdkworker "go.temporal.io/sdk/worker"
+	"go.temporal.io/sdk/workflow"
+	"go.temporal.io/server/tests/testutils"
+	"go.uber.org/fx"
+
+	enumspb "go.temporal.io/server/api/enums/v1"
+	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/primitives"
+	"go.temporal.io/server/common/primitives/timestamp"
+	"go.temporal.io/server/service/history/replication"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/tests"
+	"go.temporal.io/server/tools/tdbg"
+)
+
+// This file contains tests for the history replication DLQ feature. It uses a faulty replication task executor to force
+// replication tasks to fail, causing them to be DLQ'd. It then uses the tdbg CLI to read the replication tasks from the
+// DLQ and verify that they are correct.
+
+type (
+	historyReplicationDLQSuite struct {
+		xdcBaseSuite
+		// This test is parameterized on whether to use streaming for replication or not. Previously, replication was
+		// based on a pull-based architecture with standby clusters polling the active cluster for a given namespace
+		// whenever they wanted to process tasks. There's now a push-based, or "streaming", option based on a dynamic
+		// config flag. We want to test both code paths, so we run the test suite twice, once with streaming enabled and
+		// once with it disabled.
+		enableReplicationStream bool
+
+		// The below "params" objects are used to propagate parameters to the dependencies that we inject into the
+		// Temporal server. Mainly, we use this to share channels between the main test goroutine and the background
+		// task processing goroutines so that we can synchronize on them.
+
+		replicationTaskExecutorParams          replicationTaskExecutorParams
+		executionManagerParams                 executionManagerParams
+		namespaceReplicationTaskExecutorParams namespaceReplicationTaskExecutorParams
+	}
+
+	// The below types are used to inject our own implementations of replication dependencies, so that we can both
+	// observe events like namespace replication tasks being processed and inject our own faulty code to cause tasks
+	// to fail.
+
+	replicationTaskExecutorParams struct {
+		// We use an interface{} for these tasks because we don't care about the data, and the concrete type changes
+		// depending on whether we have streaming enabled for replication or not.
+		tasks chan interface{}
+	}
+	testReplicationTaskExecutor struct {
+		*replicationTaskExecutorParams
+		taskExecutor replication.TaskExecutor
+	}
+	executionManagerParams struct {
+		// This channel is sent to once we're done processing a request to add a message to the DLQ.
+		dlqRequests chan *persistence.PutReplicationTaskToDLQRequest
+	}
+	testExecutionManager struct {
+		*executionManagerParams
+		persistence.ExecutionManager
+	}
+	namespaceReplicationTaskExecutorParams struct {
+		// This channel is sent to once we're done processing a namespace replication task.
+		tasks chan *replicationspb.NamespaceTaskAttributes
+	}
+	testNamespaceReplicationTaskExecutor struct {
+		*namespaceReplicationTaskExecutorParams
+		replicationTaskExecutor namespace.ReplicationTaskExecutor
+	}
+	testExecutableTaskConverter struct {
+		*replicationTaskExecutorParams
+		converter replication.ExecutableTaskConverter
+	}
+	testExecutableTask struct {
+		*replicationTaskExecutorParams
+		replication.TrackableExecutableTask
+	}
+)
+
+const (
+	testTimeout      = 30 * time.Second
+	workflowIDToFail = "history-replication-dlq-test-workflow"
+)
+
+func TestHistoryReplicationDLQSuite(t *testing.T) {
+	for _, tc := range []struct {
+		name                    string
+		enableReplicationStream bool
+	}{
+		{
+			name:                    "ReplicationStreamEnabled",
+			enableReplicationStream: true,
+		},
+		{
+			name:                    "ReplicationStreamDisabled",
+			enableReplicationStream: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := &historyReplicationDLQSuite{
+				enableReplicationStream: tc.enableReplicationStream,
+			}
+			suite.Run(t, s)
+		})
+	}
+}
+
+func (s *historyReplicationDLQSuite) SetupSuite() {
+	// Conditionally switch replication from polling to streaming.
+	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
+		dynamicconfig.EnableReplicationStream: s.enableReplicationStream,
+	}
+
+	// Buffer this channel by one because we only care about the first request to add a message to the DLQ.
+	s.executionManagerParams.dlqRequests = make(chan *persistence.PutReplicationTaskToDLQRequest, 1)
+
+	// Buffer these channels by 100 because we don't know how many replication tasks there will be until the one that
+	// replicates our namespace is executed.
+	s.namespaceReplicationTaskExecutorParams.tasks = make(chan *replicationspb.NamespaceTaskAttributes, 100)
+	s.replicationTaskExecutorParams.tasks = make(chan interface{}, 100)
+
+	// This can't be very long, so we just use a UUID instead of a more descriptive name.
+	// We also don't escape this string in many places, so it can't contain any dashes.
+	format := strings.Replace(uuid.New(), "-", "", -1) + "_%s"
+	taskExecutorDecorator := s.getTaskExecutorDecorator()
+	s.setupSuite(
+		[]string{
+			fmt.Sprintf(format, "active"),
+			fmt.Sprintf(format, "standby"),
+		},
+		tests.WithFxOptionsForService(primitives.HistoryService,
+			fx.Decorate(
+				taskExecutorDecorator,
+				func(executionManager persistence.ExecutionManager) persistence.ExecutionManager {
+					// Replace the execution manager with one that records DLQ requests so that we can wait until a
+					// task is added to the DLQ before querying tdbg.
+					return &testExecutionManager{
+						executionManagerParams: &s.executionManagerParams,
+						ExecutionManager:       executionManager,
+					}
+				},
+			),
+		),
+		tests.WithFxOptionsForService(primitives.WorkerService,
+			fx.Decorate(
+				func(namespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor) namespace.ReplicationTaskExecutor {
+					return &testNamespaceReplicationTaskExecutor{
+						replicationTaskExecutor:                namespaceReplicationTaskExecutor,
+						namespaceReplicationTaskExecutorParams: &s.namespaceReplicationTaskExecutorParams,
+					}
+				},
+			),
+		),
+	)
+}
+
+func (s *historyReplicationDLQSuite) TearDownSuite() {
+	s.tearDownSuite()
+}
+
+func (s *historyReplicationDLQSuite) SetupTest() {
+	s.setupTest()
+}
+
+// This test executes a workflow on the active cluster and verifies that its replication tasks show in the DLQ of the
+// standby cluster when they fail to execute.
+func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
+	// This test uses channels to synchronize between the main test goroutine and the background task processing for
+	// replication, so we use a context with a timeout to ensure that the test doesn't hang forever when we try to
+	// receive from a channel.
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, testTimeout)
+	defer cancel()
+
+	// Register a namespace.
+	ns := "history-replication-dlq-test-namespace"
+	_, err := s.cluster1.GetFrontendClient().RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
+		Namespace:                        ns,
+		Clusters:                         s.clusterReplicationConfig(),
+		ActiveClusterName:                s.clusterNames[0],
+		IsGlobalNamespace:                true,
+		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(1 * time.Hour * 24), // required param
+	})
+	s.NoError(err)
+
+	// Create a worker and register a workflow.
+	activeClient, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  s.cluster1.GetHost().FrontendGRPCAddress(),
+		Namespace: ns,
+	})
+	s.NoError(err)
+	tq := "history-replication-dlq-test-task-queue"
+	worker := sdkworker.New(activeClient, tq, sdkworker.Options{})
+	myWorkflow := func(ctx workflow.Context) (string, error) {
+		return "hello", nil
+	}
+	worker.RegisterWorkflow(myWorkflow)
+	s.NoError(worker.Start())
+	defer worker.Stop()
+
+	// Wait for the namespace to be replicated.
+	for {
+		var task *replicationspb.NamespaceTaskAttributes
+		select {
+		case task = <-s.namespaceReplicationTaskExecutorParams.tasks:
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for namespace replication task to be processed")
+		}
+		if task.Info.Name == ns {
+			break
+		}
+	}
+
+	// Execute the workflow.
+	run, err := activeClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
+		TaskQueue: tq,
+		ID:        workflowIDToFail,
+	}, myWorkflow)
+	s.NoError(err)
+
+	// Wait for the workflow to complete.
+	var result string
+	err = run.Get(ctx, &result)
+	s.NoError(err)
+	s.Equal("hello", result)
+
+	// Wait for the replication task executor to process the replication task.
+	select {
+	case <-s.replicationTaskExecutorParams.tasks:
+	case <-ctx.Done():
+		s.FailNow("timed out waiting for replication task to be processed")
+	}
+
+	// Wait for at least one replication task to be added to the DLQ. There could be more, but we only care about the
+	// first one because they should all be for this workflow since it's the only one for which we injected repliaction
+	// task failures.
+	var request *persistence.PutReplicationTaskToDLQRequest
+	select {
+	case request = <-s.executionManagerParams.dlqRequests:
+	case <-ctx.Done():
+		s.FailNow("timed out waiting for replication task to be added to DLQ")
+	}
+	s.Equal(s.clusterNames[0], request.SourceClusterName)
+	s.Equal(1, int(request.ShardID))
+
+	// Create a TDBG client pointing at the standby cluster.
+	clientFactory := tdbg.NewClientFactory(
+		tdbg.WithFrontendAddress(s.cluster2.GetHost().FrontendGRPCAddress()),
+	)
+	app := tdbg.NewCliApp(clientFactory, tasks.NewDefaultTaskCategoryRegistry())
+	app.ExitErrHandler = func(c *cli.Context, err error) {
+		// We don't want the CLI to exit when it encounters an error, so we override the default handler.
+	}
+
+	// Run the TDBG command to read replication tasks from the DLQ.
+	// The last message ID is set to MaxInt64 - 1 because the last message ID is exclusive, so if it were
+	// set to the max int64, then, because the server increments the value, it would overflow and return no results.
+	// We want the maximum possible value because we have no idea what the task ids could be, but this parameter must
+	// be specified, so we just use the maximum possible value to get all available tasks.
+	lastMessageID := strconv.Itoa(math.MaxInt64 - 1)
+	file := testutils.CreateTemp(s.T(), "", "*")
+	cmd := []string{
+		"tdbg",
+		"dlq",
+		"read",
+		"--" + tdbg.FlagDLQType, "history",
+		"--" + tdbg.FlagCluster, s.clusterNames[0],
+		"--" + tdbg.FlagShardID, "1",
+		"--" + tdbg.FlagLastMessageID, lastMessageID,
+		"--" + tdbg.FlagMaxMessageCount, "10",
+		"--" + tdbg.FlagOutputFilename, file.Name(),
+	}
+	cmdString := strings.Join(cmd, " ")
+	s.T().Log("TDBG command:", cmdString)
+	err = app.Run(cmd)
+	s.NoError(err)
+	s.T().Log("TDBG output:")
+	s.T().Log("========================================")
+	bytes, err := io.ReadAll(file)
+	s.NoError(err)
+	s.T().Log(string(bytes))
+
+	// Parse the output into replication task protos.
+	_, err = file.Seek(0, io.SeekStart)
+	s.NoError(err)
+	s.T().Log("========================================")
+	replicationTasks := s.readReplicationTasks(file)
+
+	// Verify that the replication task contains the correct information (operators will want to know which workflow
+	// failed to replicate).
+	s.NotEmpty(replicationTasks)
+	task := replicationTasks[0]
+	s.Equal(enumspb.REPLICATION_TASK_TYPE_HISTORY_V2_TASK, task.GetTaskType())
+	historyTaskAttributes := task.GetHistoryTaskAttributes()
+	s.Equal(run.GetID(), historyTaskAttributes.GetWorkflowId())
+	s.Equal(run.GetRunID(), historyTaskAttributes.GetRunId())
+}
+
+func (s *historyReplicationDLQSuite) getTaskExecutorDecorator() interface{} {
+	if s.enableReplicationStream {
+		// The replication stream uses a different code path which converts tasks into executables using this interface,
+		// so that's a good injection point for us.
+		return func(converter replication.ExecutableTaskConverter) replication.ExecutableTaskConverter {
+			return &testExecutableTaskConverter{
+				replicationTaskExecutorParams: &s.replicationTaskExecutorParams,
+				converter:                     converter,
+			}
+		}
+	}
+	// Without the replication stream, we use polling that relies on a task executor, so we can inject our own
+	// faulty version here.
+	return func(provider replication.TaskExecutorProvider) replication.TaskExecutorProvider {
+		return func(params replication.TaskExecutorParams) replication.TaskExecutor {
+			taskExecutor := provider(params)
+			return &testReplicationTaskExecutor{
+				replicationTaskExecutorParams: &s.replicationTaskExecutorParams,
+				taskExecutor:                  taskExecutor,
+			}
+		}
+	}
+}
+
+// This function iterates through the given file parsing replication tasks until it encounters an EOF. It expects the
+// input file to be in JSONL format (JSON objects separated by newlines).
+func (s *historyReplicationDLQSuite) readReplicationTasks(file *os.File) []replicationspb.ReplicationTask {
+	decoder := json.NewDecoder(file)
+	var (
+		unmarshaler      jsonpb.Unmarshaler
+		replicationTasks []replicationspb.ReplicationTask
+	)
+	for {
+		var task replicationspb.ReplicationTask
+		err := unmarshaler.UnmarshalNext(decoder, &task)
+		if err == io.EOF { // Don't need errors.Is because io.EOF should never be wrapped.
+			return replicationTasks
+		}
+		s.NoError(err)
+		replicationTasks = append(replicationTasks, task)
+	}
+}
+
+// Execute the replication task as-normal, but also send it to the channel so that the test can wait for it to
+// know that the namespace data has been replicated.
+func (t *testNamespaceReplicationTaskExecutor) Execute(
+	ctx context.Context,
+	task *replicationspb.NamespaceTaskAttributes,
+) error {
+	err := t.replicationTaskExecutor.Execute(ctx, task)
+	if err != nil {
+		return err
+	}
+	select {
+	case t.tasks <- task:
+	default:
+	}
+	return nil
+}
+
+// PutReplicationTaskToDLQ is the same as the normal execution manager, but also sends the request to the channel so
+// that the test can wait for it to know that the replication task has been added to the DLQ.
+func (t *testExecutionManager) PutReplicationTaskToDLQ(
+	ctx context.Context,
+	request *persistence.PutReplicationTaskToDLQRequest,
+) error {
+	err := t.ExecutionManager.PutReplicationTaskToDLQ(ctx, request)
+	if err != nil {
+		return err
+	}
+	select {
+	case t.dlqRequests <- request:
+	default:
+	}
+	return nil
+}
+
+// Execute the replication task as-normal or return an error if the workflow ID matches the one that we want to fail.
+func (f testReplicationTaskExecutor) Execute(
+	ctx context.Context,
+	replicationTask *replicationspb.ReplicationTask,
+	forceApply bool,
+) error {
+	if replicationTask.GetHistoryTaskAttributes().WorkflowId == workflowIDToFail {
+		select {
+		case f.tasks <- replicationTask:
+		default:
+		}
+		return errors.New("failed to apply replication task")
+	}
+	return f.taskExecutor.Execute(ctx, replicationTask, forceApply)
+}
+
+// Convert the replication tasks using the base converter, but then wrap them in our own faulty executable tasks.
+func (t *testExecutableTaskConverter) Convert(
+	taskClusterName string,
+	clientShardKey replication.ClusterShardKey,
+	serverShardKey replication.ClusterShardKey,
+	replicationTasks ...*replicationspb.ReplicationTask,
+) []replication.TrackableExecutableTask {
+	convertedTasks := t.converter.Convert(taskClusterName, clientShardKey, serverShardKey, replicationTasks...)
+	testExecutableTasks := make([]replication.TrackableExecutableTask, len(convertedTasks))
+	for i, task := range convertedTasks {
+		testExecutableTasks[i] = &testExecutableTask{
+			replicationTaskExecutorParams: t.replicationTaskExecutorParams,
+			TrackableExecutableTask:       task,
+		}
+	}
+	return testExecutableTasks
+}
+
+// Execute the replication task as-normal or return an error if the workflow ID matches the one that we want to fail.
+func (t *testExecutableTask) Execute() error {
+	if et, ok := t.TrackableExecutableTask.(*replication.ExecutableHistoryTask); ok {
+		if et.WorkflowID == workflowIDToFail {
+			t.replicationTaskExecutorParams.tasks <- struct{}{}
+			return serviceerror.NewInvalidArgument("failed to apply replication task")
+		}
+	}
+	return t.TrackableExecutableTask.Execute()
+}

--- a/tools/tdbg/dlq_service.go
+++ b/tools/tdbg/dlq_service.go
@@ -111,7 +111,7 @@ func toQueueType(dlqType string) (enumsspb.DeadLetterQueueType, error) {
 	case "history":
 		return enumsspb.DEAD_LETTER_QUEUE_TYPE_REPLICATION, nil
 	default:
-		return enumsspb.DEAD_LETTER_QUEUE_TYPE_UNSPECIFIED, fmt.Errorf("unsupported Tueue type %v", dlqType)
+		return enumsspb.DEAD_LETTER_QUEUE_TYPE_UNSPECIFIED, fmt.Errorf("unsupported queue type %v", dlqType)
 	}
 }
 

--- a/tools/tdbg/dlq_v1_service.go
+++ b/tools/tdbg/dlq_v1_service.go
@@ -100,7 +100,7 @@ func (ac *DLQV1Service) ReadMessages(c *cli.Context) (err error) {
 	for iterator.HasNext() && remainingMessageCount > 0 {
 		item, err := iterator.Next()
 		if err != nil {
-			return fmt.Errorf("unable to read dlq message. Last read message id: %v", lastReadMessageID)
+			return fmt.Errorf("unable to read dlq message. Last read message id: %v, Error: %v", lastReadMessageID, err)
 		}
 
 		task := item.(*repication.ReplicationTask)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This change adds an integration test for the history replication DLQ. I also improved some error messages in replication that I found while writing this test.

<!-- Tell your future self why have you made these changes -->
**Why?**
It's mainly to help rolling out the new DLQ backend implemented using QueueV2
1. I'll need a similar test, so I can reuse a lot of this
2. I'll be refactoring some code in the replication stack, so this test verifies that I don't cause any regressions.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This test runs with streaming both enabled and disabled for replication, so it should work just fine once that's turned on by default.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This test is pretty invasive, relying on several assumptions about what types are used by the replication stack. However, this means we don't have any sleeps or retries in the test.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
