### PR TITLE
Makefile: remove install-proto-submodule as a dependency to proto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ci-build-misc: print-go-version bins ci-update-tools shell-check copyright-check
 clean: clean-bins clean-test-results
 
 # Recompile proto files.
-proto: clean-proto install-proto-submodule buf-lint api-linter protoc fix-proto-path goimports-proto proto-mocks copyright-proto
+proto: clean-proto buf-lint api-linter protoc fix-proto-path goimports-proto proto-mocks copyright-proto
 
 # Update proto submodule from remote and recompile proto files.
 update-proto: clean-proto update-proto-submodule buf-lint api-linter protoc fix-proto-path update-go-api goimports-proto proto-mocks copyright-proto gomodtidy


### PR DESCRIPTION
**What changed?**

In description

**Why?**

It make it hard to work with branches in the API repo.
I asked internally and have only gotten feedback supporting this change.

**How did you test it?**

I did not, if CI passes, we will be good.

**Potential risks**

Some dependent project's build may break if the rely on this submodule being installed as part of the `make proto` step.
This is fine as there's no contract we'll be breaking.

**Is hotfix candidate?**

No