### PR TITLE
Don't drop query results on heartbeat workflow task

### DIFF
--- a/service/history/configs/config.go
+++ b/service/history/configs/config.go
@@ -223,8 +223,8 @@ type Config struct {
 	// Workflow task settings
 	// DefaultWorkflowTaskTimeout the default workflow task timeout
 	DefaultWorkflowTaskTimeout dynamicconfig.DurationPropertyFnWithNamespaceFilter
-	// WorkflowTaskHeartbeatTimeout is to timeout behavior of: RespondWorkflowTaskComplete with ForceCreateNewWorkflowTask == true without any commands
-	// So that workflow task will be scheduled to another worker(by clear stickyness)
+	// WorkflowTaskHeartbeatTimeout is to timeout behavior of: RespondWorkflowTaskComplete with ForceCreateNewWorkflowTask == true
+	// without any commands or messages. After this timeout workflow task will be scheduled to another worker(by clear stickyness).
 	WorkflowTaskHeartbeatTimeout dynamicconfig.DurationPropertyFnWithNamespaceFilter
 	WorkflowTaskCriticalAttempts dynamicconfig.IntPropertyFn
 	WorkflowTaskRetryMaxInterval dynamicconfig.DurationPropertyFn

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -488,7 +488,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		// After this timeout is expired, WT is timed out (although this specific WT doesn't)
 		// and new WT will be scheduled on non-sticky task queue (see ClearStickyTaskQueue call bellow).
 		wtHeartbeatTimeoutDuration := handler.config.WorkflowTaskHeartbeatTimeout(nsName)
-		if !currentWorkflowTask.OriginalScheduledTime.IsZero() &&
+		if currentWorkflowTask.OriginalScheduledTime.UnixNano() > 0 &&
 			handler.timeSource.Now().After(currentWorkflowTask.OriginalScheduledTime.Add(wtHeartbeatTimeoutDuration)) {
 
 			scope := handler.metricsHandler.WithTags(

--- a/service/history/workflow_task_handler_callbacks.go
+++ b/service/history/workflow_task_handler_callbacks.go
@@ -471,21 +471,29 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 			metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope))
 	}
 
-	workflowTaskHeartbeating := request.GetForceCreateNewWorkflowTask() && len(request.Commands) == 0 && len(request.Messages) == 0
-	var workflowTaskHeartbeatTimeout bool
+	var wtHeartbeatTimedOut bool
 	var completedEvent *historypb.HistoryEvent
-	var responseMutations []workflowTaskResponseMutation
 
-	if workflowTaskHeartbeating {
-		namespace := namespaceEntry.Name()
-		timeout := handler.config.WorkflowTaskHeartbeatTimeout(namespace.String())
-		origSchedTime := currentWorkflowTask.OriginalScheduledTime
-		if origSchedTime.UnixNano() > 0 && handler.timeSource.Now().After(origSchedTime.Add(timeout)) {
-			workflowTaskHeartbeatTimeout = true
+	// SDKs set ForceCreateNewWorkflowTask flag to true when they are doing WT heartbeats.
+	// In a mean time, there might be pending commands and messages on the worker side.
+	// If those commands/messages are sent on the heartbeat WT it means that WF is making progress.
+	// WT heartbeat timeout is applicable only when WF doesn't make any progress and does heartbeats only.
+	checkWTHeartbeatTimeout := request.GetForceCreateNewWorkflowTask() && len(request.Commands) == 0 && len(request.Messages) == 0
+
+	if checkWTHeartbeatTimeout {
+		// WorkflowTaskHeartbeatTimeout is a total duration for which workflow is allowed to send continuous heartbeats.
+		// Default is 30 minutes.
+		// Heartbeat duration is computed between now and OriginalScheduledTime, which is set when WT is scheduled and
+		// carried over to the consequence WTs if they are heartbeat WTs.
+		// After this timeout is expired, WT is timed out (although this specific WT doesn't)
+		// and new WT will be scheduled on non-sticky task queue (see ClearStickyTaskQueue call bellow).
+		wtHeartbeatTimeoutDuration := handler.config.WorkflowTaskHeartbeatTimeout(nsName)
+		if !currentWorkflowTask.OriginalScheduledTime.IsZero() &&
+			handler.timeSource.Now().After(currentWorkflowTask.OriginalScheduledTime.Add(wtHeartbeatTimeoutDuration)) {
 
 			scope := handler.metricsHandler.WithTags(
 				metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope),
-				metrics.NamespaceTag(namespace.String()),
+				metrics.NamespaceTag(nsName),
 			)
 			scope.Counter(metrics.WorkflowTaskHeartbeatTimeoutCounter.Name()).Record(1)
 			completedEvent, err = ms.AddWorkflowTaskTimedOutEvent(currentWorkflowTask)
@@ -493,13 +501,11 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 				return nil, err
 			}
 			ms.ClearStickyTaskQueue()
-		} else {
-			completedEvent, err = ms.AddWorkflowTaskCompletedEvent(currentWorkflowTask, request, limits)
-			if err != nil {
-				return nil, err
-			}
+			wtHeartbeatTimedOut = true
 		}
-	} else {
+	}
+	// WT wasn't timed out (due to too many heartbeats), therefore WTCompleted event should be created.
+	if !wtHeartbeatTimedOut {
 		completedEvent, err = ms.AddWorkflowTaskCompletedEvent(currentWorkflowTask, request, limits)
 		if err != nil {
 			return nil, err
@@ -524,6 +530,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		wtFailedCause               *workflowTaskFailedCause
 		activityNotStartedCancelled bool
 		newMutableState             workflow.MutableState
+		responseMutations           []workflowTaskResponseMutation
 	)
 	// hasBufferedEvents indicates if there are any buffered events which should generate a new workflow task
 	hasBufferedEvents := ms.HasBufferedEvents()
@@ -687,7 +694,9 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 	// Speculative workflow task will be created after mutable state is persisted.
 	if newWorkflowTaskType == enumsspb.WORKFLOW_TASK_TYPE_NORMAL {
 		var newWTErr error
-		if workflowTaskHeartbeating && !workflowTaskHeartbeatTimeout {
+		// If we checked WT heartbeat timeout before and WT wasn't timed out,
+		// then OriginalScheduledTime needs to be carried over to the new WT.
+		if checkWTHeartbeatTimeout && !wtHeartbeatTimedOut {
 			newWorkflowTask, newWTErr = ms.AddWorkflowTaskScheduledEventAsHeartbeat(
 				bypassTaskGeneration,
 				timestamppb.New(currentWorkflowTask.OriginalScheduledTime),
@@ -800,9 +809,9 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleWorkflowTaskCompleted(
 		}
 	}
 
-	handler.handleBufferedQueries(ms, req.GetCompleteRequest().GetQueryResults(), newWorkflowTask != nil, namespaceEntry, workflowTaskHeartbeating)
+	handler.handleBufferedQueries(ms, req.GetCompleteRequest().GetQueryResults(), newWorkflowTask != nil, namespaceEntry)
 
-	if workflowTaskHeartbeatTimeout {
+	if wtHeartbeatTimedOut {
 		// at this point, update is successful, but we still return an error to client so that the worker will give up this workflow
 		// release workflow lock with nil error to prevent mutable state from being cleared and reloaded
 		workflowContext.GetReleaseFn()(nil)
@@ -1169,7 +1178,7 @@ func (handler *workflowTaskHandlerCallbacksImpl) withNewWorkflowTask(
 	)
 }
 
-func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(ms workflow.MutableState, queryResults map[string]*querypb.WorkflowQueryResult, createNewWorkflowTask bool, namespaceEntry *namespace.Namespace, workflowTaskHeartbeating bool) {
+func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(ms workflow.MutableState, queryResults map[string]*querypb.WorkflowQueryResult, createNewWorkflowTask bool, namespaceEntry *namespace.Namespace) {
 	queryRegistry := ms.GetQueryRegistry()
 	if !queryRegistry.HasBufferedQuery() {
 		return
@@ -1183,12 +1192,6 @@ func (handler *workflowTaskHandlerCallbacksImpl) handleBufferedQueries(ms workfl
 		metrics.OperationTag(metrics.HistoryRespondWorkflowTaskCompletedScope),
 		metrics.NamespaceTag(namespaceEntry.Name().String()),
 		metrics.CommandTypeTag("ConsistentQuery"))
-
-	// if its a heartbeat workflow task it means local activities may still be running on the worker
-	// which were started by an external event which happened before the query
-	if workflowTaskHeartbeating {
-		return
-	}
 
 	sizeLimitError := handler.config.BlobSizeLimitError(namespaceName.String())
 	sizeLimitWarn := handler.config.BlobSizeLimitWarn(namespaceName.String())

--- a/service/history/workflow_task_handler_callbacks_test.go
+++ b/service/history/workflow_task_handler_callbacks_test.go
@@ -272,19 +272,11 @@ func (s *WorkflowTaskHandlerCallbackSuite) TestVerifyFirstWorkflowTaskScheduled_
 	s.NoError(err)
 }
 
-func (s *WorkflowTaskHandlerCallbackSuite) TestHandleBufferedQueries_HeartbeatWorkflowTask() {
-	queryRegistry, mockMutableState := s.setupBufferedQueriesMocks()
-	s.assertQueryCounts(queryRegistry, 10, 0, 0, 0)
-	queryResults := s.constructQueryResults(queryRegistry.GetBufferedIDs()[0:5], 10)
-	s.workflowTaskHandlerCallback.handleBufferedQueries(mockMutableState, queryResults, false, tests.GlobalNamespaceEntry, true)
-	s.assertQueryCounts(queryRegistry, 10, 0, 0, 0)
-}
-
 func (s *WorkflowTaskHandlerCallbackSuite) TestHandleBufferedQueries_NewWorkflowTask() {
 	queryRegistry, mockMutableState := s.setupBufferedQueriesMocks()
 	s.assertQueryCounts(queryRegistry, 10, 0, 0, 0)
 	queryResults := s.constructQueryResults(queryRegistry.GetBufferedIDs()[0:5], 10)
-	s.workflowTaskHandlerCallback.handleBufferedQueries(mockMutableState, queryResults, true, tests.GlobalNamespaceEntry, false)
+	s.workflowTaskHandlerCallback.handleBufferedQueries(mockMutableState, queryResults, true, tests.GlobalNamespaceEntry)
 	s.assertQueryCounts(queryRegistry, 5, 5, 0, 0)
 }
 
@@ -292,7 +284,7 @@ func (s *WorkflowTaskHandlerCallbackSuite) TestHandleBufferedQueries_NoNewWorkfl
 	queryRegistry, mockMutableState := s.setupBufferedQueriesMocks()
 	s.assertQueryCounts(queryRegistry, 10, 0, 0, 0)
 	queryResults := s.constructQueryResults(queryRegistry.GetBufferedIDs()[0:5], 10)
-	s.workflowTaskHandlerCallback.handleBufferedQueries(mockMutableState, queryResults, false, tests.GlobalNamespaceEntry, false)
+	s.workflowTaskHandlerCallback.handleBufferedQueries(mockMutableState, queryResults, false, tests.GlobalNamespaceEntry)
 	s.assertQueryCounts(queryRegistry, 0, 5, 5, 0)
 }
 
@@ -303,7 +295,7 @@ func (s *WorkflowTaskHandlerCallbackSuite) TestHandleBufferedQueries_QueryTooLar
 	queryResults := s.constructQueryResults(bufferedIDs[0:5], 10)
 	largeQueryResults := s.constructQueryResults(bufferedIDs[5:10], 10*1024*1024)
 	maps.Copy(queryResults, largeQueryResults)
-	s.workflowTaskHandlerCallback.handleBufferedQueries(mockMutableState, queryResults, false, tests.GlobalNamespaceEntry, false)
+	s.workflowTaskHandlerCallback.handleBufferedQueries(mockMutableState, queryResults, false, tests.GlobalNamespaceEntry)
 	s.assertQueryCounts(queryRegistry, 0, 5, 0, 5)
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Don't drop query results on heartbeat workflow task.

I also renamed confusing `workflowTaskHeartbeating` local var and added comments to explain WT heartbeat logic.

## Why?
<!-- Tell your future self why have you made these changes -->
Currently, if SDKs completes WT with `ForceNewWorkflowTask` set to `true` and w/o specifying any commands or messages but query results, these query results are dropped by server and query is sent to worker again. After bunch internal discussion we don't see why server does it for queries while normally accepting commands and messages at the same time. So I decided to remove this "drop" for the parity with messages and commands. After all, currently, if all what workflow does is a local activity, there is no way to query it. 

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Removed existing UT.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
User code which relays on the fact that local activity must be completed before worker serves the query will see these queries completed first. But this is not a guarantee which Temporal provides.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.