### PR TITLE
No shard lock on I/O: task key manager

### DIFF
--- a/service/history/shard/task_key_manager.go
+++ b/service/history/shard/task_key_manager.go
@@ -1,0 +1,143 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"time"
+
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/configs"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	taskKeyManager struct {
+		generator *taskKeyGenerator
+		tracker   *taskRequestTracker
+
+		timeSource clock.TimeSource
+		config     *configs.Config
+		logger     log.Logger
+	}
+)
+
+func newTaskKeyManager(
+	taskCategoryRegistry tasks.TaskCategoryRegistry,
+	timeSource clock.TimeSource,
+	config *configs.Config,
+	logger log.Logger,
+	renewRangeIDFn renewRangeIDFn,
+) *taskKeyManager {
+	return &taskKeyManager{
+		generator: newTaskKeyGenerator(
+			config.RangeSizeBits,
+			timeSource,
+			logger,
+			renewRangeIDFn,
+		),
+		tracker:    newTaskRequestTracker(taskCategoryRegistry),
+		timeSource: timeSource,
+		logger:     logger,
+		config:     config,
+	}
+}
+
+func (m *taskKeyManager) setAndTrackTaskKeys(
+	taskMaps ...map[tasks.Category][]tasks.Task,
+) (taskRequestCompletionFn, error) {
+
+	if err := m.generator.setTaskKeys(taskMaps...); err != nil {
+		return nil, err
+	}
+
+	return m.tracker.track(taskMaps...), nil
+}
+
+func (m *taskKeyManager) peekTaskKey(
+	category tasks.Category,
+) tasks.Key {
+	return m.generator.peekTaskKey(category)
+}
+
+func (m *taskKeyManager) generateTaskKey(
+	category tasks.Category,
+) (tasks.Key, error) {
+	return m.generator.generateTaskKey(category)
+}
+
+func (m *taskKeyManager) drainTaskRequests() {
+	m.tracker.drain()
+}
+
+func (m *taskKeyManager) setRangeID(
+	rangeID int64,
+) {
+	m.generator.setRangeID(rangeID)
+
+	// rangeID update means all pending add tasks requests either already succeeded
+	// are guaranteed to fail, so we can clear pending requests in the tracker
+	m.tracker.clear()
+}
+
+func (m *taskKeyManager) setTaskMinScheduledTime(
+	taskMinScheduledTime time.Time,
+) {
+	m.generator.setTaskMinScheduledTime(taskMinScheduledTime)
+}
+
+func (m *taskKeyManager) getExclusiveReaderHighWatermark(
+	category tasks.Category,
+) tasks.Key {
+	minTaskKey, ok := m.tracker.minTaskKey(category)
+	if !ok {
+		minTaskKey = tasks.MaximumKey
+	}
+
+	// TODO: should this be moved generator.setTaskKeys() ?
+	m.setTaskMinScheduledTime(
+		// TODO: Truncation here is just to make sure task scheduled time has the same precision as the old logic.
+		// Remove this truncation once we validate the rest of the code can worker correctly with higher precision.
+		m.timeSource.Now().Add(m.config.TimerProcessorMaxTimeShift()).Truncate(persistence.ScheduledTaskMinPrecision),
+	)
+
+	nextTaskKey := m.generator.peekTaskKey(category)
+
+	exclusiveReaderHighWatermark := tasks.MinKey(
+		minTaskKey,
+		nextTaskKey,
+	)
+	if category.Type() == tasks.CategoryTypeScheduled {
+		exclusiveReaderHighWatermark.TaskID = 0
+
+		// TODO: Truncation here is just to make sure task scheduled time has the same precision as the old logic.
+		// Remove this truncation once we validate the rest of the code can worker correctly with higher precision.
+		exclusiveReaderHighWatermark.FireTime = exclusiveReaderHighWatermark.FireTime.
+			Truncate(persistence.ScheduledTaskMinPrecision)
+	}
+
+	return exclusiveReaderHighWatermark
+}

--- a/service/history/shard/task_key_manager_test.go
+++ b/service/history/shard/task_key_manager_test.go
@@ -1,0 +1,199 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package shard
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"go.temporal.io/server/common/clock"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+)
+
+type (
+	taskKeyManagerSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		rangeID       int64
+		rangeSizeBits uint
+		initialTaskID int64
+
+		mockTimeSource *clock.EventTimeSource
+
+		manager *taskKeyManager
+	}
+)
+
+func TestTaskKeyManagerSuite(t *testing.T) {
+	s := &taskKeyManagerSuite{}
+	suite.Run(t, s)
+}
+
+func (s *taskKeyManagerSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.rangeID = 1
+	s.rangeSizeBits = 3 // 1 << 3 = 8 tasks per range
+	s.initialTaskID = s.rangeID << int64(s.rangeSizeBits)
+	config := tests.NewDynamicConfig()
+	config.RangeSizeBits = s.rangeSizeBits
+	s.mockTimeSource = clock.NewEventTimeSource()
+
+	s.manager = newTaskKeyManager(
+		tasks.NewDefaultTaskCategoryRegistry(),
+		s.mockTimeSource,
+		config,
+		log.NewTestLogger(),
+		func() error {
+			s.rangeID++
+			s.manager.setRangeID(s.rangeID)
+			return nil
+		},
+	)
+	s.manager.setRangeID(s.rangeID)
+	s.manager.setTaskMinScheduledTime(time.Now().Add(-time.Second))
+}
+
+func (s *taskKeyManagerSuite) TestSetAndTrackTaskKeys() {
+	now := time.Now()
+
+	// this tests is just for making sure task keys are set and tracked
+	// the actual logic of task key generation is tested in taskKeyGeneratorTest
+
+	numTask := 5
+	transferTasks := make([]tasks.Task, 0, numTask)
+	for i := 0; i < numTask; i++ {
+		transferTasks = append(
+			transferTasks,
+			tasks.NewFakeTask(
+				tests.WorkflowKey,
+				tasks.CategoryTransfer,
+				now,
+			),
+		)
+	}
+	// assert that task keys are not set
+	for _, transferTask := range transferTasks {
+		s.Zero(transferTask.GetKey().TaskID)
+	}
+
+	completionFn, err := s.manager.setAndTrackTaskKeys(map[tasks.Category][]tasks.Task{
+		tasks.CategoryTransfer: transferTasks,
+	})
+	s.NoError(err)
+
+	// assert that task keys are set after calling setAndTrackTaskKeys
+	for _, transferTask := range transferTasks {
+		s.NotZero(transferTask.GetKey().TaskID)
+	}
+
+	// assert that task keys are tracked
+	highReaderWatermark := s.manager.getExclusiveReaderHighWatermark(tasks.CategoryTransfer)
+	s.Equal(s.initialTaskID, highReaderWatermark.TaskID)
+
+	// assert that pending task keys are cleared after calling completionFn
+	completionFn(nil)
+	highReaderWatermark = s.manager.getExclusiveReaderHighWatermark(tasks.CategoryTransfer)
+	s.Equal(s.initialTaskID+int64(numTask), highReaderWatermark.TaskID)
+}
+
+func (s *taskKeyManagerSuite) TestSetRangeID() {
+	_, err := s.manager.setAndTrackTaskKeys(map[tasks.Category][]tasks.Task{
+		tasks.CategoryTransfer: {
+			tasks.NewFakeTask(
+				tests.WorkflowKey,
+				tasks.CategoryTransfer,
+				time.Now(),
+			),
+		},
+	})
+	s.NoError(err)
+
+	s.Equal(
+		s.initialTaskID,
+		s.manager.getExclusiveReaderHighWatermark(tasks.CategoryTransfer).TaskID,
+	)
+
+	s.rangeID++
+	s.manager.setRangeID(s.rangeID)
+
+	expectedNextTaskID := s.rangeID << int64(s.rangeSizeBits)
+	s.Equal(
+		expectedNextTaskID,
+		s.manager.peekTaskKey(tasks.CategoryTransfer).TaskID,
+	)
+
+	// setRangeID should also clear pending task requests
+	s.Equal(
+		expectedNextTaskID,
+		s.manager.getExclusiveReaderHighWatermark(tasks.CategoryTransfer).TaskID,
+	)
+}
+
+func (s *taskKeyManagerSuite) TestSetTaskMinScheduledTime_NoPendingTask() {
+	highReaderWatermark := s.manager.getExclusiveReaderHighWatermark(tasks.CategoryTransfer)
+	s.Zero(tasks.NewImmediateKey(s.initialTaskID).CompareTo(highReaderWatermark))
+
+	now := time.Now()
+	s.mockTimeSource.Update(now)
+
+	highReaderWatermark = s.manager.getExclusiveReaderHighWatermark(tasks.CategoryTimer)
+	// for scheduled category type, we only need to make sure TaskID is 0 and FireTime is moved forwarded
+	s.Zero(highReaderWatermark.TaskID)
+	s.True(highReaderWatermark.FireTime.After(now))
+	s.False(highReaderWatermark.FireTime.After(now.Add(s.manager.config.TimerProcessorMaxTimeShift())))
+}
+
+func (s *taskKeyManagerSuite) TestSetTaskMinScheduledTime_WithPendingTask() {
+	now := time.Now()
+	s.mockTimeSource.Update(now)
+
+	transferTask := tasks.NewFakeTask(
+		tests.WorkflowKey,
+		tasks.CategoryTransfer,
+		time.Now(),
+	)
+	timerTask := tasks.NewFakeTask(
+		tests.WorkflowKey,
+		tasks.CategoryTimer,
+		now.Add(-time.Minute),
+	)
+	_, err := s.manager.setAndTrackTaskKeys(map[tasks.Category][]tasks.Task{
+		tasks.CategoryTransfer: {transferTask},
+		tasks.CategoryTimer:    {timerTask},
+	})
+	s.NoError(err)
+
+	highReaderWatermark := s.manager.getExclusiveReaderHighWatermark(tasks.CategoryTransfer)
+	s.Zero(tasks.NewImmediateKey(s.initialTaskID).CompareTo(highReaderWatermark))
+
+	highReaderWatermark = s.manager.getExclusiveReaderHighWatermark(tasks.CategoryTimer)
+	s.Zero(tasks.NewKey(timerTask.GetVisibilityTime(), 0).CompareTo(highReaderWatermark))
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add task key manager for shard context
- This is a thin wrapper around task request tracker and task key generator. Shard context will use this component instead of talking to request tracker or key generator directly for allocating task key or getting the max read watermark for history task queues.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Needed for later work for releasing shard lock on shard I/O. For the full change check: https://github.com/temporalio/temporal/tree/remove-shard-lock-v2/service/history/shard

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test & tested in test cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- N/A, not wired up yet

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
