### PR TITLE
OTEL setup via environment variables

### DIFF
--- a/common/telemetry/env.go
+++ b/common/telemetry/env.go
@@ -25,11 +25,11 @@
 package telemetry
 
 import (
-	"fmt"
 	"os"
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	otelsdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"gopkg.in/errgo.v2/fmt/errors"
 )
 
 // EnvSpanExporter creates gRPC span exporters from environment variables as specified in
@@ -40,12 +40,12 @@ func EnvSpanExporter() (otelsdktrace.SpanExporter, error) {
 		return nil, nil
 	}
 	if typeOf != "oltp" {
-		return nil, fmt.Errorf("unsupported OTEL_TRACES_EXPORTER: %v", typeOf)
+		return nil, errors.Newf("unsupported OTEL_TRACES_EXPORTER: %v", typeOf)
 	}
 
 	protocol, found := os.LookupEnv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
 	if found && protocol != "grpc" {
-		return nil, fmt.Errorf("unsupported OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: %v", protocol)
+		return nil, errors.Newf("unsupported OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: %v", protocol)
 	}
 
 	return otlptracegrpc.NewUnstarted(), nil

--- a/common/telemetry/env.go
+++ b/common/telemetry/env.go
@@ -41,7 +41,7 @@ const (
 
 var unsupportedEnvVar = errors.New("unsupported OpenTelemetry env var")
 
-// EnvSpanExporter creates gRPC span exporters from environment variables as specified in
+// EnvSpanExporter creates a gRPC span exporter from environment variables, if present, as specified in
 // https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options
 func EnvSpanExporter() (otelsdktrace.SpanExporter, error) {
 

--- a/common/telemetry/env.go
+++ b/common/telemetry/env.go
@@ -1,0 +1,52 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package telemetry
+
+import (
+	"fmt"
+	"os"
+
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	otelsdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// EnvSpanExporter creates gRPC span exporters from environment variables as specified in
+// https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options
+func EnvSpanExporter() (otelsdktrace.SpanExporter, error) {
+	typeOf, found := os.LookupEnv("OTEL_TRACES_EXPORTER")
+	if !found {
+		return nil, nil
+	}
+	if typeOf != "oltp" {
+		return nil, fmt.Errorf("unsupported OTEL_TRACES_EXPORTER: %v", typeOf)
+	}
+
+	protocol, found := os.LookupEnv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL")
+	if found && protocol != "grpc" {
+		return nil, fmt.Errorf("unsupported OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: %v", protocol)
+	}
+
+	return otlptracegrpc.NewUnstarted(), nil
+}

--- a/common/telemetry/env.go
+++ b/common/telemetry/env.go
@@ -29,7 +29,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/davecgh/go-spew/spew"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	otelsdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.temporal.io/server/common/primitives"
@@ -61,9 +60,7 @@ func SupplementTraceExportersFromEnv(
 			case OtelTracesOtlpExporterType:
 				if _, exists := exporters[OtelTracesOtlpExporterType]; !exists {
 					// other OTEL configuration env variables are picked up automatically by the exporter itself
-					exporter := otlptracegrpc.NewUnstarted()
-					spew.Dump(exporter)
-					supplements[OtelTracesOtlpExporterType] = exporter
+					supplements[OtelTracesOtlpExporterType] = otlptracegrpc.NewUnstarted()
 				}
 			default:
 				return fmt.Errorf("%w: %v=%v", unsupportedTraceExporter, OtelTracesExporterEnvKey, val)

--- a/common/telemetry/env.go
+++ b/common/telemetry/env.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/davecgh/go-spew/spew"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	otelsdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.temporal.io/server/common/primitives"
@@ -60,7 +61,9 @@ func SupplementTraceExportersFromEnv(
 			case OtelTracesOtlpExporterType:
 				if _, exists := exporters[OtelTracesOtlpExporterType]; !exists {
 					// other OTEL configuration env variables are picked up automatically by the exporter itself
-					supplements[OtelTracesOtlpExporterType] = otlptracegrpc.NewUnstarted()
+					exporter := otlptracegrpc.NewUnstarted()
+					spew.Dump(exporter)
+					supplements[OtelTracesOtlpExporterType] = exporter
 				}
 			default:
 				return fmt.Errorf("%w: %v=%v", unsupportedTraceExporter, OtelTracesExporterEnvKey, val)

--- a/common/telemetry/env.go
+++ b/common/telemetry/env.go
@@ -37,6 +37,7 @@ import (
 const (
 	OtelTracesExporterEnvKey         = "OTEL_TRACES_EXPORTER"
 	OtelTracesExporterProtocolEnvKey = "OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"
+	OtelServiceNameEnvKey            = "OTEL_SERVICE_NAME"
 )
 
 var unsupportedEnvVar = errors.New("unsupported OpenTelemetry env var")

--- a/common/telemetry/env.go
+++ b/common/telemetry/env.go
@@ -53,12 +53,13 @@ type envVarLookup = func(string) (string, bool)
 func SpanExportersFromEnv(
 	envVars envVarLookup,
 ) (map[SpanExporterType]otelsdktrace.SpanExporter, error) {
+	exporters := map[SpanExporterType]otelsdktrace.SpanExporter{}
+
 	exporterTypes, ok := envVars(OtelTracesExporterTypesEnvKey)
 	if !ok {
-		return nil, nil
+		return exporters, nil
 	}
 
-	exporters := map[SpanExporterType]otelsdktrace.SpanExporter{}
 	for _, exporterType := range strings.Split(exporterTypes, ",") {
 		switch SpanExporterType(exporterType) {
 		case OtelTracesOtlpExporterType:
@@ -76,6 +77,7 @@ func SpanExportersFromEnv(
 			return nil, fmt.Errorf("%w: %v=%v", unsupportedTraceExporter, OtelTracesExporterTypesEnvKey, exporterType)
 		}
 	}
+
 	return exporters, nil
 }
 

--- a/common/telemetry/env.go
+++ b/common/telemetry/env.go
@@ -32,6 +32,7 @@ import (
 
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	otelsdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.temporal.io/server/common/primitives"
 )
 
 const (
@@ -64,4 +65,13 @@ func EnvSpanExporter() (otelsdktrace.SpanExporter, error) {
 
 func unsupportedEnvVarErr(key, val string) error {
 	return fmt.Errorf("%w: %s=%s", unsupportedEnvVar, key, val)
+}
+
+// ResourceServiceName returns the logical name of the service.
+func ResourceServiceName(rsn primitives.ServiceName) string {
+	serviceNamePrefix := "io.temporal"
+	if customServicePrefix, found := os.LookupEnv(OtelServiceNameEnvKey); found {
+		serviceNamePrefix = customServicePrefix
+	}
+	return fmt.Sprintf("%s.%s", serviceNamePrefix, string(rsn))
 }

--- a/common/telemetry/env_test.go
+++ b/common/telemetry/env_test.go
@@ -41,8 +41,7 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
-				switch key {
-				case telemetry.OtelTracesExporterTypesEnvKey:
+				if key == telemetry.OtelTracesExporterTypesEnvKey {
 					return string(telemetry.OtelTracesOtlpExporterType), true
 				}
 				return "", false
@@ -80,8 +79,7 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
-				switch key {
-				case telemetry.OtelTracesExporterTypesEnvKey:
+				if key == telemetry.OtelTracesExporterTypesEnvKey {
 					return string(telemetry.OtelTracesOtlpExporterType), true
 				}
 				return "", false
@@ -97,8 +95,7 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
-				switch key {
-				case telemetry.OtelTracesExporterTypesEnvKey:
+				if key == telemetry.OtelTracesExporterTypesEnvKey {
 					return fmt.Sprintf("%v,%v", telemetry.OtelTracesOtlpExporterType, "nonsense"), true
 				}
 				return "", false

--- a/common/telemetry/env_test.go
+++ b/common/telemetry/env_test.go
@@ -37,31 +37,31 @@ func TestEnvSpanExporter(t *testing.T) {
 	require.Nil(t, exp)
 	require.NoError(t, err)
 
-	os.Setenv("OTEL_TRACES_EXPORTER", "invalid-exporter")
+	_ = os.Setenv("OTEL_TRACES_EXPORTER", "invalid-exporter")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.Nil(t, exp)
 	require.EqualError(t, err, "unsupported OTEL_TRACES_EXPORTER: invalid-exporter")
 
-	os.Setenv("OTEL_TRACES_EXPORTER", "oltp")
+	_ = os.Setenv("OTEL_TRACES_EXPORTER", "oltp")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.NotNil(t, exp)
 	require.NoError(t, err)
 
-	os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
+	_ = os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.NotNil(t, exp)
 	require.NoError(t, err)
 
-	os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
+	_ = os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.NotNil(t, exp)
 	require.NoError(t, err)
 
-	os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "invalid-protocol")
+	_ = os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "invalid-protocol")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.Nil(t, exp)

--- a/common/telemetry/env_test.go
+++ b/common/telemetry/env_test.go
@@ -41,24 +41,24 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 			exporters,
 			func(key string) (string, bool) {
 				require.Equal(t, telemetry.OtelTracesExporterEnvKey, key)
-				return string(telemetry.OtelTracesOtelExporterType), true
+				return string(telemetry.OtelTracesOtlpExporterType), true
 			})
 		require.NoError(t, err)
 		require.Len(t, exporters, 1)
 	})
 
 	t.Run("when env variable specifies OTEL exporter type but the type already exists, don't add exporter", func(t *testing.T) {
-		var mockExporter otelsdktrace.SpanExporter = nil
+		var mockExporter otelsdktrace.SpanExporter
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{
-			telemetry.OtelTracesOtelExporterType: mockExporter,
+			telemetry.OtelTracesOtlpExporterType: mockExporter,
 		}
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
-				return string(telemetry.OtelTracesOtelExporterType), true
+				return string(telemetry.OtelTracesOtlpExporterType), true
 			})
 		require.NoError(t, err)
-		require.Equal(t, exporters[telemetry.OtelTracesOtelExporterType], mockExporter)
+		require.Equal(t, exporters[telemetry.OtelTracesOtlpExporterType], mockExporter)
 	})
 
 	t.Run("when env variable is specified but exporter type is not supported, return error", func(t *testing.T) {
@@ -66,9 +66,9 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
-				return fmt.Sprintf("%v,%v", telemetry.OtelTracesOtelExporterType, "nonsense"), true
+				return fmt.Sprintf("%v,%v", telemetry.OtelTracesOtlpExporterType, "nonsense"), true
 			})
-		require.EqualError(t, err, "unsupported OTEL_TRACES_EXPORTER: nonsense")
+		require.EqualError(t, err, "unsupported OTEL env: OTEL_TRACES_EXPORTER=nonsense")
 		require.Empty(t, exporters)
 	})
 

--- a/common/telemetry/env_test.go
+++ b/common/telemetry/env_test.go
@@ -29,15 +29,12 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	otelsdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.temporal.io/server/common/primitives"
 	"go.temporal.io/server/common/telemetry"
 )
 
 func TestSupplementTraceExportersFromEnv(t *testing.T) {
 	t.Run("when env variable specifies valid OTEL exporter type, add exporter", func(t *testing.T) {
-		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
-
 		exporters, err := telemetry.SpanExportersFromEnv(
 			func(key string) (string, bool) {
 				if key == telemetry.OtelTracesExporterTypesEnvKey {
@@ -51,8 +48,6 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 	})
 
 	t.Run("when env variable specifies valid OTEL exporter type but invalid protocol, return error", func(t *testing.T) {
-		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
-
 		exporters, err := telemetry.SpanExportersFromEnv(
 			func(key string) (string, bool) {
 				switch key {
@@ -69,8 +64,6 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 	})
 
 	t.Run("when env variable is specified but exporter type is not supported, return error", func(t *testing.T) {
-		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
-
 		exporters, err := telemetry.SpanExportersFromEnv(
 			func(key string) (string, bool) {
 				if key == telemetry.OtelTracesExporterTypesEnvKey {
@@ -84,8 +77,6 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 	})
 
 	t.Run("when not specified, do not create any exporters", func(t *testing.T) {
-		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
-
 		exporters, err := telemetry.SpanExportersFromEnv(
 			func(key string) (string, bool) {
 				return "", false

--- a/common/telemetry/env_test.go
+++ b/common/telemetry/env_test.go
@@ -1,0 +1,69 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package telemetry_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/telemetry"
+)
+
+func TestEnvSpanExporter(t *testing.T) {
+	exp, err := telemetry.EnvSpanExporter()
+	require.Nil(t, exp)
+	require.NoError(t, err)
+
+	os.Setenv("OTEL_TRACES_EXPORTER", "invalid-exporter")
+
+	exp, err = telemetry.EnvSpanExporter()
+	require.Nil(t, exp)
+	require.EqualError(t, err, "unsupported OTEL_TRACES_EXPORTER: invalid-exporter")
+
+	os.Setenv("OTEL_TRACES_EXPORTER", "oltp")
+
+	exp, err = telemetry.EnvSpanExporter()
+	require.NotNil(t, exp)
+	require.NoError(t, err)
+
+	os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
+
+	exp, err = telemetry.EnvSpanExporter()
+	require.NotNil(t, exp)
+	require.NoError(t, err)
+
+	os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
+
+	exp, err = telemetry.EnvSpanExporter()
+	require.NotNil(t, exp)
+	require.NoError(t, err)
+
+	os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "invalid-protocol")
+
+	exp, err = telemetry.EnvSpanExporter()
+	require.Nil(t, exp)
+	require.EqualError(t, err, "unsupported OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: invalid-protocol")
+}

--- a/common/telemetry/env_test.go
+++ b/common/telemetry/env_test.go
@@ -37,12 +37,14 @@ import (
 func TestSupplementTraceExportersFromEnv(t *testing.T) {
 	t.Run("when env variable specifies OTEL exporter type, add exporter", func(t *testing.T) {
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
+
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
 				require.Equal(t, telemetry.OtelTracesExporterEnvKey, key)
 				return string(telemetry.OtelTracesOtlpExporterType), true
 			})
+
 		require.NoError(t, err)
 		require.Len(t, exporters, 1)
 	})
@@ -52,33 +54,39 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{
 			telemetry.OtelTracesOtlpExporterType: mockExporter,
 		}
+
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
 				return string(telemetry.OtelTracesOtlpExporterType), true
 			})
+
 		require.NoError(t, err)
 		require.Equal(t, exporters[telemetry.OtelTracesOtlpExporterType], mockExporter)
 	})
 
 	t.Run("when env variable is specified but exporter type is not supported, return error", func(t *testing.T) {
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
+
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
 				return fmt.Sprintf("%v,%v", telemetry.OtelTracesOtlpExporterType, "nonsense"), true
 			})
+
 		require.EqualError(t, err, "unsupported OTEL env: OTEL_TRACES_EXPORTER=nonsense")
 		require.Empty(t, exporters)
 	})
 
 	t.Run("when not specified, do not create any exporters", func(t *testing.T) {
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
+
 		err := telemetry.SupplementTraceExportersFromEnv(
 			exporters,
 			func(key string) (string, bool) {
 				return "", false
 			})
+
 		require.NoError(t, err)
 		require.Empty(t, exporters)
 	})

--- a/common/telemetry/env_test.go
+++ b/common/telemetry/env_test.go
@@ -37,33 +37,33 @@ func TestEnvSpanExporter(t *testing.T) {
 	require.Nil(t, exp)
 	require.NoError(t, err)
 
-	_ = os.Setenv("OTEL_TRACES_EXPORTER", "invalid-exporter")
+	_ = os.Setenv(telemetry.OtelTracesExporterEnvKey, "invalid-exporter")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.Nil(t, exp)
-	require.EqualError(t, err, "unsupported OTEL_TRACES_EXPORTER: invalid-exporter")
+	require.EqualError(t, err, "unsupported OpenTelemetry env var: OTEL_TRACES_EXPORTER=invalid-exporter")
 
-	_ = os.Setenv("OTEL_TRACES_EXPORTER", "oltp")
-
-	exp, err = telemetry.EnvSpanExporter()
-	require.NotNil(t, exp)
-	require.NoError(t, err)
-
-	_ = os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
+	_ = os.Setenv(telemetry.OtelTracesExporterEnvKey, "oltp")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.NotNil(t, exp)
 	require.NoError(t, err)
 
-	_ = os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "grpc")
+	_ = os.Setenv(telemetry.OtelTracesExporterProtocolEnvKey, "grpc")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.NotNil(t, exp)
 	require.NoError(t, err)
 
-	_ = os.Setenv("OTEL_EXPORTER_OTLP_TRACES_PROTOCOL", "invalid-protocol")
+	_ = os.Setenv(telemetry.OtelTracesExporterProtocolEnvKey, "grpc")
+
+	exp, err = telemetry.EnvSpanExporter()
+	require.NotNil(t, exp)
+	require.NoError(t, err)
+
+	_ = os.Setenv(telemetry.OtelTracesExporterProtocolEnvKey, "invalid-protocol")
 
 	exp, err = telemetry.EnvSpanExporter()
 	require.Nil(t, exp)
-	require.EqualError(t, err, "unsupported OTEL_EXPORTER_OTLP_TRACES_PROTOCOL: invalid-protocol")
+	require.EqualError(t, err, "unsupported OpenTelemetry env var: OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=invalid-protocol")
 }

--- a/common/telemetry/env_test.go
+++ b/common/telemetry/env_test.go
@@ -38,8 +38,7 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 	t.Run("when env variable specifies valid OTEL exporter type, add exporter", func(t *testing.T) {
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
 
-		err := telemetry.SupplementTraceExportersFromEnv(
-			exporters,
+		exporters, err := telemetry.SpanExportersFromEnv(
 			func(key string) (string, bool) {
 				if key == telemetry.OtelTracesExporterTypesEnvKey {
 					return string(telemetry.OtelTracesOtlpExporterType), true
@@ -54,8 +53,7 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 	t.Run("when env variable specifies valid OTEL exporter type but invalid protocol, return error", func(t *testing.T) {
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
 
-		err := telemetry.SupplementTraceExportersFromEnv(
-			exporters,
+		exporters, err := telemetry.SpanExportersFromEnv(
 			func(key string) (string, bool) {
 				switch key {
 				case telemetry.OtelTracesExporterTypesEnvKey:
@@ -70,30 +68,10 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 		require.Empty(t, exporters)
 	})
 
-	t.Run("when env variable specifies OTEL exporter type but the type already exists, don't add exporter", func(t *testing.T) {
-		var mockExporter otelsdktrace.SpanExporter
-		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{
-			telemetry.OtelTracesOtlpExporterType: mockExporter,
-		}
-
-		err := telemetry.SupplementTraceExportersFromEnv(
-			exporters,
-			func(key string) (string, bool) {
-				if key == telemetry.OtelTracesExporterTypesEnvKey {
-					return string(telemetry.OtelTracesOtlpExporterType), true
-				}
-				return "", false
-			})
-
-		require.NoError(t, err)
-		require.Equal(t, exporters[telemetry.OtelTracesOtlpExporterType], mockExporter)
-	})
-
 	t.Run("when env variable is specified but exporter type is not supported, return error", func(t *testing.T) {
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
 
-		err := telemetry.SupplementTraceExportersFromEnv(
-			exporters,
+		exporters, err := telemetry.SpanExportersFromEnv(
 			func(key string) (string, bool) {
 				if key == telemetry.OtelTracesExporterTypesEnvKey {
 					return fmt.Sprintf("%v,%v", telemetry.OtelTracesOtlpExporterType, "nonsense"), true
@@ -108,8 +86,7 @@ func TestSupplementTraceExportersFromEnv(t *testing.T) {
 	t.Run("when not specified, do not create any exporters", func(t *testing.T) {
 		exporters := map[telemetry.SpanExporterType]otelsdktrace.SpanExporter{}
 
-		err := telemetry.SupplementTraceExportersFromEnv(
-			exporters,
+		exporters, err := telemetry.SpanExportersFromEnv(
 			func(key string) (string, bool) {
 				return "", false
 			})

--- a/develop/docs/tracing.md
+++ b/develop/docs/tracing.md
@@ -81,7 +81,7 @@ An OTEL span exporter can also be configured via environment variables: [OTEL_TR
 https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection) 
 creates a span exporter.
 
-```json
+```
 OTEL_TRACES_EXPORTER=otlp
 ```
 
@@ -95,8 +95,8 @@ of the exporter. So if you prefer setting environment variables to writing YAML 
 [variables defined in the OTEL spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
 
 For example:
-```json
-OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
+```
+OTEL_SERVICE_NAME=my-service OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
 ```
 
 **NOTE: If an environment variable conflicts with YAML-provided configuration then the environment 

--- a/develop/docs/tracing.md
+++ b/develop/docs/tracing.md
@@ -25,7 +25,7 @@ abstract. The concrete implementation of an exporter is determined by a
 - "model" indicates the abstract data model for the span and trace data being exported,
 - and the "protocol" specifies the concrete application protocol binding for the indicated model.
 
-Temporal is known to support exporting trace data as defined by otlp over either grpc or http.
+Temporal is known to support exporting trace data as defined by otlp over grpc.
 
 ### Configuration File
 

--- a/develop/docs/tracing.md
+++ b/develop/docs/tracing.md
@@ -99,8 +99,8 @@ For example:
 OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
 ```
 
-**NOTE: If an environment variable conflicts with YAML-provided configuration then the environment 
-variable takes precedence.**
+**If an environment variable conflicts with YAML-provided configuration then the environment 
+variable is ignored.**
 
 ## Instrumenting
 

--- a/develop/docs/tracing.md
+++ b/develop/docs/tracing.md
@@ -21,12 +21,9 @@ collected nor emitted without additional configuration.
 In OpenTelemetry, the concept of an "exporter" is
 abstract. The concrete implementation of an exporter is determined by a
 3-tuple of values: the exporter signal, model, and protocol:
-- a "signal" is one of traces, metrics, or logs (in this document we will only deal with
-traces),
-- "model" indicates the abstract data model for the span and trace data
-being exported,
-- and the "protocol" specifies the concrete application protocol
-binding for the indicated model.
+- a "signal" is one of traces, metrics, or logs (in this document we will only deal with traces),
+- "model" indicates the abstract data model for the span and trace data being exported,
+- and the "protocol" specifies the concrete application protocol binding for the indicated model.
 
 Temporal is known to support exporting trace data as defined by otlp over either grpc or http.
 

--- a/develop/docs/tracing.md
+++ b/develop/docs/tracing.md
@@ -99,8 +99,8 @@ For example:
 OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
 ```
 
-**If an environment variable conflicts with YAML-provided configuration then the environment 
-variable is ignored.**
+**NOTE: If an environment variable conflicts with YAML-provided configuration then the environment 
+variable takes precedence.**
 
 ## Instrumenting
 

--- a/develop/docs/tracing.md
+++ b/develop/docs/tracing.md
@@ -16,18 +16,24 @@ itself](https://github.com/open-telemetry/opentelemetry-specification/blob/main/
 ## Configuring
 
 No trace exporters are configured by default and thus trace data is neither
-collected nor emitted without additional configuration added to the server's
-yaml configuration files. 
+collected nor emitted without additional configuration.
 
-The server now supports a new `otel` YAML stanza which is used to configure a
-set of process-wide exporters. In OpenTelemetry, the concept of an "exporter" is
+In OpenTelemetry, the concept of an "exporter" is
 abstract. The concrete implementation of an exporter is determined by a
-3-tuple of values: the exporter signal, model, and protocol. In OTEL, a "signal"
-is one of traces, metrics, or logs (in this document we will only deal with
-traces), "model" indicates the abstract data model for the span and trace data
-being exported, and the "protocol" specifies the concrete application protocol
-binding for the indicated model. Temporal is known to support exporting trace
-data as defined by otlp over either grpc or http.
+3-tuple of values: the exporter signal, model, and protocol:
+- a "signal" is one of traces, metrics, or logs (in this document we will only deal with
+traces),
+- "model" indicates the abstract data model for the span and trace data
+being exported,
+- and the "protocol" specifies the concrete application protocol
+binding for the indicated model.
+
+Temporal is known to support exporting trace data as defined by otlp over either grpc or http.
+
+### Configuration File
+
+The server supports an `otel` YAML stanza which is used to configure a
+set of process-wide exporters. 
 
 A common configuration is to emit tracing data to an agent such as the
 [otel-collector](https://opentelemetry.io/docs/collector/) running locally. To
@@ -70,12 +76,34 @@ fields can be found in [config_test.go](../../common/telemetry/config_test.go)
 and are mostly related to the underlying gRPC client configuration (retries,
 timeouts, etc).
 
-Note that the Go OTEL SDK will also read a well-known set of environment
-variables for configuration. So if you prefer setting environment variables to
-writing YAML then you can use the [variables defined in the OTEL
-spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/sdk-environment-variables.md).
-If environment variables conflict with YAML-provided configuration then the YAML
-takes precedence.
+### Environment Variables
+
+#### Creating Exporter
+
+An OTEL span exporter can also be configured via environment variables: [OTEL_TRACES_EXPORTER](
+https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/#exporter-selection) 
+creates a span exporter.
+
+```json
+OTEL_TRACES_EXPORTER=otlp
+```
+
+Note that if the configuration file already defines a traces exporter, no additional exporter 
+will be created.
+
+#### Configuring Exporter
+
+The Go OTEL SDK will also read a well-known set of environment variables for the configuration
+of the exporter. So if you prefer setting environment variables to writing YAML then you can use the
+[variables defined in the OTEL spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/).
+
+For example:
+```json
+OTEL_EXPORTER_OTLP_TRACES_PROTOCOL=grpc OTEL_EXPORTER_OTLP_TRACES_INSECURE=true
+```
+
+**NOTE: If an environment variable conflicts with YAML-provided configuration then the environment 
+variable takes precedence.**
 
 ## Instrumenting
 

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/pborman/uuid"
 	"go.opentelemetry.io/otel"
@@ -961,14 +960,8 @@ var ServiceTracingModule = fx.Options(
 					rsn = primitives.FrontendService
 				}
 
-				serviceNamePrefix := "io.temporal"
-				if customServicePrefix, found := os.LookupEnv(telemetry.OtelServiceNameEnvKey); found {
-					serviceNamePrefix = customServicePrefix
-				}
-				serviceName := fmt.Sprintf("%s.%s", serviceNamePrefix, string(rsn))
-
 				attrs := []attribute.KeyValue{
-					semconv.ServiceNameKey.String(serviceName),
+					semconv.ServiceNameKey.String(telemetry.ResourceServiceName(rsn)),
 					semconv.ServiceVersionKey.String(headers.ServerVersion),
 				}
 				if rsi != "" {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -907,10 +907,13 @@ var TraceExportModule = fx.Options(
 			return nil, err
 		}
 
-		err = telemetry.SupplementTraceExportersFromEnv(exportersByType, os.LookupEnv)
+		exportersByTypeFromEnv, err := telemetry.SpanExportersFromEnv(os.LookupEnv)
 		if err != nil {
 			return nil, err
 		}
+
+		// config-defined exporters override env-defined exporters with the same type
+		maps.Copy(exportersByTypeFromEnv, exportersByType)
 
 		exporters := maps.Values(exportersByType)
 		lc.Append(fx.Hook{

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/pborman/uuid"
 	"go.opentelemetry.io/otel"
@@ -906,7 +907,7 @@ var TraceExportModule = fx.Options(
 			return nil, err
 		}
 
-		exporterFromEnv, err := telemetry.EnvSpanExporter()
+		exporterFromEnv, err := telemetry.EnvSpanExporter(os.LookupEnv)
 		if err != nil {
 			return nil, err
 		} else if exporterFromEnv != nil {
@@ -955,13 +956,8 @@ var ServiceTracingModule = fx.Options(
 	fx.Provide(
 		fx.Annotate(
 			func(rsn primitives.ServiceName, rsi resource.InstanceID) (*otelresource.Resource, error) {
-				// map "internal-frontend" to "frontend" for the purpose of tracing
-				if rsn == primitives.InternalFrontendService {
-					rsn = primitives.FrontendService
-				}
-
 				attrs := []attribute.KeyValue{
-					semconv.ServiceNameKey.String(telemetry.ResourceServiceName(rsn)),
+					semconv.ServiceNameKey.String(telemetry.ResourceServiceName(rsn, os.LookupEnv)),
 					semconv.ServiceVersionKey.String(headers.ServerVersion),
 				}
 				if rsi != "" {

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -913,7 +913,7 @@ var TraceExportModule = fx.Options(
 		}
 
 		// config-defined exporters override env-defined exporters with the same type
-		maps.Copy(exportersByTypeFromEnv, exportersByType)
+		maps.Copy(exportersByType, exportersByTypeFromEnv)
 
 		exporters := maps.Values(exportersByType)
 		lc.Append(fx.Hook{

--- a/temporal/fx.go
+++ b/temporal/fx.go
@@ -962,7 +962,7 @@ var ServiceTracingModule = fx.Options(
 				}
 
 				serviceNamePrefix := "io.temporal"
-				if customServicePrefix, found := os.LookupEnv("OTEL_SERVICE_NAME"); found {
+				if customServicePrefix, found := os.LookupEnv(telemetry.OtelServiceNameEnvKey); found {
 					serviceNamePrefix = customServicePrefix
 				}
 				serviceName := fmt.Sprintf("%s.%s", serviceNamePrefix, string(rsn))


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

- allow configuring a custom OTEL `service.name` prefix
- allow configuring an OTEL exporter via env vars (following the [OTEL spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/protocol/exporter.md#configuration-options))

**Note that the OTEL exporter from the environment variables will only be created if there isn't already one from the config.** Creating an additional one wouldn't make any sense since the env variables would be applied to both anyways and there would not be any difference between them.

## Why?
<!-- Tell your future self why have you made these changes -->

Addresses:
- https://github.com/temporalio/temporal/issues/4042
- https://github.com/temporalio/temporal/issues/4041
- our own (increasing) need to enable OpenTelemetry tracing without touching the Server config (for ad-hoc debugging when working on a SDK, for example)

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

I ran an OTEL collector to verify it sends the tracing exports.

These are the env vars I set to make it work:
```go
os.Setenv("OTEL_TRACES_EXPORTER", "oltp")
os.Setenv("OTEL_EXPORTER_OTLP_TRACES_INSECURE", "true")
```

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

I doubt anyone would accidentally have these env variables specified and turn on OpenTelemetry by accident.

Unless these are specified; no behavior change occurs.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->

No