### PR TITLE
Get the actual error type for fmt.Errorf errors

### DIFF
--- a/common/metrics/errors.go
+++ b/common/metrics/errors.go
@@ -1,3 +1,27 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import (

--- a/common/metrics/errors.go
+++ b/common/metrics/errors.go
@@ -1,0 +1,56 @@
+package metrics
+
+import (
+	"errors"
+	"fmt"
+)
+
+// typedError is an error that has a type name.
+// It is useful for attaching low-cardinality type names to errors that are suitable for telemetry tags.
+// See ErrorType for more details.
+type typedError interface {
+	ErrorTypeName() string
+}
+
+var wrapperErrorTypes = map[string]bool{
+	"*fmt.wrapError":      true,
+	"*errors.joinError":   true,
+	"*errors.withMessage": true,
+	"*errors.withStack":   true,
+}
+
+// errorType returns a best effort guess at the most meaningful type name for the given error.
+// If any of err's underlying errors implement TypedError, then the type name of the first such error is returned.
+// This allows us to be explicit about the tag values we want to use for telemetry.
+// Otherwise, the type name of the first non-wrapper error in the depth-first traversal of err's tree is returned.
+// We consider errors wrapped via [fmt.Errorf], [errors.Join] and some pkg/errors functions to be wrapper errors.
+func errorType(err error) string {
+	// If any error in the tree has an explicit type name, use it, preferring the first one in the DFS traversal.
+	var typedErr typedError
+	if errors.As(err, &typedErr) {
+		return typedErr.ErrorTypeName()
+	}
+	// Otherwise, do a DFS traversal of the error tree, ignoring wrapper errors.
+	q := []error{err}
+	for len(q) > 0 {
+		err = q[len(q)-1]
+		q = q[:len(q)-1]
+		errType := fmt.Sprintf("%T", err)
+		if !wrapperErrorTypes[errType] {
+			return errType
+		}
+		// The error could implement zero or one of the unary or multi-error wrapper interfaces. It's impossible to
+		// implement both because they have the same method name. As a result, this is still deterministic.
+		// In any case, add the unwrapped error(s) to the DFS stack.
+		switch t := err.(type) {
+		case interface{ Unwrap() error }:
+			q = append(q, t.Unwrap())
+		case interface{ Unwrap() []error }:
+			q = append(q, t.Unwrap()...)
+		}
+	}
+	// This should never happen, but it could if the error is non-nil, the error does not implement TypedError, and
+	// there is no non-wrapper error in the error tree. For example, if there is a bug in `errors.Join()` where it
+	// accepts an empty slice of errors, then this function will return "unknown" for that error.
+	return "unknown"
+}

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -25,8 +25,6 @@
 package metrics
 
 import (
-	"errors"
-	"fmt"
 	"strconv"
 	"strings"
 
@@ -253,21 +251,6 @@ func VisibilityPluginNameTag(value string) Tag {
 // VersionedTag represents whether a loaded task queue manager represents a specific version set.
 func VersionedTag(versioned bool) Tag {
 	return &tagImpl{key: versionedTagName, value: strconv.FormatBool(versioned)}
-}
-
-func errorType(err error) string {
-	// There isn't a better way to do this as the type is private, but it obscures the actual error's type
-	// so it's worth unwrapping
-	errType := fmt.Sprintf("%T", err)
-	for errType == "*fmt.wrapError" {
-		underlying := errors.Unwrap(err)
-		if underlying == nil {
-			break
-		}
-		errType = fmt.Sprintf("%T", underlying)
-		err = underlying
-	}
-	return errType
 }
 
 func ServiceErrorTypeTag(err error) Tag {


### PR DESCRIPTION
## What changed?
When reporting error type metrics we will now unwrap errors wrapped by fmt.Errorf

## Why?
Seeing `*fmt.wrapError` in your error metrics isn't particularly helpful. This little loop will unwrap the error until either a non-fmt-error is returned or there's nothing left to unwrap

## How did you test it?
[I manually tested the code on the go playground](https://go.dev/play/p/HtPvAmdL82A)

## Potential risks
None

## Is hotfix candidate?
No
