### PR TITLE
Remove detail from debug logs in schedule workflow

### DIFF
--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -383,7 +383,7 @@ func (s *scheduler) now() time.Time {
 }
 
 func (s *scheduler) processPatch(patch *schedpb.SchedulePatch) {
-	s.logger.Debug("Schedule patch", "patch", patch.String())
+	s.logger.Debug("Schedule patch")
 
 	if trigger := patch.TriggerImmediately; trigger != nil {
 		now := s.now()
@@ -717,7 +717,7 @@ func (s *scheduler) processUpdate(req *schedspb.FullUpdateRequest) {
 		return
 	}
 
-	s.logger.Debug("Schedule update", "new-schedule", req.Schedule.String())
+	s.logger.Debug("Schedule update")
 
 	s.Schedule.Spec = req.Schedule.GetSpec()
 	s.Schedule.Action = req.Schedule.GetAction()


### PR DESCRIPTION
## What changed?
Remove a `.String()` call from a couple `logger.Debug` calls

## Why?
In normal situations with log level set to info, these calls would be ignored, but the string would be constructed first. For schedule update, it may be quite large and this is a waste of time. To make things worse, this would even happen on replay.

## How did you test it?
existing tests
