### PR TITLE
Reuse cached RemoteAdminClient in VerifyReplicationTasks (#4997)

### DIFF
--- a/service/worker/migration/activities.go
+++ b/service/worker/migration/activities.go
@@ -39,13 +39,16 @@ import (
 	"go.temporal.io/sdk/activity"
 
 	"go.temporal.io/sdk/temporal"
+
 	"go.temporal.io/server/api/adminservice/v1"
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
+	serverClient "go.temporal.io/server/client"
 	"go.temporal.io/server/client/admin"
 	"go.temporal.io/server/common/definition"
 	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
@@ -55,6 +58,21 @@ import (
 )
 
 type (
+	activities struct {
+		historyShardCount              int32
+		executionManager               persistence.ExecutionManager
+		taskManager                    persistence.TaskManager
+		namespaceRegistry              namespace.Registry
+		historyClient                  historyservice.HistoryServiceClient
+		frontendClient                 workflowservice.WorkflowServiceClient
+		clientFactory                  serverClient.Factory
+		clientBean                     serverClient.Bean
+		logger                         log.Logger
+		metricsHandler                 metrics.Handler
+		forceReplicationMetricsHandler metrics.Handler
+		namespaceReplicationQueue      persistence.NamespaceReplicationQueue
+	}
+
 	SkippedWorkflowExecution struct {
 		WorkflowExecution commonpb.WorkflowExecution
 		Reason            string
@@ -665,13 +683,24 @@ const (
 
 func (a *activities) VerifyReplicationTasks(ctx context.Context, request *verifyReplicationTasksRequest) (verifyReplicationTasksResponse, error) {
 	ctx = headers.SetCallerInfo(ctx, headers.NewPreemptableCallerInfo(request.Namespace))
-	remoteClient := a.clientFactory.NewRemoteAdminClientWithTimeout(
-		request.TargetClusterEndpoint,
-		admin.DefaultTimeout,
-		admin.DefaultLargeTimeout,
-	)
-
 	var response verifyReplicationTasksResponse
+	var remoteClient adminservice.AdminServiceClient
+	var err error
+
+	if len(request.TargetClusterName) > 0 {
+		remoteClient, err = a.clientBean.GetRemoteAdminClient(request.TargetClusterName)
+		if err != nil {
+			return response, err
+		}
+	} else {
+		// TODO: remove once TargetClusterEndpoint is no longer used.
+		remoteClient = a.clientFactory.NewRemoteAdminClientWithTimeout(
+			request.TargetClusterEndpoint,
+			admin.DefaultTimeout,
+			admin.DefaultLargeTimeout,
+		)
+	}
+
 	var details replicationTasksHeartbeatDetails
 	if activity.HasHeartbeatDetails(ctx) {
 		if err := activity.GetHeartbeatDetails(ctx, &details); err != nil {

--- a/service/worker/migration/force_replication_workflow_test.go
+++ b/service/worker/migration/force_replication_workflow_test.go
@@ -43,6 +43,7 @@ import (
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
 	"go.temporal.io/sdk/worker"
+
 	replicationspb "go.temporal.io/server/api/replication/v1"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/persistence"
@@ -98,6 +99,7 @@ func TestForceReplicationWorkflow(t *testing.T) {
 		ListWorkflowsPageSize:   1,
 		PageCountPerExecution:   4,
 		EnableVerification:      true,
+		TargetClusterEndpoint:   "test-target",
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
@@ -165,6 +167,7 @@ func TestForceReplicationWorkflow_ContinueAsNew(t *testing.T) {
 		ListWorkflowsPageSize:   1,
 		PageCountPerExecution:   maxPageCountPerExecution,
 		EnableVerification:      true,
+		TargetClusterEndpoint:   "test-target",
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
@@ -307,6 +310,7 @@ func TestForceReplicationWorkflow_GenerateReplicationTaskNonRetryableError(t *te
 		ListWorkflowsPageSize:   1,
 		PageCountPerExecution:   4,
 		EnableVerification:      true,
+		TargetClusterEndpoint:   "test-target",
 	})
 
 	require.True(t, env.IsWorkflowCompleted())
@@ -362,6 +366,7 @@ func TestForceReplicationWorkflow_VerifyReplicationTaskNonRetryableError(t *test
 		ListWorkflowsPageSize:   1,
 		PageCountPerExecution:   4,
 		EnableVerification:      true,
+		TargetClusterEndpoint:   "test-target",
 	})
 
 	require.True(t, env.IsWorkflowCompleted())

--- a/service/worker/migration/fx.go
+++ b/service/worker/migration/fx.go
@@ -49,6 +49,7 @@ type (
 		HistoryClient             resource.HistoryClient
 		FrontendClient            workflowservice.WorkflowServiceClient
 		ClientFactory             serverClient.Factory
+		ClientBean                serverClient.Bean
 		NamespaceReplicationQueue persistence.NamespaceReplicationQueue
 		TaskManager               persistence.TaskManager
 		Logger                    log.Logger
@@ -98,6 +99,7 @@ func (wc *replicationWorkerComponent) activities() *activities {
 		historyClient:                  wc.HistoryClient,
 		frontendClient:                 wc.FrontendClient,
 		clientFactory:                  wc.ClientFactory,
+		clientBean:                     wc.ClientBean,
 		namespaceReplicationQueue:      wc.NamespaceReplicationQueue,
 		taskManager:                    wc.TaskManager,
 		logger:                         wc.Logger,

--- a/service/worker/migration/handover_workflow.go
+++ b/service/worker/migration/handover_workflow.go
@@ -28,16 +28,8 @@ import (
 	"time"
 
 	enumspb "go.temporal.io/api/enums/v1"
-	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/workflow"
-
-	"go.temporal.io/server/api/historyservice/v1"
-	serverClient "go.temporal.io/server/client"
-	"go.temporal.io/server/common/log"
-	"go.temporal.io/server/common/metrics"
-	"go.temporal.io/server/common/namespace"
-	"go.temporal.io/server/common/persistence"
 )
 
 const (
@@ -58,20 +50,6 @@ type (
 
 		// how long to wait for handover to complete before rollback
 		HandoverTimeoutSeconds int
-	}
-
-	activities struct {
-		historyShardCount              int32
-		executionManager               persistence.ExecutionManager
-		taskManager                    persistence.TaskManager
-		namespaceRegistry              namespace.Registry
-		historyClient                  historyservice.HistoryServiceClient
-		frontendClient                 workflowservice.WorkflowServiceClient
-		clientFactory                  serverClient.Factory
-		logger                         log.Logger
-		metricsHandler                 metrics.Handler
-		forceReplicationMetricsHandler metrics.Handler
-		namespaceReplicationQueue      persistence.NamespaceReplicationQueue
 	}
 
 	replicationStatus struct {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Cherry pick 4997

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
