### PR TITLE
Rename MutableState Replicate* to Apply*

### DIFF
--- a/service/history/ndc/activity_state_replicator.go
+++ b/service/history/ndc/activity_state_replicator.go
@@ -176,7 +176,7 @@ func (r *ActivityStateReplicatorImpl) SyncActivityState(
 		request.GetAttempt(),
 		activityInfo,
 	)
-	err = mutableState.ReplicateActivityInfo(request, refreshTask)
+	err = mutableState.ApplyActivityInfo(request, refreshTask)
 	if err != nil {
 		return err
 	}

--- a/service/history/ndc/activity_state_replicator.go
+++ b/service/history/ndc/activity_state_replicator.go
@@ -176,7 +176,7 @@ func (r *ActivityStateReplicatorImpl) SyncActivityState(
 		request.GetAttempt(),
 		activityInfo,
 	)
-	err = mutableState.ApplyActivityInfo(request, refreshTask)
+	err = mutableState.UpdateActivityInfo(request, refreshTask)
 	if err != nil {
 		return err
 	}

--- a/service/history/ndc/activity_state_replicator_test.go
+++ b/service/history/ndc/activity_state_replicator_test.go
@@ -832,7 +832,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_Zombie() {
 	s.mockMutableState.EXPECT().GetActivityInfo(scheduledEventID).Return(&persistencespb.ActivityInfo{
 		Version: version,
 	}, true)
-	s.mockMutableState.EXPECT().ReplicateActivityInfo(request, false).Return(nil)
+	s.mockMutableState.EXPECT().ApplyActivityInfo(request, false).Return(nil)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
 	s.mockClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
 
@@ -929,7 +929,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_NonZombie(
 	s.mockMutableState.EXPECT().GetActivityInfo(scheduledEventID).Return(&persistencespb.ActivityInfo{
 		Version: version,
 	}, true)
-	s.mockMutableState.EXPECT().ReplicateActivityInfo(request, false).Return(nil)
+	s.mockMutableState.EXPECT().ApplyActivityInfo(request, false).Return(nil)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
 
 	s.mockClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)

--- a/service/history/ndc/activity_state_replicator_test.go
+++ b/service/history/ndc/activity_state_replicator_test.go
@@ -832,7 +832,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_Zombie() {
 	s.mockMutableState.EXPECT().GetActivityInfo(scheduledEventID).Return(&persistencespb.ActivityInfo{
 		Version: version,
 	}, true)
-	s.mockMutableState.EXPECT().ApplyActivityInfo(request, false).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivityInfo(request, false).Return(nil)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
 	s.mockClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)
 
@@ -929,7 +929,7 @@ func (s *activityReplicatorStateSuite) TestSyncActivity_ActivityFound_NonZombie(
 	s.mockMutableState.EXPECT().GetActivityInfo(scheduledEventID).Return(&persistencespb.ActivityInfo{
 		Version: version,
 	}, true)
-	s.mockMutableState.EXPECT().ApplyActivityInfo(request, false).Return(nil)
+	s.mockMutableState.EXPECT().UpdateActivityInfo(request, false).Return(nil)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(map[int64]*persistencespb.ActivityInfo{})
 
 	s.mockClusterMetadata.EXPECT().IsVersionFromSameCluster(version, version).Return(true)

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -234,7 +234,7 @@ type (
 		IsResourceDuplicated(resourceDedupKey definition.DeduplicationID) bool
 		IsWorkflowPendingOnWorkflowTaskBackoff() bool
 		UpdateDuplicatedResource(resourceDedupKey definition.DeduplicationID)
-		ApplyActivityInfo(*historyservice.SyncActivityRequest, bool) error
+		UpdateActivityInfo(*historyservice.SyncActivityRequest, bool) error
 		ApplyActivityTaskCancelRequestedEvent(*historypb.HistoryEvent) error
 		ApplyActivityTaskCanceledEvent(*historypb.HistoryEvent) error
 		ApplyActivityTaskCompletedEvent(*historypb.HistoryEvent) error

--- a/service/history/workflow/mutable_state.go
+++ b/service/history/workflow/mutable_state.go
@@ -234,50 +234,50 @@ type (
 		IsResourceDuplicated(resourceDedupKey definition.DeduplicationID) bool
 		IsWorkflowPendingOnWorkflowTaskBackoff() bool
 		UpdateDuplicatedResource(resourceDedupKey definition.DeduplicationID)
-		ReplicateActivityInfo(*historyservice.SyncActivityRequest, bool) error
-		ReplicateActivityTaskCancelRequestedEvent(*historypb.HistoryEvent) error
-		ReplicateActivityTaskCanceledEvent(*historypb.HistoryEvent) error
-		ReplicateActivityTaskCompletedEvent(*historypb.HistoryEvent) error
-		ReplicateActivityTaskFailedEvent(*historypb.HistoryEvent) error
-		ReplicateActivityTaskScheduledEvent(int64, *historypb.HistoryEvent) (*persistencespb.ActivityInfo, error)
-		ReplicateActivityTaskStartedEvent(*historypb.HistoryEvent) error
-		ReplicateActivityTaskTimedOutEvent(*historypb.HistoryEvent) error
-		ReplicateChildWorkflowExecutionCanceledEvent(*historypb.HistoryEvent) error
-		ReplicateChildWorkflowExecutionCompletedEvent(*historypb.HistoryEvent) error
-		ReplicateChildWorkflowExecutionFailedEvent(*historypb.HistoryEvent) error
-		ReplicateChildWorkflowExecutionStartedEvent(*historypb.HistoryEvent, *clockspb.VectorClock) error
-		ReplicateChildWorkflowExecutionTerminatedEvent(*historypb.HistoryEvent) error
-		ReplicateChildWorkflowExecutionTimedOutEvent(*historypb.HistoryEvent) error
-		ReplicateWorkflowTaskCompletedEvent(*historypb.HistoryEvent) error
-		ReplicateWorkflowTaskFailedEvent() error
-		ReplicateWorkflowTaskScheduledEvent(int64, int64, *taskqueuepb.TaskQueue, *durationpb.Duration, int32, *timestamppb.Timestamp, *timestamppb.Timestamp, enumsspb.WorkflowTaskType) (*WorkflowTaskInfo, error)
-		ReplicateWorkflowTaskStartedEvent(*WorkflowTaskInfo, int64, int64, int64, string, time.Time, bool, int64) (*WorkflowTaskInfo, error)
-		ReplicateWorkflowTaskTimedOutEvent(enumspb.TimeoutType) error
-		ReplicateExternalWorkflowExecutionCancelRequested(*historypb.HistoryEvent) error
-		ReplicateExternalWorkflowExecutionSignaled(*historypb.HistoryEvent) error
-		ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(*historypb.HistoryEvent) error
-		ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent(int64, *historypb.HistoryEvent, string) (*persistencespb.RequestCancelInfo, error)
-		ReplicateSignalExternalWorkflowExecutionFailedEvent(*historypb.HistoryEvent) error
-		ReplicateSignalExternalWorkflowExecutionInitiatedEvent(int64, *historypb.HistoryEvent, string) (*persistencespb.SignalInfo, error)
-		ReplicateStartChildWorkflowExecutionFailedEvent(*historypb.HistoryEvent) error
-		ReplicateStartChildWorkflowExecutionInitiatedEvent(int64, *historypb.HistoryEvent, string) (*persistencespb.ChildExecutionInfo, error)
-		ReplicateTimerCanceledEvent(*historypb.HistoryEvent) error
-		ReplicateTimerFiredEvent(*historypb.HistoryEvent) error
-		ReplicateTimerStartedEvent(*historypb.HistoryEvent) (*persistencespb.TimerInfo, error)
-		ReplicateTransientWorkflowTaskScheduled() (*WorkflowTaskInfo, error)
-		ReplicateWorkflowPropertiesModifiedEvent(*historypb.HistoryEvent)
-		ReplicateUpsertWorkflowSearchAttributesEvent(*historypb.HistoryEvent)
-		ReplicateWorkflowExecutionCancelRequestedEvent(*historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionCanceledEvent(int64, *historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionCompletedEvent(int64, *historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionContinuedAsNewEvent(int64, *historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionFailedEvent(int64, *historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionSignaled(*historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionStartedEvent(*clockspb.VectorClock, *commonpb.WorkflowExecution, string, *historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionTerminatedEvent(int64, *historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionTimedoutEvent(int64, *historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionUpdateAcceptedEvent(*historypb.HistoryEvent) error
-		ReplicateWorkflowExecutionUpdateCompletedEvent(event *historypb.HistoryEvent, batchID int64) error
+		ApplyActivityInfo(*historyservice.SyncActivityRequest, bool) error
+		ApplyActivityTaskCancelRequestedEvent(*historypb.HistoryEvent) error
+		ApplyActivityTaskCanceledEvent(*historypb.HistoryEvent) error
+		ApplyActivityTaskCompletedEvent(*historypb.HistoryEvent) error
+		ApplyActivityTaskFailedEvent(*historypb.HistoryEvent) error
+		ApplyActivityTaskScheduledEvent(int64, *historypb.HistoryEvent) (*persistencespb.ActivityInfo, error)
+		ApplyActivityTaskStartedEvent(*historypb.HistoryEvent) error
+		ApplyActivityTaskTimedOutEvent(*historypb.HistoryEvent) error
+		ApplyChildWorkflowExecutionCanceledEvent(*historypb.HistoryEvent) error
+		ApplyChildWorkflowExecutionCompletedEvent(*historypb.HistoryEvent) error
+		ApplyChildWorkflowExecutionFailedEvent(*historypb.HistoryEvent) error
+		ApplyChildWorkflowExecutionStartedEvent(*historypb.HistoryEvent, *clockspb.VectorClock) error
+		ApplyChildWorkflowExecutionTerminatedEvent(*historypb.HistoryEvent) error
+		ApplyChildWorkflowExecutionTimedOutEvent(*historypb.HistoryEvent) error
+		ApplyWorkflowTaskCompletedEvent(*historypb.HistoryEvent) error
+		ApplyWorkflowTaskFailedEvent() error
+		ApplyWorkflowTaskScheduledEvent(int64, int64, *taskqueuepb.TaskQueue, *durationpb.Duration, int32, *timestamppb.Timestamp, *timestamppb.Timestamp, enumsspb.WorkflowTaskType) (*WorkflowTaskInfo, error)
+		ApplyWorkflowTaskStartedEvent(*WorkflowTaskInfo, int64, int64, int64, string, time.Time, bool, int64) (*WorkflowTaskInfo, error)
+		ApplyWorkflowTaskTimedOutEvent(enumspb.TimeoutType) error
+		ApplyExternalWorkflowExecutionCancelRequested(*historypb.HistoryEvent) error
+		ApplyExternalWorkflowExecutionSignaled(*historypb.HistoryEvent) error
+		ApplyRequestCancelExternalWorkflowExecutionFailedEvent(*historypb.HistoryEvent) error
+		ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(int64, *historypb.HistoryEvent, string) (*persistencespb.RequestCancelInfo, error)
+		ApplySignalExternalWorkflowExecutionFailedEvent(*historypb.HistoryEvent) error
+		ApplySignalExternalWorkflowExecutionInitiatedEvent(int64, *historypb.HistoryEvent, string) (*persistencespb.SignalInfo, error)
+		ApplyStartChildWorkflowExecutionFailedEvent(*historypb.HistoryEvent) error
+		ApplyStartChildWorkflowExecutionInitiatedEvent(int64, *historypb.HistoryEvent, string) (*persistencespb.ChildExecutionInfo, error)
+		ApplyTimerCanceledEvent(*historypb.HistoryEvent) error
+		ApplyTimerFiredEvent(*historypb.HistoryEvent) error
+		ApplyTimerStartedEvent(*historypb.HistoryEvent) (*persistencespb.TimerInfo, error)
+		ApplyTransientWorkflowTaskScheduled() (*WorkflowTaskInfo, error)
+		ApplyWorkflowPropertiesModifiedEvent(*historypb.HistoryEvent)
+		ApplyUpsertWorkflowSearchAttributesEvent(*historypb.HistoryEvent)
+		ApplyWorkflowExecutionCancelRequestedEvent(*historypb.HistoryEvent) error
+		ApplyWorkflowExecutionCanceledEvent(int64, *historypb.HistoryEvent) error
+		ApplyWorkflowExecutionCompletedEvent(int64, *historypb.HistoryEvent) error
+		ApplyWorkflowExecutionContinuedAsNewEvent(int64, *historypb.HistoryEvent) error
+		ApplyWorkflowExecutionFailedEvent(int64, *historypb.HistoryEvent) error
+		ApplyWorkflowExecutionSignaled(*historypb.HistoryEvent) error
+		ApplyWorkflowExecutionStartedEvent(*clockspb.VectorClock, *commonpb.WorkflowExecution, string, *historypb.HistoryEvent) error
+		ApplyWorkflowExecutionTerminatedEvent(int64, *historypb.HistoryEvent) error
+		ApplyWorkflowExecutionTimedoutEvent(int64, *historypb.HistoryEvent) error
+		ApplyWorkflowExecutionUpdateAcceptedEvent(*historypb.HistoryEvent) error
+		ApplyWorkflowExecutionUpdateCompletedEvent(event *historypb.HistoryEvent, batchID int64) error
 		SetCurrentBranchToken(branchToken []byte) error
 		SetHistoryBuilder(hBuilder *HistoryBuilder)
 		SetHistoryTree(ctx context.Context, executionTimeout *durationpb.Duration, runTimeout *durationpb.Duration, treeID string) error

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1247,8 +1247,8 @@ func (ms *MutableStateImpl) UpdateActivityProgress(
 	ms.syncActivityTasks[ai.ScheduledEventId] = struct{}{}
 }
 
-// ApplyActivityInfo applies the necessary activity information
-func (ms *MutableStateImpl) ApplyActivityInfo(
+// UpdateActivityInfo applies the necessary activity information
+func (ms *MutableStateImpl) UpdateActivityInfo(
 	request *historyservice.SyncActivityRequest,
 	resetActivityTimerTaskStatus bool,
 ) error {

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1248,7 +1248,7 @@ func (ms *MutableStateImpl) UpdateActivityProgress(
 }
 
 // ReplicateActivityInfo replicate the necessary activity information
-func (ms *MutableStateImpl) ReplicateActivityInfo(
+func (ms *MutableStateImpl) ApplyActivityInfo(
 	request *historyservice.SyncActivityRequest,
 	resetActivityTimerTaskStatus bool,
 ) error {
@@ -1799,7 +1799,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionStartedEventWithOptions(
 		firstRunID,
 		execution.GetRunId(),
 	)
-	if err := ms.ReplicateWorkflowExecutionStartedEvent(
+	if err := ms.ApplyWorkflowExecutionStartedEvent(
 		startRequest.GetParentExecutionInfo().GetClock(),
 		execution,
 		startRequest.StartRequest.GetRequestId(),
@@ -1822,7 +1822,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionStartedEventWithOptions(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionStartedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionStartedEvent(
 	parentClock *clockspb.VectorClock,
 	execution *commonpb.WorkflowExecution,
 	requestID string,
@@ -1986,11 +1986,11 @@ func (ms *MutableStateImpl) AddWorkflowTaskScheduledEventAsHeartbeat(
 	return ms.workflowTaskManager.AddWorkflowTaskScheduledEventAsHeartbeat(bypassTaskGeneration, originalScheduledTimestamp, workflowTaskType)
 }
 
-func (ms *MutableStateImpl) ReplicateTransientWorkflowTaskScheduled() (*WorkflowTaskInfo, error) {
+func (ms *MutableStateImpl) ApplyTransientWorkflowTaskScheduled() (*WorkflowTaskInfo, error) {
 	return ms.workflowTaskManager.ReplicateTransientWorkflowTaskScheduled()
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowTaskScheduledEvent(
+func (ms *MutableStateImpl) ApplyWorkflowTaskScheduledEvent(
 	version int64,
 	scheduledEventID int64,
 	taskQueue *taskqueuepb.TaskQueue,
@@ -2016,7 +2016,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskStartedEvent(
 	return ms.workflowTaskManager.AddWorkflowTaskStartedEvent(scheduledEventID, requestID, taskQueue, identity)
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowTaskStartedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowTaskStartedEvent(
 	workflowTask *WorkflowTaskInfo,
 	version int64,
 	scheduledEventID int64,
@@ -2229,7 +2229,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskCompletedEvent(
 	return ms.workflowTaskManager.AddWorkflowTaskCompletedEvent(workflowTask, request, limits)
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowTaskCompletedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowTaskCompletedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 	return ms.workflowTaskManager.ReplicateWorkflowTaskCompletedEvent(event)
@@ -2245,7 +2245,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskTimedOutEvent(
 	return ms.workflowTaskManager.AddWorkflowTaskTimedOutEvent(workflowTask)
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowTaskTimedOutEvent(
+func (ms *MutableStateImpl) ApplyWorkflowTaskTimedOutEvent(
 	timeoutType enumspb.TimeoutType,
 ) error {
 	return ms.workflowTaskManager.ReplicateWorkflowTaskTimedOutEvent(timeoutType)
@@ -2287,7 +2287,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskFailedEvent(
 	)
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowTaskFailedEvent() error {
+func (ms *MutableStateImpl) ApplyWorkflowTaskFailedEvent() error {
 	return ms.workflowTaskManager.ReplicateWorkflowTaskFailedEvent()
 }
 
@@ -2311,7 +2311,7 @@ func (ms *MutableStateImpl) AddActivityTaskScheduledEvent(
 	}
 
 	event := ms.hBuilder.AddActivityTaskScheduledEvent(workflowTaskCompletedEventID, command)
-	ai, err := ms.ReplicateActivityTaskScheduledEvent(workflowTaskCompletedEventID, event)
+	ai, err := ms.ApplyActivityTaskScheduledEvent(workflowTaskCompletedEventID, event)
 	// TODO merge active & passive task generation
 	if !bypassTaskGeneration {
 		if err := ms.taskGenerator.GenerateActivityTasks(
@@ -2324,7 +2324,7 @@ func (ms *MutableStateImpl) AddActivityTaskScheduledEvent(
 	return event, ai, err
 }
 
-func (ms *MutableStateImpl) ReplicateActivityTaskScheduledEvent(
+func (ms *MutableStateImpl) ApplyActivityTaskScheduledEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 ) (*persistencespb.ActivityInfo, error) {
@@ -2402,7 +2402,7 @@ func (ms *MutableStateImpl) addTransientActivityStartedEvent(
 		// overwrite started event time to the one recorded in ActivityInfo
 		event.EventTime = ai.StartedTime
 	}
-	return ms.ReplicateActivityTaskStartedEvent(event)
+	return ms.ApplyActivityTaskStartedEvent(event)
 }
 
 func (ms *MutableStateImpl) AddActivityTaskStartedEvent(
@@ -2425,7 +2425,7 @@ func (ms *MutableStateImpl) AddActivityTaskStartedEvent(
 			identity,
 			ai.RetryLastFailure,
 		)
-		if err := ms.ReplicateActivityTaskStartedEvent(event); err != nil {
+		if err := ms.ApplyActivityTaskStartedEvent(event); err != nil {
 			return nil, err
 		}
 		return event, nil
@@ -2445,7 +2445,7 @@ func (ms *MutableStateImpl) AddActivityTaskStartedEvent(
 	return nil, nil
 }
 
-func (ms *MutableStateImpl) ReplicateActivityTaskStartedEvent(
+func (ms *MutableStateImpl) ApplyActivityTaskStartedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -2501,14 +2501,14 @@ func (ms *MutableStateImpl) AddActivityTaskCompletedEvent(
 		request.Identity,
 		request.Result,
 	)
-	if err := ms.ReplicateActivityTaskCompletedEvent(event); err != nil {
+	if err := ms.ApplyActivityTaskCompletedEvent(event); err != nil {
 		return nil, err
 	}
 
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateActivityTaskCompletedEvent(
+func (ms *MutableStateImpl) ApplyActivityTaskCompletedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -2551,14 +2551,14 @@ func (ms *MutableStateImpl) AddActivityTaskFailedEvent(
 		retryState,
 		identity,
 	)
-	if err := ms.ReplicateActivityTaskFailedEvent(event); err != nil {
+	if err := ms.ApplyActivityTaskFailedEvent(event); err != nil {
 		return nil, err
 	}
 
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateActivityTaskFailedEvent(
+func (ms *MutableStateImpl) ApplyActivityTaskFailedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -2605,14 +2605,14 @@ func (ms *MutableStateImpl) AddActivityTaskTimedOutEvent(
 		timeoutFailure,
 		retryState,
 	)
-	if err := ms.ReplicateActivityTaskTimedOutEvent(event); err != nil {
+	if err := ms.ApplyActivityTaskTimedOutEvent(event); err != nil {
 		return nil, err
 	}
 
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateActivityTaskTimedOutEvent(
+func (ms *MutableStateImpl) ApplyActivityTaskTimedOutEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -2661,14 +2661,14 @@ func (ms *MutableStateImpl) AddActivityTaskCancelRequestedEvent(
 	// At this point we know this is a valid activity cancellation request
 	actCancelReqEvent := ms.hBuilder.AddActivityTaskCancelRequestedEvent(workflowTaskCompletedEventID, scheduledEventID)
 
-	if err := ms.ReplicateActivityTaskCancelRequestedEvent(actCancelReqEvent); err != nil {
+	if err := ms.ApplyActivityTaskCancelRequestedEvent(actCancelReqEvent); err != nil {
 		return nil, nil, err
 	}
 
 	return actCancelReqEvent, ai, nil
 }
 
-func (ms *MutableStateImpl) ReplicateActivityTaskCancelRequestedEvent(
+func (ms *MutableStateImpl) ApplyActivityTaskCancelRequestedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -2741,14 +2741,14 @@ func (ms *MutableStateImpl) AddActivityTaskCanceledEvent(
 		details,
 		identity,
 	)
-	if err := ms.ReplicateActivityTaskCanceledEvent(event); err != nil {
+	if err := ms.ApplyActivityTaskCanceledEvent(event); err != nil {
 		return nil, err
 	}
 
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateActivityTaskCanceledEvent(
+func (ms *MutableStateImpl) ApplyActivityTaskCanceledEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -2770,7 +2770,7 @@ func (ms *MutableStateImpl) AddCompletedWorkflowEvent(
 	}
 
 	event := ms.hBuilder.AddCompletedWorkflowEvent(workflowTaskCompletedEventID, command, newExecutionRunID)
-	if err := ms.ReplicateWorkflowExecutionCompletedEvent(workflowTaskCompletedEventID, event); err != nil {
+	if err := ms.ApplyWorkflowExecutionCompletedEvent(workflowTaskCompletedEventID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -2783,7 +2783,7 @@ func (ms *MutableStateImpl) AddCompletedWorkflowEvent(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionCompletedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionCompletedEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 ) error {
@@ -2815,7 +2815,7 @@ func (ms *MutableStateImpl) AddFailWorkflowEvent(
 	}
 
 	event, batchID := ms.hBuilder.AddFailWorkflowEvent(workflowTaskCompletedEventID, retryState, command, newExecutionRunID)
-	if err := ms.ReplicateWorkflowExecutionFailedEvent(batchID, event); err != nil {
+	if err := ms.ApplyWorkflowExecutionFailedEvent(batchID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -2828,7 +2828,7 @@ func (ms *MutableStateImpl) AddFailWorkflowEvent(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionFailedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionFailedEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 ) error {
@@ -2859,7 +2859,7 @@ func (ms *MutableStateImpl) AddTimeoutWorkflowEvent(
 	}
 
 	event := ms.hBuilder.AddTimeoutWorkflowEvent(retryState, newExecutionRunID)
-	if err := ms.ReplicateWorkflowExecutionTimedoutEvent(firstEventID, event); err != nil {
+	if err := ms.ApplyWorkflowExecutionTimedoutEvent(firstEventID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -2872,7 +2872,7 @@ func (ms *MutableStateImpl) AddTimeoutWorkflowEvent(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionTimedoutEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionTimedoutEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 ) error {
@@ -2912,7 +2912,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionCancelRequestedEvent(
 	}
 
 	event := ms.hBuilder.AddWorkflowExecutionCancelRequestedEvent(request)
-	if err := ms.ReplicateWorkflowExecutionCancelRequestedEvent(event); err != nil {
+	if err := ms.ApplyWorkflowExecutionCancelRequestedEvent(event); err != nil {
 		return nil, err
 	}
 
@@ -2921,7 +2921,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionCancelRequestedEvent(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionCancelRequestedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionCancelRequestedEvent(
 	_ *historypb.HistoryEvent,
 ) error {
 
@@ -2940,7 +2940,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionCanceledEvent(
 	}
 
 	event := ms.hBuilder.AddWorkflowExecutionCanceledEvent(workflowTaskCompletedEventID, command)
-	if err := ms.ReplicateWorkflowExecutionCanceledEvent(workflowTaskCompletedEventID, event); err != nil {
+	if err := ms.ApplyWorkflowExecutionCanceledEvent(workflowTaskCompletedEventID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -2953,7 +2953,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionCanceledEvent(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionCanceledEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionCanceledEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 ) error {
@@ -2984,7 +2984,7 @@ func (ms *MutableStateImpl) AddRequestCancelExternalWorkflowExecutionInitiatedEv
 	}
 
 	event := ms.hBuilder.AddRequestCancelExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, command, targetNamespaceID)
-	rci, err := ms.ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event, cancelRequestID)
+	rci, err := ms.ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event, cancelRequestID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -2997,7 +2997,7 @@ func (ms *MutableStateImpl) AddRequestCancelExternalWorkflowExecutionInitiatedEv
 	return event, rci, nil
 }
 
-func (ms *MutableStateImpl) ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent(
+func (ms *MutableStateImpl) ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 	cancelRequestID string,
@@ -3050,13 +3050,13 @@ func (ms *MutableStateImpl) AddExternalWorkflowExecutionCancelRequested(
 		workflowID,
 		runID,
 	)
-	if err := ms.ReplicateExternalWorkflowExecutionCancelRequested(event); err != nil {
+	if err := ms.ApplyExternalWorkflowExecutionCancelRequested(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateExternalWorkflowExecutionCancelRequested(
+func (ms *MutableStateImpl) ApplyExternalWorkflowExecutionCancelRequested(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -3097,13 +3097,13 @@ func (ms *MutableStateImpl) AddRequestCancelExternalWorkflowExecutionFailedEvent
 		runID,
 		cause,
 	)
-	if err := ms.ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(event); err != nil {
+	if err := ms.ApplyRequestCancelExternalWorkflowExecutionFailedEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(
+func (ms *MutableStateImpl) ApplyRequestCancelExternalWorkflowExecutionFailedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -3125,7 +3125,7 @@ func (ms *MutableStateImpl) AddSignalExternalWorkflowExecutionInitiatedEvent(
 	}
 
 	event := ms.hBuilder.AddSignalExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, command, targetNamespaceID)
-	si, err := ms.ReplicateSignalExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event, signalRequestID)
+	si, err := ms.ApplySignalExternalWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event, signalRequestID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -3138,7 +3138,7 @@ func (ms *MutableStateImpl) AddSignalExternalWorkflowExecutionInitiatedEvent(
 	return event, si, nil
 }
 
-func (ms *MutableStateImpl) ReplicateSignalExternalWorkflowExecutionInitiatedEvent(
+func (ms *MutableStateImpl) ApplySignalExternalWorkflowExecutionInitiatedEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 	signalRequestID string,
@@ -3173,7 +3173,7 @@ func (ms *MutableStateImpl) AddUpsertWorkflowSearchAttributesEvent(
 	}
 
 	event := ms.hBuilder.AddUpsertWorkflowSearchAttributesEvent(workflowTaskCompletedEventID, command)
-	ms.ReplicateUpsertWorkflowSearchAttributesEvent(event)
+	ms.ApplyUpsertWorkflowSearchAttributesEvent(event)
 	// TODO merge active & passive task generation
 	if err := ms.taskGenerator.GenerateUpsertVisibilityTask(); err != nil {
 		return nil, err
@@ -3181,7 +3181,7 @@ func (ms *MutableStateImpl) AddUpsertWorkflowSearchAttributesEvent(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateUpsertWorkflowSearchAttributesEvent(
+func (ms *MutableStateImpl) ApplyUpsertWorkflowSearchAttributesEvent(
 	event *historypb.HistoryEvent,
 ) {
 	upsertSearchAttr := event.GetUpsertWorkflowSearchAttributesEventAttributes().GetSearchAttributes().GetIndexedFields()
@@ -3200,7 +3200,7 @@ func (ms *MutableStateImpl) AddWorkflowPropertiesModifiedEvent(
 	}
 
 	event := ms.hBuilder.AddWorkflowPropertiesModifiedEvent(workflowTaskCompletedEventID, command)
-	ms.ReplicateWorkflowPropertiesModifiedEvent(event)
+	ms.ApplyWorkflowPropertiesModifiedEvent(event)
 	// TODO merge active & passive task generation
 	if err := ms.taskGenerator.GenerateUpsertVisibilityTask(); err != nil {
 		return nil, err
@@ -3208,7 +3208,7 @@ func (ms *MutableStateImpl) AddWorkflowPropertiesModifiedEvent(
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowPropertiesModifiedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowPropertiesModifiedEvent(
 	event *historypb.HistoryEvent,
 ) {
 	attr := event.GetWorkflowPropertiesModifiedEventAttributes()
@@ -3251,13 +3251,13 @@ func (ms *MutableStateImpl) AddExternalWorkflowExecutionSignaled(
 		runID,
 		control, // TODO this field is probably deprecated
 	)
-	if err := ms.ReplicateExternalWorkflowExecutionSignaled(event); err != nil {
+	if err := ms.ApplyExternalWorkflowExecutionSignaled(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateExternalWorkflowExecutionSignaled(
+func (ms *MutableStateImpl) ApplyExternalWorkflowExecutionSignaled(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -3300,13 +3300,13 @@ func (ms *MutableStateImpl) AddSignalExternalWorkflowExecutionFailedEvent(
 		control, // TODO this field is probably deprecated
 		cause,
 	)
-	if err := ms.ReplicateSignalExternalWorkflowExecutionFailedEvent(event); err != nil {
+	if err := ms.ApplySignalExternalWorkflowExecutionFailedEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateSignalExternalWorkflowExecutionFailedEvent(
+func (ms *MutableStateImpl) ApplySignalExternalWorkflowExecutionFailedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -3336,14 +3336,14 @@ func (ms *MutableStateImpl) AddTimerStartedEvent(
 	}
 
 	event := ms.hBuilder.AddTimerStartedEvent(workflowTaskCompletedEventID, command)
-	ti, err := ms.ReplicateTimerStartedEvent(event)
+	ti, err := ms.ApplyTimerStartedEvent(event)
 	if err != nil {
 		return nil, nil, err
 	}
 	return event, ti, err
 }
 
-func (ms *MutableStateImpl) ReplicateTimerStartedEvent(
+func (ms *MutableStateImpl) ApplyTimerStartedEvent(
 	event *historypb.HistoryEvent,
 ) (*persistencespb.TimerInfo, error) {
 
@@ -3391,13 +3391,13 @@ func (ms *MutableStateImpl) AddTimerFiredEvent(
 
 	// Timer is running.
 	event := ms.hBuilder.AddTimerFiredEvent(timerInfo.GetStartedEventId(), timerInfo.TimerId)
-	if err := ms.ReplicateTimerFiredEvent(event); err != nil {
+	if err := ms.ApplyTimerFiredEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateTimerFiredEvent(
+func (ms *MutableStateImpl) ApplyTimerFiredEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -3446,14 +3446,14 @@ func (ms *MutableStateImpl) AddTimerCanceledEvent(
 		identity,
 	)
 	if ok {
-		if err := ms.ReplicateTimerCanceledEvent(event); err != nil {
+		if err := ms.ApplyTimerCanceledEvent(event); err != nil {
 			return nil, err
 		}
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateTimerCanceledEvent(
+func (ms *MutableStateImpl) ApplyTimerCanceledEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -3490,7 +3490,7 @@ func (ms *MutableStateImpl) AddWorkflowExecutionTerminatedEvent(
 	}
 
 	event := ms.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity)
-	if err := ms.ReplicateWorkflowExecutionTerminatedEvent(firstEventID, event); err != nil {
+	if err := ms.ApplyWorkflowExecutionTerminatedEvent(firstEventID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -3513,13 +3513,13 @@ func (ms *MutableStateImpl) AddWorkflowExecutionUpdateAcceptedEvent(
 		return nil, err
 	}
 	event := ms.hBuilder.AddWorkflowExecutionUpdateAcceptedEvent(protocolInstanceID, acceptedRequestMessageId, acceptedRequestSequencingEventId, acceptedRequest)
-	if err := ms.ReplicateWorkflowExecutionUpdateAcceptedEvent(event); err != nil {
+	if err := ms.ApplyWorkflowExecutionUpdateAcceptedEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionUpdateAcceptedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionUpdateAcceptedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 	attrs := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
@@ -3560,13 +3560,13 @@ func (ms *MutableStateImpl) AddWorkflowExecutionUpdateCompletedEvent(
 		return nil, err
 	}
 	event, batchID := ms.hBuilder.AddWorkflowExecutionUpdateCompletedEvent(acceptedEventID, updResp)
-	if err := ms.ReplicateWorkflowExecutionUpdateCompletedEvent(event, batchID); err != nil {
+	if err := ms.ApplyWorkflowExecutionUpdateCompletedEvent(event, batchID); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionUpdateCompletedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionUpdateCompletedEvent(
 	event *historypb.HistoryEvent,
 	batchID int64,
 ) error {
@@ -3608,7 +3608,7 @@ func (ms *MutableStateImpl) RejectWorkflowExecutionUpdate(_ string, _ *updatepb.
 	return nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionTerminatedEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionTerminatedEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 ) error {
@@ -3641,13 +3641,13 @@ func (ms *MutableStateImpl) AddWorkflowExecutionSignaled(
 	}
 
 	event := ms.hBuilder.AddWorkflowExecutionSignaledEvent(signalName, input, identity, header, skipGenerateWorkflowTask)
-	if err := ms.ReplicateWorkflowExecutionSignaled(event); err != nil {
+	if err := ms.ApplyWorkflowExecutionSignaled(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionSignaled(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionSignaled(
 	_ *historypb.HistoryEvent,
 ) error {
 
@@ -3730,7 +3730,7 @@ func (ms *MutableStateImpl) AddContinueAsNewEvent(
 		return nil, nil, err
 	}
 
-	if err = ms.ReplicateWorkflowExecutionContinuedAsNewEvent(
+	if err = ms.ApplyWorkflowExecutionContinuedAsNewEvent(
 		firstEventID,
 		continueAsNewEvent,
 	); err != nil {
@@ -3772,7 +3772,7 @@ func rolloverAutoResetPointsWithExpiringTime(
 	return &workflowpb.ResetPoints{Points: newPoints}
 }
 
-func (ms *MutableStateImpl) ReplicateWorkflowExecutionContinuedAsNewEvent(
+func (ms *MutableStateImpl) ApplyWorkflowExecutionContinuedAsNewEvent(
 	firstEventID int64,
 	continueAsNewEvent *historypb.HistoryEvent,
 ) error {
@@ -3804,7 +3804,7 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 	}
 
 	event := ms.hBuilder.AddStartChildWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, command, targetNamespaceID)
-	ci, err := ms.ReplicateStartChildWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event, createRequestID)
+	ci, err := ms.ApplyStartChildWorkflowExecutionInitiatedEvent(workflowTaskCompletedEventID, event, createRequestID)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -3817,7 +3817,7 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionInitiatedEvent(
 	return event, ci, nil
 }
 
-func (ms *MutableStateImpl) ReplicateStartChildWorkflowExecutionInitiatedEvent(
+func (ms *MutableStateImpl) ApplyStartChildWorkflowExecutionInitiatedEvent(
 	firstEventID int64,
 	event *historypb.HistoryEvent,
 	createRequestID string,
@@ -3878,13 +3878,13 @@ func (ms *MutableStateImpl) AddChildWorkflowExecutionStartedEvent(
 		workflowType,
 		header,
 	)
-	if err := ms.ReplicateChildWorkflowExecutionStartedEvent(event, clock); err != nil {
+	if err := ms.ApplyChildWorkflowExecutionStartedEvent(event, clock); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateChildWorkflowExecutionStartedEvent(
+func (ms *MutableStateImpl) ApplyChildWorkflowExecutionStartedEvent(
 	event *historypb.HistoryEvent,
 	clock *clockspb.VectorClock,
 ) error {
@@ -3943,13 +3943,13 @@ func (ms *MutableStateImpl) AddStartChildWorkflowExecutionFailedEvent(
 		initiatedEventAttributes.WorkflowType,
 		initiatedEventAttributes.Control, // TODO this field is probably deprecated
 	)
-	if err := ms.ReplicateStartChildWorkflowExecutionFailedEvent(event); err != nil {
+	if err := ms.ApplyStartChildWorkflowExecutionFailedEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateStartChildWorkflowExecutionFailedEvent(
+func (ms *MutableStateImpl) ApplyStartChildWorkflowExecutionFailedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -3993,13 +3993,13 @@ func (ms *MutableStateImpl) AddChildWorkflowExecutionCompletedEvent(
 		workflowType,
 		attributes.Result,
 	)
-	if err := ms.ReplicateChildWorkflowExecutionCompletedEvent(event); err != nil {
+	if err := ms.ApplyChildWorkflowExecutionCompletedEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateChildWorkflowExecutionCompletedEvent(
+func (ms *MutableStateImpl) ApplyChildWorkflowExecutionCompletedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -4044,13 +4044,13 @@ func (ms *MutableStateImpl) AddChildWorkflowExecutionFailedEvent(
 		attributes.Failure,
 		attributes.RetryState,
 	)
-	if err := ms.ReplicateChildWorkflowExecutionFailedEvent(event); err != nil {
+	if err := ms.ApplyChildWorkflowExecutionFailedEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateChildWorkflowExecutionFailedEvent(
+func (ms *MutableStateImpl) ApplyChildWorkflowExecutionFailedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -4094,13 +4094,13 @@ func (ms *MutableStateImpl) AddChildWorkflowExecutionCanceledEvent(
 		workflowType,
 		attributes.Details,
 	)
-	if err := ms.ReplicateChildWorkflowExecutionCanceledEvent(event); err != nil {
+	if err := ms.ApplyChildWorkflowExecutionCanceledEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateChildWorkflowExecutionCanceledEvent(
+func (ms *MutableStateImpl) ApplyChildWorkflowExecutionCanceledEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -4143,13 +4143,13 @@ func (ms *MutableStateImpl) AddChildWorkflowExecutionTerminatedEvent(
 		childExecution,
 		workflowType,
 	)
-	if err := ms.ReplicateChildWorkflowExecutionTerminatedEvent(event); err != nil {
+	if err := ms.ApplyChildWorkflowExecutionTerminatedEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateChildWorkflowExecutionTerminatedEvent(
+func (ms *MutableStateImpl) ApplyChildWorkflowExecutionTerminatedEvent(
 	event *historypb.HistoryEvent,
 ) error {
 
@@ -4193,13 +4193,13 @@ func (ms *MutableStateImpl) AddChildWorkflowExecutionTimedOutEvent(
 		workflowType,
 		attributes.RetryState,
 	)
-	if err := ms.ReplicateChildWorkflowExecutionTimedOutEvent(event); err != nil {
+	if err := ms.ApplyChildWorkflowExecutionTimedOutEvent(event); err != nil {
 		return nil, err
 	}
 	return event, nil
 }
 
-func (ms *MutableStateImpl) ReplicateChildWorkflowExecutionTimedOutEvent(
+func (ms *MutableStateImpl) ApplyChildWorkflowExecutionTimedOutEvent(
 	event *historypb.HistoryEvent,
 ) error {
 

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -1247,7 +1247,7 @@ func (ms *MutableStateImpl) UpdateActivityProgress(
 	ms.syncActivityTasks[ai.ScheduledEventId] = struct{}{}
 }
 
-// ReplicateActivityInfo replicate the necessary activity information
+// ApplyActivityInfo applies the necessary activity information
 func (ms *MutableStateImpl) ApplyActivityInfo(
 	request *historyservice.SyncActivityRequest,
 	resetActivityTimerTaskStatus bool,
@@ -1987,7 +1987,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskScheduledEventAsHeartbeat(
 }
 
 func (ms *MutableStateImpl) ApplyTransientWorkflowTaskScheduled() (*WorkflowTaskInfo, error) {
-	return ms.workflowTaskManager.ReplicateTransientWorkflowTaskScheduled()
+	return ms.workflowTaskManager.ApplyTransientWorkflowTaskScheduled()
 }
 
 func (ms *MutableStateImpl) ApplyWorkflowTaskScheduledEvent(
@@ -2000,7 +2000,7 @@ func (ms *MutableStateImpl) ApplyWorkflowTaskScheduledEvent(
 	originalScheduledTimestamp *timestamppb.Timestamp,
 	workflowTaskType enumsspb.WorkflowTaskType,
 ) (*WorkflowTaskInfo, error) {
-	return ms.workflowTaskManager.ReplicateWorkflowTaskScheduledEvent(version, scheduledEventID, taskQueue, startToCloseTimeout, attempt, scheduleTimestamp, originalScheduledTimestamp, workflowTaskType)
+	return ms.workflowTaskManager.ApplyWorkflowTaskScheduledEvent(version, scheduledEventID, taskQueue, startToCloseTimeout, attempt, scheduleTimestamp, originalScheduledTimestamp, workflowTaskType)
 }
 
 func (ms *MutableStateImpl) AddWorkflowTaskStartedEvent(
@@ -2026,7 +2026,7 @@ func (ms *MutableStateImpl) ApplyWorkflowTaskStartedEvent(
 	suggestContinueAsNew bool,
 	historySizeBytes int64,
 ) (*WorkflowTaskInfo, error) {
-	return ms.workflowTaskManager.ReplicateWorkflowTaskStartedEvent(workflowTask, version, scheduledEventID,
+	return ms.workflowTaskManager.ApplyWorkflowTaskStartedEvent(workflowTask, version, scheduledEventID,
 		startedEventID, requestID, timestamp, suggestContinueAsNew, historySizeBytes)
 }
 
@@ -2232,7 +2232,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskCompletedEvent(
 func (ms *MutableStateImpl) ApplyWorkflowTaskCompletedEvent(
 	event *historypb.HistoryEvent,
 ) error {
-	return ms.workflowTaskManager.ReplicateWorkflowTaskCompletedEvent(event)
+	return ms.workflowTaskManager.ApplyWorkflowTaskCompletedEvent(event)
 }
 
 func (ms *MutableStateImpl) AddWorkflowTaskTimedOutEvent(
@@ -2248,7 +2248,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskTimedOutEvent(
 func (ms *MutableStateImpl) ApplyWorkflowTaskTimedOutEvent(
 	timeoutType enumspb.TimeoutType,
 ) error {
-	return ms.workflowTaskManager.ReplicateWorkflowTaskTimedOutEvent(timeoutType)
+	return ms.workflowTaskManager.ApplyWorkflowTaskTimedOutEvent(timeoutType)
 }
 
 func (ms *MutableStateImpl) AddWorkflowTaskScheduleToStartTimeoutEvent(
@@ -2288,7 +2288,7 @@ func (ms *MutableStateImpl) AddWorkflowTaskFailedEvent(
 }
 
 func (ms *MutableStateImpl) ApplyWorkflowTaskFailedEvent() error {
-	return ms.workflowTaskManager.ReplicateWorkflowTaskFailedEvent()
+	return ms.workflowTaskManager.ApplyWorkflowTaskFailedEvent()
 }
 
 func (ms *MutableStateImpl) AddActivityTaskScheduledEvent(
@@ -3524,7 +3524,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionUpdateAcceptedEvent(
 ) error {
 	attrs := event.GetWorkflowExecutionUpdateAcceptedEventAttributes()
 	if attrs == nil {
-		return serviceerror.NewInternal("wrong event type in call to ReplicateWorkflowExecutionUpdateAcceptedEvent")
+		return serviceerror.NewInternal("wrong event type in call to ApplyWorkflowExecutionUpdateAcceptedEvent")
 	}
 	if ms.executionInfo.UpdateInfos == nil {
 		ms.executionInfo.UpdateInfos = make(map[string]*updatespb.UpdateInfo, 1)
@@ -3572,7 +3572,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionUpdateCompletedEvent(
 ) error {
 	attrs := event.GetWorkflowExecutionUpdateCompletedEventAttributes()
 	if attrs == nil {
-		return serviceerror.NewInternal("wrong event type in call to ReplicateWorkflowExecutionUpdateCompletedEvent")
+		return serviceerror.NewInternal("wrong event type in call to ApplyWorkflowExecutionUpdateCompletedEvent")
 	}
 	if ms.executionInfo.UpdateInfos == nil {
 		ms.executionInfo.UpdateInfos = make(map[string]*updatespb.UpdateInfo, 1)

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -134,7 +134,7 @@ func (s *mutableStateSuite) TearDownTest() {
 	s.mockShard.StopForTest()
 }
 
-func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplicated_ApplyWorkflowTaskCompleted() {
+func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchApplied_ApplyWorkflowTaskCompleted() {
 	version := int64(12)
 	runID := uuid.New()
 	s.mutableState = TestGlobalMutableState(
@@ -145,7 +145,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 		runID,
 	)
 
-	newWorkflowTaskScheduleEvent, newWorkflowTaskStartedEvent := s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
+	newWorkflowTaskScheduleEvent, newWorkflowTaskStartedEvent := s.prepareTransientWorkflowTaskCompletionFirstBatchApplied(version, runID)
 
 	newWorkflowTaskCompletedEvent := &historypb.HistoryEvent{
 		Version:   version,
@@ -166,7 +166,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
 }
 
-func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplicated_FailoverWorkflowTaskTimeout() {
+func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchApplied_FailoverWorkflowTaskTimeout() {
 	version := int64(12)
 	runID := uuid.New()
 	s.mutableState = TestGlobalMutableState(
@@ -177,7 +177,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 		runID,
 	)
 
-	newWorkflowTaskScheduleEvent, _ := s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
+	newWorkflowTaskScheduleEvent, _ := s.prepareTransientWorkflowTaskCompletionFirstBatchApplied(version, runID)
 
 	newWorkflowTask := s.mutableState.GetWorkflowTaskByID(newWorkflowTaskScheduleEvent.GetEventId())
 	s.NotNil(newWorkflowTask)
@@ -189,7 +189,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
 }
 
-func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplicated_FailoverWorkflowTaskFailed() {
+func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchApplied_FailoverWorkflowTaskFailed() {
 	version := int64(12)
 	runID := uuid.New()
 	s.mutableState = TestGlobalMutableState(
@@ -200,7 +200,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 		runID,
 	)
 
-	newWorkflowTaskScheduleEvent, _ := s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
+	newWorkflowTaskScheduleEvent, _ := s.prepareTransientWorkflowTaskCompletionFirstBatchApplied(version, runID)
 
 	newWorkflowTask := s.mutableState.GetWorkflowTaskByID(newWorkflowTaskScheduleEvent.GetEventId())
 	s.NotNil(newWorkflowTask)
@@ -412,7 +412,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskSchedule_CurrentVersionChan
 		version,
 		runID,
 	)
-	_, _ = s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
+	_, _ = s.prepareTransientWorkflowTaskCompletionFirstBatchApplied(version, runID)
 	err := s.mutableState.ApplyWorkflowTaskFailedEvent()
 	s.NoError(err)
 
@@ -445,7 +445,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskStart_CurrentVersionChanged
 		version,
 		runID,
 	)
-	_, _ = s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
+	_, _ = s.prepareTransientWorkflowTaskCompletionFirstBatchApplied(version, runID)
 	err := s.mutableState.ApplyWorkflowTaskFailedEvent()
 	s.NoError(err)
 
@@ -519,7 +519,7 @@ func (s *mutableStateSuite) TestSanitizedMutableState() {
 	}
 }
 
-func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version int64, runID string) (*historypb.HistoryEvent, *historypb.HistoryEvent) {
+func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchApplied(version int64, runID string) (*historypb.HistoryEvent, *historypb.HistoryEvent) {
 	namespaceID := tests.NamespaceID
 	execution := &commonpb.WorkflowExecution{
 		WorkflowId: "some random workflow ID",

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -134,7 +134,7 @@ func (s *mutableStateSuite) TearDownTest() {
 	s.mockShard.StopForTest()
 }
 
-func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplicated_ReplicateWorkflowTaskCompleted() {
+func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplicated_ApplyWorkflowTaskCompleted() {
 	version := int64(12)
 	runID := uuid.New()
 	s.mutableState = TestGlobalMutableState(

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -900,7 +900,7 @@ func (s *mutableStateSuite) TestUpdateInfos() {
 		"expected 1 completed update + 2 accepted in mutation")
 }
 
-func (s *mutableStateSuite) TestReplicateActivityTaskStartedEvent() {
+func (s *mutableStateSuite) TestApplyActivityTaskStartedEvent() {
 	state := s.buildWorkflowMutableState()
 
 	var err error

--- a/service/history/workflow/mutable_state_impl_test.go
+++ b/service/history/workflow/mutable_state_impl_test.go
@@ -161,7 +161,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskCompletionFirstBatchReplica
 	s.mutableState.SetHistoryBuilder(NewImmutableHistoryBuilder([]*historypb.HistoryEvent{
 		newWorkflowTaskCompletedEvent,
 	}))
-	err := s.mutableState.ReplicateWorkflowTaskCompletedEvent(newWorkflowTaskCompletedEvent)
+	err := s.mutableState.ApplyWorkflowTaskCompletedEvent(newWorkflowTaskCompletedEvent)
 	s.NoError(err)
 	s.Equal(0, s.mutableState.hBuilder.NumBufferedEvents())
 }
@@ -413,7 +413,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskSchedule_CurrentVersionChan
 		runID,
 	)
 	_, _ = s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
-	err := s.mutableState.ReplicateWorkflowTaskFailedEvent()
+	err := s.mutableState.ApplyWorkflowTaskFailedEvent()
 	s.NoError(err)
 
 	err = s.mutableState.UpdateCurrentVersion(version+1, true)
@@ -446,7 +446,7 @@ func (s *mutableStateSuite) TestTransientWorkflowTaskStart_CurrentVersionChanged
 		runID,
 	)
 	_, _ = s.prepareTransientWorkflowTaskCompletionFirstBatchReplicated(version, runID)
-	err := s.mutableState.ReplicateWorkflowTaskFailedEvent()
+	err := s.mutableState.ApplyWorkflowTaskFailedEvent()
 	s.NoError(err)
 
 	versionHistories := s.mutableState.GetExecutionInfo().GetVersionHistories()
@@ -598,7 +598,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchRepl
 		},
 		workflowStartEvent,
 	)
-	err := s.mutableState.ReplicateWorkflowExecutionStartedEvent(
+	err := s.mutableState.ApplyWorkflowExecutionStartedEvent(
 		nil,
 		execution,
 		uuid.New(),
@@ -607,7 +607,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchRepl
 	s.Nil(err)
 
 	// setup transient workflow task
-	wt, err := s.mutableState.ReplicateWorkflowTaskScheduledEvent(
+	wt, err := s.mutableState.ApplyWorkflowTaskScheduledEvent(
 		workflowTaskScheduleEvent.GetVersion(),
 		workflowTaskScheduleEvent.GetEventId(),
 		workflowTaskScheduleEvent.GetWorkflowTaskScheduledEventAttributes().GetTaskQueue(),
@@ -620,7 +620,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchRepl
 	s.Nil(err)
 	s.NotNil(wt)
 
-	wt, err = s.mutableState.ReplicateWorkflowTaskStartedEvent(nil,
+	wt, err = s.mutableState.ApplyWorkflowTaskStartedEvent(nil,
 		workflowTaskStartedEvent.GetVersion(),
 		workflowTaskScheduleEvent.GetEventId(),
 		workflowTaskStartedEvent.GetEventId(),
@@ -632,7 +632,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchRepl
 	s.Nil(err)
 	s.NotNil(wt)
 
-	err = s.mutableState.ReplicateWorkflowTaskFailedEvent()
+	err = s.mutableState.ApplyWorkflowTaskFailedEvent()
 	s.Nil(err)
 
 	workflowTaskAttempt = int32(123)
@@ -661,7 +661,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchRepl
 	}
 	eventID++
 
-	wt, err = s.mutableState.ReplicateWorkflowTaskScheduledEvent(
+	wt, err = s.mutableState.ApplyWorkflowTaskScheduledEvent(
 		newWorkflowTaskScheduleEvent.GetVersion(),
 		newWorkflowTaskScheduleEvent.GetEventId(),
 		newWorkflowTaskScheduleEvent.GetWorkflowTaskScheduledEventAttributes().GetTaskQueue(),
@@ -674,7 +674,7 @@ func (s *mutableStateSuite) prepareTransientWorkflowTaskCompletionFirstBatchRepl
 	s.Nil(err)
 	s.NotNil(wt)
 
-	wt, err = s.mutableState.ReplicateWorkflowTaskStartedEvent(nil,
+	wt, err = s.mutableState.ApplyWorkflowTaskStartedEvent(nil,
 		newWorkflowTaskStartedEvent.GetVersion(),
 		newWorkflowTaskScheduleEvent.GetEventId(),
 		newWorkflowTaskStartedEvent.GetEventId(),
@@ -922,7 +922,7 @@ func (s *mutableStateSuite) TestReplicateActivityTaskStartedEvent() {
 		ScheduledEventId: scheduledEventID,
 		RequestId:        requestID,
 	}
-	err = s.mutableState.ReplicateActivityTaskStartedEvent(&historypb.HistoryEvent{
+	err = s.mutableState.ApplyActivityTaskStartedEvent(&historypb.HistoryEvent{
 		EventId:   eventID,
 		EventTime: timestamppb.New(now),
 		Version:   version,

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -834,20 +834,6 @@ func (mr *MockMutableStateMockRecorder) AddWorkflowTaskTimedOutEvent(workflowTas
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowTaskTimedOutEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowTaskTimedOutEvent), workflowTask)
 }
 
-// ApplyActivityInfo mocks base method.
-func (m *MockMutableState) ApplyActivityInfo(arg0 *v111.SyncActivityRequest, arg1 bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ApplyActivityInfo", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ApplyActivityInfo indicates an expected call of ApplyActivityInfo.
-func (mr *MockMutableStateMockRecorder) ApplyActivityInfo(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityInfo", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityInfo), arg0, arg1)
-}
-
 // ApplyActivityTaskCancelRequestedEvent mocks base method.
 func (m *MockMutableState) ApplyActivityTaskCancelRequestedEvent(arg0 *v13.HistoryEvent) error {
 	m.ctrl.T.Helper()
@@ -2731,6 +2717,20 @@ func (m *MockMutableState) UpdateActivity(arg0 *v112.ActivityInfo) error {
 func (mr *MockMutableStateMockRecorder) UpdateActivity(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivity", reflect.TypeOf((*MockMutableState)(nil).UpdateActivity), arg0)
+}
+
+// UpdateActivityInfo mocks base method.
+func (m *MockMutableState) UpdateActivityInfo(arg0 *v111.SyncActivityRequest, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateActivityInfo", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateActivityInfo indicates an expected call of UpdateActivityInfo.
+func (mr *MockMutableStateMockRecorder) UpdateActivityInfo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateActivityInfo", reflect.TypeOf((*MockMutableState)(nil).UpdateActivityInfo), arg0, arg1)
 }
 
 // UpdateActivityProgress mocks base method.

--- a/service/history/workflow/mutable_state_mock.go
+++ b/service/history/workflow/mutable_state_mock.go
@@ -834,6 +834,626 @@ func (mr *MockMutableStateMockRecorder) AddWorkflowTaskTimedOutEvent(workflowTas
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddWorkflowTaskTimedOutEvent", reflect.TypeOf((*MockMutableState)(nil).AddWorkflowTaskTimedOutEvent), workflowTask)
 }
 
+// ApplyActivityInfo mocks base method.
+func (m *MockMutableState) ApplyActivityInfo(arg0 *v111.SyncActivityRequest, arg1 bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyActivityInfo", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyActivityInfo indicates an expected call of ApplyActivityInfo.
+func (mr *MockMutableStateMockRecorder) ApplyActivityInfo(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityInfo", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityInfo), arg0, arg1)
+}
+
+// ApplyActivityTaskCancelRequestedEvent mocks base method.
+func (m *MockMutableState) ApplyActivityTaskCancelRequestedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyActivityTaskCancelRequestedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyActivityTaskCancelRequestedEvent indicates an expected call of ApplyActivityTaskCancelRequestedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyActivityTaskCancelRequestedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityTaskCancelRequestedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityTaskCancelRequestedEvent), arg0)
+}
+
+// ApplyActivityTaskCanceledEvent mocks base method.
+func (m *MockMutableState) ApplyActivityTaskCanceledEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyActivityTaskCanceledEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyActivityTaskCanceledEvent indicates an expected call of ApplyActivityTaskCanceledEvent.
+func (mr *MockMutableStateMockRecorder) ApplyActivityTaskCanceledEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityTaskCanceledEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityTaskCanceledEvent), arg0)
+}
+
+// ApplyActivityTaskCompletedEvent mocks base method.
+func (m *MockMutableState) ApplyActivityTaskCompletedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyActivityTaskCompletedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyActivityTaskCompletedEvent indicates an expected call of ApplyActivityTaskCompletedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyActivityTaskCompletedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityTaskCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityTaskCompletedEvent), arg0)
+}
+
+// ApplyActivityTaskFailedEvent mocks base method.
+func (m *MockMutableState) ApplyActivityTaskFailedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyActivityTaskFailedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyActivityTaskFailedEvent indicates an expected call of ApplyActivityTaskFailedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyActivityTaskFailedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityTaskFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityTaskFailedEvent), arg0)
+}
+
+// ApplyActivityTaskScheduledEvent mocks base method.
+func (m *MockMutableState) ApplyActivityTaskScheduledEvent(arg0 int64, arg1 *v13.HistoryEvent) (*v112.ActivityInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyActivityTaskScheduledEvent", arg0, arg1)
+	ret0, _ := ret[0].(*v112.ActivityInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyActivityTaskScheduledEvent indicates an expected call of ApplyActivityTaskScheduledEvent.
+func (mr *MockMutableStateMockRecorder) ApplyActivityTaskScheduledEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityTaskScheduledEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityTaskScheduledEvent), arg0, arg1)
+}
+
+// ApplyActivityTaskStartedEvent mocks base method.
+func (m *MockMutableState) ApplyActivityTaskStartedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyActivityTaskStartedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyActivityTaskStartedEvent indicates an expected call of ApplyActivityTaskStartedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyActivityTaskStartedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityTaskStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityTaskStartedEvent), arg0)
+}
+
+// ApplyActivityTaskTimedOutEvent mocks base method.
+func (m *MockMutableState) ApplyActivityTaskTimedOutEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyActivityTaskTimedOutEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyActivityTaskTimedOutEvent indicates an expected call of ApplyActivityTaskTimedOutEvent.
+func (mr *MockMutableStateMockRecorder) ApplyActivityTaskTimedOutEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyActivityTaskTimedOutEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyActivityTaskTimedOutEvent), arg0)
+}
+
+// ApplyChildWorkflowExecutionCanceledEvent mocks base method.
+func (m *MockMutableState) ApplyChildWorkflowExecutionCanceledEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyChildWorkflowExecutionCanceledEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyChildWorkflowExecutionCanceledEvent indicates an expected call of ApplyChildWorkflowExecutionCanceledEvent.
+func (mr *MockMutableStateMockRecorder) ApplyChildWorkflowExecutionCanceledEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyChildWorkflowExecutionCanceledEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyChildWorkflowExecutionCanceledEvent), arg0)
+}
+
+// ApplyChildWorkflowExecutionCompletedEvent mocks base method.
+func (m *MockMutableState) ApplyChildWorkflowExecutionCompletedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyChildWorkflowExecutionCompletedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyChildWorkflowExecutionCompletedEvent indicates an expected call of ApplyChildWorkflowExecutionCompletedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyChildWorkflowExecutionCompletedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyChildWorkflowExecutionCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyChildWorkflowExecutionCompletedEvent), arg0)
+}
+
+// ApplyChildWorkflowExecutionFailedEvent mocks base method.
+func (m *MockMutableState) ApplyChildWorkflowExecutionFailedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyChildWorkflowExecutionFailedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyChildWorkflowExecutionFailedEvent indicates an expected call of ApplyChildWorkflowExecutionFailedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyChildWorkflowExecutionFailedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyChildWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyChildWorkflowExecutionFailedEvent), arg0)
+}
+
+// ApplyChildWorkflowExecutionStartedEvent mocks base method.
+func (m *MockMutableState) ApplyChildWorkflowExecutionStartedEvent(arg0 *v13.HistoryEvent, arg1 *v18.VectorClock) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyChildWorkflowExecutionStartedEvent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyChildWorkflowExecutionStartedEvent indicates an expected call of ApplyChildWorkflowExecutionStartedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyChildWorkflowExecutionStartedEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyChildWorkflowExecutionStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyChildWorkflowExecutionStartedEvent), arg0, arg1)
+}
+
+// ApplyChildWorkflowExecutionTerminatedEvent mocks base method.
+func (m *MockMutableState) ApplyChildWorkflowExecutionTerminatedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyChildWorkflowExecutionTerminatedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyChildWorkflowExecutionTerminatedEvent indicates an expected call of ApplyChildWorkflowExecutionTerminatedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyChildWorkflowExecutionTerminatedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyChildWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyChildWorkflowExecutionTerminatedEvent), arg0)
+}
+
+// ApplyChildWorkflowExecutionTimedOutEvent mocks base method.
+func (m *MockMutableState) ApplyChildWorkflowExecutionTimedOutEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyChildWorkflowExecutionTimedOutEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyChildWorkflowExecutionTimedOutEvent indicates an expected call of ApplyChildWorkflowExecutionTimedOutEvent.
+func (mr *MockMutableStateMockRecorder) ApplyChildWorkflowExecutionTimedOutEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyChildWorkflowExecutionTimedOutEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyChildWorkflowExecutionTimedOutEvent), arg0)
+}
+
+// ApplyExternalWorkflowExecutionCancelRequested mocks base method.
+func (m *MockMutableState) ApplyExternalWorkflowExecutionCancelRequested(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyExternalWorkflowExecutionCancelRequested", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyExternalWorkflowExecutionCancelRequested indicates an expected call of ApplyExternalWorkflowExecutionCancelRequested.
+func (mr *MockMutableStateMockRecorder) ApplyExternalWorkflowExecutionCancelRequested(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyExternalWorkflowExecutionCancelRequested", reflect.TypeOf((*MockMutableState)(nil).ApplyExternalWorkflowExecutionCancelRequested), arg0)
+}
+
+// ApplyExternalWorkflowExecutionSignaled mocks base method.
+func (m *MockMutableState) ApplyExternalWorkflowExecutionSignaled(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyExternalWorkflowExecutionSignaled", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyExternalWorkflowExecutionSignaled indicates an expected call of ApplyExternalWorkflowExecutionSignaled.
+func (mr *MockMutableStateMockRecorder) ApplyExternalWorkflowExecutionSignaled(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyExternalWorkflowExecutionSignaled", reflect.TypeOf((*MockMutableState)(nil).ApplyExternalWorkflowExecutionSignaled), arg0)
+}
+
+// ApplyRequestCancelExternalWorkflowExecutionFailedEvent mocks base method.
+func (m *MockMutableState) ApplyRequestCancelExternalWorkflowExecutionFailedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyRequestCancelExternalWorkflowExecutionFailedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyRequestCancelExternalWorkflowExecutionFailedEvent indicates an expected call of ApplyRequestCancelExternalWorkflowExecutionFailedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyRequestCancelExternalWorkflowExecutionFailedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyRequestCancelExternalWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyRequestCancelExternalWorkflowExecutionFailedEvent), arg0)
+}
+
+// ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent mocks base method.
+func (m *MockMutableState) ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(arg0 int64, arg1 *v13.HistoryEvent, arg2 string) (*v112.RequestCancelInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v112.RequestCancelInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent indicates an expected call of ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent), arg0, arg1, arg2)
+}
+
+// ApplySignalExternalWorkflowExecutionFailedEvent mocks base method.
+func (m *MockMutableState) ApplySignalExternalWorkflowExecutionFailedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplySignalExternalWorkflowExecutionFailedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplySignalExternalWorkflowExecutionFailedEvent indicates an expected call of ApplySignalExternalWorkflowExecutionFailedEvent.
+func (mr *MockMutableStateMockRecorder) ApplySignalExternalWorkflowExecutionFailedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySignalExternalWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplySignalExternalWorkflowExecutionFailedEvent), arg0)
+}
+
+// ApplySignalExternalWorkflowExecutionInitiatedEvent mocks base method.
+func (m *MockMutableState) ApplySignalExternalWorkflowExecutionInitiatedEvent(arg0 int64, arg1 *v13.HistoryEvent, arg2 string) (*v112.SignalInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplySignalExternalWorkflowExecutionInitiatedEvent", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v112.SignalInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplySignalExternalWorkflowExecutionInitiatedEvent indicates an expected call of ApplySignalExternalWorkflowExecutionInitiatedEvent.
+func (mr *MockMutableStateMockRecorder) ApplySignalExternalWorkflowExecutionInitiatedEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplySignalExternalWorkflowExecutionInitiatedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplySignalExternalWorkflowExecutionInitiatedEvent), arg0, arg1, arg2)
+}
+
+// ApplyStartChildWorkflowExecutionFailedEvent mocks base method.
+func (m *MockMutableState) ApplyStartChildWorkflowExecutionFailedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyStartChildWorkflowExecutionFailedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyStartChildWorkflowExecutionFailedEvent indicates an expected call of ApplyStartChildWorkflowExecutionFailedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyStartChildWorkflowExecutionFailedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyStartChildWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyStartChildWorkflowExecutionFailedEvent), arg0)
+}
+
+// ApplyStartChildWorkflowExecutionInitiatedEvent mocks base method.
+func (m *MockMutableState) ApplyStartChildWorkflowExecutionInitiatedEvent(arg0 int64, arg1 *v13.HistoryEvent, arg2 string) (*v112.ChildExecutionInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyStartChildWorkflowExecutionInitiatedEvent", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*v112.ChildExecutionInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyStartChildWorkflowExecutionInitiatedEvent indicates an expected call of ApplyStartChildWorkflowExecutionInitiatedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyStartChildWorkflowExecutionInitiatedEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyStartChildWorkflowExecutionInitiatedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyStartChildWorkflowExecutionInitiatedEvent), arg0, arg1, arg2)
+}
+
+// ApplyTimerCanceledEvent mocks base method.
+func (m *MockMutableState) ApplyTimerCanceledEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyTimerCanceledEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyTimerCanceledEvent indicates an expected call of ApplyTimerCanceledEvent.
+func (mr *MockMutableStateMockRecorder) ApplyTimerCanceledEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTimerCanceledEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyTimerCanceledEvent), arg0)
+}
+
+// ApplyTimerFiredEvent mocks base method.
+func (m *MockMutableState) ApplyTimerFiredEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyTimerFiredEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyTimerFiredEvent indicates an expected call of ApplyTimerFiredEvent.
+func (mr *MockMutableStateMockRecorder) ApplyTimerFiredEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTimerFiredEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyTimerFiredEvent), arg0)
+}
+
+// ApplyTimerStartedEvent mocks base method.
+func (m *MockMutableState) ApplyTimerStartedEvent(arg0 *v13.HistoryEvent) (*v112.TimerInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyTimerStartedEvent", arg0)
+	ret0, _ := ret[0].(*v112.TimerInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyTimerStartedEvent indicates an expected call of ApplyTimerStartedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyTimerStartedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTimerStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyTimerStartedEvent), arg0)
+}
+
+// ApplyTransientWorkflowTaskScheduled mocks base method.
+func (m *MockMutableState) ApplyTransientWorkflowTaskScheduled() (*WorkflowTaskInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyTransientWorkflowTaskScheduled")
+	ret0, _ := ret[0].(*WorkflowTaskInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyTransientWorkflowTaskScheduled indicates an expected call of ApplyTransientWorkflowTaskScheduled.
+func (mr *MockMutableStateMockRecorder) ApplyTransientWorkflowTaskScheduled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyTransientWorkflowTaskScheduled", reflect.TypeOf((*MockMutableState)(nil).ApplyTransientWorkflowTaskScheduled))
+}
+
+// ApplyUpsertWorkflowSearchAttributesEvent mocks base method.
+func (m *MockMutableState) ApplyUpsertWorkflowSearchAttributesEvent(arg0 *v13.HistoryEvent) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ApplyUpsertWorkflowSearchAttributesEvent", arg0)
+}
+
+// ApplyUpsertWorkflowSearchAttributesEvent indicates an expected call of ApplyUpsertWorkflowSearchAttributesEvent.
+func (mr *MockMutableStateMockRecorder) ApplyUpsertWorkflowSearchAttributesEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyUpsertWorkflowSearchAttributesEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyUpsertWorkflowSearchAttributesEvent), arg0)
+}
+
+// ApplyWorkflowExecutionCancelRequestedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionCancelRequestedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionCancelRequestedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionCancelRequestedEvent indicates an expected call of ApplyWorkflowExecutionCancelRequestedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionCancelRequestedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionCancelRequestedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionCancelRequestedEvent), arg0)
+}
+
+// ApplyWorkflowExecutionCanceledEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionCanceledEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionCanceledEvent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionCanceledEvent indicates an expected call of ApplyWorkflowExecutionCanceledEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionCanceledEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionCanceledEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionCanceledEvent), arg0, arg1)
+}
+
+// ApplyWorkflowExecutionCompletedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionCompletedEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionCompletedEvent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionCompletedEvent indicates an expected call of ApplyWorkflowExecutionCompletedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionCompletedEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionCompletedEvent), arg0, arg1)
+}
+
+// ApplyWorkflowExecutionContinuedAsNewEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionContinuedAsNewEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionContinuedAsNewEvent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionContinuedAsNewEvent indicates an expected call of ApplyWorkflowExecutionContinuedAsNewEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionContinuedAsNewEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionContinuedAsNewEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionContinuedAsNewEvent), arg0, arg1)
+}
+
+// ApplyWorkflowExecutionFailedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionFailedEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionFailedEvent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionFailedEvent indicates an expected call of ApplyWorkflowExecutionFailedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionFailedEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionFailedEvent), arg0, arg1)
+}
+
+// ApplyWorkflowExecutionSignaled mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionSignaled(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionSignaled", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionSignaled indicates an expected call of ApplyWorkflowExecutionSignaled.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionSignaled(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionSignaled", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionSignaled), arg0)
+}
+
+// ApplyWorkflowExecutionStartedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionStartedEvent(arg0 *v18.VectorClock, arg1 *v10.WorkflowExecution, arg2 string, arg3 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionStartedEvent", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionStartedEvent indicates an expected call of ApplyWorkflowExecutionStartedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionStartedEvent(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionStartedEvent), arg0, arg1, arg2, arg3)
+}
+
+// ApplyWorkflowExecutionTerminatedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionTerminatedEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionTerminatedEvent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionTerminatedEvent indicates an expected call of ApplyWorkflowExecutionTerminatedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionTerminatedEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionTerminatedEvent), arg0, arg1)
+}
+
+// ApplyWorkflowExecutionTimedoutEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionTimedoutEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionTimedoutEvent", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionTimedoutEvent indicates an expected call of ApplyWorkflowExecutionTimedoutEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionTimedoutEvent(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionTimedoutEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionTimedoutEvent), arg0, arg1)
+}
+
+// ApplyWorkflowExecutionUpdateAcceptedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionUpdateAcceptedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionUpdateAcceptedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionUpdateAcceptedEvent indicates an expected call of ApplyWorkflowExecutionUpdateAcceptedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionUpdateAcceptedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionUpdateAcceptedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionUpdateAcceptedEvent), arg0)
+}
+
+// ApplyWorkflowExecutionUpdateCompletedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowExecutionUpdateCompletedEvent(event *v13.HistoryEvent, batchID int64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowExecutionUpdateCompletedEvent", event, batchID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowExecutionUpdateCompletedEvent indicates an expected call of ApplyWorkflowExecutionUpdateCompletedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowExecutionUpdateCompletedEvent(event, batchID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowExecutionUpdateCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowExecutionUpdateCompletedEvent), event, batchID)
+}
+
+// ApplyWorkflowPropertiesModifiedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowPropertiesModifiedEvent(arg0 *v13.HistoryEvent) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "ApplyWorkflowPropertiesModifiedEvent", arg0)
+}
+
+// ApplyWorkflowPropertiesModifiedEvent indicates an expected call of ApplyWorkflowPropertiesModifiedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowPropertiesModifiedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowPropertiesModifiedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowPropertiesModifiedEvent), arg0)
+}
+
+// ApplyWorkflowTaskCompletedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowTaskCompletedEvent(arg0 *v13.HistoryEvent) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowTaskCompletedEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowTaskCompletedEvent indicates an expected call of ApplyWorkflowTaskCompletedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowTaskCompletedEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowTaskCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowTaskCompletedEvent), arg0)
+}
+
+// ApplyWorkflowTaskFailedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowTaskFailedEvent() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowTaskFailedEvent")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowTaskFailedEvent indicates an expected call of ApplyWorkflowTaskFailedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowTaskFailedEvent() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowTaskFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowTaskFailedEvent))
+}
+
+// ApplyWorkflowTaskScheduledEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowTaskScheduledEvent(arg0, arg1 int64, arg2 *v14.TaskQueue, arg3 *durationpb.Duration, arg4 int32, arg5, arg6 *timestamppb.Timestamp, arg7 v19.WorkflowTaskType) (*WorkflowTaskInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowTaskScheduledEvent", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret0, _ := ret[0].(*WorkflowTaskInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyWorkflowTaskScheduledEvent indicates an expected call of ApplyWorkflowTaskScheduledEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowTaskScheduledEvent(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowTaskScheduledEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowTaskScheduledEvent), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+}
+
+// ApplyWorkflowTaskStartedEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowTaskStartedEvent(arg0 *WorkflowTaskInfo, arg1, arg2, arg3 int64, arg4 string, arg5 time.Time, arg6 bool, arg7 int64) (*WorkflowTaskInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowTaskStartedEvent", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+	ret0, _ := ret[0].(*WorkflowTaskInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ApplyWorkflowTaskStartedEvent indicates an expected call of ApplyWorkflowTaskStartedEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowTaskStartedEvent(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowTaskStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowTaskStartedEvent), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
+}
+
+// ApplyWorkflowTaskTimedOutEvent mocks base method.
+func (m *MockMutableState) ApplyWorkflowTaskTimedOutEvent(arg0 v11.TimeoutType) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyWorkflowTaskTimedOutEvent", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyWorkflowTaskTimedOutEvent indicates an expected call of ApplyWorkflowTaskTimedOutEvent.
+func (mr *MockMutableStateMockRecorder) ApplyWorkflowTaskTimedOutEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyWorkflowTaskTimedOutEvent", reflect.TypeOf((*MockMutableState)(nil).ApplyWorkflowTaskTimedOutEvent), arg0)
+}
+
 // CheckResettable mocks base method.
 func (m *MockMutableState) CheckResettable() error {
 	m.ctrl.T.Helper()
@@ -1962,626 +2582,6 @@ func (m *MockMutableState) RemoveSpeculativeWorkflowTaskTimeoutTask() {
 func (mr *MockMutableStateMockRecorder) RemoveSpeculativeWorkflowTaskTimeoutTask() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveSpeculativeWorkflowTaskTimeoutTask", reflect.TypeOf((*MockMutableState)(nil).RemoveSpeculativeWorkflowTaskTimeoutTask))
-}
-
-// ReplicateActivityInfo mocks base method.
-func (m *MockMutableState) ReplicateActivityInfo(arg0 *v111.SyncActivityRequest, arg1 bool) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateActivityInfo", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateActivityInfo indicates an expected call of ReplicateActivityInfo.
-func (mr *MockMutableStateMockRecorder) ReplicateActivityInfo(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateActivityInfo", reflect.TypeOf((*MockMutableState)(nil).ReplicateActivityInfo), arg0, arg1)
-}
-
-// ReplicateActivityTaskCancelRequestedEvent mocks base method.
-func (m *MockMutableState) ReplicateActivityTaskCancelRequestedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateActivityTaskCancelRequestedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateActivityTaskCancelRequestedEvent indicates an expected call of ReplicateActivityTaskCancelRequestedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateActivityTaskCancelRequestedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateActivityTaskCancelRequestedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateActivityTaskCancelRequestedEvent), arg0)
-}
-
-// ReplicateActivityTaskCanceledEvent mocks base method.
-func (m *MockMutableState) ReplicateActivityTaskCanceledEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateActivityTaskCanceledEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateActivityTaskCanceledEvent indicates an expected call of ReplicateActivityTaskCanceledEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateActivityTaskCanceledEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateActivityTaskCanceledEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateActivityTaskCanceledEvent), arg0)
-}
-
-// ReplicateActivityTaskCompletedEvent mocks base method.
-func (m *MockMutableState) ReplicateActivityTaskCompletedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateActivityTaskCompletedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateActivityTaskCompletedEvent indicates an expected call of ReplicateActivityTaskCompletedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateActivityTaskCompletedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateActivityTaskCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateActivityTaskCompletedEvent), arg0)
-}
-
-// ReplicateActivityTaskFailedEvent mocks base method.
-func (m *MockMutableState) ReplicateActivityTaskFailedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateActivityTaskFailedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateActivityTaskFailedEvent indicates an expected call of ReplicateActivityTaskFailedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateActivityTaskFailedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateActivityTaskFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateActivityTaskFailedEvent), arg0)
-}
-
-// ReplicateActivityTaskScheduledEvent mocks base method.
-func (m *MockMutableState) ReplicateActivityTaskScheduledEvent(arg0 int64, arg1 *v13.HistoryEvent) (*v112.ActivityInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateActivityTaskScheduledEvent", arg0, arg1)
-	ret0, _ := ret[0].(*v112.ActivityInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplicateActivityTaskScheduledEvent indicates an expected call of ReplicateActivityTaskScheduledEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateActivityTaskScheduledEvent(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateActivityTaskScheduledEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateActivityTaskScheduledEvent), arg0, arg1)
-}
-
-// ReplicateActivityTaskStartedEvent mocks base method.
-func (m *MockMutableState) ReplicateActivityTaskStartedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateActivityTaskStartedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateActivityTaskStartedEvent indicates an expected call of ReplicateActivityTaskStartedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateActivityTaskStartedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateActivityTaskStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateActivityTaskStartedEvent), arg0)
-}
-
-// ReplicateActivityTaskTimedOutEvent mocks base method.
-func (m *MockMutableState) ReplicateActivityTaskTimedOutEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateActivityTaskTimedOutEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateActivityTaskTimedOutEvent indicates an expected call of ReplicateActivityTaskTimedOutEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateActivityTaskTimedOutEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateActivityTaskTimedOutEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateActivityTaskTimedOutEvent), arg0)
-}
-
-// ReplicateChildWorkflowExecutionCanceledEvent mocks base method.
-func (m *MockMutableState) ReplicateChildWorkflowExecutionCanceledEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateChildWorkflowExecutionCanceledEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateChildWorkflowExecutionCanceledEvent indicates an expected call of ReplicateChildWorkflowExecutionCanceledEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateChildWorkflowExecutionCanceledEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateChildWorkflowExecutionCanceledEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateChildWorkflowExecutionCanceledEvent), arg0)
-}
-
-// ReplicateChildWorkflowExecutionCompletedEvent mocks base method.
-func (m *MockMutableState) ReplicateChildWorkflowExecutionCompletedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateChildWorkflowExecutionCompletedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateChildWorkflowExecutionCompletedEvent indicates an expected call of ReplicateChildWorkflowExecutionCompletedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateChildWorkflowExecutionCompletedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateChildWorkflowExecutionCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateChildWorkflowExecutionCompletedEvent), arg0)
-}
-
-// ReplicateChildWorkflowExecutionFailedEvent mocks base method.
-func (m *MockMutableState) ReplicateChildWorkflowExecutionFailedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateChildWorkflowExecutionFailedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateChildWorkflowExecutionFailedEvent indicates an expected call of ReplicateChildWorkflowExecutionFailedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateChildWorkflowExecutionFailedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateChildWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateChildWorkflowExecutionFailedEvent), arg0)
-}
-
-// ReplicateChildWorkflowExecutionStartedEvent mocks base method.
-func (m *MockMutableState) ReplicateChildWorkflowExecutionStartedEvent(arg0 *v13.HistoryEvent, arg1 *v18.VectorClock) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateChildWorkflowExecutionStartedEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateChildWorkflowExecutionStartedEvent indicates an expected call of ReplicateChildWorkflowExecutionStartedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateChildWorkflowExecutionStartedEvent(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateChildWorkflowExecutionStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateChildWorkflowExecutionStartedEvent), arg0, arg1)
-}
-
-// ReplicateChildWorkflowExecutionTerminatedEvent mocks base method.
-func (m *MockMutableState) ReplicateChildWorkflowExecutionTerminatedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateChildWorkflowExecutionTerminatedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateChildWorkflowExecutionTerminatedEvent indicates an expected call of ReplicateChildWorkflowExecutionTerminatedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateChildWorkflowExecutionTerminatedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateChildWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateChildWorkflowExecutionTerminatedEvent), arg0)
-}
-
-// ReplicateChildWorkflowExecutionTimedOutEvent mocks base method.
-func (m *MockMutableState) ReplicateChildWorkflowExecutionTimedOutEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateChildWorkflowExecutionTimedOutEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateChildWorkflowExecutionTimedOutEvent indicates an expected call of ReplicateChildWorkflowExecutionTimedOutEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateChildWorkflowExecutionTimedOutEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateChildWorkflowExecutionTimedOutEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateChildWorkflowExecutionTimedOutEvent), arg0)
-}
-
-// ReplicateExternalWorkflowExecutionCancelRequested mocks base method.
-func (m *MockMutableState) ReplicateExternalWorkflowExecutionCancelRequested(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateExternalWorkflowExecutionCancelRequested", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateExternalWorkflowExecutionCancelRequested indicates an expected call of ReplicateExternalWorkflowExecutionCancelRequested.
-func (mr *MockMutableStateMockRecorder) ReplicateExternalWorkflowExecutionCancelRequested(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateExternalWorkflowExecutionCancelRequested", reflect.TypeOf((*MockMutableState)(nil).ReplicateExternalWorkflowExecutionCancelRequested), arg0)
-}
-
-// ReplicateExternalWorkflowExecutionSignaled mocks base method.
-func (m *MockMutableState) ReplicateExternalWorkflowExecutionSignaled(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateExternalWorkflowExecutionSignaled", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateExternalWorkflowExecutionSignaled indicates an expected call of ReplicateExternalWorkflowExecutionSignaled.
-func (mr *MockMutableStateMockRecorder) ReplicateExternalWorkflowExecutionSignaled(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateExternalWorkflowExecutionSignaled", reflect.TypeOf((*MockMutableState)(nil).ReplicateExternalWorkflowExecutionSignaled), arg0)
-}
-
-// ReplicateRequestCancelExternalWorkflowExecutionFailedEvent mocks base method.
-func (m *MockMutableState) ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateRequestCancelExternalWorkflowExecutionFailedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateRequestCancelExternalWorkflowExecutionFailedEvent indicates an expected call of ReplicateRequestCancelExternalWorkflowExecutionFailedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateRequestCancelExternalWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateRequestCancelExternalWorkflowExecutionFailedEvent), arg0)
-}
-
-// ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent mocks base method.
-func (m *MockMutableState) ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent(arg0 int64, arg1 *v13.HistoryEvent, arg2 string) (*v112.RequestCancelInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*v112.RequestCancelInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent indicates an expected call of ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent), arg0, arg1, arg2)
-}
-
-// ReplicateSignalExternalWorkflowExecutionFailedEvent mocks base method.
-func (m *MockMutableState) ReplicateSignalExternalWorkflowExecutionFailedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateSignalExternalWorkflowExecutionFailedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateSignalExternalWorkflowExecutionFailedEvent indicates an expected call of ReplicateSignalExternalWorkflowExecutionFailedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateSignalExternalWorkflowExecutionFailedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateSignalExternalWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateSignalExternalWorkflowExecutionFailedEvent), arg0)
-}
-
-// ReplicateSignalExternalWorkflowExecutionInitiatedEvent mocks base method.
-func (m *MockMutableState) ReplicateSignalExternalWorkflowExecutionInitiatedEvent(arg0 int64, arg1 *v13.HistoryEvent, arg2 string) (*v112.SignalInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateSignalExternalWorkflowExecutionInitiatedEvent", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*v112.SignalInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplicateSignalExternalWorkflowExecutionInitiatedEvent indicates an expected call of ReplicateSignalExternalWorkflowExecutionInitiatedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateSignalExternalWorkflowExecutionInitiatedEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateSignalExternalWorkflowExecutionInitiatedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateSignalExternalWorkflowExecutionInitiatedEvent), arg0, arg1, arg2)
-}
-
-// ReplicateStartChildWorkflowExecutionFailedEvent mocks base method.
-func (m *MockMutableState) ReplicateStartChildWorkflowExecutionFailedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateStartChildWorkflowExecutionFailedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateStartChildWorkflowExecutionFailedEvent indicates an expected call of ReplicateStartChildWorkflowExecutionFailedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateStartChildWorkflowExecutionFailedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateStartChildWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateStartChildWorkflowExecutionFailedEvent), arg0)
-}
-
-// ReplicateStartChildWorkflowExecutionInitiatedEvent mocks base method.
-func (m *MockMutableState) ReplicateStartChildWorkflowExecutionInitiatedEvent(arg0 int64, arg1 *v13.HistoryEvent, arg2 string) (*v112.ChildExecutionInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateStartChildWorkflowExecutionInitiatedEvent", arg0, arg1, arg2)
-	ret0, _ := ret[0].(*v112.ChildExecutionInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplicateStartChildWorkflowExecutionInitiatedEvent indicates an expected call of ReplicateStartChildWorkflowExecutionInitiatedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateStartChildWorkflowExecutionInitiatedEvent(arg0, arg1, arg2 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateStartChildWorkflowExecutionInitiatedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateStartChildWorkflowExecutionInitiatedEvent), arg0, arg1, arg2)
-}
-
-// ReplicateTimerCanceledEvent mocks base method.
-func (m *MockMutableState) ReplicateTimerCanceledEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateTimerCanceledEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateTimerCanceledEvent indicates an expected call of ReplicateTimerCanceledEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateTimerCanceledEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateTimerCanceledEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateTimerCanceledEvent), arg0)
-}
-
-// ReplicateTimerFiredEvent mocks base method.
-func (m *MockMutableState) ReplicateTimerFiredEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateTimerFiredEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateTimerFiredEvent indicates an expected call of ReplicateTimerFiredEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateTimerFiredEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateTimerFiredEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateTimerFiredEvent), arg0)
-}
-
-// ReplicateTimerStartedEvent mocks base method.
-func (m *MockMutableState) ReplicateTimerStartedEvent(arg0 *v13.HistoryEvent) (*v112.TimerInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateTimerStartedEvent", arg0)
-	ret0, _ := ret[0].(*v112.TimerInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplicateTimerStartedEvent indicates an expected call of ReplicateTimerStartedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateTimerStartedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateTimerStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateTimerStartedEvent), arg0)
-}
-
-// ReplicateTransientWorkflowTaskScheduled mocks base method.
-func (m *MockMutableState) ReplicateTransientWorkflowTaskScheduled() (*WorkflowTaskInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateTransientWorkflowTaskScheduled")
-	ret0, _ := ret[0].(*WorkflowTaskInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplicateTransientWorkflowTaskScheduled indicates an expected call of ReplicateTransientWorkflowTaskScheduled.
-func (mr *MockMutableStateMockRecorder) ReplicateTransientWorkflowTaskScheduled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateTransientWorkflowTaskScheduled", reflect.TypeOf((*MockMutableState)(nil).ReplicateTransientWorkflowTaskScheduled))
-}
-
-// ReplicateUpsertWorkflowSearchAttributesEvent mocks base method.
-func (m *MockMutableState) ReplicateUpsertWorkflowSearchAttributesEvent(arg0 *v13.HistoryEvent) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReplicateUpsertWorkflowSearchAttributesEvent", arg0)
-}
-
-// ReplicateUpsertWorkflowSearchAttributesEvent indicates an expected call of ReplicateUpsertWorkflowSearchAttributesEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateUpsertWorkflowSearchAttributesEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateUpsertWorkflowSearchAttributesEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateUpsertWorkflowSearchAttributesEvent), arg0)
-}
-
-// ReplicateWorkflowExecutionCancelRequestedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionCancelRequestedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionCancelRequestedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionCancelRequestedEvent indicates an expected call of ReplicateWorkflowExecutionCancelRequestedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionCancelRequestedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionCancelRequestedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionCancelRequestedEvent), arg0)
-}
-
-// ReplicateWorkflowExecutionCanceledEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionCanceledEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionCanceledEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionCanceledEvent indicates an expected call of ReplicateWorkflowExecutionCanceledEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionCanceledEvent(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionCanceledEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionCanceledEvent), arg0, arg1)
-}
-
-// ReplicateWorkflowExecutionCompletedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionCompletedEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionCompletedEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionCompletedEvent indicates an expected call of ReplicateWorkflowExecutionCompletedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionCompletedEvent(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionCompletedEvent), arg0, arg1)
-}
-
-// ReplicateWorkflowExecutionContinuedAsNewEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionContinuedAsNewEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionContinuedAsNewEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionContinuedAsNewEvent indicates an expected call of ReplicateWorkflowExecutionContinuedAsNewEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionContinuedAsNewEvent(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionContinuedAsNewEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionContinuedAsNewEvent), arg0, arg1)
-}
-
-// ReplicateWorkflowExecutionFailedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionFailedEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionFailedEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionFailedEvent indicates an expected call of ReplicateWorkflowExecutionFailedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionFailedEvent(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionFailedEvent), arg0, arg1)
-}
-
-// ReplicateWorkflowExecutionSignaled mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionSignaled(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionSignaled", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionSignaled indicates an expected call of ReplicateWorkflowExecutionSignaled.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionSignaled(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionSignaled", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionSignaled), arg0)
-}
-
-// ReplicateWorkflowExecutionStartedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionStartedEvent(arg0 *v18.VectorClock, arg1 *v10.WorkflowExecution, arg2 string, arg3 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionStartedEvent", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionStartedEvent indicates an expected call of ReplicateWorkflowExecutionStartedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionStartedEvent(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionStartedEvent), arg0, arg1, arg2, arg3)
-}
-
-// ReplicateWorkflowExecutionTerminatedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionTerminatedEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionTerminatedEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionTerminatedEvent indicates an expected call of ReplicateWorkflowExecutionTerminatedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionTerminatedEvent(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionTerminatedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionTerminatedEvent), arg0, arg1)
-}
-
-// ReplicateWorkflowExecutionTimedoutEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionTimedoutEvent(arg0 int64, arg1 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionTimedoutEvent", arg0, arg1)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionTimedoutEvent indicates an expected call of ReplicateWorkflowExecutionTimedoutEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionTimedoutEvent(arg0, arg1 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionTimedoutEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionTimedoutEvent), arg0, arg1)
-}
-
-// ReplicateWorkflowExecutionUpdateAcceptedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionUpdateAcceptedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionUpdateAcceptedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionUpdateAcceptedEvent indicates an expected call of ReplicateWorkflowExecutionUpdateAcceptedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionUpdateAcceptedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionUpdateAcceptedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionUpdateAcceptedEvent), arg0)
-}
-
-// ReplicateWorkflowExecutionUpdateCompletedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowExecutionUpdateCompletedEvent(event *v13.HistoryEvent, batchID int64) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowExecutionUpdateCompletedEvent", event, batchID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowExecutionUpdateCompletedEvent indicates an expected call of ReplicateWorkflowExecutionUpdateCompletedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowExecutionUpdateCompletedEvent(event, batchID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowExecutionUpdateCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowExecutionUpdateCompletedEvent), event, batchID)
-}
-
-// ReplicateWorkflowPropertiesModifiedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowPropertiesModifiedEvent(arg0 *v13.HistoryEvent) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "ReplicateWorkflowPropertiesModifiedEvent", arg0)
-}
-
-// ReplicateWorkflowPropertiesModifiedEvent indicates an expected call of ReplicateWorkflowPropertiesModifiedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowPropertiesModifiedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowPropertiesModifiedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowPropertiesModifiedEvent), arg0)
-}
-
-// ReplicateWorkflowTaskCompletedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowTaskCompletedEvent(arg0 *v13.HistoryEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowTaskCompletedEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowTaskCompletedEvent indicates an expected call of ReplicateWorkflowTaskCompletedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowTaskCompletedEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowTaskCompletedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowTaskCompletedEvent), arg0)
-}
-
-// ReplicateWorkflowTaskFailedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowTaskFailedEvent() error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowTaskFailedEvent")
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowTaskFailedEvent indicates an expected call of ReplicateWorkflowTaskFailedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowTaskFailedEvent() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowTaskFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowTaskFailedEvent))
-}
-
-// ReplicateWorkflowTaskScheduledEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowTaskScheduledEvent(arg0, arg1 int64, arg2 *v14.TaskQueue, arg3 *durationpb.Duration, arg4 int32, arg5, arg6 *timestamppb.Timestamp, arg7 v19.WorkflowTaskType) (*WorkflowTaskInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowTaskScheduledEvent", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-	ret0, _ := ret[0].(*WorkflowTaskInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplicateWorkflowTaskScheduledEvent indicates an expected call of ReplicateWorkflowTaskScheduledEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowTaskScheduledEvent(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowTaskScheduledEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowTaskScheduledEvent), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-}
-
-// ReplicateWorkflowTaskStartedEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowTaskStartedEvent(arg0 *WorkflowTaskInfo, arg1, arg2, arg3 int64, arg4 string, arg5 time.Time, arg6 bool, arg7 int64) (*WorkflowTaskInfo, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowTaskStartedEvent", arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-	ret0, _ := ret[0].(*WorkflowTaskInfo)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReplicateWorkflowTaskStartedEvent indicates an expected call of ReplicateWorkflowTaskStartedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowTaskStartedEvent(arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowTaskStartedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowTaskStartedEvent), arg0, arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-}
-
-// ReplicateWorkflowTaskTimedOutEvent mocks base method.
-func (m *MockMutableState) ReplicateWorkflowTaskTimedOutEvent(arg0 v11.TimeoutType) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateWorkflowTaskTimedOutEvent", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ReplicateWorkflowTaskTimedOutEvent indicates an expected call of ReplicateWorkflowTaskTimedOutEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateWorkflowTaskTimedOutEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateWorkflowTaskTimedOutEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateWorkflowTaskTimedOutEvent), arg0)
 }
 
 // RetryActivity mocks base method.

--- a/service/history/workflow/mutable_state_rebuilder.go
+++ b/service/history/workflow/mutable_state_rebuilder.go
@@ -174,7 +174,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 				attributes.ParentWorkflowNamespaceId = parentNamespaceEntry.ID().String()
 			}
 
-			if err := b.mutableState.ReplicateWorkflowExecutionStartedEvent(
+			if err := b.mutableState.ApplyWorkflowExecutionStartedEvent(
 				nil, // shard clock is local to cluster
 				execution,
 				requestID,
@@ -215,7 +215,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 		case enumspb.EVENT_TYPE_WORKFLOW_TASK_SCHEDULED:
 			attributes := event.GetWorkflowTaskScheduledEventAttributes()
 			// use event.GetEventTime() as WorkflowTaskOriginalScheduledTimestamp, because the heartbeat is not happening here.
-			workflowTask, err := b.mutableState.ReplicateWorkflowTaskScheduledEvent(
+			workflowTask, err := b.mutableState.ApplyWorkflowTaskScheduledEvent(
 				event.GetVersion(),
 				event.GetEventId(),
 				attributes.TaskQueue,
@@ -240,7 +240,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 
 		case enumspb.EVENT_TYPE_WORKFLOW_TASK_STARTED:
 			attributes := event.GetWorkflowTaskStartedEventAttributes()
-			workflowTask, err := b.mutableState.ReplicateWorkflowTaskStartedEvent(
+			workflowTask, err := b.mutableState.ApplyWorkflowTaskStartedEvent(
 				nil,
 				event.GetVersion(),
 				attributes.GetScheduledEventId(),
@@ -261,21 +261,21 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_TASK_COMPLETED:
-			if err := b.mutableState.ReplicateWorkflowTaskCompletedEvent(
+			if err := b.mutableState.ApplyWorkflowTaskCompletedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_TASK_TIMED_OUT:
-			if err := b.mutableState.ReplicateWorkflowTaskTimedOutEvent(
+			if err := b.mutableState.ApplyWorkflowTaskTimedOutEvent(
 				event.GetWorkflowTaskTimedOutEventAttributes().GetTimeoutType(),
 			); err != nil {
 				return nil, err
 			}
 
 			// this is for transient workflowTask
-			workflowTask, err := b.mutableState.ReplicateTransientWorkflowTaskScheduled()
+			workflowTask, err := b.mutableState.ApplyTransientWorkflowTaskScheduled()
 			if err != nil {
 				return nil, err
 			}
@@ -292,12 +292,12 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_TASK_FAILED:
-			if err := b.mutableState.ReplicateWorkflowTaskFailedEvent(); err != nil {
+			if err := b.mutableState.ApplyWorkflowTaskFailedEvent(); err != nil {
 				return nil, err
 			}
 
 			// this is for transient workflowTask
-			workflowTask, err := b.mutableState.ReplicateTransientWorkflowTaskScheduled()
+			workflowTask, err := b.mutableState.ApplyTransientWorkflowTaskScheduled()
 			if err != nil {
 				return nil, err
 			}
@@ -314,7 +314,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:
-			if _, err := b.mutableState.ReplicateActivityTaskScheduledEvent(
+			if _, err := b.mutableState.ApplyActivityTaskScheduledEvent(
 				firstEvent.GetEventId(),
 				event,
 			); err != nil {
@@ -328,70 +328,70 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_STARTED:
-			if err := b.mutableState.ReplicateActivityTaskStartedEvent(
+			if err := b.mutableState.ApplyActivityTaskStartedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_COMPLETED:
-			if err := b.mutableState.ReplicateActivityTaskCompletedEvent(
+			if err := b.mutableState.ApplyActivityTaskCompletedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_FAILED:
-			if err := b.mutableState.ReplicateActivityTaskFailedEvent(
+			if err := b.mutableState.ApplyActivityTaskFailedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_TIMED_OUT:
-			if err := b.mutableState.ReplicateActivityTaskTimedOutEvent(
+			if err := b.mutableState.ApplyActivityTaskTimedOutEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCEL_REQUESTED:
-			if err := b.mutableState.ReplicateActivityTaskCancelRequestedEvent(
+			if err := b.mutableState.ApplyActivityTaskCancelRequestedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_ACTIVITY_TASK_CANCELED:
-			if err := b.mutableState.ReplicateActivityTaskCanceledEvent(
+			if err := b.mutableState.ApplyActivityTaskCanceledEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_TIMER_STARTED:
-			if _, err := b.mutableState.ReplicateTimerStartedEvent(
+			if _, err := b.mutableState.ApplyTimerStartedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_TIMER_FIRED:
-			if err := b.mutableState.ReplicateTimerFiredEvent(
+			if err := b.mutableState.ApplyTimerFiredEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_TIMER_CANCELED:
-			if err := b.mutableState.ReplicateTimerCanceledEvent(
+			if err := b.mutableState.ApplyTimerCanceledEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED:
-			if _, err := b.mutableState.ReplicateStartChildWorkflowExecutionInitiatedEvent(
+			if _, err := b.mutableState.ApplyStartChildWorkflowExecutionInitiatedEvent(
 				firstEvent.GetEventId(),
 				event,
 				// create a new request ID which is used by transfer queue processor
@@ -408,14 +408,14 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_FAILED:
-			if err := b.mutableState.ReplicateStartChildWorkflowExecutionFailedEvent(
+			if err := b.mutableState.ApplyStartChildWorkflowExecutionFailedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_STARTED:
-			if err := b.mutableState.ReplicateChildWorkflowExecutionStartedEvent(
+			if err := b.mutableState.ApplyChildWorkflowExecutionStartedEvent(
 				event,
 				nil, // shard clock is local to cluster
 			); err != nil {
@@ -423,42 +423,42 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED:
-			if err := b.mutableState.ReplicateChildWorkflowExecutionCompletedEvent(
+			if err := b.mutableState.ApplyChildWorkflowExecutionCompletedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED:
-			if err := b.mutableState.ReplicateChildWorkflowExecutionFailedEvent(
+			if err := b.mutableState.ApplyChildWorkflowExecutionFailedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED:
-			if err := b.mutableState.ReplicateChildWorkflowExecutionCanceledEvent(
+			if err := b.mutableState.ApplyChildWorkflowExecutionCanceledEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT:
-			if err := b.mutableState.ReplicateChildWorkflowExecutionTimedOutEvent(
+			if err := b.mutableState.ApplyChildWorkflowExecutionTimedOutEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED:
-			if err := b.mutableState.ReplicateChildWorkflowExecutionTerminatedEvent(
+			if err := b.mutableState.ApplyChildWorkflowExecutionTerminatedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED:
-			if _, err := b.mutableState.ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent(
+			if _, err := b.mutableState.ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(
 				firstEvent.GetEventId(),
 				event,
 				// create a new request ID which is used by transfer queue processor
@@ -475,14 +475,14 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_FAILED:
-			if err := b.mutableState.ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(
+			if err := b.mutableState.ApplyRequestCancelExternalWorkflowExecutionFailedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
-			if err := b.mutableState.ReplicateExternalWorkflowExecutionCancelRequested(
+			if err := b.mutableState.ApplyExternalWorkflowExecutionCancelRequested(
 				event,
 			); err != nil {
 				return nil, err
@@ -491,7 +491,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 		case enumspb.EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_INITIATED:
 			// Create a new request ID which is used by transfer queue processor if namespace is failed over at this point
 			signalRequestID := uuid.New()
-			if _, err := b.mutableState.ReplicateSignalExternalWorkflowExecutionInitiatedEvent(
+			if _, err := b.mutableState.ApplySignalExternalWorkflowExecutionInitiatedEvent(
 				firstEvent.GetEventId(),
 				event,
 				signalRequestID,
@@ -506,14 +506,14 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_SIGNAL_EXTERNAL_WORKFLOW_EXECUTION_FAILED:
-			if err := b.mutableState.ReplicateSignalExternalWorkflowExecutionFailedEvent(
+			if err := b.mutableState.ApplySignalExternalWorkflowExecutionFailedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_EXTERNAL_WORKFLOW_EXECUTION_SIGNALED:
-			if err := b.mutableState.ReplicateExternalWorkflowExecutionSignaled(
+			if err := b.mutableState.ApplyExternalWorkflowExecutionSignaled(
 				event,
 			); err != nil {
 				return nil, err
@@ -523,33 +523,33 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			// No mutable state action is needed
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_SIGNALED:
-			if err := b.mutableState.ReplicateWorkflowExecutionSignaled(
+			if err := b.mutableState.ApplyWorkflowExecutionSignaled(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCEL_REQUESTED:
-			if err := b.mutableState.ReplicateWorkflowExecutionCancelRequestedEvent(
+			if err := b.mutableState.ApplyWorkflowExecutionCancelRequestedEvent(
 				event,
 			); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_UPSERT_WORKFLOW_SEARCH_ATTRIBUTES:
-			b.mutableState.ReplicateUpsertWorkflowSearchAttributesEvent(event)
+			b.mutableState.ApplyUpsertWorkflowSearchAttributesEvent(event)
 			if err := taskGenerator.GenerateUpsertVisibilityTask(); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_PROPERTIES_MODIFIED:
-			b.mutableState.ReplicateWorkflowPropertiesModifiedEvent(event)
+			b.mutableState.ApplyWorkflowPropertiesModifiedEvent(event)
 			if err := taskGenerator.GenerateUpsertVisibilityTask(); err != nil {
 				return nil, err
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_COMPLETED:
-			if err := b.mutableState.ReplicateWorkflowExecutionCompletedEvent(
+			if err := b.mutableState.ApplyWorkflowExecutionCompletedEvent(
 				firstEvent.GetEventId(),
 				event,
 			); err != nil {
@@ -564,7 +564,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_FAILED:
-			if err := b.mutableState.ReplicateWorkflowExecutionFailedEvent(
+			if err := b.mutableState.ApplyWorkflowExecutionFailedEvent(
 				firstEvent.GetEventId(),
 				event,
 			); err != nil {
@@ -579,7 +579,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TIMED_OUT:
-			if err := b.mutableState.ReplicateWorkflowExecutionTimedoutEvent(
+			if err := b.mutableState.ApplyWorkflowExecutionTimedoutEvent(
 				firstEvent.GetEventId(),
 				event,
 			); err != nil {
@@ -594,7 +594,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_CANCELED:
-			if err := b.mutableState.ReplicateWorkflowExecutionCanceledEvent(
+			if err := b.mutableState.ApplyWorkflowExecutionCanceledEvent(
 				firstEvent.GetEventId(),
 				event,
 			); err != nil {
@@ -609,7 +609,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 			}
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_TERMINATED:
-			if err := b.mutableState.ReplicateWorkflowExecutionTerminatedEvent(
+			if err := b.mutableState.ApplyWorkflowExecutionTerminatedEvent(
 				firstEvent.GetEventId(),
 				event,
 			); err != nil {
@@ -655,7 +655,7 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 				}
 			}
 
-			err := b.mutableState.ReplicateWorkflowExecutionContinuedAsNewEvent(
+			err := b.mutableState.ApplyWorkflowExecutionContinuedAsNewEvent(
 				firstEvent.GetEventId(),
 				event,
 			)
@@ -672,11 +672,11 @@ func (b *MutableStateRebuilderImpl) applyEvents(
 
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_REJECTED:
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_ACCEPTED:
-			if err := b.mutableState.ReplicateWorkflowExecutionUpdateAcceptedEvent(event); err != nil {
+			if err := b.mutableState.ApplyWorkflowExecutionUpdateAcceptedEvent(event); err != nil {
 				return nil, err
 			}
 		case enumspb.EVENT_TYPE_WORKFLOW_EXECUTION_UPDATE_COMPLETED:
-			if err := b.mutableState.ReplicateWorkflowExecutionUpdateCompletedEvent(event, firstEvent.GetEventId()); err != nil {
+			if err := b.mutableState.ApplyWorkflowExecutionUpdateCompletedEvent(event, firstEvent.GetEventId()); err != nil {
 				return nil, err
 			}
 

--- a/service/history/workflow/mutable_state_rebuilder_test.go
+++ b/service/history/workflow/mutable_state_rebuilder_test.go
@@ -192,7 +192,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_No
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: startWorkflowAttribute},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionStartedEvent(nil, execution, requestID, protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionStartedEvent(nil, execution, requestID, protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateRecordWorkflowStartedTasks(
 		protomock.Eq(event),
@@ -238,7 +238,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_Wi
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionStartedEventAttributes{WorkflowExecutionStartedEventAttributes: startWorkflowAttribute},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionStartedEvent(nil, protomock.Eq(execution), requestID, protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionStartedEvent(nil, protomock.Eq(execution), requestID, protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateRecordWorkflowStartedTasks(
 		protomock.Eq(event),
@@ -276,7 +276,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut()
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionTimedOutEventAttributes{WorkflowExecutionTimedOutEventAttributes: &historypb.WorkflowExecutionTimedOutEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionTimedoutEvent(event.GetEventId(), protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionTimedoutEvent(event.GetEventId(), protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		now,
@@ -308,7 +308,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionTerminatedEventAttributes{WorkflowExecutionTerminatedEventAttributes: &historypb.WorkflowExecutionTerminatedEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionTerminatedEvent(event.GetEventId(), protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionTerminatedEvent(event.GetEventId(), protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		now,
@@ -339,7 +339,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed() {
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionFailedEventAttributes{WorkflowExecutionFailedEventAttributes: &historypb.WorkflowExecutionFailedEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionFailedEvent(event.GetEventId(), protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionFailedEvent(event.GetEventId(), protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		now,
@@ -371,7 +371,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted(
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionCompletedEventAttributes{WorkflowExecutionCompletedEventAttributes: &historypb.WorkflowExecutionCompletedEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionCompletedEvent(event.GetEventId(), event).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionCompletedEvent(event.GetEventId(), event).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		now,
@@ -403,7 +403,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCanceled()
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionCanceledEventAttributes{WorkflowExecutionCanceledEventAttributes: &historypb.WorkflowExecutionCanceledEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionCanceledEvent(event.GetEventId(), event).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionCanceledEvent(event.GetEventId(), event).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		now,
@@ -497,7 +497,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	}
 
 	s.mockClusterMetadata.EXPECT().ClusterNameForFailoverVersion(true, continueAsNewEvent.GetVersion()).Return(s.sourceCluster).AnyTimes()
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionContinuedAsNewEvent(
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionContinuedAsNewEvent(
 		continueAsNewEvent.GetEventId(),
 		protomock.Eq(continueAsNewEvent),
 	).Return(nil)
@@ -554,7 +554,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 		}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionContinuedAsNewEvent(
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionContinuedAsNewEvent(
 		continueAsNewEvent.GetEventId(),
 		protomock.Eq(continueAsNewEvent),
 	).Return(nil)
@@ -596,7 +596,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionSignaled()
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionSignaledEventAttributes{WorkflowExecutionSignaledEventAttributes: &historypb.WorkflowExecutionSignaledEventAttributes{}},
 	}
 	s.mockUpdateVersion(event)
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionSignaled(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionSignaled(protomock.Eq(event)).Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
 	_, err := s.stateRebuilder.ApplyEvents(context.Background(), tests.NamespaceID, requestID, execution, s.toHistory(event), nil)
@@ -623,7 +623,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCancelRequ
 		Attributes: &historypb.HistoryEvent_WorkflowExecutionCancelRequestedEventAttributes{WorkflowExecutionCancelRequestedEventAttributes: &historypb.WorkflowExecutionCancelRequestedEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionCancelRequestedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionCancelRequestedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -653,7 +653,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeUpsertWorkflowSearchAttribu
 			UpsertWorkflowSearchAttributesEventAttributes: &historypb.UpsertWorkflowSearchAttributesEventAttributes{},
 		},
 	}
-	s.mockMutableState.EXPECT().ReplicateUpsertWorkflowSearchAttributesEvent(protomock.Eq(event)).Return()
+	s.mockMutableState.EXPECT().ApplyUpsertWorkflowSearchAttributesEvent(protomock.Eq(event)).Return()
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateUpsertVisibilityTask().Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
@@ -684,7 +684,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowPropertiesModified(
 			WorkflowPropertiesModifiedEventAttributes: &historypb.WorkflowPropertiesModifiedEventAttributes{},
 		},
 	}
-	s.mockMutableState.EXPECT().ReplicateWorkflowPropertiesModifiedEvent(protomock.Eq(event)).Return()
+	s.mockMutableState.EXPECT().ApplyWorkflowPropertiesModifiedEvent(protomock.Eq(event)).Return()
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateUpsertVisibilityTask().Return(nil)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
@@ -759,7 +759,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskScheduled() {
 		Type:                enumsspb.WORKFLOW_TASK_TYPE_NORMAL,
 	}
 	s.executionInfo.TaskQueue = taskqueue.GetName()
-	s.mockMutableState.EXPECT().ReplicateWorkflowTaskScheduledEvent(
+	s.mockMutableState.EXPECT().ApplyWorkflowTaskScheduledEvent(
 		event.GetVersion(), event.GetEventId(), taskqueue, durationpb.New(timeout), workflowTaskAttempt, event.GetEventTime(), event.GetEventTime(), enumsspb.WORKFLOW_TASK_TYPE_NORMAL,
 	).Return(wt, nil)
 	s.mockUpdateVersion(event)
@@ -807,7 +807,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskStarted() {
 		TaskQueue:           taskqueue,
 		Attempt:             1,
 	}
-	s.mockMutableState.EXPECT().ReplicateWorkflowTaskStartedEvent(
+	s.mockMutableState.EXPECT().ApplyWorkflowTaskStartedEvent(
 		(*WorkflowTaskInfo)(nil), event.GetVersion(), scheduledEventID, event.GetEventId(), workflowTaskRequestID, timestamp.TimeValue(event.GetEventTime()),
 		false, gomock.Any(),
 	).Return(wt, nil)
@@ -847,11 +847,11 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskTimedOut() {
 			TimeoutType:      enumspb.TIMEOUT_TYPE_START_TO_CLOSE,
 		}},
 	}
-	s.mockMutableState.EXPECT().ReplicateWorkflowTaskTimedOutEvent(enumspb.TIMEOUT_TYPE_START_TO_CLOSE).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowTaskTimedOutEvent(enumspb.TIMEOUT_TYPE_START_TO_CLOSE).Return(nil)
 	taskqueue := &taskqueuepb.TaskQueue{Kind: enumspb.TASK_QUEUE_KIND_NORMAL, Name: "some random taskqueue"}
 	newScheduledEventID := int64(233)
 	s.executionInfo.TaskQueue = taskqueue.GetName()
-	s.mockMutableState.EXPECT().ReplicateTransientWorkflowTaskScheduled().Return(&WorkflowTaskInfo{
+	s.mockMutableState.EXPECT().ApplyTransientWorkflowTaskScheduled().Return(&WorkflowTaskInfo{
 		Version:          version,
 		ScheduledEventID: newScheduledEventID,
 		TaskQueue:        taskqueue,
@@ -891,11 +891,11 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskFailed() {
 			StartedEventId:   startedEventID,
 		}},
 	}
-	s.mockMutableState.EXPECT().ReplicateWorkflowTaskFailedEvent().Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowTaskFailedEvent().Return(nil)
 	taskqueue := &taskqueuepb.TaskQueue{Kind: enumspb.TASK_QUEUE_KIND_NORMAL, Name: "some random taskqueue"}
 	newScheduledEventID := int64(233)
 	s.executionInfo.TaskQueue = taskqueue.GetName()
-	s.mockMutableState.EXPECT().ReplicateTransientWorkflowTaskScheduled().Return(&WorkflowTaskInfo{
+	s.mockMutableState.EXPECT().ApplyTransientWorkflowTaskScheduled().Return(&WorkflowTaskInfo{
 		Version:          version,
 		ScheduledEventID: newScheduledEventID,
 		TaskQueue:        taskqueue,
@@ -935,7 +935,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowTaskCompleted() {
 			StartedEventId:   startedEventID,
 		}},
 	}
-	s.mockMutableState.EXPECT().ReplicateWorkflowTaskCompletedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowTaskCompletedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -978,7 +978,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerStarted() {
 		StartedEventId: event.GetEventId(),
 		TaskStatus:     TimerTaskStatusNone,
 	}
-	s.mockMutableState.EXPECT().ReplicateTimerStartedEvent(protomock.Eq(event)).Return(ti, nil)
+	s.mockMutableState.EXPECT().ApplyTimerStartedEvent(protomock.Eq(event)).Return(ti, nil)
 	s.mockUpdateVersion(event)
 	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
 	// need to be refreshed each time
@@ -1009,7 +1009,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerFired() {
 		Attributes: &historypb.HistoryEvent_TimerFiredEventAttributes{TimerFiredEventAttributes: &historypb.TimerFiredEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateTimerFiredEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyTimerFiredEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
 	// need to be refreshed each time
@@ -1040,7 +1040,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeTimerCanceled() {
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_TimerCanceledEventAttributes{TimerCanceledEventAttributes: &historypb.TimerCanceledEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateTimerCanceledEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyTimerCanceledEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
 	// need to be refreshed each time
@@ -1095,7 +1095,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskScheduled() {
 		TaskQueue:               taskqueue,
 	}
 	s.executionInfo.TaskQueue = taskqueue
-	s.mockMutableState.EXPECT().ReplicateActivityTaskScheduledEvent(event.GetEventId(), protomock.Eq(event)).Return(ai, nil)
+	s.mockMutableState.EXPECT().ApplyActivityTaskScheduledEvent(event.GetEventId(), protomock.Eq(event)).Return(ai, nil)
 	s.mockUpdateVersion(event)
 	s.mockTaskGenerator.EXPECT().GenerateActivityTasks(
 		protomock.Eq(event),
@@ -1141,7 +1141,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskStarted() {
 	}
 
 	s.executionInfo.TaskQueue = taskqueue
-	s.mockMutableState.EXPECT().ReplicateActivityTaskStartedEvent(protomock.Eq(startedEvent)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyActivityTaskStartedEvent(protomock.Eq(startedEvent)).Return(nil)
 	s.mockUpdateVersion(startedEvent)
 	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
 	// need to be refreshed each time
@@ -1172,7 +1172,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskTimedOut() {
 		Attributes: &historypb.HistoryEvent_ActivityTaskTimedOutEventAttributes{ActivityTaskTimedOutEventAttributes: &historypb.ActivityTaskTimedOutEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateActivityTaskTimedOutEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyActivityTaskTimedOutEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
 	// need to be refreshed each time// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
@@ -1204,7 +1204,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskFailed() {
 		Attributes: &historypb.HistoryEvent_ActivityTaskFailedEventAttributes{ActivityTaskFailedEventAttributes: &historypb.ActivityTaskFailedEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateActivityTaskFailedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyActivityTaskFailedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
 	// need to be refreshed each time
@@ -1235,7 +1235,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCompleted() {
 		Attributes: &historypb.HistoryEvent_ActivityTaskCompletedEventAttributes{ActivityTaskCompletedEventAttributes: &historypb.ActivityTaskCompletedEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateActivityTaskCompletedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyActivityTaskCompletedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
 	// need to be refreshed each time
@@ -1265,7 +1265,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCancelRequested
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ActivityTaskCancelRequestedEventAttributes{ActivityTaskCancelRequestedEventAttributes: &historypb.ActivityTaskCancelRequestedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateActivityTaskCancelRequestedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyActivityTaskCancelRequestedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1294,7 +1294,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskCanceled() {
 		Attributes: &historypb.HistoryEvent_ActivityTaskCanceledEventAttributes{ActivityTaskCanceledEventAttributes: &historypb.ActivityTaskCanceledEventAttributes{}},
 	}
 
-	s.mockMutableState.EXPECT().ReplicateActivityTaskCanceledEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyActivityTaskCanceledEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	// assertion on timer generated is in `mockUpdateVersion` function, since activity / user timer
 	// need to be refreshed each time
@@ -1344,7 +1344,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 	}
 
 	// the create request ID is generated inside, cannot assert equal
-	s.mockMutableState.EXPECT().ReplicateStartChildWorkflowExecutionInitiatedEvent(
+	s.mockMutableState.EXPECT().ApplyStartChildWorkflowExecutionInitiatedEvent(
 		event.GetEventId(), protomock.Eq(event), gomock.Any(),
 	).Return(ci, nil)
 	s.mockUpdateVersion(event)
@@ -1377,7 +1377,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_StartChildWorkflowExecutionFailedEventAttributes{StartChildWorkflowExecutionFailedEventAttributes: &historypb.StartChildWorkflowExecutionFailedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateStartChildWorkflowExecutionFailedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyStartChildWorkflowExecutionFailedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1405,7 +1405,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionStart
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionStartedEventAttributes{ChildWorkflowExecutionStartedEventAttributes: &historypb.ChildWorkflowExecutionStartedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateChildWorkflowExecutionStartedEvent(protomock.Eq(event), nil).Return(nil)
+	s.mockMutableState.EXPECT().ApplyChildWorkflowExecutionStartedEvent(protomock.Eq(event), nil).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1433,7 +1433,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionTimed
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionTimedOutEventAttributes{ChildWorkflowExecutionTimedOutEventAttributes: &historypb.ChildWorkflowExecutionTimedOutEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateChildWorkflowExecutionTimedOutEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyChildWorkflowExecutionTimedOutEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1461,7 +1461,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionTermi
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionTerminatedEventAttributes{ChildWorkflowExecutionTerminatedEventAttributes: &historypb.ChildWorkflowExecutionTerminatedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateChildWorkflowExecutionTerminatedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyChildWorkflowExecutionTerminatedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1489,7 +1489,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionFaile
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionFailedEventAttributes{ChildWorkflowExecutionFailedEventAttributes: &historypb.ChildWorkflowExecutionFailedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateChildWorkflowExecutionFailedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyChildWorkflowExecutionFailedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1517,7 +1517,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionCompl
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionCompletedEventAttributes{ChildWorkflowExecutionCompletedEventAttributes: &historypb.ChildWorkflowExecutionCompletedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateChildWorkflowExecutionCompletedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyChildWorkflowExecutionCompletedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1569,7 +1569,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeRequestCancelExternalWorkfl
 	}
 
 	// the cancellation request ID is generated inside, cannot assert equal
-	s.mockMutableState.EXPECT().ReplicateRequestCancelExternalWorkflowExecutionInitiatedEvent(
+	s.mockMutableState.EXPECT().ApplyRequestCancelExternalWorkflowExecutionInitiatedEvent(
 		event.GetEventId(), protomock.Eq(event), gomock.Any(),
 	).Return(rci, nil)
 	s.mockUpdateVersion(event)
@@ -1602,7 +1602,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeRequestCancelExternalWorkfl
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_RequestCancelExternalWorkflowExecutionFailedEventAttributes{RequestCancelExternalWorkflowExecutionFailedEventAttributes: &historypb.RequestCancelExternalWorkflowExecutionFailedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyRequestCancelExternalWorkflowExecutionFailedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1630,7 +1630,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeExternalWorkflowExecutionCa
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ExternalWorkflowExecutionCancelRequestedEventAttributes{ExternalWorkflowExecutionCancelRequestedEventAttributes: &historypb.ExternalWorkflowExecutionCancelRequestedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateExternalWorkflowExecutionCancelRequested(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyExternalWorkflowExecutionCancelRequested(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1658,7 +1658,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeChildWorkflowExecutionCance
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ChildWorkflowExecutionCanceledEventAttributes{ChildWorkflowExecutionCanceledEventAttributes: &historypb.ChildWorkflowExecutionCanceledEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateChildWorkflowExecutionCanceledEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyChildWorkflowExecutionCanceledEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1716,7 +1716,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeSignalExternalWorkflowExecu
 	}
 
 	// the cancellation request ID is generated inside, cannot assert equal
-	s.mockMutableState.EXPECT().ReplicateSignalExternalWorkflowExecutionInitiatedEvent(
+	s.mockMutableState.EXPECT().ApplySignalExternalWorkflowExecutionInitiatedEvent(
 		event.GetEventId(), protomock.Eq(event), gomock.Any(),
 	).Return(si, nil)
 	s.mockUpdateVersion(event)
@@ -1749,7 +1749,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeSignalExternalWorkflowExecu
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_SignalExternalWorkflowExecutionFailedEventAttributes{SignalExternalWorkflowExecutionFailedEventAttributes: &historypb.SignalExternalWorkflowExecutionFailedEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateSignalExternalWorkflowExecutionFailedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplySignalExternalWorkflowExecutionFailedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1777,7 +1777,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeExternalWorkflowExecutionSi
 		EventType:  evenType,
 		Attributes: &historypb.HistoryEvent_ExternalWorkflowExecutionSignaledEventAttributes{ExternalWorkflowExecutionSignaledEventAttributes: &historypb.ExternalWorkflowExecutionSignaledEventAttributes{}},
 	}
-	s.mockMutableState.EXPECT().ReplicateExternalWorkflowExecutionSignaled(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyExternalWorkflowExecutionSignaled(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1809,7 +1809,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionUpdateAcce
 			},
 		},
 	}
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionUpdateAcceptedEvent(protomock.Eq(event)).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionUpdateAcceptedEvent(protomock.Eq(event)).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 
@@ -1839,7 +1839,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionUpdateComp
 			WorkflowExecutionUpdateCompletedEventAttributes: &historypb.WorkflowExecutionUpdateCompletedEventAttributes{},
 		},
 	}
-	s.mockMutableState.EXPECT().ReplicateWorkflowExecutionUpdateCompletedEvent(protomock.Eq(event), event.EventId).Return(nil)
+	s.mockMutableState.EXPECT().ApplyWorkflowExecutionUpdateCompletedEvent(protomock.Eq(event), event.EventId).Return(nil)
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().ClearStickyTaskQueue()
 

--- a/tests/xdc/failover_test.go
+++ b/tests/xdc/failover_test.go
@@ -1791,7 +1791,7 @@ func (s *FunctionalClustersTestSuite) TestTransientWorkflowTaskFailover() {
 
 	// for failover transient workflow task, it is guaranteed that the transient workflow task
 	// after the failover has attempt 1
-	// for details see ReplicateTransientWorkflowTaskScheduled
+	// for details see ApplyTransientWorkflowTaskScheduled
 	_, err = poller2.PollAndProcessWorkflowTask(tests.WithExpectedAttemptCount(1))
 	s.NoError(err)
 	s.True(workflowFinished)


### PR DESCRIPTION
## What changed?

The MutableState functions called Replicate* are renamed to Apply*.

## Why?

It's a common source of confusion; the functions have nothing to do with replication per se.

The replication code _uses_ some of these functions, but it is merely _applying_ data to MS.

## How did you test it?

Go compiler.

## Potential risks

Unlikely: code using reflection to call them.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->

no