### PR TITLE
Migrate from gofakeit to go-faker

### DIFF
--- a/common/persistence/serialization/serializer_test.go
+++ b/common/persistence/serialization/serializer_test.go
@@ -30,7 +30,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	enumspb "go.temporal.io/api/enums/v1"
@@ -41,6 +40,7 @@ import (
 	"go.temporal.io/server/common"
 	"go.temporal.io/server/common/log"
 	"go.temporal.io/server/common/payloads"
+	"go.temporal.io/server/common/testing/fakedata"
 	"go.temporal.io/server/common/testing/protorequire"
 )
 
@@ -184,7 +184,7 @@ func (s *temporalSerializerSuite) TestSerializeShardInfo_EmptyMapSlice() {
 
 func (s *temporalSerializerSuite) TestSerializeShardInfo_Random() {
 	var shardInfo persistencespb.ShardInfo
-	err := gofakeit.Struct(&shardInfo)
+	err := fakedata.FakeStruct(&shardInfo)
 	s.NoError(err)
 
 	blob, err := s.serializer.ShardInfoToBlob(&shardInfo, enumspb.ENCODING_TYPE_PROTO3)

--- a/common/persistence/tests/util.go
+++ b/common/persistence/tests/util.go
@@ -28,7 +28,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/google/uuid"
 	commonpb "go.temporal.io/api/common/v1"
 	historypb "go.temporal.io/api/history/v1"
@@ -43,6 +42,7 @@ import (
 	persistencespb "go.temporal.io/server/api/persistence/v1"
 	p "go.temporal.io/server/common/persistence"
 	"go.temporal.io/server/common/shuffle"
+	"go.temporal.io/server/common/testing/fakedata"
 	"go.temporal.io/server/service/history/tasks"
 )
 
@@ -51,7 +51,7 @@ func RandomShardInfo(
 	rangeID int64,
 ) *persistencespb.ShardInfo {
 	var shardInfo persistencespb.ShardInfo
-	_ = gofakeit.Struct(&shardInfo)
+	_ = fakedata.FakeStruct(&shardInfo)
 	shardInfo.ShardId = shardID
 	shardInfo.RangeId = rangeID
 	return &shardInfo
@@ -154,7 +154,7 @@ func RandomExecutionInfo(
 	lastWriteVersion int64,
 ) *persistencespb.WorkflowExecutionInfo {
 	var executionInfo persistencespb.WorkflowExecutionInfo
-	_ = gofakeit.Struct(&executionInfo)
+	_ = fakedata.FakeStruct(&executionInfo)
 	executionInfo.NamespaceId = namespaceID
 	executionInfo.WorkflowId = workflowID
 	executionInfo.VersionHistories = RandomVersionHistory(lastWriteVersion)
@@ -205,52 +205,38 @@ func RandomInt64SignalInfoMap() map[int64]*persistencespb.SignalInfo {
 }
 
 func RandomActivityInfo() *persistencespb.ActivityInfo {
-	// cannot use gofakeit due to RetryLastFailure is of type Failure
-	// and Failure can contain another Failure -> stack overflow
-	return &persistencespb.ActivityInfo{
-		Version:                rand.Int63(),
-		ScheduledEventBatchId:  rand.Int63(),
-		ScheduledTime:          RandomTime(),
-		StartedEventId:         rand.Int63(),
-		StartedTime:            RandomTime(),
-		ActivityId:             uuid.New().String(),
-		RequestId:              uuid.New().String(),
-		ScheduleToStartTimeout: RandomDuration(),
-		ScheduleToCloseTimeout: RandomDuration(),
-		StartToCloseTimeout:    RandomDuration(),
-		HeartbeatTimeout:       RandomDuration(),
-
-		// other fields omitted, above should be enough for tests
-	}
+	var activityInfo persistencespb.ActivityInfo
+	_ = fakedata.FakeStruct(&activityInfo)
+	return &activityInfo
 }
 
 func RandomTimerInfo() *persistencespb.TimerInfo {
 	var timerInfo persistencespb.TimerInfo
-	_ = gofakeit.Struct(&timerInfo)
+	_ = fakedata.FakeStruct(&timerInfo)
 	return &timerInfo
 }
 
 func RandomChildExecutionInfo() *persistencespb.ChildExecutionInfo {
 	var childExecutionInfo persistencespb.ChildExecutionInfo
-	_ = gofakeit.Struct(&childExecutionInfo)
+	_ = fakedata.FakeStruct(&childExecutionInfo)
 	return &childExecutionInfo
 }
 
 func RandomRequestCancelInfo() *persistencespb.RequestCancelInfo {
 	var requestCancelInfo persistencespb.RequestCancelInfo
-	_ = gofakeit.Struct(&requestCancelInfo)
+	_ = fakedata.FakeStruct(&requestCancelInfo)
 	return &requestCancelInfo
 }
 
 func RandomSignalInfo() *persistencespb.SignalInfo {
 	var signalInfo persistencespb.SignalInfo
-	_ = gofakeit.Struct(&signalInfo)
+	_ = fakedata.FakeStruct(&signalInfo)
 	return &signalInfo
 }
 
 func RandomHistoryEvent() *historypb.HistoryEvent {
 	var historyEvent historypb.HistoryEvent
-	_ = gofakeit.Struct(&historyEvent)
+	_ = fakedata.FakeStruct(&historyEvent)
 	return &historyEvent
 }
 
@@ -273,7 +259,7 @@ func RandomStringPayloadMap() map[string]*commonpb.Payload {
 
 func RandomPayload() *commonpb.Payload {
 	var payload commonpb.Payload
-	_ = gofakeit.Struct(&payload)
+	_ = fakedata.FakeStruct(&payload)
 	return &payload
 }
 

--- a/common/testing/fakedata/fakedata.go
+++ b/common/testing/fakedata/fakedata.go
@@ -1,0 +1,52 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+// Package fakedata provides utilities for generating random data for testing. We recently migrated from gofakeit to
+// go-faker. This was to avoid the problem described here: https://github.com/brianvoe/gofakeit/issues/281#issue-2071796056.
+// To make such migrations easier in the future, and to ensure that we use [faker.SetIgnoreInterface] before any
+// invocation, we created this package.
+package fakedata
+
+import (
+	"github.com/go-faker/faker/v4"
+)
+
+func init() {
+	// We need this option to prevent faker.FakeData from returning an error for any struct that has an interface{} field.
+	faker.SetIgnoreInterface(true)
+	// We need this option to prevent faker from taking a long time while generating random data for structs that have
+	// map or slice fields. This is especially relevant for persistence.ShardInfo, which takes about 1s without this
+	// option, but only ~100µs with it.
+	if err := faker.SetRandomMapAndSliceMaxSize(2); err != nil {
+		panic(err)
+	}
+}
+
+// FakeStruct generates random data for the given struct pointer. Example usage:
+//
+//	var shardInfo persistencespb.ShardInfo
+//	_ = fakedata.FakeStruct(&shardInfo)
+func FakeStruct(a interface{}) error {
+	return faker.FakeData(a)
+}

--- a/common/testing/fakedata/fakedata_test.go
+++ b/common/testing/fakedata/fakedata_test.go
@@ -1,0 +1,48 @@
+// The MIT License
+//
+// Copyright (c) 2020 Temporal Technologies Inc.  All rights reserved.
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package fakedata_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/common/testing/fakedata"
+)
+
+type Failure struct {
+	Cause   *Failure
+	Message string
+}
+
+func TestCircularReference(t *testing.T) {
+	var failure Failure
+	err := fakedata.FakeStruct(&failure)
+	require.NoError(t, err, "should not fail to generate fake data for struct with circular reference")
+	assert.NotEmpty(t, failure.Message)
+	require.NotNil(t, failure.Cause, "should fake data for reference to field of same type")
+	assert.NotEmpty(t, failure.Cause.Message)
+	require.Nil(t, failure.Cause.Cause, "should avoid infinite recursion")
+}

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,11 @@ require (
 	cloud.google.com/go/storage v1.30.1
 	github.com/aws/aws-sdk-go v1.44.289
 	github.com/blang/semver/v4 v4.0.0
-	github.com/brianvoe/gofakeit/v6 v6.22.0
 	github.com/cactus/go-statsd-client/v5 v5.0.0
 	github.com/dgryski/go-farm v0.0.0-20200201041132-a6ae2369ad13
 	github.com/emirpasic/gods v1.18.1
 	github.com/fatih/color v1.15.0
+	github.com/go-faker/faker/v4 v4.2.0
 	github.com/go-sql-driver/mysql v1.5.0
 	github.com/gocql/gocql v1.5.2
 	github.com/golang-jwt/jwt/v4 v4.5.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,6 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
-github.com/brianvoe/gofakeit/v6 v6.22.0 h1:BzOsDot1o3cufTfOk+fWKE9nFYojyDV+XHdCWL2+uyE=
-github.com/brianvoe/gofakeit/v6 v6.22.0/go.mod h1:Ow6qC71xtwm79anlwKRlWZW6zVq9D2XHE4QSSMP/rU8=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c h1:HIGF0r/56+7fuIZw2V4isE22MK6xpxWx7BbV8dJ290w=
 github.com/cactus/go-statsd-client/statsd v0.0.0-20200423205355-cb0885a1018c/go.mod h1:l/bIBLeOl9eX+wxJAzxS4TveKRtAqlyDpHjhkfO0MEI=
@@ -89,6 +87,8 @@ github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBD
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/fortytw2/leaktest v1.3.0 h1:u8491cBMTQ8ft8aeV+adlcytMZylmA5nnwwkRZjI8vw=
 github.com/fortytw2/leaktest v1.3.0/go.mod h1:jDsjWgpAGjm2CA7WthBh/CdZYEPF31XHquHwclZch5g=
+github.com/go-faker/faker/v4 v4.2.0 h1:dGebOupKwssrODV51E0zbMrv5e2gO9VWSLNC1WDCpWg=
+github.com/go-faker/faker/v4 v4.2.0/go.mod h1:F/bBy8GH9NxOxMInug5Gx4WYeG6fHJZ8Ol/dhcpRub4=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
 github.com/go-kit/kit v0.9.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
+++ b/service/history/api/signalwithstartworkflow/signal_with_start_workflow_test.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/brianvoe/gofakeit/v6"
 	"github.com/golang/mock/gomock"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -40,6 +39,7 @@ import (
 	"go.temporal.io/server/api/persistence/v1"
 	"go.temporal.io/server/common/clock"
 	"go.temporal.io/server/common/log"
+	"go.temporal.io/server/common/testing/fakedata"
 	"go.temporal.io/server/service/history/api"
 	"go.temporal.io/server/service/history/consts"
 	"go.temporal.io/server/service/history/shard"
@@ -215,6 +215,6 @@ func (s *signalWithStartWorkflowSuite) TestSignalWorkflow_NoNewWorkflowTask() {
 
 func (s *signalWithStartWorkflowSuite) randomRequest() *workflowservice.SignalWithStartWorkflowExecutionRequest {
 	var request workflowservice.SignalWithStartWorkflowExecutionRequest
-	_ = gofakeit.Struct(&request)
+	_ = fakedata.FakeStruct(&request)
 	return &request
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
I migrated our usage of `gofakeit` to `go-faker`.

## Why?
<!-- Tell your future self why have you made these changes -->
Because `go-faker` does not handle circular references, which we have in our `Failure` proto. See https://github.com/brianvoe/gofakeit/issues/281#issue-2071796056

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I added a test which verifies that these cases are handled gracefully. I also removed the workaround we had for this in our `ActivityInfo` generator. 

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
By default, this is less performant than `gofakeit`. However, by calling `SetRandomMapAndSliceMaxSize(2)` (down from the default of 100), we have comparable performance (on the order of 100 micro seconds for large structs). 

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.