### PR TITLE
Fix set up search attributes in secondary SQL visibility

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -606,17 +606,12 @@ func ApplyClusterMetadataConfigProvider(
 	}
 	defer clusterMetadataManager.Close()
 
-	var sqlIndexNames []string
 	initialIndexSearchAttributes := make(map[string]*persistencespb.IndexSearchAttributes)
 	if ds := svc.Persistence.GetVisibilityStoreConfig(); ds.SQL != nil {
-		indexName := ds.GetIndexName()
-		sqlIndexNames = append(sqlIndexNames, indexName)
-		initialIndexSearchAttributes[indexName] = searchattribute.GetSqlDbIndexSearchAttributes()
+		initialIndexSearchAttributes[ds.GetIndexName()] = searchattribute.GetSqlDbIndexSearchAttributes()
 	}
 	if ds := svc.Persistence.GetSecondaryVisibilityStoreConfig(); ds.SQL != nil {
-		indexName := ds.GetIndexName()
-		sqlIndexNames = append(sqlIndexNames, indexName)
-		initialIndexSearchAttributes[indexName] = searchattribute.GetSqlDbIndexSearchAttributes()
+		initialIndexSearchAttributes[ds.GetIndexName()] = searchattribute.GetSqlDbIndexSearchAttributes()
 	}
 
 	clusterMetadata := svc.ClusterMetadata
@@ -643,6 +638,7 @@ func ApplyClusterMetadataConfigProvider(
 			ctx,
 			clusterMetadataManager,
 			svc,
+			initialIndexSearchAttributes,
 			resp,
 		); updateErr != nil {
 			return svc.ClusterMetadata, svc.Persistence, updateErr
@@ -779,6 +775,7 @@ func updateCurrentClusterMetadataRecord(
 	ctx context.Context,
 	clusterMetadataManager persistence.ClusterMetadataManager,
 	svc *config.Config,
+	initialIndexSearchAttributes map[string]*persistencespb.IndexSearchAttributes,
 	currentClusterDBRecord *persistence.GetClusterMetadataResponse,
 ) error {
 	updateDBRecord := false
@@ -799,6 +796,20 @@ func updateCurrentClusterMetadataRecord(
 	if !maps.Equal(currentClusterDBRecord.Tags, svc.ClusterMetadata.Tags) {
 		currentClusterDBRecord.Tags = svc.ClusterMetadata.Tags
 		updateDBRecord = true
+	}
+
+	if len(initialIndexSearchAttributes) > 0 {
+		if currentClusterDBRecord.IndexSearchAttributes == nil {
+			currentClusterDBRecord.IndexSearchAttributes = initialIndexSearchAttributes
+			updateDBRecord = true
+		} else {
+			for indexName, initialValue := range initialIndexSearchAttributes {
+				if _, ok := currentClusterDBRecord.IndexSearchAttributes[indexName]; !ok {
+					currentClusterDBRecord.IndexSearchAttributes[indexName] = initialValue
+					updateDBRecord = true
+				}
+			}
+		}
 	}
 
 	if !updateDBRecord {

--- a/temporal/fx_test.go
+++ b/temporal/fx_test.go
@@ -97,6 +97,7 @@ func TestUpdateCurrentClusterMetadataRecord(t *testing.T) {
 		context.TODO(),
 		mockClusterMetadataManager,
 		cfg,
+		nil,
 		updateRecord,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix setting up pre-allocated search attributes when a secondary SQL visibility is added.

<!-- Tell your future self why have you made these changes -->
**Why?**
PR https://github.com/temporalio/temporal/pull/4531 removed code that did this.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Started single SQL visibility, and then added secondary SQL visibility. Checked cluster metadata, it looks right.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.