### PR TITLE
Re-run flaky tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -327,12 +327,12 @@ prepare-coverage-test: update-gotestsum $(TEST_OUTPUT_ROOT)
 
 unit-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run unit tests with coverage..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(UNIT_TEST_DIRS)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(UNIT_TEST_DIRS)" -- \
 		-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE)
 
 integration-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run integration tests with coverage..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(INTEGRATION_TEST_DIRS)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(INTEGRATION_TEST_DIRS)" -- \
 		-timeout=$(TEST_TIMEOUT) $(TEST_TAG) $(INTEGRATION_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 # This should use the same build flags as functional-test-coverage for best build caching.
@@ -341,17 +341,17 @@ pre-build-functional-test-coverage: prepare-coverage-test
 
 functional-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional tests with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(FUNCTIONAL_TEST_ROOT)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(FUNCTIONAL_TEST_ROOT)" -- \
 		-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 functional-test-xdc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for cross DC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(FUNCTIONAL_TEST_XDC_ROOT)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(FUNCTIONAL_TEST_XDC_ROOT)" -- \
 	  	-timeout=$(TEST_TIMEOUT) $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 functional-test-ndc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for NDC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(FUNCTIONAL_TEST_NDC_ROOT)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(FUNCTIONAL_TEST_NDC_ROOT)" -- \
 	  	-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 .PHONY: $(SUMMARY_COVER_PROFILE)

--- a/Makefile
+++ b/Makefile
@@ -327,12 +327,12 @@ prepare-coverage-test: update-gotestsum $(TEST_OUTPUT_ROOT)
 
 unit-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run unit tests with coverage..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(UNIT_TEST_DIRS)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=2 --packages="$(UNIT_TEST_DIRS)" -- \
 		-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE)
 
 integration-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run integration tests with coverage..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(INTEGRATION_TEST_DIRS)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=2 --packages="$(INTEGRATION_TEST_DIRS)" -- \
 		-timeout=$(TEST_TIMEOUT) $(TEST_TAG) $(INTEGRATION_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 # This should use the same build flags as functional-test-coverage for best build caching.
@@ -341,17 +341,17 @@ pre-build-functional-test-coverage: prepare-coverage-test
 
 functional-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional tests with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(FUNCTIONAL_TEST_ROOT)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=2 --packages="$(FUNCTIONAL_TEST_ROOT)" -- \
 		-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 functional-test-xdc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for cross DC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(FUNCTIONAL_TEST_XDC_ROOT)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=2 --packages="$(FUNCTIONAL_TEST_XDC_ROOT)" -- \
 	  	-timeout=$(TEST_TIMEOUT) $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 functional-test-ndc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for NDC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=4 --packages="$(FUNCTIONAL_TEST_NDC_ROOT)" -- \
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=2 --packages="$(FUNCTIONAL_TEST_NDC_ROOT)" -- \
 	  	-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 .PHONY: $(SUMMARY_COVER_PROFILE)

--- a/Makefile
+++ b/Makefile
@@ -327,13 +327,13 @@ prepare-coverage-test: update-gotestsum $(TEST_OUTPUT_ROOT)
 
 unit-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run unit tests with coverage..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
-		$(UNIT_TEST_DIRS) -timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE)
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(UNIT_TEST_DIRS)" -- \
+		-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE)
 
 integration-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run integration tests with coverage..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
-		$(INTEGRATION_TEST_DIRS) -timeout=$(TEST_TIMEOUT) $(TEST_TAG) $(INTEGRATION_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(INTEGRATION_TEST_DIRS)" -- \
+		-timeout=$(TEST_TIMEOUT) $(TEST_TAG) $(INTEGRATION_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
 
 # This should use the same build flags as functional-test-coverage for best build caching.
 pre-build-functional-test-coverage: prepare-coverage-test
@@ -341,18 +341,18 @@ pre-build-functional-test-coverage: prepare-coverage-test
 
 functional-test-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional tests with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
-		$(FUNCTIONAL_TEST_ROOT) -timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(FUNCTIONAL_TEST_ROOT)" -- \
+		-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 functional-test-xdc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for cross DC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
-		$(FUNCTIONAL_TEST_XDC_ROOT) -timeout=$(TEST_TIMEOUT) $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(FUNCTIONAL_TEST_XDC_ROOT)" -- \
+	  	-timeout=$(TEST_TIMEOUT) $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 functional-test-ndc-coverage: prepare-coverage-test
 	@printf $(COLOR) "Run functional test for NDC with coverage with $(PERSISTENCE_DRIVER) driver..."
-	@gotestsum --junitfile $(NEW_REPORT) -- \
-		$(FUNCTIONAL_TEST_NDC_ROOT) -timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER) $(FUNCTIONAL_TEST_COVERPKG) -coverprofile=$(NEW_COVER_PROFILE)
+	@gotestsum --junitfile $(NEW_REPORT) --rerun-fails=1 --packages="$(FUNCTIONAL_TEST_NDC_ROOT)" -- \
+	  	-timeout=$(TEST_TIMEOUT) -race $(TEST_TAG) -coverprofile=$(NEW_COVER_PROFILE) $(FUNCTIONAL_TEST_COVERPKG) -args -persistenceType=$(PERSISTENCE_TYPE) -persistenceDriver=$(PERSISTENCE_DRIVER)
 
 .PHONY: $(SUMMARY_COVER_PROFILE)
 $(SUMMARY_COVER_PROFILE):

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -27,9 +27,11 @@ package backoff
 import (
 	"context"
 	"fmt"
+	"math/rand"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"go.temporal.io/api/serviceerror"
@@ -223,6 +225,16 @@ func (s *RetrySuite) TestContextErrorFromSomeOtherContext() {
 		NewExponentialRetryPolicy(1*time.Millisecond),
 		retryEverything)
 	s.NoError(err)
+
+	if rand.Intn(2) == 1 {
+		assert.True(s.T(), false)
+	}
+}
+
+func (s *RetrySuite) TestFlakyTestReporting() {
+	if rand.Intn(2) == 1 {
+		assert.True(s.T(), false)
+	}
 }
 
 func (s *RetrySuite) TestThrottleRetryContext() {

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -29,7 +29,6 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
-	"math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -109,10 +108,6 @@ func (s *archivalSuite) TestArchival_TimerQueueProcessor() {
 	s.True(s.isArchived(s.archivalNamespace, execution))
 	s.True(s.isHistoryDeleted(execution))
 	s.True(s.isMutableStateDeleted(namespaceID, execution))
-
-	if rand.Intn(2) == 1 {
-		panic("boom")
-	}
 }
 
 func (s *archivalSuite) TestArchival_ContinueAsNew() {

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -29,6 +29,7 @@ import (
 	"encoding/binary"
 	"flag"
 	"fmt"
+	"math/rand"
 	"strconv"
 	"testing"
 	"time"
@@ -108,6 +109,10 @@ func (s *archivalSuite) TestArchival_TimerQueueProcessor() {
 	s.True(s.isArchived(s.archivalNamespace, execution))
 	s.True(s.isHistoryDeleted(execution))
 	s.True(s.isMutableStateDeleted(namespaceID, execution))
+
+	if rand.Intn(1) == 0 {
+		panic("boom")
+	}
 }
 
 func (s *archivalSuite) TestArchival_ContinueAsNew() {

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -110,7 +110,7 @@ func (s *archivalSuite) TestArchival_TimerQueueProcessor() {
 	s.True(s.isHistoryDeleted(execution))
 	s.True(s.isMutableStateDeleted(namespaceID, execution))
 
-	if rand.Intn(1) == 1 {
+	if rand.Intn(2) == 1 {
 		panic("boom")
 	}
 }

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -110,7 +110,7 @@ func (s *archivalSuite) TestArchival_TimerQueueProcessor() {
 	s.True(s.isHistoryDeleted(execution))
 	s.True(s.isMutableStateDeleted(namespaceID, execution))
 
-	if rand.Intn(1) == 0 {
+	if rand.Intn(1) == 1 {
 		panic("boom")
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

`gotestsum` to re-run failed tests.

<img width="1178" alt="image" src="https://github.com/temporalio/temporal/assets/159852/32e236e3-86c2-42ef-93d8-593bf670b8b0">


<!-- Tell your future self why have you made these changes -->
**Why?**

When a single (flaky) test in a large suite fails, Buildkite will re-run the entire test suite - re-running that single test can be much faster.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Put a random panic in a test and [observed that the build completed successfully](https://buildkite.com/temporal/temporal-public/builds/13211#018b969b-a560-4561-bd26-0629fce6041b) _and_ no test step was repeated.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

There main risk is that it _obscures_ the real problem of our flaky tests and will reduce our incentives to fix them.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**

No