### PR TITLE
Fix output artifact names in coverage report in buildkite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -357,7 +357,7 @@ functional-test-ndc-coverage: prepare-coverage-test
 .PHONY: $(SUMMARY_COVER_PROFILE)
 $(SUMMARY_COVER_PROFILE):
 	@printf $(COLOR) "Combine coverage reports to $(SUMMARY_COVER_PROFILE)..."
-	@rm -f $(SUMMARY_COVER_PROFILE)
+	@rm -f $(SUMMARY_COVER_PROFILE) $(SUMMARY_COVER_PROFILE).html
 	@if [ -z "$(wildcard $(TEST_OUTPUT_ROOT)/*.cover.out)" ]; then \
 		echo "No coverage data, aborting!" && exit 1; \
 	fi

--- a/develop/buildkite/pipeline.yml
+++ b/develop/buildkite/pipeline.yml
@@ -632,8 +632,8 @@ steps:
       docker: "*"
     command: "make ci-coverage-report"
     artifact_paths:
-      - ".testoutput/summary.out"
-      - ".testoutput/summary.out.html"
+      - ".testoutput/summary.cover.out"
+      - ".testoutput/summary.cover.out.html"
     retry:
       automatic:
         limit: 2


### PR DESCRIPTION
**What changed?**
Fix names of artifact paths to upload.

**Why?**
I mixed these up in a previous PR.
