### PR TITLE
Automatically clear dc overrides after tests

### DIFF
--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -2037,10 +2037,8 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_UnversionedWor
 func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorker() {
 	// Use only one partition to avoid having to wait for user data propagation later
 	dc := s.testCluster.host.dcClient
-	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
-	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
-	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
-	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueWritePartitions)
+	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
 
 	ctx := NewContext()
 	id := s.randomizeStr(s.T().Name())
@@ -2204,10 +2202,8 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorke
 func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnReset() {
 	// Use only one partition to avoid having to wait for user data propagation later
 	dc := s.testCluster.host.dcClient
-	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
-	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
-	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
-	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueWritePartitions)
+	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
 
 	ctx := NewContext()
 	id := s.randomizeStr(s.T().Name())
@@ -2291,10 +2287,8 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnReset() {
 func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnRetry() {
 	// Use only one partition to avoid having to wait for user data propagation later
 	dc := s.testCluster.host.dcClient
-	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
-	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueReadPartitions)
-	dc.OverrideValue(dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
-	defer dc.RemoveOverride(dynamicconfig.MatchingNumTaskqueueWritePartitions)
+	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
+	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
 
 	ctx := NewContext()
 	id := s.randomizeStr(s.T().Name())
@@ -2475,8 +2469,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId() {
 	s.checkReachability(ctx, tq1, v01, enumspb.TASK_REACHABILITY_NEW_WORKFLOWS, enumspb.TASK_REACHABILITY_EXISTING_WORKFLOWS)
 	s.checkReachability(ctx, tq1, v01, enumspb.TASK_REACHABILITY_NEW_WORKFLOWS, enumspb.TASK_REACHABILITY_CLOSED_WORKFLOWS)
 
-	defer dc.RemoveOverride(dynamicconfig.ReachabilityQuerySetDurationSinceDefault)
-	dc.OverrideValue(dynamicconfig.ReachabilityQuerySetDurationSinceDefault, time.Microsecond)
+	dc.OverrideValue(s.T(), dynamicconfig.ReachabilityQuerySetDurationSinceDefault, time.Microsecond)
 	// Verify new workflows aren't reachable
 	s.checkReachability(ctx, tq1, v01, enumspb.TASK_REACHABILITY_EXISTING_WORKFLOWS)
 	s.checkReachability(ctx, tq1, v01, enumspb.TASK_REACHABILITY_CLOSED_WORKFLOWS)
@@ -2615,8 +2608,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InTaskQ
 	s.checkReachability(ctx, tq, "", enumspb.TASK_REACHABILITY_NEW_WORKFLOWS, enumspb.TASK_REACHABILITY_EXISTING_WORKFLOWS)
 	s.checkReachability(ctx, tq, "", enumspb.TASK_REACHABILITY_NEW_WORKFLOWS, enumspb.TASK_REACHABILITY_CLOSED_WORKFLOWS)
 
-	defer dc.RemoveOverride(dynamicconfig.ReachabilityQuerySetDurationSinceDefault)
-	dc.OverrideValue(dynamicconfig.ReachabilityQuerySetDurationSinceDefault, time.Microsecond)
+	dc.OverrideValue(s.T(), dynamicconfig.ReachabilityQuerySetDurationSinceDefault, time.Microsecond)
 
 	s.checkReachability(ctx, tq, "", enumspb.TASK_REACHABILITY_EXISTING_WORKFLOWS)
 	s.checkReachability(ctx, tq, "", enumspb.TASK_REACHABILITY_CLOSED_WORKFLOWS)

--- a/tests/dynamicconfig.go
+++ b/tests/dynamicconfig.go
@@ -26,6 +26,7 @@ package tests
 
 import (
 	"sync"
+	"testing"
 	"time"
 
 	"golang.org/x/exp/maps"
@@ -57,14 +58,18 @@ var (
 
 type dcClient struct {
 	sync.RWMutex
-	overrides map[dynamicconfig.Key]any
-	fallback  dynamicconfig.Client
+	overrides      map[dynamicconfig.Key]any
+	suiteOverrides map[dynamicconfig.Key]any
+	fallback       dynamicconfig.Client
 }
 
 func (d *dcClient) getRawValue(name dynamicconfig.Key) (any, bool) {
 	d.RLock()
 	defer d.RUnlock()
 	v, ok := d.overrides[name]
+	if !ok {
+		v, ok = d.suiteOverrides[name]
+	}
 	return v, ok
 }
 
@@ -75,10 +80,27 @@ func (d *dcClient) GetValue(name dynamicconfig.Key) []dynamicconfig.ConstrainedV
 	return d.fallback.GetValue(name)
 }
 
-func (d *dcClient) OverrideValue(name dynamicconfig.Key, value any) {
+// OverrideValue overrides a value for the duration of a test. All values overridden via
+// this API will be cleared when ClearOverrides is called.
+func (d *dcClient) OverrideValue(t *testing.T, name dynamicconfig.Key, value any) {
 	d.Lock()
 	defer d.Unlock()
 	d.overrides[name] = value
+
+	t.Cleanup(func() {
+		d.RemoveOverride(name)
+	})
+}
+
+// OverrideValueForSuite overrides a value for the entirety of a test suite (this object's lifetime)
+func (d *dcClient) OverrideValueForSuite(t *testing.T, name dynamicconfig.Key, value any) {
+	d.Lock()
+	defer d.Unlock()
+	d.suiteOverrides[name] = value
+
+	t.Cleanup(func() {
+		d.RemoveOverrideForSuite(name)
+	})
 }
 
 func (d *dcClient) RemoveOverride(name dynamicconfig.Key) {
@@ -87,10 +109,31 @@ func (d *dcClient) RemoveOverride(name dynamicconfig.Key) {
 	delete(d.overrides, name)
 }
 
+func (d *dcClient) RemoveOverrideForSuite(name dynamicconfig.Key) {
+	replacement, ok := staticOverrides[name]
+
+	d.Lock()
+	defer d.Unlock()
+	if ok {
+		d.suiteOverrides[name] = replacement
+	} else {
+		delete(d.suiteOverrides, name)
+	}
+}
+
+// ResetOverrides clears all overrides specified by OverrideValue but /not/ those
+// overridden by OverrideValueForSuite.
+func (d *dcClient) ResetOverrides() {
+	d.Lock()
+	defer d.Unlock()
+	d.overrides = make(map[dynamicconfig.Key]any)
+}
+
 // newTestDCClient - returns a dynamic config client for functional testing
 func newTestDCClient(fallback dynamicconfig.Client) *dcClient {
 	return &dcClient{
-		overrides: maps.Clone(staticOverrides),
-		fallback:  fallback,
+		overrides:      make(map[dynamicconfig.Key]any),
+		suiteOverrides: maps.Clone(staticOverrides),
+		fallback:       fallback,
 	}
 }

--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -136,7 +136,7 @@ func (s *FunctionalTestBase) setupSuite(defaultClusterConfigFile string, options
 		s.httpAPIAddress = TestFlags.FrontendHTTPAddr
 	} else {
 		s.Logger.Info("Running functional test against test cluster")
-		cluster, err := NewCluster(clusterConfig, s.Logger)
+		cluster, err := NewCluster(s.T(), clusterConfig, s.Logger)
 		s.Require().NoError(err)
 		s.testCluster = cluster
 		s.engine = s.testCluster.GetFrontendClient()

--- a/tests/namespace_delete_test.go
+++ b/tests/namespace_delete_test.go
@@ -99,7 +99,7 @@ func (s *namespaceTestSuite) SetupSuite() {
 
 	s.clusterConfig.DynamicConfigOverrides = dynamicConfig()
 
-	cluster, err := NewCluster(s.clusterConfig, s.logger)
+	cluster, err := NewCluster(s.T(), s.clusterConfig, s.logger)
 	s.Require().NoError(err)
 	s.cluster = cluster
 	s.frontendClient = s.cluster.GetFrontendClient()

--- a/tests/ndc/ndc_test.go
+++ b/tests/ndc/ndc_test.go
@@ -155,7 +155,7 @@ func (s *nDCFunctionalTestSuite) SetupSuite() {
 	}
 	clusterConfigs[0].MockAdminClient = s.mockAdminClient
 
-	cluster, err := tests.NewCluster(clusterConfigs[0], log.With(s.logger, tag.ClusterName(clusterName[0])))
+	cluster, err := tests.NewCluster(s.T(), clusterConfigs[0], log.With(s.logger, tag.ClusterName(clusterName[0])))
 	s.Require().NoError(err)
 	s.cluster = cluster
 

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -188,7 +188,7 @@ type (
 func newTemporal(t *testing.T, params *TemporalParams) *temporalImpl {
 	testDCClient := newTestDCClient(dynamicconfig.NewNoopClient())
 	for k, v := range params.DynamicConfigOverrides {
-		testDCClient.OverrideValueForSuite(t, k, v)
+		testDCClient.OverrideValue(t, k, v)
 	}
 	impl := &temporalImpl{
 		logger:                           params.Logger,

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -32,6 +32,7 @@ import (
 	"net"
 	"strconv"
 	"sync"
+	"testing"
 	"time"
 
 	"go.uber.org/fx"
@@ -184,10 +185,10 @@ type (
 )
 
 // newTemporal returns an instance that hosts full temporal in one process
-func newTemporal(params *TemporalParams) *temporalImpl {
+func newTemporal(t *testing.T, params *TemporalParams) *temporalImpl {
 	testDCClient := newTestDCClient(dynamicconfig.NewNoopClient())
 	for k, v := range params.DynamicConfigOverrides {
-		testDCClient.OverrideValue(k, v)
+		testDCClient.OverrideValueForSuite(t, k, v)
 	}
 	impl := &temporalImpl{
 		logger:                           params.Logger,
@@ -216,7 +217,7 @@ func newTemporal(params *TemporalParams) *temporalImpl {
 		serviceFxOptions:                 params.ServiceFxOptions,
 		taskCategoryRegistry:             params.TaskCategoryRegistry,
 	}
-	impl.overrideHistoryDynamicConfig(testDCClient)
+	impl.overrideHistoryDynamicConfig(t, testDCClient)
 	return impl
 }
 
@@ -809,42 +810,42 @@ func (c *temporalImpl) frontendConfigProvider() *config.Config {
 	}
 }
 
-func (c *temporalImpl) overrideHistoryDynamicConfig(client *dcClient) {
-	client.OverrideValue(dynamicconfig.ReplicationTaskProcessorStartWait, time.Nanosecond)
+func (c *temporalImpl) overrideHistoryDynamicConfig(t *testing.T, client *dcClient) {
+	client.OverrideValue(t, dynamicconfig.ReplicationTaskProcessorStartWait, time.Nanosecond)
 
 	if c.esConfig != nil {
-		client.OverrideValue(dynamicconfig.AdvancedVisibilityWritingMode, visibility.SecondaryVisibilityWritingModeDual)
+		client.OverrideValue(t, dynamicconfig.AdvancedVisibilityWritingMode, visibility.SecondaryVisibilityWritingModeDual)
 	}
 	if c.historyConfig.HistoryCountLimitWarn != 0 {
-		client.OverrideValue(dynamicconfig.HistoryCountLimitWarn, c.historyConfig.HistoryCountLimitWarn)
+		client.OverrideValue(t, dynamicconfig.HistoryCountLimitWarn, c.historyConfig.HistoryCountLimitWarn)
 	}
 	if c.historyConfig.HistoryCountLimitError != 0 {
-		client.OverrideValue(dynamicconfig.HistoryCountLimitError, c.historyConfig.HistoryCountLimitError)
+		client.OverrideValue(t, dynamicconfig.HistoryCountLimitError, c.historyConfig.HistoryCountLimitError)
 	}
 	if c.historyConfig.HistorySizeLimitWarn != 0 {
-		client.OverrideValue(dynamicconfig.HistorySizeLimitWarn, c.historyConfig.HistorySizeLimitWarn)
+		client.OverrideValue(t, dynamicconfig.HistorySizeLimitWarn, c.historyConfig.HistorySizeLimitWarn)
 	}
 	if c.historyConfig.HistorySizeLimitError != 0 {
-		client.OverrideValue(dynamicconfig.HistorySizeLimitError, c.historyConfig.HistorySizeLimitError)
+		client.OverrideValue(t, dynamicconfig.HistorySizeLimitError, c.historyConfig.HistorySizeLimitError)
 	}
 	if c.historyConfig.BlobSizeLimitError != 0 {
-		client.OverrideValue(dynamicconfig.BlobSizeLimitError, c.historyConfig.BlobSizeLimitError)
+		client.OverrideValue(t, dynamicconfig.BlobSizeLimitError, c.historyConfig.BlobSizeLimitError)
 	}
 	if c.historyConfig.BlobSizeLimitWarn != 0 {
-		client.OverrideValue(dynamicconfig.BlobSizeLimitWarn, c.historyConfig.BlobSizeLimitWarn)
+		client.OverrideValue(t, dynamicconfig.BlobSizeLimitWarn, c.historyConfig.BlobSizeLimitWarn)
 	}
 	if c.historyConfig.MutableStateSizeLimitError != 0 {
-		client.OverrideValue(dynamicconfig.MutableStateSizeLimitError, c.historyConfig.MutableStateSizeLimitError)
+		client.OverrideValue(t, dynamicconfig.MutableStateSizeLimitError, c.historyConfig.MutableStateSizeLimitError)
 	}
 	if c.historyConfig.MutableStateSizeLimitWarn != 0 {
-		client.OverrideValue(dynamicconfig.MutableStateSizeLimitWarn, c.historyConfig.MutableStateSizeLimitWarn)
+		client.OverrideValue(t, dynamicconfig.MutableStateSizeLimitWarn, c.historyConfig.MutableStateSizeLimitWarn)
 	}
 
 	// For DeleteWorkflowExecution tests
-	client.OverrideValue(dynamicconfig.TransferProcessorUpdateAckInterval, 1*time.Second)
-	client.OverrideValue(dynamicconfig.VisibilityProcessorUpdateAckInterval, 1*time.Second)
+	client.OverrideValue(t, dynamicconfig.TransferProcessorUpdateAckInterval, 1*time.Second)
+	client.OverrideValue(t, dynamicconfig.VisibilityProcessorUpdateAckInterval, 1*time.Second)
 
-	client.OverrideValue(dynamicconfig.EnableAPIGetCurrentRunIDLock, true)
+	client.OverrideValue(t, dynamicconfig.EnableAPIGetCurrentRunIDLock, true)
 }
 
 func (c *temporalImpl) newRPCFactory(

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -667,7 +667,7 @@ func (s *scheduleFunctionalSuite) TestListBeforeRun() {
 
 	// disable per-ns worker so that the schedule workflow never runs
 	dc := s.testCluster.host.dcClient
-	dc.OverrideValue(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
+	dc.OverrideValue(s.T(), dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 	time.Sleep(2 * time.Second)
 
@@ -742,8 +742,8 @@ func (s *scheduleFunctionalSuite) TestRateLimit() {
 	// waiting one minute) we have to cause the whole worker to be stopped and started. The
 	// sleeps are needed because the refresh is asynchronous, and there's no way to get access
 	// to the actual rate limiter object to refresh it directly.
-	s.testCluster.host.dcClient.OverrideValue(dynamicconfig.SchedulerNamespaceStartWorkflowRPS, 1.0)
-	s.testCluster.host.dcClient.OverrideValue(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
+	s.testCluster.host.dcClient.OverrideValue(s.T(), dynamicconfig.SchedulerNamespaceStartWorkflowRPS, 1.0)
+	s.testCluster.host.dcClient.OverrideValue(s.T(), dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 	time.Sleep(2 * time.Second)
 	s.testCluster.host.dcClient.RemoveOverride(dynamicconfig.WorkerPerNamespaceWorkerCount)
@@ -805,7 +805,7 @@ func (s *scheduleFunctionalSuite) TestRateLimit() {
 	}
 
 	s.testCluster.host.dcClient.RemoveOverride(dynamicconfig.SchedulerNamespaceStartWorkflowRPS)
-	s.testCluster.host.dcClient.OverrideValue(dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
+	s.testCluster.host.dcClient.OverrideValue(s.T(), dynamicconfig.WorkerPerNamespaceWorkerCount, 0)
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 	time.Sleep(2 * time.Second)
 	s.testCluster.host.dcClient.RemoveOverride(dynamicconfig.WorkerPerNamespaceWorkerCount)

--- a/tests/test_cluster.go
+++ b/tests/test_cluster.go
@@ -32,6 +32,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"testing"
 
 	"github.com/pborman/uuid"
 	"go.temporal.io/api/operatorservice/v1"
@@ -119,7 +120,7 @@ const (
 )
 
 // NewCluster creates and sets up the test cluster
-func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, error) {
+func NewCluster(t *testing.T, options *TestClusterConfig, logger log.Logger) (*TestCluster, error) {
 	clusterMetadataConfig := cluster.NewTestClusterMetadataConfig(
 		options.ClusterMetadata.EnableGlobalNamespace,
 		options.IsMasterCluster,
@@ -285,7 +286,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 		logger.Fatal("Failed to start pprof", tag.Error(err))
 	}
 
-	cluster := newTemporal(temporalParams)
+	cluster := newTemporal(t, temporalParams)
 	if err := cluster.Start(); err != nil {
 		return nil, err
 	}

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -162,7 +162,7 @@ func (s *functionalSuite) TestTransientWorkflowTaskHistorySize() {
 	}
 
 	// start with 2mb limit
-	s.testCluster.host.dcClient.OverrideValue(dynamicconfig.HistorySizeSuggestContinueAsNew, 2*1024*1024)
+	s.testCluster.host.dcClient.OverrideValue(s.T(), dynamicconfig.HistorySizeSuggestContinueAsNew, 2*1024*1024)
 
 	// workflow logic
 	stage := 0
@@ -282,7 +282,7 @@ func (s *functionalSuite) TestTransientWorkflowTaskHistorySize() {
 
 	// change the dynamic config so that SuggestContinueAsNew should now be false. the current
 	// workflow task should still see true, but the next one will see false.
-	s.testCluster.host.dcClient.OverrideValue(dynamicconfig.HistorySizeSuggestContinueAsNew, 8*1024*1024)
+	s.testCluster.host.dcClient.OverrideValue(s.T(), dynamicconfig.HistorySizeSuggestContinueAsNew, 8*1024*1024)
 
 	// stage 4
 	_, err = poller.PollAndProcessWorkflowTask(WithNoDumpCommands)

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -124,11 +124,11 @@ func (s *advVisCrossDCTestSuite) SetupSuite() {
 	s.Require().NoError(yaml.Unmarshal(confContent, &clusterConfigs))
 	s.clusterConfigs = clusterConfigs
 
-	c, err := tests.NewCluster(clusterConfigs[0], log.With(s.logger, tag.ClusterName(clusterNameAdvVis[0])))
+	c, err := tests.NewCluster(s.T(), clusterConfigs[0], log.With(s.logger, tag.ClusterName(clusterNameAdvVis[0])))
 	s.Require().NoError(err)
 	s.cluster1 = c
 
-	c, err = tests.NewCluster(clusterConfigs[1], log.With(s.logger, tag.ClusterName(clusterNameAdvVis[1])))
+	c, err = tests.NewCluster(s.T(), clusterConfigs[1], log.With(s.logger, tag.ClusterName(clusterNameAdvVis[1])))
 	s.Require().NoError(err)
 	s.cluster2 = c
 

--- a/tests/xdc/base.go
+++ b/tests/xdc/base.go
@@ -107,11 +107,11 @@ func (s *xdcBaseSuite) setupSuite(clusterNames []string, opts ...tests.Option) {
 		clusterConfigs[i].ServiceFxOptions = params.ServiceOptions
 	}
 
-	c, err := tests.NewCluster(clusterConfigs[0], log.With(s.logger, tag.ClusterName(s.clusterNames[0])))
+	c, err := tests.NewCluster(s.T(), clusterConfigs[0], log.With(s.logger, tag.ClusterName(s.clusterNames[0])))
 	s.Require().NoError(err)
 	s.cluster1 = c
 
-	c, err = tests.NewCluster(clusterConfigs[1], log.With(s.logger, tag.ClusterName(s.clusterNames[1])))
+	c, err = tests.NewCluster(s.T(), clusterConfigs[1], log.With(s.logger, tag.ClusterName(s.clusterNames[1])))
 	s.Require().NoError(err)
 	s.cluster2 = c
 


### PR DESCRIPTION
**What changed?**

I cleaned up how we manage dynamicconfig overrides in our functional tests.

**Why?**

Forgetting to clean up after ourselves causes bugs (see #5046). By taking a `testing.T` as a parameter when overriding a value we can automatically clean up after ourselves when a test ends.

I added a separate path here for suite-wide config as there's currently an issue where a test can override a suite's value for a config then clear it, leaving us with _no_ value for the config rather than the value the suite specifies.

**How did you test it?**
Functional tests

**Potential risks**


**Is hotfix candidate?**
No