### PR TITLE
Support STARTS_WITH in visibility queries

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/converter.go
+++ b/common/persistence/visibility/store/elasticsearch/converter.go
@@ -33,16 +33,18 @@ import (
 )
 
 var allowedComparisonOperators = map[string]struct{}{
-	sqlparser.EqualStr:        {},
-	sqlparser.NotEqualStr:     {},
-	sqlparser.GreaterThanStr:  {},
-	sqlparser.GreaterEqualStr: {},
-	sqlparser.LessThanStr:     {},
-	sqlparser.LessEqualStr:    {},
-	sqlparser.LikeStr:         {},
-	sqlparser.NotLikeStr:      {},
-	sqlparser.InStr:           {},
-	sqlparser.NotInStr:        {},
+	sqlparser.EqualStr:         {},
+	sqlparser.NotEqualStr:      {},
+	sqlparser.GreaterThanStr:   {},
+	sqlparser.GreaterEqualStr:  {},
+	sqlparser.LessThanStr:      {},
+	sqlparser.LessEqualStr:     {},
+	sqlparser.LikeStr:          {},
+	sqlparser.NotLikeStr:       {},
+	sqlparser.InStr:            {},
+	sqlparser.NotInStr:         {},
+	sqlparser.StartsWithStr:    {},
+	sqlparser.NotStartsWithStr: {},
 }
 
 func newQueryConverter(

--- a/common/persistence/visibility/store/elasticsearch/converter_test.go
+++ b/common/persistence/visibility/store/elasticsearch/converter_test.go
@@ -93,6 +93,8 @@ var supportedWhereCases = map[string]string{
 	"create_time BETWEEN '2015-01-01 00:00:00' and '2016-02-02 00:00:00'":     `{"bool":{"filter":{"range":{"create_time":{"from":"2015-01-01 00:00:00","include_lower":true,"include_upper":true,"to":"2016-02-02 00:00:00"}}}}}`,
 	"create_time nOt between '2015-01-01 00:00:00' and '2016-02-02 00:00:00'": `{"bool":{"must_not":{"range":{"create_time":{"from":"2015-01-01 00:00:00","include_lower":true,"include_upper":true,"to":"2016-02-02 00:00:00"}}}}}`,
 	"create_time between '2015-01-01T00:00:00+0800' and '2017-01-01T00:00:00+0800' and process_id = 0 and status >= 1 and content = '三个男人' and phone = '15810324322'": `{"bool":{"filter":[{"range":{"create_time":{"from":"2015-01-01T00:00:00+0800","include_lower":true,"include_upper":true,"to":"2017-01-01T00:00:00+0800"}}},{"match":{"process_id":{"query":0}}},{"range":{"status":{"from":1,"include_lower":true,"include_upper":true,"to":null}}},{"match":{"content":{"query":"三个男人"}}},{"match":{"phone":{"query":"15810324322"}}}]}}`,
+	"value starts_with 'prefix'":     `{"bool":{"filter":{"prefix":{"value":"prefix"}}}}`,
+	"value not starts_with 'prefix'": `{"bool":{"must_not":{"prefix":{"value":"prefix"}}}}`,
 }
 
 var supportedWhereOrderCases = map[string]struct {

--- a/common/persistence/visibility/store/query/converter.go
+++ b/common/persistence/visibility/store/query/converter.go
@@ -479,24 +479,36 @@ func (c *comparisonExprConverter) Convert(expr sqlparser.Expr) (elastic.Query, e
 
 	var query elastic.Query
 	switch comparisonExpr.Operator {
-	case ">=":
+	case sqlparser.GreaterEqualStr:
 		query = elastic.NewRangeQuery(colName).Gte(colValues[0])
-	case "<=":
+	case sqlparser.LessEqualStr:
 		query = elastic.NewRangeQuery(colName).Lte(colValues[0])
-	case ">":
+	case sqlparser.GreaterThanStr:
 		query = elastic.NewRangeQuery(colName).Gt(colValues[0])
-	case "<":
+	case sqlparser.LessThanStr:
 		query = elastic.NewRangeQuery(colName).Lt(colValues[0])
-	case "=", "like": // The only difference is that "%" is removed for LIKE queries.
+	case sqlparser.EqualStr, sqlparser.LikeStr: // The only difference is that "%" is removed for LIKE queries.
 		// Not elastic.NewTermQuery to support partial word match for String custom search attributes.
 		query = elastic.NewMatchQuery(colName, colValues[0])
-	case "!=", "not like":
+	case sqlparser.NotEqualStr, sqlparser.NotLikeStr:
 		// Not elastic.NewTermQuery to support partial word match for String custom search attributes.
 		query = elastic.NewBoolQuery().MustNot(elastic.NewMatchQuery(colName, colValues[0]))
-	case "in":
+	case sqlparser.InStr:
 		query = elastic.NewTermsQuery(colName, colValues...)
-	case "not in":
+	case sqlparser.NotInStr:
 		query = elastic.NewBoolQuery().MustNot(elastic.NewTermsQuery(colName, colValues...))
+	case sqlparser.StartsWithStr:
+		v, ok := colValues[0].(string)
+		if !ok {
+			return nil, NewConverterError("right-hand side of '%v' must be a string", comparisonExpr.Operator)
+		}
+		query = elastic.NewPrefixQuery(colName, v)
+	case sqlparser.NotStartsWithStr:
+		v, ok := colValues[0].(string)
+		if !ok {
+			return nil, NewConverterError("right-hand side of '%v' must be a string", comparisonExpr.Operator)
+		}
+		query = elastic.NewBoolQuery().MustNot(elastic.NewPrefixQuery(colName, v))
 	}
 
 	return query, nil

--- a/common/persistence/visibility/store/sql/query_converter_test.go
+++ b/common/persistence/visibility/store/sql/query_converter_test.go
@@ -329,6 +329,38 @@ func (s *queryConverterSuite) TestConvertComparisonExpr() {
 			err:    nil,
 		},
 		{
+			name:   "starts_with expression",
+			input:  "AliasForKeyword01 starts_with 'foo_bar%'",
+			output: `Keyword01 like 'foo!_bar!%%' escape '!'`,
+			err:    nil,
+		},
+		{
+			name:   "not starts_with expression",
+			input:  "AliasForKeyword01 not starts_with 'foo_bar%'",
+			output: `Keyword01 not like 'foo!_bar!%%' escape '!'`,
+			err:    nil,
+		},
+		{
+			name:   "starts_with expression error",
+			input:  "AliasForKeyword01 starts_with 123",
+			output: "",
+			err: query.NewConverterError(
+				"%s: right-hand side of '%s' must be a literal string (got: 123)",
+				query.InvalidExpressionErrMessage,
+				sqlparser.StartsWithStr,
+			),
+		},
+		{
+			name:   "not starts_with expression error",
+			input:  "AliasForKeyword01 not starts_with 123",
+			output: "",
+			err: query.NewConverterError(
+				"%s: right-hand side of '%s' must be a literal string (got: 123)",
+				query.InvalidExpressionErrMessage,
+				sqlparser.NotStartsWithStr,
+			),
+		},
+		{
 			name:   "like expression",
 			input:  "AliasForKeyword01 like 'foo%'",
 			output: "",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Parse `STARTS_WITH` queries to visibility, and build queries to Elasticsearch and SQL.

<!-- Tell your future self why have you made these changes -->
**Why?**
Support prefix search in visibility queries.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit tests, and integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.