### PR TITLE
Change replication batch task metrics from counter to gauge

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -829,7 +829,7 @@ var (
 	StaleMutableStateCounter                      = NewCounterDef("stale_mutable_state")
 	AutoResetPointsLimitExceededCounter           = NewCounterDef("auto_reset_points_exceed_limit")
 	AutoResetPointCorruptionCounter               = NewCounterDef("auto_reset_point_corruption")
-	BatchableTaskBatchCount                       = NewCounterDef("batchable_task_batch_count")
+	BatchableTaskBatchCount                       = NewGaugeDef("batchable_task_batch_count")
 	ConcurrencyUpdateFailureCounter               = NewCounterDef("concurrency_update_failure")
 	ServiceErrShardOwnershipLostCounter           = NewCounterDef("service_errors_shard_ownership_lost")
 	HeartbeatTimeoutCounter                       = NewCounterDef("heartbeat_timeout")

--- a/service/history/replication/batchable_task.go
+++ b/service/history/replication/batchable_task.go
@@ -89,8 +89,8 @@ func (w *batchedTask) MarkPoisonPill() error {
 }
 
 func (w *batchedTask) Ack() {
-	w.metricsHandler.Counter(metrics.BatchableTaskBatchCount.GetMetricName()).Record(
-		int64(len(w.individualTasks)),
+	w.metricsHandler.Gauge(metrics.BatchableTaskBatchCount.GetMetricName()).Record(
+		float64(len(w.individualTasks)),
 	)
 	w.callIndividual(TrackableExecutableTask.Ack)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change replication batch task metrics from counter to gauge

<!-- Tell your future self why have you made these changes -->
**Why?**
Counter is not what we need. From this metrics, we want to know in avg, how many tasks are batched together

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
n/a

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
n/a

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
no