### PR TITLE
Implement Callback State Machine

### DIFF
--- a/service/history/callbacks/statemachine.go
+++ b/service/history/callbacks/statemachine.go
@@ -1,0 +1,180 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package callbacks
+
+import (
+	"fmt"
+	"net/url"
+	"time"
+
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	failurepb "go.temporal.io/api/failure/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common/backoff"
+	"go.temporal.io/server/service/history/statemachines"
+	"go.temporal.io/server/service/history/tasks"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+type adapter struct{}
+
+func (adapter) GetState(data *persistencespb.CallbackInfo) enumspb.CallbackState {
+	return data.PublicInfo.State
+}
+
+func (adapter) SetState(data *persistencespb.CallbackInfo, state enumspb.CallbackState) {
+	data.PublicInfo.State = state
+}
+
+func (adapter) OnTransition(data *persistencespb.CallbackInfo, from, to enumspb.CallbackState, env statemachines.Environment) {
+	// TODO: consider moving this into the "framework".
+	data.Version = env.GetVersion()
+	if from == enumspb.CALLBACK_STATE_SCHEDULED {
+		// Reset all of previous attempt's information.
+		data.PublicInfo.Attempt++
+		data.PublicInfo.LastAttemptCompleteTime = timestamppb.New(env.GetCurrentTime())
+		data.PublicInfo.LastAttemptFailure = nil
+	}
+
+}
+
+// EventMarkedReady is triggered when a callback is triggered but is not yet ready to be scheduled, e.g. it is
+// waiting for another callback to complete.
+type EventMarkedReady struct{}
+
+var TransitionMarkedReady = statemachines.Transition[*persistencespb.CallbackInfo, enumspb.CallbackState, EventMarkedReady]{
+	Adapter: adapter{},
+	Src:     []enumspb.CallbackState{enumspb.CALLBACK_STATE_STANDBY},
+	Dst:     enumspb.CALLBACK_STATE_READY,
+}
+
+// EventBlocked is triggered when a triggered callback cannot be scheduled due to a large backlog for the
+// callback's namespace and destination.
+type EventBlocked struct{}
+
+var TransitionBlocked = statemachines.Transition[*persistencespb.CallbackInfo, enumspb.CallbackState, EventBlocked]{
+	Adapter: adapter{},
+	Src: []enumspb.CallbackState{
+		enumspb.CALLBACK_STATE_STANDBY,
+		enumspb.CALLBACK_STATE_READY,
+		enumspb.CALLBACK_STATE_BACKING_OFF,
+	},
+	Dst: enumspb.CALLBACK_STATE_BLOCKED,
+}
+
+// EventScheduled is triggered when the callback is meant to be scheduled, either immediately after triggering
+// or after backing off from a previous attempt.
+type EventScheduled struct{}
+
+var TransitionScheduled = statemachines.Transition[*persistencespb.CallbackInfo, enumspb.CallbackState, EventScheduled]{
+	Adapter: adapter{},
+	Src: []enumspb.CallbackState{
+		enumspb.CALLBACK_STATE_BLOCKED,
+		enumspb.CALLBACK_STATE_STANDBY,
+		enumspb.CALLBACK_STATE_READY,
+		enumspb.CALLBACK_STATE_BACKING_OFF,
+	},
+	Dst: enumspb.CALLBACK_STATE_SCHEDULED,
+	After: func(data *persistencespb.CallbackInfo, _ EventScheduled, env statemachines.Environment) error {
+		data.PublicInfo.NextAttemptScheduleTime = nil
+
+		var destination string
+		switch v := data.PublicInfo.Callback.GetVariant().(type) {
+		case *commonpb.Callback_Nexus_:
+			u, err := url.Parse(data.PublicInfo.Callback.GetNexus().Url)
+			if err != nil {
+				return fmt.Errorf("failed to parse URL: %v", &data.PublicInfo)
+			}
+			destination = u.Host
+		default:
+			return fmt.Errorf("unsupported callback variant %v", v)
+		}
+
+		env.Schedule(&tasks.CallbackTask{
+			CallbackID:         data.Id,
+			Attempt:            data.PublicInfo.Attempt,
+			DestinationAddress: destination,
+		})
+		return nil
+	},
+}
+
+// EventAttemptFailed is triggered when an attempt is failed with a retryable error.
+type EventAttemptFailed error
+
+var TransitionAttemptFailed = statemachines.Transition[*persistencespb.CallbackInfo, enumspb.CallbackState, EventAttemptFailed]{
+	Adapter: adapter{},
+	Src:     []enumspb.CallbackState{enumspb.CALLBACK_STATE_SCHEDULED},
+	Dst:     enumspb.CALLBACK_STATE_BACKING_OFF,
+	After: func(data *persistencespb.CallbackInfo, err EventAttemptFailed, env statemachines.Environment) error {
+		// Use 0 for elapsed time as we don't limit the retry by time (for now).
+		// TODO: Make the retry policy intial interval configurable.
+		nextDelay := backoff.NewExponentialRetryPolicy(time.Second).ComputeNextDelay(0, int(data.PublicInfo.Attempt))
+		nextAttemptScheduleTime := env.GetCurrentTime().Add(nextDelay)
+		data.PublicInfo.NextAttemptScheduleTime = timestamppb.New(nextAttemptScheduleTime)
+		data.PublicInfo.LastAttemptFailure = &failurepb.Failure{
+			Message: err.Error(),
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+					NonRetryable: false,
+				},
+			},
+		}
+		env.Schedule(&tasks.CallbackBackoffTask{
+			CallbackID:          data.Id,
+			Attempt:             data.PublicInfo.Attempt,
+			VisibilityTimestamp: nextAttemptScheduleTime,
+		})
+		return nil
+	},
+}
+
+// EventFailed is triggered when an attempt is failed with a non retryable error.
+type EventFailed error
+
+var TransitionFailed = statemachines.Transition[*persistencespb.CallbackInfo, enumspb.CallbackState, EventFailed]{
+	Adapter: adapter{},
+	Src:     []enumspb.CallbackState{enumspb.CALLBACK_STATE_SCHEDULED},
+	Dst:     enumspb.CALLBACK_STATE_FAILED,
+	After: func(data *persistencespb.CallbackInfo, err EventFailed, env statemachines.Environment) error {
+		data.PublicInfo.LastAttemptFailure = &failurepb.Failure{
+			Message: err.Error(),
+			FailureInfo: &failurepb.Failure_ApplicationFailureInfo{
+				ApplicationFailureInfo: &failurepb.ApplicationFailureInfo{
+					NonRetryable: true,
+				},
+			},
+		}
+		return nil
+	},
+}
+
+// EventSucceeded is triggered when an attempt succeeds.
+type EventSucceeded struct{}
+
+var TransitionSucceeded = statemachines.Transition[*persistencespb.CallbackInfo, enumspb.CallbackState, EventSucceeded]{
+	Adapter: adapter{},
+	Src:     []enumspb.CallbackState{enumspb.CALLBACK_STATE_SCHEDULED},
+	Dst:     enumspb.CALLBACK_STATE_SUCCEEDED,
+}

--- a/service/history/callbacks/statemachine.go
+++ b/service/history/callbacks/statemachine.go
@@ -104,11 +104,11 @@ var TransitionScheduled = statemachines.Transition[*persistencespb.CallbackInfo,
 		case *commonpb.Callback_Nexus_:
 			u, err := url.Parse(data.PublicInfo.Callback.GetNexus().Url)
 			if err != nil {
-				return fmt.Errorf("failed to parse URL: %v", &data.PublicInfo)
+				return fmt.Errorf("failed to parse URL: %v", &data.PublicInfo) // nolint:goerr113
 			}
 			destination = u.Host
 		default:
-			return fmt.Errorf("unsupported callback variant %v", v)
+			return fmt.Errorf("unsupported callback variant %v", v) // nolint:goerr113
 		}
 
 		env.Schedule(&tasks.CallbackTask{

--- a/service/history/callbacks/statemachine_test.go
+++ b/service/history/callbacks/statemachine_test.go
@@ -1,0 +1,149 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package callbacks_test
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	commonpb "go.temporal.io/api/common/v1"
+	enumspb "go.temporal.io/api/enums/v1"
+	workflowpb "go.temporal.io/api/workflow/v1"
+	persistencespb "go.temporal.io/server/api/persistence/v1"
+	"go.temporal.io/server/common"
+	"go.temporal.io/server/service/history/callbacks"
+	"go.temporal.io/server/service/history/statemachines"
+	"go.temporal.io/server/service/history/tasks"
+)
+
+func TestMarkedReady(t *testing.T) {
+	env := &statemachines.MockEnvironment{
+		Version: 3,
+	}
+	info := &persistencespb.CallbackInfo{
+		PublicInfo: &workflowpb.CallbackInfo{
+			State: enumspb.CALLBACK_STATE_STANDBY,
+		},
+	}
+	err := callbacks.TransitionMarkedReady.Apply(info, callbacks.EventMarkedReady{}, env)
+	require.NoError(t, err)
+	// Use this test to verify version and state are synced.
+	require.Equal(t, int64(3), info.Version)
+	require.Equal(t, enumspb.CALLBACK_STATE_READY, info.PublicInfo.State)
+}
+
+func TestValidTransitions(t *testing.T) {
+	// Setup
+	env := &statemachines.MockEnvironment{
+		CurrentTime: time.Now().UTC(),
+	}
+	info := &persistencespb.CallbackInfo{
+		Id: "ID",
+		PublicInfo: &workflowpb.CallbackInfo{
+			Callback: &commonpb.Callback{
+				Variant: &commonpb.Callback_Nexus_{
+					Nexus: &commonpb.Callback_Nexus{
+						Url: "http://address:666",
+					},
+				},
+			},
+			State: enumspb.CALLBACK_STATE_SCHEDULED,
+		},
+	}
+	// AttemptFailed
+	err := callbacks.TransitionAttemptFailed.Apply(info, callbacks.EventAttemptFailed(fmt.Errorf("test")), env)
+	require.NoError(t, err)
+
+	// Assert info object is updated
+	require.Equal(t, enumspb.CALLBACK_STATE_BACKING_OFF, info.PublicInfo.State)
+	require.Equal(t, int32(1), info.PublicInfo.Attempt)
+	require.Equal(t, "test", info.PublicInfo.LastAttemptFailure.Message)
+	require.False(t, info.PublicInfo.LastAttemptFailure.GetApplicationFailureInfo().NonRetryable)
+	require.Equal(t, env.CurrentTime, info.PublicInfo.LastAttemptCompleteTime.AsTime())
+	dt := env.CurrentTime.Add(time.Second).Sub(info.PublicInfo.NextAttemptScheduleTime.AsTime())
+	require.True(t, dt < time.Millisecond*200)
+
+	// Assert backoff task is generated
+	require.Equal(t, 1, len(env.ScheduledTasks))
+	boTask := env.ScheduledTasks[0].(*tasks.CallbackBackoffTask)
+	require.Equal(t, info.PublicInfo.Attempt, boTask.Attempt)
+	require.Equal(t, "ID", boTask.CallbackID)
+	require.Equal(t, info.PublicInfo.NextAttemptScheduleTime.AsTime(), boTask.VisibilityTimestamp)
+
+	// Scheduled
+	err = callbacks.TransitionScheduled.Apply(info, callbacks.EventScheduled{}, env)
+	require.NoError(t, err)
+
+	// Assert info object is updated only where needed
+	require.Equal(t, enumspb.CALLBACK_STATE_SCHEDULED, info.PublicInfo.State)
+	require.Equal(t, int32(1), info.PublicInfo.Attempt)
+	require.Equal(t, "test", info.PublicInfo.LastAttemptFailure.Message)
+	require.Equal(t, env.CurrentTime, info.PublicInfo.LastAttemptCompleteTime.AsTime())
+	require.Nil(t, info.PublicInfo.NextAttemptScheduleTime)
+
+	// Assert callback task is generated
+	require.Equal(t, 2, len(env.ScheduledTasks))
+	cbTask := env.ScheduledTasks[1].(*tasks.CallbackTask)
+	require.Equal(t, info.PublicInfo.Attempt, cbTask.Attempt)
+	require.Equal(t, "ID", cbTask.CallbackID)
+	require.Equal(t, "address:666", cbTask.DestinationAddress)
+
+	// Store the pre-succeeded state to test Failed later
+	infoDup := common.CloneProto(info)
+
+	// Succeeded
+	env.CurrentTime = env.CurrentTime.Add(time.Second)
+	err = callbacks.TransitionSucceeded.Apply(info, callbacks.EventSucceeded{}, env)
+	require.NoError(t, err)
+
+	// Assert info object is updated only where needed
+	require.Equal(t, enumspb.CALLBACK_STATE_SUCCEEDED, info.PublicInfo.State)
+	require.Equal(t, int32(2), info.PublicInfo.Attempt)
+	require.Nil(t, info.PublicInfo.LastAttemptFailure)
+	require.Equal(t, env.CurrentTime, info.PublicInfo.LastAttemptCompleteTime.AsTime())
+	require.Nil(t, info.PublicInfo.NextAttemptScheduleTime)
+
+	// Assert no additional tasks were generated
+	require.Equal(t, 2, len(env.ScheduledTasks))
+
+	// Reset back to scheduled
+	info = infoDup
+	info.PublicInfo.State = enumspb.CALLBACK_STATE_SCHEDULED
+
+	// Failed
+	err = callbacks.TransitionFailed.Apply(info, callbacks.EventFailed(fmt.Errorf("failed")), env)
+	require.NoError(t, err)
+
+	// Assert info object is updated only where needed
+	require.Equal(t, enumspb.CALLBACK_STATE_FAILED, info.PublicInfo.State)
+	require.Equal(t, int32(2), info.PublicInfo.Attempt)
+	require.Equal(t, "failed", info.PublicInfo.LastAttemptFailure.Message)
+	require.True(t, info.PublicInfo.LastAttemptFailure.GetApplicationFailureInfo().NonRetryable)
+	require.Equal(t, env.CurrentTime, info.PublicInfo.LastAttemptCompleteTime.AsTime())
+	require.Nil(t, info.PublicInfo.NextAttemptScheduleTime)
+
+	// Assert no additional tasks were generated
+	require.Equal(t, 2, len(env.ScheduledTasks))
+}

--- a/service/history/statemachines/sm.go
+++ b/service/history/statemachines/sm.go
@@ -1,0 +1,128 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package statemachines
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"time"
+
+	"go.temporal.io/server/service/history/tasks"
+)
+
+// Environment for executing state machine transitions.
+type Environment interface {
+	// GetVersion returns the current cluster failover version.
+	GetVersion() int64
+	// Schedule schedules a partial task. WorkflowKey and Version is set by the Environment.
+	Schedule(task tasks.PartialTask)
+	// GetCurrentTime returns the current time.
+	GetCurrentTime() time.Time
+}
+
+// MockEnvironment for testing purposes.
+type MockEnvironment struct {
+	// The current time to return in GetCurrentTime.
+	CurrentTime time.Time
+	// The version to return in GetVersion.
+	Version int64
+	// Tasks scheduled in this environment are appended to this slice.
+	ScheduledTasks []tasks.Task
+}
+
+// GetCurrentTime implements Environment.
+func (m *MockEnvironment) GetCurrentTime() time.Time {
+	return m.CurrentTime
+}
+
+// GetVersion implements Environment.
+func (m *MockEnvironment) GetVersion() int64 {
+	return m.Version
+}
+
+// Schedule implements Environment.
+func (m *MockEnvironment) Schedule(task tasks.PartialTask) {
+	m.ScheduledTasks = append(m.ScheduledTasks, task)
+}
+
+var _ Environment = &MockEnvironment{}
+
+// ErrInvalidTransition is returned from [Transition.Apply] on an invalid state transition.
+var ErrInvalidTransition = errors.New("invalid transition")
+
+// Transition represents a state machine transition for an object of type T with state S and event E.
+type Transition[T any, S comparable, E any] struct {
+	// Adapter to get and set the state S on an object of type T.
+	// If it is also a Transitioner, OnTransition hooks are applied.
+	Adapter Adapter[T, S]
+	// Source states that are valid for this transition.
+	Src []S
+	// Destination state.
+	Dst S
+	// Before hook, applied before running the OnTransition hook.
+	Before func(T, E, Environment) error
+	// After hook, applied after running the OnTransition hook.
+	After func(T, E, Environment) error
+}
+
+// Possible returns a boolean indicating whether the transtion is possible for the current state.
+func (t Transition[T, S, E]) Possible(data T) bool {
+	return slices.Contains(t.Src, t.Adapter.GetState(data))
+}
+
+// Apply applies a transition event to the given data.
+func (t Transition[T, S, E]) Apply(data T, event E, env Environment) error {
+	prevState := t.Adapter.GetState(data)
+	if !t.Possible(data) {
+		return fmt.Errorf("%w from %v: %v", ErrInvalidTransition, prevState, event)
+	}
+	if t.Before != nil {
+		if err := t.Before(data, event, env); err != nil {
+			return err
+		}
+	}
+	t.Adapter.SetState(data, t.Dst)
+	if transitioner, canTransition := t.Adapter.(Transitioner[T, S]); canTransition {
+		transitioner.OnTransition(data, prevState, t.Dst, env)
+	}
+	if t.After != nil {
+		if err := t.After(data, event, env); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Adapter gets and sets state S from objects of type T.
+type Adapter[T any, S comparable] interface {
+	GetState(T) S
+	SetState(T, S)
+}
+
+// Transitioner adds transition hooks.
+type Transitioner[T any, S comparable] interface {
+	// Transition hook, applied between the transition's Before and After hooks. Data will have already transitioned
+	// to the new state.
+	OnTransition(data T, from S, to S, env Environment)
+}

--- a/service/history/statemachines/sm_test.go
+++ b/service/history/statemachines/sm_test.go
@@ -1,0 +1,119 @@
+// The MIT License
+//
+// Copyright (c) 2024 Temporal Technologies Inc.  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package statemachines_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.temporal.io/server/service/history/statemachines"
+)
+
+type state string
+
+const (
+	state1 state = "state1"
+	state2 state = "state2"
+	state3 state = "state3"
+	state4 state = "state4"
+)
+
+type data struct {
+	state       state
+	transitions []struct{ from, to state }
+}
+
+type event struct{ failBeforeHook, failAfterHook bool }
+
+type adapter struct{}
+
+func (adapter) GetState(d *data) state {
+	return d.state
+}
+
+func (adapter) SetState(d *data, s state) {
+	d.state = s
+}
+
+func (adapter) OnTransition(d *data, from, to state, env statemachines.Environment) {
+	d.transitions = append(d.transitions, struct {
+		from state
+		to   state
+	}{from, to})
+}
+
+var transition = statemachines.Transition[*data, state, event]{
+	Adapter: adapter{},
+	Src:     []state{state1, state2},
+	Dst:     state3,
+}
+
+func TestTransition_Possible(t *testing.T) {
+	d := &data{state: state4}
+	require.False(t, transition.Possible(d))
+	d = &data{state: state3}
+	require.False(t, transition.Possible(d))
+	d = &data{state: state1}
+	require.True(t, transition.Possible(d))
+	d = &data{state: state2}
+	require.True(t, transition.Possible(d))
+}
+
+func TestTransition_WithoutBeforeAndAfterHooks(t *testing.T) {
+	d := &data{state: state1}
+	require.NoError(t, transition.Apply(d, event{}, &statemachines.MockEnvironment{}))
+	require.Equal(t, state3, d.state)
+	require.Equal(t, []struct{ from, to state }{{state1, state3}}, d.transitions)
+}
+
+func TestTransition_InvalidTransition(t *testing.T) {
+	d := &data{state: state4}
+	err := transition.Apply(d, event{}, &statemachines.MockEnvironment{})
+	require.ErrorIs(t, err, statemachines.ErrInvalidTransition)
+}
+
+func TestTransition_WithHooks(t *testing.T) {
+	transitionWithHooks := transition
+	beforeErr := errors.New("before")
+	afterErr := errors.New("after")
+
+	transitionWithHooks.Before = func(d *data, e event, env statemachines.Environment) error {
+		if e.failBeforeHook {
+			return beforeErr
+		}
+		return nil
+	}
+	transitionWithHooks.After = func(d *data, e event, env statemachines.Environment) error {
+		if e.failAfterHook {
+			return afterErr
+		}
+		return nil
+	}
+
+	d := &data{state: state1}
+	err := transitionWithHooks.Apply(d, event{failBeforeHook: true}, &statemachines.MockEnvironment{})
+	require.ErrorIs(t, err, beforeErr)
+	err = transitionWithHooks.Apply(d, event{failAfterHook: true}, &statemachines.MockEnvironment{})
+	require.ErrorIs(t, err, afterErr)
+}

--- a/service/history/tasks/callback_backoff_task.go
+++ b/service/history/tasks/callback_backoff_task.go
@@ -41,7 +41,7 @@ type CallbackBackoffTask struct {
 	Attempt int32
 }
 
-var _ PartialTask = (*CallbackBackoffTask)(nil)
+var _ Task = (*CallbackBackoffTask)(nil)
 
 func (t *CallbackBackoffTask) SetWorkflowKey(key definition.WorkflowKey) {
 	t.WorkflowKey = key

--- a/service/history/tasks/callback_backoff_task.go
+++ b/service/history/tasks/callback_backoff_task.go
@@ -41,7 +41,11 @@ type CallbackBackoffTask struct {
 	Attempt int32
 }
 
-var _ Task = (*CallbackBackoffTask)(nil)
+var _ PartialTask = (*CallbackBackoffTask)(nil)
+
+func (t *CallbackBackoffTask) SetWorkflowKey(key definition.WorkflowKey) {
+	t.WorkflowKey = key
+}
 
 func (t *CallbackBackoffTask) GetKey() Key {
 	return NewKey(t.VisibilityTimestamp, t.TaskID)

--- a/service/history/tasks/callback_task.go
+++ b/service/history/tasks/callback_task.go
@@ -45,7 +45,11 @@ type CallbackTask struct {
 }
 
 var _ HasDestination = (*CallbackTask)(nil)
-var _ Task = (*CallbackTask)(nil)
+var _ PartialTask = (*CallbackTask)(nil)
+
+func (t *CallbackTask) SetWorkflowKey(key definition.WorkflowKey) {
+	t.WorkflowKey = key
+}
 
 func (t *CallbackTask) GetDestination() string {
 	return t.DestinationAddress

--- a/service/history/tasks/callback_task.go
+++ b/service/history/tasks/callback_task.go
@@ -45,7 +45,7 @@ type CallbackTask struct {
 }
 
 var _ HasDestination = (*CallbackTask)(nil)
-var _ PartialTask = (*CallbackTask)(nil)
+var _ Task = (*CallbackTask)(nil)
 
 func (t *CallbackTask) SetWorkflowKey(key definition.WorkflowKey) {
 	t.WorkflowKey = key

--- a/service/history/tasks/task.go
+++ b/service/history/tasks/task.go
@@ -31,6 +31,7 @@ import (
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common"
+	"go.temporal.io/server/common/definition"
 )
 
 type (
@@ -53,6 +54,14 @@ type (
 	// HasDestination must be implemented by all tasks used in multi-destination queues.
 	HasDestination interface {
 		GetDestination() string
+	}
+
+	// PartialTask is a task that is generated without a workflow key or version.
+	// The missing fields are meant to be filled in by mutable state.
+	PartialTask interface {
+		Task
+		SetWorkflowKey(definition.WorkflowKey)
+		SetVersion(int64)
 	}
 )
 

--- a/service/history/tasks/task.go
+++ b/service/history/tasks/task.go
@@ -31,7 +31,6 @@ import (
 
 	enumsspb "go.temporal.io/server/api/enums/v1"
 	"go.temporal.io/server/common"
-	"go.temporal.io/server/common/definition"
 )
 
 type (
@@ -54,14 +53,6 @@ type (
 	// HasDestination must be implemented by all tasks used in multi-destination queues.
 	HasDestination interface {
 		GetDestination() string
-	}
-
-	// PartialTask is a task that is generated without a workflow key or version.
-	// The missing fields are meant to be filled in by mutable state.
-	PartialTask interface {
-		Task
-		SetWorkflowKey(definition.WorkflowKey)
-		SetVersion(int64)
 	}
 )
 

--- a/service/history/tasks/task_mock.go
+++ b/service/history/tasks/task_mock.go
@@ -34,6 +34,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 	v1 "go.temporal.io/server/api/enums/v1"
+	definition "go.temporal.io/server/common/definition"
 )
 
 // MockTask is a mock of Task interface.
@@ -244,4 +245,201 @@ func (m *MockHasDestination) GetDestination() string {
 func (mr *MockHasDestinationMockRecorder) GetDestination() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDestination", reflect.TypeOf((*MockHasDestination)(nil).GetDestination))
+}
+
+// MockPartialTask is a mock of PartialTask interface.
+type MockPartialTask struct {
+	ctrl     *gomock.Controller
+	recorder *MockPartialTaskMockRecorder
+}
+
+// MockPartialTaskMockRecorder is the mock recorder for MockPartialTask.
+type MockPartialTaskMockRecorder struct {
+	mock *MockPartialTask
+}
+
+// NewMockPartialTask creates a new mock instance.
+func NewMockPartialTask(ctrl *gomock.Controller) *MockPartialTask {
+	mock := &MockPartialTask{ctrl: ctrl}
+	mock.recorder = &MockPartialTaskMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockPartialTask) EXPECT() *MockPartialTaskMockRecorder {
+	return m.recorder
+}
+
+// GetCategory mocks base method.
+func (m *MockPartialTask) GetCategory() Category {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCategory")
+	ret0, _ := ret[0].(Category)
+	return ret0
+}
+
+// GetCategory indicates an expected call of GetCategory.
+func (mr *MockPartialTaskMockRecorder) GetCategory() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCategory", reflect.TypeOf((*MockPartialTask)(nil).GetCategory))
+}
+
+// GetKey mocks base method.
+func (m *MockPartialTask) GetKey() Key {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetKey")
+	ret0, _ := ret[0].(Key)
+	return ret0
+}
+
+// GetKey indicates an expected call of GetKey.
+func (mr *MockPartialTaskMockRecorder) GetKey() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetKey", reflect.TypeOf((*MockPartialTask)(nil).GetKey))
+}
+
+// GetNamespaceID mocks base method.
+func (m *MockPartialTask) GetNamespaceID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespaceID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNamespaceID indicates an expected call of GetNamespaceID.
+func (mr *MockPartialTaskMockRecorder) GetNamespaceID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespaceID", reflect.TypeOf((*MockPartialTask)(nil).GetNamespaceID))
+}
+
+// GetRunID mocks base method.
+func (m *MockPartialTask) GetRunID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRunID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetRunID indicates an expected call of GetRunID.
+func (mr *MockPartialTaskMockRecorder) GetRunID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunID", reflect.TypeOf((*MockPartialTask)(nil).GetRunID))
+}
+
+// GetTaskID mocks base method.
+func (m *MockPartialTask) GetTaskID() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTaskID")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetTaskID indicates an expected call of GetTaskID.
+func (mr *MockPartialTaskMockRecorder) GetTaskID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTaskID", reflect.TypeOf((*MockPartialTask)(nil).GetTaskID))
+}
+
+// GetType mocks base method.
+func (m *MockPartialTask) GetType() v1.TaskType {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetType")
+	ret0, _ := ret[0].(v1.TaskType)
+	return ret0
+}
+
+// GetType indicates an expected call of GetType.
+func (mr *MockPartialTaskMockRecorder) GetType() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetType", reflect.TypeOf((*MockPartialTask)(nil).GetType))
+}
+
+// GetVersion mocks base method.
+func (m *MockPartialTask) GetVersion() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVersion")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetVersion indicates an expected call of GetVersion.
+func (mr *MockPartialTaskMockRecorder) GetVersion() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockPartialTask)(nil).GetVersion))
+}
+
+// GetVisibilityTime mocks base method.
+func (m *MockPartialTask) GetVisibilityTime() time.Time {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetVisibilityTime")
+	ret0, _ := ret[0].(time.Time)
+	return ret0
+}
+
+// GetVisibilityTime indicates an expected call of GetVisibilityTime.
+func (mr *MockPartialTaskMockRecorder) GetVisibilityTime() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVisibilityTime", reflect.TypeOf((*MockPartialTask)(nil).GetVisibilityTime))
+}
+
+// GetWorkflowID mocks base method.
+func (m *MockPartialTask) GetWorkflowID() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkflowID")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetWorkflowID indicates an expected call of GetWorkflowID.
+func (mr *MockPartialTaskMockRecorder) GetWorkflowID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkflowID", reflect.TypeOf((*MockPartialTask)(nil).GetWorkflowID))
+}
+
+// SetTaskID mocks base method.
+func (m *MockPartialTask) SetTaskID(id int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetTaskID", id)
+}
+
+// SetTaskID indicates an expected call of SetTaskID.
+func (mr *MockPartialTaskMockRecorder) SetTaskID(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetTaskID", reflect.TypeOf((*MockPartialTask)(nil).SetTaskID), id)
+}
+
+// SetVersion mocks base method.
+func (m *MockPartialTask) SetVersion(arg0 int64) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetVersion", arg0)
+}
+
+// SetVersion indicates an expected call of SetVersion.
+func (mr *MockPartialTaskMockRecorder) SetVersion(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVersion", reflect.TypeOf((*MockPartialTask)(nil).SetVersion), arg0)
+}
+
+// SetVisibilityTime mocks base method.
+func (m *MockPartialTask) SetVisibilityTime(timestamp time.Time) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetVisibilityTime", timestamp)
+}
+
+// SetVisibilityTime indicates an expected call of SetVisibilityTime.
+func (mr *MockPartialTaskMockRecorder) SetVisibilityTime(timestamp interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetVisibilityTime", reflect.TypeOf((*MockPartialTask)(nil).SetVisibilityTime), timestamp)
+}
+
+// SetWorkflowKey mocks base method.
+func (m *MockPartialTask) SetWorkflowKey(arg0 definition.WorkflowKey) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetWorkflowKey", arg0)
+}
+
+// SetWorkflowKey indicates an expected call of SetWorkflowKey.
+func (mr *MockPartialTaskMockRecorder) SetWorkflowKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWorkflowKey", reflect.TypeOf((*MockPartialTask)(nil).SetWorkflowKey), arg0)
 }


### PR DESCRIPTION
## What changed?

- Add a small statemachine library to history service
- Implement the callback state machine

## Why?

More prep work for Nexus callbacks

## How did you test it?

Added unit tests.
I also ran this as part of the callback poc integration tests, but the rest of the work there is not quite ready to be merged.