### PR TITLE
Modify default histogram boundaries to align with the limit sizes

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -236,6 +236,9 @@ var (
 			10_000,
 			20_000,
 			50_000,
+			// 51_200 : the default value of limit.historyCount.error.
+			// So that we can see the error rate in the prometheus and alert on it without any config change.
+			51_200,
 			100_000,
 		},
 		Milliseconds: {
@@ -275,6 +278,9 @@ var (
 			4194304,
 			8388608,
 			16777216,
+			// 50MB : the default value of limit.historySize.error.
+			// So that we can see the error rate in the prometheus and alert on it without any config change.
+			52428800,
 		},
 	}
 )


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Modify default histogram boundaries to align with the limit sizes.
## Why?
<!-- Tell your future self why have you made these changes -->
For now, the default bucket sizes of some metrics did not align with the default limit sizes. Such as the default threshold of history_size_error is 50MB but the default max bucket sizes is 16MB. We can see the error rate in the prometheus and alert on it without any config change.
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Tested locally.
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
