### PR TITLE
Change behavior of Update APIs on server-imposed deadline expiry

### DIFF
--- a/service/history/api/pollupdate/api.go
+++ b/service/history/api/pollupdate/api.go
@@ -49,7 +49,7 @@ func Invoke(
 ) (*historyservice.PollWorkflowExecutionUpdateResponse, error) {
 	waitStage := req.GetRequest().GetWaitPolicy().GetLifecycleStage()
 	if waitStage != enums.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED {
-		return nil, serviceerror.NewUnimplemented(fmt.Sprintf("support for LifecycleStage=%v is not implemented", waitStage))
+		return nil, serviceerror.NewInvalidArgument(fmt.Sprintf("support for LifecycleStage=%v is not implemented", waitStage))
 	}
 	updateRef := req.GetRequest().GetUpdateRef()
 	wfexec := updateRef.GetWorkflowExecution()

--- a/service/history/api/pollupdate/api_test.go
+++ b/service/history/api/pollupdate/api_test.go
@@ -29,8 +29,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
 	failurepb "go.temporal.io/api/failure/v1"
 	"go.temporal.io/api/serviceerror"
 	updatepb "go.temporal.io/api/update/v1"
@@ -38,8 +40,11 @@ import (
 	clockspb "go.temporal.io/server/api/clock/v1"
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/common/definition"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/api/pollupdate"
+	"go.temporal.io/server/service/history/shard"
+	"go.temporal.io/server/service/history/tests"
 	"go.temporal.io/server/service/history/workflow"
 	wcache "go.temporal.io/server/service/history/workflow/cache"
 	"go.temporal.io/server/service/history/workflow/update"
@@ -118,6 +123,16 @@ func TestPollOutcome(t *testing.T) {
 		},
 	}
 
+	serverImposedTimeout := 10 * time.Millisecond
+	mockController := gomock.NewController(t)
+	mockNamespaceRegistry := namespace.NewMockRegistry(mockController)
+	mockNamespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(tests.GlobalNamespaceEntry, nil).AnyTimes()
+	shardContext := shard.NewMockContext(mockController)
+	mockConfig := tests.NewDynamicConfig()
+	mockConfig.LongPollExpirationInterval = func(_ string) time.Duration { return serverImposedTimeout }
+	shardContext.EXPECT().GetConfig().Return(mockConfig).AnyTimes()
+	shardContext.EXPECT().GetNamespaceRegistry().Return(mockNamespaceRegistry).AnyTimes()
+
 	updateID := t.Name() + "-update-id"
 	req := historyservice.PollWorkflowExecutionUpdateRequest{
 		Request: &workflowservice.PollWorkflowExecutionUpdateRequest{
@@ -128,6 +143,9 @@ func TestPollOutcome(t *testing.T) {
 				},
 				UpdateId: updateID,
 			},
+			WaitPolicy: &updatepb.WaitPolicy{
+				LifecycleStage: enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED,
+			},
 		},
 	}
 
@@ -135,18 +153,29 @@ func TestPollOutcome(t *testing.T) {
 		reg.FindFunc = func(ctx context.Context, updateID string) (*update.Update, bool) {
 			return nil, false
 		}
-		_, err := pollupdate.Invoke(context.TODO(), &req, wfcc)
+		_, err := pollupdate.Invoke(context.TODO(), &req, shardContext, wfcc)
 		var notfound *serviceerror.NotFound
 		require.ErrorAs(t, err, &notfound)
 	})
-	t.Run("future timeout", func(t *testing.T) {
+	t.Run("context deadline expiry before server-imposed deadline expiry", func(t *testing.T) {
 		reg.FindFunc = func(ctx context.Context, updateID string) (*update.Update, bool) {
 			return update.New(updateID), true
 		}
-		ctx, cncl := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		ctx, cncl := context.WithTimeout(context.Background(), serverImposedTimeout/2)
 		defer cncl()
-		_, err := pollupdate.Invoke(ctx, &req, wfcc)
+		_, err := pollupdate.Invoke(ctx, &req, shardContext, wfcc)
 		require.Error(t, err)
+	})
+	t.Run("context deadline expiry after server-imposed deadline expiry", func(t *testing.T) {
+		reg.FindFunc = func(ctx context.Context, updateID string) (*update.Update, bool) {
+			return update.New(updateID), true
+		}
+		ctx, cncl := context.WithTimeout(context.Background(), serverImposedTimeout*2)
+		defer cncl()
+		resp, err := pollupdate.Invoke(ctx, &req, shardContext, wfcc)
+		require.NoError(t, err)
+		require.Nil(t, resp.GetResponse().Outcome)
+		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED, resp.Response.GetStage())
 	})
 	t.Run("get an outcome", func(t *testing.T) {
 		upd := update.New(updateID)
@@ -168,7 +197,7 @@ func TestPollOutcome(t *testing.T) {
 		errCh := make(chan error, 1)
 		respCh := make(chan *historyservice.PollWorkflowExecutionUpdateResponse, 1)
 		go func() {
-			resp, err := pollupdate.Invoke(context.TODO(), &req, wfcc)
+			resp, err := pollupdate.Invoke(context.TODO(), &req, shardContext, wfcc)
 			errCh <- err
 			respCh <- resp
 		}()
@@ -180,5 +209,6 @@ func TestPollOutcome(t *testing.T) {
 		require.NoError(t, <-errCh)
 		resp := <-respCh
 		require.Equal(t, &wantOutcome, resp.GetResponse().Outcome)
+		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, resp.Response.GetStage())
 	})
 }

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -26,7 +26,6 @@ package updateworkflow
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -67,28 +66,6 @@ func Invoke(
 	workflowConsistencyChecker api.WorkflowConsistencyChecker,
 	matchingClient matchingservice.MatchingServiceClient,
 ) (*historyservice.UpdateWorkflowExecutionResponse, error) {
-
-	var waitLifecycleStage func(ctx context.Context, u *update.Update) (*updatepb.Outcome, error)
-	waitStage := req.GetRequest().GetWaitPolicy().GetLifecycleStage()
-	switch waitStage {
-	case enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED:
-		waitLifecycleStage = func(
-			ctx context.Context,
-			u *update.Update,
-		) (*updatepb.Outcome, error) {
-			return u.WaitAccepted(ctx)
-		}
-	case enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED:
-		waitLifecycleStage = func(
-			ctx context.Context,
-			u *update.Update,
-		) (*updatepb.Outcome, error) {
-			return u.WaitOutcome(ctx)
-		}
-	default:
-		return nil, serviceerror.NewUnimplemented(
-			fmt.Sprintf("%v is not implemented", waitStage))
-	}
 
 	wfKey := definition.NewWorkflowKey(
 		req.NamespaceId,
@@ -236,7 +213,15 @@ func Invoke(
 		}
 	}
 
-	updOutcome, err := waitLifecycleStage(ctx, upd)
+	namespaceID := namespace.ID(req.GetNamespaceId())
+	namespaceRegistry, err := shardCtx.GetNamespaceRegistry().GetNamespaceByID(namespaceID)
+	if err != nil {
+		return nil, err
+	}
+	serverTimeout := shardCtx.GetConfig().LongPollExpirationInterval(namespaceRegistry.Name().String())
+	waitStage := req.GetRequest().GetWaitPolicy().GetLifecycleStage()
+	// If the long-poll times out due to serverTimeout then return a non-error empty response.
+	stage, outcome, err := upd.WaitLifecycleStage(ctx, waitStage, serverTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -249,7 +234,8 @@ func Invoke(
 				},
 				UpdateId: req.GetRequest().GetRequest().GetMeta().GetUpdateId(),
 			},
-			Outcome: updOutcome,
+			Outcome: outcome,
+			Stage:   stage,
 		},
 	}
 

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -580,7 +580,7 @@ func (e *historyEngineImpl) PollWorkflowExecutionUpdate(
 	ctx context.Context,
 	req *historyservice.PollWorkflowExecutionUpdateRequest,
 ) (*historyservice.PollWorkflowExecutionUpdateResponse, error) {
-	return pollupdate.Invoke(ctx, req, e.workflowConsistencyChecker)
+	return pollupdate.Invoke(ctx, req, e.shardContext, e.workflowConsistencyChecker)
 }
 
 // RemoveSignalMutableState remove the signal request id in signal_requested for deduplicate

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -199,7 +199,7 @@ func (u *Update) waitLifecycleStage(
 		ctx, cancel := context.WithTimeout(context.Background(), softTimeout)
 		defer cancel()
 		stage, outcome, err := waitFn(ctx)
-		if err != nil && common.IsContextDeadlineExceededErr(err) {
+		if ctx.Err() != nil {
 			// Handle the deadline expiry as a violation of a soft deadline:
 			// return non-error empty response.
 			ch <- result{stage, nil, nil}

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -201,7 +201,11 @@ func (u *Update) WaitAccepted(ctx context.Context) (enumspb.UpdateWorkflowExecut
 // if any. If there is a timeout due to the supplied soft timeout, then
 // unspecified stage and nil outcome are returned, without an error. If there is
 // a timeout due to context deadline expiry, then the error is returned as usual.
-func (u *Update) WaitLifecycleStage(ctx context.Context, waitStage enumspb.UpdateWorkflowExecutionLifecycleStage, softTimeout time.Duration) (stage enumspb.UpdateWorkflowExecutionLifecycleStage, outcome *updatepb.Outcome, err error) {
+func (u *Update) WaitLifecycleStage(
+	ctx context.Context,
+	waitStage enumspb.UpdateWorkflowExecutionLifecycleStage,
+	softTimeout time.Duration) (stage enumspb.UpdateWorkflowExecutionLifecycleStage, outcome *updatepb.Outcome, err error) {
+
 	stage = enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_UNSPECIFIED
 	switch waitStage {
 	case enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_ACCEPTED:
@@ -214,7 +218,10 @@ func (u *Update) WaitLifecycleStage(ctx context.Context, waitStage enumspb.Updat
 	}
 }
 
-func (u *Update) waitLifecycleStage(ctx context.Context, waitFn func(ctx context.Context) (enumspb.UpdateWorkflowExecutionLifecycleStage, *updatepb.Outcome, error), softTimeout time.Duration) (enumspb.UpdateWorkflowExecutionLifecycleStage, *updatepb.Outcome, error) {
+func (u *Update) waitLifecycleStage(
+	ctx context.Context,
+	waitFn func(ctx context.Context) (enumspb.UpdateWorkflowExecutionLifecycleStage, *updatepb.Outcome, error),
+	softTimeout time.Duration) (enumspb.UpdateWorkflowExecutionLifecycleStage, *updatepb.Outcome, error) {
 
 	type result struct {
 		stage   enumspb.UpdateWorkflowExecutionLifecycleStage

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -195,11 +195,12 @@ func (u *Update) waitLifecycleStage(
 	}
 	ch := make(chan result, 1)
 
+	waitCtx, cancel := context.WithTimeout(context.Background(), softTimeout)
+	defer cancel()
+
 	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), softTimeout)
-		defer cancel()
-		stage, outcome, err := waitFn(ctx)
-		if ctx.Err() != nil {
+		stage, outcome, err := waitFn(waitCtx)
+		if waitCtx.Err() != nil {
 			// Handle the deadline expiry as a violation of a soft deadline:
 			// return non-error empty response.
 			ch <- result{stage, nil, nil}

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -224,7 +224,7 @@ func (u *Update) waitLifecycleStage(ctx context.Context, waitFn func(ctx context
 	ch := make(chan result, 1)
 
 	go func() {
-		ctx, cancel := context.WithTimeout(ctx, softTimeout)
+		ctx, cancel := context.WithTimeout(context.Background(), softTimeout)
 		defer cancel()
 		stage, outcome, err := waitFn(ctx)
 		if err != nil && common.IsContextDeadlineExceededErr(err) {


### PR DESCRIPTION
This PR makes the following changes, except that it does **not** implement non-blocking poll:

<img width="1263" alt="image" src="https://github.com/temporalio/temporal/assets/52205/0660a021-588a-4573-94d3-301cae0c0040">


### Background
- `UpdateWorkflowExecutionRequest` attempts to wait until the Update has reached Accepted or Completed.
- Similarly, `PollWorkflowExecutionUpdateRequest` attempts to wait until it has reached `Completed`
- If the context deadline expires while they are waiting, they allow the `DeadlineExceeded` error to be returned.

### What changed?
The behavior of `PollWorkflowExecutionUpdate` and `UpdateWorkflowExecution` was changed as follows:
- They introduce a "server-imposed deadline" equal to current time plus `LongPollExpirationInterval`
- If a timeout occurs due to the server-imposed deadline, then they do not return an error, but return a response with an empty outcome.
- Otherwise, their behavior is unchanged (in particular, if a timeout occurs due context deadline expiry, they return the error as before)


### Why?
- This makes the behavior of the endoint consistent with `GetWorkflowExecutionHistory`.
- This makes sense, because that endpoint is used in an analogous way (e.g. `GetWorkflowExecutionHistory` is used for `wfHandle.result()` and `PollWorkflowExecutionUpdateRequest` is used for `updateHandle.result()`, and both involve polling for the result).
- In particular, a polling client interprets timeout-on-server-imposed-deadline to mean that it should continue polling, and we would prefer not to use an error to communicate this non-exceptional situation.


### How did you test it?
- Unit tests
- I changed the poll loop in sdk-typescript to no longer catch `DeadlineExceeded`, ran the `update/basic_async` feature test against the local SDK and against server binaries built prior to and with this commit, and confirmed that the change in this PR fixed the poll loop.


### TODO
- [ ] `updateworkflow` needs an `api_test` mirroring that for `pollupdate`

### Potential risks
- It could break Update across all SDKs.


### Is hotfix candidate?
No