### PR TITLE
Fix matching read-level race condition

### DIFF
--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/emirpasic/gods/maps/treemap"
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally/v4"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -83,6 +84,7 @@ import (
 type (
 	matchingEngineSuite struct {
 		suite.Suite
+		*require.Assertions
 		controller            *gomock.Controller
 		mockHistoryClient     *historyservicemock.MockHistoryServiceClient
 		mockMatchingClient    *matchingservicemock.MockMatchingServiceClient
@@ -112,6 +114,7 @@ func (s *matchingEngineSuite) TearDownSuite() {
 }
 
 func (s *matchingEngineSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
 	s.logger = log.NewTestLogger()
 	s.Lock()
 	defer s.Unlock()

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -251,7 +251,8 @@ writerLoop:
 			}
 
 			resp, err := w.appendTasks(ctx, tasks)
-			// Update the maxReadLevel after the writes are completed.
+			// Update the maxReadLevel after the writes are completed, but before we send the response,
+			// so that taskReader is guaranteed to see the new read level when SpoolTask wakes it up.
 			if maxReadLevel > 0 {
 				atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
 			}

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -251,11 +251,11 @@ writerLoop:
 			}
 
 			resp, err := w.appendTasks(ctx, tasks)
-			w.sendWriteResponse(reqs, resp, err)
 			// Update the maxReadLevel after the writes are completed.
 			if maxReadLevel > 0 {
 				atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
 			}
+			w.sendWriteResponse(reqs, resp, err)
 
 		case <-ctx.Done():
 			return ctx.Err()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I fixed a small and extremely rare race condition in matching. 

<!-- Tell your future self why have you made these changes -->
**Why?**
This was causing test failures e.g. https://buildkite.com/temporal/temporal-public/builds/13342#018bb7f8-c04f-4f91-b12b-ca4ce6336c1b

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go test ./service/matching -run TestMatchingEngineSuite/TestAddTaskAfterStartFailure -count 100000
```

Rationale for why this happens is that there is a goroutine reading from `w.maxReadLevel`, and it may or may not read from it before we write to it if we wake it up with the w.sendWriteResponse call before setting the read level.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
