### PR TITLE
Set delete namespace activity concurrency limits

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -928,4 +928,12 @@ const (
 	WorkerStickyCacheSize = "worker.stickyCacheSize"
 	// SchedulerNamespaceStartWorkflowRPS is the per-namespace limit for starting workflows by schedules
 	SchedulerNamespaceStartWorkflowRPS = "worker.schedulerNamespaceStartWorkflowRPS"
+	// WorkerDeleteNamespaceMaxConcurrentActivityExecutionSize is the maximum concurrent activity executions the delete namespace activity worker can have
+	WorkerDeleteNamespaceMaxConcurrentActivityExecutionSize = "worker.deleteNamespaceMaxConcurrentActivityExecutionSize"
+	// WorkerDeleteNamespaceTaskQueueActivitiesPerSecond is the limit for concurrent activities on the delete namespace activity task queue
+	WorkerDeleteNamespaceTaskQueueActivitiesPerSecond = "worker.deleteNamespaceTaskQueueActivitiesPerSecond"
+	// WorkerDeleteNamespaceWorkerActivitiesPerSecond is the rate limit on number of activities that can be executed per second per delete namespace activity worker
+	WorkerDeleteNamespaceWorkerActivitiesPerSecond = "worker.deleteNamespaceWorkerActivitiesPerSecond"
+	// WorkerDeleteNamespaceMaxConcurrentActivityTaskPollers is the maximum number of goroutines that will concurrently poll for delete namespace activities
+	WorkerDeleteNamespaceMaxConcurrentActivityTaskPollers = "worker.deleteNamespaceMaxConcurrentActivityTaskPollers"
 )

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -928,7 +928,7 @@ const (
 	WorkerStickyCacheSize = "worker.stickyCacheSize"
 	// SchedulerNamespaceStartWorkflowRPS is the per-namespace limit for starting workflows by schedules
 	SchedulerNamespaceStartWorkflowRPS = "worker.schedulerNamespaceStartWorkflowRPS"
-	// WorkerDeleteNamespaceActivityConcurrencyConfig is a map that contains a copy of relevant sdkworker.Options
+	// WorkerDeleteNamespaceActivityLimitsConfig is a map that contains a copy of relevant sdkworker.Options
 	// settings for controlling remote activity concurrency for delete namespace workflows.
-	WorkerDeleteNamespaceActivityConcurrencyConfig = "worker.deleteNamespaceActivityConcurrencyConfig"
+	WorkerDeleteNamespaceActivityLimitsConfig = "worker.deleteNamespaceActivityLimitsConfig"
 )

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -928,12 +928,7 @@ const (
 	WorkerStickyCacheSize = "worker.stickyCacheSize"
 	// SchedulerNamespaceStartWorkflowRPS is the per-namespace limit for starting workflows by schedules
 	SchedulerNamespaceStartWorkflowRPS = "worker.schedulerNamespaceStartWorkflowRPS"
-	// WorkerDeleteNamespaceMaxConcurrentActivityExecutionSize is the maximum concurrent activity executions the delete namespace activity worker can have
-	WorkerDeleteNamespaceMaxConcurrentActivityExecutionSize = "worker.deleteNamespaceMaxConcurrentActivityExecutionSize"
-	// WorkerDeleteNamespaceTaskQueueActivitiesPerSecond is the limit for concurrent activities on the delete namespace activity task queue
-	WorkerDeleteNamespaceTaskQueueActivitiesPerSecond = "worker.deleteNamespaceTaskQueueActivitiesPerSecond"
-	// WorkerDeleteNamespaceWorkerActivitiesPerSecond is the rate limit on number of activities that can be executed per second per delete namespace activity worker
-	WorkerDeleteNamespaceWorkerActivitiesPerSecond = "worker.deleteNamespaceWorkerActivitiesPerSecond"
-	// WorkerDeleteNamespaceMaxConcurrentActivityTaskPollers is the maximum number of goroutines that will concurrently poll for delete namespace activities
-	WorkerDeleteNamespaceMaxConcurrentActivityTaskPollers = "worker.deleteNamespaceMaxConcurrentActivityTaskPollers"
+	// WorkerDeleteNamespaceActivityConcurrencyConfig is a map that contains a copy of relevant sdkworker.Options
+	// settings for controlling remote activity concurrency for delete namespace workflows.
+	WorkerDeleteNamespaceActivityConcurrencyConfig = "worker.deleteNamespaceActivityConcurrencyConfig"
 )

--- a/service/worker/common/interface.go
+++ b/service/worker/common/interface.go
@@ -58,6 +58,14 @@ type (
 		Options sdkworker.Options
 	}
 
+	ActivityWorkerConcurrencyConfig struct {
+		// copy of relevant remote activity concurrency controls from sdkworker.Options
+		MaxConcurrentActivityExecutionSize int
+		TaskQueueActivitiesPerSecond       float64
+		WorkerActivitiesPerSecond          float64
+		MaxConcurrentActivityTaskPollers   int
+	}
+
 	// PerNSWorkerComponent represents a per-namespace worker needed for worker role
 	PerNSWorkerComponent interface {
 		// Register registers Workflow and Activity types provided by this worker component.

--- a/service/worker/common/interface.go
+++ b/service/worker/common/interface.go
@@ -58,8 +58,8 @@ type (
 		Options sdkworker.Options
 	}
 
-	ActivityWorkerConcurrencyConfig struct {
-		// copy of relevant remote activity concurrency controls from sdkworker.Options
+	ActivityWorkerLimitsConfig struct {
+		// copy of relevant remote activity controls from sdkworker.Options
 		MaxConcurrentActivityExecutionSize int
 		TaskQueueActivitiesPerSecond       float64
 		WorkerActivitiesPerSecond          float64

--- a/service/worker/common/util.go
+++ b/service/worker/common/util.go
@@ -30,15 +30,15 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 )
 
-// NewActivityWorkerConcurrencyConfig constructs an ActivityWorkerConcurrencyConfig from the map of values identified
+// NewActivityWorkerConcurrencyConfig constructs an ActivityWorkerLimitsConfig from the map of values identified
 // by key in the dynamic collection. Any errors are ignored and 0 values will be returned instead.
 func NewActivityWorkerConcurrencyConfig(
 	dc *dynamicconfig.Collection,
 	key dynamicconfig.Key,
 	defaults map[string]any,
-) ActivityWorkerConcurrencyConfig {
+) ActivityWorkerLimitsConfig {
 	dcOptions := dc.GetMapProperty(key, defaults)()
-	var config ActivityWorkerConcurrencyConfig
+	var config ActivityWorkerLimitsConfig
 	b, err := json.Marshal(dcOptions)
 	if err != nil {
 		return config

--- a/service/worker/common/util.go
+++ b/service/worker/common/util.go
@@ -1,0 +1,48 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package common
+
+import (
+	"encoding/json"
+
+	"go.temporal.io/server/common/dynamicconfig"
+)
+
+// NewActivityWorkerConcurrencyConfig constructs an ActivityWorkerConcurrencyConfig from the map of values identified
+// by key in the dynamic collection. Any errors are ignored and 0 values will be returned instead.
+func NewActivityWorkerConcurrencyConfig(
+	dc *dynamicconfig.Collection,
+	key dynamicconfig.Key,
+	defaults map[string]any,
+) ActivityWorkerConcurrencyConfig {
+	dcOptions := dc.GetMapProperty(key, defaults)
+	var config ActivityWorkerConcurrencyConfig
+	b, err := json.Marshal(dcOptions)
+	if err != nil {
+		return config
+	}
+	_ = json.Unmarshal(b, &config) // ignore errors, just use the zero value anyway
+	return config
+}

--- a/service/worker/common/util.go
+++ b/service/worker/common/util.go
@@ -37,7 +37,7 @@ func NewActivityWorkerConcurrencyConfig(
 	key dynamicconfig.Key,
 	defaults map[string]any,
 ) ActivityWorkerConcurrencyConfig {
-	dcOptions := dc.GetMapProperty(key, defaults)
+	dcOptions := dc.GetMapProperty(key, defaults)()
 	var config ActivityWorkerConcurrencyConfig
 	b, err := json.Marshal(dcOptions)
 	if err != nil {

--- a/service/worker/deletenamespace/fx.go
+++ b/service/worker/deletenamespace/fx.go
@@ -31,6 +31,7 @@ import (
 	"go.temporal.io/sdk/workflow"
 	"go.uber.org/fx"
 
+	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/headers"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/metrics"
@@ -44,8 +45,18 @@ import (
 )
 
 type (
+	activityWorkerConfig struct {
+		// worker concurrency option changes require a restart to take effect
+		// default to 0 to use SDK-defined defaults
+		maxConcurrentActivityExecutionSize dynamicconfig.IntPropertyFn
+		taskQueueActivitiesPerSecond       dynamicconfig.FloatPropertyFn
+		workerActivitiesPerSecond          dynamicconfig.FloatPropertyFn
+		maxConcurrentActivityTaskPollers   dynamicconfig.IntPropertyFn
+	}
+
 	// deleteNamespaceComponent represent background work needed for delete namespace.
 	deleteNamespaceComponent struct {
+		atWorkerCfg       activityWorkerConfig
 		visibilityManager manager.VisibilityManager
 		metadataManager   persistence.MetadataManager
 		historyClient     resource.HistoryClient
@@ -54,20 +65,36 @@ type (
 	}
 	componentParams struct {
 		fx.In
-		VisibilityManager manager.VisibilityManager
-		MetadataManager   persistence.MetadataManager
-		HistoryClient     resource.HistoryClient
-		MetricsHandler    metrics.Handler
-		Logger            log.Logger
+		ActivityWorkerConfig activityWorkerConfig
+		VisibilityManager    manager.VisibilityManager
+		MetadataManager      persistence.MetadataManager
+		HistoryClient        resource.HistoryClient
+		MetricsHandler       metrics.Handler
+		Logger               log.Logger
 	}
 )
 
-var Module = workercommon.AnnotateWorkerComponentProvider(newComponent)
+var Module = fx.Options(
+	fx.Provide(newActivityWorkerConfig),
+	workercommon.AnnotateWorkerComponentProvider(newComponent),
+)
+
+func newActivityWorkerConfig(
+	dc *dynamicconfig.Collection,
+) activityWorkerConfig {
+	return activityWorkerConfig{
+		maxConcurrentActivityExecutionSize: dc.GetIntProperty(dynamicconfig.WorkerDeleteNamespaceMaxConcurrentActivityExecutionSize, 0),
+		taskQueueActivitiesPerSecond:       dc.GetFloat64Property(dynamicconfig.WorkerDeleteNamespaceTaskQueueActivitiesPerSecond, 1000),
+		workerActivitiesPerSecond:          dc.GetFloat64Property(dynamicconfig.WorkerDeleteNamespaceWorkerActivitiesPerSecond, 0),
+		maxConcurrentActivityTaskPollers:   dc.GetIntProperty(dynamicconfig.WorkerDeleteNamespaceMaxConcurrentActivityTaskPollers, 0),
+	}
+}
 
 func newComponent(
 	params componentParams,
 ) workercommon.WorkerComponent {
 	return &deleteNamespaceComponent{
+		atWorkerCfg:       params.ActivityWorkerConfig,
 		visibilityManager: params.VisibilityManager,
 		metadataManager:   params.MetadataManager,
 		historyClient:     params.HistoryClient,
@@ -101,7 +128,11 @@ func (wc *deleteNamespaceComponent) DedicatedActivityWorkerOptions() *workercomm
 	return &workercommon.DedicatedWorkerOptions{
 		TaskQueue: primitives.DeleteNamespaceActivityTQ,
 		Options: sdkworker.Options{
-			BackgroundActivityContext: headers.SetCallerType(context.Background(), headers.CallerTypePreemptable),
+			BackgroundActivityContext:          headers.SetCallerType(context.Background(), headers.CallerTypePreemptable),
+			MaxConcurrentActivityExecutionSize: wc.atWorkerCfg.maxConcurrentActivityExecutionSize(),
+			TaskQueueActivitiesPerSecond:       wc.atWorkerCfg.taskQueueActivitiesPerSecond(),
+			WorkerActivitiesPerSecond:          wc.atWorkerCfg.workerActivitiesPerSecond(),
+			MaxConcurrentActivityTaskPollers:   wc.atWorkerCfg.maxConcurrentActivityTaskPollers(),
 		},
 	}
 }

--- a/service/worker/deletenamespace/fx.go
+++ b/service/worker/deletenamespace/fx.go
@@ -44,10 +44,6 @@ import (
 	"go.temporal.io/server/service/worker/deletenamespace/reclaimresources"
 )
 
-var activityWorkerConcurrencyDefaults = map[string]any{
-	"MaxConcurrentActivityExecutionSize": 4,
-}
-
 type (
 	// deleteNamespaceComponent represent background work needed for delete namespace.
 	deleteNamespaceComponent struct {
@@ -78,7 +74,7 @@ func newComponent(
 		atWorkerCfg: workercommon.NewActivityWorkerConcurrencyConfig(
 			params.dc,
 			dynamicconfig.WorkerDeleteNamespaceActivityConcurrencyConfig,
-			activityWorkerConcurrencyDefaults,
+			map[string]any{},
 		),
 		visibilityManager: params.VisibilityManager,
 		metadataManager:   params.MetadataManager,

--- a/service/worker/deletenamespace/fx.go
+++ b/service/worker/deletenamespace/fx.go
@@ -56,7 +56,7 @@ type (
 	}
 	componentParams struct {
 		fx.In
-		dc                *dynamicconfig.Collection
+		DynamicCollection *dynamicconfig.Collection
 		VisibilityManager manager.VisibilityManager
 		MetadataManager   persistence.MetadataManager
 		HistoryClient     resource.HistoryClient
@@ -72,7 +72,7 @@ func newComponent(
 ) workercommon.WorkerComponent {
 	return &deleteNamespaceComponent{
 		atWorkerCfg: workercommon.NewActivityWorkerConcurrencyConfig(
-			params.dc,
+			params.DynamicCollection,
 			dynamicconfig.WorkerDeleteNamespaceActivityLimitsConfig,
 			map[string]any{},
 		),

--- a/service/worker/deletenamespace/fx.go
+++ b/service/worker/deletenamespace/fx.go
@@ -47,7 +47,7 @@ import (
 type (
 	// deleteNamespaceComponent represent background work needed for delete namespace.
 	deleteNamespaceComponent struct {
-		atWorkerCfg       workercommon.ActivityWorkerConcurrencyConfig
+		atWorkerCfg       workercommon.ActivityWorkerLimitsConfig
 		visibilityManager manager.VisibilityManager
 		metadataManager   persistence.MetadataManager
 		historyClient     resource.HistoryClient
@@ -73,7 +73,7 @@ func newComponent(
 	return &deleteNamespaceComponent{
 		atWorkerCfg: workercommon.NewActivityWorkerConcurrencyConfig(
 			params.dc,
-			dynamicconfig.WorkerDeleteNamespaceActivityConcurrencyConfig,
+			dynamicconfig.WorkerDeleteNamespaceActivityLimitsConfig,
 			map[string]any{},
 		),
 		visibilityManager: params.VisibilityManager,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added new dynamic config map of options to set concurrency limits for the delete namespace activity worker: `worker.deleteNamespaceActivityLimitsConfig`

<!-- Tell your future self why have you made these changes -->
**Why?**
For finer-grained control over worker service resource usage

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No