### PR TITLE
Fix stale DLQ history clients

### DIFF
--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -33,20 +33,31 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.temporal.io/api/serviceerror"
-
 	"go.temporal.io/server/api/historyservice/v1"
 	"go.temporal.io/server/client/history"
 	"go.temporal.io/server/common/dynamicconfig"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/membership"
+	"go.temporal.io/server/internal/nettest"
+	"google.golang.org/grpc"
 )
 
-func TestErrGetAnyHistoryHost(t *testing.T) {
+type (
+	testHistoryService struct {
+		historyservice.UnimplementedHistoryServiceServer
+	}
+	testRPCFactory struct {
+		base            *nettest.RPCFactory
+		dialedAddresses []string
+	}
+)
+
+func TestErrLookup(t *testing.T) {
 	t.Parallel()
 
 	ctrl := gomock.NewController(t)
 	serviceResolver := membership.NewMockServiceResolver(ctrl)
-	serviceResolver.EXPECT().Members().Return([]membership.HostInfo{}).AnyTimes()
+	serviceResolver.EXPECT().Lookup("1").Return(nil, assert.AnError).AnyTimes()
 	client := history.NewClient(
 		dynamicconfig.NewNoopCollection(),
 		serviceResolver,
@@ -78,11 +89,109 @@ func TestErrGetAnyHistoryHost(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			_, err := client.GetDLQTasks(context.Background(), &historyservice.GetDLQTasksRequest{})
+			err := tc.fn()
 			var unavailableErr *serviceerror.Unavailable
 			require.ErrorAs(t, err, &unavailableErr, "Should return an 'Unavailable' error when there "+
 				"are no history hosts available to serve the request")
-			assert.ErrorContains(t, err, history.ErrNoHosts.Error())
+			assert.ErrorContains(t, err, assert.AnError.Error())
 		})
 	}
+}
+
+// This tests our strategy for getting history hosts to serve shard-agnostic requests, like those interacting with the
+// DLQ. For such requests, we should round-robin over all available history shards. In addition, we should re-use any
+// available connections when the round-robin wraps around.
+func TestShardAgnosticConnectionStrategy(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name string
+		fn   func(client historyservice.HistoryServiceClient) error
+	}{
+		{
+			name: "GetDLQTasks",
+			fn: func(client historyservice.HistoryServiceClient) error {
+				_, err := client.GetDLQTasks(context.Background(), &historyservice.GetDLQTasksRequest{})
+				return err
+			},
+		},
+		{
+			name: "DeleteDLQTasks",
+			fn: func(client historyservice.HistoryServiceClient) error {
+				_, err := client.DeleteDLQTasks(context.Background(), &historyservice.DeleteDLQTasksRequest{})
+				return err
+			},
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+
+			// Create a service resolver that just returns 2 hosts for the first 3 requests. We want to send 3 requests
+			// with 2 hosts so that we can verify that we re-use the connection of "test1" on the last request.
+			serviceResolver := membership.NewMockServiceResolver(ctrl)
+			serviceResolver.EXPECT().Lookup("1").Return(membership.NewHostInfoFromAddress("test1"), nil)
+			serviceResolver.EXPECT().Lookup("2").Return(membership.NewHostInfoFromAddress("test2"), nil)
+			serviceResolver.EXPECT().Lookup("1").Return(membership.NewHostInfoFromAddress("test1"), nil)
+
+			// Create an in-memory gRPC server.
+			listener := nettest.NewListener(nettest.NewPipe())
+			rpcFactory := &testRPCFactory{
+				base: nettest.NewRPCFactory(listener),
+			}
+			grpcServer := grpc.NewServer()
+			testSvc := &testHistoryService{}
+			historyservice.RegisterHistoryServiceServer(grpcServer, testSvc)
+			errs := make(chan error)
+			go func() {
+				errs <- grpcServer.Serve(listener)
+			}()
+			defer func() {
+				grpcServer.Stop()
+				require.NoError(t, <-errs)
+			}()
+
+			// Send 3 requests to verify that we re-use a connection for the last request.
+			client := history.NewClient(
+				dynamicconfig.NewNoopCollection(),
+				serviceResolver,
+				log.NewTestLogger(),
+				2,
+				rpcFactory,
+				time.Duration(0),
+			)
+			for i := 0; i < 3; i++ {
+				err := tc.fn(client)
+				require.NoError(t, err)
+			}
+
+			// Verify that there are no repeated dialed addresses (indicating that we re-used the connection).
+			assert.Equal(
+				t,
+				[]string{"test1", "test2"},
+				rpcFactory.dialedAddresses,
+				"Should cache the client connection and reuse it for subsequent requests",
+			)
+		})
+	}
+}
+
+func (s *testHistoryService) GetDLQTasks(
+	context.Context,
+	*historyservice.GetDLQTasksRequest,
+) (*historyservice.GetDLQTasksResponse, error) {
+	return &historyservice.GetDLQTasksResponse{}, nil
+}
+
+func (s *testHistoryService) DeleteDLQTasks(
+	context.Context,
+	*historyservice.DeleteDLQTasksRequest,
+) (*historyservice.DeleteDLQTasksResponse, error) {
+	return &historyservice.DeleteDLQTasksResponse{}, nil
+}
+
+func (t *testRPCFactory) CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn {
+	t.dialedAddresses = append(t.dialedAddresses, rpcAddress)
+	return t.base.CreateInternodeGRPCConnection(rpcAddress)
 }

--- a/client/history/connections_mock.go
+++ b/client/history/connections_mock.go
@@ -32,7 +32,45 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+	grpc "google.golang.org/grpc"
 )
+
+// MockRPCFactory is a mock of RPCFactory interface.
+type MockRPCFactory struct {
+	ctrl     *gomock.Controller
+	recorder *MockRPCFactoryMockRecorder
+}
+
+// MockRPCFactoryMockRecorder is the mock recorder for MockRPCFactory.
+type MockRPCFactoryMockRecorder struct {
+	mock *MockRPCFactory
+}
+
+// NewMockRPCFactory creates a new mock instance.
+func NewMockRPCFactory(ctrl *gomock.Controller) *MockRPCFactory {
+	mock := &MockRPCFactory{ctrl: ctrl}
+	mock.recorder = &MockRPCFactoryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockRPCFactory) EXPECT() *MockRPCFactoryMockRecorder {
+	return m.recorder
+}
+
+// CreateInternodeGRPCConnection mocks base method.
+func (m *MockRPCFactory) CreateInternodeGRPCConnection(rpcAddress string) *grpc.ClientConn {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateInternodeGRPCConnection", rpcAddress)
+	ret0, _ := ret[0].(*grpc.ClientConn)
+	return ret0
+}
+
+// CreateInternodeGRPCConnection indicates an expected call of CreateInternodeGRPCConnection.
+func (mr *MockRPCFactoryMockRecorder) CreateInternodeGRPCConnection(rpcAddress interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateInternodeGRPCConnection", reflect.TypeOf((*MockRPCFactory)(nil).CreateInternodeGRPCConnection), rpcAddress)
+}
 
 // MockconnectionPool is a mock of connectionPool interface.
 type MockconnectionPool struct {
@@ -69,22 +107,6 @@ func (m *MockconnectionPool) getAllClientConns() []clientConnection {
 func (mr *MockconnectionPoolMockRecorder) getAllClientConns() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getAllClientConns", reflect.TypeOf((*MockconnectionPool)(nil).getAllClientConns))
-}
-
-// getAnyClientConn mocks base method.
-func (m *MockconnectionPool) getAnyClientConn() (clientConnection, bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "getAnyClientConn")
-	ret0, _ := ret[0].(clientConnection)
-	ret1, _ := ret[1].(bool)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// getAnyClientConn indicates an expected call of getAnyClientConn.
-func (mr *MockconnectionPoolMockRecorder) getAnyClientConn() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "getAnyClientConn", reflect.TypeOf((*MockconnectionPool)(nil).getAnyClientConn))
 }
 
 // getOrCreateClientConn mocks base method.

--- a/client/history/historytest/clienttest.go
+++ b/client/history/historytest/clienttest.go
@@ -166,9 +166,11 @@ func createServer(historyTaskQueueManager persistence.HistoryTaskQueueManager) *
 
 func createClient(ctrl *gomock.Controller, listener *nettest.PipeListener) historyservice.HistoryServiceClient {
 	serviceResolver := membership.NewMockServiceResolver(ctrl)
+	address := membership.NewHostInfoFromAddress("127.0.0.1:7104")
 	serviceResolver.EXPECT().Members().Return([]membership.HostInfo{
-		membership.NewHostInfoFromAddress("127.0.0.1:7104"),
+		address,
 	}).AnyTimes()
+	serviceResolver.EXPECT().Lookup(gomock.Any()).Return(address, nil).AnyTimes()
 	rpcFactory := nettest.NewRPCFactory(listener)
 	client := history.NewClient(
 		dynamicconfig.NewNoopCollection(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR changes the behavior of `getAnyClientConn` to round-robin through the list of members in the history pool, instead of looking in the connection pool.

<!-- Tell your future self why have you made these changes -->
**Why?**
This fixes an issue where DLQ commands like merge would end up using zombie connections to history hosts that no longer exist. Why? This was part of a small optimization I was making. I figured that we would end up making the client pool large if we kept making connections to different hosts by running DLQ commands over and over when we can instead use any valid connection. However, we never remove connections to dead hosts from this pool, so that strategy doesn't work. Instead, we now round-robin through the list of members in the pool.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I added unit tests for both the connection pool and the history client. I also fixed a broken unit test in `TestErrGetAnyHistoryHost`. In addition, I deployed these changes to a test environment, and I verified that we no longer get errors, even after following this sequence:
1. Deploy the change to the frontend
2. Run a bunch of DLQ admin commands (to fill up the connection pool on the frontend)
3. Restart the history service to get all new history hosts
4. Repeat step 2 and verify that there are no more "no route to host" errors

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
