### PR TITLE
Update queue internals to use our new Metrics API

### DIFF
--- a/service/history/queues/dlq_writer.go
+++ b/service/history/queues/dlq_writer.go
@@ -109,7 +109,7 @@ func (q *DLQWriter) WriteTaskToDLQ(ctx context.Context, sourceCluster, targetClu
 	if err != nil {
 		return fmt.Errorf("%w: %v", ErrSendTaskToDLQ, err)
 	}
-	q.metricsHandler.Counter(metrics.DLQWrites.Name()).Record(1)
+	metrics.DLQWrites.With(q.metricsHandler).Record(1)
 	ns, err := q.namespaceRegistry.GetNamespaceByID(namespace.ID(task.GetNamespaceID()))
 	var namespaceTag tag.Tag
 	if err != nil {

--- a/service/history/queues/executable.go
+++ b/service/history/queues/executable.go
@@ -251,11 +251,11 @@ func (e *executableImpl) Execute() (retErr error) {
 		attemptLatency := e.timeSource.Now().Sub(startTime)
 		e.attemptNoUserLatency = attemptLatency - attemptUserLatency
 		// emit total attempt latency so that we know how much time a task will occpy a worker goroutine
-		e.taggedMetricsHandler.Timer(metrics.TaskProcessingLatency.Name()).Record(attemptLatency)
+		metrics.TaskProcessingLatency.With(e.taggedMetricsHandler).Record(attemptLatency)
 
 		priorityTaggedProvider := e.taggedMetricsHandler.WithTags(metrics.TaskPriorityTag(e.priority.String()))
-		priorityTaggedProvider.Counter(metrics.TaskRequests.Name()).Record(1)
-		priorityTaggedProvider.Timer(metrics.TaskScheduleLatency.Name()).Record(e.scheduleLatency)
+		metrics.TaskRequests.With(priorityTaggedProvider).Record(1)
+		metrics.TaskScheduleLatency.With(priorityTaggedProvider).Record(e.scheduleLatency)
 
 		if retErr == nil {
 			e.inMemoryNoUserLatency += e.scheduleLatency + e.attemptNoUserLatency
@@ -315,7 +315,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 
 			e.attempt++
 			if e.attempt > taskCriticalLogMetricAttempts {
-				e.taggedMetricsHandler.Histogram(metrics.TaskAttempt.Name(), metrics.TaskAttempt.Unit()).Record(int64(e.attempt))
+				metrics.TaskAttempt.With(e.taggedMetricsHandler).Record(int64(e.attempt))
 				e.logger.Error("Critical error processing task, retrying.", tag.Attempt(int32(e.attempt)), tag.Error(err), tag.OperationCritical)
 			}
 		}
@@ -328,7 +328,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 				err = consts.ErrResourceExhaustedAPSLimit
 			}
 			e.resourceExhaustedCount++
-			e.taggedMetricsHandler.Counter(metrics.TaskThrottledCounter.Name()).Record(1)
+			metrics.TaskThrottledCounter.With(e.taggedMetricsHandler).Record(1)
 			return err
 		}
 
@@ -346,32 +346,32 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	}
 
 	if err == consts.ErrDependencyTaskNotCompleted {
-		e.taggedMetricsHandler.Counter(metrics.TasksDependencyTaskNotCompleted.Name()).Record(1)
+		metrics.TasksDependencyTaskNotCompleted.With(e.taggedMetricsHandler).Record(1)
 		return err
 	}
 
 	if err == consts.ErrTaskRetry {
-		e.taggedMetricsHandler.Counter(metrics.TaskStandbyRetryCounter.Name()).Record(1)
+		metrics.TaskStandbyRetryCounter.With(e.taggedMetricsHandler).Record(1)
 		return err
 	}
 
 	if errors.Is(err, consts.ErrResourceExhaustedBusyWorkflow) {
-		e.taggedMetricsHandler.Counter(metrics.TaskWorkflowBusyCounter.Name()).Record(1)
+		metrics.TaskWorkflowBusyCounter.With(e.taggedMetricsHandler).Record(1)
 		return err
 	}
 
 	if err == consts.ErrTaskDiscarded {
-		e.taggedMetricsHandler.Counter(metrics.TaskDiscarded.Name()).Record(1)
+		metrics.TaskDiscarded.With(e.taggedMetricsHandler).Record(1)
 		return nil
 	}
 
 	if err == consts.ErrTaskVersionMismatch {
-		e.taggedMetricsHandler.Counter(metrics.TaskVersionMisMatch.Name()).Record(1)
+		metrics.TaskVersionMisMatch.With(e.taggedMetricsHandler).Record(1)
 		return nil
 	}
 
 	if err.Error() == consts.ErrNamespaceHandover.Error() {
-		e.taggedMetricsHandler.Counter(metrics.TaskNamespaceHandoverCounter.Name()).Record(1)
+		metrics.TaskNamespaceHandoverCounter.With(e.taggedMetricsHandler).Record(1)
 		err = consts.ErrNamespaceHandover
 		return err
 	}
@@ -379,7 +379,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 	if _, ok := err.(*serviceerror.NamespaceNotActive); ok {
 		// error is expected when there's namespace failover,
 		// so don't count it into task failures.
-		e.taggedMetricsHandler.Counter(metrics.TaskNotActiveCounter.Name()).Record(1)
+		metrics.TaskNotActiveCounter.With(e.taggedMetricsHandler).Record(1)
 		return err
 	}
 
@@ -388,7 +388,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 		errors.As(err, new(*serialization.UnknownEncodingTypeError)) {
 		// likely due to data corruption, emit logs, metrics & drop the task by return nil so that
 		// task will be marked as completed, or send it to the DLQ if that is enabled.
-		e.taggedMetricsHandler.Counter(metrics.TaskCorruptionCounter.Name()).Record(1)
+		metrics.TaskCorruptionCounter.With(e.taggedMetricsHandler).Record(1)
 		if e.dlqEnabled() {
 			e.logger.Error("Marking task as terminally failed, will send to DLQ", tag.Error(err))
 			e.terminalFailureCause = err
@@ -398,7 +398,7 @@ func (e *executableImpl) HandleErr(err error) (retErr error) {
 		return nil
 	}
 
-	e.taggedMetricsHandler.Counter(metrics.TaskFailures.Name()).Record(1)
+	metrics.TaskFailures.With(e.taggedMetricsHandler).Record(1)
 
 	e.logger.Error("Fail to process task", tag.Error(err), tag.LifeCycleProcessingFailed)
 	return err
@@ -447,17 +447,16 @@ func (e *executableImpl) Ack() {
 
 	e.state = ctasks.TaskStateAcked
 
-	e.taggedMetricsHandler.Timer(metrics.TaskLoadLatency.Name()).Record(
+	metrics.TaskLoadLatency.With(e.taggedMetricsHandler).Record(
 		e.loadTime.Sub(e.GetVisibilityTime()),
 		metrics.QueueReaderIDTag(e.readerID),
 	)
-	e.taggedMetricsHandler.Histogram(metrics.TaskAttempt.Name(), metrics.TaskAttempt.Unit()).Record(int64(e.attempt))
+	metrics.TaskAttempt.With(e.taggedMetricsHandler).Record(int64(e.attempt))
 
 	priorityTaggedProvider := e.taggedMetricsHandler.WithTags(metrics.TaskPriorityTag(e.lowestPriority.String()))
-	priorityTaggedProvider.Timer(metrics.TaskLatency.Name()).Record(e.inMemoryNoUserLatency)
-
-	readerIDTaggedProvider := priorityTaggedProvider.WithTags(metrics.QueueReaderIDTag(e.readerID))
-	readerIDTaggedProvider.Timer(metrics.TaskQueueLatency.Name()).Record(time.Since(e.GetVisibilityTime()))
+	metrics.TaskLatency.With(priorityTaggedProvider).Record(e.inMemoryNoUserLatency)
+	metrics.TaskQueueLatency.With(priorityTaggedProvider.WithTags(metrics.QueueReaderIDTag(e.readerID))).
+		Record(time.Since(e.GetVisibilityTime()))
 }
 
 func (e *executableImpl) Nack(err error) {

--- a/service/history/queues/memory_scheduled_queue.go
+++ b/service/history/queues/memory_scheduled_queue.go
@@ -157,7 +157,7 @@ func (q *memoryScheduledQueue) processQueueLoop() {
 				}
 				q.nextTaskTimer.Reset(newTask.GetVisibilityTime().Sub(q.timeSource.Now()))
 			}
-			q.metricsHandler.Counter(metrics.NewTimerNotifyCounter.Name()).Record(1)
+			metrics.NewTimerNotifyCounter.With(q.metricsHandler).Record(1)
 		case <-q.nextTaskTimer.C:
 			taskToExecute := q.taskQueue.Remove()
 			// Skip tasks which are already canceled. Majority of the tasks in the queue should be cancelled already.

--- a/service/history/queues/mitigator.go
+++ b/service/history/queues/mitigator.go
@@ -123,11 +123,11 @@ func runAction(
 	logger log.Logger,
 ) error {
 	metricsHandler = metricsHandler.WithTags(metrics.QueueActionTag(action.Name()))
-	metricsHandler.Counter(metrics.QueueActionCounter.Name()).Record(1)
+	metrics.QueueActionCounter.With(metricsHandler).Record(1)
 
 	if err := action.Run(readerGroup); err != nil {
 		logger.Error("Queue action failed", tag.Error(err))
-		metricsHandler.Counter(metrics.QueueActionFailures.Name()).Record(1)
+		metrics.QueueActionFailures.With(metricsHandler).Record(1)
 		return err
 	}
 

--- a/service/history/queues/queue_base.go
+++ b/service/history/queues/queue_base.go
@@ -344,12 +344,9 @@ func (p *queueBase) checkpoint() {
 			newExclusiveDeletionHighWatermark = tasks.MinKey(newExclusiveDeletionHighWatermark, scopes[0].Range.InclusiveMin)
 		}
 	}
-	p.metricsHandler.Histogram(metrics.QueueReaderCountHistogram.Name(), metrics.QueueReaderCountHistogram.Unit()).
-		Record(int64(len(readerScopes)))
-	p.metricsHandler.Histogram(metrics.QueueSliceCountHistogram.Name(), metrics.QueueSliceCountHistogram.Unit()).
-		Record(int64(p.monitor.GetTotalSliceCount()))
-	p.metricsHandler.Histogram(metrics.PendingTasksCounter.Name(), metrics.PendingTasksCounter.Unit()).
-		Record(int64(p.monitor.GetTotalPendingTaskCount()))
+	metrics.QueueReaderCountHistogram.With(p.metricsHandler).Record(int64(len(readerScopes)))
+	metrics.QueueSliceCountHistogram.With(p.metricsHandler).Record(int64(p.monitor.GetTotalSliceCount()))
+	metrics.PendingTasksCounter.With(p.metricsHandler).Record(int64(p.monitor.GetTotalPendingTaskCount()))
 
 	p.updateReaderProgress(readerScopes)
 
@@ -359,7 +356,7 @@ func (p *queueBase) checkpoint() {
 	//
 	// Emit metric before the deletion watermark comparison so we have the emit even if there's no task
 	// for the queue.
-	p.metricsHandler.Counter(metrics.TaskBatchCompleteCounter.Name()).Record(1)
+	metrics.TaskBatchCompleteCounter.With(p.metricsHandler).Record(1)
 	if newExclusiveDeletionHighWatermark.CompareTo(p.exclusiveDeletionHighWatermark) > 0 ||
 		(p.updateShardRangeID() && newExclusiveDeletionHighWatermark.CompareTo(tasks.MinimumKey) > 0) {
 		// When shard rangeID is updated, perform range completion again in case the underlying persistence implementation
@@ -459,7 +456,7 @@ func (p *queueBase) rangeCompleteTasks(
 func (p *queueBase) updateQueueState(
 	readerScopes map[int64][]Scope,
 ) error {
-	p.metricsHandler.Counter(metrics.AckLevelUpdateCounter.Name()).Record(1)
+	metrics.AckLevelUpdateCounter.With(p.metricsHandler).Record(1)
 	for readerID, scopes := range readerScopes {
 		if len(scopes) == 0 {
 			delete(readerScopes, readerID)
@@ -471,7 +468,7 @@ func (p *queueBase) updateQueueState(
 		exclusiveReaderHighWatermark: p.nonReadableScope.Range.InclusiveMin,
 	}))
 	if err != nil {
-		p.metricsHandler.Counter(metrics.AckLevelUpdateFailedCounter.Name()).Record(1)
+		metrics.AckLevelUpdateFailedCounter.With(p.metricsHandler).Record(1)
 		p.logger.Error("Error updating queue state", tag.Error(err), tag.OperationFailed)
 	}
 	return err

--- a/service/history/queues/queue_scheduled.go
+++ b/service/history/queues/queue_scheduled.go
@@ -211,7 +211,7 @@ func (p *scheduledQueue) processEventLoop() {
 		case <-p.shutdownCh:
 			return
 		case <-p.newTimerCh:
-			p.metricsHandler.Counter(metrics.NewTimerNotifyCounter.Name()).Record(1)
+			metrics.NewTimerNotifyCounter.With(p.metricsHandler).Record(1)
 			p.processNewTime()
 		case <-p.lookAheadCh:
 			p.lookAheadTask()

--- a/service/history/queues/rescheduler.go
+++ b/service/history/queues/rescheduler.go
@@ -227,8 +227,7 @@ func (r *reschedulerImpl) reschedule() {
 	r.Lock()
 	defer r.Unlock()
 
-	r.metricsHandler.Histogram(metrics.TaskReschedulerPendingTasks.Name(), metrics.TaskReschedulerPendingTasks.Unit()).Record(int64(r.numExecutables))
-
+	metrics.TaskReschedulerPendingTasks.With(r.metricsHandler).Record(int64(r.numExecutables))
 	now := r.timeSource.Now()
 	for _, pq := range r.pqMap {
 		for !pq.IsEmpty() {

--- a/service/history/queues/scheduler_monitor.go
+++ b/service/history/queues/scheduler_monitor.go
@@ -195,8 +195,7 @@ func (m *schedulerMonitor) emitMetric(
 		totalLatency = totalLatency / time.Duration(stats.numStarted) * time.Duration(m.options.aggregationCount)
 	}
 
-	stats.taggedMetricsHandler.Timer(metrics.QueueScheduleLatency.Name()).Record(totalLatency)
-
+	metrics.QueueScheduleLatency.With(stats.taggedMetricsHandler).Record(totalLatency)
 	m.resetStats(stats)
 }
 


### PR DESCRIPTION
## What changed?

I updated all metric usage within our history service's queue code to use our new `metric.With` APIs.

## Why?

See [the initial PR](https://github.com/temporalio/temporal/pull/5187) for details.

## How did you test it?
Existing tests

## Potential risks

None.

## Is hotfix candidate?
No.