### PR TITLE
Use all-apis-forwarding for xdc development

### DIFF
--- a/config/development-cluster-a.yaml
+++ b/config/development-cluster-a.yaml
@@ -87,7 +87,7 @@ clusterMetadata:
 #      rpcAddress: "localhost:9233"
 
 dcRedirectionPolicy:
-  policy: "selected-apis-forwarding"
+  policy: "all-apis-forwarding"
 
 archival:
   history:

--- a/config/development-cluster-b.yaml
+++ b/config/development-cluster-b.yaml
@@ -91,7 +91,7 @@ clusterMetadata:
 #      rpcAddress: "localhost:9233"
 
 dcRedirectionPolicy:
-  policy: "selected-apis-forwarding"
+  policy: "all-apis-forwarding"
 
 archival:
   history:

--- a/config/development-cluster-c.yaml
+++ b/config/development-cluster-c.yaml
@@ -91,7 +91,7 @@ clusterMetadata:
 #      rpcAddress: "localhost:8233"
 
 dcRedirectionPolicy:
-  policy: "selected-apis-forwarding"
+  policy: "all-apis-forwarding"
 
 archival:
   history:


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- use `all-apis-forwarding` instead of `selected-api-forwarding` policy for local xdc development

## Why?
<!-- Tell your future self why have you made these changes -->
- `all-apis-forwarding` policy forwards worker requests as well, so only one worker needs to be started for development instead of one worker for each cluster. 
- `all-apis-forwarding` is also what's used in production.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
