### PR TITLE
Add build id to reset points

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.19.0
 	go.opentelemetry.io/otel/sdk v1.19.0
 	go.opentelemetry.io/otel/sdk/metric v1.19.0
-	go.temporal.io/api v1.26.1
+	go.temporal.io/api v1.26.2-0.20231129165614-630d88440548
 	go.temporal.io/sdk v1.25.2-0.20231129171107-288a04f72145
 	go.temporal.io/version v0.3.0
 	go.uber.org/atomic v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -375,8 +375,8 @@ go.opentelemetry.io/otel/trace v1.19.0 h1:DFVQmlVbfVeOuBRrwdtaehRrWiL1JoVs9CPIQ1
 go.opentelemetry.io/otel/trace v1.19.0/go.mod h1:mfaSyvGyEJEI0nyV2I4qhNQnbBOUUmYZpYojqMnX2vo=
 go.opentelemetry.io/proto/otlp v1.0.0 h1:T0TX0tmXU8a3CbNXzEKGeU5mIVOdf0oykP+u2lIVU/I=
 go.opentelemetry.io/proto/otlp v1.0.0/go.mod h1:Sy6pihPLfYHkr3NkUbEhGHFhINUSI/v80hjKIs5JXpM=
-go.temporal.io/api v1.26.1 h1:YqGQsOr/Tx4nVdA8wCv74AxesaIzCRHWb3KkHrYqI8k=
-go.temporal.io/api v1.26.1/go.mod h1:Y/rALXTprFO+bvAlAfLFoJj7KpQIcL4GDQVN6fhYIa4=
+go.temporal.io/api v1.26.2-0.20231129165614-630d88440548 h1:9CV7l/WG7Nd4Ai8mSIUlCvf0W+Mdra5ei38I860Esac=
+go.temporal.io/api v1.26.2-0.20231129165614-630d88440548/go.mod h1:Y/rALXTprFO+bvAlAfLFoJj7KpQIcL4GDQVN6fhYIa4=
 go.temporal.io/sdk v1.25.2-0.20231129171107-288a04f72145 h1:aV7tRpzB3tr9LGs4/SN7MSWSbVx+bgDYfOoGMjk4oEM=
 go.temporal.io/sdk v1.25.2-0.20231129171107-288a04f72145/go.mod h1:MHw8PEOVmOJC1yduTVxYq1GsM5kkQg0sIwRST7cRHoo=
 go.temporal.io/version v0.3.0 h1:dMrei9l9NyHt8nG6EB8vAwDLLTwx2SvRyucCSumAiig=

--- a/service/history/api/describeworkflow/api.go
+++ b/service/history/api/describeworkflow/api.go
@@ -97,20 +97,6 @@ func Invoke(
 	executionInfo := mutableState.GetExecutionInfo()
 	executionState := mutableState.GetExecutionState()
 
-	resetPoints := &workflowpb.ResetPoints{
-		Points: make([]*workflowpb.ResetPointInfo, len(executionInfo.AutoResetPoints.GetPoints())),
-	}
-	for i, p := range executionInfo.AutoResetPoints.GetPoints() {
-		resetPoints.Points[i] = &workflowpb.ResetPointInfo{
-			BinaryChecksum:               p.BinaryChecksum,
-			RunId:                        p.RunId,
-			FirstWorkflowTaskCompletedId: p.FirstWorkflowTaskCompletedId,
-			CreateTime:                   p.CreateTime,
-			ExpireTime:                   p.ExpireTime,
-			Resettable:                   p.Resettable,
-		}
-	}
-
 	result := &historyservice.DescribeWorkflowExecutionResponse{
 		ExecutionConfig: &workflowpb.WorkflowExecutionConfig{
 			TaskQueue: &taskqueuepb.TaskQueue{
@@ -132,7 +118,7 @@ func Invoke(
 			HistoryLength: mutableState.GetNextEventID() - common.FirstEventID,
 			ExecutionTime: executionInfo.ExecutionTime,
 			// Memo and SearchAttributes are set below
-			AutoResetPoints:      resetPoints,
+			AutoResetPoints:      common.CloneProto(executionInfo.AutoResetPoints),
 			TaskQueue:            executionInfo.TaskQueue,
 			StateTransitionCount: executionInfo.StateTransitionCount,
 			HistorySizeBytes:     executionInfo.GetExecutionStats().GetHistorySize(),

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -41,6 +41,7 @@ import (
 	updatepb "go.temporal.io/api/update/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
 	"go.temporal.io/api/workflowservice/v1"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -68,6 +69,7 @@ import (
 	"go.temporal.io/server/common/persistence/versionhistory"
 	"go.temporal.io/server/common/primitives/timestamp"
 	"go.temporal.io/server/common/searchattribute"
+	"go.temporal.io/server/common/util"
 	"go.temporal.io/server/common/worker_versioning"
 	"go.temporal.io/server/service/history/configs"
 	"go.temporal.io/server/service/history/consts"
@@ -2039,27 +2041,16 @@ func (ms *MutableStateImpl) GetTransientWorkflowTaskInfo(
 	return ms.workflowTaskManager.GetTransientWorkflowTaskInfo(workflowTask, identity)
 }
 
-// add BinaryCheckSum for the first workflowTaskCompletedID for auto-reset
-func (ms *MutableStateImpl) addBinaryCheckSumIfNotExists(
-	event *historypb.HistoryEvent,
-	maxResetPoints int,
-) error {
-	binChecksum := event.GetWorkflowTaskCompletedEventAttributes().GetBinaryChecksum()
-	if len(binChecksum) == 0 {
-		return nil
-	}
-	if !ms.addResetPointFromCompletion(binChecksum, event.GetEventId(), maxResetPoints) {
-		return nil
-	}
+func (ms *MutableStateImpl) updateBinaryChecksumSearchAttribute() error {
 	exeInfo := ms.executionInfo
 	resetPoints := exeInfo.AutoResetPoints.Points
 	// List of all recent binary checksums associated with the workflow.
-	recentBinaryChecksums := make([]string, len(resetPoints))
-
-	for i, rp := range resetPoints {
-		recentBinaryChecksums[i] = rp.GetBinaryChecksum()
+	recentBinaryChecksums := make([]string, 0, len(resetPoints))
+	for _, rp := range resetPoints {
+		if rp.BinaryChecksum != "" {
+			recentBinaryChecksums = append(recentBinaryChecksums, rp.BinaryChecksum)
+		}
 	}
-
 	checksumsPayload, err := searchattribute.EncodeValue(recentBinaryChecksums, enumspb.INDEXED_VALUE_TYPE_KEYWORD_LIST)
 	if err != nil {
 		return err
@@ -2067,70 +2058,59 @@ func (ms *MutableStateImpl) addBinaryCheckSumIfNotExists(
 	if exeInfo.SearchAttributes == nil {
 		exeInfo.SearchAttributes = make(map[string]*commonpb.Payload, 1)
 	}
+	if proto.Equal(exeInfo.SearchAttributes[searchattribute.BinaryChecksums], checksumsPayload) {
+		return nil // unchanged
+	}
 	exeInfo.SearchAttributes[searchattribute.BinaryChecksums] = checksumsPayload
 	return ms.taskGenerator.GenerateUpsertVisibilityTask()
 }
 
 // Add a reset point for current task completion if needed.
 // Returns true if the reset point was added or false if there was no need or no ability to add.
+// Note that a new reset point is added when the pair <binaryChecksum, buildId> changes.
 func (ms *MutableStateImpl) addResetPointFromCompletion(
 	binaryChecksum string,
+	buildId string,
 	eventID int64,
 	maxResetPoints int,
 ) bool {
-	if maxResetPoints < 1 {
-		// Nothing to do here
-		return false
-	}
-	exeInfo := ms.executionInfo
-	var resetPoints []*workflowpb.ResetPointInfo
-	if exeInfo.AutoResetPoints != nil && exeInfo.AutoResetPoints.Points != nil {
-		resetPoints = ms.executionInfo.AutoResetPoints.Points
-		if len(resetPoints) >= maxResetPoints {
-			// If limit is exceeded, drop the oldest ones.
-			resetPoints = resetPoints[len(resetPoints)-maxResetPoints+1:]
-		}
-	} else {
-		resetPoints = make([]*workflowpb.ResetPointInfo, 0, 1)
-	}
-
+	resetPoints := ms.executionInfo.AutoResetPoints.GetPoints()
 	for _, rp := range resetPoints {
-		if rp.GetBinaryChecksum() == binaryChecksum {
+		if rp.GetBinaryChecksum() == binaryChecksum && rp.GetBuildId() == buildId {
 			return false
 		}
 	}
 
-	info := &workflowpb.ResetPointInfo{
+	newPoint := &workflowpb.ResetPointInfo{
 		BinaryChecksum:               binaryChecksum,
+		BuildId:                      buildId,
 		RunId:                        ms.executionState.GetRunId(),
 		FirstWorkflowTaskCompletedId: eventID,
 		CreateTime:                   timestamppb.New(ms.timeSource.Now()),
 		Resettable:                   ms.CheckResettable() == nil,
 	}
-	exeInfo.AutoResetPoints = &workflowpb.ResetPoints{
-		Points: append(resetPoints, info),
+	ms.executionInfo.AutoResetPoints = &workflowpb.ResetPoints{
+		Points: util.SliceTail(append(resetPoints, newPoint), maxResetPoints),
 	}
 	return true
 }
 
-// Similar to (the to-be-deprecated) addBinaryCheckSumIfNotExists but works on build IDs.
-func (ms *MutableStateImpl) trackBuildIdFromCompletion(
+func (ms *MutableStateImpl) updateBuildIdsSearchAttribute(
 	version *commonpb.WorkerVersionStamp,
 	eventID int64,
-	limits WorkflowTaskCompletionLimits,
+	maxSearchAttributeValueSize int,
 ) error {
 	var toAdd []string
 	if !version.GetUseVersioning() {
 		toAdd = append(toAdd, worker_versioning.UnversionedSearchAttribute)
 	}
 	if version.GetBuildId() != "" {
-		ms.addResetPointFromCompletion(version.GetBuildId(), eventID, limits.MaxResetPoints)
 		toAdd = append(toAdd, worker_versioning.VersionStampToBuildIdSearchAttribute(version))
 	}
 	if len(toAdd) == 0 {
 		return nil
 	}
-	if changed, err := ms.addBuildIdsWithNoVisibilityTask(toAdd, limits.MaxSearchAttributeValueSize); err != nil {
+	if changed, err := ms.addBuildIdsWithNoVisibilityTask(toAdd, maxSearchAttributeValueSize); err != nil {
 		return err
 	} else if !changed {
 		return nil
@@ -3770,24 +3750,26 @@ func (ms *MutableStateImpl) AddContinueAsNewEvent(
 func rolloverAutoResetPointsWithExpiringTime(
 	resetPoints *workflowpb.ResetPoints,
 	prevRunID string,
-	now time.Time,
+	newExecutionStartTime time.Time,
 	namespaceRetention time.Duration,
 ) *workflowpb.ResetPoints {
-
-	if resetPoints == nil || resetPoints.Points == nil {
+	if resetPoints.GetPoints() == nil {
 		return resetPoints
 	}
 	newPoints := make([]*workflowpb.ResetPointInfo, 0, len(resetPoints.Points))
-	expireTime := now.Add(namespaceRetention)
+	// For continue-as-new, new execution start time is the same as previous execution close time,
+	// so reset points from the previous run will expire at new execution start time plus retention.
+	expireTime := newExecutionStartTime.Add(namespaceRetention)
 	for _, rp := range resetPoints.Points {
+		if rp.ExpireTime != nil && rp.ExpireTime.AsTime().Before(newExecutionStartTime) {
+			continue // run is expired, don't preserve it
+		}
 		if rp.GetRunId() == prevRunID {
 			rp.ExpireTime = timestamppb.New(expireTime)
 		}
 		newPoints = append(newPoints, rp)
 	}
-	return &workflowpb.ResetPoints{
-		Points: newPoints,
-	}
+	return &workflowpb.ResetPoints{Points: newPoints}
 }
 
 func (ms *MutableStateImpl) ReplicateWorkflowExecutionContinuedAsNewEvent(

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -920,10 +920,13 @@ func (m *workflowTaskStateMachine) afterAddWorkflowTaskCompletedEvent(
 	if err := m.ms.updateBuildIdsSearchAttribute(attrs.GetWorkerVersion(), event.GetEventId(), limits.MaxSearchAttributeValueSize); err != nil {
 		return err
 	}
-	if !addedResetPoint {
-		return nil
+	if addedResetPoint && len(attrs.GetBinaryChecksum()) > 0 {
+		if err := m.ms.updateBinaryChecksumSearchAttribute(); err != nil {
+			return err
+		}
 	}
-	return m.ms.updateBinaryChecksumSearchAttribute()
+	return nil
+
 }
 
 func (m *workflowTaskStateMachine) emitWorkflowTaskAttemptStats(

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -303,7 +303,9 @@ func (s *UserDataReplicationTestSuite) TestUserDataTombstonesAreReplicated() {
 		ID:                 workflowID,
 		TaskQueue:          build_ids.BuildIdScavengerTaskQueueName,
 		WorkflowRunTimeout: time.Second * 30,
-	}, build_ids.BuildIdScavangerWorkflowName)
+	}, build_ids.BuildIdScavangerWorkflowName, build_ids.BuildIdScavangerInput{
+		IgnoreRetentionTime: true,
+	})
 	s.NoError(err)
 	err = run.Get(ctx, nil)
 	s.NoError(err)


### PR DESCRIPTION
## What changed?
Add build id to reset points

## Why?
To enable reset by build id in batch reset (maybe later individual workflow reset)

## How did you test it?
New unit tests
