### PR TITLE
Don't unload task queue while child is polling user data

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -437,7 +437,8 @@ const (
 	MatchingLoadUserData = "matching.loadUserData"
 	// MatchingUpdateAckInterval is the interval for update ack
 	MatchingUpdateAckInterval = "matching.updateAckInterval"
-	// MatchingMaxTaskQueueIdleTime is the time after which an idle task queue will be unloaded
+	// MatchingMaxTaskQueueIdleTime is the time after which an idle task queue will be unloaded.
+	// Note: this should be greater than matching.longPollExpirationInterval and matching.getUserDataLongPollTimeout.
 	MatchingMaxTaskQueueIdleTime = "matching.maxTaskQueueIdleTime"
 	// MatchingOutstandingTaskAppendsThreshold is the threshold for outstanding task appends
 	MatchingOutstandingTaskAppendsThreshold = "matching.outstandingTaskAppendsThreshold"

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -196,7 +196,7 @@ func NewConfig(
 		VersionCompatibleSetLimitPerQueue:     dc.GetIntPropertyFilteredByNamespace(dynamicconfig.VersionCompatibleSetLimitPerQueue, 10),
 		VersionBuildIdLimitPerQueue:           dc.GetIntPropertyFilteredByNamespace(dynamicconfig.VersionBuildIdLimitPerQueue, 100),
 		TaskQueueLimitPerBuildId:              dc.GetIntPropertyFilteredByNamespace(dynamicconfig.TaskQueuesPerBuildIdLimit, 20),
-		GetUserDataLongPollTimeout:            dc.GetDurationProperty(dynamicconfig.MatchingGetUserDataLongPollTimeout, 5*time.Minute),
+		GetUserDataLongPollTimeout:            dc.GetDurationProperty(dynamicconfig.MatchingGetUserDataLongPollTimeout, 5*time.Minute-10*time.Second),
 		BacklogNegligibleAge:                  dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingBacklogNegligibleAge, 24*365*10*time.Hour),
 		MaxWaitForPollerBeforeFwd:             dc.GetDurationPropertyFilteredByTaskQueueInfo(dynamicconfig.MatchingMaxWaitForPollerBeforeFwd, 200*time.Millisecond),
 

--- a/service/matching/matching_engine.go
+++ b/service/matching/matching_engine.go
@@ -1041,6 +1041,8 @@ func (e *matchingEngineImpl) GetTaskQueueUserData(
 		var cancel context.CancelFunc
 		ctx, cancel = newChildContext(ctx, e.config.GetUserDataLongPollTimeout(), returnEmptyTaskTimeBudget)
 		defer cancel()
+		// mark alive so that it doesn't unload while a child partition is doing a long poll
+		tqMgr.MarkAlive()
 	}
 
 	for {


### PR DESCRIPTION
## What changed?
- Mark a tqm live when we're doing a long poll for user data.
- Adjust timeouts so that user data long poll is slightly less than idle unload timeout.

## Why?
This prevents the annoying `task queue closed` errors from `GetTaskQueueUserData` by keeping a parent partition alive while a child is doing a user data long poll (i.e. as long as any children are loaded).

## How did you test it?
Mostly manually, with shortened timeouts. (There aren't currently good tests around the idle unload.)