### PR TITLE
Adding metrics when a task is enqueued to DLQ

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -722,6 +722,11 @@ func SourceCluster(sourceCluster string) ZapTag {
 	return NewStringTag("xdc-source-cluster", sourceCluster)
 }
 
+// TargetCluster returns tag for TargetCluster
+func TargetCluster(targetCluster string) ZapTag {
+	return NewStringTag("xdc-target-cluster", targetCluster)
+}
+
 // PrevActiveCluster returns tag for PrevActiveCluster
 func PrevActiveCluster(prevActiveCluster string) ZapTag {
 	return NewStringTag("xdc-prev-active-cluster", prevActiveCluster)

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -911,6 +911,7 @@ var (
 	ShardLingerSuccess                             = NewTimerDef("shard_linger_success")
 	ShardLingerTimeouts                            = NewCounterDef("shard_linger_timeouts")
 	DynamicRateLimiterMultiplier                   = NewGaugeDef("dynamic_rate_limit_multiplier")
+	DLQWrites                                      = NewCounterDef("dlq_writes")
 
 	// Deadlock detector latency metrics
 	DDClusterMetadataLockLatency         = NewTimerDef("dd_cluster_metadata_lock_latency")

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -913,7 +913,7 @@ var (
 	DynamicRateLimiterMultiplier                   = NewGaugeDef("dynamic_rate_limit_multiplier")
 	DLQWrites                                      = NewCounterDef(
 		"dlq_writes",
-		WithDescription("The number of times a history task is enqueued to a DLQ"),
+		WithDescription("The number of times a message is enqueued to DLQ. DLQ can be inspected using tdbg dlq command."),
 	)
 
 	// Deadlock detector latency metrics

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -911,7 +911,10 @@ var (
 	ShardLingerSuccess                             = NewTimerDef("shard_linger_success")
 	ShardLingerTimeouts                            = NewCounterDef("shard_linger_timeouts")
 	DynamicRateLimiterMultiplier                   = NewGaugeDef("dynamic_rate_limit_multiplier")
-	DLQWrites                                      = NewCounterDef("dlq_writes")
+	DLQWrites                                      = NewCounterDef(
+		"dlq_writes",
+		WithDescription("The number of times a history task is enqueued to a DLQ"),
+	)
 
 	// Deadlock detector latency metrics
 	DDClusterMetadataLockLatency         = NewTimerDef("dd_cluster_metadata_lock_latency")

--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -111,24 +111,21 @@ func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetClu
 	}
 	q.metricsHandler.Counter(metrics.DLQWrites.GetMetricName()).Record(1)
 	ns, err := q.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
+	var namespaceTag tag.Tag
 	if err != nil {
 		q.logger.Warn("Failed to get namespace name while trying to write a task to DLQ",
 			tag.WorkflowNamespace(task.GetNamespaceID()),
 			tag.Error(err),
 		)
-		q.logger.Warn("Task enqueued to DLQ",
-			tag.SourceCluster(sourceCluster),
-			tag.TargetCluster(targetCluster),
-			tag.TaskType(task.GetType()),
-			tag.WorkflowNamespaceID(task.GetNamespaceID()),
-		)
-		return nil
+		namespaceTag = tag.WorkflowNamespaceID(task.GetNamespaceID())
+	} else {
+		namespaceTag = tag.WorkflowNamespace(string(ns.Name()))
 	}
 	q.logger.Warn("Task enqueued to DLQ",
 		tag.SourceCluster(sourceCluster),
 		tag.TargetCluster(targetCluster),
 		tag.TaskType(task.GetType()),
-		tag.WorkflowNamespace(string(ns.Name())),
+		namespaceTag,
 	)
 	return nil
 }

--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -113,12 +113,6 @@ func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetClu
 	ns, err := q.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
 	if err != nil {
 		q.logger.Warn("Failed to get namespace name", tag.WorkflowNamespace(task.GetNamespaceID()))
-		q.logger.Warn("Task enqueued to DLQ",
-			tag.SourceCluster(sourceCluster),
-			tag.TargetCluster(targetCluster),
-			tag.TaskType(task.GetType()),
-			tag.WorkflowNamespaceID(task.GetNamespaceID()),
-		)
 		return nil
 	}
 	q.logger.Warn("Task enqueued to DLQ",

--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -112,7 +112,16 @@ func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetClu
 	q.metricsHandler.Counter(metrics.DLQWrites.GetMetricName()).Record(1)
 	ns, err := q.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
 	if err != nil {
-		q.logger.Warn("Failed to get namespace name", tag.WorkflowNamespace(task.GetNamespaceID()))
+		q.logger.Warn("Failed to get namespace name while trying to write a task to DLQ",
+			tag.WorkflowNamespace(task.GetNamespaceID()),
+			tag.Error(err),
+		)
+		q.logger.Warn("Task enqueued to DLQ",
+			tag.SourceCluster(sourceCluster),
+			tag.TargetCluster(targetCluster),
+			tag.TaskType(task.GetType()),
+			tag.WorkflowNamespaceID(task.GetNamespaceID()),
+		)
 		return nil
 	}
 	q.logger.Warn("Task enqueued to DLQ",

--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -30,6 +30,10 @@ import (
 	"fmt"
 
 	"go.temporal.io/server/common/cluster"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/log/tag"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/tasks"
 )
@@ -37,8 +41,11 @@ import (
 type (
 	// DLQWriter can be used to write tasks to the DLQ.
 	DLQWriter struct {
-		dlqWriter       QueueWriter
-		clusterMetadata cluster.Metadata
+		dlqWriter         QueueWriter
+		clusterMetadata   cluster.Metadata
+		metricsHandler    metrics.Handler
+		logger            log.SnTaggedLogger
+		namespaceRegistry namespace.Registry
 	}
 	// QueueWriter is a subset of persistence.HistoryTaskQueueManager.
 	QueueWriter interface {
@@ -60,10 +67,13 @@ var (
 )
 
 // NewDLQWriter returns a DLQ which will write to the given QueueWriter.
-func NewDLQWriter(w QueueWriter, m cluster.Metadata) *DLQWriter {
+func NewDLQWriter(w QueueWriter, m cluster.Metadata, h metrics.Handler, l log.SnTaggedLogger, r namespace.Registry) *DLQWriter {
 	return &DLQWriter{
-		dlqWriter:       w,
-		clusterMetadata: m,
+		dlqWriter:         w,
+		clusterMetadata:   m,
+		metricsHandler:    h,
+		logger:            l,
+		namespaceRegistry: r,
 	}
 }
 
@@ -99,5 +109,13 @@ func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetClu
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrSendTaskToDLQ, err)
 	}
+	q.metricsHandler.Counter(metrics.DLQWrites.GetMetricName()).Record(1)
+	ns, err := q.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
+	q.logger.Warn("Task enqueued to DLQ",
+		tag.SourceCluster(sourceCluster),
+		tag.TargetCluster(targetCluster),
+		tag.TaskType(task.GetType()),
+		tag.WorkflowNamespace(string(ns.Name())),
+	)
 	return nil
 }

--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -111,6 +111,16 @@ func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetClu
 	}
 	q.metricsHandler.Counter(metrics.DLQWrites.GetMetricName()).Record(1)
 	ns, err := q.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
+	if err != nil {
+		q.logger.Warn("Failed to get namespace name", tag.WorkflowNamespace(task.GetNamespaceID()))
+		q.logger.Warn("Task enqueued to DLQ",
+			tag.SourceCluster(sourceCluster),
+			tag.TargetCluster(targetCluster),
+			tag.TaskType(task.GetType()),
+			tag.WorkflowNamespaceID(task.GetNamespaceID()),
+		)
+		return nil
+	}
 	q.logger.Warn("Task enqueued to DLQ",
 		tag.SourceCluster(sourceCluster),
 		tag.TargetCluster(targetCluster),

--- a/service/history/queues/dlq_writer_test.go
+++ b/service/history/queues/dlq_writer_test.go
@@ -122,6 +122,7 @@ func TestDLQWriter_ErrGetNamespaceName(t *testing.T) {
 	assert.NotEmpty(t, logger.records)
 	assert.Contains(t, logger.records[0].msg, "Failed to get namespace name while trying to write a task to DLQ")
 	assert.Equal(t, logger.records[0].tags[1].Value(), errorMsg)
+	assert.Contains(t, logger.records[1].msg, "Task enqueued to DLQ")
 }
 
 func TestDLQWriter_Ok(t *testing.T) {

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -357,7 +357,7 @@ func (s *executableSuite) TestExecuteHandleErr_ResetAttempt() {
 func (s *executableSuite) TestExecuteHandleErr_Corrupted() {
 	queueWriter := &queuestest.FakeQueueWriter{}
 	executable := s.newTestExecutable(func(p *params) {
-		p.dlqWriter = queues.NewDLQWriter(queueWriter, s.mockClusterMetadata)
+		p.dlqWriter = queues.NewDLQWriter(queueWriter, s.mockClusterMetadata, metrics.NoopMetricsHandler, log.NewTestLogger(), s.mockNamespaceRegistry)
 		p.dlqEnabled = func() bool {
 			return false
 		}
@@ -377,7 +377,7 @@ func (s *executableSuite) TestExecuteHandleErr_Corrupted() {
 func (s *executableSuite) TestExecute_DLQ() {
 	queueWriter := &queuestest.FakeQueueWriter{}
 	executable := s.newTestExecutable(func(p *params) {
-		p.dlqWriter = queues.NewDLQWriter(queueWriter, s.mockClusterMetadata)
+		p.dlqWriter = queues.NewDLQWriter(queueWriter, s.mockClusterMetadata, metrics.NoopMetricsHandler, log.NewTestLogger(), s.mockNamespaceRegistry)
 		p.dlqEnabled = func() bool {
 			return true
 		}
@@ -399,7 +399,7 @@ func (s *executableSuite) TestExecute_DLQThenDisable() {
 	queueWriter := &queuestest.FakeQueueWriter{}
 	dlqEnabled := true
 	executable := s.newTestExecutable(func(p *params) {
-		p.dlqWriter = queues.NewDLQWriter(queueWriter, s.mockClusterMetadata)
+		p.dlqWriter = queues.NewDLQWriter(queueWriter, s.mockClusterMetadata, metrics.NoopMetricsHandler, log.NewTestLogger(), s.mockNamespaceRegistry)
 		p.dlqEnabled = func() bool {
 			return dlqEnabled
 		}
@@ -421,7 +421,7 @@ func (s *executableSuite) TestExecute_DLQThenDisable() {
 func (s *executableSuite) TestExecute_DLQFailThenRetry() {
 	queueWriter := &queuestest.FakeQueueWriter{}
 	executable := s.newTestExecutable(func(p *params) {
-		p.dlqWriter = queues.NewDLQWriter(queueWriter, s.mockClusterMetadata)
+		p.dlqWriter = queues.NewDLQWriter(queueWriter, s.mockClusterMetadata, metrics.NoopMetricsHandler, log.NewTestLogger(), s.mockNamespaceRegistry)
 		p.dlqEnabled = func() bool {
 			return true
 		}

--- a/service/history/replication/dlq_writer_test.go
+++ b/service/history/replication/dlq_writer_test.go
@@ -32,6 +32,9 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/namespace"
 
 	enumspb "go.temporal.io/server/api/enums/v1"
 	persistencespb "go.temporal.io/server/api/persistence/v1"
@@ -101,8 +104,10 @@ func TestNewDLQWriterAdapter(t *testing.T) {
 					ShardCount: 1,
 				},
 			}).AnyTimes()
+			namespaceRegistry := namespace.NewMockRegistry(controller)
+			namespaceRegistry.EXPECT().GetNamespaceByID(gomock.Any()).Return(&namespace.Namespace{}, nil).AnyTimes()
 			writer := replication.NewDLQWriterAdapter(
-				queues.NewDLQWriter(queueWriter, clusterMetadata),
+				queues.NewDLQWriter(queueWriter, clusterMetadata, metrics.NoopMetricsHandler, log.NewTestLogger(), namespaceRegistry),
 				taskSerializer,
 				"test-current-cluster",
 			)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding a metric when a task is written to DLQ.
Also added warning log with task details.

<!-- Tell your future self why have you made these changes -->
**Why?**
We will have to monitor this metric to see if there are any tasks in DLQ.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally by making a workflow task fail.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
