### PR TITLE
Generate Github app token for create-tag workflow

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -17,9 +17,6 @@ on:
         description: "Base tag to generate commit list for release notes"
         required: false
 
-permissions:
-  contents: write
-
 jobs:
   create-tag:
     name: "Create a tag"
@@ -30,11 +27,18 @@ jobs:
         shell: bash
 
     steps:
+      - name: Generate token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.TEMPORAL_CICD_APP_ID }}
+          private-key: ${{ secrets.TEMPORAL_CICD_PRIVATE_KEY }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
           persist-credentials: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.generate_token.outputs.token }}
           ref: ${{ github.event.inputs.branch }}
           fetch-depth: 0
           fetch-tags: true
@@ -78,7 +82,7 @@ jobs:
       - name: Create draft release notes
         if: ${{ github.event.inputs.release_notes }}
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
           BASE_TAG: ${{ github.event.inputs.base_tag }}
           TAG: 'v${{ github.event.inputs.tag}}'
         run: |


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Generate Github app token for create-tag workflow

## Why?
<!-- Tell your future self why have you made these changes -->
The `GITHUB_TOKEN` doesn't trigger GHA events, and this workflow is pushing a commit which needs to trigger GHA events.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
