### PR TITLE
Fix delete namespace workflow

### DIFF
--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -114,6 +114,7 @@ func (a *LocalActivities) GetNextPageTokenActivity(ctx context.Context, params G
 		Namespace:     params.Namespace,
 		PageSize:      params.PageSize,
 		NextPageToken: params.NextPageToken,
+		Query:         allWorkflowQuery,
 	}
 
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -42,7 +42,7 @@ import (
 )
 
 const (
-	allWorkflowQuery = `TemporalNamespaceDivision = "__never_used__"`
+	allWorkflowQuery = `TemporalNamespaceDivision != "__never_used__"`
 )
 
 type (

--- a/service/worker/deletenamespace/deleteexecutions/activities.go
+++ b/service/worker/deletenamespace/deleteexecutions/activities.go
@@ -41,6 +41,10 @@ import (
 	"go.temporal.io/server/common/quotas"
 )
 
+const (
+	allWorkflowQuery = `TemporalNamespaceDivision = "__never_used__"`
+)
+
 type (
 	Activities struct {
 		visibilityManager manager.VisibilityManager
@@ -134,6 +138,7 @@ func (a *Activities) DeleteExecutionsActivity(ctx context.Context, params Delete
 		Namespace:     params.Namespace,
 		PageSize:      params.ListPageSize,
 		NextPageToken: params.NextPageToken,
+		Query:         allWorkflowQuery,
 	}
 	resp, err := a.visibilityManager.ListWorkflowExecutions(ctx, req)
 	if err != nil {

--- a/service/worker/deletenamespace/deleteexecutions/workflow_test.go
+++ b/service/worker/deletenamespace/deleteexecutions/workflow_test.go
@@ -97,6 +97,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_NoExecutions(t *testing.T) {
 		Namespace:     "namespace",
 		PageSize:      1000,
 		NextPageToken: nil,
+		Query:         allWorkflowQuery,
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions:    nil,
 		NextPageToken: nil,
@@ -265,6 +266,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: nil,
+		Query:         allWorkflowQuery,
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -291,6 +293,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_ManyExecutions(t *testing.T) 
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: []byte{22, 8, 78},
+		Query:         allWorkflowQuery,
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -364,6 +367,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: nil,
+		Query:         allWorkflowQuery,
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{
@@ -390,6 +394,7 @@ func Test_DeleteExecutionsWorkflow_NoActivityMocks_HistoryClientError(t *testing
 		Namespace:     "namespace",
 		PageSize:      2,
 		NextPageToken: []byte{22, 8, 78},
+		Query:         allWorkflowQuery,
 	}).Return(&manager.ListWorkflowExecutionsResponse{
 		Executions: []*workflowpb.WorkflowExecutionInfo{
 			{


### PR DESCRIPTION
## What changed?
Fix delete namespace workflow

## Why?
Fix delete namespace workflow with all namespace division

## How did you test it?
Tested with local docker

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
