### PR TITLE
Add update acceptance message validation

### DIFF
--- a/service/history/workflow/update/registry_test.go
+++ b/service/history/workflow/update/registry_test.go
@@ -127,7 +127,9 @@ func TestHasOutgoingMessages(t *testing.T) {
 	require.True(t, reg.HasOutgoingMessages(true))
 
 	acptReq := protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
-		AcceptedRequest: &req,
+		AcceptedRequestMessageId:         "random",
+		AcceptedRequestSequencingEventId: testSequencingEventID,
+		AcceptedRequest:                  &req,
 	})}
 
 	err = upd.OnProtocolMessage(ctx, &acptReq, evStore)
@@ -601,7 +603,9 @@ func TestCancelIncomplete(t *testing.T) {
 	_ = updAccepted.Request(ctx, msgRequest4, evStore)
 	updAccepted.Send(ctx, false, sequencingID, evStore)
 	_ = updAccepted.OnProtocolMessage(ctx, &protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
-		AcceptedRequest: msgRequest4,
+		AcceptedRequestMessageId:         "random",
+		AcceptedRequestSequencingEventId: testSequencingEventID,
+		AcceptedRequest:                  msgRequest4,
 	})}, evStore)
 
 	msgRequest5 := &updatepb.Request{
@@ -612,7 +616,9 @@ func TestCancelIncomplete(t *testing.T) {
 	_ = updCompleted.Request(ctx, msgRequest5, evStore)
 	updCompleted.Send(ctx, false, sequencingID, evStore)
 	_ = updCompleted.OnProtocolMessage(ctx, &protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
-		AcceptedRequest: msgRequest4,
+		AcceptedRequestMessageId:         "random",
+		AcceptedRequestSequencingEventId: testSequencingEventID,
+		AcceptedRequest:                  msgRequest4,
 	})}, evStore)
 	_ = updCompleted.OnProtocolMessage(
 		ctx,

--- a/service/history/workflow/update/update.go
+++ b/service/history/workflow/update/update.go
@@ -412,6 +412,12 @@ func (u *Update) onAcceptanceMsg(
 	}
 	u.instrumentation.CountAcceptanceMsg()
 
+	// AcceptedRequest is not sent back by the worker to the server.
+	// Instead, the server store it in update registry and use it to generate event.
+	// There are at least two scenarios when getting it from the worker would make sense:
+	// 1. If validation handler on worker side mutates original request and accepts it.
+	//   Then server should store this mutated request but not original one.
+	// 2. To support scenario when update acceptance message is processed even if registry is lost.
 	acceptedRequest := &updatepb.Request{}
 	if err := u.request.UnmarshalTo(acceptedRequest); err != nil {
 		return internalErrorf("unable to unmarshal original request: %v", err)

--- a/service/history/workflow/update/update_test.go
+++ b/service/history/workflow/update/update_test.go
@@ -152,7 +152,6 @@ func TestRequestSendAcceptComplete(t *testing.T) {
 		acpt       = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         "random",
 			AcceptedRequestSequencingEventId: 2208,
-			AcceptedRequest:                  &req,
 		})}
 		resp         = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
 		sequencingID = &protocolpb.Message_EventId{EventId: testSequencingEventID}
@@ -535,18 +534,6 @@ func TestMessageValidation(t *testing.T) {
 		)
 		require.ErrorAs(t, err, &invalidArg)
 		require.ErrorContains(t, err, "invalid *update.Acceptance: accepted_request_message_id is not set")
-
-		err = upd.OnProtocolMessage(
-			ctx,
-			&protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
-				AcceptedRequestSequencingEventId: testSequencingEventID,
-				AcceptedRequestMessageId:         "random",
-			})},
-			store,
-		)
-		require.ErrorAs(t, err, &invalidArg)
-		require.ErrorContains(t, err, "invalid *update.Acceptance: accepted_request is not set")
-
 	})
 	t.Run("invalid response msg", func(t *testing.T) {
 		upd := update.NewAccepted("", testAcceptedEventID)
@@ -576,7 +563,6 @@ func TestDoubleRollback(t *testing.T) {
 		acpt      = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         reqMsgID,
 			AcceptedRequestSequencingEventId: testSequencingEventID,
-			AcceptedRequest:                  &req,
 		})}
 		resp         = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Response{Meta: &meta, Outcome: successOutcome(t, "success!")})}
 		sequencingID = &protocolpb.Message_EventId{EventId: testSequencingEventID}
@@ -764,7 +750,6 @@ func TestWaitLifecycleStage(t *testing.T) {
 		acpt      = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Acceptance{
 			AcceptedRequestMessageId:         "random",
 			AcceptedRequestSequencingEventId: 2208,
-			AcceptedRequest:                  &req,
 		})}
 		rej = protocolpb.Message{Body: mustMarshalAny(t, &updatepb.Rejection{
 			RejectedRequest: &req,

--- a/service/history/workflow/update/validation.go
+++ b/service/history/workflow/update/validation.go
@@ -85,6 +85,9 @@ func validateRequestMsgPrefix(
 func validateAcceptanceMsg(msg *updatepb.Acceptance) error {
 	return validate(
 		notZero(msg, "body", msg),
+		notZero(msg.GetAcceptedRequestSequencingEventId(), "accepted_request_sequencing_event_id", msg),
+		notZero(msg.GetAcceptedRequestMessageId(), "accepted_request_message_id", msg),
+		notZero(msg.GetAcceptedRequest(), "accepted_request", msg),
 	)
 }
 

--- a/service/history/workflow/update/validation.go
+++ b/service/history/workflow/update/validation.go
@@ -87,7 +87,6 @@ func validateAcceptanceMsg(msg *updatepb.Acceptance) error {
 		notZero(msg, "body", msg),
 		notZero(msg.GetAcceptedRequestSequencingEventId(), "accepted_request_sequencing_event_id", msg),
 		notZero(msg.GetAcceptedRequestMessageId(), "accepted_request_message_id", msg),
-		notZero(msg.GetAcceptedRequest(), "accepted_request", msg),
 	)
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Add update acceptance message validation.

## Why?
<!-- Tell your future self why have you made these changes -->
If SDK omitted these fields, they are not written into the history event, and then this partially filled history event will not be proceessed properly by SDK.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Added unit tests.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks, all current SDK should set these fields.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.
