### PR TITLE
Fix HistoryCacheGetOrCreateCurrent metric tag

### DIFF
--- a/common/metrics/metric_defs.go
+++ b/common/metrics/metric_defs.go
@@ -386,7 +386,7 @@ const (
 	// HistoryCacheGetOrCreateScope is the scope used by history cache
 	HistoryCacheGetOrCreateScope = "HistoryCacheGetOrCreate"
 	// HistoryCacheGetOrCreateCurrentScope is the scope used by history cache
-	HistoryCacheGetOrCreateCurrentScope = "CacheGetOrCreateCurrent"
+	HistoryCacheGetOrCreateCurrentScope = "HistoryCacheGetOrCreateCurrent"
 
 	// TransferQueueProcessorScope is the scope used by all metric emitted by transfer queue processor
 	TransferQueueProcessorScope = "TransferQueueProcessor"


### PR DESCRIPTION
## What changed?
<!-- Describe what has changed in this PR -->
- Fix HistoryCacheGetOrCreateCurrent metric tag

## Why?
<!-- Tell your future self why have you made these changes -->
- That's missed in a previous fix for metric tags: https://github.com/temporalio/temporal/pull/3579/files#diff-929edcb087a0a718eb68396d7c4c1508325ec9ee31a7633ee8c9ae7625658d56R1024

## How did you test it?
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->

## Potential risks
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->

## Is hotfix candidate?
<!-- Is this PR a hotfix candidate or does it require a notification to be sent to the broader community? (Yes/No) -->
