### PR TITLE
Ability to enable AWS SDK logging (#5051)

### DIFF
--- a/common/archiver/s3store/README.md
+++ b/common/archiver/s3store/README.md
@@ -11,12 +11,14 @@ archival:
     provider:
       s3store:
         region: "us-east-1"
+        logLevel: 0
   visibility:
     state: "enabled"
     enableRead: true
     provider:
       s3store:
         region: "us-east-1"
+        logLevel: 0
 
 namespaceDefaults:
   archival:
@@ -69,6 +71,17 @@ s3://<bucket-name>/<namespace-id>/
                 startTimeout/2020-01-21T16:16:11Z/<run-id>
                 closeTimeout/2020-01-21T16:16:11Z/<run-id>
 ```
+
+Enable AWS SDK Logging with config parameter `logLevel`. For example enable debug logging with `logLevel: 4096`. Possbile Values:
+* LogOff = 0 = 0x0
+* LogDebug = 4096 = 0x1000
+* LogDebugWithSigning = 4097 = 0x1001
+* LogDebugWithHTTPBody = 4098 = 0x1002
+* LogDebugWithRequestRetries = 4100 = 0x1004
+* LogDebugWithRequestErrors = 4104 = 0x1008
+* LogDebugWithEventStreamBody = 4112 = 0x1010
+* LogDebugWithDeprecated = 4128 = 0x1020
+
 
 ## Using localstack for local development
 1. Install awscli from [here](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html)

--- a/common/archiver/s3store/history_archiver.go
+++ b/common/archiver/s3store/history_archiver.go
@@ -109,6 +109,7 @@ func newHistoryArchiver(
 		Endpoint:         config.Endpoint,
 		Region:           aws.String(config.Region),
 		S3ForcePathStyle: aws.Bool(config.S3ForcePathStyle),
+		LogLevel:         (*aws.LogLevelType)(&config.LogLevel),
 	}
 	sess, err := session.NewSession(s3Config)
 	if err != nil {

--- a/common/archiver/s3store/visibility_archiver.go
+++ b/common/archiver/s3store/visibility_archiver.go
@@ -91,6 +91,7 @@ func newVisibilityArchiver(
 		Endpoint:         config.Endpoint,
 		Region:           aws.String(config.Region),
 		S3ForcePathStyle: aws.Bool(config.S3ForcePathStyle),
+		LogLevel:         (*aws.LogLevelType)(&config.LogLevel),
 	}
 	sess, err := session.NewSession(s3Config)
 	if err != nil {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -497,6 +497,7 @@ type (
 		Region           string  `yaml:"region"`
 		Endpoint         *string `yaml:"endpoint"`
 		S3ForcePathStyle bool    `yaml:"s3ForcePathStyle"`
+		LogLevel         uint    `yaml:"logLevel"`
 	}
 
 	// PublicClient is the config for internal nodes (history/matching/worker) connecting to


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ability to configure a loglevel for AWS SDK, which is used during s3 archival. 

<!-- Tell your future self why have you made these changes -->
**Why?**
This is relevant if one want to troubleshoot s3 archival.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk, because by default it is turned `off`, so no change for existing deployments 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No