### PR TITLE
Add NamespaceValidatorInterceptor to Nexus requests

### DIFF
--- a/common/rpc/interceptor/namespace_validator_test.go
+++ b/common/rpc/interceptor/namespace_validator_test.go
@@ -185,103 +185,103 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromNamesp
 		{
 			state:       enumspb.NAMESPACE_STATE_REGISTERED,
 			expectedErr: nil,
-			method:      "/temporal/StartWorkflowExecution",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution",
 			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
-			method:      "/temporal/StartWorkflowExecution",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution",
 			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
-			method:      "/temporal/StartWorkflowExecution",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution",
 			req:         &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:            enumspb.NAMESPACE_STATE_REGISTERED,
 			replicationState: enumspb.REPLICATION_STATE_HANDOVER,
 			expectedErr:      common.ErrNamespaceHandover,
-			method:           "/temporal/StartWorkflowExecution",
+			method:           "/temporal.api.workflowservice.v1.WorkflowService/StartWorkflowExecution",
 			req:              &workflowservice.StartWorkflowExecutionRequest{Namespace: "test-namespace"},
 		},
 		// DescribeNamespace
 		{
 			state:       enumspb.NAMESPACE_STATE_UNSPECIFIED,
 			expectedErr: errNamespaceNotSet,
-			method:      "/temporal/DescribeNamespace",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/DescribeNamespace",
 			req:         &workflowservice.DescribeNamespaceRequest{},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_UNSPECIFIED,
 			expectedErr: nil,
-			method:      "/temporal/DescribeNamespace",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/DescribeNamespace",
 			req:         &workflowservice.DescribeNamespaceRequest{Id: "test-namespace-id"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_UNSPECIFIED,
 			expectedErr: nil,
-			method:      "/temporal/DescribeNamespace",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/DescribeNamespace",
 			req:         &workflowservice.DescribeNamespaceRequest{Namespace: "test-namespace"},
 		},
 		// RegisterNamespace
 		{
 			state:       enumspb.NAMESPACE_STATE_UNSPECIFIED,
 			expectedErr: nil,
-			method:      "/temporal/RegisterNamespace",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/RegisterNamespace",
 			req:         &workflowservice.RegisterNamespaceRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_UNSPECIFIED,
 			expectedErr: errNamespaceNotSet,
-			method:      "/temporal/RegisterNamespace",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/RegisterNamespace",
 			req:         &workflowservice.RegisterNamespaceRequest{},
 		},
 		// PollWorkflowTaskQueue (default)
 		{
 			state:       enumspb.NAMESPACE_STATE_REGISTERED,
 			expectedErr: nil,
-			method:      "/temporal/PollWorkflowTaskQueue",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue",
 			req:         &workflowservice.PollWorkflowTaskQueueRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
 			expectedErr: nil,
-			method:      "/temporal/PollWorkflowTaskQueue",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue",
 			req:         &workflowservice.PollWorkflowTaskQueueRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
-			method:      "/temporal/PollWorkflowTaskQueue",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/PollWorkflowTaskQueue",
 			req:         &workflowservice.PollWorkflowTaskQueueRequest{Namespace: "test-namespace"},
 		},
 		// UpdateNamespace
 		{
 			state:       enumspb.NAMESPACE_STATE_REGISTERED,
 			expectedErr: nil,
-			method:      "/temporal/UpdateNamespace",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/UpdateNamespace",
 			req:         &workflowservice.UpdateNamespaceRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
 			expectedErr: nil,
-			method:      "/temporal/UpdateNamespace",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/UpdateNamespace",
 			req:         &workflowservice.UpdateNamespaceRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:            enumspb.NAMESPACE_STATE_REGISTERED,
 			replicationState: enumspb.REPLICATION_STATE_HANDOVER,
 			expectedErr:      nil,
-			method:           "/temporal/UpdateNamespace",
+			method:           "/temporal.api.workflowservice.v1.WorkflowService/UpdateNamespace",
 			req:              &workflowservice.UpdateNamespaceRequest{Namespace: "test-namespace"},
 		},
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
-			method:      "/temporal/UpdateNamespace",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/UpdateNamespace",
 			req:         &workflowservice.UpdateNamespaceRequest{Namespace: "test-namespace"},
 		},
 	}
@@ -345,7 +345,7 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromToken(
 		{
 			state:       enumspb.NAMESPACE_STATE_REGISTERED,
 			expectedErr: nil,
-			method:      "/temporal/RespondWorkflowTaskCompleted",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted",
 			req: &workflowservice.RespondWorkflowTaskCompletedRequest{
 				TaskToken: taskToken,
 			},
@@ -353,7 +353,7 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromToken(
 		{
 			state:       enumspb.NAMESPACE_STATE_DEPRECATED,
 			expectedErr: nil,
-			method:      "/temporal/RespondWorkflowTaskCompleted",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted",
 			req: &workflowservice.RespondWorkflowTaskCompletedRequest{
 				TaskToken: taskToken,
 			},
@@ -361,7 +361,7 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_StatusFromToken(
 		{
 			state:       enumspb.NAMESPACE_STATE_DELETED,
 			expectedErr: &serviceerror.NamespaceInvalidState{},
-			method:      "/temporal/RespondWorkflowTaskCompleted",
+			method:      "/temporal.api.workflowservice.v1.WorkflowService/RespondWorkflowTaskCompleted",
 			req: &workflowservice.RespondWorkflowTaskCompletedRequest{
 				TaskToken: taskToken,
 			},
@@ -575,7 +575,7 @@ func (s *namespaceValidatorSuite) Test_StateValidationIntercept_TokenNamespaceEn
 			dynamicconfig.GetBoolPropertyFn(testCase.enableTokenNamespaceEnforcement),
 			dynamicconfig.GetIntPropertyFn(100))
 		serverInfo := &grpc.UnaryServerInfo{
-			FullMethod: "/temporal/RandomMethod",
+			FullMethod: "/temporal.api.workflowservice.v1.WorkflowService/RandomMethod",
 		}
 
 		handlerCalled := false
@@ -667,7 +667,7 @@ func (s *namespaceValidatorSuite) Test_Intercept_SearchAttributeRequests() {
 			dynamicconfig.GetIntPropertyFn(100),
 		)
 		serverInfo := &grpc.UnaryServerInfo{
-			FullMethod: "/temporal/random",
+			FullMethod: "/temporal.api.workflowservice.v1.WorkflowService/random",
 		}
 
 		handlerCalled := false
@@ -691,7 +691,7 @@ func (s *namespaceValidatorSuite) Test_NamespaceValidateIntercept() {
 		dynamicconfig.GetBoolPropertyFn(false),
 		dynamicconfig.GetIntPropertyFn(10))
 	serverInfo := &grpc.UnaryServerInfo{
-		FullMethod: "/temporal/random",
+		FullMethod: "/temporal.api.workflowservice.v1.WorkflowService/random",
 	}
 	requestNamespace := namespace.FromPersistentState(
 		&persistence.GetNamespaceResponse{

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/iancoleman/strcase v0.3.0
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/lib/pq v1.10.9
-	github.com/nexus-rpc/sdk-go v0.0.4
+	github.com/nexus-rpc/sdk-go v0.0.5
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/olivere/elastic/v7 v7.0.32
 	github.com/pborman/uuid v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -241,8 +241,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/nexus-rpc/sdk-go v0.0.4 h1:snzRw5n81GsmjNku+KIVfA+wn2u3s4FF/6TPoRkHCZ8=
-github.com/nexus-rpc/sdk-go v0.0.4/go.mod h1:uBe8fX151zUW9DhXxwHjji19d6YfnNUqJ81tR3JbwHY=
+github.com/nexus-rpc/sdk-go v0.0.5 h1:AVSfCqkqOkvaT/Ab0JaGDpStv0Xtb7POq5Eed+CF13M=
+github.com/nexus-rpc/sdk-go v0.0.5/go.mod h1:uBe8fX151zUW9DhXxwHjji19d6YfnNUqJ81tR3JbwHY=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=

--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -642,6 +642,9 @@ func NexusHTTPHandlerProvider(
 	metricsHandler metrics.Handler,
 	namespaceRegistry namespace.Registry,
 	authInterceptor *authorization.Interceptor,
+	namespaceRateLimiterInterceptor *interceptor.NamespaceRateLimitInterceptor,
+	namespaceCountLimiterInterceptor *interceptor.ConcurrentRequestLimitInterceptor,
+	namespaceValidatorInterceptor *interceptor.NamespaceValidatorInterceptor,
 	logger log.Logger,
 ) *NexusHTTPHandler {
 	return NewNexusHTTPHandler(
@@ -650,6 +653,7 @@ func NexusHTTPHandlerProvider(
 		metricsHandler,
 		namespaceRegistry,
 		authInterceptor,
+		namespaceValidatorInterceptor,
 		logger,
 	)
 }

--- a/service/frontend/nexus_handler_test.go
+++ b/service/frontend/nexus_handler_test.go
@@ -1,0 +1,91 @@
+// The MIT License
+//
+// Copyright (c) 2023 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package frontend
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/nexus-rpc/sdk-go/nexus"
+	"github.com/stretchr/testify/require"
+	enumspb "go.temporal.io/api/enums/v1"
+	"go.temporal.io/server/api/matchingservice/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/authorization"
+	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/metrics/metricstest"
+	"go.temporal.io/server/common/namespace"
+	"go.temporal.io/server/common/persistence"
+)
+
+type mockAuthorizer struct {
+}
+
+// Authorize implements authorization.Authorizer.
+func (mockAuthorizer) Authorize(ctx context.Context, caller *authorization.Claims, target *authorization.CallTarget) (authorization.Result, error) {
+	return authorization.Result{Decision: authorization.DecisionAllow}, nil
+}
+
+var _ authorization.Authorizer = mockAuthorizer{}
+
+func newOperationContext() *operationContext {
+	oc := &operationContext{}
+	oc.logger = log.NewTestLogger()
+	mh := metricstest.NewCaptureHandler()
+	oc.metricsHandler = mh
+	oc.namespace = namespace.FromPersistentState(&persistence.GetNamespaceResponse{
+		Namespace: &persistencespb.NamespaceDetail{
+			Info: &persistencespb.NamespaceInfo{
+				Id:    uuid.NewString(),
+				Name:  "test",
+				State: enumspb.NAMESPACE_STATE_DELETED,
+			},
+			Config: &persistencespb.NamespaceConfig{
+				CustomSearchAttributeAliases: make(map[string]string),
+			},
+		},
+	})
+	oc.auth = authorization.NewInterceptor(nil, mockAuthorizer{}, oc.metricsHandler, oc.logger, nil, "", "")
+	return oc
+}
+
+func TestNexusInterceptRequeset_InvalidNamespaceState_ResultsInBadRequest(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	var err error
+	oc := newOperationContext()
+	err = oc.interceptRequest(ctx, &matchingservice.DispatchNexusTaskRequest{})
+	var handlerError *nexus.HandlerError
+	require.ErrorAs(t, err, &handlerError)
+	require.Equal(t, nexus.HandlerErrorTypeBadRequest, handlerError.Type)
+	require.Equal(t, "Namespace has invalid state: Unspecified. Must be Registered or Deprecated.", handlerError.Failure.Message)
+	mh := oc.metricsHandler.(*metricstest.CaptureHandler) //nolint:revive
+	capture := mh.StartCapture()
+	oc.metricsHandler.Counter("test").Record(1)
+	mh.StopCapture(capture)
+	snap := capture.Snapshot()
+	require.Equal(t, 1, len(snap["test"]))
+	require.Equal(t, map[string]string{"outcome": "invalid_namespace_state"}, snap["test"][0].Tags)
+}

--- a/service/frontend/nexus_http_handler.go
+++ b/service/frontend/nexus_http_handler.go
@@ -39,16 +39,18 @@ import (
 	"go.temporal.io/server/common/namespace"
 	commonnexus "go.temporal.io/server/common/nexus"
 	"go.temporal.io/server/common/rpc"
+	"go.temporal.io/server/common/rpc/interceptor"
 	"google.golang.org/grpc/credentials"
 )
 
 // Small wrapper that does some pre-processing before handing requests over to the Nexus SDK's HTTP handler.
 type NexusHTTPHandler struct {
-	logger                 log.Logger
-	nexusHandler           http.Handler
-	preprocessErrorCounter metrics.CounterFunc
-	auth                   *authorization.Interceptor
-	enabled                func() bool
+	logger                         log.Logger
+	nexusHandler                   http.Handler
+	preprocessErrorCounter         metrics.CounterFunc
+	auth                           *authorization.Interceptor
+	namespaceValidationInterceptor *interceptor.NamespaceValidatorInterceptor
+	enabled                        func() bool
 }
 
 func NewNexusHTTPHandler(
@@ -57,13 +59,15 @@ func NewNexusHTTPHandler(
 	metricsHandler metrics.Handler,
 	namespaceRegistry namespace.Registry,
 	authInterceptor *authorization.Interceptor,
+	namespaceValidationInterceptor *interceptor.NamespaceValidatorInterceptor,
 	logger log.Logger,
 ) *NexusHTTPHandler {
 	return &NexusHTTPHandler{
-		logger:                 logger,
-		auth:                   authInterceptor,
-		enabled:                serviceConfig.EnableNexusHTTPHandler,
-		preprocessErrorCounter: metricsHandler.Counter(metrics.NexusRequestPreProcessErrors.GetMetricName()).Record,
+		logger:                         logger,
+		auth:                           authInterceptor,
+		namespaceValidationInterceptor: namespaceValidationInterceptor,
+		enabled:                        serviceConfig.EnableNexusHTTPHandler,
+		preprocessErrorCounter:         metricsHandler.Counter(metrics.NexusRequestPreProcessErrors.GetMetricName()).Record,
 		nexusHandler: nexus.NewHTTPHandler(nexus.HandlerOptions{
 			Handler: &nexusHandler{
 				logger:            logger,
@@ -120,6 +124,7 @@ func (h *NexusHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w http.Respo
 	var err error
 	vars := mux.Vars(r)
 	nc := nexusContext{
+		namespaceValidationInterceptor: h.namespaceValidationInterceptor,
 		// This name does not map to an underlying gRPC service. This format is used for consistency with the
 		// gRPC API names on which the authorizer - the consumer of this string - may depend.
 		apiName: "/temporal.api.nexusservice.v1.NexusService/DispatchNexusTask",
@@ -133,6 +138,11 @@ func (h *NexusHTTPHandler) dispatchNexusTaskByNamespaceAndTaskQueue(w http.Respo
 	if nc.taskQueue, err = url.PathUnescape(vars["task_queue"]); err != nil {
 		h.logger.Error("invalid URL", tag.Error(err))
 		h.writeNexusFailure(w, http.StatusBadRequest, &nexus.Failure{Message: "invalid URL"})
+		return
+	}
+	if err := h.namespaceValidationInterceptor.ValidateName(nc.namespaceName); err != nil {
+		h.logger.Error("invalid namespace name", tag.Error(err))
+		h.writeNexusFailure(w, http.StatusBadRequest, &nexus.Failure{Message: err.Error()})
 		return
 	}
 	var tlsInfo *credentials.TLSInfo


### PR DESCRIPTION
## What changed?

Run `NamespaceValidatorInterceptor` as part of Nexus request interception.

## Why?

Part of my quest to add all of the gRPC interceptors for Nexus requests.

## How did you test it?

Functional and unit tests