### PR TITLE
Fix visibility query with ExecutionStatus as int

### DIFF
--- a/common/persistence/visibility/store/elasticsearch/query_interceptors.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors.go
@@ -166,7 +166,10 @@ func parseSystemSearchAttributeValues(name string, value any) (any, error) {
 		}
 	case searchattribute.ExecutionStatus:
 		if status, isNumber := value.(int64); isNumber {
-			value = enumspb.WorkflowExecutionStatus_name[int32(status)]
+			if _, ok := enumspb.WorkflowExecutionStatus_name[int32(status)]; !ok {
+				return nil, query.NewConverterError("invalid value for search attribute %s: %v", name, value)
+			}
+			value = enumspb.WorkflowExecutionStatus(status).String()
 		}
 	case searchattribute.ExecutionDuration:
 		if durationStr, isString := value.(string); isString {

--- a/common/persistence/visibility/store/elasticsearch/query_interceptors_test.go
+++ b/common/persistence/visibility/store/elasticsearch/query_interceptors_test.go
@@ -117,9 +117,9 @@ func (s *QueryInterceptorSuite) TestStatusProcessFunc() {
 		returnErr bool
 	}{
 		{value: "Completed", returnErr: false},
-		{value: "WORKFLOW_EXECUTION_STATUS_RUNNING", returnErr: false},
+		{value: "Running", returnErr: false},
 		{value: "1", returnErr: false},
-		{value: "", returnErr: false},
+		{value: "", returnErr: true},
 		{value: "100", returnErr: false},
 		{value: "BadStatus", returnErr: false},
 		{value: "should not be modified", returnErr: false},


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Fix Elasticsearch visibility query with `ExecutionStatus` when comparing to int.

## Why?
<!-- Tell your future self why have you made these changes -->
It should auto convert the int code to the corresponding string (eg: 2 -> 'Completed')

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Fixed unit tests

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.
