### PR TITLE
Always set RPS on dynamic rate limiter refresh

### DIFF
--- a/common/persistence/client/health_request_rate_limiter.go
+++ b/common/persistence/client/health_request_rate_limiter.go
@@ -152,18 +152,17 @@ func (rl *HealthRequestRateLimiterImpl) refreshRate() {
 	if rl.latencyThresholdExceeded() || rl.errorThresholdExceeded() {
 		// limit exceeded, do backoff
 		rl.curRateMultiplier = math.Max(rl.curOptions.RateMultiMin, rl.curRateMultiplier-rl.curOptions.RateBackoffStepSize)
-		rl.rateLimiter.SetRPS(rl.curRateMultiplier * rl.rateFn())
-		rl.rateLimiter.SetBurst(int(rl.rateToBurstRatio * rl.rateFn()))
 		rl.metricsHandler.Gauge(metrics.DynamicRateLimiterMultiplier.GetMetricName()).Record(rl.curRateMultiplier)
 		rl.logger.Info("Health threshold exceeded, reducing rate limit.", tag.NewFloat64("newMulti", rl.curRateMultiplier), tag.NewFloat64("newRate", rl.rateLimiter.Rate()), tag.NewFloat64("latencyAvg", rl.healthSignals.AverageLatency()), tag.NewFloat64("errorRatio", rl.healthSignals.ErrorRatio()))
 	} else if rl.curRateMultiplier < rl.curOptions.RateMultiMax {
 		// already doing backoff and under thresholds, increase limit
 		rl.curRateMultiplier = math.Min(rl.curOptions.RateMultiMax, rl.curRateMultiplier+rl.curOptions.RateIncreaseStepSize)
-		rl.rateLimiter.SetRPS(rl.curRateMultiplier * rl.rateFn())
-		rl.rateLimiter.SetBurst(int(rl.rateToBurstRatio * rl.rateFn()))
 		rl.metricsHandler.Gauge(metrics.DynamicRateLimiterMultiplier.GetMetricName()).Record(rl.curRateMultiplier)
 		rl.logger.Info("System healthy, increasing rate limit.", tag.NewFloat64("newMulti", rl.curRateMultiplier), tag.NewFloat64("newRate", rl.rateLimiter.Rate()), tag.NewFloat64("latencyAvg", rl.healthSignals.AverageLatency()), tag.NewFloat64("errorRatio", rl.healthSignals.ErrorRatio()))
 	}
+	// Always set rate to pickup changes to underlying rate limit dynamic config
+	rl.rateLimiter.SetRPS(rl.curRateMultiplier * rl.rateFn())
+	rl.rateLimiter.SetBurst(int(rl.rateToBurstRatio * rl.rateFn()))
 }
 
 func (rl *HealthRequestRateLimiterImpl) refreshDynamicParams() {


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Always set the RPS of the dynamic rate limiter when it is refreshed

## Why?
<!-- Tell your future self why have you made these changes -->
Previously it would only apply changes made to `rateFn` when the dynamic multiplier should be adjusted. The rate function should always be checked to pick up any changes to the maximum RPS dynamic config.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Existing tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Extra rate limiting

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
