### PR TITLE
Decode DLQ tasks in tdbg

### DIFF
--- a/tests/xdc/history_replication_dlq_test.go
+++ b/tests/xdc/history_replication_dlq_test.go
@@ -26,6 +26,7 @@ package xdc
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
@@ -36,31 +37,31 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/jsonpb"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
-	"github.com/urfave/cli/v2"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
-	commonspb "go.temporal.io/server/api/common/v1"
-	"go.temporal.io/server/common/config"
-	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/persistence/serialization"
-	"go.temporal.io/server/tests/testutils"
 	"go.uber.org/fx"
 
 	enumspb "go.temporal.io/server/api/enums/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests"
+	"go.temporal.io/server/tests/testutils"
 	"go.temporal.io/server/tools/tdbg"
+	"go.temporal.io/server/tools/tdbg/tdbgtest"
 )
 
 // This file contains tests for the history replication DLQ feature. It uses a faulty replication task executor to force
@@ -321,12 +322,9 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 	clientFactory := tdbg.NewClientFactory(
 		tdbg.WithFrontendAddress(s.cluster2.GetHost().FrontendGRPCAddress()),
 	)
-	app := tdbg.NewCliApp(func(params *tdbg.Params) {
+	app := tdbgtest.NewCliApp(func(params *tdbg.Params) {
 		params.ClientFactory = clientFactory
 	})
-	app.ExitErrHandler = func(c *cli.Context, err error) {
-		// We don't want the CLI to exit when it encounters an error, so we override the default handler.
-	}
 
 	// Run the TDBG command to read replication tasks from the DLQ.
 	// The last message ID is set to MaxInt64 - 1 because the last message ID is exclusive, so if it were
@@ -376,28 +374,27 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 	// Verify that the replication task contains the correct information (operators will want to know which workflow
 	// failed to replicate).
 	if s.enableQueueV2 {
-		replicationTasks := tests.ParseJSONLProtos[*commonspb.HistoryDLQTask](
-			s.Assertions,
+		replicationTasks, err := tdbgtest.ParseDLQMessages(
 			file,
-			func() *commonspb.HistoryDLQTask {
-				return &commonspb.HistoryDLQTask{}
+			func() *persistencespb.ReplicationTaskInfo {
+				return new(persistencespb.ReplicationTaskInfo)
 			},
 		)
-		s.NotEmpty(replicationTasks)
-		blob := replicationTasks[0].Payload.Blob
-		task, err := serialization.ReplicationTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
 		s.NoError(err)
+		s.NotEmpty(replicationTasks)
+		task := replicationTasks[0].Payload
 		s.Equal(enumspb.TASK_TYPE_REPLICATION_HISTORY, task.GetTaskType())
 		s.Equal(run.GetID(), task.WorkflowId)
 		s.Equal(run.GetRunID(), task.RunId)
 	} else {
-		replicationTasks := tests.ParseJSONLProtos[*replicationspb.ReplicationTask](
-			s.Assertions,
+		replicationTasks, err := tdbgtest.ParseJSONL(
 			file,
-			func() *replicationspb.ReplicationTask {
-				return &replicationspb.ReplicationTask{}
+			func(decoder *json.Decoder) (*replicationspb.ReplicationTask, error) {
+				task := &replicationspb.ReplicationTask{}
+				return task, jsonpb.UnmarshalNext(decoder, task)
 			},
 		)
+		s.NoError(err)
 		s.NotEmpty(replicationTasks)
 		task := replicationTasks[0]
 		s.Equal(enumspb.REPLICATION_TASK_TYPE_HISTORY_V2_TASK, task.GetTaskType())

--- a/tools/tdbg/dlq_service.go
+++ b/tools/tdbg/dlq_service.go
@@ -48,20 +48,27 @@ type (
 	}
 	DLQServiceProvider struct {
 		clientFactory        ClientFactory
+		taskBlobEncoder      TaskBlobEncoder
 		taskCategoryRegistry tasks.TaskCategoryRegistry
 		writer               io.Writer
 		prompterFactory      PrompterFactory
+	}
+	// noCloseWriter adapts an [io.Writer] with no cleanup logic to an [io.WriteCloser].
+	noCloseWriter struct {
+		io.Writer
 	}
 )
 
 func NewDLQServiceProvider(
 	clientFactory ClientFactory,
+	taskBlobEncoder TaskBlobEncoder,
 	taskCategoryRegistry tasks.TaskCategoryRegistry,
 	writer io.Writer,
 	prompterFactory PrompterFactory,
 ) *DLQServiceProvider {
 	return &DLQServiceProvider{
 		clientFactory:        clientFactory,
+		taskBlobEncoder:      taskBlobEncoder,
 		taskCategoryRegistry: taskCategoryRegistry,
 		writer:               writer,
 		prompterFactory:      prompterFactory,
@@ -75,10 +82,17 @@ func (p *DLQServiceProvider) GetDLQService(
 	prompter := p.prompterFactory(c)
 	version := c.String(FlagDLQVersion)
 	if version == "v1" {
-		return NewDLQV1Service(p.clientFactory, prompter), nil
+		return NewDLQV1Service(p.clientFactory, prompter, p.writer), nil
 	}
 	if version == "v2" {
-		return getDLQV2Service(c, p.clientFactory, p.taskCategoryRegistry, p.writer, prompter)
+		return getDLQV2Service(
+			c,
+			p.clientFactory,
+			p.taskCategoryRegistry,
+			p.writer,
+			prompter,
+			p.taskBlobEncoder,
+		)
 	}
 	return nil, fmt.Errorf("unknown DLQ version: %v", version)
 }
@@ -89,6 +103,7 @@ func getDLQV2Service(
 	taskCategoryRegistry tasks.TaskCategoryRegistry,
 	writer io.Writer,
 	prompter *Prompter,
+	taskBlobEncoder TaskBlobEncoder,
 ) (DLQService, error) {
 	dlqType := c.String(FlagDLQType)
 	category, ok, err := getCategoryByID(taskCategoryRegistry, dlqType)
@@ -111,7 +126,15 @@ func getDLQV2Service(
 		}
 		sourceCluster = targetCluster
 	}
-	return NewDLQV2Service(category, sourceCluster, targetCluster, clientFactory, writer, prompter), nil
+	return NewDLQV2Service(
+		category,
+		sourceCluster,
+		targetCluster,
+		clientFactory,
+		writer,
+		prompter,
+		taskBlobEncoder,
+	), nil
 }
 
 func getTargetCluster(c *cli.Context, clientFactory ClientFactory) (string, DLQService, error) {
@@ -142,13 +165,17 @@ func toQueueType(dlqType string) (enumsspb.DeadLetterQueueType, error) {
 	}
 }
 
-func getOutputFile(outputFile string) (*os.File, error) {
+func getOutputFile(outputFile string, writer io.Writer) (io.WriteCloser, error) {
 	if len(outputFile) == 0 {
-		return os.Stdout, nil
+		return noCloseWriter{writer}, nil
 	}
 	f, err := os.Create(outputFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create output file: %s", err)
 	}
 	return f, nil
+}
+
+func (n noCloseWriter) Close() error {
+	return nil
 }

--- a/tools/tdbg/dlq_service_test.go
+++ b/tools/tdbg/dlq_service_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli/v2"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/tools/tdbg/tdbgtest"
 	"google.golang.org/grpc"
 
 	"go.temporal.io/server/api/adminservice/v1"
@@ -128,12 +129,9 @@ func (tc *dlqTestCase) Run(t *testing.T, firstAppRun chan struct{}) {
 		clientFactory:         faultyClientFactory{err: errors.New("did not expect client to be used")},
 	}
 	tc.override(&p)
-	app := tdbg.NewCliApp(func(params *tdbg.Params) {
+	app := tdbgtest.NewCliApp(func(params *tdbg.Params) {
 		params.ClientFactory = p.clientFactory
 	})
-	app.ExitErrHandler = func(c *cli.Context, err error) {
-		return
-	}
 	runArgs := []string{
 		"tdbg",
 		"--" + tdbg.FlagYes,
@@ -274,15 +272,6 @@ func TestDLQCommands(t *testing.T) {
 			},
 		},
 		{
-			name: "v2 purge client nil response",
-			override: func(p *dlqTestParams) {
-				p.dlqVersion = "v2"
-				p.command = "purge"
-				p.clientFactory = faultyClientFactory{}
-				p.expectedErrSubstrings = []string{"unable to encode PurgeDLQTasks"}
-			},
-		},
-		{
 			name: "v2 merge invalid last message ID",
 			override: func(p *dlqTestParams) {
 				p.dlqVersion = "v2"
@@ -298,15 +287,6 @@ func TestDLQCommands(t *testing.T) {
 				p.command = "merge"
 				p.clientFactory = faultyClientFactory{err: errors.New("some error")}
 				p.expectedErrSubstrings = []string{"some error", "MergeDLQTasks"}
-			},
-		},
-		{
-			name: "v2 merge client nil response",
-			override: func(p *dlqTestParams) {
-				p.dlqVersion = "v2"
-				p.command = "merge"
-				p.clientFactory = faultyClientFactory{}
-				p.expectedErrSubstrings = []string{"unable to encode MergeDLQTasks"}
 			},
 		},
 	} {

--- a/tools/tdbg/flags.go
+++ b/tools/tdbg/flags.go
@@ -81,4 +81,6 @@ var (
 	FlagBinaryFile                 = "binary-file"
 	FlagBase64Data                 = "base64-data"
 	FlagBase64File                 = "base64-file"
+	FlagTaskCategoryID             = "task-category-id"
+	FlagEncoding                   = "encoding"
 )

--- a/tools/tdbg/task_encoder.go
+++ b/tools/tdbg/task_encoder.go
@@ -1,0 +1,127 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tdbg
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	commonpb "go.temporal.io/api/common/v1"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+type (
+	// TaskBlobEncoder takes a blob for a given task category and encodes it to a human-readable format.
+	// Here's a breakdown of the relationship between all the related types needed to implement a custom encoder:
+	// - NewCliApp accepts a list of Option objects.
+	// - Option objects modify Params.
+	// - Params contain a TaskBlobEncoder.
+	// - TaskBlobEncoder is implemented by ProtoTaskBlobEncoder.
+	// - ProtoTaskBlobEncoder uses jsonpb to marshal [proto.Message] objects from a TaskBlobProtoDeserializer.
+	// - TaskBlobProtoDeserializer is implemented by the stock PredefinedTaskBlobDeserializer.
+	// - PredefinedTaskBlobDeserializer deserializes [commonpb.DataBlob] objects into [proto.Message] objects.
+	TaskBlobEncoder interface {
+		Encode(writer io.Writer, taskCategoryID int, blob commonpb.DataBlob) error
+	}
+	// TaskBlobEncoderFn implements TaskBlobEncoder by calling a function.
+	TaskBlobEncoderFn func(writer io.Writer, taskCategoryID int, blob commonpb.DataBlob) error
+	// TaskBlobProtoDeserializer is used to deserialize task blobs into proto messages. This makes it easier to create
+	// an encoder if your tasks are all backed by protos. We separate this from the encoder because we don't want the
+	// encoder to be tied to protos as the wire format.
+	TaskBlobProtoDeserializer interface {
+		Deserialize(taskCategoryID int, blob commonpb.DataBlob) (proto.Message, error)
+	}
+	// ProtoTaskBlobEncoder is a TaskBlobEncoder that uses a TaskBlobProtoDeserializer to deserialize the blob into a
+	// proto message, and then uses jsonpb to marshal the proto message into a human-readable format.
+	ProtoTaskBlobEncoder struct {
+		deserializer TaskBlobProtoDeserializer
+	}
+	// PredefinedTaskBlobDeserializer is a TaskBlobProtoDeserializer that deserializes task blobs into the predefined
+	// task categories that are used by Temporal. If your server has custom categories, you'll want to build something
+	// on top of this.
+	PredefinedTaskBlobDeserializer struct{}
+)
+
+var (
+	jsonpbMarshaler = jsonpb.Marshaler{
+		EnumsAsInts:  false, // It's ok to use strings because this is for human consumption.
+		EmitDefaults: true,  // We want to see all fields clearly even if they have the default value.
+		Indent:       "  ",  // Indent with two spaces to pretty-print.
+		OrigName:     true,  // The proto field names are more JSON-esque than the Go field names.
+	}
+)
+
+// NewProtoTaskBlobEncoder returns a TaskBlobEncoder that uses a TaskBlobProtoDeserializer to deserialize the blob.
+func NewProtoTaskBlobEncoder(deserializer TaskBlobProtoDeserializer) *ProtoTaskBlobEncoder {
+	return &ProtoTaskBlobEncoder{
+		deserializer: deserializer,
+	}
+}
+
+// NewPredefinedTaskBlobDeserializer returns a TaskBlobProtoDeserializer that works for the stock task categories of the
+// server. You need to extend this if you have custom task categories.
+func NewPredefinedTaskBlobDeserializer() PredefinedTaskBlobDeserializer {
+	return PredefinedTaskBlobDeserializer{}
+}
+
+// Deserialize a task blob from one of the server's predefined task categories into a proto message.
+func (d PredefinedTaskBlobDeserializer) Deserialize(categoryID int, blob commonpb.DataBlob) (proto.Message, error) {
+	switch categoryID {
+	case tasks.CategoryIDTransfer:
+		return serialization.TransferTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	case tasks.CategoryIDTimer:
+		return serialization.TimerTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	case tasks.CategoryIDVisibility:
+		return serialization.VisibilityTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	case tasks.CategoryIDReplication:
+		return serialization.ReplicationTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	case tasks.CategoryIDArchival:
+		return serialization.ArchivalTaskInfoFromBlob(blob.Data, blob.EncodingType.String())
+	default:
+		return nil, fmt.Errorf("unsupported task category %v", categoryID)
+	}
+}
+
+// Encode a blob for a given task category to a human-readable format by deserializing the blob into a proto message and
+// then pretty-printing it using jsonpb.
+func (e *ProtoTaskBlobEncoder) Encode(writer io.Writer, categoryID int, blob commonpb.DataBlob) error {
+	message, err := e.deserializer.Deserialize(categoryID, blob)
+	if err != nil {
+		return fmt.Errorf("failed to deserialize task blob: %w", err)
+	}
+	err = jsonpbMarshaler.Marshal(writer, message)
+	if err != nil {
+		return fmt.Errorf("failed to marshal task blob: %w", err)
+	}
+	return nil
+}
+
+// Encode the task by calling the function.
+func (e TaskBlobEncoderFn) Encode(writer io.Writer, taskCategoryID int, blob commonpb.DataBlob) error {
+	return e(writer, taskCategoryID, blob)
+}

--- a/tools/tdbg/task_encoder_test.go
+++ b/tools/tdbg/task_encoder_test.go
@@ -1,0 +1,172 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tdbg_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"testing"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/tools/tdbg"
+)
+
+type (
+	// nilDeserializer is a [tdbg.TaskBlobProtoDeserializer] that returns nil [proto.Message] objects.
+	nilDeserializer struct{}
+	// faultyDeserializer is a [tdbg.TaskBlobProtoDeserializer] that returns an error when you try to deserialize a blob.
+	faultyDeserializer struct{}
+	// faultyWriter is an [io.Writer] that returns an error when you try to write to it.
+	faultyWriter       struct{}
+	exampleAdminClient struct {
+		adminservice.AdminServiceClient
+	}
+)
+
+var (
+	customCategory = tasks.Category{}
+)
+
+func ExampleTaskBlobEncoder() {
+	var output bytes.Buffer
+	app := tdbg.NewCliApp(func(params *tdbg.Params) {
+		params.Writer = &output
+		stockEncoder := params.TaskBlobEncoder
+		params.TaskBlobEncoder = tdbg.TaskBlobEncoderFn(func(
+			writer io.Writer,
+			taskCategoryID int,
+			blob commonpb.DataBlob,
+		) error {
+			if taskCategoryID == customCategory.ID() {
+				_, err := writer.Write(append([]byte("hello, "), blob.Data...))
+				return err
+			}
+			return stockEncoder.Encode(writer, taskCategoryID, blob)
+		})
+	})
+	file, err := os.CreateTemp("", "*")
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		if err := os.Remove(file.Name()); err != nil {
+			panic(err)
+		}
+	}()
+	_, err = file.Write([]byte("\"world\""))
+	if err != nil {
+		panic(err)
+	}
+	err = app.Run([]string{
+		"tdbg", "decode", "task",
+		"--" + tdbg.FlagEncoding, enumspb.ENCODING_TYPE_JSON.String(),
+		"--" + tdbg.FlagTaskCategoryID, strconv.Itoa(customCategory.ID()),
+		"--" + tdbg.FlagBinaryFile, file.Name(),
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Println(output.String())
+
+	// Output:
+	// hello, "world"
+}
+
+// Tests the [tdbg.NewPredefinedTaskBlobDeserializer] function.
+func TestPredefinedTasks(t *testing.T) {
+	t.Parallel()
+	encoder := tdbg.NewProtoTaskBlobEncoder(tdbg.NewPredefinedTaskBlobDeserializer())
+	var buf bytes.Buffer
+	historyTasks := []tasks.Task{
+		&tasks.WorkflowTask{},
+		&tasks.UserTimerTask{},
+		&tasks.CloseExecutionVisibilityTask{},
+		&tasks.HistoryReplicationTask{},
+		&tasks.ArchiveExecutionTask{},
+	}
+	serializer := serialization.NewTaskSerializer()
+	expectedTaskTypes := make([]string, len(historyTasks))
+	for i, task := range historyTasks {
+		expectedTaskTypes[i] = task.GetType().String()
+		blob, err := serializer.SerializeTask(task)
+		require.NoError(t, err)
+		err = encoder.Encode(&buf, task.GetCategory().ID(), blob)
+		require.NoError(t, err)
+		buf.WriteString("\n")
+	}
+	output := buf.String()
+	t.Log("output:")
+	t.Log(output)
+	for _, taskType := range expectedTaskTypes {
+		assert.Contains(t, output, taskType)
+	}
+
+	// Test an unsupported task category.
+	err := encoder.Encode(io.Discard, -1, commonpb.DataBlob{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "unsupported task category")
+}
+
+// Tests the [tdbg.ProtoTaskBlobEncoder.Encode] function with a [tdbg.TaskBlobProtoDeserializer] that returns an error.
+func TestProtoTaskBlobEncoder_DeserializeFailed(t *testing.T) {
+	t.Parallel()
+	encoder := tdbg.NewProtoTaskBlobEncoder(faultyDeserializer{})
+	err := encoder.Encode(io.Discard, 0, commonpb.DataBlob{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to deserialize task blob")
+}
+
+// Tests the [tdbg.ProtoTaskBlobEncoder.Encode] function with an [io.Writer] that returns an error.
+func TestProtoTaskBlobEncoder_WriteFailed(t *testing.T) {
+	t.Parallel()
+	encoder := tdbg.NewProtoTaskBlobEncoder(nilDeserializer{})
+	err := encoder.Encode(faultyWriter{}, 0, commonpb.DataBlob{})
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "failed to marshal task blob")
+}
+
+func (t nilDeserializer) Deserialize(int, commonpb.DataBlob) (proto.Message, error) {
+	return nil, nil
+}
+
+func (f faultyDeserializer) Deserialize(int, commonpb.DataBlob) (proto.Message, error) {
+	return nil, assert.AnError
+}
+
+func (w faultyWriter) Write(_ []byte) (int, error) {
+	return 0, assert.AnError
+}

--- a/tools/tdbg/tdbgtest/app.go
+++ b/tools/tdbg/tdbgtest/app.go
@@ -22,33 +22,16 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package tests
+package tdbgtest
 
 import (
-	"encoding/json"
-	"io"
-	"os"
-
-	"github.com/gogo/protobuf/jsonpb"
-	"github.com/gogo/protobuf/proto"
-	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	"go.temporal.io/server/tools/tdbg"
 )
 
-// ParseJSONLProtos parses protos from a JSONL file until EOF.
-// The newMessage argument should return a new instance of the type of message that is being parsed.
-func ParseJSONLProtos[T proto.Message](t *require.Assertions, file *os.File, newMessage func() T) []T {
-	decoder := json.NewDecoder(file)
-	var (
-		unmarshaler jsonpb.Unmarshaler
-		messages    []T
-	)
-	for {
-		message := newMessage()
-		err := unmarshaler.UnmarshalNext(decoder, message)
-		if err == io.EOF {
-			return messages
-		}
-		t.NoError(err)
-		messages = append(messages, message)
-	}
+// NewCliApp is a wrapper around [tdbg.NewCliApp] that sets the [cli.App.ExitErrHandler] to a no-op function.
+func NewCliApp(opts ...tdbg.Option) *cli.App {
+	app := tdbg.NewCliApp(opts...)
+	app.ExitErrHandler = func(context *cli.Context, err error) {}
+	return app
 }

--- a/tools/tdbg/tdbgtest/output_parsing.go
+++ b/tools/tdbg/tdbgtest/output_parsing.go
@@ -1,0 +1,84 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tdbgtest
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+
+	"github.com/gogo/protobuf/jsonpb"
+	"github.com/gogo/protobuf/proto"
+	"go.temporal.io/server/tools/tdbg"
+)
+
+type (
+	// DLQMessage is a parsed version of [tdbg.DLQMessage], where the payload is a deserialized [proto.Message].
+	DLQMessage[T proto.Message] struct {
+		MessageID int64
+		ShardID   int32
+		Payload   T
+	}
+)
+
+// ParseDLQMessages parses a JSONL file containing serialized [tdbg.DLQMessage] objects.
+func ParseDLQMessages[T proto.Message](file io.Reader, newMessage func() T) ([]DLQMessage[T], error) {
+	decodeNext := func(decoder *json.Decoder) (DLQMessage[T], error) {
+		var dlqMessage tdbg.DLQMessage
+		err := decoder.Decode(&dlqMessage)
+		if err != nil {
+			return DLQMessage[T]{}, err
+		}
+		protoMessage := newMessage()
+		b := dlqMessage.Payload.Bytes()
+		err = jsonpb.Unmarshal(bytes.NewReader(b), protoMessage)
+		if err != nil {
+			return DLQMessage[T]{}, err
+		}
+		return DLQMessage[T]{
+			MessageID: dlqMessage.MessageID,
+			ShardID:   dlqMessage.ShardID,
+			Payload:   protoMessage,
+		}, nil
+	}
+	return ParseJSONL(file, decodeNext)
+}
+
+// ParseJSONL parses a JSONL file. We separate this out from [ParseDLQMessages] so that we can reuse it for other JSONL
+// files that don't contain [tdbg.DLQMessage] objects (i.e. when [tdbg.DLQV1Service] is used).
+func ParseJSONL[T any](file io.Reader, decodeNext func(decoder *json.Decoder) (T, error)) ([]T, error) {
+	decoder := json.NewDecoder(file)
+	var (
+		messages []T
+	)
+	for decoder.More() {
+		message, err := decodeNext(decoder)
+		if err != nil {
+			return nil, err
+		}
+		messages = append(messages, message)
+	}
+	return messages, nil
+}

--- a/tools/tdbg/tdbgtest/output_parsing_test.go
+++ b/tools/tdbg/tdbgtest/output_parsing_test.go
@@ -1,0 +1,125 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package tdbgtest_test
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/api/adminservice/v1"
+	commonspb "go.temporal.io/server/api/common/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/persistence/serialization"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+	"go.temporal.io/server/tools/tdbg"
+	"go.temporal.io/server/tools/tdbg/tdbgtest"
+	"google.golang.org/grpc"
+)
+
+type (
+	testClient struct {
+		adminservice.AdminServiceClient
+		getDLQTasksFn func(request *adminservice.GetDLQTasksRequest) (*adminservice.GetDLQTasksResponse, error)
+	}
+)
+
+// TestParseDLQMessages tests that [tdbgtest.ParseDLQMessages] can parse a JSONL file containing serialized tasks.
+func TestParseDLQMessages(t *testing.T) {
+	t.Parallel()
+
+	task := &tasks.WorkflowTask{
+		WorkflowKey: definition.WorkflowKey{
+			WorkflowID: tests.WorkflowID,
+		},
+		TaskID: 13,
+	}
+	blob, err := serialization.NewTaskSerializer().SerializeTask(task)
+	require.NoError(t, err)
+	client := &testClient{
+		getDLQTasksFn: func(request *adminservice.GetDLQTasksRequest) (*adminservice.GetDLQTasksResponse, error) {
+			return &adminservice.GetDLQTasksResponse{
+				DlqTasks: []*commonspb.HistoryDLQTask{{
+					Metadata: &commonspb.HistoryDLQTaskMetadata{
+						MessageId: 21,
+					},
+					Payload: &commonspb.HistoryTask{
+						ShardId: 34,
+						Blob:    &blob,
+					},
+				},
+				},
+			}, nil
+		},
+	}
+	var b bytes.Buffer
+	app := tdbgtest.NewCliApp(func(params *tdbg.Params) {
+		params.ClientFactory = client
+		params.Writer = &b
+	})
+	err = app.Run([]string{
+		"tdbg",
+		"--" + tdbg.FlagYes,
+		"dlq",
+		"--" + tdbg.FlagDLQVersion, "v2",
+		"read",
+		"--" + tdbg.FlagDLQType, "1",
+		"--" + tdbg.FlagTargetCluster, "test-target-cluster",
+	})
+	require.NoError(t, err)
+	output := b.String()
+	t.Log("output:", output)
+	messages, err := tdbgtest.ParseDLQMessages(&b, func() *persistencespb.TransferTaskInfo {
+		return new(persistencespb.TransferTaskInfo)
+	})
+	require.NoError(t, err)
+	require.Len(t, messages, 1)
+	message := messages[0]
+	assert.Equal(t, 13, int(message.Payload.TaskId))
+	assert.Equal(t, 21, int(message.MessageID))
+	assert.Equal(t, 34, int(message.ShardID))
+}
+
+func (t *testClient) AdminClient(*cli.Context) adminservice.AdminServiceClient {
+	return t
+}
+
+func (t *testClient) WorkflowClient(*cli.Context) workflowservice.WorkflowServiceClient {
+	panic("unimplemented")
+}
+
+func (t *testClient) GetDLQTasks(
+	_ context.Context,
+	request *adminservice.GetDLQTasksRequest,
+	_ ...grpc.CallOption,
+) (*adminservice.GetDLQTasksResponse, error) {
+	return t.getDLQTasksFn(request)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I added pluggable logic to decode DLQ tasks in tdbg. The default behavior uses the predefined set of categories in the server, deserializes them into protos, and then uses jsonpb to marshal them. However, for deployments with custom task categories, there is an option of extending this behavior.

Registering a custom task category will look something like this:

```go
package main

import (
	"os"

	"github.com/gogo/protobuf/proto"
	commonpb "go.temporal.io/api/common/v1"
	"go.temporal.io/server/service/history/tasks"
	"go.temporal.io/server/tools/tdbg"
)

type (
	myTaskDeserializer struct {
		baseDeserializer tdbg.PredefinedTaskBlobDeserializer // the zero value is valid
	}
	myTaskCategoryRegistry struct {
		baseRegistry tasks.TaskCategoryRegistry
	}
)

var (
	myTaskCategory = tasks.Category{
		// ...
	}
)

func (m myTaskDeserializer) Deserialize(taskCategoryID int, blob commonpb.DataBlob) (proto.Message, error) {
	if taskCategoryID == myTaskCategory.ID() {
		panic("TODO")
	}
	return m.baseDeserializer.Deserialize(taskCategoryID, blob)
}

func (m myTaskCategoryRegistry) GetCategoryByID(id int) (tasks.Category, bool) {
	if id == myTaskCategory.ID() {
		return myTaskCategory, true
	}
	return m.baseRegistry.GetCategoryByID(id)
}

func (m myTaskCategoryRegistry) GetCategories() map[int]tasks.Category {
	categories := m.baseRegistry.GetCategories()
	categories[myTaskCategory.ID()] = myTaskCategory
	return categories
}

func main() {
	_ = tdbg.NewCliApp(func(params *tdbg.Params) {
		params.TaskBlobEncoder = tdbg.NewProtoTaskBlobEncoder(myTaskDeserializer{})
		params.TaskCategoryRegistry = myTaskCategoryRegistry{
			baseRegistry: tasks.NewDefaultTaskCategoryRegistry(),
		}
	}).Run(os.Args)
}
```

<!-- Tell your future self why have you made these changes -->
**Why?**
Before this change, tasks looked like this:

```json
{
  "metadata": {
    "messageId": "0"
  },
  "payload": {
    "shardId": 1,
    "blob": {
      "encodingType": "Proto3",
      "data": "CiRhZjllOTY4Ni0yNThiLTRiOGYtYWU2ZC0xMWNhMjIzZWQ1ZGYSO2RscS10ZXN0LXRlcm1pbmFsLXdmdHMtNGJlN2RlMTctZWQ4Yy00NjliLWExOGMtYmExMjJmZmI5YzE2GiQ0YTI4YzA1ZC1kZGIyLTQxYzYtOWQ0Ni0xYjhkYTU2OWFlNTQgAyokYWY5ZTk2ODYtMjU4Yi00YjhmLWFlNmQtMTFjYTIyM2VkNWRmQhNkbHEtdGVzdC10YXNrLXF1ZXVlUAJghIBAagwIm6ftqQYQkLiC4AE="
    }
  }
}
```

Now they're much more informative:
```json
{
  "message_id": 0,
  "shard_id": 3,
  "payload": {
    "namespace_id": "0d911dda-4c83-4890-9a00-aa4b709bfea6",
    "workflow_id": "dlq-test-terminal-wfts-b6871484-2840-40b4-9460-c8289ee8e178",
    "run_id": "1d8dfa7c-09e5-4845-a16f-69eed57fec9d",
    "task_type": "TransferWorkflowTask",
    "target_namespace_id": "0d911dda-4c83-4890-9a00-aa4b709bfea6",
    "target_workflow_id": "",
    "target_run_id": "",
    "task_queue": "dlq-test-task-queue",
    "target_child_workflow_only": false,
    "scheduled_event_id": "2",
    "version": "0",
    "task_id": "1048580",
    "visibility_time": "2023-10-27T06:08:08.993945Z",
    "delete_after_close": false
  }
}
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
There's quite a few tests which verify that the output contains task details now without further parsing of any "data" field. In addition, I did some manual testing to inspect the output.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
