### PR TITLE
Make Schedule backfill start inclusive

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -202,8 +202,8 @@ var (
 		MaxBufferSize:                     1000,
 		AllowZeroSleep:                    true,
 		ReuseTimer:                        true,
-		NextTimeCacheV2Size:               14, // see note below
-		Version:                           InclusiveBackfillStartTime,
+		NextTimeCacheV2Size:               14,                   // see note below
+		Version:                           DontTrackOverlapping, // TODO: upgrade to InclusiveBackfillStartTime
 	}
 
 	// Note on NextTimeCacheV2Size: This value must be > FutureActionCountForList. Each

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"go.temporal.io/api/workflowservice/v1"
 	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -40,6 +39,7 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	schedpb "go.temporal.io/api/schedule/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
+	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	sdklog "go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/temporal"

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"go.temporal.io/api/workflowservice/v1"
 	"golang.org/x/exp/slices"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -39,7 +40,6 @@ import (
 	enumspb "go.temporal.io/api/enums/v1"
 	schedpb "go.temporal.io/api/schedule/v1"
 	workflowpb "go.temporal.io/api/workflow/v1"
-	"go.temporal.io/api/workflowservice/v1"
 	sdkclient "go.temporal.io/sdk/client"
 	sdklog "go.temporal.io/sdk/log"
 	"go.temporal.io/sdk/temporal"
@@ -70,6 +70,8 @@ const (
 	// Don't put possibly-overlapping runs (from SCHEDULE_OVERLAP_POLICY_ALLOW_ALL) in
 	// RunningWorkflows.
 	DontTrackOverlapping = 3
+	// start time in backfill is inclusive rather than exclusive
+	InclusiveBackfillStartTime = 4
 )
 
 const (
@@ -201,7 +203,7 @@ var (
 		AllowZeroSleep:                    true,
 		ReuseTimer:                        true,
 		NextTimeCacheV2Size:               14, // see note below
-		Version:                           DontTrackOverlapping,
+		Version:                           InclusiveBackfillStartTime,
 	}
 
 	// Note on NextTimeCacheV2Size: This value must be > FutureActionCountForList. Each
@@ -389,8 +391,17 @@ func (s *scheduler) processPatch(patch *schedpb.SchedulePatch) {
 	}
 
 	for _, bfr := range patch.BackfillRequest {
+		startTime := timestamp.TimeValue(bfr.GetStartTime())
+
+		// In previous versions the backfill start time was exclusive, ie when
+		// the start time of the backfill matched the schedule's spec, it would
+		// not be executed. This new version makes it inclusive instead.
+		if s.hasMinVersion(InclusiveBackfillStartTime) {
+			startTime = startTime.Add(-1 * time.Second)
+		}
+
 		s.processTimeRange(
-			timestamp.TimeValue(bfr.GetStartTime()),
+			startTime,
 			timestamp.TimeValue(bfr.GetEndTime()),
 			bfr.GetOverlapPolicy(),
 			true,

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1178,6 +1178,10 @@ func (s *workflowSuite) TestTriggerImmediate() {
 }
 
 func (s *workflowSuite) TestBackfill() {
+	if currentTweakablePolicies.Version != InclusiveBackfillStartTime {
+		s.T().Skip()
+	}
+
 	s.runAcrossContinue(
 		[]workflowRun{
 			{

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1245,6 +1245,57 @@ func (s *workflowSuite) TestBackfill() {
 	)
 }
 
+func (s *workflowSuite) TestBackfillInclusiveStartEnd() {
+	s.runAcrossContinue(
+		[]workflowRun{
+			// if start and end time were not inclusive, this backfill run would not exist
+			{
+				id:     "myid-2022-05-31T19:17:00Z",
+				start:  time.Date(2022, 6, 1, 0, 5, 0, 0, time.UTC),
+				end:    time.Date(2022, 6, 1, 0, 9, 0, 0, time.UTC),
+				result: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+			// this is the scheduled one
+			{
+				id:     "myid-2022-07-31T19:00:00Z",
+				start:  time.Date(2022, 7, 31, 19, 0, 0, 0, time.UTC),
+				end:    time.Date(2022, 7, 31, 19, 5, 0, 0, time.UTC),
+				result: enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED,
+			},
+		},
+		[]delayedCallback{
+			{
+				at: time.Date(2022, 6, 1, 0, 5, 0, 0, time.UTC),
+				f: func() {
+					s.env.SignalWorkflow(SignalNamePatch, &schedpb.SchedulePatch{
+						BackfillRequest: []*schedpb.BackfillRequest{{
+							StartTime:     timestamppb.New(time.Date(2022, 5, 31, 19, 17, 0, 0, time.UTC)),
+							EndTime:       timestamppb.New(time.Date(2022, 5, 31, 19, 17, 0, 0, time.UTC)),
+							OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
+						}},
+					})
+				},
+			},
+			{
+				at:         time.Date(2022, 7, 31, 19, 6, 0, 0, time.UTC),
+				finishTest: true,
+			},
+		},
+		&schedpb.Schedule{
+			Spec: &schedpb.ScheduleSpec{
+				Calendar: []*schedpb.CalendarSpec{{
+					Minute:     "*/17",
+					Hour:       "19",
+					DayOfMonth: "31",
+				}},
+			},
+			Policies: &schedpb.SchedulePolicies{
+				OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_SKIP,
+			},
+		},
+	)
+}
+
 func (s *workflowSuite) TestPause() {
 	s.runAcrossContinue(
 		[]workflowRun{

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1246,6 +1246,8 @@ func (s *workflowSuite) TestBackfill() {
 }
 
 func (s *workflowSuite) TestBackfillInclusiveStartEnd() {
+	backfillTime := timestamppb.New(time.Date(2022, 5, 31, 19, 17, 0, 0, time.UTC))
+
 	s.runAcrossContinue(
 		[]workflowRun{
 			// if start and end time were not inclusive, this backfill run would not exist
@@ -1269,8 +1271,8 @@ func (s *workflowSuite) TestBackfillInclusiveStartEnd() {
 				f: func() {
 					s.env.SignalWorkflow(SignalNamePatch, &schedpb.SchedulePatch{
 						BackfillRequest: []*schedpb.BackfillRequest{{
-							StartTime:     timestamppb.New(time.Date(2022, 5, 31, 19, 17, 0, 0, time.UTC)),
-							EndTime:       timestamppb.New(time.Date(2022, 5, 31, 19, 17, 0, 0, time.UTC)),
+							StartTime:     backfillTime,
+							EndTime:       backfillTime,
 							OverlapPolicy: enumspb.SCHEDULE_OVERLAP_POLICY_BUFFER_ALL,
 						}},
 					})

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1178,10 +1178,6 @@ func (s *workflowSuite) TestTriggerImmediate() {
 }
 
 func (s *workflowSuite) TestBackfill() {
-	if currentTweakablePolicies.Version != InclusiveBackfillStartTime {
-		s.T().Skip()
-	}
-
 	s.runAcrossContinue(
 		[]workflowRun{
 			{
@@ -1250,6 +1246,11 @@ func (s *workflowSuite) TestBackfill() {
 }
 
 func (s *workflowSuite) TestBackfillInclusiveStartEnd() {
+	// TODO: remove once default version is InclusiveBackfillStartTime
+	currentVersion := currentTweakablePolicies.Version
+	currentTweakablePolicies.Version = InclusiveBackfillStartTime
+	defer func() { currentTweakablePolicies.Version = currentVersion }()
+
 	backfillTime := timestamppb.New(time.Date(2022, 5, 31, 19, 17, 0, 0, time.UTC))
 
 	s.runAcrossContinue(


### PR DESCRIPTION
## What changed?

Currently Schedule backfill start time is exclusive, this makes change makes it inclusive.

## Why?

Exclusive schedule backfill start time is confusing. 

## How did you test it?

Added a new test.

## Potential risks

Break existing developer's assumptions. To mitigate that, a new Workflow version has been introduced. Furthermore, the documentation will be updated.

## Is hotfix candidate?

No