### PR TITLE
Rename metricDefinition getters to follow Go's guidelines

### DIFF
--- a/client/admin/metric_client.go
+++ b/client/admin/metric_client.go
@@ -65,7 +65,7 @@ func (c *metricClient) startMetricsRecording(
 ) (metrics.Handler, time.Time) {
 	caller := headers.GetCallerInfo(ctx).CallerName
 	metricsHandler := c.metricsHandler.WithTags(metrics.OperationTag(operation), metrics.NamespaceTag(caller), metrics.ServiceRoleTag(metrics.AdminRoleTagValue))
-	metricsHandler.Counter(metrics.ClientRequests.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.ClientRequests.Name()).Record(1)
 	return metricsHandler, time.Now().UTC()
 }
 
@@ -87,9 +87,9 @@ func (c *metricClient) finishMetricsRecording(
 		default:
 			c.throttledLogger.Info("admin client encountered error", tag.Error(err), tag.ErrorType(err))
 		}
-		metricsHandler.Counter(metrics.ClientFailures.GetMetricName()).Record(1, metrics.ServiceErrorTypeTag(err))
+		metricsHandler.Counter(metrics.ClientFailures.Name()).Record(1, metrics.ServiceErrorTypeTag(err))
 	}
-	metricsHandler.Timer(metrics.ClientLatency.GetMetricName()).Record(time.Since(startTime))
+	metricsHandler.Timer(metrics.ClientLatency.Name()).Record(time.Since(startTime))
 }
 
 func (c *metricClient) StreamWorkflowReplicationMessages(

--- a/client/frontend/metric_client.go
+++ b/client/frontend/metric_client.go
@@ -64,7 +64,7 @@ func (c *metricClient) startMetricsRecording(
 ) (metrics.Handler, time.Time) {
 	caller := headers.GetCallerInfo(ctx).CallerName
 	handler := c.metricsHandler.WithTags(metrics.OperationTag(operation), metrics.NamespaceTag(caller), metrics.ServiceRoleTag(metrics.FrontendRoleTagValue))
-	handler.Counter(metrics.ClientRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.ClientRequests.Name()).Record(1)
 	return handler, time.Now().UTC()
 }
 
@@ -86,7 +86,7 @@ func (c *metricClient) finishMetricsRecording(
 		default:
 			c.throttledLogger.Info("frontend client encountered error", tag.Error(err), tag.ErrorType(err))
 		}
-		handler.Counter(metrics.ClientFailures.GetMetricName()).Record(1, metrics.ServiceErrorTypeTag(err))
+		handler.Counter(metrics.ClientFailures.Name()).Record(1, metrics.ServiceErrorTypeTag(err))
 	}
-	handler.Timer(metrics.ClientLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.ClientLatency.Name()).Record(time.Since(startTime))
 }

--- a/client/history/metric_client.go
+++ b/client/history/metric_client.go
@@ -81,7 +81,7 @@ func (c *metricClient) startMetricsRecording(
 ) (metrics.Handler, time.Time) {
 	caller := headers.GetCallerInfo(ctx).CallerName
 	metricsHandler := c.metricsHandler.WithTags(metrics.OperationTag(operation), metrics.NamespaceTag(caller), metrics.ServiceRoleTag(metrics.HistoryRoleTagValue))
-	metricsHandler.Counter(metrics.ClientRequests.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.ClientRequests.Name()).Record(1)
 	return metricsHandler, time.Now().UTC()
 }
 
@@ -103,7 +103,7 @@ func (c *metricClient) finishMetricsRecording(
 		default:
 			c.throttledLogger.Info("history client encountered error", tag.Error(err), tag.ErrorType(err))
 		}
-		metricsHandler.Counter(metrics.ClientFailures.GetMetricName()).Record(1, metrics.ServiceErrorTypeTag(err))
+		metricsHandler.Counter(metrics.ClientFailures.Name()).Record(1, metrics.ServiceErrorTypeTag(err))
 	}
-	metricsHandler.Timer(metrics.ClientLatency.GetMetricName()).Record(time.Since(startTime))
+	metricsHandler.Timer(metrics.ClientLatency.Name()).Record(time.Since(startTime))
 }

--- a/client/matching/metric_client.go
+++ b/client/matching/metric_client.go
@@ -180,11 +180,11 @@ func (c *metricClient) emitForwardedSourceStats(
 
 	switch {
 	case forwardedFrom != "":
-		metricsHandler.Counter(metrics.MatchingClientForwardedCounter.GetMetricName()).Record(1)
+		metricsHandler.Counter(metrics.MatchingClientForwardedCounter.Name()).Record(1)
 	default:
 		_, err := tqname.FromBaseName(taskQueue.GetName())
 		if err != nil {
-			metricsHandler.Counter(metrics.MatchingClientInvalidTaskQueueName.GetMetricName()).Record(1)
+			metricsHandler.Counter(metrics.MatchingClientInvalidTaskQueueName.Name()).Record(1)
 		}
 	}
 }
@@ -195,7 +195,7 @@ func (c *metricClient) startMetricsRecording(
 ) (metrics.Handler, time.Time) {
 	caller := headers.GetCallerInfo(ctx).CallerName
 	handler := c.metricsHandler.WithTags(metrics.OperationTag(operation), metrics.NamespaceTag(caller), metrics.ServiceRoleTag(metrics.MatchingRoleTagValue))
-	handler.Counter(metrics.ClientRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.ClientRequests.Name()).Record(1)
 	return handler, time.Now().UTC()
 }
 
@@ -218,7 +218,7 @@ func (c *metricClient) finishMetricsRecording(
 		default:
 			c.throttledLogger.Info("matching client encountered error", tag.Error(err), tag.ErrorType(err))
 		}
-		metricsHandler.Counter(metrics.ClientFailures.GetMetricName()).Record(1, metrics.ServiceErrorTypeTag(err))
+		metricsHandler.Counter(metrics.ClientFailures.Name()).Record(1, metrics.ServiceErrorTypeTag(err))
 	}
-	metricsHandler.Timer(metrics.ClientLatency.GetMetricName()).Record(time.Since(startTime))
+	metricsHandler.Timer(metrics.ClientLatency.Name()).Record(time.Since(startTime))
 }

--- a/common/archiver/gcloud/history_archiver.go
+++ b/common/archiver/gcloud/history_archiver.go
@@ -111,15 +111,15 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
 	startTime := time.Now().UTC()
 	defer func() {
-		handler.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime))
+		handler.Timer(metrics.ServiceLatency.Name()).Record(time.Since(startTime))
 		if err != nil {
 
 			if err.Error() != errUploadNonRetryable.Error() {
-				handler.Counter(metrics.HistoryArchiverArchiveTransientErrorCount.GetMetricName()).Record(1)
+				handler.Counter(metrics.HistoryArchiverArchiveTransientErrorCount.Name()).Record(1)
 				return
 			}
 
-			handler.Counter(metrics.HistoryArchiverArchiveNonRetryableErrorCount.GetMetricName()).Record(1)
+			handler.Counter(metrics.HistoryArchiverArchiveNonRetryableErrorCount.Name()).Record(1)
 			if featureCatalog.NonRetryableError != nil {
 				err = featureCatalog.NonRetryableError()
 			}
@@ -157,7 +157,7 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 				// this may happen even in the middle of iterating history as two archival signals
 				// can be processed concurrently.
 				logger.Info(archiver.ArchiveSkippedInfoMsg)
-				handler.Counter(metrics.HistoryArchiverDuplicateArchivalsCount.GetMetricName()).Record(1)
+				handler.Counter(metrics.HistoryArchiverDuplicateArchivalsCount.Name()).Record(1)
 				return nil
 			}
 
@@ -185,7 +185,7 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 		if exist, _ := h.gcloudStorage.Exist(ctx, URI, filename); !exist {
 			if err := h.gcloudStorage.Upload(ctx, URI, filename, encodedHistoryPart); err != nil {
 				logger.Error(archiver.ArchiveTransientErrorMsg, tag.ArchivalArchiveFailReason(errWriteFile), tag.Error(err))
-				handler.Counter(metrics.HistoryArchiverArchiveTransientErrorCount.GetMetricName()).Record(1)
+				handler.Counter(metrics.HistoryArchiverArchiveTransientErrorCount.Name()).Record(1)
 				return err
 			}
 
@@ -197,9 +197,9 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 		}
 	}
 
-	handler.Counter(metrics.HistoryArchiverTotalUploadSize.GetMetricName()).Record(totalUploadSize)
-	handler.Counter(metrics.HistoryArchiverHistorySize.GetMetricName()).Record(totalUploadSize)
-	handler.Counter(metrics.HistoryArchiverArchiveSuccessCount.GetMetricName()).Record(1)
+	handler.Counter(metrics.HistoryArchiverTotalUploadSize.Name()).Record(totalUploadSize)
+	handler.Counter(metrics.HistoryArchiverHistorySize.Name()).Record(totalUploadSize)
+	handler.Counter(metrics.HistoryArchiverArchiveSuccessCount.Name()).Record(1)
 	return
 }
 

--- a/common/archiver/gcloud/visibility_archiver.go
+++ b/common/archiver/gcloud/visibility_archiver.go
@@ -97,12 +97,12 @@ func (v *visibilityArchiver) Archive(ctx context.Context, URI archiver.URI, requ
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
 	startTime := time.Now().UTC()
 	defer func() {
-		handler.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime))
+		handler.Timer(metrics.ServiceLatency.Name()).Record(time.Since(startTime))
 		if err != nil {
 			if isRetryableError(err) {
-				handler.Counter(metrics.VisibilityArchiverArchiveTransientErrorCount.GetMetricName()).Record(1)
+				handler.Counter(metrics.VisibilityArchiverArchiveTransientErrorCount.Name()).Record(1)
 			} else {
-				handler.Counter(metrics.VisibilityArchiverArchiveNonRetryableErrorCount.GetMetricName()).Record(1)
+				handler.Counter(metrics.VisibilityArchiverArchiveNonRetryableErrorCount.Name()).Record(1)
 				if featureCatalog.NonRetryableError != nil {
 					err = featureCatalog.NonRetryableError()
 				}
@@ -146,7 +146,7 @@ func (v *visibilityArchiver) Archive(ctx context.Context, URI archiver.URI, requ
 		return errRetryable
 	}
 
-	handler.Counter(metrics.VisibilityArchiveSuccessCount.GetMetricName()).Record(1)
+	handler.Counter(metrics.VisibilityArchiveSuccessCount.Name()).Record(1)
 	return nil
 }
 

--- a/common/archiver/s3store/visibility_archiver.go
+++ b/common/archiver/s3store/visibility_archiver.go
@@ -116,13 +116,13 @@ func (v *visibilityArchiver) Archive(
 	logger := archiver.TagLoggerWithArchiveVisibilityRequestAndURI(v.container.Logger, request, URI.String())
 	archiveFailReason := ""
 	defer func() {
-		handler.Timer(metrics.ServiceLatency.GetMetricName()).Record(time.Since(startTime))
+		handler.Timer(metrics.ServiceLatency.Name()).Record(time.Since(startTime))
 		if err != nil {
 			if isRetryableError(err) {
-				handler.Counter(metrics.VisibilityArchiverArchiveTransientErrorCount.GetMetricName()).Record(1)
+				handler.Counter(metrics.VisibilityArchiverArchiveTransientErrorCount.Name()).Record(1)
 				logger.Error(archiver.ArchiveTransientErrorMsg, tag.ArchivalArchiveFailReason(archiveFailReason), tag.Error(err))
 			} else {
-				handler.Counter(metrics.VisibilityArchiverArchiveNonRetryableErrorCount.GetMetricName()).Record(1)
+				handler.Counter(metrics.VisibilityArchiverArchiveNonRetryableErrorCount.Name()).Record(1)
 				logger.Error(archiver.ArchiveNonRetryableErrorMsg, tag.ArchivalArchiveFailReason(archiveFailReason), tag.Error(err))
 				if featureCatalog.NonRetryableError != nil {
 					err = featureCatalog.NonRetryableError()
@@ -155,7 +155,7 @@ func (v *visibilityArchiver) Archive(
 			return err
 		}
 	}
-	handler.Counter(metrics.VisibilityArchiveSuccessCount.GetMetricName()).Record(1)
+	handler.Counter(metrics.VisibilityArchiveSuccessCount.Name()).Record(1)
 	return nil
 }
 

--- a/common/authorization/interceptor.go
+++ b/common/authorization/interceptor.go
@@ -146,12 +146,12 @@ func (a *interceptor) Interceptor(
 			Request:   req,
 		}, handler)
 		if err != nil {
-			handler.Counter(metrics.ServiceErrAuthorizeFailedCounter.GetMetricName()).Record(1)
+			handler.Counter(metrics.ServiceErrAuthorizeFailedCounter.Name()).Record(1)
 			a.logAuthError(err)
 			return nil, errUnauthorized // return a generic error to the caller without disclosing details
 		}
 		if result.Decision != DecisionAllow {
-			handler.Counter(metrics.ServiceErrUnauthorizedCounter.GetMetricName()).Record(1)
+			handler.Counter(metrics.ServiceErrUnauthorizedCounter.Name()).Record(1)
 			// if a reason is included in the result, include it in the error message
 			if result.Reason != "" {
 				return nil, serviceerror.NewPermissionDenied(RequestUnauthorized, result.Reason)
@@ -169,7 +169,7 @@ func (a *interceptor) authorize(
 	metricsHandler metrics.Handler) (Result, error) {
 	startTime := time.Now().UTC()
 	defer func() {
-		metricsHandler.Timer(metrics.ServiceAuthorizationLatency.GetMetricName()).Record(time.Since(startTime))
+		metricsHandler.Timer(metrics.ServiceAuthorizationLatency.Name()).Record(time.Since(startTime))
 	}()
 	return a.authorizer.Authorize(ctx, claims, callTarget)
 }

--- a/common/authorization/interceptor_test.go
+++ b/common/authorization/interceptor_test.go
@@ -82,7 +82,7 @@ func (s *authorizerInterceptorSuite) SetupTest() {
 	s.mockAuthorizer = NewMockAuthorizer(s.controller)
 	s.mockMetricsHandler = metrics.NewMockHandler(s.controller)
 	s.mockMetricsHandler.EXPECT().WithTags(metrics.OperationTag(metrics.AuthorizationScope)).Return(s.mockMetricsHandler).AnyTimes()
-	s.mockMetricsHandler.EXPECT().Timer(metrics.ServiceAuthorizationLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc).AnyTimes()
+	s.mockMetricsHandler.EXPECT().Timer(metrics.ServiceAuthorizationLatency.Name()).Return(metrics.NoopTimerMetricFunc).AnyTimes()
 	s.mockClaimMapper = NewMockClaimMapper(s.controller)
 	s.interceptor = NewAuthorizationInterceptor(
 		s.mockClaimMapper,
@@ -121,7 +121,7 @@ func (s *authorizerInterceptorSuite) TestIsAuthorizedWithNamespace() {
 func (s *authorizerInterceptorSuite) TestIsUnauthorized() {
 	s.mockAuthorizer.EXPECT().Authorize(ctx, nil, describeNamespaceTarget).
 		Return(Result{Decision: DecisionDeny}, nil)
-	s.mockMetricsHandler.EXPECT().Counter(metrics.ServiceErrUnauthorizedCounter.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	s.mockMetricsHandler.EXPECT().Counter(metrics.ServiceErrUnauthorizedCounter.Name()).Return(metrics.NoopCounterMetricFunc)
 
 	res, err := s.interceptor(ctx, describeNamespaceRequest, describeNamespaceInfo, s.handler)
 	s.Nil(res)
@@ -131,7 +131,7 @@ func (s *authorizerInterceptorSuite) TestIsUnauthorized() {
 func (s *authorizerInterceptorSuite) TestAuthorizationFailed() {
 	s.mockAuthorizer.EXPECT().Authorize(ctx, nil, describeNamespaceTarget).
 		Return(Result{Decision: DecisionDeny}, errUnauthorized)
-	s.mockMetricsHandler.EXPECT().Counter(metrics.ServiceErrAuthorizeFailedCounter.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	s.mockMetricsHandler.EXPECT().Counter(metrics.ServiceErrAuthorizeFailedCounter.Name()).Return(metrics.NoopCounterMetricFunc)
 
 	res, err := s.interceptor(ctx, describeNamespaceRequest, describeNamespaceInfo, s.handler)
 	s.Nil(res)

--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -273,7 +273,7 @@ func (m *metadataImpl) GetPingChecks() []common.PingCheck {
 				m.clusterLock.Unlock()
 				return nil
 			},
-			MetricsName: metrics.DDClusterMetadataLockLatency.GetMetricName(),
+			MetricsName: metrics.DDClusterMetadataLockLatency.Name(),
 		},
 		{
 			Name: "cluster metadata callback lock",
@@ -286,7 +286,7 @@ func (m *metadataImpl) GetPingChecks() []common.PingCheck {
 				m.clusterCallbackLock.Unlock()
 				return nil
 			},
-			MetricsName: metrics.DDClusterMetadataCallbackLockLatency.GetMetricName(),
+			MetricsName: metrics.DDClusterMetadataCallbackLockLatency.Name(),
 		},
 	}
 }

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -45,11 +45,11 @@ const (
 	Bytes         = "By"
 )
 
-func (md metricDefinition) GetMetricName() string {
+func (md metricDefinition) Name() string {
 	return md.name
 }
 
-func (md metricDefinition) GetMetricUnit() MetricUnit {
+func (md metricDefinition) Unit() MetricUnit {
 	return md.unit
 }
 

--- a/common/metrics/panic.go
+++ b/common/metrics/panic.go
@@ -50,7 +50,7 @@ func CapturePanic(logger log.Logger, metricHandler Handler, retError *error) {
 
 		logger.Error("Panic is captured", tag.SysStackTrace(st), tag.Error(err))
 
-		metricHandler.Counter(ServicePanic.GetMetricName()).Record(1)
+		metricHandler.Counter(ServicePanic.Name()).Record(1)
 		*retError = serviceerror.NewInternal(err.Error())
 	}
 }

--- a/common/namespace/registry.go
+++ b/common/namespace/registry.go
@@ -259,7 +259,7 @@ func (r *registry) GetPingChecks() []common.PingCheck {
 				r.cacheLock.Unlock()
 				return nil
 			},
-			MetricsName: metrics.DDNamespaceRegistryLockLatency.GetMetricName(),
+			MetricsName: metrics.DDNamespaceRegistryLockLatency.Name(),
 		},
 	}
 }

--- a/common/persistence/client/health_request_rate_limiter.go
+++ b/common/persistence/client/health_request_rate_limiter.go
@@ -152,12 +152,12 @@ func (rl *HealthRequestRateLimiterImpl) refreshRate() {
 	if rl.latencyThresholdExceeded() || rl.errorThresholdExceeded() {
 		// limit exceeded, do backoff
 		rl.curRateMultiplier = math.Max(rl.curOptions.RateMultiMin, rl.curRateMultiplier-rl.curOptions.RateBackoffStepSize)
-		rl.metricsHandler.Gauge(metrics.DynamicRateLimiterMultiplier.GetMetricName()).Record(rl.curRateMultiplier)
+		rl.metricsHandler.Gauge(metrics.DynamicRateLimiterMultiplier.Name()).Record(rl.curRateMultiplier)
 		rl.logger.Info("Health threshold exceeded, reducing rate limit.", tag.NewFloat64("newMulti", rl.curRateMultiplier), tag.NewFloat64("newRate", rl.rateLimiter.Rate()), tag.NewFloat64("latencyAvg", rl.healthSignals.AverageLatency()), tag.NewFloat64("errorRatio", rl.healthSignals.ErrorRatio()))
 	} else if rl.curRateMultiplier < rl.curOptions.RateMultiMax {
 		// already doing backoff and under thresholds, increase limit
 		rl.curRateMultiplier = math.Min(rl.curOptions.RateMultiMax, rl.curRateMultiplier+rl.curOptions.RateIncreaseStepSize)
-		rl.metricsHandler.Gauge(metrics.DynamicRateLimiterMultiplier.GetMetricName()).Record(rl.curRateMultiplier)
+		rl.metricsHandler.Gauge(metrics.DynamicRateLimiterMultiplier.Name()).Record(rl.curRateMultiplier)
 		rl.logger.Info("System healthy, increasing rate limit.", tag.NewFloat64("newMulti", rl.curRateMultiplier), tag.NewFloat64("newRate", rl.rateLimiter.Rate()), tag.NewFloat64("latencyAvg", rl.healthSignals.AverageLatency()), tag.NewFloat64("errorRatio", rl.healthSignals.ErrorRatio()))
 	}
 	// Always set rate to pickup changes to underlying rate limit dynamic config

--- a/common/persistence/health_signal_aggregator.go
+++ b/common/persistence/health_signal_aggregator.go
@@ -173,7 +173,7 @@ func (s *HealthSignalAggregatorImpl) emitMetricsLoop() {
 				}
 
 				shardRPS := int64(float64(shardRequestCount) / emitMetricsInterval.Seconds())
-				s.metricsHandler.Histogram(metrics.PersistenceShardRPS.GetMetricName(), metrics.PersistenceShardRPS.GetMetricUnit()).Record(shardRPS)
+				s.metricsHandler.Histogram(metrics.PersistenceShardRPS.Name(), metrics.PersistenceShardRPS.Unit()).Record(shardRPS)
 				if shardRPS > int64(s.perShardRPSWarnLimit()) {
 					s.logger.Warn("Per shard RPS warn limit exceeded", tag.ShardID(shardID), tag.RPS(shardRPS))
 				}

--- a/common/persistence/namespace_replication_queue.go
+++ b/common/persistence/namespace_replication_queue.go
@@ -166,7 +166,7 @@ func (q *namespaceReplicationQueueImpl) PublishToDLQ(ctx context.Context, task *
 		return err
 	}
 
-	q.metricsHandler.Gauge(metrics.NamespaceReplicationDLQMaxLevelGauge.GetMetricName()).
+	q.metricsHandler.Gauge(metrics.NamespaceReplicationDLQMaxLevelGauge.Name()).
 		Record(float64(messageID), metrics.OperationTag(metrics.PersistenceNamespaceReplicationQueueScope))
 	return nil
 }
@@ -408,7 +408,7 @@ func (q *namespaceReplicationQueueImpl) purgeAckedMessages(
 	if err != nil {
 		return fmt.Errorf("failed to purge messages: %v", err)
 	}
-	q.metricsHandler.Gauge(metrics.NamespaceReplicationTaskAckLevelGauge.GetMetricName()).
+	q.metricsHandler.Gauge(metrics.NamespaceReplicationTaskAckLevelGauge.Name()).
 		Record(float64(*minAckLevel), metrics.OperationTag(metrics.PersistenceNamespaceReplicationQueueScope))
 	return nil
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session.go
@@ -98,7 +98,7 @@ func (s *session) refresh() {
 		s.logger.Warn("gocql wrapper: did not refresh gocql session because the last refresh was too close",
 			tag.NewDurationTag("min_refresh_interval_seconds", sessionRefreshMinInternal))
 		handler := s.metricsHandler.WithTags(metrics.FailureTag(refreshThrottleTagValue))
-		handler.Counter(metrics.CassandraSessionRefreshFailures.GetMetricName()).Record(1)
+		handler.Counter(metrics.CassandraSessionRefreshFailures.Name()).Record(1)
 		return
 	}
 
@@ -106,7 +106,7 @@ func (s *session) refresh() {
 	if err != nil {
 		s.logger.Error("gocql wrapper: unable to refresh gocql session", tag.Error(err))
 		handler := s.metricsHandler.WithTags(metrics.FailureTag(refreshErrorTagValue))
-		handler.Counter(metrics.CassandraSessionRefreshFailures.GetMetricName()).Record(1)
+		handler.Counter(metrics.CassandraSessionRefreshFailures.Name()).Record(1)
 		return
 	}
 
@@ -127,7 +127,7 @@ func initSession(
 	}
 	start := time.Now()
 	defer func() {
-		metricsHandler.Timer(metrics.CassandraInitSessionLatency.GetMetricName()).Record(time.Since(start))
+		metricsHandler.Timer(metrics.CassandraInitSessionLatency.Name()).Record(time.Since(start))
 	}()
 	return cluster.CreateSession()
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/session_test.go
@@ -49,7 +49,7 @@ func TestSessionEmitsMetricOnRefreshError(t *testing.T) {
 	}
 
 	metricsHandler.EXPECT().WithTags(metrics.FailureTag(refreshErrorTagValue)).Return(metricsHandler)
-	metricsHandler.EXPECT().Counter(metrics.CassandraSessionRefreshFailures.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	metricsHandler.EXPECT().Counter(metrics.CassandraSessionRefreshFailures.Name()).Return(metrics.NoopCounterMetricFunc)
 
 	s.refresh()
 }
@@ -65,7 +65,7 @@ func TestSessionEmitsMetricOnRefreshThrottle(t *testing.T) {
 	}
 
 	metricsHandler.EXPECT().WithTags(metrics.FailureTag(refreshThrottleTagValue)).Return(metricsHandler)
-	metricsHandler.EXPECT().Counter(metrics.CassandraSessionRefreshFailures.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	metricsHandler.EXPECT().Counter(metrics.CassandraSessionRefreshFailures.Name()).Return(metrics.NoopCounterMetricFunc)
 
 	s.refresh()
 }

--- a/common/persistence/persistence_metric_clients.go
+++ b/common/persistence/persistence_metric_clients.go
@@ -1253,14 +1253,14 @@ func (p *metadataPersistenceClient) InitializeSystemNamespaces(
 
 func (p *metricEmitter) recordRequestMetrics(operation string, caller string, latency time.Duration, err error) {
 	handler := p.metricsHandler.WithTags(metrics.OperationTag(operation), metrics.NamespaceTag(caller))
-	handler.Counter(metrics.PersistenceRequests.GetMetricName()).Record(1)
-	handler.Timer(metrics.PersistenceLatency.GetMetricName()).Record(latency)
+	handler.Counter(metrics.PersistenceRequests.Name()).Record(1)
+	handler.Timer(metrics.PersistenceLatency.Name()).Record(latency)
 	updateErrorMetric(handler, p.logger, operation, err)
 }
 
 func updateErrorMetric(handler metrics.Handler, logger log.Logger, operation string, err error) {
 	if err != nil {
-		handler.Counter(metrics.PersistenceErrorWithType.GetMetricName()).Record(1, metrics.ServiceErrorTypeTag(err))
+		handler.Counter(metrics.PersistenceErrorWithType.Name()).Record(1, metrics.ServiceErrorTypeTag(err))
 		switch err := err.(type) {
 		case *ShardAlreadyExistError,
 			*ShardOwnershipLostError,
@@ -1276,10 +1276,10 @@ func updateErrorMetric(handler metrics.Handler, logger log.Logger, operation str
 			// no-op
 
 		case *serviceerror.ResourceExhausted:
-			handler.Counter(metrics.PersistenceErrResourceExhaustedCounter.GetMetricName()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
+			handler.Counter(metrics.PersistenceErrResourceExhaustedCounter.Name()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
 		default:
 			logger.Error("Operation failed with internal error.", tag.Error(err), tag.Operation(operation))
-			handler.Counter(metrics.PersistenceFailures.GetMetricName()).Record(1)
+			handler.Counter(metrics.PersistenceFailures.Name()).Record(1)
 		}
 	}
 }

--- a/common/persistence/visibility/store/elasticsearch/processor.go
+++ b/common/persistence/visibility/store/elasticsearch/processor.go
@@ -197,7 +197,7 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 		}
 
 		p.logger.Warn("Skipping duplicate ES request for visibility task key.", tag.Key(visibilityTaskKey), tag.ESDocID(request.ID), tag.Value(request.Doc), tag.NewDurationTag("interval-between-duplicates", newFuture.createdAt.Sub(existingFuture.createdAt)))
-		p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorDuplicateRequest.GetMetricName()).Record(1)
+		p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorDuplicateRequest.Name()).Record(1)
 		newFuture = existingFuture
 		return nil
 	})
@@ -210,8 +210,8 @@ func (p *processorImpl) Add(request *client.BulkableRequest, visibilityTaskKey s
 
 // bulkBeforeAction is triggered before bulk processor commit
 func (p *processorImpl) bulkBeforeAction(_ int64, requests []elastic.BulkableRequest) {
-	p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorRequests.GetMetricName()).Record(int64(len(requests)))
-	p.metricsHandler.Histogram(metrics.ElasticsearchBulkProcessorBulkSize.GetMetricName(), metrics.ElasticsearchBulkProcessorBulkSize.GetMetricUnit()).
+	p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorRequests.Name()).Record(int64(len(requests)))
+	p.metricsHandler.Histogram(metrics.ElasticsearchBulkProcessorBulkSize.Name(), metrics.ElasticsearchBulkProcessorBulkSize.Unit()).
 		Record(int64(len(requests)))
 
 	for _, request := range requests {
@@ -246,7 +246,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 				logRequests.WriteString(request.String())
 				logRequests.WriteRune('\n')
 			}
-			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorFailures.GetMetricName()).Record(1, metrics.HttpStatusTag(httpStatus))
+			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorFailures.Name()).Record(1, metrics.HttpStatusTag(httpStatus))
 			visibilityTaskKey := p.extractVisibilityTaskKey(request)
 			if visibilityTaskKey == "" {
 				continue
@@ -258,7 +258,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 	}
 
 	// Record how long the Elasticsearch took to process the bulk request.
-	p.metricsHandler.Timer(metrics.ElasticsearchBulkProcessorBulkResquestTookLatency.GetMetricName()).
+	p.metricsHandler.Timer(metrics.ElasticsearchBulkProcessorBulkResquestTookLatency.Name()).
 		Record(time.Duration(response.Took) * time.Millisecond)
 
 	responseIndex := p.buildResponseIndex(response)
@@ -276,7 +276,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 				tag.Key(visibilityTaskKey),
 				tag.ESDocID(docID),
 				tag.ESRequest(request.String()))
-			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Record(1)
+			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Record(1)
 			p.notifyResult(visibilityTaskKey, false)
 			continue
 		}
@@ -288,7 +288,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 				tag.Key(visibilityTaskKey),
 				tag.ESDocID(docID),
 				tag.ESRequest(request.String()))
-			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorFailures.GetMetricName()).Record(1, metrics.HttpStatusTag(responseItem.Status))
+			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorFailures.Name()).Record(1, metrics.HttpStatusTag(responseItem.Status))
 			p.notifyResult(visibilityTaskKey, false)
 			continue
 		}
@@ -297,7 +297,7 @@ func (p *processorImpl) bulkAfterAction(_ int64, requests []elastic.BulkableRequ
 	}
 
 	// Record how many documents are waiting to be flushed to Elasticsearch after this bulk is committed.
-	p.metricsHandler.Histogram(metrics.ElasticsearchBulkProcessorQueuedRequests.GetMetricName(), metrics.ElasticsearchBulkProcessorBulkSize.GetMetricUnit()).
+	p.metricsHandler.Histogram(metrics.ElasticsearchBulkProcessorQueuedRequests.Name(), metrics.ElasticsearchBulkProcessorBulkSize.Unit()).
 		Record(int64(p.mapToAckFuture.Len()))
 }
 
@@ -334,7 +334,7 @@ func (p *processorImpl) extractVisibilityTaskKey(request elastic.BulkableRequest
 	req, err := request.Source()
 	if err != nil {
 		p.logger.Error("Unable to get ES request source.", tag.Error(err), tag.ESRequest(request.String()))
-		p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Record(1)
+		p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Record(1)
 		return ""
 	}
 
@@ -342,14 +342,14 @@ func (p *processorImpl) extractVisibilityTaskKey(request elastic.BulkableRequest
 		var body map[string]interface{}
 		if err = json.Unmarshal([]byte(req[1]), &body); err != nil {
 			p.logger.Error("Unable to unmarshal ES request body.", tag.Error(err))
-			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Record(1)
+			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Record(1)
 			return ""
 		}
 
 		k, ok := body[searchattribute.VisibilityTaskKey]
 		if !ok {
 			p.logger.Error("Unable to extract VisibilityTaskKey from ES request.", tag.ESRequest(request.String()))
-			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Record(1)
+			p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Record(1)
 			return ""
 		}
 		return k.(string)
@@ -362,7 +362,7 @@ func (p *processorImpl) extractDocID(request elastic.BulkableRequest) string {
 	req, err := request.Source()
 	if err != nil {
 		p.logger.Error("Unable to get ES request source.", tag.Error(err), tag.ESRequest(request.String()))
-		p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Record(1)
+		p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Record(1)
 
 		return ""
 	}
@@ -370,7 +370,7 @@ func (p *processorImpl) extractDocID(request elastic.BulkableRequest) string {
 	var body map[string]map[string]interface{}
 	if err = json.Unmarshal([]byte(req[0]), &body); err != nil {
 		p.logger.Error("Unable to unmarshal ES request body.", tag.Error(err), tag.ESRequest(request.String()))
-		p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Record(1)
+		p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Record(1)
 		return ""
 	}
 
@@ -383,7 +383,7 @@ func (p *processorImpl) extractDocID(request elastic.BulkableRequest) string {
 	}
 
 	p.logger.Error("Unable to extract _id from ES request.", tag.ESRequest(request.String()))
-	p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Record(1)
+	p.metricsHandler.Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Record(1)
 	return ""
 }
 
@@ -429,14 +429,14 @@ func newAckFuture() *ackFuture {
 func (a *ackFuture) recordAdd(metricsHandler metrics.Handler) {
 	addedAt := time.Now().UTC()
 	a.addedAt.Store(addedAt)
-	metricsHandler.Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).Record(addedAt.Sub(a.createdAt))
+	metricsHandler.Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).Record(addedAt.Sub(a.createdAt))
 }
 
 func (a *ackFuture) recordStart(metricsHandler metrics.Handler) {
 	a.startedAt = time.Now().UTC()
 	addedAt := a.addedAt.Load().(time.Time)
 	if !addedAt.IsZero() {
-		metricsHandler.Timer(metrics.ElasticsearchBulkProcessorWaitStartLatency.GetMetricName()).Record(a.startedAt.Sub(addedAt))
+		metricsHandler.Timer(metrics.ElasticsearchBulkProcessorWaitStartLatency.Name()).Record(a.startedAt.Sub(addedAt))
 	}
 }
 
@@ -444,9 +444,9 @@ func (a *ackFuture) done(ack bool, metricsHandler metrics.Handler) {
 	a.future.Set(ack, nil)
 	doneAt := time.Now().UTC()
 	if !a.createdAt.IsZero() {
-		metricsHandler.Timer(metrics.ElasticsearchBulkProcessorRequestLatency.GetMetricName()).Record(doneAt.Sub(a.createdAt))
+		metricsHandler.Timer(metrics.ElasticsearchBulkProcessorRequestLatency.Name()).Record(doneAt.Sub(a.createdAt))
 	}
 	if !a.startedAt.IsZero() {
-		metricsHandler.Timer(metrics.ElasticsearchBulkProcessorCommitLatency.GetMetricName()).Record(doneAt.Sub(a.startedAt))
+		metricsHandler.Timer(metrics.ElasticsearchBulkProcessorCommitLatency.Name()).Record(doneAt.Sub(a.startedAt))
 	}
 }

--- a/common/persistence/visibility/store/elasticsearch/processor_test.go
+++ b/common/persistence/visibility/store/elasticsearch/processor_test.go
@@ -137,7 +137,7 @@ func (s *processorSuite) TestAdd() {
 	visibilityTaskKey := "test-key"
 	s.Equal(0, s.esProcessor.mapToAckFuture.Len())
 
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).Return(metrics.NoopTimerMetricFunc)
 	s.mockBulkProcessor.EXPECT().Add(request)
 
 	future1 := s.esProcessor.Add(request, visibilityTaskKey)
@@ -147,7 +147,7 @@ func (s *processorSuite) TestAdd() {
 	}
 
 	// duplicate request returns same future object
-	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorDuplicateRequest.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorDuplicateRequest.Name()).Return(metrics.NoopCounterMetricFunc)
 	future2 := s.esProcessor.Add(request, visibilityTaskKey)
 	s.Equal(1, s.esProcessor.mapToAckFuture.Len())
 
@@ -167,7 +167,7 @@ func (s *processorSuite) TestAdd_ConcurrentAdd() {
 	wg := sync.WaitGroup{}
 	wg.Add(parallelFactor)
 	s.mockBulkProcessor.EXPECT().Add(request).Times(docsCount)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc).Times(docsCount)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).Return(metrics.NoopTimerMetricFunc).Times(docsCount)
 	for i := 0; i < parallelFactor; i++ {
 		go func(i int) {
 			for j := 0; j < docsCount/parallelFactor; j++ {
@@ -192,10 +192,10 @@ func (s *processorSuite) TestAdd_ConcurrentAdd_Duplicates() {
 	duplicates := 100
 	futures := make([]future.Future[bool], duplicates)
 	s.mockMetricHandler.EXPECT().
-		Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).
+		Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).
 		Return(metrics.NoopTimerMetricFunc)
 	s.mockMetricHandler.EXPECT().
-		Counter(metrics.ElasticsearchBulkProcessorDuplicateRequest.GetMetricName()).
+		Counter(metrics.ElasticsearchBulkProcessorDuplicateRequest.Name()).
 		Return(metrics.NoopCounterMetricFunc).Times(duplicates - 1)
 
 	wg := sync.WaitGroup{}
@@ -229,7 +229,7 @@ func (s *processorSuite) TestAdd_ConcurrentAdd_Shutdown() {
 
 	s.mockBulkProcessor.EXPECT().Add(request).MaxTimes(docsCount + 2) // +2 for explicit adds before and after shutdown
 	s.mockBulkProcessor.EXPECT().Stop().Return(nil).Times(1)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc).MaxTimes(docsCount + 2)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).Return(metrics.NoopTimerMetricFunc).MaxTimes(docsCount + 2)
 
 	addBefore := s.esProcessor.Add(request, "test-key-before")
 
@@ -284,12 +284,12 @@ func (s *processorSuite) TestBulkAfterAction_Ack() {
 
 	queuedRequestHistogram := metrics.NewMockHistogramIface(s.controller)
 	s.mockMetricHandler.EXPECT().Histogram(
-		metrics.ElasticsearchBulkProcessorQueuedRequests.GetMetricName(),
-		metrics.ElasticsearchBulkProcessorQueuedRequests.GetMetricUnit(),
+		metrics.ElasticsearchBulkProcessorQueuedRequests.Name(),
+		metrics.ElasticsearchBulkProcessorQueuedRequests.Unit(),
 	).Return(queuedRequestHistogram)
 	queuedRequestHistogram.EXPECT().Record(int64(0))
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorBulkResquestTookLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorBulkResquestTookLatency.Name()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.Name()).Return(metrics.NoopTimerMetricFunc)
 	mapVal := newAckFuture()
 	s.esProcessor.mapToAckFuture.Put(testKey, mapVal)
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
@@ -334,16 +334,16 @@ func (s *processorSuite) TestBulkAfterAction_Nack() {
 
 	queuedRequestHistogram := metrics.NewMockHistogramIface(s.controller)
 	s.mockMetricHandler.EXPECT().Histogram(
-		metrics.ElasticsearchBulkProcessorQueuedRequests.GetMetricName(),
-		metrics.ElasticsearchBulkProcessorQueuedRequests.GetMetricUnit(),
+		metrics.ElasticsearchBulkProcessorQueuedRequests.Name(),
+		metrics.ElasticsearchBulkProcessorQueuedRequests.Unit(),
 	).Return(queuedRequestHistogram)
 	queuedRequestHistogram.EXPECT().Record(int64(0))
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorBulkResquestTookLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorBulkResquestTookLatency.Name()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.Name()).Return(metrics.NoopTimerMetricFunc)
 	mapVal := newAckFuture()
 	s.esProcessor.mapToAckFuture.Put(testKey, mapVal)
 	counterMetric := metrics.NewMockCounterIface(s.controller)
-	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorFailures.GetMetricName()).Return(counterMetric)
+	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorFailures.Name()).Return(counterMetric)
 	counterMetric.EXPECT().Record(int64(1), metrics.HttpStatusTag(400))
 
 	s.esProcessor.bulkAfterAction(0, requests, response, nil)
@@ -380,7 +380,7 @@ func (s *processorSuite) TestBulkAfterAction_Error() {
 	}
 
 	counterMetric := metrics.NewMockCounterIface(s.controller)
-	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorFailures.GetMetricName()).Return(counterMetric)
+	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorFailures.Name()).Return(counterMetric)
 	counterMetric.EXPECT().Record(int64(1), metrics.HttpStatusTag(400))
 	s.esProcessor.bulkAfterAction(0, requests, response, &elastic.Error{Status: 400})
 }
@@ -396,16 +396,16 @@ func (s *processorSuite) TestBulkBeforeAction() {
 	requests := []elastic.BulkableRequest{request}
 
 	counterMetric := metrics.NewMockCounterIface(s.controller)
-	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorRequests.GetMetricName()).Return(counterMetric)
+	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorRequests.Name()).Return(counterMetric)
 	counterMetric.EXPECT().Record(int64(1))
 	bulkSizeHistogram := metrics.NewMockHistogramIface(s.controller)
 	s.mockMetricHandler.EXPECT().Histogram(
-		metrics.ElasticsearchBulkProcessorBulkSize.GetMetricName(),
-		metrics.ElasticsearchBulkProcessorBulkSize.GetMetricUnit(),
+		metrics.ElasticsearchBulkProcessorBulkSize.Name(),
+		metrics.ElasticsearchBulkProcessorBulkSize.Unit(),
 	).Return(bulkSizeHistogram)
 	bulkSizeHistogram.EXPECT().Record(int64(1))
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitStartLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitStartLatency.Name()).Return(metrics.NoopTimerMetricFunc)
 	mapVal := newAckFuture()
 	mapVal.recordAdd(s.mockMetricHandler)
 	s.esProcessor.mapToAckFuture.Put(testKey, mapVal)
@@ -420,8 +420,8 @@ func (s *processorSuite) TestAckChan() {
 	s.esProcessor.notifyResult(key, true)
 
 	request := &client.BulkableRequest{}
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.Name()).Return(metrics.NoopTimerMetricFunc)
 	s.mockBulkProcessor.EXPECT().Add(request)
 	future := s.esProcessor.Add(request, key)
 	s.Equal(1, s.esProcessor.mapToAckFuture.Len())
@@ -440,8 +440,8 @@ func (s *processorSuite) TestNackChan() {
 
 	request := &client.BulkableRequest{}
 	s.mockBulkProcessor.EXPECT().Add(request)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.Name()).Return(metrics.NoopTimerMetricFunc)
 	future := s.esProcessor.Add(request, key)
 	s.Equal(1, s.esProcessor.mapToAckFuture.Len())
 
@@ -459,7 +459,7 @@ func (s *processorSuite) TestHashFn() {
 
 func (s *processorSuite) TestExtractVisibilityTaskKey() {
 	request := elastic.NewBulkIndexRequest()
-	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Return(metrics.NoopCounterMetricFunc)
 	visibilityTaskKey := s.esProcessor.extractVisibilityTaskKey(request)
 	s.Equal("", visibilityTaskKey)
 
@@ -488,7 +488,7 @@ func (s *processorSuite) TestExtractVisibilityTaskKey_Delete() {
 	_, ok := body["delete"]
 	s.True(ok)
 
-	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorCorruptedData.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorCorruptedData.Name()).Return(metrics.NoopCounterMetricFunc)
 	key := s.esProcessor.extractVisibilityTaskKey(request)
 	s.Equal("", key)
 
@@ -546,7 +546,7 @@ func (s *processorSuite) Test_End2End() {
 	wg.Add(parallelFactor)
 	s.mockBulkProcessor.EXPECT().Add(request).Times(docsCount)
 	s.mockMetricHandler.EXPECT().
-		Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.GetMetricName()).
+		Timer(metrics.ElasticsearchBulkProcessorWaitAddLatency.Name()).
 		Return(metrics.NoopTimerMetricFunc).Times(docsCount)
 	for i := 0; i < parallelFactor; i++ {
 		go func(i int) {
@@ -580,26 +580,26 @@ func (s *processorSuite) Test_End2End() {
 	// Emulate bulk commit.
 
 	counterMetric := metrics.NewMockCounterIface(s.controller)
-	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorRequests.GetMetricName()).Return(counterMetric)
+	s.mockMetricHandler.EXPECT().Counter(metrics.ElasticsearchBulkProcessorRequests.Name()).Return(counterMetric)
 	counterMetric.EXPECT().Record(int64(docsCount))
 	queuedRequestsHistogram := metrics.NewMockHistogramIface(s.controller)
 	s.mockMetricHandler.EXPECT().Histogram(
-		metrics.ElasticsearchBulkProcessorQueuedRequests.GetMetricName(),
-		metrics.ElasticsearchBulkProcessorQueuedRequests.GetMetricUnit(),
+		metrics.ElasticsearchBulkProcessorQueuedRequests.Name(),
+		metrics.ElasticsearchBulkProcessorQueuedRequests.Unit(),
 	).Return(queuedRequestsHistogram)
 	queuedRequestsHistogram.EXPECT().Record(int64(0))
 	bulkSizeHistogram := metrics.NewMockHistogramIface(s.controller)
 	s.mockMetricHandler.EXPECT().Histogram(
-		metrics.ElasticsearchBulkProcessorBulkSize.GetMetricName(),
-		metrics.ElasticsearchBulkProcessorBulkSize.GetMetricUnit(),
+		metrics.ElasticsearchBulkProcessorBulkSize.Name(),
+		metrics.ElasticsearchBulkProcessorBulkSize.Unit(),
 	).Return(bulkSizeHistogram)
 	bulkSizeHistogram.EXPECT().Record(int64(docsCount))
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitStartLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc).Times(docsCount)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorWaitStartLatency.Name()).Return(metrics.NoopTimerMetricFunc).Times(docsCount)
 	s.esProcessor.bulkBeforeAction(0, bulkIndexRequests)
 
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorBulkResquestTookLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc).Times(docsCount)
-	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorCommitLatency.GetMetricName()).Return(metrics.NoopTimerMetricFunc).Times(docsCount)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorBulkResquestTookLatency.Name()).Return(metrics.NoopTimerMetricFunc)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorRequestLatency.Name()).Return(metrics.NoopTimerMetricFunc).Times(docsCount)
+	s.mockMetricHandler.EXPECT().Timer(metrics.ElasticsearchBulkProcessorCommitLatency.Name()).Return(metrics.NoopTimerMetricFunc).Times(docsCount)
 	s.esProcessor.bulkAfterAction(0, bulkIndexRequests, bulkIndexResponse, nil)
 
 	for i := 0; i < docsCount; i++ {

--- a/common/persistence/visibility/store/elasticsearch/visibility_store.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store.go
@@ -795,7 +795,7 @@ func (s *visibilityStore) buildSearchParametersV2(
 	if len(queryParams.Sorter) > 0 {
 		// If params.Sorter is not empty, then it's using custom order by.
 		s.metricsHandler.WithTags(metrics.NamespaceTag(request.Namespace.String())).
-			Counter(metrics.ElasticsearchCustomOrderByClauseCount.GetMetricName()).Record(1)
+			Counter(metrics.ElasticsearchCustomOrderByClauseCount.Name()).Record(1)
 	}
 
 	searchParams.Sorter, err = getFieldSorter(queryParams.Sorter)
@@ -1040,13 +1040,13 @@ func (s *visibilityStore) generateESDoc(
 
 	typeMap, err := s.searchAttributesProvider.GetSearchAttributes(s.index, false)
 	if err != nil {
-		s.metricsHandler.Counter(metrics.ElasticsearchDocumentGenerateFailuresCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.ElasticsearchDocumentGenerateFailuresCount.Name()).Record(1)
 		return nil, serviceerror.NewUnavailable(fmt.Sprintf("Unable to read search attribute types: %v", err))
 	}
 
 	searchAttributes, err := searchattribute.Decode(request.SearchAttributes, &typeMap, true)
 	if err != nil {
-		s.metricsHandler.Counter(metrics.ElasticsearchDocumentGenerateFailuresCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.ElasticsearchDocumentGenerateFailuresCount.Name()).Record(1)
 		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to decode search attributes: %v", err))
 	}
 	// This is to prevent existing tasks to fail indefinitely.
@@ -1071,7 +1071,7 @@ func (s *visibilityStore) generateESDoc(
 
 func (s *visibilityStore) parseESDoc(docID string, docSource json.RawMessage, saTypeMap searchattribute.NameTypeMap, namespace namespace.Name) (*store.InternalWorkflowExecutionInfo, error) {
 	logParseError := func(fieldName string, fieldValue interface{}, err error, docID string) error {
-		s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.Name()).Record(1)
 		return serviceerror.NewInternal(fmt.Sprintf("Unable to parse Elasticsearch document(%s) %q field value %q: %v", docID, fieldName, fieldValue, err))
 	}
 
@@ -1080,7 +1080,7 @@ func (s *visibilityStore) parseESDoc(docID string, docSource json.RawMessage, sa
 	// Very important line. See finishParseJSONValue bellow.
 	d.UseNumber()
 	if err := d.Decode(&sourceMap); err != nil {
-		s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.Name()).Record(1)
 		return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to unmarshal JSON from Elasticsearch document(%s): %v", docID, err))
 	}
 
@@ -1121,7 +1121,7 @@ func (s *visibilityStore) parseESDoc(docID string, docSource json.RawMessage, sa
 			if errors.Is(err, searchattribute.ErrInvalidName) {
 				continue
 			}
-			s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.GetMetricName()).Record(1)
+			s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.Name()).Record(1)
 			return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to get type for Elasticsearch document(%s) field %q: %v", docID, fieldName, err))
 		}
 
@@ -1174,7 +1174,7 @@ func (s *visibilityStore) parseESDoc(docID string, docSource json.RawMessage, sa
 		var err error
 		record.SearchAttributes, err = searchattribute.Encode(customSearchAttributes, &saTypeMap)
 		if err != nil {
-			s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.GetMetricName()).Record(1)
+			s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.Name()).Record(1)
 			return nil, serviceerror.NewInternal(fmt.Sprintf("Unable to encode custom search attributes of Elasticsearch document(%s): %v", docID, err))
 		}
 		aliasedSas, err := searchattribute.AliasFields(s.searchAttributesMapperProvider, record.SearchAttributes, namespace.String())
@@ -1190,7 +1190,7 @@ func (s *visibilityStore) parseESDoc(docID string, docSource json.RawMessage, sa
 	if memoEncoding != "" {
 		record.Memo = persistence.NewDataBlob(memo, memoEncoding)
 	} else if memo != nil {
-		s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.ElasticsearchDocumentParseFailuresCount.Name()).Record(1)
 		return nil, serviceerror.NewInternal(fmt.Sprintf("%q field is missing in Elasticsearch document(%s)", searchattribute.MemoEncoding, docID))
 	}
 

--- a/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
+++ b/common/persistence/visibility/store/elasticsearch/visibility_store_read_test.go
@@ -503,7 +503,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	request.Query = `Order bY WorkflowId`
 	boolQuery = elastic.NewBoolQuery().Filter(matchNamespaceQuery).MustNot(namespaceDivisionExists)
 	s.mockMetricsHandler.EXPECT().WithTags(metrics.NamespaceTag(request.Namespace.String())).Return(s.mockMetricsHandler)
-	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.Name()).Return(metrics.NoopCounterMetricFunc)
 	p, err = s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getListFieldSorter)
 	s.NoError(err)
 	s.Equal(&client.SearchParameters{
@@ -538,7 +538,7 @@ func (s *ESVisibilitySuite) TestBuildSearchParametersV2() {
 	// test with Scan API with custom sort
 	request.Query = `Order bY WorkflowId`
 	s.mockMetricsHandler.EXPECT().WithTags(metrics.NamespaceTag(request.Namespace.String())).Return(s.mockMetricsHandler)
-	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchCustomOrderByClauseCount.Name()).Return(metrics.NoopCounterMetricFunc)
 	p, err = s.visibilityStore.buildSearchParametersV2(request, s.visibilityStore.getScanFieldSorter)
 	s.Error(err)
 	s.Nil(p)
@@ -968,7 +968,7 @@ func (s *ESVisibilitySuite) TestParseESDoc() {
 
 	// test for error case
 	docSource = []byte(`corrupted data`)
-	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchDocumentParseFailuresCount.GetMetricName()).Return(metrics.NoopCounterMetricFunc)
+	s.mockMetricsHandler.EXPECT().Counter(metrics.ElasticsearchDocumentParseFailuresCount.Name()).Return(metrics.NoopCounterMetricFunc)
 	info, err = s.visibilityStore.parseESDoc("", docSource, searchattribute.TestNameTypeMap, testNamespace)
 	s.Error(err)
 	s.Nil(info)

--- a/common/persistence/visibility/visiblity_manager_metrics.go
+++ b/common/persistence/visibility/visiblity_manager_metrics.go
@@ -95,7 +95,7 @@ func (m *visibilityManagerMetrics) RecordWorkflowExecutionStarted(
 ) error {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceRecordWorkflowExecutionStartedScope)
 	err := m.delegate.RecordWorkflowExecutionStarted(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return m.updateErrorMetric(handler, err)
 }
 
@@ -105,7 +105,7 @@ func (m *visibilityManagerMetrics) RecordWorkflowExecutionClosed(
 ) error {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceRecordWorkflowExecutionClosedScope)
 	err := m.delegate.RecordWorkflowExecutionClosed(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return m.updateErrorMetric(handler, err)
 }
 
@@ -115,7 +115,7 @@ func (m *visibilityManagerMetrics) UpsertWorkflowExecution(
 ) error {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceUpsertWorkflowExecutionScope)
 	err := m.delegate.UpsertWorkflowExecution(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return m.updateErrorMetric(handler, err)
 }
 
@@ -125,7 +125,7 @@ func (m *visibilityManagerMetrics) DeleteWorkflowExecution(
 ) error {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceDeleteWorkflowExecutionScope)
 	err := m.delegate.DeleteWorkflowExecution(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return m.updateErrorMetric(handler, err)
 }
 
@@ -135,7 +135,7 @@ func (m *visibilityManagerMetrics) ListOpenWorkflowExecutions(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsScope)
 	response, err := m.delegate.ListOpenWorkflowExecutions(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -145,7 +145,7 @@ func (m *visibilityManagerMetrics) ListClosedWorkflowExecutions(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsScope)
 	response, err := m.delegate.ListClosedWorkflowExecutions(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -155,7 +155,7 @@ func (m *visibilityManagerMetrics) ListOpenWorkflowExecutionsByType(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsByTypeScope)
 	response, err := m.delegate.ListOpenWorkflowExecutionsByType(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -165,7 +165,7 @@ func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByType(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByTypeScope)
 	response, err := m.delegate.ListClosedWorkflowExecutionsByType(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -175,7 +175,7 @@ func (m *visibilityManagerMetrics) ListOpenWorkflowExecutionsByWorkflowID(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceListOpenWorkflowExecutionsByWorkflowIDScope)
 	response, err := m.delegate.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -185,7 +185,7 @@ func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByWorkflowID(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByWorkflowIDScope)
 	response, err := m.delegate.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -195,7 +195,7 @@ func (m *visibilityManagerMetrics) ListClosedWorkflowExecutionsByStatus(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceListClosedWorkflowExecutionsByStatusScope)
 	response, err := m.delegate.ListClosedWorkflowExecutionsByStatus(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -205,7 +205,7 @@ func (m *visibilityManagerMetrics) ListWorkflowExecutions(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceListWorkflowExecutionsScope)
 	response, err := m.delegate.ListWorkflowExecutions(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -215,7 +215,7 @@ func (m *visibilityManagerMetrics) ScanWorkflowExecutions(
 ) (*manager.ListWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceScanWorkflowExecutionsScope)
 	response, err := m.delegate.ScanWorkflowExecutions(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -225,7 +225,7 @@ func (m *visibilityManagerMetrics) CountWorkflowExecutions(
 ) (*manager.CountWorkflowExecutionsResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceCountWorkflowExecutionsScope)
 	response, err := m.delegate.CountWorkflowExecutions(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
@@ -235,13 +235,13 @@ func (m *visibilityManagerMetrics) GetWorkflowExecution(
 ) (*manager.GetWorkflowExecutionResponse, error) {
 	handler, startTime := m.tagScope(metrics.VisibilityPersistenceGetWorkflowExecutionScope)
 	response, err := m.delegate.GetWorkflowExecution(ctx, request)
-	handler.Timer(metrics.VisibilityPersistenceLatency.GetMetricName()).Record(time.Since(startTime))
+	handler.Timer(metrics.VisibilityPersistenceLatency.Name()).Record(time.Since(startTime))
 	return response, m.updateErrorMetric(handler, err)
 }
 
 func (m *visibilityManagerMetrics) tagScope(operation string) (metrics.Handler, time.Time) {
 	taggedHandler := m.metricHandler.WithTags(metrics.OperationTag(operation), m.visibilityPluginNameMetricsTag)
-	taggedHandler.Counter(metrics.VisibilityPersistenceRequests.GetMetricName()).Record(1)
+	taggedHandler.Counter(metrics.VisibilityPersistenceRequests.Name()).Record(1)
 	return taggedHandler, time.Now().UTC()
 }
 
@@ -250,7 +250,7 @@ func (m *visibilityManagerMetrics) updateErrorMetric(handler metrics.Handler, er
 		return nil
 	}
 
-	handler.Counter(metrics.VisibilityPersistenceErrorWithType.GetMetricName()).Record(1, metrics.ServiceErrorTypeTag(err))
+	handler.Counter(metrics.VisibilityPersistenceErrorWithType.Name()).Record(1, metrics.ServiceErrorTypeTag(err))
 
 	switch err := err.(type) {
 	case *serviceerror.InvalidArgument,
@@ -260,10 +260,10 @@ func (m *visibilityManagerMetrics) updateErrorMetric(handler metrics.Handler, er
 		// no-op
 
 	case *serviceerror.ResourceExhausted:
-		handler.Counter(metrics.VisibilityPersistenceResourceExhausted.GetMetricName()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
+		handler.Counter(metrics.VisibilityPersistenceResourceExhausted.Name()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
 	default:
 		m.logger.Error("Operation failed with an error.", tag.Error(err))
-		handler.Counter(metrics.VisibilityPersistenceFailures.GetMetricName()).Record(1)
+		handler.Counter(metrics.VisibilityPersistenceFailures.Name()).Record(1)
 	}
 
 	return err

--- a/common/rpc/encryption/local_store_tls_provider.go
+++ b/common/rpc/encryption/local_store_tls_provider.go
@@ -457,8 +457,8 @@ func (s *localStoreTlsProvider) checkCertExpiration() {
 			return
 		}
 		if s.metricsHandler != nil {
-			s.metricsHandler.Gauge(metrics.TlsCertsExpired.GetMetricName()).Record(float64(len(expired)))
-			s.metricsHandler.Gauge(metrics.TlsCertsExpiring.GetMetricName()).Record(float64(len(expiring)))
+			s.metricsHandler.Gauge(metrics.TlsCertsExpired.Name()).Record(float64(len(expired)))
+			s.metricsHandler.Gauge(metrics.TlsCertsExpiring.Name()).Record(float64(len(expiring)))
 		}
 		s.logCerts(expired, true, errorTime)
 		s.logCerts(expiring, false, errorTime)

--- a/common/rpc/interceptor/concurrent_request_limit.go
+++ b/common/rpc/interceptor/concurrent_request_limit.go
@@ -109,7 +109,7 @@ func (ni *ConcurrentRequestLimitInterceptor) Intercept(
 		defer atomic.AddInt32(counter, -int32(token))
 
 		handler := GetMetricsHandlerFromContext(ctx, ni.logger)
-		handler.Gauge(metrics.ServicePendingRequests.GetMetricName()).Record(float64(count))
+		handler.Gauge(metrics.ServicePendingRequests.Name()).Record(float64(count))
 
 		// frontend.namespaceCount is applied per poller type temporarily to prevent
 		// one poller type to take all token waiting in the long poll.

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -148,26 +148,26 @@ func (ti *TelemetryInterceptor) UnaryIntercept(
 	metricsHandler, logTags := ti.unaryMetricsHandlerLogTags(req, info.FullMethod, methodName)
 
 	ctx = context.WithValue(ctx, metricsCtxKey, metricsHandler)
-	metricsHandler.Counter(metrics.ServiceRequests.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.ServiceRequests.Name()).Record(1)
 
 	startTime := time.Now().UTC()
 	userLatencyDuration := time.Duration(0)
 	defer func() {
 		latency := time.Since(startTime)
-		metricsHandler.Timer(metrics.ServiceLatency.GetMetricName()).Record(latency)
+		metricsHandler.Timer(metrics.ServiceLatency.Name()).Record(latency)
 		noUserLatency := latency - userLatencyDuration
 		if noUserLatency < 0 {
 			noUserLatency = 0
 		}
-		metricsHandler.Timer(metrics.ServiceLatencyNoUserLatency.GetMetricName()).Record(noUserLatency)
+		metricsHandler.Timer(metrics.ServiceLatencyNoUserLatency.Name()).Record(noUserLatency)
 	}()
 
 	resp, err := handler(ctx, req)
 
-	if val, ok := metrics.ContextCounterGet(ctx, metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName()); ok {
+	if val, ok := metrics.ContextCounterGet(ctx, metrics.HistoryWorkflowExecutionCacheLatency.Name()); ok {
 		userLatencyDuration = time.Duration(val)
 		startTime.Add(userLatencyDuration)
-		metricsHandler.Timer(metrics.ServiceLatencyUserLatency.GetMetricName()).Record(userLatencyDuration)
+		metricsHandler.Timer(metrics.ServiceLatencyUserLatency.Name()).Record(userLatencyDuration)
 	}
 
 	if err != nil {
@@ -189,7 +189,7 @@ func (ti *TelemetryInterceptor) StreamIntercept(
 ) error {
 	_, methodName := SplitMethodName(info.FullMethod)
 	metricsHandler, logTags := ti.streamMetricsHandlerLogTags(info.FullMethod, methodName)
-	metricsHandler.Counter(metrics.ServiceRequests.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.ServiceRequests.Name()).Record(1)
 
 	err := handler(service, serverStream)
 	if err != nil {
@@ -228,11 +228,11 @@ func (ti *TelemetryInterceptor) emitActionMetric(
 					hasMarker = true
 				case enums.COMMAND_TYPE_START_CHILD_WORKFLOW_EXECUTION:
 					// Each child workflow counts as 2 actions. We use separate tags to track them separately.
-					metricsHandler.Counter(metrics.ActionCounter.GetMetricName()).Record(1, metrics.ActionType("command_"+command.CommandType.String()))
-					metricsHandler.Counter(metrics.ActionCounter.GetMetricName()).Record(1, metrics.ActionType("command_"+command.CommandType.String()+"_Extra"))
+					metricsHandler.Counter(metrics.ActionCounter.Name()).Record(1, metrics.ActionType("command_"+command.CommandType.String()))
+					metricsHandler.Counter(metrics.ActionCounter.Name()).Record(1, metrics.ActionType("command_"+command.CommandType.String()+"_Extra"))
 				default:
 					// handle all other command action
-					metricsHandler.Counter(metrics.ActionCounter.GetMetricName()).Record(1, metrics.ActionType("command_"+command.CommandType.String()))
+					metricsHandler.Counter(metrics.ActionCounter.Name()).Record(1, metrics.ActionType("command_"+command.CommandType.String()))
 				}
 			}
 		}
@@ -241,7 +241,7 @@ func (ti *TelemetryInterceptor) emitActionMetric(
 			// One workflow task response may contain multiple marker commands. Each marker will emit one
 			// command_RecordMarker_Xxx action metric. Depending on pricing model, you may want to ignore all individual
 			// command_RecordMarker_Xxx and use command_BatchMarkers instead.
-			metricsHandler.Counter(metrics.ActionCounter.GetMetricName()).Record(1, metrics.ActionType("command_BatchMarkers"))
+			metricsHandler.Counter(metrics.ActionCounter.Name()).Record(1, metrics.ActionType("command_BatchMarkers"))
 		}
 
 	case pollActivityTaskQueue:
@@ -255,12 +255,12 @@ func (ti *TelemetryInterceptor) emitActionMetric(
 			return
 		}
 		if activityPollResponse.Attempt > 1 {
-			metricsHandler.Counter(metrics.ActionCounter.GetMetricName()).Record(1, metrics.ActionType("activity_retry"))
+			metricsHandler.Counter(metrics.ActionCounter.Name()).Record(1, metrics.ActionType("activity_retry"))
 		}
 
 	default:
 		// grpc action
-		metricsHandler.Counter(metrics.ActionCounter.GetMetricName()).Record(1, metrics.ActionType("grpc_"+methodName))
+		metricsHandler.Counter(metrics.ActionCounter.Name()).Record(1, metrics.ActionType("grpc_"+methodName))
 	}
 }
 
@@ -297,7 +297,7 @@ func (ti *TelemetryInterceptor) handleError(
 	err error,
 ) {
 
-	metricsHandler.Counter(metrics.ServiceErrorWithType.GetMetricName()).Record(1, metrics.ServiceErrorTypeTag(err))
+	metricsHandler.Counter(metrics.ServiceErrorWithType.Name()).Record(1, metrics.ServiceErrorTypeTag(err))
 
 	if common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err) {
 		return
@@ -329,7 +329,7 @@ func (ti *TelemetryInterceptor) handleError(
 
 	// specific metric for resource exhausted error with throttle reason
 	case *serviceerror.ResourceExhausted:
-		metricsHandler.Counter(metrics.ServiceErrResourceExhaustedCounter.GetMetricName()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
+		metricsHandler.Counter(metrics.ServiceErrResourceExhaustedCounter.Name()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
 
 	// Any other errors are treated as ServiceFailures against SLA.
 	// Including below known errors and any other unknown errors.
@@ -337,7 +337,7 @@ func (ti *TelemetryInterceptor) handleError(
 	//  *serviceerror.Internal
 	//	*serviceerror.Unavailable:
 	default:
-		metricsHandler.Counter(metrics.ServiceFailures.GetMetricName()).Record(1)
+		metricsHandler.Counter(metrics.ServiceFailures.Name()).Record(1)
 		ti.logger.Error("service failures", append(logTags, tag.Error(err))...)
 	}
 }

--- a/common/tasks/rate_limited_scheduler.go
+++ b/common/tasks/rate_limited_scheduler.go
@@ -121,7 +121,7 @@ func (s *RateLimitedScheduler[T]) wait(task T) {
 		return
 	}
 
-	s.metricsHandler.Counter(metrics.TaskSchedulerThrottled.GetMetricName()).Record(1, s.metricTagsFn(task)...)
+	s.metricsHandler.Counter(metrics.TaskSchedulerThrottled.Name()).Record(1, s.metricTagsFn(task)...)
 	if s.options.EnableShadowMode {
 		// in shadow mode, only emit metrics, but don't actually throttle
 		return
@@ -138,7 +138,7 @@ func (s *RateLimitedScheduler[T]) allow(task T) bool {
 		return true
 	}
 
-	s.metricsHandler.Counter(metrics.TaskSchedulerThrottled.GetMetricName()).Record(1, s.metricTagsFn(task)...)
+	s.metricsHandler.Counter(metrics.TaskSchedulerThrottled.Name()).Record(1, s.metricTagsFn(task)...)
 
 	// in shadow mode, only emit metrics, but don't actually throttle
 	return s.options.EnableShadowMode

--- a/common/util.go
+++ b/common/util.go
@@ -694,7 +694,7 @@ func CheckEventBlobSizeLimit(
 	blobSizeViolationOperationTag tag.ZapTag,
 ) error {
 
-	metricsHandler.Histogram(metrics.EventBlobSize.GetMetricName(), metrics.EventBlobSize.GetMetricUnit()).Record(int64(actualSize))
+	metricsHandler.Histogram(metrics.EventBlobSize.Name(), metrics.EventBlobSize.Unit()).Record(int64(actualSize))
 	if actualSize > warnLimit {
 		if logger != nil {
 			logger.Warn("Blob data size exceeds the warning limit.",

--- a/service/frontend/admin_handler_deprecated.go
+++ b/service/frontend/admin_handler_deprecated.go
@@ -146,7 +146,7 @@ func (adh *AdminHandler) getWorkflowExecutionRawHistoryV2(
 
 	pageToken.PersistenceToken = rawHistoryResponse.NextPageToken
 	size := rawHistoryResponse.Size
-	adh.metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(
+	adh.metricsHandler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(
 		int64(size),
 		metrics.NamespaceTag(ns.Name().String()),
 		metrics.OperationTag(metrics.AdminGetWorkflowExecutionRawHistoryV2Scope),

--- a/service/frontend/http_api_server.go
+++ b/service/frontend/http_api_server.go
@@ -370,7 +370,7 @@ func newInlineClientConn(
 	return &inlineClientConn{
 		methods:           methods,
 		interceptor:       chainUnaryServerInterceptors(interceptors),
-		requestsCounter:   metricsHandler.Counter(metrics.HTTPServiceRequests.GetMetricName()),
+		requestsCounter:   metricsHandler.Counter(metrics.HTTPServiceRequests.Name()),
 		namespaceRegistry: namespaceRegistry,
 	}
 }

--- a/service/frontend/operator_handler.go
+++ b/service/frontend/operator_handler.go
@@ -193,10 +193,10 @@ func (h *OperatorHandlerImpl) AddSearchAttributes(
 		err = h.addSearchAttributesElasticsearch(ctx, request, indexName, currentSearchAttributes)
 		if err != nil {
 			if _, isWorkflowErr := err.(*serviceerror.SystemWorkflow); isWorkflowErr {
-				scope.Counter(metrics.AddSearchAttributesWorkflowFailuresCount.GetMetricName()).Record(1)
+				scope.Counter(metrics.AddSearchAttributesWorkflowFailuresCount.Name()).Record(1)
 			}
 		} else {
-			scope.Counter(metrics.AddSearchAttributesWorkflowSuccessCount.GetMetricName()).Record(1)
+			scope.Counter(metrics.AddSearchAttributesWorkflowSuccessCount.Name()).Record(1)
 		}
 	} else {
 		err = h.addSearchAttributesSQL(ctx, request, currentSearchAttributes)
@@ -588,11 +588,11 @@ func (h *OperatorHandlerImpl) DeleteNamespace(
 	var wfResult deletenamespace.DeleteNamespaceWorkflowResult
 	err = run.Get(ctx, &wfResult)
 	if err != nil {
-		scope.Counter(metrics.DeleteNamespaceWorkflowFailuresCount.GetMetricName()).Record(1)
+		scope.Counter(metrics.DeleteNamespaceWorkflowFailuresCount.Name()).Record(1)
 		execution := &commonpb.WorkflowExecution{WorkflowId: deletenamespace.WorkflowName, RunId: run.GetRunID()}
 		return nil, serviceerror.NewSystemWorkflow(execution, err)
 	}
-	scope.Counter(metrics.DeleteNamespaceWorkflowSuccessCount.GetMetricName()).Record(1)
+	scope.Counter(metrics.DeleteNamespaceWorkflowSuccessCount.Name()).Record(1)
 
 	return &operatorservice.DeleteNamespaceResponse{
 		DeletedNamespace: wfResult.DeletedNamespace.String(),

--- a/service/frontend/redirection_interceptor.go
+++ b/service/frontend/redirection_interceptor.go
@@ -266,10 +266,10 @@ func (i *RedirectionInterceptor) afterCall(
 	retError error,
 ) {
 	metricsHandler = metricsHandler.WithTags(metrics.TargetClusterTag(clusterName))
-	metricsHandler.Counter(metrics.ClientRedirectionRequests.GetMetricName()).Record(1)
-	metricsHandler.Timer(metrics.ClientRedirectionLatency.GetMetricName()).Record(i.timeSource.Now().Sub(startTime))
+	metricsHandler.Counter(metrics.ClientRedirectionRequests.Name()).Record(1)
+	metricsHandler.Timer(metrics.ClientRedirectionLatency.Name()).Record(i.timeSource.Now().Sub(startTime))
 	if retError != nil {
-		metricsHandler.Counter(metrics.ClientRedirectionFailures.GetMetricName()).Record(1)
+		metricsHandler.Counter(metrics.ClientRedirectionFailures.Name()).Record(1)
 	}
 }
 

--- a/service/frontend/version_checker.go
+++ b/service/frontend/version_checker.go
@@ -113,11 +113,11 @@ func (vc *VersionChecker) performVersionCheck(
 ) {
 	startTime := time.Now().UTC()
 	defer func() {
-		vc.metricsHandler.Timer(metrics.VersionCheckLatency.GetMetricName()).Record(time.Since(startTime))
+		vc.metricsHandler.Timer(metrics.VersionCheckLatency.Name()).Record(time.Since(startTime))
 	}()
 	metadata, err := vc.clusterMetadataManager.GetCurrentClusterMetadata(ctx)
 	if err != nil {
-		vc.metricsHandler.Counter(metrics.VersionCheckFailedCount.GetMetricName()).Record(1)
+		vc.metricsHandler.Counter(metrics.VersionCheckFailedCount.Name()).Record(1)
 		return
 	}
 
@@ -127,21 +127,21 @@ func (vc *VersionChecker) performVersionCheck(
 
 	req, err := vc.createVersionCheckRequest(metadata)
 	if err != nil {
-		vc.metricsHandler.Counter(metrics.VersionCheckFailedCount.GetMetricName()).Record(1)
+		vc.metricsHandler.Counter(metrics.VersionCheckFailedCount.Name()).Record(1)
 		return
 	}
 	resp, err := vc.getVersionInfo(req)
 	if err != nil {
-		vc.metricsHandler.Counter(metrics.VersionCheckRequestFailedCount.GetMetricName()).Record(1)
-		vc.metricsHandler.Counter(metrics.VersionCheckFailedCount.GetMetricName()).Record(1)
+		vc.metricsHandler.Counter(metrics.VersionCheckRequestFailedCount.Name()).Record(1)
+		vc.metricsHandler.Counter(metrics.VersionCheckFailedCount.Name()).Record(1)
 		return
 	}
 	err = vc.saveVersionInfo(ctx, resp)
 	if err != nil {
-		vc.metricsHandler.Counter(metrics.VersionCheckFailedCount.GetMetricName()).Record(1)
+		vc.metricsHandler.Counter(metrics.VersionCheckFailedCount.Name()).Record(1)
 		return
 	}
-	vc.metricsHandler.Counter(metrics.VersionCheckSuccessCount.GetMetricName()).Record(1)
+	vc.metricsHandler.Counter(metrics.VersionCheckSuccessCount.Name()).Record(1)
 }
 
 func isUpdateNeeded(metadata *persistence.GetClusterMetadataResponse) bool {

--- a/service/frontend/workflow_handler.go
+++ b/service/frontend/workflow_handler.go
@@ -737,7 +737,7 @@ func (wh *WorkflowHandler) RespondWorkflowTaskFailed(
 			tag.WorkflowID(taskToken.GetWorkflowId()),
 			tag.WorkflowRunID(taskToken.GetRunId()),
 		)
-		wh.metricsScope(ctx).Counter(metrics.ServiceErrNonDeterministicCounter.GetMetricName()).Record(1)
+		wh.metricsScope(ctx).Counter(metrics.ServiceErrNonDeterministicCounter.Name()).Record(1)
 	}
 
 	_, err = wh.historyClient.RespondWorkflowTaskFailed(ctx, &historyservice.RespondWorkflowTaskFailedRequest{

--- a/service/frontend/workflow_handler_deprecated.go
+++ b/service/frontend/workflow_handler_deprecated.go
@@ -524,7 +524,7 @@ func (wh *WorkflowHandler) getRawHistory(
 
 	if len(resp.NextPageToken) == 0 && transientWorkflowTaskInfo != nil {
 		if err := wh.validateTransientWorkflowTaskEvents(nextEventID, transientWorkflowTaskInfo); err != nil {
-			metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.GetMetricName()).Record(1)
+			metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.Name()).Record(1)
 			wh.logger.Error("getHistory error",
 				tag.WorkflowNamespaceID(namespaceID.String()),
 				tag.WorkflowID(execution.GetWorkflowId()),
@@ -592,7 +592,7 @@ func (wh *WorkflowHandler) getHistory(
 		return nil, nil, err
 	}
 
-	metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(size))
+	metricsHandler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(int64(size))
 
 	isLastPage := len(nextPageToken) == 0
 	if err := wh.verifyHistoryIsComplete(
@@ -602,7 +602,7 @@ func (wh *WorkflowHandler) getHistory(
 		isFirstPage,
 		isLastPage,
 		int(pageSize)); err != nil {
-		metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.GetMetricName()).Record(1)
+		metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.Name()).Record(1)
 		wh.logger.Error("getHistory: incomplete history",
 			tag.WorkflowNamespaceID(namespaceID.String()),
 			tag.WorkflowID(execution.GetWorkflowId()),
@@ -612,7 +612,7 @@ func (wh *WorkflowHandler) getHistory(
 
 	if len(nextPageToken) == 0 && transientWorkflowTaskInfo != nil {
 		if err := wh.validateTransientWorkflowTaskEvents(nextEventID, transientWorkflowTaskInfo); err != nil {
-			metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.GetMetricName()).Record(1)
+			metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.Name()).Record(1)
 			wh.logger.Error("getHistory error",
 				tag.WorkflowNamespaceID(namespaceID.String()),
 				tag.WorkflowID(execution.GetWorkflowId()),
@@ -671,7 +671,7 @@ func (wh *WorkflowHandler) getHistoryReverse(
 		return nil, nil, 0, err
 	}
 
-	metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(size))
+	metricsHandler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(int64(size))
 
 	if err := wh.processOutgoingSearchAttributes(historyEvents, namespace); err != nil {
 		return nil, nil, 0, err

--- a/service/history/api/create_workflow_util.go
+++ b/service/history/api/create_workflow_util.go
@@ -225,7 +225,7 @@ func ValidateStart(
 	}
 
 	handler := interceptor.GetMetricsHandlerFromContext(ctx, logger).WithTags(metrics.CommandTypeTag(operation))
-	handler.Histogram(metrics.MemoSize.GetMetricName(), metrics.MemoSize.GetMetricUnit()).Record(int64(workflowMemoSize))
+	handler.Histogram(metrics.MemoSize.Name(), metrics.MemoSize.Unit()).Record(int64(workflowMemoSize))
 	if err := common.CheckEventBlobSizeLimit(
 		workflowMemoSize,
 		config.MemoSizeLimitWarn(namespaceName),
@@ -315,7 +315,7 @@ func OverrideStartWorkflowExecutionRequest(
 	)
 	if workflowRunTimeout != timestamp.DurationValue(request.GetWorkflowRunTimeout()) {
 		request.WorkflowRunTimeout = durationpb.New(workflowRunTimeout)
-		metricsHandler.Counter(metrics.WorkflowRunTimeoutOverrideCount.GetMetricName()).Record(
+		metricsHandler.Counter(metrics.WorkflowRunTimeoutOverrideCount.Name()).Record(
 			1,
 			metrics.OperationTag(operation),
 			metrics.NamespaceTag(namespace),
@@ -330,7 +330,7 @@ func OverrideStartWorkflowExecutionRequest(
 	)
 	if workflowTaskStartToCloseTimeout != timestamp.DurationValue(request.GetWorkflowTaskTimeout()) {
 		request.WorkflowTaskTimeout = durationpb.New(workflowTaskStartToCloseTimeout)
-		metricsHandler.Counter(metrics.WorkflowTaskTimeoutOverrideCount.GetMetricName()).Record(
+		metricsHandler.Counter(metrics.WorkflowTaskTimeoutOverrideCount.Name()).Record(
 			1,
 			metrics.OperationTag(operation),
 			metrics.NamespaceTag(namespace),

--- a/service/history/api/get_history_util.go
+++ b/service/history/api/get_history_util.go
@@ -85,7 +85,7 @@ func GetRawHistory(
 		if err := validateTransientWorkflowTaskEvents(nextEventID, transientWorkflowTaskInfo); err != nil {
 			logger := shard.GetLogger()
 			metricsHandler := interceptor.GetMetricsHandlerFromContext(ctx, logger).WithTags(metrics.OperationTag(metrics.HistoryGetRawHistoryScope))
-			metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.GetMetricName()).Record(1)
+			metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.Name()).Record(1)
 			logger.Error("getHistory error",
 				tag.WorkflowNamespaceID(namespaceID.String()),
 				tag.WorkflowID(execution.GetWorkflowId()),
@@ -154,7 +154,7 @@ func GetHistory(
 
 	logger := shard.GetLogger()
 	metricsHandler := interceptor.GetMetricsHandlerFromContext(ctx, logger).WithTags(metrics.OperationTag(metrics.HistoryGetHistoryScope))
-	metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(size))
+	metricsHandler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(int64(size))
 
 	isLastPage := len(nextPageToken) == 0
 	if err := verifyHistoryIsComplete(
@@ -164,7 +164,7 @@ func GetHistory(
 		isFirstPage,
 		isLastPage,
 		int(pageSize)); err != nil {
-		metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.GetMetricName()).Record(1)
+		metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.Name()).Record(1)
 		logger.Error("getHistory: incomplete history",
 			tag.WorkflowNamespaceID(namespaceID.String()),
 			tag.WorkflowID(execution.GetWorkflowId()),
@@ -174,7 +174,7 @@ func GetHistory(
 
 	if len(nextPageToken) == 0 && transientWorkflowTaskInfo != nil {
 		if err := validateTransientWorkflowTaskEvents(nextEventID, transientWorkflowTaskInfo); err != nil {
-			metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.GetMetricName()).Record(1)
+			metricsHandler.Counter(metrics.ServiceErrIncompleteHistoryCounter.Name()).Record(1)
 			logger.Error("getHistory error",
 				tag.WorkflowNamespaceID(namespaceID.String()),
 				tag.WorkflowID(execution.GetWorkflowId()),
@@ -234,7 +234,7 @@ func GetHistoryReverse(
 	}
 
 	metricsHandler := interceptor.GetMetricsHandlerFromContext(ctx, logger).WithTags(metrics.OperationTag(metrics.HistoryGetHistoryReverseScope))
-	metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(size))
+	metricsHandler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(int64(size))
 
 	if err := ProcessOutgoingSearchAttributes(shard, historyEvents, namespaceID, persistenceVisibilityMgr); err != nil {
 		return nil, nil, 0, err

--- a/service/history/api/getworkflowexecutionrawhistoryv2/api.go
+++ b/service/history/api/getworkflowexecutionrawhistoryv2/api.go
@@ -157,7 +157,7 @@ func Invoke(
 	pageToken.PersistenceToken = rawHistoryResponse.NextPageToken
 	size := rawHistoryResponse.Size
 	metricsHandler := interceptor.GetMetricsHandlerFromContext(ctx, shardContext.GetLogger()).WithTags(metrics.OperationTag(metrics.HistoryGetWorkflowExecutionRawHistoryV2Scope))
-	metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(
+	metricsHandler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(
 		int64(size),
 		metrics.NamespaceTag(ns.Name().String()),
 		metrics.OperationTag(metrics.AdminGetWorkflowExecutionRawHistoryV2Scope),

--- a/service/history/api/reapplyevents/api.go
+++ b/service/history/api/reapplyevents/api.go
@@ -118,7 +118,7 @@ func Invoke(
 						tag.WorkflowNamespaceID(namespaceID.String()),
 						tag.WorkflowID(workflowID),
 					)
-					shard.GetMetricsHandler().Counter(metrics.EventReapplySkippedCount.GetMetricName()).Record(
+					shard.GetMetricsHandler().Counter(metrics.EventReapplySkippedCount.Name()).Record(
 						1,
 						metrics.OperationTag(metrics.HistoryReapplyEventsScope))
 					return &api.UpdateWorkflowAction{

--- a/service/history/api/recordactivitytaskheartbeat/api.go
+++ b/service/history/api/recordactivitytaskheartbeat/api.go
@@ -86,7 +86,7 @@ func Invoke(
 			// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduledEventID >= mutableState.GetNextEventID() {
-				shard.GetMetricsHandler().Counter(metrics.StaleMutableStateCounter.GetMetricName()).Record(
+				shard.GetMetricsHandler().Counter(metrics.StaleMutableStateCounter.Name()).Record(
 					1,
 					metrics.OperationTag(metrics.HistoryRecordActivityTaskHeartbeatScope))
 				return nil, consts.ErrStaleState

--- a/service/history/api/recordactivitytaskstarted/api.go
+++ b/service/history/api/recordactivitytaskstarted/api.go
@@ -77,7 +77,7 @@ func Invoke(
 			// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduledEventID >= mutableState.GetNextEventID() {
-				taggedMetrics.Counter(metrics.StaleMutableStateCounter.GetMetricName()).Record(1)
+				taggedMetrics.Counter(metrics.StaleMutableStateCounter.Name()).Record(1)
 				return nil, consts.ErrStaleState
 			}
 
@@ -127,7 +127,7 @@ func Invoke(
 				namespaceName.String(),
 				taskQueueName,
 				enumspb.TASK_QUEUE_KIND_NORMAL,
-			).Timer(metrics.TaskScheduleToStartLatency.GetMetricName()).Record(
+			).Timer(metrics.TaskScheduleToStartLatency.Name()).Record(
 				scheduleToStartLatency,
 				metrics.TaskQueueTypeTag(enumspb.TASK_QUEUE_TYPE_ACTIVITY),
 			)

--- a/service/history/api/respondactivitytaskcanceled/api.go
+++ b/service/history/api/respondactivitytaskcanceled/api.go
@@ -91,7 +91,7 @@ func Invoke(
 			// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduledEventID >= mutableState.GetNextEventID() {
-				shard.GetMetricsHandler().Counter(metrics.StaleMutableStateCounter.GetMetricName()).Record(
+				shard.GetMetricsHandler().Counter(metrics.StaleMutableStateCounter.Name()).Record(
 					1,
 					metrics.OperationTag(metrics.HistoryRespondActivityTaskCanceledScope))
 				return nil, consts.ErrStaleState
@@ -132,7 +132,7 @@ func Invoke(
 	)
 
 	if err == nil && !activityStartedTime.IsZero() {
-		shard.GetMetricsHandler().Timer(metrics.ActivityE2ELatency.GetMetricName()).Record(
+		shard.GetMetricsHandler().Timer(metrics.ActivityE2ELatency.Name()).Record(
 			time.Since(activityStartedTime),
 			metrics.OperationTag(metrics.HistoryRespondActivityTaskCanceledScope),
 			metrics.NamespaceTag(namespace.String()),

--- a/service/history/api/respondactivitytaskcompleted/api.go
+++ b/service/history/api/respondactivitytaskcompleted/api.go
@@ -90,7 +90,7 @@ func Invoke(
 			// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduledEventID >= mutableState.GetNextEventID() {
-				shard.GetMetricsHandler().Counter(metrics.StaleMutableStateCounter.GetMetricName()).Record(
+				shard.GetMetricsHandler().Counter(metrics.StaleMutableStateCounter.Name()).Record(
 					1,
 					metrics.OperationTag(metrics.HistoryRespondActivityTaskCompletedScope))
 				return nil, consts.ErrStaleState
@@ -120,7 +120,7 @@ func Invoke(
 	)
 
 	if err == nil && !activityStartedTime.IsZero() {
-		shard.GetMetricsHandler().Timer(metrics.ActivityE2ELatency.GetMetricName()).Record(
+		shard.GetMetricsHandler().Timer(metrics.ActivityE2ELatency.Name()).Record(
 			time.Since(activityStartedTime),
 			metrics.OperationTag(metrics.HistoryRespondActivityTaskCompletedScope),
 			metrics.NamespaceTag(namespace.String()),

--- a/service/history/api/respondactivitytaskfailed/api.go
+++ b/service/history/api/respondactivitytaskfailed/api.go
@@ -94,7 +94,7 @@ func Invoke(
 			// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 			// some extreme cassandra failure cases.
 			if !isRunning && scheduledEventID >= mutableState.GetNextEventID() {
-				shard.GetMetricsHandler().Counter(metrics.StaleMutableStateCounter.GetMetricName()).Record(
+				shard.GetMetricsHandler().Counter(metrics.StaleMutableStateCounter.Name()).Record(
 					1,
 					metrics.OperationTag(metrics.HistoryRespondActivityTaskFailedScope))
 				return nil, consts.ErrStaleState
@@ -141,7 +141,7 @@ func Invoke(
 		workflowConsistencyChecker,
 	)
 	if err == nil && !activityStartedTime.IsZero() {
-		shard.GetMetricsHandler().Timer(metrics.ActivityE2ELatency.GetMetricName()).Record(
+		shard.GetMetricsHandler().Timer(metrics.ActivityE2ELatency.Name()).Record(
 			time.Since(activityStartedTime),
 			metrics.OperationTag(metrics.HistoryRespondActivityTaskFailedScope),
 			metrics.NamespaceTag(namespace.String()),

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -123,7 +123,7 @@ func (s *Starter) prepare(ctx context.Context) error {
 	}
 
 	if request.RequestEagerExecution {
-		metricsHandler.Counter(metrics.WorkflowEagerExecutionCounter.GetMetricName()).Record(
+		metricsHandler.Counter(metrics.WorkflowEagerExecutionCounter.Name()).Record(
 			1,
 			metrics.NamespaceTag(s.namespace.Name().String()),
 			metrics.TaskQueueTag(request.TaskQueue.Name),
@@ -145,7 +145,7 @@ func (s *Starter) prepare(ctx context.Context) error {
 
 func (s *Starter) recordEagerDenied(reason eagerStartDeniedReason) {
 	metricsHandler := s.shardContext.GetMetricsHandler()
-	metricsHandler.Counter(metrics.WorkflowEagerExecutionDeniedCounter.GetMetricName()).Record(
+	metricsHandler.Counter(metrics.WorkflowEagerExecutionDeniedCounter.Name()).Record(
 		1,
 		metrics.NamespaceTag(s.namespace.Name().String()),
 		metrics.TaskQueueTag(s.request.StartRequest.TaskQueue.Name),

--- a/service/history/archival/archiver.go
+++ b/service/history/archival/archiver.go
@@ -154,7 +154,7 @@ func (a *archiver) Archive(ctx context.Context, request *Request) (res *Response
 			logger.Warn("failed to archive workflow", tag.Error(err))
 		}
 
-		metricsScope.Timer(metrics.ArchiverArchiveLatency.GetMetricName()).
+		metricsScope.Timer(metrics.ArchiverArchiveLatency.Name()).
 			Record(time.Since(start), metrics.StringTag("status", status))
 	}(time.Now())
 
@@ -286,6 +286,6 @@ func (a *archiver) recordArchiveTargetResult(logger log.Logger, startTime time.T
 		metrics.StringTag("target", string(target)),
 		metrics.StringTag("status", status),
 	}
-	latency := metrics.ArchiverArchiveTargetLatency.GetMetricName()
+	latency := metrics.ArchiverArchiveTargetLatency.Name()
 	a.metricsHandler.Timer(latency).Record(duration, tags...)
 }

--- a/service/history/archival_queue_task_executor.go
+++ b/service/history/archival_queue_task_executor.go
@@ -174,7 +174,7 @@ func (e *archivalQueueTaskExecutor) getArchiveTaskRequest(
 		visibilityURIString := namespaceEntry.VisibilityArchivalState().URI
 		visibilityURI, err = carchiver.NewURI(visibilityURIString)
 		if err != nil {
-			e.metricsHandler.Counter(metrics.ArchivalTaskInvalidURI.GetMetricName()).Record(
+			e.metricsHandler.Counter(metrics.ArchivalTaskInvalidURI.Name()).Record(
 				1,
 				metrics.NamespaceTag(namespaceName.String()),
 				metrics.FailureTag(metrics.InvalidVisibilityURITagValue),
@@ -192,7 +192,7 @@ func (e *archivalQueueTaskExecutor) getArchiveTaskRequest(
 		historyURIString := namespaceEntry.HistoryArchivalState().URI
 		historyURI, err = carchiver.NewURI(historyURIString)
 		if err != nil {
-			e.metricsHandler.Counter(metrics.ArchivalTaskInvalidURI.GetMetricName()).Record(
+			e.metricsHandler.Counter(metrics.ArchivalTaskInvalidURI.Name()).Record(
 				1,
 				metrics.NamespaceTag(namespaceName.String()),
 				metrics.FailureTag(metrics.InvalidHistoryURITagValue),

--- a/service/history/command_checker.go
+++ b/service/history/command_checker.go
@@ -149,7 +149,7 @@ func (c *workflowSizeChecker) checkIfMemoSizeExceedsLimit(
 	commandTypeTag metrics.Tag,
 	message string,
 ) error {
-	c.metricsHandler.Histogram(metrics.MemoSize.GetMetricName(), metrics.MemoSize.GetMetricUnit()).Record(
+	c.metricsHandler.Histogram(metrics.MemoSize.Name(), metrics.MemoSize.Unit()).Record(
 		int64(memo.Size()),
 		commandTypeTag)
 
@@ -219,7 +219,7 @@ func (c *workflowSizeChecker) checkIfNumChildWorkflowsExceedsLimit() error {
 	return c.checkCountConstraint(
 		len(c.mutableState.GetPendingChildExecutionInfos()),
 		c.numPendingChildExecutionsLimit,
-		metrics.TooManyPendingChildWorkflows.GetMetricName(),
+		metrics.TooManyPendingChildWorkflows.Name(),
 		PendingChildWorkflowExecutionsDescription,
 	)
 }
@@ -228,7 +228,7 @@ func (c *workflowSizeChecker) checkIfNumPendingActivitiesExceedsLimit() error {
 	return c.checkCountConstraint(
 		len(c.mutableState.GetPendingActivityInfos()),
 		c.numPendingActivitiesLimit,
-		metrics.TooManyPendingActivities.GetMetricName(),
+		metrics.TooManyPendingActivities.Name(),
 		PendingActivitiesDescription,
 	)
 }
@@ -237,7 +237,7 @@ func (c *workflowSizeChecker) checkIfNumPendingCancelRequestsExceedsLimit() erro
 	return c.checkCountConstraint(
 		len(c.mutableState.GetPendingRequestCancelExternalInfos()),
 		c.numPendingCancelsRequestLimit,
-		metrics.TooManyPendingCancelRequests.GetMetricName(),
+		metrics.TooManyPendingCancelRequests.Name(),
 		PendingCancelRequestsDescription,
 	)
 }
@@ -246,7 +246,7 @@ func (c *workflowSizeChecker) checkIfNumPendingSignalsExceedsLimit() error {
 	return c.checkCountConstraint(
 		len(c.mutableState.GetPendingSignalExternalInfos()),
 		c.numPendingSignalsLimit,
-		metrics.TooManyPendingSignalsToExternalWorkflows.GetMetricName(),
+		metrics.TooManyPendingSignalsToExternalWorkflows.Name(),
 		PendingSignalsDescription,
 	)
 }
@@ -256,7 +256,7 @@ func (c *workflowSizeChecker) checkIfSearchAttributesSizeExceedsLimit(
 	namespace namespace.Name,
 	commandTypeTag metrics.Tag,
 ) error {
-	c.metricsHandler.Histogram(metrics.SearchAttributesSize.GetMetricName(), metrics.SearchAttributesSize.GetMetricUnit()).Record(
+	c.metricsHandler.Histogram(metrics.SearchAttributesSize.Name(), metrics.SearchAttributesSize.Unit()).Record(
 		int64(searchAttributes.Size()),
 		commandTypeTag)
 	err := c.searchAttributesValidator.ValidateSize(searchAttributes, namespace.String())

--- a/service/history/deletemanager/delete_manager.go
+++ b/service/history/deletemanager/delete_manager.go
@@ -214,6 +214,6 @@ func (m *DeleteManagerImpl) deleteWorkflowExecutionInternal(
 	// Clear workflow execution context here to prevent further readers to get stale copy of non-exiting workflow execution.
 	weCtx.Clear()
 
-	metricsHandler.Counter(metrics.WorkflowCleanupDeleteCount.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.WorkflowCleanupDeleteCount.Name()).Record(1)
 	return nil
 }

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -114,9 +114,9 @@ func (e *CacheImpl) validateKey(key EventKey) bool {
 
 func (e *CacheImpl) GetEvent(ctx context.Context, key EventKey, firstEventID int64, branchToken []byte) (*historypb.HistoryEvent, error) {
 	handler := e.metricsHandler.WithTags(metrics.OperationTag(metrics.EventsCacheGetEventScope))
-	handler.Counter(metrics.CacheRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.CacheRequests.Name()).Record(1)
 	startTime := time.Now().UTC()
-	defer func() { handler.Timer(metrics.CacheLatency.GetMetricName()).Record(time.Since(startTime)) }()
+	defer func() { handler.Timer(metrics.CacheLatency.Name()).Record(time.Since(startTime)) }()
 
 	validKey := e.validateKey(key)
 
@@ -128,10 +128,10 @@ func (e *CacheImpl) GetEvent(ctx context.Context, key EventKey, firstEventID int
 		}
 	}
 
-	handler.Counter(metrics.CacheMissCounter.GetMetricName()).Record(1)
+	handler.Counter(metrics.CacheMissCounter.Name()).Record(1)
 	event, err := e.getHistoryEventFromStore(ctx, key, firstEventID, branchToken)
 	if err != nil {
-		handler.Counter(metrics.CacheFailures.GetMetricName()).Record(1)
+		handler.Counter(metrics.CacheFailures.Name()).Record(1)
 		e.logger.Error("Cache unable to retrieve event from store",
 			tag.Error(err),
 			tag.WorkflowID(key.WorkflowID),
@@ -150,9 +150,9 @@ func (e *CacheImpl) GetEvent(ctx context.Context, key EventKey, firstEventID int
 
 func (e *CacheImpl) PutEvent(key EventKey, event *historypb.HistoryEvent) {
 	handler := e.metricsHandler.WithTags(metrics.OperationTag(metrics.EventsCachePutEventScope))
-	handler.Counter(metrics.CacheRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.CacheRequests.Name()).Record(1)
 	startTime := time.Now().UTC()
-	defer func() { handler.Timer(metrics.CacheLatency.GetMetricName()).Record(time.Since(startTime)) }()
+	defer func() { handler.Timer(metrics.CacheLatency.Name()).Record(time.Since(startTime)) }()
 
 	if !e.validateKey(key) {
 		return
@@ -162,9 +162,9 @@ func (e *CacheImpl) PutEvent(key EventKey, event *historypb.HistoryEvent) {
 
 func (e *CacheImpl) DeleteEvent(key EventKey) {
 	handler := e.metricsHandler.WithTags(metrics.OperationTag(metrics.EventsCacheDeleteEventScope))
-	handler.Counter(metrics.CacheRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.CacheRequests.Name()).Record(1)
 	startTime := time.Now().UTC()
-	defer func() { handler.Timer(metrics.CacheLatency.GetMetricName()).Record(time.Since(startTime)) }()
+	defer func() { handler.Timer(metrics.CacheLatency.Name()).Record(time.Since(startTime)) }()
 
 	e.validateKey(key) // just for log message, delete anyway
 	e.Delete(key)
@@ -178,9 +178,9 @@ func (e *CacheImpl) getHistoryEventFromStore(
 ) (*historypb.HistoryEvent, error) {
 
 	handler := e.metricsHandler.WithTags(metrics.OperationTag(metrics.EventsCacheGetFromStoreScope))
-	handler.Counter(metrics.CacheRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.CacheRequests.Name()).Record(1)
 	startTime := time.Now().UTC()
-	defer func() { handler.Timer(metrics.CacheLatency.GetMetricName()).Record(time.Since(startTime)) }()
+	defer func() { handler.Timer(metrics.CacheLatency.Name()).Record(time.Since(startTime)) }()
 
 	response, err := e.eventsMgr.ReadHistoryBranch(ctx, &persistence.ReadHistoryBranchRequest{
 		BranchToken:   branchToken,
@@ -196,10 +196,10 @@ func (e *CacheImpl) getHistoryEventFromStore(
 	case *serviceerror.DataLoss:
 		// log event
 		e.logger.Error("encounter data loss event", tag.WorkflowNamespaceID(key.NamespaceID.String()), tag.WorkflowID(key.WorkflowID), tag.WorkflowRunID(key.RunID))
-		handler.Counter(metrics.CacheFailures.GetMetricName()).Record(1)
+		handler.Counter(metrics.CacheFailures.Name()).Record(1)
 		return nil, err
 	default:
-		handler.Counter(metrics.CacheFailures.GetMetricName()).Record(1)
+		handler.Counter(metrics.CacheFailures.Name()).Record(1)
 		return nil, err
 	}
 

--- a/service/history/events/notifier.go
+++ b/service/history/events/notifier.go
@@ -202,7 +202,7 @@ func (notifier *NotifierImpl) dispatchHistoryEventNotification(event *Notificati
 
 	startTime := time.Now().UTC()
 	defer func() {
-		notifier.metricsHandler.Timer(metrics.HistoryEventNotificationFanoutLatency.GetMetricName()).Record(time.Since(startTime))
+		notifier.metricsHandler.Timer(metrics.HistoryEventNotificationFanoutLatency.Name()).Record(time.Since(startTime))
 	}()
 	_, _, _ = notifier.eventsPubsubs.GetAndDo(identifier, func(key interface{}, value interface{}) error {
 		subscribers := value.(map[string]chan *Notification)
@@ -227,19 +227,19 @@ func (notifier *NotifierImpl) enqueueHistoryEventNotification(event *Notificatio
 	default:
 		// in case the channel is already filled with message
 		// this can be caused by high load
-		notifier.metricsHandler.Counter(metrics.HistoryEventNotificationFailDeliveryCount.GetMetricName()).Record(1)
+		notifier.metricsHandler.Counter(metrics.HistoryEventNotificationFailDeliveryCount.Name()).Record(1)
 	}
 }
 
 func (notifier *NotifierImpl) dequeueHistoryEventNotifications() {
 	for {
 		// send out metrics about the current number of messages in flight
-		notifier.metricsHandler.Gauge(metrics.HistoryEventNotificationInFlightMessageGauge.GetMetricName()).Record(float64(len(notifier.eventsChan)))
+		notifier.metricsHandler.Gauge(metrics.HistoryEventNotificationInFlightMessageGauge.Name()).Record(float64(len(notifier.eventsChan)))
 		select {
 		case event := <-notifier.eventsChan:
 			// send out metrics about message processing delay
 			timeelapsed := time.Since(event.Timestamp)
-			notifier.metricsHandler.Timer(metrics.HistoryEventNotificationQueueingLatency.GetMetricName()).Record(timeelapsed)
+			notifier.metricsHandler.Timer(metrics.HistoryEventNotificationQueueingLatency.Name()).Record(timeelapsed)
 
 			notifier.dispatchHistoryEventNotification(event)
 		case <-notifier.closeChan:

--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -292,7 +292,7 @@ func (r *HistoryReplicatorImpl) doApplyEvents(
 			if err != nil {
 				return err
 			} else if !prepareHistoryBranchOut.DoContinue {
-				r.metricsHandler.Counter(metrics.DuplicateReplicationEventsCounter.GetMetricName()).Record(
+				r.metricsHandler.Counter(metrics.DuplicateReplicationEventsCounter.Name()).Record(
 					1,
 					metrics.OperationTag(metrics.ReplicateHistoryEventsScope))
 				return nil

--- a/service/history/ndc_task_util.go
+++ b/service/history/ndc_task_util.go
@@ -159,7 +159,7 @@ func LoadMutableStateForTask(
 		return mutableState, nil
 	}
 
-	metricsHandler.Counter(metrics.StaleMutableStateCounter.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.StaleMutableStateCounter.Name()).Record(1)
 	wfContext.Clear()
 
 	mutableState, err = wfContext.LoadMutableState(ctx, shardContext)
@@ -168,7 +168,7 @@ func LoadMutableStateForTask(
 	}
 	// after refresh, still mutable state's next event ID <= task's event ID
 	if eventID >= mutableState.GetNextEventID() {
-		metricsHandler.Counter(metrics.TaskSkipped.GetMetricName()).Record(1)
+		metricsHandler.Counter(metrics.TaskSkipped.Name()).Record(1)
 		logger.Info("Task Processor: task event ID >= MS NextEventID, skip.",
 			tag.WorkflowNextEventID(mutableState.GetNextEventID()),
 		)

--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -109,7 +109,7 @@ func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetClu
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrSendTaskToDLQ, err)
 	}
-	q.metricsHandler.Counter(metrics.DLQWrites.GetMetricName()).Record(1)
+	q.metricsHandler.Counter(metrics.DLQWrites.Name()).Record(1)
 	ns, err := q.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
 	var namespaceTag tag.Tag
 	if err != nil {

--- a/service/history/queues/dlq_writer_test.go
+++ b/service/history/queues/dlq_writer_test.go
@@ -121,7 +121,7 @@ func TestDLQWriter_ErrGetNamespaceName(t *testing.T) {
 	assert.Equal(t, logger.records[0].tags[1].Value(), errorMsg)
 	assert.Contains(t, logger.records[1].msg, "Task enqueued to DLQ")
 	snapshot := capture.Snapshot()
-	recordings := snapshot[metrics.DLQWrites.GetMetricName()]
+	recordings := snapshot[metrics.DLQWrites.Name()]
 	assert.Len(t, recordings, 1)
 	counter, ok := recordings[0].Value.(int64)
 	assert.True(t, ok)
@@ -167,7 +167,7 @@ func TestDLQWriter_Ok(t *testing.T) {
 	assert.Contains(t, logger.records[0].msg, "Task enqueued to DLQ")
 	assert.Contains(t, logger.records[0].tags, tag.DLQMessageID(0))
 	snapshot := capture.Snapshot()
-	recordings := snapshot[metrics.DLQWrites.GetMetricName()]
+	recordings := snapshot[metrics.DLQWrites.Name()]
 	assert.Len(t, recordings, 1)
 	counter, ok := recordings[0].Value.(int64)
 	assert.True(t, ok)

--- a/service/history/queues/executable_test.go
+++ b/service/history/queues/executable_test.go
@@ -186,7 +186,7 @@ func (s *executableSuite) TestExecute_InMemoryNoUserLatency_SingleAttempt() {
 			s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Do(func(ctx context.Context, taskInfo interface{}) {
 				metrics.ContextCounterAdd(
 					ctx,
-					metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName(),
+					metrics.HistoryWorkflowExecutionCacheLatency.Name(),
 					int64(userLatency),
 				)
 
@@ -213,7 +213,7 @@ func (s *executableSuite) TestExecute_InMemoryNoUserLatency_SingleAttempt() {
 				capture := s.metricsHandler.StartCapture()
 				executable.Ack()
 				snapshot := capture.Snapshot()
-				recordings := snapshot[metrics.TaskLatency.GetMetricName()]
+				recordings := snapshot[metrics.TaskLatency.Name()]
 				s.Len(recordings, 1)
 				actualAttemptNoUserLatency, ok := recordings[0].Value.(time.Duration)
 				s.True(ok)
@@ -255,7 +255,7 @@ func (s *executableSuite) TestExecute_InMemoryNoUserLatency_MultipleAttempts() {
 		s.mockExecutor.EXPECT().Execute(gomock.Any(), executable).Do(func(ctx context.Context, taskInfo interface{}) {
 			metrics.ContextCounterAdd(
 				ctx,
-				metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName(),
+				metrics.HistoryWorkflowExecutionCacheLatency.Name(),
 				int64(userLatencies[i]),
 			)
 
@@ -281,7 +281,7 @@ func (s *executableSuite) TestExecute_InMemoryNoUserLatency_MultipleAttempts() {
 			capture := s.metricsHandler.StartCapture()
 			executable.Ack()
 			snapshot := capture.Snapshot()
-			recordings := snapshot[metrics.TaskLatency.GetMetricName()]
+			recordings := snapshot[metrics.TaskLatency.Name()]
 			s.Len(recordings, 1)
 			actualInMemoryNoUserLatency, ok := recordings[0].Value.(time.Duration)
 			s.True(ok)

--- a/service/history/queues/memory_scheduled_queue.go
+++ b/service/history/queues/memory_scheduled_queue.go
@@ -157,7 +157,7 @@ func (q *memoryScheduledQueue) processQueueLoop() {
 				}
 				q.nextTaskTimer.Reset(newTask.GetVisibilityTime().Sub(q.timeSource.Now()))
 			}
-			q.metricsHandler.Counter(metrics.NewTimerNotifyCounter.GetMetricName()).Record(1)
+			q.metricsHandler.Counter(metrics.NewTimerNotifyCounter.Name()).Record(1)
 		case <-q.nextTaskTimer.C:
 			taskToExecute := q.taskQueue.Remove()
 			// Skip tasks which are already canceled. Majority of the tasks in the queue should be cancelled already.

--- a/service/history/queues/mitigator.go
+++ b/service/history/queues/mitigator.go
@@ -123,11 +123,11 @@ func runAction(
 	logger log.Logger,
 ) error {
 	metricsHandler = metricsHandler.WithTags(metrics.QueueActionTag(action.Name()))
-	metricsHandler.Counter(metrics.QueueActionCounter.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.QueueActionCounter.Name()).Record(1)
 
 	if err := action.Run(readerGroup); err != nil {
 		logger.Error("Queue action failed", tag.Error(err))
-		metricsHandler.Counter(metrics.QueueActionFailures.GetMetricName()).Record(1)
+		metricsHandler.Counter(metrics.QueueActionFailures.Name()).Record(1)
 		return err
 	}
 

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -344,11 +344,11 @@ func (p *queueBase) checkpoint() {
 			newExclusiveDeletionHighWatermark = tasks.MinKey(newExclusiveDeletionHighWatermark, scopes[0].Range.InclusiveMin)
 		}
 	}
-	p.metricsHandler.Histogram(metrics.QueueReaderCountHistogram.GetMetricName(), metrics.QueueReaderCountHistogram.GetMetricUnit()).
+	p.metricsHandler.Histogram(metrics.QueueReaderCountHistogram.Name(), metrics.QueueReaderCountHistogram.Unit()).
 		Record(int64(len(readerScopes)))
-	p.metricsHandler.Histogram(metrics.QueueSliceCountHistogram.GetMetricName(), metrics.QueueSliceCountHistogram.GetMetricUnit()).
+	p.metricsHandler.Histogram(metrics.QueueSliceCountHistogram.Name(), metrics.QueueSliceCountHistogram.Unit()).
 		Record(int64(p.monitor.GetTotalSliceCount()))
-	p.metricsHandler.Histogram(metrics.PendingTasksCounter.GetMetricName(), metrics.PendingTasksCounter.GetMetricUnit()).
+	p.metricsHandler.Histogram(metrics.PendingTasksCounter.Name(), metrics.PendingTasksCounter.Unit()).
 		Record(int64(p.monitor.GetTotalPendingTaskCount()))
 
 	p.updateReaderProgress(readerScopes)
@@ -359,7 +359,7 @@ func (p *queueBase) checkpoint() {
 	//
 	// Emit metric before the deletion watermark comparison so we have the emit even if there's no task
 	// for the queue.
-	p.metricsHandler.Counter(metrics.TaskBatchCompleteCounter.GetMetricName()).Record(1)
+	p.metricsHandler.Counter(metrics.TaskBatchCompleteCounter.Name()).Record(1)
 	if newExclusiveDeletionHighWatermark.CompareTo(p.exclusiveDeletionHighWatermark) > 0 ||
 		(p.updateShardRangeID() && newExclusiveDeletionHighWatermark.CompareTo(tasks.MinimumKey) > 0) {
 		// When shard rangeID is updated, perform range completion again in case the underlying persistence implementation
@@ -459,7 +459,7 @@ func (p *queueBase) rangeCompleteTasks(
 func (p *queueBase) updateQueueState(
 	readerScopes map[int64][]Scope,
 ) error {
-	p.metricsHandler.Counter(metrics.AckLevelUpdateCounter.GetMetricName()).Record(1)
+	p.metricsHandler.Counter(metrics.AckLevelUpdateCounter.Name()).Record(1)
 	for readerID, scopes := range readerScopes {
 		if len(scopes) == 0 {
 			delete(readerScopes, readerID)
@@ -471,7 +471,7 @@ func (p *queueBase) updateQueueState(
 		exclusiveReaderHighWatermark: p.nonReadableScope.Range.InclusiveMin,
 	}))
 	if err != nil {
-		p.metricsHandler.Counter(metrics.AckLevelUpdateFailedCounter.GetMetricName()).Record(1)
+		p.metricsHandler.Counter(metrics.AckLevelUpdateFailedCounter.Name()).Record(1)
 		p.logger.Error("Error updating queue state", tag.Error(err), tag.OperationFailed)
 	}
 	return err

--- a/service/history/queues/queue_scheduled.go
+++ b/service/history/queues/queue_scheduled.go
@@ -211,7 +211,7 @@ func (p *scheduledQueue) processEventLoop() {
 		case <-p.shutdownCh:
 			return
 		case <-p.newTimerCh:
-			p.metricsHandler.Counter(metrics.NewTimerNotifyCounter.GetMetricName()).Record(1)
+			p.metricsHandler.Counter(metrics.NewTimerNotifyCounter.Name()).Record(1)
 			p.processNewTime()
 		case <-p.lookAheadCh:
 			p.lookAheadTask()

--- a/service/history/queues/rescheduler.go
+++ b/service/history/queues/rescheduler.go
@@ -227,7 +227,7 @@ func (r *reschedulerImpl) reschedule() {
 	r.Lock()
 	defer r.Unlock()
 
-	r.metricsHandler.Histogram(metrics.TaskReschedulerPendingTasks.GetMetricName(), metrics.TaskReschedulerPendingTasks.GetMetricUnit()).Record(int64(r.numExecutables))
+	r.metricsHandler.Histogram(metrics.TaskReschedulerPendingTasks.Name(), metrics.TaskReschedulerPendingTasks.Unit()).Record(int64(r.numExecutables))
 
 	now := r.timeSource.Now()
 	for _, pq := range r.pqMap {

--- a/service/history/queues/scheduler_monitor.go
+++ b/service/history/queues/scheduler_monitor.go
@@ -195,7 +195,7 @@ func (m *schedulerMonitor) emitMetric(
 		totalLatency = totalLatency / time.Duration(stats.numStarted) * time.Duration(m.options.aggregationCount)
 	}
 
-	stats.taggedMetricsHandler.Timer(metrics.QueueScheduleLatency.GetMetricName()).Record(totalLatency)
+	stats.taggedMetricsHandler.Timer(metrics.QueueScheduleLatency.Name()).Record(totalLatency)
 
 	m.resetStats(stats)
 }

--- a/service/history/queues/scheuduler_monitor_test.go
+++ b/service/history/queues/scheuduler_monitor_test.go
@@ -77,7 +77,7 @@ func (s *schedulerMonitorSuite) SetupTest() {
 
 	s.mockNamespaceRegistry.EXPECT().GetNamespaceName(gomock.Any()).Return(tests.Namespace, nil).AnyTimes()
 	s.mockMetricsHandler.EXPECT().WithTags(gomock.Any()).Return(s.mockMetricsHandler).AnyTimes()
-	s.mockMetricsHandler.EXPECT().Timer(metrics.QueueScheduleLatency.GetMetricName()).Return(s.mockTimerMetric).AnyTimes()
+	s.mockMetricsHandler.EXPECT().Timer(metrics.QueueScheduleLatency.Name()).Return(s.mockTimerMetric).AnyTimes()
 
 	s.schedulerMonitor = newSchedulerMonitor(
 		func(e Executable) TaskChannelKey {

--- a/service/history/replication/ack_manager.go
+++ b/service/history/replication/ack_manager.go
@@ -266,13 +266,13 @@ func (p *ackMgrImpl) GetTasks(
 	}
 
 	// Note this is a very rough indicator of how much the remote DC is behind on this shard.
-	p.metricsHandler.Histogram(metrics.ReplicationTasksLag.GetMetricName(), metrics.ReplicationTasksLag.GetMetricUnit()).Record(
+	p.metricsHandler.Histogram(metrics.ReplicationTasksLag.Name(), metrics.ReplicationTasksLag.Unit()).Record(
 		maxTaskID-lastTaskID,
 		metrics.TargetClusterTag(pollingCluster),
 		metrics.OperationTag(metrics.ReplicationTaskFetcherScope),
 	)
 
-	p.metricsHandler.Histogram(metrics.ReplicationTasksFetched.GetMetricName(), metrics.ReplicationTasksFetched.GetMetricUnit()).
+	p.metricsHandler.Histogram(metrics.ReplicationTasksFetched.Name(), metrics.ReplicationTasksFetched.Unit()).
 		Record(int64(len(replicationTasks)))
 
 	replicationEventTime := timestamppb.New(p.shardContext.GetTimeSource().Now())

--- a/service/history/replication/batchable_task.go
+++ b/service/history/replication/batchable_task.go
@@ -89,7 +89,7 @@ func (w *batchedTask) MarkPoisonPill() error {
 }
 
 func (w *batchedTask) Ack() {
-	w.metricsHandler.Gauge(metrics.BatchableTaskBatchCount.GetMetricName()).Record(
+	w.metricsHandler.Gauge(metrics.BatchableTaskBatchCount.Name()).Record(
 		float64(len(w.individualTasks)),
 	)
 	w.callIndividual(TrackableExecutableTask.Ack)

--- a/service/history/replication/eager_namespace_refresher.go
+++ b/service/history/replication/eager_namespace_refresher.go
@@ -176,7 +176,7 @@ func (e *eagerNamespaceRefresherImpl) SyncNamespaceFromSourceCluster(
 		}
 	}
 	if !hasCurrentCluster {
-		e.metricsHandler.Counter(metrics.ReplicationOutlierNamespace.GetMetricName()).Record(1)
+		e.metricsHandler.Counter(metrics.ReplicationOutlierNamespace.Name()).Record(1)
 		return nil, serviceerror.NewFailedPrecondition("Namespace does not belong to current cluster")
 	}
 	task := &replicationspb.NamespaceTaskAttributes{

--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -116,7 +116,7 @@ func (e *ExecutableActivityStateTask) Execute() error {
 			tag.WorkflowRunID(e.RunID),
 			tag.TaskID(e.ExecutableTask.TaskID()),
 		)
-		e.MetricsHandler.Counter(metrics.ReplicationTasksSkipped.GetMetricName()).Record(
+		e.MetricsHandler.Counter(metrics.ReplicationTasksSkipped.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.SyncActivityTaskScope),
 			metrics.NamespaceTag(namespaceName),

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -126,7 +126,7 @@ func (e *ExecutableHistoryTask) Execute() error {
 			tag.WorkflowRunID(e.RunID),
 			tag.TaskID(e.ExecutableTask.TaskID()),
 		)
-		e.MetricsHandler.Counter(metrics.ReplicationTasksSkipped.GetMetricName()).Record(
+		e.MetricsHandler.Counter(metrics.ReplicationTasksSkipped.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryReplicationTaskScope),
 			metrics.NamespaceTag(namespaceName),

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -200,7 +200,7 @@ func (e *ExecutableTaskImpl) Nack(err error) {
 	if item != nil {
 		namespaceName = item.(namespace.Name).String()
 	}
-	e.MetricsHandler.Counter(metrics.ReplicationTasksFailed.GetMetricName()).Record(
+	e.MetricsHandler.Counter(metrics.ReplicationTasksFailed.Name()).Record(
 		1,
 		metrics.OperationTag(e.metricsTag),
 		metrics.NamespaceTag(namespaceName),
@@ -284,12 +284,12 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 	if item != nil {
 		nsTag = metrics.NamespaceTag(item.(namespace.Name).String())
 	}
-	e.MetricsHandler.Timer(metrics.ServiceLatency.GetMetricName()).Record(
+	e.MetricsHandler.Timer(metrics.ServiceLatency.Name()).Record(
 		now.Sub(e.taskReceivedTime),
 		metrics.OperationTag(e.metricsTag),
 		nsTag,
 	)
-	e.MetricsHandler.Timer(metrics.ReplicationLatency.GetMetricName()).Record(
+	e.MetricsHandler.Timer(metrics.ReplicationLatency.Name()).Record(
 		e.taskReceivedTime.Sub(e.taskCreationTime),
 		metrics.OperationTag(e.metricsTag),
 		nsTag,
@@ -315,13 +315,13 @@ func (e *ExecutableTaskImpl) Resend(
 		return false, ErrResendAttemptExceeded
 	}
 
-	e.MetricsHandler.Counter(metrics.ClientRequests.GetMetricName()).Record(
+	e.MetricsHandler.Counter(metrics.ClientRequests.Name()).Record(
 		1,
 		metrics.OperationTag(e.metricsTag+"Resend"),
 	)
 	startTime := time.Now().UTC()
 	defer func() {
-		e.MetricsHandler.Timer(metrics.ClientLatency.GetMetricName()).Record(
+		e.MetricsHandler.Timer(metrics.ClientLatency.Name()).Record(
 			time.Since(startTime),
 			metrics.OperationTag(e.metricsTag+"Resend"),
 		)
@@ -461,13 +461,13 @@ func (e *ExecutableTaskImpl) Import(
 	endEventId int64,
 	endEventVersion int64,
 ) error {
-	e.MetricsHandler.Counter(metrics.ClientRequests.GetMetricName()).Record(
+	e.MetricsHandler.Counter(metrics.ClientRequests.Name()).Record(
 		1,
 		metrics.OperationTag(e.metricsTag+"Import"),
 	)
 	startTime := time.Now().UTC()
 	defer func() {
-		e.MetricsHandler.Timer(metrics.ClientLatency.GetMetricName()).Record(
+		e.MetricsHandler.Timer(metrics.ClientLatency.Name()).Record(
 			time.Since(startTime),
 			metrics.OperationTag(e.metricsTag+"Import"),
 		)

--- a/service/history/replication/executable_task_converter.go
+++ b/service/history/replication/executable_task_converter.go
@@ -64,7 +64,7 @@ func (e *executableTaskConverterImpl) Convert(
 ) []TrackableExecutableTask {
 	tasks := make([]TrackableExecutableTask, len(replicationTasks))
 	for index, replicationTask := range replicationTasks {
-		e.processToolBox.MetricsHandler.Counter(metrics.ReplicationTasksRecv.GetMetricName()).Record(
+		e.processToolBox.MetricsHandler.Counter(metrics.ReplicationTasksRecv.Name()).Record(
 			int64(1),
 			metrics.FromClusterIDTag(serverShardKey.ClusterID),
 			metrics.ToClusterIDTag(clientShardKey.ClusterID),

--- a/service/history/replication/executable_workflow_state_task.go
+++ b/service/history/replication/executable_workflow_state_task.go
@@ -110,7 +110,7 @@ func (e *ExecutableWorkflowStateTask) Execute() error {
 			tag.WorkflowRunID(e.RunID),
 			tag.TaskID(e.ExecutableTask.TaskID()),
 		)
-		e.MetricsHandler.Counter(metrics.ReplicationTasksSkipped.GetMetricName()).Record(
+		e.MetricsHandler.Counter(metrics.ReplicationTasksSkipped.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.SyncWorkflowStateTaskScope),
 			metrics.NamespaceTag(namespaceName),

--- a/service/history/replication/stream_receiver.go
+++ b/service/history/replication/stream_receiver.go
@@ -147,7 +147,7 @@ func (r *StreamReceiverImpl) sendEventLoop() {
 	var panicErr error
 	defer func() {
 		if panicErr != nil {
-			r.MetricsHandler.Counter(metrics.ReplicationStreamPanic.GetMetricName()).Record(1)
+			r.MetricsHandler.Counter(metrics.ReplicationStreamPanic.Name()).Record(1)
 		}
 	}()
 	defer log.CapturePanic(r.logger, &panicErr)
@@ -174,7 +174,7 @@ func (r *StreamReceiverImpl) recvEventLoop() {
 	var panicErr error
 	defer func() {
 		if panicErr != nil {
-			r.MetricsHandler.Counter(metrics.ReplicationStreamPanic.GetMetricName()).Record(1)
+			r.MetricsHandler.Counter(metrics.ReplicationStreamPanic.Name()).Record(1)
 		}
 	}()
 	defer log.CapturePanic(r.logger, &panicErr)
@@ -204,12 +204,12 @@ func (r *StreamReceiverImpl) ackMessage(
 		r.logger.Error("StreamReceiver unable to send message, err", tag.Error(err))
 		return err
 	}
-	r.MetricsHandler.Histogram(metrics.ReplicationTasksRecvBacklog.GetMetricName(), metrics.ReplicationTasksRecvBacklog.GetMetricUnit()).Record(
+	r.MetricsHandler.Histogram(metrics.ReplicationTasksRecvBacklog.Name(), metrics.ReplicationTasksRecvBacklog.Unit()).Record(
 		int64(size),
 		metrics.FromClusterIDTag(r.serverShardKey.ClusterID),
 		metrics.ToClusterIDTag(r.clientShardKey.ClusterID),
 	)
-	r.MetricsHandler.Counter(metrics.ReplicationTasksSend.GetMetricName()).Record(
+	r.MetricsHandler.Counter(metrics.ReplicationTasksSend.Name()).Record(
 		int64(1),
 		metrics.FromClusterIDTag(r.clientShardKey.ClusterID),
 		metrics.ToClusterIDTag(r.serverShardKey.ClusterID),

--- a/service/history/replication/stream_sender.go
+++ b/service/history/replication/stream_sender.go
@@ -141,7 +141,7 @@ func (s *StreamSenderImpl) recvEventLoop() (retErr error) {
 	defer func() {
 		if panicErr != nil {
 			retErr = panicErr
-			s.metrics.Counter(metrics.ReplicationStreamPanic.GetMetricName()).Record(1)
+			s.metrics.Counter(metrics.ReplicationStreamPanic.Name()).Record(1)
 		}
 	}()
 
@@ -161,7 +161,7 @@ func (s *StreamSenderImpl) recvEventLoop() (retErr error) {
 				s.logger.Error("StreamSender unable to handle SyncReplicationState", tag.Error(err))
 				return err
 			}
-			s.metrics.Counter(metrics.ReplicationTasksRecv.GetMetricName()).Record(
+			s.metrics.Counter(metrics.ReplicationTasksRecv.Name()).Record(
 				int64(1),
 				metrics.FromClusterIDTag(s.clientShardKey.ClusterID),
 				metrics.ToClusterIDTag(s.serverShardKey.ClusterID),
@@ -184,7 +184,7 @@ func (s *StreamSenderImpl) sendEventLoop() (retErr error) {
 	defer func() {
 		if panicErr != nil {
 			retErr = panicErr
-			s.metrics.Counter(metrics.ReplicationStreamPanic.GetMetricName()).Record(1)
+			s.metrics.Counter(metrics.ReplicationStreamPanic.Name()).Record(1)
 		}
 	}()
 
@@ -362,7 +362,7 @@ Loop:
 		}); err != nil {
 			return err
 		}
-		s.metrics.Counter(metrics.ReplicationTasksSend.GetMetricName()).Record(
+		s.metrics.Counter(metrics.ReplicationTasksSend.Name()).Record(
 			int64(1),
 			metrics.FromClusterIDTag(s.serverShardKey.ClusterID),
 			metrics.ToClusterIDTag(s.clientShardKey.ClusterID),

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -138,7 +138,7 @@ func (e *taskExecutorImpl) handleActivityTask(
 
 	startTime := time.Now().UTC()
 	defer func() {
-		e.metricsHandler.Timer(metrics.ServiceLatency.GetMetricName()).Record(
+		e.metricsHandler.Timer(metrics.ServiceLatency.Name()).Record(
 			time.Since(startTime),
 			metrics.OperationTag(metrics.SyncActivityTaskScope),
 		)
@@ -171,13 +171,13 @@ func (e *taskExecutorImpl) handleActivityTask(
 		return nil
 
 	case *serviceerrors.RetryReplication:
-		e.metricsHandler.Counter(metrics.ClientRequests.GetMetricName()).Record(
+		e.metricsHandler.Counter(metrics.ClientRequests.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryRereplicationByActivityReplicationScope),
 		)
 		startTime := time.Now().UTC()
 		defer func() {
-			e.metricsHandler.Timer(metrics.ClientLatency.GetMetricName()).Record(
+			e.metricsHandler.Timer(metrics.ClientLatency.Name()).Record(
 				time.Since(startTime),
 				metrics.OperationTag(metrics.HistoryRereplicationByActivityReplicationScope),
 			)
@@ -228,7 +228,7 @@ func (e *taskExecutorImpl) handleHistoryReplicationTask(
 
 	startTime := time.Now().UTC()
 	defer func() {
-		e.metricsHandler.Timer(metrics.ServiceLatency.GetMetricName()).Record(
+		e.metricsHandler.Timer(metrics.ServiceLatency.Name()).Record(
 			time.Since(startTime),
 			metrics.OperationTag(metrics.HistoryReplicationTaskScope),
 		)
@@ -256,13 +256,13 @@ func (e *taskExecutorImpl) handleHistoryReplicationTask(
 		return nil
 
 	case *serviceerrors.RetryReplication:
-		e.metricsHandler.Counter(metrics.ClientRequests.GetMetricName()).Record(
+		e.metricsHandler.Counter(metrics.ClientRequests.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryRereplicationByHistoryReplicationScope),
 		)
 		startTime := time.Now().UTC()
 		defer func() {
-			e.metricsHandler.Timer(metrics.ClientLatency.GetMetricName()).Record(
+			e.metricsHandler.Timer(metrics.ClientLatency.Name()).Record(
 				time.Since(startTime),
 				metrics.OperationTag(metrics.HistoryRereplicationByHistoryReplicationScope),
 			)

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -213,7 +213,7 @@ func (p *taskProcessorImpl) eventLoop() {
 		case <-syncShardTimer.C:
 			if err := p.handleSyncShardStatus(syncShardTask); err != nil {
 				p.logger.Error("unable to sync shard status", tag.Error(err))
-				p.metricsHandler.Counter(metrics.SyncShardFromRemoteFailure.GetMetricName()).Record(
+				p.metricsHandler.Counter(metrics.SyncShardFromRemoteFailure.Name()).Record(
 					1,
 					metrics.OperationTag(metrics.HistorySyncShardStatusScope))
 			}
@@ -253,7 +253,7 @@ func (p *taskProcessorImpl) pollProcessReplicationTasks() (retError error) {
 		taskCreationTime := replicationTask.GetVisibilityTime()
 		if taskCreationTime != nil {
 			now := p.shard.GetTimeSource().Now()
-			p.metricsHandler.Timer(metrics.ReplicationLatency.GetMetricName()).Record(
+			p.metricsHandler.Timer(metrics.ReplicationLatency.Name()).Record(
 				now.Sub(taskCreationTime.AsTime()),
 				metrics.OperationTag(metrics.ReplicationTaskFetcherScope))
 		}
@@ -311,7 +311,7 @@ func (p *taskProcessorImpl) handleSyncShardStatus(
 		return nil
 	}
 
-	p.metricsHandler.Counter(metrics.SyncShardFromRemoteCounter.GetMetricName()).Record(
+	p.metricsHandler.Counter(metrics.SyncShardFromRemoteCounter.Name()).Record(
 		1,
 		metrics.OperationTag(metrics.HistorySyncShardStatusScope))
 	ctx, cancel := context.WithTimeout(context.Background(), replicationTimeout)
@@ -365,7 +365,7 @@ func (p *taskProcessorImpl) handleReplicationDLQTask(
 		tag.WorkflowRunID(request.TaskInfo.GetRunId()),
 		tag.TaskID(request.TaskInfo.GetTaskId()),
 	)
-	p.metricsHandler.Gauge(metrics.ReplicationDLQMaxLevelGauge.GetMetricName()).Record(
+	p.metricsHandler.Gauge(metrics.ReplicationDLQMaxLevelGauge.Name()).Record(
 		float64(request.TaskInfo.GetTaskId()),
 		metrics.OperationTag(metrics.ReplicationDLQStatsScope),
 		metrics.TargetClusterTag(p.sourceCluster),
@@ -375,7 +375,7 @@ func (p *taskProcessorImpl) handleReplicationDLQTask(
 		err := writeTaskToDLQ(ctx, p.dlqWriter, p.shard, request.SourceClusterName, request.TaskInfo)
 		if err != nil {
 			p.logger.Error("failed to enqueue replication task to DLQ", tag.Error(err))
-			p.metricsHandler.Counter(metrics.ReplicationDLQFailed.GetMetricName()).Record(1, metrics.OperationTag(metrics.ReplicationTaskFetcherScope))
+			p.metricsHandler.Counter(metrics.ReplicationDLQFailed.Name()).Record(1, metrics.OperationTag(metrics.ReplicationTaskFetcherScope))
 		}
 		return err
 	}, p.dlqRetryPolicy, p.isRetryableError)
@@ -522,32 +522,32 @@ func (p *taskProcessorImpl) paginationFn(_ []byte) ([]interface{}, []byte, error
 func (p *taskProcessorImpl) emitTaskMetrics(operation string, err error) {
 	metricsScope := p.metricsHandler.WithTags(metrics.OperationTag(operation))
 	if common.IsContextDeadlineExceededErr(err) || common.IsContextCanceledErr(err) {
-		metricsScope.Counter(metrics.ServiceErrContextTimeoutCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ServiceErrContextTimeoutCounter.Name()).Record(1)
 		return
 	}
 
 	// Also update counter to distinguish between type of failures
 	switch err := err.(type) {
 	case nil:
-		metricsScope.Counter(metrics.ReplicationTasksApplied.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ReplicationTasksApplied.Name()).Record(1)
 		return
 	case *serviceerrors.ShardOwnershipLost:
-		metricsScope.Counter(metrics.ServiceErrShardOwnershipLostCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ServiceErrShardOwnershipLostCounter.Name()).Record(1)
 	case *serviceerror.InvalidArgument:
-		metricsScope.Counter(metrics.ServiceErrInvalidArgumentCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ServiceErrInvalidArgumentCounter.Name()).Record(1)
 	case *serviceerror.NamespaceNotActive:
-		metricsScope.Counter(metrics.ServiceErrNamespaceNotActiveCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ServiceErrNamespaceNotActiveCounter.Name()).Record(1)
 	case *serviceerror.WorkflowExecutionAlreadyStarted:
-		metricsScope.Counter(metrics.ServiceErrExecutionAlreadyStartedCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ServiceErrExecutionAlreadyStartedCounter.Name()).Record(1)
 	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
-		metricsScope.Counter(metrics.ServiceErrNotFoundCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ServiceErrNotFoundCounter.Name()).Record(1)
 	case *serviceerror.ResourceExhausted:
-		metricsScope.Counter(metrics.ServiceErrResourceExhaustedCounter.GetMetricName()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
+		metricsScope.Counter(metrics.ServiceErrResourceExhaustedCounter.Name()).Record(1, metrics.ResourceExhaustedCauseTag(err.Cause))
 	case *serviceerrors.RetryReplication:
-		metricsScope.Counter(metrics.ServiceErrRetryTaskCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ServiceErrRetryTaskCounter.Name()).Record(1)
 	default:
 	}
-	metricsScope.Counter(metrics.ReplicationTasksFailed.GetMetricName()).Record(1)
+	metricsScope.Counter(metrics.ReplicationTasksFailed.Name()).Record(1)
 }
 
 func (p *taskProcessorImpl) getOperationTagValue(

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -248,7 +248,7 @@ func (r *taskProcessorManagerImpl) completeReplicationTaskLoop() {
 		case <-cleanupTimer.C:
 			if err := r.cleanupReplicationTasks(); err != nil {
 				r.logger.Error("Failed to clean up replication messages.", tag.Error(err))
-				r.metricsHandler.Counter(metrics.ReplicationTaskCleanupFailure.GetMetricName()).Record(
+				r.metricsHandler.Counter(metrics.ReplicationTaskCleanupFailure.Name()).Record(
 					1,
 					metrics.OperationTag(metrics.ReplicationTaskCleanupScope),
 				)
@@ -309,11 +309,11 @@ func (r *taskProcessorManagerImpl) cleanupReplicationTasks() error {
 	}
 
 	r.logger.Debug("cleaning up replication task queue", tag.ReadLevel(minAckedTaskID))
-	r.metricsHandler.Counter(metrics.ReplicationTaskCleanupCount.GetMetricName()).Record(
+	r.metricsHandler.Counter(metrics.ReplicationTaskCleanupCount.Name()).Record(
 		1,
 		metrics.OperationTag(metrics.ReplicationTaskCleanupScope),
 	)
-	r.metricsHandler.Histogram(metrics.ReplicationTasksLag.GetMetricName(), metrics.ReplicationTasksLag.GetMetricUnit()).Record(
+	r.metricsHandler.Histogram(metrics.ReplicationTasksLag.Name(), metrics.ReplicationTasksLag.Unit()).Record(
 		r.shard.GetQueueExclusiveHighReadWatermark(tasks.CategoryReplication).Prev().TaskID-minAckedTaskID,
 		metrics.TargetClusterTag(currentClusterName),
 		metrics.OperationTag(metrics.ReplicationTaskCleanupScope),
@@ -369,7 +369,7 @@ func (r *taskProcessorManagerImpl) checkReplicationDLQSize() {
 			return
 		}
 		if !isEmpty {
-			r.metricsHandler.Counter(metrics.ReplicationNonEmptyDLQCount.GetMetricName()).Record(1, metrics.OperationTag(metrics.ReplicationDLQStatsScope))
+			r.metricsHandler.Counter(metrics.ReplicationNonEmptyDLQCount.Name()).Record(1, metrics.OperationTag(metrics.ReplicationDLQStatsScope))
 			break
 		}
 	}

--- a/service/history/shard/context_impl.go
+++ b/service/history/shard/context_impl.go
@@ -250,7 +250,7 @@ func (s *ContextImpl) GetPingChecks() []common.PingCheck {
 				s.rwLock.Unlock()
 				return nil
 			},
-			MetricsName: metrics.DDShardLockLatency.GetMetricName(),
+			MetricsName: metrics.DDShardLockLatency.Name(),
 		},
 		{
 			Name: s.String() + "-io-semaphore",
@@ -262,7 +262,7 @@ func (s *ContextImpl) GetPingChecks() []common.PingCheck {
 				s.ioSemaphore.Release(1)
 				return nil
 			},
-			MetricsName: metrics.DDShardIOSemaphoreLatency.GetMetricName(),
+			MetricsName: metrics.DDShardIOSemaphoreLatency.Name(),
 		},
 	}
 }
@@ -465,7 +465,7 @@ func (s *ContextImpl) UpdateReplicatorDLQAckLevel(
 		return err
 	}
 
-	s.GetMetricsHandler().Gauge(metrics.ReplicationDLQAckLevelGauge.GetMetricName()).
+	s.GetMetricsHandler().Gauge(metrics.ReplicationDLQAckLevelGauge.Name()).
 		Record(float64(ackLevel),
 			metrics.OperationTag(metrics.ReplicationDLQStatsScope),
 			metrics.TargetClusterTag(sourceCluster),
@@ -907,9 +907,9 @@ func (s *ContextImpl) AppendHistoryEvents(
 		// N.B. - Dual emit here makes sense so that we can see aggregate timer stats across all
 		// namespaces along with the individual namespaces stats
 		handler := s.GetMetricsHandler().WithTags(metrics.OperationTag(metrics.SessionStatsScope))
-		handler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(size))
+		handler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(int64(size))
 		if entry, err := s.GetNamespaceRegistry().GetNamespaceByID(namespaceID); err == nil && entry != nil {
-			handler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).
+			handler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).
 				Record(int64(size), metrics.NamespaceTag(entry.Name().String()))
 		}
 		if size >= historySizeLogThreshold {
@@ -1276,8 +1276,8 @@ Loop:
 				)
 			}
 			metricsHandler.Histogram(
-				metrics.ShardInfoImmediateQueueLagHistogram.GetMetricName(),
-				metrics.ShardInfoImmediateQueueLagHistogram.GetMetricUnit(),
+				metrics.ShardInfoImmediateQueueLagHistogram.Name(),
+				metrics.ShardInfoImmediateQueueLagHistogram.Unit(),
 			).Record(lag, metrics.TaskCategoryTag(category.Name()))
 
 		case tasks.CategoryTypeScheduled:
@@ -1293,7 +1293,7 @@ Loop:
 				)
 			}
 			metricsHandler.Timer(
-				metrics.ShardInfoScheduledQueueLagTimer.GetMetricName(),
+				metrics.ShardInfoScheduledQueueLagTimer.Name(),
 			).Record(lag, metrics.TaskCategoryTag(category.Name()))
 		default:
 			s.contextTaggedLogger.Error("Unknown task category type", tag.NewStringTag("task-category", category.Type().String()))
@@ -1408,7 +1408,7 @@ func (s *ContextImpl) handleWriteErrorLocked(
 
 func (s *ContextImpl) maybeRecordShardAcquisitionLatency(ownershipChanged bool) {
 	if ownershipChanged {
-		s.GetMetricsHandler().Timer(metrics.ShardContextAcquisitionLatency.GetMetricName()).
+		s.GetMetricsHandler().Timer(metrics.ShardContextAcquisitionLatency.Name()).
 			Record(s.GetCurrentTime(s.GetClusterMetadata().GetCurrentClusterName()).Sub(s.getLastUpdatedTime()),
 				metrics.OperationTag(metrics.ShardInfoScope),
 			)
@@ -1463,18 +1463,18 @@ func (s *ContextImpl) stoppedForOwnershipLost() bool {
 
 func (s *ContextImpl) wLock() {
 	handler := s.metricsHandler.WithTags(metrics.OperationTag(metrics.ShardInfoScope))
-	handler.Counter(metrics.LockRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.LockRequests.Name()).Record(1)
 	startTime := time.Now().UTC()
-	defer func() { handler.Timer(metrics.LockLatency.GetMetricName()).Record(time.Since(startTime)) }()
+	defer func() { handler.Timer(metrics.LockLatency.Name()).Record(time.Since(startTime)) }()
 
 	s.rwLock.Lock()
 }
 
 func (s *ContextImpl) rLock() {
 	handler := s.metricsHandler.WithTags(metrics.OperationTag(metrics.ShardInfoScope))
-	handler.Counter(metrics.LockRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.LockRequests.Name()).Record(1)
 	startTime := time.Now().UTC()
-	defer func() { handler.Timer(metrics.LockLatency.GetMetricName()).Record(time.Since(startTime)) }()
+	defer func() { handler.Timer(metrics.LockLatency.Name()).Record(time.Since(startTime)) }()
 
 	s.rwLock.RLock()
 }
@@ -1491,12 +1491,12 @@ func (s *ContextImpl) ioSemaphoreAcquire(
 	ctx context.Context,
 ) (retErr error) {
 	handler := s.metricsHandler.WithTags(metrics.OperationTag(metrics.ShardInfoScope))
-	handler.Counter(metrics.SemaphoreRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.SemaphoreRequests.Name()).Record(1)
 	startTime := time.Now().UTC()
 	defer func() {
-		handler.Timer(metrics.SemaphoreLatency.GetMetricName()).Record(time.Since(startTime))
+		handler.Timer(metrics.SemaphoreLatency.Name()).Record(time.Since(startTime))
 		if retErr != nil {
-			handler.Counter(metrics.SemaphoreFailures.GetMetricName()).Record(1)
+			handler.Counter(metrics.SemaphoreFailures.Name()).Record(1)
 		}
 	}()
 

--- a/service/history/shard/controller_impl.go
+++ b/service/history/shard/controller_impl.go
@@ -165,7 +165,7 @@ func (c *ControllerImpl) GetPingChecks() []common.PingCheck {
 			}
 			return out
 		},
-		MetricsName: metrics.DDShardControllerLockLatency.GetMetricName(),
+		MetricsName: metrics.DDShardControllerLockLatency.Name(),
 	}}
 }
 
@@ -192,7 +192,7 @@ func (c *ControllerImpl) GetShardByID(
 ) (Context, error) {
 	startTime := time.Now().UTC()
 	defer func() {
-		c.taggedMetricsHandler.Timer(metrics.GetEngineForShardLatency.GetMetricName()).Record(time.Since(startTime))
+		c.taggedMetricsHandler.Timer(metrics.GetEngineForShardLatency.Name()).Record(time.Since(startTime))
 	}()
 
 	return c.getOrCreateShardContext(shardID)
@@ -201,7 +201,7 @@ func (c *ControllerImpl) GetShardByID(
 func (c *ControllerImpl) CloseShardByID(shardID int32) {
 	startTime := time.Now().UTC()
 	defer func() {
-		c.taggedMetricsHandler.Timer(metrics.RemoveEngineForShardLatency.GetMetricName()).Record(time.Since(startTime))
+		c.taggedMetricsHandler.Timer(metrics.RemoveEngineForShardLatency.Name()).Record(time.Since(startTime))
 	}()
 
 	shard := c.removeShard(shardID, nil)
@@ -226,10 +226,10 @@ func (c *ControllerImpl) ShardIDs() []int32 {
 func (c *ControllerImpl) shardRemoveAndStop(shard ControllableContext) {
 	startTime := time.Now().UTC()
 	defer func() {
-		c.taggedMetricsHandler.Timer(metrics.RemoveEngineForShardLatency.GetMetricName()).Record(time.Since(startTime))
+		c.taggedMetricsHandler.Timer(metrics.RemoveEngineForShardLatency.Name()).Record(time.Since(startTime))
 	}()
 
-	c.taggedMetricsHandler.Counter(metrics.ShardContextClosedCounter.GetMetricName()).Record(1)
+	c.taggedMetricsHandler.Counter(metrics.ShardContextClosedCounter.Name()).Record(1)
 	_ = c.removeShard(shard.GetShardID(), shard)
 
 	// Whether shard was in the shards map or not, in both cases we should stop it.
@@ -281,7 +281,7 @@ func (c *ControllerImpl) getOrCreateShardContext(shardID int32) (ControllableCon
 		return nil, err
 	}
 	c.historyShards[shardID] = shard
-	c.taggedMetricsHandler.Counter(metrics.ShardContextCreatedCounter.GetMetricName()).Record(1)
+	c.taggedMetricsHandler.Counter(metrics.ShardContextCreatedCounter.Name()).Record(1)
 	c.contextTaggedLogger.Info("", numShardsTag(len(c.historyShards)))
 
 	return shard, nil
@@ -306,7 +306,7 @@ func (c *ControllerImpl) removeShardLocked(shardID int32, expected ControllableC
 
 	delete(c.historyShards, shardID)
 	c.contextTaggedLogger.Info("", numShardsTag(len(c.historyShards)))
-	c.taggedMetricsHandler.Counter(metrics.ShardContextRemovedCounter.GetMetricName()).Record(1)
+	c.taggedMetricsHandler.Counter(metrics.ShardContextRemovedCounter.Name()).Record(1)
 
 	return current
 }
@@ -371,7 +371,7 @@ func (c *ControllerImpl) doLinger(ctx context.Context, shard ControllableContext
 
 	for {
 		if !shard.IsValid() {
-			c.taggedMetricsHandler.Timer(metrics.ShardLingerSuccess.GetMetricName()).Record(time.Since(startTime))
+			c.taggedMetricsHandler.Timer(metrics.ShardLingerSuccess.Name()).Record(time.Since(startTime))
 			break
 		}
 
@@ -380,7 +380,7 @@ func (c *ControllerImpl) doLinger(ctx context.Context, shard ControllableContext
 				tag.ShardID(shard.GetShardID()),
 				tag.NewDurationTag("duration", time.Now().Sub(startTime)),
 			)
-			c.taggedMetricsHandler.Counter(metrics.ShardLingerTimeouts.GetMetricName()).Record(1)
+			c.taggedMetricsHandler.Counter(metrics.ShardLingerTimeouts.Name()).Record(1)
 			break
 		}
 
@@ -393,10 +393,10 @@ func (c *ControllerImpl) doLinger(ctx context.Context, shard ControllableContext
 }
 
 func (c *ControllerImpl) acquireShards(ctx context.Context) {
-	c.taggedMetricsHandler.Counter(metrics.AcquireShardsCounter.GetMetricName()).Record(1)
+	c.taggedMetricsHandler.Counter(metrics.AcquireShardsCounter.Name()).Record(1)
 	startTime := time.Now().UTC()
 	defer func() {
-		c.taggedMetricsHandler.Timer(metrics.AcquireShardsLatency.GetMetricName()).Record(time.Since(startTime))
+		c.taggedMetricsHandler.Timer(metrics.AcquireShardsLatency.Name()).Record(time.Since(startTime))
 	}()
 
 	ctx = headers.SetCallerInfo(ctx, headers.SystemBackgroundCallerInfo)
@@ -416,7 +416,7 @@ func (c *ControllerImpl) acquireShards(ctx context.Context) {
 
 		shard, err := c.GetShardByID(shardID)
 		if err != nil {
-			c.taggedMetricsHandler.Counter(metrics.GetEngineForShardErrorCounter.GetMetricName()).Record(1)
+			c.taggedMetricsHandler.Counter(metrics.GetEngineForShardErrorCounter.Name()).Record(1)
 			c.contextTaggedLogger.Error("Unable to create history shard context", tag.Error(err), tag.OperationFailed, tag.ShardID(shardID))
 			return
 		}
@@ -453,7 +453,7 @@ func (c *ControllerImpl) acquireShards(ctx context.Context) {
 	numOfOwnedShards := len(c.historyShards)
 	c.RUnlock()
 
-	c.taggedMetricsHandler.Gauge(metrics.NumShardsGauge.GetMetricName()).Record(float64(numOfOwnedShards))
+	c.taggedMetricsHandler.Gauge(metrics.NumShardsGauge.Name()).Record(float64(numOfOwnedShards))
 	c.publishShardCountUpdate(numOfOwnedShards)
 }
 

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -764,7 +764,7 @@ func (s *controllerSuite) TestShardLingerTimeout() {
 	s.False(shard.IsValid())
 
 	s.Equal(float64(1), s.readMetricsCounter(
-		metrics.ShardLingerTimeouts.GetMetricName(),
+		metrics.ShardLingerTimeouts.Name(),
 		metrics.OperationTag(metrics.HistoryShardControllerScope)))
 }
 

--- a/service/history/shard/ownership.go
+++ b/service/history/shard/ownership.go
@@ -111,7 +111,7 @@ func (o *ownership) eventLoop(ctx context.Context) {
 		case <-acquireTicker.C:
 			o.scheduleAcquire()
 		case changedEvent := <-o.membershipUpdateCh:
-			o.metricsHandler.Counter(metrics.MembershipChangedCounter.GetMetricName()).Record(1)
+			o.metricsHandler.Counter(metrics.MembershipChangedCounter.Name()).Record(1)
 
 			o.logger.Info("", tag.ValueRingMembershipChangedEvent,
 				tag.NumberProcessed(len(changedEvent.HostsAdded)),

--- a/service/history/timer_queue_active_task_executor.go
+++ b/service/history/timer_queue_active_task_executor.go
@@ -407,17 +407,17 @@ func (t *timerQueueActiveTaskExecutor) executeWorkflowBackoffTimerTask(
 	}
 
 	if task.WorkflowBackoffType == enumsspb.WORKFLOW_BACKOFF_TYPE_RETRY {
-		t.metricHandler.Counter(metrics.WorkflowRetryBackoffTimerCount.GetMetricName()).Record(
+		t.metricHandler.Counter(metrics.WorkflowRetryBackoffTimerCount.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.TimerActiveTaskWorkflowBackoffTimerScope),
 		)
 	} else if task.WorkflowBackoffType == enumsspb.WORKFLOW_BACKOFF_TYPE_CRON {
-		t.metricHandler.Counter(metrics.WorkflowCronBackoffTimerCount.GetMetricName()).Record(
+		t.metricHandler.Counter(metrics.WorkflowCronBackoffTimerCount.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.TimerActiveTaskWorkflowBackoffTimerScope),
 		)
 	} else if task.WorkflowBackoffType == enumsspb.WORKFLOW_BACKOFF_TYPE_DELAY_START {
-		t.metricHandler.Counter(metrics.WorkflowDelayedStartBackoffTimerCount.GetMetricName()).Record(
+		t.metricHandler.Counter(metrics.WorkflowDelayedStartBackoffTimerCount.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.TimerActiveTaskWorkflowBackoffTimerScope),
 		)
@@ -670,12 +670,12 @@ func (t *timerQueueActiveTaskExecutor) emitTimeoutMetricScopeWithNamespaceTag(
 	)
 	switch timerType {
 	case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_START:
-		metricsScope.Counter(metrics.ScheduleToStartTimeoutCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ScheduleToStartTimeoutCounter.Name()).Record(1)
 	case enumspb.TIMEOUT_TYPE_SCHEDULE_TO_CLOSE:
-		metricsScope.Counter(metrics.ScheduleToCloseTimeoutCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.ScheduleToCloseTimeoutCounter.Name()).Record(1)
 	case enumspb.TIMEOUT_TYPE_START_TO_CLOSE:
-		metricsScope.Counter(metrics.StartToCloseTimeoutCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.StartToCloseTimeoutCounter.Name()).Record(1)
 	case enumspb.TIMEOUT_TYPE_HEARTBEAT:
-		metricsScope.Counter(metrics.HeartbeatTimeoutCounter.GetMetricName()).Record(1)
+		metricsScope.Counter(metrics.HeartbeatTimeoutCounter.Name()).Record(1)
 	}
 }

--- a/service/history/timer_queue_standby_task_executor.go
+++ b/service/history/timer_queue_standby_task_executor.go
@@ -513,9 +513,9 @@ func (t *timerQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 	}
 
 	scope := t.metricHandler.WithTags(metrics.OperationTag(metrics.HistoryRereplicationByTimerTaskScope))
-	scope.Counter(metrics.ClientRequests.GetMetricName()).Record(1)
+	scope.Counter(metrics.ClientRequests.Name()).Record(1)
 	startTime := time.Now()
-	defer func() { scope.Timer(metrics.ClientLatency.GetMetricName()).Record(time.Since(startTime)) }()
+	defer func() { scope.Timer(metrics.ClientLatency.Name()).Record(time.Since(startTime)) }()
 
 	if resendInfo.lastEventID == common.EmptyEventID || resendInfo.lastEventVersion == common.EmptyVersion {
 		t.logger.Error("Error re-replicating history from remote: timerQueueStandbyProcessor encountered empty historyResendInfo.",

--- a/service/history/transfer_queue_active_task_executor.go
+++ b/service/history/transfer_queue_active_task_executor.go
@@ -1416,7 +1416,7 @@ func (t *transferQueueActiveTaskExecutor) resetWorkflow(
 	case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 		// This means the reset point is corrupted and not retry able.
 		// There must be a bug in our system that we must fix.(for example, history is not the same in active/passive)
-		t.metricHandler.Counter(metrics.AutoResetPointCorruptionCounter.GetMetricName()).Record(
+		t.metricHandler.Counter(metrics.AutoResetPointCorruptionCounter.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.TransferQueueProcessorScope),
 		)
@@ -1491,13 +1491,13 @@ func (t *transferQueueActiveTaskExecutor) processParentClosePolicy(
 		err := t.applyParentClosePolicy(ctx, parentExecution, childInfo)
 		switch err.(type) {
 		case nil:
-			scope.Counter(metrics.ParentClosePolicyProcessorSuccess.GetMetricName()).Record(1)
+			scope.Counter(metrics.ParentClosePolicyProcessorSuccess.Name()).Record(1)
 		case *serviceerror.NotFound:
 			// If child execution is deleted there is nothing to close.
 		case *serviceerror.NamespaceNotFound:
 			// If child namespace is deleted there is nothing to close.
 		default:
-			scope.Counter(metrics.ParentClosePolicyProcessorFailures.GetMetricName()).Record(1)
+			scope.Counter(metrics.ParentClosePolicyProcessorFailures.Name()).Record(1)
 			return err
 		}
 	}

--- a/service/history/transfer_queue_standby_task_executor.go
+++ b/service/history/transfer_queue_standby_task_executor.go
@@ -612,9 +612,9 @@ func (t *transferQueueStandbyTaskExecutor) fetchHistoryFromRemote(
 	}
 
 	scope := t.metricHandler.WithTags(metrics.OperationTag(metrics.HistoryRereplicationByTransferTaskScope))
-	scope.Counter(metrics.ClientRequests.GetMetricName()).Record(1)
+	scope.Counter(metrics.ClientRequests.Name()).Record(1)
 	startTime := time.Now().UTC()
-	defer func() { scope.Timer(metrics.ClientLatency.GetMetricName()).Record(time.Since(startTime)) }()
+	defer func() { scope.Timer(metrics.ClientLatency.Name()).Record(time.Since(startTime)) }()
 
 	if resendInfo.lastEventID == common.EmptyEventID || resendInfo.lastEventVersion == common.EmptyVersion {
 		t.logger.Error("Error re-replicating history from remote: transferQueueStandbyProcessor encountered empty historyResendInfo.",

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -153,9 +153,9 @@ func (c *CacheImpl) GetOrCreateCurrentWorkflowExecution(
 		metrics.OperationTag(metrics.HistoryCacheGetOrCreateCurrentScope),
 		metrics.CacheTypeTag(metrics.MutableStateCacheTypeTagValue),
 	)
-	handler.Counter(metrics.CacheRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.CacheRequests.Name()).Record(1)
 	start := time.Now()
-	defer func() { handler.Timer(metrics.CacheLatency.GetMetricName()).Record(time.Since(start)) }()
+	defer func() { handler.Timer(metrics.CacheLatency.Name()).Record(time.Since(start)) }()
 
 	execution := commonpb.WorkflowExecution{
 		WorkflowId: workflowID,
@@ -173,7 +173,7 @@ func (c *CacheImpl) GetOrCreateCurrentWorkflowExecution(
 		lockPriority,
 	)
 
-	metrics.ContextCounterAdd(ctx, metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName(), time.Since(start).Nanoseconds())
+	metrics.ContextCounterAdd(ctx, metrics.HistoryWorkflowExecutionCacheLatency.Name(), time.Since(start).Nanoseconds())
 
 	return weCtx, weReleaseFn, err
 }
@@ -194,9 +194,9 @@ func (c *CacheImpl) GetOrCreateWorkflowExecution(
 		metrics.OperationTag(metrics.HistoryCacheGetOrCreateScope),
 		metrics.CacheTypeTag(metrics.MutableStateCacheTypeTagValue),
 	)
-	handler.Counter(metrics.CacheRequests.GetMetricName()).Record(1)
+	handler.Counter(metrics.CacheRequests.Name()).Record(1)
 	start := time.Now()
-	defer func() { handler.Timer(metrics.CacheLatency.GetMetricName()).Record(time.Since(start)) }()
+	defer func() { handler.Timer(metrics.CacheLatency.Name()).Record(time.Since(start)) }()
 
 	weCtx, weReleaseFunc, err := c.getOrCreateWorkflowExecutionInternal(
 		ctx,
@@ -208,7 +208,7 @@ func (c *CacheImpl) GetOrCreateWorkflowExecution(
 		lockPriority,
 	)
 
-	metrics.ContextCounterAdd(ctx, metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName(), time.Since(start).Nanoseconds())
+	metrics.ContextCounterAdd(ctx, metrics.HistoryWorkflowExecutionCacheLatency.Name(), time.Since(start).Nanoseconds())
 
 	return weCtx, weReleaseFunc, err
 }
@@ -229,12 +229,12 @@ func (c *CacheImpl) getOrCreateWorkflowExecutionInternal(
 	}
 	workflowCtx, cacheHit := c.Get(cacheKey).(workflow.Context)
 	if !cacheHit {
-		handler.Counter(metrics.CacheMissCounter.GetMetricName()).Record(1)
+		handler.Counter(metrics.CacheMissCounter.Name()).Record(1)
 		// Let's create the workflow execution workflowCtx
 		workflowCtx = workflow.NewContext(shardContext.GetConfig(), cacheKey.WorkflowKey, shardContext.GetLogger(), shardContext.GetThrottledLogger(), shardContext.GetMetricsHandler())
 		elem, err := c.PutIfNotExist(cacheKey, workflowCtx)
 		if err != nil {
-			handler.Counter(metrics.CacheFailures.GetMetricName()).Record(1)
+			handler.Counter(metrics.CacheFailures.Name()).Record(1)
 			return nil, nil, err
 		}
 		workflowCtx = elem.(workflow.Context)
@@ -244,8 +244,8 @@ func (c *CacheImpl) getOrCreateWorkflowExecutionInternal(
 	releaseFunc := c.makeReleaseFunc(cacheKey, shardContext, workflowCtx, forceClearContext, lockPriority)
 
 	if err := c.lockWorkflowExecution(ctx, workflowCtx, cacheKey, lockPriority); err != nil {
-		handler.Counter(metrics.CacheFailures.GetMetricName()).Record(1)
-		handler.Counter(metrics.AcquireLockFailedCounter.GetMetricName()).Record(1)
+		handler.Counter(metrics.CacheFailures.Name()).Record(1)
+		handler.Counter(metrics.AcquireLockFailedCounter.Name()).Record(1)
 		return nil, nil, err
 	}
 

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -435,7 +435,7 @@ func (s *workflowCacheSuite) TestHistoryCache_CacheLatencyMetricContext() {
 	s.NoError(err)
 	defer currentRelease(nil)
 
-	latency1, ok := metrics.ContextCounterGet(ctx, metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName())
+	latency1, ok := metrics.ContextCounterGet(ctx, metrics.HistoryWorkflowExecutionCacheLatency.Name())
 	s.True(ok)
 	s.NotZero(latency1)
 
@@ -452,7 +452,7 @@ func (s *workflowCacheSuite) TestHistoryCache_CacheLatencyMetricContext() {
 	s.NoError(err)
 	defer release(nil)
 
-	latency2, ok := metrics.ContextCounterGet(ctx, metrics.HistoryWorkflowExecutionCacheLatency.GetMetricName())
+	latency2, ok := metrics.ContextCounterGet(ctx, metrics.HistoryWorkflowExecutionCacheLatency.Name())
 	s.True(ok)
 	s.Greater(latency2, latency1)
 

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -216,7 +216,7 @@ func (c *ContextImpl) IsDirty() bool {
 }
 
 func (c *ContextImpl) Clear() {
-	c.metricsHandler.Counter(metrics.WorkflowContextCleared.GetMetricName()).Record(1)
+	c.metricsHandler.Counter(metrics.WorkflowContextCleared.Name()).Record(1)
 	if c.MutableState != nil {
 		c.MutableState.GetQueryRegistry().Clear()
 	}
@@ -664,7 +664,7 @@ func (c *ContextImpl) SetWorkflowExecution(
 		return err
 	}
 	if len(resetWorkflowEventsSeq) != 0 {
-		c.metricsHandler.Counter(metrics.ClosedWorkflowBufferEventCount.GetMetricName()).Record(1)
+		c.metricsHandler.Counter(metrics.ClosedWorkflowBufferEventCount.Name()).Record(1)
 		c.logger.Warn("SetWorkflowExecution encountered new events")
 	}
 
@@ -1041,8 +1041,8 @@ func emitStateTransitionCount(
 
 	namespaceEntry := mutableState.GetNamespaceEntry()
 	metricsHandler.Histogram(
-		metrics.StateTransitionCount.GetMetricName(),
-		metrics.StateTransitionCount.GetMetricUnit(),
+		metrics.StateTransitionCount.Name(),
+		metrics.StateTransitionCount.Unit(),
 	).Record(
 		mutableState.GetExecutionInfo().StateTransitionCount,
 		metrics.NamespaceTag(namespaceEntry.Name().String()),

--- a/service/history/workflow/history_builder.go
+++ b/service/history/workflow/history_builder.go
@@ -1571,7 +1571,7 @@ func (b *HistoryBuilder) emitInorderedBufferedEvents(bufferedEvents []*historypb
 	}
 
 	if inorderedEventsCount > 0 && b.metricsHandler != nil {
-		b.metricsHandler.Counter(metrics.InorderBufferedEventsCounter.GetMetricName()).Record(inorderedEventsCount)
+		b.metricsHandler.Counter(metrics.InorderBufferedEventsCounter.Name()).Record(inorderedEventsCount)
 	}
 }
 

--- a/service/history/workflow/metrics.go
+++ b/service/history/workflow/metrics.go
@@ -40,8 +40,8 @@ func emitWorkflowHistoryStats(
 ) {
 
 	executionScope := metricsHandler.WithTags(metrics.OperationTag(metrics.ExecutionStatsScope), metrics.NamespaceTag(namespace.String()))
-	executionScope.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(historySize))
-	executionScope.Histogram(metrics.HistoryCount.GetMetricName(), metrics.HistoryCount.GetMetricUnit()).Record(int64(historyCount))
+	executionScope.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(int64(historySize))
+	executionScope.Histogram(metrics.HistoryCount.Name(), metrics.HistoryCount.Unit()).Record(int64(historyCount))
 }
 
 func emitMutableStateStatus(
@@ -52,38 +52,38 @@ func emitMutableStateStatus(
 		return
 	}
 
-	metricsHandler.Histogram(metrics.MutableStateSize.GetMetricName(), metrics.MutableStateSize.GetMetricUnit()).Record(int64(stats.TotalSize))
-	metricsHandler.Histogram(metrics.ExecutionInfoSize.GetMetricName(), metrics.ExecutionInfoSize.GetMetricUnit()).Record(int64(stats.ExecutionInfoSize))
-	metricsHandler.Histogram(metrics.ExecutionStateSize.GetMetricName(), metrics.ExecutionStateSize.GetMetricUnit()).Record(int64(stats.ExecutionStateSize))
-	metricsHandler.Histogram(metrics.ActivityInfoSize.GetMetricName(), metrics.ActivityInfoSize.GetMetricUnit()).Record(int64(stats.ActivityInfoSize))
-	metricsHandler.Histogram(metrics.ActivityInfoCount.GetMetricName(), metrics.ActivityInfoCount.GetMetricUnit()).Record(int64(stats.ActivityInfoCount))
-	metricsHandler.Histogram(metrics.TotalActivityCount.GetMetricName(), metrics.TotalActivityCount.GetMetricUnit()).Record(stats.TotalActivityCount)
-	metricsHandler.Histogram(metrics.TimerInfoSize.GetMetricName(), metrics.TimerInfoSize.GetMetricUnit()).Record(int64(stats.TimerInfoSize))
-	metricsHandler.Histogram(metrics.TimerInfoCount.GetMetricName(), metrics.TimerInfoCount.GetMetricUnit()).Record(int64(stats.TimerInfoCount))
-	metricsHandler.Histogram(metrics.TotalUserTimerCount.GetMetricName(), metrics.TotalUserTimerCount.GetMetricUnit()).Record(stats.TotalUserTimerCount)
-	metricsHandler.Histogram(metrics.ChildInfoSize.GetMetricName(), metrics.ChildInfoSize.GetMetricUnit()).Record(int64(stats.ChildInfoSize))
-	metricsHandler.Histogram(metrics.ChildInfoCount.GetMetricName(), metrics.ChildInfoCount.GetMetricUnit()).Record(int64(stats.ChildInfoCount))
-	metricsHandler.Histogram(metrics.TotalChildExecutionCount.GetMetricName(), metrics.TotalChildExecutionCount.GetMetricUnit()).Record(stats.TotalChildExecutionCount)
-	metricsHandler.Histogram(metrics.RequestCancelInfoSize.GetMetricName(), metrics.RequestCancelInfoSize.GetMetricUnit()).Record(int64(stats.RequestCancelInfoSize))
-	metricsHandler.Histogram(metrics.RequestCancelInfoCount.GetMetricName(), metrics.RequestCancelInfoCount.GetMetricUnit()).Record(int64(stats.RequestCancelInfoCount))
-	metricsHandler.Histogram(metrics.TotalRequestCancelExternalCount.GetMetricName(), metrics.TotalRequestCancelExternalCount.GetMetricUnit()).Record(stats.TotalRequestCancelExternalCount)
-	metricsHandler.Histogram(metrics.SignalInfoSize.GetMetricName(), metrics.SignalInfoSize.GetMetricUnit()).Record(int64(stats.SignalInfoSize))
-	metricsHandler.Histogram(metrics.SignalInfoCount.GetMetricName(), metrics.SignalInfoCount.GetMetricUnit()).Record(int64(stats.SignalInfoCount))
-	metricsHandler.Histogram(metrics.TotalSignalExternalCount.GetMetricName(), metrics.TotalSignalExternalCount.GetMetricUnit()).Record(stats.TotalSignalExternalCount)
-	metricsHandler.Histogram(metrics.SignalRequestIDSize.GetMetricName(), metrics.SignalRequestIDSize.GetMetricUnit()).Record(int64(stats.SignalRequestIDSize))
-	metricsHandler.Histogram(metrics.SignalRequestIDCount.GetMetricName(), metrics.SignalRequestIDCount.GetMetricUnit()).Record(int64(stats.SignalRequestIDCount))
-	metricsHandler.Histogram(metrics.TotalSignalCount.GetMetricName(), metrics.TotalSignalCount.GetMetricUnit()).Record(stats.TotalSignalCount)
-	metricsHandler.Histogram(metrics.BufferedEventsSize.GetMetricName(), metrics.BufferedEventsSize.GetMetricUnit()).Record(int64(stats.BufferedEventsSize))
-	metricsHandler.Histogram(metrics.BufferedEventsCount.GetMetricName(), metrics.BufferedEventsCount.GetMetricUnit()).Record(int64(stats.BufferedEventsCount))
+	metricsHandler.Histogram(metrics.MutableStateSize.Name(), metrics.MutableStateSize.Unit()).Record(int64(stats.TotalSize))
+	metricsHandler.Histogram(metrics.ExecutionInfoSize.Name(), metrics.ExecutionInfoSize.Unit()).Record(int64(stats.ExecutionInfoSize))
+	metricsHandler.Histogram(metrics.ExecutionStateSize.Name(), metrics.ExecutionStateSize.Unit()).Record(int64(stats.ExecutionStateSize))
+	metricsHandler.Histogram(metrics.ActivityInfoSize.Name(), metrics.ActivityInfoSize.Unit()).Record(int64(stats.ActivityInfoSize))
+	metricsHandler.Histogram(metrics.ActivityInfoCount.Name(), metrics.ActivityInfoCount.Unit()).Record(int64(stats.ActivityInfoCount))
+	metricsHandler.Histogram(metrics.TotalActivityCount.Name(), metrics.TotalActivityCount.Unit()).Record(stats.TotalActivityCount)
+	metricsHandler.Histogram(metrics.TimerInfoSize.Name(), metrics.TimerInfoSize.Unit()).Record(int64(stats.TimerInfoSize))
+	metricsHandler.Histogram(metrics.TimerInfoCount.Name(), metrics.TimerInfoCount.Unit()).Record(int64(stats.TimerInfoCount))
+	metricsHandler.Histogram(metrics.TotalUserTimerCount.Name(), metrics.TotalUserTimerCount.Unit()).Record(stats.TotalUserTimerCount)
+	metricsHandler.Histogram(metrics.ChildInfoSize.Name(), metrics.ChildInfoSize.Unit()).Record(int64(stats.ChildInfoSize))
+	metricsHandler.Histogram(metrics.ChildInfoCount.Name(), metrics.ChildInfoCount.Unit()).Record(int64(stats.ChildInfoCount))
+	metricsHandler.Histogram(metrics.TotalChildExecutionCount.Name(), metrics.TotalChildExecutionCount.Unit()).Record(stats.TotalChildExecutionCount)
+	metricsHandler.Histogram(metrics.RequestCancelInfoSize.Name(), metrics.RequestCancelInfoSize.Unit()).Record(int64(stats.RequestCancelInfoSize))
+	metricsHandler.Histogram(metrics.RequestCancelInfoCount.Name(), metrics.RequestCancelInfoCount.Unit()).Record(int64(stats.RequestCancelInfoCount))
+	metricsHandler.Histogram(metrics.TotalRequestCancelExternalCount.Name(), metrics.TotalRequestCancelExternalCount.Unit()).Record(stats.TotalRequestCancelExternalCount)
+	metricsHandler.Histogram(metrics.SignalInfoSize.Name(), metrics.SignalInfoSize.Unit()).Record(int64(stats.SignalInfoSize))
+	metricsHandler.Histogram(metrics.SignalInfoCount.Name(), metrics.SignalInfoCount.Unit()).Record(int64(stats.SignalInfoCount))
+	metricsHandler.Histogram(metrics.TotalSignalExternalCount.Name(), metrics.TotalSignalExternalCount.Unit()).Record(stats.TotalSignalExternalCount)
+	metricsHandler.Histogram(metrics.SignalRequestIDSize.Name(), metrics.SignalRequestIDSize.Unit()).Record(int64(stats.SignalRequestIDSize))
+	metricsHandler.Histogram(metrics.SignalRequestIDCount.Name(), metrics.SignalRequestIDCount.Unit()).Record(int64(stats.SignalRequestIDCount))
+	metricsHandler.Histogram(metrics.TotalSignalCount.Name(), metrics.TotalSignalCount.Unit()).Record(stats.TotalSignalCount)
+	metricsHandler.Histogram(metrics.BufferedEventsSize.Name(), metrics.BufferedEventsSize.Unit()).Record(int64(stats.BufferedEventsSize))
+	metricsHandler.Histogram(metrics.BufferedEventsCount.Name(), metrics.BufferedEventsCount.Unit()).Record(int64(stats.BufferedEventsCount))
 
 	if stats.HistoryStatistics != nil {
-		metricsHandler.Histogram(metrics.HistorySize.GetMetricName(), metrics.HistorySize.GetMetricUnit()).Record(int64(stats.HistoryStatistics.SizeDiff))
-		metricsHandler.Histogram(metrics.HistoryCount.GetMetricName(), metrics.HistoryCount.GetMetricUnit()).Record(int64(stats.HistoryStatistics.CountDiff))
+		metricsHandler.Histogram(metrics.HistorySize.Name(), metrics.HistorySize.Unit()).Record(int64(stats.HistoryStatistics.SizeDiff))
+		metricsHandler.Histogram(metrics.HistoryCount.Name(), metrics.HistoryCount.Unit()).Record(int64(stats.HistoryStatistics.CountDiff))
 
 	}
 
 	for category, taskCount := range stats.TaskCountByCategory {
-		metricsHandler.Histogram(metrics.TaskCount.GetMetricName(), metrics.TaskCount.GetMetricUnit()).
+		metricsHandler.Histogram(metrics.TaskCount.Name(), metrics.TaskCount.Unit()).
 			Record(int64(taskCount), metrics.TaskCategoryTag(category))
 	}
 }
@@ -104,16 +104,16 @@ func emitWorkflowCompletionStats(
 
 	switch status {
 	case enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED:
-		handler.Counter(metrics.WorkflowSuccessCount.GetMetricName()).Record(1)
+		handler.Counter(metrics.WorkflowSuccessCount.Name()).Record(1)
 	case enumspb.WORKFLOW_EXECUTION_STATUS_CANCELED:
-		handler.Counter(metrics.WorkflowCancelCount.GetMetricName()).Record(1)
+		handler.Counter(metrics.WorkflowCancelCount.Name()).Record(1)
 	case enumspb.WORKFLOW_EXECUTION_STATUS_FAILED:
-		handler.Counter(metrics.WorkflowFailedCount.GetMetricName()).Record(1)
+		handler.Counter(metrics.WorkflowFailedCount.Name()).Record(1)
 	case enumspb.WORKFLOW_EXECUTION_STATUS_TIMED_OUT:
-		handler.Counter(metrics.WorkflowTimeoutCount.GetMetricName()).Record(1)
+		handler.Counter(metrics.WorkflowTimeoutCount.Name()).Record(1)
 	case enumspb.WORKFLOW_EXECUTION_STATUS_TERMINATED:
-		handler.Counter(metrics.WorkflowTerminateCount.GetMetricName()).Record(1)
+		handler.Counter(metrics.WorkflowTerminateCount.Name()).Record(1)
 	case enumspb.WORKFLOW_EXECUTION_STATUS_CONTINUED_AS_NEW:
-		handler.Counter(metrics.WorkflowContinuedAsNewCount.GetMetricName()).Record(1)
+		handler.Counter(metrics.WorkflowContinuedAsNewCount.Name()).Record(1)
 	}
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -380,13 +380,13 @@ func NewMutableStateFromDB(
 		switch {
 		case mutableState.shouldInvalidateCheckum():
 			mutableState.checksum = nil
-			mutableState.metricsHandler.Counter(metrics.MutableStateChecksumInvalidated.GetMetricName()).Record(1)
+			mutableState.metricsHandler.Counter(metrics.MutableStateChecksumInvalidated.Name()).Record(1)
 		case mutableState.shouldVerifyChecksum():
 			if err := verifyMutableStateChecksum(mutableState, dbRecord.Checksum); err != nil {
 				// we ignore checksum verification errors for now until this
 				// feature is tested and/or we have mechanisms in place to deal
 				// with these types of errors
-				mutableState.metricsHandler.Counter(metrics.MutableStateChecksumMismatch.GetMetricName()).Record(1)
+				mutableState.metricsHandler.Counter(metrics.MutableStateChecksumMismatch.Name()).Record(1)
 				mutableState.logError("mutable state checksum mismatch", tag.Error(err))
 			}
 		}
@@ -4415,7 +4415,7 @@ func (ms *MutableStateImpl) StartTransaction(
 			tag.WorkflowRunID(ms.executionState.RunId),
 			tag.Value(ms.hBuilder),
 		)
-		ms.metricsHandler.Counter(metrics.MutableStateChecksumInvalidated.GetMetricName()).Record(1)
+		ms.metricsHandler.Counter(metrics.MutableStateChecksumInvalidated.Name()).Record(1)
 		return false, serviceerror.NewUnavailable("MutableState encountered dirty transaction")
 	}
 

--- a/service/history/workflow/update/util.go
+++ b/service/history/workflow/update/util.go
@@ -63,27 +63,27 @@ func internalErrorf(tmpl string, args ...any) error {
 
 // CountRequestMsg adds 1 to the update request message counter
 func (i *instrumentation) CountRequestMsg() {
-	i.countMessage(metrics.MessageTypeRequestWorkflowExecutionUpdateCounter.GetMetricName())
+	i.countMessage(metrics.MessageTypeRequestWorkflowExecutionUpdateCounter.Name())
 }
 
 // CountAcceptanceMsg adds 1 to the update acceptance message counter
 func (i *instrumentation) CountAcceptanceMsg() {
-	i.countMessage(metrics.MessageTypeAcceptWorkflowExecutionUpdateCounter.GetMetricName())
+	i.countMessage(metrics.MessageTypeAcceptWorkflowExecutionUpdateCounter.Name())
 }
 
 // CountRejectionMsg counter adds 1 to the update rejection message counter
 func (i *instrumentation) CountRejectionMsg() {
-	i.countMessage(metrics.MessageTypeRejectWorkflowExecutionUpdateCounter.GetMetricName())
+	i.countMessage(metrics.MessageTypeRejectWorkflowExecutionUpdateCounter.Name())
 }
 
 // CountResponseMsg counter adds 1 to the update response message counter
 func (i *instrumentation) CountResponseMsg() {
-	i.countMessage(metrics.MessageTypeRespondWorkflowExecutionUpdateCounter.GetMetricName())
+	i.countMessage(metrics.MessageTypeRespondWorkflowExecutionUpdateCounter.Name())
 }
 
 // CountInvalidStateTransition counter adds 1 to invalid update state machine transition counter
 func (i *instrumentation) CountInvalidStateTransition() {
-	i.countMessage(metrics.InvalidStateTransitionWorkflowExecutionUpdateCounter.GetMetricName())
+	i.countMessage(metrics.InvalidStateTransitionWorkflowExecutionUpdateCounter.Name())
 }
 
 func (i *instrumentation) countMessage(ctrName string) {

--- a/service/history/workflow/workflow_task_state_machine.go
+++ b/service/history/workflow/workflow_task_state_machine.go
@@ -921,7 +921,7 @@ func (m *workflowTaskStateMachine) emitWorkflowTaskAttemptStats(
 	attempt int32,
 ) {
 	namespaceName := m.ms.GetNamespaceEntry().Name().String()
-	m.ms.metricsHandler.Histogram(metrics.WorkflowTaskAttempt.GetMetricName(), metrics.WorkflowTaskAttempt.GetMetricUnit()).
+	m.ms.metricsHandler.Histogram(metrics.WorkflowTaskAttempt.Name(), metrics.WorkflowTaskAttempt.Unit()).
 		Record(int64(attempt), metrics.NamespaceTag(namespaceName))
 	if attempt >= int32(m.ms.shard.GetConfig().WorkflowTaskCriticalAttempts()) {
 		m.ms.shard.GetThrottledLogger().Warn("Critical attempts processing workflow task",

--- a/service/history/workflow_task_handler.go
+++ b/service/history/workflow_task_handler.go
@@ -218,7 +218,7 @@ func (handler *workflowTaskHandlerImpl) handleCommand(
 	msgs *collection.IndexedTakeList[string, *protocolpb.Message],
 ) (*handleCommandResponse, error) {
 
-	handler.metricsHandler.Counter(metrics.CommandCounter.GetMetricName()).
+	handler.metricsHandler.Counter(metrics.CommandCounter.Name()).
 		Record(1, metrics.CommandTypeTag(command.GetCommandType().String()))
 
 	switch command.GetCommandType() {
@@ -315,7 +315,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandProtocolMessage(
 	attr *commandpb.ProtocolMessageCommandAttributes,
 	msgs *collection.IndexedTakeList[string, *protocolpb.Message],
 ) error {
-	handler.metricsHandler.Counter(metrics.CommandTypeProtocolMessage.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeProtocolMessage.Name()).Record(1)
 
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
@@ -346,7 +346,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandScheduleActivity(
 	attr *commandpb.ScheduleActivityTaskCommandAttributes,
 ) (*handleCommandResponse, error) {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeScheduleActivityCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeScheduleActivityCounter.Name()).Record(1)
 
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
@@ -486,7 +486,7 @@ func (handler *workflowTaskHandlerImpl) handlePostCommandEagerExecuteActivity(
 		WorkflowNamespace:           handler.mutableState.GetNamespaceEntry().Name().String(),
 	}
 	handler.metricsHandler.Counter(
-		metrics.ActivityEagerExecutionCounter.GetMetricName(),
+		metrics.ActivityEagerExecutionCounter.Name(),
 	).Record(
 		1,
 		metrics.NamespaceTag(string(handler.mutableState.GetNamespaceEntry().Name())),
@@ -504,7 +504,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandRequestCancelActivity(
 	attr *commandpb.RequestCancelActivityTaskCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeCancelActivityCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeCancelActivityCounter.Name()).Record(1)
 
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
@@ -551,7 +551,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartTimer(
 	attr *commandpb.StartTimerCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeStartTimerCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeStartTimerCounter.Name()).Record(1)
 
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
@@ -581,7 +581,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCompleteWorkflow(
 		}
 	}
 
-	handler.metricsHandler.Counter(metrics.CommandTypeCompleteWorkflowCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeCompleteWorkflowCounter.Name()).Record(1)
 
 	if handler.hasBufferedEvents {
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
@@ -607,7 +607,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCompleteWorkflow(
 
 	// If the workflow task has more than one completion event than just pick the first one
 	if !handler.mutableState.IsWorkflowExecutionRunning() {
-		handler.metricsHandler.Counter(metrics.MultipleCompletionCommandsCounter.GetMetricName()).Record(1)
+		handler.metricsHandler.Counter(metrics.MultipleCompletionCommandsCounter.Name()).Record(1)
 		handler.logger.Warn(
 			"Multiple completion commands",
 			tag.WorkflowCommandType(enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION),
@@ -641,7 +641,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandFailWorkflow(
 	attr *commandpb.FailWorkflowExecutionCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeFailWorkflowCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeFailWorkflowCounter.Name()).Record(1)
 
 	if handler.hasBufferedEvents {
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
@@ -668,7 +668,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandFailWorkflow(
 
 	// If the workflow task has more than one completion event than just pick the first one
 	if !handler.mutableState.IsWorkflowExecutionRunning() {
-		handler.metricsHandler.Counter(metrics.MultipleCompletionCommandsCounter.GetMetricName()).Record(1)
+		handler.metricsHandler.Counter(metrics.MultipleCompletionCommandsCounter.Name()).Record(1)
 		handler.logger.Warn(
 			"Multiple completion commands",
 			tag.WorkflowCommandType(enumspb.COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION),
@@ -716,7 +716,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCancelTimer(
 	attr *commandpb.CancelTimerCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeCancelTimerCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeCancelTimerCounter.Name()).Record(1)
 
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
@@ -745,7 +745,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCancelWorkflow(
 	attr *commandpb.CancelWorkflowExecutionCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeCancelWorkflowCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeCancelWorkflowCounter.Name()).Record(1)
 
 	if handler.hasBufferedEvents {
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
@@ -763,7 +763,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandCancelWorkflow(
 
 	// If the workflow task has more than one completion event than just pick the first one
 	if !handler.mutableState.IsWorkflowExecutionRunning() {
-		handler.metricsHandler.Counter(metrics.MultipleCompletionCommandsCounter.GetMetricName()).Record(1)
+		handler.metricsHandler.Counter(metrics.MultipleCompletionCommandsCounter.Name()).Record(1)
 		handler.logger.Warn(
 			"Multiple completion commands",
 			tag.WorkflowCommandType(enumspb.COMMAND_TYPE_CANCEL_WORKFLOW_EXECUTION),
@@ -781,7 +781,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandRequestCancelExternalWorkfl
 	attr *commandpb.RequestCancelExternalWorkflowExecutionCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeCancelExternalWorkflowCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeCancelExternalWorkflowCounter.Name()).Record(1)
 
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
@@ -823,7 +823,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandRecordMarker(
 	attr *commandpb.RecordMarkerCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeRecordMarkerCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeRecordMarkerCounter.Name()).Record(1)
 
 	if err := handler.validateCommandAttr(
 		func() (enumspb.WorkflowTaskFailedCause, error) {
@@ -850,7 +850,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 	attr *commandpb.ContinueAsNewWorkflowExecutionCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeContinueAsNewCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeContinueAsNewCounter.Name()).Record(1)
 
 	if handler.hasBufferedEvents {
 		return handler.failWorkflowTask(enumspb.WORKFLOW_TASK_FAILED_CAUSE_UNHANDLED_COMMAND, nil)
@@ -921,7 +921,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandContinueAsNewWorkflow(
 
 	// If the workflow task has more than one completion event than just pick the first one
 	if !handler.mutableState.IsWorkflowExecutionRunning() {
-		handler.metricsHandler.Counter(metrics.MultipleCompletionCommandsCounter.GetMetricName()).Record(1)
+		handler.metricsHandler.Counter(metrics.MultipleCompletionCommandsCounter.Name()).Record(1)
 		handler.logger.Warn(
 			"Multiple completion commands",
 			tag.WorkflowCommandType(enumspb.COMMAND_TYPE_CONTINUE_AS_NEW_WORKFLOW_EXECUTION),
@@ -960,7 +960,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartChildWorkflow(
 	attr *commandpb.StartChildWorkflowExecutionCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeChildWorkflowCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeChildWorkflowCounter.Name()).Record(1)
 
 	parentNamespaceEntry := handler.mutableState.GetNamespaceEntry()
 	parentNamespaceID := parentNamespaceEntry.ID()
@@ -1070,7 +1070,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandSignalExternalWorkflow(
 	attr *commandpb.SignalExternalWorkflowExecutionCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeSignalExternalWorkflowCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeSignalExternalWorkflowCounter.Name()).Record(1)
 
 	executionInfo := handler.mutableState.GetExecutionInfo()
 	namespaceID := namespace.ID(executionInfo.NamespaceId)
@@ -1118,7 +1118,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandUpsertWorkflowSearchAttribu
 	attr *commandpb.UpsertWorkflowSearchAttributesCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeUpsertWorkflowSearchAttributesCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeUpsertWorkflowSearchAttributesCounter.Name()).Record(1)
 
 	// get namespace name
 	executionInfo := handler.mutableState.GetExecutionInfo()
@@ -1190,7 +1190,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandModifyWorkflowProperties(
 	attr *commandpb.ModifyWorkflowPropertiesCommandAttributes,
 ) error {
 
-	handler.metricsHandler.Counter(metrics.CommandTypeModifyWorkflowPropertiesCounter.GetMetricName()).Record(1)
+	handler.metricsHandler.Counter(metrics.CommandTypeModifyWorkflowPropertiesCounter.Name()).Record(1)
 
 	// get namespace name
 	executionInfo := handler.mutableState.GetExecutionInfo()

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -210,7 +210,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 			// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 			// some extreme cassandra failure cases.
 			if workflowTask == nil && scheduledEventID >= mutableState.GetNextEventID() {
-				metricsScope.Counter(metrics.StaleMutableStateCounter.GetMetricName()).Record(1)
+				metricsScope.Counter(metrics.StaleMutableStateCounter.Name()).Record(1)
 				// Reload workflow execution history
 				// ErrStaleState will trigger updateWorkflow function to reload the mutable state
 				return nil, consts.ErrStaleState
@@ -281,7 +281,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskStarted(
 				namespaceName.String(),
 				taskQueue.GetName(),
 				taskQueue.GetKind(),
-			).Timer(metrics.TaskScheduleToStartLatency.GetMetricName()).Record(
+			).Timer(metrics.TaskScheduleToStartLatency.Name()).Record(
 				workflowScheduleToStartLatency,
 				metrics.TaskQueueTypeTag(enumspb.TASK_QUEUE_TYPE_WORKFLOW),
 			)
@@ -403,7 +403,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		func(mutableState workflow.MutableState) bool {
 			workflowTask := mutableState.GetWorkflowTaskByID(token.GetScheduledEventId())
 			if workflowTask == nil && token.GetScheduledEventId() >= mutableState.GetNextEventID() {
-				handler.metricsHandler.Counter(metrics.StaleMutableStateCounter.GetMetricName()).Record(
+				handler.metricsHandler.Counter(metrics.StaleMutableStateCounter.Name()).Record(
 					1,
 					metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))
 				return false
@@ -465,7 +465,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	}
 	// TODO: this metric is inaccurate, it should only be emitted if a new binary checksum (or build ID) is added in this completion.
 	if ms.GetExecutionInfo().AutoResetPoints != nil && limits.MaxResetPoints == len(ms.GetExecutionInfo().AutoResetPoints.Points) {
-		handler.metricsHandler.Counter(metrics.AutoResetPointsLimitExceededCounter.GetMetricName()).Record(
+		handler.metricsHandler.Counter(metrics.AutoResetPointsLimitExceededCounter.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))
 	}
@@ -486,7 +486,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 				metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope),
 				metrics.NamespaceTag(namespace.String()),
 			)
-			scope.Counter(metrics.WorkflowTaskHeartbeatTimeoutCounter.GetMetricName()).Record(1)
+			scope.Counter(metrics.WorkflowTaskHeartbeatTimeoutCounter.Name()).Record(1)
 			completedEvent, err = ms.AddWorkflowTaskTimedOutEvent(currentWorkflowTask)
 			if err != nil {
 				return nil, err
@@ -508,12 +508,12 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	// See workflowTaskStateMachine.skipWorkflowTaskCompletedEvent for more details.
 
 	if request.StickyAttributes == nil || request.StickyAttributes.WorkerTaskQueue == nil {
-		handler.metricsHandler.Counter(metrics.CompleteWorkflowTaskWithStickyDisabledCounter.GetMetricName()).Record(
+		handler.metricsHandler.Counter(metrics.CompleteWorkflowTaskWithStickyDisabledCounter.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))
 		ms.ClearStickyTaskQueue()
 	} else {
-		handler.metricsHandler.Counter(metrics.CompleteWorkflowTaskWithStickyEnabledCounter.GetMetricName()).Record(
+		handler.metricsHandler.Counter(metrics.CompleteWorkflowTaskWithStickyEnabledCounter.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))
 		ms.SetStickyTaskQueue(request.StickyAttributes.WorkerTaskQueue.GetName(), request.StickyAttributes.GetScheduleToStartTimeout())
@@ -600,7 +600,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	wtFailedShouldCreateNewTask := false
 	if wtFailedCause != nil {
 		effects.Cancel(ctx)
-		handler.metricsHandler.Counter(metrics.FailedWorkflowTasksCounter.GetMetricName()).Record(
+		handler.metricsHandler.Counter(metrics.FailedWorkflowTasksCounter.Name()).Record(
 			1,
 			metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))
 		handler.logger.Info("Failing the workflow task.",
@@ -729,7 +729,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	if updateErr != nil {
 		effects.Cancel(ctx)
 		if persistence.IsConflictErr(updateErr) {
-			handler.metricsHandler.Counter(metrics.ConcurrencyUpdateFailureCounter.GetMetricName()).Record(
+			handler.metricsHandler.Counter(metrics.ConcurrencyUpdateFailureCounter.Name()).Record(
 				1,
 				metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))
 		}
@@ -1198,7 +1198,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(ms workfl
 					tag.WorkflowRunID(runID),
 					tag.QueryID(id),
 					tag.Error(err))
-				scope.Counter(metrics.QueryRegistryInvalidStateCount.GetMetricName()).Record(1)
+				scope.Counter(metrics.QueryRegistryInvalidStateCount.Name()).Record(1)
 			}
 		} else {
 			succeededCompletionState := &workflow.QueryCompletionState{
@@ -1213,7 +1213,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(ms workfl
 					tag.WorkflowRunID(runID),
 					tag.QueryID(id),
 					tag.Error(err))
-				scope.Counter(metrics.QueryRegistryInvalidStateCount.GetMetricName()).Record(1)
+				scope.Counter(metrics.QueryRegistryInvalidStateCount.Name()).Record(1)
 			}
 		}
 	}
@@ -1234,7 +1234,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(ms workfl
 					tag.WorkflowRunID(runID),
 					tag.QueryID(id),
 					tag.Error(err))
-				scope.Counter(metrics.QueryRegistryInvalidStateCount.GetMetricName()).Record(1)
+				scope.Counter(metrics.QueryRegistryInvalidStateCount.Name()).Record(1)
 			}
 		}
 	}

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -151,7 +151,7 @@ func (h *Handler) AddActivityTask(
 
 	syncMatch, err := h.engine.AddActivityTask(ctx, request)
 	if syncMatch {
-		opMetrics.Timer(metrics.SyncMatchLatencyPerTaskQueue.GetMetricName()).Record(time.Since(startT))
+		opMetrics.Timer(metrics.SyncMatchLatencyPerTaskQueue.Name()).Record(time.Since(startT))
 	}
 
 	return &matchingservice.AddActivityTaskResponse{}, err
@@ -176,7 +176,7 @@ func (h *Handler) AddWorkflowTask(
 
 	syncMatch, err := h.engine.AddWorkflowTask(ctx, request)
 	if syncMatch {
-		opMetrics.Timer(metrics.SyncMatchLatencyPerTaskQueue.GetMetricName()).Record(time.Since(startT))
+		opMetrics.Timer(metrics.SyncMatchLatencyPerTaskQueue.Name()).Record(time.Since(startT))
 	}
 	return &matchingservice.AddWorkflowTaskResponse{}, err
 }
@@ -373,8 +373,8 @@ func (h *Handler) namespaceName(id namespace.ID) namespace.Name {
 }
 
 func (h *Handler) reportForwardedPerTaskQueueCounter(opMetrics metrics.Handler, namespaceId namespace.ID) {
-	opMetrics.Counter(metrics.ForwardedPerTaskQueueCounter.GetMetricName()).Record(1)
-	h.metricsHandler.Counter(metrics.MatchingClientForwardedCounter.GetMetricName()).
+	opMetrics.Counter(metrics.ForwardedPerTaskQueueCounter.Name()).Record(1)
+	h.metricsHandler.Counter(metrics.MatchingClientForwardedCounter.Name()).
 		Record(
 			1,
 			metrics.OperationTag(metrics.MatchingAddWorkflowTaskScope),

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -807,7 +807,7 @@ func (e *matchingEngineImpl) RespondQueryTaskCompleted(
 	opMetrics metrics.Handler,
 ) error {
 	if err := e.deliverQueryResult(request.GetTaskId(), &queryResult{workerResponse: request}); err != nil {
-		opMetrics.Counter(metrics.RespondQueryTaskFailedPerTaskQueueCounter.GetMetricName()).Record(1)
+		opMetrics.Counter(metrics.RespondQueryTaskFailedPerTaskQueueCounter.Name()).Record(1)
 		return err
 	}
 	return nil
@@ -1329,7 +1329,7 @@ func (e *matchingEngineImpl) updateTaskQueueGauge(tqm taskQueueManager, delta in
 		ns = nsEntry.Name()
 	}
 
-	e.metricsHandler.Gauge(metrics.LoadedTaskQueueGauge.GetMetricName()).Record(
+	e.metricsHandler.Gauge(metrics.LoadedTaskQueueGauge.Name()).Record(
 		float64(newCount),
 		metrics.NamespaceTag(ns.String()),
 		metrics.TaskTypeTag(countKey.taskType.String()),
@@ -1370,7 +1370,7 @@ func (e *matchingEngineImpl) createPollWorkflowTaskQueueResponse(
 		serializedToken, _ = e.tokenSerializer.Serialize(taskToken)
 		if task.responseC == nil {
 			ct := timestamp.TimeValue(task.event.Data.CreateTime)
-			metricsHandler.Timer(metrics.AsyncMatchLatencyPerTaskQueue.GetMetricName()).Record(time.Since(ct))
+			metricsHandler.Timer(metrics.AsyncMatchLatencyPerTaskQueue.Name()).Record(time.Since(ct))
 		}
 	}
 
@@ -1405,7 +1405,7 @@ func (e *matchingEngineImpl) createPollActivityTaskQueueResponse(
 	}
 	if task.responseC == nil {
 		ct := timestamp.TimeValue(task.event.Data.CreateTime)
-		metricsHandler.Timer(metrics.AsyncMatchLatencyPerTaskQueue.GetMetricName()).Record(time.Since(ct))
+		metricsHandler.Timer(metrics.AsyncMatchLatencyPerTaskQueue.Name()).Record(time.Since(ct))
 	}
 
 	taskToken := tasktoken.NewActivityTaskToken(

--- a/service/matching/task_queue_manager.go
+++ b/service/matching/task_queue_manager.go
@@ -303,7 +303,7 @@ func (c *taskQueueManagerImpl) signalIfFatal(err error) bool {
 	}
 	var condfail *persistence.ConditionFailedError
 	if errors.As(err, &condfail) {
-		c.taggedMetricsHandler.Counter(metrics.ConditionFailedErrorPerTaskQueueCounter.GetMetricName()).Record(1)
+		c.taggedMetricsHandler.Counter(metrics.ConditionFailedErrorPerTaskQueueCounter.Name()).Record(1)
 		c.skipFinalUpdate.Store(true)
 		c.unloadFromEngine()
 		return true
@@ -328,7 +328,7 @@ func (c *taskQueueManagerImpl) Start() {
 		c.goroGroup.Go(c.fetchUserData)
 	}
 	c.logger.Info("", tag.LifeCycleStarted)
-	c.taggedMetricsHandler.Counter(metrics.TaskQueueStartedCounter.GetMetricName()).Record(1)
+	c.taggedMetricsHandler.Counter(metrics.TaskQueueStartedCounter.Name()).Record(1)
 }
 
 func (c *taskQueueManagerImpl) Stop() {
@@ -360,7 +360,7 @@ func (c *taskQueueManagerImpl) Stop() {
 	// Set user data state on stop to wake up anyone blocked on the user data changed channel.
 	c.db.setUserDataState(userDataClosed)
 	c.logger.Info("", tag.LifeCycleStopped)
-	c.taggedMetricsHandler.Counter(metrics.TaskQueueStoppedCounter.GetMetricName()).Record(1)
+	c.taggedMetricsHandler.Counter(metrics.TaskQueueStoppedCounter.Name()).Record(1)
 	// This may call Stop again, but the status check above makes that a no-op.
 	c.unloadFromEngine()
 }
@@ -429,7 +429,7 @@ func (c *taskQueueManagerImpl) AddTask(
 	// TODO: make this work for versioned queues too
 	if c.QueueID().IsRoot() && c.QueueID().VersionSet() == "" && !c.HasPollerAfter(time.Now().Add(-noPollerThreshold)) {
 		// Only checks recent pollers in the root partition
-		c.taggedMetricsHandler.Counter(metrics.NoRecentPollerTasksPerTaskQueueCounter.GetMetricName()).Record(1)
+		c.taggedMetricsHandler.Counter(metrics.NoRecentPollerTasksPerTaskQueueCounter.Name()).Record(1)
 	}
 
 	taskInfo := params.taskInfo
@@ -909,12 +909,12 @@ func (c *taskQueueManagerImpl) RedirectToVersionedQueueForAdd(ctx context.Contex
 
 func (c *taskQueueManagerImpl) recordUnknownBuildPoll(buildId string) {
 	c.logger.Warn("unknown build id in poll", tag.BuildId(buildId))
-	c.taggedMetricsHandler.Counter(metrics.UnknownBuildPollsCounter.GetMetricName()).Record(1)
+	c.taggedMetricsHandler.Counter(metrics.UnknownBuildPollsCounter.Name()).Record(1)
 }
 
 func (c *taskQueueManagerImpl) recordUnknownBuildTask(buildId string) {
 	c.logger.Warn("unknown build id in task", tag.BuildId(buildId))
-	c.taggedMetricsHandler.Counter(metrics.UnknownBuildTasksCounter.GetMetricName()).Record(1)
+	c.taggedMetricsHandler.Counter(metrics.UnknownBuildTasksCounter.Name()).Record(1)
 }
 
 func (c *taskQueueManagerImpl) callerInfoContext(ctx context.Context) context.Context {

--- a/service/matching/task_reader.go
+++ b/service/matching/task_reader.go
@@ -127,7 +127,7 @@ dispatchLoop:
 			for ctx.Err() == nil {
 				if !tr.taskValidator.maybeValidate(taskInfo, tr.tlMgr.taskQueueID.taskType) {
 					task.finish(nil)
-					tr.taggedMetricsHandler().Counter(metrics.ExpiredTasksPerTaskQueueCounter.GetMetricName()).Record(1)
+					tr.taggedMetricsHandler().Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1)
 					// Don't try to set read level here because it may have been advanced already.
 					continue dispatchLoop
 				}
@@ -140,7 +140,7 @@ dispatchLoop:
 				}
 
 				// if task is still valid (truly valid or unable to verify if task is valid)
-				tr.taggedMetricsHandler().Counter(metrics.BufferThrottlePerTaskQueueCounter.GetMetricName()).Record(1)
+				tr.taggedMetricsHandler().Counter(metrics.BufferThrottlePerTaskQueueCounter.Name()).Record(1)
 				if !errors.Is(err, errUserDataDisabled) && !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 					// Don't log here if encounters missing user data error when dispatch a versioned task.
 					tr.throttledLogger().Error("taskReader: unexpected error dispatching task", tag.Error(err))
@@ -281,7 +281,7 @@ func (tr *taskReader) addTasksToBuffer(
 ) error {
 	for _, t := range tasks {
 		if IsTaskExpired(t) {
-			tr.taggedMetricsHandler().Counter(metrics.ExpiredTasksPerTaskQueueCounter.GetMetricName()).Record(1)
+			tr.taggedMetricsHandler().Counter(metrics.ExpiredTasksPerTaskQueueCounter.Name()).Record(1)
 			// Also increment readLevel for expired tasks otherwise it could result in
 			// looping over the same tasks if all tasks read in the batch are expired
 			tr.tlMgr.taskAckManager.setReadLevel(t.GetTaskId())
@@ -329,7 +329,7 @@ func (tr *taskReader) emitTaskLagMetric(ackLevel int64) {
 	// note: this metric is only an estimation for the lag.
 	// taskID in DB may not be continuous, especially when task list ownership changes.
 	maxReadLevel := tr.tlMgr.taskWriter.GetMaxReadLevel()
-	tr.taggedMetricsHandler().Gauge(metrics.TaskLagPerTaskQueueGauge.GetMetricName()).Record(float64(maxReadLevel - ackLevel))
+	tr.taggedMetricsHandler().Gauge(metrics.TaskLagPerTaskQueueGauge.Name()).Record(float64(maxReadLevel - ackLevel))
 }
 
 func (tr *taskReader) reEnqueueAfterDelay(duration time.Duration) {

--- a/service/matching/task_writer.go
+++ b/service/matching/task_writer.go
@@ -166,7 +166,7 @@ func (w *taskWriter) appendTask(
 	case w.appendCh <- req:
 		select {
 		case r := <-ch:
-			w.tlMgr.metricsHandler.Timer(metrics.TaskWriteLatencyPerTaskQueue.GetMetricName()).Record(time.Since(startTime))
+			w.tlMgr.metricsHandler.Timer(metrics.TaskWriteLatencyPerTaskQueue.Name()).Record(time.Since(startTime))
 			return r.persistenceResponse, r.err
 		case <-w.writeLoop.Done():
 			// if we are shutting down, this request will never make
@@ -174,7 +174,7 @@ func (w *taskWriter) appendTask(
 			return nil, errShutdown
 		}
 	default: // channel is full, throttle
-		w.tlMgr.metricsHandler.Counter(metrics.TaskWriteThrottlePerTaskQueueCounter.GetMetricName()).Record(1)
+		w.tlMgr.metricsHandler.Counter(metrics.TaskWriteThrottlePerTaskQueueCounter.Name()).Record(1)
 		return nil, serviceerror.NewResourceExhausted(
 			enumspb.RESOURCE_EXHAUSTED_CAUSE_SYSTEM_OVERLOADED,
 			"Too many outstanding appends to the task queue")
@@ -302,10 +302,10 @@ func (w *taskWriter) renewLeaseWithRetry(
 		newState, err = w.idAlloc.RenewLease(ctx)
 		return
 	}
-	w.tlMgr.metricsHandler.Counter(metrics.LeaseRequestPerTaskQueueCounter.GetMetricName()).Record(1)
+	w.tlMgr.metricsHandler.Counter(metrics.LeaseRequestPerTaskQueueCounter.Name()).Record(1)
 	err := backoff.ThrottleRetryContext(ctx, op, retryPolicy, retryErrors)
 	if err != nil {
-		w.tlMgr.metricsHandler.Counter(metrics.LeaseFailurePerTaskQueueCounter.GetMetricName()).Record(1)
+		w.tlMgr.metricsHandler.Counter(metrics.LeaseFailurePerTaskQueueCounter.Name()).Record(1)
 		return newState, err
 	}
 	return newState, nil

--- a/service/worker/addsearchattributes/workflow.go
+++ b/service/worker/addsearchattributes/workflow.go
@@ -144,7 +144,7 @@ func (a *activities) AddESMappingFieldActivity(ctx context.Context, params Workf
 	a.logger.Info("Creating Elasticsearch mapping.", tag.ESIndex(params.IndexName), tag.ESMapping(params.CustomAttributesToAdd))
 	_, err := a.esClient.PutMapping(ctx, params.IndexName, params.CustomAttributesToAdd)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.AddSearchAttributesFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.AddSearchAttributesFailuresCount.Name()).Record(1)
 
 		if a.isRetryableError(err) {
 			a.logger.Error("Unable to update Elasticsearch mapping (retryable error).", tag.ESIndex(params.IndexName), tag.Error(err))
@@ -181,7 +181,7 @@ func (a *activities) WaitForYellowStatusActivity(ctx context.Context, indexName 
 	status, err := a.esClient.WaitForYellowStatus(ctx, indexName)
 	if err != nil {
 		a.logger.Error("Unable to get Elasticsearch cluster status.", tag.ESIndex(indexName), tag.Error(err))
-		a.metricsHandler.Counter(metrics.AddSearchAttributesFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.AddSearchAttributesFailuresCount.Name()).Record(1)
 		return err
 	}
 	a.logger.Info("Elasticsearch cluster status.", tag.ESIndex(indexName), tag.ESClusterStatus(status))
@@ -199,7 +199,7 @@ func (a *activities) UpdateClusterMetadataActivity(ctx context.Context, params W
 	err = a.saManager.SaveSearchAttributes(ctx, params.IndexName, newCustomSearchAttributes)
 	if err != nil {
 		a.logger.Info("Unable to save search attributes to cluster metadata.", tag.ESIndex(params.IndexName), tag.Error(err))
-		a.metricsHandler.Counter(metrics.AddSearchAttributesFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.AddSearchAttributesFailuresCount.Name()).Record(1)
 		return fmt.Errorf("%w: %v", ErrUnableToSaveSearchAttributes, err)
 	}
 	a.logger.Info("Search attributes saved to cluster metadata.", tag.ESIndex(params.IndexName))

--- a/service/worker/batcher/activities.go
+++ b/service/worker/batcher/activities.go
@@ -80,7 +80,7 @@ func (a *activities) BatchActivity(ctx context.Context, batchParams BatchParams)
 	metricsHandler := a.MetricsHandler.WithTags(metrics.OperationTag(metrics.BatcherScope), metrics.NamespaceTag(batchParams.Namespace))
 
 	if err := a.checkNamespace(batchParams.Namespace); err != nil {
-		metricsHandler.Counter(metrics.BatcherOperationFailures.GetMetricName()).Record(1)
+		metricsHandler.Counter(metrics.BatcherOperationFailures.Name()).Record(1)
 		logger.Error("Failed to run batch operation due to namespace mismatch", tag.Error(err))
 		return hbd, err
 	}
@@ -105,7 +105,7 @@ func (a *activities) BatchActivity(ctx context.Context, batchParams BatchParams)
 				Query: batchParams.Query,
 			})
 			if err != nil {
-				metricsHandler.Counter(metrics.BatcherOperationFailures.GetMetricName()).Record(1)
+				metricsHandler.Counter(metrics.BatcherOperationFailures.Name()).Record(1)
 				logger.Error("Failed to get estimate workflow count", tag.Error(err))
 				return HeartBeatDetails{}, err
 			}
@@ -133,7 +133,7 @@ func (a *activities) BatchActivity(ctx context.Context, batchParams BatchParams)
 				Query:         batchParams.Query,
 			})
 			if err != nil {
-				metricsHandler.Counter(metrics.BatcherOperationFailures.GetMetricName()).Record(1)
+				metricsHandler.Counter(metrics.BatcherOperationFailures.Name()).Record(1)
 				logger.Error("Failed to list workflow executions", tag.Error(err))
 				return HeartBeatDetails{}, err
 			}
@@ -172,7 +172,7 @@ func (a *activities) BatchActivity(ctx context.Context, batchParams BatchParams)
 					break Loop
 				}
 			case <-ctx.Done():
-				metricsHandler.Counter(metrics.BatcherOperationFailures.GetMetricName()).Record(1)
+				metricsHandler.Counter(metrics.BatcherOperationFailures.Name()).Record(1)
 				logger.Error("Failed to complete batch operation", tag.Error(ctx.Err()))
 				return HeartBeatDetails{}, ctx.Err()
 			}
@@ -298,7 +298,7 @@ func startTaskProcessor(
 					})
 			}
 			if err != nil {
-				metricsHandler.Counter(metrics.BatcherProcessorFailures.GetMetricName()).Record(1)
+				metricsHandler.Counter(metrics.BatcherProcessorFailures.Name()).Record(1)
 				logger.Error("Failed to process batch operation task", tag.Error(err))
 
 				_, ok := batchParams._nonRetryableErrors[err.Error()]
@@ -310,7 +310,7 @@ func startTaskProcessor(
 					taskCh <- task
 				}
 			} else {
-				metricsHandler.Counter(metrics.BatcherProcessorSuccess.GetMetricName()).Record(1)
+				metricsHandler.Counter(metrics.BatcherProcessorSuccess.Name()).Record(1)
 				respCh <- nil
 			}
 		}

--- a/service/worker/deletenamespace/activities.go
+++ b/service/worker/deletenamespace/activities.go
@@ -98,14 +98,14 @@ func (a *localActivities) MarkNamespaceDeletedActivity(ctx context.Context, nsNa
 
 	metadata, err := a.metadataManager.GetMetadata(ctx)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.ReadNamespaceFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.ReadNamespaceFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to get cluster metadata.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return err
 	}
 
 	ns, err := a.metadataManager.GetNamespace(ctx, getNamespaceRequest)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.ReadNamespaceFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.ReadNamespaceFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to get namespace details.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return err
 	}
@@ -120,7 +120,7 @@ func (a *localActivities) MarkNamespaceDeletedActivity(ctx context.Context, nsNa
 
 	err = a.metadataManager.UpdateNamespace(ctx, updateRequest)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.UpdateNamespaceFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.UpdateNamespaceFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to update namespace state to Deleted.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return err
 	}
@@ -150,7 +150,7 @@ func (a *localActivities) GenerateDeletedNamespaceNameActivity(ctx context.Conte
 			a.logger.Info("Generated new name for deleted namespace.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowNamespace(newName))
 			return namespace.Name(newName), nil
 		default:
-			a.metricsHandler.Counter(metrics.ReadNamespaceFailuresCount.GetMetricName()).Record(1)
+			a.metricsHandler.Counter(metrics.ReadNamespaceFailuresCount.Name()).Record(1)
 			a.logger.Error("Unable to get namespace details.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 			return namespace.EmptyName, err
 		}
@@ -173,12 +173,12 @@ func (a *localActivities) RenameNamespaceActivity(ctx context.Context, previousN
 
 	err := a.metadataManager.RenameNamespace(ctx, renameNamespaceRequest)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.RenameNamespaceFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.RenameNamespaceFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to rename namespace.", tag.WorkflowNamespace(previousName.String()), tag.Error(err))
 		return err
 	}
 
-	a.metricsHandler.Counter(metrics.RenameNamespaceSuccessCount.GetMetricName()).Record(1)
+	a.metricsHandler.Counter(metrics.RenameNamespaceSuccessCount.Name()).Record(1)
 	a.logger.Info("Namespace renamed successfully.", tag.WorkflowNamespace(previousName.String()), tag.WorkflowNamespace(newName.String()))
 	return nil
 }

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -114,7 +114,7 @@ func (a *LocalActivities) GetNextPageTokenActivity(ctx context.Context, params G
 
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.ListExecutionsFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.ListExecutionsFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to list all workflows to get next page token.", tag.WorkflowNamespace(params.Namespace.String()), tag.Error(err))
 		return nil, err
 	}
@@ -137,14 +137,14 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.ListExecutionsFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.ListExecutionsFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to list all workflow executions.", tag.WorkflowNamespace(params.Namespace.String()), tag.Error(err))
 		return result, err
 	}
 	for _, execution := range resp.Executions {
 		err = rateLimiter.Wait(ctx)
 		if err != nil {
-			a.metricsHandler.Counter(metrics.RateLimiterFailuresCount.GetMetricName()).Record(1)
+			a.metricsHandler.Counter(metrics.RateLimiterFailuresCount.Name()).Record(1)
 			a.logger.Error("Workflow executions delete rate limiter error.", tag.WorkflowNamespace(params.Namespace.String()), tag.Error(err))
 			return result, err
 		}
@@ -155,10 +155,10 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 		switch err.(type) {
 		case nil:
 			result.SuccessCount++
-			a.metricsHandler.Counter(metrics.DeleteExecutionsSuccessCount.GetMetricName()).Record(1)
+			a.metricsHandler.Counter(metrics.DeleteExecutionsSuccessCount.Name()).Record(1)
 
 		case *serviceerror.NotFound:
-			a.metricsHandler.Counter(metrics.DeleteExecutionNotFoundCount.GetMetricName()).Record(1)
+			a.metricsHandler.Counter(metrics.DeleteExecutionNotFoundCount.Name()).Record(1)
 			a.logger.Info("Workflow execution is not found in history service.", tag.WorkflowNamespace(params.Namespace.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
 			// The reasons why workflow execution doesn't exist in history service, but exists in visibility store might be:
 			// 1. The workflow execution was deleted by someone else after last ListWorkflowExecutions call but before historyClient.DeleteWorkflowExecution call.
@@ -170,7 +170,7 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 
 		default:
 			result.ErrorCount++
-			a.metricsHandler.Counter(metrics.DeleteExecutionFailuresCount.GetMetricName()).Record(1)
+			a.metricsHandler.Counter(metrics.DeleteExecutionFailuresCount.Name()).Record(1)
 			a.logger.Error("Unable to delete workflow execution.", tag.WorkflowNamespace(params.Namespace.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()), tag.Error(err))
 		}
 		activity.RecordHeartbeat(ctx, result)
@@ -199,7 +199,7 @@ func (a *Activities) deleteWorkflowExecutionFromVisibility(
 	switch err.(type) {
 	case nil:
 		// Indicates that main and visibility stores were in inconsistent state.
-		a.metricsHandler.Counter(metrics.DeleteExecutionsSuccessCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.DeleteExecutionsSuccessCount.Name()).Record(1)
 		a.logger.Info("Workflow execution deleted from visibility.", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
 		return 1, 0
 	case *serviceerror.NotFound:
@@ -207,7 +207,7 @@ func (a *Activities) deleteWorkflowExecutionFromVisibility(
 		a.logger.Error("Workflow execution is not found in visibility store.", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()))
 		return 0, 0
 	default:
-		a.metricsHandler.Counter(metrics.DeleteExecutionFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.DeleteExecutionFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to delete workflow execution from visibility store.", tag.WorkflowNamespaceID(namespaceID.String()), tag.WorkflowID(execution.Execution.GetWorkflowId()), tag.WorkflowRunID(execution.Execution.GetRunId()), tag.Error(err))
 		return 0, 1
 	}

--- a/service/worker/deletenamespace/reclaimresources/activities.go
+++ b/service/worker/deletenamespace/reclaimresources/activities.go
@@ -102,7 +102,7 @@ func (a *LocalActivities) CountExecutionsAdvVisibilityActivity(ctx context.Conte
 	}
 	resp, err := a.visibilityManager.CountWorkflowExecutions(ctx, req)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.CountExecutionsFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.CountExecutionsFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to count workflow executions.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return 0, err
 	}
@@ -124,7 +124,7 @@ func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context
 	}
 	resp, err := a.visibilityManager.CountWorkflowExecutions(ctx, req)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.CountExecutionsFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.CountExecutionsFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to count workflow executions.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return err
 	}
@@ -136,7 +136,7 @@ func (a *Activities) EnsureNoExecutionsAdvVisibilityActivity(ctx context.Context
 		if activity.HasHeartbeatDetails(ctx) && activityInfo.Attempt > 7 {
 			var previousAttemptCount int
 			if err := activity.GetHeartbeatDetails(ctx, &previousAttemptCount); err != nil {
-				a.metricsHandler.Counter(metrics.CountExecutionsFailuresCount.GetMetricName()).Record(1)
+				a.metricsHandler.Counter(metrics.CountExecutionsFailuresCount.Name()).Record(1)
 				a.logger.Error("Unable to get previous heartbeat details.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 				return err
 			}
@@ -177,7 +177,7 @@ func (a *Activities) EnsureNoExecutionsStdVisibilityActivity(ctx context.Context
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.ListExecutionsFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.ListExecutionsFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to count workflow executions using list.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return err
 	}
@@ -200,12 +200,12 @@ func (a *LocalActivities) DeleteNamespaceActivity(ctx context.Context, nsID name
 
 	err := a.metadataManager.DeleteNamespaceByName(ctx, deleteNamespaceRequest)
 	if err != nil {
-		a.metricsHandler.Counter(metrics.DeleteNamespaceFailuresCount.GetMetricName()).Record(1)
+		a.metricsHandler.Counter(metrics.DeleteNamespaceFailuresCount.Name()).Record(1)
 		a.logger.Error("Unable to delete namespace from persistence.", tag.WorkflowNamespace(nsName.String()), tag.Error(err))
 		return err
 	}
 
-	a.metricsHandler.Counter(metrics.DeleteNamespaceSuccessCount.GetMetricName()).Record(1)
+	a.metricsHandler.Counter(metrics.DeleteNamespaceSuccessCount.Name()).Record(1)
 	a.logger.Info("Namespace is deleted.", tag.WorkflowNamespace(nsName.String()), tag.WorkflowNamespaceID(nsID.String()))
 	return nil
 }

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -162,13 +162,13 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 
 		switch typedErr := err.(type) {
 		case nil:
-			processor.metricsHandler.Counter(metrics.ParentClosePolicyProcessorSuccess.GetMetricName()).Record(1)
+			processor.metricsHandler.Counter(metrics.ParentClosePolicyProcessorSuccess.Name()).Record(1)
 		case *serviceerror.NotFound, *serviceerror.NamespaceNotFound:
 			// no-op
 		case *serviceerror.NamespaceNotActive:
 			remoteExecutions[typedErr.ActiveCluster] = append(remoteExecutions[typedErr.ActiveCluster], execution)
 		default:
-			processor.metricsHandler.Counter(metrics.ParentClosePolicyProcessorFailures.GetMetricName()).Record(1)
+			processor.metricsHandler.Counter(metrics.ParentClosePolicyProcessorFailures.Name()).Record(1)
 			getActivityLogger(ctx).Error("failed to process parent close policy", tag.Error(err))
 			return err
 		}

--- a/service/worker/replicator/namespace_replication_message_processor.go
+++ b/service/worker/replicator/namespace_replication_message_processor.go
@@ -181,7 +181,7 @@ func (p *namespaceReplicationMessageProcessor) getAndHandleNamespaceReplicationT
 		}, p.retryPolicy, isTransientRetryableError)
 
 		if err != nil {
-			p.metricsHandler.Counter(metrics.ReplicatorFailures.GetMetricName()).Record(1)
+			p.metricsHandler.Counter(metrics.ReplicatorFailures.Name()).Record(1)
 			p.logger.Error("Failed to apply namespace replication tasks", tag.Error(err))
 
 			dlqErr := backoff.ThrottleRetry(func() error {
@@ -190,7 +190,7 @@ func (p *namespaceReplicationMessageProcessor) getAndHandleNamespaceReplicationT
 			}, p.retryPolicy, isTransientRetryableError)
 			if dlqErr != nil {
 				p.logger.Error("Failed to put replication tasks to DLQ", tag.Error(dlqErr))
-				p.metricsHandler.Counter(metrics.ReplicatorDLQFailures.GetMetricName()).Record(1)
+				p.metricsHandler.Counter(metrics.ReplicatorDLQFailures.Name()).Record(1)
 				return
 			}
 		}
@@ -206,7 +206,7 @@ func (p *namespaceReplicationMessageProcessor) putNamespaceReplicationTaskToDLQ(
 ) error {
 	switch task.TaskType {
 	case enumsspb.REPLICATION_TASK_TYPE_NAMESPACE_TASK:
-		p.metricsHandler.Counter(metrics.NamespaceReplicationEnqueueDLQCount.GetMetricName()).
+		p.metricsHandler.Counter(metrics.NamespaceReplicationEnqueueDLQCount.Name()).
 			Record(1,
 				metrics.ReplicationTaskTypeTag(task.TaskType),
 				metrics.NamespaceTag(task.GetNamespaceTaskAttributes().GetInfo().GetName()),
@@ -216,7 +216,7 @@ func (p *namespaceReplicationMessageProcessor) putNamespaceReplicationTaskToDLQ(
 		if err != nil {
 			return err
 		}
-		p.metricsHandler.Counter(metrics.NamespaceReplicationEnqueueDLQCount.GetMetricName()).
+		p.metricsHandler.Counter(metrics.NamespaceReplicationEnqueueDLQCount.Name()).
 			Record(1,
 				metrics.ReplicationTaskTypeTag(task.TaskType),
 				metrics.NamespaceTag(ns.Name().String()),
@@ -234,10 +234,10 @@ func (p *namespaceReplicationMessageProcessor) handleNamespaceReplicationTask(
 	task *replicationspb.ReplicationTask,
 ) error {
 	metricsTag := metrics.ReplicationTaskTypeTag(task.TaskType)
-	p.metricsHandler.Counter(metrics.ReplicatorMessages.GetMetricName()).Record(1, metricsTag)
+	p.metricsHandler.Counter(metrics.ReplicatorMessages.Name()).Record(1, metricsTag)
 	startTime := time.Now().UTC()
 	defer func() {
-		p.metricsHandler.Timer(metrics.ReplicatorLatency.GetMetricName()).Record(time.Since(startTime), metricsTag)
+		p.metricsHandler.Timer(metrics.ReplicatorLatency.Name()).Record(time.Since(startTime), metricsTag)
 	}()
 
 	switch task.TaskType {

--- a/service/worker/scanner/executions/scavenger.go
+++ b/service/worker/scanner/executions/scavenger.go
@@ -137,7 +137,7 @@ func (s *Scavenger) Start() {
 	s.stopWG.Add(1)
 	s.executor.Start()
 	go s.run()
-	s.metricsHandler.Counter(metrics.StartedCount.GetMetricName()).Record(1)
+	s.metricsHandler.Counter(metrics.StartedCount.Name()).Record(1)
 	s.logger.Info("Executions scavenger started")
 }
 
@@ -150,7 +150,7 @@ func (s *Scavenger) Stop() {
 	) {
 		return
 	}
-	s.metricsHandler.Counter(metrics.StoppedCount.GetMetricName()).Record(1)
+	s.metricsHandler.Counter(metrics.StoppedCount.Name()).Record(1)
 	s.logger.Info("Executions scavenger stopping")
 	close(s.stopC)
 	s.executor.Stop()
@@ -200,7 +200,7 @@ func (s *Scavenger) run() {
 
 func (s *Scavenger) awaitExecutor() {
 	// gauge value persists, so we want to reset it to 0
-	defer s.metricsHandler.Gauge(metrics.ExecutionsOutstandingCount.GetMetricName()).Record(float64(0))
+	defer s.metricsHandler.Gauge(metrics.ExecutionsOutstandingCount.Name()).Record(float64(0))
 
 	outstanding := s.executor.TaskCount()
 	for outstanding > 0 {
@@ -208,7 +208,7 @@ func (s *Scavenger) awaitExecutor() {
 		select {
 		case <-timer.C:
 			outstanding = s.executor.TaskCount()
-			s.metricsHandler.Gauge(metrics.ExecutionsOutstandingCount.GetMetricName()).Record(float64(outstanding))
+			s.metricsHandler.Gauge(metrics.ExecutionsOutstandingCount.Name()).Record(float64(outstanding))
 		case <-s.stopC:
 			timer.Stop()
 			return

--- a/service/worker/scanner/executions/task.go
+++ b/service/worker/scanner/executions/task.go
@@ -120,7 +120,7 @@ func (t *task) Run() executor.TaskStatus {
 		_ = t.rateLimiter.Wait(t.ctx)
 		record, err := iter.Next()
 		if err != nil {
-			t.metricsHandler.Counter(metrics.ScavengerValidationSkipsCount.GetMetricName()).Record(1)
+			t.metricsHandler.Counter(metrics.ScavengerValidationSkipsCount.Name()).Record(1)
 			// continue validation process and retry after all workflow records has been iterated.
 			t.logger.Error("unable to paginate concrete execution", tag.ShardID(t.shardID), tag.Error(err))
 			retryTask = true
@@ -138,7 +138,7 @@ func (t *task) Run() executor.TaskStatus {
 		if err != nil {
 			// continue validation process and retry after all workflow records has been iterated.
 			executionInfo := mutableState.GetExecutionInfo()
-			t.metricsHandler.Counter(metrics.ScavengerValidationSkipsCount.GetMetricName()).Record(1)
+			t.metricsHandler.Counter(metrics.ScavengerValidationSkipsCount.Name()).Record(1)
 			t.logger.Error("unable to process failure result",
 				tag.ShardID(t.shardID),
 				tag.Error(err),
@@ -278,14 +278,14 @@ func printValidationResult(
 	metricsHandler metrics.Handler,
 	logger log.Logger,
 ) {
-	metricsHandler.Counter(metrics.ScavengerValidationRequestsCount.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.ScavengerValidationRequestsCount.Name()).Record(1)
 	if len(results) == 0 {
 		return
 	}
 
-	metricsHandler.Counter(metrics.ScavengerValidationFailuresCount.GetMetricName()).Record(1)
+	metricsHandler.Counter(metrics.ScavengerValidationFailuresCount.Name()).Record(1)
 	for _, result := range results {
-		metricsHandler.Counter(metrics.ScavengerValidationFailuresCount.GetMetricName()).Record(1, metrics.FailureTag(result.failureType))
+		metricsHandler.Counter(metrics.ScavengerValidationFailuresCount.Name()).Record(1, metrics.FailureTag(result.failureType))
 		logger.Info(
 			"validation failed for execution.",
 			tag.WorkflowNamespaceID(mutableState.GetExecutionInfo().GetNamespaceId()),

--- a/service/worker/scanner/executor/executor.go
+++ b/service/worker/scanner/executor/executor.go
@@ -145,18 +145,18 @@ func (e *fixedPoolExecutor) worker() {
 		switch status {
 		case TaskStatusDone:
 			atomic.AddInt64(&e.outstanding, -1)
-			e.metricsHandler.Counter(metrics.ExecutorTasksDoneCount.GetMetricName()).Record(1)
+			e.metricsHandler.Counter(metrics.ExecutorTasksDoneCount.Name()).Record(1)
 		case TaskStatusDefer:
 			if e.runQ.deferredCount() < e.maxDeferred {
 				e.runQ.addAndDefer(task)
-				e.metricsHandler.Counter(metrics.ExecutorTasksDeferredCount.GetMetricName()).Record(1)
+				e.metricsHandler.Counter(metrics.ExecutorTasksDeferredCount.Name()).Record(1)
 			} else {
 				atomic.AddInt64(&e.outstanding, -1)
-				e.metricsHandler.Counter(metrics.ExecutorTasksDroppedCount.GetMetricName()).Record(1)
+				e.metricsHandler.Counter(metrics.ExecutorTasksDroppedCount.Name()).Record(1)
 			}
 		case TaskStatusErr:
 			atomic.AddInt64(&e.outstanding, -1)
-			e.metricsHandler.Counter(metrics.ExecutorTasksErrCount.GetMetricName()).Record(1)
+			e.metricsHandler.Counter(metrics.ExecutorTasksErrCount.Name()).Record(1)
 		default:
 			panic(fmt.Sprintf("unknown task status: %v", status))
 		}

--- a/service/worker/scanner/history/scavenger.go
+++ b/service/worker/scanner/history/scavenger.go
@@ -231,7 +231,7 @@ func (s *Scavenger) filterTask(
 ) *taskDetail {
 
 	if time.Now().UTC().Add(-s.historyDataMinAge()).Before(timestamp.TimeValue(branch.ForkTime)) {
-		s.metricsHandler.Counter(metrics.HistoryScavengerSkipCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.HistoryScavengerSkipCount.Name()).Record(1)
 
 		s.Lock()
 		defer s.Unlock()
@@ -242,7 +242,7 @@ func (s *Scavenger) filterTask(
 	namespaceID, workflowID, runID, err := persistence.SplitHistoryGarbageCleanupInfo(branch.Info)
 	if err != nil {
 		s.logger.Error("unable to parse the history cleanup info", tag.DetailInfo(branch.Info), tag.Error(err))
-		s.metricsHandler.Counter(metrics.HistoryScavengerErrorCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.HistoryScavengerErrorCount.Name()).Record(1)
 
 		s.Lock()
 		defer s.Unlock()
@@ -254,7 +254,7 @@ func (s *Scavenger) filterTask(
 	branchToken, err := serialization.HistoryBranchToBlob(branch.BranchInfo)
 	if err != nil {
 		s.logger.Error("unable to serialize the history branch token", tag.DetailInfo(branch.Info), tag.Error(err))
-		s.metricsHandler.Counter(metrics.HistoryScavengerErrorCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.HistoryScavengerErrorCount.Name()).Record(1)
 
 		s.Lock()
 		defer s.Unlock()
@@ -316,12 +316,12 @@ func (s *Scavenger) handleErr(
 	s.Lock()
 	defer s.Unlock()
 	if err != nil {
-		s.metricsHandler.Counter(metrics.HistoryScavengerErrorCount.GetMetricName()).Record(1)
+		s.metricsHandler.Counter(metrics.HistoryScavengerErrorCount.Name()).Record(1)
 		s.hbd.ErrorCount++
 		return
 	}
 
-	s.metricsHandler.Counter(metrics.HistoryScavengerSuccessCount.GetMetricName()).Record(1)
+	s.metricsHandler.Counter(metrics.HistoryScavengerSuccessCount.Name()).Record(1)
 	s.hbd.SuccessCount++
 }
 

--- a/service/worker/scanner/taskqueue/scavenger.go
+++ b/service/worker/scanner/taskqueue/scavenger.go
@@ -131,7 +131,7 @@ func (s *Scavenger) Start() {
 	s.stopWG.Add(1)
 	s.executor.Start()
 	go s.run()
-	s.metricsHandler.Counter(metrics.StartedCount.GetMetricName()).Record(1)
+	s.metricsHandler.Counter(metrics.StartedCount.Name()).Record(1)
 	s.logger.Info("Taskqueue scavenger started")
 }
 
@@ -140,7 +140,7 @@ func (s *Scavenger) Stop() {
 	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
-	s.metricsHandler.Counter(metrics.StoppedCount.GetMetricName()).Record(1)
+	s.metricsHandler.Counter(metrics.StoppedCount.Name()).Record(1)
 	s.logger.Info("Taskqueue scavenger stopping")
 	s.lifecycleCancel()
 	close(s.stopC)
@@ -198,7 +198,7 @@ func (s *Scavenger) awaitExecutor() {
 		select {
 		case <-timer.C:
 			outstanding = s.executor.TaskCount()
-			s.metricsHandler.Gauge(metrics.TaskQueueOutstandingCount.GetMetricName()).Record(float64(outstanding))
+			s.metricsHandler.Gauge(metrics.TaskQueueOutstandingCount.Name()).Record(float64(outstanding))
 		case <-s.stopC:
 			timer.Stop()
 			return
@@ -207,10 +207,10 @@ func (s *Scavenger) awaitExecutor() {
 }
 
 func (s *Scavenger) emitStats() {
-	s.metricsHandler.Gauge(metrics.TaskProcessedCount.GetMetricName()).Record(float64(s.stats.task.nProcessed))
-	s.metricsHandler.Gauge(metrics.TaskDeletedCount.GetMetricName()).Record(float64(s.stats.task.nDeleted))
-	s.metricsHandler.Gauge(metrics.TaskQueueProcessedCount.GetMetricName()).Record(float64(s.stats.taskqueue.nProcessed))
-	s.metricsHandler.Gauge(metrics.TaskQueueDeletedCount.GetMetricName()).Record(float64(s.stats.taskqueue.nDeleted))
+	s.metricsHandler.Gauge(metrics.TaskProcessedCount.Name()).Record(float64(s.stats.task.nProcessed))
+	s.metricsHandler.Gauge(metrics.TaskDeletedCount.Name()).Record(float64(s.stats.task.nDeleted))
+	s.metricsHandler.Gauge(metrics.TaskQueueProcessedCount.Name()).Record(float64(s.stats.taskqueue.nProcessed))
+	s.metricsHandler.Gauge(metrics.TaskQueueDeletedCount.Name()).Record(float64(s.stats.taskqueue.nDeleted))
 }
 
 // newTask returns a new instance of an executable task which will process a single task queue

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -543,7 +543,7 @@ func (s *scheduler) processTimeRange(
 		}
 		if !manual && t2.Sub(t1) > catchupWindow {
 			s.logger.Warn("Schedule missed catchup window", "now", t2, "time", t1)
-			s.metrics.Counter(metrics.ScheduleMissedCatchupWindow.GetMetricName()).Inc(1)
+			s.metrics.Counter(metrics.ScheduleMissedCatchupWindow.Name()).Inc(1)
 			s.Info.MissedCatchupWindow++
 			continue
 		}
@@ -920,7 +920,7 @@ func (s *scheduler) addStart(nominalTime, actualTime time.Time, overlapPolicy en
 	s.logger.Debug("addStart", "start-time", nominalTime, "actual-start-time", actualTime, "overlap-policy", overlapPolicy, "manual", manual)
 	if s.tweakables.MaxBufferSize > 0 && len(s.State.BufferedStarts) >= s.tweakables.MaxBufferSize {
 		s.logger.Warn("Buffer too large", "start-time", nominalTime, "overlap-policy", overlapPolicy, "manual", manual)
-		s.metrics.Counter(metrics.ScheduleBufferOverruns.GetMetricName()).Inc(1)
+		s.metrics.Counter(metrics.ScheduleBufferOverruns.Name()).Inc(1)
 		s.Info.BufferDropped += 1
 		return
 	}
@@ -982,14 +982,14 @@ func (s *scheduler) processBuffer() bool {
 			metrics.ScheduleActionTypeTag: metrics.ScheduleActionStartWorkflow})
 		if err != nil {
 			s.logger.Error("Failed to start workflow", "error", err)
-			metricsWithTag.Counter(metrics.ScheduleActionErrors.GetMetricName()).Inc(1)
+			metricsWithTag.Counter(metrics.ScheduleActionErrors.Name()).Inc(1)
 			// TODO: we could put this back in the buffer and retry (after a delay) up until
 			// the catchup window. of course, it's unlikely that this workflow would be making
 			// progress while we're unable to start a new one, so maybe it's not that valuable.
 			tryAgain = true
 			continue
 		}
-		metricsWithTag.Counter(metrics.ScheduleActionSuccess.GetMetricName()).Inc(1)
+		metricsWithTag.Counter(metrics.ScheduleActionSuccess.Name()).Inc(1)
 		nonOverlapping := start == action.nonOverlappingStart
 		s.recordAction(result, nonOverlapping)
 	}
@@ -1091,7 +1091,7 @@ func (s *scheduler) startWorkflow(
 		var appErr *temporal.ApplicationError
 		var details rateLimitedDetails
 		if errors.As(err, &appErr) && appErr.Type() == rateLimitedErrorType && appErr.Details(&details) == nil {
-			s.metrics.Counter(metrics.ScheduleRateLimited.GetMetricName()).Inc(1)
+			s.metrics.Counter(metrics.ScheduleRateLimited.Name()).Inc(1)
 			workflow.Sleep(s.ctx, details.Delay)
 			req.CompletedRateLimitSleep = true // only use rate limiter once
 			continue
@@ -1190,7 +1190,7 @@ func (s *scheduler) cancelWorkflow(ex *commonpb.WorkflowExecution) {
 	err := workflow.ExecuteLocalActivity(ctx, s.a.CancelWorkflow, areq).Get(s.ctx, nil)
 	if err != nil {
 		s.logger.Error("cancel workflow failed", "workflow", ex.WorkflowId, "error", err)
-		s.metrics.Counter(metrics.ScheduleCancelWorkflowErrors.GetMetricName()).Inc(1)
+		s.metrics.Counter(metrics.ScheduleCancelWorkflowErrors.Name()).Inc(1)
 	}
 	// Note: the local activity has completed (or failed) here but the workflow might take time
 	// to close since a cancel is only a request.
@@ -1208,7 +1208,7 @@ func (s *scheduler) terminateWorkflow(ex *commonpb.WorkflowExecution) {
 	err := workflow.ExecuteLocalActivity(ctx, s.a.TerminateWorkflow, areq).Get(s.ctx, nil)
 	if err != nil {
 		s.logger.Error("terminate workflow failed", "workflow", ex.WorkflowId, "error", err)
-		s.metrics.Counter(metrics.ScheduleTerminateWorkflowErrors.GetMetricName()).Inc(1)
+		s.metrics.Counter(metrics.ScheduleTerminateWorkflowErrors.Name()).Inc(1)
 	}
 	// Note: the local activity has completed (or failed) here but we'll still wait until we
 	// observe the workflow close (with a watcher) to start the next one.

--- a/tests/http_api_test.go
+++ b/tests/http_api_test.go
@@ -110,7 +110,7 @@ func (s *clientFunctionalSuite) runHTTPAPIBasicsTest(
 	// can't test overall counts because the metrics handler is shared across
 	// concurrently executing tests.
 	var found bool
-	for _, metric := range capture.Snapshot()[metrics.HTTPServiceRequests.GetMetricName()] {
+	for _, metric := range capture.Snapshot()[metrics.HTTPServiceRequests.Name()] {
 		found =
 			metric.Tags[metrics.OperationTagName] == "/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution" &&
 				metric.Tags["namespace"] == s.namespace &&


### PR DESCRIPTION
## What changed?
I renamed the getters on `metricDefinition` to follow go's guidelines.

## Why?
Not only does it save typing, it's better Go.

Quoth [Effective Go](https://go.dev/doc/effective_go#Getters):

> ...it's neither idiomatic nor necessary to put Get into the getter's name. If you have a field called owner (lower case, unexported), the getter method should be called Owner (upper case, exported), not GetOwner.

## How did you test it?
Our current tests are sufficient

## Potential risks
None

## Is hotfix candidate?
No.
