### PR TITLE
Fix an ordering bug in matching behavior tests

### DIFF
--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -245,11 +245,6 @@ func (s *versioningIntegSuite) TestMaxTaskQueuesPerBuildIdEnforced() {
 
 func (s *versioningIntegSuite) testWithMatchingBehavior(subtest func()) {
 	dc := s.testCluster.host.dcClient
-	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
-	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueWritePartitions)
-	defer dc.RemoveOverride(dynamicconfig.TestMatchingLBForceReadPartition)
-	defer dc.RemoveOverride(dynamicconfig.TestMatchingLBForceWritePartition)
-	defer dc.RemoveOverride(dynamicconfig.TestMatchingDisableSyncMatch)
 	for _, forceForward := range []bool{false, true} {
 		for _, forceAsync := range []bool{false, true} {
 			name := ""
@@ -276,6 +271,11 @@ func (s *versioningIntegSuite) testWithMatchingBehavior(subtest func()) {
 				name += "AllowSync"
 			}
 			s.Run(name, subtest)
+			dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
+			dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueWritePartitions)
+			dc.RemoveOverride(dynamicconfig.TestMatchingLBForceReadPartition)
+			dc.RemoveOverride(dynamicconfig.TestMatchingLBForceWritePartition)
+			dc.RemoveOverride(dynamicconfig.TestMatchingDisableSyncMatch)
 		}
 	}
 }


### PR DESCRIPTION
**What changed?**

We now clear dynamicconfig overrides after each subtest rather than after all subtests have run.

**Why?**

Not doing so caused us to panic in certian conditions. I hit a specific ordering where:

- we force forwarding, setting the forced read partition to 5
- we run without forwarding, setting the number of partitions to 1
- our load balancer code ensured we had one partition then promptly tried to access the fifth partition

These tests look like they run in a deterministic order so I'm not entirely sure how we hit this, but it definitely happend.

**How did you test it?**
This is hard to reproduce and only occurred once in buildkite; see [functional test with cassandra](https://buildkite.com/temporal/temporal-public/builds/13072#018b71a7-2fea-451e-86a2-ef0bcff602f2).

**Potential risks**

None.

**Is hotfix candidate?**

No.