### PR TITLE
Min-max cache for MutableStates

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -660,6 +660,8 @@ var (
 	CacheFailures                                = NewCounterDef("cache_errors")
 	CacheLatency                                 = NewTimerDef("cache_latency")
 	CacheMissCounter                             = NewCounterDef("cache_miss")
+	CacheUsage                                   = NewGaugeDef("cache_usage")
+	CacheDemand                                  = NewGaugeDef("cache_demand")
 	HistoryEventNotificationQueueingLatency      = NewTimerDef("history_event_notification_queueing_latency")
 	HistoryEventNotificationFanoutLatency        = NewTimerDef("history_event_notification_fanout_latency")
 	HistoryEventNotificationInFlightMessageGauge = NewGaugeDef("history_event_notification_inflight_message_gauge")

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -42,3 +42,6 @@ frontend.workerVersioningWorkflowAPIs:
   - value: true
 frontend.accessHistoryFraction:
   - value: 1.0
+history.cacheMaxSize:
+  - value: 100
+

--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -369,7 +369,7 @@ func NewConfig(
 		HistoryCacheMaxSize:                   dc.GetIntProperty(dynamicconfig.HistoryCacheMaxSize, 256000),
 		HistoryCacheTTL:                       dc.GetDurationProperty(dynamicconfig.HistoryCacheTTL, time.Hour),
 		HistoryCacheNonUserContextLockTimeout: dc.GetDurationProperty(dynamicconfig.HistoryCacheNonUserContextLockTimeout, 500*time.Millisecond),
-		EnableHostLevelHistoryCache:           dc.GetBoolProperty(dynamicconfig.EnableHostHistoryCache, false),
+		EnableHostLevelHistoryCache:           dc.GetBoolProperty(dynamicconfig.EnableHostHistoryCache, true),
 		HistoryShardLevelCacheMaxSize:         dc.GetIntProperty(dynamicconfig.HistoryCacheShardLevelMaxSize, 512),
 		EnableAPIGetCurrentRunIDLock:          dc.GetBoolProperty(dynamicconfig.EnableAPIGetCurrentRunIDLock, false),
 


### PR DESCRIPTION
This PR is not ready to merge, just for testing and gathering initial opinions.

## What changed?
Adding code to implement min-max allocation for mutable state cache.
This will divide the cache among namespaces according to their demand.

## Why?
To prevent a few namespaces from starving other namespaces.
MutableState cache is currently a shard level cache. We plan to make it a host level
cache. In that case, starvation will have high impact.

## How did you test it?
NOT YET TESTED.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
