### PR TITLE
Add EnableHistoryReplicationDLQV2 dc

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -475,6 +475,10 @@ const (
 
 	// EnableReplicationStream turn on replication stream
 	EnableReplicationStream = "history.enableReplicationStream"
+	// EnableHistoryReplicationDLQV2 switches to the DLQ v2 implementation for history replication. See details in
+	// [go.temporal.io/server/common/persistence.QueueV2]. This feature is currently in development. Do NOT use it in
+	// production.
+	EnableHistoryReplicationDLQV2 = "history.enableHistoryReplicationDLQV2"
 
 	// HistoryRPS is request rate per second for each history host
 	HistoryRPS = "history.rps"

--- a/common/persistence/persistence-tests/persistence_test_base.go
+++ b/common/persistence/persistence-tests/persistence_test_base.go
@@ -80,6 +80,7 @@ type (
 		StoreType         string                 `yaml:"-"`
 		SchemaDir         string                 `yaml:"-"`
 		FaultInjection    *config.FaultInjection `yaml:"faultinjection"`
+		Logger            log.Logger             `yaml:"-"`
 	}
 
 	// TestBase wraps the base setup needed to create workflows over persistence layer.
@@ -139,7 +140,10 @@ func NewTestBaseWithSQL(options *TestBaseOptions) TestBase {
 	if options.DBName == "" {
 		options.DBName = "test_" + GenerateRandomDBName(3)
 	}
-	logger := log.NewTestLogger()
+	logger := options.Logger
+	if logger == nil {
+		logger = log.NewTestLogger()
+	}
 
 	if options.DBPort == 0 {
 		switch options.SQLDBPluginName {

--- a/common/persistence/serialization/serializer.go
+++ b/common/persistence/serialization/serializer.go
@@ -105,6 +105,9 @@ type (
 
 		ReplicationTaskToBlob(replicationTask *replicationspb.ReplicationTask, encodingType enumspb.EncodingType) (*commonpb.DataBlob, error)
 		ReplicationTaskFromBlob(data *commonpb.DataBlob) (*replicationspb.ReplicationTask, error)
+		// ParseReplicationTask is unique among these methods in that it does not serialize or deserialize a type to or
+		// from a byte array. Instead, it takes a proto and "parses" it into a more structured type.
+		ParseReplicationTask(replicationTask *persistencespb.ReplicationTaskInfo) (tasks.Task, error)
 
 		SerializeTask(task tasks.Task) (commonpb.DataBlob, error)
 		DeserializeTask(category tasks.Category, blob commonpb.DataBlob) (tasks.Task, error)

--- a/common/persistence/serialization/task_serializer.go
+++ b/common/persistence/serialization/task_serializer.go
@@ -289,19 +289,20 @@ func (s *TaskSerializer) deserializeReplicationTasks(
 	if err != nil {
 		return nil, err
 	}
-	var replication tasks.Task
+	return s.ParseReplicationTask(replicationTask)
+}
+
+func (s *TaskSerializer) ParseReplicationTask(replicationTask *persistencespb.ReplicationTaskInfo) (tasks.Task, error) {
 	switch replicationTask.TaskType {
 	case enumsspb.TASK_TYPE_REPLICATION_SYNC_ACTIVITY:
-		replication = s.replicationActivityTaskFromProto(replicationTask)
+		return s.replicationActivityTaskFromProto(replicationTask), nil
 	case enumsspb.TASK_TYPE_REPLICATION_HISTORY:
-		replication = s.replicationHistoryTaskFromProto(replicationTask)
+		return s.replicationHistoryTaskFromProto(replicationTask), nil
 	case enumsspb.TASK_TYPE_REPLICATION_SYNC_WORKFLOW_STATE:
-		replication = s.replicationSyncWorkflowStateTaskFromProto(replicationTask)
+		return s.replicationSyncWorkflowStateTaskFromProto(replicationTask), nil
 	default:
 		return nil, serviceerror.NewInternal(fmt.Sprintf("Unknown replication task type: %v", replicationTask.TaskType))
 	}
-
-	return replication, nil
 }
 
 func (s *TaskSerializer) serializeArchivalTask(

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	NumberOfShards int32
 
 	EnableReplicationStream dynamicconfig.BoolPropertyFn
+	HistoryReplicationDLQV2 dynamicconfig.BoolPropertyFn
 
 	RPS                                   dynamicconfig.IntPropertyFn
 	OperatorRPSRatio                      dynamicconfig.FloatPropertyFn
@@ -333,6 +334,7 @@ func NewConfig(
 		NumberOfShards: numberOfShards,
 
 		EnableReplicationStream: dc.GetBoolProperty(dynamicconfig.EnableReplicationStream, false),
+		HistoryReplicationDLQV2: dc.GetBoolProperty(dynamicconfig.EnableHistoryReplicationDLQV2, false),
 
 		RPS:                                   dc.GetIntProperty(dynamicconfig.HistoryRPS, 3000),
 		OperatorRPSRatio:                      dc.GetFloat64Property(dynamicconfig.OperatorRPSRatio, common.DefaultOperatorRPSRatio),

--- a/service/history/replication/dlq_writer_test.go
+++ b/service/history/replication/dlq_writer_test.go
@@ -26,63 +26,117 @@ package replication_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/persistence"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/queues/queuestest"
 	"go.temporal.io/server/service/history/replication"
-	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tests"
 )
 
 type (
-	fakeShardContext struct {
-		shard.Context
-		requests []*persistence.PutReplicationTaskToDLQRequest
-		shardID  int
-	}
 	fakeExecutionManager struct {
-		persistence.ExecutionManager
-		requests *[]*persistence.PutReplicationTaskToDLQRequest
+		requests []*persistence.PutReplicationTaskToDLQRequest
 	}
 )
 
-func TestNewExecutionManagerDLQWriter_ReplicationTask(t *testing.T) {
+func TestNewExecutionManagerDLQWriter(t *testing.T) {
 	t.Parallel()
 
+	executionManager := &fakeExecutionManager{}
 	writer := replication.NewExecutionManagerDLQWriter()
-	shardContext := &fakeShardContext{
-		shardID: 13,
-	}
 	replicationTaskInfo := &persistencespb.ReplicationTaskInfo{
 		TaskId: 21,
 	}
 	err := writer.WriteTaskToDLQ(context.Background(), replication.WriteRequest{
-		ShardContext:        shardContext,
+		ShardID:             13,
+		ExecutionManager:    executionManager,
 		SourceCluster:       "test-source-cluster",
 		ReplicationTaskInfo: replicationTaskInfo,
 	})
 	require.NoError(t, err)
-	if assert.Len(t, shardContext.requests, 1) {
-		assert.Equal(t, 13, int(shardContext.requests[0].ShardID))
-		assert.Equal(t, "test-source-cluster", shardContext.requests[0].SourceClusterName)
-		assert.Equal(t, replicationTaskInfo, shardContext.requests[0].TaskInfo)
+	require.Len(t, executionManager.requests, 1)
+	request := executionManager.requests[0]
+	assert.Equal(t, 13, int(request.ShardID))
+	assert.Equal(t, "test-source-cluster", request.SourceClusterName)
+	assert.Equal(t, replicationTaskInfo, request.TaskInfo)
+}
+
+func TestNewDLQWriterAdapter(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name      string
+		taskType  enumspb.TaskType
+		expectErr bool
+	}{
+		{
+			name:      "history replication task",
+			taskType:  enumspb.TASK_TYPE_REPLICATION_HISTORY,
+			expectErr: false,
+		},
+		{
+			name:      "unspecified task type",
+			taskType:  enumspb.TASK_TYPE_UNSPECIFIED,
+			expectErr: true,
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			queueWriter := &queuestest.FakeQueueWriter{}
+			taskSerializer := serialization.NewTaskSerializer()
+			writer := replication.NewDLQWriterAdapter(
+				queues.NewDLQWriter(queueWriter),
+				taskSerializer,
+				"test-current-cluster",
+			)
+			executionManager := &fakeExecutionManager{}
+
+			replicationTaskInfo := &persistencespb.ReplicationTaskInfo{
+				NamespaceId: string(tests.NamespaceID),
+				WorkflowId:  tests.WorkflowID,
+				RunId:       tests.RunID,
+				TaskType:    tc.taskType,
+				TaskId:      21,
+			}
+			err := writer.WriteTaskToDLQ(context.Background(), replication.WriteRequest{
+				ShardID:             13,
+				ExecutionManager:    executionManager,
+				SourceCluster:       "test-source-cluster",
+				ReplicationTaskInfo: replicationTaskInfo,
+			})
+			if tc.expectErr {
+				require.Error(t, err)
+				assert.Contains(t, strings.ToLower(err.Error()), "unknown replication task type")
+				assert.Empty(t, executionManager.requests)
+				assert.Empty(t, queueWriter.EnqueueTaskRequests)
+			} else {
+				require.NoError(t, err)
+				assert.Empty(t, executionManager.requests)
+				require.Len(t, queueWriter.EnqueueTaskRequests, 1)
+				request := queueWriter.EnqueueTaskRequests[0]
+				assert.Equal(t, string(tests.NamespaceID), request.Task.GetNamespaceID())
+				assert.Equal(t, tests.WorkflowID, request.Task.GetWorkflowID())
+				assert.Equal(t, tests.RunID, request.Task.GetRunID())
+				assert.Equal(t, 21, int(request.Task.GetTaskID()))
+				assert.Equal(t, "test-source-cluster", request.SourceCluster)
+				assert.Equal(t, "test-current-cluster", request.TargetCluster)
+			}
+		})
 	}
-}
-
-func (f *fakeShardContext) GetShardID() int32 {
-	return int32(f.shardID)
-}
-
-func (f *fakeShardContext) GetExecutionManager() persistence.ExecutionManager {
-	return &fakeExecutionManager{requests: &f.requests}
 }
 
 func (f *fakeExecutionManager) PutReplicationTaskToDLQ(
 	_ context.Context,
 	request *persistence.PutReplicationTaskToDLQRequest,
 ) error {
-	*f.requests = append(*f.requests, request)
+	f.requests = append(f.requests, request)
 	return nil
 }

--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"go.temporal.io/api/serviceerror"
-
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -202,9 +201,5 @@ func (e *ExecutableActivityStateTask) MarkPoisonPill() error {
 	ctx, cancel := newTaskContext(e.NamespaceID)
 	defer cancel()
 
-	return e.DLQWriter.WriteTaskToDLQ(ctx, WriteRequest{
-		ShardContext:        shardContext,
-		SourceCluster:       e.SourceClusterName(),
-		ReplicationTaskInfo: replicationTaskInfo,
-	})
+	return writeTaskToDLQ(ctx, e.DLQWriter, shardContext, e.SourceClusterName(), replicationTaskInfo)
 }

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -246,11 +246,7 @@ func (e *ExecutableHistoryTask) MarkPoisonPill() error {
 	ctx, cancel := newTaskContext(e.NamespaceID)
 	defer cancel()
 
-	return e.DLQWriter.WriteTaskToDLQ(ctx, WriteRequest{
-		ShardContext:        shardContext,
-		SourceCluster:       e.SourceClusterName(),
-		ReplicationTaskInfo: taskInfo,
-	})
+	return writeTaskToDLQ(ctx, e.DLQWriter, shardContext, e.SourceClusterName(), taskInfo)
 }
 
 func (e *ExecutableHistoryTask) getDeserializedEvents() (_ []*historypb.HistoryEvent, _ []*historypb.HistoryEvent, retError error) {

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -193,9 +193,5 @@ func (e *ExecutableWorkflowStateTask) MarkPoisonPill() error {
 	ctx, cancel := newTaskContext(e.NamespaceID)
 	defer cancel()
 
-	return e.DLQWriter.WriteTaskToDLQ(ctx, WriteRequest{
-		ShardContext:        shardContext,
-		SourceCluster:       e.ExecutableTask.SourceClusterName(),
-		ReplicationTaskInfo: taskInfo,
-	})
+	return writeTaskToDLQ(ctx, e.DLQWriter, shardContext, e.SourceClusterName(), taskInfo)
 }

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -27,6 +27,7 @@ package replication
 import (
 	"context"
 
+	"go.temporal.io/server/service/history/queues"
 	"go.uber.org/fx"
 
 	"go.temporal.io/server/common/metrics"
@@ -55,6 +56,8 @@ var Module = fx.Provide(
 	ndcHistoryResenderProvider,
 	eagerNamespaceRefresherProvider,
 	sequentialTaskQueueFactoryProvider,
+	dlqWriterAdapterProvider,
+	newDLQWriterToggle,
 )
 
 func eagerNamespaceRefresherProvider(
@@ -176,4 +179,12 @@ func ndcHistoryResenderProvider(
 		config.StandbyTaskReReplicationContextTimeout,
 		logger,
 	)
+}
+
+func dlqWriterAdapterProvider(
+	dlqWriter *queues.DLQWriter,
+	taskSerializer serialization.Serializer,
+	clusterMetadata cluster.Metadata,
+) *DLQWriterAdapter {
+	return NewDLQWriterAdapter(dlqWriter, taskSerializer, clusterMetadata.GetCurrentClusterName())
 }

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -371,11 +371,7 @@ func (p *taskProcessorImpl) handleReplicationDLQTask(
 		metrics.InstanceTag(convert.Int32ToString(p.shard.GetShardID())))
 	// The following is guaranteed to success or retry forever until processor is shutdown.
 	return backoff.ThrottleRetry(func() error {
-		err := p.dlqWriter.WriteTaskToDLQ(ctx, WriteRequest{
-			ShardContext:        p.shard,
-			SourceCluster:       request.SourceClusterName,
-			ReplicationTaskInfo: request.TaskInfo,
-		})
+		err := writeTaskToDLQ(ctx, p.dlqWriter, p.shard, request.SourceClusterName, request.TaskInfo)
 		if err != nil {
 			p.logger.Error("failed to enqueue replication task to DLQ", tag.Error(err))
 			p.metricsHandler.Counter(metrics.ReplicationDLQFailed.GetMetricName()).Record(1, metrics.OperationTag(metrics.ReplicationTaskFetcherScope))

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -174,6 +174,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	if TestFlags.PersistenceFaultInjectionRate > 0 {
 		options.Persistence.FaultInjection.Rate = TestFlags.PersistenceFaultInjectionRate
 	}
+	options.Persistence.Logger = logger
 
 	testBase := persistencetests.NewTestBase(&options.Persistence)
 	testBase.Setup(clusterMetadataConfig)

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -74,7 +74,9 @@ func (s *xdcBaseSuite) clusterReplicationConfig() []*replicationpb.ClusterReplic
 func (s *xdcBaseSuite) setupSuite(clusterNames []string, opts ...tests.Option) {
 	params := tests.ApplyTestClusterParams(opts)
 	s.clusterNames = clusterNames
-	s.logger = log.NewTestLogger()
+	if s.logger == nil {
+		s.logger = log.NewTestLogger()
+	}
 	if s.dynamicConfigOverrides == nil {
 		s.dynamicConfigOverrides = make(map[dynamicconfig.Key]interface{})
 	}

--- a/tools/tdbg/tdbg_commands.go
+++ b/tools/tdbg/tdbg_commands.go
@@ -501,9 +501,10 @@ func newAdminDLQCommands(clientFactory ClientFactory, taskCategoryRegistry tasks
 					Name:  FlagOutputFilename,
 					Usage: "Output file to write to, if not provided output is written to stdout",
 				},
-				&cli.StringFlag{
+				&cli.IntFlag{
 					Name:  FlagPageSize,
 					Usage: "Page size to use when reading messages from the DB, v2 only",
+					Value: defaultPageSize,
 				},
 			),
 			Action: func(c *cli.Context) error {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR adds a dynamic config flag which controls the rollout of the persistence queue V2 backend for writing history replication tasks to the DLQ.

<!-- Tell your future self why have you made these changes -->
**Why?**
Our first priority of the queue v2 migration is to make it work for history replication tasks, so this PR adds the ability for us to roll that out.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added branches to our history replciation DLQ integration test that turn on this dynamic config flag.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
