### PR TITLE
Fix default persistence request priority

### DIFF
--- a/common/persistence/client/quotas.go
+++ b/common/persistence/client/quotas.go
@@ -245,8 +245,8 @@ func RequestPriorityFn(req quotas.Request) int {
 	case headers.CallerTypePreemptable:
 		return CallerTypeDefaultPriority[req.CallerType]
 	default:
-		// default requests to high priority to be consistent with existing behavior
-		return RequestPrioritiesOrdered[0]
+		// default requests to API priority to be consistent with existing behavior
+		return CallerTypeDefaultPriority[headers.CallerTypeAPI]
 	}
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
-  Use API priority as the default persistence priority

## Why?
<!-- Tell your future self why have you made these changes -->
- highest priority used to be API but is now "Operator". And operator level will use 0.2 * specified rate as the limit.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
