### PR TITLE
Support sql connector

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -387,7 +387,7 @@ type (
 	// SQL is the configuration for connecting to a SQL backed datastore
 	SQL struct {
 		// Connect is a function that returns a sql db connection. String based configuration is ignored if this is provided.
-		Connect func(sqlConfig *SQL) (*sqlx.DB, error) `yaml:"-" ,json:"-"`
+		Connect func(sqlConfig *SQL) (*sqlx.DB, error) `yaml:"-" json:"-"`
 		// User is the username to be used for the conn
 		User string `yaml:"user"`
 		// Password is the password corresponding to the user name

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -387,7 +387,7 @@ type (
 	// SQL is the configuration for connecting to a SQL backed datastore
 	SQL struct {
 		// Connect is a function that returns a sql db connection. String based configuration is ignored if this is provided.
-		Connect func(sqlConfig *SQL) (*sqlx.DB, error) `yaml:"-"`
+		Connect func(sqlConfig *SQL) (*sqlx.DB, error) `yaml:"-" ,json:"-"`
 		// User is the username to be used for the conn
 		User string `yaml:"user"`
 		// Password is the password corresponding to the user name

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -30,6 +30,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jmoiron/sqlx"
 	"gopkg.in/yaml.v3"
 
 	"go.temporal.io/server/common/auth"
@@ -385,6 +386,8 @@ type (
 
 	// SQL is the configuration for connecting to a SQL backed datastore
 	SQL struct {
+		// Connect is a function that returns a sql db connection. String based configuration is ignored if this is provided.
+		Connect func(sqlConfig *SQL) (*sqlx.DB, error) `yaml:"-"`
 		// User is the username to be used for the conn
 		User string `yaml:"user"`
 		// Password is the password corresponding to the user name

--- a/common/persistence/sql/sqlplugin/mysql/plugin.go
+++ b/common/persistence/sql/sqlplugin/mysql/plugin.go
@@ -58,6 +58,9 @@ func (p *plugin) CreateDB(
 	metricsHandler metrics.Handler,
 ) (sqlplugin.DB, error) {
 	connect := func() (*sqlx.DB, error) {
+		if cfg.Connect != nil {
+			return cfg.Connect(cfg)
+		}
 		return p.createDBConnection(dbKind, cfg, r)
 	}
 	handle := sqlplugin.NewDatabaseHandle(connect, isConnNeedsRefreshError, logger, metricsHandler)
@@ -74,6 +77,9 @@ func (p *plugin) CreateAdminDB(
 	metricsHandler metrics.Handler,
 ) (sqlplugin.AdminDB, error) {
 	connect := func() (*sqlx.DB, error) {
+		if cfg.Connect != nil {
+			return cfg.Connect(cfg)
+		}
 		return p.createDBConnection(dbKind, cfg, r)
 	}
 	handle := sqlplugin.NewDatabaseHandle(connect, isConnNeedsRefreshError, logger, metricsHandler)

--- a/common/persistence/sql/sqlplugin/postgresql/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgresql/plugin.go
@@ -75,6 +75,9 @@ func (d *plugin) CreateDB(
 	metricsHandler metrics.Handler,
 ) (sqlplugin.DB, error) {
 	connect := func() (*sqlx.DB, error) {
+		if cfg.Connect != nil {
+			return cfg.Connect(cfg)
+		}
 		return d.createDBConnection(cfg, r)
 	}
 	needsRefresh := d.d.IsConnNeedsRefreshError
@@ -92,6 +95,9 @@ func (d *plugin) CreateAdminDB(
 	metricsHandler metrics.Handler,
 ) (sqlplugin.AdminDB, error) {
 	connect := func() (*sqlx.DB, error) {
+		if cfg.Connect != nil {
+			return cfg.Connect(cfg)
+		}
 		return d.createDBConnection(cfg, r)
 	}
 	needsRefresh := d.d.IsConnNeedsRefreshError


### PR DESCRIPTION
## What changed?
SQL config now supports passing a connect function.

## Why?
It's currently not possible to embed a Temporal server to a host application where the database connection is managed by the host application and is provided as a database connector. This allows the host application to pass a db connector rather than the the individual sql config strings.

## How did you test it?
I have embedded this code into a custom application and verified that the connector is working properly.

## Potential risks
This is a non-breaking change with very minimal risks.

## Is hotfix candidate?
No.
