### PR TITLE
Fix schedule workflow unit test

### DIFF
--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1718,6 +1718,9 @@ func (s *workflowSuite) TestCANByIterations() {
 		s.Fail("too many starts")
 		return nil, nil
 	}).Times(0).Maybe()
+	s.expectWatch(func(req *schedspb.WatchWorkflowRequest) (*schedspb.WatchWorkflowResponse, error) {
+		return &schedspb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED}, nil
+	}).Times(0).Maybe()
 
 	// this is ignored because we set iters explicitly
 	s.env.RegisterDelayedCallback(func() {
@@ -1755,6 +1758,9 @@ func (s *workflowSuite) TestCANBySuggested() {
 		s.Fail("too many starts", req.Request.WorkflowId)
 		return nil, nil
 	}).Times(0).Maybe()
+	s.expectWatch(func(req *schedspb.WatchWorkflowRequest) (*schedspb.WatchWorkflowResponse, error) {
+		return &schedspb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED}, nil
+	}).Times(0).Maybe()
 
 	s.env.RegisterDelayedCallback(func() {
 		s.env.SetContinueAsNewSuggested(true)
@@ -1790,6 +1796,9 @@ func (s *workflowSuite) TestCANBySignal() {
 	s.expectStart(func(req *schedspb.StartWorkflowRequest) (*schedspb.StartWorkflowResponse, error) {
 		s.Fail("too many starts", req.Request.WorkflowId)
 		return nil, nil
+	}).Times(0).Maybe()
+	s.expectWatch(func(req *schedspb.WatchWorkflowRequest) (*schedspb.WatchWorkflowResponse, error) {
+		return &schedspb.WatchWorkflowResponse{Status: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED}, nil
 	}).Times(0).Maybe()
 
 	s.env.RegisterDelayedCallback(func() {


### PR DESCRIPTION
**What changed?**
Fix unit tests on release branch

**Why?**
The tests assumed that the change to not track ALLOW_ALL workflows was already active, but it's not on the release branch. So we just need mocks for WatchWorkflow.

**How did you test it?**
is tests
