### PR TITLE
Only return ReleaseFn when locking current workflow execution

### DIFF
--- a/service/history/api/consistency_checker.go
+++ b/service/history/api/consistency_checker.go
@@ -310,7 +310,7 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentRunID(
 	lockPriority workflow.LockPriority,
 ) (runID string, retErr error) {
 	if c.shardContext.GetConfig().EnableAPIGetCurrentRunIDLock() {
-		_, release, err := c.workflowCache.GetOrCreateCurrentWorkflowExecution(
+		currentRelease, err := c.workflowCache.GetOrCreateCurrentWorkflowExecution(
 			ctx,
 			c.shardContext,
 			namespace.ID(namespaceID),
@@ -320,7 +320,7 @@ func (c *WorkflowConsistencyCheckerImpl) getCurrentRunID(
 		if err != nil {
 			return "", err
 		}
-		defer release(retErr)
+		defer currentRelease(retErr)
 	}
 
 	resp, err := c.shardContext.GetCurrentExecution(

--- a/service/history/api/consistency_checker_test.go
+++ b/service/history/api/consistency_checker_test.go
@@ -279,7 +279,6 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Success() {
 	ctx := context.Background()
 	shardOwnershipAsserted := false
 
-	wfContext := workflow.NewMockContext(s.controller)
 	released := false
 	releaseFn := func(err error) { released = true }
 
@@ -289,7 +288,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Success() {
 		namespace.ID(s.namespaceID),
 		s.workflowID,
 		workflow.LockPriorityHigh,
-	).Return(wfContext, releaseFn, nil)
+	).Return(releaseFn, nil)
 	s.shardContext.EXPECT().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{
@@ -309,7 +308,6 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_Ownership
 	ctx := context.Background()
 	shardOwnershipAsserted := false
 
-	wfContext := workflow.NewMockContext(s.controller)
 	released := false
 	releaseFn := func(err error) { released = true }
 
@@ -319,7 +317,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_Ownership
 		namespace.ID(s.namespaceID),
 		s.workflowID,
 		workflow.LockPriorityHigh,
-	).Return(wfContext, releaseFn, nil)
+	).Return(releaseFn, nil)
 	s.shardContext.EXPECT().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{
@@ -340,7 +338,6 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_Ownership
 	ctx := context.Background()
 	shardOwnershipAsserted := false
 
-	wfContext := workflow.NewMockContext(s.controller)
 	released := false
 	releaseFn := func(err error) { released = true }
 
@@ -350,7 +347,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_NotFound_Ownership
 		namespace.ID(s.namespaceID),
 		s.workflowID,
 		workflow.LockPriorityHigh,
-	).Return(wfContext, releaseFn, nil)
+	).Return(releaseFn, nil)
 	s.shardContext.EXPECT().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{
@@ -371,7 +368,6 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Error() {
 	ctx := context.Background()
 	shardOwnershipAsserted := false
 
-	wfContext := workflow.NewMockContext(s.controller)
 	released := false
 	releaseFn := func(err error) { released = true }
 
@@ -381,7 +377,7 @@ func (s *workflowConsistencyCheckerSuite) TestGetCurrentRunID_Error() {
 		namespace.ID(s.namespaceID),
 		s.workflowID,
 		workflow.LockPriorityHigh,
-	).Return(wfContext, releaseFn, nil)
+	).Return(releaseFn, nil)
 	s.shardContext.EXPECT().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{

--- a/service/history/api/startworkflow/api.go
+++ b/service/history/api/startworkflow/api.go
@@ -198,7 +198,7 @@ func (s *Starter) Invoke(
 func (s *Starter) lockCurrentWorkflowExecution(
 	ctx context.Context,
 ) (cache.ReleaseCacheFunc, error) {
-	_, currentRelease, err := s.workflowConsistencyChecker.GetWorkflowCache().GetOrCreateCurrentWorkflowExecution(
+	currentRelease, err := s.workflowConsistencyChecker.GetWorkflowCache().GetOrCreateCurrentWorkflowExecution(
 		ctx,
 		s.shardContext,
 		s.namespace.ID(),

--- a/service/history/workflow/cache/cache.go
+++ b/service/history/workflow/cache/cache.go
@@ -64,7 +64,7 @@ type (
 			namespaceID namespace.ID,
 			workflowID string,
 			lockPriority workflow.LockPriority,
-		) (workflow.Context, ReleaseCacheFunc, error)
+		) (ReleaseCacheFunc, error)
 
 		GetOrCreateWorkflowExecution(
 			ctx context.Context,
@@ -143,10 +143,10 @@ func (c *CacheImpl) GetOrCreateCurrentWorkflowExecution(
 	namespaceID namespace.ID,
 	workflowID string,
 	lockPriority workflow.LockPriority,
-) (workflow.Context, ReleaseCacheFunc, error) {
+) (ReleaseCacheFunc, error) {
 
 	if err := c.validateWorkflowID(workflowID); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	handler := shardContext.GetMetricsHandler().WithTags(
@@ -163,7 +163,7 @@ func (c *CacheImpl) GetOrCreateCurrentWorkflowExecution(
 		RunId: "",
 	}
 
-	weCtx, weReleaseFn, err := c.getOrCreateWorkflowExecutionInternal(
+	_, weReleaseFn, err := c.getOrCreateWorkflowExecutionInternal(
 		ctx,
 		shardContext,
 		namespaceID,
@@ -175,7 +175,7 @@ func (c *CacheImpl) GetOrCreateCurrentWorkflowExecution(
 
 	metrics.ContextCounterAdd(ctx, metrics.HistoryWorkflowExecutionCacheLatency.Name(), time.Since(start).Nanoseconds())
 
-	return weCtx, weReleaseFn, err
+	return weReleaseFn, err
 }
 
 func (c *CacheImpl) GetOrCreateWorkflowExecution(

--- a/service/history/workflow/cache/cache_mock.go
+++ b/service/history/workflow/cache/cache_mock.go
@@ -63,13 +63,12 @@ func (m *MockCache) EXPECT() *MockCacheMockRecorder {
 }
 
 // GetOrCreateCurrentWorkflowExecution mocks base method.
-func (m *MockCache) GetOrCreateCurrentWorkflowExecution(ctx context.Context, shardContext shard.Context, namespaceID namespace.ID, workflowID string, lockPriority workflow.LockPriority) (workflow.Context, ReleaseCacheFunc, error) {
+func (m *MockCache) GetOrCreateCurrentWorkflowExecution(ctx context.Context, shardContext shard.Context, namespaceID namespace.ID, workflowID string, lockPriority workflow.LockPriority) (ReleaseCacheFunc, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOrCreateCurrentWorkflowExecution", ctx, shardContext, namespaceID, workflowID, lockPriority)
-	ret0, _ := ret[0].(workflow.Context)
-	ret1, _ := ret[1].(ReleaseCacheFunc)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret0, _ := ret[0].(ReleaseCacheFunc)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // GetOrCreateCurrentWorkflowExecution indicates an expected call of GetOrCreateCurrentWorkflowExecution.

--- a/service/history/workflow/cache/cache_test.go
+++ b/service/history/workflow/cache/cache_test.go
@@ -425,7 +425,7 @@ func (s *workflowCacheSuite) TestHistoryCache_CacheLatencyMetricContext() {
 	s.cache = NewHostLevelCache(s.mockShard.GetConfig())
 
 	ctx := metrics.AddMetricsContext(context.Background())
-	_, currentRelease, err := s.cache.GetOrCreateCurrentWorkflowExecution(
+	currentRelease, err := s.cache.GetOrCreateCurrentWorkflowExecution(
 		ctx,
 		s.mockShard,
 		tests.NamespaceID,


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Only return ReleaseFn when locking current workflow execution, not the workflow context.

## Why?
<!-- Tell your future self why have you made these changes -->
- Workflow context of the current workflow is not supposed to be used by application logic. The fact that a workflow context is created is just an implementation detail of the cache.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
