### PR TITLE
Fix eager workflow start mapping of per namespace search attributes

### DIFF
--- a/service/history/api/get_history_util.go
+++ b/service/history/api/get_history_util.go
@@ -185,7 +185,7 @@ func GetHistory(
 		historyEvents = append(historyEvents, transientWorkflowTaskInfo.HistorySuffix...)
 	}
 
-	if err := processOutgoingSearchAttributes(shard, historyEvents, namespaceID, persistenceVisibilityMgr); err != nil {
+	if err := ProcessOutgoingSearchAttributes(shard, historyEvents, namespaceID, persistenceVisibilityMgr); err != nil {
 		return nil, nil, err
 	}
 
@@ -236,7 +236,7 @@ func GetHistoryReverse(
 	metricsHandler := interceptor.GetMetricsHandlerFromContext(ctx, logger).WithTags(metrics.OperationTag(metrics.HistoryGetHistoryReverseScope))
 	metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(size))
 
-	if err := processOutgoingSearchAttributes(shard, historyEvents, namespaceID, persistenceVisibilityMgr); err != nil {
+	if err := ProcessOutgoingSearchAttributes(shard, historyEvents, namespaceID, persistenceVisibilityMgr); err != nil {
 		return nil, nil, 0, err
 	}
 
@@ -254,7 +254,7 @@ func GetHistoryReverse(
 	return executionHistory, nextPageToken, newNextEventID, nil
 }
 
-func processOutgoingSearchAttributes(
+func ProcessOutgoingSearchAttributes(
 	shard shard.Context,
 	events []*historypb.HistoryEvent,
 	namespaceId namespace.ID,

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -536,9 +536,6 @@ func (s *Starter) generateResponse(
 	workflowTaskInfo *workflow.WorkflowTaskInfo,
 	historyEvents []*historypb.HistoryEvent,
 ) (*historyservice.StartWorkflowExecutionResponse, error) {
-	if err := api.ProcessOutgoingSearchAttributes(s.shardContext, historyEvents, s.namespace.ID(), s.visibilityManager); err != nil {
-		return nil, err
-	}
 	shardCtx := s.shardContext
 	tokenSerializer := s.tokenSerializer
 	request := s.request.StartRequest
@@ -549,6 +546,11 @@ func (s *Starter) generateResponse(
 			RunId: runID,
 		}, nil
 	}
+
+	if err := api.ProcessOutgoingSearchAttributes(s.shardContext, historyEvents, s.namespace.ID(), s.visibilityManager); err != nil {
+		return nil, err
+	}
+
 	clock, err := shardCtx.NewVectorClock()
 	if err != nil {
 		return nil, err

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -37,6 +37,7 @@ import (
 
 	"go.temporal.io/server/api/historyservice/v1"
 
+	"go.temporal.io/server/common/persistence/visibility/manager"
 	"go.temporal.io/server/common/tasktoken"
 
 	"go.temporal.io/server/common"
@@ -64,6 +65,7 @@ type Starter struct {
 	shardContext               shard.Context
 	workflowConsistencyChecker api.WorkflowConsistencyChecker
 	tokenSerializer            common.TaskTokenSerializer
+	visibilityManager          manager.VisibilityManager
 	request                    *historyservice.StartWorkflowExecutionRequest
 	namespace                  *namespace.Namespace
 }
@@ -92,6 +94,7 @@ func NewStarter(
 	shardContext shard.Context,
 	workflowConsistencyChecker api.WorkflowConsistencyChecker,
 	tokenSerializer common.TaskTokenSerializer,
+	visibilityManager manager.VisibilityManager,
 	request *historyservice.StartWorkflowExecutionRequest,
 ) (*Starter, error) {
 	namespaceEntry, err := api.GetActiveNamespace(shardContext, namespace.ID(request.GetNamespaceId()))
@@ -102,6 +105,7 @@ func NewStarter(
 		shardContext:               shardContext,
 		workflowConsistencyChecker: workflowConsistencyChecker,
 		tokenSerializer:            tokenSerializer,
+		visibilityManager:          visibilityManager,
 		request:                    request,
 		namespace:                  namespaceEntry,
 	}, nil
@@ -532,6 +536,9 @@ func (s *Starter) generateResponse(
 	workflowTaskInfo *workflow.WorkflowTaskInfo,
 	historyEvents []*historypb.HistoryEvent,
 ) (*historyservice.StartWorkflowExecutionResponse, error) {
+	if err := api.ProcessOutgoingSearchAttributes(s.shardContext, historyEvents, s.namespace.ID(), s.visibilityManager); err != nil {
+		return nil, err
+	}
 	shardCtx := s.shardContext
 	tokenSerializer := s.tokenSerializer
 	request := s.request.StartRequest

--- a/service/history/history_engine.go
+++ b/service/history/history_engine.go
@@ -368,6 +368,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 		e.shardContext,
 		e.workflowConsistencyChecker,
 		e.tokenSerializer,
+		e.persistenceVisibilityMgr,
 		startRequest,
 	)
 	if err != nil {

--- a/service/history/history_engine_test.go
+++ b/service/history/history_engine_test.go
@@ -5278,6 +5278,9 @@ func (s *engineSuite) TestReapplyEvents_ResetWorkflow() {
 func (s *engineSuite) TestEagerWorkflowStart_DoesNotCreateTransferTask() {
 	var recordedTasks []tasks.Task
 
+	s.mockNamespaceCache.EXPECT().GetNamespaceName(gomock.Any()).Return(tests.Namespace, nil)
+	s.mockVisibilityMgr.EXPECT().GetIndexName().Return("mock")
+	s.mockSearchAttributesProvider.EXPECT().GetSearchAttributes("mock", false).Return(searchattribute.NameTypeMap{}, nil)
 	s.mockExecutionMgr.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(func(ctx context.Context, request *persistence.CreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error) {
 		recordedTasks = request.NewWorkflowSnapshot.Tasks[tasks.CategoryTransfer]
 		persistenceResponse := persistence.CreateWorkflowExecutionResponse{NewMutableStateStats: tests.CreateWorkflowExecutionResponse.NewMutableStateStats}

--- a/tests/eager_workflow_start_test.go
+++ b/tests/eager_workflow_start_test.go
@@ -36,6 +36,7 @@ import (
 	"go.temporal.io/api/workflowservice/v1"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
@@ -49,7 +50,7 @@ func (s *functionalSuite) defaultTaskQueue() *taskqueuepb.TaskQueue {
 }
 
 func (s *functionalSuite) startEagerWorkflow(baseOptions *workflowservice.StartWorkflowExecutionRequest) *workflowservice.StartWorkflowExecutionResponse {
-	options := baseOptions
+	options := proto.Clone(baseOptions).(*workflowservice.StartWorkflowExecutionRequest)
 	options.RequestEagerExecution = true
 
 	if options.Namespace == "" {

--- a/tests/eager_workflow_start_test.go
+++ b/tests/eager_workflow_start_test.go
@@ -121,9 +121,22 @@ func (s *functionalSuite) getWorkflowStringResult(workflowID, runID string) stri
 }
 
 func (s *functionalSuite) TestEagerWorkflowStart_StartNew() {
-	response := s.startEagerWorkflow(&workflowservice.StartWorkflowExecutionRequest{})
+	// Add a search attribute to verify that per namespace search attribute mapping is properly applied in the
+	// response.
+	response := s.startEagerWorkflow(&workflowservice.StartWorkflowExecutionRequest{
+		SearchAttributes: &commonpb.SearchAttributes{
+			IndexedFields: map[string]*commonpb.Payload{
+				"CustomKeywordField": {
+					Metadata: map[string][]byte{"encoding": []byte("json/plain")},
+					Data:     []byte(`"value"`),
+				},
+			},
+		},
+	})
 	task := response.GetEagerWorkflowTask()
 	s.Require().NotNil(task, "StartWorkflowExecution response did not contain a workflow task")
+	kwData := task.History.Events[0].GetWorkflowExecutionStartedEventAttributes().SearchAttributes.IndexedFields["CustomKeywordField"].Data
+	s.Require().Equal(`"value"`, string(kwData))
 	s.respondWorkflowTaskCompleted(task, "ok")
 	// Verify workflow completes and client can get the result
 	result := s.getWorkflowStringResult(s.defaultWorkflowID(), response.RunId)


### PR DESCRIPTION
**What changed?**


Fixed a bug where per namespace search attributes weren't properly aliased in the workflow task's history returned in the eager workflow start path.

The SDK submitted a StartWorkflowExecution request with a `CustomKeywordField` search attribute and the workflow task returned contained a `Keyword04` attribute instead.

**Why?**

It's a bug, it needs fixing.

**How did you test it?**

Locally reproduced the issue and verified the fix.

Also added a test that executes this path.

**Potential risks**

Can't think of any.

**Is hotfix candidate?**

Considering the eager workflow start is still experimental, I don't think we need a hotfix.