### PR TITLE
Adding FOR UPDATE for SelectFromQueueV2Metadata

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/mysql/queue_v2.go
@@ -38,10 +38,10 @@ const (
 	templateGetMessagesQueryV2               = `SELECT message_id, message_payload, message_encoding FROM queue_messages WHERE queue_type = ? and queue_name = ? and queue_partition = ? and message_id >= ? ORDER BY message_id ASC LIMIT ?`
 	templateRangeDeleteMessagesQueryV2       = `DELETE FROM queue_messages WHERE queue_type = ? and queue_name = ? and queue_partition = ? and message_id >= ? and message_id <= ?`
 	templateGetLastMessageIDQueryV2          = `SELECT max(message_id) FROM queue_messages WHERE queue_type=? and queue_name=? and queue_partition=? and message_id >= (SELECT message_id FROM queue_messages WHERE queue_type=? and queue_name=? and queue_partition=? ORDER BY message_id DESC LIMIT 1) FOR UPDATE`
-	templateCreateQueueMetadataQueryV2       = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding, version) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding, :version)`
-	templateUpdateQueueMetadataQueryV2       = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding, version = :version+1 WHERE queue_type = :queue_type and queue_name = :queue_name and version = :version`
-	templateGetQueueMetadataQueryV2          = `SELECT metadata_payload, metadata_encoding, version from queues WHERE queue_type=? and queue_name=?`
-	templateGetQueueMetadataQueryV2ForUpdate = `SELECT metadata_payload, metadata_encoding, version from queues WHERE queue_type=? and queue_name=? FOR UPDATE`
+	templateCreateQueueMetadataQueryV2       = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding)`
+	templateUpdateQueueMetadataQueryV2       = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding WHERE queue_type = :queue_type and queue_name = :queue_name`
+	templateGetQueueMetadataQueryV2          = `SELECT metadata_payload, metadata_encoding from queues WHERE queue_type=? and queue_name=?`
+	templateGetQueueMetadataQueryV2ForUpdate = `SELECT metadata_payload, metadata_encoding from queues WHERE queue_type=? and queue_name=? FOR UPDATE`
 	templateGetNameFromQueueMetadataV2       = `SELECT queue_name from queues WHERE queue_type=? LIMIT ? OFFSET ?`
 )
 

--- a/common/persistence/sql/sqlplugin/postgresql/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/postgresql/queue_v2.go
@@ -38,10 +38,10 @@ const (
 	templateGetMessagesQueryV2               = `SELECT message_id, message_payload, message_encoding FROM queue_messages WHERE queue_type = $1 and queue_name = $2 and queue_partition = $3 and message_id >= $4 ORDER BY message_id ASC LIMIT $5`
 	templateRangeDeleteMessagesQueryV2       = `DELETE FROM queue_messages WHERE queue_type = $1 and queue_name = $2 and queue_partition = $3 and message_id >= $4 and message_id <= $5`
 	templateGetLastMessageIDQueryV2          = `SELECT message_id FROM queue_messages WHERE queue_type=$1 and queue_name=$2 and queue_partition=$3 and message_id >= (SELECT message_id FROM queue_messages WHERE queue_type=$1 and queue_name=$2 and queue_partition=$3 ORDER BY message_id DESC LIMIT 1) FOR UPDATE`
-	templateCreateQueueMetadataQueryV2       = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding, version) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding, :version)`
-	templateUpdateQueueMetadataQueryV2       = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding, version = :version+1 WHERE queue_type = :queue_type and queue_name = :queue_name and version = :version`
-	templateGetQueueMetadataQueryV2          = `SELECT metadata_payload, metadata_encoding, version from queues WHERE queue_type=$1 and queue_name=$2`
-	templateGetQueueMetadataQueryV2ForUpdate = `SELECT metadata_payload, metadata_encoding, version from queues WHERE queue_type=$1 and queue_name=$2 FOR UPDATE`
+	templateCreateQueueMetadataQueryV2       = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding)`
+	templateUpdateQueueMetadataQueryV2       = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding WHERE queue_type = :queue_type and queue_name = :queue_name`
+	templateGetQueueMetadataQueryV2          = `SELECT metadata_payload, metadata_encoding from queues WHERE queue_type=$1 and queue_name=$2`
+	templateGetQueueMetadataQueryV2ForUpdate = `SELECT metadata_payload, metadata_encoding from queues WHERE queue_type=$1 and queue_name=$2 FOR UPDATE`
 	templateGetNameFromQueueMetadataV2       = `SELECT queue_name from queues WHERE queue_type=$1 LIMIT $2 OFFSET $3`
 )
 

--- a/common/persistence/sql/sqlplugin/postgresql/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/postgresql/queue_v2.go
@@ -34,14 +34,15 @@ import (
 )
 
 const (
-	templateEnqueueMessageQueryV2      = `INSERT INTO queue_messages (queue_type, queue_name, queue_partition, message_id, message_payload, message_encoding) VALUES(:queue_type, :queue_name, :queue_partition, :message_id, :message_payload, :message_encoding)`
-	templateGetMessagesQueryV2         = `SELECT message_id, message_payload, message_encoding FROM queue_messages WHERE queue_type = $1 and queue_name = $2 and queue_partition = $3 and message_id >= $4 ORDER BY message_id ASC LIMIT $5`
-	templateRangeDeleteMessagesQueryV2 = `DELETE FROM queue_messages WHERE queue_type = $1 and queue_name = $2 and queue_partition = $3 and message_id >= $4 and message_id <= $5`
-	templateGetLastMessageIDQueryV2    = `SELECT message_id FROM queue_messages WHERE queue_type=$1 and queue_name=$2 and queue_partition=$3 and message_id >= (SELECT message_id FROM queue_messages WHERE queue_type=$1 and queue_name=$2 and queue_partition=$3 ORDER BY message_id DESC LIMIT 1) FOR UPDATE`
-	templateCreateQueueMetadataQueryV2 = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding, version) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding, :version)`
-	templateUpdateQueueMetadataQueryV2 = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding, version = :version+1 WHERE queue_type = :queue_type and queue_name = :queue_name and version = :version`
-	templateGetQueueMetadataQueryV2    = `SELECT metadata_payload, metadata_encoding, version from queues WHERE queue_type=$1 and queue_name=$2`
-	templateGetNameFromQueueMetadataV2 = `SELECT queue_name from queues WHERE queue_type=$1 LIMIT $2 OFFSET $3`
+	templateEnqueueMessageQueryV2            = `INSERT INTO queue_messages (queue_type, queue_name, queue_partition, message_id, message_payload, message_encoding) VALUES(:queue_type, :queue_name, :queue_partition, :message_id, :message_payload, :message_encoding)`
+	templateGetMessagesQueryV2               = `SELECT message_id, message_payload, message_encoding FROM queue_messages WHERE queue_type = $1 and queue_name = $2 and queue_partition = $3 and message_id >= $4 ORDER BY message_id ASC LIMIT $5`
+	templateRangeDeleteMessagesQueryV2       = `DELETE FROM queue_messages WHERE queue_type = $1 and queue_name = $2 and queue_partition = $3 and message_id >= $4 and message_id <= $5`
+	templateGetLastMessageIDQueryV2          = `SELECT message_id FROM queue_messages WHERE queue_type=$1 and queue_name=$2 and queue_partition=$3 and message_id >= (SELECT message_id FROM queue_messages WHERE queue_type=$1 and queue_name=$2 and queue_partition=$3 ORDER BY message_id DESC LIMIT 1) FOR UPDATE`
+	templateCreateQueueMetadataQueryV2       = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding, version) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding, :version)`
+	templateUpdateQueueMetadataQueryV2       = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding, version = :version+1 WHERE queue_type = :queue_type and queue_name = :queue_name and version = :version`
+	templateGetQueueMetadataQueryV2          = `SELECT metadata_payload, metadata_encoding, version from queues WHERE queue_type=$1 and queue_name=$2`
+	templateGetQueueMetadataQueryV2ForUpdate = `SELECT metadata_payload, metadata_encoding, version from queues WHERE queue_type=$1 and queue_name=$2 FOR UPDATE`
+	templateGetNameFromQueueMetadataV2       = `SELECT queue_name from queues WHERE queue_type=$1 LIMIT $2 OFFSET $3`
 )
 
 func (pdb *db) InsertIntoQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {
@@ -50,12 +51,14 @@ func (pdb *db) InsertIntoQueueV2Metadata(ctx context.Context, row *sqlplugin.Que
 		row,
 	)
 }
+
 func (pdb *db) UpdateQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {
 	return pdb.conn.NamedExecContext(ctx,
 		templateUpdateQueueMetadataQueryV2,
 		row,
 	)
 }
+
 func (pdb *db) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
 	var row sqlplugin.QueueV2MetadataRow
 	err := pdb.conn.GetContext(ctx,
@@ -69,6 +72,21 @@ func (pdb *db) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.Q
 	}
 	return &row, nil
 }
+
+func (pdb *db) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
+	var row sqlplugin.QueueV2MetadataRow
+	err := pdb.conn.GetContext(ctx,
+		&row,
+		templateGetQueueMetadataQueryV2ForUpdate,
+		filter.QueueType,
+		filter.QueueName,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &row, nil
+}
+
 func (pdb *db) SelectNameFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataTypeFilter) ([]sqlplugin.QueueV2MetadataRow, error) {
 	var rows []sqlplugin.QueueV2MetadataRow
 	err := pdb.conn.GetContext(ctx,
@@ -83,12 +101,14 @@ func (pdb *db) SelectNameFromQueueV2Metadata(ctx context.Context, filter sqlplug
 	}
 	return rows, nil
 }
+
 func (pdb *db) InsertIntoQueueV2Messages(ctx context.Context, row []sqlplugin.QueueV2MessageRow) (sql.Result, error) {
 	return pdb.conn.NamedExecContext(ctx,
 		templateEnqueueMessageQueryV2,
 		row,
 	)
 }
+
 func (pdb *db) RangeSelectFromQueueV2Messages(ctx context.Context, filter sqlplugin.QueueV2MessagesFilter) ([]sqlplugin.QueueV2MessageRow, error) {
 	var rows []sqlplugin.QueueV2MessageRow
 	err := pdb.conn.SelectContext(ctx,
@@ -102,6 +122,7 @@ func (pdb *db) RangeSelectFromQueueV2Messages(ctx context.Context, filter sqlplu
 	)
 	return rows, err
 }
+
 func (pdb *db) RangeDeleteFromQueueV2Messages(ctx context.Context, filter sqlplugin.QueueV2MessagesFilter) (sql.Result, error) {
 	return pdb.conn.ExecContext(ctx,
 		templateRangeDeleteMessagesQueryV2,

--- a/common/persistence/sql/sqlplugin/queue_v2_metadata.go
+++ b/common/persistence/sql/sqlplugin/queue_v2_metadata.go
@@ -56,6 +56,7 @@ type (
 		InsertIntoQueueV2Metadata(ctx context.Context, row *QueueV2MetadataRow) (sql.Result, error)
 		UpdateQueueV2Metadata(ctx context.Context, row *QueueV2MetadataRow) (sql.Result, error)
 		SelectFromQueueV2Metadata(ctx context.Context, filter QueueV2MetadataFilter) (*QueueV2MetadataRow, error)
+		SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter QueueV2MetadataFilter) (*QueueV2MetadataRow, error)
 		SelectNameFromQueueV2Metadata(ctx context.Context, filter QueueV2MetadataTypeFilter) ([]QueueV2MetadataRow, error)
 	}
 )

--- a/common/persistence/sql/sqlplugin/queue_v2_metadata.go
+++ b/common/persistence/sql/sqlplugin/queue_v2_metadata.go
@@ -38,7 +38,6 @@ type (
 		QueueName        string
 		MetadataPayload  []byte
 		MetadataEncoding string
-		Version          int64
 	}
 
 	QueueV2MetadataFilter struct {

--- a/common/persistence/sql/sqlplugin/sqlite/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/sqlite/queue_v2.go
@@ -38,9 +38,9 @@ const (
 	templateGetMessagesQueryV2         = `SELECT message_id, message_payload, message_encoding FROM queue_messages WHERE queue_type = ? and queue_name = ? and queue_partition = ? and message_id >= ? ORDER BY message_id ASC LIMIT ?`
 	templateRangeDeleteMessagesQueryV2 = `DELETE FROM queue_messages WHERE queue_type = ? and queue_name = ? and queue_partition = ? and message_id >= ? and message_id <= ?`
 	templateGetLastMessageIDQueryV2    = `SELECT message_id FROM queue_messages WHERE queue_type=? and queue_name=? and queue_partition=? ORDER BY message_id DESC LIMIT 1`
-	templateCreateQueueMetadataQueryV2 = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding, version) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding, :version)`
-	templateUpdateQueueMetadataQueryV2 = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding, version = :version+1 WHERE queue_type = :queue_type and queue_name = :queue_name and version = :version`
-	templateGetQueueMetadataQueryV2    = `SELECT metadata_payload, metadata_encoding, version from queues WHERE queue_type=? and queue_name=?`
+	templateCreateQueueMetadataQueryV2 = `INSERT INTO queues (queue_type, queue_name, metadata_payload, metadata_encoding) VALUES(:queue_type, :queue_name, :metadata_payload, :metadata_encoding)`
+	templateUpdateQueueMetadataQueryV2 = `UPDATE queues SET metadata_payload = :metadata_payload, metadata_encoding = :metadata_encoding WHERE queue_type = :queue_type and queue_name = :queue_name`
+	templateGetQueueMetadataQueryV2    = `SELECT metadata_payload, metadata_encoding from queues WHERE queue_type=? and queue_name=?`
 	templateGetNameFromQueueMetadataV2 = `SELECT queue_name from queues WHERE queue_type=? LIMIT ? OFFSET ?`
 )
 

--- a/common/persistence/sql/sqlplugin/sqlite/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/sqlite/queue_v2.go
@@ -69,6 +69,10 @@ func (sdb *db) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.Q
 	}
 	return &row, nil
 }
+func (sdb *db) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
+	// sqlite does not have FOR UPDATE clause. Calling SelectFromQueueV2Metadata() itself.
+	return sdb.SelectFromQueueV2Metadata(ctx, filter)
+}
 func (sdb *db) SelectNameFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataTypeFilter) ([]sqlplugin.QueueV2MetadataRow, error) {
 	var rows []sqlplugin.QueueV2MetadataRow
 	err := sdb.conn.GetContext(ctx,

--- a/common/persistence/sql/sqlplugin/tests/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/tests/queue_v2.go
@@ -130,11 +130,25 @@ func (db *faultyDB) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplu
 	return db.DB.SelectFromQueueV2Metadata(ctx, filter)
 }
 
+func (db *faultyDB) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
+	if db.selectMetadataError != nil {
+		return &sqlplugin.QueueV2MetadataRow{}, db.selectMetadataError
+	}
+	return db.DB.SelectFromQueueV2MetadataForUpdate(ctx, filter)
+}
+
 func (tx *faultyTx) SelectFromQueueV2Metadata(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
 	if tx.db.selectMetadataError != nil {
 		return &sqlplugin.QueueV2MetadataRow{}, tx.db.selectMetadataError
 	}
 	return tx.Tx.SelectFromQueueV2Metadata(ctx, filter)
+}
+
+func (tx *faultyTx) SelectFromQueueV2MetadataForUpdate(ctx context.Context, filter sqlplugin.QueueV2MetadataFilter) (*sqlplugin.QueueV2MetadataRow, error) {
+	if tx.db.selectMetadataError != nil {
+		return &sqlplugin.QueueV2MetadataRow{}, tx.db.selectMetadataError
+	}
+	return tx.Tx.SelectFromQueueV2MetadataForUpdate(ctx, filter)
 }
 
 func (db *faultyDB) InsertIntoQueueV2Metadata(ctx context.Context, row *sqlplugin.QueueV2MetadataRow) (sql.Result, error) {

--- a/common/persistence/sql/sqlplugin/tests/queue_v2.go
+++ b/common/persistence/sql/sqlplugin/tests/queue_v2.go
@@ -403,7 +403,6 @@ func testGetPartitionFails(ctx context.Context, t *testing.T, baseDB sqlplugin.D
 		QueueName:        queueName,
 		MetadataPayload:  bytes,
 		MetadataEncoding: enumspb.ENCODING_TYPE_PROTO3.String(),
-		Version:          0,
 	}
 	_, err := baseDB.InsertIntoQueueV2Metadata(ctx, &row)
 	require.NoError(t, err)
@@ -526,7 +525,6 @@ func testInvalidMetadataPayload(ctx context.Context, t *testing.T, baseDB sqlplu
 		QueueName:        queueName,
 		MetadataPayload:  []byte("invalid_payload"),
 		MetadataEncoding: enumspb.ENCODING_TYPE_PROTO3.String(),
-		Version:          0,
 	}
 	_, err := baseDB.InsertIntoQueueV2Metadata(ctx, &row)
 	require.NoError(t, err)
@@ -550,7 +548,6 @@ func testInvalidMetadataEncoding(ctx context.Context, t *testing.T, baseDB sqlpl
 		QueueName:        queueName,
 		MetadataPayload:  []byte("test"),
 		MetadataEncoding: "invalid_encoding",
-		Version:          0,
 	}
 	_, err := baseDB.InsertIntoQueueV2Metadata(ctx, &row)
 	require.NoError(t, err)

--- a/schema/mysql/v57/temporal/schema.sql
+++ b/schema/mysql/v57/temporal/schema.sql
@@ -320,7 +320,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload MEDIUMBLOB NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/mysql/v57/temporal/versioned/v1.11/queues.sql
+++ b/schema/mysql/v57/temporal/versioned/v1.11/queues.sql
@@ -3,7 +3,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload MEDIUMBLOB NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/mysql/v8/temporal/schema.sql
+++ b/schema/mysql/v8/temporal/schema.sql
@@ -319,7 +319,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload MEDIUMBLOB NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/mysql/v8/temporal/versioned/v1.11/queues.sql
+++ b/schema/mysql/v8/temporal/versioned/v1.11/queues.sql
@@ -3,7 +3,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload MEDIUMBLOB NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/postgresql/v12/temporal/schema.sql
+++ b/schema/postgresql/v12/temporal/schema.sql
@@ -315,7 +315,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload BYTEA NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/postgresql/v12/temporal/versioned/v1.11/queue_v2.sql
+++ b/schema/postgresql/v12/temporal/versioned/v1.11/queue_v2.sql
@@ -3,7 +3,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload BYTEA NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/postgresql/v96/temporal/schema.sql
+++ b/schema/postgresql/v96/temporal/schema.sql
@@ -315,7 +315,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload BYTEA NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/postgresql/v96/temporal/versioned/v1.11/queue_v2.sql
+++ b/schema/postgresql/v96/temporal/versioned/v1.11/queue_v2.sql
@@ -3,7 +3,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload BYTEA NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/sqlite/v3/temporal/schema.sql
+++ b/schema/sqlite/v3/temporal/schema.sql
@@ -319,7 +319,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload MEDIUMBLOB NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/schema/sqlite/v3/temporal/versioned/v0.3/queue_v2.sql
+++ b/schema/sqlite/v3/temporal/versioned/v0.3/queue_v2.sql
@@ -3,7 +3,6 @@ CREATE TABLE queues (
     queue_name VARCHAR(255) NOT NULL,
     metadata_payload MEDIUMBLOB NOT NULL,
     metadata_encoding VARCHAR(16) NOT NULL,
-    version BIGINT NOT NULL,
     PRIMARY KEY (queue_type, queue_name)
 );
 

--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -162,9 +162,6 @@ func myWorkflow(workflow.Context) (string, error) {
 }
 
 func (s *dlqSuite) SetupTest() {
-	if TestFlags.PersistenceType == "sql" {
-		s.T().Skip("skipping DLQ tests for SQL persistence")
-	}
 	s.setAssertions()
 	s.failingWorkflowIDPrefix = "dlq-test-terminal-wfts-"
 }

--- a/tests/purge_dlq_tasks_api_test.go
+++ b/tests/purge_dlq_tasks_api_test.go
@@ -37,7 +37,6 @@ import (
 
 	"go.temporal.io/server/api/adminservice/v1"
 	commonspb "go.temporal.io/server/api/common/v1"
-	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/persistence/persistencetest"
 	"go.temporal.io/server/common/primitives"
@@ -107,10 +106,6 @@ func (s *purgeDLQTasksSuite) SetupTest() {
 }
 
 func TestPurgeDLQTasksSuite(t *testing.T) {
-	if TestFlags.PersistenceType != config.StoreTypeNoSQL {
-		t.Skip("skipping dlq tests for non-cassandra persistence")
-	}
-
 	suite.Run(t, new(purgeDLQTasksSuite))
 }
 

--- a/tests/xdc/history_replication_dlq_test.go
+++ b/tests/xdc/history_replication_dlq_test.go
@@ -50,7 +50,6 @@ import (
 	enumspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	replicationspb "go.temporal.io/server/api/replication/v1"
-	"go.temporal.io/server/common/config"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/namespace"
@@ -164,11 +163,6 @@ func TestHistoryReplicationDLQSuite(t *testing.T) {
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			if tc.enableQueueV2 {
-				if tests.TestFlags.PersistenceType != config.StoreTypeNoSQL {
-					t.Skip("this test only works with cassandra")
-				}
-			}
 			s := &historyReplicationDLQSuite{
 				enableReplicationStream: tc.enableReplicationStream,
 				enableQueueV2:           tc.enableQueueV2,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding FOR UPDATE clause when fetching queueV2 metadata and removing unused field version from queue metadata.

<!-- Tell your future self why have you made these changes -->
**Why?**
If a queueV2 metadata row is fetched in a transaction, we have to place a lock on that row
to avoid another transaction reading from that line. This can happen when two threads are trying to 
delete messages from the queue. Two of them will update queue metadata and write it back. This will lead 
to a race condition. By adding 'FOR UPDATE' SQL clause, the first transaction will get an exclusive lock
on the row. The second transaction will wait until the first transaction is complete or rollback.

Also, removing the version field from QueueV2 metadata table. We will not be using this field since we are using sql transactions.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test. Executed through the debugger to make sure SelectFromQueueV2MetadataForUpdate() is called instead of 
SelectFromQueueV2Metadata() when executed inside a trancation.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
