### PR TITLE
Modify PR template to introduce less noise into commit messages

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,14 @@
+## What changed?
 <!-- Describe what has changed in this PR -->
-**What changed?**
 
-
+## Why?
 <!-- Tell your future self why have you made these changes -->
-**Why?**
 
-
+## How did you test it?
 <!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
-**How did you test it?**
 
-
+## Potential risks
 <!-- Assuming the worst case, what can be broken when deploying this change to production? -->
-**Potential risks**
 
-
+## Is hotfix candidate?
 <!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
-**Is hotfix candidate?**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,4 +11,4 @@
 <!-- Assuming the worst case, what can be broken when deploying this change to production? -->
 
 ## Is hotfix candidate?
-<!-- Is this PR a hotfix candidate or require that a notification be sent to the broader community? (Yes/No) -->
+<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->


### PR DESCRIPTION
## What changed?
- Place comments below section headings
- Use `## Foo` instead of `**Foo**`

## Why?
- This reduces the amount of noise in the resulting git commit messages, because users will probably understand to delete the comment, replacing it with the requested content.
- `## Foo` is a minor cosmetic improvement over `**Foo**` when reading commit messages. It's quite a big change to the rendered appearance in GitHub, but hopefully people are OK with the new look; it's used by `sdk-go` also.

## How did you test it?
I used the template to write this PR intro.

## Potential risks
None

## Is hotfix candidate?
No
