### PR TITLE
Add cache for time.LoadLocation

### DIFF
--- a/service/frontend/fx.go
+++ b/service/frontend/fx.go
@@ -66,12 +66,14 @@ import (
 	"go.temporal.io/server/service"
 	"go.temporal.io/server/service/frontend/configs"
 	"go.temporal.io/server/service/history/tasks"
+	"go.temporal.io/server/service/worker/scheduler"
 )
 
 type FEReplicatorNamespaceReplicationQueue persistence.NamespaceReplicationQueue
 
 var Module = fx.Options(
 	resource.Module,
+	scheduler.Module,
 	fx.Provide(dynamicconfig.NewCollection),
 	fx.Provide(ConfigProvider),
 	fx.Provide(NamespaceLogInterceptorProvider),
@@ -599,6 +601,7 @@ func HandlerProvider(
 	healthServer *health.Server,
 	membershipMonitor membership.Monitor,
 	healthInterceptor *interceptor.HealthInterceptor,
+	scheduleSpecBuilder *scheduler.SpecBuilder,
 ) Handler {
 	wfHandler := NewWorkflowHandler(
 		serviceConfig,
@@ -622,6 +625,7 @@ func HandlerProvider(
 		timeSource,
 		membershipMonitor,
 		healthInterceptor,
+		scheduleSpecBuilder,
 	)
 	return wfHandler
 }

--- a/service/frontend/workflow_handler_test.go
+++ b/service/frontend/workflow_handler_test.go
@@ -76,6 +76,7 @@ import (
 	"go.temporal.io/server/common/rpc/interceptor"
 	"go.temporal.io/server/common/searchattribute"
 	"go.temporal.io/server/service/worker/batcher"
+	"go.temporal.io/server/service/worker/scheduler"
 )
 
 const (
@@ -190,6 +191,7 @@ func (s *workflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandl
 		clock.NewRealTimeSource(),
 		s.mockResource.GetMembershipMonitor(),
 		healthInterceptor,
+		scheduler.NewSpecBuilder(),
 	)
 }
 

--- a/service/worker/scheduler/spec_test.go
+++ b/service/worker/scheduler/spec_test.go
@@ -39,19 +39,22 @@ import (
 type specSuite struct {
 	suite.Suite
 	protorequire.ProtoAssertions
+
+	specBuilder *SpecBuilder
 }
 
 func TestSpec(t *testing.T) {
 	suite.Run(t, new(specSuite))
 }
 
-func (s *specSuite) Setuptest() {
+func (s *specSuite) SetupTest() {
 	s.ProtoAssertions = protorequire.New(s.T())
+	s.specBuilder = NewSpecBuilder()
 }
 
 func (s *specSuite) checkSequenceRaw(spec *schedpb.ScheduleSpec, start time.Time, seq ...time.Time) {
 	s.T().Helper()
-	cs, err := NewCompiledSpec(spec)
+	cs, err := s.specBuilder.NewCompiledSpec(spec)
 	s.NoError(err)
 	for _, exp := range seq {
 		next := cs.rawNextTime(start)
@@ -62,7 +65,7 @@ func (s *specSuite) checkSequenceRaw(spec *schedpb.ScheduleSpec, start time.Time
 
 func (s *specSuite) checkSequenceFull(jitterSeed string, spec *schedpb.ScheduleSpec, start time.Time, seq ...time.Time) {
 	s.T().Helper()
-	cs, err := NewCompiledSpec(spec)
+	cs, err := s.specBuilder.NewCompiledSpec(spec)
 	s.NoError(err)
 	for _, exp := range seq {
 		result := cs.getNextTime(jitterSeed, start)

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -114,7 +114,11 @@ type (
 		logger  sdklog.Logger
 		metrics sdkclient.MetricsHandler
 
-		cspec *CompiledSpec
+		// SpecBuilder is technically a non-deterministic dependency, but it's safe as
+		// long as we only call methods on cspec inside of SideEffect (or in a query
+		// without modifying state).
+		specBuilder *SpecBuilder
+		cspec       *CompiledSpec
 
 		tweakables tweakablePolicies
 
@@ -217,12 +221,17 @@ var (
 )
 
 func SchedulerWorkflow(ctx workflow.Context, args *schedspb.StartScheduleArgs) error {
+	return schedulerWorkflowWithSpecBuilder(ctx, args, NewSpecBuilder())
+}
+
+func schedulerWorkflowWithSpecBuilder(ctx workflow.Context, args *schedspb.StartScheduleArgs, specBuilder *SpecBuilder) error {
 	scheduler := &scheduler{
 		StartScheduleArgs: args,
 		ctx:               ctx,
 		a:                 nil,
 		logger:            sdklog.With(workflow.GetLogger(ctx), "wf-namespace", args.State.Namespace, "schedule-id", args.State.ScheduleId),
 		metrics:           workflow.GetMetricsHandler(ctx).WithTags(map[string]string{"namespace": args.State.Namespace}),
+		specBuilder:       specBuilder,
 	}
 	return scheduler.run()
 }
@@ -348,7 +357,7 @@ func (s *scheduler) compileSpec() {
 	s.nextTimeCacheV1 = nil
 	s.nextTimeCacheV2.clear()
 
-	cspec, err := NewCompiledSpec(s.Schedule.Spec)
+	cspec, err := s.specBuilder.NewCompiledSpec(s.Schedule.Spec)
 	if err != nil {
 		if s.logger != nil {
 			s.logger.Error("Invalid schedule", "error", err)
@@ -1274,12 +1283,13 @@ func panicIfErr(err error) {
 	}
 }
 
-func GetListInfoFromStartArgs(args *schedspb.StartScheduleArgs, now time.Time) *schedpb.ScheduleListInfo {
+func GetListInfoFromStartArgs(args *schedspb.StartScheduleArgs, now time.Time, specBuilder *SpecBuilder) *schedpb.ScheduleListInfo {
 	// Create a scheduler outside of workflow context with just the fields we need to call
 	// getListInfo. Note that this does not take into account InitialPatch.
 	s := &scheduler{
 		StartScheduleArgs: args,
 		tweakables:        currentTweakablePolicies,
+		specBuilder:       specBuilder,
 	}
 	s.ensureFields()
 	s.compileSpec()


### PR DESCRIPTION
## What changed?
Add a cache for time.LoadLocation as used when compiling schedule specs.

## Why?
This function can be relatively slow (it accesses the filesystem) and runs each time a schedule with a timezone is replayed, or more if there are updates with timezones too. The results should generally not change within the lifetime of a process, but just in case they do, the cache has a ttl.

## How did you test it?
existing tests

## Potential risks
This is a dependency to a workflow function so we have to sneak it in in an awkward way. Note that previously it was just calling `time.LoadLocation` which is not deterministic either, so this isn't any worse, it's just a cache. We still guarantee determinism by calling methods on `cspec` in a side effect.