### PR TITLE
Use replication event handler for handling replication resend event

### DIFF
--- a/common/xdc/ndc_history_resender.go
+++ b/common/xdc/ndc_history_resender.go
@@ -54,6 +54,7 @@ type (
 	// the provided func should be thread safe
 	nDCHistoryReplicationFn func(
 		ctx context.Context,
+		sourceClusterName string,
 		namespaceId namespace.ID,
 		workflowId string,
 		runId string,
@@ -168,6 +169,7 @@ func (n *NDCHistoryResenderImpl) SendSingleWorkflowHistory(
 		}
 		err = n.ApplyReplicateFn(
 			ctx,
+			remoteClusterName,
 			namespaceID,
 			workflowID,
 			runID,
@@ -232,6 +234,7 @@ func (n *NDCHistoryResenderImpl) getPaginationFn(
 
 func (n *NDCHistoryResenderImpl) ApplyReplicateFn(
 	ctx context.Context,
+	sourceClusterName string,
 	namespaceId namespace.ID,
 	workflowId string,
 	runId string,
@@ -241,7 +244,7 @@ func (n *NDCHistoryResenderImpl) ApplyReplicateFn(
 	ctx, cancel := context.WithTimeout(ctx, resendContextTimeout)
 	defer cancel()
 
-	return n.historyReplicationFn(ctx, namespaceId, workflowId, runId, events, versionHistory)
+	return n.historyReplicationFn(ctx, sourceClusterName, namespaceId, workflowId, runId, events, versionHistory)
 }
 
 func (n *NDCHistoryResenderImpl) getHistory(

--- a/common/xdc/ndc_history_resender_test.go
+++ b/common/xdc/ndc_history_resender_test.go
@@ -201,6 +201,7 @@ func (s *nDCHistoryResenderSuite) TestSendSingleWorkflowHistory() {
 		s.mockClientBean,
 		func(
 			ctx context.Context,
+			sourceClusterName string,
 			namespaceId namespace.ID,
 			workflowId string,
 			runId string,
@@ -267,6 +268,7 @@ func (s *nDCHistoryResenderSuite) TestGetHistory() {
 		s.mockClientBean,
 		func(
 			ctx context.Context,
+			sourceClusterName string,
 			namespaceId namespace.ID,
 			workflowId string,
 			runId string,

--- a/service/frontend/admin_handler.go
+++ b/service/frontend/admin_handler.go
@@ -1534,6 +1534,7 @@ func (adh *AdminHandler) ResendReplicationTasks(
 		adh.clientBean,
 		func(
 			ctx context.Context,
+			sourceClusterName string,
 			namespaceId namespace.ID,
 			workflowId string,
 			runId string,

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -125,6 +125,7 @@ func newDLQHandler(
 			clientBean,
 			func(
 				ctx context.Context,
+				sourceClusterName string,
 				namespaceId namespace.ID,
 				workflowId string,
 				runId string,

--- a/service/history/replication/fx.go
+++ b/service/history/replication/fx.go
@@ -184,6 +184,7 @@ func ndcHistoryResenderProvider(
 		clientBean,
 		func(
 			ctx context.Context,
+			sourceClusterName string,
 			namespaceId namespace.ID,
 			workflowId string,
 			runId string,

--- a/service/history/replication/task_processor_manager.go
+++ b/service/history/replication/task_processor_manager.go
@@ -110,6 +110,7 @@ func NewTaskProcessorManager(
 			clientBean,
 			func(
 				ctx context.Context,
+				sourceClusterName string,
 				namespaceId namespace.ID,
 				workflowId string,
 				runId string,

--- a/service/history/timer_queue_factory.go
+++ b/service/history/timer_queue_factory.go
@@ -156,6 +156,7 @@ func (f *timerQueueFactory) CreateQueue(
 			f.ClientBean,
 			func(
 				ctx context.Context,
+				sourceClusterName string,
 				namespaceId namespace.ID,
 				workflowId string,
 				runId string,

--- a/service/history/transfer_queue_factory.go
+++ b/service/history/transfer_queue_factory.go
@@ -152,6 +152,7 @@ func (f *transferQueueFactory) CreateQueue(
 			f.ClientBean,
 			func(
 				ctx context.Context,
+				sourceClusterName string,
 				namespaceId namespace.ID,
 				workflowId string,
 				runId string,


### PR DESCRIPTION
- change method signature
- Use replication history event handler for resend usecase

## What changed?
<!-- Describe what has changed in this PR -->
Use replication event handler for handling replication resend event
## Why?
<!-- Tell your future self why have you made these changes -->
To allow passive side handle resend when migration ns back to original cluster
## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
integration test
## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
n/a
## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
