### PR TITLE
Pin GOOS and GOARCH for `update-third-party-deps`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ bins: temporal-server temporal-cassandra-tool temporal-sql-tool tdbg
 all: update-tools clean proto bins check test
 
 # Used by Buildkite.
-ci-build-misc: bins ci-update-tools shell-check copyright-check proto go-generate gomodtidy ensure-no-changes
+ci-build-misc: print-go-version bins ci-update-tools shell-check copyright-check proto go-generate gomodtidy ensure-no-changes
 
 # Delete all build artifacts
 clean: clean-bins clean-test-results
@@ -118,6 +118,9 @@ define silent_exec
 endef
 
 ##### Tools #####
+print-go-version:
+	@go version
+
 update-goimports:
 	@printf $(COLOR) "Install/update goimports..."
 	@go install golang.org/x/tools/cmd/goimports@latest
@@ -532,7 +535,7 @@ update-dependencies:
 	@$(MAKE) update-third-party-deps
 
 update-third-party-deps:
-	@go list -deps $(FUNCTIONAL_TEST_ROOT) | sort -u | grep '^[a-z]\+\.[a-z.]\+/' | grep -v go.temporal.io > develop/buildkite/third_party_deps.txt
+	@GOOS=linux GOARCH=amd64 go list -deps $(FUNCTIONAL_TEST_ROOT) | sort -u | grep '^[a-z]\+\.[a-z.]\+/' | grep -v go.temporal.io > develop/buildkite/third_party_deps.txt
 
 go-generate:
 	@printf $(COLOR) "Process go:generate directives..."


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Pinning the `GOOS` and `GOARCH` for the `update-third-party-deps` Makefile target.

<!-- Tell your future self why have you made these changes -->
**Why?**

Without this, the user's local `GOOS` and `GOARCH` change the list - but it should align with the CI's system.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

CI

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Mismatch of `GOOS` / `GOARCH` in future CI agents?

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No