### PR TITLE
Use source cluster shard ID for DLQ

### DIFF
--- a/api/persistence/v1/queues.pb.go
+++ b/api/persistence/v1/queues.pb.go
@@ -294,7 +294,9 @@ func (m *ReadQueueMessagesNextPageToken) GetLastReadMessageId() int64 {
 // common proto for all task proto types.
 type HistoryTask struct {
 	// shard_id that this task belonged to when it was created. Technically, you can derive this from the task data
-	// blob, but it's useful to have it here for quick access and to avoid deserializing the blob.
+	// blob, but it's useful to have it here for quick access and to avoid deserializing the blob. Note that this may be
+	// different from the shard id of this task in the current cluster because it could have come from a cluster with a
+	// different shard id. This will always be the shard id of the task in its original cluster.
 	ShardId int32 `protobuf:"varint,1,opt,name=shard_id,json=shardId,proto3" json:"shard_id,omitempty"`
 	// blob that contains the history task proto. There is a GoLang-specific generic deserializer for this blob, but
 	// there is no common proto for all task proto types, so deserializing in other languages will require a custom

--- a/client/history/historytest/clienttest.go
+++ b/client/history/historytest/clienttest.go
@@ -37,8 +37,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc"
-
 	commonspb "go.temporal.io/server/api/common/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/client/history"
@@ -50,6 +48,7 @@ import (
 	"go.temporal.io/server/internal/nettest"
 	historyserver "go.temporal.io/server/service/history"
 	"go.temporal.io/server/service/history/tasks"
+	"google.golang.org/grpc"
 )
 
 // fakeTracerProvider is needed to construct a [historyserver.Handler] object.
@@ -200,6 +199,7 @@ func enqueueTasks(
 			SourceCluster: sourceCluster,
 			TargetCluster: targetCluster,
 			Task:          task,
+			SourceShardID: 1,
 		})
 		require.NoError(t, err)
 	}

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -219,7 +219,7 @@ func (f *factoryImpl) NewHistoryTaskQueueManager() (p.HistoryTaskQueueManager, e
 	if err != nil {
 		return nil, err
 	}
-	return p.NewHistoryTaskQueueManager(q, int(f.config.NumHistoryShards)), nil
+	return p.NewHistoryTaskQueueManager(q), nil
 }
 
 // Close closes this factory

--- a/common/persistence/data_interfaces.go
+++ b/common/persistence/data_interfaces.go
@@ -37,11 +37,9 @@ import (
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
 	historypb "go.temporal.io/api/history/v1"
-
-	"go.temporal.io/server/common/persistence/serialization"
-
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/persistence/serialization"
 	"go.temporal.io/server/service/history/tasks"
 )
 
@@ -1222,9 +1220,8 @@ type (
 	}
 
 	HistoryTaskQueueManagerImpl struct {
-		queue            QueueV2
-		serializer       *serialization.TaskSerializer
-		numHistoryShards int
+		queue      QueueV2
+		serializer *serialization.TaskSerializer
 	}
 
 	// QueueKey identifies a history task queue. It is converted to a queue name using the GetQueueName method.
@@ -1243,6 +1240,9 @@ type (
 		SourceCluster string
 		TargetCluster string
 		Task          tasks.Task
+		// SourceShardID of the task in its original cluster. Note that tasks may move between clusters, so this shard
+		// id may not be the same as the shard id of the task in the current cluster.
+		SourceShardID int
 	}
 
 	EnqueueTaskResponse struct {

--- a/common/persistence/history_task_queue_manager.go
+++ b/common/persistence/history_task_queue_manager.go
@@ -33,10 +33,8 @@ import (
 
 	commonpb "go.temporal.io/api/common/v1"
 	"go.temporal.io/api/enums/v1"
-
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/persistence/serialization"
-	"go.temporal.io/server/service/history/tasks"
 )
 
 const (
@@ -64,13 +62,13 @@ var (
 	ErrHistoryTaskBlobIsNil         = errors.New("history task from queue has nil blob")
 	ErrEnqueueTaskRequestTaskIsNil  = errors.New("enqueue task request task is nil")
 	ErrQueueAlreadyExists           = errors.New("queue already exists")
+	ErrShardIDInvalid               = errors.New("shard ID must be greater than 0")
 )
 
-func NewHistoryTaskQueueManager(queue QueueV2, numHistoryShards int) *HistoryTaskQueueManagerImpl {
+func NewHistoryTaskQueueManager(queue QueueV2) *HistoryTaskQueueManagerImpl {
 	return &HistoryTaskQueueManagerImpl{
-		queue:            queue,
-		serializer:       serialization.NewTaskSerializer(),
-		numHistoryShards: numHistoryShards,
+		queue:      queue,
+		serializer: serialization.NewTaskSerializer(),
 	}
 }
 
@@ -85,11 +83,13 @@ func (m *HistoryTaskQueueManagerImpl) EnqueueTask(
 	if err != nil {
 		return nil, fmt.Errorf("%v: %w", ErrMsgSerializeTaskToEnqueue, err)
 	}
+	if request.SourceShardID <= 0 {
+		return nil, fmt.Errorf("%w: shardID = %d", ErrShardIDInvalid, request.SourceShardID)
+	}
 
-	shardID := tasks.GetShardIDForTask(request.Task, m.numHistoryShards)
 	taskCategory := request.Task.GetCategory()
 	task := persistencespb.HistoryTask{
-		ShardId: int32(shardID),
+		ShardId: int32(request.SourceShardID),
 		Blob:    &blob,
 	}
 	taskBytes, _ := task.Marshal()

--- a/common/persistence/tests/history_task_queue_manager_test_suite.go
+++ b/common/persistence/tests/history_task_queue_manager_test_suite.go
@@ -98,7 +98,7 @@ func (q faultyQueue) RangeDeleteMessages(
 // RunHistoryTaskQueueManagerTestSuite runs all tests for the history task queue manager against a given queue provided by a
 // particular database. This test suite should be re-used to test all queue implementations.
 func RunHistoryTaskQueueManagerTestSuite(t *testing.T, queue persistence.QueueV2) {
-	historyTaskQueueManager := persistence.NewHistoryTaskQueueManager(queue, 1)
+	historyTaskQueueManager := persistence.NewHistoryTaskQueueManager(queue)
 	t.Run("TestHistoryTaskQueueManagerEnqueueTasks", func(t *testing.T) {
 		t.Parallel()
 		testHistoryTaskQueueManagerEnqueueTasks(t, historyTaskQueueManager)
@@ -142,7 +142,7 @@ func testHistoryTaskQueueManagerCreateQueueErr(t *testing.T, queue persistence.Q
 	manager := persistence.NewHistoryTaskQueueManager(faultyQueue{
 		base:           queue,
 		createQueueErr: retErr,
-	}, 1)
+	})
 	_, err := manager.CreateQueue(context.Background(), &persistence.CreateQueueRequest{
 		QueueKey: persistencetest.GetQueueKey(t),
 	})
@@ -203,7 +203,7 @@ func testHistoryTaskQueueManagerEnqueueTasksErr(t *testing.T, queue persistence.
 	manager := persistence.NewHistoryTaskQueueManager(faultyQueue{
 		base:       queue,
 		enqueueErr: retErr,
-	}, 1)
+	})
 	queueKey := persistencetest.GetQueueKey(t)
 	_, err := manager.CreateQueue(ctx, &persistence.CreateQueueRequest{
 		QueueKey: queueKey,
@@ -313,7 +313,7 @@ func testHistoryTaskQueueManagerDeleteTasksErr(t *testing.T, queue persistence.Q
 	manager := persistence.NewHistoryTaskQueueManager(faultyQueue{
 		base:                   queue,
 		rangeDeleteMessagesErr: retErr,
-	}, 1)
+	})
 	queueKey := persistencetest.GetQueueKey(t)
 	_, err := manager.CreateQueue(ctx, &persistence.CreateQueueRequest{
 		QueueKey: queueKey,
@@ -343,5 +343,6 @@ func enqueueTask(
 		SourceCluster: queueKey.SourceCluster,
 		TargetCluster: queueKey.TargetCluster,
 		Task:          task,
+		SourceShardID: 1,
 	})
 }

--- a/proto/internal/temporal/server/api/persistence/v1/queues.proto
+++ b/proto/internal/temporal/server/api/persistence/v1/queues.proto
@@ -54,7 +54,9 @@ message ReadQueueMessagesNextPageToken {
 // common proto for all task proto types.
 message HistoryTask {
     // shard_id that this task belonged to when it was created. Technically, you can derive this from the task data
-    // blob, but it's useful to have it here for quick access and to avoid deserializing the blob.
+    // blob, but it's useful to have it here for quick access and to avoid deserializing the blob. Note that this may be
+    // different from the shard id of this task in the current cluster because it could have come from a cluster with a
+    // different shard id. This will always be the shard id of the task in its original cluster.
     int32 shard_id = 1;
     // blob that contains the history task proto. There is a GoLang-specific generic deserializer for this blob, but
     // there is no common proto for all task proto types, so deserializing in other languages will require a custom

--- a/service/history/api/deletedlqtasks/deletedlqtaskstest/apitest.go
+++ b/service/history/api/deletedlqtasks/deletedlqtaskstest/apitest.go
@@ -57,6 +57,7 @@ func TestInvoke(t *testing.T, manager persistence.HistoryTaskQueueManager) {
 				SourceCluster: queueKey.SourceCluster,
 				TargetCluster: queueKey.TargetCluster,
 				Task:          &tasks.WorkflowTask{},
+				SourceShardID: 1,
 			})
 			require.NoError(t, err)
 		}

--- a/service/history/api/getdlqtasks/getdlqtaskstest/apitest.go
+++ b/service/history/api/getdlqtasks/getdlqtaskstest/apitest.go
@@ -63,6 +63,7 @@ func TestInvoke(t *testing.T, manager persistence.HistoryTaskQueueManager) {
 		SourceCluster: sourceCluster,
 		TargetCluster: targetCluster,
 		Task:          inTask,
+		SourceShardID: 1,
 	})
 	require.NoError(t, err)
 	res, err := getdlqtasks.Invoke(

--- a/service/history/queues/dlq_writer_test.go
+++ b/service/history/queues/dlq_writer_test.go
@@ -1,0 +1,90 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package queues_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/service/history/queues"
+	"go.temporal.io/server/service/history/queues/queuestest"
+	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/tests"
+)
+
+func TestDLQWriter_ErrGetClusterMetadata(t *testing.T) {
+	t.Parallel()
+
+	queueWriter := &queuestest.FakeQueueWriter{}
+	ctrl := gomock.NewController(t)
+	clusterMetadata := cluster.NewMockMetadata(ctrl)
+	clusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{})
+	writer := queues.NewDLQWriter(queueWriter, clusterMetadata)
+	err := writer.WriteTaskToDLQ(
+		context.Background(),
+		"source-cluster",
+		"target-cluster",
+		&tasks.WorkflowTask{},
+	)
+	assert.ErrorIs(t, err, queues.ErrGetClusterMetadata)
+	assert.Empty(t, queueWriter.EnqueueTaskRequests)
+}
+
+func TestDLQWriter_Ok(t *testing.T) {
+	t.Parallel()
+
+	queueWriter := &queuestest.FakeQueueWriter{}
+	ctrl := gomock.NewController(t)
+	clusterMetadata := cluster.NewMockMetadata(ctrl)
+	clusterMetadata.EXPECT().GetAllClusterInfo().Return(map[string]cluster.ClusterInformation{
+		"source-cluster": {
+			ShardCount: 100,
+		},
+	})
+	writer := queues.NewDLQWriter(queueWriter, clusterMetadata)
+	task := &tasks.WorkflowTask{
+		WorkflowKey: definition.WorkflowKey{
+			NamespaceID: string(tests.NamespaceID),
+			WorkflowID:  tests.WorkflowID,
+			RunID:       tests.RunID,
+		},
+	}
+	err := writer.WriteTaskToDLQ(
+		context.Background(),
+		"source-cluster",
+		"target-cluster",
+		task,
+	)
+	require.NoError(t, err)
+	require.Len(t, queueWriter.EnqueueTaskRequests, 1)
+	request := queueWriter.EnqueueTaskRequests[0]
+	expectedShardID := tasks.GetShardIDForTask(task, 100)
+	assert.Equal(t, expectedShardID, request.SourceShardID)
+}

--- a/tests/dlq_test.go
+++ b/tests/dlq_test.go
@@ -209,6 +209,7 @@ func (s *dlqSuite) TestReadArtificialDLQTasks() {
 			SourceCluster: queueKey.SourceCluster,
 			TargetCluster: queueKey.TargetCluster,
 			Task:          task,
+			SourceShardID: tasks.GetShardIDForTask(task, int(s.testClusterConfig.HistoryConfig.NumHistoryShards)),
 		})
 		s.NoError(err)
 	}

--- a/tests/purge_dlq_tasks_api_test.go
+++ b/tests/purge_dlq_tasks_api_test.go
@@ -241,6 +241,7 @@ func (s *purgeDLQTasksSuite) enqueueTasks(ctx context.Context, queueKey persiste
 			SourceCluster: queueKey.SourceCluster,
 			TargetCluster: queueKey.TargetCluster,
 			Task:          task,
+			SourceShardID: tasks.GetShardIDForTask(task, int(s.testClusterConfig.HistoryConfig.NumHistoryShards)),
 		})
 		s.NoError(err)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR makes us use the shard ID of the task in the original cluster instead of the shard ID in the current cluster when merging DLQ'd replication tasks (or writing any task to the DLQ actually). 

<!-- Tell your future self why have you made these changes -->
**Why?**
The number of shards between any two clusters for a given namespace don't have to be the same. One has to be a multiple of the other, though. However, I noticed a bug when using our local xdc config with cluster-a and cluster-b:

```
  "Error": "AddTasks failed while re-enqueuing tasks to shard 9 (type: dlq-error-type-invalid-request, retryable: false): Task is for wrong shard: index = 0, task shard = 25, request shard = 9",
```

This error was caused by the fact that the task in question has a different computed shard ID in cluster-b, where there are only 16 shards, than it does in cluster-a, where there are 32 shards.

<img width="740" alt="Untitled" src="https://github.com/temporalio/temporal/assets/5942963/ac9c2754-acfc-44ae-bb8d-a98f9ecd6b4d">

Fortunately, the V2 replication DLQ hasn't even been turned on anywhere yet, so this didn't cause any issues. It was caught as part of testing before rollout.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I wrote some unit tests, and I also re-ran the manual test I was doing. I even generated a significant amount of load with `maru`, forced 10s of thousands of replication tasks to fail, and successfully merged all of them.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
