### PR TITLE
[GHA test] Cache docker images

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -46,6 +46,25 @@ jobs:
 
       - run: make build-tests
 
+  cache-docker-images:
+    name: Cache Docker images
+    strategy:
+      fail-fast: false
+      matrix:
+        runs-on: [ubuntu-latest]
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles(env.DOCKER_COMPOSE_FILE) }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          ref: ${{ env.COMMIT }}
+
+      - run: docker-compose -f ${{ env.DOCKER_COMPOSE_FILE }} pull
+
   unit-test:
     name: Unit test
     needs: misc-checks
@@ -71,13 +90,17 @@ jobs:
 
   integration-test:
     name: Integration test
-    needs: misc-checks
+    needs: [misc-checks, cache-docker-images]
     strategy:
       fail-fast: false
       matrix:
         runs-on: [ubuntu-latest]
     runs-on: ${{ matrix.runs-on }}
     steps:
+      - uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles(env.DOCKER_COMPOSE_FILE) }}
+
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -103,7 +126,7 @@ jobs:
 
   functional-test:
     name: Functional test
-    needs: misc-checks
+    needs: [misc-checks, cache-docker-images]
     strategy:
       fail-fast: false
       matrix:
@@ -154,6 +177,10 @@ jobs:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
     steps:
+      - uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles(env.DOCKER_COMPOSE_FILE) }}
+
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -180,7 +207,7 @@ jobs:
 
   functional-test-xdc:
     name: Functional test xdc
-    needs: misc-checks
+    needs: [misc-checks, cache-docker-images]
     strategy:
       fail-fast: false
       matrix:
@@ -224,6 +251,10 @@ jobs:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
     steps:
+      - uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles(env.DOCKER_COMPOSE_FILE) }}
+
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -250,7 +281,7 @@ jobs:
 
   functional-test-ndc:
     name: Functional test ndc
-    needs: misc-checks
+    needs: [misc-checks, cache-docker-images]
     strategy:
       fail-fast: false
       matrix:
@@ -294,6 +325,10 @@ jobs:
       PERSISTENCE_TYPE: ${{ matrix.persistence_type }}
       PERSISTENCE_DRIVER: ${{ matrix.persistence_driver }}
     steps:
+      - uses: ScribeMD/docker-cache@0.3.7
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles(env.DOCKER_COMPOSE_FILE) }}
+
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Cache docker images in GHA tests.

## Why?
<!-- Tell your future self why have you made these changes -->
Docker pull have rate limits. Changing to pull only once per workflow.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
https://github.com/temporalio/temporal/actions/runs/7504293030/job/20431126643

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.
