### PR TITLE
Switch from docker-compose to docker compose

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,6 @@ This doc is for contributors to Temporal Server (hopefully that's you!)
 
 ### Runtime (server and tests) prerequisites
 * [docker](https://docs.docker.com/engine/install/)
-* [docker-compose](https://docs.docker.com/compose/install/)
 
 > Note: it is possible to run Temporal server without a `docker`. If for some reason (for example, performance on macOS)
 > you want to run dependencies on the host OS, please follow the [doc](develop/docs/run_dependencies_host.md).
@@ -55,7 +54,7 @@ We defined three categories of tests.
 * Integration test: Those tests cover the integration between the server and the dependencies (Cassandra, SQL, ES etc.). 
 * Functional test: Those tests cover the E2E functionality of Temporal server. They are all under ./tests directory.
 
-Integration and functional tests require runtime dependencies. They can be run with `start-dependencies` target (uses `docker-compose` internally). Open new terminal window and run:
+Integration and functional tests require runtime dependencies. They can be run with `start-dependencies` target (uses `docker compose` internally). Open new terminal window and run:
 ```bash
 make start-dependencies
 ```
@@ -94,13 +93,13 @@ for example:
 go test -v github.com/temporalio/temporal/common/persistence -run TestCassandraPersistenceSuite -testify.m TestPersistenceStartWorkflow
 ```
 
-When you are done, don't forget to stop `docker-compose` (with `Ctrl+C`) and clean up all dependencies:
+When you are done, don't forget to stop `docker compose` (with `Ctrl+C`) and clean up all dependencies:
 ```bash
 make stop-dependencies
 ```
 
 ## Run Temporal Server locally
-First start runtime dependencies. They can be run with `start-dependencies` target (uses `docker-compose` internally). Open new terminal window and run:
+First start runtime dependencies. They can be run with `start-dependencies` target (uses `docker compose` internally). Open new terminal window and run:
 ```bash
 make start-dependencies
 ```

--- a/Makefile
+++ b/Makefile
@@ -485,16 +485,16 @@ install-schema-xdc: temporal-cassandra-tool
 DOCKER_COMPOSE_FILES     := -f ./develop/docker-compose/docker-compose.yml -f ./develop/docker-compose/docker-compose.$(GOOS).yml
 DOCKER_COMPOSE_CDC_FILES := -f ./develop/docker-compose/docker-compose.cdc.yml -f ./develop/docker-compose/docker-compose.cdc.$(GOOS).yml
 start-dependencies:
-	docker-compose $(DOCKER_COMPOSE_FILES) up
+	docker compose $(DOCKER_COMPOSE_FILES) up
 
 stop-dependencies:
-	docker-compose $(DOCKER_COMPOSE_FILES) down
+	docker compose $(DOCKER_COMPOSE_FILES) down
 
 start-dependencies-cdc:
-	docker-compose $(DOCKER_COMPOSE_FILES) $(DOCKER_COMPOSE_CDC_FILES) up
+	docker compose $(DOCKER_COMPOSE_FILES) $(DOCKER_COMPOSE_CDC_FILES) up
 
 stop-dependencies-cdc:
-	docker-compose $(DOCKER_COMPOSE_FILES) $(DOCKER_COMPOSE_CDC_FILES) down
+	docker compose $(DOCKER_COMPOSE_FILES) $(DOCKER_COMPOSE_CDC_FILES) down
 
 start: temporal-server
 	./temporal-server --env development-cass --allow-no-auth start

--- a/develop/buildkite/README.md
+++ b/develop/buildkite/README.md
@@ -10,11 +10,11 @@ Create an empty directory at `/usr/bin/buildkite-agent`. This directory is mount
 present for the container to start.
 
 ### Run Locally
-To run tests locally use `docker-compose run` command in `develop/buildkite` directory:
+To run tests locally use `docker compose run` command in `develop/buildkite` directory:
 
 ```bash
 cd develop/buildkite
-docker-compose run <container_name> <command>
+docker compose run <container_name> <command>
 ```
 
 Get `<container_name>` and `<command>` form [pipeline.yml](pipeline.yml):
@@ -37,15 +37,15 @@ Get `<container_name>` and `<command>` form [pipeline.yml](pipeline.yml):
 
 For example to run unit tests:
 ```bash
-docker-compose run unit-test make unit-test-coverage
+docker compose run unit-test make unit-test-coverage
 ```
 or run integration tests with Cassandra:
 ```bash
-docker-compose run integration-test-cassandra make integration-test-coverage
+docker compose run integration-test-cassandra make integration-test-coverage
 ```
 or run integration tests with MySQL:
 ```bash
-docker-compose run integration-test-mysql make integration-test-coverage
+docker compose run integration-test-mysql make integration-test-coverage
 ```
 
 ## Testing the build in Buildkite

--- a/develop/docker-compose/README.md
+++ b/develop/docker-compose/README.md
@@ -1,6 +1,6 @@
-# Temporal Server docker-compose files for server development
+# Temporal Server `docker compose` files for server development
 
-These docker-compose files run Temporal server development dependencies. Basically, they run everything you need to run
+These `docker compose` files run Temporal server development dependencies. Basically, they run everything you need to run
 Temporal server besides a server itself which you suppose to run locally on the host in your favorite IDE or as binary.   
 
 You are not supposed to use these files directly. Please use [Makefile](../../Makefile) targets instead. To start dependencies:

--- a/develop/docs/run_dependencies_host.md
+++ b/develop/docs/run_dependencies_host.md
@@ -6,4 +6,4 @@ a bad docker file system performance on macOS. Please follow the doc for the dat
 [Cassandra](macos/cassandra.md), [MySQL](macos/mysql.md), or [PostgreSQL](macos/postgresql.md).
 
 ### Linux
-Linux users should use `docker-compose` as described in the [contribution guide](../../CONTRIBUTING.md). 
+Linux users should use `docker compose` as described in the [contribution guide](../../CONTRIBUTING.md). 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
Switch from `docker-compose` to `docker compose`.

## Why?
<!-- Tell your future self why have you made these changes -->
`docker-compose` was deprecated some time ago.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Run locally.

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
No risks.

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
No.