### PR TITLE
Mutable state approximate size should not change if we do not retry the activity

### DIFF
--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -4245,8 +4245,9 @@ func (ms *MutableStateImpl) RetryActivity(
 		return enumspb.RETRY_STATE_CANCEL_REQUESTED, nil
 	}
 
+	originalSize := 0
 	if prev, ok := ms.pendingActivityInfoIDs[ai.ScheduledEventId]; ok {
-		ms.approximateSize -= prev.Size()
+		originalSize = prev.Size()
 	}
 
 	now := ms.timeSource.Now()
@@ -4285,7 +4286,7 @@ func (ms *MutableStateImpl) RetryActivity(
 
 	ms.updateActivityInfos[ai.ScheduledEventId] = ai
 	ms.syncActivityTasks[ai.ScheduledEventId] = struct{}{}
-	ms.approximateSize += ai.Size()
+	ms.approximateSize += ai.Size() - originalSize
 	return enumspb.RETRY_STATE_IN_PROGRESS, nil
 }
 


### PR DESCRIPTION
## What changed?
Keep approximate size of mutable state when activity cannot be restarted because of deadline exceeded or other error by nextBackoffInterval 

## Why?
It is wrong behavior, the mutable state size was reduced before activity replaced

## How did you test it?
unit tests

## Potential risks
not sure what persistence was doing with the wrong size

## Is hotfix candidate?
No
