### PR TITLE
Enable integration testing against dotnet SDK

### DIFF
--- a/.github/workflows/features-integration.yml
+++ b/.github/workflows/features-integration.yml
@@ -50,3 +50,11 @@ jobs:
       version: v1.17.0
       version-is-repo-ref: false
       docker-image-artifact-name: temporal-server-docker
+
+  feature-tests-dotnet:
+    needs: build-docker-image
+    uses: temporalio/features/.github/workflows/dotnet.yaml@main
+    with:
+      version: 1.0.0
+      version-is-repo-ref: false
+      docker-image-artifact-name: temporal-server-docker


### PR DESCRIPTION
Proof that this is working is in the `feature-tests-dotnet` [CI output](https://github.com/temporalio/temporal/actions/runs/7575278907/job/20633643954?pr=5318) below.