### PR TITLE
ScheduleToStart timeout for speculative WT on normal task queue

### DIFF
--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -211,7 +211,14 @@ func Invoke(
 		}
 
 		if err != nil {
-			return nil, err
+			// Intentionally ignore error here.
+			// If adding speculative WT to matching failed with error,
+			// this error can't be handled outside of WF lock and can't be returned to the client (because it is not a client error).
+			// This speculative WT will be eventually converted to normal WT and corresponding transfer task
+			// will be created to add it to the matching. Default timeout is controlled by tasks.SpeculativeWorkflowTaskScheduleToStartTimeout (10 seconds).
+			// If subsequent attempt succeeds within current context timeout, caller of this API will get a valid response.
+			err = nil
+			// TODO: emit metric, write warn log?
 		}
 	}
 

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -211,14 +211,20 @@ func Invoke(
 		}
 
 		if err != nil {
-			// Intentionally ignore error here.
+			shardCtx.GetLogger().Warn("Unable to add WorkflowTask directly to matching.",
+				tag.WorkflowNamespace(req.Request.Namespace),
+				tag.WorkflowNamespaceID(wfKey.NamespaceID),
+				tag.WorkflowID(wfKey.WorkflowID),
+				tag.WorkflowRunID(wfKey.RunID),
+				tag.Error(err))
+
+			// Intentionally just log error here and don't return it to the client.
 			// If adding speculative WT to matching failed with error,
 			// this error can't be handled outside of WF lock and can't be returned to the client (because it is not a client error).
-			// This speculative WT will be timed out in tasks.SpeculativeWorkflowTaskScheduleToStartTimeout (10) seconds,
+			// This speculative WT will be timed out in tasks.SpeculativeWorkflowTaskScheduleToStartTimeout (5) seconds,
 			// and new normal WT will be scheduled.
 			// If subsequent attempt succeeds within current context timeout, caller of this API will get a valid response.
 			err = nil
-			// TODO: emit metric, write warn log?
 		}
 	}
 

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -214,8 +214,8 @@ func Invoke(
 			// Intentionally ignore error here.
 			// If adding speculative WT to matching failed with error,
 			// this error can't be handled outside of WF lock and can't be returned to the client (because it is not a client error).
-			// This speculative WT will be eventually converted to normal WT and corresponding transfer task
-			// will be created to add it to the matching. Default timeout is controlled by tasks.SpeculativeWorkflowTaskScheduleToStartTimeout (10 seconds).
+			// This speculative WT will be timed out in tasks.SpeculativeWorkflowTaskScheduleToStartTimeout (10) seconds,
+			// and new normal WT will be scheduled.
 			// If subsequent attempt succeeds within current context timeout, caller of this API will get a valid response.
 			err = nil
 			// TODO: emit metric, write warn log?

--- a/service/history/tasks/workflow_task_timer.go
+++ b/service/history/tasks/workflow_task_timer.go
@@ -36,7 +36,10 @@ import (
 )
 
 const (
-	SpeculativeWorkflowTaskScheduleToStartTimeout = 10 * time.Second
+	// SpeculativeWorkflowTaskScheduleToStartTimeout is the timeout for a speculative workflow task on a normal task queue.
+	// Default ScheduleToStart timeout for a sticky task queue is 5 seconds.
+	// Setting this value also to 5 seconds to match the sticky queue timeout.
+	SpeculativeWorkflowTaskScheduleToStartTimeout = 5 * time.Second
 )
 
 var _ Task = (*WorkflowTaskTimeoutTask)(nil)

--- a/service/history/tasks/workflow_task_timer.go
+++ b/service/history/tasks/workflow_task_timer.go
@@ -35,6 +35,10 @@ import (
 	ctasks "go.temporal.io/server/common/tasks"
 )
 
+const (
+	SpeculativeWorkflowTaskScheduleToStartTimeout = 10 * time.Second
+)
+
 var _ Task = (*WorkflowTaskTimeoutTask)(nil)
 
 type (

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -370,6 +370,29 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowTaskTimeoutTask(
 			return nil
 		}
 
+		// Only speculative WT has ScheduleToStart timeout on normal task queue.
+		if workflowTask.TaskQueue.Kind == enumspb.TASK_QUEUE_KIND_NORMAL {
+			// But it speculative WT is converted to normal WT every time when
+			// mutable state is persisted to the database during lifetime of speculative WT (i.e. signal comes in).
+			// Nothing needs to be done here is WT is not speculative anymore.
+			if workflowTask.Type != enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE {
+				return nil
+			}
+
+			// If current WT in mutable state is different from WT for which this timer task was created,
+			// then just ignore this task. There will be another one which will fire at the right moment.
+			if task.VisibilityTimestamp != workflowTask.ScheduledTime.Add(tasks.SpeculativeWorkflowTaskScheduleToStartTimeout) {
+				return nil
+			}
+
+			// If speculative WT is still not started after tasks.SpeculativeWorkflowTaskScheduleToStartTimeout
+			// then there is a chance that it wasn't added to matching after creation
+			// (i.e. from UpdateWorkflowExecution API handler) because of transient failure.
+			// It needs to be converted to normal WT and transfer task queue processor will add it to matching.
+			// No events will be added to the history because this timeout is internal and not visible to the user.
+			break
+		}
+
 		t.emitTimeoutMetricScopeWithNamespaceTag(
 			namespace.ID(mutableState.GetExecutionInfo().NamespaceId),
 			metrics.TimerActiveTaskWorkflowTaskTimeoutScope,

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -370,11 +370,22 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowTaskTimeoutTask(
 			return nil
 		}
 
+		// ScheduleToStart timeout timer task is created only for sticky task queue.
+		// But after task was created and this timeout task is fired, sticky task queue may be cleared.
+		// Therefore, workflowTask.TaskQueue.Kind can be Normal or Sticky.
+
+		// if workflowTask.Type == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE {
+		// 	if task.VisibilityTimestamp != workflowTask.ScheduledTime.Add(tasks.SpeculativeWorkflowTaskScheduleToStartTimeout) {
+		// 		return nil
+		// 	}
+		// 	break
+		// }
+
 		// Only speculative WT has ScheduleToStart timeout on normal task queue.
 		if workflowTask.TaskQueue.Kind == enumspb.TASK_QUEUE_KIND_NORMAL {
 			// But it speculative WT is converted to normal WT every time when
 			// mutable state is persisted to the database during lifetime of speculative WT (i.e. signal comes in).
-			// Nothing needs to be done here is WT is not speculative anymore.
+			// Nothing needs to be done here if WT is not speculative anymore.
 			if workflowTask.Type != enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE {
 				return nil
 			}

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -234,7 +234,6 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			// NOTE: at the beginning of the loop, stickyness is cleared
 			if err := taskGenerator.GenerateScheduleWorkflowTaskTasks(
 				workflowTask.ScheduledEventID,
-				false,
 			); err != nil {
 				return nil, err
 			}
@@ -287,7 +286,6 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 				// NOTE: at the beginning of the loop, stickyness is cleared
 				if err := taskGenerator.GenerateScheduleWorkflowTaskTasks(
 					workflowTask.ScheduledEventID,
-					false,
 				); err != nil {
 					return nil, err
 				}
@@ -310,7 +308,6 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 				// NOTE: at the beginning of the loop, stickyness is cleared
 				if err := taskGenerator.GenerateScheduleWorkflowTaskTasks(
 					workflowTask.ScheduledEventID,
-					false,
 				); err != nil {
 					return nil, err
 				}

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -520,7 +520,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	).Return(nil)
 	s.mockTaskGeneratorForNew.EXPECT().GenerateScheduleWorkflowTaskTasks(
 		newRunWorkflowTaskEvent.GetEventId(),
-		false,
 	).Return(nil)
 	s.mockTaskGeneratorForNew.EXPECT().GenerateActivityTimerTasks().Return(nil)
 	s.mockTaskGeneratorForNew.EXPECT().GenerateUserTimerTasks().Return(nil)
@@ -766,7 +765,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskScheduled() {
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateScheduleWorkflowTaskTasks(
 		wt.ScheduledEventID,
-		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -861,7 +859,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskTimedOut() {
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateScheduleWorkflowTaskTasks(
 		newScheduledEventID,
-		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -906,7 +903,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskFailed() {
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateScheduleWorkflowTaskTasks(
 		newScheduledEventID,
-		false,
 	).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -338,7 +338,7 @@ func (r *TaskGeneratorImpl) GenerateScheduleWorkflowTaskTasks(
 			// there is no good way to handle the error.
 			// In this case WT will be timed out (as if it was on sticky task queue),
 			// and new normal WT will be created.
-			// Note: this timeout will also fire if workflow received an update,
+			// Note: this timer will also fire if workflow received an update,
 			// but there is no workers available. Speculative WT will time out, and normal WT will be created.
 			scheduleToStartTimeout = tasks.SpeculativeWorkflowTaskScheduleToStartTimeout
 		}

--- a/service/history/workflow/task_generator.go
+++ b/service/history/workflow/task_generator.go
@@ -333,12 +333,13 @@ func (r *TaskGeneratorImpl) GenerateScheduleWorkflowTaskTasks(
 	if workflowTask.Type == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE {
 		if !r.mutableState.IsStickyTaskQueueSet() {
 			// Speculative WT has ScheduleToStart timeout even on normal task queue.
-			// This timeout is internal and not visible to the user.
 			// Normally WT should be added to matching right after being created
 			// (i.e. from UpdateWorkflowExecution API handler), but if this "add" operation failed,
 			// there is no good way to handle the error.
-			// In this case ScheduleToStart timeout will fire, convert speculative WT to normal,
-			// and create transfer task to add this WT to matching.
+			// In this case WT will be timed out (as if it was on sticky task queue),
+			// and new normal WT will be created.
+			// Note: this timeout will also fire if workflow received an update,
+			// but there is no workers available. Speculative WT will time out, and normal WT will be created.
 			scheduleToStartTimeout = tasks.SpeculativeWorkflowTaskScheduleToStartTimeout
 		}
 

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -218,17 +218,17 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateRequestCancelExternalTasks(even
 }
 
 // GenerateScheduleWorkflowTaskTasks mocks base method.
-func (m *MockTaskGenerator) GenerateScheduleWorkflowTaskTasks(workflowTaskScheduledEventID int64, generateTimeoutTaskOnly bool) error {
+func (m *MockTaskGenerator) GenerateScheduleWorkflowTaskTasks(workflowTaskScheduledEventID int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateScheduleWorkflowTaskTasks", workflowTaskScheduledEventID, generateTimeoutTaskOnly)
+	ret := m.ctrl.Call(m, "GenerateScheduleWorkflowTaskTasks", workflowTaskScheduledEventID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateScheduleWorkflowTaskTasks indicates an expected call of GenerateScheduleWorkflowTaskTasks.
-func (mr *MockTaskGeneratorMockRecorder) GenerateScheduleWorkflowTaskTasks(workflowTaskScheduledEventID, generateTimeoutTaskOnly interface{}) *gomock.Call {
+func (mr *MockTaskGeneratorMockRecorder) GenerateScheduleWorkflowTaskTasks(workflowTaskScheduledEventID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateScheduleWorkflowTaskTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateScheduleWorkflowTaskTasks), workflowTaskScheduledEventID, generateTimeoutTaskOnly)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateScheduleWorkflowTaskTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateScheduleWorkflowTaskTasks), workflowTaskScheduledEventID)
 }
 
 // GenerateSignalExternalTasks mocks base method.

--- a/service/history/workflow/task_generator_mock.go
+++ b/service/history/workflow/task_generator_mock.go
@@ -33,7 +33,7 @@ import (
 	time "time"
 
 	gomock "github.com/golang/mock/gomock"
-	history "go.temporal.io/api/history/v1"
+	v1 "go.temporal.io/api/history/v1"
 	tasks "go.temporal.io/server/service/history/tasks"
 )
 
@@ -75,7 +75,7 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateActivityRetryTasks(activitySche
 }
 
 // GenerateActivityTasks mocks base method.
-func (m *MockTaskGenerator) GenerateActivityTasks(event *history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateActivityTasks(event *v1.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateActivityTasks", event)
 	ret0, _ := ret[0].(error)
@@ -103,7 +103,7 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateActivityTimerTasks() *gomock.Ca
 }
 
 // GenerateChildWorkflowTasks mocks base method.
-func (m *MockTaskGenerator) GenerateChildWorkflowTasks(event *history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateChildWorkflowTasks(event *v1.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateChildWorkflowTasks", event)
 	ret0, _ := ret[0].(error)
@@ -117,7 +117,7 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateChildWorkflowTasks(event interf
 }
 
 // GenerateDelayedWorkflowTasks mocks base method.
-func (m *MockTaskGenerator) GenerateDelayedWorkflowTasks(startEvent *history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateDelayedWorkflowTasks(startEvent *v1.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateDelayedWorkflowTasks", startEvent)
 	ret0, _ := ret[0].(error)
@@ -160,7 +160,7 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateDeleteHistoryEventTask(closeTim
 }
 
 // GenerateHistoryReplicationTasks mocks base method.
-func (m *MockTaskGenerator) GenerateHistoryReplicationTasks(events []*history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateHistoryReplicationTasks(events []*v1.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateHistoryReplicationTasks", events)
 	ret0, _ := ret[0].(error)
@@ -190,7 +190,7 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateMigrationTasks() *gomock.Call {
 }
 
 // GenerateRecordWorkflowStartedTasks mocks base method.
-func (m *MockTaskGenerator) GenerateRecordWorkflowStartedTasks(startEvent *history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateRecordWorkflowStartedTasks(startEvent *v1.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateRecordWorkflowStartedTasks", startEvent)
 	ret0, _ := ret[0].(error)
@@ -204,7 +204,7 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateRecordWorkflowStartedTasks(star
 }
 
 // GenerateRequestCancelExternalTasks mocks base method.
-func (m *MockTaskGenerator) GenerateRequestCancelExternalTasks(event *history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateRequestCancelExternalTasks(event *v1.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateRequestCancelExternalTasks", event)
 	ret0, _ := ret[0].(error)
@@ -215,6 +215,20 @@ func (m *MockTaskGenerator) GenerateRequestCancelExternalTasks(event *history.Hi
 func (mr *MockTaskGeneratorMockRecorder) GenerateRequestCancelExternalTasks(event interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateRequestCancelExternalTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateRequestCancelExternalTasks), event)
+}
+
+// GenerateScheduleSpeculativeWorkflowTaskTasks mocks base method.
+func (m *MockTaskGenerator) GenerateScheduleSpeculativeWorkflowTaskTasks(workflowTask *WorkflowTaskInfo) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GenerateScheduleSpeculativeWorkflowTaskTasks", workflowTask)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// GenerateScheduleSpeculativeWorkflowTaskTasks indicates an expected call of GenerateScheduleSpeculativeWorkflowTaskTasks.
+func (mr *MockTaskGeneratorMockRecorder) GenerateScheduleSpeculativeWorkflowTaskTasks(workflowTask interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateScheduleSpeculativeWorkflowTaskTasks", reflect.TypeOf((*MockTaskGenerator)(nil).GenerateScheduleSpeculativeWorkflowTaskTasks), workflowTask)
 }
 
 // GenerateScheduleWorkflowTaskTasks mocks base method.
@@ -232,7 +246,7 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateScheduleWorkflowTaskTasks(workf
 }
 
 // GenerateSignalExternalTasks mocks base method.
-func (m *MockTaskGenerator) GenerateSignalExternalTasks(event *history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateSignalExternalTasks(event *v1.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateSignalExternalTasks", event)
 	ret0, _ := ret[0].(error)
@@ -316,7 +330,7 @@ func (mr *MockTaskGeneratorMockRecorder) GenerateWorkflowResetTasks() *gomock.Ca
 }
 
 // GenerateWorkflowStartTasks mocks base method.
-func (m *MockTaskGenerator) GenerateWorkflowStartTasks(startEvent *history.HistoryEvent) error {
+func (m *MockTaskGenerator) GenerateWorkflowStartTasks(startEvent *v1.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GenerateWorkflowStartTasks", startEvent)
 	ret0, _ := ret[0].(error)

--- a/service/history/workflow/task_refresher.go
+++ b/service/history/workflow/task_refresher.go
@@ -262,7 +262,6 @@ func (r *TaskRefresherImpl) refreshWorkflowTaskTasks(
 	// workflowTask only scheduled
 	return taskGenerator.GenerateScheduleWorkflowTaskTasks(
 		workflowTask.ScheduledEventID,
-		false,
 	)
 }
 

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -357,14 +357,8 @@ func (m *workflowTaskStateMachine) AddWorkflowTaskScheduledEventAsHeartbeat(
 	// TODO merge active & passive task generation
 	// Always bypass task generation for speculative workflow task.
 	if !bypassTaskGeneration {
-		generateTimeoutTaskOnly := false
-		if workflowTask.Type == enumsspb.WORKFLOW_TASK_TYPE_SPECULATIVE {
-			generateTimeoutTaskOnly = true
-		}
-
 		if err := m.ms.taskGenerator.GenerateScheduleWorkflowTaskTasks(
 			scheduledEventID,
-			generateTimeoutTaskOnly,
 		); err != nil {
 			return nil, err
 		}
@@ -1036,7 +1030,6 @@ func (m *workflowTaskStateMachine) convertSpeculativeWorkflowTaskToNormal() erro
 	} else {
 		if err := m.ms.taskGenerator.GenerateScheduleWorkflowTaskTasks(
 			scheduledEvent.EventId,
-			true, // Only generate SCHEDULE_TO_START timeout timer task, but not a transfer task which push WT to matching because WT was already pushed to matching.
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add `ScheduleToStart` timeout for speculative WT on normal task queue.

<!-- Tell your future self why have you made these changes -->
**Why?**
`UpdateWorkflowExecution` API handler tries to add WT to matching directly. This call must be made outside of workflow lock and might fail (if matching is temporarily unavailable, for example). There is no good way to handle this error after lock was released. This is why I introduced this `ScheduleToStart` timeout for speculative WT on the normal task queue. This timeout will ensure that WT will be eventually added to matching and workflow won't stuck.

Also removed special flag which was used to skip transfer task creation when speculative WT is converted to normal before MS with speculative WT is persisted.

Both these speculative WT logic changes (timeout on normal and skip transfer task) are extracted to special `GenerateScheduleSpeculativeWorkflowTaskTasks` method.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added functional test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Speculative WT times out once if there is no worker available.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
No.