### PR TITLE
Remove unnecessary lock on executable task

### DIFF
--- a/service/history/replication/executable_activity_state_task.go
+++ b/service/history/replication/executable_activity_state_task.go
@@ -26,7 +26,6 @@ package replication
 
 import (
 	"context"
-	"sync"
 	"time"
 
 	"go.temporal.io/api/serviceerror"
@@ -52,7 +51,6 @@ type (
 		req *historyservice.SyncActivityRequest
 
 		// following fields are used only for batching functionality
-		batchLock     sync.Mutex
 		batchable     bool
 		activityInfos []*historyservice.ActivitySyncInfo
 	}
@@ -245,13 +243,7 @@ func (e *ExecutableActivityStateTask) BatchWith(incomingTask BatchableTask) (Tra
 	if !e.batchable || !incomingTask.CanBatch() {
 		return nil, false
 	}
-	e.batchLock.Lock()
-	defer e.batchLock.Unlock()
 
-	if !e.batchable || !incomingTask.CanBatch() {
-		return nil, false
-	}
-	
 	incomingActivityTask, err := e.validateIncomingBatchTask(incomingTask)
 	if err != nil {
 		return nil, false
@@ -281,13 +273,9 @@ func (e *ExecutableActivityStateTask) validateIncomingBatchTask(incomingTask Bat
 }
 
 func (e *ExecutableActivityStateTask) CanBatch() bool {
-	e.batchLock.Lock()
-	defer e.batchLock.Unlock()
 	return e.batchable
 }
 
 func (e *ExecutableActivityStateTask) MarkUnbatchable() {
-	e.batchLock.Lock()
-	defer e.batchLock.Unlock()
 	e.batchable = false
 }

--- a/service/history/replication/executable_history_task.go
+++ b/service/history/replication/executable_history_task.go
@@ -62,7 +62,6 @@ type (
 		deserializeLock   sync.Mutex
 		eventsDesResponse *eventsDeserializeResponse
 
-		batchLock sync.Mutex
 		batchable bool
 	}
 	eventsDeserializeResponse struct {
@@ -321,12 +320,6 @@ func (e *ExecutableHistoryTask) getDeserializedEvents() (_ [][]*historypb.Histor
 }
 
 func (e *ExecutableHistoryTask) BatchWith(incomingTask BatchableTask) (TrackableExecutableTask, bool) {
-	if !e.batchable {
-		return nil, false
-	}
-	e.batchLock.Lock()
-	defer e.batchLock.Unlock()
-
 	if !e.batchable || !incomingTask.CanBatch() {
 		return nil, false
 	}
@@ -471,13 +464,9 @@ func (e *ExecutableHistoryTask) checkEvents(incomingEventBatches [][]*historypb.
 }
 
 func (e *ExecutableHistoryTask) CanBatch() bool {
-	e.batchLock.Lock()
-	defer e.batchLock.Unlock()
 	return e.batchable
 }
 
 func (e *ExecutableHistoryTask) MarkUnbatchable() {
-	e.batchLock.Lock()
-	defer e.batchLock.Unlock()
 	e.batchable = false
 }


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Remove unnecessary lock on executable history/activity task.
## Why?
<!-- Tell your future self why have you made these changes -->
The replication stack is built on an assumption: only one go routine is processing replication tasks for a single workflow run.
So when batching task, all replication tasks are processed by single go-routine, so no race condition is expected. 
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
n/a
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
no, feature is not enabled
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.