### PR TITLE
OTEL gRPC debug

### DIFF
--- a/common/clock/context.go
+++ b/common/clock/context.go
@@ -71,25 +71,25 @@ func (ctx *ctxWithDeadline) cancel() {
 	})
 }
 
-func ContextWithDeadline(
-	ctx context.Context,
-	deadline time.Time,
-	timeSource TimeSource,
-) (context.Context, context.CancelFunc) {
-	ctxd := &ctxWithDeadline{
-		Context:  ctx,
-		deadline: deadline,
-		done:     make(chan struct{}),
-	}
-	timer := timeSource.AfterFunc(deadline.Sub(timeSource.Now()), ctxd.deadlineExceeded)
-	ctxd.timer = timer
-	return ctxd, ctxd.cancel
-}
-
-func ContextWithTimeout(
-	ctx context.Context,
-	timeout time.Duration,
-	timeSource TimeSource,
-) (context.Context, context.CancelFunc) {
-	return ContextWithDeadline(ctx, timeSource.Now().Add(timeout), timeSource)
-}
+//func ContextWithDeadline(
+//	ctx context.Context,
+//	deadline time.Time,
+//	timeSource TimeSource,
+//) (context.Context, context.CancelFunc) {
+//	ctxd := &ctxWithDeadline{
+//		Context:  ctx,
+//		deadline: deadline,
+//		done:     make(chan struct{}),
+//	}
+//	timer := timeSource.AfterFunc(deadline.Sub(timeSource.Now()), ctxd.deadlineExceeded)
+//	ctxd.timer = timer
+//	return ctxd, ctxd.cancel
+//}
+//
+//func ContextWithTimeout(
+//	ctx context.Context,
+//	timeout time.Duration,
+//	timeSource TimeSource,
+//) (context.Context, context.CancelFunc) {
+//	return ContextWithDeadline(ctx, timeSource.Now().Add(timeout), timeSource)
+//}

--- a/common/telemetry/attributes.go
+++ b/common/telemetry/attributes.go
@@ -1,0 +1,31 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package telemetry
+
+import "go.opentelemetry.io/otel/attribute"
+
+var (
+	WorkflowId = attribute.Key("rpc.request.payload")
+)

--- a/common/telemetry/config.go
+++ b/common/telemetry/config.go
@@ -237,7 +237,7 @@ func (ec *exportConfig) SpanExporters() ([]otelsdktrace.SpanExporter, error) {
 			Spec: &otlpGrpcSpanExporter{
 				otlpGrpcExporter: otlpGrpcExporter{
 					Connection: grpcconn{
-						Endpoint: "localhost:4318",
+						Endpoint: "localhost:4317",
 						Insecure: true,
 					},
 				},

--- a/common/telemetry/config.go
+++ b/common/telemetry/config.go
@@ -237,7 +237,7 @@ func (ec *exportConfig) SpanExporters() ([]otelsdktrace.SpanExporter, error) {
 			Spec: &otlpGrpcSpanExporter{
 				otlpGrpcExporter: otlpGrpcExporter{
 					Connection: grpcconn{
-						Endpoint: "localhost:4317",
+						Endpoint: "localhost:4318",
 						Insecure: true,
 					},
 				},

--- a/common/telemetry/grpc.go
+++ b/common/telemetry/grpc.go
@@ -25,10 +25,15 @@
 package telemetry
 
 import (
+	"context"
+
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/trace"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
 )
 
 type (
@@ -48,12 +53,46 @@ func NewServerTraceInterceptor(
 	tp trace.TracerProvider,
 	tmp propagation.TextMapPropagator,
 ) ServerTraceInterceptor {
-	return ServerTraceInterceptor(
-		otelgrpc.UnaryServerInterceptor(
-			otelgrpc.WithPropagators(tmp),
-			otelgrpc.WithTracerProvider(tp),
-		),
+	otelInterceptor := otelgrpc.UnaryServerInterceptor(
+		otelgrpc.WithPropagators(tmp),
+		otelgrpc.WithTracerProvider(tp),
 	)
+
+	if debugMode() {
+		return func(
+			ctx context.Context,
+			req interface{},
+			info *grpc.UnaryServerInfo,
+			handler grpc.UnaryHandler,
+		) (any, error) {
+			return otelInterceptor(ctx, req, info, debugHandler(handler))
+		}
+	}
+
+	return ServerTraceInterceptor(otelInterceptor)
+}
+
+func debugHandler(origHandler grpc.UnaryHandler) grpc.UnaryHandler {
+	return func(ctx context.Context, req any) (resp any, err error) {
+		resp, err = origHandler(ctx, req)
+		span := trace.SpanFromContext(ctx)
+		if span.IsRecording() {
+			reqMsg := req.(proto.Message)
+			payload, _ := protojson.Marshal(reqMsg)
+			msgType := string(proto.MessageName(reqMsg).Name())
+			span.SetAttributes(attribute.Key("rpc.request.payload").String(string(payload)))
+			span.SetAttributes(attribute.Key("rpc.request.type").String(msgType))
+
+			if err == nil {
+				respMsg := resp.(proto.Message)
+				payload, _ = protojson.Marshal(respMsg)
+				msgType = string(proto.MessageName(respMsg).Name())
+				span.SetAttributes(attribute.Key("rpc.response.payload").String(string(payload)))
+				span.SetAttributes(attribute.Key("rpc.response.type").String(msgType))
+			}
+		}
+		return
+	}
 }
 
 // NewClientTraceInterceptor creates a new gRPC client interceptor that tracks

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -35,6 +35,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/pborman/uuid"
+	"go.opentelemetry.io/otel/trace"
 	batchpb "go.temporal.io/api/batch/v1"
 	commonpb "go.temporal.io/api/common/v1"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -47,6 +48,7 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"go.temporal.io/server/common/telemetry"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -3124,6 +3126,7 @@ func (wh *WorkflowHandler) UpdateWorkflowExecution(
 	request *workflowservice.UpdateWorkflowExecutionRequest,
 ) (_ *workflowservice.UpdateWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.logger, &retError)
+	trace.SpanFromContext(ctx).SetAttributes(telemetry.WorkflowId.String(request.WorkflowExecution.WorkflowId))
 
 	if request == nil {
 		return nil, errRequestNotSet

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -936,13 +936,12 @@ var TraceExportModule = fx.Options(
 //   - telemetry.ServerTraceInterceptor
 //   - telemetry.ClientTraceInterceptor
 var ServiceTracingModule = fx.Options(
-	fx.Supply([]otelsdktrace.BatchSpanProcessorOption{}),
 	fx.Provide(
 		fx.Annotate(
-			func(exps []otelsdktrace.SpanExporter, opts []otelsdktrace.BatchSpanProcessorOption) []otelsdktrace.SpanProcessor {
+			func(exps []otelsdktrace.SpanExporter, c *config.Config) []otelsdktrace.SpanProcessor {
 				sps := make([]otelsdktrace.SpanProcessor, 0, len(exps))
 				for _, exp := range exps {
-					sps = append(sps, otelsdktrace.NewBatchSpanProcessor(exp, opts...))
+					sps = append(sps, c.ExporterConfig.SpanProcessor(exp))
 				}
 				return sps
 			},

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -921,10 +921,6 @@ var TraceExportModule = fx.Options(
 // ServiceTracingModule holds per-service (i.e. frontend/history/matching/worker) fx
 // state. The following types can be overriden with fx.Replace/fx.Decorate:
 //
-//   - []go.opentelemetry.io/otel/sdk/trace.BatchSpanProcessorOption
-//     default: empty slice
-//   - []go.opentelemetry.io/otel/sdk/trace.SpanProcessor
-//     default: wrap each otelsdktrace.SpanExporter with otelsdktrace.NewBatchSpanProcessor
 //   - *go.opentelemetry.io/otel/sdk/resource.Resource
 //     default: resource.Default() augmented with the supplied serviceName
 //   - []go.opentelemetry.io/otel/sdk/trace.TracerProviderOption

--- a/tests/onebox.go
+++ b/tests/onebox.go
@@ -127,6 +127,7 @@ type (
 		mockAdminClient                  map[string]adminservice.AdminServiceClient
 		namespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor
 		spanExporters                    []otelsdktrace.SpanExporter
+		spanProcessors                   []otelsdktrace.SpanProcessor
 		tlsConfigProvider                *encryption.FixedTLSConfigProvider
 		captureMetricsHandler            *metricstest.CaptureHandler
 
@@ -175,6 +176,7 @@ type (
 		MockAdminClient                  map[string]adminservice.AdminServiceClient
 		NamespaceReplicationTaskExecutor namespace.ReplicationTaskExecutor
 		SpanExporters                    []otelsdktrace.SpanExporter
+		SpanProcessors                   []otelsdktrace.SpanProcessor
 		DynamicConfigOverrides           map[dynamicconfig.Key]interface{}
 		TLSConfigProvider                *encryption.FixedTLSConfigProvider
 		CaptureMetricsHandler            *metricstest.CaptureHandler
@@ -215,6 +217,7 @@ func newTemporal(t *testing.T, params *TemporalParams) *temporalImpl {
 		mockAdminClient:                  params.MockAdminClient,
 		namespaceReplicationTaskExecutor: params.NamespaceReplicationTaskExecutor,
 		spanExporters:                    params.SpanExporters,
+		spanProcessors:                   params.SpanProcessors,
 		tlsConfigProvider:                params.TLSConfigProvider,
 		captureMetricsHandler:            params.CaptureMetricsHandler,
 		dcClient:                         testDCClient,
@@ -457,6 +460,7 @@ func (c *temporalImpl) startFrontend(hosts map[primitives.ServiceName][]string, 
 		fx.Provide(c.GetTLSConfigProvider),
 		fx.Provide(c.GetTaskCategoryRegistry),
 		fx.Supply(c.spanExporters),
+		fx.Replace(c.spanProcessors),
 		temporal.ServiceTracingModule,
 		frontend.Module,
 		fx.Populate(&frontendService, &clientBean, &namespaceRegistry, &rpcFactory),
@@ -551,6 +555,7 @@ func (c *temporalImpl) startHistory(
 			fx.Provide(workflow.NewTaskGeneratorProvider),
 			fx.Provide(c.GetTaskCategoryRegistry),
 			fx.Supply(c.spanExporters),
+			fx.Replace(c.spanProcessors),
 			temporal.ServiceTracingModule,
 			history.QueueModule,
 			history.Module,
@@ -646,6 +651,7 @@ func (c *temporalImpl) startMatching(hosts map[primitives.ServiceName][]string, 
 		fx.Provide(resource.DefaultSnTaggedLoggerProvider),
 		fx.Provide(c.GetTaskCategoryRegistry),
 		fx.Supply(c.spanExporters),
+		fx.Replace(c.spanProcessors),
 		temporal.ServiceTracingModule,
 		matching.Module,
 		fx.Populate(&matchingService, &clientBean, &namespaceRegistry),
@@ -744,6 +750,7 @@ func (c *temporalImpl) startWorker(hosts map[primitives.ServiceName][]string, st
 		fx.Provide(c.GetTLSConfigProvider),
 		fx.Provide(c.GetTaskCategoryRegistry),
 		fx.Supply(c.spanExporters),
+		fx.Replace(c.spanProcessors),
 		temporal.ServiceTracingModule,
 		worker.Module,
 		fx.Populate(&workerService, &clientBean, &namespaceRegistry),


### PR DESCRIPTION
## What changed?

Extended the existing OpenTelemetry (OTEL) functionality with a "debug mode" to emit the gRPC request and response payloads.

⚠️ TODO: use env vars as described in https://github.com/temporalio/temporal/issues/4041 instead

## Why?

This is the first step in a larger effort to improve _local_ observability of the Server (and eventually the SDKs, too). There is a need to be able to observe important events - such as gRPC calls - in greater detail during development.

It also helps with onboarding new developers.

## How did you test it?

An OTEL gRPC collector was used to verify the OTEL exports (internal link: https://github.com/temporalio/temporal-rpc-playground/pull/1).

## Potential risks

The debug functionality is guarded through an environment variable. Unless the check is incorrect, no effect on regular use is expected.

## Is hotfix candidate?

No