### PR TITLE
Improve ackManager.completeTask performance by two orders of magnitude

### DIFF
--- a/develop/buildkite/third_party_deps.txt
+++ b/develop/buildkite/third_party_deps.txt
@@ -70,6 +70,12 @@ github.com/cpuguy83/go-md2man/v2/md2man
 github.com/davecgh/go-spew/spew
 github.com/dgryski/go-farm
 github.com/dustin/go-humanize
+github.com/emirpasic/gods/containers
+github.com/emirpasic/gods/maps
+github.com/emirpasic/gods/maps/treemap
+github.com/emirpasic/gods/trees
+github.com/emirpasic/gods/trees/redblacktree
+github.com/emirpasic/gods/utils
 github.com/facebookgo/clock
 github.com/fatih/color
 github.com/go-logr/logr

--- a/service/matching/ack_manager.go
+++ b/service/matching/ack_manager.go
@@ -138,6 +138,8 @@ func (m *ackManager) completeTask(taskID int64) int64 {
 		return m.ackLevel
 	}
 
+	// TODO the ack level management should be done by a dedicated coroutine
+	//  this is only a temporarily solution
 	m.outstandingTasks.Put(taskID, true)
 	m.backlogCounter.Dec()
 

--- a/service/matching/ack_manager_test.go
+++ b/service/matching/ack_manager_test.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package matching
 
 import (

--- a/service/matching/ack_manager_test.go
+++ b/service/matching/ack_manager_test.go
@@ -1,0 +1,55 @@
+package matching
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/log"
+)
+
+func TestAckManager_AddingTasksIncreasesBacklogCounter(t *testing.T) {
+	t.Parallel()
+	mgr := newAckManager(log.NewTestLogger())
+	mgr.addTask(1)
+	require.Equal(t, mgr.getBacklogCountHint(), int64(1))
+	mgr.addTask(12)
+	require.Equal(t, mgr.getBacklogCountHint(), int64(2))
+}
+
+func TestAckManager_CompleteTaskMovesAckLevelUpToGap(t *testing.T) {
+	t.Parallel()
+	mgr := newAckManager(log.NewTestLogger())
+	mgr.addTask(1)
+	require.Equal(t, int64(-1), mgr.getAckLevel(), "should only move ack level on completion")
+	require.Equal(t, int64(1), mgr.completeTask(1), "should move ack level on completion")
+
+	mgr.addTask(2)
+	mgr.addTask(3)
+	mgr.addTask(12)
+
+	require.Equal(t, int64(1), mgr.completeTask(3), "task 2 is not complete, we should not move ack level")
+	require.Equal(t, int64(3), mgr.completeTask(2), "both tasks 2 and 3 are complete")
+}
+
+// Add 1000 tasks in order and complete them in a random order.
+// This will cause our ack level to jump as we complete them
+func BenchmarkAckManager_CompleteTask(b *testing.B) {
+	tasks := make([]int, 1000)
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		mgr := newAckManager(log.NewTestLogger())
+		for i := 0; i < len(tasks); i++ {
+			tasks[i] = i
+			mgr.addTask(int64(i))
+		}
+		rand.Shuffle(len(tasks), func(i, j int) {
+			tasks[i], tasks[j] = tasks[j], tasks[i]
+		})
+		b.StartTimer()
+
+		for i := 0; i < len(tasks); i++ {
+			mgr.completeTask(int64(i))
+		}
+	}
+}

--- a/service/matching/ack_manager_test.go
+++ b/service/matching/ack_manager_test.go
@@ -32,11 +32,34 @@ func TestAckManager_CompleteTaskMovesAckLevelUpToGap(t *testing.T) {
 	require.Equal(t, int64(3), mgr.completeTask(2), "both tasks 2 and 3 are complete")
 }
 
-// Add 1000 tasks in order and complete them in a random order.
-// This will cause our ack level to jump as we complete them
+func BenchmarkAckManager_AddTask(b *testing.B) {
+	tasks := make([]int, 1000)
+	for i := 0; i < len(tasks); i++ {
+		tasks[i] = i
+	}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		// Add 1000 tasks in order and complete them in a random order.
+		// This will cause our ack level to jump as we complete them
+		b.StopTimer()
+		mgr := newAckManager(log.NewTestLogger())
+		rand.Shuffle(len(tasks), func(i, j int) {
+			tasks[i], tasks[j] = tasks[j], tasks[i]
+		})
+		b.StartTimer()
+		for i := 0; i < len(tasks); i++ {
+			tasks[i] = i
+			mgr.addTask(int64(i))
+		}
+	}
+}
+
 func BenchmarkAckManager_CompleteTask(b *testing.B) {
 	tasks := make([]int, 1000)
+	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
+		// Add 1000 tasks in order and complete them in a random order.
+		// This will cause our ack level to jump as we complete them
 		b.StopTimer()
 		mgr := newAckManager(log.NewTestLogger())
 		for i := 0; i < len(tasks); i++ {

--- a/service/matching/matching_engine_test.go
+++ b/service/matching/matching_engine_test.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/emirpasic/gods/maps/treemap"
+	godsutils "github.com/emirpasic/gods/utils"
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
@@ -2802,21 +2803,8 @@ func (m *testTaskQueueManager) RangeID() int64 {
 	return m.rangeID
 }
 
-func Int64Comparator(a, b interface{}) int {
-	aAsserted := a.(int64)
-	bAsserted := b.(int64)
-	switch {
-	case aAsserted > bAsserted:
-		return 1
-	case aAsserted < bAsserted:
-		return -1
-	default:
-		return 0
-	}
-}
-
 func newTestTaskQueueManager() *testTaskQueueManager {
-	return &testTaskQueueManager{tasks: treemap.NewWith(Int64Comparator)}
+	return &testTaskQueueManager{tasks: treemap.NewWith(godsutils.Int64Comparator)}
 }
 
 func newTestTaskQueueID(namespaceID namespace.ID, name string, taskType enumspb.TaskQueueType) *taskQueueID {


### PR DESCRIPTION
## What changed?
I replaced the outstandingTasks map with an ordered treemap and optimized
completeTask to only scan what was necessary to update the ack level.

## Why?
The old implementation of completeTask required a full scan of the task
map in order to move the ack level which had terrible performance. 
By storing tasks in an ordered set we can limit the scan's size by
stopping at the first unacked task.

This trades addTask performance for completeTask performance but since all 
added tasks are presumably completed we should be fine with 1/3 the 
performance on addTask for 227x the completeTask performance. With this
change both operations run in about the same amount of time.

Before:
```
$ go test -bench=AckManager ./service/matching/... -run=FooBarBaz
goos: darwin
goarch: arm64
pkg: go.temporal.io/server/service/matching
BenchmarkAckManager_AddTask-12         	  22768	    52206 ns/op
BenchmarkAckManager_CompleteTask-12    	     38	 29293019 ns/op
```

After:
```
$ go test -bench=AckManager ./service/matching -run=FooBarBaz
goos: darwin
goarch: arm64
pkg: go.temporal.io/server/service/matching
BenchmarkAckManager_AddTask-12         	   8127	   147226 ns/op
BenchmarkAckManager_CompleteTask-12    	   8626	   136614 ns/op
```

## How did you test it?
I added both tests and benchmarks to ensure the ackManager worked as before

## Potential risks
None.

## Is hotfix candidate?
No
