### PR TITLE
Change replication latency metrics definition

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -888,7 +888,7 @@ var (
 	// ReplicationTasksFetched records the number of tasks fetched by the poller.
 	ReplicationTasksFetched                        = NewDimensionlessHistogramDef("replication_tasks_fetched")
 	ReplicationLatency                             = NewTimerDef("replication_latency")
-	ReplicationTaskReceiveLatency                  = NewTimerDef("replication_task_receive_latency")
+	ReplicationTaskTransmissionLatency             = NewTimerDef("replication_task_transmission_latency")
 	ReplicationDLQFailed                           = NewCounterDef("replication_dlq_enqueue_failed")
 	ReplicationDLQMaxLevelGauge                    = NewGaugeDef("replication_dlq_max_level")
 	ReplicationDLQAckLevelGauge                    = NewGaugeDef("replication_dlq_ack_level")

--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -888,6 +888,7 @@ var (
 	// ReplicationTasksFetched records the number of tasks fetched by the poller.
 	ReplicationTasksFetched                        = NewDimensionlessHistogramDef("replication_tasks_fetched")
 	ReplicationLatency                             = NewTimerDef("replication_latency")
+	ReplicationTaskReceiveLatency                  = NewTimerDef("replication_task_receive_latency")
 	ReplicationDLQFailed                           = NewCounterDef("replication_dlq_enqueue_failed")
 	ReplicationDLQMaxLevelGauge                    = NewGaugeDef("replication_dlq_max_level")
 	ReplicationDLQAckLevelGauge                    = NewGaugeDef("replication_dlq_ack_level")

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -276,7 +276,7 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 		metrics.OperationTag(e.metricsTag),
 		nsTag,
 	)
-	e.MetricsHandler.Timer(metrics.ReplicationTaskReceiveLatency.Name()).Record(
+	e.MetricsHandler.Timer(metrics.ReplicationTaskTransmissionLatency.Name()).Record(
 		e.taskReceivedTime.Sub(e.taskCreationTime),
 		metrics.OperationTag(e.metricsTag),
 		nsTag,

--- a/service/history/replication/executable_task.go
+++ b/service/history/replication/executable_task.go
@@ -272,6 +272,11 @@ func (e *ExecutableTaskImpl) emitFinishMetrics(
 		nsTag,
 	)
 	e.MetricsHandler.Timer(metrics.ReplicationLatency.Name()).Record(
+		now.Sub(e.taskCreationTime),
+		metrics.OperationTag(e.metricsTag),
+		nsTag,
+	)
+	e.MetricsHandler.Timer(metrics.ReplicationTaskReceiveLatency.Name()).Record(
 		e.taskReceivedTime.Sub(e.taskCreationTime),
 		metrics.OperationTag(e.metricsTag),
 		nsTag,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Change replication latency metrics definition and add a new metrics to replace old one.
## Why?
<!-- Tell your future self why have you made these changes -->
To provide better visibility of replication lag
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
n/a
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
no.