### PR TITLE
Enable the history task DLQ

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -392,7 +392,7 @@ func NewConfig(
 		QueuePendingTaskMaxCount:         dc.GetIntProperty(dynamicconfig.QueuePendingTaskMaxCount, 10000),
 		QueueMaxReaderCount:              dc.GetIntProperty(dynamicconfig.QueueMaxReaderCount, 2),
 
-		TaskDLQEnabled: dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQEnabled, false),
+		TaskDLQEnabled: dc.GetBoolProperty(dynamicconfig.HistoryTaskDLQEnabled, true),
 
 		TaskSchedulerEnableRateLimiter:           dc.GetBoolProperty(dynamicconfig.TaskSchedulerEnableRateLimiter, false),
 		TaskSchedulerEnableRateLimiterShadowMode: dc.GetBoolProperty(dynamicconfig.TaskSchedulerEnableRateLimiterShadowMode, true),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
🚀  This PR turns on the new history task DLQ by default.

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously, if history tasks, e.g. transfer, timer, etc., failed with terminal errors (i.e. data corruption issues), we would drop the tasks completely 💀 . Now, we guarantee that they will be sent to the history task DLQ. We retry sends forever until they succeed. The history task DLQ supports operation via `tdbg` (under `cmd/tools/tdbg/main.go`). There is also a previous DLQ which only worked for replication and namespace replication tasks, but that one never worked for history tasks. As a result, there are two version of the dlq in tdbg. To use the new one, which is the only way to interact with the history task DLQ, you can run the following command: `tdbg dlq --dlq-version v2 <subcommand>`. The supported subcommands are:
- 📖  `read` view messages in DLQs
- 🗑️  `purge` drop messages from a DLQ
- ♻️  `merge` re-enqueue (AKA retry) DLQ'd messages

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
🧪  **How did you test it?**
There are end-to-end tests in the `tests` package which create workflows with data corruption issues and retry them using `tdbg`, verifying that they eventually succeed.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
I think the biggest risk is a bug in the ability to write tasks to the DLQ because we retry such attempts infinitely. 

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No, we plan on releasing this as part of the next minor release because it has many dependencies.