### PR TITLE
Process update rejection when workflow is completing itself

### DIFF
--- a/common/auth/tls_config_helper_test.go
+++ b/common/auth/tls_config_helper_test.go
@@ -156,8 +156,6 @@ func Test_NewTLSConfig(t *testing.T) {
 }
 
 func Test_ConnectToTLSServerWithCA(t *testing.T) {
-	t.Skip("expired test certificate")
-
 	// setup server
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello World")
@@ -258,8 +256,6 @@ func Test_ConnectToTLSServerWithCA(t *testing.T) {
 }
 
 func Test_ConnectToTLSServerWithClientCertificate(t *testing.T) {
-	t.Skip("expired test certificate")
-
 	// setup server
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello World")

--- a/common/auth/tls_config_helper_test.go
+++ b/common/auth/tls_config_helper_test.go
@@ -156,6 +156,8 @@ func Test_NewTLSConfig(t *testing.T) {
 }
 
 func Test_ConnectToTLSServerWithCA(t *testing.T) {
+	t.Skip("expired test certificate")
+
 	// setup server
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello World")
@@ -256,6 +258,8 @@ func Test_ConnectToTLSServerWithCA(t *testing.T) {
 }
 
 func Test_ConnectToTLSServerWithClientCertificate(t *testing.T) {
+	t.Skip("expired test certificate")
+
 	// setup server
 	h := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintln(w, "Hello World")

--- a/service/history/api/pollupdate/api_test.go
+++ b/service/history/api/pollupdate/api_test.go
@@ -245,9 +245,9 @@ func TestPollOutcome(t *testing.T) {
 		}()
 
 		evStore := mockUpdateEventStore{}
-		require.NoError(t, upd.OnMessage(context.TODO(), &reqMsg, evStore))
+		require.NoError(t, upd.OnMessage(context.TODO(), &reqMsg, true, evStore))
 		upd.Send(context.TODO(), false, &protocolpb.Message_EventId{EventId: 2208}, evStore)
-		require.NoError(t, upd.OnMessage(context.TODO(), &rejMsg, evStore))
+		require.NoError(t, upd.OnMessage(context.TODO(), &rejMsg, true, evStore))
 
 		require.NoError(t, <-errCh)
 		resp := <-respCh

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -125,7 +125,7 @@ func Invoke(
 			if upd, alreadyExisted, err = updateReg.FindOrCreate(ctx, updateID); err != nil {
 				return nil, err
 			}
-			if err = upd.OnMessage(ctx, req.GetRequest().GetRequest(), workflow.WithEffects(effect.Immediate(ctx), ms)); err != nil {
+			if err = upd.OnMessage(ctx, req.GetRequest().GetRequest(), ms.IsWorkflowExecutionRunning(), workflow.WithEffects(effect.Immediate(ctx), ms)); err != nil {
 				return nil, err
 			}
 

--- a/service/history/api/updateworkflow/api.go
+++ b/service/history/api/updateworkflow/api.go
@@ -26,6 +26,7 @@ package updateworkflow
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	commonpb "go.temporal.io/api/common/v1"
@@ -192,6 +193,21 @@ func Invoke(
 	// (including any mutable state fields) outside of this func after workflow lock is released.
 	// It is important to release workflow lock before calling matching.
 	if err != nil {
+		// If update is received while WFT is running, it will be waiting for the next WFT.
+		// And if that running WFT completes workflow, then update is rejected (see CancelIncomplete).
+		// Special handling for consts.ErrWorkflowCompleted here is needed to keep parity with this.
+		// I.e. if update is received and workflow was completed, or is about to be completed,
+		// then update is consistently rejected (instead of returning error in some cases).
+		if errors.Is(err, consts.ErrWorkflowCompleted) {
+			rejectionResp := createResponse(
+				wfKey,
+				req,
+				&updatepb.Outcome{
+					Value: &updatepb.Outcome_Failure{Failure: update.CancelReasonWorkflowCompleted.RejectionFailure()},
+				},
+				enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED)
+			return rejectionResp, err
+		}
 		return nil, err
 	}
 
@@ -240,20 +256,7 @@ func Invoke(
 	if err != nil {
 		return nil, err
 	}
-	resp := &historyservice.UpdateWorkflowExecutionResponse{
-		Response: &workflowservice.UpdateWorkflowExecutionResponse{
-			UpdateRef: &updatepb.UpdateRef{
-				WorkflowExecution: &commonpb.WorkflowExecution{
-					WorkflowId: wfKey.WorkflowID,
-					RunId:      wfKey.RunID,
-				},
-				UpdateId: req.GetRequest().GetRequest().GetMeta().GetUpdateId(),
-			},
-			Outcome: status.Outcome,
-			Stage:   status.Stage,
-		},
-	}
-
+	resp := createResponse(wfKey, req, status.Outcome, status.Stage)
 	return resp, nil
 }
 
@@ -291,4 +294,25 @@ func addWorkflowTaskToMatching(
 	}
 
 	return nil
+}
+
+func createResponse(
+	wfKey definition.WorkflowKey,
+	req *historyservice.UpdateWorkflowExecutionRequest,
+	outcome *updatepb.Outcome,
+	stage enumspb.UpdateWorkflowExecutionLifecycleStage,
+) *historyservice.UpdateWorkflowExecutionResponse {
+	return &historyservice.UpdateWorkflowExecutionResponse{
+		Response: &workflowservice.UpdateWorkflowExecutionResponse{
+			UpdateRef: &updatepb.UpdateRef{
+				WorkflowExecution: &commonpb.WorkflowExecution{
+					WorkflowId: wfKey.WorkflowID,
+					RunId:      wfKey.RunID,
+				},
+				UpdateId: req.GetRequest().GetRequest().GetMeta().GetUpdateId(),
+			},
+			Outcome: outcome,
+			Stage:   stage,
+		},
+	}
 }

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -3592,7 +3592,7 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionUpdateCompletedEvent(
 	} else {
 		ui := updatespb.UpdateInfo{
 			Value: &updatespb.UpdateInfo_Completion{
-				Completion: &updatespb.CompletionInfo{EventId: event.EventId},
+				Completion: &updatespb.CompletionInfo{EventId: event.EventId}, // TODO (alex): why EventBatchID is not set here?
 			},
 		}
 		ms.executionInfo.UpdateInfos[updateID] = &ui

--- a/service/history/workflow/mutable_state_impl.go
+++ b/service/history/workflow/mutable_state_impl.go
@@ -3590,9 +3590,12 @@ func (ms *MutableStateImpl) ApplyWorkflowExecutionUpdateCompletedEvent(
 		}
 		sizeDelta = ui.Size() - sizeBefore
 	} else {
+		// TODO (alex): this should never happened because UpdateInfo should always be created before
+		// with UpdateAccepted event which MUST preceded UpdateCompleted event.
+		// Better to return error here!
 		ui := updatespb.UpdateInfo{
 			Value: &updatespb.UpdateInfo_Completion{
-				Completion: &updatespb.CompletionInfo{EventId: event.EventId}, // TODO (alex): why EventBatchID is not set here?
+				Completion: &updatespb.CompletionInfo{EventId: event.EventId},
 			},
 		}
 		ms.executionInfo.UpdateInfos[updateID] = &ui

--- a/service/history/workflow/update/cancel_reason.go
+++ b/service/history/workflow/update/cancel_reason.go
@@ -47,14 +47,3 @@ func (r CancelReason) RejectionFailure() *failurepb.Failure {
 		panic("unknown cancel reason")
 	}
 }
-
-func (r CancelReason) Error() error {
-	switch r {
-	case CancelReasonWorkflowCompleted:
-		return completedWorkflowErr
-	case CancelReasonWorkflowTerminated:
-		return terminatedWorkflowErr
-	default:
-		panic("unknown cancel reason")
-	}
-}

--- a/service/history/workflow/update/cancel_reason.go
+++ b/service/history/workflow/update/cancel_reason.go
@@ -1,0 +1,60 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+import (
+	failurepb "go.temporal.io/api/failure/v1"
+)
+
+type (
+	CancelReason uint32
+)
+
+const (
+	CancelReasonWorkflowCompleted CancelReason = iota + 1
+	CancelReasonWorkflowTerminated
+)
+
+func (r CancelReason) RejectionFailure() *failurepb.Failure {
+	switch r {
+	case CancelReasonWorkflowCompleted:
+		return completedWorkflowFailure
+	case CancelReasonWorkflowTerminated:
+		return terminatedWorkflowFailure
+	default:
+		panic("unknown cancel reason")
+	}
+}
+
+func (r CancelReason) Error() error {
+	switch r {
+	case CancelReasonWorkflowCompleted:
+		return completedWorkflowErr
+	case CancelReasonWorkflowTerminated:
+		return terminatedWorkflowErr
+	default:
+		panic("unknown cancel reason")
+	}
+}

--- a/service/history/workflow/update/errors_failures.go
+++ b/service/history/workflow/update/errors_failures.go
@@ -43,7 +43,7 @@ var (
 		Message: "Workflow Update is rejected because Workflow Execution is terminated.",
 		Source:  "Server",
 		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-			Type:         "TerminatedUpdate",
+			Type:         "CanceledUpdate",
 			NonRetryable: true,
 		}},
 	}
@@ -51,7 +51,7 @@ var (
 		Message: "Workflow Update is rejected because Workflow Execution is completed.",
 		Source:  "Server",
 		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
-			Type:         "TerminatedUpdate",
+			Type:         "CanceledUpdate",
 			NonRetryable: true,
 		}},
 	}

--- a/service/history/workflow/update/errors_failures.go
+++ b/service/history/workflow/update/errors_failures.go
@@ -1,0 +1,61 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package update
+
+import (
+	failurepb "go.temporal.io/api/failure/v1"
+	"go.temporal.io/api/serviceerror"
+)
+
+var (
+	unprocessedUpdateFailure = &failurepb.Failure{
+		Message: "Workflow Update is rejected because it wasn't processed by worker. Probably, Workflow Update is not supported by the worker.",
+		Source:  "Server",
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+			Type:         "UnprocessedUpdate",
+			NonRetryable: true,
+		}},
+	}
+
+	terminatedWorkflowFailure = &failurepb.Failure{
+		Message: "Workflow Update is rejected because Workflow Execution is terminated.",
+		Source:  "Server",
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+			Type:         "TerminatedUpdate",
+			NonRetryable: true,
+		}},
+	}
+	completedWorkflowFailure = &failurepb.Failure{
+		Message: "Workflow Update is rejected because Workflow Execution is completed.",
+		Source:  "Server",
+		FailureInfo: &failurepb.Failure_ApplicationFailureInfo{ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+			Type:         "TerminatedUpdate",
+			NonRetryable: true,
+		}},
+	}
+
+	terminatedWorkflowErr = serviceerror.NewCanceled("Workflow Update is cancelled because Workflow Execution is terminated.")
+	completedWorkflowErr  = serviceerror.NewCanceled("Workflow Update is cancelled because Workflow Execution is completed.")
+)

--- a/service/history/workflow/update/errors_failures.go
+++ b/service/history/workflow/update/errors_failures.go
@@ -26,7 +26,6 @@ package update
 
 import (
 	failurepb "go.temporal.io/api/failure/v1"
-	"go.temporal.io/api/serviceerror"
 )
 
 var (
@@ -55,7 +54,4 @@ var (
 			NonRetryable: true,
 		}},
 	}
-
-	terminatedWorkflowErr = serviceerror.NewCanceled("Workflow Update is cancelled because Workflow Execution is terminated.")
-	completedWorkflowErr  = serviceerror.NewCanceled("Workflow Update is cancelled because Workflow Execution is completed.")
 )

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -196,8 +196,9 @@ func (r *registry) Find(ctx context.Context, id string) (*Update, bool) {
 }
 
 // CancelIncomplete cancels all incomplete updates in the registry:
-//   - updates in stateAdmitted, stateRequested, and stateSent are rejected,
-//   - updates in stateAccepted completes with error.
+//   - updates in stateAdmitted, stateRequested, or stateSent are rejected,
+//   - updates in stateAccepted are ignored (see CancelIncomplete() in update.go for details),
+//   - updates in stateCompleted are ignored.
 func (r *registry) CancelIncomplete(ctx context.Context, reason CancelReason, eventStore EventStore) error {
 	incompleteUpdates := r.enumerate(func(u *Update) bool { return u.isIncomplete() })
 	for _, upd := range incompleteUpdates {

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -75,8 +75,9 @@ type (
 		RejectUnprocessed(ctx context.Context, eventStore EventStore) ([]string, error)
 
 		// CancelIncomplete cancels all incomplete updates in the registry:
-		//  - updates in stateAdmitted, stateRequested, and stateSent are rejected,
-		//  - updates in stateAccepted completes with error.
+		//   - updates in stateAdmitted, stateRequested, or stateSent are rejected,
+		//   - updates in stateAccepted are ignored (see CancelIncomplete() in update.go for details),
+		//   - updates in stateCompleted are ignored.
 		CancelIncomplete(ctx context.Context, reason CancelReason, eventStore EventStore) error
 
 		// Len observes the number of incomplete updates in this Registry.

--- a/service/history/workflow/update/registry.go
+++ b/service/history/workflow/update/registry.go
@@ -75,9 +75,9 @@ type (
 		// that worker processed (rejected or accepted) all updates that were delivered on the workflow task.
 		RejectUnprocessed(ctx context.Context, eventStore EventStore) ([]string, error)
 
-		// TerminateUpdates terminates all existing updates in the registry
+		// Terminate all existing updates in the registry
 		// and notifies update API callers with corresponding error.
-		TerminateUpdates(ctx context.Context, eventStore EventStore)
+		Terminate(ctx context.Context, eventStore EventStore)
 
 		// Len observes the number of incomplete updates in this Registry.
 		Len() int
@@ -195,10 +195,13 @@ func (r *registry) Find(ctx context.Context, id string) (*Update, bool) {
 	return r.findLocked(ctx, id)
 }
 
-func (r *registry) TerminateUpdates(_ context.Context, _ EventStore) {
+func (r *registry) Terminate(ctx context.Context, eventStore EventStore) {
 	// TODO (alex-update): implement
 	// This method is not implemented and update API callers will just timeout.
 	// In future, it should remove all existing updates and notify callers with better error.
+	for _, upd := range r.updates {
+		_ = upd.Terminate(ctx, eventStore)
+	}
 }
 
 // RejectUnprocessed reject all updates that are waiting for workflow task to be completed.

--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -117,7 +117,7 @@ func TestHasOutgoingMessages(t *testing.T) {
 		Meta:  &updatepb.Meta{UpdateId: updateID},
 		Input: &updatepb.Input{Name: "not_empty"},
 	}
-	require.NoError(t, upd.OnMessage(ctx, &req, evStore))
+	require.NoError(t, upd.OnMessage(ctx, &req, true, evStore))
 	require.True(t, reg.HasOutgoingMessages(false))
 
 	msg := reg.Send(ctx, false, testSequencingEventID, evStore)
@@ -129,7 +129,7 @@ func TestHasOutgoingMessages(t *testing.T) {
 		AcceptedRequest: &req,
 	}
 
-	err = upd.OnMessage(ctx, &acptReq, evStore)
+	err = upd.OnMessage(ctx, &acptReq, true, evStore)
 	require.NoError(t, err)
 	require.False(t, reg.HasOutgoingMessages(false))
 	require.False(t, reg.HasOutgoingMessages(true))
@@ -247,6 +247,7 @@ func TestUpdateRemovalFromRegistry(t *testing.T) {
 	err = upd.OnMessage(
 		ctx,
 		&updatepb.Response{Meta: &meta, Outcome: outcome},
+		true,
 		evStore,
 	)
 
@@ -278,7 +279,7 @@ func TestSendMessageGathering(t *testing.T) {
 	err = upd1.OnMessage(ctx, &updatepb.Request{
 		Meta:  &updatepb.Meta{UpdateId: updateID1},
 		Input: &updatepb.Input{Name: t.Name() + "-update-func"},
-	}, evStore)
+	}, true, evStore)
 	require.NoError(t, err)
 
 	msgs = reg.Send(ctx, false, wftStartedEventID, evStore)
@@ -299,7 +300,7 @@ func TestSendMessageGathering(t *testing.T) {
 	err = upd2.OnMessage(ctx, &updatepb.Request{
 		Meta:  &updatepb.Meta{UpdateId: updateID2},
 		Input: &updatepb.Input{Name: t.Name() + "-update-func"},
-	}, evStore)
+	}, true, evStore)
 	require.NoError(t, err)
 
 	msgs = reg.Send(ctx, false, wftStartedEventID, evStore)
@@ -353,7 +354,7 @@ func TestInFlightLimit(t *testing.T) {
 		Meta:  &updatepb.Meta{UpdateId: "update1"},
 		Input: &updatepb.Input{Name: "not_empty"},
 	}
-	require.NoError(t, upd1.OnMessage(ctx, &req, evStore))
+	require.NoError(t, upd1.OnMessage(ctx, &req, true, evStore))
 
 	_ = upd1.Send(ctx, false, sequencingID, evStore)
 
@@ -371,7 +372,7 @@ func TestInFlightLimit(t *testing.T) {
 			Message: "intentional failure in " + t.Name(),
 		},
 	}
-	require.NoError(t, upd1.OnMessage(ctx, &rej, evStore))
+	require.NoError(t, upd1.OnMessage(ctx, &rej, true, evStore))
 	require.Equal(t, 0, reg.Len(),
 		"completed update should have been removed from registry")
 
@@ -433,7 +434,7 @@ func TestTotalLimit(t *testing.T) {
 		Meta:  &updatepb.Meta{UpdateId: "update1"},
 		Input: &updatepb.Input{Name: "not_empty"},
 	}
-	require.NoError(t, upd1.OnMessage(ctx, &req, evStore))
+	require.NoError(t, upd1.OnMessage(ctx, &req, true, evStore))
 
 	_ = upd1.Send(ctx, false, sequencingID, evStore)
 
@@ -451,7 +452,7 @@ func TestTotalLimit(t *testing.T) {
 			Message: "intentional failure in " + t.Name(),
 		},
 	}
-	require.NoError(t, upd1.OnMessage(ctx, &rej, evStore))
+	require.NoError(t, upd1.OnMessage(ctx, &rej, true, evStore))
 
 	t.Run("try to admit next after completing previous", func(t *testing.T) {
 		_, existed, err = reg.FindOrCreate(ctx, "update2")
@@ -532,12 +533,12 @@ func TestRejectUnprocessed(t *testing.T) {
 	err = upd1.OnMessage(ctx, &updatepb.Request{
 		Meta:  &updatepb.Meta{UpdateId: updateID1},
 		Input: &updatepb.Input{Name: t.Name() + "-update-func"},
-	}, evStore)
+	}, true, evStore)
 	require.NoError(t, err)
 	err = upd2.OnMessage(ctx, &updatepb.Request{
 		Meta:  &updatepb.Meta{UpdateId: updateID2},
 		Input: &updatepb.Input{Name: t.Name() + "-update-func"},
-	}, evStore)
+	}, true, evStore)
 	require.NoError(t, err)
 
 	rejectedIDs, err = reg.RejectUnprocessed(ctx, evStore)
@@ -555,7 +556,7 @@ func TestRejectUnprocessed(t *testing.T) {
 	err = upd3.OnMessage(ctx, &updatepb.Request{
 		Meta:  &updatepb.Meta{UpdateId: updateID3},
 		Input: &updatepb.Input{Name: t.Name() + "-update-func"},
-	}, evStore)
+	}, true, evStore)
 	require.NoError(t, err)
 	upd2.Send(ctx, false, sequencingID, evStore)
 	upd3.Send(ctx, false, sequencingID, evStore)

--- a/service/history/workflow/update/state.go
+++ b/service/history/workflow/update/state.go
@@ -39,8 +39,8 @@ const (
 	stateAdmitted state = 1 << iota
 	stateProvisionallyRequested
 	stateRequested
-	stateSent
 	stateProvisionallySent
+	stateSent
 	stateProvisionallyAccepted
 	stateAccepted
 	stateProvisionallyCompleted

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -494,7 +494,7 @@ func (u *Update) onResponseMsg(
 	return nil
 }
 
-// isSent checks if update was sent to worker.
+// isIncomplete checks if update is already completed (rejected or processed).
 func (u *Update) isIncomplete() bool {
 	return !u.state.Matches(stateSet(stateProvisionallyCompleted | stateCompleted))
 }

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -293,7 +293,9 @@ func (u *Update) OnMessage(
 
 	// If workflow was completed while processing this WFT, then only Rejection messages can be processed,
 	// because they don't create new events in the history. All other updates must be cancelled.
-	if _, isRejection := msg.(*updatepb.Rejection); !isWorkflowRunning && !isRejection {
+	_, isRejection := msg.(*updatepb.Rejection)
+	shouldCancel := !(isWorkflowRunning || isRejection)
+	if shouldCancel {
 		return u.CancelIncomplete(ctx, CancelReasonWorkflowCompleted, eventStore)
 	}
 

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -916,7 +916,7 @@ func TestCompletedWorkflow(t *testing.T) {
 		store = mockEventStore{Controller: effects}
 	)
 
-	t.Run("request", func(t *testing.T) {
+	t.Run("new update is rejected if workflow is completed", func(t *testing.T) {
 		upd := update.New(meta.UpdateId)
 		err := upd.OnMessage(ctx, &req, false, store)
 		require.NoError(t, err)
@@ -928,7 +928,7 @@ func TestCompletedWorkflow(t *testing.T) {
 		require.Equal(t, "CanceledUpdate", status.Outcome.GetFailure().GetApplicationFailureInfo().Type)
 	})
 
-	t.Run("accept", func(t *testing.T) {
+	t.Run("sent update is rejected if completed workflow tries to accept it", func(t *testing.T) {
 		upd := update.New(meta.UpdateId)
 		_ = upd.OnMessage(ctx, &req, true, store)
 		upd.Send(ctx, false, &protocolpb.Message_EventId{EventId: testSequencingEventID}, store)
@@ -944,7 +944,7 @@ func TestCompletedWorkflow(t *testing.T) {
 		require.Equal(t, "CanceledUpdate", status.Outcome.GetFailure().GetApplicationFailureInfo().Type)
 	})
 
-	t.Run("reject", func(t *testing.T) {
+	t.Run("sent update is rejected with user rejection if completed workflow rejects it", func(t *testing.T) {
 		upd := update.New(meta.UpdateId)
 		_ = upd.OnMessage(ctx, &req, true, store)
 		upd.Send(ctx, false, &protocolpb.Message_EventId{EventId: testSequencingEventID}, store)
@@ -962,7 +962,7 @@ func TestCompletedWorkflow(t *testing.T) {
 		require.Equal(t, "An intentional failure", status.Outcome.GetFailure().GetMessage())
 	})
 
-	t.Run("complete", func(t *testing.T) {
+	t.Run("accepted update is timed out if completed workflow completes it", func(t *testing.T) {
 		upd := update.NewAccepted(meta.UpdateId, testAcceptedEventID)
 
 		resp := updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")}

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -925,7 +925,7 @@ func TestCompletedWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
 		require.Equal(t, "Workflow Update is rejected because Workflow Execution is completed.", status.Outcome.GetFailure().GetMessage())
-		require.Equal(t, "TerminatedUpdate", status.Outcome.GetFailure().GetApplicationFailureInfo().Type)
+		require.Equal(t, "CanceledUpdate", status.Outcome.GetFailure().GetApplicationFailureInfo().Type)
 	})
 
 	t.Run("accept", func(t *testing.T) {
@@ -941,7 +941,7 @@ func TestCompletedWorkflow(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, enumspb.UPDATE_WORKFLOW_EXECUTION_LIFECYCLE_STAGE_COMPLETED, status.Stage)
 		require.Equal(t, "Workflow Update is rejected because Workflow Execution is completed.", status.Outcome.GetFailure().GetMessage())
-		require.Equal(t, "TerminatedUpdate", status.Outcome.GetFailure().GetApplicationFailureInfo().Type)
+		require.Equal(t, "CanceledUpdate", status.Outcome.GetFailure().GetApplicationFailureInfo().Type)
 	})
 
 	t.Run("reject", func(t *testing.T) {

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -969,13 +969,13 @@ func TestCompletedWorkflow(t *testing.T) {
 		err := upd.OnMessage(ctx, &resp, false, store)
 		require.NoError(t, err)
 
-		status, err := upd.WaitOutcome(ctx)
+		oneMsCtx, cancel := context.WithTimeout(ctx, 1*time.Millisecond)
+		defer cancel()
+		status, err := upd.WaitOutcome(oneMsCtx)
 		require.Error(t, err)
 
-		var canceled *serviceerror.Canceled
-		require.ErrorAs(t, err, &canceled,
-			"expected Canceled error when workflow is completed and update is in Accepted state")
-		require.Equal(t, "Workflow Update is cancelled because Workflow Execution is completed.", err.Error())
+		require.ErrorIs(t, err, context.DeadlineExceeded,
+			"expected DeadlineExceeded error when workflow is completed and update is in Accepted state")
 		require.Nil(t, status.Outcome)
 	})
 }

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -150,7 +150,10 @@ func TimeoutWorkflow(
 }
 
 func TerminateWorkflow(
+	// ctx context.Context,
 	mutableState MutableState,
+	// effects *effect.Buffer,
+	// updateRegistry update.Registry,
 	terminateReason string,
 	terminateDetails *commonpb.Payloads,
 	terminateIdentity string,
@@ -187,6 +190,9 @@ func TerminateWorkflow(
 		terminateIdentity,
 		deleteAfterTerminate,
 	)
+
+	// err = updateRegistry.CancelIncomplete(ctx, update.CancelReasonWorkflowTerminated, WithEffects(effects, mutableState))
+
 	return err
 }
 

--- a/service/history/workflow_task_handler.go
+++ b/service/history/workflow_task_handler.go
@@ -356,7 +356,11 @@ func (handler *workflowTaskHandlerImpl) handleMessage(
 				serviceerror.NewNotFound(fmt.Sprintf("update %q not found", message.ProtocolInstanceId)))
 		}
 
-		if err := upd.OnMessage(ctx, message, handler.mutableState.IsWorkflowExecutionRunning(), workflow.WithEffects(handler.effects, handler.mutableState)); err != nil {
+		if err := upd.OnMessage(
+			ctx,
+			message,
+			handler.mutableState.IsWorkflowExecutionRunning(),
+			workflow.WithEffects(handler.effects, handler.mutableState)); err != nil {
 			return handler.failWorkflowTaskOnInvalidArgument(
 				enumspb.WORKFLOW_TASK_FAILED_CAUSE_BAD_UPDATE_WORKFLOW_EXECUTION_MESSAGE, err)
 		}

--- a/service/history/workflow_task_handler.go
+++ b/service/history/workflow_task_handler.go
@@ -284,7 +284,7 @@ func (handler *workflowTaskHandlerImpl) handleCommand(
 		return handler.handleCommandScheduleActivity(ctx, command.GetScheduleActivityTaskCommandAttributes())
 
 	case enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION:
-		return nil, handler.handleCommandCompleteWorkflow(ctx, command.GetCompleteWorkflowExecutionCommandAttributes(), msgs)
+		return nil, handler.handleCommandCompleteWorkflow(ctx, command.GetCompleteWorkflowExecutionCommandAttributes())
 
 	case enumspb.COMMAND_TYPE_FAIL_WORKFLOW_EXECUTION:
 		return nil, handler.handleCommandFailWorkflow(ctx, command.GetFailWorkflowExecutionCommandAttributes())
@@ -630,15 +630,7 @@ func (handler *workflowTaskHandlerImpl) handleCommandStartTimer(
 func (handler *workflowTaskHandlerImpl) handleCommandCompleteWorkflow(
 	ctx context.Context,
 	attr *commandpb.CompleteWorkflowExecutionCommandAttributes,
-	msgs *collection.IndexedTakeList[string, *protocolpb.Message],
 ) error {
-
-	for _, msg := range msgs.TakeRemaining() {
-		err := handler.handleMessage(ctx, msg)
-		if err != nil || handler.stopProcessing {
-			return err
-		}
-	}
 
 	handler.metricsHandler.Counter(metrics.CommandTypeCompleteWorkflowCounter.Name()).Record(1)
 

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -606,6 +606,23 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			return nil, err
 		}
 
+		if !ms.IsWorkflowExecutionRunning() {
+			// If workflow competed itself with one of the completion command, terminate all incomplete updates in the registry.
+			// Because all unprocessed updates were already rejected, incomplete updates in the registry are:
+			// - updates that were received while this WT was running,
+			// - updates that were accepted but not completed by this WT.
+			err = weContext.UpdateRegistry(ctx).CancelIncomplete(ctx, update.CancelReasonWorkflowCompleted, workflow.WithEffects(&effects, ms))
+			if err != nil {
+				// Just log error here because it is more important to complete workflow than canceling updates.
+				handler.logger.Warn("Unable to cancel incomplete updates while completing the workflow.",
+					tag.WorkflowNamespaceID(weContext.GetWorkflowKey().NamespaceID),
+					tag.WorkflowID(weContext.GetWorkflowKey().WorkflowID),
+					tag.WorkflowRunID(weContext.GetWorkflowKey().RunID),
+					tag.WorkflowEventID(currentWorkflowTask.ScheduledEventID),
+					tag.Error(err))
+			}
+		}
+
 		// set the vars used by following logic
 		// further refactor should also clean up the vars used below
 		wtFailedCause = workflowTaskHandler.workflowTaskFailedCause

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -607,7 +607,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		}
 
 		if !ms.IsWorkflowExecutionRunning() {
-			// If workflow competed itself with one of the completion command, terminate all incomplete updates in the registry.
+			// If workflow competed itself with one of the completion command, cancel all incomplete updates in the registry.
 			// Because all unprocessed updates were already rejected, incomplete updates in the registry are:
 			// - updates that were received while this WT was running,
 			// - updates that were accepted but not completed by this WT.

--- a/service/history/workflow_task_handler_test.go
+++ b/service/history/workflow_task_handler_test.go
@@ -258,6 +258,7 @@ func TestCommandProtocolMessage(t *testing.T) {
 		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
 		tc.ms.EXPECT().GetExecutionState().AnyTimes().Return(&persistencespb.WorkflowExecutionState{})
 		tc.ms.EXPECT().GetUpdateOutcome(gomock.Any(), updateID).Return(nil, serviceerror.NewNotFound(""))
+		tc.ms.EXPECT().IsWorkflowExecutionRunning().AnyTimes().Return(true)
 
 		t.Log("create the expected protocol instance")
 		_, _, err := tc.updates.FindOrCreate(context.Background(), updateID)
@@ -294,6 +295,7 @@ func TestCommandProtocolMessage(t *testing.T) {
 		tc.ms.EXPECT().GetExecutionInfo().AnyTimes().Return(&persistencespb.WorkflowExecutionInfo{})
 		tc.ms.EXPECT().GetExecutionState().AnyTimes().Return(&persistencespb.WorkflowExecutionState{})
 		tc.ms.EXPECT().GetUpdateOutcome(gomock.Any(), updateID).Return(nil, serviceerror.NewNotFound(""))
+		tc.ms.EXPECT().IsWorkflowExecutionRunning().AnyTimes().Return(true)
 
 		t.Log("create the expected protocol instance")
 		_, _, err := tc.updates.FindOrCreate(context.Background(), updateID)

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -3291,14 +3291,15 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Te
 }
 
 func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate() {
-	testCases := []struct {
+	type testCase struct {
 		Name          string
 		Description   string
 		UpdateErr     string
 		UpdateFailure string
 		Commands      func(tv *testvars.TestVars) []*commandpb.Command
 		Messages      func(tv *testvars.TestVars, updRequestMsg *protocolpb.Message) []*protocolpb.Message
-	}{
+	}
+	testCases := []testCase{
 		{
 			Name:          "requested",
 			Description:   "update in stateRequested must be rejected by server with server generated rejection failure",
@@ -3394,7 +3395,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate() 
 			s.NoError(err)
 
 			updateResultCh := make(chan struct{})
-			go func() {
+			go func(tc testCase) {
 				resp, err1 := s.sendUpdate(tv, "1")
 
 				if tc.UpdateErr != "" {
@@ -3412,7 +3413,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate() 
 				}
 
 				updateResultCh <- struct{}{}
-			}()
+			}(tc) // To prevent capturing of tc range value by reference.
 
 			// Complete workflow.
 			_, err = poller.PollAndProcessWorkflowTask()

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -3290,7 +3290,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_ScheduledSpeculativeWorkflowTask_Te
 	s.EqualValues(5, msResp.GetDatabaseMutableState().GetExecutionInfo().GetCompletionEventBatchId(), "completion_event_batch_id should point to WFTerminated event")
 }
 
-func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_TerminateUpdate() {
+func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_CancelUpdate() {
 	type testCase struct {
 		Name          string
 		Description   string

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -2727,7 +2727,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWorkf
 			// Emulate slow worker: sleep more than WT timeout.
 			time.Sleep(1*time.Second + 100*time.Millisecond)
 			// This doesn't matter because WT times out before update is applied.
-			return s.acceptUpdateCommands(tv, "1"), nil
+			return s.acceptCompleteUpdateCommands(tv, "1"), nil
 		case 3:
 			// Speculative WT timed out and retried as normal WT.
 			s.EqualHistory(`
@@ -2740,7 +2740,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_StartToCloseTimeoutSpeculativeWorkf
   7 WorkflowTaskTimedOut
   8 WorkflowTaskScheduled {"Attempt":2 } // Transient WT.
   9 WorkflowTaskStarted`, history)
-			commands := append(s.acceptUpdateCommands(tv, "1"),
+			commands := append(s.acceptCompleteUpdateCommands(tv, "1"),
 				&commandpb.Command{
 					CommandType: enumspb.COMMAND_TYPE_COMPLETE_WORKFLOW_EXECUTION,
 					Attributes:  &commandpb.Command_CompleteWorkflowExecutionCommandAttributes{CompleteWorkflowExecutionCommandAttributes: &commandpb.CompleteWorkflowExecutionCommandAttributes{}},

--- a/tests/update_workflow_test.go
+++ b/tests/update_workflow_test.go
@@ -3310,7 +3310,7 @@ func (s *FunctionalSuite) TestUpdateWorkflow_CompleteWorkflow_CancelUpdate() {
 		},
 		{
 			Name:          "accepted",
-			Description:   "update in stateAccepted must got an error because there is no way for workflow to complete it and already accepted update can't be rejected",
+			Description:   "update in stateAccepted must get an error because there is no way for workflow to complete it and already accepted update can't be rejected",
 			UpdateErr:     "context deadline exceeded",
 			UpdateFailure: "",
 			Commands:      func(tv *testvars.TestVars) []*commandpb.Command { return s.acceptUpdateCommands(tv, "1") },


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Process update rejection and cancel incomplete updates when workflow is completing itself.

## Why?
<!-- Tell your future self why have you made these changes -->
Update rejection messages are processed after commands and if there is a command to complete workflow those messages were not processed at all. This PR fixes it.

Also all not accepted updates are canceled if workflow completes itself.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added new unit and functional tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.