### PR TITLE
Update GHA setup-go to pull version from go.mod file

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -8,14 +8,14 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v4
-        with:
-          go-version: "1.21"
-          check-latest: true
-
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - uses: actions/setup-go@v4
+        with:
+          go-version-file: 'go.mod'
+          check-latest: true
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,8 +1,13 @@
 name: goreleaser
+
 on:
   release:
     types:
       - released
+
+permissions:
+  contents: write
+
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
@@ -11,11 +16,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: "1.21"
+          go-version-file: 'go.mod'
           check-latest: true
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5
         with:

--- a/.github/workflows/trigger-publish.yml
+++ b/.github/workflows/trigger-publish.yml
@@ -20,7 +20,7 @@ jobs:
         id: get_branch
         run: |
           echo "::set-output name=branch::${GITHUB_REF#refs/heads/}"
-      
+
       - name: Generate a token
         id: generate_token
         uses: tibdex/github-app-token@b62528385c34dbc9f38e5f4225ac829252d1ea92


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Github actions that use `setup-go`, changed to pull the Go version from `go.mod` file.

## Why?
<!-- Tell your future self why have you made these changes -->
Less manual change to Go version when upgrading.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
