### PR TITLE
Allow list of keywords in dual visibility setting

### DIFF
--- a/common/persistence/visibility/defs.go
+++ b/common/persistence/visibility/defs.go
@@ -138,12 +138,6 @@ func AllowListForValidation(storeNames []string) bool {
 		return false
 	}
 
-	if len(storeNames) > 1 {
-		// If more than one store is configured then it means that dual visibility is enabled.
-		// Dual visibility is used for migration to advanced, don't allow list of values because it will be removed soon.
-		return false
-	}
-
 	switch storeNames[0] {
 	case mysql.PluginNameV8, postgresql.PluginNameV12, postgresql.PluginNameV12PGX, sqlite.PluginName:
 		// Advanced visibility with SQL DB don't support list of values


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allow list of keywords in dual visibility setting

<!-- Tell your future self why have you made these changes -->
**Why?**
Let dual visibility with Elasticsearch work with list of keywords for backwards compatibility.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No. Any setting involving standard visibility will work as usual: custom search attributes are just ignored and not persisted.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.