### PR TITLE
Support re-enqueuing DLQ'd replication tasks

### DIFF
--- a/service/history/replication/executable_activity_state_task_test.go
+++ b/service/history/replication/executable_activity_state_task_test.go
@@ -71,6 +71,7 @@ type (
 		logger                  log.Logger
 		executableTask          *MockExecutableTask
 		EagerNamespaceRefresher *MockEagerNamespaceRefresher
+		mockExecutionManager    *persistence.MockExecutionManager
 
 		replicationTask   *replicationspb.SyncActivityTaskAttributes
 		sourceClusterName string
@@ -123,6 +124,7 @@ func (s *executableActivityStateTaskSuite) SetupTest() {
 	}
 	s.sourceClusterName = cluster.TestCurrentClusterName
 	s.taskID = rand.Int63()
+	s.mockExecutionManager = persistence.NewMockExecutionManager(s.controller)
 	s.task = NewExecutableActivityStateTask(
 		ProcessToolBox{
 			ClusterMetadata:    s.clusterMetadata,
@@ -132,7 +134,7 @@ func (s *executableActivityStateTaskSuite) SetupTest() {
 			NDCHistoryResender: s.ndcHistoryResender,
 			MetricsHandler:     s.metricsHandler,
 			Logger:             s.logger,
-			DLQWriter:          NewExecutionManagerDLQWriter(),
+			DLQWriter:          NewExecutionManagerDLQWriter(s.mockExecutionManager),
 		},
 		s.taskID,
 		time.Unix(0, rand.Int63()),
@@ -288,14 +290,12 @@ func (s *executableActivityStateTaskSuite) TestHandleErr_Other() {
 func (s *executableActivityStateTaskSuite) TestMarkPoisonPill() {
 	shardID := rand.Int31()
 	shardContext := shard.NewMockContext(s.controller)
-	executionManager := persistence.NewMockExecutionManager(s.controller)
 	s.shardController.EXPECT().GetShardByNamespaceWorkflow(
 		namespace.ID(s.task.NamespaceID),
 		s.task.WorkflowID,
 	).Return(shardContext, nil).AnyTimes()
 	shardContext.EXPECT().GetShardID().Return(shardID).AnyTimes()
-	shardContext.EXPECT().GetExecutionManager().Return(executionManager).AnyTimes()
-	executionManager.EXPECT().PutReplicationTaskToDLQ(gomock.Any(), &persistence.PutReplicationTaskToDLQRequest{
+	s.mockExecutionManager.EXPECT().PutReplicationTaskToDLQ(gomock.Any(), &persistence.PutReplicationTaskToDLQRequest{
 		ShardID:           shardID,
 		SourceClusterName: s.sourceClusterName,
 		TaskInfo: &persistencespb.ReplicationTaskInfo{

--- a/service/history/replication/executable_noop_task_test.go
+++ b/service/history/replication/executable_noop_task_test.go
@@ -97,7 +97,7 @@ func (s *executableNoopTaskSuite) SetupTest() {
 			MetricsHandler:          s.metricsHandler,
 			Logger:                  s.logger,
 			EagerNamespaceRefresher: s.eagerNamespaceRefresher,
-			DLQWriter:               NewExecutionManagerDLQWriter(),
+			DLQWriter:               NoopDLQWriter{},
 		},
 		rand.Int63(),
 		time.Unix(0, rand.Int63()),

--- a/service/history/replication/executable_task_test.go
+++ b/service/history/replication/executable_task_test.go
@@ -117,7 +117,7 @@ func (s *executableTaskSuite) SetupTest() {
 			MetricsHandler:          s.metricsHandler,
 			Logger:                  s.logger,
 			EagerNamespaceRefresher: s.eagerNamespaceRefresher,
-			DLQWriter:               NewExecutionManagerDLQWriter(),
+			DLQWriter:               NoopDLQWriter{},
 		},
 		rand.Int63(),
 		"metrics-tag",

--- a/service/history/replication/executable_unknown_task_test.go
+++ b/service/history/replication/executable_unknown_task_test.go
@@ -99,7 +99,7 @@ func (s *executableUnknownTaskSuite) SetupTest() {
 			MetricsHandler:          s.metricsHandler,
 			Logger:                  s.logger,
 			EagerNamespaceRefresher: s.eagerNamespaceRefresher,
-			DLQWriter:               NewExecutionManagerDLQWriter(),
+			DLQWriter:               NoopDLQWriter{},
 		},
 		s.taskID,
 		time.Unix(0, rand.Int63()),

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -47,6 +47,9 @@ import (
 
 var Module = fx.Provide(
 	NewTaskFetcherFactory,
+	func(m persistence.ExecutionManager) ExecutionManager {
+		return m
+	},
 	NewExecutionManagerDLQWriter,
 	replicationTaskConverterFactoryProvider,
 	replicationTaskExecutorProvider,

--- a/service/history/replication/noop_dlq_writer.go
+++ b/service/history/replication/noop_dlq_writer.go
@@ -1,0 +1,37 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package replication
+
+import "context"
+
+// NoopDLQWriter is a DLQWriter that does nothing. The zero value is a valid instance.
+type NoopDLQWriter struct {
+}
+
+var _ DLQWriter = NoopDLQWriter{}
+
+func (w NoopDLQWriter) WriteTaskToDLQ(context.Context, DLQWriteRequest) error {
+	return nil
+}

--- a/service/history/replication/stream_receiver_monitor_test.go
+++ b/service/history/replication/stream_receiver_monitor_test.go
@@ -93,7 +93,7 @@ func (s *streamReceiverMonitorSuite) SetupTest() {
 		ShardController: s.shardController,
 		MetricsHandler:  metrics.NoopMetricsHandler,
 		Logger:          log.NewNoopLogger(),
-		DLQWriter:       NewExecutionManagerDLQWriter(),
+		DLQWriter:       NoopDLQWriter{},
 	}
 	s.streamReceiverMonitor = NewStreamReceiverMonitor(
 		processToolBox,

--- a/service/history/replication/stream_receiver_test.go
+++ b/service/history/replication/stream_receiver_test.go
@@ -100,7 +100,7 @@ func (s *streamReceiverSuite) SetupTest() {
 		TaskScheduler:   s.taskScheduler,
 		MetricsHandler:  metrics.NoopMetricsHandler,
 		Logger:          log.NewTestLogger(),
-		DLQWriter:       NewExecutionManagerDLQWriter(),
+		DLQWriter:       NoopDLQWriter{},
 	}
 	s.streamReceiver = NewStreamReceiver(
 		processToolBox,

--- a/service/history/replication/task_processor_manager_test.go
+++ b/service/history/replication/task_processor_manager_test.go
@@ -130,7 +130,7 @@ func (s *taskProcessorManagerSuite) SetupTest() {
 		func(params TaskExecutorParams) TaskExecutor {
 			return s.mockReplicationTaskExecutor
 		},
-		NewExecutionManagerDLQWriter(),
+		NewExecutionManagerDLQWriter(s.mockExecutionManager),
 	)
 }
 

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -144,7 +144,7 @@ func (s *taskProcessorSuite) SetupTest() {
 		s.mockReplicationTaskFetcher,
 		s.mockReplicationTaskExecutor,
 		serialization.NewSerializer(),
-		NewExecutionManagerDLQWriter(),
+		NewExecutionManagerDLQWriter(s.mockExecutionManager),
 	).(*taskProcessorImpl)
 }
 

--- a/service/worker/dlq/workflow.go
+++ b/service/worker/dlq/workflow.go
@@ -37,15 +37,16 @@ import (
 	"go.temporal.io/sdk/temporal"
 	sdkworker "go.temporal.io/sdk/worker"
 	"go.temporal.io/sdk/workflow"
-	"go.temporal.io/server/api/adminservice/v1"
-	"go.temporal.io/server/common/debug"
-	"go.temporal.io/server/common/persistence"
+	"go.uber.org/fx"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 
+	"go.temporal.io/server/api/adminservice/v1"
 	commonspb "go.temporal.io/server/api/common/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/common/debug"
 	"go.temporal.io/server/common/headers"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/primitives"
 	workercommon "go.temporal.io/server/service/worker/common"
 )
@@ -60,6 +61,7 @@ type (
 		// MergeParams is only used for WorkflowTypeMerge.
 		MergeParams MergeParams
 	}
+
 	// Key uniquely identifies a DLQ.
 	Key struct {
 		// TaskCategoryID is the id used by [go.temporal.io/server/service/history/tasks.TaskCategoryRegistry].
@@ -72,12 +74,14 @@ type (
 		// if we add cross-cluster tasks in the future.
 		TargetCluster string
 	}
+
 	// DeleteParams contain the target DLQ and the max message ID to delete up to.
 	DeleteParams struct {
 		Key
 		// MaxMessageID is inclusive.
 		MaxMessageID int64
 	}
+
 	// MergeParams contain the target DLQ and the max message ID to merge up to.
 	MergeParams struct {
 		Key
@@ -95,26 +99,63 @@ type (
 		WorkflowType              string
 		DlqKey                    Key
 	}
-	// HistoryClient is a subset of the [historyservice.HistoryServiceClient] interface.
+
+	// HistoryClient contains the subset of methods from [historyservice.HistoryServiceClient] that we need, to make it
+	// easier to implement in tests.
 	HistoryClient interface {
 		DeleteDLQTasks(
 			ctx context.Context,
 			in *historyservice.DeleteDLQTasksRequest,
 			opts ...grpc.CallOption,
 		) (*historyservice.DeleteDLQTasksResponse, error)
-		AddTasks(
-			ctx context.Context,
-			in *historyservice.AddTasksRequest,
-			opts ...grpc.CallOption,
-		) (*historyservice.AddTasksResponse, error)
 		GetDLQTasks(
 			ctx context.Context,
 			in *historyservice.GetDLQTasksRequest,
 			opts ...grpc.CallOption,
 		) (*historyservice.GetDLQTasksResponse, error)
 	}
+
+	// TaskClient contains the subset of methods from [adminservice.AdminServiceClient] that we need, to make it easier
+	// to implement in tests.
+	TaskClient interface {
+		AddTasks(
+			ctx context.Context,
+			in *adminservice.AddTasksRequest,
+		) (*adminservice.AddTasksResponse, error)
+	}
+
+	// AddTasksFn provides a convenient method for implementing the [TaskClient] interface.
+	AddTasksFn func(
+		ctx context.Context,
+		req *adminservice.AddTasksRequest,
+	) (*adminservice.AddTasksResponse, error)
+
+	// TaskClientDialer is a function that returns a [TaskClient] given a cluster name.
+	TaskClientDialer interface {
+		// Dial returns a [TaskClient] given a cluster name. You don't need to close this client. Note that some
+		// implementations will cache clients.
+		Dial(ctx context.Context, cluster string) (TaskClient, error)
+	}
+
+	// TaskClientDialerFn is a function that returns a [TaskClient] given an address.
+	TaskClientDialerFn func(ctx context.Context, address string) (TaskClient, error)
+
+	// CurrentClusterName is its own type just to make fx injection easier. It's similar to the same type that exists
+	// in the persistence package, but I thought that re-using that would look weird here because it has nothing to do
+	// with persistence.
+	CurrentClusterName string
+
+	workerComponentParams struct {
+		fx.In
+		HistoryClient      HistoryClient
+		CurrentClusterName CurrentClusterName
+		TaskClientDialer   TaskClientDialer
+	}
+
 	workerComponent struct {
-		historyClient HistoryClient
+		historyClient      HistoryClient
+		taskClientDialer   TaskClientDialer
+		currentClusterName string
 	}
 )
 
@@ -150,8 +191,8 @@ const (
 )
 
 var (
-	// Module provides a [workercommon.WorkerComponent] annotated with [workercommon.WorkerComponentTag] to the graph, given
-	// a [HistoryClient] dependency.
+	// Module provides a [workercommon.WorkerComponent] annotated with [workercommon.WorkerComponentTag] to the graph,
+	// given a [HistoryClient], a [TaskClientDialer], and a value for [CurrentClusterName].
 	Module = workercommon.AnnotateWorkerComponentProvider(newComponent)
 
 	ErrNegativeBatchSize      = errors.New("BatchSize must be positive or 0 to use the default")
@@ -175,9 +216,11 @@ var (
 	}
 )
 
-func newComponent(client HistoryClient) workercommon.WorkerComponent {
+func newComponent(params workerComponentParams) workercommon.WorkerComponent {
 	return &workerComponent{
-		historyClient: client,
+		historyClient:      params.HistoryClient,
+		currentClusterName: string(params.CurrentClusterName),
+		taskClientDialer:   params.TaskClientDialer,
 	}
 }
 
@@ -283,18 +326,18 @@ func (c *workerComponent) mergeTasks(
 		nextPageToken = response.NextPageToken
 
 		// 1.b. Filter out tasks from messages beyond the last-desired message.
-		tasks := make([]*commonspb.HistoryTask, 0, len(response.DlqTasks))
+		historyTasks := make([]*commonspb.HistoryTask, 0, len(response.DlqTasks))
 		maxBatchMessageID := int64(persistence.FirstQueueMessageID)
 
 		for _, task := range response.DlqTasks {
 			if task.Metadata.MessageId <= params.MaxMessageID {
-				tasks = append(tasks, task.Payload)
+				historyTasks = append(historyTasks, task.Payload)
 				maxBatchMessageID = max(maxBatchMessageID, task.Metadata.MessageId)
 			}
 		}
 
 		// 2. Re-enqueue tasks.
-		err = workflow.ExecuteActivity(ctx, reEnqueueTasksActivityName, params, tasks).Get(ctx, nil)
+		err = workflow.ExecuteActivity(ctx, reEnqueueTasksActivityName, params, historyTasks).Get(ctx, nil)
 		if err != nil {
 			return err
 		}
@@ -316,7 +359,7 @@ func (c *workerComponent) mergeTasks(
 			return err
 		}
 		*lastProcessedMessageID = maxBatchMessageID
-		*numberOfMessagesProcessed += int64(len(tasks))
+		*numberOfMessagesProcessed += int64(len(historyTasks))
 		// 4. Check if we're done.
 		if len(nextPageToken) == 0 {
 			return nil
@@ -361,25 +404,33 @@ func parseMergeParams(params MergeParams) (MergeParams, error) {
 func (c *workerComponent) reEnqueueTasks(
 	ctx context.Context,
 	params MergeParams,
-	tasks []*commonspb.HistoryTask,
+	historyTasks []*commonspb.HistoryTask,
 ) error {
-	tasksByShard := make(map[int32][]*historyservice.AddTasksRequest_Task)
-
-	for _, task := range tasks {
-		newTask := &historyservice.AddTasksRequest_Task{
+	// Group tasks by shard ID.
+	tasksByShard := make(map[int32][]*adminservice.AddTasksRequest_Task)
+	for _, task := range historyTasks {
+		newTask := &adminservice.AddTasksRequest_Task{
 			CategoryId: int32(params.TaskCategoryID),
 			Blob:       task.Blob,
 		}
 		tasksByShard[task.ShardId] = append(tasksByShard[task.ShardId], newTask)
 	}
 
-	for shardID, historyTasks := range tasksByShard {
-		_, err := c.historyClient.AddTasks(ctx, &historyservice.AddTasksRequest{
+	// Connect to the admin service with the source cluster.
+	taskClient, err := c.taskClientDialer.Dial(ctx, params.SourceCluster)
+	if err != nil {
+		return fmt.Errorf("unable to dial admin service for cluster %q: %w", params.SourceCluster, err)
+	}
+
+	for shardID, batch := range tasksByShard {
+		_, err := taskClient.AddTasks(ctx, &adminservice.AddTasksRequest{
 			ShardId: shardID,
-			Tasks:   historyTasks,
+			Tasks:   batch,
 		})
 		if err != nil {
-			return c.convertServerErr(err, "AddTasks failed while re-enqueuing tasks")
+			return c.convertServerErr(err, fmt.Sprintf(
+				"AddTasks failed while re-enqueuing tasks to shard %d", shardID,
+			))
 		}
 	}
 
@@ -454,4 +505,17 @@ func (c *workerComponent) DedicatedActivityWorkerOptions() *workercommon.Dedicat
 			),
 		},
 	}
+}
+
+// Dial implements [TaskClientDialer] by calling the [TaskClientDialerFn] with the cluster name.
+func (f TaskClientDialerFn) Dial(ctx context.Context, cluster string) (TaskClient, error) {
+	return f(ctx, cluster)
+}
+
+// AddTasks implements [TaskClient] by calling the [AddTasksFn] with the request.
+func (f AddTasksFn) AddTasks(
+	ctx context.Context,
+	in *adminservice.AddTasksRequest,
+) (*adminservice.AddTasksResponse, error) {
+	return f(ctx, in)
 }

--- a/service/worker/dlq/workflow_test.go
+++ b/service/worker/dlq/workflow_test.go
@@ -26,6 +26,7 @@ package dlq_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -33,15 +34,18 @@ import (
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/sdk/temporal"
 	"go.temporal.io/sdk/testsuite"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+	"google.golang.org/grpc"
+
+	"go.temporal.io/server/api/adminservice/v1"
 	commonspb "go.temporal.io/server/api/common/v1"
 	"go.temporal.io/server/api/historyservice/v1"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/service/history/tasks"
 	workercommon "go.temporal.io/server/service/worker/common"
 	"go.temporal.io/server/service/worker/dlq"
-	"go.uber.org/fx"
-	"go.uber.org/fx/fxtest"
-	"google.golang.org/grpc"
 )
 
 type (
@@ -51,8 +55,10 @@ type (
 		configure func(t *testing.T, params *testParams)
 	}
 	testParams struct {
-		workflowParams dlq.WorkflowParams
-		client         *testHistoryClient
+		workflowParams     dlq.WorkflowParams
+		client             *testHistoryClient
+		taskClientDialer   dlq.TaskClientDialer
+		currentClusterName string
 		// expectation is run with the result of the workflow execution
 		expectation       func(err error)
 		expectedQueryResp dlq.ProgressQueryResponse
@@ -62,7 +68,6 @@ type (
 	testHistoryClient struct {
 		getTasksFn    func(req *historyservice.GetDLQTasksRequest) (*historyservice.GetDLQTasksResponse, error)
 		deleteTasksFn func(req *historyservice.DeleteDLQTasksRequest) (*historyservice.DeleteDLQTasksResponse, error)
-		addTasksFn    func(req *historyservice.AddTasksRequest) (*historyservice.AddTasksResponse, error)
 	}
 )
 
@@ -210,7 +215,7 @@ func TestModule(t *testing.T) {
 				params.expectedQueryResp.LastProcessedMessageID = 0
 				var (
 					getRequests []*historyservice.GetDLQTasksRequest
-					addRequests []*historyservice.AddTasksRequest
+					addRequests []*adminservice.AddTasksRequest
 				)
 				params.client.getTasksFn = func(
 					req *historyservice.GetDLQTasksRequest,
@@ -230,17 +235,17 @@ func TestModule(t *testing.T) {
 						NextPageToken: nil,
 					}, nil
 				}
-				params.client.addTasksFn = func(
-					req *historyservice.AddTasksRequest,
-				) (*historyservice.AddTasksResponse, error) {
-					addRequests = append(addRequests, req)
-					return nil, nil
-				}
+				params.taskClientDialer = dlq.TaskClientDialerFn(func(ctx context.Context, address string) (dlq.TaskClient, error) {
+					return dlq.AddTasksFn(func(ctx context.Context, req *adminservice.AddTasksRequest) (*adminservice.AddTasksResponse, error) {
+						addRequests = append(addRequests, req)
+						return nil, nil
+					}), nil
+				})
 				params.expectation = func(err error) {
 					require.NoError(t, err)
 					assert.Len(t, getRequests, 1)
 					require.Len(t, addRequests, 1)
-					requestsByShardID := make(map[int32]*historyservice.AddTasksRequest)
+					requestsByShardID := make(map[int32]*adminservice.AddTasksRequest)
 					for _, request := range addRequests {
 						requestsByShardID[request.GetShardId()] = request
 					}
@@ -262,17 +267,19 @@ func TestModule(t *testing.T) {
 				) (*historyservice.GetDLQTasksResponse, error) {
 					return getPaginatedResponse(req)
 				}
-				var addRequests []*historyservice.AddTasksRequest
-				params.client.addTasksFn = func(
-					req *historyservice.AddTasksRequest,
-				) (*historyservice.AddTasksResponse, error) {
-					addRequests = append(addRequests, req)
-					return nil, nil
-				}
+				var (
+					addRequests []*adminservice.AddTasksRequest
+				)
+				params.taskClientDialer = dlq.TaskClientDialerFn(func(ctx context.Context, address string) (dlq.TaskClient, error) {
+					return dlq.AddTasksFn(func(ctx context.Context, req *adminservice.AddTasksRequest) (*adminservice.AddTasksResponse, error) {
+						addRequests = append(addRequests, req)
+						return nil, nil
+					}), nil
+				})
 				params.expectation = func(err error) {
 					require.NoError(t, err)
 					require.Len(t, addRequests, 3)
-					requestsByShardID := make(map[int32]*historyservice.AddTasksRequest)
+					requestsByShardID := make(map[int32]*adminservice.AddTasksRequest)
 					for _, request := range addRequests {
 						requestsByShardID[request.GetShardId()] = request
 					}
@@ -305,13 +312,19 @@ func TestModule(t *testing.T) {
 				) (*historyservice.GetDLQTasksResponse, error) {
 					return res, nil
 				}
-				var addTasksRequests []*historyservice.AddTasksRequest
-				params.client.addTasksFn = func(
-					req *historyservice.AddTasksRequest,
-				) (*historyservice.AddTasksResponse, error) {
-					addTasksRequests = append(addTasksRequests, req)
-					return nil, new(serviceerror.InvalidArgument)
-				}
+				var addTasksRequests []*adminservice.AddTasksRequest
+				params.taskClientDialer = dlq.TaskClientDialerFn(func(
+					ctx context.Context,
+					address string,
+				) (dlq.TaskClient, error) {
+					return dlq.AddTasksFn(func(
+						ctx context.Context,
+						req *adminservice.AddTasksRequest,
+					) (*adminservice.AddTasksResponse, error) {
+						addTasksRequests = append(addTasksRequests, req)
+						return nil, new(serviceerror.InvalidArgument)
+					}), nil
+				})
 				params.expectation = func(err error) {
 					var applicationErr *temporal.ApplicationError
 					require.ErrorAs(t, err, &applicationErr)
@@ -346,15 +359,21 @@ func TestModule(t *testing.T) {
 					return res, nil
 				}
 				var (
-					addRequests    []*historyservice.AddTasksRequest
+					addRequests    []*adminservice.AddTasksRequest
 					deleteRequests []*historyservice.DeleteDLQTasksRequest
 				)
-				params.client.addTasksFn = func(
-					req *historyservice.AddTasksRequest,
-				) (*historyservice.AddTasksResponse, error) {
-					addRequests = append(addRequests, req)
-					return nil, nil
-				}
+				params.taskClientDialer = dlq.TaskClientDialerFn(func(
+					ctx context.Context,
+					address string,
+				) (dlq.TaskClient, error) {
+					return dlq.AddTasksFn(func(
+						ctx context.Context,
+						req *adminservice.AddTasksRequest,
+					) (*adminservice.AddTasksResponse, error) {
+						addRequests = append(addRequests, req)
+						return nil, nil
+					}), nil
+				})
 				params.client.deleteTasksFn = func(
 					req *historyservice.DeleteDLQTasksRequest,
 				) (*historyservice.DeleteDLQTasksResponse, error) {
@@ -372,6 +391,46 @@ func TestModule(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "merge_replication_tasks_dial_error",
+			configure: func(t *testing.T, params *testParams) {
+				params.setDefaultMergeParams(t)
+				params.workflowParams.MergeParams.Key.SourceCluster = "source-cluster"
+				params.workflowParams.MergeParams.Key.TargetCluster = "current-cluster"
+				params.currentClusterName = "current-cluster"
+				params.workflowParams.MergeParams.Key.TaskCategoryID = tasks.CategoryIDReplication
+				params.expectedQueryResp.DlqKey = params.workflowParams.MergeParams.Key
+				var replicationTask tasks.HistoryReplicationTask
+				blob, err := serialization.NewTaskSerializer().SerializeTask(&replicationTask)
+				require.NoError(t, err)
+				params.client.getTasksFn = func(req *historyservice.GetDLQTasksRequest) (*historyservice.GetDLQTasksResponse, error) {
+					return &historyservice.GetDLQTasksResponse{
+						DlqTasks: []*commonspb.HistoryDLQTask{
+							{
+								Metadata: &commonspb.HistoryDLQTaskMetadata{
+									MessageId: 0,
+								},
+								Payload: &commonspb.HistoryTask{
+									ShardId: 1,
+									Blob:    &blob,
+								},
+							},
+						},
+					}, nil
+				}
+				params.taskClientDialer = dlq.TaskClientDialerFn(func(ctx context.Context, address string) (dlq.TaskClient, error) {
+					return nil, assert.AnError
+				})
+				params.expectation = func(err error) {
+					var applicationErr *temporal.ApplicationError
+					require.ErrorAs(t, err, &applicationErr)
+					assert.False(t, applicationErr.NonRetryable())
+					msg := strings.ToLower(err.Error())
+					assert.Contains(t, msg, "unable to dial admin service for cluster")
+					assert.Contains(t, msg, "source-cluster")
+				}
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
@@ -385,9 +444,17 @@ func TestModule(t *testing.T) {
 			fxtest.New(
 				t,
 				dlq.Module,
-				fx.Provide(func() dlq.HistoryClient {
-					return params.client
-				}),
+				fx.Provide(
+					func() dlq.HistoryClient {
+						return params.client
+					},
+					func() dlq.TaskClientDialer {
+						return params.taskClientDialer
+					},
+					func() dlq.CurrentClusterName {
+						return dlq.CurrentClusterName(params.currentClusterName)
+					},
+				),
 				fx.Populate(fx.Annotate(&components, fx.ParamTags(workercommon.WorkerComponentTag))),
 			)
 			require.Len(t, components, 1)
@@ -475,8 +542,8 @@ func (p *testParams) setDefaultDeleteParams(t *testing.T) {
 		DeleteParams: dlq.DeleteParams{
 			Key: dlq.Key{
 				TaskCategoryID: tasks.CategoryTransfer.ID(),
-				SourceCluster:  "source-cluster",
-				TargetCluster:  "target-cluster",
+				SourceCluster:  "current-cluster",
+				TargetCluster:  "current-cluster",
 			},
 		},
 	}
@@ -496,8 +563,8 @@ func (p *testParams) setDefaultMergeParams(t *testing.T) {
 		MergeParams: dlq.MergeParams{
 			Key: dlq.Key{
 				TaskCategoryID: tasks.CategoryTransfer.ID(),
-				SourceCluster:  "source-cluster",
-				TargetCluster:  "target-cluster",
+				SourceCluster:  "current-cluster",
+				TargetCluster:  "current-cluster",
 			},
 		},
 	}
@@ -507,6 +574,7 @@ func (p *testParams) setDefaultMergeParams(t *testing.T) {
 		WorkflowType:           p.workflowParams.WorkflowType,
 		DlqKey:                 p.workflowParams.MergeParams.Key,
 	}
+	p.currentClusterName = "current-cluster"
 }
 
 func (p *testParams) setDefaultParams(t *testing.T) {
@@ -514,11 +582,6 @@ func (p *testParams) setDefaultParams(t *testing.T) {
 	p.client.getTasksFn = func(
 		*historyservice.GetDLQTasksRequest,
 	) (*historyservice.GetDLQTasksResponse, error) {
-		return nil, nil
-	}
-	p.client.addTasksFn = func(
-		request *historyservice.AddTasksRequest,
-	) (*historyservice.AddTasksResponse, error) {
 		return nil, nil
 	}
 	p.client.deleteTasksFn = func(
@@ -531,15 +594,17 @@ func (p *testParams) setDefaultParams(t *testing.T) {
 	}
 	p.queryExpectation = func(response dlq.ProgressQueryResponse) {
 		require.NotNil(t, response)
-	}
-	p.queryExpectation = func(response dlq.ProgressQueryResponse) {
-		require.NotNil(t, response)
 		require.Equal(t, p.expectedQueryResp.MaxMessageIDToProcess, response.MaxMessageIDToProcess)
 		require.Equal(t, p.expectedQueryResp.LastProcessedMessageID, response.LastProcessedMessageID)
 		require.Equal(t, p.expectedQueryResp.WorkflowType, response.WorkflowType)
 		require.Equal(t, p.expectedQueryResp.NumberOfMessagesProcessed, response.NumberOfMessagesProcessed)
 		require.EqualValues(t, p.expectedQueryResp.DlqKey, response.DlqKey)
 	}
+	p.taskClientDialer = dlq.TaskClientDialerFn(func(ctx context.Context, address string) (dlq.TaskClient, error) {
+		return dlq.AddTasksFn(func(ctx context.Context, req *adminservice.AddTasksRequest) (*adminservice.AddTasksResponse, error) {
+			return nil, nil
+		}), nil
+	})
 }
 
 func (c *testHistoryClient) GetDLQTasks(
@@ -552,10 +617,4 @@ func (c *testHistoryClient) DeleteDLQTasks(
 	_ context.Context, req *historyservice.DeleteDLQTasksRequest, _ ...grpc.CallOption,
 ) (*historyservice.DeleteDLQTasksResponse, error) {
 	return c.deleteTasksFn(req)
-}
-
-func (c *testHistoryClient) AddTasks(
-	_ context.Context, req *historyservice.AddTasksRequest, _ ...grpc.CallOption,
-) (*historyservice.AddTasksResponse, error) {
-	return c.addTasksFn(req)
 }

--- a/tests/xdc/history_replication_dlq_test.go
+++ b/tests/xdc/history_replication_dlq_test.go
@@ -25,12 +25,11 @@
 package xdc
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
-	"io"
 	"math"
 	"strconv"
 	"strings"
@@ -40,6 +39,9 @@ import (
 	"github.com/gogo/protobuf/jsonpb"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
+	"github.com/urfave/cli/v2"
+	"go.temporal.io/api/enums/v1"
+	historypb "go.temporal.io/api/history/v1"
 	"go.temporal.io/api/serviceerror"
 	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
@@ -53,12 +55,12 @@ import (
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/service/history/replication"
 	"go.temporal.io/server/service/history/tasks"
 	"go.temporal.io/server/tests"
-	"go.temporal.io/server/tests/testutils"
 	"go.temporal.io/server/tools/tdbg"
 	"go.temporal.io/server/tools/tdbg/tdbgtest"
 )
@@ -83,10 +85,9 @@ type (
 		// The below "params" objects are used to propagate parameters to the dependencies that we inject into the
 		// Temporal server. Mainly, we use this to share channels between the main test goroutine and the background
 		// task processing goroutines so that we can synchronize on them.
-
-		replicationTaskExecutorParams          replicationTaskExecutorParams
-		executionManagerParams                 dlqWriterParams
-		namespaceReplicationTaskExecutorParams namespaceReplicationTaskExecutorParams
+		replicationTaskExecutors          replicationTaskExecutorParams
+		namespaceReplicationTaskExecutors namespaceReplicationTaskExecutorParams
+		dlqWriters                        dlqWriterParams
 	}
 
 	// The below types are used to inject our own implementations of replication dependencies, so that we can both
@@ -96,7 +97,9 @@ type (
 	replicationTaskExecutorParams struct {
 		// We use an interface{} for these tasks because we don't care about the data, and the concrete type changes
 		// depending on whether we have streaming enabled for replication or not.
-		tasks chan interface{}
+		executedTasks       chan *replicationspb.ReplicationTask
+		workflowIDToFail    string
+		workflowIDToObserve string
 	}
 	testReplicationTaskExecutor struct {
 		*replicationTaskExecutorParams
@@ -104,7 +107,7 @@ type (
 	}
 	dlqWriterParams struct {
 		// This channel is sent to once we're done processing a request to add a message to the DLQ.
-		dlqRequests chan replication.WriteRequest
+		processedDLQRequests chan replication.DLQWriteRequest
 	}
 	testDLQWriter struct {
 		*dlqWriterParams
@@ -125,12 +128,12 @@ type (
 	testExecutableTask struct {
 		*replicationTaskExecutorParams
 		replication.TrackableExecutableTask
+		replicationTask *replicationspb.ReplicationTask
 	}
 )
 
 const (
-	testTimeout      = 30 * time.Second
-	workflowIDToFail = "history-replication-dlq-test-workflow"
+	testTimeout = 30 * time.Second
 )
 
 func TestHistoryReplicationDLQSuite(t *testing.T) {
@@ -178,13 +181,14 @@ func (s *historyReplicationDLQSuite) SetupSuite() {
 		dynamicconfig.EnableHistoryReplicationDLQV2: s.enableQueueV2,
 	}
 
-	// Buffer this channel by one because we only care about the first request to add a message to the DLQ.
-	s.executionManagerParams.dlqRequests = make(chan replication.WriteRequest, 1)
-
-	// Buffer these channels by 100 because we don't know how many replication tasks there will be until the one that
-	// replicates our namespace is executed.
-	s.namespaceReplicationTaskExecutorParams.tasks = make(chan *replicationspb.NamespaceTaskAttributes, 100)
-	s.replicationTaskExecutorParams.tasks = make(chan interface{}, 100)
+	// We don't know how many messages these channels are actually going to produce, and we may not read them all, so we
+	// need to buffer them by a good amount.
+	s.namespaceReplicationTaskExecutors.tasks = make(chan *replicationspb.NamespaceTaskAttributes, 100)
+	s.replicationTaskExecutors.executedTasks = make(chan *replicationspb.ReplicationTask, 100)
+	s.dlqWriters.processedDLQRequests = make(chan replication.DLQWriteRequest, 100)
+	workflowIDToFail := uuid.New()
+	s.replicationTaskExecutors.workflowIDToFail = workflowIDToFail
+	s.replicationTaskExecutors.workflowIDToObserve = workflowIDToFail
 
 	// This can't be very long, so we just use a UUID instead of a more descriptive name.
 	// We also don't escape this string in many places, so it can't contain any dashes.
@@ -203,7 +207,7 @@ func (s *historyReplicationDLQSuite) SetupSuite() {
 					// Replace the dlq writer with one that records DLQ requests so that we can wait until a task is
 					// added to the DLQ before querying tdbg.
 					return &testDLQWriter{
-						dlqWriterParams: &s.executionManagerParams,
+						dlqWriterParams: &s.dlqWriters,
 						DLQWriter:       dlqWriter,
 					}
 				},
@@ -211,10 +215,10 @@ func (s *historyReplicationDLQSuite) SetupSuite() {
 		),
 		tests.WithFxOptionsForService(primitives.WorkerService,
 			fx.Decorate(
-				func(namespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor) namespace.ReplicationTaskExecutor {
+				func(executor namespace.ReplicationTaskExecutor) namespace.ReplicationTaskExecutor {
 					return &testNamespaceReplicationTaskExecutor{
-						replicationTaskExecutor:                namespaceReplicationTaskExecutor,
-						namespaceReplicationTaskExecutorParams: &s.namespaceReplicationTaskExecutorParams,
+						replicationTaskExecutor:                executor,
+						namespaceReplicationTaskExecutorParams: &s.namespaceReplicationTaskExecutors,
 					}
 				},
 			),
@@ -230,8 +234,9 @@ func (s *historyReplicationDLQSuite) SetupTest() {
 	s.setupTest()
 }
 
-// This test executes a workflow on the active cluster and verifies that its replication tasks show in the DLQ of the
-// standby cluster when they fail to execute.
+// This test executes a workflow on the active cluster, verifies that its replication tasks all appear in the DLQ, re-
+// enqueues them, and then verifies that the replication task executor re-executes them on the standby cluster,
+// completing the previously-failed replication attempt.
 func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 	// This test uses channels to synchronize between the main test goroutine and the background task processing for
 	// replication, so we use a context with a timeout to ensure that the test doesn't hang forever when we try to
@@ -243,15 +248,18 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 	// Register a namespace.
 	ns := "history-replication-dlq-test-namespace"
 	_, err := s.cluster1.GetFrontendClient().RegisterNamespace(ctx, &workflowservice.RegisterNamespaceRequest{
-		Namespace:                        ns,
-		Clusters:                         s.clusterReplicationConfig(),
-		ActiveClusterName:                s.clusterNames[0],
-		IsGlobalNamespace:                true,
-		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(1 * time.Hour * 24), // required param
+		Namespace: ns,
+		Clusters:  s.clusterReplicationConfig(),
+		// The first cluster is the active cluster.
+		ActiveClusterName: s.clusterNames[0],
+		// Needed so that the namespace is replicated.
+		IsGlobalNamespace: true,
+		// This is a required parameter.
+		WorkflowExecutionRetentionPeriod: timestamp.DurationPtr(time.Hour * 24),
 	})
 	s.NoError(err)
 
-	// Create a worker and register a workflow.
+	// Create a worker and register a workflow on the active cluster.
 	activeClient, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:  s.cluster1.GetHost().FrontendGRPCAddress(),
 		Namespace: ns,
@@ -268,22 +276,13 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 	defer worker.Stop()
 
 	// Wait for the namespace to be replicated.
-	for {
-		var task *replicationspb.NamespaceTaskAttributes
-		select {
-		case task = <-s.namespaceReplicationTaskExecutorParams.tasks:
-		case <-ctx.Done():
-			s.FailNow("timed out waiting for namespace replication task to be processed")
-		}
-		if task.Info.Name == ns {
-			break
-		}
-	}
+	s.waitForNSReplication(ctx, ns)
 
 	// Execute the workflow.
+	workflowID := s.replicationTaskExecutors.workflowIDToFail
 	run, err := activeClient.ExecuteWorkflow(ctx, sdkclient.StartWorkflowOptions{
 		TaskQueue: tq,
-		ID:        workflowIDToFail,
+		ID:        workflowID,
 	}, myWorkflow)
 	s.NoError(err)
 
@@ -293,83 +292,186 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 	s.NoError(err)
 	s.Equal("hello", result)
 
-	// Wait for the replication task executor to process the replication task.
-	select {
-	case <-s.replicationTaskExecutorParams.tasks:
-	case <-ctx.Done():
-		s.FailNow("timed out waiting for replication task to be processed")
-	}
+	// Wait for the replication task executor to process all the replication tasks for this workflow.
+	// That way, we will know when the DLQ contains everything it needs for this workflow.
+	serializer := serialization.NewSerializer()
+	events := s.waitUntilWorkflowReplicated(ctx, serializer, workflowID)
 
-	// Wait for at least one replication task to be added to the DLQ. There could be more, but we only care about the
-	// first one because they should all be for this workflow since it's the only one for which we injected replication
-	// task failures.
-	var request replication.WriteRequest
-	select {
-	case request = <-s.executionManagerParams.dlqRequests:
-	case <-ctx.Done():
-		s.FailNow("timed out waiting for replication task to be added to DLQ")
-	}
-	s.Equal(s.clusterNames[0], request.SourceCluster)
-	s.Equal(1, int(request.ShardID))
+	// Wait until all the replication tasks for this workflow are in the DLQ.
+	// We need to do this because we don't want to start re-enqueuing the DLQ until it contains all the replication
+	// tasks for this workflow.
+	s.waitUntilReplicationTasksAreInDLQ(ctx, events)
 
+	// Before we re-enqueue the replication tasks, we want to call the `tdbg dlq read` command. This acts as both a
+	// sanity check because merge will certainly fail if the DLQ is empty, and also a way to verify that the tdbg
+	// command itself works.
 	// Create a TDBG client pointing at the standby cluster.
 	clientFactory := tdbg.NewClientFactory(
 		tdbg.WithFrontendAddress(s.cluster2.GetHost().FrontendGRPCAddress()),
 	)
+	// Send the output to a bytes buffer instead of a file because it's faster and simpler.
+	var cliOutputBuffer bytes.Buffer
 	app := tdbgtest.NewCliApp(func(params *tdbg.Params) {
 		params.ClientFactory = clientFactory
+		params.Writer = &cliOutputBuffer
 	})
 
 	// Run the TDBG command to read replication tasks from the DLQ.
 	// The last message ID is set to MaxInt64 - 1 because the last message ID is exclusive, so if it were
 	// set to the max int64, then, because the server increments the value, it would overflow and return no results.
 	// We want the maximum possible value because we have no idea what the task ids could be, but this parameter must
-	// be specified, so we just use the maximum possible value to get all available tasks.
+	// be specified (only for queue v1), so we just use the maximum possible value to get all available tasks.
 	lastMessageID := strconv.Itoa(math.MaxInt64 - 1)
-	file := testutils.CreateTemp(s.T(), "", "*")
 	dlqVersion := "v1"
+	dlqType := "history"
 	if s.enableQueueV2 {
 		dlqVersion = "v2"
+		dlqType = strconv.Itoa(tasks.CategoryReplication.ID())
 	}
+	s.testReadTasks(app, &cliOutputBuffer, dlqVersion, dlqType, run, lastMessageID)
+
+	// Stop failing the replication tasks for this workflow.
+	s.replicationTaskExecutors.workflowIDToFail = "something-else"
+
+	// Re-enqueue the replication tasks.
 	cmd := []string{
 		"tdbg",
+		"--" + tdbg.FlagYes,
+		"dlq",
+		"--" + tdbg.FlagDLQVersion, dlqVersion,
+		"merge",
+		"--" + tdbg.FlagCluster, s.clusterNames[0],
+		"--" + tdbg.FlagShardID, "1",
+		"--" + tdbg.FlagLastMessageID, lastMessageID,
+		"--" + tdbg.FlagDLQType, dlqType,
+	}
+	cliOutputBuffer.Truncate(0)
+	s.runTDBGCommand(app, &cliOutputBuffer, cmd)
+
+	if s.enableQueueV2 {
+		// DLQ v2 merges tasks asynchronously, so we need to wait for it to finish. In v1, the merge is synchronous.
+		// Specifically, v1 executes the replication tasks in-place, instead of putting them back on a task queue, so
+		// we both don't need to wait for the merge to finish, and there would be no events on the task executor channel
+		// to wait for anyway.
+		s.waitUntilWorkflowReplicated(context.Background(), serializer, workflowID)
+	}
+
+	// Wait for the workflow to complete on the standby cluster.
+	standbyClient, err := sdkclient.Dial(sdkclient.Options{
+		HostPort:  s.cluster2.GetHost().FrontendGRPCAddress(),
+		Namespace: ns,
+	})
+	s.NoError(err)
+	run = standbyClient.GetWorkflow(ctx, workflowID, "")
+	err = run.Get(ctx, &result)
+	s.NoError(err)
+	s.Equal("hello", result)
+}
+
+// This method blocks until the DLQ has received replication tasks which cover all the provided history events.
+func (s *historyReplicationDLQSuite) waitUntilReplicationTasksAreInDLQ(
+	ctx context.Context,
+	events []*historypb.HistoryEvent,
+) {
+	// Make a map containing all the event IDs that we haven't seen in the DLQ'd replication tasks yet.
+	eventIDs := make(map[int64]struct{})
+	for _, event := range events {
+		eventIDs[event.GetEventId()] = struct{}{}
+	}
+	for len(eventIDs) > 0 {
+		select {
+		case request := <-s.dlqWriters.processedDLQRequests:
+			firstEventID := request.ReplicationTaskInfo.FirstEventId
+			// nextEventID is exclusive.
+			nextEventID := request.ReplicationTaskInfo.NextEventId
+			if request.ReplicationTaskInfo.TaskType == enumspb.TASK_TYPE_REPLICATION_HISTORY {
+				// A single replication task could contain multiple events, so we need to mark all the event IDs that it
+				// spans as complete.
+				for eventID := firstEventID; eventID < nextEventID; eventID++ {
+					delete(eventIDs, eventID)
+				}
+			}
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for replication task to be added to DLQ")
+		}
+	}
+}
+
+// waitForNSReplication blocks until the namespace has been replicated. We want to do this because replication tasks
+// will get dropped if the namespace does not exist.
+func (s *historyReplicationDLQSuite) waitForNSReplication(ctx context.Context, ns string) {
+	for {
+		select {
+		case task := <-s.namespaceReplicationTaskExecutors.tasks:
+			if task.Info.Name == ns {
+				return
+			}
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for namespace replication task to be processed")
+		}
+	}
+}
+
+// waitUntilWorkflowReplicated waits until the workflow with the given ID has been replicated to the standby cluster.
+// It does this by waiting for the replication task executor to process the workflow completion replication event.
+func (s *historyReplicationDLQSuite) waitUntilWorkflowReplicated(
+	ctx context.Context,
+	serializer serialization.Serializer,
+	workflowID string,
+) []*historypb.HistoryEvent {
+	var historyEvents []*historypb.HistoryEvent
+	for {
+		select {
+		case task := <-s.replicationTaskExecutors.executedTasks:
+			attr := task.GetHistoryTaskAttributes()
+			if attr == nil {
+				continue
+			}
+			if attr.WorkflowId != workflowID {
+				continue
+			}
+			events, err := serializer.DeserializeEvents(attr.Events)
+			s.NoError(err)
+			historyEvents = append(historyEvents, events...)
+			for _, event := range events {
+				if event.GetEventType() == enums.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED {
+					return historyEvents
+				}
+			}
+		case <-ctx.Done():
+			s.FailNow("timed out waiting for replication task to be processed")
+		}
+	}
+}
+
+// This method calls `tdbg dlq read`, verifying that it contains the correct replication tasks.
+func (s *historyReplicationDLQSuite) testReadTasks(
+	app *cli.App,
+	buffer *bytes.Buffer,
+	dlqVersion string,
+	dlqType string,
+	run sdkclient.WorkflowRun,
+	lastMessageID string,
+) {
+	cmd := []string{
+		"tdbg",
+		"--" + tdbg.FlagYes,
 		"dlq",
 		"--" + tdbg.FlagDLQVersion, dlqVersion,
 		"read",
 		"--" + tdbg.FlagCluster, s.clusterNames[0],
 		"--" + tdbg.FlagShardID, "1",
 		"--" + tdbg.FlagLastMessageID, lastMessageID,
-		"--" + tdbg.FlagMaxMessageCount, "10",
-		"--" + tdbg.FlagOutputFilename, file.Name(),
+		"--" + tdbg.FlagDLQType, dlqType,
 	}
-	if s.enableQueueV2 {
-		cmd = append(cmd,
-			"--"+tdbg.FlagDLQType, strconv.Itoa(tasks.CategoryReplication.ID()),
-		)
-	} else {
-		cmd = append(cmd,
-			"--"+tdbg.FlagDLQType, "history",
-		)
-	}
-	cmdString := strings.Join(cmd, " ")
-	s.T().Log("TDBG command:", cmdString)
-	err = app.Run(cmd)
-	s.NoError(err)
-	s.T().Log("TDBG output:")
-	s.T().Log("========================================")
-	bytes, err := io.ReadAll(file)
-	s.NoError(err)
-	s.T().Log(string(bytes))
+	s.runTDBGCommand(app, buffer, cmd)
 
 	// Parse the output into replication task protos.
-	_, err = file.Seek(0, io.SeekStart)
-	s.NoError(err)
-	s.T().Log("========================================")
 	// Verify that the replication task contains the correct information (operators will want to know which workflow
 	// failed to replicate).
 	if s.enableQueueV2 {
 		replicationTasks, err := tdbgtest.ParseDLQMessages(
-			file,
+			buffer,
 			func() *persistencespb.ReplicationTaskInfo {
 				return new(persistencespb.ReplicationTaskInfo)
 			},
@@ -382,7 +484,7 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 		s.Equal(run.GetRunID(), task.RunId)
 	} else {
 		replicationTasks, err := tdbgtest.ParseJSONL(
-			file,
+			buffer,
 			func(decoder *json.Decoder) (*replicationspb.ReplicationTask, error) {
 				task := &replicationspb.ReplicationTask{}
 				return task, jsonpb.UnmarshalNext(decoder, task)
@@ -398,13 +500,31 @@ func (s *historyReplicationDLQSuite) TestWorkflowReplicationTaskFailure() {
 	}
 }
 
+// runTDBGCommand is useful for manually testing the TDBG CLI because, in addition to automated checks that we can run
+// on the parsed output, we also just want to know that it looks good to a human.
+func (s *historyReplicationDLQSuite) runTDBGCommand(
+	app *cli.App,
+	buffer *bytes.Buffer,
+	cmd []string,
+) {
+	cmdString := strings.Join(cmd, " ")
+	s.T().Log("TDBG command:", cmdString)
+	err := app.Run(cmd)
+	s.NoError(err)
+	s.T().Log("TDBG output:")
+	s.T().Log("========================================")
+	b := buffer.Bytes()
+	s.T().Log(string(b))
+	s.T().Log("========================================")
+}
+
 func (s *historyReplicationDLQSuite) getTaskExecutorDecorator() interface{} {
 	if s.enableReplicationStream {
 		// The replication stream uses a different code path which converts tasks into executables using this interface,
 		// so that's a good injection point for us.
 		return func(converter replication.ExecutableTaskConverter) replication.ExecutableTaskConverter {
 			return &testExecutableTaskConverter{
-				replicationTaskExecutorParams: &s.replicationTaskExecutorParams,
+				replicationTaskExecutorParams: &s.replicationTaskExecutors,
 				converter:                     converter,
 			}
 		}
@@ -415,7 +535,7 @@ func (s *historyReplicationDLQSuite) getTaskExecutorDecorator() interface{} {
 		return func(params replication.TaskExecutorParams) replication.TaskExecutor {
 			taskExecutor := provider(params)
 			return &testReplicationTaskExecutor{
-				replicationTaskExecutorParams: &s.replicationTaskExecutorParams,
+				replicationTaskExecutorParams: &s.replicationTaskExecutors,
 				taskExecutor:                  taskExecutor,
 			}
 		}
@@ -432,10 +552,7 @@ func (t *testNamespaceReplicationTaskExecutor) Execute(
 	if err != nil {
 		return err
 	}
-	select {
-	case t.tasks <- task:
-	default:
-	}
+	t.tasks <- task
 	return nil
 }
 
@@ -443,33 +560,37 @@ func (t *testNamespaceReplicationTaskExecutor) Execute(
 // wait for it to know that the replication task has been added to the DLQ.
 func (t *testDLQWriter) WriteTaskToDLQ(
 	ctx context.Context,
-	request replication.WriteRequest,
+	request replication.DLQWriteRequest,
 ) error {
 	err := t.DLQWriter.WriteTaskToDLQ(ctx, request)
-	if err != nil {
-		return err
-	}
-	select {
-	case t.dlqRequests <- request:
-	default:
-	}
-	return nil
+	t.processedDLQRequests <- request
+	return err
 }
 
 // Execute the replication task as-normal or return an error if the workflow ID matches the one that we want to fail.
+// This is run only when streaming is disabled for replication.
 func (f testReplicationTaskExecutor) Execute(
 	ctx context.Context,
 	replicationTask *replicationspb.ReplicationTask,
 	forceApply bool,
 ) error {
-	if replicationTask.GetHistoryTaskAttributes().WorkflowId == workflowIDToFail {
-		select {
-		case f.tasks <- replicationTask:
-		default:
-		}
-		return errors.New("failed to apply replication task")
+	err := f.execute(ctx, replicationTask, forceApply)
+	if attr := replicationTask.GetHistoryTaskAttributes(); attr != nil && attr.WorkflowId == f.workflowIDToObserve {
+		f.executedTasks <- replicationTask
 	}
-	return f.taskExecutor.Execute(ctx, replicationTask, forceApply)
+	return err
+}
+
+func (f testReplicationTaskExecutor) execute(
+	ctx context.Context,
+	replicationTask *replicationspb.ReplicationTask,
+	forceApply bool,
+) error {
+	if attr := replicationTask.GetHistoryTaskAttributes(); attr != nil && attr.WorkflowId == f.workflowIDToFail {
+		return serviceerror.NewInvalidArgument("failed to apply replication task")
+	}
+	err := f.taskExecutor.Execute(ctx, replicationTask, forceApply)
+	return err
 }
 
 // Convert the replication tasks using the base converter, but then wrap them in our own faulty executable tasks.
@@ -485,16 +606,23 @@ func (t *testExecutableTaskConverter) Convert(
 		testExecutableTasks[i] = &testExecutableTask{
 			replicationTaskExecutorParams: t.replicationTaskExecutorParams,
 			TrackableExecutableTask:       task,
+			replicationTask:               replicationTasks[i],
 		}
 	}
 	return testExecutableTasks
 }
 
 // Execute the replication task as-normal or return an error if the workflow ID matches the one that we want to fail.
+// This is run only when streaming is enabled for replication.
 func (t *testExecutableTask) Execute() error {
+	err := t.execute()
+	t.replicationTaskExecutorParams.executedTasks <- t.replicationTask
+	return err
+}
+
+func (t *testExecutableTask) execute() error {
 	if et, ok := t.TrackableExecutableTask.(*replication.ExecutableHistoryTask); ok {
-		if et.WorkflowID == workflowIDToFail {
-			t.replicationTaskExecutorParams.tasks <- struct{}{}
+		if et.WorkflowID == t.workflowIDToFail {
 			return serviceerror.NewInvalidArgument("failed to apply replication task")
 		}
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR adds support for re-enqueuing replication tasks from the DLQ back to their original queue for queue v2.

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, we only support re-enqueuing history tasks for queue v2. Support wasn't added for replication tasks immediately for 2 reasons:
1. Testing it is *much* more complicated
2. It requires the ability to connect to a remote cluster

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
In addition to unit tests, there's an integration test which uses tdbg merge with queue v1, v2, and replication streaming enabled and disabled. It does this:
1. Execute a workflow with replication tasks that we override to return terminal errors
2. Verify that they all end up in the DLQ using tdbg dlq read
3. Use tdbg dlq merge to re-enqueue them all
4. Verify that the workflow now completes in the standby cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This won't work if the original source cluster is no longer active, but I'll fix that in a follow-up PR because this isn't running in production yet, and I think that change will probably deserve its own dedicated review anyway.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
