### PR TITLE
Add option to create a draft release notes when creating a tag

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -9,6 +9,13 @@ on:
       tag:
         description: "Tag for new version (1.23.4)"
         required: true
+      release_notes:
+        type: boolean
+        description: "Create draft release notes"
+        default: false
+      base_tag:
+        description: "Base tag to generate commit list for release notes"
+        required: false
 
 jobs:
   create-tag:
@@ -34,6 +41,7 @@ jobs:
           token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Github credentials
         env:
@@ -64,8 +72,49 @@ jobs:
 
       - name: Create and push tag
         env:
-          TAG: ${{ github.event.inputs.tag }}
+          TAG: 'v${{ github.event.inputs.tag }}'
           BRANCH: ${{ github.event.inputs.branch }}
         run: |
-          git tag "v$TAG"
-          git push origin "v$TAG"
+          if [ -z "$(git tag -l $TAG)" ]; then
+            git tag "$TAG"
+            git push origin "$TAG"
+          elif [ "$(git rev-list -n 1 $TAG)" != "$(git rev-parse HEAD)" ]; then
+            echo "::error::Tag already exists and it doesn't reference current HEAD of branch $BRANCH"
+            exit 1
+          fi
+
+      - name: Create draft release notes
+        if: ${{ github.event.inputs.release_notes }}
+        env:
+          CURRENT_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          BASE_TAG: ${{ github.event.inputs.base_tag }}
+          TAG: 'v${{ github.event.inputs.tag}}'
+        run: |
+          if [ -z "$BASE_TAG" ] || [ -z "$(git tag -l $BASE_TAG)" ]; then
+            echo "::error::Base tag not specified or does not exist"
+            exit 1
+          fi
+
+          TEMPFILE=$(mktemp)
+          cat > $TEMPFILE <<- EOF
+          # Release Highlights
+          Add highlights if any.
+
+          # All Changes
+          $(git log --cherry-pick --right-only --pretty='%cd - %h - %s' --date=short ${BASE_TAG}..${TAG})
+
+          # Helpful links to get you started with Temporal
+          [Temporal Docs](https://docs.temporal.io/)
+          [Server](https://github.com/temporalio/temporal)
+          [Docker Compose](https://github.com/temporalio/docker-compose)
+          [Helm Chart](https://github.com/temporalio/helm-charts)
+
+          # Docker images for this release (use the tag \`${TAG#v}\`)
+          [Server](https://hub.docker.com/repository/docker/temporalio/server)
+          [Server With Auto Setup](https://hub.docker.com/repository/docker/temporalio/auto-setup) ([what is Auto-Setup?](https://docs.temporal.io/blog/auto-setup))
+          [Admin-Tools](https://hub.docker.com/repository/docker/temporalio/admin-tools)
+          EOF
+
+          gh repo set-default $CURRENT_REPO
+          gh release create "$TAG" --verify-tag --draft --title "$TAG" -F $TEMPFILE


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add option to create a draft release notes when creating a tag
Also fixed the step to create a tag to check if it already exists.

## Why?
<!-- Tell your future self why have you made these changes -->
Help creating release notes.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run workflow locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.