### PR TITLE
Validate history task by shard clock

### DIFF
--- a/service/history/ndc_task_util.go
+++ b/service/history/ndc_task_util.go
@@ -207,7 +207,7 @@ func validateTaskByClock(
 	if err != nil {
 		return err
 	}
-	if result > 0 {
+	if result >= 0 {
 		shardContext.UnloadForOwnershipLost()
 		return &persistence.ShardOwnershipLostError{
 			ShardID: shardID,

--- a/service/history/ndc_task_util.go
+++ b/service/history/ndc_task_util.go
@@ -26,6 +26,7 @@ package history
 
 import (
 	"context"
+	"fmt"
 
 	enumspb "go.temporal.io/api/enums/v1"
 	"go.temporal.io/api/serviceerror"
@@ -36,9 +37,11 @@ import (
 	"go.temporal.io/server/common/log/tag"
 	"go.temporal.io/server/common/metrics"
 	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/history/vclock"
 	"go.temporal.io/server/service/history/workflow"
 )
 
@@ -146,10 +149,22 @@ func LoadMutableStateForTask(
 	logger log.Logger,
 ) (workflow.MutableState, error) {
 
+	if err := validateTaskByClock(shardContext, task); err != nil {
+		return nil, err
+	}
+
 	mutableState, err := wfContext.LoadMutableState(ctx, shardContext)
 	if err != nil {
 		return nil, err
 	}
+
+	// TODO: With validateTaskByClock check above, we should never run into the situation where
+	// mutable state cache is stale. This is based on the assumption that shard context
+	// will never re-acquire the shard after it has been stolen.
+	// We should monitor the StaleMutableStateCounter metric and remove the logic below once we are confident.
+
+	// Validation based on eventID is not good enough as certain operation does not generate events.
+	// For example, scheduling transient workflow task, or starting activities that have retry policy.
 
 	// check to see if cache needs to be refreshed as we could potentially have stale workflow execution
 	// the exception is workflow task consistently fail
@@ -175,6 +190,32 @@ func LoadMutableStateForTask(
 		return nil, nil
 	}
 	return mutableState, nil
+}
+
+func validateTaskByClock(
+	shardContext shard.Context,
+	task tasks.Task,
+) error {
+	shardID := shardContext.GetShardID()
+	taskClock := vclock.NewVectorClock(
+		shardContext.GetClusterMetadata().GetClusterID(),
+		shardContext.GetShardID(),
+		task.GetTaskID(),
+	)
+	currentClock := shardContext.CurrentVectorClock()
+	result, err := vclock.Compare(taskClock, currentClock)
+	if err != nil {
+		return err
+	}
+	if result > 0 {
+		shardContext.UnloadForOwnershipLost()
+		return &persistence.ShardOwnershipLostError{
+			ShardID: shardID,
+			Msg:     fmt.Sprintf("Shard: %v task clock validation failed, reloading", shardID),
+		}
+	}
+
+	return nil
 }
 
 func getTransferTaskEventIDAndRetryable(

--- a/service/history/timer_queue_task_executor_base_test.go
+++ b/service/history/timer_queue_task_executor_base_test.go
@@ -91,6 +91,7 @@ func (s *timerQueueTaskExecutorBaseSuite) SetupTest() {
 		config,
 	)
 	s.testShardContext.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.testShardContext.Resource.ClusterMetadata.EXPECT().GetClusterID().Return(cluster.TestCurrentClusterInitialFailoverVersion).AnyTimes()
 
 	s.timerQueueTaskExecutorBase = newTimerQueueTaskExecutorBase(
 		s.testShardContext,

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -2457,7 +2457,12 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 
 			mockClusterMetadata := cluster.NewMockMetadata(ctrl)
 			mockClusterMetadata.EXPECT().IsGlobalNamespaceEnabled().Return(false).AnyTimes()
+			mockClusterMetadata.EXPECT().GetClusterID().Return(cluster.TestCurrentClusterInitialFailoverVersion).AnyTimes()
 
+			mockShard.EXPECT().GetShardID().Return(int32(1)).AnyTimes()
+			mockShard.EXPECT().CurrentVectorClock().Return(
+				vclock.NewVectorClock(mockClusterMetadata.GetClusterID(), mockShard.GetShardID(), deleteExecutionTaskId),
+			).Times(1)
 			mockShard.EXPECT().GetConfig().Return(&configs.Config{
 				TransferProcessorEnsureCloseBeforeDelete: func() bool {
 					return c.EnsureCloseBeforeDelete

--- a/service/history/transfer_queue_active_task_executor_test.go
+++ b/service/history/transfer_queue_active_task_executor_test.go
@@ -2461,7 +2461,7 @@ func (s *transferQueueActiveTaskExecutorSuite) TestPendingCloseExecutionTasks() 
 
 			mockShard.EXPECT().GetShardID().Return(int32(1)).AnyTimes()
 			mockShard.EXPECT().CurrentVectorClock().Return(
-				vclock.NewVectorClock(mockClusterMetadata.GetClusterID(), mockShard.GetShardID(), deleteExecutionTaskId),
+				vclock.NewVectorClock(mockClusterMetadata.GetClusterID(), mockShard.GetShardID(), deleteExecutionTaskId+1),
 			).Times(1)
 			mockShard.EXPECT().GetConfig().Return(&configs.Config{
 				TransferProcessorEnsureCloseBeforeDelete: func() bool {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Validate history task by shard clock

## Why?
<!-- Tell your future self why have you made these changes -->
- Validation based on eventID is not good enough as certain operation does not generate events.
- E.g activity heartbeat timer will not be processed if a stale mutable state has no idea that the activity is started. Check based on eventID don't be able to catch this since there's no new event when starting the activity.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit test

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
- More shard movement.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
- Could be.