### PR TITLE
Add generated proto and mock files to gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,14 @@
 *.png filter=lfs diff=lfs merge=lfs -text
 *.jpg filter=lfs diff=lfs merge=lfs -text
+# vendor is marked as linguist-vendored by default, but this
+# only excludes the code from stats.
+#
+# Forcing it to be linguist-generated will also exclude it from diffs.
+#
+# See https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#summary
+# for more info.
+api/ linguist-generated
+common/persistence/mock/ linguist-generated
+*.pb.go linguist-generated
+*.mock.go linguist-generated
+*_mock.go linguist-generated

--- a/.gitattributes
+++ b/.gitattributes
@@ -8,7 +8,6 @@
 # See https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#summary
 # for more info.
 api/ linguist-generated
-common/persistence/mock/ linguist-generated
 *.pb.go linguist-generated
 *.mock.go linguist-generated
 *_mock.go linguist-generated

--- a/client/client_bean_mock.go
+++ b/client/client_bean_mock.go
@@ -139,7 +139,6 @@ func (mr *MockBeanMockRecorder) GetRemoteFrontendClient(arg0 interface{}) *gomoc
 // SetRemoteAdminClient mocks base method.
 func (m *MockBean) SetRemoteAdminClient(arg0 string, arg1 v10.AdminServiceClient) {
 	m.ctrl.T.Helper()
-
 	m.ctrl.Call(m, "SetRemoteAdminClient", arg0, arg1)
 }
 

--- a/client/client_bean_mock.go
+++ b/client/client_bean_mock.go
@@ -139,6 +139,7 @@ func (mr *MockBeanMockRecorder) GetRemoteFrontendClient(arg0 interface{}) *gomoc
 // SetRemoteAdminClient mocks base method.
 func (m *MockBean) SetRemoteAdminClient(arg0 string, arg1 v10.AdminServiceClient) {
 	m.ctrl.T.Helper()
+
 	m.ctrl.Call(m, "SetRemoteAdminClient", arg0, arg1)
 }
 


### PR DESCRIPTION
**What changed?**
I added all generated files (mocks and proto code) to .gitattributes as generated files

**Why?**
This will exclude them from GitHub PR review so we don't need to scroll past them

**How did you test it?**
CI

**Potential risks**
None.

**Is hotfix candidate?**
No.
