### PR TITLE
Fix buildkite cassandra setup

### DIFF
--- a/develop/buildkite/docker-compose.yml
+++ b/develop/buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:3.11.15
     networks:
       services-network:
         aliases:


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Specify patch version of Cassandra image to use in buildkite.

## Why?
<!-- Tell your future self why have you made these changes -->
It seems that the latest version (3.11.16) has some issues with buildkite (`Cassandra 3.0 and later require Java 8u40 or later.`)

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
