### PR TITLE
Use separate flag for forwarding admin DeleteWorkflowExecution requests

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -351,7 +351,12 @@ const (
 	FrontendEnableBatcher = "frontend.enableBatcher"
 	// FrontendAccessHistoryFraction (0.0~1.0) is the fraction of history operations that are sent to the history
 	// service using the new RPCs. The remaining access history via the existing implementation.
-	FrontendAccessHistoryFraction = "frontend.accessHistoryFraction" // TODO: remove once migration complete
+	// TODO: remove once migration completes.
+	FrontendAccessHistoryFraction = "frontend.accessHistoryFraction"
+	// FrontendAdminDeleteAccessHistoryFraction (0.0~1.0) is the fraction of admin DeleteWorkflowExecution requests
+	// that are sent to the history service using the new RPCs. The remaining access history via the existing implementation.
+	// TODO: remove once migration completes.
+	FrontendAdminDeleteAccessHistoryFraction = "frontend.adminDeleteAccessHistoryFraction"
 
 	// FrontendEnableUpdateWorkflowExecution enables UpdateWorkflowExecution API in the frontend.
 	// The UpdateWorkflowExecution API has gone through rigorous testing efforts but this config's default is `false` until the

--- a/config/dynamicconfig/development-cass.yaml
+++ b/config/dynamicconfig/development-cass.yaml
@@ -42,3 +42,5 @@ frontend.workerVersioningWorkflowAPIs:
   - value: true
 frontend.accessHistoryFraction:
   - value: 1.0
+frontend.adminDeleteAccessHistoryFraction:
+  - value: 1.0

--- a/config/dynamicconfig/development-sql.yaml
+++ b/config/dynamicconfig/development-sql.yaml
@@ -45,3 +45,5 @@ frontend.enableUpdateWorkflowExecutionAsyncAccepted:
   - value: true
 frontend.accessHistoryFraction:
   - value: 1.0
+frontend.adminDeleteAccessHistoryFraction:
+  - value: 1.0

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -959,7 +959,10 @@ func (adh *AdminHandler) GetWorkflowExecutionRawHistoryV2(ctx context.Context, r
 		return nil, err
 	}
 
-	if dynamicconfig.AccessHistory(adh.config.AccessHistoryFraction, adh.metricsHandler.WithTags(metrics.OperationTag(metrics.AdminGetWorkflowExecutionRawHistoryV2Tag))) {
+	if dynamicconfig.AccessHistory(
+		adh.config.AccessHistoryFraction,
+		adh.metricsHandler.WithTags(metrics.OperationTag(metrics.AdminGetWorkflowExecutionRawHistoryV2Tag)),
+	) {
 		response, err := adh.historyClient.GetWorkflowExecutionRawHistoryV2(ctx,
 			&historyservice.GetWorkflowExecutionRawHistoryV2Request{
 				NamespaceId: request.NamespaceId,
@@ -1630,7 +1633,10 @@ func (adh *AdminHandler) DeleteWorkflowExecution(
 		return nil, err
 	}
 
-	if dynamicconfig.AccessHistory(adh.config.AccessHistoryFraction, adh.metricsHandler.WithTags(metrics.OperationTag(metrics.AdminDeleteWorkflowExecutionTag))) {
+	if dynamicconfig.AccessHistory(
+		adh.config.AdminDeleteAccessHistoryFraction,
+		adh.metricsHandler.WithTags(metrics.OperationTag(metrics.AdminDeleteWorkflowExecutionTag)),
+	) {
 		response, err := adh.historyClient.ForceDeleteWorkflowExecution(ctx,
 			&historyservice.ForceDeleteWorkflowExecutionRequest{
 				NamespaceId: namespaceID.String(),

--- a/service/frontend/admin_handler_test.go
+++ b/service/frontend/admin_handler_test.go
@@ -140,8 +140,9 @@ func (s *adminHandlerSuite) SetupTest() {
 	}
 
 	cfg := &Config{
-		NumHistoryShards:      4,
-		AccessHistoryFraction: dynamicconfig.GetFloatPropertyFn(0.0),
+		NumHistoryShards:                 4,
+		AccessHistoryFraction:            dynamicconfig.GetFloatPropertyFn(0.0),
+		AdminDeleteAccessHistoryFraction: dynamicconfig.GetFloatPropertyFn(0.0),
 	}
 	args := NewAdminHandlerArgs{
 		persistenceConfig,

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -184,8 +184,9 @@ type Config struct {
 	EnableWorkerVersioningData     dynamicconfig.BoolPropertyFnWithNamespaceFilter
 	EnableWorkerVersioningWorkflow dynamicconfig.BoolPropertyFnWithNamespaceFilter
 
-	// AccessHistoryFraction is an interim flag across 2 minor releases and will be removed once fully enabled.
-	AccessHistoryFraction dynamicconfig.FloatPropertyFn
+	// AccessHistoryFraction are interim flags across 2 minor releases and will be removed once fully enabled.
+	AccessHistoryFraction            dynamicconfig.FloatPropertyFn
+	AdminDeleteAccessHistoryFraction dynamicconfig.FloatPropertyFn
 }
 
 // NewConfig returns new service config with default values
@@ -281,7 +282,8 @@ func NewConfig(
 		EnableWorkerVersioningData:     dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableWorkerVersioningDataAPIs, false),
 		EnableWorkerVersioningWorkflow: dc.GetBoolPropertyFnWithNamespaceFilter(dynamicconfig.FrontendEnableWorkerVersioningWorkflowAPIs, false),
 
-		AccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
+		AccessHistoryFraction:            dc.GetFloat64Property(dynamicconfig.FrontendAccessHistoryFraction, 0.0),
+		AdminDeleteAccessHistoryFraction: dc.GetFloat64Property(dynamicconfig.FrontendAdminDeleteAccessHistoryFraction, 0.0),
 	}
 }
 


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Use separate flag for forwarding admin DeleteWorkflowExecution requests

- Originally I want to call the new flag "AdminHandlerAccessHistoryFraction", but there another admin requests "GetWorkflowExecutionRawHistoryV2" in admin handler (used by normal xdc logic) that should be controlled together with rest of the workflow history related APIs in workflow handler.  

## Why?
<!-- Tell your future self why have you made these changes -->
- So that we can have the capability of deleting a corrupted workflow sooner in production. Decoupled with those workflow history related api, which may need more testing and rollout time.

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Tested admin delete locally with new flag set to 1.0

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
