### PR TITLE
Log pkg/errors stack traces

### DIFF
--- a/develop/buildkite/third_party_deps.txt
+++ b/develop/buildkite/third_party_deps.txt
@@ -320,6 +320,8 @@ go.uber.org/zap/internal
 go.uber.org/zap/internal/bufferpool
 go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
+go.uber.org/zap/internal/pool
+go.uber.org/zap/internal/stacktrace
 go.uber.org/zap/zapcore
 golang.org/x/crypto/chacha20
 golang.org/x/crypto/chacha20poly1305

--- a/go.mod
+++ b/go.mod
@@ -50,7 +50,7 @@ require (
 	go.uber.org/automaxprocs v1.5.2
 	go.uber.org/fx v1.20.0
 	go.uber.org/multierr v1.11.0
-	go.uber.org/zap v1.24.0
+	go.uber.org/zap v1.26.0
 	golang.org/x/exp v0.0.0-20230728194245-b0cb94b80691
 	golang.org/x/oauth2 v0.11.0
 	golang.org/x/sync v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -422,8 +422,8 @@ go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN8
 go.uber.org/tools v0.0.0-20190618225709-2cfd321de3ee/go.mod h1:vJERXedbb3MVM5f9Ejo0C68/HhF8uaILCdgjnY+goOA=
 go.uber.org/zap v1.14.0/go.mod h1:zwrFLgMcdUuIBviXEYEH1YKNaOBnKXsx2IPda5bBwHM=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
-go.uber.org/zap v1.24.0 h1:FiJd5l1UOLj0wCgbSE0rwwXHzEdAZS6hiiSnxJN/D60=
-go.uber.org/zap v1.24.0/go.mod h1:2kMP+WWQ8aoFoedH3T2sq6iJ2yDWpHbP0f6MQbS9Gkg=
+go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
+go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I upgraded our zap version from v1.24.0 to v1.26.0, which contains support for pkg/errors. See [this issue](https://github.com/uber-go/zap/issues/303) and [this commit](https://github.com/uber-go/zap/commit/5fc2db7f38284219d67ba209747ff8d30c756f03). 
<img width="448" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/7d15d91a-27d3-45f6-9628-30bdcac38771">


<!-- Tell your future self why have you made these changes -->
**Why?**
Before this change, our logs would only contain the stack trace from where the logger itself was invoked, not from the source of where the error was generated or wrapped. This provided very little useful information.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I ran a custom [build of server](https://gist.github.com/MichaelSnowden/c649dfd1efeb92f10bc72a040a792a8d) which overwrote some deep code in history to return an error. I then set up docker-compose to output logs -> promtail -> loki -> grafana. Then, I queried Grafana to verify that the error log contained an "errorVerbose" field with the stack trace from where my error was generated. As you can see from the below image, the stack trace does appear under this field, and if you turn on JSON parsing and newline escaping, you can both see it rendered correctly, and you can copy-paste the stack trace.

<img width="983" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/cb9b0c83-b146-4060-9eac-3ccf9b807657">
<img width="683" alt="image" src="https://github.com/temporalio/temporal/assets/5942963/6fa28f2f-5d04-47ae-b8a3-7512c3dd85e7">

The stack trace from Grafana:

```
oopsie woopsie
main.(*faultyShardEngine).StartWorkflowExecution
	/Users/mikey/src/temporalio/temporal/.scratches/main.go:39
go.temporal.io/server/service/history.(*Handler).StartWorkflowExecution
	/Users/mikey/src/temporalio/temporal/service/history/handler.go:595
go.temporal.io/server/api/historyservice/v1._HistoryService_StartWorkflowExecution_Handler.func1
	/Users/mikey/src/temporalio/temporal/api/historyservice/v1/service.pb.go:1300
...
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The stack traces are pretty deep because of all our gRPC interceptors. However, we can definitely fix that later if we want by filtering the `pkg/errors.StackTrace`. I'd rather do that in a follow-up after getting support for this initial change first, though.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.