### PR TITLE
Add a metric for schedule delay

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -1066,6 +1066,10 @@ var (
 		"schedule_terminate_workflow_errors",
 		WithDescription("The number of times a schedule got an error trying to terminate a previous run"),
 	)
+	ScheduleActionDelay = NewTimerDef(
+		"schedule_action_delay",
+		WithDescription("Delay between when scheduled actions should/actually happen"),
+	)
 
 	// Force replication
 	EncounterZombieWorkflowCount        = NewCounterDef("encounter_zombie_workflow_count")

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1185,6 +1185,11 @@ func (s *scheduler) startWorkflow(
 			return nil, err
 		}
 
+		if !start.Manual {
+			// record metric only for _scheduled_ actions, not trigger/backfill, otherwise it's not meaningful
+			s.metrics.Timer(metrics.ScheduleActionDelay.Name()).Record(res.RealStartTime.AsTime().Sub(start.ActualTime.AsTime()))
+		}
+
 		return &schedpb.ScheduleActionResult{
 			ScheduleTime: start.ActualTime,
 			ActualTime:   res.RealStartTime,


### PR DESCRIPTION
## What changed?
Add `schedule_action_delay` metric for the delay between when a scheduled workflow is supposed to start and when it did start.

## Why?
Have a more accessible metric for schedule delay.

## How did you test it?
Manually