### PR TITLE
Do not provide custom frontend interceptors to history or matching

### DIFF
--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -124,7 +124,7 @@ type (
 		CustomVisibilityStore  visibility.VisibilityStoreFactory
 
 		SearchAttributesMapper searchattribute.Mapper
-		CustomInterceptors     []grpc.UnaryServerInterceptor
+		CustomInterceptors     []grpc.UnaryServerInterceptor `group:"frontendInterceptors"`
 		Authorizer             authorization.Authorizer
 		ClaimMapper            authorization.ClaimMapper
 		AudienceGetter         authorization.JWTAudienceMapper
@@ -354,7 +354,7 @@ type (
 		PersistenceServiceResolver resolver.ServiceResolver
 		PersistenceFactoryProvider persistenceClient.FactoryProviderFn
 		SearchAttributesMapper     searchattribute.Mapper
-		CustomInterceptors         []grpc.UnaryServerInterceptor
+		CustomInterceptors         []grpc.UnaryServerInterceptor `group:"frontendInterceptors"`
 		Authorizer                 authorization.Authorizer
 		ClaimMapper                authorization.ClaimMapper
 		DataStoreFactory           persistenceClient.AbstractDataStoreFactory
@@ -402,9 +402,6 @@ func (params ServiceProviderParamsCommon) GetCommonServiceOptions(serviceName pr
 			},
 			func() searchattribute.Mapper {
 				return params.SearchAttributesMapper
-			},
-			func() []grpc.UnaryServerInterceptor {
-				return params.CustomInterceptors
 			},
 			func() authorization.Authorizer {
 				return params.Authorizer
@@ -528,6 +525,9 @@ func genericFrontendServiceProvider(
 
 	app := fx.New(
 		params.GetCommonServiceOptions(serviceName),
+		fx.Provide(fx.Annotate(
+			func() []grpc.UnaryServerInterceptor { return params.CustomInterceptors },
+			fx.ParamTags(`group:"frontendInterceptors"`))),
 		fx.Decorate(func() authorization.ClaimMapper {
 			switch serviceName {
 			case primitives.FrontendService:


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
No longer providing custom frontend interceptors to history or matching fx graphs
Added an fx value group, `group:"frontendInterceptors"` to prevent custom frontend interceptors from being injected where they are not intended

## Why?
<!-- Tell your future self why have you made these changes -->
Bug fix

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added an interceptor to `server_test.TestNewServer()` which will fail if supplied to any handler other than frontend

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
None

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No
