### PR TITLE
Make target for generating service clients

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ci-build-misc: print-go-version ci-update-tools proto bins shell-check copyright
 clean: clean-bins clean-test-results
 
 # Recompile proto files.
-proto: clean-proto buf-lint api-linter protoc proto-clients goimports-proto proto-mocks copyright-proto
+proto: clean-proto buf-lint api-linter protoc service-clients goimports-proto proto-mocks copyright-proto
 
 # Update proto submodule from remote and recompile proto files.
 update-proto: update-proto-submodule proto gomodtidy
@@ -207,8 +207,8 @@ proto-mocks: protoc
 		mockgen -copyright_file ../LICENSE -package $(call service_name,$(PROTO_GRPC_SERVICE))mock -source $(PROTO_GRPC_SERVICE) -destination $(call mock_file_name,$(PROTO_GRPC_SERVICE)) \
 	$(NEWLINE))
 
-proto-clients:
-	@printf $(COLOR) "Generate proto clients..."
+service-clients:
+	@printf $(COLOR) "Generate service clients..."
 	@go generate ./client/...
 
 update-go-api:

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ PROTO_OPTS = paths=source_relative:$(PROTO_OUT)
 PROTO_OUT := api
 PROTO_ENUMS := $(shell grep -R '^enum ' $(PROTO_ROOT) | cut -d ' ' -f2)
 PROTO_PATHS = paths=source_relative:$(PROTO_OUT)
-PROTO_GRPC_CLIENTS = $(shell find ./client -name "client.go")
 
 ALL_SRC         := $(shell find . -name "*.go")
 ALL_SRC         += go.mod
@@ -210,9 +209,7 @@ proto-mocks: protoc
 
 proto-clients:
 	@printf $(COLOR) "Generate proto clients..."
-	$(foreach PROTO_GRPC_CLIENT,$(PROTO_GRPC_CLIENTS),\
-		@go generate $(PROTO_GRPC_CLIENT) \
-	$(NEWLINE))
+	@go generate ./client/...
 
 update-go-api:
 	@printf $(COLOR) "Update go.temporal.io/api@master..."


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->

Added a step to re-generate gRPC API clients under `/client`.

## Why?
<!-- Tell your future self why have you made these changes -->

Whenever proto files are re-compiled, the gRPC clients should also be re-generated.

Right now the developer has to manually invoke `go generate` (and know where to find them first).

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

Running `make proto` and `make update-proto` - and observing the clients being updated.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

There could be some subtle ordering assumption in `update-proto` that is violated now?

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->

No