### PR TITLE
return non-zero exit status when cli tools have bad arguments

### DIFF
--- a/cmd/tools/cassandra/main.go
+++ b/cmd/tools/cassandra/main.go
@@ -31,5 +31,7 @@ import (
 )
 
 func main() {
-	_ = cassandra.RunTool(os.Args)
+	if err := cassandra.RunTool(os.Args); err != nil {
+		os.Exit(1)
+	}
 }

--- a/cmd/tools/sql/main.go
+++ b/cmd/tools/sql/main.go
@@ -34,5 +34,7 @@ import (
 )
 
 func main() {
-	_ = sql.RunTool(os.Args)
+	if err := sql.RunTool(os.Args); err != nil {
+		os.Exit(1)
+	}
 }

--- a/cmd/tools/tdbg/main.go
+++ b/cmd/tools/tdbg/main.go
@@ -32,5 +32,7 @@ import (
 
 func main() {
 	app := tdbg.NewCliApp()
-	_ = app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
## What changed?
Return non-zero exit status when cli tools have bad arguments instead of ignoring the `app.Run` error

## Why?
Make it possible to integrate tools into a wrapping script that needs to react to whether it succeeds or fails.

## How did you test it?
Tested exit status locally.

## Potential risks
There may be scripts out there that are failing silently. They will now fail loudly, which is appropriate.

## Is hotfix candidate?
No
