### PR TITLE
Fix tchannel race condition

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	github.com/temporalio/ringpop-go v0.0.0-20230606200434-b5c079f412d3
 	github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb
-	github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b
+	github.com/temporalio/tchannel-go v1.22.1-0.20231116015023-bd4fb7678499
 	github.com/temporalio/tctl-kit v0.0.0-20230328153839-577f95d16fa0
 	github.com/uber-go/tally/v4 v4.1.7
 	github.com/urfave/cli v1.22.14

--- a/go.sum
+++ b/go.sum
@@ -342,8 +342,9 @@ github.com/temporalio/ringpop-go v0.0.0-20230606200434-b5c079f412d3 h1:V1U9fvhus
 github.com/temporalio/ringpop-go v0.0.0-20230606200434-b5c079f412d3/go.mod h1:LA2yFb94r5XoEnuMVHkCC/P5174whMy2Dd+cu+AEcQA=
 github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb h1:YzHH/U/dN7vMP+glybzcXRTczTrgfdRisNTzAj7La04=
 github.com/temporalio/sqlparser v0.0.0-20231115171017-f4060bcfa6cb/go.mod h1:143qKdh3G45IgV9p+gbAwp3ikRDI8mxsijFiXDfuxsw=
-github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b h1:Fs3LdlF7xbnOWHymbFmvIEuxIEt1dNRCfaDkoajSaZk=
 github.com/temporalio/tchannel-go v1.22.1-0.20220818200552-1be8d8cffa5b/go.mod h1:c+V9Z/ZgkzAdyGvHrvC5AsXgN+M9Qwey04cBdKYzV7U=
+github.com/temporalio/tchannel-go v1.22.1-0.20231116015023-bd4fb7678499 h1:PUclzwrSQgakQIiEvvgVdcfulynpX0JM1f716pEcCTU=
+github.com/temporalio/tchannel-go v1.22.1-0.20231116015023-bd4fb7678499/go.mod h1:ezRQRwu9KQXy8Wuuv1aaFFxoCNz5CeNbVOOkh3xctbY=
 github.com/temporalio/tctl-kit v0.0.0-20230328153839-577f95d16fa0 h1:E1iAre7/4VvSJri8uOnItKVsMKnP+WEQourm+zVO0cc=
 github.com/temporalio/tctl-kit v0.0.0-20230328153839-577f95d16fa0/go.mod h1:hk/LJCKZNNmtVSWRKepbdUJme+k/4fb/hPkekXk40sk=
 github.com/twmb/murmur3 v1.1.5/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR updates our version of tchannel to one that contains this change: https://github.com/temporalio/tchannel-go/pull/7.

<!-- Tell your future self why have you made these changes -->
**Why?**
This should fix a rare race condition that happens where a tchannel is used while there are still handlers being added to it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I didn't reproduce it actually, but it's a very small change, and the race condition is pretty clear to see.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The only other changes pulled in from this upgrade were changes to the go.mod in tchannel-go, which look pretty innocuous:

```
-    golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f
-    golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
+    golang.org/x/net v0.7.0
+    golang.org/x/sys v0.5.0
```

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No, it can wait. This only comes up super rarely.
