### PR TITLE
Add postgres12_pgx in docker config template

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -127,7 +127,7 @@ persistence:
                     keyFile: {{ default .Env.SQL_CERT_KEY "" }}
                     enableHostVerification: {{ default .Env.SQL_HOST_VERIFICATION "false" }}
                     serverName: {{ default .Env.SQL_HOST_NAME "" }}
-        {{- else if eq $db "postgresql" "postgres" "postgres12" }}
+        {{- else if eq $db "postgresql" "postgres" "postgres12" "postgres12_pgx" }}
         {{- $db := replace $db "postgresql" "postgres" 1 }}
         default:
             sql:


### PR DESCRIPTION
## What changed?
Add the constant `postgres12_pgx` in the docker configuration template
Related PR : https://github.com/temporalio/docker-builds/pull/179

## Why?
Support for `jackc/pgx` was added in #4913 but it wasn't possible to use it within the provided configuration template

## How did you test it?
Checked template generation with `dockerize`

## Potential risks
Low risks, doesn't change default behavior

## Is hotfix candidate?
No
