### PR TITLE
Don't rewrap marshalled DataBlobs

### DIFF
--- a/service/frontend/workflow_handler_deprecated.go
+++ b/service/frontend/workflow_handler_deprecated.go
@@ -516,10 +516,7 @@ func (wh *WorkflowHandler) getRawHistory(
 	}
 
 	for _, data := range resp.HistoryEventBlobs {
-		rawHistory = append(rawHistory, &commonpb.DataBlob{
-			EncodingType: data.EncodingType,
-			Data:         data.Data,
-		})
+		rawHistory = append(rawHistory, data)
 	}
 
 	if len(resp.NextPageToken) == 0 && transientWorkflowTaskInfo != nil {
@@ -538,10 +535,7 @@ func (wh *WorkflowHandler) getRawHistory(
 			if err != nil {
 				return nil, nil, err
 			}
-			rawHistory = append(rawHistory, &commonpb.DataBlob{
-				EncodingType: enumspb.ENCODING_TYPE_PROTO3,
-				Data:         blob.Data,
-			})
+			rawHistory = append(rawHistory, blob)
 		}
 	}
 

--- a/service/history/api/get_history_util.go
+++ b/service/history/api/get_history_util.go
@@ -58,7 +58,6 @@ func GetRawHistory(
 	transientWorkflowTaskInfo *historyspb.TransientWorkflowTaskInfo,
 	branchToken []byte,
 ) ([]*commonpb.DataBlob, []byte, error) {
-	var rawHistory []*commonpb.DataBlob
 	shardID := common.WorkflowIDToHistoryShard(namespaceID.String(), execution.GetWorkflowId(), shard.GetConfig().NumberOfShards)
 
 	persistenceExecutionManager := shard.GetExecutionManager()
@@ -74,12 +73,7 @@ func GetRawHistory(
 		return nil, nil, err
 	}
 
-	for _, data := range resp.HistoryEventBlobs {
-		rawHistory = append(rawHistory, &commonpb.DataBlob{
-			EncodingType: data.EncodingType,
-			Data:         data.Data,
-		})
-	}
+	rawHistory := resp.HistoryEventBlobs
 
 	if len(resp.NextPageToken) == 0 && transientWorkflowTaskInfo != nil {
 		if err := validateTransientWorkflowTaskEvents(nextEventID, transientWorkflowTaskInfo); err != nil {
@@ -99,10 +93,7 @@ func GetRawHistory(
 			if err != nil {
 				return nil, nil, err
 			}
-			rawHistory = append(rawHistory, &commonpb.DataBlob{
-				EncodingType: enumspb.ENCODING_TYPE_PROTO3,
-				Data:         blob.Data,
-			})
+			rawHistory = append(rawHistory, blob)
 		}
 	}
 

--- a/service/history/ndc/replication_task.go
+++ b/service/history/ndc/replication_task.go
@@ -497,17 +497,12 @@ func deserializeBlob(
 	historySerializer serialization.Serializer,
 	blob *commonpb.DataBlob,
 ) ([]*historypb.HistoryEvent, error) {
-
 	if blob == nil {
 		return nil, nil
 	}
 
-	events, err := historySerializer.DeserializeEvents(&commonpb.DataBlob{
-		EncodingType: enumspb.ENCODING_TYPE_PROTO3,
-		Data:         blob.Data,
-	})
-
-	return events, err
+	blob.EncodingType = enumspb.ENCODING_TYPE_PROTO3
+	return historySerializer.DeserializeEvents(blob)
 }
 
 func DeserializeBlobs(
@@ -519,10 +514,8 @@ func DeserializeBlobs(
 		return eventBatches, nil
 	}
 	for _, blob := range blobs {
-		events, err := historySerializer.DeserializeEvents(&commonpb.DataBlob{
-			EncodingType: enumspb.ENCODING_TYPE_PROTO3,
-			Data:         blob.Data,
-		})
+		blob.EncodingType = enumspb.ENCODING_TYPE_PROTO3
+		events, err := historySerializer.DeserializeEvents(blob)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## What changed?
I removed a handful of locations where we needlessly rewrap and reallocate DataBlob objects

## Why?
These are unnecessary allocations: when we create a data blob we set it's encoding type.
It's also incorrect to stomp that with proto3: were they serialized with some other encoding we'd create blobs we could no longer deserialize

## How did you test it?
Existing tests

## Potential risks
None

## Is hotfix candidate?
No
