### PR TITLE
Use the official SDK and feature repos

### DIFF
--- a/.github/workflows/features-integration.yml
+++ b/.github/workflows/features-integration.yml
@@ -29,7 +29,7 @@ jobs:
     needs: build-docker-image
     uses: temporalio/features/.github/workflows/go.yaml@main
     with:
-      version: replace-gogo-protobuf
+      version: f9d73bfdf7c8d3ec0311306140fbfafa7fb6f9cf
       version-is-repo-ref: true
       docker-image-artifact-name: temporal-server-docker
 

--- a/.github/workflows/features-integration.yml
+++ b/.github/workflows/features-integration.yml
@@ -24,8 +24,6 @@ jobs:
       version: 1.5.2
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
-      features-repo-path: "tdeebswihart/temporal-features"
-      features-repo-ref: "nomo-gogo"
 
   feature-tests-go:
     needs: build-docker-image
@@ -34,12 +32,6 @@ jobs:
       version: replace-gogo-protobuf
       version-is-repo-ref: true
       docker-image-artifact-name: temporal-server-docker
-      # TODO: remove these after they've hit the main branch
-      go-repo-path: tdeebswihart/temporal-sdk-go
-      sdk-repo-url: http://github.com/tdeebswihart/temporal-sdk-go
-      sdk-repo-ref: replace-gogo-protobuf
-      features-repo-path: "tdeebswihart/temporal-features"
-      features-repo-ref: "nomo-gogo"
 
   feature-tests-python:
     needs: build-docker-image
@@ -48,8 +40,6 @@ jobs:
       version: 0.1b4
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
-      features-repo-path: "tdeebswihart/temporal-features"
-      features-repo-ref: "nomo-gogo"
 
   feature-tests-java:
     needs: build-docker-image
@@ -58,5 +48,3 @@ jobs:
       version: v1.17.0
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
-      features-repo-path: "tdeebswihart/temporal-features"
-      features-repo-ref: "nomo-gogo"


### PR DESCRIPTION
## What was changed
This repo now uses the official features repo, not my fork.

## Why?
This needed to point at my fork temporarily so that I could release a new version of that repo (which relies on the server itself).