### PR TITLE
Add a With(Handler) method to all metricDefinition objects

### DIFF
--- a/common/archiver/gcloud/history_archiver.go
+++ b/common/archiver/gcloud/history_archiver.go
@@ -111,7 +111,7 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 	featureCatalog := archiver.GetFeatureCatalog(opts...)
 	startTime := time.Now().UTC()
 	defer func() {
-		handler.Timer(metrics.ServiceLatency.Name()).Record(time.Since(startTime))
+		metrics.ServiceLatency.With(handler).Record(time.Since(startTime))
 		if err != nil {
 
 			if err.Error() != errUploadNonRetryable.Error() {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -35,6 +35,22 @@ type (
 		description string
 		unit        MetricUnit
 	}
+
+	histogramDefinition struct {
+		metricDefinition
+	}
+
+	counterDefinition struct {
+		metricDefinition
+	}
+
+	gaugeDefinition struct {
+		metricDefinition
+	}
+
+	timerDefinition struct {
+		metricDefinition
+	}
 )
 
 // MetricUnit supported values
@@ -53,22 +69,38 @@ func (md metricDefinition) Unit() MetricUnit {
 	return md.unit
 }
 
-func NewTimerDef(name string, opts ...Option) metricDefinition {
-	return globalRegistry.register(name, append(opts, WithUnit(Milliseconds))...)
+func NewTimerDef(name string, opts ...Option) timerDefinition {
+	return timerDefinition{globalRegistry.register(name, append(opts, WithUnit(Milliseconds))...)}
 }
 
-func NewBytesHistogramDef(name string, opts ...Option) metricDefinition {
-	return globalRegistry.register(name, append(opts, WithUnit(Bytes))...)
+func NewBytesHistogramDef(name string, opts ...Option) histogramDefinition {
+	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Bytes))...)}
 }
 
-func NewDimensionlessHistogramDef(name string, opts ...Option) metricDefinition {
-	return globalRegistry.register(name, append(opts, WithUnit(Dimensionless))...)
+func NewDimensionlessHistogramDef(name string, opts ...Option) histogramDefinition {
+	return histogramDefinition{globalRegistry.register(name, append(opts, WithUnit(Dimensionless))...)}
 }
 
-func NewCounterDef(name string, opts ...Option) metricDefinition {
-	return globalRegistry.register(name, opts...)
+func NewCounterDef(name string, opts ...Option) counterDefinition {
+	return counterDefinition{globalRegistry.register(name, opts...)}
 }
 
-func NewGaugeDef(name string, opts ...Option) metricDefinition {
-	return globalRegistry.register(name, opts...)
+func NewGaugeDef(name string, opts ...Option) gaugeDefinition {
+	return gaugeDefinition{globalRegistry.register(name, opts...)}
+}
+
+func (d histogramDefinition) With(handler Handler) HistogramIface {
+	return handler.Histogram(d.name, d.unit)
+}
+
+func (d counterDefinition) With(handler Handler) CounterIface {
+	return handler.Counter(d.name)
+}
+
+func (d gaugeDefinition) With(handler Handler) GaugeIface {
+	return handler.Gauge(d.name)
+}
+
+func (d timerDefinition) With(handler Handler) TimerIface {
+	return handler.Timer(d.name)
 }

--- a/common/metrics/metrics.go
+++ b/common/metrics/metrics.go
@@ -36,10 +36,13 @@ import (
 // https://github.com/temporalio/sdk-go/blob/master/internal/common/metrics/handler.go
 // and adapted to depend on golang.org/x/exp/event
 type (
-	// Handler is a wrapper around a metrics client
+	// Handler is a wrapper around a metrics client.
+	// If you are interacting with metrics registered with New*Def functions, e.g. NewCounterDef, please use the With
+	// method of those definitions instead of calling Counter directly on the Handler. This will ensure that you don't
+	// accidentally use the wrong metric type, and you don't need to re-specify metric types or units.
 	Handler interface {
-		// WithTags creates a new MetricProvder with provided []Tag
-		// Tags are merged with registered Tags from the source MetricsHandler
+		// WithTags creates a new Handler with provided Tag list.
+		// Tags are merged with registered Tags from the source Handler.
 		WithTags(...Tag) Handler
 
 		// Counter obtains a counter for the given name.

--- a/common/metrics/metrics_test.go
+++ b/common/metrics/metrics_test.go
@@ -1,0 +1,77 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics_test
+
+import (
+	"fmt"
+	"time"
+
+	"go.temporal.io/server/common/metrics"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+)
+
+var (
+	bytesHist = metrics.NewBytesHistogramDef("test-bytes-histogram")
+	counter   = metrics.NewCounterDef("test-counter")
+	gauge     = metrics.NewGaugeDef("test-gauge")
+	hist      = metrics.NewDimensionlessHistogramDef("test-histogram")
+	timer     = metrics.NewTimerDef("test-timer")
+)
+
+func ExampleHandler() {
+	handler := metricstest.NewCaptureHandler()
+	capture := handler.StartCapture()
+
+	// Instead of calling handler.Histogram(bytesHist.Name(), bytesHist.Unit()).Record(1), you should use the With
+	// method of the metric definition instead.
+
+	bytesHist.With(handler).Record(1)
+	counter.With(handler).Record(2)
+	gauge.With(handler).Record(3)
+	hist.With(handler).Record(4)
+	timer.With(handler).Record(5 * time.Second)
+
+	snapshot := capture.Snapshot()
+	keys := maps.Keys(snapshot)
+	slices.Sort(keys)
+	for _, key := range keys {
+		fmt.Printf("%s:", key)
+		for _, rec := range snapshot[key] {
+			fmt.Printf(" %v (%v)", rec.Value, rec.Unit)
+		}
+		fmt.Println()
+	}
+
+	// Notice that the output includes the proper units without having to specify them in the call to Record.
+
+	// Output:
+	// test-bytes-histogram: 1 (By)
+	// test-counter: 2 ()
+	// test-gauge: 3 ()
+	// test-histogram: 4 (1)
+	// test-timer: 5s ()
+}

--- a/common/rpc/interceptor/concurrent_request_limit.go
+++ b/common/rpc/interceptor/concurrent_request_limit.go
@@ -109,7 +109,7 @@ func (ni *ConcurrentRequestLimitInterceptor) Intercept(
 		defer atomic.AddInt32(counter, -int32(token))
 
 		handler := GetMetricsHandlerFromContext(ctx, ni.logger)
-		handler.Gauge(metrics.ServicePendingRequests.Name()).Record(float64(count))
+		metrics.ServicePendingRequests.With(handler).Record(float64(count))
 
 		// frontend.namespaceCount is applied per poller type temporarily to prevent
 		// one poller type to take all token waiting in the long poll.

--- a/common/rpc/interceptor/telemetry.go
+++ b/common/rpc/interceptor/telemetry.go
@@ -148,7 +148,7 @@ func (ti *TelemetryInterceptor) UnaryIntercept(
 	metricsHandler, logTags := ti.unaryMetricsHandlerLogTags(req, info.FullMethod, methodName)
 
 	ctx = context.WithValue(ctx, metricsCtxKey, metricsHandler)
-	metricsHandler.Counter(metrics.ServiceRequests.Name()).Record(1)
+	metrics.ServiceRequests.With(metricsHandler).Record(1)
 
 	startTime := time.Now().UTC()
 	userLatencyDuration := time.Duration(0)

--- a/common/util.go
+++ b/common/util.go
@@ -694,7 +694,7 @@ func CheckEventBlobSizeLimit(
 	blobSizeViolationOperationTag tag.ZapTag,
 ) error {
 
-	metricsHandler.Histogram(metrics.EventBlobSize.Name(), metrics.EventBlobSize.Unit()).Record(int64(actualSize))
+	metrics.EventBlobSize.With(metricsHandler).Record(int64(actualSize))
 	if actualSize > warnLimit {
 		if logger != nil {
 			logger.Warn("Blob data size exceeds the warning limit.",

--- a/service/history/workflow/context.go
+++ b/service/history/workflow/context.go
@@ -1040,10 +1040,7 @@ func emitStateTransitionCount(
 	}
 
 	namespaceEntry := mutableState.GetNamespaceEntry()
-	metricsHandler.Histogram(
-		metrics.StateTransitionCount.Name(),
-		metrics.StateTransitionCount.Unit(),
-	).Record(
+	metrics.StateTransitionCount.With(metricsHandler).Record(
 		mutableState.GetExecutionInfo().StateTransitionCount,
 		metrics.NamespaceTag(namespaceEntry.Name().String()),
 		metrics.NamespaceStateTag(namespaceState(clusterMetadata, convert.Int64Ptr(mutableState.GetCurrentVersion()))),


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
I created new structs that embed `metricDefinition` (e.g. `histogramDefinition`), and I added a `With(Handler)` method to each of them. I also added an example that migrates the usage of `Handler` to this new approach, for one of each type of metric definition.

If this lands, I will also create an issue with the "good first issue" tag to migrate all usage to the new approach. There's no need to do it right away, though.

## Why?
<!-- Tell your future self why have you made these changes -->
Previously, usage of our `metrics.Handler` could be both redundant and unsafe:
```
handler.Histogram( myHisto.Name(), myHisto.Unit() ).Record(...)
            │             │               └───┐
            │             │                   │
            └─────┐       └───────────┐       │
                  │                   │       │
   Redundant and Unsafe: 'Histogram'  │       │
   is specified despite knowing       │       │
   'myHisto' is a histogram. There's  │       │
   also a risk if 'myHisto.Name()'    │       │
   refers to a metric definition that │       │
   is not a histogram.                │       │
                                      └─── Redundant information
```

If you use the new `With(Handler)` method, there's no need to specify redundant information.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I added an `ExampleHandler` which tests all the new methods and also serves as documentation on how to use the `Handler`, to encourage people to use the new approach.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
People can still use the old approach after this PR lands because we are keeping the `Handler` interface as-is. However, we need to do that because we can't break existing users / implementors.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.