### PR TITLE
Don't enable system scanners in functional tests

### DIFF
--- a/tests/functional_test_base.go
+++ b/tests/functional_test_base.go
@@ -30,6 +30,7 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"os"
 	"reflect"
 	"regexp"
@@ -119,7 +120,16 @@ func (s *FunctionalTestBase) setupSuite(defaultClusterConfigFile string, options
 
 	clusterConfig, err := GetTestClusterConfig(defaultClusterConfigFile)
 	s.Require().NoError(err)
-	clusterConfig.DynamicConfigOverrides = s.dynamicConfigOverrides
+	if clusterConfig.DynamicConfigOverrides == nil {
+		clusterConfig.DynamicConfigOverrides = make(map[dynamicconfig.Key]interface{})
+	}
+	maps.Copy(clusterConfig.DynamicConfigOverrides, map[dynamicconfig.Key]any{
+		dynamicconfig.HistoryScannerEnabled:    false,
+		dynamicconfig.TaskQueueScannerEnabled:  false,
+		dynamicconfig.ExecutionsScannerEnabled: false,
+		dynamicconfig.BuildIdScavengerEnabled:  false,
+	})
+	maps.Copy(clusterConfig.DynamicConfigOverrides, s.dynamicConfigOverrides)
 	clusterConfig.ServiceFxOptions = params.ServiceOptions
 	s.testClusterConfig = clusterConfig
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I turned off the history and task queue scanners for all the tests that use `FunctionalTestBase`.

<!-- Tell your future self why have you made these changes -->
**Why?**
None of the tests we run rely on them, they make extra overhead, and they also trigger some race conditions in several tests that override our task executors. Those race conditions will be fixed separately because those tests shouldn't depend on running in an environment with no system workflows, though.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I reran the tests/dlq_test which was triggering a race condition, slept for 5 seconds, and verified that no other workflow tasks were sent to the task executor except for the ones for the DLQ test itself.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This will mean we're testing the scanners themselves less, but they're already run as part of the `tests/server_test`, and they have their own unit tests, so I'm not too concerned.

<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
