### PR TITLE
Capitalize test suite names

### DIFF
--- a/tests/acquire_shard_test.go
+++ b/tests/acquire_shard_test.go
@@ -36,22 +36,22 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-// acquireShardFunctionalSuite is the base test suite for testing acquire shard.
-type acquireShardFunctionalSuite struct {
+// AcquireShardFunctionalSuite is the base test suite for testing acquire shard.
+type AcquireShardFunctionalSuite struct {
 	FunctionalTestBase
 	logRecorder *logRecorder
 	logs        chan logRecord
 }
 
 // SetupSuite sets up the test suite by setting the log recorder.
-func (s *acquireShardFunctionalSuite) SetupSuite() {
+func (s *AcquireShardFunctionalSuite) SetupSuite() {
 	s.logs = make(chan logRecord, 100)
 	s.logRecorder = newLogRecorder(s.logs)
 	s.Logger = s.logRecorder
 }
 
 // TearDownSuite tears down the test suite by shutting down the test cluster after a short delay.
-func (s *acquireShardFunctionalSuite) TearDownSuite() {
+func (s *AcquireShardFunctionalSuite) TearDownSuite() {
 	// we need to wait for all components to start before we can safely tear down
 	time.Sleep(time.Second * 5)
 	s.tearDownSuite()
@@ -105,24 +105,24 @@ func (r *logRecorder) record(msg string, tags ...tag.Tag) {
 
 // TestAcquireShard_OwnershipLostErrorSuite tests what happens when acquire shard returns an ownership lost error.
 func TestAcquireShard_OwnershipLostErrorSuite(t *testing.T) {
-	s := new(ownershipLostErrorSuite)
+	s := new(OwnershipLostErrorSuite)
 	suite.Run(t, s)
 }
 
-// ownershipLostErrorSuite is the test suite for testing what happens when acquire shard returns an ownership lost
+// OwnershipLostErrorSuite is the test suite for testing what happens when acquire shard returns an ownership lost
 // error.
-type ownershipLostErrorSuite struct {
-	acquireShardFunctionalSuite
+type OwnershipLostErrorSuite struct {
+	AcquireShardFunctionalSuite
 }
 
 // SetupSuite reads the shard ownership lost error fault injection config from the testdata folder.
-func (s *ownershipLostErrorSuite) SetupSuite() {
-	s.acquireShardFunctionalSuite.SetupSuite()
+func (s *OwnershipLostErrorSuite) SetupSuite() {
+	s.AcquireShardFunctionalSuite.SetupSuite()
 	s.setupSuite("testdata/acquire_shard_ownership_lost_error.yaml")
 }
 
 // TestDoesNotRetry verifies that we do not retry acquiring the shard when we get an ownership lost error.
-func (s *ownershipLostErrorSuite) TestDoesNotRetry() {
+func (s *OwnershipLostErrorSuite) TestDoesNotRetry() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
@@ -154,24 +154,24 @@ func (s *ownershipLostErrorSuite) TestDoesNotRetry() {
 
 // TestAcquireShard_DeadlineExceededErrorSuite tests what happens when acquire shard returns a deadline exceeded error
 func TestAcquireShard_DeadlineExceededErrorSuite(t *testing.T) {
-	s := new(deadlineExceededErrorSuite)
+	s := new(DeadlineExceededErrorSuite)
 	suite.Run(t, s)
 }
 
-// deadlineExceededErrorSuite is the test suite for testing what happens when acquire shard returns a deadline exceeded.
-type deadlineExceededErrorSuite struct {
-	acquireShardFunctionalSuite
+// DeadlineExceededErrorSuite is the test suite for testing what happens when acquire shard returns a deadline exceeded.
+type DeadlineExceededErrorSuite struct {
+	AcquireShardFunctionalSuite
 }
 
 // SetupSuite reads the deadline exceeded error targeted fault injection config from the test data folder.
-func (s *deadlineExceededErrorSuite) SetupSuite() {
-	s.acquireShardFunctionalSuite.SetupSuite()
+func (s *DeadlineExceededErrorSuite) SetupSuite() {
+	s.AcquireShardFunctionalSuite.SetupSuite()
 	s.setupSuite("testdata/acquire_shard_deadline_exceeded_error.yaml")
 }
 
 // TestDoesRetry verifies that we do retry acquiring the shard when we get a deadline exceeded error because that should
 // be considered a transient error.
-func (s *deadlineExceededErrorSuite) TestDoesRetry() {
+func (s *DeadlineExceededErrorSuite) TestDoesRetry() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 
@@ -201,27 +201,27 @@ func (s *deadlineExceededErrorSuite) TestDoesRetry() {
 // exceeded error followed by a successful acquire shard call.
 // To make this test deterministic, we set the seed to in the config file to a fixed value.
 func TestAcquireShard_EventualSuccess(t *testing.T) {
-	s := new(eventualSuccessSuite)
+	s := new(EventualSuccessSuite)
 	suite.Run(t, s)
 }
 
-// eventualSuccessSuite is the test suite for testing what happens when acquire shard returns a deadline exceeded error
+// EventualSuccessSuite is the test suite for testing what happens when acquire shard returns a deadline exceeded error
 // followed by a successful acquire shard call.
-type eventualSuccessSuite struct {
-	acquireShardFunctionalSuite
+type EventualSuccessSuite struct {
+	AcquireShardFunctionalSuite
 }
 
 // SetupSuite reads the targeted eventual success fault injection config from the testdata folder.
 // This config deterministically causes the first acquire shard call to return a deadline exceeded error, and it causes
 // the next call to return a successful response.
-func (s *eventualSuccessSuite) SetupSuite() {
-	s.acquireShardFunctionalSuite.SetupSuite()
+func (s *EventualSuccessSuite) SetupSuite() {
+	s.AcquireShardFunctionalSuite.SetupSuite()
 	s.setupSuite("testdata/acquire_shard_eventual_success.yaml")
 }
 
 // TestEventuallySucceeds verifies that we eventually succeed in acquiring the shard when we get a deadline exceeded
 // error followed by a successful acquire shard call.
-func (s *eventualSuccessSuite) TestEventuallySucceeds() {
+func (s *EventualSuccessSuite) TestEventuallySucceeds() {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	defer cancel()
 

--- a/tests/activity_test.go
+++ b/tests/activity_test.go
@@ -54,7 +54,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestActivityHeartBeatWorkflow_Success() {
+func (s *FunctionalSuite) TestActivityHeartBeatWorkflow_Success() {
 	id := "functional-heartbeat-test"
 	wt := "functional-heartbeat-test-type"
 	tl := "functional-heartbeat-test-taskqueue"
@@ -181,7 +181,7 @@ func (s *functionalSuite) TestActivityHeartBeatWorkflow_Success() {
 	}
 }
 
-func (s *functionalSuite) TestActivityRetry() {
+func (s *FunctionalSuite) TestActivityRetry() {
 	id := "functional-activity-retry-test"
 	wt := "functional-activity-retry-type"
 	tl := "functional-activity-retry-taskqueue"
@@ -394,7 +394,7 @@ func (s *functionalSuite) TestActivityRetry() {
 	s.True(activityExecutedCount == 2)
 }
 
-func (s *functionalSuite) TestActivityRetry_Infinite() {
+func (s *FunctionalSuite) TestActivityRetry_Infinite() {
 	id := "functional-activity-retry-test"
 	wt := "functional-activity-retry-type"
 	tl := "functional-activity-retry-taskqueue"
@@ -499,7 +499,7 @@ func (s *functionalSuite) TestActivityRetry_Infinite() {
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestActivityHeartBeatWorkflow_Timeout() {
+func (s *FunctionalSuite) TestActivityHeartBeatWorkflow_Timeout() {
 	id := "functional-heartbeat-timeout-test"
 	wt := "functional-heartbeat-timeout-test-type"
 	tl := "functional-heartbeat-timeout-test-taskqueue"
@@ -603,7 +603,7 @@ func (s *functionalSuite) TestActivityHeartBeatWorkflow_Timeout() {
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestTryActivityCancellationFromWorkflow() {
+func (s *FunctionalSuite) TestTryActivityCancellationFromWorkflow() {
 	id := "functional-activity-cancellation-test"
 	wt := "functional-activity-cancellation-test-type"
 	tl := "functional-activity-cancellation-test-taskqueue"
@@ -748,7 +748,7 @@ func (s *functionalSuite) TestTryActivityCancellationFromWorkflow() {
 	s.Logger.Info("Activity cancelled.", tag.WorkflowRunID(we.RunId))
 }
 
-func (s *functionalSuite) TestActivityCancellationNotStarted() {
+func (s *FunctionalSuite) TestActivityCancellationNotStarted() {
 	id := "functional-activity-notstarted-cancellation-test"
 	wt := "functional-activity-notstarted-cancellation-test-type"
 	tl := "functional-activity-notstarted-cancellation-test-taskqueue"
@@ -871,7 +871,7 @@ func (s *functionalSuite) TestActivityCancellationNotStarted() {
 	s.True(err == nil || err == errNoTasks)
 }
 
-func (s *clientFunctionalSuite) TestActivityHeartbeatDetailsDuringRetry() {
+func (s *ClientFunctionalSuite) TestActivityHeartbeatDetailsDuringRetry() {
 	// Latest reported heartbeat on activity should be available throughout workflow execution or until activity succeeds.
 	// 1. Start workflow with single activity
 	// 2. First invocation of activity sets heartbeat details and times out.

--- a/tests/add_tasks_test.go
+++ b/tests/add_tasks_test.go
@@ -56,8 +56,8 @@ import (
 // retried.
 
 type (
-	// addTasksSuite is a separate suite because we need to override the history service's executable wrapper.
-	addTasksSuite struct {
+	// AddTasksSuite is a separate suite because we need to override the history service's executable wrapper.
+	AddTasksSuite struct {
 		FunctionalTestBase
 		*require.Assertions
 		shardController *faultyShardController
@@ -71,22 +71,22 @@ type (
 	}
 	faultyShardController struct {
 		shard.Controller
-		s *addTasksSuite
+		s *AddTasksSuite
 	}
 	faultyShardContext struct {
 		shard.Context
-		suite *addTasksSuite
+		suite *AddTasksSuite
 	}
 	// executorWrapper is used to wrap any [queues.Executable] that the history service makes so that we can intercept
 	// workflow tasks.
 	executorWrapper struct {
-		s *addTasksSuite
+		s *AddTasksSuite
 	}
 	// noopExecutor skips any workflow task which meets the criteria specified in shouldExecute and records them to
 	// the tasks channel.
 	noopExecutor struct {
 		base  queues.Executor
-		suite *addTasksSuite
+		suite *AddTasksSuite
 	}
 )
 
@@ -135,7 +135,7 @@ func (e *noopExecutor) shouldExecute(task tasks.Task) bool {
 }
 
 // SetupSuite creates the test cluster and registers the executorWrapper with the history service.
-func (s *addTasksSuite) SetupSuite() {
+func (s *AddTasksSuite) SetupSuite() {
 	// We do this here and in SetupTest because we need assertions in the SetupSuite method as well as the individual
 	// tests, but this is called before SetupTest, and the s.T() value will change when SetupTest is called.
 	s.Assertions = require.New(s.T())
@@ -160,20 +160,20 @@ func (s *addTasksSuite) SetupSuite() {
 	s.sdkClient = s.newSDKClient()
 }
 
-func (s *addTasksSuite) TearDownSuite() {
+func (s *AddTasksSuite) TearDownSuite() {
 	s.sdkClient.Close()
 	s.tearDownSuite()
 }
 
-func (s *addTasksSuite) SetupTest() {
+func (s *AddTasksSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 }
 
 func TestAddTasksSuite(t *testing.T) {
-	suite.Run(t, new(addTasksSuite))
+	suite.Run(t, new(AddTasksSuite))
 }
 
-func (s *addTasksSuite) TestAddTasks_Ok() {
+func (s *AddTasksSuite) TestAddTasks_Ok() {
 	for _, tc := range []struct {
 		name               string
 		shouldCallAddTasks bool
@@ -253,7 +253,7 @@ func (s *addTasksSuite) TestAddTasks_Ok() {
 	}
 }
 
-func (s *addTasksSuite) TestAddTasks_ErrGetShardByID() {
+func (s *AddTasksSuite) TestAddTasks_ErrGetShardByID() {
 	_, err := s.testCluster.GetHistoryClient().AddTasks(context.Background(), &historyservice.AddTasksRequest{
 		ShardId: 0,
 	})
@@ -261,7 +261,7 @@ func (s *addTasksSuite) TestAddTasks_ErrGetShardByID() {
 	s.Contains(strings.ToLower(err.Error()), "shard id")
 }
 
-func (s *addTasksSuite) TestAddTasks_GetEngineErr() {
+func (s *AddTasksSuite) TestAddTasks_GetEngineErr() {
 	defer func() {
 		s.getEngineErr.Store(nil)
 	}()
@@ -273,7 +273,7 @@ func (s *addTasksSuite) TestAddTasks_GetEngineErr() {
 	s.ErrorContains(err, s.getEngineErr.Load().Error())
 }
 
-func (s *addTasksSuite) newSDKClient() sdkclient.Client {
+func (s *AddTasksSuite) newSDKClient() sdkclient.Client {
 	client, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:  s.hostPort,
 		Namespace: s.namespace,

--- a/tests/admin_test.go
+++ b/tests/admin_test.go
@@ -36,7 +36,7 @@ import (
 	"go.temporal.io/server/api/adminservice/v1"
 )
 
-func (s *clientFunctionalSuite) TestAdminRebuildMutableState() {
+func (s *ClientFunctionalSuite) TestAdminRebuildMutableState() {
 
 	workflowFn := func(ctx workflow.Context) error {
 		var randomUUID string

--- a/tests/advanced_visibility_test.go
+++ b/tests/advanced_visibility_test.go
@@ -77,7 +77,7 @@ const (
 	waitForESToSettle = 4 * time.Second // wait es shards for some time ensure data consistent
 )
 
-type advancedVisibilitySuite struct {
+type AdvancedVisibilitySuite struct {
 	// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 	// not merely log an error
 	*require.Assertions
@@ -93,7 +93,7 @@ type advancedVisibilitySuite struct {
 }
 
 // This cluster use customized threshold for history config
-func (s *advancedVisibilitySuite) SetupSuite() {
+func (s *AdvancedVisibilitySuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
 		dynamicconfig.VisibilityDisableOrderByClause:             false,
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:     true,
@@ -142,12 +142,12 @@ func (s *advancedVisibilitySuite) SetupSuite() {
 	s.sysSDKClient = sysSDKClient
 }
 
-func (s *advancedVisibilitySuite) TearDownSuite() {
+func (s *AdvancedVisibilitySuite) TearDownSuite() {
 	s.sdkClient.Close()
 	s.tearDownSuite()
 }
 
-func (s *advancedVisibilitySuite) SetupTest() {
+func (s *AdvancedVisibilitySuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
@@ -157,10 +157,10 @@ func (s *advancedVisibilitySuite) SetupTest() {
 
 func TestAdvancedVisibilitySuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(advancedVisibilitySuite))
+	suite.Run(t, new(AdvancedVisibilitySuite))
 }
 
-func (s *advancedVisibilitySuite) TestListOpenWorkflow() {
+func (s *AdvancedVisibilitySuite) TestListOpenWorkflow() {
 	id := "es-functional-start-workflow-test"
 	wt := "es-functional-start-workflow-test-type"
 	tl := "es-functional-start-workflow-test-taskqueue"
@@ -211,7 +211,7 @@ func (s *advancedVisibilitySuite) TestListOpenWorkflow() {
 	s.True(len(attrType) > 0)
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow() {
 	id := "es-functional-list-workflow-test"
 	wt := "es-functional-list-workflow-test-type"
 	tl := "es-functional-list-workflow-test-taskqueue"
@@ -224,7 +224,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow() {
 	s.testHelperForReadOnce(we.GetRunId(), query, false)
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_ExecutionTime() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_ExecutionTime() {
 	id := "es-functional-list-workflow-execution-time-test"
 	wt := "es-functional-list-workflow-execution-time-test-type"
 	tl := "es-functional-list-workflow-execution-time-test-taskqueue"
@@ -266,7 +266,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_ExecutionTime() {
 	s.testHelperForReadOnce(weCron.GetRunId(), cronQuery, false)
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_SearchAttribute() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAttribute() {
 	id := "es-functional-list-workflow-by-search-attr-test"
 	wt := "es-functional-list-workflow-by-search-attr-test-type"
 	tl := "es-functional-list-workflow-by-search-attr-test-taskqueue"
@@ -351,7 +351,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_SearchAttribute() {
 	}
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_PageToken() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_PageToken() {
 	id := "es-functional-list-workflow-token-test"
 	wt := "es-functional-list-workflow-token-test-type"
 	tl := "es-functional-list-workflow-token-test-taskqueue"
@@ -363,7 +363,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_PageToken() {
 	s.testListWorkflowHelper(numOfWorkflows, pageSize, request, id, wt, false)
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_SearchAfter() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_SearchAfter() {
 	id := "es-functional-list-workflow-searchAfter-test"
 	wt := "es-functional-list-workflow-searchAfter-test-type"
 	tl := "es-functional-list-workflow-searchAfter-test-taskqueue"
@@ -375,7 +375,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_SearchAfter() {
 	s.testListWorkflowHelper(numOfWorkflows, pageSize, request, id, wt, false)
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_OrQuery() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_OrQuery() {
 	id := "es-functional-list-workflow-or-query-test"
 	wt := "es-functional-list-workflow-or-query-test-type"
 	tl := "es-functional-list-workflow-or-query-test-taskqueue"
@@ -482,7 +482,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_OrQuery() {
 	s.Equal(3, searchVal)
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_KeywordQuery() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_KeywordQuery() {
 	id := "es-functional-list-workflow-keyword-query-test"
 	wt := "es-functional-list-workflow-keyword-query-test-type"
 	tl := "es-functional-list-workflow-keyword-query-test-taskqueue"
@@ -570,7 +570,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_KeywordQuery() {
 	s.Len(resp.GetExecutions(), 0)
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_LikeQuery() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_LikeQuery() {
 	if !s.isElasticsearchEnabled {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
@@ -642,7 +642,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_LikeQuery() {
 	s.Equal(executionCount, 1)
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_StringQuery() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_StringQuery() {
 	id := "es-functional-list-workflow-string-query-test"
 	wt := "es-functional-list-workflow-string-query-test-type"
 	tl := "es-functional-list-workflow-string-query-test-taskqueue"
@@ -759,7 +759,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_StringQuery() {
 }
 
 // To test last page search trigger max window size error
-func (s *advancedVisibilitySuite) TestListWorkflow_MaxWindowSize() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_MaxWindowSize() {
 	id := "es-functional-list-workflow-max-window-size-test"
 	wt := "es-functional-list-workflow-max-window-size-test-type"
 	tl := "es-functional-list-workflow-max-window-size-test-taskqueue"
@@ -804,7 +804,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_MaxWindowSize() {
 	s.Nil(resp.GetNextPageToken())
 }
 
-func (s *advancedVisibilitySuite) TestListWorkflow_OrderBy() {
+func (s *AdvancedVisibilitySuite) TestListWorkflow_OrderBy() {
 	if !s.isElasticsearchEnabled {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
@@ -953,7 +953,7 @@ func (s *advancedVisibilitySuite) TestListWorkflow_OrderBy() {
 }
 
 //nolint:revive // isScan is a control flag
-func (s *advancedVisibilitySuite) testListWorkflowHelper(numOfWorkflows, pageSize int,
+func (s *AdvancedVisibilitySuite) testListWorkflowHelper(numOfWorkflows, pageSize int,
 	startRequest *workflowservice.StartWorkflowExecutionRequest, wid, wType string, isScan bool) {
 
 	// start enough number of workflows
@@ -1040,7 +1040,7 @@ func (s *advancedVisibilitySuite) testListWorkflowHelper(numOfWorkflows, pageSiz
 }
 
 //nolint:revive // isScan is a control flag
-func (s *advancedVisibilitySuite) testHelperForReadOnce(expectedRunID string, query string, isScan bool) {
+func (s *AdvancedVisibilitySuite) testHelperForReadOnce(expectedRunID string, query string, isScan bool) {
 	var openExecution *workflowpb.WorkflowExecutionInfo
 	listRequest := &workflowservice.ListWorkflowExecutionsRequest{
 		Namespace: s.namespace,
@@ -1084,7 +1084,7 @@ func (s *advancedVisibilitySuite) testHelperForReadOnce(expectedRunID string, qu
 	}
 }
 
-func (s *advancedVisibilitySuite) TestScanWorkflow() {
+func (s *AdvancedVisibilitySuite) TestScanWorkflow() {
 	if !s.isElasticsearchEnabled {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
@@ -1116,7 +1116,7 @@ func (s *advancedVisibilitySuite) TestScanWorkflow() {
 	s.testHelperForReadOnce(we.GetRunId(), query, true)
 }
 
-func (s *advancedVisibilitySuite) TestScanWorkflow_SearchAttribute() {
+func (s *AdvancedVisibilitySuite) TestScanWorkflow_SearchAttribute() {
 	if !s.isElasticsearchEnabled {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
@@ -1140,7 +1140,7 @@ func (s *advancedVisibilitySuite) TestScanWorkflow_SearchAttribute() {
 	s.testHelperForReadOnce(we.GetRunId(), query, true)
 }
 
-func (s *advancedVisibilitySuite) TestScanWorkflow_PageToken() {
+func (s *AdvancedVisibilitySuite) TestScanWorkflow_PageToken() {
 	if !s.isElasticsearchEnabled {
 		s.T().Skip("This test is only for Elasticsearch")
 	}
@@ -1170,7 +1170,7 @@ func (s *advancedVisibilitySuite) TestScanWorkflow_PageToken() {
 	s.testListWorkflowHelper(numOfWorkflows, pageSize, request, id, wt, true)
 }
 
-func (s *advancedVisibilitySuite) TestCountWorkflow() {
+func (s *AdvancedVisibilitySuite) TestCountWorkflow() {
 	id := "es-functional-count-workflow-test"
 	wt := "es-functional-count-workflow-test-type"
 	tl := "es-functional-count-workflow-test-taskqueue"
@@ -1210,7 +1210,7 @@ func (s *advancedVisibilitySuite) TestCountWorkflow() {
 	s.Equal(int64(0), resp.GetCount())
 }
 
-func (s *advancedVisibilitySuite) TestCountGroupByWorkflow() {
+func (s *AdvancedVisibilitySuite) TestCountGroupByWorkflow() {
 	id := "es-functional-count-groupby-workflow-test"
 	wt := "es-functional-count-groupby-workflow-test-type"
 	tl := "es-functional-count-groupby-workflow-test-taskqueue"
@@ -1291,7 +1291,7 @@ func (s *advancedVisibilitySuite) TestCountGroupByWorkflow() {
 	s.Contains(err.Error(), "'group by' clause supports only a single field")
 }
 
-func (s *advancedVisibilitySuite) createStartWorkflowExecutionRequest(id, wt, tl string) *workflowservice.StartWorkflowExecutionRequest {
+func (s *AdvancedVisibilitySuite) createStartWorkflowExecutionRequest(id, wt, tl string) *workflowservice.StartWorkflowExecutionRequest {
 	identity := "worker1"
 	workflowType := &commonpb.WorkflowType{Name: wt}
 	taskQueue := &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
@@ -1309,7 +1309,7 @@ func (s *advancedVisibilitySuite) createStartWorkflowExecutionRequest(id, wt, tl
 	return request
 }
 
-func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() {
+func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() {
 	id := "es-functional-upsert-workflow-search-attributes-test"
 	wt := "es-functional-upsert-workflow-search-attributes-test-type"
 	tl := "es-functional-upsert-workflow-search-attributes-test-taskqueue"
@@ -1607,7 +1607,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecutionSearchAttributes() 
 	}
 }
 
-func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
+func (s *AdvancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	id := "es-functional-modify-workflow-properties-test"
 	wt := "es-functional-modify-workflow-properties-test-type"
 	tl := "es-functional-modify-workflow-properties-test-taskqueue"
@@ -1823,7 +1823,7 @@ func (s *advancedVisibilitySuite) TestModifyWorkflowExecutionProperties() {
 	s.ProtoEqual(expectedMemo, descResp.WorkflowExecutionInfo.Memo)
 }
 
-func (s *advancedVisibilitySuite) testListResultForUpsertSearchAttributes(listRequest *workflowservice.ListWorkflowExecutionsRequest) {
+func (s *AdvancedVisibilitySuite) testListResultForUpsertSearchAttributes(listRequest *workflowservice.ListWorkflowExecutionsRequest) {
 	verified := false
 	for i := 0; i < numOfRetry; i++ {
 		resp, err := s.engine.ListWorkflowExecutions(NewContext(), listRequest)
@@ -1873,7 +1873,7 @@ func (s *advancedVisibilitySuite) testListResultForUpsertSearchAttributes(listRe
 	s.True(verified)
 }
 
-func (s *advancedVisibilitySuite) createSearchAttributes() *commonpb.SearchAttributes {
+func (s *AdvancedVisibilitySuite) createSearchAttributes() *commonpb.SearchAttributes {
 	searchAttributes, err := searchattribute.Encode(map[string]interface{}{
 		"CustomTextField":               "another string",
 		"CustomIntField":                123,
@@ -1884,7 +1884,7 @@ func (s *advancedVisibilitySuite) createSearchAttributes() *commonpb.SearchAttri
 	return searchAttributes
 }
 
-func (s *advancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey() {
+func (s *AdvancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey() {
 	id := "es-functional-upsert-workflow-failed-test"
 	wt := "es-functional-upsert-workflow-failed-test-type"
 	tl := "es-functional-upsert-workflow-failed-test-taskqueue"
@@ -1962,7 +1962,7 @@ func (s *advancedVisibilitySuite) TestUpsertWorkflowExecution_InvalidKey() {
 	s.NotNil(failedEventAttr.GetFailure())
 }
 
-func (s *advancedVisibilitySuite) TestChildWorkflow_ParentWorkflow() {
+func (s *AdvancedVisibilitySuite) TestChildWorkflow_ParentWorkflow() {
 	var (
 		ctx         = NewContext()
 		id          = s.randomizeStr(s.T().Name())
@@ -2050,7 +2050,7 @@ func (s *advancedVisibilitySuite) TestChildWorkflow_ParentWorkflow() {
 	s.Nil(wfInfo.GetParentExecution())
 }
 
-func (s *advancedVisibilitySuite) Test_LongWorkflowID() {
+func (s *AdvancedVisibilitySuite) Test_LongWorkflowID() {
 	if s.testClusterConfig.Persistence.StoreType == config.StoreTypeSQL {
 		// TODO: remove this when workflow_id field size is increased from varchar(255) in SQL schema.
 		return
@@ -2068,7 +2068,7 @@ func (s *advancedVisibilitySuite) Test_LongWorkflowID() {
 	s.testHelperForReadOnce(we.GetRunId(), query, false)
 }
 
-func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_UnversionedWorker() {
+func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_UnversionedWorker() {
 	ctx := NewContext()
 	id := s.randomizeStr(s.T().Name())
 	workflowType := "functional-build-id"
@@ -2169,7 +2169,7 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_UnversionedWor
 	}
 }
 
-func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorker() {
+func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorker() {
 	// Use only one partition to avoid having to wait for user data propagation later
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -2334,7 +2334,7 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnCompletion_VersionedWorke
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnReset() {
+func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnReset() {
 	// Use only one partition to avoid having to wait for user data propagation later
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -2419,7 +2419,7 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnReset() {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnRetry() {
+func (s *AdvancedVisibilitySuite) Test_BuildIdIndexedOnRetry() {
 	// Use only one partition to avoid having to wait for user data propagation later
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -2488,7 +2488,7 @@ func (s *advancedVisibilitySuite) Test_BuildIdIndexedOnRetry() {
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func (s *advancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId() {
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId() {
 	ctx := NewContext()
 	tq1 := s.T().Name()
 	tq2 := s.T().Name() + "-2"
@@ -2611,7 +2611,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId() {
 
 }
 
-func (s *advancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInNamespace() {
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInNamespace() {
 	ctx := NewContext()
 	buildId := s.T().Name() + "v0"
 
@@ -2627,7 +2627,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInName
 	}}, reachabilityResponse.BuildIdReachability)
 }
 
-func (s *advancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInTaskQueue() {
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInTaskQueue() {
 	ctx := NewContext()
 	tq := s.T().Name()
 	v0 := s.T().Name() + "v0"
@@ -2661,7 +2661,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_ByBuildId_NotInTask
 	checkReachability()
 }
 
-func (s *advancedVisibilitySuite) TestWorkerTaskReachability_EmptyBuildIds() {
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_EmptyBuildIds() {
 	ctx := NewContext()
 
 	_, err := s.engine.GetWorkerTaskReachability(ctx, &workflowservice.GetWorkerTaskReachabilityRequest{
@@ -2671,7 +2671,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_EmptyBuildIds() {
 	s.Require().ErrorAs(err, &invalidArgument)
 }
 
-func (s *advancedVisibilitySuite) TestWorkerTaskReachability_TooManyBuildIds() {
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_TooManyBuildIds() {
 	ctx := NewContext()
 
 	_, err := s.engine.GetWorkerTaskReachability(ctx, &workflowservice.GetWorkerTaskReachabilityRequest{
@@ -2682,7 +2682,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_TooManyBuildIds() {
 	s.Require().ErrorAs(err, &invalidArgument)
 }
 
-func (s *advancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InNamespace() {
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InNamespace() {
 	ctx := NewContext()
 
 	_, err := s.engine.GetWorkerTaskReachability(ctx, &workflowservice.GetWorkerTaskReachabilityRequest{
@@ -2693,7 +2693,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InNames
 	s.Require().ErrorAs(err, &invalidArgument)
 }
 
-func (s *advancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InTaskQueue() {
+func (s *AdvancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InTaskQueue() {
 	ctx := NewContext()
 	tq := s.T().Name()
 
@@ -2749,7 +2749,7 @@ func (s *advancedVisibilitySuite) TestWorkerTaskReachability_Unversioned_InTaskQ
 	s.checkReachability(ctx, tq, "", enumspb.TASK_REACHABILITY_CLOSED_WORKFLOWS)
 }
 
-func (s *advancedVisibilitySuite) TestBuildIdScavenger_DeletesUnusedBuildId() {
+func (s *AdvancedVisibilitySuite) TestBuildIdScavenger_DeletesUnusedBuildId() {
 	ctx := NewContext()
 	tq := s.T().Name()
 	v0 := s.T().Name() + "-v0"
@@ -2798,7 +2798,7 @@ func (s *advancedVisibilitySuite) TestBuildIdScavenger_DeletesUnusedBuildId() {
 	s.Require().Equal(0, len(res.BuildIdReachability[0].TaskQueueReachability))
 }
 
-func (s *advancedVisibilitySuite) checkReachability(ctx context.Context, taskQueue, buildId string, expectedReachability ...enumspb.TaskReachability) {
+func (s *AdvancedVisibilitySuite) checkReachability(ctx context.Context, taskQueue, buildId string, expectedReachability ...enumspb.TaskReachability) {
 	s.Require().Eventually(func() bool {
 		reachabilityResponse, err := s.engine.GetWorkerTaskReachability(ctx, &workflowservice.GetWorkerTaskReachabilityRequest{
 			Namespace:    s.namespace,
@@ -2828,7 +2828,7 @@ func (s *advancedVisibilitySuite) checkReachability(ctx context.Context, taskQue
 	}, 15*time.Second, 100*time.Millisecond)
 }
 
-func (s *advancedVisibilitySuite) getBuildIds(ctx context.Context, execution *commonpb.WorkflowExecution) []string {
+func (s *AdvancedVisibilitySuite) getBuildIds(ctx context.Context, execution *commonpb.WorkflowExecution) []string {
 	description, err := s.engine.DescribeWorkflowExecution(ctx, &workflowservice.DescribeWorkflowExecutionRequest{
 		Namespace: s.namespace,
 		Execution: execution,
@@ -2844,7 +2844,7 @@ func (s *advancedVisibilitySuite) getBuildIds(ctx context.Context, execution *co
 	return buildIDs
 }
 
-func (s *advancedVisibilitySuite) updateMaxResultWindow() {
+func (s *AdvancedVisibilitySuite) updateMaxResultWindow() {
 	esConfig := s.testClusterConfig.ESConfig
 
 	esClient, err := esclient.NewFunctionalTestsClient(esConfig, s.Logger)

--- a/tests/archival_test.go
+++ b/tests/archival_test.go
@@ -62,27 +62,27 @@ const (
 	retryBackoffTime = 500 * time.Millisecond
 )
 
-type archivalSuite struct {
+type ArchivalSuite struct {
 	*require.Assertions
 	FunctionalTestBase
 }
 
-func (s *archivalSuite) SetupSuite() {
+func (s *ArchivalSuite) SetupSuite() {
 	s.setupSuite("testdata/cluster.yaml")
 }
 
-func (s *archivalSuite) TearDownSuite() {
+func (s *ArchivalSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *archivalSuite) SetupTest() {
+func (s *ArchivalSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 }
 
 func TestArchivalSuite(t *testing.T) {
 	flag.Parse()
-	s := new(archivalSuite)
+	s := new(ArchivalSuite)
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
 		dynamicconfig.RetentionTimerJitterDuration:  time.Second,
 		dynamicconfig.ArchivalProcessorArchiveDelay: time.Duration(0),
@@ -90,7 +90,7 @@ func TestArchivalSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func (s *archivalSuite) TestArchival_TimerQueueProcessor() {
+func (s *ArchivalSuite) TestArchival_TimerQueueProcessor() {
 	s.True(s.testCluster.archiverBase.metadata.GetHistoryConfig().ClusterConfiguredForArchival())
 
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
@@ -110,7 +110,7 @@ func (s *archivalSuite) TestArchival_TimerQueueProcessor() {
 	s.True(s.isMutableStateDeleted(namespaceID, execution))
 }
 
-func (s *archivalSuite) TestArchival_ContinueAsNew() {
+func (s *ArchivalSuite) TestArchival_ContinueAsNew() {
 	s.True(s.testCluster.archiverBase.metadata.GetHistoryConfig().ClusterConfiguredForArchival())
 
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
@@ -132,7 +132,7 @@ func (s *archivalSuite) TestArchival_ContinueAsNew() {
 	}
 }
 
-func (s *archivalSuite) TestArchival_ArchiverWorker() {
+func (s *ArchivalSuite) TestArchival_ArchiverWorker() {
 	s.T().SkipNow() // flaky test, skip for now, will reimplement archival feature.
 
 	s.True(s.testCluster.archiverBase.metadata.GetHistoryConfig().ClusterConfiguredForArchival())
@@ -153,7 +153,7 @@ func (s *archivalSuite) TestArchival_ArchiverWorker() {
 	s.True(s.isMutableStateDeleted(namespaceID, execution))
 }
 
-func (s *archivalSuite) TestVisibilityArchival() {
+func (s *ArchivalSuite) TestVisibilityArchival() {
 	s.True(s.testCluster.archiverBase.metadata.GetVisibilityConfig().ClusterConfiguredForArchival())
 
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
@@ -207,7 +207,7 @@ func (s *FunctionalTestBase) getNamespaceID(namespace string) string {
 }
 
 // isArchived returns true if both the workflow history and workflow visibility are archived.
-func (s *archivalSuite) isArchived(namespace string, execution *commonpb.WorkflowExecution) bool {
+func (s *ArchivalSuite) isArchived(namespace string, execution *commonpb.WorkflowExecution) bool {
 	serviceName := string(primitives.HistoryService)
 	historyURI, err := archiver.NewURI(s.testCluster.archiverBase.historyURI)
 	s.NoError(err)
@@ -272,7 +272,7 @@ func (s *archivalSuite) isArchived(namespace string, execution *commonpb.Workflo
 	return false
 }
 
-func (s *archivalSuite) isHistoryDeleted(execution *commonpb.WorkflowExecution) bool {
+func (s *ArchivalSuite) isHistoryDeleted(execution *commonpb.WorkflowExecution) bool {
 	namespaceID := s.getNamespaceID(s.archivalNamespace)
 	shardID := common.WorkflowIDToHistoryShard(namespaceID, execution.GetWorkflowId(),
 		s.testClusterConfig.HistoryConfig.NumHistoryShards)
@@ -291,7 +291,7 @@ func (s *archivalSuite) isHistoryDeleted(execution *commonpb.WorkflowExecution) 
 	return false
 }
 
-func (s *archivalSuite) isMutableStateDeleted(namespaceID string, execution *commonpb.WorkflowExecution) bool {
+func (s *ArchivalSuite) isMutableStateDeleted(namespaceID string, execution *commonpb.WorkflowExecution) bool {
 	shardID := common.WorkflowIDToHistoryShard(namespaceID, execution.GetWorkflowId(),
 		s.testClusterConfig.HistoryConfig.NumHistoryShards)
 	request := &persistence.GetWorkflowExecutionRequest{
@@ -311,7 +311,7 @@ func (s *archivalSuite) isMutableStateDeleted(namespaceID string, execution *com
 	return false
 }
 
-func (s *archivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceID string, numActivities, numRuns int) []string {
+func (s *ArchivalSuite) startAndFinishWorkflow(id, wt, tq, namespace, namespaceID string, numActivities, numRuns int) []string {
 	identity := "worker1"
 	activityName := "activity_type1"
 	workflowType := &commonpb.WorkflowType{Name: wt}

--- a/tests/cancel_workflow_test.go
+++ b/tests/cancel_workflow_test.go
@@ -43,7 +43,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestExternalRequestCancelWorkflowExecution() {
+func (s *FunctionalSuite) TestExternalRequestCancelWorkflowExecution() {
 	id := "functional-request-cancel-workflow-test"
 	wt := "functional-request-cancel-workflow-test-type"
 	tl := "functional-request-cancel-workflow-test-taskqueue"
@@ -138,7 +138,7 @@ func (s *functionalSuite) TestExternalRequestCancelWorkflowExecution() {
 	s.Equal("Cancelled", s.decodePayloadsString(cancelledEventAttributes.GetDetails()))
 }
 
-func (s *functionalSuite) TestRequestCancelWorkflowCommandExecution_TargetRunning() {
+func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetRunning() {
 	id := "functional-cancel-workflow-command-target-running-test"
 	wt := "functional-cancel-workflow-command-target-running-test-type"
 	tl := "functional-cancel-workflow-command-target-running-test-taskqueue"
@@ -274,7 +274,7 @@ func (s *functionalSuite) TestRequestCancelWorkflowCommandExecution_TargetRunnin
 	s.NoError(err)
 }
 
-func (s *functionalSuite) TestRequestCancelWorkflowCommandExecution_TargetFinished() {
+func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetFinished() {
 	id := "functional-cancel-workflow-command-target-finished-test"
 	wt := "functional-cancel-workflow-command-target-finished-test-type"
 	tl := "functional-cancel-workflow-command-target-finished-test-taskqueue"
@@ -406,7 +406,7 @@ func (s *functionalSuite) TestRequestCancelWorkflowCommandExecution_TargetFinish
 	s.NoError(err)
 }
 
-func (s *functionalSuite) TestRequestCancelWorkflowCommandExecution_TargetNotFound() {
+func (s *FunctionalSuite) TestRequestCancelWorkflowCommandExecution_TargetNotFound() {
 	id := "functional-cancel-workflow-command-target-not-found-test"
 	wt := "functional-cancel-workflow-command-target-not-found-test-type"
 	tl := "functional-cancel-workflow-command-target-not-found-test-taskqueue"
@@ -486,7 +486,7 @@ func (s *functionalSuite) TestRequestCancelWorkflowCommandExecution_TargetNotFou
 	s.NoError(err)
 }
 
-func (s *functionalSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
+func (s *FunctionalSuite) TestImmediateChildCancellation_WorkflowTaskFailed() {
 	id := "functional-immediate-child-cancellation-workflow-task-failed-test"
 	wt := "functional-immediate-child-cancellation-workflow-task-failed-test-type"
 	tl := "functional-immediate-child-cancellation-workflow-task-failed-test-taskqueue"

--- a/tests/child_workflow_test.go
+++ b/tests/child_workflow_test.go
@@ -47,7 +47,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestChildWorkflowExecution() {
+func (s *FunctionalSuite) TestChildWorkflowExecution() {
 	parentID := "functional-child-workflow-test-parent"
 	childID := "functional-child-workflow-test-child"
 	wtParent := "functional-child-workflow-test-parent-type"
@@ -236,7 +236,7 @@ func (s *functionalSuite) TestChildWorkflowExecution() {
 	s.Equal("Child Done", s.decodePayloadsString(completedAttributes.GetResult()))
 }
 
-func (s *functionalSuite) TestCronChildWorkflowExecution() {
+func (s *FunctionalSuite) TestCronChildWorkflowExecution() {
 	parentID := "functional-cron-child-workflow-test-parent"
 	childID := "functional-cron-child-workflow-test-child"
 	wtParent := "functional-cron-child-workflow-test-parent-type"
@@ -427,7 +427,7 @@ func (s *functionalSuite) TestCronChildWorkflowExecution() {
 	}
 }
 
-func (s *functionalSuite) TestRetryChildWorkflowExecution() {
+func (s *FunctionalSuite) TestRetryChildWorkflowExecution() {
 	parentID := "functional-retry-child-workflow-test-parent"
 	childID := "functional-retry-child-workflow-test-child"
 	wtParent := "functional-retry-child-workflow-test-parent-type"
@@ -600,7 +600,7 @@ func (s *functionalSuite) TestRetryChildWorkflowExecution() {
 	s.Equal("Child Done", s.decodePayloadsString(completedAttributes.GetResult()))
 }
 
-func (s *functionalSuite) TestRetryFailChildWorkflowExecution() {
+func (s *FunctionalSuite) TestRetryFailChildWorkflowExecution() {
 	parentID := "functional-retry-fail-child-workflow-test-parent"
 	childID := "functional-retry-fail-child-workflow-test-child"
 	wtParent := "functional-retry-fail-child-workflow-test-parent-type"

--- a/tests/continue_as_new_test.go
+++ b/tests/continue_as_new_test.go
@@ -45,7 +45,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestContinueAsNewWorkflow() {
+func (s *FunctionalSuite) TestContinueAsNewWorkflow() {
 	id := "functional-continue-as-new-workflow-test"
 	wt := "functional-continue-as-new-workflow-test-type"
 	tl := "functional-continue-as-new-workflow-test-taskqueue"
@@ -155,7 +155,7 @@ func (s *functionalSuite) TestContinueAsNewWorkflow() {
 	s.Equal("Keyword", string(lastRunStartedEvent.GetWorkflowExecutionStartedEventAttributes().GetSearchAttributes().GetIndexedFields()[saName].GetMetadata()["type"]))
 }
 
-func (s *functionalSuite) TestContinueAsNewRun_Timeout() {
+func (s *FunctionalSuite) TestContinueAsNewRun_Timeout() {
 	id := "functional-continue-as-new-workflow-timeout-test"
 	wt := "functional-continue-as-new-workflow-timeout-test-type"
 	tl := "functional-continue-as-new-workflow-timeout-test-taskqueue"
@@ -256,7 +256,7 @@ GetHistoryLoop:
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestWorkflowContinueAsNew_TaskID() {
+func (s *FunctionalSuite) TestWorkflowContinueAsNew_TaskID() {
 	id := "functional-wf-continue-as-new-task-id-test"
 	wt := "functional-wf-continue-as-new-task-id-type"
 	tl := "functional-wf-continue-as-new-task-id-taskqueue"
@@ -346,7 +346,7 @@ func (s *functionalSuite) TestWorkflowContinueAsNew_TaskID() {
 
 type (
 	ParentWithChildContinueAsNew struct {
-		suite *functionalSuite
+		suite *FunctionalSuite
 
 		parentID           string
 		parentType         string
@@ -366,7 +366,7 @@ type (
 	}
 )
 
-func newParentWithChildContinueAsNew(s *functionalSuite,
+func newParentWithChildContinueAsNew(s *FunctionalSuite,
 	parentID, parentType, childID, childType string,
 	closePolicy enumspb.ParentClosePolicy) *ParentWithChildContinueAsNew {
 	workflow := &ParentWithChildContinueAsNew{
@@ -466,7 +466,7 @@ func (w *ParentWithChildContinueAsNew) workflow(
 	return nil, nil
 }
 
-func (s *functionalSuite) TestChildWorkflowWithContinueAsNew() {
+func (s *FunctionalSuite) TestChildWorkflowWithContinueAsNew() {
 	parentID := "functional-child-workflow-with-continue-as-new-test-parent"
 	childID := "functional-child-workflow-with-continue-as-new-test-child"
 	wtParent := "functional-child-workflow-with-continue-as-new-test-parent-type"
@@ -549,7 +549,7 @@ func (s *functionalSuite) TestChildWorkflowWithContinueAsNew() {
 	})
 }
 
-func (s *functionalSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
+func (s *FunctionalSuite) TestChildWorkflowWithContinueAsNewParentTerminate() {
 	parentID := "functional-child-workflow-with-continue-as-new-parent-terminate-test-parent"
 	childID := "functional-child-workflow-with-continue-as-new-parent-terminate-test-child"
 	wtParent := "functional-child-workflow-with-continue-as-new-parent-terminate-test-parent-type"

--- a/tests/cron_test.go
+++ b/tests/cron_test.go
@@ -52,7 +52,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (s *functionalSuite) TestCronWorkflow_Failed_Infinite() {
+func (s *FunctionalSuite) TestCronWorkflow_Failed_Infinite() {
 	id := "functional-wf-cron-failed-infinite-test"
 	wt := "functional-wf-cron-failed-infinite-type"
 	tl := "functional-wf-cron-failed-infinite-taskqueue"
@@ -133,7 +133,7 @@ func (s *functionalSuite) TestCronWorkflow_Failed_Infinite() {
 	s.True(seeRetry)
 }
 
-func (s *functionalSuite) TestCronWorkflow() {
+func (s *FunctionalSuite) TestCronWorkflow() {
 	id := "functional-wf-cron-test"
 	wt := "functional-wf-cron-type"
 	tl := "functional-wf-cron-taskqueue"
@@ -365,7 +365,7 @@ func (s *functionalSuite) TestCronWorkflow() {
 	}
 }
 
-func (s *clientFunctionalSuite) TestCronWorkflowCompletionStates() {
+func (s *ClientFunctionalSuite) TestCronWorkflowCompletionStates() {
 	// Run a cron workflow that completes in (almost) all the possible ways:
 	// Run 1: succeeds
 	// Run 2: fails
@@ -559,7 +559,7 @@ func (s *clientFunctionalSuite) TestCronWorkflowCompletionStates() {
 	s.Equal("test is over", attrs4.GetReason())
 }
 
-func (s *clientFunctionalSuite) listOpenWorkflowExecutions(start, end time.Time, id string, expectedNumber int) []*workflowpb.WorkflowExecutionInfo {
+func (s *ClientFunctionalSuite) listOpenWorkflowExecutions(start, end time.Time, id string, expectedNumber int) []*workflowpb.WorkflowExecutionInfo {
 	s.T().Helper()
 	for i := 0; i < 20; i++ {
 		resp, err := s.sdkClient.ListOpenWorkflow(NewContext(), &workflowservice.ListOpenWorkflowExecutionsRequest{
@@ -580,7 +580,7 @@ func (s *clientFunctionalSuite) listOpenWorkflowExecutions(start, end time.Time,
 	panic("unreached")
 }
 
-func (s *clientFunctionalSuite) listClosedWorkflowExecutions(start, end time.Time, id string, expectedNumber int) []*workflowpb.WorkflowExecutionInfo {
+func (s *ClientFunctionalSuite) listClosedWorkflowExecutions(start, end time.Time, id string, expectedNumber int) []*workflowpb.WorkflowExecutionInfo {
 	s.T().Helper()
 	for i := 0; i < 20; i++ {
 		resp, err := s.sdkClient.ListClosedWorkflow(NewContext(), &workflowservice.ListClosedWorkflowExecutionsRequest{

--- a/tests/describe_test.go
+++ b/tests/describe_test.go
@@ -44,7 +44,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
-func (s *functionalSuite) TestDescribeWorkflowExecution() {
+func (s *FunctionalSuite) TestDescribeWorkflowExecution() {
 	id := "functional-describe-wfe-test"
 	wt := "functional-describe-wfe-test-type"
 	tq := "functional-describe-wfe-test-taskqueue"
@@ -167,7 +167,7 @@ func (s *functionalSuite) TestDescribeWorkflowExecution() {
 	s.Equal(int64(11), dweResponse.WorkflowExecutionInfo.HistoryLength) // WorkflowTaskStarted, WorkflowTaskCompleted, WorkflowCompleted
 }
 
-func (s *functionalSuite) TestDescribeTaskQueue() {
+func (s *FunctionalSuite) TestDescribeTaskQueue() {
 	workflowID := "functional-get-poller-history"
 	wt := "functional-get-poller-history-type"
 	tl := "functional-get-poller-history-taskqueue"

--- a/tests/eager_workflow_start_test.go
+++ b/tests/eager_workflow_start_test.go
@@ -40,16 +40,16 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func (s *functionalSuite) defaultWorkflowID() string {
+func (s *FunctionalSuite) defaultWorkflowID() string {
 	return fmt.Sprintf("functional-%v", s.T().Name())
 }
 
-func (s *functionalSuite) defaultTaskQueue() *taskqueuepb.TaskQueue {
+func (s *FunctionalSuite) defaultTaskQueue() *taskqueuepb.TaskQueue {
 	name := fmt.Sprintf("functional-queue-%v", s.T().Name())
 	return &taskqueuepb.TaskQueue{Name: name, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}
 }
 
-func (s *functionalSuite) startEagerWorkflow(baseOptions *workflowservice.StartWorkflowExecutionRequest) *workflowservice.StartWorkflowExecutionResponse {
+func (s *FunctionalSuite) startEagerWorkflow(baseOptions *workflowservice.StartWorkflowExecutionRequest) *workflowservice.StartWorkflowExecutionResponse {
 	options := proto.Clone(baseOptions).(*workflowservice.StartWorkflowExecutionRequest)
 	options.RequestEagerExecution = true
 
@@ -78,7 +78,7 @@ func (s *functionalSuite) startEagerWorkflow(baseOptions *workflowservice.StartW
 	return response
 }
 
-func (s *functionalSuite) respondWorkflowTaskCompleted(task *workflowservice.PollWorkflowTaskQueueResponse, result interface{}) {
+func (s *FunctionalSuite) respondWorkflowTaskCompleted(task *workflowservice.PollWorkflowTaskQueueResponse, result interface{}) {
 	dataConverter := converter.GetDefaultDataConverter()
 	payloads, err := dataConverter.ToPayloads(result)
 	s.Require().NoError(err)
@@ -96,7 +96,7 @@ func (s *functionalSuite) respondWorkflowTaskCompleted(task *workflowservice.Pol
 	s.Require().NoError(err)
 }
 
-func (s *functionalSuite) pollWorkflowTaskQueue() *workflowservice.PollWorkflowTaskQueueResponse {
+func (s *FunctionalSuite) pollWorkflowTaskQueue() *workflowservice.PollWorkflowTaskQueueResponse {
 	task, err := s.engine.PollWorkflowTaskQueue(NewContext(), &workflowservice.PollWorkflowTaskQueueRequest{
 		Namespace: s.namespace,
 		TaskQueue: s.defaultTaskQueue(),
@@ -107,7 +107,7 @@ func (s *functionalSuite) pollWorkflowTaskQueue() *workflowservice.PollWorkflowT
 	return task
 }
 
-func (s *functionalSuite) getWorkflowStringResult(workflowID, runID string) string {
+func (s *FunctionalSuite) getWorkflowStringResult(workflowID, runID string) string {
 	hostPort := "127.0.0.1:7134"
 	if TestFlags.FrontendAddr != "" {
 		hostPort = TestFlags.FrontendAddr
@@ -121,7 +121,7 @@ func (s *functionalSuite) getWorkflowStringResult(workflowID, runID string) stri
 	return result
 }
 
-func (s *functionalSuite) TestEagerWorkflowStart_StartNew() {
+func (s *FunctionalSuite) TestEagerWorkflowStart_StartNew() {
 	// Add a search attribute to verify that per namespace search attribute mapping is properly applied in the
 	// response.
 	response := s.startEagerWorkflow(&workflowservice.StartWorkflowExecutionRequest{
@@ -144,7 +144,7 @@ func (s *functionalSuite) TestEagerWorkflowStart_StartNew() {
 	s.Require().Equal("ok", result)
 }
 
-func (s *functionalSuite) TestEagerWorkflowStart_RetryTaskAfterTimeout() {
+func (s *FunctionalSuite) TestEagerWorkflowStart_RetryTaskAfterTimeout() {
 	response := s.startEagerWorkflow(&workflowservice.StartWorkflowExecutionRequest{
 		// Should give enough grace time even in slow CI
 		WorkflowTaskTimeout: durationpb.New(2 * time.Second),
@@ -159,7 +159,7 @@ func (s *functionalSuite) TestEagerWorkflowStart_RetryTaskAfterTimeout() {
 	s.Require().Equal("ok", result)
 }
 
-func (s *functionalSuite) TestEagerWorkflowStart_RetryStartAfterTimeout() {
+func (s *FunctionalSuite) TestEagerWorkflowStart_RetryStartAfterTimeout() {
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		// Should give enough grace time even in slow CI
 		WorkflowTaskTimeout: durationpb.New(2 * time.Second),
@@ -182,7 +182,7 @@ func (s *functionalSuite) TestEagerWorkflowStart_RetryStartAfterTimeout() {
 	s.Require().Equal("ok", result)
 }
 
-func (s *functionalSuite) TestEagerWorkflowStart_RetryStartImmediately() {
+func (s *FunctionalSuite) TestEagerWorkflowStart_RetryStartImmediately() {
 	request := &workflowservice.StartWorkflowExecutionRequest{RequestId: uuid.New()}
 	response := s.startEagerWorkflow(request)
 	task := response.GetEagerWorkflowTask()
@@ -197,7 +197,7 @@ func (s *functionalSuite) TestEagerWorkflowStart_RetryStartImmediately() {
 	s.Require().Equal("ok", result)
 }
 
-func (s *functionalSuite) TestEagerWorkflowStart_TerminateDuplicate() {
+func (s *FunctionalSuite) TestEagerWorkflowStart_TerminateDuplicate() {
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		WorkflowIdReusePolicy: enumspb.WORKFLOW_ID_REUSE_POLICY_TERMINATE_IF_RUNNING,
 	}

--- a/tests/functional_test.go
+++ b/tests/functional_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 type (
-	functionalSuite struct {
+	FunctionalSuite struct {
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions
@@ -54,7 +54,7 @@ type (
 	}
 )
 
-func (s *functionalSuite) SetupSuite() {
+func (s *FunctionalSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
 		dynamicconfig.RetentionTimerJitterDuration: time.Second,
 		dynamicconfig.EnableEagerWorkflowStart:     true,
@@ -62,11 +62,11 @@ func (s *functionalSuite) SetupSuite() {
 	s.setupSuite("testdata/cluster.yaml")
 }
 
-func (s *functionalSuite) TearDownSuite() {
+func (s *FunctionalSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *functionalSuite) SetupTest() {
+func (s *FunctionalSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
@@ -74,10 +74,10 @@ func (s *functionalSuite) SetupTest() {
 
 func TestFunctionalSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(functionalSuite))
+	suite.Run(t, new(FunctionalSuite))
 }
 
-func (s *functionalSuite) sendSignal(namespace string, execution *commonpb.WorkflowExecution, signalName string,
+func (s *FunctionalSuite) sendSignal(namespace string, execution *commonpb.WorkflowExecution, signalName string,
 	input *commonpb.Payloads, identity string) error {
 	_, err := s.engine.SignalWorkflowExecution(NewContext(), &workflowservice.SignalWorkflowExecutionRequest{
 		Namespace:         namespace,
@@ -90,7 +90,7 @@ func (s *functionalSuite) sendSignal(namespace string, execution *commonpb.Workf
 	return err
 }
 
-func (s *functionalSuite) closeShard(wid string) {
+func (s *FunctionalSuite) closeShard(wid string) {
 	s.T().Helper()
 
 	resp, err := s.engine.DescribeNamespace(NewContext(), &workflowservice.DescribeNamespaceRequest{
@@ -104,7 +104,7 @@ func (s *functionalSuite) closeShard(wid string) {
 	s.NoError(err)
 }
 
-func unmarshalAny[T proto.Message](s *functionalSuite, a *anypb.Any) T {
+func unmarshalAny[T proto.Message](s *FunctionalSuite, a *anypb.Any) T {
 	s.T().Helper()
 	pb := new(T)
 	ppb := reflect.ValueOf(pb).Elem()
@@ -115,14 +115,14 @@ func unmarshalAny[T proto.Message](s *functionalSuite, a *anypb.Any) T {
 	return *pb
 }
 
-func marshalAny(s *functionalSuite, pb proto.Message) *anypb.Any {
+func marshalAny(s *FunctionalSuite, pb proto.Message) *anypb.Any {
 	s.T().Helper()
 	a, err := anypb.New(pb)
 	s.NoError(err)
 	return a
 }
 
-func decodeString(s *functionalSuite, pls *commonpb.Payloads) string {
+func decodeString(s *FunctionalSuite, pls *commonpb.Payloads) string {
 	s.T().Helper()
 	var str string
 	err := payloads.Decode(pls, &str)

--- a/tests/functional_test_base_test.go
+++ b/tests/functional_test_base_test.go
@@ -34,7 +34,7 @@ import (
 	"go.temporal.io/server/common/primitives"
 )
 
-type functionalTestBaseSuite struct {
+type FunctionalTestBaseSuite struct {
 	*require.Assertions
 	FunctionalTestBase
 	frontendServiceName primitives.ServiceName
@@ -43,7 +43,7 @@ type functionalTestBaseSuite struct {
 	workerServiceName   primitives.ServiceName
 }
 
-func (s *functionalTestBaseSuite) SetupSuite() {
+func (s *FunctionalTestBaseSuite) SetupSuite() {
 	s.setupSuite("testdata/cluster.yaml",
 		WithFxOptionsForService(primitives.FrontendService, fx.Populate(&s.frontendServiceName)),
 		WithFxOptionsForService(primitives.MatchingService, fx.Populate(&s.matchingServiceName)),
@@ -53,11 +53,11 @@ func (s *functionalTestBaseSuite) SetupSuite() {
 
 }
 
-func (s *functionalTestBaseSuite) TearDownSuite() {
+func (s *FunctionalTestBaseSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *functionalTestBaseSuite) TestWithFxOptionsForService() {
+func (s *FunctionalTestBaseSuite) TestWithFxOptionsForService() {
 	// This test works by using the WithFxOptionsForService option to obtain the ServiceName from the graph, and then
 	// it verifies that the ServiceName is correct. It does this because we are targeting the fx.App for a particular
 	// service, so we'll know our fx options were provided to the right service if, when we use them to get the current
@@ -70,10 +70,10 @@ func (s *functionalTestBaseSuite) TestWithFxOptionsForService() {
 	s.Equal(primitives.WorkerService, s.workerServiceName)
 }
 
-func (s *functionalTestBaseSuite) SetupTest() {
+func (s *FunctionalTestBaseSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 }
 
 func TestFunctionalTestBaseSuite(t *testing.T) {
-	suite.Run(t, new(functionalTestBaseSuite))
+	suite.Run(t, new(FunctionalTestBaseSuite))
 }

--- a/tests/gethistory_test.go
+++ b/tests/gethistory_test.go
@@ -54,32 +54,32 @@ import (
 	"go.temporal.io/server/common/persistence/serialization"
 )
 
-type rawHistorySuite struct {
+type RawHistorySuite struct {
 	*require.Assertions
 	FunctionalTestBase
 }
 
-func (s *rawHistorySuite) SetupSuite() {
+func (s *RawHistorySuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
 		dynamicconfig.SendRawWorkflowHistory: true,
 	}
 	s.setupSuite("testdata/cluster.yaml")
 }
 
-func (s *rawHistorySuite) TearDownSuite() {
+func (s *RawHistorySuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *rawHistorySuite) SetupTest() {
+func (s *RawHistorySuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 }
 
 func TestRawHistorySuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(rawHistorySuite))
+	suite.Run(t, new(RawHistorySuite))
 }
 
-func (s *functionalSuite) TestGetWorkflowExecutionHistory_All() {
+func (s *FunctionalSuite) TestGetWorkflowExecutionHistory_All() {
 	workflowID := "functional-get-workflow-history-events-long-poll-test-all"
 	workflowTypeName := "functional-get-workflow-history-events-long-poll-test-all-type"
 	taskqueueName := "functional-get-workflow-history-events-long-poll-test-all-taskqueue"
@@ -245,7 +245,7 @@ func (s *functionalSuite) TestGetWorkflowExecutionHistory_All() {
 	s.Equal(11, len(allEvents))
 }
 
-func (s *functionalSuite) TestGetWorkflowExecutionHistory_Close() {
+func (s *FunctionalSuite) TestGetWorkflowExecutionHistory_Close() {
 	workflowID := "functional-get-workflow-history-events-long-poll-test-close"
 	workflowTypeName := "functional-get-workflow-history-events-long-poll-test-close-type"
 	taskqueueName := "functional-get-workflow-history-events-long-poll-test-close-taskqueue"
@@ -404,7 +404,7 @@ func (s *functionalSuite) TestGetWorkflowExecutionHistory_Close() {
 	s.Logger.Info("Done TestGetWorkflowExecutionHistory_Close")
 }
 
-func (s *rawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
+func (s *RawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 	workflowID := "functional-poll-for-workflow-raw-history-events-long-poll-test-all"
 	workflowTypeName := "functional-poll-for-workflow-raw-history-events-long-poll-test-all-type"
 	taskqueueName := "functional-poll-for-workflow-raw-history-events-long-poll-test-all-taskqueue"
@@ -606,7 +606,7 @@ func (s *rawHistorySuite) TestGetWorkflowExecutionHistory_GetRawHistoryData() {
 	s.Equal(11, len(allEvents))
 }
 
-func (s *clientFunctionalSuite) TestGetHistoryReverse() {
+func (s *ClientFunctionalSuite) TestGetHistoryReverse() {
 	activityFn := func(ctx context.Context) error {
 		return nil
 	}
@@ -674,7 +674,7 @@ func (s *clientFunctionalSuite) TestGetHistoryReverse() {
 	s.Equal(eventDefaultOrder, events)
 }
 
-func (s *clientFunctionalSuite) TestGetHistoryReverse_MultipleBranches() {
+func (s *ClientFunctionalSuite) TestGetHistoryReverse_MultipleBranches() {
 	activityFn := func(ctx context.Context) error {
 		return nil
 	}

--- a/tests/http_api_test.go
+++ b/tests/http_api_test.go
@@ -63,10 +63,10 @@ func jsonPayload(data string) *common.Payloads {
 	}
 }
 
-func (s *clientFunctionalSuite) runHTTPAPIBasicsTest(
+func (s *ClientFunctionalSuite) runHTTPAPIBasicsTest(
 	contentType string,
 	startWFRequestBody, queryBody, signalBody func() string,
-	verifyQueryResult, verifyHistory func(*clientFunctionalSuite, []byte)) {
+	verifyQueryResult, verifyHistory func(*ClientFunctionalSuite, []byte)) {
 	// Create basic workflow that can answer queries, get signals, etc
 	workflowFn := func(ctx workflow.Context, arg *SomeJSONStruct) (*SomeJSONStruct, error) {
 		// Query that just returns query arg
@@ -160,23 +160,23 @@ func (s *clientFunctionalSuite) runHTTPAPIBasicsTest(
 	verifyHistory(s, respBody)
 }
 
-func (s *clientFunctionalSuite) TestHTTPAPIBasics_Protojson() {
+func (s *ClientFunctionalSuite) TestHTTPAPIBasics_Protojson() {
 	s.runHTTPAPIBasicsTest_Protojson("application/json+no-payload-shorthand", false)
 }
 
-func (s *clientFunctionalSuite) TestHTTPAPIBasics_ProtojsonPretty() {
+func (s *ClientFunctionalSuite) TestHTTPAPIBasics_ProtojsonPretty() {
 	s.runHTTPAPIBasicsTest_Protojson("application/json+pretty+no-payload-shorthand", true)
 }
 
-func (s *clientFunctionalSuite) TestHTTPAPIBasics_Shorthand() {
+func (s *ClientFunctionalSuite) TestHTTPAPIBasics_Shorthand() {
 	s.runHTTPAPIBasicsTest_Shorthand("application/json", false)
 }
 
-func (s *clientFunctionalSuite) TestHTTPAPIBasics_ShorthandPretty() {
+func (s *ClientFunctionalSuite) TestHTTPAPIBasics_ShorthandPretty() {
 	s.runHTTPAPIBasicsTest_Shorthand("application/json+pretty", true)
 }
 
-func (s *clientFunctionalSuite) runHTTPAPIBasicsTest_Protojson(contentType string, pretty bool) {
+func (s *ClientFunctionalSuite) runHTTPAPIBasicsTest_Protojson(contentType string, pretty bool) {
 	if s.httpAPIAddress == "" {
 		s.T().Skip("HTTP API server not enabled")
 	}
@@ -206,7 +206,7 @@ func (s *clientFunctionalSuite) runHTTPAPIBasicsTest_Protojson(contentType strin
 		s.Require().NoError(err)
 		return string(signalBody)
 	}
-	verifyQueryResult := func(s *clientFunctionalSuite, respBody []byte) {
+	verifyQueryResult := func(s *ClientFunctionalSuite, respBody []byte) {
 		s.T().Log(string(respBody))
 		if pretty {
 			// This is lazy but it'll work
@@ -220,7 +220,7 @@ func (s *clientFunctionalSuite) runHTTPAPIBasicsTest_Protojson(contentType strin
 		s.Require().NoError(conv.FromPayload(queryResp.QueryResult.Payloads[0], &payload))
 		s.Require().Equal("query-arg", payload.SomeField)
 	}
-	verifyHistory := func(s *clientFunctionalSuite, respBody []byte) {
+	verifyHistory := func(s *ClientFunctionalSuite, respBody []byte) {
 		s.T().Log(string(respBody))
 		if pretty {
 			// This is lazy but it'll work
@@ -241,7 +241,7 @@ func (s *clientFunctionalSuite) runHTTPAPIBasicsTest_Protojson(contentType strin
 	s.runHTTPAPIBasicsTest(contentType, reqBody, queryBody, signalBody, verifyQueryResult, verifyHistory)
 }
 
-func (s *clientFunctionalSuite) runHTTPAPIBasicsTest_Shorthand(contentType string, pretty bool) {
+func (s *ClientFunctionalSuite) runHTTPAPIBasicsTest_Shorthand(contentType string, pretty bool) {
 	if s.httpAPIAddress == "" {
 		s.T().Skip("HTTP API server not enabled")
 	}
@@ -259,7 +259,7 @@ func (s *clientFunctionalSuite) runHTTPAPIBasicsTest_Shorthand(contentType strin
 	signalBody := func() string {
 		return `{ "input": [{ "someField": "signal-arg" }] }`
 	}
-	verifyQueryResult := func(s *clientFunctionalSuite, respBody []byte) {
+	verifyQueryResult := func(s *ClientFunctionalSuite, respBody []byte) {
 		if pretty {
 			// This is lazy but it'll work
 			s.Require().Contains(respBody, byte('\n'), "Response body should have been prettified")
@@ -270,7 +270,7 @@ func (s *clientFunctionalSuite) runHTTPAPIBasicsTest_Shorthand(contentType strin
 		s.Require().NoError(json.Unmarshal(respBody, &queryResp))
 		s.Require().JSONEq(`[{ "someField": "query-arg" }]`, string(queryResp.QueryResult))
 	}
-	verifyHistory := func(s *clientFunctionalSuite, respBody []byte) {
+	verifyHistory := func(s *ClientFunctionalSuite, respBody []byte) {
 		if pretty {
 			// This is lazy but it'll work
 			s.Require().Contains(respBody, byte('\n'), "Response body should have been prettified")
@@ -295,7 +295,7 @@ func (s *clientFunctionalSuite) runHTTPAPIBasicsTest_Shorthand(contentType strin
 	s.runHTTPAPIBasicsTest(contentType, reqBody, queryBody, signalBody, verifyQueryResult, verifyHistory)
 }
 
-func (s *clientFunctionalSuite) TestHTTPAPIHeaders() {
+func (s *ClientFunctionalSuite) TestHTTPAPIHeaders() {
 	if s.httpAPIAddress == "" {
 		s.T().Skip("HTTP API server not enabled")
 	}
@@ -348,7 +348,7 @@ func (s *clientFunctionalSuite) TestHTTPAPIHeaders() {
 	s.Require().Equal(headers.ServerVersion, listWorkflowMetadata[headers.ClientVersionHeaderName][0])
 }
 
-func (s *clientFunctionalSuite) TestHTTPAPIPretty() {
+func (s *ClientFunctionalSuite) TestHTTPAPIPretty() {
 	if s.httpAPIAddress == "" {
 		s.T().Skip("HTTP API server not enabled")
 	}
@@ -360,7 +360,7 @@ func (s *clientFunctionalSuite) TestHTTPAPIPretty() {
 	s.Require().Contains(b, byte('\n'))
 }
 
-func (s *clientFunctionalSuite) httpGet(expectedStatus int, url, contentType string) (*http.Response, []byte) {
+func (s *ClientFunctionalSuite) httpGet(expectedStatus int, url, contentType string) (*http.Response, []byte) {
 	req, err := http.NewRequest("GET", url, nil)
 	s.Require().NoError(err)
 	req.Header.Add("Accept", contentType)
@@ -369,7 +369,7 @@ func (s *clientFunctionalSuite) httpGet(expectedStatus int, url, contentType str
 	return s.httpRequest(expectedStatus, req)
 }
 
-func (s *clientFunctionalSuite) httpPost(expectedStatus int, url, contentType, jsonBody string) (*http.Response, []byte) {
+func (s *ClientFunctionalSuite) httpPost(expectedStatus int, url, contentType, jsonBody string) (*http.Response, []byte) {
 	req, err := http.NewRequest("POST", url, strings.NewReader(jsonBody))
 	s.Require().NoError(err)
 	req.Header.Add("Accept", contentType)
@@ -378,7 +378,7 @@ func (s *clientFunctionalSuite) httpPost(expectedStatus int, url, contentType, j
 	return s.httpRequest(expectedStatus, req)
 }
 
-func (s *clientFunctionalSuite) httpRequest(expectedStatus int, req *http.Request) (*http.Response, []byte) {
+func (s *ClientFunctionalSuite) httpRequest(expectedStatus int, req *http.Request) (*http.Response, []byte) {
 	if req.URL.Scheme == "" {
 		req.URL.Scheme = "http"
 	}

--- a/tests/max_buffered_event_test.go
+++ b/tests/max_buffered_event_test.go
@@ -37,7 +37,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *clientFunctionalSuite) TestMaxBufferedEventsLimit() {
+func (s *ClientFunctionalSuite) TestMaxBufferedEventsLimit() {
 	/*
 		This test starts a workflow, and block its workflow task, then sending
 		signals to it which will be buffered. The default max buffered event
@@ -124,7 +124,7 @@ func (s *clientFunctionalSuite) TestMaxBufferedEventsLimit() {
 	s.Equal(enumspb.WORKFLOW_TASK_FAILED_CAUSE_FORCE_CLOSE_COMMAND, failedCause)
 }
 
-func (s *clientFunctionalSuite) TestBufferedEventsMutableStateSizeLimit() {
+func (s *ClientFunctionalSuite) TestBufferedEventsMutableStateSizeLimit() {
 	/*
 			This test starts a workflow, and block its workflow task, then sending
 			signals to it which will be buffered. The default max mutable state

--- a/tests/namespace_interceptor_test.go
+++ b/tests/namespace_interceptor_test.go
@@ -39,7 +39,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestServerRejectsInvalidRequests() {
+func (s *FunctionalSuite) TestServerRejectsInvalidRequests() {
 	sut := newSystemUnderTestConnector(s)
 
 	customersNamespace := namespace.Name(s.namespace)
@@ -58,7 +58,7 @@ func (s *functionalSuite) TestServerRejectsInvalidRequests() {
 }
 
 type sutConnector struct {
-	suite           *functionalSuite
+	suite           *FunctionalSuite
 	identity        string
 	taskQueue       *taskqueuepb.TaskQueue
 	stickyTaskQueue *taskqueuepb.TaskQueue
@@ -66,7 +66,7 @@ type sutConnector struct {
 	taskToken       []byte
 }
 
-func newSystemUnderTestConnector(s *functionalSuite) *sutConnector {
+func newSystemUnderTestConnector(s *FunctionalSuite) *sutConnector {
 	id := uuid.New()
 	return &sutConnector{
 		suite:           s,

--- a/tests/ndc/ndc_test.go
+++ b/tests/ndc/ndc_test.go
@@ -80,7 +80,7 @@ import (
 )
 
 type (
-	nDCFunctionalTestSuite struct {
+	NDCFunctionalTestSuite struct {
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions
@@ -107,10 +107,10 @@ type (
 
 func TestNDCFuncTestSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(nDCFunctionalTestSuite))
+	suite.Run(t, new(NDCFunctionalTestSuite))
 }
 
-func (s *nDCFunctionalTestSuite) SetupSuite() {
+func (s *NDCFunctionalTestSuite) SetupSuite() {
 	s.logger = log.NewTestLogger()
 	s.serializer = serialization.NewSerializer()
 	s.testClusterFactory = tests.NewTestClusterFactory()
@@ -172,7 +172,7 @@ func (s *nDCFunctionalTestSuite) SetupSuite() {
 	s.generator = test.InitializeHistoryEventGenerator(s.namespace, s.namespaceID, s.version)
 }
 
-func (s *nDCFunctionalTestSuite) GetReplicationMessagesMock(
+func (s *NDCFunctionalTestSuite) GetReplicationMessagesMock(
 	ctx context.Context,
 	request *adminservice.GetReplicationMessagesRequest,
 	opts ...grpc.CallOption,
@@ -205,14 +205,14 @@ func (s *nDCFunctionalTestSuite) GetReplicationMessagesMock(
 	}
 }
 
-func (s *nDCFunctionalTestSuite) SetupTest() {
+func (s *NDCFunctionalTestSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.generator = test.InitializeHistoryEventGenerator(s.namespace, s.namespaceID, s.version)
 }
 
-func (s *nDCFunctionalTestSuite) TearDownSuite() {
+func (s *NDCFunctionalTestSuite) TearDownSuite() {
 	if s.generator != nil {
 		s.generator.Reset()
 	}
@@ -220,7 +220,7 @@ func (s *nDCFunctionalTestSuite) TearDownSuite() {
 	s.NoError(s.cluster.TearDownCluster())
 }
 
-func (s *nDCFunctionalTestSuite) TestSingleBranch() {
+func (s *NDCFunctionalTestSuite) TestSingleBranch() {
 
 	s.setupRemoteFrontendClients()
 	workflowID := "ndc-single-branch-test" + uuid.New()
@@ -264,7 +264,7 @@ func (s *nDCFunctionalTestSuite) TestSingleBranch() {
 	}
 }
 
-func (s *nDCFunctionalTestSuite) TestMultipleBranches() {
+func (s *NDCFunctionalTestSuite) TestMultipleBranches() {
 
 	s.setupRemoteFrontendClients()
 	workflowID := "ndc-multiple-branches-test" + uuid.New()
@@ -396,7 +396,7 @@ func (s *nDCFunctionalTestSuite) TestMultipleBranches() {
 	}
 }
 
-func (s *nDCFunctionalTestSuite) TestEmptyVersionAndNonEmptyVersion() {
+func (s *NDCFunctionalTestSuite) TestEmptyVersionAndNonEmptyVersion() {
 	workflowID := "ndc-migration-test" + uuid.New()
 
 	workflowType := "event-generator-workflow-type"
@@ -456,7 +456,7 @@ func (s *nDCFunctionalTestSuite) TestEmptyVersionAndNonEmptyVersion() {
 	)
 }
 
-func (s *nDCFunctionalTestSuite) TestReplicateWorkflowState_PartialReplicated() {
+func (s *NDCFunctionalTestSuite) TestReplicateWorkflowState_PartialReplicated() {
 
 	s.setupRemoteFrontendClients()
 	workflowID := "replicate-workflow-state-partially-replicated" + uuid.New()
@@ -530,7 +530,7 @@ func (s *nDCFunctionalTestSuite) TestReplicateWorkflowState_PartialReplicated() 
 	s.NoError(err)
 }
 
-func (s *nDCFunctionalTestSuite) TestHandcraftedMultipleBranches() {
+func (s *NDCFunctionalTestSuite) TestHandcraftedMultipleBranches() {
 
 	s.setupRemoteFrontendClients()
 	workflowID := "ndc-handcrafted-multiple-branches-test" + uuid.New()
@@ -873,7 +873,7 @@ func (s *nDCFunctionalTestSuite) TestHandcraftedMultipleBranches() {
 	s.verifyEventHistorySize(workflowID, runID, historySize)
 }
 
-func (s *nDCFunctionalTestSuite) TestHandcraftedMultipleBranchesWithZombieContinueAsNew() {
+func (s *NDCFunctionalTestSuite) TestHandcraftedMultipleBranchesWithZombieContinueAsNew() {
 
 	s.setupRemoteFrontendClients()
 	workflowID := "ndc-handcrafted-multiple-branches-with-continue-as-new-test" + uuid.New()
@@ -1173,7 +1173,7 @@ func (s *nDCFunctionalTestSuite) TestHandcraftedMultipleBranchesWithZombieContin
 	s.verifyEventHistorySize(workflowID, runID, historySize)
 }
 
-func (s *nDCFunctionalTestSuite) TestImportSingleBranch() {
+func (s *NDCFunctionalTestSuite) TestImportSingleBranch() {
 
 	s.setupRemoteFrontendClients()
 	workflowID := "ndc-import-single-branch-test" + uuid.New()
@@ -1217,7 +1217,7 @@ func (s *nDCFunctionalTestSuite) TestImportSingleBranch() {
 	}
 }
 
-func (s *nDCFunctionalTestSuite) TestImportMultipleBranches() {
+func (s *NDCFunctionalTestSuite) TestImportMultipleBranches() {
 
 	s.setupRemoteFrontendClients()
 	workflowID := "ndc-import-multiple-branches-test" + uuid.New()
@@ -1359,7 +1359,7 @@ func (s *nDCFunctionalTestSuite) TestImportMultipleBranches() {
 	}
 }
 
-func (s *nDCFunctionalTestSuite) TestEventsReapply_ZombieWorkflow() {
+func (s *NDCFunctionalTestSuite) TestEventsReapply_ZombieWorkflow() {
 
 	workflowID := "ndc-events-reapply-zombie-workflow-test" + uuid.New()
 
@@ -1443,7 +1443,7 @@ func (s *nDCFunctionalTestSuite) TestEventsReapply_ZombieWorkflow() {
 	s.verifyEventHistorySize(workflowID, runID, historySize)
 }
 
-func (s *nDCFunctionalTestSuite) TestEventsReapply_NonCurrentBranch() {
+func (s *NDCFunctionalTestSuite) TestEventsReapply_NonCurrentBranch() {
 
 	workflowID := "ndc-events-reapply-non-current-test" + uuid.New()
 	runID := uuid.New()
@@ -1558,7 +1558,7 @@ func (s *nDCFunctionalTestSuite) TestEventsReapply_NonCurrentBranch() {
 	)
 }
 
-func (s *nDCFunctionalTestSuite) TestResend() {
+func (s *NDCFunctionalTestSuite) TestResend() {
 
 	workflowID := "ndc-re-send-test" + uuid.New()
 	runID := uuid.New()
@@ -2056,7 +2056,7 @@ func (s *nDCFunctionalTestSuite) TestResend() {
 	s.Equal(batchCount, 10)
 }
 
-func (s *nDCFunctionalTestSuite) registerNamespace() {
+func (s *NDCFunctionalTestSuite) registerNamespace() {
 	s.namespace = namespace.Name("test-simple-workflow-ndc-" + common.GenerateRandomString(5))
 	client1 := s.cluster.GetFrontendClient() // cluster
 	_, err := client1.RegisterNamespace(s.newContext(), &workflowservice.RegisterNamespaceRequest{
@@ -2082,7 +2082,7 @@ func (s *nDCFunctionalTestSuite) registerNamespace() {
 	s.logger.Info("Registered namespace", tag.WorkflowNamespace(s.namespace.String()), tag.WorkflowNamespaceID(s.namespaceID.String()))
 }
 
-func (s *nDCFunctionalTestSuite) generateNewRunHistory(
+func (s *NDCFunctionalTestSuite) generateNewRunHistory(
 	event *historypb.HistoryEvent,
 	nsName namespace.Name,
 	nsID namespace.ID,
@@ -2136,7 +2136,7 @@ func (s *nDCFunctionalTestSuite) generateNewRunHistory(
 	return eventBlob
 }
 
-func (s *nDCFunctionalTestSuite) generateEventBlobs(
+func (s *NDCFunctionalTestSuite) generateEventBlobs(
 	workflowID string,
 	runID string,
 	workflowType string,
@@ -2156,7 +2156,7 @@ func (s *nDCFunctionalTestSuite) generateEventBlobs(
 	return eventBlob, newRunEventBlob
 }
 
-func (s *nDCFunctionalTestSuite) applyEvents(
+func (s *NDCFunctionalTestSuite) applyEvents(
 	workflowID string,
 	runID string,
 	workflowType string,
@@ -2192,7 +2192,7 @@ func (s *nDCFunctionalTestSuite) applyEvents(
 	}
 }
 
-func (s *nDCFunctionalTestSuite) importEvents(
+func (s *NDCFunctionalTestSuite) importEvents(
 	workflowID string,
 	runID string,
 	workflowType string,
@@ -2255,7 +2255,7 @@ func (s *nDCFunctionalTestSuite) importEvents(
 	s.Nil(resp.Token)
 }
 
-func (s *nDCFunctionalTestSuite) applyEventsThroughFetcher(
+func (s *NDCFunctionalTestSuite) applyEventsThroughFetcher(
 	workflowID string,
 	runID string,
 	workflowType string,
@@ -2287,7 +2287,7 @@ func (s *nDCFunctionalTestSuite) applyEventsThroughFetcher(
 	}
 }
 
-func (s *nDCFunctionalTestSuite) eventBatchesToVersionHistory(
+func (s *NDCFunctionalTestSuite) eventBatchesToVersionHistory(
 	versionHistory *historyspb.VersionHistory,
 	eventBatches []*historypb.History,
 ) *historyspb.VersionHistory {
@@ -2311,7 +2311,7 @@ func (s *nDCFunctionalTestSuite) eventBatchesToVersionHistory(
 	return versionHistory
 }
 
-func (s *nDCFunctionalTestSuite) verifyEventHistorySize(
+func (s *NDCFunctionalTestSuite) verifyEventHistorySize(
 	workflowID string,
 	runID string,
 	historySize int64,
@@ -2333,7 +2333,7 @@ func (s *nDCFunctionalTestSuite) verifyEventHistorySize(
 	s.True(historySize <= describeWorkflow.WorkflowExecutionInfo.HistorySizeBytes)
 }
 
-func (s *nDCFunctionalTestSuite) verifyVersionHistory(
+func (s *NDCFunctionalTestSuite) verifyVersionHistory(
 	workflowID string,
 	runID string,
 	expectedVersionHistory *historyspb.VersionHistory,
@@ -2379,7 +2379,7 @@ func (s *nDCFunctionalTestSuite) verifyVersionHistory(
 	))
 }
 
-func (s *nDCFunctionalTestSuite) verifyEventHistory(
+func (s *NDCFunctionalTestSuite) verifyEventHistory(
 	workflowID string,
 	runID string,
 	historyBatch []*historypb.History,
@@ -2417,12 +2417,12 @@ func (s *nDCFunctionalTestSuite) verifyEventHistory(
 	}
 }
 
-func (s *nDCFunctionalTestSuite) setupRemoteFrontendClients() {
+func (s *NDCFunctionalTestSuite) setupRemoteFrontendClients() {
 	s.mockAdminClient["cluster-b"].(*adminservicemock.MockAdminServiceClient).EXPECT().ReapplyEvents(gomock.Any(), gomock.Any()).Return(&adminservice.ReapplyEventsResponse{}, nil).AnyTimes()
 	s.mockAdminClient["cluster-c"].(*adminservicemock.MockAdminServiceClient).EXPECT().ReapplyEvents(gomock.Any(), gomock.Any()).Return(&adminservice.ReapplyEventsResponse{}, nil).AnyTimes()
 }
 
-func (s *nDCFunctionalTestSuite) sizeOfHistoryEvents(
+func (s *NDCFunctionalTestSuite) sizeOfHistoryEvents(
 	events []*historypb.HistoryEvent,
 ) int64 {
 	blob, err := serialization.NewSerializer().SerializeEvents(events, enumspb.ENCODING_TYPE_PROTO3)
@@ -2430,7 +2430,7 @@ func (s *nDCFunctionalTestSuite) sizeOfHistoryEvents(
 	return int64(len(blob.Data))
 }
 
-func (s *nDCFunctionalTestSuite) newContext() context.Context {
+func (s *NDCFunctionalTestSuite) newContext() context.Context {
 	ctx := tests.NewContext()
 	return headers.SetCallerInfo(
 		ctx,
@@ -2438,7 +2438,7 @@ func (s *nDCFunctionalTestSuite) newContext() context.Context {
 	)
 }
 
-func (s *nDCFunctionalTestSuite) IsForceTerminated(
+func (s *NDCFunctionalTestSuite) IsForceTerminated(
 	workflowID string,
 	runID string,
 ) bool {

--- a/tests/ndc/replication_test.go
+++ b/tests/ndc/replication_test.go
@@ -39,7 +39,7 @@ import (
 	"go.temporal.io/server/tests"
 )
 
-func (s *nDCFunctionalTestSuite) TestReplicationMessageDLQ() {
+func (s *NDCFunctionalTestSuite) TestReplicationMessageDLQ() {
 	s.T().SkipNow()
 
 	var shardID int32 = 1

--- a/tests/purge_dlq_tasks_api_test.go
+++ b/tests/purge_dlq_tasks_api_test.go
@@ -45,7 +45,7 @@ import (
 )
 
 type (
-	purgeDLQTasksSuite struct {
+	PurgeDLQTasksSuite struct {
 		*require.Assertions
 		FunctionalTestBase
 		dlq              *faultyDLQ
@@ -81,7 +81,7 @@ func (q *faultyDLQ) DeleteTasks(
 	return q.HistoryTaskQueueManager.DeleteTasks(ctx, request)
 }
 
-func (s *purgeDLQTasksSuite) SetupSuite() {
+func (s *PurgeDLQTasksSuite) SetupSuite() {
 	s.Assertions = require.New(s.T())
 	s.setupSuite(
 		"testdata/cluster.yaml",
@@ -97,19 +97,19 @@ func (s *purgeDLQTasksSuite) SetupSuite() {
 	)
 }
 
-func (s *purgeDLQTasksSuite) TearDownSuite() {
+func (s *PurgeDLQTasksSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *purgeDLQTasksSuite) SetupTest() {
+func (s *PurgeDLQTasksSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 }
 
 func TestPurgeDLQTasksSuite(t *testing.T) {
-	suite.Run(t, new(purgeDLQTasksSuite))
+	suite.Run(t, new(PurgeDLQTasksSuite))
 }
 
-func (s *purgeDLQTasksSuite) TestPurgeDLQTasks() {
+func (s *PurgeDLQTasksSuite) TestPurgeDLQTasks() {
 	for _, tc := range []purgeDLQTasksTestCase{
 		{
 			name: "HappyPath",
@@ -219,7 +219,7 @@ func (s *purgeDLQTasksSuite) TestPurgeDLQTasks() {
 	}
 }
 
-func (s *purgeDLQTasksSuite) defaultDlqTestParams() purgeDLQTasksTestParams {
+func (s *PurgeDLQTasksSuite) defaultDlqTestParams() purgeDLQTasksTestParams {
 	queueKey := persistencetest.GetQueueKey(s.T())
 
 	return purgeDLQTasksTestParams{
@@ -229,7 +229,7 @@ func (s *purgeDLQTasksSuite) defaultDlqTestParams() purgeDLQTasksTestParams {
 	}
 }
 
-func (s *purgeDLQTasksSuite) enqueueTasks(ctx context.Context, queueKey persistence.QueueKey, task *tasks.WorkflowTask) {
+func (s *PurgeDLQTasksSuite) enqueueTasks(ctx context.Context, queueKey persistence.QueueKey, task *tasks.WorkflowTask) {
 	_, err := s.dlq.CreateQueue(ctx, &persistence.CreateQueueRequest{
 		QueueKey: queueKey,
 	})

--- a/tests/query_workflow_test.go
+++ b/tests/query_workflow_test.go
@@ -43,7 +43,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (s *clientFunctionalSuite) TestQueryWorkflow_Sticky() {
+func (s *ClientFunctionalSuite) TestQueryWorkflow_Sticky() {
 	var replayCount int32
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		// every replay will start from here
@@ -89,7 +89,7 @@ func (s *clientFunctionalSuite) TestQueryWorkflow_Sticky() {
 	s.Equal(int32(1), replayCount)
 }
 
-func (s *clientFunctionalSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
+func (s *ClientFunctionalSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		var receivedMsgs string
 		workflow.SetQueryHandler(ctx, "test", func() (string, error) {
@@ -145,7 +145,7 @@ func (s *clientFunctionalSuite) TestQueryWorkflow_Consistent_PiggybackQuery() {
 	s.Equal("pauseabc", queryResultStr)
 }
 
-func (s *clientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff() {
+func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff() {
 	testname := s.T().Name()
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		workflow.SetQueryHandler(ctx, testname, func() (string, error) {
@@ -199,7 +199,7 @@ func (s *clientFunctionalSuite) TestQueryWorkflow_QueryWhileBackoff() {
 	s.ErrorContains(err, consts.ErrWorkflowTaskNotScheduled.Error())
 }
 
-func (s *clientFunctionalSuite) TestQueryWorkflow_QueryBeforeStart() {
+func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryBeforeStart() {
 	// stop the worker, so the workflow won't be started before query
 	s.worker.Stop()
 
@@ -261,7 +261,7 @@ func (s *clientFunctionalSuite) TestQueryWorkflow_QueryBeforeStart() {
 	wg.Wait()
 }
 
-func (s *clientFunctionalSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
+func (s *ClientFunctionalSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
 	testname := s.T().Name()
 	var failures int32
 	workflowFn := func(ctx workflow.Context) (string, error) {
@@ -307,7 +307,7 @@ func (s *clientFunctionalSuite) TestQueryWorkflow_QueryFailedWorkflowTask() {
 
 }
 
-func (s *clientFunctionalSuite) TestQueryWorkflow_ClosedWithoutWorkflowTaskStarted() {
+func (s *ClientFunctionalSuite) TestQueryWorkflow_ClosedWithoutWorkflowTaskStarted() {
 	testname := s.T().Name()
 	workflowFn := func(ctx workflow.Context) (string, error) {
 		return "", errors.New("workflow should never execute")

--- a/tests/relay_task_test.go
+++ b/tests/relay_task_test.go
@@ -39,7 +39,7 @@ import (
 	"go.temporal.io/server/common/log/tag"
 )
 
-func (s *functionalSuite) TestRelayWorkflowTaskTimeout() {
+func (s *FunctionalSuite) TestRelayWorkflowTaskTimeout() {
 	id := "functional-relay-workflow-task-timeout-test"
 	wt := "functional-relay-workflow-task-timeout-test-type"
 	tl := "functional-relay-workflow-task-timeout-test-taskqueue"

--- a/tests/reset_workflow_test.go
+++ b/tests/reset_workflow_test.go
@@ -44,7 +44,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestResetWorkflow() {
+func (s *FunctionalSuite) TestResetWorkflow() {
 	id := "functional-reset-workflow-test"
 	wt := "functional-reset-workflow-test-type"
 	tq := "functional-reset-workflow-test-taskqueue"
@@ -201,7 +201,7 @@ func (s *functionalSuite) TestResetWorkflow() {
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestResetWorkflow_ReapplyAll() {
+func (s *FunctionalSuite) TestResetWorkflow_ReapplyAll() {
 	workflowID := "functional-reset-workflow-test-reapply-all"
 	workflowTypeName := "functional-reset-workflow-test-reapply-all-type"
 	taskQueueName := "functional-reset-workflow-test-reapply-all-taskqueue"
@@ -209,7 +209,7 @@ func (s *functionalSuite) TestResetWorkflow_ReapplyAll() {
 	s.testResetWorkflowReapply(workflowID, workflowTypeName, taskQueueName, 4, 3, enumspb.RESET_REAPPLY_TYPE_SIGNAL)
 }
 
-func (s *functionalSuite) TestResetWorkflow_ReapplyNone() {
+func (s *FunctionalSuite) TestResetWorkflow_ReapplyNone() {
 	workflowID := "functional-reset-workflow-test-reapply-none"
 	workflowTypeName := "functional-reset-workflow-test-reapply-none-type"
 	taskQueueName := "functional-reset-workflow-test-reapply-none-taskqueue"
@@ -217,7 +217,7 @@ func (s *functionalSuite) TestResetWorkflow_ReapplyNone() {
 	s.testResetWorkflowReapply(workflowID, workflowTypeName, taskQueueName, 4, 3, enumspb.RESET_REAPPLY_TYPE_NONE)
 }
 
-func (s *functionalSuite) testResetWorkflowReapply(
+func (s *FunctionalSuite) testResetWorkflowReapply(
 	workflowID string,
 	workflowTypeName string,
 	taskQueueName string,
@@ -349,7 +349,7 @@ func (s *functionalSuite) testResetWorkflowReapply(
 
 }
 
-func (s *functionalSuite) TestResetWorkflow_ReapplyBufferAll() {
+func (s *FunctionalSuite) TestResetWorkflow_ReapplyBufferAll() {
 	workflowID := "functional-reset-workflow-test-reapply-buffer-all"
 	workflowTypeName := "functional-reset-workflow-test-reapply-buffer-all-type"
 	taskQueueName := "functional-reset-workflow-test-reapply-buffer-all-taskqueue"
@@ -357,7 +357,7 @@ func (s *functionalSuite) TestResetWorkflow_ReapplyBufferAll() {
 	s.testResetWorkflowReapplyBuffer(workflowID, workflowTypeName, taskQueueName, enumspb.RESET_REAPPLY_TYPE_SIGNAL)
 }
 
-func (s *functionalSuite) TestResetWorkflow_ReapplyBufferNone() {
+func (s *FunctionalSuite) TestResetWorkflow_ReapplyBufferNone() {
 	workflowID := "functional-reset-workflow-test-reapply-buffer-none"
 	workflowTypeName := "functional-reset-workflow-test-reapply-buffer-none-type"
 	taskQueueName := "functional-reset-workflow-test-reapply-buffer-none-taskqueue"
@@ -365,7 +365,7 @@ func (s *functionalSuite) TestResetWorkflow_ReapplyBufferNone() {
 	s.testResetWorkflowReapplyBuffer(workflowID, workflowTypeName, taskQueueName, enumspb.RESET_REAPPLY_TYPE_NONE)
 }
 
-func (s *functionalSuite) testResetWorkflowReapplyBuffer(
+func (s *FunctionalSuite) testResetWorkflowReapplyBuffer(
 	workflowID string,
 	workflowTypeName string,
 	taskQueueName string,
@@ -494,28 +494,28 @@ func (s *functionalSuite) testResetWorkflowReapplyBuffer(
 
 }
 
-func (s *functionalSuite) TestResetWorkflow_WorkflowTask_Schedule() {
+func (s *FunctionalSuite) TestResetWorkflow_WorkflowTask_Schedule() {
 	workflowID := "functional-reset-workflow-test-schedule"
 	workflowTypeName := "functional-reset-workflow-test-schedule-type"
 	taskQueueName := "functional-reset-workflow-test-schedule-taskqueue"
 	s.testResetWorkflowRangeScheduleToStart(workflowID, workflowTypeName, taskQueueName, 3)
 }
 
-func (s *functionalSuite) TestResetWorkflow_WorkflowTask_ScheduleToStart() {
+func (s *FunctionalSuite) TestResetWorkflow_WorkflowTask_ScheduleToStart() {
 	workflowID := "functional-reset-workflow-test-schedule-to-start"
 	workflowTypeName := "functional-reset-workflow-test-schedule-to-start-type"
 	taskQueueName := "functional-reset-workflow-test-schedule-to-start-taskqueue"
 	s.testResetWorkflowRangeScheduleToStart(workflowID, workflowTypeName, taskQueueName, 4)
 }
 
-func (s *functionalSuite) TestResetWorkflow_WorkflowTask_Start() {
+func (s *FunctionalSuite) TestResetWorkflow_WorkflowTask_Start() {
 	workflowID := "functional-reset-workflow-test-start"
 	workflowTypeName := "functional-reset-workflow-test-start-type"
 	taskQueueName := "functional-reset-workflow-test-start-taskqueue"
 	s.testResetWorkflowRangeScheduleToStart(workflowID, workflowTypeName, taskQueueName, 5)
 }
 
-func (s *functionalSuite) testResetWorkflowRangeScheduleToStart(
+func (s *FunctionalSuite) testResetWorkflowRangeScheduleToStart(
 	workflowID string,
 	workflowTypeName string,
 	taskQueueName string,

--- a/tests/schedule_test.go
+++ b/tests/schedule_test.go
@@ -75,7 +75,7 @@ worker restart/long-poll activity failure:
 */
 
 type (
-	scheduleFunctionalSuite struct {
+	ScheduleFunctionalSuite struct {
 		*require.Assertions
 		protorequire.ProtoAssertions
 		FunctionalTestBase
@@ -88,10 +88,10 @@ type (
 
 func TestScheduleFunctionalSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(scheduleFunctionalSuite))
+	suite.Run(t, new(ScheduleFunctionalSuite))
 }
 
-func (s *scheduleFunctionalSuite) SetupSuite() {
+func (s *ScheduleFunctionalSuite) SetupSuite() {
 	switch TestFlags.PersistenceDriver {
 	case mysql.PluginNameV8, postgresql.PluginNameV12, postgresql.PluginNameV12PGX, sqlite.PluginName:
 		s.setupSuite("testdata/cluster.yaml")
@@ -102,11 +102,11 @@ func (s *scheduleFunctionalSuite) SetupSuite() {
 	}
 }
 
-func (s *scheduleFunctionalSuite) TearDownSuite() {
+func (s *ScheduleFunctionalSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *scheduleFunctionalSuite) SetupTest() {
+func (s *ScheduleFunctionalSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
 	s.dataConverter = newTestDataConverter()
@@ -126,12 +126,12 @@ func (s *scheduleFunctionalSuite) SetupTest() {
 	}
 }
 
-func (s *scheduleFunctionalSuite) TearDownTest() {
+func (s *ScheduleFunctionalSuite) TearDownTest() {
 	s.worker.Stop()
 	s.sdkClient.Close()
 }
 
-func (s *scheduleFunctionalSuite) TestBasics() {
+func (s *ScheduleFunctionalSuite) TestBasics() {
 	sid := "sched-test-basics"
 	wid := "sched-test-basics-wf"
 	wt := "sched-test-basics-wt"
@@ -426,7 +426,7 @@ func (s *scheduleFunctionalSuite) TestBasics() {
 	}, 10*time.Second, 1*time.Second)
 }
 
-func (s *scheduleFunctionalSuite) TestInput() {
+func (s *ScheduleFunctionalSuite) TestInput() {
 	sid := "sched-test-input"
 	wid := "sched-test-input-wf"
 	wt := "sched-test-input-wt"
@@ -494,7 +494,7 @@ func (s *scheduleFunctionalSuite) TestInput() {
 	s.NoError(err)
 }
 
-func (s *scheduleFunctionalSuite) TestLastCompletionAndError() {
+func (s *ScheduleFunctionalSuite) TestLastCompletionAndError() {
 	sid := "sched-test-last"
 	wid := "sched-test-last-wf"
 	wt := "sched-test-last-wt"
@@ -573,7 +573,7 @@ func (s *scheduleFunctionalSuite) TestLastCompletionAndError() {
 	s.NoError(err)
 }
 
-func (s *scheduleFunctionalSuite) TestRefresh() {
+func (s *ScheduleFunctionalSuite) TestRefresh() {
 	sid := "sched-test-refresh"
 	wid := "sched-test-refresh-wf"
 	wt := "sched-test-refresh-wt"
@@ -663,7 +663,7 @@ func (s *scheduleFunctionalSuite) TestRefresh() {
 	s.NoError(err)
 }
 
-func (s *scheduleFunctionalSuite) TestListBeforeRun() {
+func (s *ScheduleFunctionalSuite) TestListBeforeRun() {
 	sid := "sched-test-list-before-run"
 	wid := "sched-test-list-before-run-wf"
 	wt := "sched-test-list-before-run-wt"
@@ -736,7 +736,7 @@ func (s *scheduleFunctionalSuite) TestListBeforeRun() {
 	time.Sleep(2 * time.Second)
 }
 
-func (s *scheduleFunctionalSuite) TestRateLimit() {
+func (s *ScheduleFunctionalSuite) TestRateLimit() {
 	sid := "sched-test-rate-limit-%d"
 	wid := "sched-test-rate-limit-wf-%d"
 	wt := "sched-test-rate-limit-wt"
@@ -815,7 +815,7 @@ func (s *scheduleFunctionalSuite) TestRateLimit() {
 	s.testCluster.host.workerService.RefreshPerNSWorkerManager()
 }
 
-func (s *scheduleFunctionalSuite) TestNextTimeCache() {
+func (s *ScheduleFunctionalSuite) TestNextTimeCache() {
 	sid := "sched-test-next-time-cache"
 	wid := "sched-test-next-time-cache-wf"
 	wt := "sched-test-next-time-cache-wt"

--- a/tests/signal_workflow_test.go
+++ b/tests/signal_workflow_test.go
@@ -51,7 +51,7 @@ import (
 	"go.temporal.io/server/service/history/consts"
 )
 
-func (s *functionalSuite) TestSignalWorkflow() {
+func (s *FunctionalSuite) TestSignalWorkflow() {
 	id := "functional-signal-workflow-test"
 	wt := "functional-signal-workflow-test-type"
 	tl := "functional-signal-workflow-test-taskqueue"
@@ -245,7 +245,7 @@ func (s *functionalSuite) TestSignalWorkflow() {
 	s.IsType(&serviceerror.NotFound{}, err)
 }
 
-func (s *functionalSuite) TestSignalWorkflow_DuplicateRequest() {
+func (s *FunctionalSuite) TestSignalWorkflow_DuplicateRequest() {
 	id := "functional-signal-workflow-test-duplicate"
 	wt := "functional-signal-workflow-test-duplicate-type"
 	tl := "functional-signal-workflow-test-duplicate-taskqueue"
@@ -387,7 +387,7 @@ func (s *functionalSuite) TestSignalWorkflow_DuplicateRequest() {
 	s.Equal(0, numOfSignaledEvent)
 }
 
-func (s *functionalSuite) TestSignalExternalWorkflowCommand() {
+func (s *FunctionalSuite) TestSignalExternalWorkflowCommand() {
 	id := "functional-signal-external-workflow-test"
 	wt := "functional-signal-external-workflow-test-type"
 	tl := "functional-signal-external-workflow-test-taskqueue"
@@ -608,7 +608,7 @@ CheckHistoryLoopForSignalSent:
 	s.Equal("history-service", signalEvent.GetWorkflowExecutionSignaledEventAttributes().Identity)
 }
 
-func (s *functionalSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated() {
+func (s *FunctionalSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated() {
 	id := "functional-signal-workflow-test-cron"
 	wt := "functional-signal-workflow-test-cron-type"
 	tl := "functional-signal-workflow-test-cron-taskqueue"
@@ -685,7 +685,7 @@ func (s *functionalSuite) TestSignalWorkflow_Cron_NoWorkflowTaskCreated() {
 	s.True(workflowTaskDelay > time.Second*2)
 }
 
-func (s *functionalSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
+func (s *FunctionalSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
 	id := "functional-signal-workflow-test-skip-wft"
 	wt := "functional-signal-workflow-test-skip-wft-type"
 	tl := "functional-signal-workflow-test-skip-wft-taskqueue"
@@ -800,7 +800,7 @@ func (s *functionalSuite) TestSignalWorkflow_NoWorkflowTaskCreated() {
  10 WorkflowExecutionCompleted`, historyResponse.GetHistory())
 }
 
-func (s *functionalSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
+func (s *FunctionalSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 	id := "functional-signal-workflow-workflow-close-attempted-test"
 	wt := "functional-signal-workflow-workflow-close-attempted-test-type"
 	tl := "functional-signal-workflow-workflow-close-attempted-test-taskqueue"
@@ -886,7 +886,7 @@ func (s *functionalSuite) TestSignalWorkflow_WorkflowCloseAttempted() {
 	s.NoError(err)
 }
 
-func (s *functionalSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
+func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_WithoutRunID() {
 	id := "functional-signal-external-workflow-test-without-run-id"
 	wt := "functional-signal-external-workflow-test-without-run-id-type"
 	tl := "functional-signal-external-workflow-test-without-run-id-taskqueue"
@@ -1101,7 +1101,7 @@ CheckHistoryLoopForSignalSent:
 	s.Equal("history-service", signalEvent.GetWorkflowExecutionSignaledEventAttributes().Identity)
 }
 
-func (s *functionalSuite) TestSignalExternalWorkflowCommand_UnKnownTarget() {
+func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_UnKnownTarget() {
 	id := "functional-signal-unknown-workflow-command-test"
 	wt := "functional-signal-unknown-workflow-command-test-type"
 	tl := "functional-signal-unknown-workflow-command-test-taskqueue"
@@ -1226,7 +1226,7 @@ CheckHistoryLoopForCancelSent:
 	s.True(signalSentFailed)
 }
 
-func (s *functionalSuite) TestSignalExternalWorkflowCommand_SignalSelf() {
+func (s *FunctionalSuite) TestSignalExternalWorkflowCommand_SignalSelf() {
 	id := "functional-signal-self-workflow-command-test"
 	wt := "functional-signal-self-workflow-command-test-type"
 	tl := "functional-signal-self-workflow-command-test-taskqueue"
@@ -1352,7 +1352,7 @@ CheckHistoryLoopForCancelSent:
 
 }
 
-func (s *functionalSuite) TestSignalWithStartWorkflow() {
+func (s *FunctionalSuite) TestSignalWithStartWorkflow() {
 	id := "functional-signal-with-start-workflow-test"
 	wt := "functional-signal-with-start-workflow-test-type"
 	tl := "functional-signal-with-start-workflow-test-taskqueue"
@@ -1617,7 +1617,7 @@ func (s *functionalSuite) TestSignalWithStartWorkflow() {
 	s.Equal(1, len(listClosedResp.Executions))
 }
 
-func (s *functionalSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
+func (s *FunctionalSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	id := "functional-signal-with-start-workflow-id-reuse-test"
 	wt := "functional-signal-with-start-workflow-id-reuse-test-type"
 	tl := "functional-signal-with-start-workflow-id-reuse-test-taskqueue"
@@ -1792,7 +1792,7 @@ func (s *functionalSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, descResp.WorkflowExecutionInfo.Status)
 }
 
-func (s *functionalSuite) TestSignalWithStartWorkflow_StartDelay() {
+func (s *FunctionalSuite) TestSignalWithStartWorkflow_StartDelay() {
 	id := "functional-signal-with-start-workflow-start-delay-test"
 	wt := "functional-signal-with-start-workflow-start-delay-test-type"
 	tl := "functional-signal-with-start-workflow-start-delay-test-taskqueue"
@@ -1875,7 +1875,7 @@ func (s *functionalSuite) TestSignalWithStartWorkflow_StartDelay() {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, descResp.WorkflowExecutionInfo.Status)
 }
 
-func (s *functionalSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
+func (s *FunctionalSuite) TestSignalWithStartWorkflow_NoWorkflowTaskCreated() {
 	id := "functional-signal-with-start-workflow-no-wft-test"
 	wt := "functional-signal-with-start-workflow-no-wft-test-type"
 	tl := "functional-signal-with-start-workflow-no-wft-test-taskqueue"

--- a/tests/sizelimit_test.go
+++ b/tests/sizelimit_test.go
@@ -51,7 +51,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-type sizeLimitFunctionalSuite struct {
+type SizeLimitFunctionalSuite struct {
 	// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 	// not merely log an error
 	*require.Assertions
@@ -59,25 +59,25 @@ type sizeLimitFunctionalSuite struct {
 }
 
 // This cluster use customized threshold for history config
-func (s *sizeLimitFunctionalSuite) SetupSuite() {
+func (s *SizeLimitFunctionalSuite) SetupSuite() {
 	s.setupSuite("testdata/sizelimit_cluster.yaml")
 }
 
-func (s *sizeLimitFunctionalSuite) TearDownSuite() {
+func (s *SizeLimitFunctionalSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *sizeLimitFunctionalSuite) SetupTest() {
+func (s *SizeLimitFunctionalSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 }
 
 func TestSizeLimitFunctionalSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(sizeLimitFunctionalSuite))
+	suite.Run(t, new(SizeLimitFunctionalSuite))
 }
 
-func (s *sizeLimitFunctionalSuite) TestTerminateWorkflowCausedByHistoryCountLimit() {
+func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByHistoryCountLimit() {
 	id := "functional-terminate-workflow-by-history-count-limit-test"
 	wt := "functional-terminate-workflow-by-history-count-limit-test-type"
 	tq := "functional-terminate-workflow-by-history-count-limit-test-taskqueue"
@@ -245,7 +245,7 @@ SignalLoop:
 	s.True(isCloseCorrect)
 }
 
-func (s *sizeLimitFunctionalSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
+func (s *SizeLimitFunctionalSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 
 	id := "functional-workflow-failed-large-payload"
 	wt := "functional-workflow-failed-large-payload-type"
@@ -343,7 +343,7 @@ func (s *sizeLimitFunctionalSuite) TestWorkflowFailed_PayloadSizeTooLarge() {
 	s.Fail("Missing signal event")
 }
 
-func (s *sizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
+func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 	id := "functional-terminate-workflow-by-ms-size-limit-test"
 	wt := "functional-terminate-workflow-by-ms-size-limit-test-type"
 	tq := "functional-terminate-workflow-by-ms-size-limit-test-taskqueue"
@@ -496,7 +496,7 @@ func (s *sizeLimitFunctionalSuite) TestTerminateWorkflowCausedByMsSizeLimit() {
 	s.True(isCloseCorrect)
 }
 
-func (s *sizeLimitFunctionalSuite) TestTerminateWorkflowCausedByHistorySizeLimit() {
+func (s *SizeLimitFunctionalSuite) TestTerminateWorkflowCausedByHistorySizeLimit() {
 	id := "functional-terminate-workflow-by-history-size-limit-test"
 	wt := "functional-terminate-workflow-by-history-size-limit-test-type"
 	tq := "functional-terminate-workflow-by-history-size-limit-test-taskqueue"

--- a/tests/stickytq_test.go
+++ b/tests/stickytq_test.go
@@ -41,7 +41,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestStickyTimeout_NonTransientWorkflowTask() {
+func (s *FunctionalSuite) TestStickyTimeout_NonTransientWorkflowTask() {
 	id := "functional-sticky-timeout-non-transient-workflow-task"
 	wt := "functional-sticky-timeout-non-transient-command-type"
 	tl := "functional-sticky-timeout-non-transient-workflow-taskqueue"
@@ -212,7 +212,7 @@ WaitForStickyTimeoutLoop:
 	s.Equal(2, failedWorkflowTasks, "Mismatched failed workflow tasks count")
 }
 
-func (s *functionalSuite) TestStickyTaskqueueResetThenTimeout() {
+func (s *FunctionalSuite) TestStickyTaskqueueResetThenTimeout() {
 	id := "functional-reset-sticky-fire-schedule-to-start-timeout"
 	wt := "functional-reset-sticky-fire-schedule-to-start-timeout-type"
 	tl := "functional-reset-sticky-fire-schedule-to-start-timeout-taskqueue"

--- a/tests/tls_test.go
+++ b/tests/tls_test.go
@@ -41,26 +41,26 @@ import (
 	"go.temporal.io/server/common/rpc"
 )
 
-type tlsFunctionalSuite struct {
+type TLSFunctionalSuite struct {
 	FunctionalTestBase
 	sdkClient sdkclient.Client
 }
 
 func TestTLSFunctionalSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(tlsFunctionalSuite))
+	suite.Run(t, new(TLSFunctionalSuite))
 }
 
-func (s *tlsFunctionalSuite) SetupSuite() {
+func (s *TLSFunctionalSuite) SetupSuite() {
 	s.setupSuite("testdata/tls_cluster.yaml")
 
 }
 
-func (s *tlsFunctionalSuite) TearDownSuite() {
+func (s *TLSFunctionalSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *tlsFunctionalSuite) SetupTest() {
+func (s *TLSFunctionalSuite) SetupTest() {
 	var err error
 	s.sdkClient, err = sdkclient.Dial(sdkclient.Options{
 		HostPort:  s.hostPort,
@@ -74,11 +74,11 @@ func (s *tlsFunctionalSuite) SetupTest() {
 	}
 }
 
-func (s *tlsFunctionalSuite) TearDownTest() {
+func (s *TLSFunctionalSuite) TearDownTest() {
 	s.sdkClient.Close()
 }
 
-func (s *tlsFunctionalSuite) TestGRPCMTLS() {
+func (s *TLSFunctionalSuite) TestGRPCMTLS() {
 	ctx, cancel := rpc.NewContextWithTimeoutAndVersionHeaders(time.Minute)
 	defer cancel()
 
@@ -94,7 +94,7 @@ func (s *tlsFunctionalSuite) TestGRPCMTLS() {
 	s.Require().Equal(tlsCertCommonName, authInfo.(*authorization.AuthInfo).TLSSubject.CommonName)
 }
 
-func (s *tlsFunctionalSuite) TestHTTPMTLS() {
+func (s *TLSFunctionalSuite) TestHTTPMTLS() {
 	if s.httpAPIAddress == "" {
 		s.T().Skip("HTTP API server not enabled")
 	}
@@ -126,7 +126,7 @@ func (s *tlsFunctionalSuite) TestHTTPMTLS() {
 	s.Require().Equal(tlsCertCommonName, authInfo.(*authorization.AuthInfo).TLSSubject.CommonName)
 }
 
-func (s *tlsFunctionalSuite) trackAuthInfoByCall() *sync.Map {
+func (s *TLSFunctionalSuite) trackAuthInfoByCall() *sync.Map {
 	var calls sync.Map
 	// Put auth info on claim, then use authorizer to set on the map by call
 	s.testCluster.host.SetOnGetClaims(func(authInfo *authorization.AuthInfo) (*authorization.Claims, error) {

--- a/tests/transient_task_test.go
+++ b/tests/transient_task_test.go
@@ -43,7 +43,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestTransientWorkflowTaskTimeout() {
+func (s *FunctionalSuite) TestTransientWorkflowTaskTimeout() {
 	id := "functional-transient-workflow-task-timeout-test"
 	wt := "functional-transient-workflow-task-timeout-test-type"
 	tl := "functional-transient-workflow-task-timeout-test-taskqueue"
@@ -133,7 +133,7 @@ func (s *functionalSuite) TestTransientWorkflowTaskTimeout() {
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestTransientWorkflowTaskHistorySize() {
+func (s *FunctionalSuite) TestTransientWorkflowTaskHistorySize() {
 	id := "functional-transient-workflow-task-history-size-test"
 	wt := "functional-transient-workflow-task-history-size-test-type"
 	tl := "functional-transient-workflow-task-history-size-test-taskqueue"
@@ -325,7 +325,7 @@ func (s *functionalSuite) TestTransientWorkflowTaskHistorySize() {
 	}
 }
 
-func (s *functionalSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents() {
+func (s *FunctionalSuite) TestNoTransientWorkflowTaskAfterFlushBufferedEvents() {
 	id := "functional-no-transient-workflow-task-after-flush-buffered-events-test"
 	wt := "functional-no-transient-workflow-task-after-flush-buffered-events-test-type"
 	tl := "functional-no-transient-workflow-task-after-flush-buffered-events-test-taskqueue"

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -49,7 +49,7 @@ import (
 	"go.temporal.io/server/tests/testvars"
 )
 
-func (s *functionalSuite) startWorkflow(tv *testvars.TestVars) *testvars.TestVars {
+func (s *FunctionalSuite) startWorkflow(tv *testvars.TestVars) *testvars.TestVars {
 	s.T().Helper()
 	request := &workflowservice.StartWorkflowExecutionRequest{
 		RequestId:    tv.Any(),
@@ -65,7 +65,7 @@ func (s *functionalSuite) startWorkflow(tv *testvars.TestVars) *testvars.TestVar
 	return tv.WithRunID(startResp.GetRunId())
 }
 
-func (s *functionalSuite) acceptUpdateCommands(tv *testvars.TestVars, updateID string) []*commandpb.Command {
+func (s *FunctionalSuite) acceptUpdateCommands(tv *testvars.TestVars, updateID string) []*commandpb.Command {
 	s.T().Helper()
 	return []*commandpb.Command{{
 		CommandType: enumspb.COMMAND_TYPE_PROTOCOL_MESSAGE,
@@ -75,7 +75,7 @@ func (s *functionalSuite) acceptUpdateCommands(tv *testvars.TestVars, updateID s
 	}}
 }
 
-func (s *functionalSuite) completeUpdateCommands(tv *testvars.TestVars, updateID string) []*commandpb.Command {
+func (s *FunctionalSuite) completeUpdateCommands(tv *testvars.TestVars, updateID string) []*commandpb.Command {
 	s.T().Helper()
 	return []*commandpb.Command{
 		{
@@ -87,12 +87,12 @@ func (s *functionalSuite) completeUpdateCommands(tv *testvars.TestVars, updateID
 	}
 }
 
-func (s *functionalSuite) acceptCompleteUpdateCommands(tv *testvars.TestVars, updateID string) []*commandpb.Command {
+func (s *FunctionalSuite) acceptCompleteUpdateCommands(tv *testvars.TestVars, updateID string) []*commandpb.Command {
 	s.T().Helper()
 	return append(s.acceptUpdateCommands(tv, updateID), s.completeUpdateCommands(tv, updateID)...)
 }
 
-func (s *functionalSuite) acceptUpdateMessages(tv *testvars.TestVars, updRequestMsg *protocolpb.Message, updateID string) []*protocolpb.Message {
+func (s *FunctionalSuite) acceptUpdateMessages(tv *testvars.TestVars, updRequestMsg *protocolpb.Message, updateID string) []*protocolpb.Message {
 	s.T().Helper()
 	updRequest := unmarshalAny[*updatepb.Request](s, updRequestMsg.GetBody())
 
@@ -110,7 +110,7 @@ func (s *functionalSuite) acceptUpdateMessages(tv *testvars.TestVars, updRequest
 	}
 }
 
-func (s *functionalSuite) completeUpdateMessages(tv *testvars.TestVars, updRequestMsg *protocolpb.Message, updateID string) []*protocolpb.Message {
+func (s *FunctionalSuite) completeUpdateMessages(tv *testvars.TestVars, updRequestMsg *protocolpb.Message, updateID string) []*protocolpb.Message {
 	s.T().Helper()
 	updRequest := unmarshalAny[*updatepb.Request](s, updRequestMsg.GetBody())
 
@@ -131,12 +131,12 @@ func (s *functionalSuite) completeUpdateMessages(tv *testvars.TestVars, updReque
 	}
 }
 
-func (s *functionalSuite) acceptCompleteUpdateMessages(tv *testvars.TestVars, updRequestMsg *protocolpb.Message, updateID string) []*protocolpb.Message {
+func (s *FunctionalSuite) acceptCompleteUpdateMessages(tv *testvars.TestVars, updRequestMsg *protocolpb.Message, updateID string) []*protocolpb.Message {
 	s.T().Helper()
 	return append(s.acceptUpdateMessages(tv, updRequestMsg, updateID), s.completeUpdateMessages(tv, updRequestMsg, updateID)...)
 }
 
-func (s *functionalSuite) rejectUpdateMessages(tv *testvars.TestVars, updRequestMsg *protocolpb.Message, updateID string) []*protocolpb.Message {
+func (s *FunctionalSuite) rejectUpdateMessages(tv *testvars.TestVars, updRequestMsg *protocolpb.Message, updateID string) []*protocolpb.Message {
 	s.T().Helper()
 	updRequest := unmarshalAny[*updatepb.Request](s, updRequestMsg.GetBody())
 
@@ -158,7 +158,7 @@ func (s *functionalSuite) rejectUpdateMessages(tv *testvars.TestVars, updRequest
 	}
 }
 
-func (s *functionalSuite) sendUpdateNoError(tv *testvars.TestVars, updateID string) *workflowservice.UpdateWorkflowExecutionResponse {
+func (s *FunctionalSuite) sendUpdateNoError(tv *testvars.TestVars, updateID string) *workflowservice.UpdateWorkflowExecutionResponse {
 	s.T().Helper()
 	resp, err := s.sendUpdate(tv, updateID)
 	// It is important to do assert here to fail fast without trying to process update in wtHandler.
@@ -166,7 +166,7 @@ func (s *functionalSuite) sendUpdateNoError(tv *testvars.TestVars, updateID stri
 	return resp
 }
 
-func (s *functionalSuite) sendUpdate(tv *testvars.TestVars, updateID string) (*workflowservice.UpdateWorkflowExecutionResponse, error) {
+func (s *FunctionalSuite) sendUpdate(tv *testvars.TestVars, updateID string) (*workflowservice.UpdateWorkflowExecutionResponse, error) {
 	s.T().Helper()
 	return s.engine.UpdateWorkflowExecution(NewContext(), &workflowservice.UpdateWorkflowExecutionRequest{
 		Namespace:         s.namespace,
@@ -181,7 +181,7 @@ func (s *functionalSuite) sendUpdate(tv *testvars.TestVars, updateID string) (*w
 	})
 }
 
-func (s *functionalSuite) pollUpdate(tv *testvars.TestVars, updateID string, waitPolicy *updatepb.WaitPolicy) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
+func (s *FunctionalSuite) pollUpdate(tv *testvars.TestVars, updateID string, waitPolicy *updatepb.WaitPolicy) (*workflowservice.PollWorkflowExecutionUpdateResponse, error) {
 	s.T().Helper()
 	return s.engine.PollWorkflowExecutionUpdate(NewContext(), &workflowservice.PollWorkflowExecutionUpdateRequest{
 		Namespace: s.namespace,
@@ -193,7 +193,7 @@ func (s *functionalSuite) pollUpdate(tv *testvars.TestVars, updateID string, wai
 	})
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_AcceptComplete() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_AcceptComplete() {
 	testCases := []struct {
 		Name     string
 		UseRunID bool
@@ -341,7 +341,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_AcceptCo
 	}
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_AcceptComplete() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_AcceptComplete() {
 	testCases := []struct {
 		Name     string
 		UseRunID bool
@@ -491,7 +491,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_AcceptComplet
 	}
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_AcceptComplete() {
+func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_AcceptComplete() {
 
 	testCases := []struct {
 		Name     string
@@ -617,7 +617,7 @@ func (s *functionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Ac
 	}
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_AcceptComplete() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_AcceptComplete() {
 
 	testCases := []struct {
 		Name     string
@@ -764,7 +764,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NormalScheduledWorkflowTask_AcceptC
 	}
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowTask_Rejected() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowTask_Rejected() {
 
 	tv := testvars.New(s.T().Name())
 
@@ -874,7 +874,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewSpeculativeFromStartedWorkflowTa
   8 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewNormalFromStartedWorkflowTask_Rejected() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalFromStartedWorkflowTask_Rejected() {
 
 	tv := testvars.New(s.T().Name())
 
@@ -997,7 +997,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewNormalFromStartedWorkflowTask_Re
  12 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
+func (s *FunctionalSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 	testCases := []struct {
 		Name                     string
 		RespondWorkflowTaskError string
@@ -1344,7 +1344,7 @@ func (s *functionalSuite) TestUpdateWorkflow_ValidateWorkerMessages() {
 	}
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_AcceptComplete() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_AcceptComplete() {
 	testCases := []struct {
 		Name     string
 		UseRunID bool
@@ -1483,7 +1483,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_Ac
 	}
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_AcceptComplete_StickyWorkerUnavailable() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_AcceptComplete_StickyWorkerUnavailable() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -1611,7 +1611,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewStickySpeculativeWorkflowTask_Ac
  13 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Reject() {
+func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Reject() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -1709,7 +1709,7 @@ func (s *functionalSuite) TestUpdateWorkflow_FirstNormalScheduledWorkflowTask_Re
   8 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -1818,7 +1818,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewSpeculativeWorkflowTask_Reject()
   8 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -1940,7 +1940,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewNormalWorkflowTask_Reject() {
  12 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1stComplete() {
+func (s *FunctionalSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1stComplete() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -2112,7 +2112,7 @@ func (s *functionalSuite) TestUpdateWorkflow_1stAccept_2ndAccept_2ndComplete_1st
  21 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() {
+func (s *FunctionalSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -2264,7 +2264,7 @@ func (s *functionalSuite) TestUpdateWorkflow_1stAccept_2ndReject_1stComplete() {
  16 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
+func (s *FunctionalSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -2440,7 +2440,7 @@ func (s *functionalSuite) TestUpdateWorkflow_FailSpeculativeWorkflowTask() {
  11 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowTaskToNormal_BecauseOfBufferedSignal() {
+func (s *FunctionalSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowTaskToNormal_BecauseOfBufferedSignal() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -2557,7 +2557,7 @@ func (s *functionalSuite) TestUpdateWorkflow_ConvertStartedSpeculativeWorkflowTa
  12 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflowTaskToNormal_BecauseOfSignal() {
+func (s *FunctionalSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflowTaskToNormal_BecauseOfSignal() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -2677,7 +2677,7 @@ func (s *functionalSuite) TestUpdateWorkflow_ConvertScheduledSpeculativeWorkflow
  12 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWorkflowTask() {
+func (s *FunctionalSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWorkflowTask() {
 	tv := testvars.New(s.T().Name())
 
 	request := &workflowservice.StartWorkflowExecutionRequest{
@@ -2817,7 +2817,7 @@ func (s *functionalSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWorkf
  13 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWorkflowTask() {
+func (s *FunctionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWorkflowTask() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -2932,7 +2932,7 @@ func (s *functionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWo
  13 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWorkflowTask_NormalTaskQueue() {
+func (s *FunctionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWorkflowTask_NormalTaskQueue() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -3058,7 +3058,7 @@ func (s *functionalSuite) TestUpdateWorkflow_ScheduleToStartTimeoutSpeculativeWo
  13 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_TerminateWorkflow() {
+func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_TerminateWorkflow() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -3176,7 +3176,7 @@ func (s *functionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Term
 	s.EqualValues(7, msResp.GetDatabaseMutableState().GetExecutionInfo().GetCompletionEventBatchId(), "completion_event_batch_id should point to WTFailed event")
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_TerminateWorkflow() {
+func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_TerminateWorkflow() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -3276,7 +3276,7 @@ func (s *functionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Te
 	s.EqualValues(5, msResp.GetDatabaseMutableState().GetExecutionInfo().GetCompletionEventBatchId(), "completion_event_batch_id should point to WFTerminated event")
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate() {
+func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate() {
 	testCases := []struct {
 		Name         string
 		UpdateErrMsg string
@@ -3400,7 +3400,7 @@ func (s *functionalSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate() 
 	}
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat() {
+func (s *FunctionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -3528,7 +3528,7 @@ func (s *functionalSuite) TestUpdateWorkflow_SpeculativeWorkflowTask_Heartbeat()
  14 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTaskLost_BecauseOfShardMove() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTaskLost_BecauseOfShardMove() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -3656,7 +3656,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewScheduledSpeculativeWorkflowTask
   9 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskLost_BecauseOfShardMove() {
+func (s *FunctionalSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskLost_BecauseOfShardMove() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -3794,7 +3794,7 @@ func (s *functionalSuite) TestUpdateWorkflow_NewStartedSpeculativeWorkflowTaskLo
   9 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_BecauseOfShardMove() {
+func (s *FunctionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_BecauseOfShardMove() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -3913,7 +3913,7 @@ func (s *functionalSuite) TestUpdateWorkflow_FirstNormalWorkflowTaskUpdateLost_B
   8 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_DeduplicateID() {
+func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_DeduplicateID() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -4036,7 +4036,7 @@ func (s *functionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_De
  13 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_DeduplicateID() {
+func (s *FunctionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_DeduplicateID() {
 	tv := testvars.New(s.T().Name())
 
 	tv = s.startWorkflow(tv)
@@ -4159,7 +4159,7 @@ func (s *functionalSuite) TestUpdateWorkflow_StartedSpeculativeWorkflowTask_Dedu
  13 WorkflowExecutionCompleted`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_DeduplicateID() {
+func (s *FunctionalSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_DeduplicateID() {
 	testCases := []struct {
 		Name       string
 		CloseShard bool
@@ -4313,7 +4313,7 @@ func (s *functionalSuite) TestUpdateWorkflow_CompletedSpeculativeWorkflowTask_De
 	}
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_CloseShard_DifferentStartedId_Rejected() {
+func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_CloseShard_DifferentStartedId_Rejected() {
 	/*
 		Test scenario:
 		An update created a speculative WT and WT is dispatched to the worker (started).
@@ -4489,7 +4489,7 @@ func (s *functionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_CloseS
 	`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_CloseShard_SameStartedId_SameUpdateId_Accepted() {
+func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_CloseShard_SameStartedId_SameUpdateId_Accepted() {
 	/*
 		Test scenario:
 		An update created a speculative WT and WT is dispatched to the worker (started).
@@ -4665,7 +4665,7 @@ func (s *functionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_CloseS
 	`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_ClearMutableState_Accepted() {
+func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_ClearMutableState_Accepted() {
 	/*
 		Test scenario:
 		An update created a speculative WT and WT is dispatched to the worker (started).
@@ -4883,7 +4883,7 @@ func (s *functionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_ClearM
 	`, events)
 }
 
-func (s *functionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_SameStartedId_DifferentUpdateId_Rejected() {
+func (s *FunctionalSuite) TestUpdateWorkflow_StaleSpeculativeWorkflowTask_SameStartedId_DifferentUpdateId_Rejected() {
 	/*
 		Test scenario:
 		An update created a speculative WT and WT is dispatched to the worker (started).

--- a/tests/user_timers_test.go
+++ b/tests/user_timers_test.go
@@ -45,7 +45,7 @@ import (
 	"go.temporal.io/server/common/timer"
 )
 
-func (s *functionalSuite) TestUserTimers_Sequential() {
+func (s *FunctionalSuite) TestUserTimers_Sequential() {
 	id := "functional-user-timers-sequential-test"
 	wt := "functional-user-timers-sequential-test-type"
 	tl := "functional-user-timers-sequential-test-taskqueue"
@@ -118,7 +118,7 @@ func (s *functionalSuite) TestUserTimers_Sequential() {
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestUserTimers_CapDuration() {
+func (s *FunctionalSuite) TestUserTimers_CapDuration() {
 	id := "functional-user-timers-cap-duration-test"
 	wt := "functional-user-timers-cap-duration-test-type"
 	tl := "functional-user-timers-cap-duration-test-taskqueue"

--- a/tests/versioning_test.go
+++ b/tests/versioning_test.go
@@ -59,7 +59,7 @@ import (
 	"go.temporal.io/server/common/tqname"
 )
 
-type versioningIntegSuite struct {
+type VersioningIntegSuite struct {
 	// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 	// not merely log an error
 	*require.Assertions
@@ -74,7 +74,7 @@ const (
 	numPollers = 4
 )
 
-func (s *versioningIntegSuite) SetupSuite() {
+func (s *VersioningIntegSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]any{
 		dynamicconfig.FrontendEnableWorkerVersioningDataAPIs:     true,
 		dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs: true,
@@ -95,11 +95,11 @@ func (s *versioningIntegSuite) SetupSuite() {
 	s.setupSuite("testdata/cluster.yaml")
 }
 
-func (s *versioningIntegSuite) TearDownSuite() {
+func (s *VersioningIntegSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *versioningIntegSuite) SetupTest() {
+func (s *VersioningIntegSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 
@@ -113,16 +113,16 @@ func (s *versioningIntegSuite) SetupTest() {
 	s.sdkClient = sdkClient
 }
 
-func (s *versioningIntegSuite) TearDownTest() {
+func (s *VersioningIntegSuite) TearDownTest() {
 	s.sdkClient.Close()
 }
 
 func TestVersioningFunctionalSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(versioningIntegSuite))
+	suite.Run(t, new(VersioningIntegSuite))
 }
 
-func (s *versioningIntegSuite) TestBasicVersionUpdate() {
+func (s *VersioningIntegSuite) TestBasicVersionUpdate() {
 	ctx := NewContext()
 	tq := "functional-versioning-basic"
 
@@ -138,7 +138,7 @@ func (s *versioningIntegSuite) TestBasicVersionUpdate() {
 	s.Equal(foo, getCurrentDefault(res2))
 }
 
-func (s *versioningIntegSuite) TestSeriesOfUpdates() {
+func (s *VersioningIntegSuite) TestSeriesOfUpdates() {
 	ctx := NewContext()
 	tq := "functional-versioning-series"
 
@@ -158,7 +158,7 @@ func (s *versioningIntegSuite) TestSeriesOfUpdates() {
 	s.Equal(s.prefixed("foo-2"), res.GetMajorVersionSets()[2].GetBuildIds()[0])
 }
 
-func (s *versioningIntegSuite) TestLinkToNonexistentCompatibleVersionReturnsNotFound() {
+func (s *VersioningIntegSuite) TestLinkToNonexistentCompatibleVersionReturnsNotFound() {
 	ctx := NewContext()
 	tq := "functional-versioning-compat-not-found"
 
@@ -177,7 +177,7 @@ func (s *versioningIntegSuite) TestLinkToNonexistentCompatibleVersionReturnsNotF
 	s.IsType(&serviceerror.NotFound{}, err)
 }
 
-func (s *versioningIntegSuite) TestVersioningStatePersistsAcrossUnload() {
+func (s *VersioningIntegSuite) TestVersioningStatePersistsAcrossUnload() {
 	ctx := NewContext()
 	tq := "functional-versioning-persists"
 
@@ -195,7 +195,7 @@ func (s *versioningIntegSuite) TestVersioningStatePersistsAcrossUnload() {
 	s.Equal(s.prefixed("foo"), getCurrentDefault(res))
 }
 
-func (s *versioningIntegSuite) TestVersioningChangesPropagate() {
+func (s *VersioningIntegSuite) TestVersioningChangesPropagate() {
 	ctx := NewContext()
 	tq := "functional-versioning-propagate"
 
@@ -212,7 +212,7 @@ func (s *versioningIntegSuite) TestVersioningChangesPropagate() {
 	}
 }
 
-func (s *versioningIntegSuite) TestMaxTaskQueuesPerBuildIdEnforced() {
+func (s *VersioningIntegSuite) TestMaxTaskQueuesPerBuildIdEnforced() {
 	ctx := NewContext()
 	buildId := fmt.Sprintf("b-%s", s.T().Name())
 	// Map a 3 task queues to this build id and verify success
@@ -242,7 +242,7 @@ func (s *versioningIntegSuite) TestMaxTaskQueuesPerBuildIdEnforced() {
 	s.Equal("Exceeded max task queues allowed to be mapped to a single build id: 3", failedPreconditionError.Message)
 }
 
-func (s *versioningIntegSuite) testWithMatchingBehavior(subtest func()) {
+func (s *VersioningIntegSuite) testWithMatchingBehavior(subtest func()) {
 	dc := s.testCluster.host.dcClient
 	for _, forceForward := range []bool{false, true} {
 		for _, forceAsync := range []bool{false, true} {
@@ -279,11 +279,11 @@ func (s *versioningIntegSuite) testWithMatchingBehavior(subtest func()) {
 	}
 }
 
-func (s *versioningIntegSuite) TestDispatchNewWorkflow() {
+func (s *VersioningIntegSuite) TestDispatchNewWorkflow() {
 	s.testWithMatchingBehavior(s.dispatchNewWorkflow)
 }
 
-func (s *versioningIntegSuite) dispatchNewWorkflow() {
+func (s *VersioningIntegSuite) dispatchNewWorkflow() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 
@@ -313,11 +313,11 @@ func (s *versioningIntegSuite) dispatchNewWorkflow() {
 	s.Equal("done!", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchNotUsingVersioning() {
+func (s *VersioningIntegSuite) TestDispatchNotUsingVersioning() {
 	s.testWithMatchingBehavior(s.dispatchNotUsingVersioning)
 }
 
-func (s *versioningIntegSuite) dispatchNotUsingVersioning() {
+func (s *VersioningIntegSuite) dispatchNotUsingVersioning() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 
@@ -358,11 +358,11 @@ func (s *versioningIntegSuite) dispatchNotUsingVersioning() {
 	s.Equal("done with versioning!", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchNewWorkflowStartWorkerFirst() {
+func (s *VersioningIntegSuite) TestDispatchNewWorkflowStartWorkerFirst() {
 	s.testWithMatchingBehavior(s.dispatchNewWorkflowStartWorkerFirst)
 }
 
-func (s *versioningIntegSuite) dispatchNewWorkflowStartWorkerFirst() {
+func (s *VersioningIntegSuite) dispatchNewWorkflowStartWorkerFirst() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 
@@ -396,7 +396,7 @@ func (s *versioningIntegSuite) dispatchNewWorkflowStartWorkerFirst() {
 	s.Equal("done!", out)
 }
 
-func (s *versioningIntegSuite) TestDisableUserData_DefaultTasksBecomeUnversioned() {
+func (s *VersioningIntegSuite) TestDisableUserData_DefaultTasksBecomeUnversioned() {
 	// force one partition so that we can unload the task queue
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -471,11 +471,11 @@ func (s *versioningIntegSuite) TestDisableUserData_DefaultTasksBecomeUnversioned
 	s.Equal("done!", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchUnversionedRemainsUnversioned() {
+func (s *VersioningIntegSuite) TestDispatchUnversionedRemainsUnversioned() {
 	s.testWithMatchingBehavior(s.dispatchUnversionedRemainsUnversioned)
 }
 
-func (s *versioningIntegSuite) dispatchUnversionedRemainsUnversioned() {
+func (s *VersioningIntegSuite) dispatchUnversionedRemainsUnversioned() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 
@@ -512,15 +512,15 @@ func (s *versioningIntegSuite) dispatchUnversionedRemainsUnversioned() {
 	s.Equal("done!", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchUpgradeStopOld() {
+func (s *VersioningIntegSuite) TestDispatchUpgradeStopOld() {
 	s.testWithMatchingBehavior(func() { s.dispatchUpgrade(true) })
 }
 
-func (s *versioningIntegSuite) TestDispatchUpgradeWait() {
+func (s *VersioningIntegSuite) TestDispatchUpgradeWait() {
 	s.testWithMatchingBehavior(func() { s.dispatchUpgrade(false) })
 }
 
-func (s *versioningIntegSuite) dispatchUpgrade(stopOld bool) {
+func (s *VersioningIntegSuite) dispatchUpgrade(stopOld bool) {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 	v11 := s.prefixed("v11")
@@ -602,19 +602,19 @@ const (
 	timeoutActivity
 )
 
-func (s *versioningIntegSuite) TestDispatchActivity() {
+func (s *VersioningIntegSuite) TestDispatchActivity() {
 	s.testWithMatchingBehavior(func() { s.dispatchActivity(dontFailActivity) })
 }
 
-func (s *versioningIntegSuite) TestDispatchActivityFail() {
+func (s *VersioningIntegSuite) TestDispatchActivityFail() {
 	s.testWithMatchingBehavior(func() { s.dispatchActivity(failActivity) })
 }
 
-func (s *versioningIntegSuite) TestDispatchActivityTimeout() {
+func (s *VersioningIntegSuite) TestDispatchActivityTimeout() {
 	s.testWithMatchingBehavior(func() { s.dispatchActivity(timeoutActivity) })
 }
 
-func (s *versioningIntegSuite) dispatchActivity(failMode activityFailMode) {
+func (s *VersioningIntegSuite) dispatchActivity(failMode activityFailMode) {
 	// This also implicitly tests that a workflow stays on a compatible version set if a new
 	// incompatible set is registered, because wf2 just panics. It further tests that
 	// stickiness on v1 is not broken by registering v2, because the channel send will panic on
@@ -722,11 +722,11 @@ func (s *versioningIntegSuite) dispatchActivity(failMode activityFailMode) {
 	s.Equal("v1v2", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchActivityCompatible() {
+func (s *VersioningIntegSuite) TestDispatchActivityCompatible() {
 	s.testWithMatchingBehavior(s.dispatchActivityCompatible)
 }
 
-func (s *versioningIntegSuite) dispatchActivityCompatible() {
+func (s *VersioningIntegSuite) dispatchActivityCompatible() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 	v11 := s.prefixed("v11")
@@ -796,7 +796,7 @@ func (s *versioningIntegSuite) dispatchActivityCompatible() {
 	s.Equal("v1.1", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchActivityEager() {
+func (s *VersioningIntegSuite) TestDispatchActivityEager() {
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.EnableActivityEagerExecution, true)
 
@@ -869,7 +869,7 @@ func (s *versioningIntegSuite) TestDispatchActivityEager() {
 	s.Require().Equal("compatible", completionResponse.ActivityTasks[0].ActivityId)
 }
 
-func (s *versioningIntegSuite) TestDispatchActivityCrossTQFails() {
+func (s *VersioningIntegSuite) TestDispatchActivityCrossTQFails() {
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
@@ -924,11 +924,11 @@ func (s *versioningIntegSuite) TestDispatchActivityCrossTQFails() {
 	s.Error(run.Get(ctx, &out))
 }
 
-func (s *versioningIntegSuite) TestDispatchChildWorkflow() {
+func (s *VersioningIntegSuite) TestDispatchChildWorkflow() {
 	s.testWithMatchingBehavior(s.dispatchChildWorkflow)
 }
 
-func (s *versioningIntegSuite) dispatchChildWorkflow() {
+func (s *VersioningIntegSuite) dispatchChildWorkflow() {
 	// This also implicitly tests that a workflow stays on a compatible version set if a new
 	// incompatible set is registered, because wf2 just panics. It further tests that
 	// stickiness on v1 is not broken by registering v2, because the channel send will panic on
@@ -1004,11 +1004,11 @@ func (s *versioningIntegSuite) dispatchChildWorkflow() {
 	s.Equal("v1v2", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchChildWorkflowUpgrade() {
+func (s *VersioningIntegSuite) TestDispatchChildWorkflowUpgrade() {
 	s.testWithMatchingBehavior(s.dispatchChildWorkflowUpgrade)
 }
 
-func (s *versioningIntegSuite) dispatchChildWorkflowUpgrade() {
+func (s *VersioningIntegSuite) dispatchChildWorkflowUpgrade() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 	v11 := s.prefixed("v11")
@@ -1074,7 +1074,7 @@ func (s *versioningIntegSuite) dispatchChildWorkflowUpgrade() {
 	s.Equal("v1.1", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchChildWorkflowCrossTQFails() {
+func (s *VersioningIntegSuite) TestDispatchChildWorkflowCrossTQFails() {
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueWritePartitions, 1)
@@ -1128,11 +1128,11 @@ func (s *versioningIntegSuite) TestDispatchChildWorkflowCrossTQFails() {
 	s.Error(run.Get(ctx, &out))
 }
 
-func (s *versioningIntegSuite) TestDispatchQuery() {
+func (s *VersioningIntegSuite) TestDispatchQuery() {
 	s.testWithMatchingBehavior(s.dispatchQuery)
 }
 
-func (s *versioningIntegSuite) dispatchQuery() {
+func (s *VersioningIntegSuite) dispatchQuery() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 	v11 := s.prefixed("v11")
@@ -1245,11 +1245,11 @@ func (s *versioningIntegSuite) dispatchQuery() {
 	s.Equal("v2", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchContinueAsNew() {
+func (s *VersioningIntegSuite) TestDispatchContinueAsNew() {
 	s.testWithMatchingBehavior(s.dispatchContinueAsNew)
 }
 
-func (s *versioningIntegSuite) dispatchContinueAsNew() {
+func (s *VersioningIntegSuite) dispatchContinueAsNew() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 	v11 := s.prefixed("v11")
@@ -1359,11 +1359,11 @@ func (s *versioningIntegSuite) dispatchContinueAsNew() {
 	s.Equal("done!", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchRetry() {
+func (s *VersioningIntegSuite) TestDispatchRetry() {
 	s.testWithMatchingBehavior(s.dispatchRetry)
 }
 
-func (s *versioningIntegSuite) dispatchRetry() {
+func (s *VersioningIntegSuite) dispatchRetry() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 	v11 := s.prefixed("v11")
@@ -1473,11 +1473,11 @@ func (s *versioningIntegSuite) dispatchRetry() {
 	s.Equal("done!", out)
 }
 
-func (s *versioningIntegSuite) TestDispatchCron() {
+func (s *VersioningIntegSuite) TestDispatchCron() {
 	s.testWithMatchingBehavior(s.dispatchCron)
 }
 
-func (s *versioningIntegSuite) dispatchCron() {
+func (s *VersioningIntegSuite) dispatchCron() {
 	tq := s.randomizeStr(s.T().Name())
 	v1 := s.prefixed("v1")
 	v11 := s.prefixed("v11")
@@ -1557,7 +1557,7 @@ func (s *versioningIntegSuite) dispatchCron() {
 	s.GreaterOrEqual(runs2.Load(), int32(3))
 }
 
-func (s *versioningIntegSuite) TestDisableUserData() {
+func (s *VersioningIntegSuite) TestDisableUserData() {
 	tq := s.T().Name()
 	v1 := s.prefixed("v1")
 	v2 := s.prefixed("v2")
@@ -1595,7 +1595,7 @@ func (s *versioningIntegSuite) TestDisableUserData() {
 	s.Require().ErrorAs(err, &failedPreconditionError)
 }
 
-func (s *versioningIntegSuite) TestDisableUserData_UnversionedWorkflowRuns() {
+func (s *VersioningIntegSuite) TestDisableUserData_UnversionedWorkflowRuns() {
 	tq := s.T().Name()
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -1621,7 +1621,7 @@ func (s *versioningIntegSuite) TestDisableUserData_UnversionedWorkflowRuns() {
 	s.Equal("ok", out)
 }
 
-func (s *versioningIntegSuite) TestDisableUserData_WorkflowGetsStuck() {
+func (s *VersioningIntegSuite) TestDisableUserData_WorkflowGetsStuck() {
 	// force one partition so that we can unload the task queue
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -1677,7 +1677,7 @@ func (s *versioningIntegSuite) TestDisableUserData_WorkflowGetsStuck() {
 	s.Require().Equal(int32(1), runs.Load())
 }
 
-func (s *versioningIntegSuite) TestDisableUserData_QueryFails() {
+func (s *VersioningIntegSuite) TestDisableUserData_QueryFails() {
 	// force one partition so that we can unload the task queue
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -1726,7 +1726,7 @@ func (s *versioningIntegSuite) TestDisableUserData_QueryFails() {
 	s.Equal(int32(0), runs.Load())
 }
 
-func (s *versioningIntegSuite) TestDisableUserData_DLQ() {
+func (s *VersioningIntegSuite) TestDisableUserData_DLQ() {
 	// force one partition so we can unload easily
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -1790,7 +1790,7 @@ func (s *versioningIntegSuite) TestDisableUserData_DLQ() {
 	s.Equal("done!", out)
 }
 
-func (s *versioningIntegSuite) TestDisableUserData_DLQ_WithUnload() {
+func (s *VersioningIntegSuite) TestDisableUserData_DLQ_WithUnload() {
 	// force one partition so we can unload easily
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -1872,7 +1872,7 @@ func (s *versioningIntegSuite) TestDisableUserData_DLQ_WithUnload() {
 	s.Equal("done!", out)
 }
 
-func (s *versioningIntegSuite) TestDescribeTaskQueue() {
+func (s *VersioningIntegSuite) TestDescribeTaskQueue() {
 	// force one partition since DescribeTaskQueue only goes to the root
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 1)
@@ -1940,7 +1940,7 @@ func (s *versioningIntegSuite) TestDescribeTaskQueue() {
 	}, 3*time.Second, 50*time.Millisecond)
 }
 
-func (s *versioningIntegSuite) TestDescribeWorkflowExecution() {
+func (s *VersioningIntegSuite) TestDescribeWorkflowExecution() {
 	dc := s.testCluster.host.dcClient
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueReadPartitions, 4)
 	dc.OverrideValue(s.T(), dynamicconfig.MatchingNumTaskqueueWritePartitions, 4)
@@ -2022,12 +2022,12 @@ func (s *versioningIntegSuite) TestDescribeWorkflowExecution() {
 }
 
 // Add a per test prefix to avoid hitting the namespace limit of mapped task queue per build id
-func (s *versioningIntegSuite) prefixed(buildId string) string {
+func (s *VersioningIntegSuite) prefixed(buildId string) string {
 	return fmt.Sprintf("t%x:%s", 0xffff&farm.Hash32([]byte(s.T().Name())), buildId)
 }
 
 // addNewDefaultBuildId updates build id info on a task queue with a new build id in a new default set.
-func (s *versioningIntegSuite) addNewDefaultBuildId(ctx context.Context, tq, newBuildId string) {
+func (s *VersioningIntegSuite) addNewDefaultBuildId(ctx context.Context, tq, newBuildId string) {
 	res, err := s.engine.UpdateWorkerBuildIdCompatibility(ctx, &workflowservice.UpdateWorkerBuildIdCompatibilityRequest{
 		Namespace: s.namespace,
 		TaskQueue: tq,
@@ -2040,7 +2040,7 @@ func (s *versioningIntegSuite) addNewDefaultBuildId(ctx context.Context, tq, new
 }
 
 // addCompatibleBuildId updates build id info on a task queue with a new compatible build id.
-func (s *versioningIntegSuite) addCompatibleBuildId(ctx context.Context, tq, newBuildId, existing string, makeSetDefault bool) {
+func (s *VersioningIntegSuite) addCompatibleBuildId(ctx context.Context, tq, newBuildId, existing string, makeSetDefault bool) {
 	res, err := s.engine.UpdateWorkerBuildIdCompatibility(ctx, &workflowservice.UpdateWorkerBuildIdCompatibilityRequest{
 		Namespace: s.namespace,
 		TaskQueue: tq,
@@ -2057,7 +2057,7 @@ func (s *versioningIntegSuite) addCompatibleBuildId(ctx context.Context, tq, new
 }
 
 // waitForPropagation waits for all partitions of tq to mention newBuildId in their versioning data (in any position).
-func (s *versioningIntegSuite) waitForPropagation(ctx context.Context, tq, newBuildId string) {
+func (s *VersioningIntegSuite) waitForPropagation(ctx context.Context, tq, newBuildId string) {
 	v, ok := s.testCluster.host.dcClient.getRawValue(dynamicconfig.MatchingNumTaskqueueReadPartitions)
 	s.True(ok, "versioning tests require setting explicit number of partitions")
 	partCount, ok := v.(int)
@@ -2096,7 +2096,7 @@ func (s *versioningIntegSuite) waitForPropagation(ctx context.Context, tq, newBu
 	}, 10*time.Second, 100*time.Millisecond)
 }
 
-func (s *versioningIntegSuite) waitForChan(ctx context.Context, ch chan struct{}) {
+func (s *VersioningIntegSuite) waitForChan(ctx context.Context, ch chan struct{}) {
 	s.T().Helper()
 	select {
 	case <-ch:
@@ -2105,7 +2105,7 @@ func (s *versioningIntegSuite) waitForChan(ctx context.Context, ch chan struct{}
 	}
 }
 
-func (s *versioningIntegSuite) unloadTaskQueue(ctx context.Context, tq string) {
+func (s *VersioningIntegSuite) unloadTaskQueue(ctx context.Context, tq string) {
 	_, err := s.testCluster.GetMatchingClient().ForceUnloadTaskQueue(ctx, &matchingservice.ForceUnloadTaskQueueRequest{
 		NamespaceId:   s.getNamespaceID(s.namespace),
 		TaskQueue:     tq,
@@ -2114,7 +2114,7 @@ func (s *versioningIntegSuite) unloadTaskQueue(ctx context.Context, tq string) {
 	s.Require().NoError(err)
 }
 
-func (s *versioningIntegSuite) getStickyQueueName(ctx context.Context, id string) string {
+func (s *VersioningIntegSuite) getStickyQueueName(ctx context.Context, id string) string {
 	ms, err := s.adminClient.DescribeMutableState(ctx, &adminservice.DescribeMutableStateRequest{
 		Namespace: s.namespace,
 		Execution: &commonpb.WorkflowExecution{WorkflowId: id},

--- a/tests/workflow_buffered_events_test.go
+++ b/tests/workflow_buffered_events_test.go
@@ -44,7 +44,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestRateLimitBufferedEvents() {
+func (s *FunctionalSuite) TestRateLimitBufferedEvents() {
 	id := "functional-rate-limit-buffered-events-test"
 	wt := "functional-rate-limit-buffered-events-test-type"
 	tl := "functional-rate-limit-buffered-events-test-taskqueue"
@@ -142,7 +142,7 @@ func (s *functionalSuite) TestRateLimitBufferedEvents() {
 	s.Equal(101, signalCount) // check that all 101 signals are received.
 }
 
-func (s *functionalSuite) TestBufferedEvents() {
+func (s *FunctionalSuite) TestBufferedEvents() {
 	id := "functional-buffered-events-test"
 	wt := "functional-buffered-events-test-type"
 	tl := "functional-buffered-events-test-taskqueue"
@@ -259,7 +259,7 @@ func (s *functionalSuite) TestBufferedEvents() {
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestBufferedEventsOutOfOrder() {
+func (s *FunctionalSuite) TestBufferedEventsOutOfOrder() {
 	id := "functional-buffered-events-out-of-order-test"
 	wt := "functional-buffered-events-out-of-order-test-type"
 	tl := "functional-buffered-events-out-of-order-test-taskqueue"

--- a/tests/workflow_delete_execution_test.go
+++ b/tests/workflow_delete_execution_test.go
@@ -40,7 +40,7 @@ import (
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
-func (s *functionalSuite) Test_DeleteWorkflowExecution_Competed() {
+func (s *FunctionalSuite) Test_DeleteWorkflowExecution_Competed() {
 	id := "functional-delete-workflow-completed-test"
 	wt := "functional-delete-workflow-completed-test-type"
 	tl := "functional-delete-workflow-completed-test-taskqueue"
@@ -176,7 +176,7 @@ func (s *functionalSuite) Test_DeleteWorkflowExecution_Competed() {
 	}
 }
 
-func (s *functionalSuite) Test_DeleteWorkflowExecution_Running() {
+func (s *FunctionalSuite) Test_DeleteWorkflowExecution_Running() {
 	id := "functional-delete-workflow-running-test"
 	wt := "functional-delete-workflow-running-test-type"
 	tl := "functional-delete-workflow-running-test-taskqueue"
@@ -288,7 +288,7 @@ func (s *functionalSuite) Test_DeleteWorkflowExecution_Running() {
 	}
 }
 
-func (s *functionalSuite) Test_DeleteWorkflowExecution_RunningWithTerminate() {
+func (s *FunctionalSuite) Test_DeleteWorkflowExecution_RunningWithTerminate() {
 	id := "functional-delete-workflow-running-with-terminate-test"
 	wt := "functional-delete-workflow-running-with-terminate-test-type"
 	tl := "functional-delete-workflow-running-with-terminate-test-taskqueue"

--- a/tests/workflow_failures_test.go
+++ b/tests/workflow_failures_test.go
@@ -48,7 +48,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestWorkflowTimeout() {
+func (s *FunctionalSuite) TestWorkflowTimeout() {
 	startTime := time.Now().UTC()
 
 	id := "functional-workflow-timeout"
@@ -129,7 +129,7 @@ ListClosedLoop:
 	s.Equal(1, closedCount)
 }
 
-func (s *functionalSuite) TestWorkflowTaskFailed() {
+func (s *FunctionalSuite) TestWorkflowTaskFailed() {
 	id := "functional-workflowtask-failed-test"
 	wt := "functional-workflowtask-failed-test-type"
 	tl := "functional-workflowtask-failed-test-taskqueue"
@@ -326,7 +326,7 @@ func (s *functionalSuite) TestWorkflowTaskFailed() {
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED, workflowCompletedEvent.GetEventType())
 }
 
-func (s *functionalSuite) TestRespondWorkflowTaskCompleted_ReturnsErrorIfInvalidArgument() {
+func (s *FunctionalSuite) TestRespondWorkflowTaskCompleted_ReturnsErrorIfInvalidArgument() {
 	id := "functional-respond-workflow-task-completed-test"
 	wt := "functional-respond-workflow-task-completed-test-type"
 	tq := "functional-respond-workflow-task-completed-test-taskqueue"

--- a/tests/workflow_memo_test.go
+++ b/tests/workflow_memo_test.go
@@ -49,7 +49,7 @@ type RunIdGetter interface {
 }
 type startFunc func() (RunIdGetter, error)
 
-func (s *functionalSuite) TestStartWithMemo() {
+func (s *FunctionalSuite) TestStartWithMemo() {
 	id := "functional-start-with-memo-test"
 	wt := "functional-start-with-memo-test-type"
 	tl := "functional-start-with-memo-test-taskqueue"
@@ -80,7 +80,7 @@ func (s *functionalSuite) TestStartWithMemo() {
 	s.startWithMemoHelper(fn, id, &taskqueuepb.TaskQueue{Name: tl, Kind: enumspb.TASK_QUEUE_KIND_NORMAL}, memo)
 }
 
-func (s *functionalSuite) TestSignalWithStartWithMemo() {
+func (s *FunctionalSuite) TestSignalWithStartWithMemo() {
 	id := "functional-signal-with-start-with-memo-test"
 	wt := "functional-signal-with-start-with-memo-test-type"
 	tl := "functional-signal-with-start-with-memo-test-taskqueue"
@@ -116,7 +116,7 @@ func (s *functionalSuite) TestSignalWithStartWithMemo() {
 }
 
 // helper function for TestStartWithMemo and TestSignalWithStartWithMemo to reduce duplicate code
-func (s *functionalSuite) startWithMemoHelper(startFn startFunc, id string, taskQueue *taskqueuepb.TaskQueue, memo *commonpb.Memo) {
+func (s *FunctionalSuite) startWithMemoHelper(startFn startFunc, id string, taskQueue *taskqueuepb.TaskQueue, memo *commonpb.Memo) {
 	identity := "worker1"
 
 	we, err0 := startFn()

--- a/tests/workflow_task_test.go
+++ b/tests/workflow_task_test.go
@@ -41,7 +41,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
+func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
 	id := uuid.New()
 	wt := "functional-workflow-workflow-task-heartbeating-local-activities"
 	tl := id
@@ -143,7 +143,7 @@ func (s *functionalSuite) TestWorkflowTaskHeartbeatingWithEmptyResult() {
 	s.assertLastHistoryEvent(we, 47, enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED)
 }
 
-func (s *functionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult() {
+func (s *FunctionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult() {
 	id := uuid.New()
 	wt := "functional-workflow-workflow-task-heartbeating-local-activities"
 	tl := id
@@ -286,7 +286,7 @@ func (s *functionalSuite) TestWorkflowTaskHeartbeatingWithLocalActivitiesResult(
 	s.assertHistory(we, expectedHistory)
 }
 
-func (s *functionalSuite) TestWorkflowTerminationSignalBeforeRegularWorkflowTaskStarted() {
+func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeRegularWorkflowTaskStarted() {
 	id := uuid.New()
 	wt := "functional-workflow-transient-workflow-task-test-type"
 	tl := id
@@ -359,7 +359,7 @@ func (s *functionalSuite) TestWorkflowTerminationSignalBeforeRegularWorkflowTask
 	s.assertHistory(we, expectedHistory)
 }
 
-func (s *functionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskStarted() {
+func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskStarted() {
 	id := uuid.New()
 	wt := "functional-workflow-transient-workflow-task-test-type"
 	tl := id
@@ -432,7 +432,7 @@ func (s *functionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
 	s.assertHistory(we, expectedHistory)
 }
 
-func (s *functionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskStartedAndFailWorkflowTask() {
+func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskStartedAndFailWorkflowTask() {
 	id := uuid.New()
 	wt := "functional-workflow-transient-workflow-task-test-type"
 	tl := id
@@ -518,7 +518,7 @@ func (s *functionalSuite) TestWorkflowTerminationSignalAfterRegularWorkflowTaskS
 	s.assertHistory(we, expectedHistory)
 }
 
-func (s *functionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTaskStarted() {
+func (s *FunctionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTaskStarted() {
 	id := uuid.New()
 	wt := "functional-workflow-transient-workflow-task-test-type"
 	tl := id
@@ -622,7 +622,7 @@ func (s *functionalSuite) TestWorkflowTerminationSignalBeforeTransientWorkflowTa
 	s.assertHistory(we, expectedHistory)
 }
 
-func (s *functionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTaskStarted() {
+func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTaskStarted() {
 	id := uuid.New()
 	wt := "functional-workflow-transient-workflow-task-test-type"
 	tl := id
@@ -723,7 +723,7 @@ func (s *functionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
 	s.assertHistory(we, expectedHistory)
 }
 
-func (s *functionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTaskStartedAndFailWorkflowTask() {
+func (s *FunctionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTaskStartedAndFailWorkflowTask() {
 	id := uuid.New()
 	wt := "functional-workflow-transient-workflow-task-test-type"
 	tl := id
@@ -835,7 +835,7 @@ func (s *functionalSuite) TestWorkflowTerminationSignalAfterTransientWorkflowTas
 	s.assertHistory(we, expectedHistory)
 }
 
-func (s *functionalSuite) assertHistory(we *commonpb.WorkflowExecution, expectedHistory []enumspb.EventType) {
+func (s *FunctionalSuite) assertHistory(we *commonpb.WorkflowExecution, expectedHistory []enumspb.EventType) {
 	historyResponse, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace: s.namespace,
 		Execution: we,
@@ -851,7 +851,7 @@ func (s *functionalSuite) assertHistory(we *commonpb.WorkflowExecution, expected
 	}
 }
 
-func (s *functionalSuite) assertLastHistoryEvent(we *commonpb.WorkflowExecution, count int, eventType enumspb.EventType) {
+func (s *FunctionalSuite) assertLastHistoryEvent(we *commonpb.WorkflowExecution, count int, eventType enumspb.EventType) {
 	historyResponse, err := s.engine.GetWorkflowExecutionHistory(NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace: s.namespace,
 		Execution: we,

--- a/tests/workflow_test.go
+++ b/tests/workflow_test.go
@@ -51,7 +51,7 @@ import (
 	"go.temporal.io/server/common/primitives/timestamp"
 )
 
-func (s *functionalSuite) TestStartWorkflowExecution() {
+func (s *FunctionalSuite) TestStartWorkflowExecution() {
 	id := "functional-start-workflow-test"
 	wt := "functional-start-workflow-test-type"
 	tl := "functional-start-workflow-test-taskqueue"
@@ -105,7 +105,7 @@ func (s *functionalSuite) TestStartWorkflowExecution() {
 	s.Nil(we2)
 }
 
-func (s *functionalSuite) TestStartWorkflowExecution_TerminateIfRunning() {
+func (s *FunctionalSuite) TestStartWorkflowExecution_TerminateIfRunning() {
 	id := "functional-start-workflow-terminate-if-running-test"
 	wt := "functional-start-workflow-terminate-if-running-test-type"
 	tl := "functional-start-workflow-terminate-if-running-test-taskqueue"
@@ -152,7 +152,7 @@ func (s *functionalSuite) TestStartWorkflowExecution_TerminateIfRunning() {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_RUNNING, descResp.WorkflowExecutionInfo.Status)
 }
 
-func (s *functionalSuite) TestStartWorkflowExecutionWithDelay() {
+func (s *FunctionalSuite) TestStartWorkflowExecutionWithDelay() {
 	id := "functional-start-workflow-with-delay-test"
 	wt := "functional-start-workflow-with-delay-test-type"
 	tl := "functional-start-workflow-with-delay-test-taskqueue"
@@ -215,7 +215,7 @@ func (s *functionalSuite) TestStartWorkflowExecutionWithDelay() {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, descResp.WorkflowExecutionInfo.Status)
 }
 
-func (s *functionalSuite) TestTerminateWorkflow() {
+func (s *FunctionalSuite) TestTerminateWorkflow() {
 	id := "functional-terminate-workflow-test"
 	wt := "functional-terminate-workflow-test-type"
 	tl := "functional-terminate-workflow-test-taskqueue"
@@ -367,7 +367,7 @@ StartNewExecutionLoop:
 	s.True(newExecutionStarted)
 }
 
-func (s *functionalSuite) TestSequentialWorkflow() {
+func (s *FunctionalSuite) TestSequentialWorkflow() {
 	id := "functional-sequential-workflow-test"
 	wt := "functional-sequential-workflow-test-type"
 	tl := "functional-sequential-workflow-test-taskqueue"
@@ -468,7 +468,7 @@ func (s *functionalSuite) TestSequentialWorkflow() {
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
+func (s *FunctionalSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 	id := "functional-complete-workflow-task-create-new-test"
 	wt := "functional-complete-workflow-task-create-new-test-type"
 	tl := "functional-complete-workflow-task-create-new-test-taskqueue"
@@ -538,7 +538,7 @@ func (s *functionalSuite) TestCompleteWorkflowTaskAndCreateNewOne() {
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED, newTask.WorkflowTask.History.Events[3].GetEventType())
 }
 
-func (s *functionalSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
+func (s *FunctionalSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 	id := "functional-timeouts-workflow-test"
 	wt := "functional-timeouts-workflow-test-type"
 	tl := "functional-timeouts-workflow-test-taskqueue"
@@ -655,7 +655,7 @@ func (s *functionalSuite) TestWorkflowTaskAndActivityTaskTimeoutsWorkflow() {
 	s.True(workflowComplete)
 }
 
-func (s *functionalSuite) TestWorkflowRetry() {
+func (s *FunctionalSuite) TestWorkflowRetry() {
 	id := "functional-wf-retry-test"
 	wt := "functional-wf-retry-type"
 	tl := "functional-wf-retry-taskqueue"
@@ -806,7 +806,7 @@ func (s *functionalSuite) TestWorkflowRetry() {
 	}
 }
 
-func (s *functionalSuite) TestWorkflowRetryFailures() {
+func (s *FunctionalSuite) TestWorkflowRetryFailures() {
 	id := "functional-wf-retry-failures-test"
 	wt := "functional-wf-retry-failures-type"
 	tl := "functional-wf-retry-failures-taskqueue"

--- a/tests/workflow_timer_test.go
+++ b/tests/workflow_timer_test.go
@@ -40,7 +40,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestCancelTimer() {
+func (s *FunctionalSuite) TestCancelTimer() {
 	id := "functional-cancel-timer-test"
 	wt := "functional-cancel-timer-test-type"
 	tl := "functional-cancel-timer-test-taskqueue"
@@ -171,7 +171,7 @@ func (s *functionalSuite) TestCancelTimer() {
 	}
 }
 
-func (s *functionalSuite) TestCancelTimer_CancelFiredAndBuffered() {
+func (s *FunctionalSuite) TestCancelTimer_CancelFiredAndBuffered() {
 	id := "functional-cancel-timer-fired-and-buffered-test"
 	wt := "functional-cancel-timer-fired-and-buffered-test-type"
 	tl := "functional-cancel-timer-fired-and-buffered-test-taskqueue"

--- a/tests/workflow_visibility_test.go
+++ b/tests/workflow_visibility_test.go
@@ -41,7 +41,7 @@ import (
 	"go.temporal.io/server/common/payloads"
 )
 
-func (s *functionalSuite) TestVisibility() {
+func (s *FunctionalSuite) TestVisibility() {
 	startTime := time.Now().UTC()
 
 	// Start 2 workflow executions

--- a/tests/xdc/advanced_visibility_test.go
+++ b/tests/xdc/advanced_visibility_test.go
@@ -66,7 +66,7 @@ import (
 	"go.temporal.io/server/tests"
 )
 
-type advVisCrossDCTestSuite struct {
+type AdvVisCrossDCTestSuite struct {
 	// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 	// not merely log an error
 	*require.Assertions
@@ -87,7 +87,7 @@ type advVisCrossDCTestSuite struct {
 
 func TestAdvVisCrossDCTestSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(advVisCrossDCTestSuite))
+	suite.Run(t, new(AdvVisCrossDCTestSuite))
 }
 
 var (
@@ -102,7 +102,7 @@ var (
 	}
 )
 
-func (s *advVisCrossDCTestSuite) SetupSuite() {
+func (s *AdvVisCrossDCTestSuite) SetupSuite() {
 	s.logger = log.NewTestLogger()
 	s.testClusterFactory = tests.NewTestClusterFactory()
 
@@ -160,18 +160,18 @@ func (s *advVisCrossDCTestSuite) SetupSuite() {
 	s.testSearchAttributeVal = "test value"
 }
 
-func (s *advVisCrossDCTestSuite) SetupTest() {
+func (s *AdvVisCrossDCTestSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 	s.ProtoAssertions = protorequire.New(s.T())
 }
 
-func (s *advVisCrossDCTestSuite) TearDownSuite() {
+func (s *AdvVisCrossDCTestSuite) TearDownSuite() {
 	s.cluster1.TearDownCluster()
 	s.cluster2.TearDownCluster()
 }
 
-func (s *advVisCrossDCTestSuite) TestSearchAttributes() {
+func (s *AdvVisCrossDCTestSuite) TestSearchAttributes() {
 	namespace := "test-xdc-search-attr-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -69,34 +69,34 @@ import (
 )
 
 type (
-	functionalClustersTestSuite struct {
+	FunctionalClustersTestSuite struct {
 		xdcBaseSuite
 	}
 )
 
 func TestFuncClustersTestSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(functionalClustersTestSuite))
+	suite.Run(t, new(FunctionalClustersTestSuite))
 }
 
-func (s *functionalClustersTestSuite) SetupSuite() {
+func (s *FunctionalClustersTestSuite) SetupSuite() {
 	s.setupSuite([]string{"integ_active", "integ_standby"})
 }
 
-func (s *functionalClustersTestSuite) SetupTest() {
+func (s *FunctionalClustersTestSuite) SetupTest() {
 	s.setupTest()
 }
 
-func (s *functionalClustersTestSuite) TearDownSuite() {
+func (s *FunctionalClustersTestSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *functionalClustersTestSuite) decodePayloadsString(ps *commonpb.Payloads) (r string) {
+func (s *FunctionalClustersTestSuite) decodePayloadsString(ps *commonpb.Payloads) (r string) {
 	s.NoError(payloads.Decode(ps, &r))
 	return
 }
 
-func (s *functionalClustersTestSuite) TestNamespaceFailover() {
+func (s *FunctionalClustersTestSuite) TestNamespaceFailover() {
 	namespace := "test-namespace-for-fail-over-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -171,7 +171,7 @@ func (s *functionalClustersTestSuite) TestNamespaceFailover() {
 	s.NotNil(we.GetRunId())
 }
 
-func (s *functionalClustersTestSuite) TestSimpleWorkflowFailover() {
+func (s *FunctionalClustersTestSuite) TestSimpleWorkflowFailover() {
 	namespaceName := "test-simple-workflow-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -452,7 +452,7 @@ func (s *functionalClustersTestSuite) TestSimpleWorkflowFailover() {
 	s.True(eventsReplicated)
 }
 
-func (s *functionalClustersTestSuite) TestStickyWorkflowTaskFailover() {
+func (s *FunctionalClustersTestSuite) TestStickyWorkflowTaskFailover() {
 	namespace := "test-sticky-workflow-task-workflow-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -602,7 +602,7 @@ func (s *functionalClustersTestSuite) TestStickyWorkflowTaskFailover() {
 	s.True(workflowCompleted)
 }
 
-func (s *functionalClustersTestSuite) TestStartWorkflowExecution_Failover_WorkflowIDReusePolicy() {
+func (s *FunctionalClustersTestSuite) TestStartWorkflowExecution_Failover_WorkflowIDReusePolicy() {
 	namespaceName := "test-start-workflow-failover-ID-reuse-policy" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -725,7 +725,7 @@ func (s *functionalClustersTestSuite) TestStartWorkflowExecution_Failover_Workfl
 	s.Equal(2, workflowCompleteTimes)
 }
 
-func (s *functionalClustersTestSuite) TestTerminateFailover() {
+func (s *FunctionalClustersTestSuite) TestTerminateFailover() {
 	namespace := "test-terminate-workflow-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -896,7 +896,7 @@ GetHistoryLoop2:
 	s.True(eventsReplicated)
 }
 
-func (s *functionalClustersTestSuite) TestResetWorkflowFailover() {
+func (s *FunctionalClustersTestSuite) TestResetWorkflowFailover() {
 	namespace := "test-reset-workflow-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1053,7 +1053,7 @@ func (s *functionalClustersTestSuite) TestResetWorkflowFailover() {
 	s.Equal(enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED, events[len(events)-1].GetEventType())
 }
 
-func (s *functionalClustersTestSuite) TestContinueAsNewFailover() {
+func (s *FunctionalClustersTestSuite) TestContinueAsNewFailover() {
 	namespace := "test-continueAsNew-workflow-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1177,7 +1177,7 @@ func (s *functionalClustersTestSuite) TestContinueAsNewFailover() {
 	s.Equal(previousRunID, lastRunStartedEvent.GetWorkflowExecutionStartedEventAttributes().GetContinuedExecutionRunId())
 }
 
-func (s *functionalClustersTestSuite) TestSignalFailover() {
+func (s *FunctionalClustersTestSuite) TestSignalFailover() {
 	namespace := "test-signal-workflow-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1380,7 +1380,7 @@ func (s *functionalClustersTestSuite) TestSignalFailover() {
 	s.True(eventsReplicated)
 }
 
-func (s *functionalClustersTestSuite) TestUserTimerFailover() {
+func (s *FunctionalClustersTestSuite) TestUserTimerFailover() {
 	namespace := "test-user-timer-workflow-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1538,7 +1538,7 @@ func (s *functionalClustersTestSuite) TestUserTimerFailover() {
 	}
 }
 
-func (s *functionalClustersTestSuite) TestForceWorkflowTaskClose_WithClusterReconnect() {
+func (s *FunctionalClustersTestSuite) TestForceWorkflowTaskClose_WithClusterReconnect() {
 	namespace := "test-force-workflow-task-close-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1690,7 +1690,7 @@ func (s *functionalClustersTestSuite) TestForceWorkflowTaskClose_WithClusterReco
 	s.NoError(err)
 }
 
-func (s *functionalClustersTestSuite) TestTransientWorkflowTaskFailover() {
+func (s *FunctionalClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	namespace := "test-transient-workflow-task-workflow-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1797,7 +1797,7 @@ func (s *functionalClustersTestSuite) TestTransientWorkflowTaskFailover() {
 	s.True(workflowFinished)
 }
 
-func (s *functionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
+func (s *FunctionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
 	namespace := "test-cron-workflow-start-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1887,7 +1887,7 @@ func (s *functionalClustersTestSuite) TestCronWorkflowStartAndFailover() {
 	s.NoError(err)
 }
 
-func (s *functionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
+func (s *FunctionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 	namespace := "test-cron-workflow-complete-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -1994,7 +1994,7 @@ func (s *functionalClustersTestSuite) TestCronWorkflowCompleteAndFailover() {
 	s.NoError(err)
 }
 
-func (s *functionalClustersTestSuite) TestWorkflowRetryStartAndFailover() {
+func (s *FunctionalClustersTestSuite) TestWorkflowRetryStartAndFailover() {
 	namespace := "test-workflow-retry-start-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -2091,7 +2091,7 @@ func (s *functionalClustersTestSuite) TestWorkflowRetryStartAndFailover() {
 	s.Equal(int32(2), events[0].GetWorkflowExecutionStartedEventAttributes().GetAttempt())
 }
 
-func (s *functionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
+func (s *FunctionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 	namespace := "test-workflow-retry-fail-and-failover-" + common.GenerateRandomString(5)
 	client1 := s.cluster1.GetFrontendClient() // active
 	regReq := &workflowservice.RegisterNamespaceRequest{
@@ -2196,7 +2196,7 @@ func (s *functionalClustersTestSuite) TestWorkflowRetryFailAndFailover() {
 	s.Equal(int32(2), events[0].GetWorkflowExecutionStartedEventAttributes().GetAttempt())
 }
 
-func (s *functionalClustersTestSuite) TestActivityHeartbeatFailover() {
+func (s *FunctionalClustersTestSuite) TestActivityHeartbeatFailover() {
 	namespace := "test-activity-heartbeat-workflow-failover-" + common.GenerateRandomString(5)
 	s.registerNamespace(namespace, true)
 
@@ -2312,7 +2312,7 @@ func (s *functionalClustersTestSuite) TestActivityHeartbeatFailover() {
 // 	common.PrettyPrintHistory(history, s.logger)
 // }
 
-func (s *functionalClustersTestSuite) TestLocalNamespaceMigration() {
+func (s *FunctionalClustersTestSuite) TestLocalNamespaceMigration() {
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -2667,7 +2667,7 @@ func (s *functionalClustersTestSuite) TestLocalNamespaceMigration() {
 	verify(workflowID7, run7.GetRunID())
 }
 
-func (s *functionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
+func (s *FunctionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -2791,7 +2791,7 @@ func (s *functionalClustersTestSuite) TestForceMigration_ClosedWorkflow() {
 	s.Equal(enumspb.WORKFLOW_EXECUTION_STATUS_COMPLETED, descResp.GetWorkflowExecutionInfo().Status)
 }
 
-func (s *functionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
+func (s *FunctionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 	testCtx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
@@ -2896,7 +2896,7 @@ func (s *functionalClustersTestSuite) TestForceMigration_ResetWorkflow() {
 	verifyHistory(workflowID, resp.GetRunId())
 }
 
-func (s *functionalClustersTestSuite) getHistory(client tests.FrontendClient, namespace string, execution *commonpb.WorkflowExecution) []*historypb.HistoryEvent {
+func (s *FunctionalClustersTestSuite) getHistory(client tests.FrontendClient, namespace string, execution *commonpb.WorkflowExecution) []*historypb.HistoryEvent {
 	historyResponse, err := client.GetWorkflowExecutionHistory(tests.NewContext(), &workflowservice.GetWorkflowExecutionHistoryRequest{
 		Namespace:       namespace,
 		Execution:       execution,
@@ -2918,7 +2918,7 @@ func (s *functionalClustersTestSuite) getHistory(client tests.FrontendClient, na
 	return events
 }
 
-func (s *functionalClustersTestSuite) failover(
+func (s *FunctionalClustersTestSuite) failover(
 	namespace string,
 	targetCluster string,
 	targetFailoverVersion int64,
@@ -2943,7 +2943,7 @@ func (s *functionalClustersTestSuite) failover(
 	time.Sleep(cacheRefreshInterval)
 }
 
-func (s *functionalClustersTestSuite) registerNamespace(namespace string, isGlobalNamespace bool) {
+func (s *FunctionalClustersTestSuite) registerNamespace(namespace string, isGlobalNamespace bool) {
 	clusters := s.clusterReplicationConfig()
 	if !isGlobalNamespace {
 		clusters = s.clusterReplicationConfig()[0:1]
@@ -2971,7 +2971,7 @@ func (s *functionalClustersTestSuite) registerNamespace(namespace string, isGlob
 	s.Equal(isGlobalNamespace, resp.IsGlobalNamespace)
 }
 
-func (s *functionalClustersTestSuite) newClientAndWorker(hostport, namespace, taskqueue, identity string) (sdkclient.Client, sdkworker.Worker) {
+func (s *FunctionalClustersTestSuite) newClientAndWorker(hostport, namespace, taskqueue, identity string) (sdkclient.Client, sdkworker.Worker) {
 	sdkClient1, err := sdkclient.Dial(sdkclient.Options{
 		HostPort:  hostport,
 		Namespace: namespace,

--- a/tests/xdc/user_data_replication_test.go
+++ b/tests/xdc/user_data_replication_test.go
@@ -61,17 +61,17 @@ import (
 )
 
 type (
-	userDataReplicationTestSuite struct {
+	UserDataReplicationTestSuite struct {
 		xdcBaseSuite
 	}
 )
 
 func TestUserDataReplicationTestSuite(t *testing.T) {
 	flag.Parse()
-	suite.Run(t, new(userDataReplicationTestSuite))
+	suite.Run(t, new(UserDataReplicationTestSuite))
 }
 
-func (s *userDataReplicationTestSuite) SetupSuite() {
+func (s *UserDataReplicationTestSuite) SetupSuite() {
 	s.dynamicConfigOverrides = map[dynamicconfig.Key]interface{}{
 		// Make sure we don't hit the rate limiter in tests
 		dynamicconfig.FrontendMaxNamespaceNamespaceReplicationInducingAPIsRPSPerInstance:   1000,
@@ -86,15 +86,15 @@ func (s *userDataReplicationTestSuite) SetupSuite() {
 	s.setupSuite([]string{"task_queue_repl_active", "task_queue_repl_standby"})
 }
 
-func (s *userDataReplicationTestSuite) SetupTest() {
+func (s *UserDataReplicationTestSuite) SetupTest() {
 	s.setupTest()
 }
 
-func (s *userDataReplicationTestSuite) TearDownSuite() {
+func (s *UserDataReplicationTestSuite) TearDownSuite() {
 	s.tearDownSuite()
 }
 
-func (s *userDataReplicationTestSuite) TestUserDataIsReplicatedFromActiveToPassive() {
+func (s *UserDataReplicationTestSuite) TestUserDataIsReplicatedFromActiveToPassive() {
 	namespace := s.T().Name() + "-" + common.GenerateRandomString(5)
 	taskQueue := "versioned"
 	activeFrontendClient := s.cluster1.GetFrontendClient()
@@ -136,7 +136,7 @@ func (s *userDataReplicationTestSuite) TestUserDataIsReplicatedFromActiveToPassi
 	}, 15*time.Second, 500*time.Millisecond)
 }
 
-func (s *userDataReplicationTestSuite) TestUserDataIsReplicatedFromPassiveToActive() {
+func (s *UserDataReplicationTestSuite) TestUserDataIsReplicatedFromPassiveToActive() {
 	namespace := s.T().Name() + "-" + common.GenerateRandomString(5)
 	taskQueue := "versioned"
 	activeFrontendClient := s.cluster1.GetFrontendClient()
@@ -175,7 +175,7 @@ func (s *userDataReplicationTestSuite) TestUserDataIsReplicatedFromPassiveToActi
 	}, 15*time.Second, 500*time.Millisecond)
 }
 
-func (s *userDataReplicationTestSuite) TestUserDataEntriesAreReplicatedOnDemand() {
+func (s *UserDataReplicationTestSuite) TestUserDataEntriesAreReplicatedOnDemand() {
 	ctx := tests.NewContext()
 	namespace := s.T().Name() + "-" + common.GenerateRandomString(5)
 	activeFrontendClient := s.cluster1.GetFrontendClient()
@@ -256,7 +256,7 @@ func (s *userDataReplicationTestSuite) TestUserDataEntriesAreReplicatedOnDemand(
 	s.Equal(exectedReplicatedTaskQueues, seenTaskQueues)
 }
 
-func (s *userDataReplicationTestSuite) TestUserDataTombstonesAreReplicated() {
+func (s *UserDataReplicationTestSuite) TestUserDataTombstonesAreReplicated() {
 	// Advanced visibility only enabled by default in SQLite
 	if tests.TestFlags.PersistenceDriver != sqlite.PluginName {
 		s.T().Skip("Test requires advanced visibility")
@@ -405,7 +405,7 @@ func (s *userDataReplicationTestSuite) TestUserDataTombstonesAreReplicated() {
 	s.Equal(persistencespb.STATE_ACTIVE, attrs.UserData.VersioningData.VersionSets[2].BuildIds[0].State)
 }
 
-func (s *userDataReplicationTestSuite) TestApplyReplicationEventRevivesInUseTombstones() {
+func (s *UserDataReplicationTestSuite) TestApplyReplicationEventRevivesInUseTombstones() {
 	// Advanced visibility only enabled by default in SQLite
 	if tests.TestFlags.PersistenceDriver != sqlite.PluginName {
 		s.T().Skip("Test requires advanced visibility")


### PR DESCRIPTION
## What changed?
Names of all test suites were capitalized.

## Why?
Following up on https://github.com/temporalio/temporal/pull/5118 and making another step towards exportable functional test suites.

If this PR gets merged, the next (and the final one) PR will move the test suite implementations from `*_test.go` to `.go` files.

## How did you test it?
Ran tests.

## Potential risks
Merge conflicts in other PRs.

## Is hotfix candidate?
No.