### PR TITLE
Add a replication.DLQWriter interface

### DIFF
--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -164,6 +164,7 @@ func NewEngineWithShardContext(
 	persistenceVisibilityMgr manager.VisibilityManager,
 	eventBlobCache persistence.XDCCache,
 	taskCategoryRegistry tasks.TaskCategoryRegistry,
+	dlqWriter replication.DLQWriter,
 ) shard.Engine {
 	currentClusterName := shard.GetClusterMetadata().GetCurrentClusterName()
 
@@ -283,6 +284,7 @@ func NewEngineWithShardContext(
 		eventSerializer,
 		replicationTaskFetcherFactory,
 		replicationTaskExecutorProvider,
+		dlqWriter,
 	)
 	return historyEngImpl
 }

--- a/service/history/history_engine_factory.go
+++ b/service/history/history_engine_factory.go
@@ -63,6 +63,7 @@ type (
 		PersistenceVisibilityMgr        manager.VisibilityManager
 		EventBlobCache                  persistence.XDCCache
 		TaskCategoryRegistry            tasks.TaskCategoryRegistry
+		ReplicationDLQWriter            replication.DLQWriter
 	}
 
 	historyEngineFactory struct {
@@ -99,5 +100,6 @@ func (f *historyEngineFactory) CreateEngine(
 		f.PersistenceVisibilityMgr,
 		f.EventBlobCache,
 		f.TaskCategoryRegistry,
+		f.ReplicationDLQWriter,
 	)
 }

--- a/service/history/replication/dlq_writer.go
+++ b/service/history/replication/dlq_writer.go
@@ -1,0 +1,73 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package replication
+
+import (
+	"context"
+
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/shard"
+)
+
+type (
+	// DLQWriter is an interface that can be implemented easily by the two different queue solutions that we have.
+	// - Queue V1 implements this interface via [persistence.ExecutionManager].
+	// - Queue V2 will implement this interface via [go.temporal.io/server/service/history/queues.DLQWriter].
+	//
+	// We want this interface to make the migration referenced by [persistence.QueueV2] easier.
+	DLQWriter interface {
+		WriteTaskToDLQ(ctx context.Context, request WriteRequest) error
+	}
+	// WriteRequest is a request to write a task to the DLQ.
+	WriteRequest struct {
+		// ShardContext is an argument that we can remove once we migrate to queue V2.
+		ShardContext        shard.Context
+		SourceCluster       string
+		ReplicationTaskInfo *persistencespb.ReplicationTaskInfo
+	}
+	// ExecutionManagerDLQWriter is a [DLQWriter] that uses the shard's [persistence.ExecutionManager].
+	// The zero-value is a valid instance.
+	ExecutionManagerDLQWriter struct{}
+)
+
+// NewExecutionManagerDLQWriter creates a new DLQWriter.
+func NewExecutionManagerDLQWriter() DLQWriter {
+	return &ExecutionManagerDLQWriter{}
+}
+
+// WriteTaskToDLQ implements [DLQWriter.WriteTaskToDLQ] by calling [persistence.ExecutionManager.PutReplicationTaskToDLQ].
+func (e *ExecutionManagerDLQWriter) WriteTaskToDLQ(
+	ctx context.Context,
+	request WriteRequest,
+) error {
+	return request.ShardContext.GetExecutionManager().PutReplicationTaskToDLQ(
+		ctx, &persistence.PutReplicationTaskToDLQRequest{
+			SourceClusterName: request.SourceCluster,
+			ShardID:           request.ShardContext.GetShardID(),
+			TaskInfo:          request.ReplicationTaskInfo,
+		},
+	)
+}

--- a/service/history/replication/dlq_writer_test.go
+++ b/service/history/replication/dlq_writer_test.go
@@ -1,0 +1,88 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package replication_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/service/history/replication"
+	"go.temporal.io/server/service/history/shard"
+)
+
+type (
+	fakeShardContext struct {
+		shard.Context
+		requests []*persistence.PutReplicationTaskToDLQRequest
+		shardID  int
+	}
+	fakeExecutionManager struct {
+		persistence.ExecutionManager
+		requests *[]*persistence.PutReplicationTaskToDLQRequest
+	}
+)
+
+func TestNewExecutionManagerDLQWriter_ReplicationTask(t *testing.T) {
+	t.Parallel()
+
+	writer := replication.NewExecutionManagerDLQWriter()
+	shardContext := &fakeShardContext{
+		shardID: 13,
+	}
+	replicationTaskInfo := &persistencespb.ReplicationTaskInfo{
+		TaskId: 21,
+	}
+	err := writer.WriteTaskToDLQ(context.Background(), replication.WriteRequest{
+		ShardContext:        shardContext,
+		SourceCluster:       "test-source-cluster",
+		ReplicationTaskInfo: replicationTaskInfo,
+	})
+	require.NoError(t, err)
+	if assert.Len(t, shardContext.requests, 1) {
+		assert.Equal(t, 13, int(shardContext.requests[0].ShardID))
+		assert.Equal(t, "test-source-cluster", shardContext.requests[0].SourceClusterName)
+		assert.Equal(t, replicationTaskInfo, shardContext.requests[0].TaskInfo)
+	}
+}
+
+func (f *fakeShardContext) GetShardID() int32 {
+	return int32(f.shardID)
+}
+
+func (f *fakeShardContext) GetExecutionManager() persistence.ExecutionManager {
+	return &fakeExecutionManager{requests: &f.requests}
+}
+
+func (f *fakeExecutionManager) PutReplicationTaskToDLQ(
+	_ context.Context,
+	request *persistence.PutReplicationTaskToDLQRequest,
+) error {
+	*f.requests = append(*f.requests, request)
+	return nil
+}

--- a/service/history/replication/executable_activity_state_task_test.go
+++ b/service/history/replication/executable_activity_state_task_test.go
@@ -132,6 +132,7 @@ func (s *executableActivityStateTaskSuite) SetupTest() {
 			NDCHistoryResender: s.ndcHistoryResender,
 			MetricsHandler:     s.metricsHandler,
 			Logger:             s.logger,
+			DLQWriter:          NewExecutionManagerDLQWriter(),
 		},
 		s.taskID,
 		time.Unix(0, rand.Int63()),

--- a/service/history/replication/executable_history_task_test.go
+++ b/service/history/replication/executable_history_task_test.go
@@ -151,6 +151,7 @@ func (s *executableHistoryTaskSuite) SetupTest() {
 		Logger:                  s.logger,
 		EagerNamespaceRefresher: s.eagerNamespaceRefresher,
 		EventSerializer:         s.eventSerializer,
+		DLQWriter:               NewExecutionManagerDLQWriter(),
 	}
 	s.task = NewExecutableHistoryTask(
 		s.processToolBox,

--- a/service/history/replication/executable_noop_task_test.go
+++ b/service/history/replication/executable_noop_task_test.go
@@ -97,6 +97,7 @@ func (s *executableNoopTaskSuite) SetupTest() {
 			MetricsHandler:          s.metricsHandler,
 			Logger:                  s.logger,
 			EagerNamespaceRefresher: s.eagerNamespaceRefresher,
+			DLQWriter:               NewExecutionManagerDLQWriter(),
 		},
 		rand.Int63(),
 		time.Unix(0, rand.Int63()),

--- a/service/history/replication/executable_task_test.go
+++ b/service/history/replication/executable_task_test.go
@@ -117,6 +117,7 @@ func (s *executableTaskSuite) SetupTest() {
 			MetricsHandler:          s.metricsHandler,
 			Logger:                  s.logger,
 			EagerNamespaceRefresher: s.eagerNamespaceRefresher,
+			DLQWriter:               NewExecutionManagerDLQWriter(),
 		},
 		rand.Int63(),
 		"metrics-tag",

--- a/service/history/replication/executable_task_tool_box.go
+++ b/service/history/replication/executable_task_tool_box.go
@@ -54,5 +54,6 @@ type (
 		MetricsHandler          metrics.Handler
 		Logger                  log.Logger
 		EventSerializer         serialization.Serializer
+		DLQWriter               DLQWriter
 	}
 )

--- a/service/history/replication/executable_unknown_task_test.go
+++ b/service/history/replication/executable_unknown_task_test.go
@@ -99,6 +99,7 @@ func (s *executableUnknownTaskSuite) SetupTest() {
 			MetricsHandler:          s.metricsHandler,
 			Logger:                  s.logger,
 			EagerNamespaceRefresher: s.eagerNamespaceRefresher,
+			DLQWriter:               NewExecutionManagerDLQWriter(),
 		},
 		s.taskID,
 		time.Unix(0, rand.Int63()),

--- a/service/history/replication/executable_workflow_state_task_test.go
+++ b/service/history/replication/executable_workflow_state_task_test.go
@@ -122,6 +122,7 @@ func (s *executableWorkflowStateTaskSuite) SetupTest() {
 			MetricsHandler:          s.metricsHandler,
 			Logger:                  s.logger,
 			EagerNamespaceRefresher: s.eagerNamespaceRefresher,
+			DLQWriter:               NewExecutionManagerDLQWriter(),
 		},
 		s.taskID,
 		time.Unix(0, rand.Int63()),

--- a/service/history/replication/stream_receiver_monitor_test.go
+++ b/service/history/replication/stream_receiver_monitor_test.go
@@ -93,6 +93,7 @@ func (s *streamReceiverMonitorSuite) SetupTest() {
 		ShardController: s.shardController,
 		MetricsHandler:  metrics.NoopMetricsHandler,
 		Logger:          log.NewNoopLogger(),
+		DLQWriter:       NewExecutionManagerDLQWriter(),
 	}
 	s.streamReceiverMonitor = NewStreamReceiverMonitor(
 		processToolBox,

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -100,6 +100,7 @@ func (s *streamReceiverSuite) SetupTest() {
 		TaskScheduler:   s.taskScheduler,
 		MetricsHandler:  metrics.NoopMetricsHandler,
 		Logger:          log.NewTestLogger(),
+		DLQWriter:       NewExecutionManagerDLQWriter(),
 	}
 	s.streamReceiver = NewStreamReceiver(
 		processToolBox,

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -70,6 +70,7 @@ type (
 		taskPollerManager             pollerManager
 		metricsHandler                metrics.Handler
 		logger                        log.Logger
+		dlqWriter                     DLQWriter
 
 		enableFetcher     bool
 		taskProcessorLock sync.RWMutex
@@ -89,6 +90,7 @@ func NewTaskProcessorManager(
 	eventSerializer serialization.Serializer,
 	replicationTaskFetcherFactory TaskFetcherFactory,
 	taskExecutorProvider TaskExecutorProvider,
+	dlqWriter DLQWriter,
 ) *taskProcessorManagerImpl {
 
 	return &taskProcessorManagerImpl{
@@ -113,6 +115,7 @@ func NewTaskProcessorManager(
 		),
 		logger:         shard.GetLogger(),
 		metricsHandler: shard.GetMetricsHandler(),
+		dlqWriter:      dlqWriter,
 
 		enableFetcher:        !config.EnableReplicationStream(),
 		taskProcessors:       make(map[string][]TaskProcessor),
@@ -224,6 +227,7 @@ func (r *taskProcessorManagerImpl) handleClusterMetadataUpdate(
 					WorkflowCache:   r.workflowCache,
 				}),
 				r.eventSerializer,
+				r.dlqWriter,
 			)
 			replicationTaskProcessor.Start()
 			processors = append(processors, replicationTaskProcessor)

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -130,6 +130,7 @@ func (s *taskProcessorManagerSuite) SetupTest() {
 		func(params TaskExecutorParams) TaskExecutor {
 			return s.mockReplicationTaskExecutor
 		},
+		NewExecutionManagerDLQWriter(),
 	)
 }
 

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -144,6 +144,7 @@ func (s *taskProcessorSuite) SetupTest() {
 		s.mockReplicationTaskFetcher,
 		s.mockReplicationTaskExecutor,
 		serialization.NewSerializer(),
+		NewExecutionManagerDLQWriter(),
 	).(*taskProcessorImpl)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added a `DLQWriter` interface to the `replication` package, which takes a `WriteRequest` containing a `shard.Context`, a source cluster name, and replication task info, and writes a task to the DLQ. I also added a default implementation which uses our v1 queue supplied by the shard.

I also refactored `replication/fx.go` in two ways:
1. **Don't use `fx.Options`**: Its usage is discouraged in its documentation, and we can replace it by simply having a variadic call to `fx.Provide`, and adding lifecycle hooks for the scheduler in the provider instead of an `fx.Invoke` call.
2. **Keep providers un-exported**: I didn't see a reason for having these exported, and I think it just bloats the footprint of this package. It's clearer when you see that it just provides a few constructors and a module. 

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to move away from using `ExecutionManager.PutReplicationTaskToDLQ`; however, that method is called in several places in the `replication` package. We're going to fix this in stages:

1. Hide all calls to `ExecutionManager` behind a common interface, so that it's really only called in one place
3. Add an alternate implementation based on `persistence.QueueV2` via `queues.DLQWriter`
4. Roll out the alternate implementation
5. Remove the implementation that uses the `ExecutionManager`

This PR is just step one.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added a unit test, and I also added an integration test for this in https://github.com/temporalio/temporal/pull/5003.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
