### PR TITLE
Fix a race condition in the membership monitor's lifecycle

### DIFF
--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -318,6 +318,11 @@ func (rpo *monitor) fetchCurrentBootstrapHostports() ([]string, error) {
 func (rpo *monitor) startHeartbeatUpsertLoop(request *persistence.UpsertClusterMembershipRequest) {
 	loopUpsertMembership := func() {
 		for {
+			select {
+			case <-rpo.lifecycleCtx.Done():
+				return
+			default:
+			}
 			err := rpo.upsertMyMembership(rpo.lifecycleCtx, request)
 
 			if err != nil {

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -32,7 +32,7 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"sync/atomic"
+	"sync"
 	"time"
 
 	"go.temporal.io/server/common/config"
@@ -59,7 +59,8 @@ const (
 )
 
 type monitor struct {
-	status int32
+	stateLock sync.Mutex
+	status    int32
 
 	lifecycleCtx    context.Context
 	lifecycleCancel context.CancelFunc
@@ -114,14 +115,17 @@ func newMonitor(
 	return rpo
 }
 
+// Start the membership monitor. Stop() can be called concurrently so we relinquish the state lock when
+// it's safe for Stop() to run, which is at any point when we are neither updating the status field nor
+// starting rings
 func (rpo *monitor) Start() {
-	if !atomic.CompareAndSwapInt32(
-		&rpo.status,
-		common.DaemonStatusInitialized,
-		common.DaemonStatusStarted,
-	) {
+	rpo.stateLock.Lock()
+	if rpo.status != common.DaemonStatusInitialized {
+		rpo.stateLock.Unlock()
 		return
 	}
+	rpo.status = common.DaemonStatusStarted
+	rpo.stateLock.Unlock()
 
 	broadcastAddress, err := rpo.broadcastHostPortResolver()
 	if err != nil {
@@ -136,9 +140,16 @@ func (rpo *monitor) Start() {
 		rpo.logger.Fatal("unable to initialize membership heartbeats", tag.Error(err))
 	}
 
-	rpo.rp.start(
+	err = rpo.rp.start(
 		func() ([]string, error) { return rpo.fetchCurrentBootstrapHostports() },
 		healthyHostLastHeartbeatCutoff/2)
+	if err != nil {
+		// Stop() called during Start()'s execution. This is ok
+		if strings.Contains(err.Error(), "destroyed while attempting to join") {
+			return
+		}
+		rpo.logger.Fatal("failed to start ringpop", tag.Error(err))
+	}
 
 	labels, err := rpo.rp.Labels()
 	if err != nil {
@@ -153,9 +164,12 @@ func (rpo *monitor) Start() {
 		rpo.logger.Fatal("unable to set ring pop ServiceRole label", tag.Error(err))
 	}
 
+	// Our individual rings may not support concurrent start/stop calls so we reacquire the state lock while acting upon them
+	rpo.stateLock.Lock()
 	for _, ring := range rpo.rings {
 		ring.Start()
 	}
+	rpo.stateLock.Unlock()
 
 	rpo.initialized.Set(struct{}{}, nil)
 }
@@ -318,14 +332,16 @@ func (rpo *monitor) startHeartbeatUpsertLoop(request *persistence.UpsertClusterM
 	go loopUpsertMembership()
 }
 
+// Stop the membership monitor and all associated rings. This holds the state lock
+// for the entire call as the individual ring Start/Stop functions may not be safe to
+// call concurrently
 func (rpo *monitor) Stop() {
-	if !atomic.CompareAndSwapInt32(
-		&rpo.status,
-		common.DaemonStatusStarted,
-		common.DaemonStatusStopped,
-	) {
+	rpo.stateLock.Lock()
+	defer rpo.stateLock.Unlock()
+	if rpo.status != common.DaemonStatusStarted {
 		return
 	}
+	rpo.status = common.DaemonStatusStopped
 
 	rpo.lifecycleCancel()
 

--- a/common/membership/ringpop/service_resolver.go
+++ b/common/membership/ringpop/service_resolver.go
@@ -63,7 +63,6 @@ const (
 )
 
 type serviceResolver struct {
-	status      int32
 	service     primitives.ServiceName
 	port        int
 	rp          *service
@@ -91,7 +90,6 @@ func newServiceResolver(
 	logger log.Logger,
 ) *serviceResolver {
 	resolver := &serviceResolver{
-		status:      common.DaemonStatusInitialized,
 		service:     service,
 		port:        port,
 		rp:          rp,
@@ -111,14 +109,6 @@ func newHashRing() *hashring.HashRing {
 
 // Start starts the oracle
 func (r *serviceResolver) Start() {
-	if !atomic.CompareAndSwapInt32(
-		&r.status,
-		common.DaemonStatusInitialized,
-		common.DaemonStatusStarted,
-	) {
-		return
-	}
-
 	r.rp.AddListener(r)
 	if err := r.refresh(); err != nil {
 		r.logger.Fatal("unable to start ring pop service resolver", tag.Error(err))
@@ -130,14 +120,6 @@ func (r *serviceResolver) Start() {
 
 // Stop stops the resolver
 func (r *serviceResolver) Stop() {
-	if !atomic.CompareAndSwapInt32(
-		&r.status,
-		common.DaemonStatusStarted,
-		common.DaemonStatusStopped,
-	) {
-		return
-	}
-
 	r.listenerLock.Lock()
 	defer r.listenerLock.Unlock()
 	r.rp.RemoveListener(r)


### PR DESCRIPTION
**What changed?**

I replaced the atomics we use to manage the membership monitor's state with a fine-grained latch that we hold while it's not safe for Start and Stop to run concurrently. The atomics used in the membership monitor's lifecycle functions weren't enough to prevent race conditions in either it _or_ the rings it manages.

**Why?**

The Start and Stop calls for the various subcomponents here aren't necessarily thread-safe, so we need to prevent the monitor from calling them concurrently. We hold this new lock as little as possible to prevent ringpop's bootstrap processes from stalling our application.

This was originally discovered by go's race detector as a race on the service resolver's WaitGroup: nothing prevented `Stop` from running concurrently with `Start`. It could begin at any time after the initial CAS operation completes. When this happens we'd call `wg.Add(1)` in `Start` _after_ the call to `wg.Wait` in `Stop` (in common.AwaitWaitGroup) which is an invalid operation.

[The `sync.WaitGroup` docs state that](https://pkg.go.dev/sync@go1.21.3#WaitGroup.Add)
> Note that calls with a positive delta that occur when the counter is zero must happen before a Wait. Calls with a negative delta, or calls with a positive delta that start when the counter is greater than zero, may happen at any time. Typically this means the calls to Add should execute before the statement creating the goroutine or other event to be waited for. If a WaitGroup is reused to wait for several independent sets of events, new Add calls must happen after all previous Wait calls have returned. See the WaitGroup example.

**How did you test it?**

Local tests pass.

**Potential risks**

None

**Is hotfix candidate?**
No
