### PR TITLE
Propagate ctx throughout tdbg commands

### DIFF
--- a/tools/tdbg/tdbgtest/output_parsing_test.go
+++ b/tools/tdbg/tdbgtest/output_parsing_test.go
@@ -28,6 +28,7 @@ import (
 	"bytes"
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -85,7 +86,9 @@ func TestParseDLQMessages(t *testing.T) {
 		params.ClientFactory = client
 		params.Writer = &b
 	})
-	err = app.Run([]string{
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	t.Cleanup(cancel)
+	err = app.RunContext(ctx, []string{
 		"tdbg",
 		"--" + tdbg.FlagYes,
 		"dlq",

--- a/tools/tdbg/util.go
+++ b/tools/tdbg/util.go
@@ -196,7 +196,7 @@ func newContextWithTimeout(c *cli.Context, timeout time.Duration) (context.Conte
 		timeout = time.Duration(c.Int(FlagContextTimeout)) * time.Second
 	}
 
-	return context.WithTimeout(context.Background(), timeout)
+	return context.WithTimeout(c.Context, timeout)
 }
 
 func StringToEnum(search string, candidates map[string]int32) (int32, error) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR makes us use the `context.Context` provided to the CLI command, if one is provided, and it also makes our tests provide one. 

<!-- Tell your future self why have you made these changes -->
**Why?**
This way, tests can drive timeouts and cancellations when they run `tdbg` commands.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I just looked for references to `app.Run` in our code, and I switched them to `RunContext` wherever it was applicable (not needed for things that aren't I/O related like `tdbg decode`.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
**Is hotfix candidate?**
